### PR TITLE
EAR-7655 avoid automatic enabling of autoscale by recovery functionality

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ClusterCreationEvaluator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ClusterCreationEvaluator.java
@@ -2,7 +2,6 @@ package com.sequenceiq.periscope.monitor.evaluator;
 
 import static com.sequenceiq.periscope.api.model.ClusterState.PENDING;
 import static com.sequenceiq.periscope.api.model.ClusterState.RUNNING;
-import static com.sequenceiq.periscope.api.model.ClusterState.SUSPENDED;
 
 import java.util.Optional;
 
@@ -80,7 +79,7 @@ public class ClusterCreationEvaluator implements Runnable {
         if (clusterOptional.isPresent()) {
             cluster = clusterOptional.get();
             MDCBuilder.buildMdcContext(cluster);
-            if (PENDING.equals(cluster.getState()) || SUSPENDED.equals(cluster.getState())) {
+            if (PENDING.equals(cluster.getState())) {
                 ambariHealthCheck(cluster.getUser(), resolvedAmbari);
                 LOGGER.info("Update cluster and set it's state to 'RUNNING' for Ambari host: {}", resolvedAmbari.getAmbari().getHost());
                 cluster = clusterService.update(cluster.getId(), resolvedAmbari, false, RUNNING);

--- a/autoscale/src/main/java/com/sequenceiq/periscope/rest/controller/ClusterController.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/rest/controller/ClusterController.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import com.sequenceiq.periscope.api.endpoint.ClusterEndpoint;
 import com.sequenceiq.periscope.api.model.AmbariJson;
@@ -124,7 +125,9 @@ public class ClusterController implements ClusterEndpoint {
                     cluster = clusterService.update(clusterId, resolvedAmbari);
                 }
             }
-            createHistoryAndNotification(cluster);
+            if (!StringUtils.isEmpty(json.getClusterState()) || clusterId == null) {
+                createHistoryAndNotification(cluster);
+            }
             return createClusterJsonResponse(cluster);
         }
     }


### PR DESCRIPTION
PR is dedicated to avoid automatic switch on of autoscaling by recovery's poller mechanism and only create history entries when the cluster's status should be updated according to the request.