### PR TITLE
RMP-11135 root volume size configuration enabled for GCP

### DIFF
--- a/cloud-common/src/main/resources/application.yml
+++ b/cloud-common/src/main/resources/application.yml
@@ -18,6 +18,7 @@ cb:
   platform.default.rootVolumeSize:
     AWS: 50
     AZURE: 30
+    GCP: 50
   enabled.linux.types: redhat6,redhat7,centos6,centos7,amazonlinux
   publicip:
   etc.config.dir: /etc/cloudbreak

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpDiskResourceBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpDiskResourceBuilder.java
@@ -29,8 +29,6 @@ import com.sequenceiq.cloudbreak.common.type.ResourceType;
 @Component
 public class GcpDiskResourceBuilder extends AbstractGcpComputeBuilder {
 
-    private static final long DEFAULT_ROOT_DISK_SIZE = 50L;
-
     @Inject
     private DefaultCostTaggingService defaultCostTaggingService;
 
@@ -48,7 +46,7 @@ public class GcpDiskResourceBuilder extends AbstractGcpComputeBuilder {
         Location location = context.getLocation();
 
         Disk disk = new Disk();
-        disk.setSizeGb(DEFAULT_ROOT_DISK_SIZE);
+        disk.setSizeGb((long) group.getRootVolumeSize());
         disk.setName(buildableResources.get(0).getName());
         disk.setKind(GcpDiskType.HDD.getUrl(projectId, location.getAvailabilityZone()));
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/v2/AbstractStackCreationV2Test.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/v2/AbstractStackCreationV2Test.java
@@ -88,7 +88,7 @@ public class AbstractStackCreationV2Test extends AbstractCloudbreakIntegrationTe
     public void ambariParameters(@Optional("") String blueprintName, @Optional("false") boolean enableSecurity,
             @Optional String kerberosMasterKey, @Optional String kerberosAdmin, @Optional String kerberosPassword) {
         IntegrationTestContext itContext = getItContext();
-        blueprintName = StringUtils.hasText(blueprintName) ? blueprintName : itContext.getContextParam(CloudbreakV2Constants.SSH_PUBLICKEY_ID);
+        blueprintName = StringUtils.hasText(blueprintName) ? blueprintName : itContext.getContextParam(CloudbreakV2Constants.BLUEPRINT_NAME);
 
         Assert.assertNotNull(itContext.getContextParam(CloudbreakITContextConstants.AMBARI_USER_ID), "Ambari user is mandatory.");
         Assert.assertNotNull(itContext.getContextParam(CloudbreakITContextConstants.AMBARI_PASSWORD_ID), "Ambari password is mandatory.");


### PR DESCRIPTION
Root volume size can be set in the create cluster request's template part for GCP too:
~~~~
"template": {
	"parameters": {
		"encrypted": false
	},
	"instanceType": "n1-standard-8",
	"volumeType": "pd-standard",
	"volumeCount": 1,
	"volumeSize": 100,
	"rootVolumeSize": 65
}
~~~~

Note: this feature is already implemented for AWS and Azure. 
For OpenStack, the root disc cannot be configured directly. The user must choose a flavor which satisfies her/his needs.

Closes #RMP-11135
Closes #BUG-101027