### PR TITLE
Display configured Ambari and HDP repos on cluster details

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/AmbariStackDetailsResponse.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/AmbariStackDetailsResponse.java
@@ -1,0 +1,66 @@
+package com.sequenceiq.cloudbreak.api.model;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AmbariStackDetailsResponse implements JsonEntity {
+
+    public static final String REPO_ID_TAG = "repoid";
+
+    private Map<String, String> stack;
+
+    private Map<String, String> util;
+
+    private Map<String, String> knox;
+
+    private boolean verify = true;
+
+    private String hdpVersion;
+
+    public Map<String, String> getStack() {
+        return stack;
+    }
+
+    public void setStack(Map<String, String> stack) {
+        this.stack = stack;
+    }
+
+    public Map<String, String> getUtil() {
+        return util;
+    }
+
+    public void setUtil(Map<String, String> util) {
+        this.util = util;
+    }
+
+    public Map<String, String> getKnox() {
+        return knox;
+    }
+
+    public void setKnox(Map<String, String> knox) {
+        this.knox = knox;
+    }
+
+    public boolean isVerify() {
+        return verify;
+    }
+
+    public void setVerify(boolean verify) {
+        this.verify = verify;
+    }
+
+    public String getHdpVersion() {
+        return hdpVersion;
+    }
+
+    public void setHdpVersion(String hdpVersion) {
+        this.hdpVersion = hdpVersion;
+    }
+
+    @Override
+    public String toString() {
+        return "StackRepoDetails{stack='" + stack.get(REPO_ID_TAG) + "'; utils='" + util.get(REPO_ID_TAG) + "'}";
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/ClusterResponse.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/ClusterResponse.java
@@ -96,7 +96,7 @@ public class ClusterResponse implements JsonEntity {
     private CustomContainerResponse customContainers;
 
     @ApiModelProperty(ClusterModelDescription.AMBARI_STACK_DETAILS)
-    private AmbariStackDetailsJson ambariStackDetails;
+    private AmbariStackDetailsResponse ambariStackDetails;
 
     @ApiModelProperty(ClusterModelDescription.AMBARI_REPO_DETAILS)
     private AmbariRepoDetailsJson ambariRepoDetailsJson;
@@ -318,11 +318,11 @@ public class ClusterResponse implements JsonEntity {
         this.customContainers = customContainers;
     }
 
-    public AmbariStackDetailsJson getAmbariStackDetails() {
+    public AmbariStackDetailsResponse getAmbariStackDetails() {
         return ambariStackDetails;
     }
 
-    public void setAmbariStackDetails(AmbariStackDetailsJson ambariStackDetails) {
+    public void setAmbariStackDetails(AmbariStackDetailsResponse ambariStackDetails) {
         this.ambariStackDetails = ambariStackDetails;
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/StackRepoDetailsToAmbariStackDetailsJsonConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/StackRepoDetailsToAmbariStackDetailsJsonConverter.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.cloudbreak.converter;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.api.model.AmbariStackDetailsResponse;
+import com.sequenceiq.cloudbreak.cloud.model.component.StackRepoDetails;
+
+@Component
+public class StackRepoDetailsToAmbariStackDetailsJsonConverter extends AbstractConversionServiceAwareConverter<StackRepoDetails, AmbariStackDetailsResponse> {
+
+    @Override
+    public AmbariStackDetailsResponse convert(StackRepoDetails source) {
+        AmbariStackDetailsResponse ambariRepoDetailsJson = new AmbariStackDetailsResponse();
+        ambariRepoDetailsJson.setHdpVersion(source.getHdpVersion());
+        ambariRepoDetailsJson.setVerify(source.isVerify());
+        ambariRepoDetailsJson.setKnox(source.getKnox());
+        ambariRepoDetailsJson.setStack(source.getStack());
+        ambariRepoDetailsJson.setUtil(source.getUtil());
+        return ambariRepoDetailsJson;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/ClusterComponentConfigProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/ClusterComponentConfigProvider.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.google.common.collect.Lists;
 import com.sequenceiq.cloudbreak.cloud.model.AmbariDatabase;
 import com.sequenceiq.cloudbreak.cloud.model.AmbariRepo;
 import com.sequenceiq.cloudbreak.cloud.model.component.StackRepoDetails;
@@ -47,6 +48,18 @@ public class ClusterComponentConfigProvider {
         }
     }
 
+    public StackRepoDetails getStackRepo(Set<ClusterComponent> clusterComponents) {
+        try {
+            StackRepoDetails component = getComponent(Lists.newArrayList(clusterComponents), StackRepoDetails.class, ComponentType.HDP_REPO_DETAILS);
+            if (component == null) {
+                component = getComponent(Lists.newArrayList(clusterComponents), StackRepoDetails.class, ComponentType.HDF_REPO_DETAILS);
+            }
+            return component;
+        } catch (Exception e) {
+            throw new CloudbreakServiceException("Failed to read HDP repo details.", e);
+        }
+    }
+
     public AmbariRepo getAmbariRepo(Long clusterId) {
         try {
             ClusterComponent component = getComponent(clusterId, ComponentType.AMBARI_REPO_DETAILS);
@@ -55,6 +68,14 @@ public class ClusterComponentConfigProvider {
             }
             return component.getAttributes().get(AmbariRepo.class);
         } catch (IOException e) {
+            throw new CloudbreakServiceException("Failed to read Ambari repo", e);
+        }
+    }
+
+    public AmbariRepo getAmbariRepo(Set<ClusterComponent> clusterComponents) {
+        try {
+            return getComponent(Lists.newArrayList(clusterComponents), AmbariRepo.class, ComponentType.AMBARI_REPO_DETAILS);
+        } catch (Exception e) {
             throw new CloudbreakServiceException("Failed to read Ambari repo", e);
         }
     }
@@ -77,6 +98,14 @@ public class ClusterComponentConfigProvider {
             }
             return component.getAttributes().get(AmbariDatabase.class);
         } catch (IOException e) {
+            throw new CloudbreakServiceException("Failed to read Ambari database", e);
+        }
+    }
+
+    public AmbariDatabase getAmbariDatabase(Set<ClusterComponent> clusterComponents) {
+        try {
+            return getComponent(Lists.newArrayList(clusterComponents), AmbariDatabase.class, ComponentType.AMBARI_DATABASE_DETAILS);
+        } catch (Exception e) {
             throw new CloudbreakServiceException("Failed to read Ambari database", e);
         }
     }


### PR DESCRIPTION
Sending back the stackdetails in the cluster response because that is missing previously.

RMP-9129
