### PR TITLE
CLOUD-92881 PermissionEvaluator shouldn't throw exception

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/security/OwnerBasedPermissionEvaluator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/security/OwnerBasedPermissionEvaluator.java
@@ -14,7 +14,6 @@ import org.springframework.util.ReflectionUtils;
 import com.sequenceiq.cloudbreak.common.service.user.UserFilterField;
 import com.sequenceiq.periscope.domain.Cluster;
 import com.sequenceiq.periscope.domain.PeriscopeUser;
-import com.sequenceiq.periscope.service.NotFoundException;
 
 @Service
 @Lazy
@@ -27,7 +26,7 @@ public class OwnerBasedPermissionEvaluator implements PermissionEvaluator {
     @Override
     public boolean hasPermission(Authentication authentication, Object targetDomainObject, Object permission) {
         if (targetDomainObject == null) {
-            throw new NotFoundException("Resource not found.");
+            return false;
         }
         try {
             PeriscopeUser user = userDetailsService.getDetails((String) authentication.getPrincipal(), UserFilterField.USERNAME);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/security/OwnerBasedPermissionEvaluator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/security/OwnerBasedPermissionEvaluator.java
@@ -19,7 +19,6 @@ import org.springframework.util.ReflectionUtils;
 import com.sequenceiq.cloudbreak.common.model.user.IdentityUser;
 import com.sequenceiq.cloudbreak.common.model.user.IdentityUserRole;
 import com.sequenceiq.cloudbreak.common.service.user.UserFilterField;
-import com.sequenceiq.cloudbreak.controller.NotFoundException;
 import com.sequenceiq.cloudbreak.service.user.UserDetailsService;
 
 @Service
@@ -38,7 +37,7 @@ public class OwnerBasedPermissionEvaluator implements PermissionEvaluator {
     public boolean hasPermission(Authentication authentication, Object target, Object permission) {
         Permission p = Permission.valueOf(permission.toString().toUpperCase());
         if (target == null) {
-            throw new NotFoundException("Resource not found.");
+            return false;
         }
         OAuth2Authentication oauth = (OAuth2Authentication) authentication;
         if (oauth.getUserAuthentication() == null) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/conf/OwnerBasedPermissionEvaluatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/conf/OwnerBasedPermissionEvaluatorTest.java
@@ -20,7 +20,6 @@ import com.sequenceiq.cloudbreak.TestUtil;
 import com.sequenceiq.cloudbreak.common.model.user.IdentityUser;
 import com.sequenceiq.cloudbreak.common.model.user.IdentityUserRole;
 import com.sequenceiq.cloudbreak.common.service.user.UserFilterField;
-import com.sequenceiq.cloudbreak.controller.NotFoundException;
 import com.sequenceiq.cloudbreak.domain.Stack;
 import com.sequenceiq.cloudbreak.service.security.OwnerBasedPermissionEvaluator;
 import com.sequenceiq.cloudbreak.service.user.UserDetailsService;
@@ -46,9 +45,10 @@ public class OwnerBasedPermissionEvaluatorTest {
         stack = TestUtil.stack();
     }
 
-    @Test(expected = NotFoundException.class)
+    @Test
     public void testTargetNotFound() {
-        underTest.hasPermission(null, null, "read");
+        boolean result  = underTest.hasPermission(null, null, "read");
+        Assert.assertFalse(result);
     }
 
     @Test


### PR DESCRIPTION
@mhmxs plz check

The hasPermission method shouldn't throw NotFoundException if targetDomainObject is null. The documentation of the interface' method: _the domain object for which permissions should be checked. May be null in which case implementations should return false, as the null condition can be checked explicitly in the expression_

This working could lead to information leakage because an attacker could use the API to identify existing credentials/resources.

Closes BUG-92881