### PR TITLE
CLOUD-92223 fix Ambari version checking logic and tests

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/ClusterCreationSetupService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/ClusterCreationSetupService.java
@@ -158,7 +158,7 @@ public class ClusterCreationSetupService {
     private void checkVDFFile(ClusterComponent ambariRepoConfig, ClusterComponent hdpRepoConfig, String stackName) throws IOException {
         AmbariRepo ambariRepo = ambariRepoConfig.getAttributes().get(AmbariRepo.class);
 
-        if (ambariRepositoryVersionService.isNewerOrEqualAmbariApi(AMBARI_VERSION_2_6_0_0, ambariRepo::getVersion)
+        if (ambariRepositoryVersionService.isVersionNewerOrEqualThanLimited(ambariRepo::getVersion, AMBARI_VERSION_2_6_0_0)
                 && !containsVDFUrl(hdpRepoConfig.getAttributes())) {
             throw new BadRequestException(String.format("Couldn't determine any VDF file for the stack: %s", stackName));
         }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariRepositoryVersionService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariRepositoryVersionService.java
@@ -57,7 +57,7 @@ public class AmbariRepositoryVersionService {
         StackRepoDetails stackRepoDetails = getStackRepoDetails(clusterId, orchestrator);
         AmbariRepo ambariRepoDetails = clusterComponentConfigProvider.getAmbariRepo(clusterId);
         String result = "";
-        if (stackRepoDetails != null && isNewerOrEqualAmbariApi(AMBARI_VERSION_2_6_0_0, ambariRepoDetails::getVersion)) {
+        if (stackRepoDetails != null && isVersionNewerOrEqualThanLimited(ambariRepoDetails::getVersion, AMBARI_VERSION_2_6_0_0)) {
             Optional<String> repositoryVersion = Optional.ofNullable(stackRepoDetails.getStack().get(StackRepoDetails.REPOSITORY_VERSION));
             result = repositoryVersion.orElse("");
         }
@@ -70,10 +70,10 @@ public class AmbariRepositoryVersionService {
             try {
                 LOGGER.info("Use specific Ambari repository: {}", stackRepoDetails);
                 AmbariRepo ambariRepoDetails = clusterComponentConfigProvider.getAmbariRepo(clusterId);
-                if (isNewerOrEqualAmbariApi(AMBARI_VERSION_2_6_0_0, ambariRepoDetails::getVersion)) {
-                    setRepositoryVersionOnApi(ambariClient, stackRepoDetails);
-                } else {
+                if (isVersionNewerOrEqualThanLimited(ambariRepoDetails::getVersion, AMBARI_VERSION_2_6_0_0)) {
                     addVersionDefinitionFileToAmbari(stackName, ambariClient, stackRepoDetails);
+                } else {
+                    setRepositoryVersionOnApi(ambariClient, stackRepoDetails);
                 }
             } catch (HttpResponseException e) {
                 String exceptionErrorMsg = AmbariClientExceptionUtil.getErrorMessage(e);
@@ -85,9 +85,9 @@ public class AmbariRepositoryVersionService {
         }
     }
 
-    public boolean isNewerOrEqualAmbariApi(Versioned newerVersion, Versioned currentVersion) {
+    public boolean isVersionNewerOrEqualThanLimited(Versioned currentVersion, Versioned limitedAPIVersion) {
         VersionComparator versionComparator = new VersionComparator();
-        return versionComparator.compare(newerVersion, currentVersion) > -1;
+        return versionComparator.compare(currentVersion, limitedAPIVersion) > -1;
     }
 
     private StackRepoDetails getStackRepoDetails(long clusterId, Orchestrator orchestrator) throws CloudbreakException {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariRepositoryVersionServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariRepositoryVersionServiceTest.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.service.cluster.flow;
 
+import static com.sequenceiq.cloudbreak.service.cluster.flow.AmbariRepositoryVersionService.AMBARI_VERSION_2_6_0_0;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,38 +16,55 @@ public class AmbariRepositoryVersionServiceTest {
 
     @Test
     public void testIsNewerOrEqualAmbariApi() {
-        boolean actual = underTest.isNewerOrEqualAmbariApi(() -> "2.6.0.0", () -> "2.6.0.0");
+        boolean actual = underTest.isVersionNewerOrEqualThanLimited(() -> "2.6.0.0", () -> "2.6.0.0");
         Assert.assertTrue(actual);
 
-        actual = underTest.isNewerOrEqualAmbariApi(() -> "2.6.0.0", () -> "2.5.0.0");
+        actual = underTest.isVersionNewerOrEqualThanLimited(() -> "2.6.0.0", () -> "2.5.0.0");
         Assert.assertTrue(actual);
 
-        actual = underTest.isNewerOrEqualAmbariApi(() -> "2.6.0.0", () -> "2.5.11.0");
+        actual = underTest.isVersionNewerOrEqualThanLimited(() -> "2.6.0.0", () -> "2.5.11.0");
         Assert.assertTrue(actual);
 
-        actual = underTest.isNewerOrEqualAmbariApi(() -> "2.6.0.0", () -> "2.5.11");
+        actual = underTest.isVersionNewerOrEqualThanLimited(() -> "2.6.0.0", () -> "2.5.11");
         Assert.assertTrue(actual);
 
-        actual = underTest.isNewerOrEqualAmbariApi(() -> "2.6.0", () -> "2.5.11.0");
+        actual = underTest.isVersionNewerOrEqualThanLimited(() -> "2.6.0", () -> "2.5.11.0");
         Assert.assertTrue(actual);
 
-        actual = underTest.isNewerOrEqualAmbariApi(() -> "2.6.0.0", () -> "3.0.0.0");
+        actual = underTest.isVersionNewerOrEqualThanLimited(() -> "2.6.0.0", () -> "3.0.0.0");
         Assert.assertFalse(actual);
 
-        actual = underTest.isNewerOrEqualAmbariApi(() -> "2.6.11.0", () -> "3.0.0.0");
+        actual = underTest.isVersionNewerOrEqualThanLimited(() -> "2.6.11.0", () -> "3.0.0.0");
         Assert.assertFalse(actual);
 
-        actual = underTest.isNewerOrEqualAmbariApi(() -> "2.6.0.0", () -> "3.12.0.0");
+        actual = underTest.isVersionNewerOrEqualThanLimited(() -> "2.6.0.0", () -> "3.12.0.0");
         Assert.assertFalse(actual);
 
-        actual = underTest.isNewerOrEqualAmbariApi(() -> "2.6.0.0", () -> "2.6.5.0");
+        actual = underTest.isVersionNewerOrEqualThanLimited(() -> "2.6.0.0", () -> "2.6.5.0");
         Assert.assertFalse(actual);
 
-        actual = underTest.isNewerOrEqualAmbariApi(() -> "2.6.0", () -> "2.6.5.0");
+        actual = underTest.isVersionNewerOrEqualThanLimited(() -> "2.6.0", () -> "2.6.5.0");
         Assert.assertFalse(actual);
 
-        actual = underTest.isNewerOrEqualAmbariApi(() -> "2.6.0.0", () -> "2.6.5");
+        actual = underTest.isVersionNewerOrEqualThanLimited(() -> "2.6.0.0", () -> "2.6.5");
         Assert.assertFalse(actual);
     }
 
+    @Test
+    public void testIsNewerOrEqualAmbariApiWhenCurrentVersionIsNewerThanLimitedApiVersion() {
+        boolean actual = underTest.isVersionNewerOrEqualThanLimited(() -> "2.7.0.0", AMBARI_VERSION_2_6_0_0);
+        Assert.assertTrue(actual);
+    }
+
+    @Test
+    public void testIsNewerOrEqualAmbariApiWhenCurrentVersionIsOlderThanLimitedApiVersion() {
+        boolean actual = underTest.isVersionNewerOrEqualThanLimited(() -> "2.5.0.0", AMBARI_VERSION_2_6_0_0);
+        Assert.assertFalse(actual);
+    }
+
+    @Test
+    public void testIsNewerOrEqualAmbariApiWhenCurrentVersionEqualsWithTheLimitedApiVersion() {
+        boolean actual = underTest.isVersionNewerOrEqualThanLimited(() -> "2.6.0.0", AMBARI_VERSION_2_6_0_0);
+        Assert.assertTrue(actual);
+    }
 }


### PR DESCRIPTION
Please take a look after it's become green!
Fix for wrong Ambari API version checking that has been committed by @topolyai5 and broke all of the e2e tests on QA.