### PR TITLE
BUG-104241 fix the validation of yum and deb repos availibility

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/RepositoryConfigValidationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/RepositoryConfigValidationService.java
@@ -27,7 +27,7 @@ public class RepositoryConfigValidationService {
 
             String ambariBaseUrl = request.getAmbariBaseUrl();
             if (isNoneEmpty(ambariBaseUrl)) {
-                result.setAmbariBaseUrl(validateUrl(ambariBaseUrl, "ambari.repo", client));
+                result.setAmbariBaseUrl(repoUrlAvailable(client, ambariBaseUrl, "Ambari"));
             }
 
             String ambariGpgKeyUrl = request.getAmbariGpgKeyUrl();
@@ -37,12 +37,12 @@ public class RepositoryConfigValidationService {
 
             String stackBaseURL = request.getStackBaseURL();
             if (isNoneEmpty(stackBaseURL)) {
-                result.setStackBaseURL(validateUrl(stackBaseURL, "hdp.repo", client));
+                result.setStackBaseURL(repoUrlAvailable(client, stackBaseURL, "HDP"));
             }
 
             String utilsBaseURL = request.getUtilsBaseURL();
             if (isNoneEmpty(utilsBaseURL)) {
-                result.setUtilsBaseURL(validateUrl(utilsBaseURL, "hdp-utils.repo", client));
+                result.setUtilsBaseURL(repoUrlAvailable(client, utilsBaseURL, "HDP-UTILS"));
             }
 
             String versionDefinitionFileUrl = request.getVersionDefinitionFileUrl();
@@ -56,6 +56,19 @@ public class RepositoryConfigValidationService {
             }
         }
         return result;
+    }
+
+    private boolean repoUrlAvailable(Client client, String ambariBaseUrl, String service) {
+        return rpmRepoAvailable(client, ambariBaseUrl) || debRepoAvailable(client, ambariBaseUrl, service);
+    }
+
+    private Boolean debRepoAvailable(Client client, String stackBaseURL, String serviceName) {
+        String urlExtension = String.format("dists/%s/InRelease", serviceName);
+        return validateUrl(stackBaseURL, urlExtension, client);
+    }
+
+    private Boolean rpmRepoAvailable(Client client, String stackBaseURL) {
+        return validateUrl(stackBaseURL, "repodata/repomd.xml", client);
     }
 
     Client createRestClient() {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/RepositoryConfigValidationServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/RepositoryConfigValidationServiceTest.java
@@ -4,11 +4,14 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.List;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
@@ -16,8 +19,9 @@ import javax.ws.rs.core.Response;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.springframework.http.HttpStatus;
 
 import com.sequenceiq.cloudbreak.api.model.repositoryconfig.RepoConfigValidationRequest;
@@ -25,18 +29,23 @@ import com.sequenceiq.cloudbreak.api.model.repositoryconfig.RepoConfigValidation
 
 public class RepositoryConfigValidationServiceTest {
 
+    private static final String RPM_REPO_REPODATA_PATH = "/repodata/repomd.xml";
+
     @Mock
     private Response response;
+
+    @Mock
+    private Response secondResponse;
 
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private Client client;
 
+    @Spy
     private RepositoryConfigValidationService underTest;
 
     @Before
     public void setUp() throws Exception {
         initMocks(this);
-        underTest = Mockito.spy(RepositoryConfigValidationService.class);
     }
 
     @Test
@@ -67,7 +76,7 @@ public class RepositoryConfigValidationServiceTest {
     }
 
     @Test
-    public void testValidateForAmbariBaseUrlWhenTheUrlIsReachable() {
+    public void testValidateForAmbariBaseUrlWhenTheRPMRepoIsReachable() {
         doReturn(client).when(underTest).createRestClient();
         when(client.target(anyString()).request().get()).thenReturn(response);
         when(response.getStatus()).thenReturn(HttpStatus.OK.value());
@@ -77,7 +86,7 @@ public class RepositoryConfigValidationServiceTest {
 
         RepoConfigValidationResponse result = underTest.validate(request);
 
-        verify(client, times(1)).target(ambariBaseUrl + "/ambari.repo");
+        verify(client, times(1)).target(ambariBaseUrl + "/repodata/repomd.xml");
         assertTrue(result.getAmbariBaseUrl());
         assertNull(result.getAmbariGpgKeyUrl());
         assertNull(result.getVersionDefinitionFileUrl());
@@ -87,23 +96,49 @@ public class RepositoryConfigValidationServiceTest {
     }
 
     @Test
-    public void testValidateForAmbariBaseUrlWhenTheUrlIsNotReachable() {
+    public void testValidateForAmbariBaseUrlWhenTheDebRepoIsReachable() {
         doReturn(client).when(underTest).createRestClient();
-        when(client.target(anyString()).request().get()).thenReturn(response);
-        when(response.getStatus()).thenReturn(HttpStatus.NOT_FOUND.value());
-        String ambariBaseUrl = "http://s3.amazonaws.com/dev.hortonworks.com/ambari/centos6/2.x/BUILDS/2.6.1.0-143";
+        String ambariBaseUrl = "http://s3.amazonaws.com/dev.hortonworks.com/ambari/ubuntu14/2.x/BUILDS/2.6.1.0-143";
         RepoConfigValidationRequest request = new RepoConfigValidationRequest();
         request.setAmbariBaseUrl(ambariBaseUrl);
+        String rpmRepoDataTarget = ambariBaseUrl + RPM_REPO_REPODATA_PATH;
+        String debRepoDataTarget = ambariBaseUrl + "/dists/Ambari/InRelease";
+        when(client.target(rpmRepoDataTarget).request().get()).thenReturn(response);
+        when(response.getStatus()).thenReturn(HttpStatus.NOT_FOUND.value());
+        when(client.target(debRepoDataTarget).request().get()).thenReturn(secondResponse);
+        when(secondResponse.getStatus()).thenReturn(HttpStatus.OK.value());
 
         RepoConfigValidationResponse result = underTest.validate(request);
 
-        verify(client, times(1)).target(ambariBaseUrl + "/ambari.repo");
+        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+        verify(client, atLeast(2)).target(argumentCaptor.capture());
+        List<String> arguments = argumentCaptor.getAllValues();
+        assertTrue(arguments.contains(rpmRepoDataTarget));
+        assertTrue(arguments.contains(debRepoDataTarget));
+        assertTrue(result.getAmbariBaseUrl());
+    }
+
+    @Test
+    public void testValidateForAmbariBaseUrlWhenNoRPMOrDebRepoIsReachable() {
+        String ambariBaseUrl = "http://s3.amazonaws.com/dev.hortonworks.com/ambari/centos6/2.x/BUILDS/2.6.1.0-143";
+        RepoConfigValidationRequest request = new RepoConfigValidationRequest();
+        request.setAmbariBaseUrl(ambariBaseUrl);
+        String rpmRepoDataTarget = ambariBaseUrl + RPM_REPO_REPODATA_PATH;
+        String debRepoDataTarget = ambariBaseUrl + "/dists/Ambari/InRelease";
+        doReturn(client).when(underTest).createRestClient();
+        when(client.target(rpmRepoDataTarget).request().get()).thenReturn(response);
+        when(response.getStatus()).thenReturn(HttpStatus.NOT_FOUND.value());
+        when(client.target(debRepoDataTarget).request().get()).thenReturn(secondResponse);
+        when(secondResponse.getStatus()).thenReturn(HttpStatus.NOT_FOUND.value());
+
+        RepoConfigValidationResponse result = underTest.validate(request);
+
+        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+        verify(client, atLeast(2)).target(argumentCaptor.capture());
+        List<String> arguments = argumentCaptor.getAllValues();
+        assertTrue(arguments.contains(rpmRepoDataTarget));
+        assertTrue(arguments.contains(debRepoDataTarget));
         assertFalse(result.getAmbariBaseUrl());
-        assertNull(result.getAmbariGpgKeyUrl());
-        assertNull(result.getVersionDefinitionFileUrl());
-        assertNull(result.getMpackUrl());
-        assertNull(result.getStackBaseURL());
-        assertNull(result.getUtilsBaseURL());
     }
 
     @Test
@@ -137,32 +172,126 @@ public class RepositoryConfigValidationServiceTest {
     }
 
     @Test
-    public void testValidateForStackBaseUrlWhenTheItIsReachable() {
+    public void testValidateForStackBaseUrlWhenRPMRepoIsReachable() {
         doReturn(client).when(underTest).createRestClient();
         when(client.target(anyString()).request().get()).thenReturn(response);
         when(response.getStatus()).thenReturn(HttpStatus.OK.value());
-        String stackBaseUrl = "http://public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.5.5.0/";
+        String stackBaseUrl = "http://public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.5.5.0";
         RepoConfigValidationRequest request = new RepoConfigValidationRequest();
         request.setStackBaseURL(stackBaseUrl);
+        String rpmRepoDataTarget = stackBaseUrl + RPM_REPO_REPODATA_PATH;
 
         RepoConfigValidationResponse result = underTest.validate(request);
 
-        verify(client, times(1)).target(stackBaseUrl + "hdp.repo");
+        verify(client, times(1)).target(rpmRepoDataTarget);
         assertTrue(result.getStackBaseURL());
     }
 
     @Test
-    public void testValidateForStackBaseUrlWhenTheTheRestClientThrowException() {
-        doReturn(client).when(underTest).createRestClient();
-        when(client.target(anyString()).request().get()).thenReturn(response);
-        when(response.getStatus()).thenThrow(new RuntimeException());
-        String stackBaseUrl = "http://public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.5.5.0/";
+    public void testValidateForStackBaseUrlWhenDebRepoIsReachable() {
+        String stackBaseUrl = "http://public-repo-1.hortonworks.com/HDP/ubuntu14/2.x/updates/2.5.5.0";
+        String rpmRepoDataTarget = stackBaseUrl + RPM_REPO_REPODATA_PATH;
+        String debRepoDataTarget = stackBaseUrl + "/dists/HDP/InRelease";
         RepoConfigValidationRequest request = new RepoConfigValidationRequest();
         request.setStackBaseURL(stackBaseUrl);
+        doReturn(client).when(underTest).createRestClient();
+        when(client.target(anyString()).request().get()).thenReturn(response);
+        when(response.getStatus()).thenReturn(HttpStatus.NOT_FOUND.value());
+        when(client.target(debRepoDataTarget).request().get()).thenReturn(secondResponse);
+        when(secondResponse.getStatus()).thenReturn(HttpStatus.OK.value());
 
         RepoConfigValidationResponse result = underTest.validate(request);
 
-        verify(client, times(1)).target(stackBaseUrl + "hdp.repo");
+        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+        verify(client, atLeast(2)).target(argumentCaptor.capture());
+        List<String> arguments = argumentCaptor.getAllValues();
+        assertTrue(arguments.contains(rpmRepoDataTarget));
+        assertTrue(arguments.contains(debRepoDataTarget));
+        assertTrue(result.getStackBaseURL());
+    }
+
+    @Test
+    public void testValidateForStackBaseUrlWhenNoRepoIsAvailable() {
+        String stackBaseUrl = "http://public-repo-1.hortonworks.com/HDP/ubuntu14/2.x/updates/2.5.5.0";
+        String rpmRepoDataTarget = stackBaseUrl + RPM_REPO_REPODATA_PATH;
+        String debRepoDataTarget = stackBaseUrl + "/dists/HDP/InRelease";
+        RepoConfigValidationRequest request = new RepoConfigValidationRequest();
+        request.setStackBaseURL(stackBaseUrl);
+        doReturn(client).when(underTest).createRestClient();
+        when(client.target(anyString()).request().get()).thenReturn(response);
+        when(response.getStatus()).thenReturn(HttpStatus.NOT_FOUND.value());
+        when(client.target(debRepoDataTarget).request().get()).thenReturn(secondResponse);
+        when(secondResponse.getStatus()).thenReturn(HttpStatus.NOT_FOUND.value());
+
+        RepoConfigValidationResponse result = underTest.validate(request);
+
+        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+        verify(client, atLeast(2)).target(argumentCaptor.capture());
+        List<String> arguments = argumentCaptor.getAllValues();
+        assertTrue(arguments.contains(rpmRepoDataTarget));
+        assertTrue(arguments.contains(debRepoDataTarget));
         assertFalse(result.getStackBaseURL());
+    }
+
+    @Test
+    public void testValidateForStackUtilsBaseUrlWhenRPMRepoIsReachable() {
+        doReturn(client).when(underTest).createRestClient();
+        when(client.target(anyString()).request().get()).thenReturn(response);
+        when(response.getStatus()).thenReturn(HttpStatus.OK.value());
+        String hdpUtilsBaseUrl = "http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.21/repos/sles12";
+        RepoConfigValidationRequest request = new RepoConfigValidationRequest();
+        request.setUtilsBaseURL(hdpUtilsBaseUrl);
+        String rpmRepoDataTarget = hdpUtilsBaseUrl + RPM_REPO_REPODATA_PATH;
+
+        RepoConfigValidationResponse result = underTest.validate(request);
+
+        verify(client, times(1)).target(rpmRepoDataTarget);
+        assertTrue(result.getUtilsBaseURL());
+    }
+
+    @Test
+    public void testValidateForStackUtilsBaseUrlWhenDebRepoIsReachable() {
+        String utilsBaseUrl = "http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.21/repos/ubuntu14";
+        String rpmRepoDataTarget = utilsBaseUrl + RPM_REPO_REPODATA_PATH;
+        String debRepoDataTarget = utilsBaseUrl + "/dists/HDP-UTILS/InRelease";
+        RepoConfigValidationRequest request = new RepoConfigValidationRequest();
+        request.setUtilsBaseURL(utilsBaseUrl);
+        doReturn(client).when(underTest).createRestClient();
+        when(client.target(anyString()).request().get()).thenReturn(response);
+        when(response.getStatus()).thenReturn(HttpStatus.NOT_FOUND.value());
+        when(client.target(debRepoDataTarget).request().get()).thenReturn(secondResponse);
+        when(secondResponse.getStatus()).thenReturn(HttpStatus.OK.value());
+
+        RepoConfigValidationResponse result = underTest.validate(request);
+
+        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+        verify(client, atLeast(2)).target(argumentCaptor.capture());
+        List<String> arguments = argumentCaptor.getAllValues();
+        assertTrue(arguments.contains(rpmRepoDataTarget));
+        assertTrue(arguments.contains(debRepoDataTarget));
+        assertTrue(result.getUtilsBaseURL());
+    }
+
+    @Test
+    public void testValidateForStackUtilsBaseUrlWhenNoRepoIsAvailable() {
+        String utilsBaseUrl = "http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.21/repos/sles12";
+        String rpmRepoDataTarget = utilsBaseUrl + RPM_REPO_REPODATA_PATH;
+        String debRepoDataTarget = utilsBaseUrl + "/dists/HDP-UTILS/InRelease";
+        RepoConfigValidationRequest request = new RepoConfigValidationRequest();
+        request.setUtilsBaseURL(utilsBaseUrl);
+        doReturn(client).when(underTest).createRestClient();
+        when(client.target(anyString()).request().get()).thenReturn(response);
+        when(response.getStatus()).thenReturn(HttpStatus.NOT_FOUND.value());
+        when(client.target(debRepoDataTarget).request().get()).thenReturn(secondResponse);
+        when(secondResponse.getStatus()).thenReturn(HttpStatus.NOT_FOUND.value());
+
+        RepoConfigValidationResponse result = underTest.validate(request);
+
+        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+        verify(client, atLeast(2)).target(argumentCaptor.capture());
+        List<String> arguments = argumentCaptor.getAllValues();
+        assertTrue(arguments.contains(rpmRepoDataTarget));
+        assertTrue(arguments.contains(debRepoDataTarget));
+        assertFalse(result.getUtilsBaseURL());
     }
 }


### PR DESCRIPTION
Fix the validation issue that appeared when the Ambari, Stack or HDP Utils repo base url was invalid, the new implementation supports the deb repositories for Ubuntu and Debian.
The validation always threw a warning when the Ambari/HDP version required the 1.1.0.21 version of HDP-UTILS.