### PR TITLE
BUG-105901 Better logging for ImageCatalog filtering.

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/catalog/CloudbreakVersion.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/catalog/CloudbreakVersion.java
@@ -38,4 +38,13 @@ public class CloudbreakVersion {
     public List<String> getImageIds() {
         return imageIds;
     }
+
+    @Override
+    public String toString() {
+        return "CloudbreakVersion{"
+                + "versions=" + versions
+                + ", defaults=" + defaults
+                + ", imageIds=" + imageIds
+                + '}';
+    }
 }

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/catalog/Image.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/catalog/Image.java
@@ -108,4 +108,11 @@ public class Image {
                 + ", default='" + defaultImage + '\''
                 + '}';
     }
+
+    public String shortOsDescriptionFormat() {
+        return "Image{"
+                + "uuid='" + uuid + '\''
+                + ", os='" + os + '\''
+                + '}';
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogVersionFilter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogVersionFilter.java
@@ -1,0 +1,110 @@
+package com.sequenceiq.cloudbreak.service.image;
+
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.VersionComparator;
+import com.sequenceiq.cloudbreak.cloud.model.Versioned;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakVersion;
+
+@Component
+public class ImageCatalogVersionFilter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ImageCatalogVersionFilter.class);
+
+    private static final String RELEASED_VERSION_PATTERN = "^\\d+\\.\\d+\\.\\d+";
+
+    private static final String UNRELEASED_VERSION_PATTERN = "^\\d+\\.\\d+\\.\\d+-[d,r][c,e][v]?";
+
+    private static final String EXTENDED_UNRELEASED_VERSION_PATTERN = "^\\d+\\.\\d+\\.\\d+-[d,r][c,e][v]?\\.\\d+";
+
+    private static final String UNSPECIFIED_VERSION = "unspecified";
+
+    public Set<CloudbreakVersion> filterReleasedVersions(Collection<CloudbreakVersion> cloudbreakVersions, String releasedVersion) {
+        Map<Boolean, List<CloudbreakVersion>> partitionedVersions = cloudbreakVersions.stream()
+                .collect(Collectors.partitioningBy(containsReleaseVersion(releasedVersion)));
+        if (hasFiltered(partitionedVersions)) {
+            LOGGER.debug("Used filter releaseVersion: | {} | Versions filtered: {}",
+                    releasedVersion,
+                    partitionedVersions.get(false).stream()
+                            .map(CloudbreakVersion::getVersions).flatMap(List::stream)
+                            .collect(Collectors.joining(", ")));
+        }
+        return new HashSet<>(partitionedVersions.get(true));
+    }
+
+    public Set<CloudbreakVersion> filterUnreleasedVersions(Collection<CloudbreakVersion> cloudbreakVersions, String unReleasedVersion) {
+        Map<Boolean, List<CloudbreakVersion>> partitionedVersions = cloudbreakVersions.stream()
+                .collect(Collectors.partitioningBy(containsNonReleaseVersion(unReleasedVersion)));
+        if (hasFiltered(partitionedVersions)) {
+            LOGGER.debug("Used filter unReleasedVersion: | {} | Versions filtered: {}",
+                    unReleasedVersion,
+                    partitionedVersions.get(false).stream()
+                            .map(CloudbreakVersion::getVersions).flatMap(List::stream)
+                            .collect(Collectors.joining(", ")));
+        }
+        return new HashSet<>(partitionedVersions.get(true));
+    }
+
+    private boolean hasFiltered(Map<Boolean, List<CloudbreakVersion>> partitionedVersions) {
+        return !partitionedVersions.get(false).isEmpty();
+    }
+
+    public String latestCloudbreakVersion(Iterable<CloudbreakVersion> cloudbreakVersions) {
+        SortedMap<Versioned, CloudbreakVersion> sortedCloudbreakVersions = new TreeMap<>(new VersionComparator());
+        for (CloudbreakVersion cbv : cloudbreakVersions) {
+            cbv.getVersions().forEach(cbvs -> sortedCloudbreakVersions.put(() -> cbvs, cbv));
+        }
+        return sortedCloudbreakVersions.lastKey().getVersion();
+    }
+
+    public boolean isVersionUnspecified(String cbVersion) {
+        return UNSPECIFIED_VERSION.equals(cbVersion);
+    }
+
+    public String extractUnreleasedVersion(String cbVersion) {
+        return extractCbVersion(UNRELEASED_VERSION_PATTERN, cbVersion);
+    }
+
+    public String extractReleasedVersion(String cbVersion) {
+        return extractCbVersion(RELEASED_VERSION_PATTERN, cbVersion);
+    }
+
+    public String extractExtendedUnreleasedVersion(String cbVersion) {
+        return extractCbVersion(EXTENDED_UNRELEASED_VERSION_PATTERN, cbVersion);
+    }
+
+    private static Predicate<CloudbreakVersion> isExactVersionMatch(String cbv) {
+        return cloudbreakVersion -> cloudbreakVersion.getVersions().contains(cbv);
+    }
+
+    private static Predicate<CloudbreakVersion> containsReleaseVersion(String releasedVersion) {
+        return cloudbreakVersion -> cloudbreakVersion.getVersions().contains(releasedVersion);
+    }
+
+    private static Predicate<CloudbreakVersion> containsNonReleaseVersion(String unReleasedVersion) {
+        return cbVersion -> cbVersion.getVersions().stream().anyMatch(aVersion -> aVersion.startsWith(unReleasedVersion));
+    }
+
+    private String extractCbVersion(String pattern, String cbVersion) {
+        Matcher matcher = Pattern.compile(pattern).matcher(cbVersion);
+        if (matcher.find()) {
+            return matcher.group(0);
+        }
+        return cbVersion;
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogServiceDefaultNotFoundTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogServiceDefaultNotFoundTest.java
@@ -10,15 +10,16 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakImageCatalogV2;
 import com.sequenceiq.cloudbreak.common.model.user.IdentityUser;
-import com.sequenceiq.cloudbreak.service.AuthenticatedUserService;
 import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
 import com.sequenceiq.cloudbreak.domain.UserProfile;
 import com.sequenceiq.cloudbreak.repository.ImageCatalogRepository;
+import com.sequenceiq.cloudbreak.service.AuthenticatedUserService;
 import com.sequenceiq.cloudbreak.service.AuthorizationService;
 import com.sequenceiq.cloudbreak.service.user.UserProfileService;
 import com.sequenceiq.cloudbreak.util.FileReaderUtils;
@@ -37,6 +38,9 @@ public class ImageCatalogServiceDefaultNotFoundTest {
 
     @Mock
     private UserProfileService userProfileService;
+
+    @Spy
+    private ImageCatalogVersionFilter versionFilter;
 
     @Mock
     private ImageCatalogRepository imageCatalogRepository;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogServiceDefaultTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogServiceDefaultTest.java
@@ -16,13 +16,14 @@ import org.junit.runners.Parameterized.Parameters;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakImageCatalogV2;
 import com.sequenceiq.cloudbreak.common.model.user.IdentityUser;
-import com.sequenceiq.cloudbreak.service.AuthenticatedUserService;
 import com.sequenceiq.cloudbreak.domain.UserProfile;
 import com.sequenceiq.cloudbreak.repository.ImageCatalogRepository;
+import com.sequenceiq.cloudbreak.service.AuthenticatedUserService;
 import com.sequenceiq.cloudbreak.service.AuthorizationService;
 import com.sequenceiq.cloudbreak.service.user.UserProfileService;
 import com.sequenceiq.cloudbreak.util.FileReaderUtils;
@@ -52,6 +53,9 @@ public class ImageCatalogServiceDefaultTest {
 
     @Mock
     private AuthorizationService authorizationService;
+
+    @Spy
+    private ImageCatalogVersionFilter versionFilter;
 
     @Mock
     private UserProfileService userProfileService;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogServiceTest.java
@@ -29,11 +29,11 @@ import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakImageCatalogV2;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Images;
 import com.sequenceiq.cloudbreak.common.model.user.IdentityUser;
-import com.sequenceiq.cloudbreak.service.AuthenticatedUserService;
 import com.sequenceiq.cloudbreak.controller.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.domain.ImageCatalog;
 import com.sequenceiq.cloudbreak.domain.UserProfile;
 import com.sequenceiq.cloudbreak.repository.ImageCatalogRepository;
+import com.sequenceiq.cloudbreak.service.AuthenticatedUserService;
 import com.sequenceiq.cloudbreak.service.AuthorizationService;
 import com.sequenceiq.cloudbreak.service.account.AccountPreferencesService;
 import com.sequenceiq.cloudbreak.service.user.UserProfileService;
@@ -57,6 +57,9 @@ public class ImageCatalogServiceTest {
 
     @Mock
     private AuthenticatedUserService authenticatedUserService;
+
+    @Spy
+    private ImageCatalogVersionFilter versionFilter;
 
     @Mock
     private AuthorizationService authorizationService;
@@ -88,7 +91,11 @@ public class ImageCatalogServiceTest {
         constants.addAll(Collections.singletonList(new AwsCloudConstant()));
 
         ReflectionTestUtils.setField(underTest, ImageCatalogService.class, "defaultCatalogUrl", "http://localhost/imagecatalog-url", null);
-        ReflectionTestUtils.setField(underTest, ImageCatalogService.class, "cbVersion", "unspecified", null);
+        setMockedCbVersion("cbVersion", "unspecified");
+    }
+
+    private void setMockedCbVersion(String cbVersion, String versionValue) {
+        ReflectionTestUtils.setField(underTest, ImageCatalogService.class, cbVersion, versionValue, String.class);
     }
 
     private IdentityUser getIdentityUser() {
@@ -105,7 +112,7 @@ public class ImageCatalogServiceTest {
         CloudbreakImageCatalogV2 catalog = JsonUtil.readValue(catalogJson, CloudbreakImageCatalogV2.class);
         when(imageCatalogProvider.getImageCatalogV2("http://localhost/imagecatalog-url")).thenReturn(catalog);
         when(userProfileService.get(user.getAccount(), user.getUserId())).thenReturn(userProfile);
-        ReflectionTestUtils.setField(underTest, ImageCatalogService.class, "cbVersion", "2.1.0-dev.100", null);
+        setMockedCbVersion("cbVersion", "2.1.0-dev.100");
 
         StatedImage image = underTest.getLatestBaseImageDefaultPreferred("AWS", null);
         Assert.assertEquals("7aca1fa6-980c-44e2-a75e-3144b18a5993", image.getImage().getUuid());
@@ -121,7 +128,7 @@ public class ImageCatalogServiceTest {
         CloudbreakImageCatalogV2 catalog = JsonUtil.readValue(catalogJson, CloudbreakImageCatalogV2.class);
         when(imageCatalogProvider.getImageCatalogV2("http://localhost/imagecatalog-url")).thenReturn(catalog);
         when(userProfileService.get(user.getAccount(), user.getUserId())).thenReturn(userProfile);
-        ReflectionTestUtils.setField(underTest, ImageCatalogService.class, "cbVersion", "2.1.0-dev.200", null);
+        setMockedCbVersion("cbVersion", "2.1.0-dev.200");
 
         StatedImage image = underTest.getLatestBaseImageDefaultPreferred("AWS", null);
         Assert.assertEquals("7aca1fa6-980c-44e2-a75e-3144b18a5993", image.getImage().getUuid());
@@ -137,7 +144,7 @@ public class ImageCatalogServiceTest {
         CloudbreakImageCatalogV2 catalog = JsonUtil.readValue(catalogJson, CloudbreakImageCatalogV2.class);
         when(imageCatalogProvider.getImageCatalogV2("http://localhost/imagecatalog-url")).thenReturn(catalog);
         when(userProfileService.get(user.getAccount(), user.getUserId())).thenReturn(userProfile);
-        ReflectionTestUtils.setField(underTest, ImageCatalogService.class, "cbVersion", "2.1.0-dev.1", null);
+        setMockedCbVersion("cbVersion", "2.1.0-dev.1");
 
         StatedImage image = underTest.getLatestBaseImageDefaultPreferred("AWS", null);
         Assert.assertEquals("7aca1fa6-980c-44e2-a75e-3144b18a5993", image.getImage().getUuid());
@@ -153,7 +160,7 @@ public class ImageCatalogServiceTest {
         CloudbreakImageCatalogV2 catalog = JsonUtil.readValue(catalogJson, CloudbreakImageCatalogV2.class);
         when(imageCatalogProvider.getImageCatalogV2("http://localhost/imagecatalog-url")).thenReturn(catalog);
         when(userProfileService.get(user.getAccount(), user.getUserId())).thenReturn(userProfile);
-        ReflectionTestUtils.setField(underTest, ImageCatalogService.class, "cbVersion", "2.1.0-dev.2", null);
+        setMockedCbVersion("cbVersion", "2.1.0-dev.2");
 
         StatedImage image = underTest.getLatestBaseImageDefaultPreferred("AWS", null);
         Assert.assertEquals("f6e778fc-7f17-4535-9021-515351df3691", image.getImage().getUuid());
@@ -277,7 +284,7 @@ public class ImageCatalogServiceTest {
         ImageCatalog imageCatalog = new ImageCatalog();
         imageCatalog.setImageCatalogUrl("");
         imageCatalog.setImageCatalogName("default");
-        StatedImages images = underTest.getImages(imageCatalog, "aws", "1.16.4-rc.13");
+        StatedImages images = underTest.getImages(imageCatalog, "aws",  "1.16.4-rc.13");
 
         boolean match = images.getImages().getHdpImages().stream()
                 .anyMatch(img -> "2.5.1.9-4-ccbb32dc-6c9f-43f1-8a09-64b598fda733-2.6.1.4-2".equals(img.getUuid()));

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogVersionFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogVersionFilterTest.java
@@ -1,0 +1,103 @@
+package com.sequenceiq.cloudbreak.service.image;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakVersion;
+
+public class ImageCatalogVersionFilterTest {
+
+    private ImageCatalogVersionFilter underTest = new ImageCatalogVersionFilter();
+
+    private String unspecifiedVersion = "unspecified";
+
+    private String unReleasedVersion = " 2.6.0-rc.13";
+
+    private String devVersion = "2.6.0-dev.132";
+
+    private String extendedUnreleasedVersion = "2.8.0-rev.82";
+
+    private String releasedVersion = "2.7.0";
+
+    private String latestRcVersion = "2.4.0-rc.13";
+
+    private List<CloudbreakVersion> versions;
+
+    @Test
+    public void getLatestCloudbreakVersion() {
+        List<String> list1 = generateVersionList(devVersion, unReleasedVersion);
+        List<String> list2 = generateVersionList(releasedVersion, extendedUnreleasedVersion);
+        versions = generateCloudBreakVersions(list1, list2);
+        assertEquals("2.8.0-rev.82", underTest.latestCloudbreakVersion(versions));
+    }
+
+    @Test
+    public void filterUnreleasedVersions() {
+        List<String> list1 = generateVersionList(devVersion, unReleasedVersion);
+        List<String> list2 = generateVersionList(releasedVersion, extendedUnreleasedVersion);
+        versions = generateCloudBreakVersions(list1, list2);
+        assertEquals(2, versions.size());
+        assertEquals(1, underTest.filterUnreleasedVersions(versions, unReleasedVersion).size());
+    }
+
+    @Test
+    public void isVersionUnspecified() {
+        assertTrue(underTest.isVersionUnspecified(unspecifiedVersion));
+        assertFalse(underTest.isVersionUnspecified(unReleasedVersion));
+    }
+
+    @Test
+    public void extractUnreleasedVersion() {
+        String extractedVersion = underTest.extractUnreleasedVersion(unReleasedVersion);
+        assertEquals(" 2.6.0-rc.13", extractedVersion);
+    }
+
+    @Test
+    public void extractReleasedVersion() {
+        assertEquals("2.7.0", underTest.extractReleasedVersion(releasedVersion));
+    }
+
+    @Test
+    public void extractReleaseVersionFromDev() {
+        assertEquals("2.6.0", underTest.extractReleasedVersion(devVersion));
+    }
+
+    @Test
+    public void extractReleaseVersionFromRc() {
+        assertEquals("2.4.0", underTest.extractReleasedVersion(latestRcVersion));
+    }
+
+    @Test
+    public void extractReleasedFallbackOriginalVersion() {
+        String extractedVersion = underTest.extractReleasedVersion(unReleasedVersion);
+        assertEquals(unReleasedVersion, extractedVersion);
+    }
+
+    @Test
+    public void extractExtendedUnreleasedVersion() {
+        String extractedVersion = underTest.extractExtendedUnreleasedVersion(extendedUnreleasedVersion);
+        assertEquals(extendedUnreleasedVersion, extractedVersion);
+    }
+
+    private List<CloudbreakVersion> generateCloudBreakVersions(List<String>... cbVersions) {
+        List<CloudbreakVersion> result = new ArrayList<>();
+        for (List<String> list: cbVersions) {
+            result.add(new CloudbreakVersion(list, null, null));
+        }
+        return result;
+    }
+
+    private static List<String> generateVersionList(String... ver) {
+        List<String> result = new ArrayList<>();
+        for (String v: ver) {
+            result.add(v);
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
- Added logging for image filtering with info level. Based on discussion logs should probably be debug logs,but we agreed on info. every log message start with: "Filtering images by " and lists what got filtered.
- Also did a little refactor on ImageCatalogService, and extracted version related filtering.
Unit tests for Version Filtering on the way.