### PR TITLE
RMP-11665 Updated the default Flow Management blueprint to set the Ni…

### DIFF
--- a/core/src/main/resources/defaults/blueprints/hdf31-flow-management.bp
+++ b/core/src/main/resources/defaults/blueprints/hdf31-flow-management.bp
@@ -11,7 +11,8 @@
       {
         "nifi-ambari-config": {
           "nifi.security.encrypt.configuration.password": "changethisplease",
-          "nifi.max_mem": "1g"
+          "nifi.max_mem": "1g",
+          "nifi.sensitive.props.key": "changethisplease"
         }
       },
       {
@@ -21,7 +22,6 @@
       },
       {
         "nifi-properties": {
-          "nifi.sensitive.props.key": "changethisplease",
           "nifi.security.identity.mapping.pattern.kerb": "^(.*?)@(.*?)$",
           "nifi.security.identity.mapping.value.kerb": "$1"
         }
@@ -41,7 +41,6 @@
       },
       {
         "nifi-registry-properties": {
-          "nifi.registry.sensitive.props.key": "changethisplease",
           "nifi.registry.security.identity.mapping.pattern.kerb": "^(.*?)@(.*?)$",
           "nifi.registry.security.identity.mapping.value.kerb": "$1"
         }


### PR DESCRIPTION
…Fi/NiFi Registry sensitive property keys in the proper config sites

This PR can be tested in the following steps.

1. Create a cluster with the current Flow Mangaement default blueprint.
2. Add a GetTwitter processor to the flow, using any value for the tokens and keys in the processor configuration.
3. Restart NiFi and observe that it is unable to restart due to "pad block corruption" in the Ambari operations logs.
4. Create a cluster with the updated blueprint in this PR.
5. Add a GetTwitter processor to the flow, using any value for the tokens and keys in the processor configuration.
6. Restart NiFi and observe that the restart is successful.
