### PR TITLE
BUG-111255 [E2E] Can't create hdf flow management on AWS

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/cloud/AwsCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/cloud/AwsCloudProvider.java
@@ -8,6 +8,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
+
+import com.google.common.base.Preconditions;
+import com.sequenceiq.cloudbreak.api.model.AmbariRepoDetailsJson;
 import com.sequenceiq.cloudbreak.api.model.AmbariStackDetailsJson;
 import com.sequenceiq.cloudbreak.api.model.stack.StackAuthenticationRequest;
 import com.sequenceiq.cloudbreak.api.model.v2.AmbariV2Request;
@@ -279,5 +283,21 @@ public class AwsCloudProvider extends CloudProviderHelper {
         var request = new StackCreation(aValidStackRequest());
         request.setCreationStrategy(StackAction::determineNetworkAwsFromDatalakeStack);
         return request.getStack();
+    }
+
+    @Override
+    public AmbariV2Request ambariRequestWithBlueprintNameAndCustomAmbari(String bluePrintName, String customAmbariVersion,
+            String customAmbariRepoUrl, String customAmbariRepoGpgKey) {
+        var req = ambariRequestWithBlueprintName(bluePrintName);
+        if (StringUtils.isNoneEmpty(customAmbariVersion)) {
+            Preconditions.checkNotNull(customAmbariRepoUrl);
+            Preconditions.checkNotNull(customAmbariRepoGpgKey);
+            AmbariRepoDetailsJson ambariRepoDetailsJson = new AmbariRepoDetailsJson();
+            ambariRepoDetailsJson.setVersion(customAmbariVersion);
+            ambariRepoDetailsJson.setBaseUrl(customAmbariRepoUrl);
+            ambariRepoDetailsJson.setGpgKeyUrl(customAmbariRepoGpgKey);
+            req.setAmbariRepoDetailsJson(ambariRepoDetailsJson);
+        }
+        return req;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/cloud/CloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/cloud/CloudProvider.java
@@ -30,7 +30,10 @@ public abstract class CloudProvider {
 
     public abstract StackEntity aValidAttachedStackRequest();
 
-    public abstract AmbariV2Request ambariRequestWithBlueprintName(String blueprintHdp26EdwanalyticsName);
+    public abstract AmbariV2Request ambariRequestWithBlueprintName(String bluePrintName);
+
+    public abstract AmbariV2Request ambariRequestWithBlueprintNameAndCustomAmbari(String bluePrintName, String customAmbariVersion,
+            String customAmbariRepoUrl, String customAmbariRepoGpgKey);
 
     public abstract String getClusterName();
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/cloud/CloudProviderHelper.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/cloud/CloudProviderHelper.java
@@ -214,11 +214,17 @@ public abstract class CloudProviderHelper extends CloudProvider {
     }
 
     @Override
-    public AmbariV2Request ambariRequestWithBlueprintName(String name) {
+    public AmbariV2Request ambariRequestWithBlueprintNameAndCustomAmbari(String bluePrintName, String customAmbariVersion,
+            String customAmbariRepoUrl, String customAmbariRepoGpgKey) {
+        return ambariRequestWithBlueprintName(bluePrintName);
+    }
+
+    @Override
+    public AmbariV2Request ambariRequestWithBlueprintName(String bluePrintName) {
         var req = new AmbariV2Request();
         req.setUserName(testParameter.get(DEFAULT_AMBARI_USER));
         req.setPassword(testParameter.get(DEFAULT_AMBARI_PASSWORD));
-        req.setBlueprintName(name);
+        req.setBlueprintName(bluePrintName);
         req.setValidateBlueprint(false);
         req.setValidateRepositories(Boolean.TRUE);
         req.setAmbariStackDetails(new AmbariStackDetailsJson());

--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -96,6 +96,13 @@ integrationtest:
     mockcredential:
         name:
 
+    customAmbari:
+        aws:
+          hdf:
+            version:
+            repoUrl:
+            gpgKeyUrl:
+
     cleanup:
         retryCount: 3
         cleanupBeforeStart: false


### PR DESCRIPTION
until ambari 2.7.1 is not released, we can use custom ambari repo for hdf aws base image tests