### PR TITLE
BUG-101237 – fix for sending empty kerberos admin host bug

### DIFF
--- a/blueprint-manager/src/main/java/com/sequenceiq/cloudbreak/blueprint/kerberos/KerberosBlueprintService.java
+++ b/blueprint-manager/src/main/java/com/sequenceiq/cloudbreak/blueprint/kerberos/KerberosBlueprintService.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.blueprint.kerberos;
 
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -73,8 +75,8 @@ public class KerberosBlueprintService implements BlueprintComponentConfigProvide
         Map<String, String> kerberosEnv = ImmutableMap.<String, String>builder()
                 .put("realm", realm)
                 .put("kdc_type", kdcType)
-                .put("kdc_hosts", kerberosDetailService.resolveHostForKerberos(kerberosConfig, gatewayHost))
-                .put("admin_server_host", kdcAdminHost)
+                .put("kdc_hosts", kdcHosts)
+                .put("admin_server_host", isNotEmpty(kdcAdminHost) ? kdcAdminHost : kdcHosts)
                 .put("encryption_types", "aes des3-cbc-sha1 rc4 des-cbc-md5")
                 .put("ldap_url", ldapUrl == null ? "" : ldapUrl)
                 .put("container_dn", containerDn == null ? "" : containerDn)

--- a/blueprint-manager/src/main/java/com/sequenceiq/cloudbreak/blueprint/kerberos/KerberosDetailService.java
+++ b/blueprint-manager/src/main/java/com/sequenceiq/cloudbreak/blueprint/kerberos/KerberosDetailService.java
@@ -3,8 +3,9 @@ package com.sequenceiq.cloudbreak.blueprint.kerberos;
 import java.io.IOException;
 import java.util.Map;
 
