### PR TITLE
BUG-104930 Periscope: input & runtime validation; cloudbreak: input v…

### DIFF
--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/v1/AutoScaleClusterV1Endpoint.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/v1/AutoScaleClusterV1Endpoint.java
@@ -5,6 +5,7 @@ import static com.sequenceiq.periscope.doc.ApiDescription.JSON;
 
 import java.util.List;
 
+import javax.validation.Valid;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -16,8 +17,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import com.sequenceiq.periscope.api.model.AutoscaleClusterRequest;
-import com.sequenceiq.periscope.api.model.AutoscaleClusterState;
 import com.sequenceiq.periscope.api.model.AutoscaleClusterResponse;
+import com.sequenceiq.periscope.api.model.AutoscaleClusterState;
 import com.sequenceiq.periscope.api.model.StateJson;
 import com.sequenceiq.periscope.doc.ApiDescription.ClusterNotes;
 import com.sequenceiq.periscope.doc.ApiDescription.ClusterOpDescription;
@@ -33,13 +34,13 @@ public interface AutoScaleClusterV1Endpoint {
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = ClusterOpDescription.CLUSTER_POST, produces = JSON, notes = ClusterNotes.NOTES)
-    AutoscaleClusterResponse addCluster(AutoscaleClusterRequest ambariServer);
+    AutoscaleClusterResponse addCluster(@Valid AutoscaleClusterRequest ambariServer);
 
     @PUT
     @Path("{clusterId}")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = ClusterOpDescription.CLUSTER_PUT, produces = JSON, notes = ClusterNotes.NOTES)
-    AutoscaleClusterResponse modifyCluster(AutoscaleClusterRequest ambariServer, @PathParam("clusterId") Long clusterId);
+    AutoscaleClusterResponse modifyCluster(@Valid AutoscaleClusterRequest ambariServer, @PathParam("clusterId") Long clusterId);
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/v2/AutoScaleClusterV2Endpoint.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/v2/AutoScaleClusterV2Endpoint.java
@@ -3,6 +3,7 @@ package com.sequenceiq.periscope.api.endpoint.v2;
 import static com.sequenceiq.periscope.doc.ApiDescription.CLUSTERS_DESCRIPTION;
 import static com.sequenceiq.periscope.doc.ApiDescription.JSON;
 
+import javax.validation.Valid;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -13,8 +14,8 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import com.sequenceiq.periscope.api.model.AutoscaleClusterResponse;
 import com.sequenceiq.periscope.api.model.AutoscaleClusterRequest;
+import com.sequenceiq.periscope.api.model.AutoscaleClusterResponse;
 import com.sequenceiq.periscope.doc.ApiDescription.ClusterNotes;
 import com.sequenceiq.periscope.doc.ApiDescription.ClusterOpDescription;
 
@@ -30,7 +31,7 @@ public interface AutoScaleClusterV2Endpoint {
     @Path("{cbClusterId}")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = ClusterOpDescription.CLUSTER_PUT, produces = JSON, notes = ClusterNotes.NOTES)
-    AutoscaleClusterResponse modifyByCloudbreakCluster(AutoscaleClusterRequest ambariServer, @PathParam("cbClusterId") Long stackId);
+    AutoscaleClusterResponse modifyByCloudbreakCluster(@Valid AutoscaleClusterRequest ambariServer, @PathParam("cbClusterId") Long stackId);
 
     @GET
     @Path("{cbClusterId}")

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/validator/ScalingConfigurationRequestValidator.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/validator/ScalingConfigurationRequestValidator.java
@@ -19,15 +19,18 @@ public class ScalingConfigurationRequestValidator implements ConstraintValidator
             validRequest = false;
             String message = "The specified ScalingConfiguration is not valid because the minimum cluster size can not be more than"
                     + " maximum cluster size.";
