### PR TITLE
CLOUD-88948 implement basic metrics

### DIFF
--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/common/type/MetricType.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/common/type/MetricType.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.cloudbreak.common.type;
+
+public enum MetricType {
+    STACK_CREATION_SUCCESSFUL("stack.creation.successful"),
+    STACK_CREATION_FAILED("stack.creation.failed"),
+    STACK_UPSCALE_SUCCESSFUL("stack.upscale.successful"),
+    STACK_UPSCALE_FAILED("stack.upscale.failed"),
+    STACK_STOP_SUCCESSFUL("stack.stop.successful"),
+    STACK_STOP_FAILED("stack.stop.failed"),
+    STACK_START_SUCCESSFUL("stack.start.successful"),
+    STACK_START_FAILED("stack.start.failed"),
+    STACK_TERMINATION_SUCCESSFUL("stack.termination.successful"),
+    STACK_TERMINATION_FAILED("stack.termination.failed"),
+
+    CLUSTER_CREATION_SUCCESSFUL("cluster.creation.successful"),
+    CLUSTER_CREATION_FAILED("cluster.creation.failed"),
+    CLUSTER_UPSCALE_SUCCESSFUL("cluster.upscale.successful"),
+    CLUSTER_UPSCALE_FAILED("cluster.upscale.failed"),
+    CLUSTER_STOP_SUCCESSFUL("cluster.stop.successful"),
+    CLUSTER_STOP_FAILED("cluster.stop.failed"),
+    CLUSTER_START_SUCCESSFUL("cluster.start.successful"),
+    CLUSTER_START_FAILED("cluster.start.failed"),
+
+    HEARTBEAT_UPDATE_FAILED("heartbeat.update.failed");
+
+    private final String metricName;
+
+    MetricType(String metricName) {
+        this.metricName = metricName;
+    }
+
+    public String getMetricName() {
+        return metricName;
+    }
+}

--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -21,6 +21,7 @@
     <suppress checks="CyclomaticComplexity" files="PrometheusEvaluator.java|MetadataSetupService.java"/>
     <suppress checks="ModifierOrderCheck" files="EncryptedJsonToString.java"/>
     <suppress checks="TrailingComment" files="HeartbeatServiceTest.java"/>
+    <suppress checks="VisibilityModifier" files="AbstractAction.java"/>
 
 
     <!-- suppressing checks in application runner classes -->

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/ClusterCreationActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/ClusterCreationActions.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.statemachine.action.Action;
 
 import com.sequenceiq.cloudbreak.cloud.event.Selectable;
+import com.sequenceiq.cloudbreak.common.type.MetricType;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.AbstractClusterAction;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.ClusterContext;
 import com.sequenceiq.cloudbreak.core.flow2.stack.AbstractStackFailureAction;
