### PR TITLE
Backward compatible support of Ambari's repository version related API changes

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/Image.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/Image.java
@@ -19,10 +19,18 @@ public class Image {
 
     private final Map<InstanceGroupType, String> userdata;
 
+    private final String osType;
+
+    public Image(String imageName, Map<InstanceGroupType, String> userdata) {
+        this(imageName, userdata, "");
+    }
+
     public Image(@JsonProperty("imageName") String imageName,
-            @JsonProperty("userdata") Map<InstanceGroupType, String> userdata) {
+            @JsonProperty("userdata") Map<InstanceGroupType, String> userdata,
+            @JsonProperty("osType") String osType) {
         this.imageName = imageName;
         this.userdata = userdata != null ? ImmutableMap.copyOf(userdata) : null;
+        this.osType = osType;
     }
 
     public String getImageName() {
@@ -37,10 +45,15 @@ public class Image {
         return userdata;
     }
 
+    public String getOsType() {
+        return osType;
+    }
+
     @Override
     public String toString() {
         return "Image{"
                 + "imageName='" + imageName + '\''
+                + ", osType='" + osType + '\''
                 + ", userdata=" + userdata + '}';
     }
 }

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/catalog/Image.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/catalog/Image.java
@@ -16,6 +16,8 @@ public class Image {
 
     private String os;
 
+    private String osType;
+
     private String uuid;
 
     private String version;
@@ -35,7 +37,8 @@ public class Image {
             @JsonProperty(value = "version") String version,
             @JsonProperty(value = "repo") Map<String, String> repo,
             @JsonProperty(value = "images", required = true) Map<String, Map<String, String>> imageSetsByProvider,
-            @JsonProperty(value = "stack-details") StackDetails stackDetails) {
+            @JsonProperty(value = "stack-details") StackDetails stackDetails,
+            @JsonProperty(value = "os_type") String osType) {
         this.date = date;
         this.description = description;
         this.os = os;
@@ -44,6 +47,7 @@ public class Image {
         this.repo = (repo == null) ? Collections.emptyMap() : repo;
         this.imageSetsByProvider = imageSetsByProvider;
         this.stackDetails = stackDetails;
+        this.osType = osType;
     }
 
     public String getDate() {
@@ -78,6 +82,10 @@ public class Image {
         return stackDetails;
     }
 
+    public String getOsType() {
+        return osType;
+    }
+
     @Override
     public String toString() {
         return "Image{"
@@ -85,6 +93,7 @@ public class Image {
                 + ", date='" + date + '\''
                 + ", description='" + description + '\''
                 + ", os='" + os + '\''
+                + ", osType='" + osType + '\''
                 + ", version='" + version + '\''
                 + '}';
     }

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/component/StackRepoDetails.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/component/StackRepoDetails.java
@@ -11,6 +11,12 @@ public class StackRepoDetails {
 
     public static final String MPACK_TAG = "mpack";
 
+    public static final String REPOSITORY_VERSION = "repository-version";
+
+    public static final String VDF_REPO_KEY_PREFIX = "vdf-";
+
+    public static final String CUSTOM_VDF_REPO_KEY = "vdf-url";
+
     private Map<String, String> stack;
 
     private Map<String, String> util;

--- a/cloud-common/src/main/resources/application.yml
+++ b/cloud-common/src/main/resources/application.yml
@@ -119,8 +119,8 @@ cb:
 
   ambari:
     repo:
-      version: 2.5.1.0
-      baseurl: http://public-repo-1.hortonworks.com/ambari/centos6/2.x/updates/2.5.1.0
+      version: 2.6.0.0
+      baseurl: http://public-repo-1.hortonworks.com/ambari/centos6/2.x/updates/2.6.0.0
       gpgkey: http://public-repo-1.hortonworks.com/ambari/centos6/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
     database:
       vendor: embedded
@@ -139,17 +139,23 @@ cb:
             repoid: HDP-2.5
             redhat6: http://public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.5.5.0
             redhat7: http://public-repo-1.hortonworks.com/HDP/centos7/2.x/updates/2.5.5.0
+            repository-version: 2.5.3.0-37
+            vdf-centos6: http://public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.5.3.0/HDP-2.5.3.0-37.xml
+            vdf-centos7: http://public-repo-1.hortonworks.com/HDP/centos7/2.x/updates/2.5.3.0/HDP-2.5.3.0-37.xml
           util:
             repoid: HDP-UTILS-1.1.0.21
             redhat6: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.21/repos/centos6
             redhat7: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.21/repos/centos7
       2.6:
-        version: 2.6.1.0
+        version: 2.6.3.0
         repo:
           stack:
             repoid: HDP-2.6
-            redhat6: http://public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.6.1.0
-            redhat7: http://public-repo-1.hortonworks.com/HDP/centos7/2.x/updates/2.6.1.0
+            redhat6: http://public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.6.3.0
+            redhat7: http://public-repo-1.hortonworks.com/HDP/centos7/2.x/updates/2.6.3.0
+            repository-version: 2.6.3.0-235
+            vdf-redhat6: http://public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.6.3.0/HDP-2.6.3.0-235.xml
+            vdf-redhat7: http://public-repo-1.hortonworks.com/HDP/centos7/2.x/updates/2.6.3.0/HDP-2.6.3.0-235.xml
           util:
             repoid: HDP-UTILS-1.1.0.21
             redhat6: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.21/repos/centos6

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/AmbariStackDetailsJson.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/AmbariStackDetailsJson.java
@@ -23,25 +23,27 @@ public class AmbariStackDetailsJson implements JsonEntity {
     @ApiModelProperty(AmbariStackDetailsDescription.OS)
     private String os;
 
-    @NotNull
     @ApiModelProperty(value = AmbariStackDetailsDescription.STACK_REPO_ID, required = true)
     private String stackRepoId;
 
-    @NotNull
     @ApiModelProperty(value = AmbariStackDetailsDescription.STACK_BASE_URL, required = true)
     private String stackBaseURL;
 
-    @NotNull
     @ApiModelProperty(value = AmbariStackDetailsDescription.UTILS_REPO_ID, required = true)
     private String utilsRepoId;
 
-    @NotNull
     @ApiModelProperty(value = AmbariStackDetailsDescription.UTILS_BASE_URL, required = true)
     private String utilsBaseURL;
 
     @NotNull
     @ApiModelProperty(value = AmbariStackDetailsDescription.VERIFY, required = true)
     private Boolean verify;
+
+    @ApiModelProperty(value = AmbariStackDetailsDescription.REPOSITORY_VERSION, required = true)
+    private String repositoryVersion;
+
+    @ApiModelProperty(value = AmbariStackDetailsDescription.VDF_URL, required = true)
+    private String versionDefinitionFileUrl;
 
     public String getStack() {
         return stack;
@@ -105,5 +107,21 @@ public class AmbariStackDetailsJson implements JsonEntity {
 
     public void setUtilsBaseURL(String utilsBaseURL) {
         this.utilsBaseURL = utilsBaseURL;
+    }
+
+    public String getRepositoryVersion() {
+        return repositoryVersion;
+    }
+
+    public void setRepositoryVersion(String repositoryVersion) {
+        this.repositoryVersion = repositoryVersion;
+    }
+
+    public String getVersionDefinitionFileUrl() {
+        return versionDefinitionFileUrl;
+    }
+
+    public void setVersionDefinitionFileUrl(String versionDefinitionFileUrl) {
+        this.versionDefinitionFileUrl = versionDefinitionFileUrl;
     }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/imagecatalog/ImageResponse.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/imagecatalog/ImageResponse.java
@@ -18,6 +18,9 @@ public class ImageResponse implements JsonEntity {
     @JsonProperty("os")
     private String os;
 
+    @JsonProperty("osType")
+    private String osType;
+
     @JsonProperty("uuid")
     private String uuid;
 
@@ -95,5 +98,13 @@ public class ImageResponse implements JsonEntity {
 
     public void setStackDetails(StackDetailsJson stackDetails) {
         this.stackDetails = stackDetails;
+    }
+
+    public String getOsType() {
+        return osType;
+    }
+
+    public void setOsType(String osType) {
+        this.osType = osType;
     }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
@@ -247,6 +247,8 @@ public class ModelDescriptions {
         public static final String STACK_BASE_URL = "url of the stack repository";
         public static final String UTILS_BASE_URL = "url of the stack utils repository";
         public static final String VERIFY = "whether to verify or not the repo url";
+        public static final String REPOSITORY_VERSION = "version of the repository for VDF file creation in Ambari";
+        public static final String VDF_URL = "local path on the Ambari server or URL that point to the desired VDF file";
     }
 
     public static class RDSConfig {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/ImagesToImagesResponseJsonConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/ImagesToImagesResponseJsonConverter.java
@@ -113,6 +113,7 @@ public class ImagesToImagesResponseJsonConverter extends AbstractConversionServi
         json.setDate(source.getDate());
         json.setDescription(source.getDescription());
         json.setOs(source.getOs());
+        json.setOsType(source.getOsType());
         json.setUuid(source.getUuid());
         json.setVersion(source.getVersion());
         if (source.getRepo() != null) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/AmbariServiceException.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/AmbariServiceException.java
@@ -1,0 +1,14 @@
+package com.sequenceiq.cloudbreak.service.cluster;
+
+import com.sequenceiq.cloudbreak.service.CloudbreakServiceException;
+
+public class AmbariServiceException extends CloudbreakServiceException {
+
+    public AmbariServiceException(String message) {
+        super(message);
+    }
+
+    public AmbariServiceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariClusterTemplateService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariClusterTemplateService.java
@@ -1,0 +1,65 @@
+package com.sequenceiq.cloudbreak.service.cluster.flow;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.ambari.client.AmbariClient;
+import com.sequenceiq.cloudbreak.domain.Cluster;
+import com.sequenceiq.cloudbreak.domain.KerberosConfig;
+import com.sequenceiq.cloudbreak.service.cluster.AmbariAuthenticationProvider;
+import com.sequenceiq.cloudbreak.service.cluster.AmbariServiceException;
+import com.sequenceiq.cloudbreak.service.cluster.flow.kerberos.KerberosPrincipalResolver;
+import com.sequenceiq.cloudbreak.util.JsonUtil;
+
+@Service
+public class AmbariClusterTemplateService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AmbariClusterTemplateService.class);
+
+    private static final String KEY_TYPE = "PERSISTED";
+
+    @Inject
+    private KerberosPrincipalResolver kerberosPrincipalResolver;
+
+    @Inject
+    private AmbariAuthenticationProvider ambariAuthenticationProvider;
+
+    @Inject
+    private AmbariRepositoryVersionService ambariRepositoryVersionService;
+
+    public void addClusterTemplate(Cluster cluster, Map<String, List<Map<String, String>>> hostGroupMappings, AmbariClient ambariClient) {
+        String clusterName = cluster.getName();
+        String blueprintName = cluster.getBlueprint().getAmbariName();
+        String configStrategy = cluster.getConfigStrategy().name();
+        Boolean hideQuickLinks = cluster.getGateway().getEnableGateway();
+        String clusterTemplate;
+
+        if (ambariClient.getClusterName() == null) {
+            try {
+                String repositoryVersion = ambariRepositoryVersionService.getRepositoryVersion(cluster.getId(), cluster.getStack().getOrchestrator());
+                if (cluster.isSecure()) {
+                    KerberosConfig kerberosConfig = cluster.getKerberosConfig();
+                    String principal = kerberosPrincipalResolver.resolvePrincipalForKerberos(kerberosConfig);
+                    clusterTemplate = ambariClient.createSecureCluster(clusterName, blueprintName, hostGroupMappings, configStrategy,
+                            cluster.getPassword(), principal, kerberosConfig.getKerberosPassword(), KEY_TYPE, hideQuickLinks, repositoryVersion);
+                } else {
+                    clusterTemplate = ambariClient.createCluster(clusterName, blueprintName, hostGroupMappings, configStrategy,
+                            ambariAuthenticationProvider.getAmbariPassword(cluster), hideQuickLinks, repositoryVersion);
+                }
+                LOGGER.info("Submitted cluster creation template: {}", JsonUtil.minify(clusterTemplate));
+            } catch (Exception exception) {
+                String msg = "Ambari client failed to apply cluster creation template.";
+                LOGGER.error(msg, exception);
+                throw new AmbariServiceException(msg, exception);
+            }
+        } else {
+            LOGGER.info("Ambari cluster already exists: {}", clusterName);
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariRepositoryVersionService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariRepositoryVersionService.java
@@ -1,0 +1,172 @@
+package com.sequenceiq.cloudbreak.service.cluster.flow;
+
+
+import static com.sequenceiq.cloudbreak.cloud.model.component.StackRepoDetails.CUSTOM_VDF_REPO_KEY;
+import static com.sequenceiq.cloudbreak.cloud.model.component.StackRepoDetails.VDF_REPO_KEY_PREFIX;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import com.sequenceiq.ambari.client.services.StackService;
+import com.sequenceiq.cloudbreak.cloud.model.AmbariRepo;
+import com.sequenceiq.cloudbreak.cloud.model.Image;
+import com.sequenceiq.cloudbreak.cloud.model.component.StackRepoDetails;
+import com.sequenceiq.cloudbreak.core.CloudbreakException;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.OrchestratorTypeResolver;
+import com.sequenceiq.cloudbreak.domain.Orchestrator;
+import com.sequenceiq.cloudbreak.service.ClusterComponentConfigProvider;
+import com.sequenceiq.cloudbreak.service.ComponentConfigProvider;
+import com.sequenceiq.cloudbreak.service.cluster.AmbariServiceException;
+import com.sequenceiq.cloudbreak.util.AmbariClientExceptionUtil;
+import com.sequenceiq.cloudbreak.util.JsonUtil;
+
+import groovyx.net.http.HttpResponseException;
+
+@Service
+public class AmbariRepositoryVersionService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AmbariRepositoryVersionService.class);
+
+    private static final String VERSION_PATTERN = "^\\d+\\.\\d+\\.\\d+.\\d+";
+
+    private static final long AMBARI_VERSION_OF_NEW_API = 2600L;
+
+    @Inject
+    private ClusterComponentConfigProvider clusterComponentConfigProvider;
+
+    @Inject
+    private OrchestratorTypeResolver orchestratorTypeResolver;
+
+    @Inject
+    private ComponentConfigProvider componentConfigProvider;
+
+    public String getRepositoryVersion(long clusterId, Orchestrator orchestrator) throws CloudbreakException {
+        StackRepoDetails stackRepoDetails = getStackRepoDetails(clusterId, orchestrator);
+        String result = "";
+        if (stackRepoDetails != null) {
+            Optional<String> repositoryVersion = Optional.ofNullable(stackRepoDetails.getStack().get(StackRepoDetails.REPOSITORY_VERSION));
+            result = repositoryVersion.orElse("");
+        }
+        return result;
+    }
+
+    public void setBaseRepoURL(Long stackId, long clusterId, Orchestrator orchestrator, StackService ambariClient) throws CloudbreakException {
+        StackRepoDetails stackRepoDetails = getStackRepoDetails(clusterId, orchestrator);
+        if (stackRepoDetails != null) {
+            try {
+                LOGGER.info("Use specific Ambari repository: {}", stackRepoDetails);
+                AmbariRepo ambariRepoDetails = clusterComponentConfigProvider.getAmbariRepo(clusterId);
+                long ambariVersion = extractAmbariVersion(ambariRepoDetails);
+                if (ambariVersion < AMBARI_VERSION_OF_NEW_API) {
+                    setRepositoryVersionOnApi(ambariClient, stackRepoDetails);
+                } else {
+                    addVersionDefinitionFileToAmbari(stackId, ambariClient, stackRepoDetails);
+                }
+            } catch (HttpResponseException e) {
+                String exceptionErrorMsg = AmbariClientExceptionUtil.getErrorMessage(e);
+                String msg = String.format("Cannot use the specified Ambari stack: %s. Error: %s", stackRepoDetails.toString(), exceptionErrorMsg);
+                throw new AmbariServiceException(msg, e);
+            }
+        } else {
+            LOGGER.info("Using latest HDP repository");
+        }
+    }
+
+    private StackRepoDetails getStackRepoDetails(long clusterId, Orchestrator orchestrator) throws CloudbreakException {
+        StackRepoDetails stackRepoDetails = null;
+        if (!orchestratorTypeResolver.resolveType(orchestrator).containerOrchestrator() || "YARN".equals(orchestrator.getType())) {
+            stackRepoDetails = clusterComponentConfigProvider.getHDPRepo(clusterId);
+        }
+        return stackRepoDetails;
+    }
+
+    private long extractAmbariVersion(AmbariRepo ambariRepo) {
+        String ambariVersion = ambariRepo.getVersion();
+        Matcher matcher = Pattern.compile(VERSION_PATTERN).matcher(ambariVersion);
+        if (matcher.find()) {
+            ambariVersion = matcher.group(0).replace(".", "");
+            return Long.parseLong(ambariVersion);
+        } else {
+            String message = String.format("Ambari version could not be extracted from '%s'.", ambariVersion);
+            LOGGER.error(message);
+            throw new AmbariServiceException(message);
+        }
+    }
+
+    private void setRepositoryVersionOnApi(StackService ambariClient, StackRepoDetails stackRepoDetails) throws HttpResponseException {
+        LOGGER.info("Set repository versions in Ambari via old API calls.");
+        Map<String, String> stackRepo = stackRepoDetails.getStack();
+        Map<String, String> utilRepo = stackRepoDetails.getUtil();
+        String stackRepoId = stackRepo.remove(StackRepoDetails.REPO_ID_TAG);
+        String utilRepoId = utilRepo.remove(StackRepoDetails.REPO_ID_TAG);
+        stackRepo = removeVDFRelatedRepoDetails(stackRepo);
+        stackRepo.remove(StackRepoDetails.MPACK_TAG);
+        String[] typeVersion = stackRepoId.split("-");
+        String stackType = typeVersion[0];
+        String version = "";
+        if (typeVersion.length > 1) {
+            version = typeVersion[1];
+        }
+        for (Map.Entry<String, String> entry : stackRepo.entrySet()) {
+            addRepository(ambariClient, stackType, version, entry.getKey(), stackRepoId, entry.getValue(), stackRepoDetails.isVerify());
+        }
+        for (Map.Entry<String, String> entry : utilRepo.entrySet()) {
+            addRepository(ambariClient, stackType, version, entry.getKey(), utilRepoId, entry.getValue(), stackRepoDetails.isVerify());
+        }
+    }
+
+    private Map<String, String> removeVDFRelatedRepoDetails(Map<String, String> stackRepoDetails) {
+        stackRepoDetails.remove(StackRepoDetails.REPOSITORY_VERSION);
+        return stackRepoDetails.entrySet().stream()
+                .filter(entry -> !entry.getKey().startsWith(VDF_REPO_KEY_PREFIX))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private void addRepository(StackService client, String stack, String version, String os,
+            String repoId, String repoUrl, boolean verify) throws HttpResponseException {
+        client.addStackRepository(stack, version, os, repoId, repoUrl, verify);
+    }
+
+    private void addVersionDefinitionFileToAmbari(Long stackId, StackService ambariClient, StackRepoDetails stackRepoDetails) {
+        Optional<String> vdfUrl = Optional.ofNullable(stackRepoDetails.getStack().get(CUSTOM_VDF_REPO_KEY));
+        if (!vdfUrl.isPresent()) {
+            vdfUrl = getVDFUrlByOsType(stackId, stackRepoDetails);
+        }
+
+        if (vdfUrl.isPresent()) {
+            String vdf = ambariClient.createVersionDefinition(vdfUrl.get());
+            LOGGER.info("VDF request has been sent to Ambari: '{}'.", JsonUtil.minify(vdf));
+        } else {
+            LOGGER.error("Couldn't determine any VDF file, let Ambari to start with defaults");
+        }
+    }
+
+    private Optional<String> getVDFUrlByOsType(Long stackId, StackRepoDetails stackRepoDetails) {
+        String vdfStackRepoKeyFilter = VDF_REPO_KEY_PREFIX;
+        try {
+            Image image = componentConfigProvider.getImage(stackId);
+            if (!StringUtils.isEmpty(image.getOsType())) {
+                vdfStackRepoKeyFilter = vdfStackRepoKeyFilter + image.getOsType();
+            }
+        } catch (CloudbreakImageNotFoundException e) {
+            LOGGER.error(String.format("Could not get Image Component for stack: '%s'.", stackId), e);
+        }
+
+        final String filter = vdfStackRepoKeyFilter;
+        return stackRepoDetails.getStack().entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(filter))
+                .map(Map.Entry::getValue)
+                .findFirst();
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageService.java
@@ -128,7 +128,7 @@ public class ImageService {
     private List<Component> getComponents(Stack stack, Map<InstanceGroupType, String> userData,
             com.sequenceiq.cloudbreak.cloud.model.catalog.Image imgFromCatalog, String imageName) throws JsonProcessingException {
         List<Component> components = new ArrayList<>();
-        Image image = new Image(imageName, userData);
+        Image image = new Image(imageName, userData, imgFromCatalog.getOsType());
         Component imageComponent = new Component(ComponentType.IMAGE, ComponentType.IMAGE.name(), new Json(image), stack);
         components.add(imageComponent);
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/domain/json/JsonTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/domain/json/JsonTest.java
@@ -19,7 +19,7 @@ public class JsonTest {
         userData.put(InstanceGroupType.CORE, "CORE");
         Image image = new Image("cb-centos66-amb200-2015-05-25", userData);
         Json json = new Json(image);
-        Assert.assertEquals("{\"imageName\":\"cb-centos66-amb200-2015-05-25\",\"userdata\":{\"CORE\":\"CORE\"}}",
+        Assert.assertEquals("{\"imageName\":\"cb-centos66-amb200-2015-05-25\",\"userdata\":{\"CORE\":\"CORE\"},\"osType\":\"\"}",
                 json.getValue());
     }
 
@@ -29,6 +29,18 @@ public class JsonTest {
         Map<InstanceGroupType, String> userData = new HashMap<>();
         userData.put(InstanceGroupType.CORE, "CORE");
         Image image = new Image("cb-centos66-amb200-2015-05-25", userData);
+        Json json = new Json(image);
+        String expected = json.getValue();
+        Image covertedAgain = json.get(Image.class);
+        json = new Json(covertedAgain);
+        Assert.assertEquals(expected, json.getValue());
+    }
+
+    @Test
+    public void testMultipleSerialisationWithOtherConstructorOfImage() throws IOException {
+        Map<InstanceGroupType, String> userData = new HashMap<>();
+        userData.put(InstanceGroupType.CORE, "CORE");
+        Image image = new Image("cb-centos66-amb200-2015-05-25", userData, null);
         Json json = new Json(image);
         String expected = json.getValue();
         Image covertedAgain = json.get(Image.class);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariClusterConnectorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariClusterConnectorTest.java
@@ -178,6 +178,12 @@ public class AmbariClusterConnectorTest {
     @Mock
     private CloudbreakMessagesService cloudbreakMessagesService;
 
+    @Mock
+    private AmbariClusterTemplateService ambariClusterTemplateService;
+
+    @Mock
+    private AmbariRepositoryVersionService ambariRepositoryVersionService;
+
     @InjectMocks
     private final AmbariClusterConnector underTest = new AmbariClusterConnector();
 
@@ -196,7 +202,7 @@ public class AmbariClusterConnectorTest {
         when(hostMetadataRepository.findHostsInCluster(anyLong())).thenReturn(new HashSet<>());
         when(ambariClient.extendBlueprintHostGroupConfiguration(anyString(), anyMap())).thenReturn(blueprint.getBlueprintText());
         when(ambariClient.addBlueprint(anyString())).thenReturn("");
-        when(ambariClient.createCluster(anyString(), anyString(), any(Map.class), anyString(), anyString(), anyBoolean())).thenReturn("");
+        when(ambariClient.createCluster(anyString(), anyString(), any(Map.class), anyString(), anyString(), anyBoolean(), anyString())).thenReturn("");
         when(hadoopConfigurationService.getHostGroupConfiguration(any(Cluster.class))).thenReturn(new HashMap<>());
         when(ambariClientProvider.getAmbariClient(any(HttpClientConfig.class), anyInt(), anyString(), anyString())).thenReturn(ambariClient);
         when(ambariClientProvider.getDefaultAmbariClient(any(HttpClientConfig.class), anyInt())).thenReturn(ambariClient);

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.configureondemand=true
 org.gradle.jvmargs=-Xmx4096m
 
 ambariClientName=ambari-client
-ambariClientVersion=2.4.43
+ambariClientVersion=2.4.44
 springBootVersion=1.5.3.RELEASE
 springOauthVersion=2.1.0.RELEASE
 awsSdkVersion=1.11.126

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/MockClusterCreationWithSaltSuccessTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/MockClusterCreationWithSaltSuccessTest.java
@@ -189,6 +189,7 @@ public class MockClusterCreationWithSaltSuccessTest extends AbstractMockIntegrat
         post(AMBARI_API_ROOT + "/users", new EmptyAmbariResponse());
         get(AMBARI_API_ROOT + "/clusters/:cluster/hosts", new AmbariClustersHostsResponse(instanceMap, "SUCCESSFUL"));
         put(AMBARI_API_ROOT + "/stacks/HDP/versions/:version/operating_systems/:os/repositories/:hdpversion", new EmptyAmbariResponse());
+        post(AMBARI_API_ROOT + "/version_definitions", new EmptyAmbariResponse());
     }
 
     private void addSaltMappings(Map<String, CloudVmMetaDataStatus> instanceMap) {


### PR DESCRIPTION
Backward compatible support of Ambari's repository version related API changes:
 - In case of newer Ambari API from version 2.6.0.0 uses the VDF files to set repositories to be installed
 - New "os-type" field integrated to the image catalog domain as it is available in our image catalogs
