### PR TITLE
BUG-105297 – adls fs response does not contains sensitive credential …

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v2/cli/FileSystemToFileSystemResponseConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v2/cli/FileSystemToFileSystemResponseConverter.java
@@ -36,7 +36,10 @@ public class FileSystemToFileSystemResponseConverter extends AbstractConversionS
         response.setLocations(getStorageLocationRequests(source));
         try {
             if (source.getType().isAdls()) {
-                response.setAdls(getConversionService().convert(source.getConfigurations().get(AdlsFileSystem.class), AdlsCloudStorageParameters.class));
+                AdlsCloudStorageParameters adls = getConversionService()
+                        .convert(source.getConfigurations().get(AdlsFileSystem.class), AdlsCloudStorageParameters.class);
+                adls.setCredential(null);
+                response.setAdls(adls);
             } else if (source.getType().isGcs()) {
                 response.setGcs(getConversionService().convert(source.getConfigurations().get(GcsFileSystem.class), GcsCloudStorageParameters.class));
             } else if (source.getType().isS3()) {


### PR DESCRIPTION
BUG-105297 – we shouldn't send back the adls credential key value in the response. the returning null value makes the UI to not show this property at all