### PR TITLE
CLOUD-270 unregister host when removing from cluster

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,7 @@ dependencies {
     compile('com.sequenceiq:azure-rest-client:0.1.18') {
         exclude group: 'log4j';
     }
-    compile('com.sequenceiq:ambari-client16:1.6.1') {
+    compile('com.sequenceiq:ambari-client16:1.6.6') {
         exclude group: 'org.slf4j';
     }
     compile 'org.apache.commons:commons-lang3:3.3.2'

--- a/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariClusterConnector.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariClusterConnector.java
@@ -139,7 +139,7 @@ public class AmbariClusterConnector {
         }
     }
 
-    public void decommisionAmbariNodes(Long stackId, Set<HostGroupAdjustmentJson> hosts) {
+    public void decommissionAmbariNodes(Long stackId, Set<HostGroupAdjustmentJson> hosts) {
         Stack stack = stackRepository.findOneWithLists(stackId);
         Cluster cluster = stack.getCluster();
         MDCBuilder.buildMdcContext(cluster);
@@ -176,6 +176,7 @@ public class AmbariClusterConnector {
                             waitForAmbariOperations(stack, ambariClient, installRequests);
                             ambariClient.deleteHostComponents(hostName, componentsList);
                             ambariClient.deleteHost(hostName);
+                            ambariClient.unregisterHost(hostName);
 
                             installRequests = new HashMap<>();
                             Integer zookeeperRequestId = ambariClient.restartServiceComponents("ZOOKEEPER", Arrays.asList("ZOOKEEPER_SERVER"));

--- a/src/main/java/com/sequenceiq/cloudbreak/service/cluster/handler/UpdateAmbariHostsRequestHandler.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/cluster/handler/UpdateAmbariHostsRequestHandler.java
@@ -33,7 +33,7 @@ public class UpdateAmbariHostsRequestHandler implements Consumer<Event<UpdateAmb
         MDCBuilder.buildMdcContext(stack);
         LOGGER.info("Accepted {} event.", ReactorConfig.UPDATE_AMBARI_HOSTS_REQUEST_EVENT);
         if (request.isDecommision()) {
-            ambariClusterConnector.decommisionAmbariNodes(request.getStackId(), request.getHosts());
+            ambariClusterConnector.decommissionAmbariNodes(request.getStackId(), request.getHosts());
         } else {
             ambariClusterConnector.installAmbariNode(request.getStackId(), request.getHosts());
         }


### PR DESCRIPTION
When we delete a host from the cluster it stays registered in Ambari and Ambari reports it with UNKNOWN state and generates alerts on the UI
