### PR TITLE
RMP-10343 Support Kerberos admin host

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/KerberosRequest.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/KerberosRequest.java
@@ -24,7 +24,11 @@ public class KerberosRequest implements JsonEntity {
     @Size(max = 50, min = 5, message = "The length of the Kerberos password has to be in range of 5 to 50")
     private String password;
 
+    @ApiModelProperty(StackModelDescription.KERBEROS_KDC_URL)
     private String url;
+
+    @ApiModelProperty(StackModelDescription.KERBEROS_ADMIN_URL)
+    private String adminUrl;
 
     private String realm;
 
@@ -71,6 +75,14 @@ public class KerberosRequest implements JsonEntity {
 
     public void setUrl(String url) {
         this.url = url;
+    }
+
+    public String getAdminUrl() {
+        return adminUrl;
+    }
+
+    public void setAdminUrl(String adminUrl) {
+        this.adminUrl = adminUrl;
     }
 
     public String getRealm() {

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
@@ -89,6 +89,8 @@ public class ModelDescriptions {
         public static final String KERBEROS_MASTER_KEY = "kerberos master key";
         public static final String KERBEROS_ADMIN = "kerberos admin user";
         public static final String KERBEROS_PASSWORD = "kerberos admin password";
+        public static final String KERBEROS_KDC_URL = "kerberos KDC server URL";
+        public static final String KERBEROS_ADMIN_URL = "kerberos admin server URL";
         public static final String KERBEROS_PRINCIPAL = "kerberos principal";
         public static final String PARAMETERS = "additional cloud specific parameters for stack";
         public static final String FAILURE_ACTION = "action on failure";

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/KerberosConfig.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/KerberosConfig.java
@@ -32,6 +32,9 @@ public class KerberosConfig implements ProvisionEntity {
     private String kerberosUrl;
 
     @Type(type = "encrypted_string")
+    private String kdcAdminUrl;
+
+    @Type(type = "encrypted_string")
     private String kerberosRealm;
 
     private Boolean kerberosTcpAllowed;
@@ -89,6 +92,14 @@ public class KerberosConfig implements ProvisionEntity {
 
     public void setKerberosUrl(String kerberosUrl) {
         this.kerberosUrl = kerberosUrl;
+    }
+
+    public String getKdcAdminUrl() {
+        return kdcAdminUrl;
+    }
+
+    public void setKdcAdminUrl(String kdcAdminUrl) {
+        this.kdcAdminUrl = kdcAdminUrl;
     }
 
     public String getKerberosRealm() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/JsonToClusterConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/JsonToClusterConverter.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -57,6 +58,7 @@ public class JsonToClusterConverter extends AbstractConversionServiceAwareConver
             kerberosConfig.setKerberosAdmin(kerberosSource.getAdmin());
             kerberosConfig.setKerberosPassword(kerberosSource.getPassword());
             kerberosConfig.setKerberosUrl(kerberosSource.getUrl());
+            kerberosConfig.setKdcAdminUrl(Optional.ofNullable(kerberosSource.getAdminUrl()).orElse(kerberosSource.getUrl()));
             kerberosConfig.setKerberosRealm(kerberosSource.getRealm());
             kerberosConfig.setKerberosTcpAllowed(kerberosSource.getTcpAllowed());
             kerberosConfig.setKerberosPrincipal(kerberosSource.getPrincipal());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
@@ -124,11 +124,13 @@ public class ClusterHostServiceRunner {
             putIfNotNull(kerberosPillarConf, kerberosConfig.getKerberosPassword(), "password");
             if (StringUtils.isEmpty(kerberosConfig.getKerberosDescriptor())) {
                 putIfNotNull(kerberosPillarConf, kerberosConfig.getKerberosUrl(), "url");
+                putIfNotNull(kerberosPillarConf, kerberosConfig.getKdcAdminUrl(), "adminUrl");
                 putIfNotNull(kerberosPillarConf, kerberosConfig.getKerberosRealm(), "realm");
             } else {
                 Map<String, Object> kerberosEnv = (Map<String, Object>) gson.fromJson(kerberosConfig.getKerberosDescriptor(), Map.class).get("kerberos-env");
                 Map<String, Object> properties = (Map<String, Object>) kerberosEnv.get("properties");
                 putIfNotNull(kerberosPillarConf, properties.get("kdc_hosts"), "url");
+                putIfNotNull(kerberosPillarConf, properties.get("admin_server_host"), "adminUrl");
                 putIfNotNull(kerberosPillarConf, properties.get("realm"), "realm");
             }
             putIfNotNull(kerberosPillarConf, cluster.getUserName(), "clusterUser");

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/kerberos/KerberosBlueprintService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/kerberos/KerberosBlueprintService.java
@@ -60,9 +60,11 @@ public class KerberosBlueprintService {
     private String extendBlueprintWithKerberos(String blueprintText, Cluster cluster, String gatewayHost, String realm, String domain, Integer propagationPort,
             KerberosService kerberosService) {
         KerberosConfig kerberosConfig = cluster.getKerberosConfig();
+        String kdcHosts = kerberosDetailService.resolveHostForKerberos(cluster, gatewayHost);
         blueprintText = kerberosService.extendBlueprintWithKerberos(blueprintText,
                 kerberosDetailService.resolveTypeForKerberos(kerberosConfig),
-                kerberosDetailService.resolveHostForKerberos(cluster, gatewayHost),
+                kdcHosts,
+                kerberosDetailService.resolveHostForKdcAdmin(cluster, kdcHosts),
                 realm,
                 kerberosDetailService.getDomains(domain),
                 kerberosDetailService.resolveLdapUrlForKerberos(kerberosConfig),

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/kerberos/KerberosDetailService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/kerberos/KerberosDetailService.java
@@ -25,8 +25,12 @@ public class KerberosDetailService {
         return "mit-kdc";
     }
 
-    public String resolveHostForKerberos(Cluster cluster, String gatewayHost) {
-        return Strings.isNullOrEmpty(cluster.getKerberosConfig().getKerberosUrl()) ? gatewayHost : cluster.getKerberosConfig().getKerberosUrl();
+    public String resolveHostForKerberos(Cluster cluster, String defaultHost) {
+        return Strings.isNullOrEmpty(cluster.getKerberosConfig().getKerberosUrl()) ? defaultHost : cluster.getKerberosConfig().getKerberosUrl();
+    }
+
+    public String resolveHostForKdcAdmin(Cluster cluster, String defaultHost) {
+        return Strings.isNullOrEmpty(cluster.getKerberosConfig().getKdcAdminUrl()) ? defaultHost : cluster.getKerberosConfig().getKdcAdminUrl();
     }
 
     public String getRealm(String gwDomain, KerberosConfig kerberosConfig) {

--- a/core/src/main/resources/schema/app/20180108121930_RMP-10343_Separate_kdc_server_and_admin_host.sql
+++ b/core/src/main/resources/schema/app/20180108121930_RMP-10343_Separate_kdc_server_and_admin_host.sql
@@ -1,0 +1,10 @@
+-- // RMP-10343_Separate_kdc_server_and_admin_host
+-- Migration SQL that makes the change goes here.
+
+
+ALTER TABLE kerberosconfig ADD COLUMN kdcadminurl VARCHAR(255);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE kerberosconfig DROP COLUMN kdcadminurl;

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.configureondemand=true
 org.gradle.jvmargs=-Xmx4096m
 
 ambariClientName=ambari-client
-ambariClientVersion=2.4.47
+ambariClientVersion=2.4.49
 springBootVersion=1.5.3.RELEASE
 springOauthVersion=2.1.0.RELEASE
 awsSdkVersion=1.11.126

--- a/orchestrator-salt/src/main/resources/salt/salt/kerberos/config/krb5.conf-existing
+++ b/orchestrator-salt/src/main/resources/salt/salt/kerberos/config/krb5.conf-existing
@@ -14,7 +14,7 @@
 [realms]
  {{ salt['pillar.get']('kerberos:realm')|upper }} = {
   kdc = {{ salt['pillar.get']('kerberos:url') }}
-  admin_server = {{ salt['pillar.get']('kerberos:url') }}
+  admin_server = {{ salt['pillar.get']('kerberos:adminUrl') }}
  }
 
 [domain_realm]

--- a/orchestrator-salt/src/main/resources/salt/salt/kerberos/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/kerberos/settings.sls
@@ -3,6 +3,7 @@
 {% set password = salt['pillar.get']('kerberos:password') %}
 {% set user = salt['pillar.get']('kerberos:user') %}
 {% set url = salt['pillar.get']('kerberos:url') %}
+{% set adminUrl = salt['pillar.get']('kerberos:adminUrl') %}
 {% set clusterUser = salt['pillar.get']('kerberos:clusterUser') %}
 {% set clusterPassword = salt['pillar.get']('kerberos:clusterPassword') %}
 
@@ -24,6 +25,7 @@
     'password': password,
     'user': user,
     'url': url,
+    'adminUrl': adminUrl,
     'kdcs': servers|join(" "),
     'enable_iprop': enable_iprop,
     'clusterUser': clusterUser,


### PR DESCRIPTION
Previous version supported only one url for both kdc and admin server. Now it supports both separatly.