### PR TITLE
BUG-104696 – fix for passing tag key with only space value

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/conf/AwsConfig.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/conf/AwsConfig.java
@@ -27,7 +27,7 @@ public class AwsConfig {
     @Value("${cb.aws.tag.value.max.length:255}")
     private Integer maxValueLength;
 
-    @Value("${cb.aws.tag.value.validator:^(?!aws)([\\w\\d+-=._:/@\\s]+)$}")
+    @Value("${cb.aws.tag.value.validator:^(?!aws|\\s)([\\w\\d+-=._:/@\\s]+)$}")
     private String valueValidator;
 
     @Bean(name = "AwsTagSpecification")

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/conf/AzureConfig.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/conf/AzureConfig.java
@@ -18,7 +18,7 @@ public class AzureConfig {
     @Value("${cb.azure.tag.key.max.length:512}")
     private Integer maxKeyLength;
 
-    @Value("${cb.azure.tag.key.validator:^(?!microsoft|azure|windows)[^,]*$}")
+    @Value("${cb.azure.tag.key.validator:^(?!microsoft|azure|windows|\\s)[^,]*$}")
     private String keyValidator;
 
     @Value("${cb.azure.tag.value.min.length:1}")

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/conf/GcpConfig.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/conf/GcpConfig.java
@@ -27,7 +27,7 @@ public class GcpConfig {
     @Value("${cb.gcp.tag.value.max.length:63}")
     private Integer maxValueLength;
 
-    @Value("${cb.gcp.tag.value.validator:^([a-z0-9]+)([a-z\\d-]+)$}")
+    @Value("${cb.gcp.tag.value.validator:^([a-z\\d]+)$}")
     private String valueValidator;
 
     @Bean(name = "GcpTagSpecification")

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/config/OpenStackConfig.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/config/OpenStackConfig.java
@@ -18,7 +18,7 @@ public class OpenStackConfig {
     @Value("${cb.openstack.tag.key.max.length:127}")
     private Integer maxKeyLength;
 
-    @Value("${cb.openstack.tag.key.validator:^([\\w\\d+-=._:/@\\s]+)$}")
+    @Value("${cb.openstack.tag.key.validator:^(?!\\s+)([\\w\\d+-=._:/@\\s]+)$}")
     private String keyValidator;
 
     @Value("${cb.openstack.tag.value.min.length:1}")


### PR DESCRIPTION
BUG-104696 – fix for passing tag key with only space value which caused cluster creation failure