### PR TITLE
BUG-102975 Gateway handlebars now will use the CertWithoutHeader

### DIFF
--- a/blueprint-manager/src/main/java/com/sequenceiq/cloudbreak/blueprint/template/views/GatewayView.java
+++ b/blueprint-manager/src/main/java/com/sequenceiq/cloudbreak/blueprint/template/views/GatewayView.java
@@ -5,7 +5,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringEscapeUtils;
 import org.springframework.util.CollectionUtils;
 
 import com.sequenceiq.cloudbreak.api.model.GatewayType;
@@ -95,22 +94,6 @@ public class GatewayView {
         String cert = null;
         if (signCert != null) {
             cert = signCert.replaceAll("-----BEGIN CERTIFICATE-----|-----END CERTIFICATE-----", "").trim();
-        }
-        return cert;
-    }
-
-    public String getEscSignKey() {
-        return StringEscapeUtils.escapeJson(signKey);
-    }
-
-    public String getEscSignPub() {
-        return StringEscapeUtils.escapeJson(signPub);
-    }
-
-    public String getEscSignCert() {
-        String cert = getSignCertWithoutHeader();
-        if (cert != null) {
-            cert = StringEscapeUtils.escapeJson(cert);
         }
         return cert;
     }

--- a/blueprint-manager/src/main/resources/blueprints/configurations/atlas/gateway.handlebars
+++ b/blueprint-manager/src/main/resources/blueprints/configurations/atlas/gateway.handlebars
@@ -5,7 +5,7 @@
       "atlas.authorizer.impl": "ranger",
 {{{/cp}}}
 {{{#if gateway}}}
-      "atlas.sso.knox.publicKey": "{{{ gateway.escSignCert }}}",
+      "atlas.sso.knox.publicKey": "{{{ gateway.signCertWithoutHeader }}}",
       "atlas.sso.knox.providerurl": "{{{ gateway.ssoProvider }}}",
       "atlas.sso.knox.enabled": "true",
       "atlas.sso.knox.browser.useragent": "Mozilla,chrome"

--- a/blueprint-manager/src/main/resources/blueprints/configurations/beacon/gateway.handlebars
+++ b/blueprint-manager/src/main/resources/blueprints/configurations/beacon/gateway.handlebars
@@ -3,7 +3,7 @@
   "beacon-security-site": {
     "properties": {
       "beacon.sso.knox.authentication.enabled": "true",
-      "beacon.sso.knox.publicKey": "{{{ gateway.escSignCert }}}"
+      "beacon.sso.knox.publicKey": "{{{ gateway.signCertWithoutHeader }}}"
     }
   }
 {{{/if}}}

--- a/blueprint-manager/src/main/resources/blueprints/configurations/ranger/gateway.handlebars
+++ b/blueprint-manager/src/main/resources/blueprints/configurations/ranger/gateway.handlebars
@@ -3,7 +3,7 @@
   "ranger-admin-site": {
     "properties": {
       "ranger.sso.enabled": "true",
-      "ranger.sso.publicKey": "{{{ gateway.escSignCert }}}",
+      "ranger.sso.publicKey": "{{{ gateway.signCertWithoutHeader }}}",
       "ranger.sso.providerurl": "{{{ gateway.ssoProvider }}}",
       "ranger.audit.source.type": "solr"
     }

--- a/blueprint-manager/src/test/java/com/sequenceiq/cloudbreak/blueprint/template/views/GatewayViewTest.java
+++ b/blueprint-manager/src/test/java/com/sequenceiq/cloudbreak/blueprint/template/views/GatewayViewTest.java
@@ -15,9 +15,6 @@ public class GatewayViewTest {
     public void testInitializeGatewayView() throws JsonProcessingException {
         GatewayView gatewayView = new GatewayView(TestUtil.gatewayEnabled());
 
-        Assert.assertEquals("signcert", gatewayView.getEscSignCert());
-        Assert.assertEquals("signkey", gatewayView.getEscSignKey());
-        Assert.assertEquals("signpub", gatewayView.getEscSignPub());
         Assert.assertEquals("/path", gatewayView.getPath());
         Assert.assertEquals("simple", gatewayView.getSsoProvider());
         Assert.assertEquals("tokencert", gatewayView.getTokenCert());


### PR DESCRIPTION
Removed old code for escaping the cert. 
The certWithoutHeader is used in ranger, atlas, beacon handlebars.