-            ValidatorUtil.addConstraintViolationAsStatus(context, message);
+            ValidatorUtil.addConstraintViolation(context, message, "minSize")
+                    .disableDefaultConstraintViolation();
         } else if (request.getMaxSize() < 0) {
             validRequest = false;
             String message = "The specified ScalingConfiguration is not valid because the maximum size smaller than zero.";
-            ValidatorUtil.addConstraintViolationAsStatus(context, message);
+            ValidatorUtil.addConstraintViolation(context, message, "maxSize")
+                    .disableDefaultConstraintViolation();
         } else if (request.getMinSize() < 0) {
             validRequest = false;
             String message = "The specified ScalingConfiguration is not valid because the minimum size smaller than zero.";
-            ValidatorUtil.addConstraintViolationAsStatus(context, message);
+            ValidatorUtil.addConstraintViolation(context, message, "minSize")
+                    .disableDefaultConstraintViolation();
         }
         return validRequest;
     }

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/validator/ScalingPolicyRequestValidator.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/validator/ScalingPolicyRequestValidator.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.periscope.api.endpoint.validator;
+
+import javax.inject.Inject;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+import com.sequenceiq.cloudbreak.common.type.ScalingHardLimitsService;
+import com.sequenceiq.cloudbreak.validation.ValidatorUtil;
+import com.sequenceiq.periscope.api.model.AdjustmentType;
+import com.sequenceiq.periscope.api.model.ScalingPolicyBase;
+
+public class ScalingPolicyRequestValidator implements ConstraintValidator<ValidScalingPolicy, ScalingPolicyBase> {
+
+    @Inject
+    private ScalingHardLimitsService scalingHardLimitsService;
+
+    @Override
+    public void initialize(ValidScalingPolicy constraintAnnotation) {
+
+    }
+
+    @Override
+    public boolean isValid(ScalingPolicyBase value, ConstraintValidatorContext context) {
+        if (AdjustmentType.NODE_COUNT.equals(value.getAdjustmentType())
+                && scalingHardLimitsService.isViolatingMaxUpscaleStepInNodeCount(value.getScalingAdjustment())) {
+            String message = String.format("Maximum upscale step is %d node(s)", scalingHardLimitsService.getMaxUpscaleStepInNodeCount());
+            ValidatorUtil.addConstraintViolation(context, message, "scalingAdjustment")
+                    .disableDefaultConstraintViolation();
+            return false;
+        }
+        return true;
+    }
+}

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/validator/ValidScalingPolicy.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/validator/ValidScalingPolicy.java
@@ -1,0 +1,22 @@
+package com.sequenceiq.periscope.api.endpoint.validator;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Documented
+@Constraint(validatedBy = ScalingPolicyRequestValidator.class)
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidScalingPolicy {
+    String message() default "Scaling policy validation error";
+
+    Class<?>[] groups() default { };
+
+    Class<? extends Payload>[] payload() default { };
+}

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/AutoscaleClusterRequest.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/AutoscaleClusterRequest.java
@@ -18,9 +18,11 @@ public class AutoscaleClusterRequest extends ClusterBaseJson {
     @ApiModelProperty(ClusterJsonsProperties.ENABLE_AUTOSCALING)
     private boolean enableAutoscaling;
 
+    @Valid
     @ApiModelProperty(ClusterJsonsProperties.METRIC_ALERTS)
     private List<MetricAlertRequest> metricAlerts;
 
+    @Valid
     @ApiModelProperty(ClusterJsonsProperties.TIME_ALERTS)
     private List<TimeAlertRequest> timeAlerts;
 

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/MetricAlertRequest.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/MetricAlertRequest.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.periscope.api.model;
 
+import javax.validation.Valid;
+
 import com.sequenceiq.periscope.doc.ApiDescription.BaseAlertJsonProperties;
 import com.sequenceiq.periscope.doc.ApiDescription.MetricAlertJsonProperties;
 
@@ -18,6 +20,7 @@ public class MetricAlertRequest extends AbstractAlertJson {
     @ApiModelProperty(MetricAlertJsonProperties.ALERTSTATE)
     private AlertState alertState;
 
+    @Valid
     @ApiModelProperty(BaseAlertJsonProperties.SCALINGPOLICYID)
     private ScalingPolicyRequest scalingPolicy;
 

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/ScalingPolicyBase.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/ScalingPolicyBase.java
@@ -2,15 +2,17 @@ package com.sequenceiq.periscope.api.model;
 
 import javax.validation.constraints.Pattern;
 
+import com.sequenceiq.periscope.api.endpoint.validator.ValidScalingPolicy;
 import com.sequenceiq.periscope.doc.ApiDescription.ScalingPolicyJsonProperties;
 
 import io.swagger.annotations.ApiModelProperty;
 
+@ValidScalingPolicy
 public class ScalingPolicyBase implements Json {
 
     @ApiModelProperty(ScalingPolicyJsonProperties.NAME)
     @Pattern(regexp = "(^[a-zA-Z][-a-zA-Z0-9]*$)",
-            message = "The name can only contain alphanumeric characters and hyphens and has start with an alphanumeric character")
+            message = "The name can only contain alphanumeric characters and hyphens and has to start with an alphanumeric character")
     private String name;
 
     @ApiModelProperty(ScalingPolicyJsonProperties.ADJUSTMENTTYPE)

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/TimeAlertRequest.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/TimeAlertRequest.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.periscope.api.model;
 
+import javax.validation.Valid;
+
 import com.sequenceiq.periscope.doc.ApiDescription.BaseAlertJsonProperties;
 import com.sequenceiq.periscope.doc.ApiDescription.TimeAlertJsonProperties;
 
@@ -15,6 +17,7 @@ public class TimeAlertRequest extends AbstractAlertJson {
     @ApiModelProperty(TimeAlertJsonProperties.CRON)
     private String cron;
 
+    @Valid
     @ApiModelProperty(BaseAlertJsonProperties.SCALINGPOLICYID)
     private ScalingPolicyRequest scalingPolicy;
 

--- a/autoscale/src/main/java/com/sequenceiq/periscope/controller/mapper/ConstraintViolationExceptionMapper.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/controller/mapper/ConstraintViolationExceptionMapper.java
@@ -5,21 +5,27 @@ import javax.validation.ConstraintViolationException;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.Provider;
 
-import com.sequenceiq.periscope.api.model.ExceptionResult;
+import com.sequenceiq.cloudbreak.json.ValidationResult;
 
 @Provider
 public class ConstraintViolationExceptionMapper extends BaseExceptionMapper<ConstraintViolationException> {
 
     @Override
     protected Object getEntity(ConstraintViolationException exception) {
-        for (ConstraintViolation<?> violation : exception.getConstraintViolations()) {
-            return new ExceptionResult(violation.getMessage());
-        }
-        return new ExceptionResult(exception.getMessage());
+        ValidationResult validationResult = new ValidationResult();
+        exception.getConstraintViolations()
+                .forEach(violation -> addValidationError(violation, validationResult));
+        return validationResult;
     }
 
     @Override
     Status getResponseStatus() {
         return Status.BAD_REQUEST;
     }
+
+    private void addValidationError(ConstraintViolation<?> violation, ValidationResult validationResult) {
+        String propertyPath = violation.getPropertyPath() != null ? violation.getPropertyPath().toString() : "";
+        validationResult.addValidationError(propertyPath, violation.getMessage());
+    }
+
 }

--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/common/type/ScalingHardLimitsService.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/common/type/ScalingHardLimitsService.java
@@ -1,0 +1,20 @@
+package com.sequenceiq.cloudbreak.common.type;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ScalingHardLimitsService {
+    private static final int DEFAULT_UPSCALING_MAXIMUM_NODE_COUNT = 100;
+
+    @Value("${cb.upscale.max.nodecount:" + DEFAULT_UPSCALING_MAXIMUM_NODE_COUNT + "}")
+    private int maxUpscaleStepInNodeCount;
+
+    public int getMaxUpscaleStepInNodeCount() {
+        return maxUpscaleStepInNodeCount;
+    }
+
+    public boolean isViolatingMaxUpscaleStepInNodeCount(int requestedScalingAdjustment) {
+        return maxUpscaleStepInNodeCount < requestedScalingAdjustment;
+    }
+}

--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/json/ValidationResult.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/json/ValidationResult.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.cloudbreak.controller.json;
+package com.sequenceiq.cloudbreak.json;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/ValidatorUtil.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/ValidatorUtil.java
@@ -7,14 +7,10 @@ public class ValidatorUtil {
     private ValidatorUtil() {
     }
 
-    public static void addConstraintViolation(ConstraintValidatorContext context, String message, String propertyModel) {
-        context.buildConstraintViolationWithTemplate(message)
+    public static ConstraintValidatorContext addConstraintViolation(ConstraintValidatorContext context, String message, String propertyModel) {
+        return context.buildConstraintViolationWithTemplate(message)
                 .addPropertyNode(propertyModel)
                 .addConstraintViolation();
-    }
-
-    public static void addConstraintViolationAsStatus(ConstraintValidatorContext context, String message) {
-        addConstraintViolation(context, message, "status");
     }
 
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/mapper/ConstraintViolationExceptionMapper.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/mapper/ConstraintViolationExceptionMapper.java
@@ -5,7 +5,7 @@ import javax.validation.ConstraintViolationException;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.Provider;
 
-import com.sequenceiq.cloudbreak.controller.json.ValidationResult;
+import com.sequenceiq.cloudbreak.json.ValidationResult;
 
 @Provider
 public class ConstraintViolationExceptionMapper extends SendNotificationExceptionMapper<ConstraintViolationException> {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/mapper/MethodArgumentNotValidExceptionMapper.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/mapper/MethodArgumentNotValidExceptionMapper.java
@@ -6,7 +6,7 @@ import javax.ws.rs.ext.Provider;
 import org.springframework.messaging.handler.annotation.support.MethodArgumentNotValidException;
 import org.springframework.validation.FieldError;
 
-import com.sequenceiq.cloudbreak.controller.json.ValidationResult;
+import com.sequenceiq.cloudbreak.json.ValidationResult;
 
 @Provider
 public class MethodArgumentNotValidExceptionMapper extends BaseExceptionMapper<MethodArgumentNotValidException> {


### PR DESCRIPTION
…alidation

BUG-104930 periscope: new env param renamed

BUG-104930 Fixing style issues; deleted unused test

BUG-104930 renaming ScalingHardLimits variables

BUG--104930 moved ValidationResult back to core

BUG-104930 Validation message refactored for scalingPolicy and scalingConfiguration

BUG-104930 fixing visibility for constant