+import javax.annotation.Nonnull;
+
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Strings;
@@ -19,22 +20,22 @@ public class KerberosDetailService {
 
     private final Gson gson = new Gson();
 
-    public String resolveTypeForKerberos(KerberosConfig kerberosConfig) {
+    public String resolveTypeForKerberos(@Nonnull KerberosConfig kerberosConfig) {
         if (!Strings.isNullOrEmpty(kerberosConfig.getContainerDn()) && !Strings.isNullOrEmpty(kerberosConfig.getLdapUrl())) {
             return "active-directory";
         }
         return "mit-kdc";
     }
 
-    public String resolveHostForKerberos(KerberosConfig kerberosConfig, String defaultHost) {
-        return Strings.isNullOrEmpty(kerberosConfig.getUrl()) ? defaultHost : kerberosConfig.getUrl();
+    public String resolveHostForKerberos(@Nonnull KerberosConfig kerberosConfig, String defaultHost) {
+        return kerberosConfig.getUrl() == null || kerberosConfig.getUrl().trim().isEmpty() ? defaultHost : kerberosConfig.getUrl().trim();
     }
 
-    public String resolveHostForKdcAdmin(KerberosConfig kerberosConfig, String defaultHost) {
-        return Strings.isNullOrEmpty(kerberosConfig.getAdminUrl()) ? defaultHost : kerberosConfig.getAdminUrl();
+    public String resolveHostForKdcAdmin(@Nonnull KerberosConfig kerberosConfig, String defaultHost) {
+        return kerberosConfig.getAdminUrl() == null || kerberosConfig.getAdminUrl().trim().isEmpty() ? defaultHost : kerberosConfig.getAdminUrl().trim();
     }
 
-    public String getRealm(String gwDomain, KerberosConfig kerberosConfig) {
+    public String getRealm(@Nonnull String gwDomain, @Nonnull KerberosConfig kerberosConfig) {
         return Strings.isNullOrEmpty(kerberosConfig.getRealm()) ? gwDomain.toUpperCase() : kerberosConfig.getRealm().toUpperCase();
     }
 
@@ -42,21 +43,21 @@ public class KerberosDetailService {
         return '.' + gwDomain;
     }
 
-    public String resolveLdapUrlForKerberos(KerberosConfig kerberosConfig) {
+    public String resolveLdapUrlForKerberos(@Nonnull KerberosConfig kerberosConfig) {
         return Strings.isNullOrEmpty(kerberosConfig.getLdapUrl()) ? null : kerberosConfig.getLdapUrl();
     }
 
-    public String resolveContainerDnForKerberos(KerberosConfig kerberosConfig) {
+    public String resolveContainerDnForKerberos(@Nonnull KerberosConfig kerberosConfig) {
         return Strings.isNullOrEmpty(kerberosConfig.getContainerDn()) ? null : kerberosConfig.getContainerDn();
     }
 
-    public String resolvePrincipalForKerberos(KerberosConfig kerberosConfig) {
+    public String resolvePrincipalForKerberos(@Nonnull KerberosConfig kerberosConfig) {
         return Strings.isNullOrEmpty(kerberosConfig.getPrincipal()) ? kerberosConfig.getAdmin() + PRINCIPAL
                 : kerberosConfig.getPrincipal();
     }
 
-    public boolean isAmbariManagedKerberosPackages(KerberosConfig kerberosConfig) throws IOException {
-        if (!StringUtils.hasLength(kerberosConfig.getDescriptor())) {
+    public boolean isAmbariManagedKerberosPackages(@Nonnull KerberosConfig kerberosConfig) throws IOException {
+        if (org.apache.commons.lang3.StringUtils.isEmpty(kerberosConfig.getDescriptor())) {
             return true;
         }
         try {
@@ -67,7 +68,7 @@ public class KerberosDetailService {
         }
     }
 
-    public Map<String, Object> getKerberosEnvProperties(KerberosConfig kerberosConfig) {
+    public Map<String, Object> getKerberosEnvProperties(@Nonnull KerberosConfig kerberosConfig) {
         Map<String, Object> kerberosEnv = (Map<String, Object>) gson.fromJson(kerberosConfig.getDescriptor(), Map.class).get("kerberos-env");
         return (Map<String, Object>) kerberosEnv.get("properties");
     }

--- a/blueprint-manager/src/test/java/com/sequenceiq/cloudbreak/blueprint/kerberos/KerberosDetailServiceTest.java
+++ b/blueprint-manager/src/test/java/com/sequenceiq/cloudbreak/blueprint/kerberos/KerberosDetailServiceTest.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.blueprint.kerberos;
 import java.io.IOException;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -12,24 +13,75 @@ import com.sequenceiq.cloudbreak.domain.KerberosConfig;
 @RunWith(MockitoJUnitRunner.class)
 public class KerberosDetailServiceTest {
 
-    private KerberosDetailService underTest = new KerberosDetailService();
+    private static final String TEST_DEFAULT_HOST = "some default host value";
+
+    private KerberosDetailService underTest;
+
+    private KerberosConfig config;
+
+    @Before
+    public void setUp() {
+        underTest = new KerberosDetailService();
+        config = new KerberosConfig();
+    }
+
+    @Test
+    public void testResolveHostForKerberosWhenUrlIsNullThenDefaultHostShouldReturn() {
+        config.setUrl(null);
+        String result = underTest.resolveHostForKerberos(config, TEST_DEFAULT_HOST);
+        Assert.assertEquals(TEST_DEFAULT_HOST, result);
+    }
+
+    @Test
+    public void testResolveHostForKerberosWhenUrlIsEmptyThenDefaultHostShouldReturn() {
+        config.setUrl("");
+        String result = underTest.resolveHostForKerberos(config, TEST_DEFAULT_HOST);
+        Assert.assertEquals(TEST_DEFAULT_HOST, result);
+    }
+
+    @Test
+    public void testResolveHostForKerberosWhenUrlIsNotEmptyThenThatValueShouldReturn() {
+        String expected = "some value";
+        config.setUrl(expected);
+        String result = underTest.resolveHostForKerberos(config, TEST_DEFAULT_HOST);
+        Assert.assertEquals(expected, result);
+    }
+
+    @Test
+    public void testResolveHostForKdcAdminWhenUrlIsNullThenDefaultHostShouldReturn() {
+        config.setAdminUrl(null);
+        String result = underTest.resolveHostForKdcAdmin(config, TEST_DEFAULT_HOST);
+        Assert.assertEquals(TEST_DEFAULT_HOST, result);
+    }
+
+    @Test
+    public void testResolveHostForKdcAdminWhenUrlIsEmptyThenDefaultHostShouldReturn() {
+        config.setAdminUrl("");
+        String result = underTest.resolveHostForKdcAdmin(config, TEST_DEFAULT_HOST);
+        Assert.assertEquals(TEST_DEFAULT_HOST, result);
+    }
+
+    @Test
+    public void testResolveHostForKdcAdminWhenUrlIsNotEmptyThenThatValueShouldReturn() {
+        String expected = "some value";
+        config.setAdminUrl(expected);
+        String result = underTest.resolveHostForKdcAdmin(config, TEST_DEFAULT_HOST);
+        Assert.assertEquals(expected, result);
+    }
 
     @Test
     public void testAmbariManagedKerberosMissing() throws IOException {
-        KerberosConfig config = new KerberosConfig();
         Assert.assertTrue(underTest.isAmbariManagedKerberosPackages(config));
     }
 
     @Test
     public void testAmbariManagedKerberosTrue() throws IOException {
-        KerberosConfig config = new KerberosConfig();
         config.setDescriptor("{\"kerberos-env\":{\"properties\":{\"install_packages\":true}}}");
         Assert.assertTrue(underTest.isAmbariManagedKerberosPackages(config));
     }
 
     @Test
     public void testAmbariManagedKerberosFalse() throws IOException {
-        KerberosConfig config = new KerberosConfig();
         config.setDescriptor("{\"kerberos-env\":{\"properties\":{\"install_packages\":false}}}");
         Assert.assertFalse(underTest.isAmbariManagedKerberosPackages(config));
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/KerberosRequestToKerberosConfigConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/KerberosRequestToKerberosConfigConverter.java
@@ -9,7 +9,7 @@ import com.sequenceiq.cloudbreak.domain.KerberosConfig;
 import com.sequenceiq.cloudbreak.type.KerberosType;
 
 @Component
-public class KerbersoRequestToKerberosConfigConverter extends AbstractConversionServiceAwareConverter<KerberosRequest, KerberosConfig> {
+public class KerberosRequestToKerberosConfigConverter extends AbstractConversionServiceAwareConverter<KerberosRequest, KerberosConfig> {
     @Override
     public KerberosConfig convert(KerberosRequest source) {
         KerberosConfig kerberosConfig = new KerberosConfig();


### PR DESCRIPTION
Fixes a bug when the user sends an empty value (or only spaces) as the kerberos admin host, and this empty and/or invalid data stored in the kerberos config file by the salt, which would cause malfunction