### PR TITLE
DPAAS-198 Investigate why cost tagging does not work

### DIFF
--- a/autoscale/build.gradle
+++ b/autoscale/build.gradle
@@ -1,3 +1,6 @@
+import com.github.zafarkhaja.semver.Version
+import org.ajoberstar.grgit.Grgit
+
 buildscript {
   repositories {
     mavenCentral()
@@ -99,8 +102,31 @@ class BuildInfoTask extends DefaultTask {
 
     @TaskAction
     def writeBuildInfo() {
+        File applicationDestination
+
+        // For Local-dev
+        if (buildVersion == "unspecified") {
+            def grgit = Grgit.open(project.file('./..'))
+            def tempBuildVersion = grgit.describe()
+            try {
+                Version v = Version.valueOf(tempBuildVersion)
+                Version.Builder builder = new Version.Builder()
+                builder.setNormalVersion(v.getNormalVersion())
+                builder.setPreReleaseVersion(v.getPreReleaseVersion().split('-')[0])
+                buildVersion = builder.build().toString()
+                project.logger.info("Determined version: " + buildVersion)
+
+            } catch (e) {
+                project.logger.error("Unable to parse git tag as version: " + buildVersion)
+                throw e
+            }
+            applicationDestination = new File("./out/production/resources")
+        } else {
+            applicationDestination = new File(applicationPropertiesPath + "/resources/main")
+        }
+
         destination.mkdirs()
-        File applicationDestination = new File(applicationPropertiesPath + "/resources/main")
+        String activeProfile = determineActiveProfile()
         applicationDestination.mkdirs()
         new File(destination, "build.info").withWriter { out ->
             [
@@ -111,8 +137,21 @@ class BuildInfoTask extends DefaultTask {
         new File(applicationDestination, "application.properties").withWriter { out ->
             [
                     "info.app.name=" + basename,
-                    "info.app.version=" + buildVersion
+                    "info.app.version=" + buildVersion,
+                    "spring.profiles.active=" + activeProfile
             ].each { out.println it }
         }
+    }
+
+    private String determineActiveProfile() {
+        String activeProfile = "dev"
+        if (buildVersion.contains("dev") || buildVersion.equals("unspecified")) {
+            activeProfile = "dev"
+        } else if (buildVersion.contains("rc")) {
+            activeProfile = "rc"
+        } else {
+            activeProfile = "prod"
+        }
+        return activeProfile
     }
 }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilder.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilder.java
@@ -20,6 +20,7 @@ import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
+import com.sequenceiq.cloudbreak.common.service.DefaultCostTaggingService;
 
 import freemarker.template.Configuration;
 import freemarker.template.Template;
@@ -29,6 +30,9 @@ import freemarker.template.TemplateException;
 public class CloudFormationTemplateBuilder {
     @Inject
     private Configuration freemarkerConfiguration;
+
+    @Inject
+    private DefaultCostTaggingService defaultCostTaggingService;
 
     public String build(ModelContext context) {
         Map<String, Object> model = new HashMap<>();
@@ -73,6 +77,7 @@ public class CloudFormationTemplateBuilder {
         model.put("dedicatedInstances", areDedicatedInstancesRequested(context.stack));
         model.put("availabilitySetNeeded", context.ac.getCloudContext().getLocation().getAvailabilityZone().value() != null);
         model.put("mapPublicIpOnLaunch", context.mapPublicIpOnLaunch);
+        model.putAll(defaultCostTaggingService.prepareAllTagsForTemplate());
         try {
             String template = processTemplateIntoString(new Template("aws-template", context.template, freemarkerConfiguration), model);
             return template.replaceAll("\\t|\\n| [\\s]+", "");

--- a/cloud-aws/src/main/resources/definitions/aws-zone-displaynames.json
+++ b/cloud-aws/src/main/resources/definitions/aws-zone-displaynames.json
@@ -17,6 +17,10 @@
       "displayName": "EU (Ireland)"
     },
     {
+      "name": "eu-west-3",
+      "displayName": "EU (Paris)"
+    },
+    {
       "name": "ap-northeast-2",
       "displayName": "Asia Pacific (Seoul)"
     },

--- a/cloud-aws/src/main/resources/templates/aws-cf-stack.ftl
+++ b/cloud-aws/src/main/resources/templates/aws-cf-stack.ftl
@@ -194,7 +194,8 @@
         </#if>
         "Tags" : [
           { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
-          { "Key" : "Network", "Value" : "Public" }
+          { "Key" : "Network", "Value" : "Public" },
+          { "Key" : "cb-resource-type", "Value" : "${network_resource}" }
         ]
       }
     },
@@ -217,7 +218,8 @@
         </#if>
         "Tags" : [
           { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
-          { "Key" : "Network", "Value" : "Public" }
+          { "Key" : "Network", "Value" : "Public" },
+          { "Key" : "cb-resource-type", "Value" : "${network_resource}" }
         ]
       }
     },
@@ -229,7 +231,8 @@
       "Properties" : {
         "Tags" : [
           { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
-          { "Key" : "Network", "Value" : "Public" }
+          { "Key" : "Network", "Value" : "Public" },
+          { "Key" : "cb-resource-type", "Value" : "${network_resource}" }
         ]
       }
     },
@@ -257,7 +260,8 @@
         </#if>
         "Tags" : [
           { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
-          { "Key" : "Network", "Value" : "Public" }
+          { "Key" : "Network", "Value" : "Public" },
+          { "Key" : "cb-resource-type", "Value" : "${network_resource}" }
         ]
       }
     },
@@ -312,6 +316,7 @@
         "DesiredCapacity" : ${group.instanceCount},
         "Tags" : [ { "Key" : "Name", "Value" : { "Fn::Join" : ["-", [ { "Ref" : "StackName" }, "${group.groupName}"]] }, "PropagateAtLaunch" : "true" },
         		   { "Key" : "owner", "Value" : { "Ref" : "StackOwner" }, "PropagateAtLaunch" : "true" },
+        		   { "Key" : "cb-resource-type", "Value" : "${instance_resource}", "PropagateAtLaunch" : "true" },
         		   { "Key" : "instanceGroup", "Value" : "${group.groupName}", "PropagateAtLaunch" : "true" }]
       }
     },
@@ -384,6 +389,7 @@
       "Type" : "AWS::EC2::SecurityGroup",
       "Properties" : {
         "GroupDescription" : "Allow access from web and bastion as well as outbound HTTP and HTTPS traffic",
+        "Tags" : [{ "Key" : "cb-resource-type", "Value" : "${securitygroup_resource}"}],
         <#if existingVPC>
         "VpcId" : { "Ref" : "VPCId" },
         <#else>

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilderTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilderTest.java
@@ -3,6 +3,8 @@ package com.sequenceiq.cloudbreak.cloud.aws;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -17,6 +19,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.ui.freemarker.FreeMarkerConfigurationFactoryBean;
 
@@ -43,6 +47,8 @@ import com.sequenceiq.cloudbreak.cloud.model.Security;
 import com.sequenceiq.cloudbreak.cloud.model.SecurityRule;
 import com.sequenceiq.cloudbreak.cloud.model.Subnet;
 import com.sequenceiq.cloudbreak.cloud.model.Volume;
+import com.sequenceiq.cloudbreak.common.service.DefaultCostTaggingService;
+import com.sequenceiq.cloudbreak.common.type.CloudbreakResourceType;
 
 import freemarker.template.Configuration;
 
@@ -51,6 +57,10 @@ public class CloudFormationTemplateBuilderTest {
 
     public static final String LATEST_AWS_CLOUD_FORMATION_TEMPLATE_PATH = "templates/aws-cf-stack.ftl";
 
+    @Mock
+    private DefaultCostTaggingService defaultCostTaggingService;
+
+    @InjectMocks
     private final CloudFormationTemplateBuilder cloudFormationTemplateBuilder = new CloudFormationTemplateBuilder();
 
     private CloudStack cloudStack;
@@ -66,6 +76,8 @@ public class CloudFormationTemplateBuilderTest {
     private String existingSubnetCidr;
 
     private String templatePath;
+
+    private Map<String, String> defaultTags = new HashMap<>();
 
     public CloudFormationTemplateBuilderTest(String templatePath) {
         this.templatePath = templatePath;
@@ -85,6 +97,7 @@ public class CloudFormationTemplateBuilderTest {
 
     @Before
     public void setUp() throws Exception {
+        initMocks(this);
         FreeMarkerConfigurationFactoryBean factoryBean = new FreeMarkerConfigurationFactoryBean();
         factoryBean.setPreferFileSystemAccess(false);
         factoryBean.setTemplateLoaderPath("classpath:/");
@@ -121,6 +134,14 @@ public class CloudFormationTemplateBuilderTest {
         parameters.put("attachedStorageOption", "attachedStorageOptionTest");
         Map<String, String> tags = new HashMap<>();
         tags.put("testtagkey", "testtagvalue");
+
+        defaultTags.put(CloudbreakResourceType.DISK.templateVariable(), CloudbreakResourceType.DISK.key());
+        defaultTags.put(CloudbreakResourceType.INSTANCE.templateVariable(), CloudbreakResourceType.INSTANCE.key());
+        defaultTags.put(CloudbreakResourceType.IP.templateVariable(), CloudbreakResourceType.IP.key());
+        defaultTags.put(CloudbreakResourceType.NETWORK.templateVariable(), CloudbreakResourceType.NETWORK.key());
+        defaultTags.put(CloudbreakResourceType.SECURITY.templateVariable(), CloudbreakResourceType.SECURITY.key());
+        defaultTags.put(CloudbreakResourceType.STORAGE.templateVariable(), CloudbreakResourceType.STORAGE.key());
+        defaultTags.put(CloudbreakResourceType.TEMPLATE.templateVariable(), CloudbreakResourceType.TEMPLATE.key());
         cloudStack = new CloudStack(groups, network, image, parameters, tags, null,
                 instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey());
     }
@@ -144,6 +165,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withEnableInstanceProfile(enableInstanceProfile)
                 .withInstanceProfileAvailable(instanceProfileAvailable)
                 .withTemplate(awsCloudFormationTemplate);
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
 
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
@@ -173,6 +195,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withEnableInstanceProfile(enableInstanceProfile)
                 .withInstanceProfileAvailable(instanceProfileAvailable)
                 .withTemplate(awsCloudFormationTemplate);
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
 
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
@@ -195,6 +218,7 @@ public class CloudFormationTemplateBuilderTest {
         boolean mapPublicIpOnLaunch = true;
         boolean enableInstanceProfile = false;
         boolean instanceProfileAvailable = true;
+
         //WHEN
         modelContext = new ModelContext()
                 .withAuthenticatedContext(authenticatedContext)
@@ -206,6 +230,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withEnableInstanceProfile(enableInstanceProfile)
                 .withInstanceProfileAvailable(instanceProfileAvailable)
                 .withTemplate(awsCloudFormationTemplate);
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
 
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
@@ -228,6 +253,7 @@ public class CloudFormationTemplateBuilderTest {
         boolean mapPublicIpOnLaunch = true;
         boolean enableInstanceProfile = true;
         boolean instanceProfileAvailable = false;
+
         //WHEN
         modelContext = new ModelContext()
                 .withAuthenticatedContext(authenticatedContext)
@@ -239,6 +265,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withEnableInstanceProfile(enableInstanceProfile)
                 .withInstanceProfileAvailable(instanceProfileAvailable)
                 .withTemplate(awsCloudFormationTemplate);
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
 
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
@@ -261,6 +288,7 @@ public class CloudFormationTemplateBuilderTest {
         boolean mapPublicIpOnLaunch = true;
         boolean enableInstanceProfile = false;
         boolean instanceProfileAvailable = false;
+
         //WHEN
         modelContext = new ModelContext()
                 .withAuthenticatedContext(authenticatedContext)
@@ -272,6 +300,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withEnableInstanceProfile(enableInstanceProfile)
                 .withInstanceProfileAvailable(instanceProfileAvailable)
                 .withTemplate(awsCloudFormationTemplate);
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
 
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
@@ -294,6 +323,7 @@ public class CloudFormationTemplateBuilderTest {
         boolean mapPublicIpOnLaunch = false;
         boolean enableInstanceProfile = true;
         boolean instanceProfileAvailable = true;
+
         //WHEN
         modelContext = new ModelContext()
                 .withAuthenticatedContext(authenticatedContext)
@@ -305,6 +335,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withEnableInstanceProfile(enableInstanceProfile)
                 .withInstanceProfileAvailable(instanceProfileAvailable)
                 .withTemplate(awsCloudFormationTemplate);
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
 
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
@@ -327,6 +358,7 @@ public class CloudFormationTemplateBuilderTest {
         boolean mapPublicIpOnLaunch = false;
         boolean enableInstanceProfile = false;
         boolean instanceProfileAvailable = true;
+
         //WHEN
         modelContext = new ModelContext()
                 .withAuthenticatedContext(authenticatedContext)
@@ -338,6 +370,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withEnableInstanceProfile(enableInstanceProfile)
                 .withInstanceProfileAvailable(instanceProfileAvailable)
                 .withTemplate(awsCloudFormationTemplate);
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
 
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
@@ -371,6 +404,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withEnableInstanceProfile(enableInstanceProfile)
                 .withInstanceProfileAvailable(instanceProfileAvailable)
                 .withTemplate(awsCloudFormationTemplate);
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
 
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
@@ -393,6 +427,7 @@ public class CloudFormationTemplateBuilderTest {
         boolean mapPublicIpOnLaunch = false;
         boolean enableInstanceProfile = false;
         boolean instanceProfileAvailable = false;
+
         //WHEN
         modelContext = new ModelContext()
                 .withAuthenticatedContext(authenticatedContext)
@@ -404,6 +439,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withEnableInstanceProfile(enableInstanceProfile)
                 .withInstanceProfileAvailable(instanceProfileAvailable)
                 .withTemplate(awsCloudFormationTemplate);
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
 
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
@@ -426,6 +462,7 @@ public class CloudFormationTemplateBuilderTest {
         boolean mapPublicIpOnLaunch = false;
         boolean enableInstanceProfile = true;
         boolean instanceProfileAvailable = true;
+
         //WHEN
         modelContext = new ModelContext()
                 .withAuthenticatedContext(authenticatedContext)
@@ -437,6 +474,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withEnableInstanceProfile(enableInstanceProfile)
                 .withInstanceProfileAvailable(instanceProfileAvailable)
                 .withTemplate(awsCloudFormationTemplate);
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
 
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
@@ -459,6 +497,7 @@ public class CloudFormationTemplateBuilderTest {
         boolean mapPublicIpOnLaunch = false;
         boolean enableInstanceProfile = false;
         boolean instanceProfileAvailable = true;
+
         //WHEN
         modelContext = new ModelContext()
                 .withAuthenticatedContext(authenticatedContext)
@@ -470,6 +509,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withEnableInstanceProfile(enableInstanceProfile)
                 .withInstanceProfileAvailable(instanceProfileAvailable)
                 .withTemplate(awsCloudFormationTemplate);
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
 
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
@@ -492,6 +532,7 @@ public class CloudFormationTemplateBuilderTest {
         boolean mapPublicIpOnLaunch = false;
         boolean enableInstanceProfile = true;
         boolean instanceProfileAvailable = false;
+
         //WHEN
         modelContext = new ModelContext()
                 .withAuthenticatedContext(authenticatedContext)
@@ -503,6 +544,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withEnableInstanceProfile(enableInstanceProfile)
                 .withInstanceProfileAvailable(instanceProfileAvailable)
                 .withTemplate(awsCloudFormationTemplate);
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
 
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
@@ -525,6 +567,7 @@ public class CloudFormationTemplateBuilderTest {
         boolean mapPublicIpOnLaunch = false;
         boolean enableInstanceProfile = false;
         boolean instanceProfileAvailable = false;
+
         //WHEN
         modelContext = new ModelContext()
                 .withAuthenticatedContext(authenticatedContext)
@@ -536,6 +579,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withEnableInstanceProfile(enableInstanceProfile)
                 .withInstanceProfileAvailable(instanceProfileAvailable)
                 .withTemplate(awsCloudFormationTemplate);
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
 
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
@@ -558,6 +602,7 @@ public class CloudFormationTemplateBuilderTest {
         boolean mapPublicIpOnLaunch = false;
         boolean enableInstanceProfile = true;
         boolean instanceProfileAvailable = true;
+
         //WHEN
         modelContext = new ModelContext()
                 .withAuthenticatedContext(authenticatedContext)
@@ -569,6 +614,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withEnableInstanceProfile(enableInstanceProfile)
                 .withInstanceProfileAvailable(instanceProfileAvailable)
                 .withTemplate(awsCloudFormationTemplate);
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
 
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
@@ -591,6 +637,7 @@ public class CloudFormationTemplateBuilderTest {
         boolean mapPublicIpOnLaunch = false;
         boolean enableInstanceProfile = true;
         boolean instanceProfileAvailable = false;
+
         //WHEN
         modelContext = new ModelContext()
                 .withAuthenticatedContext(authenticatedContext)
@@ -602,6 +649,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withEnableInstanceProfile(enableInstanceProfile)
                 .withInstanceProfileAvailable(instanceProfileAvailable)
                 .withTemplate(awsCloudFormationTemplate);
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
 
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
@@ -624,6 +672,7 @@ public class CloudFormationTemplateBuilderTest {
         boolean mapPublicIpOnLaunch = false;
         boolean enableInstanceProfile = false;
         boolean instanceProfileAvailable = true;
+
         //WHEN
         modelContext = new ModelContext()
                 .withAuthenticatedContext(authenticatedContext)
@@ -635,6 +684,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withEnableInstanceProfile(enableInstanceProfile)
                 .withInstanceProfileAvailable(instanceProfileAvailable)
                 .withTemplate(awsCloudFormationTemplate);
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
 
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
@@ -657,6 +707,8 @@ public class CloudFormationTemplateBuilderTest {
         boolean mapPublicIpOnLaunch = false;
         boolean enableInstanceProfile = false;
         boolean instanceProfileAvailable = false;
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
+
         //WHEN
         modelContext = new ModelContext()
                 .withAuthenticatedContext(authenticatedContext)
@@ -668,6 +720,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withEnableInstanceProfile(enableInstanceProfile)
                 .withInstanceProfileAvailable(instanceProfileAvailable)
                 .withTemplate(awsCloudFormationTemplate);
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
 
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStorage.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStorage.java
@@ -23,6 +23,7 @@ import com.sequenceiq.cloudbreak.cloud.azure.view.AzureCredentialView;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.common.service.DefaultCostTaggingService;
 //import com.sequenceiq.cloudbreak.cloud.scheduler.SyncPollingScheduler;
 
 @Service
@@ -42,6 +43,9 @@ public class AzureStorage {
 
     @Inject
     private AzureUtils armUtils;
+
+    @Inject
+    private DefaultCostTaggingService defaultCostTaggingService;
 
     public ArmAttachedStorageOption getArmAttachedStorageOption(Map<String, String> parameters) {
         String attachedStorageOption = parameters.get("attachedStorageOption");
@@ -88,7 +92,8 @@ public class AzureStorage {
             Map<String, String> tags)
             throws CloudException {
         if (!storageAccountExist(client, osStorageName)) {
-            client.createStorageAccount(storageGroup, osStorageName, region, SkuName.fromString(storageType.value()), encrypted, tags);
+            client.createStorageAccount(storageGroup, osStorageName, region, SkuName.fromString(storageType.value()), encrypted, tags,
+                    defaultCostTaggingService.prepareStorageTagging());
         }
     }
 

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilder.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilder.java
@@ -25,6 +25,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.cloud.model.Network;
+import com.sequenceiq.cloudbreak.common.service.DefaultCostTaggingService;
 
 import freemarker.template.Configuration;
 import freemarker.template.Template;
@@ -49,6 +50,9 @@ public class AzureTemplateBuilder {
 
     @Inject
     private AzureStorage azureStorage;
+
+    @Inject
+    private DefaultCostTaggingService defaultCostTaggingService;
 
     public String build(String stackName, String customImageId, AzureCredentialView armCredentialView, AzureStackView armStack, CloudContext cloudContext,
             CloudStack cloudStack) {
@@ -89,6 +93,7 @@ public class AzureTemplateBuilder {
             model.put("noPublicIp", azureUtils.isPrivateIp(network));
             model.put("noFirewallRules", azureUtils.isNoSecurityGroups(network));
             model.put("userDefinedTags", cloudStack.getTags());
+            model.putAll(defaultCostTaggingService.prepareAllTagsForTemplate());
             String generatedTemplate = processTemplateIntoString(getTemplate(cloudStack), model);
             LOGGER.debug("Generated Arm template: {}", generatedTemplate);
             return generatedTemplate;

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
@@ -7,6 +7,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -148,11 +149,16 @@ public class AzureClient {
         azure.resourceGroups().deleteByName(name);
     }
 
-    public ResourceGroup createResourceGroup(String name, String region, Map<String, String> tags) {
+    public ResourceGroup createResourceGroup(String name, String region, Map<String, String> tags, Map<String, String> costFollowerTags) {
+        Map<String, String> resultTags = new HashMap<>();
+        for (Map.Entry<String, String> entry : costFollowerTags.entrySet()) {
+            resultTags.put(entry.getKey(), entry.getValue());
+        }
+        resultTags.putAll(tags);
         return handleAuthException(() ->
                 azure.resourceGroups().define(name)
                 .withRegion(region)
-                .withTags(tags)
+                .withTags(resultTags)
                 .create()
         );
     }
@@ -210,13 +216,18 @@ public class AzureClient {
     }
 
     public StorageAccount createStorageAccount(String resourceGroup, String storageName, String storageLocation, SkuName accType, Boolean encryted,
-            Map<String, String> tags) {
+            Map<String, String> tags, Map<String, String> costFollowerTags) {
+        Map<String, String> resultTags = new HashMap<>();
+        for (Map.Entry<String, String> entry : costFollowerTags.entrySet()) {
+            resultTags.put(entry.getKey(), entry.getValue());
+        }
+        resultTags.putAll(tags);
         return handleAuthException(() -> {
             StorageAccount.DefinitionStages.WithCreate withCreate = azure.storageAccounts()
                     .define(storageName)
                     .withRegion(storageLocation)
                     .withExistingResourceGroup(resourceGroup)
-                    .withTags(tags)
+                    .withTags(resultTags)
                     .withSku(accType);
             if (encryted) {
                 withCreate.withEncryption();

--- a/cloud-azure/src/main/resources/templates/arm-v2.ftl
+++ b/cloud-azure/src/main/resources/templates/arm-v2.ftl
@@ -126,6 +126,7 @@
                  </#if>
                  <#if userDefinedTags?? && userDefinedTags?has_content>
                  "tags": {
+                      "cb-resource-type": "${network_resource}",
                       <#list userDefinedTags?keys as key>
                       "${key}": "${userDefinedTags[key]}"<#if (key_index + 1) != userDefinedTags?size>,</#if>
                       </#list>
@@ -160,6 +161,7 @@
                "location": "[parameters('region')]",
                <#if userDefinedTags?? && userDefinedTags?has_content>
                "tags": {
+                    "cb-resource-type": "${network_resource}",
                     <#list userDefinedTags?keys as key>
                     "${key}": "${userDefinedTags[key]}"<#if (key_index + 1) != userDefinedTags?size>,</#if>
                     </#list>
@@ -211,6 +213,7 @@
                    "location": "[parameters('region')]",
                    <#if userDefinedTags?? && userDefinedTags?has_content>
                    "tags": {
+                        "cb-resource-type": "${ipaddress_resource}",
                         <#list userDefinedTags?keys as key>
                         "${key}": "${userDefinedTags[key]}"<#if (key_index + 1) != userDefinedTags?size>,</#if>
                         </#list>
@@ -232,6 +235,7 @@
                    "location": "[parameters('region')]",
                    <#if userDefinedTags?? && userDefinedTags?has_content>
                    "tags": {
+                        "cb-resource-type": "${network_resource}",
                         <#list userDefinedTags?keys as key>
                         "${key}": "${userDefinedTags[key]}"<#if (key_index + 1) != userDefinedTags?size>,</#if>
                         </#list>
@@ -303,6 +307,7 @@
                    ],
                    <#if userDefinedTags?? && userDefinedTags?has_content>
                    "tags": {
+                        "cb-resource-type": "${instance_resource}",
                         <#list userDefinedTags?keys as key>
                         "${key}": "${userDefinedTags[key]}"<#if (key_index + 1) != userDefinedTags?size>,</#if>
                         </#list>

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilderTest.java
@@ -59,6 +59,8 @@ import com.sequenceiq.cloudbreak.cloud.model.Security;
 import com.sequenceiq.cloudbreak.cloud.model.SecurityRule;
 import com.sequenceiq.cloudbreak.cloud.model.Subnet;
 import com.sequenceiq.cloudbreak.cloud.model.Volume;
+import com.sequenceiq.cloudbreak.common.service.DefaultCostTaggingService;
+import com.sequenceiq.cloudbreak.common.type.CloudbreakResourceType;
 import com.sequenceiq.cloudbreak.util.Version;
 
 import freemarker.template.Configuration;
@@ -82,6 +84,9 @@ public class AzureTemplateBuilderTest {
 
     @Mock
     private Configuration freemarkerConfiguration;
+
+    @Mock
+    private DefaultCostTaggingService defaultCostTaggingService;
 
     @InjectMocks
     private final AzureTemplateBuilder azureTemplateBuilder = new AzureTemplateBuilder();
@@ -115,6 +120,8 @@ public class AzureTemplateBuilderTest {
     private final Map<String, String> tags = new HashMap<>();
 
     private String templatePath;
+
+    private Map<String, String> defaultTags = new HashMap<>();
 
     public AzureTemplateBuilderTest(String templatePath) {
         this.templatePath = templatePath;
@@ -168,6 +175,13 @@ public class AzureTemplateBuilderTest {
 
         azureSubnetStrategy = AzureSubnetStrategy.getAzureSubnetStrategy(FILL, Collections.singletonList("existingSubnet"),
                 ImmutableMap.of("existingSubnet", 100));
+        defaultTags.put(CloudbreakResourceType.DISK.templateVariable(), CloudbreakResourceType.DISK.key());
+        defaultTags.put(CloudbreakResourceType.INSTANCE.templateVariable(), CloudbreakResourceType.INSTANCE.key());
+        defaultTags.put(CloudbreakResourceType.IP.templateVariable(), CloudbreakResourceType.IP.key());
+        defaultTags.put(CloudbreakResourceType.NETWORK.templateVariable(), CloudbreakResourceType.NETWORK.key());
+        defaultTags.put(CloudbreakResourceType.SECURITY.templateVariable(), CloudbreakResourceType.SECURITY.key());
+        defaultTags.put(CloudbreakResourceType.STORAGE.templateVariable(), CloudbreakResourceType.STORAGE.key());
+        defaultTags.put(CloudbreakResourceType.TEMPLATE.templateVariable(), CloudbreakResourceType.TEMPLATE.key());
         reset(azureUtils);
     }
 
@@ -189,6 +203,7 @@ public class AzureTemplateBuilderTest {
                 instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey());
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy);
         //WHEN
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
         when(azureStorage.getImageStorageName(any(AzureCredentialView.class), any(CloudContext.class), Mockito.anyString(),
                 any(ArmAttachedStorageOption.class))).thenReturn("test");
         when(azureStorage.getDiskContainerName(any(CloudContext.class))).thenReturn("testStorageContainer");
@@ -220,6 +235,7 @@ public class AzureTemplateBuilderTest {
                 instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey());
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy);
         //WHEN
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
         when(azureStorage.getImageStorageName(any(AzureCredentialView.class), any(CloudContext.class), Mockito.anyString(),
                 any(ArmAttachedStorageOption.class))).thenReturn("test");
         when(azureStorage.getDiskContainerName(any(CloudContext.class))).thenReturn("testStorageContainer");
@@ -240,6 +256,8 @@ public class AzureTemplateBuilderTest {
         when(azureUtils.getCustomNetworkId(any())).thenReturn("existingNetworkName");
         when(azureUtils.getCustomResourceGroupName(any())).thenReturn("existingResourceGroup");
         when(azureUtils.getCustomSubnetIds(any())).thenReturn(Collections.singletonList("existingSubnet"));
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
+
         Network network = new Network(new Subnet("testSubnet"));
         when(azureUtils.isPrivateIp(any())).then(invocation -> true);
         when(azureUtils.isNoSecurityGroups(any())).then(invocation -> true);
@@ -271,6 +289,8 @@ public class AzureTemplateBuilderTest {
         Network network = new Network(new Subnet("testSubnet"));
         when(azureUtils.isPrivateIp(any())).then(invocation -> true);
         when(azureUtils.isNoSecurityGroups(any())).then(invocation -> false);
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
+
         Map<String, String> parameters = new HashMap<>();
         parameters.put("persistentStorage", "persistentStorageTest");
         parameters.put("attachedStorageOption", "attachedStorageOptionTest");
@@ -299,6 +319,8 @@ public class AzureTemplateBuilderTest {
         Network network = new Network(new Subnet("testSubnet"));
         when(azureUtils.isPrivateIp(any())).then(invocation -> false);
         when(azureUtils.isNoSecurityGroups(any())).then(invocation -> false);
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
+
         Map<String, String> parameters = new HashMap<>();
         parameters.put("persistentStorage", "persistentStorageTest");
         parameters.put("attachedStorageOption", "attachedStorageOptionTest");
@@ -341,6 +363,8 @@ public class AzureTemplateBuilderTest {
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy);
 
         //WHEN
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
+
         when(azureStorage.getImageStorageName(any(AzureCredentialView.class), any(CloudContext.class), Mockito.anyString(),
                 any(ArmAttachedStorageOption.class))).thenReturn("test");
         when(azureStorage.getDiskContainerName(any(CloudContext.class))).thenReturn("testStorageContainer");
@@ -366,6 +390,8 @@ public class AzureTemplateBuilderTest {
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy);
 
         //WHEN
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
+
         when(azureStorage.getImageStorageName(any(AzureCredentialView.class), any(CloudContext.class), Mockito.anyString(),
                 any(ArmAttachedStorageOption.class))).thenReturn("test");
         when(azureStorage.getDiskContainerName(any(CloudContext.class))).thenReturn("testStorageContainer");
@@ -391,6 +417,8 @@ public class AzureTemplateBuilderTest {
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy);
 
         //WHEN
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
+
         when(azureStorage.getImageStorageName(any(AzureCredentialView.class), any(CloudContext.class), Mockito.anyString(),
                 any(ArmAttachedStorageOption.class))).thenReturn("test");
         when(azureStorage.getDiskContainerName(any(CloudContext.class))).thenReturn("testStorageContainer");
@@ -416,6 +444,8 @@ public class AzureTemplateBuilderTest {
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy);
 
         //WHEN
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
+
         when(azureStorage.getImageStorageName(any(AzureCredentialView.class), any(CloudContext.class), Mockito.anyString(),
                 any(ArmAttachedStorageOption.class))).thenReturn("test");
         when(azureStorage.getDiskContainerName(any(CloudContext.class))).thenReturn("testStorageContainer");
@@ -443,6 +473,8 @@ public class AzureTemplateBuilderTest {
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy);
 
         //WHEN
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
+
         when(azureStorage.getImageStorageName(any(AzureCredentialView.class), any(CloudContext.class), Mockito.anyString(),
                 any(ArmAttachedStorageOption.class))).thenReturn("test");
         when(azureStorage.getDiskContainerName(any(CloudContext.class))).thenReturn("testStorageContainer");
@@ -471,6 +503,8 @@ public class AzureTemplateBuilderTest {
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy);
 
         //WHEN
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
+
         when(azureStorage.getImageStorageName(any(AzureCredentialView.class), any(CloudContext.class), Mockito.anyString(),
                 any(ArmAttachedStorageOption.class))).thenReturn("test");
         when(azureStorage.getDiskContainerName(any(CloudContext.class))).thenReturn("testStorageContainer");
@@ -502,6 +536,8 @@ public class AzureTemplateBuilderTest {
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy);
 
         //WHEN
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
+
         when(azureStorage.getImageStorageName(any(AzureCredentialView.class), any(CloudContext.class), Mockito.anyString(),
                 any(ArmAttachedStorageOption.class))).thenReturn("test");
         when(azureStorage.getDiskContainerName(any(CloudContext.class))).thenReturn("testStorageContainer");
@@ -531,6 +567,8 @@ public class AzureTemplateBuilderTest {
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy);
 
         //WHEN
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
+
         when(azureStorage.getImageStorageName(any(AzureCredentialView.class), any(CloudContext.class), Mockito.anyString(),
                 any(ArmAttachedStorageOption.class))).thenReturn("test");
         when(azureStorage.getDiskContainerName(any(CloudContext.class))).thenReturn("testStorageContainer");
@@ -558,6 +596,8 @@ public class AzureTemplateBuilderTest {
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy);
 
         //WHEN
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
+
         when(azureStorage.getImageStorageName(any(AzureCredentialView.class), any(CloudContext.class), Mockito.anyString(),
                 any(ArmAttachedStorageOption.class))).thenReturn("test");
         when(azureStorage.getDiskContainerName(any(CloudContext.class))).thenReturn("testStorageContainer");
@@ -585,6 +625,8 @@ public class AzureTemplateBuilderTest {
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy);
 
         //WHEN
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
+
         when(azureStorage.getImageStorageName(any(AzureCredentialView.class), any(CloudContext.class), Mockito.anyString(),
                 any(ArmAttachedStorageOption.class))).thenReturn("test");
         when(azureStorage.getDiskContainerName(any(CloudContext.class))).thenReturn("testStorageContainer");
@@ -612,6 +654,8 @@ public class AzureTemplateBuilderTest {
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy);
 
         //WHEN
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
+
         when(azureStorage.getImageStorageName(any(AzureCredentialView.class), any(CloudContext.class), Mockito.anyString(),
                 any(ArmAttachedStorageOption.class))).thenReturn("test");
         when(azureStorage.getDiskContainerName(any(CloudContext.class))).thenReturn("testStorageContainer");
@@ -641,6 +685,8 @@ public class AzureTemplateBuilderTest {
         azureStackView = new AzureStackView("mystack", 3, groups, azureStorageView, azureSubnetStrategy);
 
         //WHEN
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
+
         when(azureStorage.getImageStorageName(any(AzureCredentialView.class), any(CloudContext.class), Mockito.anyString(),
                 any(ArmAttachedStorageOption.class))).thenReturn("test");
         when(azureStorage.getDiskContainerName(any(CloudContext.class))).thenReturn("testStorageContainer");

--- a/cloud-common/build.gradle
+++ b/cloud-common/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     compile group: 'org.jasypt',                            name: 'jasypt-hibernate4',              version: jasyptVersion
     testCompile group: 'junit',                             name: 'junit',                          version: junitVersion
     testCompile group: 'org.mockito',                       name: 'mockito-all',                    version: mockitoAllVersion
+    testCompile group: 'org.springframework.boot',          name:'spring-boot-starter-test',        version:springBootVersion
+
 }
 
 task testJar(type: Jar, dependsOn: testClasses) {

--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/common/service/DefaultCostTaggingService.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/common/service/DefaultCostTaggingService.java
@@ -1,0 +1,91 @@
+package com.sequenceiq.cloudbreak.common.service;
+
+import static com.sequenceiq.cloudbreak.common.type.CloudbreakResourceType.DISK;
+import static com.sequenceiq.cloudbreak.common.type.CloudbreakResourceType.INSTANCE;
+import static com.sequenceiq.cloudbreak.common.type.CloudbreakResourceType.IP;
+import static com.sequenceiq.cloudbreak.common.type.CloudbreakResourceType.NETWORK;
+import static com.sequenceiq.cloudbreak.common.type.CloudbreakResourceType.SECURITY;
+import static com.sequenceiq.cloudbreak.common.type.CloudbreakResourceType.STORAGE;
+import static com.sequenceiq.cloudbreak.common.type.CloudbreakResourceType.TEMPLATE;
+import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CB_ACOUNT_NAME;
+import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CB_USER_NAME;
+import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CB_VERSION;
+import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.OWNER;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.google.common.base.Strings;
+import com.sequenceiq.cloudbreak.common.type.CloudConstants;
+import com.sequenceiq.cloudbreak.common.type.CloudbreakResourceType;
+import com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag;
+
+@Service
+public class DefaultCostTaggingService {
+
+    @Value("${info.app.version:}")
+    private String cbVersion;
+
+    public Map<String, String> prepareInstanceTagging() {
+        return prepareResourceTag(INSTANCE);
+    }
+
+    public Map<String, String> prepareNetworkTagging() {
+        return prepareResourceTag(NETWORK);
+    }
+
+    public Map<String, String> prepareTemplateTagging() {
+        return prepareResourceTag(TEMPLATE);
+    }
+
+    public Map<String, String> prepareSecurityTagging() {
+        return prepareResourceTag(SECURITY);
+    }
+
+    public Map<String, String> prepareIpTagging() {
+        return prepareResourceTag(IP);
+    }
+
+    public Map<String, String> prepareDiskTagging() {
+        return prepareResourceTag(DISK);
+    }
+
+    public Map<String, String> prepareStorageTagging() {
+        return prepareResourceTag(STORAGE);
+    }
+
+    public Map<String, String> prepareAllTagsForTemplate() {
+        Map<String, String> result = new HashMap<>();
+        for (CloudbreakResourceType cloudbreakResourceType : CloudbreakResourceType.values()) {
+            result.put(cloudbreakResourceType.templateVariable(), cloudbreakResourceType.key());
+        }
+        return result;
+    }
+
+    public Map<String, String> prepareDefaultTags(String account, String owner, Map<String, String> sourceMap, String platform) {
+        Map<String, String> result = new HashMap<>();
+        result.put(transform(CB_ACOUNT_NAME.key(), platform), transform(account, platform));
+        result.put(transform(CB_USER_NAME.key(), platform), transform(owner, platform));
+        result.put(transform(CB_VERSION.key(), platform), transform(cbVersion, platform));
+        if (sourceMap == null || Strings.isNullOrEmpty(sourceMap.get(transform(OWNER.key(), platform)))) {
+            result.put(transform(OWNER.key(), platform), transform(owner, platform));
+        }
+        return result;
+    }
+
+    private String transform(String value, String platform) {
+        String valueAfterCheck =  Strings.isNullOrEmpty(value) ? "unknown" : value;
+        return CloudConstants.GCP.equals(platform)
+                ? valueAfterCheck.split("@")[0].toLowerCase().replaceAll("[^\\w]", "-") : valueAfterCheck;
+    }
+
+    private Map<String, String> prepareResourceTag(CloudbreakResourceType cloudbreakResourceType) {
+        Map<String, String> result = new HashMap<>();
+        result.put(DefaultApplicationTag.CB_RESOURCE_TYPE.key(), cloudbreakResourceType.key());
+        return result;
+    }
+
+}

--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/common/type/CloudbreakResourceType.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/common/type/CloudbreakResourceType.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.cloudbreak.common.type;
+
+public enum CloudbreakResourceType {
+
+    NETWORK("network_resource", "network"),
+    TEMPLATE("template_resource", "template"),
+    INSTANCE("instance_resource", "instance"),
+    SECURITY("securitygroup_resource", "securitygroup"),
+    IP("ipaddress_resource", "ipaddress"),
+    DISK("disk_resource", "disk"),
+    STORAGE("storage_resource", "storage");
+
+    private final String key;
+    private final String templateVariable;
+
+    CloudbreakResourceType(String templateVariable, String key) {
+        this.key = key;
+        this.templateVariable = templateVariable;
+    }
+
+    public String key() {
+        return key;
+    }
+
+    public String templateVariable() {
+        return templateVariable;
+    }
+
+}

--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/common/type/DefaultApplicationTag.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/common/type/DefaultApplicationTag.java
@@ -1,0 +1,20 @@
+package com.sequenceiq.cloudbreak.common.type;
+
+public enum DefaultApplicationTag {
+
+    OWNER("Owner"),
+    CB_USER_NAME("cb-user-name"),
+    CB_VERSION("cb-version"),
+    CB_ACOUNT_NAME("cb-account-name"),
+    CB_RESOURCE_TYPE("cb-resource-type");
+
+    private final String key;
+
+    DefaultApplicationTag(String key) {
+        this.key = key;
+    }
+
+    public String key() {
+        return key;
+    }
+}

--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/common/type/ResourceType.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/common/type/ResourceType.java
@@ -32,6 +32,7 @@ public enum ResourceType {
 
     //AZURE
     AZURE_NETWORK,
+    AZURE_STORAGE,
     AZURE_SUBNET,
 
     // ARM

--- a/cloud-common/src/test/java/com/sequenceiq/cloudbreak/common/service/DefaultCostTaggingServiceTest.java
+++ b/cloud-common/src/test/java/com/sequenceiq/cloudbreak/common/service/DefaultCostTaggingServiceTest.java
@@ -1,0 +1,116 @@
+package com.sequenceiq.cloudbreak.common.service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.sequenceiq.cloudbreak.common.type.CloudConstants;
+import com.sequenceiq.cloudbreak.common.type.CloudbreakResourceType;
+import com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultCostTaggingServiceTest {
+
+    @InjectMocks
+    private DefaultCostTaggingService underTest;
+
+    @Before
+    public void before() {
+        ReflectionTestUtils.setField(underTest, "cbVersion", "2.2.0");
+    }
+
+    @Test
+    public void testPrepareAllTagsForTemplateShouldReturnAllResourceMap() {
+        Map<String, String> result = underTest.prepareAllTagsForTemplate();
+        Assert.assertEquals(7, result.size());
+    }
+
+    @Test
+    public void testPrepareDefaultTagsForAWSShouldReturnAllDefaultMap() {
+        Map<String, String> result = underTest.prepareDefaultTags("Apache", "apache1@apache.com", new HashMap<>(), CloudConstants.AWS);
+        Assert.assertEquals(4, result.size());
+        Assert.assertEquals("Apache", result.get(DefaultApplicationTag.CB_ACOUNT_NAME.key()));
+        Assert.assertEquals("apache1@apache.com", result.get(DefaultApplicationTag.CB_USER_NAME.key()));
+        Assert.assertEquals("2.2.0", result.get(DefaultApplicationTag.CB_VERSION.key()));
+        Assert.assertEquals("apache1@apache.com", result.get(DefaultApplicationTag.OWNER.key()));
+    }
+
+    @Test
+    public void testPrepareDefaultTagsForGCPShouldReturnAllDefaultMap() {
+        Map<String, String> result = underTest.prepareDefaultTags("Apache", "apache1@apache.com", new HashMap<>(), CloudConstants.GCP);
+        Assert.assertEquals(4, result.size());
+        Assert.assertEquals("apache", result.get(DefaultApplicationTag.CB_ACOUNT_NAME.key()));
+        Assert.assertEquals("apache1", result.get(DefaultApplicationTag.CB_USER_NAME.key()));
+        Assert.assertEquals("2-2-0", result.get(DefaultApplicationTag.CB_VERSION.key()));
+        Assert.assertEquals("apache1", result.get(DefaultApplicationTag.OWNER.key().toLowerCase()));
+    }
+
+    @Test
+    public void testPrepareDefaultTagsForAZUREWhenOwnerPresentedShouldReturnAllDefaultMap() {
+        Map<String, String> sourceMap = new HashMap<>();
+        sourceMap.put(DefaultApplicationTag.OWNER.key(), "appletree");
+        Map<String, String> result = underTest.prepareDefaultTags("Apache", "apache1@apache.com", sourceMap, CloudConstants.AZURE);
+        Assert.assertEquals(3, result.size());
+        Assert.assertEquals("Apache", result.get(DefaultApplicationTag.CB_ACOUNT_NAME.key()));
+        Assert.assertEquals("apache1@apache.com", result.get(DefaultApplicationTag.CB_USER_NAME.key()));
+        Assert.assertEquals("2.2.0", result.get(DefaultApplicationTag.CB_VERSION.key()));
+        Assert.assertNull(result.get(DefaultApplicationTag.OWNER.key()));
+    }
+
+    @Test
+    public void testPrepareInstanceTaggingShouldReturnAMapWithSingleEntry() {
+        Map<String, String> result = underTest.prepareInstanceTagging();
+        Assert.assertEquals(1, result.size());
+        Assert.assertEquals(result.get(DefaultApplicationTag.CB_RESOURCE_TYPE.key()), CloudbreakResourceType.INSTANCE.key());
+    }
+
+    @Test
+    public void testPrepareTemplateTaggingShouldReturnAMapWithSingleEntry() {
+        Map<String, String> result = underTest.prepareTemplateTagging();
+        Assert.assertEquals(1, result.size());
+        Assert.assertEquals(result.get(DefaultApplicationTag.CB_RESOURCE_TYPE.key()), CloudbreakResourceType.TEMPLATE.key());
+    }
+
+    @Test
+    public void testPrepareStorageTaggingShouldReturnAMapWithSingleEntry() {
+        Map<String, String> result = underTest.prepareStorageTagging();
+        Assert.assertEquals(1, result.size());
+        Assert.assertEquals(result.get(DefaultApplicationTag.CB_RESOURCE_TYPE.key()), CloudbreakResourceType.STORAGE.key());
+    }
+
+    @Test
+    public void testPrepareDiskTaggingShouldReturnAMapWithSingleEntry() {
+        Map<String, String> result = underTest.prepareDiskTagging();
+        Assert.assertEquals(1, result.size());
+        Assert.assertEquals(result.get(DefaultApplicationTag.CB_RESOURCE_TYPE.key()), CloudbreakResourceType.DISK.key());
+    }
+
+    @Test
+    public void testPrepareIpTaggingShouldReturnAMapWithSingleEntry() {
+        Map<String, String> result = underTest.prepareIpTagging();
+        Assert.assertEquals(1, result.size());
+        Assert.assertEquals(result.get(DefaultApplicationTag.CB_RESOURCE_TYPE.key()), CloudbreakResourceType.IP.key());
+    }
+
+    @Test
+    public void testPrepareNetworkTaggingShouldReturnAMapWithSingleEntry() {
+        Map<String, String> result = underTest.prepareNetworkTagging();
+        Assert.assertEquals(1, result.size());
+        Assert.assertEquals(result.get(DefaultApplicationTag.CB_RESOURCE_TYPE.key()), CloudbreakResourceType.NETWORK.key());
+    }
+
+    @Test
+    public void testPrepareSecurityTaggingShouldReturnAMapWithSingleEntry() {
+        Map<String, String> result = underTest.prepareSecurityTagging();
+        Assert.assertEquals(1, result.size());
+        Assert.assertEquals(result.get(DefaultApplicationTag.CB_RESOURCE_TYPE.key()), CloudbreakResourceType.SECURITY.key());
+    }
+
+}

--- a/cloud-gcp/build.gradle
+++ b/cloud-gcp/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     compile group: 'org.apache.commons',            name: 'commons-lang3',                  version: apacheCommonsLangVersion
     compile group: 'commons-io',                    name: 'commons-io',                     version: '2.4'
     compile group: 'commons-codec',                 name: 'commons-codec',                  version: '1.10'
-    compile group: 'com.google.apis',               name: 'google-api-services-compute',    version: 'v1-rev133-1.22.0'
+    compile group: 'com.google.apis',               name: 'google-api-services-compute',    version: 'beta-rev76-1.23.0'
     compile group: 'com.google.apis',               name: 'google-api-services-storage',    version: 'v1-rev94-1.22.0'
     compile group: 'com.google.apis',               name: 'google-api-services-dns',        version: 'v2beta1-rev14-1.22.0'
 

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpReservedIpResourceBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpReservedIpResourceBuilder.java
@@ -1,8 +1,11 @@
 package com.sequenceiq.cloudbreak.cloud.gcp.compute;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,11 +23,15 @@ import com.sequenceiq.cloudbreak.cloud.gcp.context.GcpContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
+import com.sequenceiq.cloudbreak.common.service.DefaultCostTaggingService;
 import com.sequenceiq.cloudbreak.common.type.ResourceType;
 
 @Service
 public class GcpReservedIpResourceBuilder extends AbstractGcpComputeBuilder {
     private static final Logger LOGGER = LoggerFactory.getLogger(GcpReservedIpResourceBuilder.class);
+
+    @Inject
+    private DefaultCostTaggingService defaultCostTaggingService;
 
     @Override
     public List<CloudResource> create(GcpContext context, long privateId, AuthenticatedContext auth, Group group, Image image) {
@@ -50,6 +57,10 @@ public class GcpReservedIpResourceBuilder extends AbstractGcpComputeBuilder {
             Address address = new Address();
             address.setName(resource.getName());
 
+            Map<String, String> customTags = new HashMap<>();
+            customTags.putAll(tags);
+            customTags.putAll(defaultCostTaggingService.prepareIpTagging());
+            address.setLabels(customTags);
             Insert networkInsert = context.getCompute().addresses().insert(projectId, region, address);
             try {
                 Operation operation = networkInsert.execute();

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/conf/GcpConfig.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/conf/GcpConfig.java
@@ -21,7 +21,7 @@ public class GcpConfig {
     @Value("${cb.gcp.tag.value.length:63}")
     private Integer valueLength;
 
-    @Value("${cb.gcp.tag.value.validator:^([a-z]+)([a-z\\d-]+)$}")
+    @Value("${cb.gcp.tag.value.validator:^([a-z0-9]+)([a-z\\d-]+)$}")
     private String valueValidator;
 
     @Bean(name = "GcpTagSpecification")

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/network/GcpFirewallInternalResourceBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/network/GcpFirewallInternalResourceBuilder.java
@@ -74,7 +74,6 @@ public class GcpFirewallInternalResourceBuilder extends AbstractGcpNetworkBuilde
         }
         firewall.setNetwork(String.format("https://www.googleapis.com/compute/v1/projects/%s/global/networks/%s", projectId,
                 context.getParameter(GcpNetworkResourceBuilder.NETWORK_NAME, String.class)));
-
         Insert firewallInsert = context.getCompute().firewalls().insert(projectId, firewall);
         try {
             Operation operation = firewallInsert.execute();

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilderTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilderTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -50,6 +51,7 @@ import com.sequenceiq.cloudbreak.cloud.model.Region;
 import com.sequenceiq.cloudbreak.cloud.model.Security;
 import com.sequenceiq.cloudbreak.cloud.model.SecurityRule;
 import com.sequenceiq.cloudbreak.cloud.model.Volume;
+import com.sequenceiq.cloudbreak.common.service.DefaultCostTaggingService;
 import com.sequenceiq.cloudbreak.common.type.ResourceType;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -83,6 +85,9 @@ public class GcpInstanceResourceBuilderTest {
 
     @Mock
     private Insert insert;
+
+    @Mock
+    private DefaultCostTaggingService defaultCostTaggingService;
 
     @Captor
     private ArgumentCaptor<Instance> instanceArg;
@@ -131,6 +136,7 @@ public class GcpInstanceResourceBuilderTest {
         when(instances.insert(anyString(), anyString(), instanceArg.capture())).thenReturn(insert);
         when(insert.setPrettyPrint(anyBoolean())).thenReturn(insert);
         when(insert.execute()).thenReturn(operation);
+        when(defaultCostTaggingService.prepareInstanceTagging()).thenReturn(new HashMap<>());
 
         builder.build(context, privateId, authenticatedContext, group, image, buildableResources, Collections.emptyMap());
 
@@ -152,6 +158,7 @@ public class GcpInstanceResourceBuilderTest {
         when(instances.insert(anyString(), anyString(), instanceArg.capture())).thenReturn(insert);
         when(insert.setPrettyPrint(anyBoolean())).thenReturn(insert);
         when(insert.execute()).thenReturn(operation);
+        when(defaultCostTaggingService.prepareInstanceTagging()).thenReturn(new HashMap<>());
 
         builder.build(context, privateId, authenticatedContext, group, image, buildableResources, Collections.emptyMap());
 
@@ -173,6 +180,7 @@ public class GcpInstanceResourceBuilderTest {
         when(instances.insert(anyString(), anyString(), instanceArg.capture())).thenReturn(insert);
         when(insert.setPrettyPrint(anyBoolean())).thenReturn(insert);
         when(insert.execute()).thenReturn(operation);
+        when(defaultCostTaggingService.prepareInstanceTagging()).thenReturn(new HashMap<>());
 
         builder.build(context, privateId, authenticatedContext, group, image, buildableResources, Collections.emptyMap());
 

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/heat/HeatTemplateBuilder.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/heat/HeatTemplateBuilder.java
@@ -29,6 +29,7 @@ import com.sequenceiq.cloudbreak.cloud.openstack.view.KeystoneCredentialView;
 import com.sequenceiq.cloudbreak.cloud.openstack.view.NeutronNetworkView;
 import com.sequenceiq.cloudbreak.cloud.openstack.view.NovaInstanceView;
 import com.sequenceiq.cloudbreak.cloud.openstack.view.OpenStackGroupView;
+import com.sequenceiq.cloudbreak.common.service.DefaultCostTaggingService;
 
 import freemarker.template.Configuration;
 import freemarker.template.Template;
@@ -48,6 +49,9 @@ public class HeatTemplateBuilder {
     @Inject
     private Configuration freemarkerConfiguration;
 
+    @Inject
+    private DefaultCostTaggingService defaultCostTaggingService;
+
     public String build(ModelContext modelContext) {
         try {
             List<NovaInstanceView> novaInstances = new OpenStackGroupView(modelContext.stackName, modelContext.groups, modelContext.tags).getFlatNovaView();
@@ -60,6 +64,7 @@ public class HeatTemplateBuilder {
             model.put("existingNetwork", modelContext.existingNetwork);
             model.put("existingSubnet", modelContext.existingSubnet);
             model.put("network", modelContext.neutronNetworkView);
+            model.putAll(defaultCostTaggingService.prepareAllTagsForTemplate());
             AvailabilityZone az = modelContext.location.getAvailabilityZone();
             if (az != null && az.value() != null) {
                 model.put("availability_zone", az.value());

--- a/cloud-openstack/src/test/java/com/sequenceiq/cloudbreak/cloud/openstack/heat/HeatTemplateBuilderTest.java
+++ b/cloud-openstack/src/test/java/com/sequenceiq/cloudbreak/cloud/openstack/heat/HeatTemplateBuilderTest.java
@@ -49,6 +49,8 @@ import com.sequenceiq.cloudbreak.cloud.model.Volume;
 import com.sequenceiq.cloudbreak.cloud.openstack.common.OpenStackUtils;
 import com.sequenceiq.cloudbreak.cloud.openstack.heat.HeatTemplateBuilder.ModelContext;
 import com.sequenceiq.cloudbreak.cloud.openstack.view.NeutronNetworkView;
+import com.sequenceiq.cloudbreak.common.service.DefaultCostTaggingService;
+import com.sequenceiq.cloudbreak.common.type.CloudbreakResourceType;
 
 import freemarker.template.Configuration;
 import freemarker.template.TemplateException;
@@ -61,6 +63,9 @@ public class HeatTemplateBuilderTest {
 
     @Mock
     private OpenStackUtils openStackUtil;
+
+    @Mock
+    private DefaultCostTaggingService defaultCostTaggingService;
 
     @InjectMocks
     private final HeatTemplateBuilder heatTemplateBuilder = new HeatTemplateBuilder();
@@ -117,6 +122,15 @@ public class HeatTemplateBuilderTest {
                 InstanceGroupType.CORE, "CORE",
                 InstanceGroupType.GATEWAY, "GATEWAY"
         );
+        Map<String, String> tags = new HashMap<>();
+        tags.put(CloudbreakResourceType.DISK.templateVariable(), CloudbreakResourceType.DISK.key());
+        tags.put(CloudbreakResourceType.INSTANCE.templateVariable(), CloudbreakResourceType.INSTANCE.key());
+        tags.put(CloudbreakResourceType.IP.templateVariable(), CloudbreakResourceType.IP.key());
+        tags.put(CloudbreakResourceType.NETWORK.templateVariable(), CloudbreakResourceType.NETWORK.key());
+        tags.put(CloudbreakResourceType.SECURITY.templateVariable(), CloudbreakResourceType.SECURITY.key());
+        tags.put(CloudbreakResourceType.STORAGE.templateVariable(), CloudbreakResourceType.STORAGE.key());
+        tags.put(CloudbreakResourceType.TEMPLATE.templateVariable(), CloudbreakResourceType.TEMPLATE.key());
+        when(defaultCostTaggingService.prepareInstanceTagging()).thenReturn(tags);
         image = new Image("cb-centos66-amb200-2015-05-25", userData, "redhat6", "url", "default", null);
     }
 

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v1/CredentialEndpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v1/CredentialEndpoint.java
@@ -112,10 +112,4 @@ public interface CredentialEndpoint {
             nickname = "publicInteractiveLoginCredential")
     Map<String, String> publicInteractiveLogin(@Valid CredentialRequest credentialRequest);
 
-    @GET
-    @Path("{name}/request")
-    @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = CredentialOpDescription.GET_BY_CREDENTIAL_NAME, produces = ContentType.JSON, notes = Notes.CREDENTIAL_NOTES,
-            nickname = "getCredentialRequestFromName")
-    CredentialRequest getRequestfromName(@PathParam("name") String name);
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/StackRequest.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/StackRequest.java
@@ -59,6 +59,9 @@ public class StackRequest extends StackBase {
     @ApiModelProperty(hidden = true)
     private String account;
 
+    @ApiModelProperty(hidden = true)
+    private String ownerEmail;
+
     public FailurePolicyRequest getFailurePolicy() {
         return failurePolicy;
     }
@@ -169,5 +172,13 @@ public class StackRequest extends StackBase {
 
     public void setCredentialName(String credentialName) {
         this.credentialName = credentialName;
+    }
+
+    public String getOwnerEmail() {
+        return ownerEmail;
+    }
+
+    public void setOwnerEmail(String ownerEmail) {
+        this.ownerEmail = ownerEmail;
     }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/v2/StackV2Request.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/v2/StackV2Request.java
@@ -115,6 +115,9 @@ public class StackV2Request implements JsonEntity {
     @ApiModelProperty(hidden = true)
     private String account;
 
+    @ApiModelProperty(hidden = true)
+    private String ownerEmail;
+
     public FailurePolicyRequest getFailurePolicy() {
         return failurePolicy;
     }
@@ -329,5 +332,13 @@ public class StackV2Request implements JsonEntity {
 
     public void setNetwork(NetworkV2Request network) {
         this.network = network;
+    }
+
+    public String getOwnerEmail() {
+        return ownerEmail;
+    }
+
+    public void setOwnerEmail(String ownerEmail) {
+        this.ownerEmail = ownerEmail;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/CredentialController.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/CredentialController.java
@@ -104,13 +104,6 @@ public class CredentialController extends NotificationController implements Cred
         return interactiveLogin(user, credentialRequest, true);
     }
 
-    @Override
-    public CredentialRequest getRequestfromName(String name) {
-        IdentityUser user = authenticatedUserService.getCbUser();
-        Credential credential = credentialService.getPublicCredential(name, user);
-        return conversionService.convert(credential, CredentialRequest.class);
-    }
-
     private Map<String, String> interactiveLogin(IdentityUser user, CredentialRequest credentialRequest, boolean publicInAccount) {
         Credential credential = convert(credentialRequest, publicInAccount);
         return credentialService.interactiveLogin(user, credential);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/StackCreatorService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/StackCreatorService.java
@@ -68,6 +68,7 @@ public class StackCreatorService {
     public StackResponse createStack(IdentityUser user, StackRequest stackRequest, boolean publicInAccount) throws Exception {
         stackRequest.setAccount(user.getAccount());
         stackRequest.setOwner(user.getUserId());
+        stackRequest.setOwnerEmail(user.getUsername());
 
         long start = System.currentTimeMillis();
         Stack stack = conversionService.convert(stackRequest, Stack.class);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v2/StackV2RequestToStackRequestConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v2/StackV2RequestToStackRequestConverter.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.stereotype.Component;
 
+import com.google.common.base.Strings;
 import com.sequenceiq.cloudbreak.api.model.ClusterRequest;
 import com.sequenceiq.cloudbreak.api.model.HostGroupRequest;
 import com.sequenceiq.cloudbreak.api.model.InstanceGroupRequest;
@@ -71,8 +72,9 @@ public class StackV2RequestToStackRequestConverter extends AbstractConversionSer
         stackRequest.setImageId(source.getImageId());
         stackRequest.setFlexId(source.getFlexId());
         stackRequest.setCredentialName(source.getCredentialName());
-        stackRequest.setOwner(source.getOwner());
-        stackRequest.setAccount(source.getAccount());
+        stackRequest.setOwner(Strings.isNullOrEmpty(source.getOwner()) ? authenticatedUserService.getCbUser().getUserId() : source.getOwner());
+        stackRequest.setAccount(Strings.isNullOrEmpty(source.getAccount()) ? authenticatedUserService.getCbUser().getAccount() : source.getAccount());
+        stackRequest.setOwnerEmail(Strings.isNullOrEmpty(source.getOwnerEmail()) ? authenticatedUserService.getCbUser().getUsername() : source.getOwnerEmail());
         if (source.getClusterRequest() != null) {
             stackRequest.setClusterRequest(conversionService.convert(source.getClusterRequest(), ClusterRequest.class));
             for (InstanceGroupV2Request instanceGroupV2Request : source.getInstanceGroups()) {
@@ -80,9 +82,6 @@ public class StackV2RequestToStackRequestConverter extends AbstractConversionSer
                 stackRequest.getClusterRequest().getHostGroups().add(convert);
             }
             stackRequest.getClusterRequest().setName(source.getName());
-        }
-        if (stackRequest.getAccount() == null) {
-            stackRequest.setAccount(authenticatedUserService.getCbUser().getAccount());
         }
         stackRequest.setCloudPlatform(credentialService.get(stackRequest.getCredentialName(), stackRequest.getAccount()).cloudPlatform());
         return stackRequest;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v2/cli/AmbariDatabaseDetailsToAmbariDatabaseDetailsRequestConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v2/cli/AmbariDatabaseDetailsToAmbariDatabaseDetailsRequestConverter.java
@@ -22,7 +22,7 @@ public class AmbariDatabaseDetailsToAmbariDatabaseDetailsRequestConverter
             ambariDatabaseDetailsJson.setHost(source.getHost());
             ambariDatabaseDetailsJson.setName(source.getName());
             ambariDatabaseDetailsJson.setPort(source.getPort());
-            ambariDatabaseDetailsJson.setPassword(source.getPassword());
+            ambariDatabaseDetailsJson.setPassword("");
             ambariDatabaseDetailsJson.setUserName(source.getUserName());
             ambariDatabaseDetailsJson.setVendor(DatabaseVendor.fromValue(source.getVendor()));
             return ambariDatabaseDetailsJson;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v2/cli/ClusterToAmbariV2RequestRequestConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v2/cli/ClusterToAmbariV2RequestRequestConverter.java
@@ -43,7 +43,7 @@ public class ClusterToAmbariV2RequestRequestConverter extends AbstractConversion
         ambariV2Request.setEnableSecurity(source.isSecure());
         ambariV2Request.setGateway(null);
         ambariV2Request.setKerberos(getConversionService().convert(source.getKerberosConfig(), KerberosRequest.class));
-        ambariV2Request.setPassword(source.getPassword());
+        ambariV2Request.setPassword("");
         ambariV2Request.setUserName(source.getUserName());
         ambariV2Request.setValidateBlueprint(null);
         return ambariV2Request;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v2/cli/KerberosToKerberosRequestConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v2/cli/KerberosToKerberosRequestConverter.java
@@ -22,8 +22,8 @@ public class KerberosToKerberosRequestConverter extends AbstractConversionServic
         kerberosRequest.setDescriptor(source.getDescriptor());
         kerberosRequest.setKrb5Conf(source.getKrb5Conf());
         kerberosRequest.setLdapUrl(source.getLdapUrl());
-        kerberosRequest.setMasterKey(source.getMasterKey());
-        kerberosRequest.setPassword(source.getPassword());
+        kerberosRequest.setMasterKey("");
+        kerberosRequest.setPassword("");
         kerberosRequest.setPrincipal(source.getPrincipal());
         kerberosRequest.setRealm(source.getRealm());
         kerberosRequest.setTcpAllowed(source.getTcpAllowed());

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/StackRequestToStackConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/StackRequestToStackConverterTest.java
@@ -2,11 +2,14 @@ package com.sequenceiq.cloudbreak.converter;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 
 import org.junit.Assert;
@@ -24,6 +27,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import com.sequenceiq.cloudbreak.api.model.InstanceGroupType;
 import com.sequenceiq.cloudbreak.api.model.OrchestratorRequest;
 import com.sequenceiq.cloudbreak.api.model.StackRequest;
+import com.sequenceiq.cloudbreak.common.service.DefaultCostTaggingService;
 import com.sequenceiq.cloudbreak.controller.AuthenticatedUserService;
 import com.sequenceiq.cloudbreak.controller.BadRequestException;
 import com.sequenceiq.cloudbreak.core.CloudbreakException;
@@ -60,6 +64,9 @@ public class StackRequestToStackConverterTest extends AbstractJsonConverterTest<
     @Mock
     private AccountPreferencesService accountPreferencesService;
 
+    @Mock
+    private DefaultCostTaggingService defaultCostTaggingService;
+
     @Before
     public void setUp() {
         underTest = new StackRequestToStackConverter();
@@ -84,6 +91,7 @@ public class StackRequestToStackConverterTest extends AbstractJsonConverterTest<
         //given(stackParameterService.getStackParams(any(IdentityUser.class), any(StackRequest.class))).willReturn(new ArrayList<>());
         given(orchestratorTypeResolver.resolveType(any(Orchestrator.class))).willReturn(OrchestratorType.HOST);
         given(orchestratorTypeResolver.resolveType(any(String.class))).willReturn(OrchestratorType.HOST);
+        given(defaultCostTaggingService.prepareDefaultTags(any(String.class), any(String.class), anyMap(), anyString())).willReturn(new HashMap<>());
         // WHEN
         Stack stack = underTest.convert(getRequest("stack/stack.json"));
         // THEN
@@ -113,6 +121,7 @@ public class StackRequestToStackConverterTest extends AbstractJsonConverterTest<
         //given(stackParameterService.getStackParams(any(IdentityUser.class), any(StackRequest.class))).willReturn(new ArrayList<>());
         given(orchestratorTypeResolver.resolveType(any(Orchestrator.class))).willReturn(OrchestratorType.HOST);
         given(orchestratorTypeResolver.resolveType(any(String.class))).willReturn(OrchestratorType.HOST);
+        given(defaultCostTaggingService.prepareDefaultTags(any(String.class), any(String.class), anyMap(), anyString())).willReturn(new HashMap<>());
         thrown.expect(BadRequestException.class);
         thrown.expectMessage("You can not modify the default user!");
         // WHEN
@@ -142,6 +151,7 @@ public class StackRequestToStackConverterTest extends AbstractJsonConverterTest<
         //given(stackParameterService.getStackParams(any(IdentityUser.class), any(StackRequest.class))).willReturn(new ArrayList<>());
         given(orchestratorTypeResolver.resolveType(any(Orchestrator.class))).willReturn(OrchestratorType.HOST);
         given(orchestratorTypeResolver.resolveType(any(String.class))).willReturn(OrchestratorType.HOST);
+        given(defaultCostTaggingService.prepareDefaultTags(any(String.class), any(String.class), anyMap(), anyString())).willReturn(new HashMap<>());
         thrown.expect(BadRequestException.class);
         thrown.expectMessage("No default region is specified. Region cannot be empty.");
 
@@ -175,6 +185,7 @@ public class StackRequestToStackConverterTest extends AbstractJsonConverterTest<
         //given(stackParameterService.getStackParams(any(IdentityUser.class), any(StackRequest.class))).willReturn(new ArrayList<>());
         given(orchestratorTypeResolver.resolveType(any(Orchestrator.class))).willReturn(OrchestratorType.HOST);
         given(orchestratorTypeResolver.resolveType(any(String.class))).willReturn(OrchestratorType.HOST);
+        given(defaultCostTaggingService.prepareDefaultTags(any(String.class), any(String.class), anyMap(), anyString())).willReturn(new HashMap<>());
 
         // WHEN
         StackRequest stackRequest = getRequest("stack/stack.json");


### PR DESCRIPTION
Cloudbreak will apply 4 default tag on every resource which are (example):

cb-user-name: elephant@hortonworks.com
cb-account-name: Hortonworks
cb-version: 2.2.0-rc.1
cb-resource-type: instance
Also adding Owner as default tag to every resource (only if the Owner tag does not exist in the specified tag list):

Owner: elephant@hortonworks.com