### PR TITLE
BUG-108486 Improve org delete experience

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/users/OrganizationResponse.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/users/OrganizationResponse.java
@@ -5,6 +5,7 @@ import java.util.Comparator;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.api.model.v2.OrganizationStatus;
 import com.sequenceiq.cloudbreak.doc.ModelDescriptions;
 
 import io.swagger.annotations.ApiModel;
@@ -17,6 +18,8 @@ public class OrganizationResponse extends OrganizationBase {
     private Long id;
 
     private Set<UserOrgPermissionsJson> users;
+
+    private OrganizationStatus status;
 
     @JsonProperty("id")
     public Long getId() {
@@ -33,6 +36,14 @@ public class OrganizationResponse extends OrganizationBase {
 
     public void setUsers(Set<UserOrgPermissionsJson> users) {
         this.users = users;
+    }
+
+    public OrganizationStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(OrganizationStatus status) {
+        this.status = status;
     }
 
     public static class NameComparator implements Comparator<OrganizationResponse>, Serializable {

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/v2/OrganizationStatus.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/v2/OrganizationStatus.java
@@ -1,0 +1,6 @@
+package com.sequenceiq.cloudbreak.api.model.v2;
+
+public enum OrganizationStatus {
+    ACTIVE,
+    DELETED
+}

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/security/Organization.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/security/Organization.java
@@ -4,6 +4,8 @@ import java.util.Objects;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -11,6 +13,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
+import com.sequenceiq.cloudbreak.api.model.v2.OrganizationStatus;
 import com.sequenceiq.cloudbreak.domain.ProvisionEntity;
 
 @Entity
@@ -29,6 +32,20 @@ public class Organization implements ProvisionEntity {
 
     @ManyToOne
     private Tenant tenant;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private OrganizationStatus status;
+
+    private Long deletionTimestamp;
+
+    public Long getDeletionTimestamp() {
+        return deletionTimestamp;
+    }
+
+    public void setDeletionTimestamp(Long deletionTimestamp) {
+        this.deletionTimestamp = deletionTimestamp;
+    }
 
     public Long getId() {
         return id;
@@ -60,6 +77,14 @@ public class Organization implements ProvisionEntity {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public OrganizationStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(OrganizationStatus status) {
+        this.status = status;
     }
 
     @Override

--- a/core-model/src/test/java/com/sequenceiq/cloudbreak/TestUtil.java
+++ b/core-model/src/test/java/com/sequenceiq/cloudbreak/TestUtil.java
@@ -37,6 +37,7 @@ import com.sequenceiq.cloudbreak.api.model.stack.cluster.gateway.SSOType;
 import com.sequenceiq.cloudbreak.api.model.stack.instance.InstanceGroupType;
 import com.sequenceiq.cloudbreak.api.model.stack.instance.InstanceMetadataType;
 import com.sequenceiq.cloudbreak.api.model.stack.instance.InstanceStatus;
+import com.sequenceiq.cloudbreak.api.model.v2.OrganizationStatus;
 import com.sequenceiq.cloudbreak.common.model.user.IdentityUser;
 import com.sequenceiq.cloudbreak.common.model.user.IdentityUserRole;
 import com.sequenceiq.cloudbreak.common.type.ResourceType;
@@ -61,6 +62,8 @@ import com.sequenceiq.cloudbreak.domain.StorageLocations;
 import com.sequenceiq.cloudbreak.domain.Template;
 import com.sequenceiq.cloudbreak.domain.json.Json;
 import com.sequenceiq.cloudbreak.domain.json.JsonToString;
+import com.sequenceiq.cloudbreak.domain.security.Organization;
+import com.sequenceiq.cloudbreak.domain.security.User;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.StackStatus;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
@@ -184,6 +187,21 @@ public class TestUtil {
         }
         orchestrator.setId(1L);
         return orchestrator;
+    }
+
+    public static Organization organization(Long id, String name) {
+        Organization organization = new Organization();
+        organization.setStatus(OrganizationStatus.ACTIVE);
+        organization.setName(name);
+        organization.setId(id);
+        return organization;
+    }
+
+    public static User user(Long id, String name) {
+        User user = new User();
+        user.setUserId(name);
+        user.setId(id);
+        return user;
     }
 
     public static SecurityGroup securityGroup(long id) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/OrganizationController.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/OrganizationController.java
@@ -67,7 +67,8 @@ public class OrganizationController extends NotificationController implements Or
 
     @Override
     public OrganizationResponse deleteByName(String name) {
-        Organization organization = organizationService.deleteByName(name);
+        IdentityUser user = authenticatedUserService.getCbUser();
+        Organization organization = organizationService.deleteByName(name, user);
         return conversionService.convert(organization, OrganizationResponse.class);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/users/OrganizationRequestToOrganizationConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/users/OrganizationRequestToOrganizationConverter.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.converter.users;
 
+import static com.sequenceiq.cloudbreak.api.model.v2.OrganizationStatus.ACTIVE;
+
 import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
@@ -28,6 +30,7 @@ public class OrganizationRequestToOrganizationConverter extends AbstractConversi
         organization.setName(json.getName());
         organization.setDescription(json.getDescription());
         organization.setTenant(user.getTenant());
+        organization.setStatus(ACTIVE);
 
         return organization;
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/users/OrganizationToOrganizationResponseConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/users/OrganizationToOrganizationResponseConverter.java
@@ -26,6 +26,7 @@ public class OrganizationToOrganizationResponseConverter extends AbstractConvers
         json.setDescription(organization.getDescription());
         json.setName(organization.getName());
         json.setId(organization.getId());
+        json.setStatus(organization.getStatus());
         Set<UserOrgPermissions> userPermissions = userOrgPermissionsRepository.findForOrganization(organization);
         json.setUsers((Set<UserOrgPermissionsJson>) getConversionService().convert(userPermissions, TypeDescriptor.forObject(userPermissions),
                 TypeDescriptor.collection(Set.class, TypeDescriptor.valueOf(UserOrgPermissionsJson.class))));

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/config/generator/OfflineStateGenerator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/config/generator/OfflineStateGenerator.java
@@ -362,6 +362,11 @@ public class OfflineStateGenerator {
         }
 
         @Override
+        public Set<Stack> findAllForOrganization(Long organizationId) {
+            return null;
+        }
+
+        @Override
         public List<Stack> findByStatuses(List<Status> statuses) {
             return null;
         }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
@@ -89,6 +89,9 @@ public interface StackRepository extends BaseRepository<Stack, Long> {
             + "AND s.stackStatus.status <> 'CREATE_IN_PROGRESS'")
     List<Stack> findAllAliveAndProvisioned();
 
+    @Query("SELECT s FROM Stack s WHERE s.stackStatus.status <> 'DELETE_COMPLETED' AND s.organization.id= :organizationId")
+    Set<Stack> findAllForOrganization(@Param("organizationId") Long organizationId);
+
     @Query("SELECT s FROM Stack s WHERE s.stackStatus.status IN :statuses")
     List<Stack> findByStatuses(@Param("statuses") List<Status> statuses);
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/security/OrganizationRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/security/OrganizationRepository.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.repository.security;
 
+import java.util.Optional;
+
 import javax.transaction.Transactional;
 
 import org.springframework.data.jpa.repository.Query;
@@ -16,7 +18,22 @@ import com.sequenceiq.cloudbreak.service.EntityType;
 @DisablePermission
 public interface OrganizationRepository extends DisabledBaseRepository<Organization, Long> {
 
-    @Query("SELECT o FROM Organization o WHERE o.name= :name AND o.tenant= :tenant")
+    @Query("SELECT o FROM Organization o WHERE o.name= :name AND o.tenant= :tenant AND o.status <> 'DELETED'")
     Organization getByName(@Param("name") String name, @Param("tenant") Tenant tenant);
 
+    @Override
+    @Query("SELECT o FROM Organization o WHERE o.id= :id AND o.status <> 'DELETED'")
+    Optional<Organization> findById(Long id);
+
+    @Override
+    @Query("SELECT o FROM Organization o WHERE o.id= :id AND o.status <> 'DELETED'")
+    boolean existsById(Long id);
+
+    @Override
+    @Query("SELECT o FROM Organization o WHERE o.status <> 'DELETED'")
+    Iterable<Organization> findAll();
+
+    @Override
+    @Query("SELECT o FROM Organization o WHERE o.status <> 'DELETED'")
+    Iterable<Organization> findAllById(Iterable<Long> ids);
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/organization/OrganizationDeleteVerifierService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/organization/OrganizationDeleteVerifierService.java
@@ -1,0 +1,36 @@
+package com.sequenceiq.cloudbreak.service.organization;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.controller.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.domain.security.Organization;
+import com.sequenceiq.cloudbreak.domain.security.User;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+
+@Service
+public class OrganizationDeleteVerifierService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(OrganizationService.class);
+
+    @Inject
+    private StackService stackService;
+
+    public void checkThatOrganizationIsDeletable(User userWhoRequestTheDeletion, Organization organizationForDelete,
+            Organization defaultOrganizationOfUserWhoRequestTheDeletion) {
+        if (defaultOrganizationOfUserWhoRequestTheDeletion.equals(organizationForDelete)) {
+            LOGGER.info("The requested {} organization for delete is the same as the default organization of the user {}.",
+                    organizationForDelete.getName(), userWhoRequestTheDeletion.getUserName());
+            throw new BadRequestException(String.format("The following organization '%s' could not deleted because this is your default organization.",
+                    organizationForDelete.getName()));
+        }
+        if (!stackService.findAllForOrganization(organizationForDelete.getId()).isEmpty()) {
+            LOGGER.info("The requested {} organization has already existing clusters. We can not delete them until those will be deleted",
+                    organizationForDelete.getName());
+            throw new BadRequestException(String.format("The requested '%s' organization has already existing clusters. "
+                    + "Please delete them before you delete the organization.", organizationForDelete.getName()));
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
@@ -767,6 +767,14 @@ public class StackService {
         });
     }
 
+    public Set<Stack> findAllForOrganization(Long organizationId) {
+        try {
+            return transactionService.required(() -> stackRepository.findAllForOrganization(organizationId));
+        } catch (TransactionExecutionException e) {
+            throw new TransactionService.TransactionRuntimeExecutionException(e);
+        }
+    }
+
     private void delete(Stack stack, Boolean forced, Boolean deleteDependencies) {
         authorizationService.hasPermission(stack, PermissionType.WRITE.name());
         LOGGER.info("Stack delete requested.");

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/user/UserService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/user/UserService.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.service.user;
 
+import static com.sequenceiq.cloudbreak.api.model.v2.OrganizationStatus.ACTIVE;
+
 import java.util.Collections;
 import java.util.Set;
 
@@ -53,6 +55,7 @@ public class UserService {
                     Organization organization = new Organization();
                     organization.setTenant(tenant);
                     organization.setName(identityUser.getUsername());
+                    organization.setStatus(ACTIVE);
                     organization.setDescription("Default organization for the user.");
                     organizationService.create(identityUser, organization);
                 }

--- a/core/src/main/resources/schema/app/20180802114825_BUG-108486_Improve_org_delete_experience.sql
+++ b/core/src/main/resources/schema/app/20180802114825_BUG-108486_Improve_org_delete_experience.sql
@@ -1,0 +1,17 @@
+-- // BUG-108486 Improve org delete experience
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE organization ADD COLUMN status VARCHAR (255) DEFAULT 'ACTIVE';
+ALTER TABLE organization ADD COLUMN deletionTimestamp BIGINT;
+
+ALTER TABLE organization DROP CONSTRAINT IF EXISTS org_in_tenant_unique;
+ALTER TABLE organization ADD CONSTRAINT org_in_tenant_deletiondate_unique UNIQUE (name, deletionTimestamp, tenant_id);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE organization DROP COLUMN IF EXISTS status;
+ALTER TABLE organization DROP COLUMN IF EXISTS deletionTimestamp;
+
+ALTER TABLE organization DROP CONSTRAINT IF EXISTS org_in_tenant_deletiondate_unique;
+ALTER TABLE organization ADD CONSTRAINT org_in_tenant_unique UNIQUE (name, tenant_id);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/organization/OrganizationDeleteVerifierServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/organization/OrganizationDeleteVerifierServiceTest.java
@@ -1,0 +1,70 @@
+package com.sequenceiq.cloudbreak.service.organization;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import java.util.HashSet;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import com.google.common.collect.ImmutableSet;
+import com.sequenceiq.cloudbreak.TestUtil;
+import com.sequenceiq.cloudbreak.controller.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.domain.security.Organization;
+import com.sequenceiq.cloudbreak.domain.security.User;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+public class OrganizationDeleteVerifierServiceTest {
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    @InjectMocks
+    private OrganizationDeleteVerifierService underTest;
+
+    @Mock
+    private StackService stackService;
+
+    @Test
+    public void testWhenTheDefultOrganizationIsSameAsOrganizationForDeleteThenShouldThrowBadRequestException() {
+        Organization organizationForDelete = TestUtil.organization(1L, "testuser@mycompany.com");
+        Organization defaultOrganizationOfUserWhoRequestTheDeletion = TestUtil.organization(1L, "testuser@mycompany.com");
+        User userWhoRequestTheDeletion = TestUtil.user(1L, "testuser@mycompany.com");
+
+        thrown.expectMessage("The following organization 'testuser@mycompany.com' could not deleted because this is your default organization.");
+        thrown.expect(BadRequestException.class);
+
+        underTest.checkThatOrganizationIsDeletable(userWhoRequestTheDeletion, organizationForDelete, defaultOrganizationOfUserWhoRequestTheDeletion);
+    }
+
+    @Test
+    public void testWhenTheOrganizationHasAlreadyRunningClustersThenShouldThrowBadRequestException() {
+        Organization defaultOrganizationOfUserWhoRequestTheDeletion = TestUtil.organization(1L, "testuser1@mycompany.com");
+        Organization organizationForDelete = TestUtil.organization(2L, "bigorg");
+        User userWhoRequestTheDeletion = TestUtil.user(1L, "testuser@mycompany.com");
+        when(stackService.findAllForOrganization(anyLong())).thenReturn(ImmutableSet.of(TestUtil.stack()));
+
+        thrown.expectMessage("The requested 'bigorg' organization has already existing clusters. "
+                + "Please delete them before you delete the organization.");
+        thrown.expect(BadRequestException.class);
+
+        underTest.checkThatOrganizationIsDeletable(userWhoRequestTheDeletion, organizationForDelete, defaultOrganizationOfUserWhoRequestTheDeletion);
+    }
+
+    @Test
+    public void testWhenTheOrganizationHasAlreadyRunningClustersThenShouldReturnWithoutError() {
+        Organization defaultOrganizationOfUserWhoRequestTheDeletion = TestUtil.organization(1L, "testuser1@mycompany.com");
+        Organization organizationForDelete = TestUtil.organization(2L, "bigorg");
+        User userWhoRequestTheDeletion = TestUtil.user(1L, "testuser@mycompany.com");
+        when(stackService.findAllForOrganization(anyLong())).thenReturn(new HashSet<>());
+
+        underTest.checkThatOrganizationIsDeletable(userWhoRequestTheDeletion, organizationForDelete, defaultOrganizationOfUserWhoRequestTheDeletion);
+    }
+}


### PR DESCRIPTION
This pr fixing BUG-108486:
- you can not delete the default org
- you can not delete org when it has cluster
- migration script for adding org status and termination date
- namedquery modifications based on active org