### PR TITLE
CLOUD-91578 remove spring consul and enable class proxying

### DIFF
--- a/autoscale/build.gradle
+++ b/autoscale/build.gradle
@@ -66,10 +66,6 @@ dependencies {
     testCompile group: 'org.springframework',       name: 'spring-test',                            version: springFrameworkVersion
     testCompile group: 'org.springframework.boot',  name: 'spring-boot-starter-test',                version: springBootVersion
 
-    runtime ('org.springframework.cloud:spring-cloud-starter-consul-config:1.0.0.M6-v3'){
-        exclude group: 'com.ecwid.consul';
-    }
-
     compile project(':core-api')
     compile project(':autoscale-api')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -277,8 +277,6 @@ subprojects {
   repositories {
     mavenCentral()
     maven { url "http://maven.sequenceiq.com/releases" }
-    maven { url "http://repo.spring.io/milestone" }
-    maven { url "https://repo.spring.io/snapshot" }
     maven { url "https://repo.spring.io/release" }
     mavenLocal()
   }

--- a/cloud-common/build.gradle
+++ b/cloud-common/build.gradle
@@ -37,9 +37,6 @@ dependencies {
     compile group: 'org.postgresql',                name: 'postgresql',                     version: '9.4.1212'
     compile group: 'com.sequenceiq',                name: 'consul-api',                     version: '1.10'
     compile group: 'org.apache.commons',            name: 'commons-lang3',                  version: apacheCommonsLangVersion
-    runtime ('org.springframework.cloud:spring-cloud-starter-consul-config:1.0.0.M6-v3'){
-      exclude group: 'com.ecwid.consul';
-    }
     testCompile group: 'junit',                     name: 'junit',                          version: junitVersion
     testCompile group: 'org.mockito',               name: 'mockito-all',                    version: mockitoAllVersion
 }

--- a/cloud-common/src/main/resources/application.yml
+++ b/cloud-common/src/main/resources/application.yml
@@ -2,9 +2,6 @@ server:
   contextPath: "/cb"
 
 spring:
-  cloud:
-    consul:
-      host: consul.service.consul
   freemarker:
     template-loader-path: file:/etc/cloudbreak,classpath:/
     prefer-file-system-access: false

--- a/core/src/main/java/com/sequenceiq/cloudbreak/CloudbreakApplication.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/CloudbreakApplication.java
@@ -5,12 +5,14 @@ import static com.sequenceiq.cloudbreak.VersionedApplication.versionedApplicatio
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @EnableAutoConfiguration
 @EnableSwagger2
 @ComponentScan(basePackages = "com.sequenceiq.cloudbreak")
+@EnableAspectJAutoProxy(proxyTargetClass = true)
 public class CloudbreakApplication {
     public static void main(String[] args) {
         if (!versionedApplication().showVersionInfo(args)) {


### PR DESCRIPTION
For some reason spring-cloud enabled the class proxying and if we remove it it will fall back to interface proxying and cannot inject services.