### PR TITLE
[RMP-9448] moving superset as seperate service from the druid template

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/ExposedService.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/ExposedService.java
@@ -44,7 +44,7 @@ public enum ExposedService {
     RANGER("Ranger Admin UI", "RANGER_ADMIN", "", "RANGERUI", "/ranger/"),
     KIBANA("Kibana", "KIBANA", "", "", ""),
     ELASTIC_SEARCH("Elastic Search", "ELASTIC_SEARCH", "", "", ""),
-    DRUID_SUPERSET("Druid Superset", "DRUID_SUPERSET", "", "", "");
+    SUPERSET("Superset", "SUPERSET", "", "", "");
 
     private final String serviceName;
     private final String portName;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariClusterConnector.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariClusterConnector.java
@@ -96,7 +96,7 @@ import com.sequenceiq.cloudbreak.service.cluster.flow.blueprint.AutoRecoveryConf
 import com.sequenceiq.cloudbreak.service.cluster.flow.blueprint.BlueprintConfigurationEntry;
 import com.sequenceiq.cloudbreak.service.cluster.flow.blueprint.BlueprintProcessor;
 import com.sequenceiq.cloudbreak.service.cluster.flow.blueprint.ContainerExecutorConfigProvider;
-import com.sequenceiq.cloudbreak.service.cluster.flow.blueprint.DruidSupersetConfigProvider;
+import com.sequenceiq.cloudbreak.service.cluster.flow.blueprint.SupersetConfigProvider;
 import com.sequenceiq.cloudbreak.service.cluster.flow.blueprint.LlapConfigProvider;
 import com.sequenceiq.cloudbreak.service.cluster.flow.blueprint.RDSConfigProvider;
 import com.sequenceiq.cloudbreak.service.cluster.flow.blueprint.SmartSenseConfigProvider;
@@ -214,7 +214,7 @@ public class AmbariClusterConnector {
     private ZeppelinConfigProvider zeppelinConfigProvider;
 
     @Inject
-    private DruidSupersetConfigProvider druidSupersetConfigProvider;
+    private SupersetConfigProvider supersetConfigProvider;
 
     @Inject
     private LlapConfigProvider llapConfigProvider;
@@ -359,7 +359,7 @@ public class AmbariClusterConnector {
         }
         blueprintText = smartSenseConfigProvider.addToBlueprint(stack, blueprintText);
         blueprintText = zeppelinConfigProvider.addToBlueprint(stack, blueprintText);
-        blueprintText = druidSupersetConfigProvider.addToBlueprint(stack, blueprintText);
+        blueprintText = supersetConfigProvider.addToBlueprint(stack, blueprintText);
         // quick fix: this should be configured by StackAdvisor, but that's not working as of now
         blueprintText = llapConfigProvider.addToBlueprint(stack, blueprintText);
         if (!orchestratorTypeResolver.resolveType(stack.getOrchestrator()).containerOrchestrator()) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/blueprint/SupersetConfigProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/blueprint/SupersetConfigProvider.java
@@ -15,8 +15,8 @@ import com.sequenceiq.cloudbreak.domain.Stack;
 import com.sequenceiq.cloudbreak.service.user.UserDetailsService;
 
 @Component
-public class DruidSupersetConfigProvider {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DruidSupersetConfigProvider.class);
+public class SupersetConfigProvider {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SupersetConfigProvider.class);
 
     @Inject
     private BlueprintProcessor blueprintProcessor;
@@ -25,8 +25,8 @@ public class DruidSupersetConfigProvider {
     private UserDetailsService userDetailsService;
 
     public String addToBlueprint(Stack stack, String blueprintText) {
-        if (blueprintProcessor.componentExistsInBlueprint("DRUID_SUPERSET", blueprintText)) {
-            LOGGER.info("Druid Superset exists in Blueprint");
+        if (blueprintProcessor.componentExistsInBlueprint("SUPERSET", blueprintText)) {
+            LOGGER.info("Superset exists in Blueprint");
             List<BlueprintConfigurationEntry> configs = getConfigs(stack.getCluster());
             blueprintText = blueprintProcessor.addConfigEntries(blueprintText, configs, false);
         }
@@ -39,16 +39,16 @@ public class DruidSupersetConfigProvider {
         cbUser = userDetailsService.getDetails(cluster.getOwner(), UserFilterField.USERID)
                 .getUsername();
 
-        configs.add(new BlueprintConfigurationEntry("druid-superset-env", "superset_admin_password",
+        configs.add(new BlueprintConfigurationEntry("superset-env", "superset_admin_password",
                 cluster.getPassword()
         ));
-        configs.add(new BlueprintConfigurationEntry("druid-superset-env", "superset_admin_firstname",
+        configs.add(new BlueprintConfigurationEntry("superset-env", "superset_admin_firstname",
                 cluster.getUserName()
         ));
-        configs.add(new BlueprintConfigurationEntry("druid-superset-env", "superset_admin_lastname",
+        configs.add(new BlueprintConfigurationEntry("superset-env", "superset_admin_lastname",
                 cluster.getUserName()
         ));
-        configs.add(new BlueprintConfigurationEntry("druid-superset-env", "superset_admin_email",
+        configs.add(new BlueprintConfigurationEntry("superset-env", "superset_admin_email",
                 cbUser
         ));
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/network/NetworkUtils.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/network/NetworkUtils.java
@@ -6,7 +6,7 @@ import static com.sequenceiq.cloudbreak.api.model.ExposedService.AMBARI;
 import static com.sequenceiq.cloudbreak.api.model.ExposedService.ATLAS;
 import static com.sequenceiq.cloudbreak.api.model.ExposedService.CONSUL;
 import static com.sequenceiq.cloudbreak.api.model.ExposedService.CONTAINER_LOGS;
-import static com.sequenceiq.cloudbreak.api.model.ExposedService.DRUID_SUPERSET;
+import static com.sequenceiq.cloudbreak.api.model.ExposedService.SUPERSET;
 import static com.sequenceiq.cloudbreak.api.model.ExposedService.ELASTIC_SEARCH;
 import static com.sequenceiq.cloudbreak.api.model.ExposedService.FALCON;
 import static com.sequenceiq.cloudbreak.api.model.ExposedService.HBASE_MASTER;
@@ -80,7 +80,7 @@ public final class NetworkUtils {
         PORTS.add(new Port(RANGER, "6080", "tcp"));
         PORTS.add(new Port(KIBANA, "3080", "tcp"));
         PORTS.add(new Port(ELASTIC_SEARCH, "9200", "tcp"));
-        PORTS.add(new Port(DRUID_SUPERSET, "9088", "tcp"));
+        PORTS.add(new Port(SUPERSET, "9088", "tcp"));
     }
 
     private NetworkUtils() {

--- a/core/src/main/resources/defaults/blueprints/hdp26-druid-bi-shared.bp
+++ b/core/src/main/resources/defaults/blueprints/hdp26-druid-bi-shared.bp
@@ -144,7 +144,7 @@
         }
       },
       {
-        "druid-superset": {
+        "superset": {
           "properties_attributes": {},
           "properties": {
             "SECRET_KEY" : "123admin123",
@@ -207,7 +207,7 @@
             "name": "DRUID_BROKER"
           },
           {
-            "name": "DRUID_SUPERSET"
+            "name": "SUPERSET"
           },
           {
             "name": "HDFS_CLIENT"

--- a/core/src/main/resources/defaults/blueprints/hdp26-druid-bi.bp
+++ b/core/src/main/resources/defaults/blueprints/hdp26-druid-bi.bp
@@ -123,7 +123,7 @@
         }
       },
       {
-        "druid-superset": {
+        "superset": {
           "properties_attributes": {},
           "properties": {
             "SECRET_KEY" : "123admin123",
@@ -186,7 +186,7 @@
             "name": "DRUID_BROKER"
           },
           {
-            "name": "DRUID_SUPERSET"
+            "name": "SUPERSET"
           },
           {
             "name": "HDFS_CLIENT"

--- a/core/src/main/resources/defaults/blueprints/hdp26-etl-edw-shared.bp
+++ b/core/src/main/resources/defaults/blueprints/hdp26-etl-edw-shared.bp
@@ -104,7 +104,7 @@
         }
       },
       {
-        "druid-superset": {
+        "superset": {
           "properties_attributes": {},
           "properties": {
             "SECRET_KEY": "123admin123",
@@ -264,7 +264,7 @@
             "provision_action": "INSTALL_ONLY"
           },
           {
-            "name": "DRUID_SUPERSET",
+            "name": "SUPERSET",
             "provision_action": "INSTALL_ONLY"
           }
         ],

--- a/core/src/main/resources/defaults/blueprints/hdp26-etl-edw.bp
+++ b/core/src/main/resources/defaults/blueprints/hdp26-etl-edw.bp
@@ -65,7 +65,7 @@
         }
       },
       {
-        "druid-superset": {
+        "superset": {
           "properties_attributes": {},
           "properties": {
             "SECRET_KEY": "123admin123",
@@ -199,7 +199,7 @@
             "provision_action": "INSTALL_ONLY"
           },
           {
-            "name": "DRUID_SUPERSET",
+            "name": "SUPERSET",
             "provision_action": "INSTALL_ONLY"
           }
         ],

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariClusterConnectorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariClusterConnectorTest.java
@@ -61,7 +61,7 @@ import com.sequenceiq.cloudbreak.service.cluster.AmbariOperationFailedException;
 import com.sequenceiq.cloudbreak.service.cluster.HadoopConfigurationService;
 import com.sequenceiq.cloudbreak.service.cluster.flow.blueprint.AutoRecoveryConfigProvider;
 import com.sequenceiq.cloudbreak.service.cluster.flow.blueprint.BlueprintProcessor;
-import com.sequenceiq.cloudbreak.service.cluster.flow.blueprint.DruidSupersetConfigProvider;
+import com.sequenceiq.cloudbreak.service.cluster.flow.blueprint.SupersetConfigProvider;
 import com.sequenceiq.cloudbreak.service.cluster.flow.blueprint.LlapConfigProvider;
 import com.sequenceiq.cloudbreak.service.cluster.flow.blueprint.SmartSenseConfigProvider;
 import com.sequenceiq.cloudbreak.service.cluster.flow.blueprint.ZeppelinConfigProvider;
@@ -107,7 +107,7 @@ public class AmbariClusterConnectorTest {
     private ZeppelinConfigProvider zeppelinConfigProvider;
 
     @Mock
-    private DruidSupersetConfigProvider druidSupersetConfigProvider;
+    private SupersetConfigProvider supersetConfigProvider;
 
     @Mock
     private LlapConfigProvider llapConfigProvider;


### PR DESCRIPTION
As part of 2.6.3 (M20) superset will be separate service independent from druid. This PR does the required changes to pull out superset as a separate service.  