### PR TITLE
BUG-102296 - fallback to V1 API added when V2 list images request fails

### DIFF
--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/common/OpenStackImageVerifier.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/common/OpenStackImageVerifier.java
@@ -2,14 +2,19 @@ package com.sequenceiq.cloudbreak.cloud.openstack.common;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
+import javax.ws.rs.ProcessingException;
+
 import org.openstack4j.api.OSClient;
+import org.openstack4j.model.common.BasicResource;
 import org.openstack4j.model.image.v2.Image;
 import org.openstack4j.model.image.v2.Image.ImageStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
 
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 
@@ -19,37 +24,72 @@ public class OpenStackImageVerifier {
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenStackImageVerifier.class);
 
     public boolean exist(OSClient<?> osClient, String name) {
-        boolean exist = false;
-        if (getStatus(osClient, name) != null) {
-            exist = true;
-        }
-        return exist;
+        return getStatus(osClient, name).isPresent();
     }
 
-    public ImageStatus getStatus(OSClient<?> osClient, String name) {
-        ImageStatus imageStatus;
-        List<? extends Image> images = osClient.imagesV2().list(Collections.singletonMap("name", name));
-        if (images == null || images.isEmpty()) {
-            imageStatus = null;
-            LOGGER.error("OpenStack image: {} not found", name);
-            List<? extends Image> allImages = osClient.imagesV2().list();
-            if (allImages != null) {
-                for (Image image : allImages) {
-                    LOGGER.info("Available images: {}, entry: {}", image.getName(), image);
-                }
-            }
-            LOGGER.warn("OpenStack image: {} not found", name);
-        } else if (images.size() > 1) {
-            for (Image image : images) {
-                LOGGER.info("Multiple images found: {}, entry: {}", image.getName(), image);
-            }
-            List<String> imageIds = images.stream().map(Image::getId).collect(Collectors.toList());
-            throw new CloudConnectorException(String.format("Multiple OpenStack images found with ids: %s, image name: %s",
-                    String.join(", ", imageIds), name));
-        } else {
-            LOGGER.info("OpenStack Image found: {}, entry: {}", name, images);
-            imageStatus = images.get(0).getStatus();
+    public Optional<ImageStatus> getStatus(OSClient<?> osClient, String name) {
+        try {
+            List<? extends BasicResource> imagesV2 = osClient.imagesV2().list(Collections.singletonMap("name", name));
+            return getStatusFromImages(osClient, imagesV2, name, true);
+        } catch (ProcessingException e) {
+            LOGGER.warn("Exception occured during listing openstack images on V2 API. Falling back to V1 API.", e);
+            List<? extends BasicResource> imagesV1 = osClient.images().list(Collections.singletonMap("name", name));
+            return getStatusFromImages(osClient, imagesV1, name, false);
         }
-        return imageStatus;
+
+    }
+
+    private Optional<ImageStatus> getStatusFromImages(OSClient<?> osClient, List<? extends BasicResource> images, String name, boolean v2Resouce) {
+        if (CollectionUtils.isEmpty(images)) {
+            return handleImageNotFound(osClient, name);
+        } else if (images.size() > 1) {
+            handleMultipleImagesFound(images, name);
+        } else {
+            return getStatusForSingleResult(images, name, v2Resouce);
+        }
+        return Optional.empty();
+    }
+
+    private Optional<ImageStatus> handleImageNotFound(OSClient<?> osClient, String name) {
+        LOGGER.error("OpenStack image: {} not found", name);
+        List<? extends BasicResource> allImages;
+        try {
+            allImages = osClient.imagesV2().list();
+        } catch (ProcessingException e) {
+            LOGGER.warn("Exception occured during listing openstack images on V2 API. Falling back to V1 API.", e);
+            allImages = osClient.images().list();
+        }
+        if (allImages != null) {
+            for (BasicResource image : allImages) {
+                LOGGER.info("Available images: {}, entry: {}", image.getName(), image);
+            }
+        }
+        LOGGER.warn("OpenStack image: {} not found", name);
+        return Optional.empty();
+    }
+
+    private void handleMultipleImagesFound(List<? extends BasicResource> images, String name) {
+        for (BasicResource image : images) {
+            LOGGER.info("Multiple images found: {}, entry: {}", image.getName(), image);
+        }
+        List<String> imageIds = images.stream().map(BasicResource::getId).collect(Collectors.toList());
+        throw new CloudConnectorException(String.format("Multiple OpenStack images found with ids: %s, image name: %s",
+                String.join(", ", imageIds), name));
+    }
+
+    private Optional<ImageStatus> getStatusForSingleResult(List<? extends BasicResource> images, String name, boolean v2Resource) {
+        ImageStatus imageStatus;
+        LOGGER.info("OpenStack Image found: {}, entry: {}", name, images);
+        BasicResource foundImage = images.get(0);
+        if (v2Resource) {
+            imageStatus = Image.class.cast(foundImage).getStatus();
+        } else {
+            imageStatus = v1StatusToV2Status(org.openstack4j.model.image.Image.class.cast(foundImage).getStatus());
+        }
+        return Optional.of(imageStatus);
+    }
+
+    private ImageStatus v1StatusToV2Status(org.openstack4j.model.image.Image.Status status) {
+        return ImageStatus.valueOf(status.name());
     }
 }

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/common/OpenStackSetup.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/common/OpenStackSetup.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.cloud.openstack.common;
 
+import java.util.Optional;
+
 import javax.inject.Inject;
 
 import org.openstack4j.api.OSClient;
@@ -57,21 +59,23 @@ public class OpenStackSetup implements Setup {
     public ImageStatusResult checkImageStatus(AuthenticatedContext authenticatedContext, CloudStack stack, com.sequenceiq.cloudbreak.cloud.model.Image image) {
         String imageName = image.getImageName();
         OSClient osClient = openStackClient.createOSClient(authenticatedContext);
-        Image.ImageStatus imageStatus = openStackImageVerifier.getStatus(osClient, imageName);
-        ImageStatusResult imageStatusResult;
-        switch (imageStatus) {
-            case ACTIVE:
-                imageStatusResult = new ImageStatusResult(ImageStatus.CREATE_FINISHED, ImageStatusResult.COMPLETED);
-                break;
-            case QUEUED:
-            case SAVING:
-                imageStatusResult = new ImageStatusResult(ImageStatus.IN_PROGRESS, ImageStatusResult.HALF);
-                break;
-            default:
-                imageStatusResult = new ImageStatusResult(ImageStatus.CREATE_FAILED, ImageStatusResult.COMPLETED);
-                break;
-        }
-        LOGGER.info("OpenStack image result. name: {}, imageStatus: {}, imageStatusResult: {}", imageName, imageStatus, imageStatusResult);
+        Optional<Image.ImageStatus> optionalImageStatus = openStackImageVerifier.getStatus(osClient, imageName);
+
+        ImageStatusResult imageStatusResult = optionalImageStatus.map(imageStatus -> {
+            switch (imageStatus) {
+                case ACTIVE:
+                    return new ImageStatusResult(ImageStatus.CREATE_FINISHED, ImageStatusResult.COMPLETED);
+                case QUEUED:
+                case SAVING:
+                    return new ImageStatusResult(ImageStatus.IN_PROGRESS, ImageStatusResult.HALF);
+                default:
+                    return new ImageStatusResult(ImageStatus.CREATE_FAILED, ImageStatusResult.COMPLETED);
+            }
+        }).orElse(
+                new ImageStatusResult(ImageStatus.CREATE_FAILED, ImageStatusResult.COMPLETED)
+        );
+
+        LOGGER.info("OpenStack image result. name: {}, imageStatus: {}, imageStatusResult: {}", imageName, optionalImageStatus.orElse(null), imageStatusResult);
         return imageStatusResult;
     }
 

--- a/cloud-openstack/src/test/java/com/sequenceiq/cloudbreak/cloud/openstack/common/OpenStackImageVerifierTest.java
+++ b/cloud-openstack/src/test/java/com/sequenceiq/cloudbreak/cloud/openstack/common/OpenStackImageVerifierTest.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.cloud.openstack.common;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.anyMap;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
@@ -7,7 +8,8 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Assert;
+import javax.ws.rs.ProcessingException;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,6 +38,9 @@ public class OpenStackImageVerifierTest {
     @Mock
     private ImageService imageService;
 
+    @Mock
+    private org.openstack4j.api.image.ImageService imageServiceV1;
+
     @Before
     public void setUp() {
         when(osClient.imagesV2()).thenReturn(imageService);
@@ -48,7 +53,7 @@ public class OpenStackImageVerifierTest {
         newImage1.setName("exist-id1");
         when(imageService.list(anyMap())).thenReturn(null);
         doReturn(ImmutableList.of(newImage1)).when(imageService).list();
-        Assert.assertEquals(false, underTest.exist(osClient, "invalidentryTgatResultsNull"));
+        assertEquals(false, underTest.exist(osClient, "invalidentryTgatResultsNull"));
     }
 
     @Test
@@ -58,13 +63,39 @@ public class OpenStackImageVerifierTest {
         }
     }
 
-    private void foundOneAnyState(Image.ImageStatus status) {
-        GlanceImage newImage = Mockito.mock(GlanceImage.class);
-        when(newImage.getStatus()).thenReturn(status);
-        List<GlanceImage> returnedImages = ImmutableList.of(newImage);
-        Map<String, String> map = ImmutableMap.of("name", "exist-id1");
-        doReturn(returnedImages).when(imageService).list(Mockito.eq(map));
-        Assert.assertEquals(true, underTest.exist(osClient, "exist-id1"));
+    @Test
+    public void testV2RequestFallsBackToV1() {
+        when(imageService.list(anyMap())).thenThrow(ProcessingException.class);
+        when(osClient.images()).thenReturn(imageServiceV1);
+        doReturn(image(org.openstack4j.model.image.Image.Status.KILLED),
+                image(org.openstack4j.model.image.Image.Status.ACTIVE),
+                image(org.openstack4j.model.image.Image.Status.DELETED),
+                image(org.openstack4j.model.image.Image.Status.PENDING_DELETE),
+                image(org.openstack4j.model.image.Image.Status.QUEUED),
+                image(org.openstack4j.model.image.Image.Status.SAVING),
+                image(org.openstack4j.model.image.Image.Status.UNRECOGNIZED))
+                .when(imageServiceV1).list(anyMap());
+
+        testWithV1ImageStatus(Image.ImageStatus.KILLED);
+        testWithV1ImageStatus(Image.ImageStatus.ACTIVE);
+        testWithV1ImageStatus(Image.ImageStatus.DELETED);
+        testWithV1ImageStatus(Image.ImageStatus.PENDING_DELETE);
+        testWithV1ImageStatus(Image.ImageStatus.QUEUED);
+        testWithV1ImageStatus(Image.ImageStatus.SAVING);
+        testWithV1ImageStatus(Image.ImageStatus.UNRECOGNIZED);
+    }
+
+    private ImmutableList<org.openstack4j.openstack.image.domain.GlanceImage> image(org.openstack4j.model.image.Image.Status status) {
+        org.openstack4j.openstack.image.domain.GlanceImage image = new org.openstack4j.openstack.image.domain.GlanceImage();
+        image.setId("id1");
+        image.setName("image1");
+        image.status(status);
+        return ImmutableList.of(image);
+    }
+
+    private void testWithV1ImageStatus(Image.ImageStatus expectedStatus) {
+        Image.ImageStatus statusResult = underTest.getStatus(osClient, "image1").get();
+        assertEquals(expectedStatus, statusResult);
     }
 
     @Test(expected = CloudConnectorException.class)
@@ -81,8 +112,17 @@ public class OpenStackImageVerifierTest {
             doReturn(returnedImages).when(imageService).list(Mockito.eq(map));
             underTest.exist(osClient, "exist-id1");
         } catch (CloudConnectorException cce) {
-            Assert.assertEquals("Multiple OpenStack images found with ids: id1, id2, image name: exist-id1", cce.getMessage());
+            assertEquals("Multiple OpenStack images found with ids: id1, id2, image name: exist-id1", cce.getMessage());
             throw cce;
         }
+    }
+
+    private void foundOneAnyState(Image.ImageStatus status) {
+        GlanceImage newImage = Mockito.mock(GlanceImage.class);
+        when(newImage.getStatus()).thenReturn(status);
+        List<GlanceImage> returnedImages = ImmutableList.of(newImage);
+        Map<String, String> map = ImmutableMap.of("name", "exist-id1");
+        doReturn(returnedImages).when(imageService).list(Mockito.eq(map));
+        assertEquals(true, underTest.exist(osClient, "exist-id1"));
     }
 }


### PR DESCRIPTION
- fallback to V1 API added when V2 list images request fails in OpenStackImageVerifier
- OpenStackImageVerifier getStatus does not return nulls anymore

Closes #BUG-102296