### PR TITLE
BUG-105170 – fix misconfigured gcp tag value regex

### DIFF
--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/conf/GcpConfig.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/conf/GcpConfig.java
@@ -27,7 +27,7 @@ public class GcpConfig {
     @Value("${cb.gcp.tag.value.max.length:63}")
     private Integer maxValueLength;
 
-    @Value("${cb.gcp.tag.value.validator:^([a-z\\d]+)$}")
+    @Value("${cb.gcp.tag.value.validator:^([a-z0-9]+)([a-z\\d-]+)$}")
     private String valueValidator;
 
     @Bean(name = "GcpTagSpecification")


### PR DESCRIPTION
BUG-105170 – fix for scenario when the user can't create a gcp cluster due to the misconfigured regex for the tag value which fails to check some autogenerated values such as the owner