### PR TITLE
fixed keyName param and created an enum for required parameters

### DIFF
--- a/src/main/java/com/sequenceiq/provisioning/controller/json/RequiredAWSRequestParam.java
+++ b/src/main/java/com/sequenceiq/provisioning/controller/json/RequiredAWSRequestParam.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.provisioning.controller.json;
+
+public enum RequiredAWSRequestParam {
+
+    ROLE_ARN("roleArn"),
+    KEY_NAME("keyName"),
+    REGION("region");
+
+    private final String paramName;
+
+    private RequiredAWSRequestParam(String paramName) {
+        this.paramName = paramName;
+    }
+
+    public String getName() {
+        return paramName;
+    }
+
+    // TODO: add other required params
+
+}

--- a/src/main/java/com/sequenceiq/provisioning/controller/validation/ProvisionParametersValidator.java
+++ b/src/main/java/com/sequenceiq/provisioning/controller/validation/ProvisionParametersValidator.java
@@ -1,12 +1,13 @@
 package com.sequenceiq.provisioning.controller.validation;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
 import com.sequenceiq.provisioning.controller.json.ProvisionRequest;
+import com.sequenceiq.provisioning.controller.json.RequiredAWSRequestParam;
 
 /**
  * Validates a provision request. Because different parameters belong to
@@ -16,11 +17,13 @@ import com.sequenceiq.provisioning.controller.json.ProvisionRequest;
  */
 public class ProvisionParametersValidator implements ConstraintValidator<ValidProvisionRequest, ProvisionRequest> {
 
-    // TODO: add other required params
-    private List<String> requiredAWSParams = Arrays.asList("roleArn", "region", "sshKey");
+    private List<String> requiredAWSParams = new ArrayList<>();
 
     @Override
     public void initialize(ValidProvisionRequest constraintAnnotation) {
+        for (RequiredAWSRequestParam param : RequiredAWSRequestParam.values()) {
+            requiredAWSParams.add(param.getName());
+        }
     }
 
     @Override

--- a/src/main/java/com/sequenceiq/provisioning/service/aws/AWSProvisionService.java
+++ b/src/main/java/com/sequenceiq/provisioning/service/aws/AWSProvisionService.java
@@ -13,6 +13,7 @@ import com.amazonaws.services.cloudformation.model.Parameter;
 import com.sequenceiq.provisioning.controller.json.AWSProvisionResult;
 import com.sequenceiq.provisioning.controller.json.ProvisionRequest;
 import com.sequenceiq.provisioning.controller.json.ProvisionResult;
+import com.sequenceiq.provisioning.controller.json.RequiredAWSRequestParam;
 import com.sequenceiq.provisioning.domain.CloudFormationTemplate;
 import com.sequenceiq.provisioning.domain.CloudPlatform;
 import com.sequenceiq.provisioning.service.ProvisionService;
@@ -38,9 +39,10 @@ public class AWSProvisionService implements ProvisionService {
 
     @Override
     public ProvisionResult provisionCluster(ProvisionRequest provisionRequest) {
-        Regions region = Regions.fromName(provisionRequest.getParameters().get("region"));
-        String keyName = provisionRequest.getParameters().get("keyName");
-        String roleArn = provisionRequest.getParameters().get("roleArn");
+
+        Regions region = Regions.fromName(provisionRequest.getParameters().get(RequiredAWSRequestParam.REGION.getName()));
+        String keyName = provisionRequest.getParameters().get(RequiredAWSRequestParam.KEY_NAME.getName());
+        String roleArn = provisionRequest.getParameters().get(RequiredAWSRequestParam.ROLE_ARN.getName());
 
         BasicSessionCredentials basicSessionCredentials = credentialsProvider.retrieveSessionCredentials(SESSION_CREDENTIALS_DURATION, "provision-ambari",
                 roleArn);


### PR DESCRIPTION
- sshKey parameter was incorrectly defined as required
- created an enum to store required AWS parameters
