### PR TITLE
Skiptests

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/IntegrationTestApp.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/IntegrationTestApp.java
@@ -10,7 +10,6 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import com.sequenceiq.it.cloudbreak.newway.log.ReportListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -35,6 +34,7 @@ import org.uncommons.reportng.HTMLReporter;
 import org.uncommons.reportng.JUnitXMLReporter;
 
 import com.sequenceiq.it.cloudbreak.config.ITProps;
+import com.sequenceiq.it.cloudbreak.newway.listener.ReportListener;
 
 @EnableAutoConfiguration(exclude = {DataSourceAutoConfiguration.class, DataSourceTransactionManagerAutoConfiguration.class,
         HibernateJpaAutoConfiguration.class})

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/listener/FirstLastTestExecutionBehaviour.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/listener/FirstLastTestExecutionBehaviour.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.it.cloudbreak.newway.listener;
+
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.IResultMap;
+import org.testng.ITestNGMethod;
+import org.testng.ITestResult;
+import org.testng.SkipException;
+
+public class FirstLastTestExecutionBehaviour implements IInvokedMethodListener {
+    @Override
+    public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
+        if (method.isTestMethod()) {
+            ITestNGMethod thisMethod = method.getTestMethod();
+            ITestNGMethod[] allTestMethods = testResult.getTestContext().getAllTestMethods();
+            ITestNGMethod firstMethod = allTestMethods[0];
+            ITestNGMethod lastMethod = allTestMethods[allTestMethods.length - 1];
+
+            if (!thisMethod.equals(firstMethod) && !thisMethod.equals(lastMethod)) {
+                IResultMap success = testResult.getTestContext().getPassedTests();
+                if (!success.getAllMethods().contains(firstMethod)) {
+                    throw new SkipException("Skipped because first method was not succcessfull");
+                }
+            }
+        }
+    }
+
+    @Override
+    public void afterInvocation(IInvokedMethod method, ITestResult testResult) {
+
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/listener/GatekeeperBehaviour.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/listener/GatekeeperBehaviour.java
@@ -1,0 +1,59 @@
+package com.sequenceiq.it.cloudbreak.newway.listener;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.IResultMap;
+import org.testng.ISuiteResult;
+import org.testng.ITestNGMethod;
+import org.testng.ITestResult;
+
+public class GatekeeperBehaviour implements IInvokedMethodListener {
+
+    private static final String IS_GATEKEEPER = "isGatekeeper";
+
+    private static final String TRUE = "true";
+
+    private static final String SKIP_MESSAGE = "Skipped because gatekeeper test in this suite failed";
+
+    @Override
+    public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
+        if (method.isTestMethod()) {
+            ITestNGMethod thisMethod = method.getTestMethod();
+            ITestNGMethod[] allTestMethods = testResult.getTestContext().getAllTestMethods();
+            ITestNGMethod firstMethod = allTestMethods[0];
+
+            if (thisMethod.equals(firstMethod)) {
+                Map<String, ISuiteResult> results = testResult.getTestContext().getSuite().getResults();
+                if (hasFailedGatekeeperTest(results)) {
+                    throw new GatekeeperException(SKIP_MESSAGE);
+                }
+            } else {
+                IResultMap skippedTests = testResult.getTestContext().getSkippedTests();
+                if (anyTestsSkippedBecauseOfGatekeeper(skippedTests)) {
+                    throw new GatekeeperException(SKIP_MESSAGE);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void afterInvocation(IInvokedMethod method, ITestResult testResult) {
+
+    }
+
+    private boolean anyTestsSkippedBecauseOfGatekeeper(IResultMap skippedTests) {
+        return skippedTests.getAllResults().stream().anyMatch((result) -> {
+            return result.getThrowable() instanceof GatekeeperException;
+        });
+    }
+
+    private boolean hasFailedGatekeeperTest(Map<String, ISuiteResult> results) {
+        return results.values().stream().anyMatch((iSuiteResult) -> {
+            return iSuiteResult.getTestContext().getFailedTests().size() != 0
+                    && Objects.equals(iSuiteResult.getTestContext().getCurrentXmlTest().getParameter(IS_GATEKEEPER), TRUE);
+        });
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/listener/GatekeeperException.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/listener/GatekeeperException.java
@@ -1,0 +1,13 @@
+package com.sequenceiq.it.cloudbreak.newway.listener;
+
+import org.testng.SkipException;
+
+public class GatekeeperException extends SkipException {
+    public GatekeeperException(String skipMessage) {
+        super(skipMessage);
+    }
+
+    public GatekeeperException(String skipMessage, Throwable cause) {
+        super(skipMessage, cause);
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/listener/ReportListener.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/listener/ReportListener.java
@@ -1,7 +1,9 @@
-package com.sequenceiq.it.cloudbreak.newway.log;
+package com.sequenceiq.it.cloudbreak.newway.listener;
 
 import org.testng.ITestResult;
 import org.testng.TestListenerAdapter;
+
+import com.sequenceiq.it.cloudbreak.newway.log.Log;
 
 public class ReportListener extends TestListenerAdapter {
     @Override

--- a/integration-test/src/main/resources/testsuites/clusterawstestset.yaml
+++ b/integration-test/src/main/resources/testsuites/clusterawstestset.yaml
@@ -7,8 +7,9 @@ parameters:
   awsCredentialName: autotesting-clusters-aws
 listeners:
   - com.sequenceiq.it.cloudbreak.newway.listener.FirstLastTestExecutionBehaviour
+  - com.sequenceiq.it.cloudbreak.newway.listener.GatekeeperBehaviour
 tests:
-  - name: "aws base image datascience"
+  - name: "aws base image datascience gatekeeper"
     preserveOrder: true
     parameters:
       clusterName: aws-base-datasci
@@ -16,6 +17,7 @@ tests:
       blueprintName: "Data Science: Apache Spark 2, Apache Zeppelin"
       image: base
       instancegroupName: worker
+      isGatekeeper: true
     classes:
       - name: com.sequenceiq.it.cloudbreak.ClusterTests
         includedMethods:

--- a/integration-test/src/main/resources/testsuites/clusterawstestset.yaml
+++ b/integration-test/src/main/resources/testsuites/clusterawstestset.yaml
@@ -5,6 +5,8 @@ parameters:
   awsRegion: us-west-1
   awsAvailabilityZone: us-west-1a
   awsCredentialName: autotesting-clusters-aws
+listeners:
+  - com.sequenceiq.it.cloudbreak.newway.listener.FirstLastTestExecutionBehaviour
 tests:
   - name: "aws base image datascience"
     preserveOrder: true

--- a/integration-test/src/main/resources/testsuites/clusterazuretestset.yaml
+++ b/integration-test/src/main/resources/testsuites/clusterazuretestset.yaml
@@ -3,6 +3,8 @@ parallel: tests
 threadCount: 4
 parameters:
   azureCredentialName: autotesting-clusters-azure
+listeners:
+  - com.sequenceiq.it.cloudbreak.newway.listener.FirstLastTestExecutionBehaviour
 tests:
   - name: "azure prewarm image edwetl"
     preserveOrder: true

--- a/integration-test/src/main/resources/testsuites/clustergcptestset.yaml
+++ b/integration-test/src/main/resources/testsuites/clustergcptestset.yaml
@@ -3,6 +3,8 @@ parallel: tests
 threadCount: 4
 parameters:
   gcpCredentialName: autotesting-clusters-gcp
+listeners:
+  - com.sequenceiq.it.cloudbreak.newway.listener.FirstLastTestExecutionBehaviour
 tests:
   - name: "gcp prewarm image edw edwetl"
     preserveOrder: true

--- a/integration-test/src/main/resources/testsuites/clusteropenstacktestset.yaml
+++ b/integration-test/src/main/resources/testsuites/clusteropenstacktestset.yaml
@@ -3,6 +3,8 @@ parallel: tests
 threadCount: 3
 parameters:
   openstackCredentialName: autotesting-clusters-os
+listeners:
+  - com.sequenceiq.it.cloudbreak.newway.listener.FirstLastTestExecutionBehaviour
 tests:
   - name: "openstack base image datascience"
     preserveOrder: true

--- a/integration-test/src/main/resources/testsuites/clusteropenstacktestset.yaml
+++ b/integration-test/src/main/resources/testsuites/clusteropenstacktestset.yaml
@@ -5,8 +5,9 @@ parameters:
   openstackCredentialName: autotesting-clusters-os
 listeners:
   - com.sequenceiq.it.cloudbreak.newway.listener.FirstLastTestExecutionBehaviour
+  - com.sequenceiq.it.cloudbreak.newway.listener.GatekeeperBehaviour
 tests:
-  - name: "openstack base image datascience"
+  - name: "openstack base image datascience gatekeeper"
     preserveOrder: true
     parameters:
       clusterName: os-base-datasci
@@ -14,6 +15,7 @@ tests:
       blueprintName: "Data Science: Apache Spark 2, Apache Zeppelin"
       image: base
       instancegroupName: worker
+      isGatekeeper: true
     classes:
       - name: com.sequenceiq.it.cloudbreak.ClusterTests
         includedMethods:


### PR DESCRIPTION
Two listeners to modify the cluster tests execution behaviour, both should be included in the test suite (yaml) to switch on (not necessary together)
- FirstLastTestExecutionBehaviour listener will skip methods (except last one) if the first method was not successful
- GatekeeperBehaviour listener checks whether a failed test has parameter 'isGatekeeper=true" and skip all test.

Closes BUG-104106
Closes BUG-104105