### PR TITLE
CLOUD-85817 explicitly set permissions of private key

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/TlsSetupService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/TlsSetupService.java
@@ -236,7 +236,7 @@ public class TlsSetupService {
         long stackId = stack.getId();
         String serverCertDir = tlsSecurityService.createServerCertDir(stackId, gwInstance);
         LOGGER.info("Server cert directory is created at: " + serverCertDir);
-        ssh.newSCPFileTransfer().download("/tmp/server.pem", serverCertDir + "/ca.pem");
+        ssh.newSCPFileTransfer().download("/etc/certs/server.pem", serverCertDir + "/ca.pem");
         InstanceMetaData metaData = instanceMetaDataRepository.findOne(gwInstance.getId());
         metaData.setServerCert(BaseEncoding.base64().encode(tlsSecurityService.readServerCert(stackId, gwInstance).getBytes()));
         instanceMetaDataRepository.save(metaData);

--- a/core/src/main/resources/init/host/tls-setup.sh
+++ b/core/src/main/resources/init/host/tls-setup.sh
@@ -8,7 +8,7 @@ setup_cbclient_cert() {
 create_certificates() {
   echo n | sudo cert-tool -d=/etc/certs -o=gateway -s localhost -s 127.0.0.1 -s ${publicIp}
   sudo rm /etc/certs/client-key.pem /etc/certs/client.pem /etc/certs/ca-key.pem
-  sudo cp /etc/certs/server.pem /tmp/server.pem
+  sudo chmod 644 /etc/certs/server.pem
 }
 
 start_nginx() {


### PR DESCRIPTION
also SCP server.pem directly from /etc/certs instead of copying it to /tmp
/tmp is still used elsewhere but I wanted to send this fix asap