### PR TITLE
BUG-98907 - fix to prevent the user from terminating the Ambari server node

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/CollectDownscaleCandidatesHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/CollectDownscaleCandidatesHandler.java
@@ -6,6 +6,7 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.controller.BadRequestException;
 import com.sequenceiq.cloudbreak.domain.Stack;
 import com.sequenceiq.cloudbreak.reactor.api.event.EventSelectorUtil;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.CollectDownscaleCandidatesRequest;
@@ -45,7 +46,8 @@ public class CollectDownscaleCandidatesHandler implements ReactorEventHandler<Co
                 hostNames = ambariDecommissioner.collectDownscaleCandidates(stack, request.getHostGroupName(), request.getScalingAdjustment());
             } else {
                 hostNames = request.getHostNames();
-                ambariDecommissioner.verifyNodeCount(stack, stack.getCluster(), hostNames.stream().findFirst().get());
+                String hostName = hostNames.stream().findFirst().orElseThrow(() -> new BadRequestException("Unable to find host name"));
+                ambariDecommissioner.verifyNodeCount(stack, stack.getCluster(), hostName);
             }
             result = new CollectDownscaleCandidatesResult(request, hostNames);
         } catch (Exception e) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/NotEnoughNodeException.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/NotEnoughNodeException.java
@@ -1,0 +1,8 @@
+package com.sequenceiq.cloudbreak.service.cluster;
+
+public class NotEnoughNodeException extends RuntimeException {
+
+    public NotEnoughNodeException(String message) {
+        super(message);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackDownscaleValidatorService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackDownscaleValidatorService.java
@@ -1,0 +1,30 @@
+package com.sequenceiq.cloudbreak.service.stack;
+
+import static com.sequenceiq.cloudbreak.api.model.InstanceMetadataType.GATEWAY;
+import static com.sequenceiq.cloudbreak.api.model.InstanceMetadataType.GATEWAY_PRIMARY;
+
+import java.util.Objects;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.api.model.InstanceMetadataType;
+import com.sequenceiq.cloudbreak.controller.BadRequestException;
+
+@Component
+public class StackDownscaleValidatorService {
+
+    public void checkInstanceIsTheAmbariServerOrNot(String instancePublicIp, InstanceMetadataType metadataType) {
+        if (GATEWAY.equals(metadataType) || GATEWAY_PRIMARY.equals(metadataType)) {
+            throw new BadRequestException(String.format("Downscale for node [public IP: %s] is prohibited because it serves as a host the Ambari server",
+                    instancePublicIp));
+        }
+    }
+
+    public void checkUserHasRightToTerminateInstance(boolean publicInAccount, String owner, String userId, Long stackId) {
+        if (!publicInAccount && !Objects.equals(owner, userId)) {
+            throw new AccessDeniedException(String.format("Private stack (%s) is only modifiable by the owner.", stackId));
+        }
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariDecommissionerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariDecommissionerTest.java
@@ -14,7 +14,9 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -24,7 +26,6 @@ import com.google.common.collect.Sets;
 import com.sequenceiq.ambari.client.AmbariClient;
 import com.sequenceiq.cloudbreak.client.HttpClientConfig;
 import com.sequenceiq.cloudbreak.common.type.HostMetadataState;
-import com.sequenceiq.cloudbreak.controller.BadRequestException;
 import com.sequenceiq.cloudbreak.core.CloudbreakSecuritySetupException;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.domain.Cluster;
@@ -34,6 +35,7 @@ import com.sequenceiq.cloudbreak.domain.Stack;
 import com.sequenceiq.cloudbreak.repository.HostMetadataRepository;
 import com.sequenceiq.cloudbreak.service.TlsSecurityService;
 import com.sequenceiq.cloudbreak.service.cluster.AmbariClientProvider;
+import com.sequenceiq.cloudbreak.service.cluster.NotEnoughNodeException;
 import com.sequenceiq.cloudbreak.service.cluster.ambari.AmbariConfigurationService;
 import com.sequenceiq.cloudbreak.service.cluster.ambari.AmbariDecommissioner;
 import com.sequenceiq.cloudbreak.service.cluster.filter.ConfigParam;
@@ -41,6 +43,9 @@ import com.sequenceiq.cloudbreak.service.hostgroup.HostGroupService;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AmbariDecommissionerTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @InjectMocks
     private AmbariDecommissioner underTest = new AmbariDecommissioner();
@@ -259,8 +264,9 @@ public class AmbariDecommissionerTest {
         verify(configurationService, times(0)).getConfiguration(ambariClient, hostGroupName);
     }
 
-    @Test(expected = BadRequestException.class)
+    @Test
     public void testVerifyNodeCountWithValidationException() throws CloudbreakSecuritySetupException {
+        thrown.expect(NotEnoughNodeException.class);
 
         String hostGroupName = "hostGroupName";
         String hostname = "hostname";

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/StackDownscaleValidatorServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/StackDownscaleValidatorServiceTest.java
@@ -1,0 +1,75 @@
+package com.sequenceiq.cloudbreak.service.stack;
+
+import static com.sequenceiq.cloudbreak.api.model.InstanceMetadataType.CORE;
+import static com.sequenceiq.cloudbreak.api.model.InstanceMetadataType.GATEWAY;
+import static com.sequenceiq.cloudbreak.api.model.InstanceMetadataType.GATEWAY_PRIMARY;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.security.access.AccessDeniedException;
+
+import com.sequenceiq.cloudbreak.controller.BadRequestException;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StackDownscaleValidatorServiceTest {
+
+    private static final Long STACK_ID = 1L;
+
+    private static final String INSTANCE_PUBLIC_IP = "2.2.2.2";
+
+    private static final String AMBARI_SERVER_HOST_EXCEPTION_MESSAGE = String.format("Downscale for node [public IP: %s] is prohibited because it serves as "
+            + "a host the Ambari server", INSTANCE_PUBLIC_IP);
+
+    private static final String ACCESS_DENIED_EXCEPTION_MESSAGE = String.format("Private stack (%s) is only modifiable by the owner.", STACK_ID);
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Mock(answer = Answers.CALLS_REAL_METHODS)
+    private StackDownscaleValidatorService underTest;
+
+    @Test
+    public void testCheckInstanceIsTheAmbariServerOrNotMethodWhenInstanceIsCoreTypeThenNoExceptionWouldInvoke() {
+        underTest.checkInstanceIsTheAmbariServerOrNot(INSTANCE_PUBLIC_IP, CORE);
+    }
+
+    @Test
+    public void testCheckInstanceIsTheAmbariServerOrNotMethodWhenTypeIsGatewayThenException() {
+        expectedException.expect(BadRequestException.class);
+        expectedException.expectMessage(AMBARI_SERVER_HOST_EXCEPTION_MESSAGE);
+
+        underTest.checkInstanceIsTheAmbariServerOrNot(INSTANCE_PUBLIC_IP, GATEWAY);
+    }
+
+    @Test
+    public void testCheckInstanceIsTheAmbariServerOrNotMethodWhenTypeIsGatewayPrimaryThenException() {
+        expectedException.expect(BadRequestException.class);
+        expectedException.expectMessage(AMBARI_SERVER_HOST_EXCEPTION_MESSAGE);
+
+        underTest.checkInstanceIsTheAmbariServerOrNot(INSTANCE_PUBLIC_IP, GATEWAY_PRIMARY);
+    }
+
+    @Test
+    public void testCheckUserHasRightToTerminateInstanceMethodWhenPublicInAccountAndOwnerAndUserIdIsSameThenNoException() {
+        underTest.checkUserHasRightToTerminateInstance(true, "same", "same", STACK_ID);
+    }
+
+    @Test
+    public void testCheckUserHasRightToTerminateInstanceMethodWhenPublicInAccountAndUserIdAndOwnerAreNotTheSameThenNoException() {
+        underTest.checkUserHasRightToTerminateInstance(true, "something here", "something else here", STACK_ID);
+    }
+
+    @Test
+    public void testCheckUserHasRightToTerminateInstanceMethodWhenNotPublicInAccountAndUserIdAndOwnerAreNotTheSameThenExceptionWouldInvoke() {
+        expectedException.expect(AccessDeniedException.class);
+        expectedException.expectMessage(ACCESS_DENIED_EXCEPTION_MESSAGE);
+
+        underTest.checkUserHasRightToTerminateInstance(false, "something here", "something else here", STACK_ID);
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/StackServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/StackServiceTest.java
@@ -1,28 +1,165 @@
 package com.sequenceiq.cloudbreak.service.stack;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.InjectMocks;
-import org.mockito.MockitoAnnotations;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static com.sequenceiq.cloudbreak.api.model.InstanceMetadataType.CORE;
+import static com.sequenceiq.cloudbreak.api.model.InstanceMetadataType.GATEWAY;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.security.access.AccessDeniedException;
+
+import com.sequenceiq.cloudbreak.common.model.user.IdentityUser;
+import com.sequenceiq.cloudbreak.controller.BadRequestException;
+import com.sequenceiq.cloudbreak.controller.NotFoundException;
+import com.sequenceiq.cloudbreak.core.flow2.service.ReactorFlowManager;
+import com.sequenceiq.cloudbreak.domain.InstanceMetaData;
+import com.sequenceiq.cloudbreak.domain.Stack;
+import com.sequenceiq.cloudbreak.repository.InstanceMetaDataRepository;
+import com.sequenceiq.cloudbreak.repository.StackRepository;
+import com.sequenceiq.cloudbreak.service.AuthorizationService;
+
+@RunWith(MockitoJUnitRunner.class)
 public class StackServiceTest {
-    private static final Logger LOGGER = LoggerFactory.getLogger(StackServiceTest.class);
+
+    private static final Long STACK_ID = 1L;
+
+    private static final String INSTANCE_ID = "instanceId";
+
+    private static final String INSTANCE_PUBLIC_IP = "2.2.2.2";
+
+    private static final String OWNER = "1234567";
+
+    private static final String USER_ID = OWNER;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @InjectMocks
-    private StackService stackService;
+    private StackService underTest;
 
-    @Before
-    public void before() {
-        stackService = new StackService();
-        MockitoAnnotations.initMocks(this);
+    @Mock
+    private StackRepository stackRepository;
+
+    @Mock
+    private InstanceMetaDataRepository instanceMetaDataRepository;
+
+    @Mock
+    private ReactorFlowManager flowManager;
+
+    @Mock
+    private StackDownscaleValidatorService downscaleValidatorService;
+
+    @Mock
+    private AuthorizationService authorizationService;
+
+    @Mock
+    private Stack stack;
+
+    @Mock
+    private InstanceMetaData instanceMetaData;
+
+    @Mock
+    private IdentityUser user;
+
+    @Test
+    public void testRemoveInstanceWhenTheInstanceIsCoreTypeAndUserHasRightToTerminateThenThenProcessWouldBeSuccessful() {
+        when(stackRepository.findOne(STACK_ID)).thenReturn(stack);
+        when(instanceMetaDataRepository.findByInstanceId(STACK_ID, INSTANCE_ID)).thenReturn(instanceMetaData);
+        when(stack.isPublicInAccount()).thenReturn(true);
+        when(stack.getOwner()).thenReturn(OWNER);
+        when(user.getUserId()).thenReturn(USER_ID);
+        when(instanceMetaData.getPublicIp()).thenReturn(INSTANCE_PUBLIC_IP);
+        when(instanceMetaData.getInstanceMetadataType()).thenReturn(CORE);
+        doNothing().when(downscaleValidatorService).checkInstanceIsTheAmbariServerOrNot(INSTANCE_PUBLIC_IP, CORE);
+        doNothing().when(downscaleValidatorService).checkUserHasRightToTerminateInstance(true, OWNER, USER_ID, STACK_ID);
+        doNothing().when(flowManager).triggerStackRemoveInstance(anyLong(), anyString(), anyString());
+
+        underTest.removeInstance(user, STACK_ID, INSTANCE_ID);
+        verify(instanceMetaDataRepository, times(1)).findByInstanceId(STACK_ID, INSTANCE_ID);
+        verify(downscaleValidatorService, times(1)).checkInstanceIsTheAmbariServerOrNot(INSTANCE_PUBLIC_IP, CORE);
+        verify(downscaleValidatorService, times(1)).checkUserHasRightToTerminateInstance(true, OWNER, USER_ID,
+                STACK_ID);
     }
 
     @Test
-    public void testLogger() {
-        Throwable t = new IllegalStateException("mamamama");
-        LOGGER.error("test. Ex: {}", 12, t);
+    public void testRemoveInstanceWhenTheHostIsGatewayTypeThenWeShoulNotAllowTerminationWithException() {
+        String exceptionMessage = String.format("Downscale for node [public IP: %s] is prohibited because it maintains the Ambari server", INSTANCE_PUBLIC_IP);
+        when(stackRepository.findOne(STACK_ID)).thenReturn(stack);
+        when(instanceMetaDataRepository.findByInstanceId(STACK_ID, INSTANCE_ID)).thenReturn(instanceMetaData);
+        when(instanceMetaData.getInstanceMetadataType()).thenReturn(GATEWAY);
+        when(instanceMetaData.getPublicIp()).thenReturn(INSTANCE_PUBLIC_IP);
+        doThrow(new BadRequestException(exceptionMessage)).when(downscaleValidatorService).checkInstanceIsTheAmbariServerOrNot(INSTANCE_PUBLIC_IP, GATEWAY);
+
+        expectedException.expect(BadRequestException.class);
+        expectedException.expectMessage(exceptionMessage);
+
+        underTest.removeInstance(user, STACK_ID, INSTANCE_ID);
+        verify(instanceMetaDataRepository, times(1)).findByInstanceId(STACK_ID, INSTANCE_ID);
+        verify(downscaleValidatorService, times(1)).checkInstanceIsTheAmbariServerOrNot(INSTANCE_PUBLIC_IP, GATEWAY);
+        verify(downscaleValidatorService, times(0)).checkUserHasRightToTerminateInstance(anyBoolean(), anyString(), anyString(),
+                anyLong());
+        verify(flowManager, times(0)).triggerStackRemoveInstance(anyLong(), anyString(), anyString());
+    }
+
+    @Test
+    public void testWhenTheUserHasNoRightToModifyTheStackThenExceptionWouldThrown() {
+        String exceptionMessage = "Private stack (%s) is only modifiable by the owner.";
+        String userId = "222";
+        String owner = "111";
+        when(stackRepository.findOne(STACK_ID)).thenReturn(stack);
+        when(instanceMetaDataRepository.findByInstanceId(STACK_ID, INSTANCE_ID)).thenReturn(instanceMetaData);
+        when(stack.isPublicInAccount()).thenReturn(false);
+        when(stack.getOwner()).thenReturn(owner);
+        when(user.getUserId()).thenReturn(userId);
+        when(instanceMetaData.getPublicIp()).thenReturn(INSTANCE_PUBLIC_IP);
+        when(instanceMetaData.getInstanceMetadataType()).thenReturn(CORE);
+        doNothing().when(downscaleValidatorService).checkInstanceIsTheAmbariServerOrNot(INSTANCE_PUBLIC_IP, CORE);
+        doThrow(new AccessDeniedException(exceptionMessage)).when(downscaleValidatorService).checkUserHasRightToTerminateInstance(false,
+                owner, userId, STACK_ID);
+
+        expectedException.expect(AccessDeniedException.class);
+        expectedException.expectMessage(exceptionMessage);
+
+        underTest.removeInstance(user, STACK_ID, INSTANCE_ID);
+        verify(instanceMetaDataRepository, times(1)).findByInstanceId(STACK_ID, INSTANCE_ID);
+        verify(downscaleValidatorService, times(1)).checkInstanceIsTheAmbariServerOrNot(INSTANCE_PUBLIC_IP, CORE);
+        verify(downscaleValidatorService, times(1)).checkUserHasRightToTerminateInstance(false, owner, userId,
+                STACK_ID);
+        verify(flowManager, times(0)).triggerStackRemoveInstance(anyLong(), anyString(), anyString());
+    }
+
+    @Test
+    public void testWhenInstanceMetaDataIsNullThenExceptionWouldThrown() {
+        when(stackRepository.findOne(STACK_ID)).thenReturn(stack);
+        when(instanceMetaDataRepository.findByInstanceId(STACK_ID, INSTANCE_ID)).thenReturn(null);
+        doNothing().when(authorizationService).hasReadPermission(stack);
+
+        expectedException.expect(NotFoundException.class);
+        expectedException.expectMessage(String.format("Metadata for instance %s has not found.", INSTANCE_ID));
+
+        underTest.removeInstance(user, STACK_ID, INSTANCE_ID);
+    }
+
+    @Test
+    public void testWhenStackCouldNotFindByItsIdThenExceptionWouldThrown() {
+        when(stackRepository.findOne(STACK_ID)).thenReturn(null);
+
+        expectedException.expect(NotFoundException.class);
+        expectedException.expectMessage(String.format("Stack '%s' has not found", STACK_ID));
+
+        underTest.get(STACK_ID);
     }
 
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/v2/mock/instanceterm/MockInstanceTerminationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/v2/mock/instanceterm/MockInstanceTerminationTest.java
@@ -43,7 +43,7 @@ public class MockInstanceTerminationTest extends AbstractCloudbreakIntegrationTe
     }
 
     @Test
-    public void testInstanceTermination() throws Exception {
+    public void testInstanceTermination() {
         // GIVEN
         // WHEN
         Long stackId = Long.parseLong(getItContext().getContextParam(CloudbreakITContextConstants.STACK_ID));


### PR DESCRIPTION
The user had the ability on the UI (with the little bin icon) to terminate that node which maintains the Ambari server what led to the total malfunction of the cluster. With this fix when the user tries to do the same operation, the UI brings up a warning message telling him/her that this operation is not allowed.
This bug recorded with the following ticket id: BUG-98907