### PR TITLE
BUG-107577 fix gw recovery when the primary gw was deleted on provide…

### DIFF
--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Stack.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Stack.java
@@ -469,7 +469,7 @@ public class Stack implements ProvisionEntity {
         List<InstanceMetaData> metadataList = new ArrayList<>();
         for (InstanceGroup instanceGroup : instanceGroups) {
             if (InstanceGroupType.GATEWAY.equals(instanceGroup.getInstanceGroupType())) {
-                metadataList.addAll(instanceGroup.getNotDeletedInstanceMetaDataSet());
+                metadataList.addAll(instanceGroup.getNotTerminatedInstanceMetaDataSet());
             }
         }
         return metadataList;


### PR DESCRIPTION
@sodre90 Do you know why we filter out the DELETED_ON_PROVIDER_SIDE instances? Due to this filter the primary gateway recovery does not work.
With a single Ambari server if you want to recover then this message is thrown: Ambari server failure cannot be repaired with single gateway! 