### PR TITLE
BUG-102974 Added logic to handle repo file creatio in case of HDF is …

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/repo.debian.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/repo.debian.sls
@@ -2,10 +2,21 @@
 
 {% if salt['pillar.get']('hdp:stack:vdf-url') != None %}
 
-create_hdp__repo:
+{% if 'HDF' in salt['pillar.get']('hdp:stack:repoid') %}
+
+create_hdf_repo:
   pkgrepo.managed:
-    - name: "deb {{ salt['cmd.run']("cat /tmp/hdp-repo-url.text") }} HDP-UTILS main"
+    - name: "deb {{ salt['cmd.run']("cat /tmp/hdf-repo-url.text") }} HDF main"
+    - file: /etc/apt/sources.list.d/hdf.list
+
+{% else %}
+
+create_hdp_repo:
+  pkgrepo.managed:
+    - name: "deb {{ salt['cmd.run']("cat /tmp/hdp-repo-url.text") }} HDP main"
     - file: /etc/apt/sources.list.d/hdp.list
+
+{% endif %}
 
 create_hdp_utils_repo:
   pkgrepo.managed:

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/repo.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/repo.sls
@@ -1,4 +1,17 @@
 {% if salt['pillar.get']('hdp:stack:vdf-url') != None %}
+
+{% if 'HDF' in salt['pillar.get']('hdp:stack:repoid') %}
+
+HDF:
+  pkgrepo.managed:
+    - humanname: {{ salt['pillar.get']('hdp:stack:repoid') }}
+    - baseurl: "{{ salt['cmd.run']("cat /tmp/hdf-repo-url.text") }}"
+    - gpgcheck: 0
+    - enabled: 1
+    - path: /
+
+{% else %}
+
 HDP:
   pkgrepo.managed:
     - humanname: {{ salt['pillar.get']('hdp:stack:repoid') }}
@@ -6,6 +19,8 @@ HDP:
     - gpgcheck: 0
     - enabled: 1
     - path: /
+
+{% endif %}
 
 HDP-UTILS:
   pkgrepo.managed:

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/yum/scripts/extract-repo-url-from-vdf.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/yum/scripts/extract-repo-url-from-vdf.sh
@@ -17,6 +17,11 @@ HDP_REPO_DATA=$(xmllint --xpath "//repository-version/repository-info/os/repo[re
 HDP_BASE_URL=$(xmllint --xpath "//baseurl/text()" - <<<"$HDP_REPO_DATA")
 echo $HDP_BASE_URL >> "/tmp/hdp-repo-url.text"
 
+#handle hdf repository
+HDP_REPO_DATA=$(xmllint --xpath "//repository-version/repository-info/os/repo[reponame='HDF']" vdf.xml)
+HDP_BASE_URL=$(xmllint --xpath "//baseurl/text()" - <<<"$HDP_REPO_DATA")
+echo $HDP_BASE_URL >> "/tmp/hdf-repo-url.text"
+
 #handle hdp-util repository
 HDP_UTIL_REPO_DATA=$(xmllint --xpath "//repository-version/repository-info/os/repo[reponame='HDP-UTILS']" vdf.xml)
 HDP_UTIL_BASE_URL=$(xmllint --xpath "//baseurl/text()" - <<<"$HDP_UTIL_REPO_DATA")


### PR DESCRIPTION
vdf.xml has different content in case we chose HDF. 
The xml examples I checked, it's either HDP or HDF repository is present, so we need the if 'HDF' switch.
Other possible solution if we really want to get rid of if HDF logic in salt files, is to generate a HDF-HDP repository which holds one of the urls.