### PR TITLE
BUG-104769 – ldap warning on delete now shows both ldap config name and related cluster's name

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/ClusterRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/ClusterRepository.java
@@ -1,18 +1,17 @@
 package com.sequenceiq.cloudbreak.repository;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
-
+import com.sequenceiq.cloudbreak.api.model.Status;
+import com.sequenceiq.cloudbreak.domain.Blueprint;
+import com.sequenceiq.cloudbreak.domain.LdapConfig;
+import com.sequenceiq.cloudbreak.domain.ProxyConfig;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 
-import com.sequenceiq.cloudbreak.api.model.Status;
-import com.sequenceiq.cloudbreak.domain.Blueprint;
-import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
-import com.sequenceiq.cloudbreak.domain.LdapConfig;
-import com.sequenceiq.cloudbreak.domain.ProxyConfig;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 
 @EntityType(entityClass = Cluster.class)
 public interface ClusterRepository extends CrudRepository<Cluster, Long> {
@@ -37,9 +36,9 @@ public interface ClusterRepository extends CrudRepository<Cluster, Long> {
     @Query("SELECT c FROM Cluster c inner join c.rdsConfigs rc WHERE rc.id= :id")
     Set<Cluster> findAllClustersByRDSConfig(@Param("id") Long rdsConfigId);
 
-    Long countByBlueprint(Blueprint blueprint);
+    List<Cluster> findByLdapConfig(LdapConfig ldapConfig);
 
-    Long countByLdapConfig(LdapConfig ldapConfig);
+    Long countByBlueprint(Blueprint blueprint);
 
     Long countByProxyConfig(ProxyConfig proxyConfig);
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/ldapconfig/LdapConfigService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/ldapconfig/LdapConfigService.java
@@ -1,23 +1,23 @@
 package com.sequenceiq.cloudbreak.service.ldapconfig;
 
-import static com.sequenceiq.cloudbreak.util.SqlUtil.getProperSqlErrorMessage;
-
-import java.util.Set;
-
-import javax.inject.Inject;
-
-import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.stereotype.Service;
-
 import com.sequenceiq.cloudbreak.common.model.user.IdentityUser;
 import com.sequenceiq.cloudbreak.common.model.user.IdentityUserRole;
 import com.sequenceiq.cloudbreak.common.type.APIResourceType;
 import com.sequenceiq.cloudbreak.controller.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.controller.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.domain.LdapConfig;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.repository.ClusterRepository;
 import com.sequenceiq.cloudbreak.repository.LdapConfigRepository;
 import com.sequenceiq.cloudbreak.service.AuthorizationService;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Set;
+
+import static com.sequenceiq.cloudbreak.util.SqlUtil.getProperSqlErrorMessage;
 
 @Service
 public class LdapConfigService {
@@ -103,9 +103,17 @@ public class LdapConfigService {
 
     private void delete(LdapConfig ldapConfig) {
         authorizationService.hasWritePermission(ldapConfig);
-        if (!clusterRepository.countByLdapConfig(ldapConfig).equals(0L)) {
+        List<Cluster> clustersWithLdap = clusterRepository.findByLdapConfig(ldapConfig);
+        if (!clustersWithLdap.isEmpty()) {
+            StringBuilder ldaps = new StringBuilder();
+            ldaps.append('[');
+            for (int i = 0; i < clustersWithLdap.size() - 1; i++) {
+                ldaps.append(clustersWithLdap.get(i).getName()).append(", ");
+            }
+            ldaps.append(clustersWithLdap.get(clustersWithLdap.size() - 1).getName()).append(']');
             throw new BadRequestException(String.format(
-                    "There are clusters associated with LDAP config '%s'. Please remove these before deleting the LDAP config.", ldapConfig.getId()));
+                    "There are clusters associated with LDAP config '%s'. Please remove these before deleting the LDAP config. "
+                            + "The following clusters are using this LDAP: %s", ldapConfig.getName(), ldaps.toString()));
         }
         ldapConfigRepository.delete(ldapConfig);
     }


### PR DESCRIPTION
BUG-104769 – ldap warning now shows both name of ldap config – instead of ID – and the related cluster's name if user tries to delete it while it's still used in a cluster