### PR TITLE
BUG-96598 handling environment variable as property at new api tests

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/ClusterTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/ClusterTests.java
@@ -1,23 +1,21 @@
 package com.sequenceiq.it.cloudbreak;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Optional;
-import org.testng.annotations.Parameters;
-import org.testng.annotations.Test;
-
 import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.newway.CloudbreakTest;
 import com.sequenceiq.it.cloudbreak.newway.Cluster;
 import com.sequenceiq.it.cloudbreak.newway.Stack;
 import com.sequenceiq.it.cloudbreak.newway.StackOperation;
 import com.sequenceiq.it.cloudbreak.newway.TestParameter;
-import com.sequenceiq.it.cloudbreak.newway.cloud.AwsCloudProvider;
 import com.sequenceiq.it.cloudbreak.newway.cloud.CloudProvider;
 import com.sequenceiq.it.cloudbreak.newway.cloud.CloudProviderHelper;
 import com.sequenceiq.it.cloudbreak.newway.cloud.OpenstackCloudProvider;
 import com.sequenceiq.it.cloudbreak.newway.priority.Priority;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Optional;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
 
 public class ClusterTests extends CloudbreakTest {
 
@@ -32,7 +30,6 @@ public class ClusterTests extends CloudbreakTest {
     private CloudProvider cloudProvider;
 
     public ClusterTests() {
-        this.cloudProvider = new AwsCloudProvider(getTestParameter());
     }
 
     public ClusterTests(CloudProvider cp, TestParameter tp) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/TestParameter.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/TestParameter.java
@@ -16,8 +16,14 @@ public class TestParameter {
     }
 
     public String get(String key) {
-        LOGGER.info("Aquiring key {} resulting: {}", key, parameters.get(key));
-        return parameters.get(key);
+        String valueAsProperty = parameters.get(key);
+        if (valueAsProperty == null) {
+            LOGGER.info("key has not been found as property, trying as environment variable");
+            valueAsProperty = parameters.get(key.toUpperCase().replaceAll("\\.", "_"));
+        }
+        LOGGER.info("Aquiring key {} resulting: {}", key, valueAsProperty);
+
+        return valueAsProperty;
     }
 
     public void put(String key, String value) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/cloud/OpenstackCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/cloud/OpenstackCloudProvider.java
@@ -102,6 +102,14 @@ public class OpenstackCloudProvider extends CloudProviderHelper {
     NetworkV2Request network() {
         NetworkV2Request network = new NetworkV2Request();
         network.setSubnetCIDR("10.0.0.0/16");
+
+        Map<String, Object> parameters = new HashMap<>();
+
+        String defaultNetId = "999e09bc-cf75-4a19-98fb-c0b4ddee6d93";
+        String netIdParameter = getTestParameter().get("integrationtest.openstack.publicNetId");
+        parameters.put("networkingOption", "self-service");
+        parameters.put("publicNetId", netIdParameter == null ? defaultNetId : netIdParameter);
+        network.setParameters(parameters);
         return network;
     }
 }


### PR DESCRIPTION
-giving openstack cluster request floating pool attribute
-handling environment variable as property 