### PR TITLE
DPAAS-180 increase default hostname length

### DIFF
--- a/cloud-common/src/main/resources/application.yml
+++ b/cloud-common/src/main/resources/application.yml
@@ -56,7 +56,7 @@ cb:
     vpc:
 
   azure:
-    host.name.prefix.length: 3
+    host.name.prefix.length: 255
 
   yarn:
     domain: default.com


### PR DESCRIPTION
First I was thinking of completely remove this feature since I was not able to reproduce the mysql hostname issue anymore, but after that, I decided to keep at least for the next release and if nobody complains then we can remove this config parameter.