### PR TITLE
CLOUD-10329 mock tests for kerberized cluster creation

### DIFF
--- a/integration-test/it-application.yml
+++ b/integration-test/it-application.yml
@@ -8,6 +8,8 @@ integrationtest:
     defaultBlueprintName: hdp-small-default
     outputdir: /it
     command: suites
-    suiteFiles: /it/src/main/resources/testsuites/mock/mock-scaling-salt.yaml
+    suiteFiles:
+      - /it/src/main/resources/testsuites/mock/mock-scaling-salt.yaml
+      - /it/src/main/resources/testsuites/mock/mock-kerberized-clustercreate-salt.yaml
     cleanup:
       cleanupBeforeStart: true

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/MockKerberizedClusterCreationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/MockKerberizedClusterCreationTest.java
@@ -1,0 +1,97 @@
+package com.sequenceiq.it.cloudbreak.mock;
+
+import static com.sequenceiq.it.spark.ITResponse.AMBARI_API_ROOT;
+import static com.sequenceiq.it.spark.ITResponse.SALT_API_ROOT;
+
+import java.util.Map;
+
+import org.junit.Before;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Optional;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import com.sequenceiq.cloudbreak.cloud.model.CloudVmMetaDataStatus;
+import com.sequenceiq.it.IntegrationTestContext;
+import com.sequenceiq.it.cloudbreak.CloudbreakITContextConstants;
+
+public class MockKerberizedClusterCreationTest extends MockClusterCreationWithSaltSuccessTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MockKerberizedClusterCreationTest.class);
+
+    private static final String DEFAULT_KERBEROS_PASSWORD = "admin123!@#";
+
+    private static final String DEFAULT_KERBEROS_ADMIN = "admin";
+
+    private static final String DEFAULT_KERBEROS_PRINCIPAL = "/admin";
+
+    private String kerberosPassword;
+
+    private String kerberosAdmin;
+
+    @Before
+    public void setup() { }
+
+    @BeforeMethod
+    public void setContextParameters() {
+        IntegrationTestContext itContext = getItContext();
+        Assert.assertNotNull(itContext.getContextParam(CloudbreakITContextConstants.BLUEPRINT_ID), "Blueprint id is mandatory.");
+        Assert.assertNotNull(itContext.getContextParam(CloudbreakITContextConstants.STACK_ID), "Stack id is mandatory.");
+    }
+
+    @Test
+    @Parameters({"clusterName", "ambariPort", "ambariUser", "ambariPassword", "emailNeeded", "enableSecurity", "kerberosMasterKey", "kerberosAdmin",
+            "kerberosPassword", "runRecipesOnHosts", "checkAmbari", "mockPort"})
+    public void testClusterCreation(@Optional("it-cluster") String clusterName, @Optional("8080") String ambariPort, @Optional("admin") String ambariUser,
+            @Optional("admin123!@#") String ambariPassword, @Optional("false") boolean emailNeeded,
+            @Optional("true") boolean enableSecurity, @Optional(DEFAULT_KERBEROS_PASSWORD) String kerberosMasterKey,
+            @Optional(DEFAULT_KERBEROS_ADMIN) String kerberosAdmin, @Optional(DEFAULT_KERBEROS_PASSWORD) String kerberosPassword,
+            @Optional("") String runRecipesOnHosts, @Optional("true") boolean checkAmbari, @Optional("9443") int mockPort) throws Exception {
+
+        this.kerberosAdmin = kerberosAdmin;
+        this.kerberosPassword = kerberosPassword;
+
+        super.testClusterCreation(clusterName,
+                ambariPort,
+                ambariUser,
+                ambariPassword,
+                emailNeeded,
+                enableSecurity,
+                kerberosMasterKey,
+                kerberosAdmin,
+                kerberosPassword,
+                runRecipesOnHosts,
+                checkAmbari,
+                mockPort);
+    }
+
+    @Override
+    protected void customMappings(Map<String, CloudVmMetaDataStatus> instanceMap) {
+        LOGGER.info("Adding custom mappings for Kerberized cluster");
+        super.customMappings(instanceMap);
+    }
+
+    @Override
+    protected void customVerifiers(Map<String, CloudVmMetaDataStatus> instanceMap, Long clusterId, String clusterName) {
+        LOGGER.info("Adding custom verifiers for Kerberized cluster");
+        super.customVerifiers(instanceMap, clusterId, clusterName);
+
+        verify(SALT_API_ROOT + "/run", "POST")
+                .bodyContains("fun=grains.append")
+                .bodyContains("kerberos_server_master")
+                .exactTimes(1)
+                .verify();
+
+        String principalKV = String.format("\"principal\": \"%s%s\"", kerberosAdmin, DEFAULT_KERBEROS_PRINCIPAL);
+        String passwordKV = String.format("\"key\": \"%s\"", kerberosPassword);
+        verify(AMBARI_API_ROOT + "/clusters/" + clusterName, "POST")
+                .exactTimes(1)
+                .bodyContains("\"alias\": \"kdc.admin.credential\"")
+                .bodyContains(principalKV)
+                .bodyContains(passwordKV)
+                .verify();
+    }
+}

