### PR TITLE
CLOUD-89127 EDW-Analytics: Apache Hive 2 LLAP cluster doesn't have th…

### DIFF
--- a/core/src/main/resources/defaults/blueprints/hdp26-edw-analytics.bp
+++ b/core/src/main/resources/defaults/blueprints/hdp26-edw-analytics.bp
@@ -42,7 +42,8 @@
         "hive-interactive-site": {
           "hive.exec.orc.split.strategy":"BI",
           "hive.stats.fetch.bitvector":"true",
-          "hive.metastore.rawstore.impl":"org.apache.hadoop.hive.metastore.cache.CachedStore"
+          "hive.metastore.rawstore.impl":"org.apache.hadoop.hive.metastore.cache.CachedStore",
+          "hive.metastore.warehouse.dir":"/apps/hive/warehouse"
        }
      },
      {
@@ -50,7 +51,8 @@
           "hive.exec.compress.output": "true",
           "hive.merge.mapfiles": "true",
           "hive.server2.tez.initialize.default.sessions": "true",
-          "hive.server2.transport.mode": "http"
+          "hive.server2.transport.mode": "http",
+          "hive.metastore.warehouse.dir":"/apps/hive/warehouse"
         }
       },
       {


### PR DESCRIPTION
added new properties based on hdp 2.6 hive changes.
based on this bp https://github.com/hortonworks/cloudbreak/blob/rc-1.16/core/src/main/resources/defaults/blueprints/hdp26-edw-analytics-shared.bp