### PR TITLE
BUG-101237 – fix for sending empty kerberos admin host bug

### DIFF
--- a/blueprint-manager/src/main/java/com/sequenceiq/cloudbreak/blueprint/kerberos/KerberosBlueprintService.java
+++ b/blueprint-manager/src/main/java/com/sequenceiq/cloudbreak/blueprint/kerberos/KerberosBlueprintService.java
@@ -73,7 +73,7 @@ public class KerberosBlueprintService implements BlueprintComponentConfigProvide
         Map<String, String> kerberosEnv = ImmutableMap.<String, String>builder()
                 .put("realm", realm)
                 .put("kdc_type", kdcType)
-                .put("kdc_hosts", kerberosDetailService.resolveHostForKerberos(kerberosConfig, gatewayHost))
+                .put("kdc_hosts", kdcHosts)
                 .put("admin_server_host", kdcAdminHost)
                 .put("encryption_types", "aes des3-cbc-sha1 rc4 des-cbc-md5")
                 .put("ldap_url", ldapUrl == null ? "" : ldapUrl)

--- a/blueprint-manager/src/main/java/com/sequenceiq/cloudbreak/blueprint/kerberos/KerberosDetailService.java
+++ b/blueprint-manager/src/main/java/com/sequenceiq/cloudbreak/blueprint/kerberos/KerberosDetailService.java
@@ -1,10 +1,14 @@
 package com.sequenceiq.cloudbreak.blueprint.kerberos;
 
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
 import java.io.IOException;
 import java.util.Map;
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
 
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Strings;
@@ -19,22 +23,24 @@ public class KerberosDetailService {
 
     private final Gson gson = new Gson();
 
-    public String resolveTypeForKerberos(KerberosConfig kerberosConfig) {
+    public String resolveTypeForKerberos(@Nonnull KerberosConfig kerberosConfig) {
         if (!Strings.isNullOrEmpty(kerberosConfig.getContainerDn()) && !Strings.isNullOrEmpty(kerberosConfig.getLdapUrl())) {
             return "active-directory";
         }
         return "mit-kdc";
     }
 
-    public String resolveHostForKerberos(KerberosConfig kerberosConfig, String defaultHost) {
-        return Strings.isNullOrEmpty(kerberosConfig.getUrl()) ? defaultHost : kerberosConfig.getUrl();
+    public String resolveHostForKerberos(@Nonnull KerberosConfig kerberosConfig, String defaultHost) {
+        String host = Optional.ofNullable(kerberosConfig.getUrl()).orElse("").trim();
+        return host.isEmpty() ? defaultHost : host;
     }
 
-    public String resolveHostForKdcAdmin(KerberosConfig kerberosConfig, String defaultHost) {
-        return Strings.isNullOrEmpty(kerberosConfig.getAdminUrl()) ? defaultHost : kerberosConfig.getAdminUrl();
+    public String resolveHostForKdcAdmin(@Nonnull KerberosConfig kerberosConfig, String defaultHost) {
+        String adminHost = Optional.ofNullable(kerberosConfig.getAdminUrl()).orElse("").trim();
+        return adminHost.isEmpty() ? defaultHost : adminHost;
     }
 
-    public String getRealm(String gwDomain, KerberosConfig kerberosConfig) {
+    public String getRealm(@Nonnull String gwDomain, @Nonnull KerberosConfig kerberosConfig) {
         return Strings.isNullOrEmpty(kerberosConfig.getRealm()) ? gwDomain.toUpperCase() : kerberosConfig.getRealm().toUpperCase();
     }
 
@@ -42,21 +48,21 @@ public class KerberosDetailService {
         return '.' + gwDomain;
     }
 
-    public String resolveLdapUrlForKerberos(KerberosConfig kerberosConfig) {
+    public String resolveLdapUrlForKerberos(@Nonnull KerberosConfig kerberosConfig) {
         return Strings.isNullOrEmpty(kerberosConfig.getLdapUrl()) ? null : kerberosConfig.getLdapUrl();
     }
 
-    public String resolveContainerDnForKerberos(KerberosConfig kerberosConfig) {
+    public String resolveContainerDnForKerberos(@Nonnull KerberosConfig kerberosConfig) {
         return Strings.isNullOrEmpty(kerberosConfig.getContainerDn()) ? null : kerberosConfig.getContainerDn();
     }
 
-    public String resolvePrincipalForKerberos(KerberosConfig kerberosConfig) {
+    public String resolvePrincipalForKerberos(@Nonnull KerberosConfig kerberosConfig) {
         return Strings.isNullOrEmpty(kerberosConfig.getPrincipal()) ? kerberosConfig.getAdmin() + PRINCIPAL
                 : kerberosConfig.getPrincipal();
     }
 
-    public boolean isAmbariManagedKerberosPackages(KerberosConfig kerberosConfig) throws IOException {
-        if (!StringUtils.hasLength(kerberosConfig.getDescriptor())) {
+    public boolean isAmbariManagedKerberosPackages(@Nonnull KerberosConfig kerberosConfig) throws IOException {
+        if (isEmpty(kerberosConfig.getDescriptor())) {
             return true;
         }
         try {
@@ -67,7 +73,7 @@ public class KerberosDetailService {
         }
     }
 
-    public Map<String, Object> getKerberosEnvProperties(KerberosConfig kerberosConfig) {
+    public Map<String, Object> getKerberosEnvProperties(@Nonnull KerberosConfig kerberosConfig) {
         Map<String, Object> kerberosEnv = (Map<String, Object>) gson.fromJson(kerberosConfig.getDescriptor(), Map.class).get("kerberos-env");
         return (Map<String, Object>) kerberosEnv.get("properties");
     }

--- a/blueprint-manager/src/test/java/com/sequenceiq/cloudbreak/blueprint/kerberos/KerberosDetailServiceTest.java
+++ b/blueprint-manager/src/test/java/com/sequenceiq/cloudbreak/blueprint/kerberos/KerberosDetailServiceTest.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.blueprint.kerberos;
 import java.io.IOException;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -12,24 +13,89 @@ import com.sequenceiq.cloudbreak.domain.KerberosConfig;
 @RunWith(MockitoJUnitRunner.class)
 public class KerberosDetailServiceTest {
 
-    private KerberosDetailService underTest = new KerberosDetailService();
+    private static final String TEST_DEFAULT_HOST = "test.host.com:88";
+
+    private KerberosDetailService underTest;
+
+    private KerberosConfig config;
+
+    @Before
+    public void setUp() {
+        underTest = new KerberosDetailService();
+        config = new KerberosConfig();
+    }
+
+    @Test
+    public void testResolveHostForKerberosWhenUrlIsNullThenDefaultHostShouldReturn() {
+        config.setUrl(null);
+        String result = underTest.resolveHostForKerberos(config, TEST_DEFAULT_HOST);
+        Assert.assertEquals(TEST_DEFAULT_HOST, result);
+    }
+
+    @Test
+    public void testResolveHostForKerberosWhenUrlIsEmptyThenDefaultHostShouldReturn() {
+        config.setUrl("");
+        String result = underTest.resolveHostForKerberos(config, TEST_DEFAULT_HOST);
+        Assert.assertEquals(TEST_DEFAULT_HOST, result);
+    }
+
+    @Test
+    public void testResolveHostForKerberosWhenUrlIsNotEmptyThenThatValueShouldReturn() {
+        String expected = "some value";
+        config.setUrl(expected);
+        String result = underTest.resolveHostForKerberos(config, TEST_DEFAULT_HOST);
+        Assert.assertEquals(expected, result);
+    }
+
+    @Test
+    public void testResolveHostForKerberosWhenUrlContainsOnlySpacesThenDefaultHostShouldReturn() {
+        config.setUrl("   ");
+        String result = underTest.resolveHostForKerberos(config, TEST_DEFAULT_HOST);
+        Assert.assertEquals(TEST_DEFAULT_HOST, result);
+    }
+
+    @Test
+    public void testResolveHostForKdcAdminWhenUrlIsNullThenDefaultHostShouldReturn() {
+        config.setAdminUrl(null);
+        String result = underTest.resolveHostForKdcAdmin(config, TEST_DEFAULT_HOST);
+        Assert.assertEquals(TEST_DEFAULT_HOST, result);
+    }
+
+    @Test
+    public void testResolveHostForKdcAdminWhenUrlIsEmptyThenDefaultHostShouldReturn() {
+        config.setAdminUrl("");
+        String result = underTest.resolveHostForKdcAdmin(config, TEST_DEFAULT_HOST);
+        Assert.assertEquals(TEST_DEFAULT_HOST, result);
+    }
+
+    @Test
+    public void testResolveHostForKdcAdminWhenUrlIsNotEmptyThenThatValueShouldReturn() {
+        String expected = "some value";
+        config.setAdminUrl(expected);
+        String result = underTest.resolveHostForKdcAdmin(config, TEST_DEFAULT_HOST);
+        Assert.assertEquals(expected, result);
+    }
+
+    @Test
+    public void testResolveHostForKdcAdminWhenUrlContainsOnlySpacesThenDefaultHostShouldReturn() {
+        config.setAdminUrl("   ");
+        String result = underTest.resolveHostForKdcAdmin(config, TEST_DEFAULT_HOST);
+        Assert.assertEquals(TEST_DEFAULT_HOST, result);
+    }
 
     @Test
     public void testAmbariManagedKerberosMissing() throws IOException {
-        KerberosConfig config = new KerberosConfig();
         Assert.assertTrue(underTest.isAmbariManagedKerberosPackages(config));
     }
 
     @Test
     public void testAmbariManagedKerberosTrue() throws IOException {
-        KerberosConfig config = new KerberosConfig();
         config.setDescriptor("{\"kerberos-env\":{\"properties\":{\"install_packages\":true}}}");
         Assert.assertTrue(underTest.isAmbariManagedKerberosPackages(config));
     }
 
     @Test
     public void testAmbariManagedKerberosFalse() throws IOException {
-        KerberosConfig config = new KerberosConfig();
         config.setDescriptor("{\"kerberos-env\":{\"properties\":{\"install_packages\":false}}}");
         Assert.assertFalse(underTest.isAmbariManagedKerberosPackages(config));
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/KerberosRequestToKerberosConfigConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/KerberosRequestToKerberosConfigConverter.java
@@ -9,7 +9,7 @@ import com.sequenceiq.cloudbreak.domain.KerberosConfig;
 import com.sequenceiq.cloudbreak.type.KerberosType;
 
 @Component
-public class KerbersoRequestToKerberosConfigConverter extends AbstractConversionServiceAwareConverter<KerberosRequest, KerberosConfig> {
+public class KerberosRequestToKerberosConfigConverter extends AbstractConversionServiceAwareConverter<KerberosRequest, KerberosConfig> {
     @Override
     public KerberosConfig convert(KerberosRequest source) {
         KerberosConfig kerberosConfig = new KerberosConfig();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
@@ -127,6 +127,45 @@ public class ClusterHostServiceRunner {
         }
     }
 
+    @Transactional
+    public Map<String, String> addAmbariServices(Long stackId, String hostGroupName, Integer scalingAdjustment) throws CloudbreakException {
+        Map<String, String> candidates;
+        try {
+            Stack stack = stackRepository.findOneWithLists(stackId);
+            Cluster cluster = stack.getCluster();
+            candidates = collectUpscaleCandidates(cluster.getId(), hostGroupName, scalingAdjustment);
+            Set<Node> allNodes = stackUtil.collectNodes(stack);
+            HostOrchestrator hostOrchestrator = hostOrchestratorResolver.get(stack.getOrchestrator().getType());
+            List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
+            SaltConfig saltConfig = createSaltConfig(stack, cluster, gatewayConfigService.getPrimaryGatewayConfig(stack), gatewayConfigs);
+            hostOrchestrator.runService(gatewayConfigs, allNodes, saltConfig, clusterDeletionBasedModel(stack.getId(), cluster.getId()));
+        } catch (CloudbreakOrchestratorCancelledException e) {
+            throw new CancellationException(e.getMessage());
+        } catch (CloudbreakOrchestratorException | IOException e) {
+            throw new CloudbreakException(e);
+        }
+        return candidates;
+    }
+
+    public String changePrimaryGateway(Stack stack) throws CloudbreakException {
+        GatewayConfig formerPrimaryGatewayConfig = gatewayConfigService.getPrimaryGatewayConfig(stack);
+        List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
+        Optional<GatewayConfig> newPrimaryCandidate = gatewayConfigs.stream().filter(gc -> !gc.isPrimary()).findFirst();
+        if (newPrimaryCandidate.isPresent()) {
+            GatewayConfig newPrimary = newPrimaryCandidate.get();
+            Set<Node> allNodes = stackUtil.collectNodes(stack);
+            try {
+                hostOrchestratorResolver.get(stack.getOrchestrator().getType()).changePrimaryGateway(formerPrimaryGatewayConfig, newPrimary, gatewayConfigs,
+                        allNodes, clusterDeletionBasedModel(stack.getId(), stack.getCluster().getId()));
+                return newPrimary.getHostname();
+            } catch (CloudbreakOrchestratorException ex) {
+                throw new CloudbreakException(ex);
+            }
+        } else {
+            throw new CloudbreakException("Primary gateway change is not possible because there is no available node for the action");
+        }
+    }
+
     private SaltConfig createSaltConfig(Stack stack, Cluster cluster, GatewayConfig primaryGatewayConfig, Iterable<GatewayConfig> gatewayConfigs)
             throws IOException, CloudbreakOrchestratorException {
         Map<String, SaltPillarProperties> servicePillar = new HashMap<>();
@@ -140,7 +179,7 @@ public class ClusterHostServiceRunner {
             putIfNotNull(kerberosPillarConf, kerberosConfig.getPassword(), "password");
             if (StringUtils.isEmpty(kerberosConfig.getDescriptor())) {
                 putIfNotNull(kerberosPillarConf, kerberosConfig.getUrl(), "url");
-                putIfNotNull(kerberosPillarConf, kerberosConfig.getAdminUrl(), "adminUrl");
+                putIfNotNull(kerberosPillarConf, kerberosDetailService.resolveHostForKdcAdmin(kerberosConfig, kerberosConfig.getUrl()), "adminUrl");
                 putIfNotNull(kerberosPillarConf, kerberosConfig.getRealm(), "realm");
             } else {
                 Map<String, Object> properties = kerberosDetailService.getKerberosEnvProperties(kerberosConfig);
@@ -286,26 +325,6 @@ public class ClusterHostServiceRunner {
         servicePillar.put("hdp", new SaltPillarProperties("/hdp/repo.sls", singletonMap("hdp", hdprepo)));
     }
 
-    @Transactional
-    public Map<String, String> addAmbariServices(Long stackId, String hostGroupName, Integer scalingAdjustment) throws CloudbreakException {
-        Map<String, String> candidates;
-        try {
-            Stack stack = stackRepository.findOneWithLists(stackId);
-            Cluster cluster = stack.getCluster();
-            candidates = collectUpscaleCandidates(cluster.getId(), hostGroupName, scalingAdjustment);
-            Set<Node> allNodes = stackUtil.collectNodes(stack);
-            HostOrchestrator hostOrchestrator = hostOrchestratorResolver.get(stack.getOrchestrator().getType());
-            List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
-            SaltConfig saltConfig = createSaltConfig(stack, cluster, gatewayConfigService.getPrimaryGatewayConfig(stack), gatewayConfigs);
-            hostOrchestrator.runService(gatewayConfigs, allNodes, saltConfig, clusterDeletionBasedModel(stack.getId(), cluster.getId()));
-        } catch (CloudbreakOrchestratorCancelledException e) {
-            throw new CancellationException(e.getMessage());
-        } catch (CloudbreakOrchestratorException | IOException e) {
-            throw new CloudbreakException(e);
-        }
-        return candidates;
-    }
-
     private Map<String, String> collectUpscaleCandidates(Long clusterId, String hostGroupName, Integer adjustment) {
         HostGroup hostGroup = hostGroupRepository.findHostGroupInClusterByName(clusterId, hostGroupName);
         if (hostGroup.getConstraint().getInstanceGroup() != null) {
@@ -324,25 +343,6 @@ public class ClusterHostServiceRunner {
     private void putIfNotNull(Map<String, String> context, Object variable, String key) {
         if (variable != null) {
             context.put(key, variable.toString());
-        }
-    }
-
-    public String changePrimaryGateway(Stack stack) throws CloudbreakException {
-        GatewayConfig formerPrimaryGatewayConfig = gatewayConfigService.getPrimaryGatewayConfig(stack);
-        List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
-        Optional<GatewayConfig> newPrimaryCandidate = gatewayConfigs.stream().filter(gc -> !gc.isPrimary()).findFirst();
-        if (newPrimaryCandidate.isPresent()) {
-            GatewayConfig newPrimary = newPrimaryCandidate.get();
-            Set<Node> allNodes = stackUtil.collectNodes(stack);
-            try {
-                hostOrchestratorResolver.get(stack.getOrchestrator().getType()).changePrimaryGateway(formerPrimaryGatewayConfig, newPrimary, gatewayConfigs,
-                        allNodes, clusterDeletionBasedModel(stack.getId(), stack.getCluster().getId()));
-                return newPrimary.getHostname();
-            } catch (CloudbreakOrchestratorException ex) {
-                throw new CloudbreakException(ex);
-            }
-        } else {
-            throw new CloudbreakException("Primary gateway change is not possible because there is no available node for the action");
         }
     }
 


### PR DESCRIPTION
Fixes a bug when the user sends an empty value (or only spaces) as the kerberos admin host, and this empty and/or invalid data stored in the kerberos config file by the salt, which would cause malfunction