### PR TITLE
CLOUD-56645 Pass JVM args to bootRun

### DIFF
--- a/autoscale/build.gradle
+++ b/autoscale/build.gradle
@@ -13,7 +13,18 @@ jar {
 }
 
 apply plugin: 'org.springframework.boot'
-apply plugin: 'application'
+
+bootRun {
+  systemProperty 'spring.profiles.active', System.properties['spring.profiles.active']
+  systemProperty 'spring.config.location', System.properties['spring.config.location']
+  if (project.hasProperty('jvmArgs')) {
+    jvmArgs += project.jvmArgs.split("\\s+").toList()
+  }
+}
+
+springBoot {
+  mainClass = 'com.sequenceiq.periscope.PeriscopeApplication'
+}
 
 dependencies {
 
@@ -80,7 +91,6 @@ test {
     logger.lifecycle("Test: " + descriptor + " produced standard out/err: " + event.message)
   }
 }
-
 
 compileJava.dependsOn buildInfo
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -23,7 +23,13 @@ apply plugin: 'org.springframework.boot'
 bootRun {
   systemProperty 'spring.profiles.active', System.properties['spring.profiles.active']
   systemProperty 'spring.config.location', System.properties['spring.config.location']
-  jvmArgs = ['-XX:MaxPermSize=1024m']
+  if (project.hasProperty('jvmArgs')) {
+    jvmArgs += project.jvmArgs.split("\\s+").toList()
+  }
+}
+
+springBoot {
+  mainClass = 'com.sequenceiq.cloudbreak.CloudbreakApplication'
 }
 
 jar {
@@ -125,10 +131,6 @@ task buildInfo(type: BuildInfoTask) {
   applicationPropertiesPath = "$buildDir"
   basename = jar.baseName
   buildVersion = version
-}
-
-springBoot {
-  mainClass = 'com.sequenceiq.cloudbreak.CloudbreakApplication'
 }
 
 task execute(type: JavaExec) {


### PR DESCRIPTION
Spring boot doesn't recive JVM arguments from Gradle. With this change can use bootRun tasks:
`./gradlew :autoscale:bootRun -PjvmArgs="-D... -D..."`
`./gradlew :core:bootRun -PjvmArgs="-D... -D..."`