### PR TITLE
do not open transaction to avoid optimistic lock exception

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
@@ -185,6 +185,7 @@ public class StackService {
         return convertStacks(stackRepository.findForUserWithLists(user.getUserId()));
     }
 
+    @Transactional(TxType.NEVER)
     public Set<StackResponse> retrieveAccountStacks(IdentityUser user) {
         if (user.getRoles().contains(IdentityUserRole.ADMIN)) {
             return convertStacks(stackRepository.findAllInAccountWithLists(user.getAccount()));
@@ -201,8 +202,10 @@ public class StackService {
         return stackRepository.findForUser(owner);
     }
 
+    @Transactional(TxType.NEVER)
+    @PostAuthorize("hasPermission(returnObject,'read')")
     public StackResponse getJsonById(Long id, Set<String> entry) {
-        Stack stack = get(id);
+        Stack stack = getByIdWithLists(id);
         StackResponse stackResponse = conversionService.convert(stack, StackResponse.class);
         stackResponse = stackResponseDecorator.decorate(stackResponse, stack, entry);
         return stackResponse;


### PR DESCRIPTION
With this fix I no longer get optimistic lock exceptions, but might be scenarios when we'll get LazyInitializationException (lets hope not :))

This PR prevents any users to get info about a stack that they dont have permission to.