### PR TITLE
Force leave nodes failed(2) nodes (Not alive(1)  and Not left(3))

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/consul/scripts/consul_cleanup.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/consul/scripts/consul_cleanup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-# remove all nodes that are failing before the new ones can join
-curl 127.0.0.1:8500/v1/agent/members | jq '.[] | select(.Status != 1) | .Name' | xargs -I@ /usr/local/bin/consul force-leave @
+# remove all nodes that are failing before the new ones can join (Force Leave nodes which are not alive - status 1 and not left - status 3)
+curl 127.0.0.1:8500/v1/agent/members | jq '.[] | select((.Status != 1) and (.Status != 3)) | .Name' | xargs -I@ /usr/local/bin/consul force-leave @


### PR DESCRIPTION
Enhance Consul cleanup to force leave only nodes which are not alive or not left.

Issue:
For a cluster which performs lot of upscale/downscale, consul dead members can accumulate quickly.
For a Cluster which had more than 500 "left" consul member nodes,
Cloudbreak 2.4 started failing to add nodes to Ambari cluster as consul cleanup would not complete in ambari server -Consul cleanup was not completing within the 90 attempts that Cloudbreak would do to get the status of Consul cleanup.
Consul cleanup was attempting to perform force-leave on any member which is not alive.
Performing a force-leave on a node which has already left will not benefit consul/cloudbreak.

Fix:
Patched consul_cleanup to force leave only nodes which are not alive and not left.
This would make consul_cleanup to perform the necessary action and only force-leave "failed" nodes.

Reference about consul:
[Consul Members](https://www.consul.io/docs/commands/members.html) can be alive, left or failed.
[Consul removes failed or left nodes](https://www.consul.io/docs/faq.html#q-are-failed-or-left-nodes-ever-removed-) every 72 hours.

Short Description:
- Enhance Consul Cleanup

