### PR TITLE
added null check for clusterRequest in StackRequestValidator

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/validation/stack/StackRequestValidator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/validation/stack/StackRequestValidator.java
@@ -30,44 +30,44 @@ public class StackRequestValidator implements Validator<StackRequest> {
         if (CollectionUtils.isEmpty(stackRequest.getInstanceGroups())) {
             validationBuilder.error("Stack request must contain instance groups.");
         }
-        validationBuilder = validateHostgroupInstanceGroupMapping(stackRequest, validationBuilder);
-        validationBuilder = validateTemplates(stackRequest, validationBuilder);
+        validateHostgroupInstanceGroupMapping(stackRequest, validationBuilder);
+        validateTemplates(stackRequest, validationBuilder);
         return validationBuilder.build();
     }
 
-    private ValidationResultBuilder validateHostgroupInstanceGroupMapping(StackRequest stackRequest, ValidationResultBuilder validationBuilder) {
+    private void validateHostgroupInstanceGroupMapping(StackRequest stackRequest, ValidationResultBuilder validationBuilder) {
         Set<String> instanceGroupSet = stackRequest.getInstanceGroups()
                 .stream()
                 .map(InstanceGroupBase::getGroup)
                 .collect(Collectors.toSet());
-        Set<String> hostGroupSet = stackRequest.getClusterRequest().getHostGroups()
-                .stream()
-                .map(HostGroupBase::getName)
-                .collect(Collectors.toSet());
 
-        if (!instanceGroupSet.containsAll(hostGroupSet)) {
-            Set<String> newHostGroupSet = Sets.newHashSet(hostGroupSet);
-            newHostGroupSet.removeAll(instanceGroupSet);
-            validationBuilder.error("There are host groups in the request that do not have a corresponding instance group: "
-                    + newHostGroupSet.stream().collect(Collectors.joining(", ")));
+        if (stackRequest.getClusterRequest() != null) {
+            Set<String> hostGroupSet = stackRequest.getClusterRequest().getHostGroups()
+                    .stream()
+                    .map(HostGroupBase::getName)
+                    .collect(Collectors.toSet());
+
+            if (!instanceGroupSet.containsAll(hostGroupSet)) {
+                Set<String> newHostGroupSet = Sets.newHashSet(hostGroupSet);
+                newHostGroupSet.removeAll(instanceGroupSet);
+                validationBuilder.error("There are host groups in the request that do not have a corresponding instance group: "
+                        + newHostGroupSet.stream().collect(Collectors.joining(", ")));
+            }
+
+            if (!hostGroupSet.containsAll(instanceGroupSet)) {
+                instanceGroupSet.removeAll(hostGroupSet);
+                validationBuilder.error("There are instance groups in the request that do not have a corresponding host group: "
+                        + instanceGroupSet.stream().collect(Collectors.joining(", ")));
+            }
         }
-
-        if (!hostGroupSet.containsAll(instanceGroupSet)) {
-            instanceGroupSet.removeAll(hostGroupSet);
-            validationBuilder.error("There are instance groups in the request that do not have a corresponding host group: "
-                    + instanceGroupSet.stream().collect(Collectors.joining(", ")));
-        }
-
-        return validationBuilder;
     }
 
-    private ValidationResultBuilder validateTemplates(StackRequest stackRequest, ValidationResultBuilder resultBuilder) {
+    private void validateTemplates(StackRequest stackRequest, ValidationResultBuilder resultBuilder) {
         stackRequest.getInstanceGroups()
                 .stream()
                 .map(i -> templateRequestValidator.validate(i.getTemplate()))
                 .reduce(ValidationResult::merge)
                 .ifPresent(resultBuilder::merge);
-        return resultBuilder;
     }
 }
 


### PR DESCRIPTION
This morning some e2e API tests failed because of a NullPointerException here.