### PR TITLE
CLOUD-95699 ssh key metadata has changed on GCP and block project lev…

### DIFF
--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilder.java
@@ -126,8 +126,12 @@ public class GcpInstanceResourceBuilder extends AbstractGcpComputeBuilder {
         metadata.setItems(new ArrayList<>());
 
         Items sshMetaData = new Items();
-        sshMetaData.setKey("sshKeys");
+        sshMetaData.setKey("ssh-keys");
         sshMetaData.setValue(group.getInstanceAuthentication().getLoginUserName() + ":" + group.getInstanceAuthentication().getPublicKey());
+
+        Items blockProjectWideSsh = new Items();
+        blockProjectWideSsh.setKey("block-project-ssh-keys");
+        blockProjectWideSsh.setValue("TRUE");
 
         Items startupScript = new Items();
         startupScript.setKey("startup-script");
@@ -135,6 +139,7 @@ public class GcpInstanceResourceBuilder extends AbstractGcpComputeBuilder {
 
         metadata.getItems().add(sshMetaData);
         metadata.getItems().add(startupScript);
+        metadata.getItems().add(blockProjectWideSsh);
         instance.setMetadata(metadata);
 
         Insert insert = compute.instances().insert(projectId, location.getAvailabilityZone().value(), instance);


### PR DESCRIPTION
sshKeys will be remove on March 17 . Related docs: https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys#block-project-keys