### PR TITLE
BUG-104480 make sure that all repositoriy calls are in transaction

### DIFF
--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -23,7 +23,7 @@
     <suppress checks="TrailingComment" files="HeartbeatServiceTest.java"/>
     <suppress checks="VisibilityModifier" files="AbstractAction.java"/>
     <suppress checks=".*" files="ModulTest.java"/>
-    <suppress id="IllegalTransaction" files="com.sequenceiq.cloudbreak.service.TransactionService.java|com.sequenceiq.cloudbreak.controller.*|com.sequenceiq.cloudbreak.structuredevent.StructuredFlowEventFactory"/>
+    <suppress id="IllegalTransaction" files="com.sequenceiq.cloudbreak.service.TransactionService.java|com.sequenceiq.cloudbreak.controller.*|com.sequenceiq.cloudbreak.structuredevent.StructuredFlowEventFactory|com.sequenceiq.cloudbreak.repository.*Repository.java|com.sequenceiq.cloudbreak.structuredevent.db.*Repository.java"/>
     <suppress checks="RegexpSingleline" files="FlexSubscription.java"/>
     <suppress id="hashtable-instantiation" files="LdapConfigValidator.java"/>
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/AccountPreferencesRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/AccountPreferencesRepository.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.repository;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -7,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import com.sequenceiq.cloudbreak.domain.AccountPreferences;
 
 @EntityType(entityClass = AccountPreferences.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface AccountPreferencesRepository extends CrudRepository<AccountPreferences, Long> {
 
     @Query("SELECT ap FROM AccountPreferences ap WHERE ap.account= :account")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/BlueprintRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/BlueprintRepository.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.repository;
 
 import java.util.Set;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -9,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
 
 @EntityType(entityClass = Blueprint.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface BlueprintRepository extends CrudRepository<Blueprint, Long> {
 
     @Query("SELECT b FROM Blueprint b WHERE b.name= :name and b.account= :account AND b.status <> 'DEFAULT_DELETED'")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/CloudbreakNodeRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/CloudbreakNodeRepository.java
@@ -1,9 +1,12 @@
 package com.sequenceiq.cloudbreak.repository;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.repository.CrudRepository;
 
 import com.sequenceiq.cloudbreak.domain.CloudbreakNode;
 
 @EntityType(entityClass = CloudbreakNode.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface CloudbreakNodeRepository extends CrudRepository<CloudbreakNode, String> {
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/CloudbreakUsageRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/CloudbreakUsageRepository.java
@@ -3,6 +3,8 @@ package com.sequenceiq.cloudbreak.repository;
 import java.util.Date;
 import java.util.List;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
@@ -11,6 +13,7 @@ import org.springframework.data.repository.query.Param;
 import com.sequenceiq.cloudbreak.domain.CloudbreakUsage;
 
 @EntityType(entityClass = CloudbreakUsage.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface CloudbreakUsageRepository extends CrudRepository<CloudbreakUsage, Long>, JpaSpecificationExecutor {
 
     @Query("SELECT u FROM CloudbreakUsage u WHERE u.stackId = :stackId AND u.status = 'OPEN'")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/ClusterComponentRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/ClusterComponentRepository.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.repository;
 
 import java.util.Set;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.data.jpa.repository.Query;
@@ -12,6 +14,7 @@ import com.sequenceiq.cloudbreak.common.type.ComponentType;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterComponent;
 
 @EntityType(entityClass = ClusterComponent.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface ClusterComponentRepository extends CrudRepository<ClusterComponent, Long> {
 
     @Query("SELECT cv FROM ClusterComponent cv WHERE cv.cluster.id = :clusterId AND cv.componentType = :componentType AND cv.name = :name")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/ClusterRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/ClusterRepository.java
@@ -4,6 +4,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -15,6 +17,7 @@ import com.sequenceiq.cloudbreak.domain.LdapConfig;
 import com.sequenceiq.cloudbreak.domain.ProxyConfig;
 
 @EntityType(entityClass = Cluster.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface ClusterRepository extends CrudRepository<Cluster, Long> {
 
     Cluster findById(@Param("id") Long id);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/ClusterTemplateRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/ClusterTemplateRepository.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.repository;
 
 import java.util.Set;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -9,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 import com.sequenceiq.cloudbreak.domain.ClusterTemplate;
 
 @EntityType(entityClass = ClusterTemplate.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface ClusterTemplateRepository extends CrudRepository<ClusterTemplate, Long> {
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/ComponentRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/ComponentRepository.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.repository;
 
 import java.util.Set;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -10,6 +12,7 @@ import com.sequenceiq.cloudbreak.common.type.ComponentType;
 import com.sequenceiq.cloudbreak.domain.stack.Component;
 
 @EntityType(entityClass = Component.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface ComponentRepository extends CrudRepository<Component, Long> {
 
     @Query("SELECT cv FROM Component cv WHERE cv.stack.id = :stackId AND cv.componentType = :componentType AND cv.name = :name")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/ConstraintRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/ConstraintRepository.java
@@ -1,10 +1,13 @@
 package com.sequenceiq.cloudbreak.repository;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.repository.CrudRepository;
 
 import com.sequenceiq.cloudbreak.domain.Constraint;
 
 @EntityType(entityClass = Constraint.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface ConstraintRepository extends CrudRepository<Constraint, Long> {
 
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/ConstraintTemplateRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/ConstraintTemplateRepository.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.repository;
 
 import java.util.Set;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -9,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 import com.sequenceiq.cloudbreak.domain.ConstraintTemplate;
 
 @EntityType(entityClass = ConstraintTemplate.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface ConstraintTemplateRepository extends CrudRepository<ConstraintTemplate, Long> {
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/ContainerRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/ContainerRepository.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.repository;
 
 import java.util.Set;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -9,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 import com.sequenceiq.cloudbreak.domain.Container;
 
 @EntityType(entityClass = Container.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface ContainerRepository extends CrudRepository<Container, Long> {
 
     @Query("SELECT c FROM Container c WHERE c.cluster.id= :clusterId")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/CredentialRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/CredentialRepository.java
@@ -3,6 +3,8 @@ package com.sequenceiq.cloudbreak.repository;
 import java.util.Collection;
 import java.util.Set;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -11,6 +13,7 @@ import com.sequenceiq.cloudbreak.domain.Credential;
 import com.sequenceiq.cloudbreak.domain.Topology;
 
 @EntityType(entityClass = Credential.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface CredentialRepository extends CrudRepository<Credential, Long> {
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/FileSystemRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/FileSystemRepository.java
@@ -2,11 +2,14 @@ package com.sequenceiq.cloudbreak.repository;
 
 import java.util.Set;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.repository.CrudRepository;
 
 import com.sequenceiq.cloudbreak.domain.FileSystem;
 
 @EntityType(entityClass = FileSystem.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface FileSystemRepository extends CrudRepository<FileSystem, Long> {
 
     Set<FileSystem> findByOwner(String owner);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/FlexSubscriptionRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/FlexSubscriptionRepository.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.repository;
 
 import java.util.List;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -11,6 +13,7 @@ import com.sequenceiq.cloudbreak.domain.FlexSubscription;
 import com.sequenceiq.cloudbreak.domain.SmartSenseSubscription;
 
 @EntityType(entityClass = FlexSubscription.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface FlexSubscriptionRepository extends CrudRepository<FlexSubscription, Long> {
 
     @PostAuthorize("hasPermission(returnObject,'read')")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/FlowChainLogRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/FlowChainLogRepository.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.repository;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
@@ -7,6 +9,7 @@ import org.springframework.data.repository.CrudRepository;
 import com.sequenceiq.cloudbreak.domain.FlowChainLog;
 
 @EntityType(entityClass = FlowChainLog.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface FlowChainLogRepository extends CrudRepository<FlowChainLog, Long> {
 
     FlowChainLog findFirstByFlowChainIdOrderByCreatedDesc(String flowChainId);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/FlowLogRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/FlowLogRepository.java
@@ -3,6 +3,8 @@ package com.sequenceiq.cloudbreak.repository;
 import java.util.List;
 import java.util.Set;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
@@ -12,6 +14,7 @@ import com.sequenceiq.cloudbreak.domain.FlowLog;
 import com.sequenceiq.cloudbreak.domain.StateStatus;
 
 @EntityType(entityClass = FlowLog.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface FlowLogRepository extends CrudRepository<FlowLog, Long> {
 
     FlowLog findFirstByFlowIdOrderByCreatedDesc(String flowId);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/GatewayRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/GatewayRepository.java
@@ -1,9 +1,12 @@
 package com.sequenceiq.cloudbreak.repository;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.sequenceiq.cloudbreak.domain.stack.cluster.gateway.Gateway;
 
 @EntityType(entityClass = Gateway.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface GatewayRepository extends JpaRepository<Gateway, Long> {
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/HostGroupRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/HostGroupRepository.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.repository;
 
 import java.util.Set;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
@@ -10,6 +12,7 @@ import org.springframework.data.repository.query.Param;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
 
 @EntityType(entityClass = HostGroup.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface HostGroupRepository extends CrudRepository<HostGroup, Long> {
 
     @EntityGraph(value = "HostGroup.constraint.instanceGroup.instanceMetaData", type = EntityGraph.EntityGraphType.LOAD)

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/HostMetadataRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/HostMetadataRepository.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.repository;
 
 import java.util.Set;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -9,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostMetadata;
 
 @EntityType(entityClass = HostMetadata.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface HostMetadataRepository extends CrudRepository<HostMetadata, Long> {
 
     @Query("SELECT h FROM HostMetadata h WHERE h.hostGroup.cluster.id= :clusterId")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/ImageCatalogRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/ImageCatalogRepository.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.repository;
 
 import java.util.List;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -10,6 +12,7 @@ import org.springframework.security.access.prepost.PostAuthorize;
 import com.sequenceiq.cloudbreak.domain.ImageCatalog;
 
 @EntityType(entityClass = ImageCatalog.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface ImageCatalogRepository extends CrudRepository<ImageCatalog, Long> {
 
     @PostAuthorize("hasPermission(returnObject,'read')")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceGroupRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceGroupRepository.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.repository;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
@@ -9,6 +11,7 @@ import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.domain.SecurityGroup;
 
 @EntityType(entityClass = InstanceGroup.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface InstanceGroupRepository extends CrudRepository<InstanceGroup, Long> {
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceMetaDataRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceMetaDataRepository.java
@@ -4,6 +4,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -13,6 +15,7 @@ import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 
 @EntityType(entityClass = InstanceMetaData.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface InstanceMetaDataRepository extends CrudRepository<InstanceMetaData, Long> {
 
     Set<InstanceMetaData> findAllByInstanceIdIn(Iterable<String> instanceId);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/KerberosConfigRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/KerberosConfigRepository.java
@@ -1,9 +1,12 @@
 package com.sequenceiq.cloudbreak.repository;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.repository.CrudRepository;
 
 import com.sequenceiq.cloudbreak.domain.KerberosConfig;
 
 @EntityType(entityClass = KerberosConfig.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface KerberosConfigRepository extends CrudRepository<KerberosConfig, Long> {
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/LdapConfigRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/LdapConfigRepository.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.repository;
 
 import java.util.Set;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -9,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 import com.sequenceiq.cloudbreak.domain.LdapConfig;
 
 @EntityType(entityClass = LdapConfig.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface LdapConfigRepository extends CrudRepository<LdapConfig, Long> {
 
     @Query("SELECT c FROM LdapConfig c WHERE c.name= :name and c.account= :account")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/ManagementPackRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/ManagementPackRepository.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.repository;
 
 import java.util.Set;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -9,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 import com.sequenceiq.cloudbreak.domain.ManagementPack;
 
 @EntityType(entityClass = ManagementPack.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface ManagementPackRepository extends CrudRepository<ManagementPack, Long> {
     ManagementPack findOneById(Long id);
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/NetworkRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/NetworkRepository.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.repository;
 
 import java.util.Set;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -11,6 +13,7 @@ import com.sequenceiq.cloudbreak.domain.Network;
 import com.sequenceiq.cloudbreak.domain.Topology;
 
 @EntityType(entityClass = Network.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface NetworkRepository extends CrudRepository<Network, Long> {
 
     @PostAuthorize("hasPermission(returnObject,'read')")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/OrchestratorRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/OrchestratorRepository.java
@@ -1,11 +1,14 @@
 package com.sequenceiq.cloudbreak.repository;
 
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.repository.CrudRepository;
 
 import com.sequenceiq.cloudbreak.domain.Orchestrator;
 
 @EntityType(entityClass = Orchestrator.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface OrchestratorRepository extends CrudRepository<Orchestrator, Long> {
 
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/ProxyConfigRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/ProxyConfigRepository.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.repository;
 
 import java.util.Set;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -9,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 import com.sequenceiq.cloudbreak.domain.ProxyConfig;
 
 @EntityType(entityClass = ProxyConfig.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface ProxyConfigRepository extends CrudRepository<ProxyConfig, Long> {
 
     Set<ProxyConfig> findAllByOwner(String owner);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/RdsConfigRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/RdsConfigRepository.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.repository;
 
 import java.util.Set;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -9,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
 
 @EntityType(entityClass = RDSConfig.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface RdsConfigRepository extends CrudRepository<RDSConfig, Long> {
 
     @Query("SELECT r FROM RDSConfig r LEFT JOIN FETCH r.clusters WHERE r.owner= :user AND r.status = 'USER_MANAGED'")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/RecipeRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/RecipeRepository.java
@@ -3,6 +3,8 @@ package com.sequenceiq.cloudbreak.repository;
 import java.util.Collection;
 import java.util.Set;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -11,6 +13,7 @@ import com.sequenceiq.cloudbreak.api.model.RecipeType;
 import com.sequenceiq.cloudbreak.domain.Recipe;
 
 @EntityType(entityClass = Recipe.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface RecipeRepository extends CrudRepository<Recipe, Long> {
 
     @Query("SELECT r FROM Recipe r WHERE r.name= :name AND r.account= :account")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/ResourceRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/ResourceRepository.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.repository;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -8,6 +10,7 @@ import com.sequenceiq.cloudbreak.common.type.ResourceType;
 import com.sequenceiq.cloudbreak.domain.Resource;
 
 @EntityType(entityClass = Resource.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface ResourceRepository extends CrudRepository<Resource, Long> {
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/SecurityConfigRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/SecurityConfigRepository.java
@@ -1,10 +1,13 @@
 package com.sequenceiq.cloudbreak.repository;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.repository.CrudRepository;
 
 import com.sequenceiq.cloudbreak.domain.SecurityConfig;
 
 @EntityType(entityClass = SecurityConfig.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface SecurityConfigRepository extends CrudRepository<SecurityConfig, Long> {
 
     SecurityConfig findOneByStackId(Long stackId);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/SecurityGroupRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/SecurityGroupRepository.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.repository;
 
 import java.util.Set;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -9,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 import com.sequenceiq.cloudbreak.domain.SecurityGroup;
 
 @EntityType(entityClass = SecurityGroup.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface SecurityGroupRepository extends CrudRepository<SecurityGroup, Long> {
 
     @Query("SELECT r FROM SecurityGroup r LEFT JOIN FETCH r.securityRules WHERE r.id= :id")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/SecurityRuleRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/SecurityRuleRepository.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.repository;
 
 import java.util.List;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -9,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 import com.sequenceiq.cloudbreak.domain.SecurityRule;
 
 @EntityType(entityClass = SecurityRule.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface SecurityRuleRepository extends CrudRepository<SecurityRule, Long> {
 
     @Query("SELECT r FROM SecurityRule r WHERE r.securityGroup.id= :securityGroupId")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/SmartSenseSubscriptionRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/SmartSenseSubscriptionRepository.java
@@ -1,11 +1,14 @@
 package com.sequenceiq.cloudbreak.repository;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.security.access.prepost.PostAuthorize;
 
 import com.sequenceiq.cloudbreak.domain.SmartSenseSubscription;
 
 @EntityType(entityClass = SmartSenseSubscription.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface SmartSenseSubscriptionRepository extends CrudRepository<SmartSenseSubscription, Long> {
 
     @PostAuthorize("hasPermission(returnObject,'read')")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
@@ -3,6 +3,8 @@ package com.sequenceiq.cloudbreak.repository;
 import java.util.List;
 import java.util.Set;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -14,6 +16,7 @@ import com.sequenceiq.cloudbreak.domain.Network;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 
 @EntityType(entityClass = Stack.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface StackRepository extends CrudRepository<Stack, Long> {
 
     @Query("SELECT s from Stack s LEFT JOIN FETCH s.resources LEFT JOIN FETCH s.instanceGroups ig LEFT JOIN FETCH ig.instanceMetaData "

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackStatusRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackStatusRepository.java
@@ -1,10 +1,13 @@
 package com.sequenceiq.cloudbreak.repository;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.repository.CrudRepository;
 
 import com.sequenceiq.cloudbreak.domain.stack.StackStatus;
 
 @EntityType(entityClass = StackStatus.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface StackStatusRepository extends CrudRepository<StackStatus, Long> {
 
     StackStatus findFirstByStackIdOrderByCreatedDesc(long stackId);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackViewRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackViewRepository.java
@@ -1,10 +1,13 @@
 package com.sequenceiq.cloudbreak.repository;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.repository.CrudRepository;
 
 import com.sequenceiq.cloudbreak.domain.view.StackView;
 
 @EntityType(entityClass = StackView.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface StackViewRepository extends CrudRepository<StackView, Long> {
 
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/SubscriptionRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/SubscriptionRepository.java
@@ -2,11 +2,14 @@ package com.sequenceiq.cloudbreak.repository;
 
 import java.util.List;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.repository.CrudRepository;
 
 import com.sequenceiq.cloudbreak.domain.Subscription;
 
 @EntityType(entityClass = Subscription.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface SubscriptionRepository extends CrudRepository<Subscription, Long> {
 
     List<Subscription> findByClientIdAndEndpoint(String clientId, String endpoint);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/TemplateRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/TemplateRepository.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.repository;
 
 import java.util.Set;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -10,6 +12,7 @@ import com.sequenceiq.cloudbreak.domain.Template;
 import com.sequenceiq.cloudbreak.domain.Topology;
 
 @EntityType(entityClass = Template.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface TemplateRepository extends CrudRepository<Template, Long> {
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/TopologyRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/TopologyRepository.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.repository;
 
 import java.util.Set;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -9,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 import com.sequenceiq.cloudbreak.domain.Topology;
 
 @EntityType(entityClass = Topology.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface TopologyRepository extends CrudRepository<Topology, Long> {
 
     @Query("SELECT t FROM Topology t WHERE t.account= :account AND deleted IS NOT TRUE")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/UserProfileRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/UserProfileRepository.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.repository;
 
 import java.util.Set;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -9,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 import com.sequenceiq.cloudbreak.domain.UserProfile;
 
 @EntityType(entityClass = UserProfile.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface UserProfileRepository extends CrudRepository<UserProfile, Long> {
 
     @Query("SELECT b FROM UserProfile b WHERE b.owner= :owner and b.account= :account")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
@@ -191,8 +191,13 @@ public class StackService {
     }
 
     public Set<StackResponse> retrieveAccountStacks(IdentityUser user) {
-        return user.getRoles().contains(IdentityUserRole.ADMIN) ? convertStacks(stackRepository.findAllInAccountWithLists(user.getAccount()))
-                : convertStacks(stackRepository.findPublicInAccountForUser(user.getUserId(), user.getAccount()));
+        try {
+            return transactionService.required(() -> user.getRoles().contains(IdentityUserRole.ADMIN)
+                    ? convertStacks(stackRepository.findAllInAccountWithLists(user.getAccount()))
+                    : convertStacks(stackRepository.findPublicInAccountForUser(user.getUserId(), user.getAccount())));
+        } catch (TransactionExecutionException e) {
+            throw new TransactionService.TransactionRuntimeExecutionException(e);
+        }
     }
 
     public Set<Stack> retrieveAccountStacks(String account) {
@@ -204,20 +209,32 @@ public class StackService {
     }
 
     public StackResponse getJsonById(Long id, Collection<String> entry) {
-        Stack stack = getByIdWithLists(id);
-        authorizationService.hasReadPermission(stack);
-        StackResponse stackResponse = conversionService.convert(stack, StackResponse.class);
-        stackResponse = stackResponseDecorator.decorate(stackResponse, stack, entry);
-        return stackResponse;
+        try {
+            return transactionService.required(() -> {
+                Stack stack = getByIdWithLists(id);
+                authorizationService.hasReadPermission(stack);
+                StackResponse stackResponse = conversionService.convert(stack, StackResponse.class);
+                stackResponse = stackResponseDecorator.decorate(stackResponse, stack, entry);
+                return stackResponse;
+            });
+        } catch (TransactionExecutionException e) {
+            throw new TransactionService.TransactionRuntimeExecutionException(e);
+        }
     }
 
     public Stack get(Long id) {
-        Stack stack = stackRepository.findOne(id);
-        if (stack == null) {
-            throw new NotFoundException(String.format(STACK_NOT_FOUND_EXCEPTION_FORMAT_TEXT, id));
+        try {
+            return transactionService.required(() -> {
+                Stack stack = stackRepository.findOne(id);
+                if (stack == null) {
+                    throw new NotFoundException(String.format(STACK_NOT_FOUND_EXCEPTION_FORMAT_TEXT, id));
+                }
+                authorizationService.hasReadPermission(stack);
+                return stack;
+            });
+        } catch (TransactionExecutionException e) {
+            throw new TransactionService.TransactionRuntimeExecutionException(e);
         }
-        authorizationService.hasReadPermission(stack);
-        return stack;
     }
 
     @PreAuthorize("#oauth2.hasScope('cloudbreak.autoscale')")
@@ -268,11 +285,17 @@ public class StackService {
     }
 
     public StackResponse get(String ambariAddress) {
-        Stack stack = stackRepository.findByAmbari(ambariAddress);
-        if (stack == null) {
-            throw new NotFoundException(String.format("Stack not found by Ambari address: '%s' not found", ambariAddress));
+        try {
+            return transactionService.required(() -> {
+                Stack stack = stackRepository.findByAmbari(ambariAddress);
+                if (stack == null) {
+                    throw new NotFoundException(String.format("Stack not found by Ambari address: '%s' not found", ambariAddress));
+                }
+                return conversionService.convert(stack, StackResponse.class);
+            });
+        } catch (TransactionExecutionException e) {
+            throw new TransactionService.TransactionRuntimeExecutionException(e);
         }
-        return conversionService.convert(stack, StackResponse.class);
     }
 
     public Stack getPrivateStack(String name, IdentityUser identityUser) {
@@ -284,33 +307,51 @@ public class StackService {
     }
 
     public StackResponse getPrivateStackJsonByName(String name, IdentityUser identityUser, Collection<String> entries) {
-        Stack stack = stackRepository.findByNameInUserWithLists(name, identityUser.getUserId());
-        if (stack == null) {
-            throw new NotFoundException(String.format(STACK_NOT_FOUND_EXCEPTION_FORMAT_TEXT, name));
+        try {
+            return transactionService.required(() -> {
+                Stack stack = stackRepository.findByNameInUserWithLists(name, identityUser.getUserId());
+                if (stack == null) {
+                    throw new NotFoundException(String.format(STACK_NOT_FOUND_EXCEPTION_FORMAT_TEXT, name));
+                }
+                StackResponse stackResponse = conversionService.convert(stack, StackResponse.class);
+                stackResponse = stackResponseDecorator.decorate(stackResponse, stack, entries);
+                return stackResponse;
+            });
+        } catch (TransactionExecutionException e) {
+            throw new TransactionService.TransactionRuntimeExecutionException(e);
         }
-        StackResponse stackResponse = conversionService.convert(stack, StackResponse.class);
-        stackResponse = stackResponseDecorator.decorate(stackResponse, stack, entries);
-        return stackResponse;
     }
 
     public StackResponse getPublicStackJsonByName(String name, IdentityUser identityUser, Collection<String> entries) {
-        Stack stack = stackRepository.findByNameInAccountWithLists(name, identityUser.getAccount());
-        if (stack == null) {
-            throw new NotFoundException(String.format(STACK_NOT_FOUND_EXCEPTION_FORMAT_TEXT, name));
+        try {
+            return transactionService.required(() -> {
+                Stack stack = stackRepository.findByNameInAccountWithLists(name, identityUser.getAccount());
+                if (stack == null) {
+                    throw new NotFoundException(String.format(STACK_NOT_FOUND_EXCEPTION_FORMAT_TEXT, name));
+                }
+                authorizationService.hasReadPermission(stack);
+                StackResponse stackResponse = conversionService.convert(stack, StackResponse.class);
+                stackResponse = stackResponseDecorator.decorate(stackResponse, stack, entries);
+                return stackResponse;
+            });
+        } catch (TransactionExecutionException e) {
+            throw new TransactionService.TransactionRuntimeExecutionException(e);
         }
-        authorizationService.hasReadPermission(stack);
-        StackResponse stackResponse = conversionService.convert(stack, StackResponse.class);
-        stackResponse = stackResponseDecorator.decorate(stackResponse, stack, entries);
-        return stackResponse;
     }
 
     public StackV2Request getStackRequestByName(String name, IdentityUser identityUser) {
-        Stack stack = stackRepository.findByNameInAccountWithLists(name, identityUser.getAccount());
-        if (stack == null) {
-            throw new NotFoundException(String.format(STACK_NOT_FOUND_EXCEPTION_FORMAT_TEXT, name));
+        try {
+            return transactionService.required(() -> {
+                Stack stack = stackRepository.findByNameInAccountWithLists(name, identityUser.getAccount());
+                if (stack == null) {
+                    throw new NotFoundException(String.format(STACK_NOT_FOUND_EXCEPTION_FORMAT_TEXT, name));
+                }
+                authorizationService.hasReadPermission(stack);
+                return conversionService.convert(stack, StackV2Request.class);
+            });
+        } catch (TransactionExecutionException e) {
+            throw new TransactionService.TransactionRuntimeExecutionException(e);
         }
-        authorizationService.hasReadPermission(stack);
-        return conversionService.convert(stack, StackV2Request.class);
     }
 
     public Stack getPublicStack(String name, IdentityUser identityUser) {
@@ -569,21 +610,29 @@ public class StackService {
     }
 
     public void updateNodeCount(Long stackId, InstanceGroupAdjustmentJson instanceGroupAdjustmentJson, boolean withClusterEvent) {
-        Stack stack = getByIdWithLists(stackId);
-        validateStackStatus(stack);
-        validateInstanceGroup(stack, instanceGroupAdjustmentJson.getInstanceGroup());
-        validateScalingAdjustment(instanceGroupAdjustmentJson, stack);
-        if (withClusterEvent) {
-            validateClusterStatus(stack);
-            validateHostGroupAdjustment(instanceGroupAdjustmentJson, stack, instanceGroupAdjustmentJson.getScalingAdjustment());
+        try {
+            transactionService.required(() -> {
+                Stack stack = getByIdWithLists(stackId);
+                validateStackStatus(stack);
+                validateInstanceGroup(stack, instanceGroupAdjustmentJson.getInstanceGroup());
+                validateScalingAdjustment(instanceGroupAdjustmentJson, stack);
+                if (withClusterEvent) {
+                    validateClusterStatus(stack);
+                    validateHostGroupAdjustment(instanceGroupAdjustmentJson, stack, instanceGroupAdjustmentJson.getScalingAdjustment());
+                }
+                if (instanceGroupAdjustmentJson.getScalingAdjustment() > 0) {
+                    stackUpdater.updateStackStatus(stackId, DetailedStackStatus.UPSCALE_REQUESTED);
+                    flowManager.triggerStackUpscale(stack.getId(), instanceGroupAdjustmentJson, withClusterEvent);
+                } else {
+                    stackUpdater.updateStackStatus(stackId, DetailedStackStatus.DOWNSCALE_REQUESTED);
+                    flowManager.triggerStackDownscale(stack.getId(), instanceGroupAdjustmentJson);
+                }
+                return null;
+            });
+        } catch (TransactionExecutionException e) {
+            throw new TransactionService.TransactionRuntimeExecutionException(e);
         }
-        if (instanceGroupAdjustmentJson.getScalingAdjustment() > 0) {
-            stackUpdater.updateStackStatus(stackId, DetailedStackStatus.UPSCALE_REQUESTED);
-            flowManager.triggerStackUpscale(stack.getId(), instanceGroupAdjustmentJson, withClusterEvent);
-        } else {
-            stackUpdater.updateStackStatus(stackId, DetailedStackStatus.DOWNSCALE_REQUESTED);
-            flowManager.triggerStackDownscale(stack.getId(), instanceGroupAdjustmentJson);
-        }
+
     }
 
     public void updateMetaDataStatusIfFound(Long id, String hostName, InstanceStatus status) {
@@ -730,22 +779,6 @@ public class StackService {
         }
     }
 
-    private enum Msg {
-        STACK_STOP_IGNORED("stack.stop.ignored"),
-        STACK_START_IGNORED("stack.start.ignored"),
-        STACK_STOP_REQUESTED("stack.stop.requested");
-
-        private final String code;
-
-        Msg(String msgCode) {
-            code = msgCode;
-        }
-
-        public String code() {
-            return code;
-        }
-    }
-
     private void addTemplateForStack(Stack stack, String template) {
         StackTemplate stackTemplate = new StackTemplate(template, cbVersion);
         try {
@@ -763,6 +796,22 @@ public class StackService {
             componentConfigProvider.store(cbDetailsComponent);
         } catch (JsonProcessingException e) {
             LOGGER.error("Could not create Cloudbreak details component.", e);
+        }
+    }
+
+    private enum Msg {
+        STACK_STOP_IGNORED("stack.stop.ignored"),
+        STACK_START_IGNORED("stack.start.ignored"),
+        STACK_STOP_REQUESTED("stack.stop.requested");
+
+        private final String code;
+
+        Msg(String msgCode) {
+            code = msgCode;
+        }
+
+        public String code() {
+            return code;
         }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/db/StructuredEventRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/db/StructuredEventRepository.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.structuredevent.db;
 
 import java.util.List;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -10,6 +12,7 @@ import com.sequenceiq.cloudbreak.domain.StructuredEventEntity;
 import com.sequenceiq.cloudbreak.repository.EntityType;
 
 @EntityType(entityClass = StructuredEventEntity.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface StructuredEventRepository extends CrudRepository<StructuredEventEntity, Long> {
     List<StructuredEventEntity> findByUserIdAndEventType(String userId, String eventType);
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/StackServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/StackServiceTest.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.service.stack;
 
 import static com.sequenceiq.cloudbreak.api.model.stack.instance.InstanceMetadataType.CORE;
 import static com.sequenceiq.cloudbreak.api.model.stack.instance.InstanceMetadataType.GATEWAY;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.anyBoolean;
@@ -9,6 +10,7 @@ import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -16,6 +18,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -49,6 +52,7 @@ import com.sequenceiq.cloudbreak.repository.StackUpdater;
 import com.sequenceiq.cloudbreak.service.AuthorizationService;
 import com.sequenceiq.cloudbreak.service.ComponentConfigProvider;
 import com.sequenceiq.cloudbreak.service.TlsSecurityService;
+import com.sequenceiq.cloudbreak.service.TransactionService;
 import com.sequenceiq.cloudbreak.service.image.ImageService;
 import com.sequenceiq.cloudbreak.service.image.StatedImage;
 import com.sequenceiq.cloudbreak.service.stack.connector.adapter.ServiceProviderConnectorAdapter;
@@ -139,6 +143,14 @@ public class StackServiceTest {
 
     @Mock
     private StackUpdater stackUpdater;
+
+    @Mock
+    private TransactionService transactionService;
+
+    @Before
+    public void setup() throws TransactionService.TransactionExecutionException {
+        doAnswer(invocation -> ((TransactionService.TransactionCallback) invocation.getArgument(0)).get()).when(transactionService).required(any());
+    }
 
     @Test
     public void testRemoveInstanceWhenTheInstanceIsCoreTypeAndUserHasRightToTerminateThenThenProcessWouldBeSuccessful() {

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/OrchestratorBootstrapRunner.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/OrchestratorBootstrapRunner.java
@@ -77,7 +77,7 @@ public class OrchestratorBootstrapRunner implements Callable<Boolean> {
         long initialStartTime = System.currentTimeMillis();
         while (success == null && belowAttemptThreshold(retryCount, errorCount)) {
             if (isExitNeeded()) {
-                LOGGER.error(exitCriteria.exitMessage());
+                LOGGER.info(exitCriteria.exitMessage());
                 throw new CloudbreakOrchestratorCancelledException(exitCriteria.exitMessage());
             }
             long startTime = System.currentTimeMillis();


### PR DESCRIPTION
Missing transactions on Repos are causing deadlocks, the @Query queries are opening a new tx and acquiring new connections from pool. Strangely they are opened for a long time e.eg sometimes until controller does not return, although closing of connections are not really deterministic.

I guess it would be nice to enforce somehow that repo interfaces are containing @Transactional, but I was unable to find anything in checkstyle.

With this fix, even one single connection is sufficient to create multiple clusters parallel.

"To let your query methods be transactional, use @Transactional at the repository interface you define, as shown in the following example:"

https://docs.spring.io/spring-data/jpa/docs/current/reference/html/#transactional-query-methods

