### PR TITLE
BUG-107235 – Prevent user from creating an attached cluster when the related datalake cluster has failed

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/ClusterRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/ClusterRepository.java
@@ -1,17 +1,18 @@
 package com.sequenceiq.cloudbreak.repository;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
 import com.sequenceiq.cloudbreak.api.model.Status;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.domain.LdapConfig;
 import com.sequenceiq.cloudbreak.domain.ProxyConfig;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.CrudRepository;
-import org.springframework.data.repository.query.Param;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
 
 @EntityType(entityClass = Cluster.class)
 public interface ClusterRepository extends CrudRepository<Cluster, Long> {


### PR DESCRIPTION
**Description:**
Now the user can create an attached cluster (through direct API call) when the related datalake cluster has failed on creation which is undesirable because this cluster's creation would take several minutes but will fail unavoidably.

The API should validate that the desired shared cluster exists and it is available.

**Note for the commit:**
I did a double check so not just checking the stack's availability but it's cluster's status to be more sure about the readiness for attaching.