### PR TITLE
BUG-109137 blueprint name typo

### DIFF
--- a/integration-test/src/main/resources/testsuites/clusterawstestset.yaml
+++ b/integration-test/src/main/resources/testsuites/clusterawstestset.yaml
@@ -162,7 +162,7 @@ tests:
     parameters:
       clusterName: aws-prewarm-hdp3
       provider: aws
-      blueprintName: "HDP 3.0 - Data Science: Apache Spark 2, Apache Zeppelin2"
+      blueprintName: "HDP 3.0 - Data Science: Apache Spark 2, Apache Zeppelin"
       image: hdp
       instancegroupName: worker
     classes:

--- a/integration-test/src/main/resources/testsuites/clusteropenstacktestset.yaml
+++ b/integration-test/src/main/resources/testsuites/clusteropenstacktestset.yaml
@@ -179,7 +179,7 @@ tests:
     parameters:
       clusterName: os-prewarm-hdp3
       provider: openstack
-      blueprintName: "HDP 3.0 - Data Science: Apache Spark 2, Apache Zeppelin2"
+      blueprintName: "HDP 3.0 - Data Science: Apache Spark 2, Apache Zeppelin"
       image: hdp
       instancegroupName: worker
     classes:


### PR DESCRIPTION
prewarm hdp3 test have had a typo in the blueprint name

Closes BUG-109137
