### PR TITLE
BUG-104109 websocket connection fails on cloudbreak launched cluster

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/ssl-user-facing.conf
+++ b/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/ssl-user-facing.conf
@@ -1,3 +1,8 @@
+map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+
 server {
     listen       443;
     ssl on;
@@ -16,9 +21,12 @@ server {
     }
     location ~ .*/ambari/(.*) {
         proxy_pass         http://ambari/$1$is_args$args;
-            proxy_redirect     off;
+        proxy_redirect     off;
+        proxy_http_version 1.1;
         proxy_set_header   Host $host;
         proxy_set_header   X-Forwarded-Host $server_name;
         proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_set_header   Upgrade $http_upgrade;
+        proxy_set_header   Connection $connection_upgrade;
     }
 }


### PR DESCRIPTION
Adding configuration changes to nginx to support websocket proxying