### PR TITLE
log shows the called method's args only when it fails

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/ProxyHandler.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/ProxyHandler.java
@@ -4,6 +4,9 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.stream.Collectors;
+import javax.ws.rs.WebApplicationException;
+
+import com.sequenceiq.it.cloudbreak.exception.ProxyMethodInvocationException;
 
 import static com.sequenceiq.it.cloudbreak.newway.log.Log.log;
 
@@ -20,9 +23,13 @@ public class ProxyHandler<I> implements InvocationHandler {
 
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) {
-        printArgs(method, args);
-        method.setAccessible(true);
-        return executor.exec(() -> method.invoke(original, args));
+        try {
+            method.setAccessible(true);
+            return executor.exec(() -> method.invoke(original, args));
+        } catch (WebApplicationException | ProxyMethodInvocationException e) {
+            printArgs(method, args);
+            throw e;
+        }
     }
 
     private void printArgs(Method method, Object[] args) {


### PR DESCRIPTION
log shows the called method's args only when it fails