### PR TITLE
BUG-103858 structured events reporter

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/GherkinTestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/GherkinTestContext.java
@@ -1,0 +1,15 @@
+package com.sequenceiq.it.cloudbreak.newway;
+
+import com.sequenceiq.it.IntegrationTestContext;
+
+public class GherkinTestContext extends GherkinTest {
+    private final GherkinTest test;
+
+    public GherkinTestContext(GherkinTest test) {
+        this.test = test;
+    }
+
+    public IntegrationTestContext getIntegrationTestContext() {
+        return test.getItContext();
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/Stack.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/Stack.java
@@ -25,7 +25,7 @@ import com.sequenceiq.it.cloudbreak.SshService;
 public class Stack extends StackEntity {
     private static final Logger LOGGER = LoggerFactory.getLogger(Stack.class);
 
-    static Function<IntegrationTestContext, Stack> getTestContextStack(String key) {
+    public static Function<IntegrationTestContext, Stack> getTestContextStack(String key) {
         return (testContext) -> testContext.getContextParam(key, Stack.class);
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/listener/StructuredEventsReporterOnFailingCluster.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/listener/StructuredEventsReporterOnFailingCluster.java
@@ -1,0 +1,41 @@
+package com.sequenceiq.it.cloudbreak.newway.listener;
+
+import static com.sequenceiq.it.cloudbreak.newway.log.Log.log;
+
+import java.util.List;
+
+import org.testng.ITestResult;
+import org.testng.TestListenerAdapter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sequenceiq.cloudbreak.structuredevent.event.StructuredEvent;
+import com.sequenceiq.it.IntegrationTestContext;
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.GherkinTest;
+import com.sequenceiq.it.cloudbreak.newway.GherkinTestContext;
+import com.sequenceiq.it.cloudbreak.newway.Stack;
+
+public class StructuredEventsReporterOnFailingCluster extends TestListenerAdapter {
+    @Override
+    public void onTestFailure(ITestResult testResult) {
+        super.onTestFailure(testResult);
+        GherkinTestContext testInstance = new GherkinTestContext((GherkinTest) testResult.getInstance());
+        IntegrationTestContext integrationTestContext = testInstance.getIntegrationTestContext();
+        Stack stack = Stack.getTestContextStack(Stack.STACK).apply(integrationTestContext);
+        CloudbreakClient client = CloudbreakClient.getTestContextCloudbreakClient(CloudbreakClient.CLOUDBREAK_CLIENT).apply(integrationTestContext);
+        if (stack != null && client != null && stack.getResponse() != null) {
+            List<StructuredEvent> events = client.getCloudbreakClient().eventEndpoint().getStructuredEvents(stack.getResponse().getId());
+            String json = null;
+            try {
+                json = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(events);
+            } catch (JsonProcessingException e) {
+                log("Failed to print structured events json");
+            }
+            if (json != null) {
+                log("Structured events for failing test:");
+                log(json);
+            }
+        }
+    }
+}

--- a/integration-test/src/main/resources/testsuites/clusterawstestset.yaml
+++ b/integration-test/src/main/resources/testsuites/clusterawstestset.yaml
@@ -8,6 +8,7 @@ parameters:
 listeners:
   - com.sequenceiq.it.cloudbreak.newway.listener.FirstLastTestExecutionBehaviour
   - com.sequenceiq.it.cloudbreak.newway.listener.GatekeeperBehaviour
+  - com.sequenceiq.it.cloudbreak.newway.listener.StructuredEventsReporterOnFailingCluster
 tests:
   - name: "aws base image datascience gatekeeper"
     preserveOrder: true

--- a/integration-test/src/main/resources/testsuites/clusterazuretestset.yaml
+++ b/integration-test/src/main/resources/testsuites/clusterazuretestset.yaml
@@ -5,6 +5,7 @@ parameters:
   azureCredentialName: autotesting-clusters-azure
 listeners:
   - com.sequenceiq.it.cloudbreak.newway.listener.FirstLastTestExecutionBehaviour
+  - com.sequenceiq.it.cloudbreak.newway.listener.StructuredEventsReporterOnFailingCluster
 tests:
   - name: "azure prewarm image edwetl"
     preserveOrder: true

--- a/integration-test/src/main/resources/testsuites/clustergcptestset.yaml
+++ b/integration-test/src/main/resources/testsuites/clustergcptestset.yaml
@@ -5,6 +5,7 @@ parameters:
   gcpCredentialName: autotesting-clusters-gcp
 listeners:
   - com.sequenceiq.it.cloudbreak.newway.listener.FirstLastTestExecutionBehaviour
+  - com.sequenceiq.it.cloudbreak.newway.listener.StructuredEventsReporterOnFailingCluster
 tests:
   - name: "gcp prewarm image edw edwetl"
     preserveOrder: true

--- a/integration-test/src/main/resources/testsuites/clusteropenstacktestset.yaml
+++ b/integration-test/src/main/resources/testsuites/clusteropenstacktestset.yaml
@@ -6,6 +6,7 @@ parameters:
 listeners:
   - com.sequenceiq.it.cloudbreak.newway.listener.FirstLastTestExecutionBehaviour
   - com.sequenceiq.it.cloudbreak.newway.listener.GatekeeperBehaviour
+  - com.sequenceiq.it.cloudbreak.newway.listener.StructuredEventsReporterOnFailingCluster
 tests:
   - name: "openstack base image datascience gatekeeper"
     preserveOrder: true


### PR DESCRIPTION
TestNG TestListener which investigates failed tests when these conditions are met:
-listener is in the tests suite (yaml listener section)
-test created, or got a stack with stack id (basically all tests which work on stack)
-the test is failed.
In this case the listener will collect structured events for stack and report out.

Closes BUG-103858