### PR TITLE
BUG-104948 Added forced option to instance termination.

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/common/StackEndpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/common/StackEndpoint.java
@@ -42,7 +42,11 @@ public interface StackEndpoint {
 
     PlatformVariantsJson variants();
 
-    Response deleteInstance(@PathParam("stackId") Long stackId, @PathParam("instanceId") String instanceId);
+    default Response deleteInstance(@PathParam("stackId") Long stackId, @PathParam("instanceId") String instanceId) {
+        return deleteInstance(stackId, instanceId, false);
+    }
+
+    Response deleteInstance(@PathParam("stackId") Long stackId, @PathParam("instanceId") String instanceId, @QueryParam("forced") boolean forced);
 
     CertificateResponse getCertificate(@PathParam("id") Long stackId);
 

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v1/StackV1Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v1/StackV1Endpoint.java
@@ -136,7 +136,9 @@ public interface StackV1Endpoint extends StackEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @Override
     @ApiOperation(value = StackOpDescription.DELETE_INSTANCE_BY_ID, produces = ContentType.JSON, notes = Notes.STACK_NOTES, nickname = "deleteInstanceStack")
-    Response deleteInstance(@PathParam("stackId") Long stackId, @PathParam("instanceId") String instanceId);
+    Response deleteInstance(@PathParam("stackId") Long stackId,
+            @PathParam("instanceId") String instanceId,
+            @QueryParam("forced") @DefaultValue("false") boolean forced);
 
     @GET
     @Path("{id}/certificate")

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v2/StackV2Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v2/StackV2Endpoint.java
@@ -23,10 +23,10 @@ import com.sequenceiq.cloudbreak.api.model.AmbariAddressJson;
 import com.sequenceiq.cloudbreak.api.model.AutoscaleStackResponse;
 import com.sequenceiq.cloudbreak.api.model.CertificateResponse;
 import com.sequenceiq.cloudbreak.api.model.PlatformVariantsJson;
-import com.sequenceiq.cloudbreak.api.model.StackResponse;
-import com.sequenceiq.cloudbreak.api.model.StackValidationRequest;
 import com.sequenceiq.cloudbreak.api.model.ReinstallRequestV2;
+import com.sequenceiq.cloudbreak.api.model.StackResponse;
 import com.sequenceiq.cloudbreak.api.model.StackScaleRequestV2;
+import com.sequenceiq.cloudbreak.api.model.StackValidationRequest;
 import com.sequenceiq.cloudbreak.api.model.UserNamePasswordJson;
 import com.sequenceiq.cloudbreak.api.model.v2.StackV2Request;
 import com.sequenceiq.cloudbreak.doc.ContentType;
@@ -194,7 +194,9 @@ public interface StackV2Endpoint extends StackEndpoint {
     @Override
     @ApiOperation(value = OperationDescriptions.StackOpDescription.DELETE_INSTANCE_BY_ID, produces = ContentType.JSON, notes = Notes.STACK_NOTES,
             nickname = "deleteInstanceStackV2")
-    Response deleteInstance(@PathParam("stackId") Long stackId, @PathParam("instanceId") String instanceId);
+    Response deleteInstance(@PathParam("stackId") Long stackId,
+            @PathParam("instanceId") String instanceId,
+            @QueryParam("forced") @DefaultValue("false") boolean forced);
 
     @GET
     @Path("{id}/certificate")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/StackCommonService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/StackCommonService.java
@@ -181,8 +181,13 @@ public class StackCommonService implements StackEndpoint {
 
     @Override
     public Response deleteInstance(Long stackId, String instanceId) {
+        return deleteInstance(stackId, instanceId, false);
+    }
+
+    @Override
+    public Response deleteInstance(Long stackId, String instanceId, boolean forced) {
         IdentityUser user = authenticatedUserService.getCbUser();
-        stackService.removeInstance(user, stackId, instanceId);
+        stackService.removeInstance(user, stackId, instanceId, forced);
         return Response.status(Status.NO_CONTENT).build();
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/StackV1Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/StackV1Controller.java
@@ -98,7 +98,12 @@ public class StackV1Controller extends NotificationController implements StackV1
 
     @Override
     public Response deleteInstance(Long stackId, String instanceId) {
-        return stackCommonService.deleteInstance(stackId, instanceId);
+        return stackCommonService.deleteInstance(stackId, instanceId, false);
+    }
+
+    @Override
+    public Response deleteInstance(Long stackId, String instanceId, boolean forced) {
+        return stackCommonService.deleteInstance(stackId, instanceId, forced);
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/StackV2Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/StackV2Controller.java
@@ -189,7 +189,12 @@ public class StackV2Controller extends NotificationController implements StackV2
 
     @Override
     public Response deleteInstance(Long stackId, String instanceId) {
-        return stackCommonService.deleteInstance(stackId, instanceId);
+        return stackCommonService.deleteInstance(stackId, instanceId, false);
+    }
+
+    @Override
+    public Response deleteInstance(Long stackId, String instanceId, boolean forced) {
+        return stackCommonService.deleteInstance(stackId, instanceId, forced);
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterRepairFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterRepairFlowEventChainFactory.java
@@ -21,6 +21,7 @@ import com.sequenceiq.cloudbreak.cloud.event.Selectable;
 import com.sequenceiq.cloudbreak.common.type.ScalingType;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.repair.ChangePrimaryGatewayEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterAndStackDownscaleTriggerEvent;
+import com.sequenceiq.cloudbreak.core.flow2.event.ClusterDownscaleDetails;
 import com.sequenceiq.cloudbreak.core.flow2.event.StackAndClusterUpscaleTriggerEvent;
 import com.sequenceiq.cloudbreak.domain.HostGroup;
 import com.sequenceiq.cloudbreak.domain.InstanceGroup;
@@ -74,7 +75,7 @@ public class ClusterRepairFlowEventChainFactory implements FlowEventChainFactory
             Stack stack = stackService.getByIdWithLists(event.getStackId());
             Set<Long> privateIdsForHostNames = stackService.getPrivateIdsForHostNames(stack.getInstanceMetaDataAsList(), hostNames);
             flowChainTriggers.add(new ClusterAndStackDownscaleTriggerEvent(FlowChainTriggers.FULL_DOWNSCALE_TRIGGER_EVENT, event.getStackId(),
-                    hostGroupName, Sets.newHashSet(privateIdsForHostNames), ScalingType.DOWNSCALE_TOGETHER, event.accepted()));
+                    hostGroupName, Sets.newHashSet(privateIdsForHostNames), ScalingType.DOWNSCALE_TOGETHER, event.accepted(), new ClusterDownscaleDetails()));
             if (!event.isRemoveOnly()) {
                 flowChainTriggers.add(new StackAndClusterUpscaleTriggerEvent(FlowChainTriggers.FULL_UPSCALE_TRIGGER_EVENT, event.getStackId(),
                         hostGroupName, hostNames.size(), ScalingType.UPSCALE_TOGETHER, Sets.newHashSet(hostNames)));

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/DownscaleFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/DownscaleFlowEventChainFactory.java
@@ -44,10 +44,10 @@ public class DownscaleFlowEventChainFactory implements FlowEventChainFactory<Clu
         ClusterScaleTriggerEvent cste;
         if (event.getPrivateIds() == null) {
             cste = new ClusterDownscaleTriggerEvent(DECOMMISSION_EVENT.event(), event.getStackId(), event.getHostGroupName(),
-                    event.getAdjustment(), event.accepted());
+                    event.getAdjustment(), event.accepted(), event.getDetails());
         } else {
             cste = new ClusterDownscaleTriggerEvent(DECOMMISSION_EVENT.event(), event.getStackId(), event.getHostGroupName(),
-                    event.getPrivateIds(), event.accepted());
+                    event.getPrivateIds(), event.accepted(), event.getDetails());
         }
         flowEventChain.add(cste);
         if (event.getScalingType() == ScalingType.DOWNSCALE_TOGETHER) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/downscale/ClusterDownscaleActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/downscale/ClusterDownscaleActions.java
@@ -34,9 +34,9 @@ public class ClusterDownscaleActions {
             @Override
             protected void doExecute(ClusterViewContext context, ClusterDownscaleTriggerEvent payload, Map<Object, Object> variables) throws Exception {
                 clusterDownscaleService.clusterDownscaleStarted(context.getStackId(), payload.getHostGroupName(), payload.getAdjustment(),
-                        payload.getPrivateIds());
+                        payload.getPrivateIds(), payload.getDetails());
                 CollectDownscaleCandidatesRequest request = new CollectDownscaleCandidatesRequest(context.getStackId(), payload.getHostGroupName(),
-                        payload.getAdjustment(), payload.getPrivateIds());
+                        payload.getAdjustment(), payload.getPrivateIds(), payload.getDetails());
                 sendEvent(context.getFlowId(), request.selector(), request);
             }
         };
@@ -47,7 +47,8 @@ public class ClusterDownscaleActions {
         return new AbstractClusterAction<CollectDownscaleCandidatesResult>(CollectDownscaleCandidatesResult.class) {
             @Override
             protected void doExecute(ClusterViewContext context, CollectDownscaleCandidatesResult payload, Map<Object, Object> variables) throws Exception {
-                DecommissionRequest request = new DecommissionRequest(context.getStackId(), payload.getHostGroupName(), payload.getPrivateIds());
+                DecommissionRequest request = new DecommissionRequest(context.getStackId(), payload.getHostGroupName(), payload.getPrivateIds(),
+                        payload.getRequest().getDetails());
                 sendEvent(context.getFlowId(), request.selector(), request);
             }
         };

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterAndStackDownscaleTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterAndStackDownscaleTriggerEvent.java
@@ -15,8 +15,8 @@ public class ClusterAndStackDownscaleTriggerEvent extends ClusterDownscaleTrigge
     }
 
     public ClusterAndStackDownscaleTriggerEvent(String selector, Long stackId, String hostGroup, Set<Long> privateIds, ScalingType scalingType,
-            Promise<Boolean> accepted) {
-        super(selector, stackId, hostGroup, privateIds, accepted);
+            Promise<Boolean> accepted, ClusterDownscaleDetails details) {
+        super(selector, stackId, hostGroup, privateIds, accepted, details);
         this.scalingType = scalingType;
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterDownscaleDetails.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterDownscaleDetails.java
@@ -1,0 +1,18 @@
+package com.sequenceiq.cloudbreak.core.flow2.event;
+
+public class ClusterDownscaleDetails {
+    private final boolean forced;
+
+    public ClusterDownscaleDetails() {
+        this.forced = false;
+    }
+
+    public ClusterDownscaleDetails(boolean forced) {
+        this.forced = forced;
+    }
+
+    public boolean isForced() {
+        return forced;
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterDownscaleTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterDownscaleTriggerEvent.java
@@ -7,27 +7,39 @@ import reactor.rx.Promise;
 public class ClusterDownscaleTriggerEvent extends ClusterScaleTriggerEvent {
     private final Set<Long> privateIds;
 
+    private final ClusterDownscaleDetails details;
+
     public ClusterDownscaleTriggerEvent(String selector, Long stackId, String hostGroup, Integer adjustment) {
         super(selector, stackId, hostGroup, adjustment);
+        details = null;
         privateIds = null;
     }
 
-    public ClusterDownscaleTriggerEvent(String selector, Long stackId, String hostGroup, Integer adjustment, Promise<Boolean> accepted) {
+    public ClusterDownscaleTriggerEvent(String selector, Long stackId, String hostGroup, Integer adjustment, Promise<Boolean> accepted,
+            ClusterDownscaleDetails details) {
         super(selector, stackId, hostGroup, adjustment, accepted);
+        this.details = details;
         privateIds = null;
     }
 
     public ClusterDownscaleTriggerEvent(String selector, Long stackId, String hostGroup, Set<Long> privateIds) {
         super(selector, stackId, hostGroup, null);
+        details = null;
         this.privateIds = privateIds;
     }
 
-    public ClusterDownscaleTriggerEvent(String selector, Long stackId, String hostGroup, Set<Long> privateIds, Promise<Boolean> accepted) {
+    public ClusterDownscaleTriggerEvent(String selector, Long stackId, String hostGroup, Set<Long> privateIds, Promise<Boolean> accepted,
+            ClusterDownscaleDetails details) {
         super(selector, stackId, hostGroup, null, accepted);
+        this.details = details;
         this.privateIds = privateIds;
     }
 
     public Set<Long> getPrivateIds() {
         return privateIds;
+    }
+
+    public ClusterDownscaleDetails getDetails() {
+        return details;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
@@ -32,6 +32,7 @@ import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.EphemeralClusterEve
 import com.sequenceiq.cloudbreak.core.flow2.cluster.termination.ClusterTerminationEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterAndStackDownscaleTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterCredentialChangeTriggerEvent;
+import com.sequenceiq.cloudbreak.core.flow2.event.ClusterDownscaleDetails;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterScaleTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.StackAndClusterUpscaleTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.StackDownscaleTriggerEvent;
@@ -105,10 +106,11 @@ public class ReactorFlowManager {
         notify(selector, new StackSyncTriggerEvent(selector, stackId, true));
     }
 
-    public void triggerStackRemoveInstance(Long stackId, String hostGroup, Long privateId) {
+    public void triggerStackRemoveInstance(Long stackId, String hostGroup, Long privateId, boolean forced) {
         String selector = FlowChainTriggers.FULL_DOWNSCALE_TRIGGER_EVENT;
+        ClusterDownscaleDetails details = new ClusterDownscaleDetails(forced);
         ClusterAndStackDownscaleTriggerEvent event = new ClusterAndStackDownscaleTriggerEvent(selector, stackId, hostGroup, Collections.singleton(privateId),
-                ScalingType.DOWNSCALE_TOGETHER, new Promise<>());
+                ScalingType.DOWNSCALE_TOGETHER, new Promise<>(), details);
         notify(selector, event);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/Msg.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/Msg.java
@@ -79,6 +79,7 @@ public enum Msg {
     AMBARI_CLUSTER_UPGRADE_FAILED("ambari.cluster.upgrade.failed"),
     AMBARI_CLUSTER_UPGRADE_FINISHED("ambari.cluster.upgrade.finished"),
     AMBARI_CLUSTER_REMOVING_NODE_FROM_HOSTGROUP("ambari.cluster.removing.node.from.hostgroup"),
+    AMBARI_CLUSTER_FORCE_REMOVING_NODE_FROM_HOSTGROUP("ambari.cluster.force.removing.node.from.hostgroup"),
     AMBARI_CLUSTER_GATEWAY_CHANGE("ambari.cluster.gateway.change"),
     AMBARI_CLUSTER_GATEWAY_CHANGED_SUCCESSFULLY("ambari.cluster.gateway.changed.successfully"),
     AMBARI_CLUSTER_GATEWAY_CHANGE_FAILED("ambari.cluster.gateway.change.failed"),

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/CollectDownscaleCandidatesHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/CollectDownscaleCandidatesHandler.java
@@ -52,8 +52,9 @@ public class CollectDownscaleCandidatesHandler implements ReactorEventHandler<Co
                 List<InstanceMetaData> notDeletedNodes = instanceMetaDataList.stream()
                         .filter(instanceMetaData -> !instanceMetaData.isTerminated() && !instanceMetaData.isDeletedOnProvider())
                         .collect(Collectors.toList());
-
-                ambariDecommissioner.verifyNodesAreRemovable(stack, notDeletedNodes);
+                if (!request.getDetails().isForced()) {
+                    ambariDecommissioner.verifyNodesAreRemovable(stack, notDeletedNodes);
+                }
             }
             result = new CollectDownscaleCandidatesResult(request, privateIds);
         } catch (Exception e) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/CollectDownscaleCandidatesRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/CollectDownscaleCandidatesRequest.java
@@ -2,15 +2,21 @@ package com.sequenceiq.cloudbreak.reactor.api.event.resource;
 
 import java.util.Set;
 
+import com.sequenceiq.cloudbreak.core.flow2.event.ClusterDownscaleDetails;
+
 public class CollectDownscaleCandidatesRequest extends AbstractClusterScaleRequest {
     private final Integer scalingAdjustment;
 
+    private final ClusterDownscaleDetails details;
+
     private final Set<Long> privateIds;
 
-    public CollectDownscaleCandidatesRequest(Long stackId, String hostGroupName, Integer scalingAdjustment, Set<Long> privateIds) {
+    public CollectDownscaleCandidatesRequest(Long stackId, String hostGroupName, Integer scalingAdjustment, Set<Long> privateIds,
+            ClusterDownscaleDetails details) {
         super(stackId, hostGroupName);
         this.scalingAdjustment = scalingAdjustment;
         this.privateIds = privateIds;
+        this.details = details;
     }
 
     public Integer getScalingAdjustment() {
@@ -19,5 +25,9 @@ public class CollectDownscaleCandidatesRequest extends AbstractClusterScaleReque
 
     public Set<Long> getPrivateIds() {
         return privateIds;
+    }
+
+    public ClusterDownscaleDetails getDetails() {
+        return details;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/DecommissionRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/DecommissionRequest.java
@@ -2,16 +2,25 @@ package com.sequenceiq.cloudbreak.reactor.api.event.resource;
 
 import java.util.Set;
 
+import com.sequenceiq.cloudbreak.core.flow2.event.ClusterDownscaleDetails;
+
 public class DecommissionRequest extends AbstractClusterScaleRequest {
 
     private final Set<Long> privateIds;
 
-    public DecommissionRequest(Long stackId, String hostGroupName, Set<Long> privateIds) {
+    private final ClusterDownscaleDetails details;
+
+    public DecommissionRequest(Long stackId, String hostGroupName, Set<Long> privateIds, ClusterDownscaleDetails details) {
         super(stackId, hostGroupName);
         this.privateIds = privateIds;
+        this.details = details;
     }
 
     public Set<Long> getPrivateIds() {
         return privateIds;
+    }
+
+    public ClusterDownscaleDetails getDetails() {
+        return details;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
@@ -422,7 +422,7 @@ public class StackService {
         delete(stack, forced, deleteDependencies);
     }
 
-    public void removeInstance(IdentityUser user, Long stackId, String instanceId) {
+    public void removeInstance(IdentityUser user, Long stackId, String instanceId, boolean forced) {
         Stack stack = get(stackId);
         InstanceMetaData instanceMetaData = instanceMetaDataRepository.findByInstanceId(stackId, instanceId);
         if (instanceMetaData == null) {
@@ -431,7 +431,7 @@ public class StackService {
         if (!stack.isPublicInAccount() && !stack.getOwner().equals(user.getUserId())) {
             throw new BadRequestException(String.format("Private stack (%s) only modifiable by the owner.", stackId));
         }
-        flowManager.triggerStackRemoveInstance(stackId, instanceMetaData.getInstanceGroupName(), instanceMetaData.getPrivateId());
+        flowManager.triggerStackRemoveInstance(stackId, instanceMetaData.getInstanceGroupName(), instanceMetaData.getPrivateId(), forced);
     }
 
     @Transactional(TxType.NEVER)

--- a/core/src/main/resources/messages/messages.properties
+++ b/core/src/main/resources/messages/messages.properties
@@ -110,6 +110,7 @@ ambari.cluster.restarting.ambari.agent=Restarting Ambari agents
 ambari.cluster.ambari.server.restarted=Ambari server restarted
 ambari.cluster.ambari.agent.restarted=Ambari agents restarted
 ambari.cluster.removing.node.from.hostgroup=Removing {0} node(s) from the host group {1}
+ambari.cluster.force.removing.node.from.hostgroup=Removing forcefully {0} node(s) from the host group {1}
 ambari.cluster.adding.node.to.hostgroup=Adding {0} new host(s) to the host group {1}
 
 stack.instance.terminate=Terminating instance {0}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow/ReactorFlowManagerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow/ReactorFlowManagerTest.java
@@ -95,7 +95,7 @@ public class ReactorFlowManagerTest {
         underTest.triggerTermination(stackId, false, true);
         underTest.triggerStackUpscale(stackId, instanceGroupAdjustment, true);
         underTest.triggerStackDownscale(stackId, instanceGroupAdjustment);
-        underTest.triggerStackRemoveInstance(stackId, "hostgroup", 5L);
+        underTest.triggerStackRemoveInstance(stackId, "hostgroup", 5L, false);
         underTest.triggerClusterUpscale(stackId, hostGroupAdjustment);
         underTest.triggerClusterDownscale(stackId, hostGroupAdjustment);
         underTest.triggerClusterSync(stackId);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/CollectDownscaleCandidatesHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/CollectDownscaleCandidatesHandlerTest.java
@@ -1,0 +1,126 @@
+package com.sequenceiq.cloudbreak.reactor;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.sequenceiq.cloudbreak.core.CloudbreakException;
+import com.sequenceiq.cloudbreak.core.CloudbreakSecuritySetupException;
+import com.sequenceiq.cloudbreak.core.flow2.event.ClusterDownscaleDetails;
+import com.sequenceiq.cloudbreak.domain.Stack;
+import com.sequenceiq.cloudbreak.reactor.api.event.resource.CollectDownscaleCandidatesRequest;
+import com.sequenceiq.cloudbreak.reactor.api.event.resource.CollectDownscaleCandidatesResult;
+import com.sequenceiq.cloudbreak.service.cluster.flow.AmbariDecommissioner;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+
+import reactor.bus.Event;
+import reactor.bus.EventBus;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CollectDownscaleCandidatesHandlerTest {
+
+    private Long stackId = 11L;
+
+    private Long privateId = 1342L;
+
+    private String hostGroupName = "master";
+
+    private Integer scalingAdjustment = -1;
+
+    @Mock
+    private EventBus eventBus;
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private AmbariDecommissioner ambariDecommissioner;
+
+    @InjectMocks
+    private CollectDownscaleCandidatesHandler testedClass;
+
+    @Test
+    public void testFlowWithPrivateIds() throws CloudbreakException {
+        //given
+        Stack stack = generateStackData();
+        when(stackService.getByIdWithLists(stackId)).thenReturn(stack);
+        Event<CollectDownscaleCandidatesRequest> event = generateTestDataEvent(Collections.singleton(privateId));
+        //when
+        testedClass.accept(event);
+        //then
+        ArgumentCaptor<Event> capturedEvent = ArgumentCaptor.forClass(Event.class);
+        verify(eventBus).notify((Object) any(), capturedEvent.capture());
+        Event<CollectDownscaleCandidatesResult> submittedEvent = capturedEvent.getValue();
+        CollectDownscaleCandidatesResult submittedResult = submittedEvent.getData();
+        assertNotNull(submittedResult);
+        verify(ambariDecommissioner, never()).collectDownscaleCandidates(stack, hostGroupName, scalingAdjustment);
+
+    }
+
+    @Test
+    public void downScaleNotForced() throws CloudbreakSecuritySetupException {
+        //given
+        Stack stack = generateStackData();
+        Event<CollectDownscaleCandidatesRequest> event = generateTestDataEvent(Collections.singleton(privateId));
+        when(stackService.getByIdWithLists(stackId)).thenReturn(stack);
+        //when
+        testedClass.accept(event);
+        //then
+        ArgumentCaptor<Event> capturedEvent = ArgumentCaptor.forClass(Event.class);
+        verify(eventBus).notify((Object) any(), capturedEvent.capture());
+        Event<CollectDownscaleCandidatesResult> submittedEvent = capturedEvent.getValue();
+        CollectDownscaleCandidatesResult submittedResult = submittedEvent.getData();
+        assertNotNull(submittedResult);
+        assertFalse(submittedResult.getRequest().getDetails().isForced());
+        verify(ambariDecommissioner).verifyNodesAreRemovable(eq(stack), anyList());
+    }
+
+    @Test
+    public void downScaleForcedForced() throws CloudbreakSecuritySetupException {
+        //given
+        Stack stack = generateStackData();
+        Event<CollectDownscaleCandidatesRequest> event = generateTestDataEvent(Collections.singleton(privateId), new ClusterDownscaleDetails(true));
+        when(stackService.getByIdWithLists(stackId)).thenReturn(stack);
+        //when
+        testedClass.accept(event);
+        //then
+        ArgumentCaptor<Event> capturedEvent = ArgumentCaptor.forClass(Event.class);
+        verify(eventBus).notify((Object) any(), capturedEvent.capture());
+        Event<CollectDownscaleCandidatesResult> submittedEvent = capturedEvent.getValue();
+        CollectDownscaleCandidatesResult submittedResult = submittedEvent.getData();
+        assertNotNull(submittedResult);
+        assertTrue(submittedResult.getRequest().getDetails().isForced());
+        verify(ambariDecommissioner, never()).verifyNodesAreRemovable(eq(stack), anyList());
+    }
+
+    private Stack generateStackData() {
+        return new Stack();
+    }
+
+    private Event<CollectDownscaleCandidatesRequest> generateTestDataEvent(Set<Long> privateIds) {
+        CollectDownscaleCandidatesRequest request = new CollectDownscaleCandidatesRequest(stackId, hostGroupName, scalingAdjustment, privateIds,
+                new ClusterDownscaleDetails());
+        return new Event<>(request);
+    }
+
+    private Event<CollectDownscaleCandidatesRequest> generateTestDataEvent(Set<Long> privateIds, ClusterDownscaleDetails details) {
+        CollectDownscaleCandidatesRequest request = new CollectDownscaleCandidatesRequest(stackId, hostGroupName, scalingAdjustment, privateIds, details);
+        return new Event<>(request);
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/v2/mock/instanceterm/MockInstanceTerminationReplicationErrorTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/v2/mock/instanceterm/MockInstanceTerminationReplicationErrorTest.java
@@ -56,13 +56,35 @@ public class MockInstanceTerminationReplicationErrorTest extends AbstractCloudbr
 
         String instanceId = getInstanceId(stackResponse, hostGroupName);
 
-        getCloudbreakClient().stackV2Endpoint().deleteInstance(stackResponse.getId(), instanceId);
+        getCloudbreakClient().stackV2Endpoint().deleteInstance(stackResponse.getId(), instanceId, false);
         Map<String, String> desiredStatuses = new HashMap<>();
         desiredStatuses.put("status", "AVAILABLE");
         desiredStatuses.put("clusterStatus", "AVAILABLE");
         String reason = CloudbreakUtil.getFailedStatusReason(getCloudbreakClient(), stackId.toString(), desiredStatuses, singleton(WaitResult.SUCCESSFUL));
         Assert.assertEquals(reason, "Node(s) could not be removed from the cluster: There is not enough node to downscale. "
                 + "Check the replication factor and the ApplicationMaster occupation.");
+    }
+
+    @Test
+    public void testInstanceTerminationForced() throws Exception {
+        // GIVEN
+        // WHEN
+        Long stackId = Long.parseLong(getItContext().getContextParam(CloudbreakITContextConstants.STACK_ID));
+        StackResponse stackResponse = getStackResponse(stackId);
+        // THEN
+        String hostGroupName = "worker";
+
+        String instanceId = getInstanceId(stackResponse, hostGroupName);
+        int before = getInstanceMetaData(stackResponse, hostGroupName).size();
+
+        getCloudbreakClient().stackV2Endpoint().deleteInstance(stackResponse.getId(), instanceId, true);
+        Map<String, String> desiredStatuses = new HashMap<>();
+        desiredStatuses.put("status", "AVAILABLE");
+        desiredStatuses.put("clusterStatus", "AVAILABLE");
+        CloudbreakUtil.waitAndCheckStatuses(getCloudbreakClient(), stackId.toString(), desiredStatuses);
+        int after = getInstanceMetaData(getStackResponse(stackId), hostGroupName).size();
+
+        Assert.assertEquals(after, before - 1);
     }
 
     protected StackResponse getStackResponse(Long stackId) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/v2/mock/instanceterm/MockInstanceTerminationReplicationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/v2/mock/instanceterm/MockInstanceTerminationReplicationTest.java
@@ -54,7 +54,7 @@ public class MockInstanceTerminationReplicationTest extends AbstractCloudbreakIn
         int before = getInstanceMetaData(stackResponse, hostGroupName).size();
         String instanceId = getInstanceId(stackResponse, hostGroupName);
 
-        getCloudbreakClient().stackV2Endpoint().deleteInstance(stackResponse.getId(), instanceId);
+        getCloudbreakClient().stackV2Endpoint().deleteInstance(stackResponse.getId(), instanceId, false);
         Map<String, String> desiredStatuses = new HashMap<>();
         desiredStatuses.put("status", "AVAILABLE");
         desiredStatuses.put("clusterStatus", "AVAILABLE");

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/v2/mock/instanceterm/MockInstanceTerminationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/v2/mock/instanceterm/MockInstanceTerminationTest.java
@@ -54,7 +54,7 @@ public class MockInstanceTerminationTest extends AbstractCloudbreakIntegrationTe
         int before = getInstanceMetaData(stackResponse, hostGroupName).size();
         String instanceId = getInstanceId(stackResponse, hostGroupName);
 
-        getCloudbreakClient().stackV2Endpoint().deleteInstance(stackResponse.getId(), instanceId);
+        getCloudbreakClient().stackV2Endpoint().deleteInstance(stackResponse.getId(), instanceId, false);
         Map<String, String> desiredStatuses = new HashMap<>();
         desiredStatuses.put("status", "AVAILABLE");
         desiredStatuses.put("clusterStatus", "AVAILABLE");

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/v2/mock/instanceterm/MockInstanceTerminationUnknownTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/v2/mock/instanceterm/MockInstanceTerminationUnknownTest.java
@@ -54,7 +54,7 @@ public class MockInstanceTerminationUnknownTest extends AbstractCloudbreakIntegr
         int before = getInstanceMetaData(stackResponse, hostGroupName).size();
         String instanceId = getInstanceId(stackResponse, hostGroupName);
 
-        getCloudbreakClient().stackV2Endpoint().deleteInstance(stackResponse.getId(), instanceId);
+        getCloudbreakClient().stackV2Endpoint().deleteInstance(stackResponse.getId(), instanceId, false);
         Map<String, String> desiredStatuses = new HashMap<>();
         desiredStatuses.put("status", "AVAILABLE");
         desiredStatuses.put("clusterStatus", "AVAILABLE");


### PR DESCRIPTION
- Added option to forcefully terminate an instance. (Skip ambari check)
- Added custom "forcefully terminated message" to events.
- Added unit integration test for flow.

Initial idea was to use a custom state for forcefully terminating an instance, but got pretty complicated pretty soon, so that's why I used the additional ClusterDownScale details.