### PR TITLE
cache temporary aws credentials until they expire

### DIFF
--- a/src/main/java/com/sequenceiq/provisioning/conf/UserInitializer.java
+++ b/src/main/java/com/sequenceiq/provisioning/conf/UserInitializer.java
@@ -44,6 +44,7 @@ public class UserInitializer implements InitializingBean {
         Stack awsStack = new Stack();
         awsStack.setTemplate(awsTemplate);
         awsStack.setClusterSize(CLUSTER_SIZE);
+        awsStack.setName("coreos");
         awsStack.setUser(user2);
 
         user2.getAwsTemplates().add(awsTemplate);

--- a/src/main/java/com/sequenceiq/provisioning/controller/StackController.java
+++ b/src/main/java/com/sequenceiq/provisioning/controller/StackController.java
@@ -48,7 +48,7 @@ public class StackController {
     @RequestMapping(method = RequestMethod.GET, value = "{stackId}")
     @ResponseBody
     public ResponseEntity<StackJson> getStack(@CurrentUser User user, @PathVariable Long stackId) {
-        StackJson stackJson = stackService.get(user, stackId);
+        StackJson stackJson = stackService.get(userRepository.findOneWithLists(user.getId()), stackId);
         return new ResponseEntity<>(stackJson, HttpStatus.OK);
     }
 

--- a/src/main/java/com/sequenceiq/provisioning/controller/json/StackJson.java
+++ b/src/main/java/com/sequenceiq/provisioning/controller/json/StackJson.java
@@ -4,15 +4,15 @@ import javax.validation.constraints.Min;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.sequenceiq.provisioning.domain.StackDescription;
 import com.sequenceiq.provisioning.domain.CloudPlatform;
+import com.sequenceiq.provisioning.domain.StackDescription;
 
 public class StackJson implements JsonEntity {
 
     private Long id;
     @Min(value = 2)
     private int clusterSize;
-    private String cloudName;
+    private String name;
     private Long templateId;
     private CloudPlatform cloudPlatform;
     private StackDescription description;
@@ -38,12 +38,12 @@ public class StackJson implements JsonEntity {
         this.clusterSize = clusterSize;
     }
 
-    public String getCloudName() {
-        return cloudName;
+    public String getName() {
+        return name;
     }
 
-    public void setCloudName(String cloudName) {
-        this.cloudName = cloudName;
+    public void setName(String name) {
+        this.name = name;
     }
 
     public Long getTemplateId() {

--- a/src/main/java/com/sequenceiq/provisioning/converter/StackConverter.java
+++ b/src/main/java/com/sequenceiq/provisioning/converter/StackConverter.java
@@ -4,8 +4,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.provisioning.controller.json.StackJson;
-import com.sequenceiq.provisioning.domain.StackDescription;
 import com.sequenceiq.provisioning.domain.Stack;
+import com.sequenceiq.provisioning.domain.StackDescription;
 import com.sequenceiq.provisioning.repository.TemplateRepository;
 
 @Component
@@ -19,27 +19,27 @@ public class StackConverter extends AbstractConverter<StackJson, Stack> {
         StackJson stackJson = new StackJson();
         stackJson.setTemplateId(entity.getTemplate().getId());
         stackJson.setClusterSize(entity.getClusterSize());
-        stackJson.setCloudName(entity.getName());
+        stackJson.setName(entity.getName());
         stackJson.setId(entity.getId());
         stackJson.setCloudPlatform(entity.getTemplate().cloudPlatform());
         return stackJson;
     }
 
     public StackJson convert(Stack entity, StackDescription description) {
-        StackJson cloudInstanceJson = new StackJson();
-        cloudInstanceJson.setTemplateId(entity.getTemplate().getId());
-        cloudInstanceJson.setClusterSize(entity.getClusterSize());
-        cloudInstanceJson.setId(entity.getId());
-        cloudInstanceJson.setCloudPlatform(entity.getTemplate().cloudPlatform());
-        cloudInstanceJson.setDescription(description);
-        return cloudInstanceJson;
+        StackJson stackJson = new StackJson();
+        stackJson.setTemplateId(entity.getTemplate().getId());
+        stackJson.setClusterSize(entity.getClusterSize());
+        stackJson.setId(entity.getId());
+        stackJson.setCloudPlatform(entity.getTemplate().cloudPlatform());
+        stackJson.setDescription(description);
+        return stackJson;
     }
 
     @Override
     public Stack convert(StackJson json) {
         Stack stack = new Stack();
         stack.setClusterSize(json.getClusterSize());
-        stack.setName(json.getCloudName());
+        stack.setName(json.getName());
         stack.setTemplate(templateRepository.findOne(Long.valueOf(json.getTemplateId())));
         return stack;
     }

--- a/src/main/java/com/sequenceiq/provisioning/domain/TemporaryAwsCredentials.java
+++ b/src/main/java/com/sequenceiq/provisioning/domain/TemporaryAwsCredentials.java
@@ -1,0 +1,49 @@
+package com.sequenceiq.provisioning.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+public class TemporaryAwsCredentials {
+
+    @Id
+    private String accessKeyId;
+    private String secretAccessKey;
+    @Column(columnDefinition = "TEXT")
+    private String sessionToken;
+    private long validUntil;
+
+    public String getAccessKeyId() {
+        return accessKeyId;
+    }
+
+    public void setAccessKeyId(String accessKeyId) {
+        this.accessKeyId = accessKeyId;
+    }
+
+    public String getSecretAccessKey() {
+        return secretAccessKey;
+    }
+
+    public void setSecretAccessKey(String secretAccessKey) {
+        this.secretAccessKey = secretAccessKey;
+    }
+
+    public String getSessionToken() {
+        return sessionToken;
+    }
+
+    public void setSessionToken(String sessionToken) {
+        this.sessionToken = sessionToken;
+    }
+
+    public long getValidUntil() {
+        return validUntil;
+    }
+
+    public void setValidUntil(long validUntil) {
+        this.validUntil = validUntil;
+    }
+
+}

--- a/src/main/java/com/sequenceiq/provisioning/domain/User.java
+++ b/src/main/java/com/sequenceiq/provisioning/domain/User.java
@@ -11,6 +11,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
 
 import org.hibernate.validator.constraints.Email;
 import org.hibernate.validator.constraints.NotEmpty;
@@ -40,6 +41,9 @@ public class User implements ProvisionEntity {
     private String email;
 
     private String roleArn;
+
+    @OneToOne
+    private TemporaryAwsCredentials temporaryAwsCredentials;
 
     private String subscriptionId;
 
@@ -136,6 +140,14 @@ public class User implements ProvisionEntity {
 
     public void setRoleArn(String roleArn) {
         this.roleArn = roleArn;
+    }
+
+    public TemporaryAwsCredentials getTemporaryAwsCredentials() {
+        return temporaryAwsCredentials;
+    }
+
+    public void setTemporaryAwsCredentials(TemporaryAwsCredentials temporaryAwsCredentials) {
+        this.temporaryAwsCredentials = temporaryAwsCredentials;
     }
 
     public String getSubscriptionId() {

--- a/src/main/java/com/sequenceiq/provisioning/repository/TemporaryAwsCredentialsRepository.java
+++ b/src/main/java/com/sequenceiq/provisioning/repository/TemporaryAwsCredentialsRepository.java
@@ -1,0 +1,9 @@
+package com.sequenceiq.provisioning.repository;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.sequenceiq.provisioning.domain.TemporaryAwsCredentials;
+
+public interface TemporaryAwsCredentialsRepository extends CrudRepository<TemporaryAwsCredentials, Long> {
+
+}

--- a/src/main/java/com/sequenceiq/provisioning/service/aws/AwsProvisionService.java
+++ b/src/main/java/com/sequenceiq/provisioning/service/aws/AwsProvisionService.java
@@ -48,8 +48,8 @@ public class AwsProvisionService implements ProvisionService {
     @Override
     public StackResult createStack(User user, Stack stack) {
         AwsTemplate awsTemplate = (AwsTemplate) stack.getTemplate();
-        BasicSessionCredentials basicSessionCredentials = credentialsProvider.retrieveSessionCredentials(SESSION_CREDENTIALS_DURATION, "provision-ambari",
-                user.getRoleArn());
+        BasicSessionCredentials basicSessionCredentials = credentialsProvider
+                .retrieveSessionCredentials(SESSION_CREDENTIALS_DURATION, "provision-ambari", user);
         AmazonCloudFormationClient amazonCloudFormationClient = new AmazonCloudFormationClient(basicSessionCredentials);
         amazonCloudFormationClient.setRegion(Region.getRegion(Regions.fromName(awsTemplate.getRegion())));
         CreateStackRequest createStackRequest = new CreateStackRequest()
@@ -68,8 +68,8 @@ public class AwsProvisionService implements ProvisionService {
     @Override
     public StackDescription describeStack(User user, Stack stack) {
         AwsTemplate awsInfra = (AwsTemplate) stack.getTemplate();
-        BasicSessionCredentials basicSessionCredentials = credentialsProvider.retrieveSessionCredentials(SESSION_CREDENTIALS_DURATION, "provision-ambari",
-                user.getRoleArn());
+        BasicSessionCredentials basicSessionCredentials = credentialsProvider
+                .retrieveSessionCredentials(SESSION_CREDENTIALS_DURATION, "provision-ambari", user);
         AmazonCloudFormationClient amazonCloudFormationClient = new AmazonCloudFormationClient(basicSessionCredentials);
         amazonCloudFormationClient.setRegion(Region.getRegion(Regions.fromName(awsInfra.getRegion())));
         DescribeStacksRequest stackRequest = new DescribeStacksRequest().withStackName(String.format("%s-%s", stack.getName(), stack.getId()));
@@ -80,8 +80,8 @@ public class AwsProvisionService implements ProvisionService {
     @Override
     public StackDescription describeStackWithResources(User user, Stack stack) {
         AwsTemplate awsInfra = (AwsTemplate) stack.getTemplate();
-        BasicSessionCredentials basicSessionCredentials = credentialsProvider.retrieveSessionCredentials(SESSION_CREDENTIALS_DURATION, "provision-ambari",
-                user.getRoleArn());
+        BasicSessionCredentials basicSessionCredentials = credentialsProvider
+                .retrieveSessionCredentials(SESSION_CREDENTIALS_DURATION, "provision-ambari", user);
         AmazonCloudFormationClient amazonCloudFormationClient = new AmazonCloudFormationClient(basicSessionCredentials);
         amazonCloudFormationClient.setRegion(Region.getRegion(Regions.fromName(awsInfra.getRegion())));
         DescribeStacksRequest stackRequest = new DescribeStacksRequest().withStackName(String.format("%s-%s", stack.getName(), stack.getId()));

--- a/src/main/java/com/sequenceiq/provisioning/service/aws/CrossAccountCredentialsProvider.java
+++ b/src/main/java/com/sequenceiq/provisioning/service/aws/CrossAccountCredentialsProvider.java
@@ -1,11 +1,18 @@
 package com.sequenceiq.provisioning.service.aws;
 
+import java.util.Date;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.amazonaws.auth.BasicSessionCredentials;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient;
 import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
 import com.amazonaws.services.securitytoken.model.AssumeRoleResult;
+import com.sequenceiq.provisioning.domain.TemporaryAwsCredentials;
+import com.sequenceiq.provisioning.domain.User;
+import com.sequenceiq.provisioning.repository.TemporaryAwsCredentialsRepository;
+import com.sequenceiq.provisioning.repository.UserRepository;
 
 /**
  * Provides temporary session credentials for cross account requests. The assume
@@ -19,17 +26,66 @@ import com.amazonaws.services.securitytoken.model.AssumeRoleResult;
 @Component
 public class CrossAccountCredentialsProvider {
 
-    public BasicSessionCredentials retrieveSessionCredentials(int durationInSeconds, String externalId, String roleARN) {
+    private static final int MILLISECONDS = 1000;
+
+    private static final int FIVE_MINUTES = 300000;
+
+    @Autowired
+    private TemporaryAwsCredentialsRepository credentialsRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    public BasicSessionCredentials retrieveSessionCredentials(int durationInSeconds, String externalId, User user) {
+
+        BasicSessionCredentials cachedSessionCredentials = getCachedCredentials(user);
+        if (cachedSessionCredentials != null) {
+            return cachedSessionCredentials;
+        }
+
         AWSSecurityTokenServiceClient client = new AWSSecurityTokenServiceClient();
         AssumeRoleRequest assumeRoleRequest = new AssumeRoleRequest()
                 .withDurationSeconds(durationInSeconds)
                 .withExternalId(externalId)
-                .withRoleArn(roleARN)
+                .withRoleArn(user.getRoleArn())
                 .withRoleSessionName("hadoop-provisioning");
         AssumeRoleResult result = client.assumeRole(assumeRoleRequest);
+
+        cacheSessionCredentials(result, durationInSeconds, user);
+
         return new BasicSessionCredentials(
                 result.getCredentials().getAccessKeyId(),
                 result.getCredentials().getSecretAccessKey(),
                 result.getCredentials().getSessionToken());
+    }
+
+    private BasicSessionCredentials getCachedCredentials(User user) {
+        long dateNow = new Date().getTime();
+        TemporaryAwsCredentials temporaryAwsCredentials = user.getTemporaryAwsCredentials();
+        if (temporaryAwsCredentials != null) {
+            if (temporaryAwsCredentials.getValidUntil() > dateNow + FIVE_MINUTES) {
+                return new BasicSessionCredentials(
+                        temporaryAwsCredentials.getAccessKeyId(),
+                        temporaryAwsCredentials.getSecretAccessKey(),
+                        temporaryAwsCredentials.getSessionToken());
+            } else {
+                user.setTemporaryAwsCredentials(null);
+                userRepository.save(user);
+                credentialsRepository.delete(temporaryAwsCredentials);
+            }
+        }
+        return null;
+    }
+
+    private void cacheSessionCredentials(AssumeRoleResult result, int durationInSeconds, User user) {
+        TemporaryAwsCredentials temporaryAwsCredentials = new TemporaryAwsCredentials();
+        temporaryAwsCredentials.setAccessKeyId(result.getCredentials().getAccessKeyId());
+        temporaryAwsCredentials.setSecretAccessKey(result.getCredentials().getSecretAccessKey());
+        temporaryAwsCredentials.setSessionToken(result.getCredentials().getSessionToken());
+        temporaryAwsCredentials.setValidUntil(new Date().getTime() + durationInSeconds * MILLISECONDS);
+        credentialsRepository.save(temporaryAwsCredentials);
+        user.setTemporaryAwsCredentials(temporaryAwsCredentials);
+        userRepository.save(user);
+
     }
 }


### PR DESCRIPTION
Every time a request was made to AWS (even a GET), new temporary credentials were assumed that is unnecessary (they are valid for an hour), and slows down the response time.
Temporary credentials are now cached in our database, so every time a new request is made by a user, an attempt is made to check if the user already has some not expired credentials. New credentials are assumed only if there is no cached credential or the cached one is expired.
