### PR TITLE
Revert "CLOUD-89127 EDW-Analytics: Apache Hive 2 LLAP cluster doesn't have th…"

### DIFF
--- a/core/src/main/resources/defaults/blueprints/hdp26-edw-analytics.bp
+++ b/core/src/main/resources/defaults/blueprints/hdp26-edw-analytics.bp
@@ -42,8 +42,7 @@
         "hive-interactive-site": {
           "hive.exec.orc.split.strategy":"BI",
           "hive.stats.fetch.bitvector":"true",
-          "hive.metastore.rawstore.impl":"org.apache.hadoop.hive.metastore.cache.CachedStore",
-          "hive.metastore.warehouse.dir":"/apps/hive/warehouse"
+          "hive.metastore.rawstore.impl":"org.apache.hadoop.hive.metastore.cache.CachedStore"
        }
      },
      {
@@ -51,8 +50,7 @@
           "hive.exec.compress.output": "true",
           "hive.merge.mapfiles": "true",
           "hive.server2.tez.initialize.default.sessions": "true",
-          "hive.server2.transport.mode": "http",
-          "hive.metastore.warehouse.dir":"/apps/hive/warehouse"
+          "hive.server2.transport.mode": "http"
         }
       },
       {


### PR DESCRIPTION
This won't fix BUG-89127 so I'm reverting it.