--- a/integration-test/src/main/resources/testsuites/mock/mock-kerberized-clustercreate-salt.yaml
+++ b/integration-test/src/main/resources/testsuites/mock/mock-kerberized-clustercreate-salt.yaml
@@ -1,0 +1,96 @@
+name: mock-kerberized-clustercreate-salt
+parameters: {
+  cloudProvider: MOCK,
+  blueprintName: "Data Science: Apache Spark 1.6, Apache Zeppelin 0.7.0"
+}
+
+tests:
+  - name: init
+    classes:
+      - com.sequenceiq.it.TestSuiteInitializer
+      - com.sequenceiq.it.cloudbreak.CloudbreakTestSuiteInitializer
+
+  - name: start ssh server on port 2020
+    parameters:
+      sshPort: 2020
+    classes:
+      - com.sequenceiq.it.cloudbreak.StartSshServerTest
+
+  - name: create mock credential
+    parameters:
+      credentialName: it-mock-krb-credential-salt
+      publicKeyFile: raw:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC3JiQtcQT48nn7Ax+yJLJqaWKRzczeJAda6x4JHFRqJW15pAmrSG7ld33V89yHeizAziLfhYYhw6uwN4aDKixS/XreQxZWyK2k/namyr8crFC83n6NNxlDa9DGujg61X8JoE2SyPHSVwhizfyoEmnkeyXJlsn6YtEnKfq23P4Di+p6I9xj7Ay52EzRHKMRMH8Q4kscKfp0taQKdOD2rCO1eOJ7vwCdMLjZc4H6TISk+lwnAJlDfbIdy6SO2jKIJvwoSjehfitWgGp8dGIEcV59GmO2aGlSwCqAwF6S9qP7O++5B5irFKc0TxuIplDSPL/yuCycWvz81FJKLTaUdJ6l
+    classes:
+      - com.sequenceiq.it.cloudbreak.mock.MockCredentialCreationTest
+
+  - name: create mock network
+    parameters:
+      networkName: it-mock-krb-network-salt
+      subnetCIDR: 10.0.36.0/24
+    classes:
+      - com.sequenceiq.it.cloudbreak.mock.MockNetworkCreationTest
+
+  - name: create mock security group
+    parameters:
+      name: it-mock-krb-security-group-salt
+      port: 22,443,8080,8500,50070,8088,8030,8050,19888,16010,60000,16020,16030,9083,10000,10001,9999,9997,21000,8443,15000,8744,11000,18080,8042,9996,9995,6080,3080,9200,3376,7070
+      provider: MOCK
+    classes:
+      - com.sequenceiq.it.cloudbreak.SecurityGroupCreationTest
+
+  - name: create master template
+    parameters:
+      mockName: it-mock-krb-smoke-gateway-salt
+      mockInstanceType: small
+      volumeType: ssd
+      volumeCount: 1
+      volumeSize: 10
+      templateAdditions: "master,1,GATEWAY"
+    classes:
+      - com.sequenceiq.it.cloudbreak.mock.MockTemplateCreationTest
+
+  - name: create worker template
+    parameters:
+      mockName: it-mock-krb-smoke-worker-salt
+      mockInstanceType: large
+      volumeType: ephemeral
+      volumeCount: 1
+      volumeSize: 40
+      templateAdditions: "worker,3"
+    classes:
+      - com.sequenceiq.it.cloudbreak.mock.MockTemplateCreationTest
+
+  - name: create compute template
+    parameters:
+      mockName: it-mock-krb-smoke-compute-salt
+      mockInstanceType: large
+      volumeType: magnetic
+      volumeCount: 3
+      volumeSize: 200
+      templateAdditions: "compute,5"
+    classes:
+      - com.sequenceiq.it.cloudbreak.mock.MockTemplateCreationTest
+
+  - name: create cluster
+    parameters: {
+      stackName: it-mock-krb-stack-salt,
+      region: europe,
+      threshold: 4,
+      availabilityZone: europe-b,
+      clusterName: it-mock-krb-cluster-salt,
+      checkAmbari: false,
+      mockPort: 9443,
+      orchestrator: SALT,
+      emailNeeded: true,
+      enableSecurity: true,
+      publicKeyFile: "raw:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0Rfl2G2vDs6yc19RxCqReunFgpYj+ucyLobpTCBtfDwzIbJot2Fmife6M42mBtiTmAK6x8kcUEeab6CB4MUzsqF7vGTFUjwWirG/XU5pYXFUBhi8xzey+KS9KVrQ+UuKJh/AN9iSQeMV+rgT1yF5+etVH+bK1/37QCKp3+mCqjFzPyQOrvkGZv4sYyRwX7BKBLleQmIVWpofpjT7BfcCxH877RzC5YMIi65aBc82Dl6tH6OEiP7mzByU52yvH6JFuwZ/9fWj1vXCWJzxx2w0F1OU8Zwg8gNNzL+SVb9+xfBE7xBHMpYFg72hBWPh862Ce36F4NZd3MpWMSjMmpDPh centos"
+    }
+    classes:
+      - com.sequenceiq.it.cloudbreak.mock.MockStackCreationWithSaltSuccessTest
+      - com.sequenceiq.it.cloudbreak.mock.MockKerberizedClusterCreationTest
+
+  - name: stop ssh server
+    parameters:
+      sshPort: 2020
+    classes:
+      - com.sequenceiq.it.cloudbreak.StopSshServerTest


### PR DESCRIPTION
@mhmxs the mock integration test has been extended with a new test run that tries to create a kerberized cluster and also validate:
 - kerberos role was assigned in the salt orchestration
 - Ambari cluster creation template contains the necessary kerberos related fields