@@ -136,6 +137,7 @@ public class ClusterCreationActions {
             @Override
             protected void doExecute(ClusterContext context, InstallClusterSuccess payload, Map<Object, Object> variables) throws Exception {
                 clusterCreationService.clusterInstallationFinished(context.getStack(), context.getCluster());
+                metricService.incrementMetricCounter(MetricType.CLUSTER_CREATION_SUCCESSFUL, context.getStack());
                 sendEvent(context);
             }
 
@@ -152,6 +154,7 @@ public class ClusterCreationActions {
             @Override
             protected void doExecute(StackFailureContext context, StackFailureEvent payload, Map<Object, Object> variables) throws Exception {
                 clusterCreationService.handleClusterCreationFailure(context.getStack(), payload.getException());
+                metricService.incrementMetricCounter(MetricType.CLUSTER_CREATION_FAILED, context.getStack());
                 sendEvent(context);
             }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/start/ClusterStartActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/start/ClusterStartActions.java
@@ -11,6 +11,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.statemachine.action.Action;
 
 import com.sequenceiq.cloudbreak.cloud.event.Selectable;
+import com.sequenceiq.cloudbreak.common.type.MetricType;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.AbstractClusterAction;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.ClusterContext;
 import com.sequenceiq.cloudbreak.core.flow2.stack.AbstractStackFailureAction;
@@ -65,6 +66,7 @@ public class ClusterStartActions {
             @Override
             protected void doExecute(ClusterContext context, ClusterStartPollingResult payload, Map<Object, Object> variables) throws Exception {
                 clusterStartService.clusterStartFinished(context.getStack());
+                metricService.incrementMetricCounter(MetricType.CLUSTER_START_SUCCESSFUL, context.getStack());
                 sendEvent(context);
             }
 
@@ -81,6 +83,7 @@ public class ClusterStartActions {
             @Override
             protected void doExecute(StackFailureContext context, StackFailureEvent payload, Map<Object, Object> variables) throws Exception {
                 clusterStartService.handleClusterStartFailure(context.getStack(), payload.getException().getMessage());
+                metricService.incrementMetricCounter(MetricType.CLUSTER_START_FAILED, context.getStack());
                 sendEvent(context);
             }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stop/ClusterStopActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stop/ClusterStopActions.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.stop;
 
-
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -10,6 +9,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.statemachine.action.Action;
 
 import com.sequenceiq.cloudbreak.cloud.event.Selectable;
+import com.sequenceiq.cloudbreak.common.type.MetricType;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.AbstractClusterAction;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.ClusterContext;
 import com.sequenceiq.cloudbreak.core.flow2.stack.AbstractStackFailureAction;
@@ -49,6 +49,7 @@ public class ClusterStopActions {
             @Override
             protected void doExecute(ClusterContext context, ClusterStopResult payload, Map<Object, Object> variables) throws Exception {
                 clusterStopService.clusterStopFinished(context.getStack());
+                metricService.incrementMetricCounter(MetricType.CLUSTER_STOP_SUCCESSFUL, context.getStack());
                 sendEvent(context);
             }
 
@@ -65,6 +66,7 @@ public class ClusterStopActions {
             @Override
             protected void doExecute(StackFailureContext context, StackFailureEvent payload, Map<Object, Object> variables) throws Exception {
                 clusterStopService.handleClusterStopFailure(context.getStack(), payload.getException().getMessage());
+                metricService.incrementMetricCounter(MetricType.CLUSTER_STOP_FAILED, context.getStack());
                 sendEvent(context);
             }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/upscale/ClusterUpscaleActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/upscale/ClusterUpscaleActions.java
@@ -17,6 +17,7 @@ import org.springframework.statemachine.action.Action;
 
 import com.sequenceiq.cloudbreak.cloud.event.Payload;
 import com.sequenceiq.cloudbreak.cloud.event.Selectable;
+import com.sequenceiq.cloudbreak.common.type.MetricType;
 import com.sequenceiq.cloudbreak.core.flow2.AbstractAction;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterScaleTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.stack.AbstractStackFailureAction;
@@ -122,6 +123,7 @@ public class ClusterUpscaleActions {
             @Override
             protected void doExecute(ClusterUpscaleContext context, UpscalePostRecipesResult payload, Map<Object, Object> variables) throws Exception {
                 clusterUpscaleFlowService.clusterUpscaleFinished(context.getStack(), payload.getHostGroupName());
+                metricService.incrementMetricCounter(MetricType.CLUSTER_UPSCALE_SUCCESSFUL, context.getStack());
                 sendEvent(context.getFlowId(), FINALIZED_EVENT.event(), payload);
             }
 
@@ -139,6 +141,7 @@ public class ClusterUpscaleActions {
             @Override
             protected void doExecute(StackFailureContext context, StackFailureEvent payload, Map<Object, Object> variables) throws Exception {
                 clusterUpscaleFlowService.clusterUpscaleFailed(context.getStack(), payload.getException());
+                metricService.incrementMetricCounter(MetricType.CLUSTER_UPSCALE_FAILED, context.getStack());
                 sendEvent(context.getFlowId(), FAIL_HANDLED_EVENT.event(), payload);
             }
         };

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/action/StackCreationActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/action/StackCreationActions.java
@@ -33,6 +33,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
+import com.sequenceiq.cloudbreak.common.type.MetricType;
 import com.sequenceiq.cloudbreak.converter.spi.InstanceMetaDataToCloudInstanceConverter;
 import com.sequenceiq.cloudbreak.converter.spi.ResourceToCloudResourceConverter;
 import com.sequenceiq.cloudbreak.converter.spi.StackToCloudStackConverter;
@@ -234,6 +235,7 @@ public class StackCreationActions {
             protected void doExecute(StackContext context, StackWithFingerprintsEvent payload, Map<Object, Object> variables) throws Exception {
                 stackCreationService.removeTemporarySShKey(context, payload.getSshFingerprints());
                 stackCreationService.stackCreationFinished(context.getStack());
+                metricService.incrementMetricCounter(MetricType.STACK_CREATION_SUCCESSFUL, context.getStack());
                 sendEvent(context);
             }
 
@@ -250,6 +252,7 @@ public class StackCreationActions {
             @Override
             protected void doExecute(StackFailureContext context, StackFailureEvent payload, Map<Object, Object> variables) throws Exception {
                 stackCreationService.handleStackCreationFailure(context.getStack(), payload.getException());
+                metricService.incrementMetricCounter(MetricType.STACK_CREATION_FAILED, context.getStack());
                 sendEvent(context);
             }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/start/StackStartActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/start/StackStartActions.java
@@ -29,6 +29,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.Location;
+import com.sequenceiq.cloudbreak.common.type.MetricType;
 import com.sequenceiq.cloudbreak.converter.spi.CredentialToCloudCredentialConverter;
 import com.sequenceiq.cloudbreak.converter.spi.InstanceMetaDataToCloudInstanceConverter;
 import com.sequenceiq.cloudbreak.converter.spi.ResourceToCloudResourceConverter;
@@ -104,6 +105,7 @@ public class StackStartActions {
             @Override
             protected void doExecute(StackStartStopContext context, CollectMetadataResult payload, Map<Object, Object> variables) throws Exception {
                 stackStartStopService.finishStackStart(context.getStack(), payload.getResults());
+                metricService.incrementMetricCounter(MetricType.STACK_START_SUCCESSFUL, context.getStack());
                 sendEvent(context);
             }
 
@@ -120,6 +122,7 @@ public class StackStartActions {
             @Override
             protected void doExecute(StackFailureContext context, StackFailureEvent payload, Map<Object, Object> variables) throws Exception {
                 stackStartStopService.handleStackStartError(context.getStack(), payload);
+                metricService.incrementMetricCounter(MetricType.STACK_START_FAILED, context.getStack());
                 sendEvent(context);
             }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/stop/StackStopActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/stop/StackStopActions.java
@@ -27,6 +27,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.Location;
+import com.sequenceiq.cloudbreak.common.type.MetricType;
 import com.sequenceiq.cloudbreak.converter.spi.CredentialToCloudCredentialConverter;
 import com.sequenceiq.cloudbreak.converter.spi.InstanceMetaDataToCloudInstanceConverter;
 import com.sequenceiq.cloudbreak.converter.spi.ResourceToCloudResourceConverter;
@@ -80,6 +81,7 @@ public class StackStopActions {
             @Override
             protected void doExecute(StackStartStopContext context, StopInstancesResult payload, Map<Object, Object> variables) throws Exception {
                 stackStartStopService.finishStackStop(context);
+                metricService.incrementMetricCounter(MetricType.STACK_STOP_SUCCESSFUL, context.getStack());
                 sendEvent(context);
             }
 
@@ -96,6 +98,7 @@ public class StackStopActions {
             @Override
             protected void doExecute(StackFailureContext context, StackFailureEvent payload, Map<Object, Object> variables) throws Exception {
                 stackStartStopService.handleStackStopError(context.getStack(), payload);
+                metricService.incrementMetricCounter(MetricType.STACK_STOP_FAILED, context.getStack());
                 sendEvent(context);
             }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/termination/StackTerminationAction.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/termination/StackTerminationAction.java
@@ -62,7 +62,7 @@ public class StackTerminationAction extends AbstractStackTerminationAction<Termi
         TerminateStackRequest terminateRequest = createRequest(context);
         Stack stack = context.getStack();
         if (stack == null || stack.getCredential() == null) {
-            LOGGER.info("Could not trigger stack event on null", terminateRequest);
+            LOGGER.info("Could not trigger stack event on null, {}", terminateRequest);
             String statusReason = "Stack or credential not found.";
             TerminateStackResult terminateStackResult = new TerminateStackResult(statusReason, new IllegalArgumentException(statusReason), terminateRequest);
             sendEvent(context.getFlowId(), StackTerminationEvent.TERMINATION_FAILED_EVENT.event(), terminateStackResult);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/termination/StackTerminationFailureAction.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/termination/StackTerminationFailureAction.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.cloud.event.Selectable;
+import com.sequenceiq.cloudbreak.common.type.MetricType;
 import com.sequenceiq.cloudbreak.core.flow2.stack.AbstractStackFailureAction;
 import com.sequenceiq.cloudbreak.core.flow2.stack.StackFailureContext;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
@@ -26,6 +27,7 @@ public class StackTerminationFailureAction extends AbstractStackFailureAction<St
         Boolean deleteDependencies = Boolean.valueOf(String.valueOf(variables.get("DELETEDEPENDENCIES")));
         stackTerminationService.handleStackTerminationError(context.getStack(), payload,
                 variables.get("FORCEDTERMINATION") != null, deleteDependencies);
+        metricService.incrementMetricCounter(MetricType.STACK_TERMINATION_FAILED, context.getStack());
         sendEvent(context);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/termination/StackTerminationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/termination/StackTerminationService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import com.sequenceiq.cloudbreak.api.model.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.cloud.event.resource.TerminateStackResult;
 import com.sequenceiq.cloudbreak.common.type.BillingStatus;
+import com.sequenceiq.cloudbreak.common.type.MetricType;
 import com.sequenceiq.cloudbreak.core.flow2.stack.FlowMessageService;
 import com.sequenceiq.cloudbreak.core.flow2.stack.Msg;
 import com.sequenceiq.cloudbreak.domain.Stack;
@@ -18,6 +19,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.StackFailureEvent;
 import com.sequenceiq.cloudbreak.repository.StackUpdater;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
 import com.sequenceiq.cloudbreak.service.cluster.flow.EmailSenderService;
+import com.sequenceiq.cloudbreak.service.metrics.MetricService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.service.stack.flow.TerminationService;
 import com.sequenceiq.cloudbreak.service.usages.UsageService;
@@ -54,6 +56,9 @@ public class StackTerminationService {
     @Inject
     private StackUtil stackUtil;
 
+    @Inject
+    private MetricService metricService;
+
     public void finishStackTermination(StackTerminationContext context, TerminateStackResult payload, Boolean deleteDependencies) {
         LOGGER.info("Terminate stack result: {}", payload);
         Stack stack = context.getStack();
@@ -70,6 +75,7 @@ public class StackTerminationService {
         if (deleteDependencies) {
             dependecyDeletionService.deleteDependencies(stack);
         }
+        metricService.incrementMetricCounter(MetricType.STACK_TERMINATION_SUCCESSFUL, stack);
     }
 
     public void handleStackTerminationError(Stack stack, StackFailureEvent payload, boolean forced, Boolean deleteDependencies) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleActions.java
@@ -23,6 +23,7 @@ import com.sequenceiq.cloudbreak.cloud.event.resource.UpscaleStackResult;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.common.type.MetricType;
 import com.sequenceiq.cloudbreak.converter.spi.CloudResourceToResourceConverter;
 import com.sequenceiq.cloudbreak.converter.spi.InstanceMetaDataToCloudInstanceConverter;
 import com.sequenceiq.cloudbreak.converter.spi.ResourceToCloudResourceConverter;
@@ -199,6 +200,7 @@ public class StackUpscaleActions {
             @Override
             protected void doExecute(StackScalingFlowContext context, ExtendHostMetadataResult payload, Map<Object, Object> variables) throws Exception {
                 stackUpscaleService.finishExtendHostMetadata(context.getStack());
+                metricService.incrementMetricCounter(MetricType.STACK_UPSCALE_SUCCESSFUL, context.getStack());
                 sendEvent(context);
             }
 
@@ -215,6 +217,7 @@ public class StackUpscaleActions {
             @Override
             protected void doExecute(StackFailureContext context, StackFailureEvent payload, Map<Object, Object> variables) throws Exception {
                 stackUpscaleService.handleStackUpscaleFailure(context.getStack(), payload);
+                metricService.incrementMetricCounter(MetricType.STACK_UPSCALE_FAILED, context.getStack());
                 sendEvent(context);
             }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/ha/HeartbeatService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/ha/HeartbeatService.java
@@ -25,6 +25,7 @@ import com.google.api.client.util.Lists;
 import com.sequenceiq.cloudbreak.api.model.Status;
 import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
 import com.sequenceiq.cloudbreak.cloud.store.InMemoryStateStore;
+import com.sequenceiq.cloudbreak.common.type.MetricType;
 import com.sequenceiq.cloudbreak.core.flow2.Flow2Handler;
 import com.sequenceiq.cloudbreak.core.flow2.FlowRegister;
 import com.sequenceiq.cloudbreak.core.flow2.chain.FlowChains;
@@ -39,6 +40,7 @@ import com.sequenceiq.cloudbreak.repository.StackRepository;
 import com.sequenceiq.cloudbreak.service.Clock;
 import com.sequenceiq.cloudbreak.service.Retry;
 import com.sequenceiq.cloudbreak.service.Retry.ActionWentFail;
+import com.sequenceiq.cloudbreak.service.metrics.MetricService;
 
 @Service
 public class HeartbeatService {
@@ -81,6 +83,9 @@ public class HeartbeatService {
     private ReactorFlowManager reactorFlowManager;
 
     @Inject
+    private MetricService metricService;
+
+    @Inject
     @Qualifier("DefaultRetryService")
     private Retry retryService;
 
@@ -100,6 +105,7 @@ public class HeartbeatService {
                         return true;
                     } catch (RuntimeException e) {
                         LOGGER.error("Failed to update the heartbeat timestamp", e);
+                        metricService.incrementMetricCounter(MetricType.HEARTBEAT_UPDATE_FAILED);
                         throw new ActionWentFail(e.getMessage());
                     }
                 });

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/metrics/MetricService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/metrics/MetricService.java
@@ -1,0 +1,68 @@
+package com.sequenceiq.cloudbreak.service.metrics;
+
+import javax.inject.Inject;
+
+import org.springframework.boot.actuate.metrics.CounterService;
+import org.springframework.boot.actuate.metrics.GaugeService;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.common.type.MetricType;
+import com.sequenceiq.cloudbreak.domain.Stack;
+
+@Service
+public class MetricService {
+
+    private static final String METRIC_PREFIX = "cloudbreak.";
+
+    @Inject
+    private CounterService counterService;
+
+    @Inject
+    private GaugeService gaugeService;
+
+    /**
+     * Increment a counter based metric.
+     *
+     * @param metric Metric name
+     */
+    public void incrementMetricCounter(MetricType metric) {
+        incrementMetricCounter(metric.getMetricName());
+    }
+
+    /**
+     * Increment a counter based metric. If the stack is provided then the metric's name
+     * will be extended with the cloud platform. If the stack is null the original metric name will be used.
+     *
+     * @param metric Metric name
+     * @param stack  Stack, used to determine the cloud platform
+     */
+    public void incrementMetricCounter(MetricType metric, Stack stack) {
+        if (stack != null && stack.getPlatformVariant() != null) {
+            incrementMetricCounter(getMetricNameWithPlatform(metric, stack));
+        } else {
+            incrementMetricCounter(metric.getMetricName());
+        }
+    }
+
+    /**
+     * Set the specified gauge value.
+     *
+     * @param metric Metric name
+     * @param value  Metric value
+     */
+    public void submit(String metric, double value) {
+        gaugeService.submit(METRIC_PREFIX + metric.toLowerCase(), value);
+    }
+
+    private void incrementMetricCounter(String metric) {
+        counterService.increment(METRIC_PREFIX + metric.toLowerCase());
+    }
+
+    private String getMetricNameWithPlatform(MetricType metric, Stack stack) {
+        return getMetricNameWithPlatform(metric.getMetricName(), stack);
+    }
+
+    private String getMetricNameWithPlatform(String metric, Stack stack) {
+        return metric + '.' + stack.cloudPlatform().toLowerCase();
+    }
+}


### PR DESCRIPTION
org_springframework_metrics_response_value{type="gauge",value="api.v1.stacks.646",} 65.0
org_springframework_metrics_response_value{type="gauge",value="api.v1.stacks.645",} 113.0
org_springframework_metrics_response_value{type="gauge",value="api.v1.stacks.user",} 2008.0
org_springframework_metrics_response_value{type="gauge",value="api.v1.stacks.645.cluster",} 1631.0
org_springframework_metrics_response_value{type="gauge",value="api.v1.stacks.validate",} 53.0
org_springframework_metrics_response_value{type="gauge",value="api.v1.stacks.646.cluster",} 1448.0
org_springframework_boot_endpoint_sensitive{name="consulEndpoint",} 0.0
org_springframework_boot_endpoint_sensitive{name="infoEndpoint",} 0.0
org_springframework_boot_endpoint_sensitive{name="healthEndpoint",} 0.0
org_springframework_boot_endpoint_sensitive{name="autoConfigurationReportEndpoint",} 1.0
org_springframework_boot_endpoint_sensitive{name="environmentEndpoint",} 1.0
org_springframework_boot_endpoint_sensitive{name="loggersEndpoint",} 1.0
org_springframework_boot_endpoint_sensitive{name="requestMappingEndpoint",} 1.0
org_springframework_boot_endpoint_sensitive{name="dumpEndpoint",} 1.0
org_springframework_boot_endpoint_sensitive{name="configurationPropertiesReportEndpoint",} 1.0
org_springframework_boot_endpoint_sensitive{name="beansEndpoint",} 1.0
org_springframework_boot_endpoint_sensitive{name="metricsEndpoint",} 1.0
org_springframework_boot_endpoint_sensitive{name="traceEndpoint",} 1.0
org_springframework_metrics_status_value{type="counter",value="200.api.v1.stacks.user",} 2.0
org_springframework_metrics_status_value{type="counter",value="200.api.v1.stacks.645.cluster",} 1.0
org_springframework_metrics_status_value{type="counter",value="200.api.v1.stacks.646",} 2.0
org_springframework_metrics_status_value{type="counter",value="200.api.v1.stacks.645",} 3.0
org_springframework_metrics_status_value{type="counter",value="204.api.v1.stacks.645",} 1.0
org_springframework_metrics_status_value{type="counter",value="202.api.v1.stacks.validate",} 2.0
org_springframework_metrics_status_value{type="counter",value="200.api.v1.stacks.646.cluster",} 1.0
org_springframework_cloud_context_restart_restartendpoint_running{type="RestartEndpoint",} 1.0
org_springframework_metrics_cloudbreak_value{type="gauge",value="flowstep.start_provisioning_state",} 44.0
org_springframework_metrics_cloudbreak_value{type="counter",value="stack.termination.successful.openstack",} 1.0
org_springframework_metrics_cloudbreak_value{type="gauge",value="flowstep.stack_creation_finished_state",} 2.0
org_springframework_metrics_cloudbreak_value{type="gauge",value="flowstep.register_proxy_state",} 0.0
org_springframework_metrics_cloudbreak_value{type="gauge",value="flowstep.provisioning_finished_state",} 5.0
org_springframework_metrics_cloudbreak_value{type="gauge",value="flowstep.starting_ambari_state",} 2.0
org_springframework_metrics_cloudbreak_value{type="gauge",value="flowstep.get_tls_info_state",} 19.0
org_springframework_metrics_cloudbreak_value{type="gauge",value="flowstep.image_check_state",} 0.0
org_springframework_metrics_cloudbreak_value{type="gauge",value="flowstep.termination_state",} 27.0
org_springframework_metrics_cloudbreak_value{type="gauge",value="flowstep.termination_finished_state",} 0.0
org_springframework_metrics_cloudbreak_value{type="gauge",value="flowstep.imagesetup_state",} 1.0
org_springframework_metrics_cloudbreak_value{type="gauge",value="flowstep.bootstrapping_machines_state",} 18.0
org_springframework_metrics_cloudbreak_value{type="gauge",value="flowstep.setup_state",} 0.0
org_springframework_metrics_cloudbreak_value{type="gauge",value="flowstep.starting_ambari_services_state",} 170.0
org_springframework_metrics_cloudbreak_value{type="gauge",value="flowstep.collectmetadata_state",} 0.0
org_springframework_metrics_cloudbreak_value{type="counter",value="stack.creation.successful.openstack",} 1.0
org_springframework_metrics_cloudbreak_value{type="gauge",value="flowstep.create_credential_state",} 0.0
org_springframework_metrics_cloudbreak_value{type="gauge",value="flowstep.collecting_host_metadata_state",} 1.0
org_springframework_metrics_cloudbreak_value{type="gauge",value="flowstep.tls_setup_state",} 12.0
org_springframework_metrics_cloudbreak_value{type="gauge",value="flowstep.validation_state",} 1.0
org_springframework_cloud_context_restart_restartendpoint_timeout{type="RestartEndpoint",} 0.0