### PR TITLE
BUG-96599 api e2e test send availability zone in case of openstack

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/cloud/AwsCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/cloud/AwsCloudProvider.java
@@ -70,9 +70,8 @@ public class AwsCloudProvider extends CloudProviderHelper {
     @Override
     StackAuthenticationRequest stackauth() {
         StackAuthenticationRequest stackauth = new StackAuthenticationRequest();
-        String defaultValue = "seq-master";
-        String param = getTestParameter().get("awsPublicKeyId");
-        stackauth.setPublicKeyId(param == null ? defaultValue : param);
+
+        stackauth.setPublicKey(getTestParameter().get(CloudProviderHelper.INTEGRATIONTEST_PUBLIC_KEY_FILE).substring(BEGIN_INDEX));
         return stackauth;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/cloud/AzureCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/cloud/AzureCloudProvider.java
@@ -50,7 +50,7 @@ public class AzureCloudProvider extends CloudProviderHelper {
     @Override
     StackAuthenticationRequest stackauth() {
         StackAuthenticationRequest stackauth = new StackAuthenticationRequest();
-        stackauth.setPublicKey(getTestParameter().get("integrationtest.publicKeyFile").substring(BEGIN_INDEX));
+        stackauth.setPublicKey(getTestParameter().get(INTEGRATIONTEST_PUBLIC_KEY_FILE).substring(BEGIN_INDEX));
         return stackauth;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/cloud/CloudProviderHelper.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/cloud/CloudProviderHelper.java
@@ -28,6 +28,8 @@ public abstract class CloudProviderHelper extends CloudProvider {
 
     public static final int BEGIN_INDEX = 4;
 
+    public static final String INTEGRATIONTEST_PUBLIC_KEY_FILE = "integrationtest.publicKeyFile";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(CloudProviderHelper.class);
 
     private TestParameter testParameter;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/cloud/GcpCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/cloud/GcpCloudProvider.java
@@ -53,9 +53,8 @@ public class GcpCloudProvider extends CloudProviderHelper {
     @Override
     StackAuthenticationRequest stackauth() {
         StackAuthenticationRequest stackauth = new StackAuthenticationRequest();
-        String defaultValue = "seq-master";
-        String param = getTestParameter().get("gcpPublicKeyId");
-        stackauth.setPublicKeyId(param == null ? defaultValue : param);
+
+        stackauth.setPublicKey(getTestParameter().get(CloudProviderHelper.INTEGRATIONTEST_PUBLIC_KEY_FILE).substring(BEGIN_INDEX));
         return stackauth;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/cloud/OpenstackCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/cloud/OpenstackCloudProvider.java
@@ -37,12 +37,15 @@ public class OpenstackCloudProvider extends CloudProviderHelper {
 
     @Override
     String availabilityZone() {
-        return null;
+        String az = "nova";
+        String azParam = getTestParameter().get("openstackAvailabilityZone");
+
+        return azParam == null ? az : azParam;
     }
 
     @Override
     String region() {
-        String region = "local";
+        String region = "RegionOne";
         String regionParam = getTestParameter().get("openstackRegion");
 
         return regionParam == null ? region : regionParam;
@@ -51,9 +54,8 @@ public class OpenstackCloudProvider extends CloudProviderHelper {
     @Override
     StackAuthenticationRequest stackauth() {
         StackAuthenticationRequest stackauth = new StackAuthenticationRequest();
-        String defaultValue = "seq-master";
-        String param = getTestParameter().get("openstackPublicKeyId");
-        stackauth.setPublicKeyId(param == null ? defaultValue : param);
+
+        stackauth.setPublicKey(getTestParameter().get(CloudProviderHelper.INTEGRATIONTEST_PUBLIC_KEY_FILE).substring(BEGIN_INDEX));
         return stackauth;
     }
 


### PR DESCRIPTION
api e2e tests are caused null pointer exception when send a cluster request (v2) without availability zone in case of openstack - this commit would not close the original jira issue, only just enable the test's run