### PR TITLE
Blueprint templating fix

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -78,7 +78,7 @@ dependencies {
     compile group: 'com.icegreen',                  name: 'greenmail',                      version: '1.4.1'
     compile group: 'org.mybatis',                   name: 'mybatis-migrations',             version: '3.2.0'
     compile group: 'com.cedarsoftware',             name: 'json-io',                        version: '4.9.12'
-    compile group: 'com.github.spullara.mustache.java',name: 'compiler',                        version: '0.9.2'
+    compile group: 'com.github.jknack',             name: 'handlebars',                     version: '4.0.6'
 
     compile project(':core-model')
     compile project(':orchestrator-api')

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/blueprint/template/BlueprintTemplateProcessor.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/blueprint/template/BlueprintTemplateProcessor.java
@@ -1,9 +1,6 @@
 package com.sequenceiq.cloudbreak.service.cluster.flow.blueprint.template;
 
 import java.io.IOException;
-import java.io.StringReader;
-import java.io.StringWriter;
-import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -14,9 +11,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.github.mustachejava.DefaultMustacheFactory;
-import com.github.mustachejava.Mustache;
-import com.github.mustachejava.MustacheFactory;
+import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.Helper;
+import com.github.jknack.handlebars.Options;
+import com.github.jknack.handlebars.Template;
 import com.sequenceiq.cloudbreak.domain.Cluster;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.service.ClusterComponentConfigProvider;
@@ -25,8 +23,6 @@ import com.sequenceiq.cloudbreak.service.ClusterComponentConfigProvider;
 public class BlueprintTemplateProcessor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BlueprintTemplateProcessor.class);
-
-    private final MustacheFactory mustacheFactory = new DefaultMustacheFactory();
 
     @Inject
     private ClusterComponentConfigProvider clusterComponentConfigProvider;
@@ -38,10 +34,16 @@ public class BlueprintTemplateProcessor {
     }
 
     private String generateBlueprintWithParameters(String blueprintText, Cluster cluster, Set<RDSConfig> rdsConfigs) throws IOException {
-        Writer writer = new StringWriter();
-        Mustache mustache = mustacheFactory.compile(new StringReader(blueprintText), "bp");
-        mustache.execute(writer, prepareTemplateObject(cluster.getBlueprintInputs().get(Map.class), cluster, rdsConfigs));
-        return writer.toString();
+        Handlebars handlebars = new Handlebars();
+        handlebars.registerHelperMissing(new Helper<Object>() {
+            @Override
+            public CharSequence apply(final Object context, final Options options) throws IOException {
+                return options.fn.text();
+            }
+        });
+        Template template = handlebars.compileInline(blueprintText);
+
+        return template.apply(prepareTemplateObject(cluster.getBlueprintInputs().get(Map.class), cluster, rdsConfigs));
     }
 
     private Map<String, Object> prepareTemplateObject(Map<String, Object> blueprintInputs, Cluster cluster, Set<RDSConfig> rdsConfigs) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/flow/blueprint/BlueprintTemplateProcessorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/flow/blueprint/BlueprintTemplateProcessorTest.java
@@ -57,8 +57,8 @@ public class BlueprintTemplateProcessorTest {
 
         String result = underTest.process(testBlueprint, cluster, cluster.getRdsConfigs());
         Assert.assertTrue(result.contains("testbucket"));
-        Assert.assertTrue(result.contains("{{zookeeper_quorum}}"));
-        Assert.assertTrue(result.contains(cluster.getName()));
+        Assert.assertTrue(result.contains("{{ zookeeper_quorum }}"));
+        Assert.assertTrue(result.contains("{{default('/configurations/hadoop-env/hdfs_log_dir_prefix', '/var/log/hadoop')}}"));
         Assert.assertTrue(result.contains(cluster.getName()));
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/flow/blueprint/BlueprintTemplateProcessorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/flow/blueprint/BlueprintTemplateProcessorTest.java
@@ -57,6 +57,7 @@ public class BlueprintTemplateProcessorTest {
 
         String result = underTest.process(testBlueprint, cluster, cluster.getRdsConfigs());
         Assert.assertTrue(result.contains("testbucket"));
+        Assert.assertTrue(result.contains("{{zookeeper_quorum}}"));
         Assert.assertTrue(result.contains(cluster.getName()));
         Assert.assertTrue(result.contains(cluster.getName()));
     }

--- a/core/src/test/resources/blueprints/bp-mustache-test.bp
+++ b/core/src/test/resources/blueprints/bp-mustache-test.bp
@@ -37,6 +37,7 @@
         "admin-properties": {
           "properties": {
             "db_user": "{{{ rangerRds.connectionUserName }}}",
+            "zookeeper_quorum": "{{ zookeeper_quorum }}",
             "db_password": "{{{ rangerRds.connectionPassword }}}",
             "db_name": "{{{ rangerRds.databaseName }}}",
             "db_host": "{{{ rangerRds.connectionHost }}}",

--- a/core/src/test/resources/blueprints/bp-mustache-test.bp
+++ b/core/src/test/resources/blueprints/bp-mustache-test.bp
@@ -41,7 +41,8 @@
             "db_password": "{{{ rangerRds.connectionPassword }}}",
             "db_name": "{{{ rangerRds.databaseName }}}",
             "db_host": "{{{ rangerRds.connectionHost }}}",
-            "DB_FLAVOR": "POSTGRES"
+            "DB_FLAVOR": "POSTGRES",
+            "exported-value": "{{default('/configurations/hadoop-env/hdfs_log_dir_prefix', '/var/log/hadoop')}}"
           }
         }
       },


### PR DESCRIPTION
@martonsereg and @doktoric please take a look
Changes:
 - backport templating fix, change mustache java to handlebars
 - adding expressions that could be occurred in exported blueprints to the test
 - configure handlebar to avoid syntax error on exported blueprint's special expressions
 - calculates and logs also the template processing time