### PR TITLE
BUG-102974 Added vdf xml parsing for package repositories

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/init.sls
@@ -1,7 +1,13 @@
 {%- from 'gateway/settings.sls' import gateway with context %}
 
 include:
+{% if grains['os_family'] == 'RedHat' %}
   - gateway.repo
+{% endif %}
+
+{% if grains['os_family'] == 'Debian' %}
+  - gateway.repo.debian
+{% endif %}
 
 knox:
   pkg.installed
@@ -203,5 +209,34 @@ start-knox-gateway:
   file.copy:
     - source: /etc/knox/conf
     - preserve: True
+
+{% endif %}
+
+{% if salt['pillar.get']('hdp:stack:vdf-url') != None %}
+
+add_vdf_parse_script_agent:
+  file.managed:
+    - name: /opt/salt/extract-repo-url-from-vdf.sh
+    - source: salt://gateway/yum/scripts/extract-repo-url-from-vdf.sh
+    - skip_verify: True
+    - makedirs: True
+    - mode: 755
+
+run_vdf_parse_script_agent:
+  cmd.run:
+    - name: sh -x /opt/salt/extract-repo-url-from-vdf.sh {{ salt['pillar.get']('hdp:stack:vdf-url') }} | tee -a /var/log/add_vdf_parse_script_agent.log && exit ${PIPESTATUS[0]}
+    - unless: ls /var/log/add_vdf_parse_script_agent.log
+    - require:
+      - file: add_vdf_parse_script_agent
+
+{% endif %}
+
+{% if 'HDF' in salt['pillar.get']('hdp:stack:repoid') %}
+
+/etc/yum.repos.d/KNOX.repo:
+  file.managed:
+    - replace: False
+    - source: salt://gateway/yum/knox.repo
+    - template: jinja
 
 {% endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/repo.debian.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/repo.debian.sls
@@ -1,0 +1,26 @@
+{% set os = grains['os'] | lower ~ grains['osmajorrelease'] %}
+
+{% if salt['pillar.get']('hdp:stack:vdf-url') != None %}
+
+create_hdp__repo:
+  pkgrepo.managed:
+    - name: "deb {{ salt['cmd.run']("cat /tmp/hdp-repo-url.text") }} HDP-UTILS main"
+    - file: /etc/apt/sources.list.d/hdp.list
+
+create_hdp_utils_repo:
+  pkgrepo.managed:
+    - name: "deb {{ salt['cmd.run']("cat /tmp/hdp-util-repo-url.text") }} HDP-UTILS main"
+    - file: /etc/apt/sources.list.d/hdp-utils.list
+
+{% else %}
+
+create_hdp_repo:
+  pkgrepo.managed:
+    - name: "deb {{ salt['pillar.get']('hdp:stack:' + os) }} HDP main"
+    - file: /etc/apt/sources.list.d/hdp.list
+
+create_hdp_utils_repo:
+  pkgrepo.managed:
+    - name: "deb {{ salt['pillar.get']('hdp:util:' + os) }} HDP-UTILS main"
+    - file: /etc/apt/sources.list.d/hdp-utils.list
+{% endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/repo.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/repo.sls
@@ -1,4 +1,21 @@
-{% if grains['os_family'] == 'RedHat' %}
+{% if salt['pillar.get']('hdp:stack:vdf-url') != None %}
+HDP:
+  pkgrepo.managed:
+    - humanname: {{ salt['pillar.get']('hdp:stack:repoid') }}
+    - baseurl: "{{ salt['cmd.run']("cat /tmp/hdp-repo-url.text") }}"
+    - gpgcheck: 0
+    - enabled: 1
+    - path: /
+
+HDP-UTILS:
+  pkgrepo.managed:
+    - humanname: {{ salt['pillar.get']('hdp:util:repoid') }}
+    - baseurl: "{{ salt['cmd.run']("cat /tmp/hdp-util-repo-url.text") }}"
+    - gpgcheck: 0
+    - enabled: 1
+    - path: /
+
+{% else %}
 
 /etc/yum.repos.d/HDP.repo:
   file.managed:
@@ -11,38 +28,5 @@
     - replace: False
     - source: salt://gateway/yum/hdp-utils.repo
     - template: jinja
-
-{% if 'HDF' in salt['pillar.get']('hdp:stack:repoid') %}
-
-/etc/yum.repos.d/KNOX.repo:
-  file.managed:
-    - replace: False
-    - source: salt://gateway/yum/knox.repo
-    - template: jinja
-
-{% endif %}
-
-{% elif grains['os_family'] == 'Debian' %}
-
-{% set os = grains['os'] | lower ~ grains['osmajorrelease'] %}
-
-create_hdp_repo:
-  pkgrepo.managed:
-    - name: "deb {{ salt['pillar.get']('hdp:stack:' + os) }} HDP main"
-    - file: /etc/apt/sources.list.d/hdp.list
-
-create_hdp_utils_repo:
-  pkgrepo.managed:
-    - name: "deb {{ salt['pillar.get']('hdp:util:' + os) }} HDP-UTILS main"
-    - file: /etc/apt/sources.list.d/hdp-utils.list
-
-{% if 'HDF' in salt['pillar.get']('hdp:stack:repoid') %}
-
-create_knox_repo:
-  pkgrepo.managed:
-    - name: "deb {{ salt['pillar.get']('hdp:knox:' + os) }} HDP main"
-    - file: /etc/apt/sources.list.d/knox.list
-
-{% endif %}
 
 {% endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/yum/scripts/extract-repo-url-from-vdf.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/yum/scripts/extract-repo-url-from-vdf.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+if [ -n "$1" ]
+  then
+    VDF_URL=$1
+  else
+    echo "Please specify a vdf-url"
+    exit 1
+fi
+
+echo "Using vdf url $VDF_URL"
+
+wget $VDF_URL --output-document=vdf.xml
+
+#handle hdp repository
+HDP_REPO_DATA=$(xmllint --xpath "//repository-version/repository-info/os/repo[reponame='HDP']" vdf.xml)
+HDP_BASE_URL=$(xmllint --xpath "//baseurl/text()" - <<<"$HDP_REPO_DATA")
+echo $HDP_BASE_URL >> "/tmp/hdp-repo-url.text"
+
+#handle hdp-util repository
+HDP_UTIL_REPO_DATA=$(xmllint --xpath "//repository-version/repository-info/os/repo[reponame='HDP-UTILS']" vdf.xml)
+HDP_UTIL_BASE_URL=$(xmllint --xpath "//baseurl/text()" - <<<"$HDP_UTIL_REPO_DATA")
+echo $HDP_UTIL_BASE_URL >> "/tmp/hdp-util-repo-url.text"
+
+#cleanup hdp-utils.repo?
+rm vdf.xml
+echo "Removed vdf.xml file"


### PR DESCRIPTION
1. In case of gateway setup I split the repo.sls file in two, because the pkgrepo works in different ways based on OS type. (Further improvement could be to rename the yum directory to something OS independent. package-management)
2. Added a script which if the salt pillar property `hdp.stack.vdf-url` is provided, will download the vdf xml, parses out the 2 repository HDP and HDP-UTIL, using xpath. These values are stored in tmp files for the pkgrepo to use.
3. Common salt states were moved to the init.sls