### PR TITLE
BUG-107662 update e2e api tests thread count to higher

### DIFF
--- a/integration-test/src/main/resources/testsuites/clusterawstestset.yaml
+++ b/integration-test/src/main/resources/testsuites/clusterawstestset.yaml
@@ -1,6 +1,6 @@
 name: "AWS cluster tests"
 parallel: tests
-threadCount: 4
+threadCount: 10
 parameters:
   awsRegion: us-west-1
   awsAvailabilityZone: us-west-1a

--- a/integration-test/src/main/resources/testsuites/clusteropenstacktestset.yaml
+++ b/integration-test/src/main/resources/testsuites/clusteropenstacktestset.yaml
@@ -1,6 +1,6 @@
 name: "OPENSTACK cluster tests"
 parallel: tests
-threadCount: 3
+threadCount: 10
 parameters:
   openstackCredentialName: autotesting-clusters-os
 listeners:


### PR DESCRIPTION
Run end to end test on parallel with thread count 10.

Closes 107662
