### PR TITLE
CLOUD-91820 [API] After upgrade time stamps are corrupted in event hi…

### DIFF
--- a/core/src/main/resources/schema/app/20171130143808_CLOUD-91820_[API]_After_upgrade_time_stamps_are_corrupted_in_event_history.sql
+++ b/core/src/main/resources/schema/app/20171130143808_CLOUD-91820_[API]_After_upgrade_time_stamps_are_corrupted_in_event_history.sql
@@ -1,0 +1,16 @@
+-- // CLOUD-91820 [API] After upgrade time stamps are corrupted in event history
+-- Migration SQL that makes the change goes here.
+
+UPDATE structuredevent
+SET structuredeventjson=(SELECT jsonb_set(structuredeventjson::jsonb, '{operation,timestamp}', (timestamp*1000)::text::jsonb)
+                            FROM structuredevent
+                            WHERE sub.id=id),
+    timestamp=timestamp*1000::bigint
+FROM (SELECT id FROM structuredevent
+        WHERE timestamp < 1000000000000) AS sub
+WHERE sub.id = structuredevent.id;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+


### PR DESCRIPTION
…story, fix previous migration

Fix previous structuredevent migration.
@schfeca75 plz check and test very carefully :)

Closes BUG-91820