### PR TITLE
BUG-106346 – unable to create rds when a name contains hyphen

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/RDSConfigJsonValidator.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/RDSConfigJsonValidator.java
@@ -47,7 +47,7 @@ public class RDSConfigJsonValidator implements ConstraintValidator<ValidRDSConfi
     }
 
     private boolean isConnectionUrlValid(String url) {
-        if (!url.matches("^(jdbc:(oracle|mysql|postgresql)(:(.*))?):(@|//)(.*?):(\\d*)[:/](\\w+)")) {
+        if (!url.matches("^(jdbc:(oracle|mysql|postgresql)(:(.*))?):(@|//)(.*?):(\\d*)[:/](\\w+)(-*\\w*)*")) {
             if (!isSupportedDatabseType(url)) {
                 failMessage = "Unsupported database type. Supported databases: PostgreSQL, Oracle, MySQL.";
             } else if (!isValidSeparator(url)) {


### PR DESCRIPTION
BUG-106346 – unable to create rds when a name contains hyphen


A user was unable to create an rds when the url contains a hyphen in the database's name which could easily happen in real life:

For example:
jdbc:postgresql://37.191.55.32:5432/my-db
or
jdbc:postgresql://37.191.55.32:5432/ranger-audit-db