### PR TITLE
Fix build branch name

### DIFF
--- a/gradle/versioning.gradle
+++ b/gradle/versioning.gradle
@@ -1,23 +1,20 @@
 import org.ajoberstar.grgit.*
 
 buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'org.ajoberstar:gradle-git:0.8.0'
-    }
+    repositories { mavenCentral() }
+    dependencies { classpath 'org.ajoberstar:gradle-git:0.8.0' }
 }
 
 def grgit = Grgit.open(project.file('.'))
 def buildNumber = System.getenv("BUILD_NUMBER")
 def branch = grgit.branch.current.name
-println "branch name from git plugin: " + branch
-if ("HEAD".equals(branch)){
-    branch = System.getenv("GIT_BRANCH")
-    println "branch name from env variable: " + branch
-    branch = branch.split("/")[1];
-    println "branch name after split: " + branch
+if ("HEAD".equals(branch)) {
+    if (System.getenv("GIT_BRANCH") != null) {
+        branch = System.getenv("GIT_BRANCH")
+        if (branch.contains("/")) {
+            branch = branch.split("/")[1];
+        }
+    }
 }
 
 version = new ProjectVersion(0, 1, buildNumber != null ? buildNumber : "dev", branch)


### PR DESCRIPTION
Grgit plugin identified branch name as HEAD when the build was executed on Jenkins. Fixed this by getting the branch name from an environment variable.
