### PR TITLE
additional integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,7 @@ jobs:
       - run:
           name: integration-test
           command: cd integration-test && make without-build && make revert-db
+          no_output_timeout: 45m
       - run:
           name: Save test results
           command: |

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/mapper/BlueprintValidationExceptionMapper.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/mapper/BlueprintValidationExceptionMapper.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.cloudbreak.controller.mapper;
+
+import com.sequenceiq.cloudbreak.blueprint.validation.BlueprintValidationException;
+import org.springframework.stereotype.Component;
+
+import javax.ws.rs.core.Response.Status;
+
+@Component
+public class BlueprintValidationExceptionMapper extends BaseExceptionMapper<BlueprintValidationException> {
+
+    @Override
+    Status getResponseStatus() {
+        return Status.BAD_REQUEST;
+    }
+
+    @Override
+    Class<BlueprintValidationException> getExceptionType() {
+        return BlueprintValidationException.class;
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/controller/validation/stack/StackRequestValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/controller/validation/stack/StackRequestValidatorTest.java
@@ -1,22 +1,11 @@
 package com.sequenceiq.cloudbreak.controller.validation.stack;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
-
 import com.google.common.collect.Sets;
+import com.sequenceiq.cloudbreak.api.model.BlueprintRequest;
 import com.sequenceiq.cloudbreak.api.model.TemplateRequest;
+import com.sequenceiq.cloudbreak.api.model.ldap.LdapConfigRequest;
+import com.sequenceiq.cloudbreak.api.model.rds.RDSConfigRequest;
+import com.sequenceiq.cloudbreak.api.model.rds.RdsType;
 import com.sequenceiq.cloudbreak.api.model.stack.StackRequest;
 import com.sequenceiq.cloudbreak.api.model.stack.cluster.ClusterRequest;
 import com.sequenceiq.cloudbreak.api.model.stack.cluster.host.HostGroupRequest;
@@ -24,15 +13,97 @@ import com.sequenceiq.cloudbreak.api.model.stack.instance.InstanceGroupRequest;
 import com.sequenceiq.cloudbreak.controller.validation.ValidationResult;
 import com.sequenceiq.cloudbreak.controller.validation.ValidationResult.State;
 import com.sequenceiq.cloudbreak.controller.validation.template.TemplateRequestValidator;
+import com.sequenceiq.cloudbreak.domain.Blueprint;
+import com.sequenceiq.cloudbreak.domain.RDSConfig;
+import com.sequenceiq.cloudbreak.domain.json.Json;
+import com.sequenceiq.cloudbreak.service.RestRequestThreadLocalService;
+import com.sequenceiq.cloudbreak.service.blueprint.BlueprintService;
+import com.sequenceiq.cloudbreak.service.rdsconfig.RdsConfigService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.sequenceiq.cloudbreak.api.model.rds.RdsType.HIVE;
+import static com.sequenceiq.cloudbreak.api.model.rds.RdsType.RANGER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class StackRequestValidatorTest {
+public class StackRequestValidatorTest extends StackRequestValidatorTestBase {
+
+    private static final Long WORKSPACE_ID = 1L;
+
+    private static final Long TEST_HIVE_ID = 1111L;
+
+    private static final Long TEST_RANGER_ID = 2222L;
+
+    private static final String TEST_LDAP_NAME = "ldap";
+
+    private static final String TEST_HIVE_NAME = "hive";
+
+    private static final String TEST_RANGER_NAME = "ranger";
+
+    private static final String TEST_BP_NAME = "testBpName";
+
+    private static final String SHARED_SERVICE_READY_BP_TAG = "shared_services_ready";
+
+    private static final String RDS_ERROR_MESSAGE_FORMAT = "For a Datalake cluster (since you have selected a datalake ready blueprint) "
+            + "you should provide at least one %s rds/database configuration to the Cluster request";
+
+    private static final String LACK_OF_LDAP_MESSAGE = "For a Datalake cluster (since you have selected a datalake ready blueprint) you should provide an "
+            + "LDAP configuration or its name/id to the Cluster request";
 
     @Spy
-    private TemplateRequestValidator templateRequestValidator = new TemplateRequestValidator();
+    private final TemplateRequestValidator templateRequestValidator = new TemplateRequestValidator();
+
+    @Mock
+    private BlueprintService blueprintService;
+
+    @Mock
+    private RestRequestThreadLocalService restRequestThreadLocalService;
 
     @InjectMocks
     private StackRequestValidator underTest;
+
+    @Mock
+    private Blueprint blueprint;
+
+    @Mock
+    private Json blueprintJson;
+
+    @Mock
+    private RdsConfigService rdsConfigService;
+
+    public StackRequestValidatorTest() {
+        super(LoggerFactory.getLogger(StackRequestValidatorTest.class));
+    }
+
+    @Before
+    public void setUp() {
+        when(blueprintService.getByNameForWorkspaceId(anyString(), eq(WORKSPACE_ID))).thenReturn(blueprint);
+        when(blueprint.getTags()).thenReturn(blueprintJson);
+        when(blueprintJson.getMap()).thenReturn(Collections.emptyMap());
+        when(restRequestThreadLocalService.getRequestedWorkspaceId()).thenReturn(WORKSPACE_ID);
+    }
 
     @Test
     public void testWithZeroRootVolumeSize() {
@@ -101,6 +172,316 @@ public class StackRequestValidatorTest {
         assertEquals(2L, validationResult.getErrors().size());
     }
 
+    @Test
+    public void testWhenBlueprintIsSharedServiceReadyAndThereIsOnlyHiveRdsWithNameThenErrorComes() {
+        when(blueprintJson.getMap()).thenReturn(Map.of(SHARED_SERVICE_READY_BP_TAG, true));
+        StackRequest request = stackRequest();
+        request.getClusterRequest().setRdsConfigNames(Set.of(TEST_HIVE_NAME));
+        request.getClusterRequest().setRdsConfigJsons(Collections.emptySet());
+        request.getClusterRequest().setRdsConfigIds(Collections.emptySet());
+        when(rdsConfigService.getByNameForWorkspaceId(TEST_HIVE_NAME, WORKSPACE_ID)).thenReturn(rdsConfig(HIVE));
+
+        ValidationResult validationResult = underTest.validate(request);
+
+        assertEquals(2L, validationResult.getErrors().size());
+        assertTrue(validationResult.getErrors().stream().anyMatch(s -> s.equals(String.format(RDS_ERROR_MESSAGE_FORMAT, "Ranger"))));
+        assertTrue(validationResult.getErrors().stream().anyMatch(s -> s.equals(LACK_OF_LDAP_MESSAGE)));
+
+        verify(blueprintService, times(1)).getByNameForWorkspaceId(TEST_BP_NAME, WORKSPACE_ID);
+        verify(blueprintService, times(1)).getByNameForWorkspaceId(anyString(), anyLong());
+        verify(rdsConfigService, times(1)).getByNameForWorkspaceId(TEST_HIVE_NAME, WORKSPACE_ID);
+        verify(rdsConfigService, times(1)).getByNameForWorkspaceId(anyString(), anyLong());
+        verify(rdsConfigService, times(0)).get(anyLong());
+    }
+
+    @Test
+    public void testWhenBlueprintIsSharedServiceReadyAndThereIsOnlyRangerRdsWithNameThenErrorComes() {
+        when(blueprintJson.getMap()).thenReturn(Map.of(SHARED_SERVICE_READY_BP_TAG, true));
+        StackRequest request = stackRequest();
+        request.getClusterRequest().setRdsConfigNames(Set.of(TEST_RANGER_NAME));
+        request.getClusterRequest().setRdsConfigJsons(Collections.emptySet());
+        request.getClusterRequest().setRdsConfigIds(Collections.emptySet());
+        when(rdsConfigService.getByNameForWorkspaceId(TEST_RANGER_NAME, WORKSPACE_ID)).thenReturn(rdsConfig(RANGER));
+
+        ValidationResult validationResult = underTest.validate(request);
+
+        assertEquals(2L, validationResult.getErrors().size());
+        assertTrue(validationResult.getErrors().stream().anyMatch(s -> s.equals(String.format(RDS_ERROR_MESSAGE_FORMAT, "Hive"))));
+        assertTrue(validationResult.getErrors().stream().anyMatch(s -> s.equals(LACK_OF_LDAP_MESSAGE)));
+
+        verify(blueprintService, times(1)).getByNameForWorkspaceId(TEST_BP_NAME, WORKSPACE_ID);
+        verify(blueprintService, times(1)).getByNameForWorkspaceId(anyString(), anyLong());
+        verify(rdsConfigService, times(1)).getByNameForWorkspaceId(TEST_RANGER_NAME, WORKSPACE_ID);
+        verify(rdsConfigService, times(1)).getByNameForWorkspaceId(anyString(), anyLong());
+        verify(rdsConfigService, times(0)).get(anyLong());
+    }
+
+    @Test
+    public void testWhenBlueprintIsSharedServiceReadyAndThereAreRangerAndHiveRdsWithNameButLdapDoesntThenErrorComes() {
+        when(blueprintJson.getMap()).thenReturn(Map.of(SHARED_SERVICE_READY_BP_TAG, true));
+        StackRequest request = stackRequest();
+        request.getClusterRequest().setRdsConfigNames(Set.of(TEST_RANGER_NAME, TEST_HIVE_NAME));
+        request.getClusterRequest().setRdsConfigJsons(Collections.emptySet());
+        request.getClusterRequest().setRdsConfigIds(Collections.emptySet());
+        when(rdsConfigService.getByNameForWorkspaceId(TEST_RANGER_NAME, WORKSPACE_ID)).thenReturn(rdsConfig(RANGER));
+        when(rdsConfigService.getByNameForWorkspaceId(TEST_HIVE_NAME, WORKSPACE_ID)).thenReturn(rdsConfig(HIVE));
+
+        ValidationResult validationResult = underTest.validate(request);
+
+        assertEquals(1L, validationResult.getErrors().size());
+        assertFalse(validationResult.getErrors().stream().anyMatch(s -> s.equals(String.format(RDS_ERROR_MESSAGE_FORMAT, "Hive"))));
+        assertFalse(validationResult.getErrors().stream().anyMatch(s -> s.equals(String.format(RDS_ERROR_MESSAGE_FORMAT, "Ranger"))));
+        assertTrue(validationResult.getErrors().stream().anyMatch(s -> s.equals(LACK_OF_LDAP_MESSAGE)));
+
+        verify(blueprintService, times(1)).getByNameForWorkspaceId(TEST_BP_NAME, WORKSPACE_ID);
+        verify(blueprintService, times(1)).getByNameForWorkspaceId(anyString(), anyLong());
+        verify(rdsConfigService, times(1)).getByNameForWorkspaceId(TEST_RANGER_NAME, WORKSPACE_ID);
+        verify(rdsConfigService, times(1)).getByNameForWorkspaceId(TEST_HIVE_NAME, WORKSPACE_ID);
+        verify(rdsConfigService, times(2)).getByNameForWorkspaceId(anyString(), anyLong());
+        verify(rdsConfigService, times(0)).get(anyLong());
+    }
+
+    @Test
+    public void testWhenBlueprintIsSharedServiceReadyAndThereAreRangerAndHiveRdsWithNameAndLdapWithNameThenEverythingIsFine() {
+        when(blueprintJson.getMap()).thenReturn(Map.of(SHARED_SERVICE_READY_BP_TAG, true));
+        StackRequest request = stackRequest();
+        request.getClusterRequest().setRdsConfigNames(Set.of(TEST_RANGER_NAME, TEST_HIVE_NAME));
+        request.getClusterRequest().setRdsConfigJsons(Collections.emptySet());
+        request.getClusterRequest().setRdsConfigIds(Collections.emptySet());
+        request.getClusterRequest().setLdapConfigName(TEST_LDAP_NAME);
+        when(rdsConfigService.getByNameForWorkspaceId(TEST_RANGER_NAME, WORKSPACE_ID)).thenReturn(rdsConfig(RANGER));
+        when(rdsConfigService.getByNameForWorkspaceId(TEST_HIVE_NAME, WORKSPACE_ID)).thenReturn(rdsConfig(HIVE));
+
+        ValidationResult validationResult = underTest.validate(request);
+
+        assertValidationErrorIsEmpty(validationResult.getErrors());
+
+        verify(blueprintService, times(1)).getByNameForWorkspaceId(TEST_BP_NAME, WORKSPACE_ID);
+        verify(blueprintService, times(1)).getByNameForWorkspaceId(anyString(), anyLong());
+        verify(rdsConfigService, times(1)).getByNameForWorkspaceId(TEST_RANGER_NAME, WORKSPACE_ID);
+        verify(rdsConfigService, times(1)).getByNameForWorkspaceId(TEST_HIVE_NAME, WORKSPACE_ID);
+        verify(rdsConfigService, times(2)).getByNameForWorkspaceId(anyString(), anyLong());
+        verify(rdsConfigService, times(0)).get(anyLong());
+    }
+
+    @Test
+    public void testWhenBlueprintIsSharedServiceReadyAndThereAreRangerAndHiveRdsWithNameAndLdapWithIdThenEverythingIsFine() {
+        when(blueprintJson.getMap()).thenReturn(Map.of(SHARED_SERVICE_READY_BP_TAG, true));
+        StackRequest request = stackRequest();
+        request.getClusterRequest().setRdsConfigNames(Set.of(TEST_RANGER_NAME, TEST_HIVE_NAME));
+        request.getClusterRequest().setRdsConfigJsons(Collections.emptySet());
+        request.getClusterRequest().setRdsConfigIds(Collections.emptySet());
+        request.getClusterRequest().setLdapConfigId(1234L);
+        when(rdsConfigService.getByNameForWorkspaceId(TEST_RANGER_NAME, WORKSPACE_ID)).thenReturn(rdsConfig(RANGER));
+        when(rdsConfigService.getByNameForWorkspaceId(TEST_HIVE_NAME, WORKSPACE_ID)).thenReturn(rdsConfig(HIVE));
+
+        ValidationResult validationResult = underTest.validate(request);
+
+        assertValidationErrorIsEmpty(validationResult.getErrors());
+
+        verify(blueprintService, times(1)).getByNameForWorkspaceId(TEST_BP_NAME, WORKSPACE_ID);
+        verify(blueprintService, times(1)).getByNameForWorkspaceId(anyString(), anyLong());
+        verify(rdsConfigService, times(1)).getByNameForWorkspaceId(TEST_RANGER_NAME, WORKSPACE_ID);
+        verify(rdsConfigService, times(1)).getByNameForWorkspaceId(TEST_HIVE_NAME, WORKSPACE_ID);
+        verify(rdsConfigService, times(2)).getByNameForWorkspaceId(anyString(), anyLong());
+        verify(rdsConfigService, times(0)).get(anyLong());
+    }
+
+    @Test
+    public void testWhenBlueprintIsSharedServiceReadyAndThereAreRangerAndHiveRdsWithNameAndLdapWithRequestThenEverythingIsFine() {
+        when(blueprintJson.getMap()).thenReturn(Map.of(SHARED_SERVICE_READY_BP_TAG, true));
+        StackRequest request = stackRequest();
+        request.getClusterRequest().setRdsConfigNames(Set.of(TEST_RANGER_NAME, TEST_HIVE_NAME));
+        request.getClusterRequest().setRdsConfigJsons(Collections.emptySet());
+        request.getClusterRequest().setRdsConfigIds(Collections.emptySet());
+        request.getClusterRequest().setLdapConfig(new LdapConfigRequest());
+        when(rdsConfigService.getByNameForWorkspaceId(TEST_RANGER_NAME, WORKSPACE_ID)).thenReturn(rdsConfig(RANGER));
+        when(rdsConfigService.getByNameForWorkspaceId(TEST_HIVE_NAME, WORKSPACE_ID)).thenReturn(rdsConfig(HIVE));
+
+        ValidationResult validationResult = underTest.validate(request);
+
+        assertValidationErrorIsEmpty(validationResult.getErrors());
+
+        verify(blueprintService, times(1)).getByNameForWorkspaceId(TEST_BP_NAME, WORKSPACE_ID);
+        verify(blueprintService, times(1)).getByNameForWorkspaceId(anyString(), anyLong());
+        verify(rdsConfigService, times(1)).getByNameForWorkspaceId(TEST_RANGER_NAME, WORKSPACE_ID);
+        verify(rdsConfigService, times(1)).getByNameForWorkspaceId(TEST_HIVE_NAME, WORKSPACE_ID);
+        verify(rdsConfigService, times(2)).getByNameForWorkspaceId(anyString(), anyLong());
+        verify(rdsConfigService, times(0)).get(anyLong());
+    }
+
+    @Test
+    public void testWhenBlueprintIsSharedServiceReadyAndThereAreRangerAndHiveRdsWithBothIdAndLdapWithNameThenEverythingIsFine() {
+        when(blueprintJson.getMap()).thenReturn(Map.of(SHARED_SERVICE_READY_BP_TAG, true));
+        StackRequest request = stackRequest();
+        request.getClusterRequest().setRdsConfigIds(Set.of(TEST_RANGER_ID, TEST_HIVE_ID));
+        request.getClusterRequest().setRdsConfigJsons(Collections.emptySet());
+        request.getClusterRequest().setRdsConfigNames(Collections.emptySet());
+        request.getClusterRequest().setLdapConfigName(TEST_LDAP_NAME);
+        when(rdsConfigService.get(TEST_RANGER_ID)).thenReturn(rdsConfig(RANGER));
+        when(rdsConfigService.get(TEST_HIVE_ID)).thenReturn(rdsConfig(HIVE));
+
+        ValidationResult validationResult = underTest.validate(request);
+
+        assertValidationErrorIsEmpty(validationResult.getErrors());
+
+        verify(blueprintService, times(1)).getByNameForWorkspaceId(TEST_BP_NAME, WORKSPACE_ID);
+        verify(blueprintService, times(1)).getByNameForWorkspaceId(anyString(), anyLong());
+        verify(rdsConfigService, times(1)).get(TEST_RANGER_ID);
+        verify(rdsConfigService, times(1)).get(TEST_HIVE_ID);
+        verify(rdsConfigService, times(2)).get(anyLong());
+        verify(rdsConfigService, times(0)).getByNameForWorkspaceId(anyString(), anyLong());
+    }
+
+    @Test
+    public void testWhenBlueprintIsSharedServiceReadyAndThereAreRangerAndHiveRdsWithBothRequestAndLdapWithNameThenEverythingIsFine() {
+        when(blueprintJson.getMap()).thenReturn(Map.of(SHARED_SERVICE_READY_BP_TAG, true));
+        StackRequest request = stackRequest();
+        request.getClusterRequest().setRdsConfigJsons(Set.of(rdsConfigRequest(HIVE), rdsConfigRequest(RANGER)));
+        request.getClusterRequest().setRdsConfigIds(Collections.emptySet());
+        request.getClusterRequest().setRdsConfigNames(Collections.emptySet());
+        request.getClusterRequest().setLdapConfigName(TEST_LDAP_NAME);
+
+        ValidationResult validationResult = underTest.validate(request);
+
+        assertValidationErrorIsEmpty(validationResult.getErrors());
+
+        verify(blueprintService, times(1)).getByNameForWorkspaceId(TEST_BP_NAME, WORKSPACE_ID);
+        verify(blueprintService, times(1)).getByNameForWorkspaceId(anyString(), anyLong());
+        verify(rdsConfigService, times(0)).get(anyLong());
+        verify(rdsConfigService, times(0)).getByNameForWorkspaceId(anyString(), anyLong());
+    }
+
+    @Test
+    public void testWhenBlueprintIsSharedServiceReadyAndThereAreRangerAndHiveRdsWithNameAndIdAndLdapWithNameThenEverythingIsFine() {
+        when(blueprintJson.getMap()).thenReturn(Map.of(SHARED_SERVICE_READY_BP_TAG, true));
+        StackRequest request = stackRequest();
+        request.getClusterRequest().setRdsConfigNames(Set.of(TEST_HIVE_NAME));
+        request.getClusterRequest().setRdsConfigIds(Set.of(TEST_RANGER_ID));
+        request.getClusterRequest().setRdsConfigJsons(Collections.emptySet());
+        request.getClusterRequest().setLdapConfigName(TEST_LDAP_NAME);
+        when(rdsConfigService.getByNameForWorkspaceId(TEST_HIVE_NAME, WORKSPACE_ID)).thenReturn(rdsConfig(HIVE));
+        when(rdsConfigService.get(TEST_RANGER_ID)).thenReturn(rdsConfig(RANGER));
+
+        ValidationResult validationResult = underTest.validate(request);
+
+        assertValidationErrorIsEmpty(validationResult.getErrors());
+
+        verify(blueprintService, times(1)).getByNameForWorkspaceId(TEST_BP_NAME, WORKSPACE_ID);
+        verify(blueprintService, times(1)).getByNameForWorkspaceId(anyString(), anyLong());
+        verify(rdsConfigService, times(1)).get(TEST_RANGER_ID);
+        verify(rdsConfigService, times(1)).get(anyLong());
+        verify(rdsConfigService, times(1)).getByNameForWorkspaceId(TEST_HIVE_NAME, WORKSPACE_ID);
+        verify(rdsConfigService, times(1)).getByNameForWorkspaceId(anyString(), anyLong());
+    }
+
+    @Test
+    public void testWhenBlueprintIsSharedServiceReadyAndThereAreRangerAndHiveRdsWithIdAndNameAndLdapWithNameThenEverythingIsFine() {
+        when(blueprintJson.getMap()).thenReturn(Map.of(SHARED_SERVICE_READY_BP_TAG, true));
+        StackRequest request = stackRequest();
+        request.getClusterRequest().setRdsConfigNames(Set.of(TEST_RANGER_NAME));
+        request.getClusterRequest().setRdsConfigIds(Set.of(TEST_HIVE_ID));
+        request.getClusterRequest().setRdsConfigJsons(Collections.emptySet());
+        request.getClusterRequest().setLdapConfigName(TEST_LDAP_NAME);
+        when(rdsConfigService.getByNameForWorkspaceId(TEST_RANGER_NAME, WORKSPACE_ID)).thenReturn(rdsConfig(RANGER));
+        when(rdsConfigService.get(TEST_HIVE_ID)).thenReturn(rdsConfig(HIVE));
+
+        ValidationResult validationResult = underTest.validate(request);
+
+        assertValidationErrorIsEmpty(validationResult.getErrors());
+
+        verify(blueprintService, times(1)).getByNameForWorkspaceId(TEST_BP_NAME, WORKSPACE_ID);
+        verify(blueprintService, times(1)).getByNameForWorkspaceId(anyString(), anyLong());
+        verify(rdsConfigService, times(1)).get(TEST_HIVE_ID);
+        verify(rdsConfigService, times(1)).get(anyLong());
+        verify(rdsConfigService, times(1)).getByNameForWorkspaceId(TEST_RANGER_NAME, WORKSPACE_ID);
+        verify(rdsConfigService, times(1)).getByNameForWorkspaceId(anyString(), anyLong());
+    }
+
+    @Test
+    public void testWhenBlueprintIsSharedServiceReadyAndThereAreRangerAndHiveRdsWithNameAndRequestAndLdapWithNameThenEverythingIsFine() {
+        when(blueprintJson.getMap()).thenReturn(Map.of(SHARED_SERVICE_READY_BP_TAG, true));
+        StackRequest request = stackRequest();
+        request.getClusterRequest().setRdsConfigNames(Set.of(TEST_HIVE_NAME));
+        request.getClusterRequest().setRdsConfigIds(Collections.emptySet());
+        request.getClusterRequest().setRdsConfigJsons(Set.of(rdsConfigRequest(RANGER)));
+        request.getClusterRequest().setLdapConfigName(TEST_LDAP_NAME);
+        when(rdsConfigService.getByNameForWorkspaceId(TEST_HIVE_NAME, WORKSPACE_ID)).thenReturn(rdsConfig(HIVE));
+
+        ValidationResult validationResult = underTest.validate(request);
+
+        assertValidationErrorIsEmpty(validationResult.getErrors());
+
+        verify(blueprintService, times(1)).getByNameForWorkspaceId(TEST_BP_NAME, WORKSPACE_ID);
+        verify(blueprintService, times(1)).getByNameForWorkspaceId(anyString(), anyLong());
+        verify(rdsConfigService, times(0)).get(anyLong());
+        verify(rdsConfigService, times(1)).getByNameForWorkspaceId(TEST_HIVE_NAME, WORKSPACE_ID);
+        verify(rdsConfigService, times(1)).getByNameForWorkspaceId(anyString(), anyLong());
+    }
+
+    @Test
+    public void testWhenBlueprintIsSharedServiceReadyAndThereAreRangerAndHiveRdsWithRequestAndNameAndLdapWithNameThenEverythingIsFine() {
+        when(blueprintJson.getMap()).thenReturn(Map.of(SHARED_SERVICE_READY_BP_TAG, true));
+        StackRequest request = stackRequest();
+        request.getClusterRequest().setRdsConfigNames(Set.of(TEST_RANGER_NAME));
+        request.getClusterRequest().setRdsConfigIds(Collections.emptySet());
+        request.getClusterRequest().setRdsConfigJsons(Set.of(rdsConfigRequest(HIVE)));
+        request.getClusterRequest().setLdapConfigName(TEST_LDAP_NAME);
+        when(rdsConfigService.getByNameForWorkspaceId(TEST_RANGER_NAME, WORKSPACE_ID)).thenReturn(rdsConfig(RANGER));
+
+        ValidationResult validationResult = underTest.validate(request);
+
+        assertValidationErrorIsEmpty(validationResult.getErrors());
+
+        verify(blueprintService, times(1)).getByNameForWorkspaceId(TEST_BP_NAME, WORKSPACE_ID);
+        verify(blueprintService, times(1)).getByNameForWorkspaceId(anyString(), anyLong());
+        verify(rdsConfigService, times(0)).get(anyLong());
+        verify(rdsConfigService, times(1)).getByNameForWorkspaceId(TEST_RANGER_NAME, WORKSPACE_ID);
+        verify(rdsConfigService, times(1)).getByNameForWorkspaceId(anyString(), anyLong());
+    }
+
+    @Test
+    public void testWhenBlueprintIsSharedServiceReadyAndThereAreRangerAndHiveRdsWithRequestAndIdAndLdapWithNameThenEverythingIsFine() {
+        when(blueprintJson.getMap()).thenReturn(Map.of(SHARED_SERVICE_READY_BP_TAG, true));
+        StackRequest request = stackRequest();
+        request.getClusterRequest().setRdsConfigNames(Collections.emptySet());
+        request.getClusterRequest().setRdsConfigIds(Set.of(TEST_RANGER_ID));
+        request.getClusterRequest().setRdsConfigJsons(Set.of(rdsConfigRequest(HIVE)));
+        request.getClusterRequest().setLdapConfigName(TEST_LDAP_NAME);
+        when(rdsConfigService.get(TEST_RANGER_ID)).thenReturn(rdsConfig(RANGER));
+
+        ValidationResult validationResult = underTest.validate(request);
+
+        assertValidationErrorIsEmpty(validationResult.getErrors());
+
+        verify(blueprintService, times(1)).getByNameForWorkspaceId(TEST_BP_NAME, WORKSPACE_ID);
+        verify(blueprintService, times(1)).getByNameForWorkspaceId(anyString(), anyLong());
+        verify(rdsConfigService, times(1)).get(TEST_RANGER_ID);
+        verify(rdsConfigService, times(1)).get(anyLong());
+        verify(rdsConfigService, times(0)).getByNameForWorkspaceId(anyString(), anyLong());
+    }
+
+    @Test
+    public void testWhenBlueprintIsSharedServiceReadyAndThereIsNoLdapAndRdsConfigGivenThenErrorComes() {
+        when(blueprintJson.getMap()).thenReturn(Map.of(SHARED_SERVICE_READY_BP_TAG, true));
+        StackRequest request = stackRequest();
+        request.getClusterRequest().setRdsConfigNames(Collections.emptySet());
+        request.getClusterRequest().setRdsConfigIds(Collections.emptySet());
+        request.getClusterRequest().setRdsConfigJsons(Collections.emptySet());
+        request.getClusterRequest().setLdapConfigName(null);
+        request.getClusterRequest().setLdapConfig(null);
+        request.getClusterRequest().setLdapConfigId(null);
+
+        ValidationResult validationResult = underTest.validate(request);
+
+        assertEquals(3L, validationResult.getErrors().size());
+
+        verify(blueprintService, times(1)).getByNameForWorkspaceId(TEST_BP_NAME, WORKSPACE_ID);
+        verify(blueprintService, times(1)).getByNameForWorkspaceId(anyString(), anyLong());
+        verify(rdsConfigService, times(0)).get(anyLong());
+        verify(rdsConfigService, times(0)).getByNameForWorkspaceId(anyString(), anyLong());
+    }
+
     private StackRequest stackRequestWithInstanceAndHostGroups(Set<String> instanceGroups, Set<String> hostGroups) {
         List<InstanceGroupRequest> instanceGroupList = instanceGroups.stream()
                 .map(ig -> getInstanceGroupRequest(new TemplateRequest(), ig))
@@ -116,8 +497,18 @@ public class StackRequestValidatorTest {
 
         ClusterRequest clusterRequest = new ClusterRequest();
         clusterRequest.setHostGroups(hostGroupSet);
-
+        BlueprintRequest bpRequest = new BlueprintRequest();
+        bpRequest.setName(TEST_BP_NAME);
+        clusterRequest.setBlueprint(bpRequest);
+        clusterRequest.setBlueprintName(TEST_BP_NAME);
         return getStackRequest(instanceGroupList, clusterRequest);
+    }
+
+    private StackRequest stackRequest() {
+        TemplateRequest templateRequest = new TemplateRequest();
+        InstanceGroupRequest instanceGroupRequest = getInstanceGroupRequest(templateRequest, "master");
+        ClusterRequest clusterRequest = getClusterRequest();
+        return getStackRequest(Collections.singletonList(instanceGroupRequest), clusterRequest);
     }
 
     private StackRequest stackRequestWithRootVolumeSize(Integer rootVolumeSize) {
@@ -140,6 +531,10 @@ public class StackRequestValidatorTest {
         ClusterRequest clusterRequest = new ClusterRequest();
         hostGroupRequest.setName("master");
         clusterRequest.setHostGroups(Sets.newHashSet(hostGroupRequest));
+        BlueprintRequest bpRequest = new BlueprintRequest();
+        bpRequest.setName(TEST_BP_NAME);
+        clusterRequest.setBlueprint(bpRequest);
+        clusterRequest.setBlueprintName(TEST_BP_NAME);
         return clusterRequest;
     }
 
@@ -148,6 +543,18 @@ public class StackRequestValidatorTest {
         stackRequest.setClusterRequest(clusterRequest);
         stackRequest.setInstanceGroups(instanceGroupRequests);
         return stackRequest;
+    }
+
+    private RDSConfig rdsConfig(RdsType type) {
+        RDSConfig rds = new RDSConfig();
+        rds.setType(type.name());
+        return rds;
+    }
+
+    private RDSConfigRequest rdsConfigRequest(RdsType type) {
+        RDSConfigRequest request = new RDSConfigRequest();
+        request.setType(type.name());
+        return request;
     }
 
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/controller/validation/stack/StackRequestValidatorTestBase.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/controller/validation/stack/StackRequestValidatorTestBase.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.cloudbreak.controller.validation.stack;
+
+import org.slf4j.Logger;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertTrue;
+
+public class StackRequestValidatorTestBase {
+
+    private final Logger logger;
+
+    public StackRequestValidatorTestBase(@Nonnull Logger logger) {
+        this.logger = logger;
+    }
+
+    public Logger getLogger() {
+        return logger;
+    }
+
+    protected void assertValidationErrorIsEmpty(List<String> errors) {
+        try {
+            assertTrue(errors.isEmpty());
+        } catch (AssertionError error) {
+            String startMessageFormat = "There should not be any StackRequest validation error but there %s!";
+            logger.error(errors.size() > 1 ? format(startMessageFormat, "are") : format(startMessageFormat, "is"));
+            errors.forEach(logger::error);
+            throw error;
+        }
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/exception/TestFailException.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/exception/TestFailException.java
@@ -1,0 +1,9 @@
+package com.sequenceiq.it.cloudbreak.exception;
+
+public class TestFailException extends RuntimeException {
+
+    public TestFailException(String message) {
+        super(message);
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/AbstractCloudbreakEntity.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/AbstractCloudbreakEntity.java
@@ -3,8 +3,10 @@ package com.sequenceiq.it.cloudbreak.newway;
 import static com.sequenceiq.it.cloudbreak.newway.context.RunningParameter.emptyRunningParameter;
 import static com.sequenceiq.it.cloudbreak.newway.finder.Finders.same;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -123,6 +125,21 @@ public abstract class AbstractCloudbreakEntity<R, S, T extends CloudbreakEntity>
 
     public T then(AssertionV2<T> assertion, RunningParameter runningParameter) {
         return testContext.then((T) this, assertion, runningParameter);
+    }
+
+    public T then(List<AssertionV2<T>> assertions) {
+        List<RunningParameter> runningParameters = new ArrayList<>(assertions.size());
+        for (int i = 0; i < assertions.size(); i++) {
+            runningParameters.add(emptyRunningParameter());
+        }
+        return then(assertions, runningParameters);
+    }
+
+    public T then(List<AssertionV2<T>> assertions, List<RunningParameter> runningParameters) {
+        for (int i = 0; i < assertions.size() - 1; i++) {
+            testContext.then((T) this, assertions.get(i), runningParameters.get(i));
+        }
+        return testContext.then((T) this, assertions.get(assertions.size() - 1), runningParameters.get(runningParameters.size() - 1));
     }
 
     public <O extends CloudbreakEntity> O given(String key, Class<O> clss) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/Blueprint.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/Blueprint.java
@@ -4,9 +4,20 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 import com.sequenceiq.it.IntegrationTestContext;
+import com.sequenceiq.it.cloudbreak.newway.action.ActionV2;
+import com.sequenceiq.it.cloudbreak.newway.action.BlueprintPostAction;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
 import com.sequenceiq.it.cloudbreak.newway.v3.BlueprintV3Action;
 
+@Prototype
 public class Blueprint extends BlueprintEntity {
+
+    public Blueprint() {
+    }
+
+    public Blueprint(TestContext testContext) {
+        super(testContext);
+    }
 
     static Function<IntegrationTestContext, Blueprint> getTestContext(String key) {
         return testContext -> testContext.getContextParam(key, Blueprint.class);
@@ -56,6 +67,17 @@ public class Blueprint extends BlueprintEntity {
 
     public static Assertion<Blueprint> assertThis(BiConsumer<Blueprint, IntegrationTestContext> check) {
         return new Assertion<>(getTestContext(GherkinTest.RESULT), check);
+    }
+
+    public static BlueprintEntity getByName(TestContext testContext, BlueprintEntity entity, CloudbreakClient cloudbreakClient) {
+        entity.setResponse(
+                cloudbreakClient.getCloudbreakClient().blueprintV3Endpoint().getByNameInWorkspace(cloudbreakClient.getWorkspaceId(), entity.getName())
+        );
+        return entity;
+    }
+
+    public static ActionV2<BlueprintEntity> postV2() {
+        return new BlueprintPostAction();
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/BlueprintEntity.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/BlueprintEntity.java
@@ -4,6 +4,9 @@ import com.sequenceiq.cloudbreak.api.model.BlueprintRequest;
 import com.sequenceiq.cloudbreak.api.model.BlueprintResponse;
 import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
 
+import javax.ws.rs.WebApplicationException;
+import java.util.List;
+
 public class BlueprintEntity extends AbstractCloudbreakEntity<BlueprintRequest, BlueprintResponse, BlueprintEntity> {
     public static final String BLUEPRINT = "BLUEPRINT";
 
@@ -18,6 +21,21 @@ public class BlueprintEntity extends AbstractCloudbreakEntity<BlueprintRequest, 
 
     public BlueprintEntity(TestContext testContext) {
         super(new BlueprintRequest(), testContext);
+    }
+
+    @Override
+    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
+        LOGGER.info("Cleaning up resource with name: {}", getName());
+        try {
+            cloudbreakClient.getCloudbreakClient().blueprintV3Endpoint().deleteInWorkspace(cloudbreakClient.getWorkspaceId(), getName());
+        } catch (WebApplicationException ignore) {
+            LOGGER.info("Something happend.");
+        }
+    }
+
+    public BlueprintEntity valid() {
+        return withName(getNameCreator().getRandomNameForMock())
+                .withAmbariBlueprint("someBlueprint");
     }
 
     public BlueprintEntity withName(String name) {
@@ -40,4 +58,15 @@ public class BlueprintEntity extends AbstractCloudbreakEntity<BlueprintRequest, 
         getRequest().setAmbariBlueprint(blueprint);
         return this;
     }
+
+    public BlueprintEntity withTag(List<String> keys, List<Object> values) {
+        if (keys.size() != values.size()) {
+            throw new IllegalStateException("The given keys number does not match with the values number");
+        }
+        for (int i = 0; i < keys.size(); i++) {
+            getRequest().getTags().put(keys.get(i), values.get(i));
+        }
+        return this;
+    }
+
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/Credential.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/Credential.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.it.cloudbreak.newway;
 
 import com.sequenceiq.it.IntegrationTestContext;
+import com.sequenceiq.it.cloudbreak.newway.action.ActionV2;
+import com.sequenceiq.it.cloudbreak.newway.action.CredentialPostAction;
 import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
 import com.sequenceiq.it.cloudbreak.newway.v3.CredentialV3Action;
 
@@ -103,5 +105,16 @@ public class Credential extends CredentialEntity {
 
     public static Assertion<Credential> assertThis(BiConsumer<Credential, IntegrationTestContext> check) {
         return new Assertion<>(getTestContextCredential(GherkinTest.RESULT), check);
+    }
+
+    public static ActionV2<CredentialEntity> postV2() {
+        return new CredentialPostAction();
+    }
+
+    public static CredentialEntity getByName(TestContext testContext, CredentialEntity entity, CloudbreakClient cloudbreakClient) {
+        entity.setResponse(
+                cloudbreakClient.getCloudbreakClient().credentialV3Endpoint().getByNameInWorkspace(cloudbreakClient.getWorkspaceId(), entity.getName())
+        );
+        return entity;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/ImageCatalog.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/ImageCatalog.java
@@ -5,6 +5,8 @@ import java.util.function.Function;
 
 import com.sequenceiq.cloudbreak.api.model.imagecatalog.ImageCatalogRequest;
 import com.sequenceiq.it.IntegrationTestContext;
+import com.sequenceiq.it.cloudbreak.newway.action.ActionV2;
+import com.sequenceiq.it.cloudbreak.newway.action.ImageCatalogPostAction;
 import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
 import com.sequenceiq.it.cloudbreak.newway.v3.ImageCatalogV3Action;
 
@@ -106,5 +108,23 @@ public class ImageCatalog extends ImageCatalogEntity {
 
     public static Action<ImageCatalog> setDefault() {
         return setDefault(IMAGE_CATALOG);
+    }
+
+    public static ImageCatalogEntity getByNameAndImages(TestContext testContext, ImageCatalogEntity entity, CloudbreakClient cloudbreakClient) {
+        entity.setResponse(
+                cloudbreakClient.getCloudbreakClient().imageCatalogV3Endpoint().getByNameInWorkspace(cloudbreakClient.getWorkspaceId(), entity.getName(), true)
+        );
+        return entity;
+    }
+
+    public static ImageCatalogEntity getByNameWithoutImages(TestContext testContext, ImageCatalogEntity entity, CloudbreakClient cloudbreakClient) {
+        entity.setResponse(
+                cloudbreakClient.getCloudbreakClient().imageCatalogV3Endpoint().getByNameInWorkspace(cloudbreakClient.getWorkspaceId(), entity.getName(), false)
+        );
+        return entity;
+    }
+
+    public static ActionV2<ImageCatalogEntity> postV2() {
+        return new ImageCatalogPostAction();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/LdapConfig.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/LdapConfig.java
@@ -4,13 +4,21 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 import com.sequenceiq.it.IntegrationTestContext;
+import com.sequenceiq.it.cloudbreak.newway.action.ActionV2;
+import com.sequenceiq.it.cloudbreak.newway.action.LdapConfigPostAction;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
 import com.sequenceiq.it.cloudbreak.newway.v3.LdapConfigV3Action;
 
+@Prototype
 public class LdapConfig extends LdapConfigEntity {
     private static final String LDAPCONFIG = "LdapCONFIG";
 
     private LdapConfig() {
         super(LDAPCONFIG);
+    }
+
+    public LdapConfig(TestContext testContext) {
+        super(testContext);
     }
 
     private static Function<IntegrationTestContext, LdapConfig> getTestContext(String key) {
@@ -82,4 +90,16 @@ public class LdapConfig extends LdapConfigEntity {
         ldapConfig.setCreationStrategy(LdapConfigV3Action::createInGiven);
         return ldapConfig;
     }
+
+    public static ActionV2<LdapConfigEntity> postV2() {
+        return new LdapConfigPostAction();
+    }
+
+    public static LdapConfigEntity getByName(TestContext testContext, LdapConfigEntity entity, CloudbreakClient cloudbreakClient) {
+        entity.setResponse(
+                cloudbreakClient.getCloudbreakClient().ldapConfigV3Endpoint().getByNameInWorkspace(cloudbreakClient.getWorkspaceId(), entity.getName())
+        );
+        return entity;
+    }
+
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/LdapConfigEntity.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/LdapConfigEntity.java
@@ -3,22 +3,70 @@ package com.sequenceiq.it.cloudbreak.newway;
 import com.sequenceiq.cloudbreak.api.model.DirectoryType;
 import com.sequenceiq.cloudbreak.api.model.ldap.LdapConfigRequest;
 import com.sequenceiq.cloudbreak.api.model.ldap.LdapConfigResponse;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+
+import javax.ws.rs.WebApplicationException;
 
 public class LdapConfigEntity extends AbstractCloudbreakEntity<LdapConfigRequest, LdapConfigResponse, LdapConfigEntity> {
     public static final String LDAP_CONFIG = "LDAP_CONFIG";
 
-    LdapConfigEntity(String newId) {
+    public LdapConfigEntity(String newId) {
         super(newId);
         setRequest(new LdapConfigRequest());
     }
 
-    LdapConfigEntity() {
+    public LdapConfigEntity() {
         this(LDAP_CONFIG);
+    }
+
+    public LdapConfigEntity(TestContext testContext) {
+        super(new LdapConfigRequest(), testContext);
+    }
+
+    @Override
+    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
+        LOGGER.info("Cleaning up resource with name: {}", getName());
+        try {
+            cloudbreakClient.getCloudbreakClient().ldapConfigV3Endpoint().deleteInWorkspace(cloudbreakClient.getWorkspaceId(), getName());
+        } catch (WebApplicationException ignore) {
+            LOGGER.info("Something happend.");
+        }
+    }
+
+    public LdapConfigEntity valid() {
+        return withName(getNameCreator().getRandomNameForMock())
+                .withBindPassword("bindPassword")
+                .withAdminGroup("group")
+                .withBindDn("bindDn")
+                .withDescription("descrition")
+                .withDirectoryType(DirectoryType.LDAP)
+                .withDomain("domain")
+                .withGroupMemberAttribute("memberAttribute")
+                .withGroupNameAttribute("nameAttribute")
+                .withGroupObjectClass("groupObjectClass")
+                .withGroupSearchBase("groupSearchBase")
+                .withProtocol("http")
+                .withServerPort(1234)
+                .withServerHost("host")
+                .withUserNameAttribute("userNameAttribute")
+                .withUserObjectClass("userObjectClass")
+                .withUserSearchBase("userSearchBase")
+                .withUserDnPattern("userDnPattern");
+    }
+
+    public LdapConfigEntity withRequest(LdapConfigRequest request) {
+        setRequest(request);
+        return this;
     }
 
     public LdapConfigEntity withName(String name) {
         getRequest().setName(name);
         setName(name);
+        return this;
+    }
+
+    public LdapConfigEntity withUserDnPattern(String userDnPattern) {
+        getRequest().setUserDnPattern(userDnPattern);
         return this;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/ProxyConfig.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/ProxyConfig.java
@@ -5,6 +5,9 @@ import java.util.function.Function;
 
 import com.sequenceiq.cloudbreak.api.model.proxy.ProxyConfigRequest;
 import com.sequenceiq.it.IntegrationTestContext;
+import com.sequenceiq.it.cloudbreak.newway.action.ActionV2;
+import com.sequenceiq.it.cloudbreak.newway.action.ProxyConfigPostAction;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
 import com.sequenceiq.it.cloudbreak.newway.v3.ProxyConfigV3Action;
 
 public class ProxyConfig extends ProxyConfigEntity {
@@ -74,5 +77,16 @@ public class ProxyConfig extends ProxyConfigEntity {
 
     public static Assertion<ProxyConfig> assertThis(BiConsumer<ProxyConfig, IntegrationTestContext> check) {
         return new Assertion<>(getTestContext(GherkinTest.RESULT), check);
+    }
+
+    public static ProxyConfigEntity getByName(TestContext testContext, ProxyConfigEntity entity, CloudbreakClient cloudbreakClient) {
+        entity.setResponse(
+                cloudbreakClient.getCloudbreakClient().proxyConfigV3Endpoint().getByNameInWorkspace(cloudbreakClient.getWorkspaceId(), entity.getName())
+        );
+        return entity;
+    }
+
+    public static ActionV2<ProxyConfigEntity> postV2() {
+        return new ProxyConfigPostAction();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/RdsConfig.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/RdsConfig.java
@@ -4,8 +4,12 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 import com.sequenceiq.it.IntegrationTestContext;
+import com.sequenceiq.it.cloudbreak.newway.action.ActionV2;
+import com.sequenceiq.it.cloudbreak.newway.action.RdsConfigPostAction;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
 import com.sequenceiq.it.cloudbreak.newway.v3.RdsConfigV3Action;
 
+@Prototype
 public class RdsConfig extends RdsConfigEntity {
     private static final String RDSCONFIG = "RDSCONFIG";
 
@@ -15,6 +19,10 @@ public class RdsConfig extends RdsConfigEntity {
 
     protected RdsConfig(String newId) {
         super(newId);
+    }
+
+    public RdsConfig(TestContext testContext) {
+        super(testContext);
     }
 
     private static Function<IntegrationTestContext, RdsConfig> getTestContext(String key) {
@@ -85,5 +93,9 @@ public class RdsConfig extends RdsConfigEntity {
 
     public static Assertion<RdsConfig> assertThis(BiConsumer<RdsConfig, IntegrationTestContext> check) {
         return new Assertion<>(getTestContext(GherkinTest.RESULT), check);
+    }
+
+    public static ActionV2<RdsConfigEntity> postV2() {
+        return new RdsConfigPostAction();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/RdsConfigEntity.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/RdsConfigEntity.java
@@ -3,6 +3,9 @@ package com.sequenceiq.it.cloudbreak.newway;
 import com.sequenceiq.cloudbreak.api.model.rds.RDSConfigRequest;
 import com.sequenceiq.cloudbreak.api.model.rds.RDSConfigResponse;
 import com.sequenceiq.cloudbreak.api.model.rds.RdsTestResult;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+
+import javax.ws.rs.WebApplicationException;
 
 public class RdsConfigEntity extends AbstractCloudbreakEntity<RDSConfigRequest, RDSConfigResponse, RdsConfigEntity> {
 
@@ -17,6 +20,33 @@ public class RdsConfigEntity extends AbstractCloudbreakEntity<RDSConfigRequest, 
 
     RdsConfigEntity() {
         this(RDS_CONFIG);
+    }
+
+    public RdsConfigEntity(TestContext testContext) {
+        super(new RDSConfigRequest(), testContext);
+    }
+
+    @Override
+    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
+        LOGGER.info("Cleaning up resource with name: {}", getName());
+        try {
+            cloudbreakClient.getCloudbreakClient().rdsConfigV3Endpoint().deleteInWorkspace(cloudbreakClient.getWorkspaceId(), getName());
+        } catch (WebApplicationException ignore) {
+            LOGGER.info("Something happend.");
+        }
+    }
+
+    public RdsConfigEntity valid() {
+        return withName(getNameCreator().getRandomNameForMock())
+                .withConnectionUserName("user")
+                .withConnectionPassword("password")
+                .withConnectionURL("jdbc:postgresql://somedb.com:5432/mydb")
+                .withType("HIVE");
+    }
+
+    public RdsConfigEntity withRequest(RDSConfigRequest request) {
+        setRequest(request);
+        return this;
     }
 
     public RdsConfigEntity withName(String name) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/Recipe.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/Recipe.java
@@ -1,12 +1,23 @@
 package com.sequenceiq.it.cloudbreak.newway;
 
+import com.sequenceiq.it.IntegrationTestContext;
+import com.sequenceiq.it.cloudbreak.newway.action.ActionV2;
+import com.sequenceiq.it.cloudbreak.newway.action.RecipePostAction;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.v3.RecipeV3Action;
+
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
-import com.sequenceiq.it.IntegrationTestContext;
-import com.sequenceiq.it.cloudbreak.newway.v3.RecipeV3Action;
-
+@Prototype
 public class Recipe extends RecipeEntity {
+
+    public Recipe() {
+    }
+
+    public Recipe(TestContext testContext) {
+        super(testContext);
+    }
 
     static Function<IntegrationTestContext, Recipe> getTestContext(String key) {
         return testContext -> testContext.getContextParam(key, Recipe.class);
@@ -30,6 +41,13 @@ public class Recipe extends RecipeEntity {
         Recipe recipe = new Recipe();
         recipe.setCreationStrategy(RecipeV3Action::createDeleteInGiven);
         return recipe;
+    }
+
+    public static RecipeEntity getByName(TestContext testContext, RecipeEntity entity, CloudbreakClient cloudbreakClient) {
+        entity.setResponse(
+                cloudbreakClient.getCloudbreakClient().recipeV3Endpoint().getByNameInWorkspace(cloudbreakClient.getWorkspaceId(), entity.getName())
+        );
+        return entity;
     }
 
     public static Action<Recipe> post(String key) {
@@ -62,5 +80,9 @@ public class Recipe extends RecipeEntity {
 
     public static Assertion<Recipe> assertThis(BiConsumer<Recipe, IntegrationTestContext> check) {
         return new Assertion<>(getTestContext(GherkinTest.RESULT), check);
+    }
+
+    public static ActionV2<RecipeEntity> postV2() {
+        return new RecipePostAction();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/RecipeEntity.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/RecipeEntity.java
@@ -3,17 +3,40 @@ package com.sequenceiq.it.cloudbreak.newway;
 import com.sequenceiq.cloudbreak.api.model.RecipeRequest;
 import com.sequenceiq.cloudbreak.api.model.RecipeResponse;
 import com.sequenceiq.cloudbreak.api.model.RecipeType;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+
+import javax.ws.rs.WebApplicationException;
 
 public class RecipeEntity extends AbstractCloudbreakEntity<RecipeRequest, RecipeResponse, RecipeEntity> {
     public static final String RECIPE = "RECIPE";
 
-    RecipeEntity(String newId) {
+    public RecipeEntity(String newId) {
         super(newId);
         setRequest(new RecipeRequest());
     }
 
-    RecipeEntity() {
+    public RecipeEntity() {
         this(RECIPE);
+    }
+
+    public RecipeEntity(TestContext testContext) {
+        super(new RecipeRequest(), testContext);
+    }
+
+    @Override
+    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
+        LOGGER.info("Cleaning up resource with name: {}", getName());
+        try {
+            cloudbreakClient.getCloudbreakClient().recipeV3Endpoint().deleteInWorkspace(cloudbreakClient.getWorkspaceId(), getName());
+        } catch (WebApplicationException ignore) {
+            LOGGER.info("Something happend.");
+        }
+    }
+
+    public RecipeEntity valid() {
+        return withName(getNameCreator().getRandomNameForMock())
+                .withRecipeType(RecipeType.PRE_AMBARI_START)
+                .withContent(String.format("#!/bin/bash%necho ALMAA"));
     }
 
     public RecipeEntity withName(String name) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/Stack.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/Stack.java
@@ -19,6 +19,10 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import com.sequenceiq.it.cloudbreak.newway.action.StackDeleteAction;
+import com.sequenceiq.it.cloudbreak.newway.action.StackStartAction;
+import com.sequenceiq.it.cloudbreak.newway.action.StackStopAction;
+import com.sequenceiq.it.cloudbreak.newway.action.StackSyncPutAction;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -125,6 +129,10 @@ public class Stack extends StackEntity {
 
     public static Action<Stack> delete(String key, Strategy strategy) {
         return new Action<>(getTestContextStack(key), strategy);
+    }
+
+    public static ActionV2<StackEntity> deleteV2() {
+        return new StackDeleteAction();
     }
 
     public static Action<Stack> delete(String key) {
@@ -338,5 +346,17 @@ public class Stack extends StackEntity {
 
     public static Action<Stack> repair(String hostgroupName) {
         return new Action<>(getTestContextStack(), new RepairNodeStrategy(hostgroupName));
+    }
+
+    public static ActionV2<StackEntity> stopV2() {
+        return new StackStopAction();
+    }
+
+    public static ActionV2<StackEntity> startV2() {
+        return new StackStartAction();
+    }
+
+    public static ActionV2<StackEntity> sync() {
+        return new StackSyncPutAction();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/BlueprintPostAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/BlueprintPostAction.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.it.cloudbreak.newway.action;
+
+import com.sequenceiq.it.cloudbreak.newway.BlueprintEntity;
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.sequenceiq.it.cloudbreak.newway.log.Log.log;
+import static com.sequenceiq.it.cloudbreak.newway.log.Log.logJSON;
+import static java.lang.String.format;
+
+public class BlueprintPostAction implements ActionV2<BlueprintEntity> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BlueprintPostAction.class);
+
+    @Override
+    public BlueprintEntity action(TestContext testContext, BlueprintEntity entity, CloudbreakClient client) throws Exception {
+        log(LOGGER, format(" Name: %s", entity.getRequest().getName()));
+        logJSON(LOGGER, format(" Blueprint post request:%n"), entity.getRequest());
+        entity.setResponse(
+                client.getCloudbreakClient()
+                        .blueprintV3Endpoint()
+                        .createInWorkspace(client.getWorkspaceId(), entity.getRequest()));
+        logJSON(LOGGER, format(" Blueprint created  successfully:%n"), entity.getResponse());
+        log(LOGGER, format(" ID: %s", entity.getResponse().getId()));
+
+        return entity;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/CredentialPostAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/CredentialPostAction.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.it.cloudbreak.newway.action;
+
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.CredentialEntity;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.sequenceiq.it.cloudbreak.newway.log.Log.log;
+import static com.sequenceiq.it.cloudbreak.newway.log.Log.logJSON;
+import static java.lang.String.format;
+
+public class CredentialPostAction implements ActionV2<CredentialEntity> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CredentialPostAction.class);
+
+    @Override
+    public CredentialEntity action(TestContext testContext, CredentialEntity entity, CloudbreakClient client) throws Exception {
+        log(LOGGER, format(" Name: %s", entity.getRequest().getName()));
+        logJSON(LOGGER, format(" Credential post request:%n"), entity.getRequest());
+        entity.setResponse(
+                client.getCloudbreakClient()
+                        .credentialV3Endpoint()
+                        .createInWorkspace(client.getWorkspaceId(), entity.getRequest()));
+        logJSON(LOGGER, format(" Credential created  successfully:%n"), entity.getResponse());
+        log(LOGGER, format(" ID: %s", entity.getResponse().getId()));
+
+        return entity;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/ImageCatalogPostAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/ImageCatalogPostAction.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.it.cloudbreak.newway.action;
+
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.ImageCatalogEntity;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.sequenceiq.it.cloudbreak.newway.log.Log.log;
+import static com.sequenceiq.it.cloudbreak.newway.log.Log.logJSON;
+import static java.lang.String.format;
+
+public class ImageCatalogPostAction implements ActionV2<ImageCatalogEntity> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ImageCatalogPostAction.class);
+
+    @Override
+    public ImageCatalogEntity action(TestContext testContext, ImageCatalogEntity entity, CloudbreakClient client) throws Exception {
+        log(LOGGER, format(" Name: %s", entity.getRequest().getName()));
+        logJSON(LOGGER, format(" Image catalog post request:%n"), entity.getRequest());
+        entity.setResponse(
+                client.getCloudbreakClient()
+                        .imageCatalogV3Endpoint()
+                        .createInWorkspace(client.getWorkspaceId(), entity.getRequest()));
+        logJSON(LOGGER, format(" Image catalog created  successfully:%n"), entity.getResponse());
+        log(LOGGER, format(" ID: %s", entity.getResponse().getId()));
+
+        return entity;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/LdapConfigPostAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/LdapConfigPostAction.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.it.cloudbreak.newway.action;
+
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.LdapConfigEntity;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.sequenceiq.it.cloudbreak.newway.log.Log.log;
+import static com.sequenceiq.it.cloudbreak.newway.log.Log.logJSON;
+import static java.lang.String.format;
+
+public class LdapConfigPostAction implements ActionV2<LdapConfigEntity> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LdapConfigPostAction.class);
+
+    @Override
+    public LdapConfigEntity action(TestContext testContext, LdapConfigEntity entity, CloudbreakClient client) throws Exception {
+        log(LOGGER, format(" Name: %s", entity.getRequest().getName()));
+        logJSON(LOGGER, format(" Ldap post request:%n"), entity.getRequest());
+        entity.setResponse(
+                client.getCloudbreakClient()
+                        .ldapConfigV3Endpoint()
+                        .createInWorkspace(client.getWorkspaceId(), entity.getRequest()));
+        logJSON(LOGGER, format(" Ldap created  successfully:%n"), entity.getResponse());
+        log(LOGGER, format(" ID: %s", entity.getResponse().getId()));
+
+        return entity;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/ProxyConfigPostAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/ProxyConfigPostAction.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.it.cloudbreak.newway.action;
+
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.ProxyConfigEntity;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.sequenceiq.it.cloudbreak.newway.log.Log.log;
+import static com.sequenceiq.it.cloudbreak.newway.log.Log.logJSON;
+import static java.lang.String.format;
+
+public class ProxyConfigPostAction implements ActionV2<ProxyConfigEntity> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProxyConfigPostAction.class);
+
+    @Override
+    public ProxyConfigEntity action(TestContext testContext, ProxyConfigEntity entity, CloudbreakClient client) throws Exception {
+        log(LOGGER, format(" Name: %s", entity.getRequest().getName()));
+        logJSON(LOGGER, format(" Proxy config post request:%n"), entity.getRequest());
+        entity.setResponse(
+                client.getCloudbreakClient()
+                        .proxyConfigV3Endpoint()
+                        .createInWorkspace(client.getWorkspaceId(), entity.getRequest()));
+        logJSON(LOGGER, format(" Image config created  successfully:%n"), entity.getResponse());
+        log(LOGGER, format(" ID: %s", entity.getResponse().getId()));
+
+        return entity;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/RdsConfigPostAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/RdsConfigPostAction.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.it.cloudbreak.newway.action;
+
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.RdsConfigEntity;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.sequenceiq.it.cloudbreak.newway.log.Log.log;
+import static com.sequenceiq.it.cloudbreak.newway.log.Log.logJSON;
+import static java.lang.String.format;
+
+public class RdsConfigPostAction implements ActionV2<RdsConfigEntity> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RdsConfigPostAction.class);
+
+    @Override
+    public RdsConfigEntity action(TestContext testContext, RdsConfigEntity entity, CloudbreakClient client) throws Exception {
+        log(LOGGER, format(" Name: %s", entity.getRequest().getName()));
+        logJSON(LOGGER, format(" RDS post request:%n"), entity.getRequest());
+        entity.setResponse(
+                client.getCloudbreakClient()
+                        .rdsConfigV3Endpoint()
+                        .createInWorkspace(client.getWorkspaceId(), entity.getRequest()));
+        logJSON(LOGGER, format(" RDS created  successfully:%n"), entity.getResponse());
+        log(LOGGER, format(" ID: %s", entity.getResponse().getId()));
+
+        return entity;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/RecipePostAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/RecipePostAction.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.it.cloudbreak.newway.action;
+
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.RecipeEntity;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.sequenceiq.it.cloudbreak.newway.log.Log.log;
+import static com.sequenceiq.it.cloudbreak.newway.log.Log.logJSON;
+import static java.lang.String.format;
+
+public class RecipePostAction implements ActionV2<RecipeEntity> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RecipePostAction.class);
+
+    @Override
+    public RecipeEntity action(TestContext testContext, RecipeEntity entity, CloudbreakClient client) throws Exception {
+        log(LOGGER, format(" Name: %s", entity.getRequest().getName()));
+        logJSON(LOGGER, format(" Recipe post request:%n"), entity.getRequest());
+        entity.setResponse(
+                client.getCloudbreakClient()
+                        .recipeV3Endpoint()
+                        .createInWorkspace(client.getWorkspaceId(), entity.getRequest()));
+        logJSON(LOGGER, format(" Recipe created  successfully:%n"), entity.getResponse());
+        log(LOGGER, format(" ID: %s", entity.getResponse().getId()));
+
+        return entity;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/StackDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/StackDeleteAction.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.it.cloudbreak.newway.action;
+
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.StackEntity;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.sequenceiq.it.cloudbreak.newway.log.Log.log;
+import static com.sequenceiq.it.cloudbreak.newway.log.Log.logJSON;
+import static java.lang.String.format;
+
+public class StackDeleteAction implements ActionV2<StackEntity> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StackDeleteAction.class);
+
+    @Override
+    public StackEntity action(TestContext testContext, StackEntity entity, CloudbreakClient client) throws Exception {
+        log(LOGGER, format(" Name: %s", entity.getRequest().getGeneral().getName()));
+        logJSON(LOGGER, format(" Stack delete request:%n"), entity.getRequest());
+        client.getCloudbreakClient()
+                .stackV3Endpoint()
+                .deleteInWorkspace(client.getWorkspaceId(), entity.getName(), false, false);
+        logJSON(LOGGER, format(" Stack deletion was successful:%n"), entity.getResponse());
+        log(LOGGER, format(" ID: %s", entity.getResponse().getId()));
+        return entity;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/StackNodeUnhealthyAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/StackNodeUnhealthyAction.java
@@ -1,0 +1,61 @@
+package com.sequenceiq.it.cloudbreak.newway.action;
+
+import com.sequenceiq.cloudbreak.api.model.FailureReport;
+import com.sequenceiq.cloudbreak.api.model.stack.instance.InstanceGroupResponse;
+import com.sequenceiq.cloudbreak.api.model.stack.instance.InstanceMetaDataJson;
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.StackEntity;
+import com.sequenceiq.it.cloudbreak.newway.actor.Actor;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.Response;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static com.sequenceiq.it.cloudbreak.newway.CloudbreakTest.SECOND_USER;
+import static com.sequenceiq.it.cloudbreak.newway.log.Log.log;
+import static com.sequenceiq.it.cloudbreak.newway.log.Log.logJSON;
+import static java.lang.String.format;
+
+public class StackNodeUnhealthyAction implements ActionV2<StackEntity> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StackNodeUnhealthyAction.class);
+
+    private final String hostgroup;
+
+    private final int nodeCount;
+
+    public StackNodeUnhealthyAction(String hostgroup, int nodeCount) {
+        this.hostgroup = hostgroup;
+        this.nodeCount = nodeCount;
+    }
+
+    @Override
+    public StackEntity action(TestContext testContext, StackEntity entity, CloudbreakClient client) throws Exception {
+        log(LOGGER, format(" Name: %s", entity.getRequest().getGeneral().getName()));
+        logJSON(LOGGER, format(" Stack unhealthy request:%n"), entity.getRequest());
+        FailureReport failureReport = new FailureReport();
+        failureReport.setFailedNodes(getNodes(getInstanceGroupResponse(entity)));
+        CloudbreakClient autoscaleClient = testContext.as(Actor::secondUser).getCloudbreakClient(SECOND_USER);
+        try (Response toClose = autoscaleClient.getCloudbreakClient().autoscaleEndpoint()
+                .failureReport(Objects.requireNonNull(entity.getResponse().getId()), failureReport)) {
+            logJSON(LOGGER, format(" Stack unhealthy was successful:%n"), entity.getResponse());
+            log(LOGGER, format(" ID: %s", entity.getResponse().getId()));
+            return entity;
+        }
+    }
+
+    private InstanceGroupResponse getInstanceGroupResponse(StackEntity entity) {
+        return entity.getResponse().getInstanceGroups().stream()
+                .filter(ig -> ig.getGroup().equals(hostgroup)).collect(Collectors.toList()).get(0);
+    }
+
+    private List<String> getNodes(InstanceGroupResponse instanceGroup) {
+        return instanceGroup.getMetadata().stream()
+                .map(InstanceMetaDataJson::getDiscoveryFQDN).collect(Collectors.toList()).subList(0, nodeCount);
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/StackStartAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/StackStartAction.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.it.cloudbreak.newway.action;
+
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.StackEntity;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.Response;
+
+import static com.sequenceiq.it.cloudbreak.newway.log.Log.log;
+import static com.sequenceiq.it.cloudbreak.newway.log.Log.logJSON;
+import static java.lang.String.format;
+
+public class StackStartAction implements ActionV2<StackEntity> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StackStartAction.class);
+
+    @Override
+    public StackEntity action(TestContext testContext, StackEntity entity, CloudbreakClient client) throws Exception {
+        log(LOGGER, format(" Name: %s", entity.getRequest().getGeneral().getName()));
+        logJSON(LOGGER, format(" Stack post request:%n"), entity.getRequest());
+        try (Response response = client.getCloudbreakClient()
+                .stackV3Endpoint()
+                .putStartInWorkspace(client.getWorkspaceId(), entity.getName())) {
+            logJSON(LOGGER, format(" Stack created  successfully:%n"), entity.getResponse());
+            log(LOGGER, format(" ID: %s", entity.getResponse().getId()));
+        }
+
+        return entity;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/StackStopAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/StackStopAction.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.it.cloudbreak.newway.action;
+
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.StackEntity;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.Response;
+
+import static com.sequenceiq.it.cloudbreak.newway.log.Log.log;
+import static com.sequenceiq.it.cloudbreak.newway.log.Log.logJSON;
+import static java.lang.String.format;
+
+public class StackStopAction implements ActionV2<StackEntity> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StackStopAction.class);
+
+    @Override
+    public StackEntity action(TestContext testContext, StackEntity entity, CloudbreakClient client) throws Exception {
+        log(LOGGER, format(" Name: %s", entity.getRequest().getGeneral().getName()));
+        logJSON(LOGGER, format(" Stack post request:%n"), entity.getRequest());
+        try (Response response = client.getCloudbreakClient()
+                .stackV3Endpoint()
+                .putStopInWorkspace(client.getWorkspaceId(), entity.getName())) {
+            logJSON(LOGGER, format(" Stack created  successfully:%n"), entity.getResponse());
+            log(LOGGER, format(" ID: %s", entity.getResponse().getId()));
+        }
+
+        return entity;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/StackSyncPutAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/StackSyncPutAction.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.it.cloudbreak.newway.action;
+
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.StackEntity;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.Response;
+
+import static com.sequenceiq.it.cloudbreak.newway.log.Log.log;
+import static com.sequenceiq.it.cloudbreak.newway.log.Log.logJSON;
+import static java.lang.String.format;
+
+public class StackSyncPutAction implements ActionV2<StackEntity> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StackSyncPutAction.class);
+
+    @Override
+    public StackEntity action(TestContext testContext, StackEntity entity, CloudbreakClient client) throws Exception {
+        log(LOGGER, format(" Name: %s", entity.getRequest().getGeneral().getName()));
+        logJSON(LOGGER, format(" Stack put request:%n"), entity.getRequest());
+        try (Response response = client.getCloudbreakClient()
+                .stackV3Endpoint()
+                .putSyncInWorkspace(client.getWorkspaceId(), entity.getName())) {
+            logJSON(LOGGER, format(" Stack sync successfull:%n"), entity.getResponse());
+            log(LOGGER, format(" ID: %s", entity.getResponse().getId()));
+        }
+
+        return entity;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/context/TestContext.java
@@ -330,7 +330,7 @@ public class TestContext implements ApplicationContextAware {
         return entity;
     }
 
-    private CloudbreakClient getCloudbreakClient(String who) {
+    public CloudbreakClient getCloudbreakClient(String who) {
         CloudbreakClient cloudbreakClient = clients.get(who);
         if (cloudbreakClient == null) {
             throw new IllegalStateException("Should create a client for this user: " + who);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/entity/InstanceGroupEntity.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/entity/InstanceGroupEntity.java
@@ -77,6 +77,13 @@ public class InstanceGroupEntity extends AbstractCloudbreakEntity<InstanceGroupV
         return this;
     }
 
+    public InstanceGroupEntity withRecipes(String... recipeNames) {
+        for (String recipeName : recipeNames) {
+            getRequest().getRecipeNames().add(recipeName);
+        }
+        return this;
+    }
+
     public InstanceGroupEntity withGroup(String group) {
         getRequest().setGroup(group);
         return this;
@@ -105,10 +112,6 @@ public class InstanceGroupEntity extends AbstractCloudbreakEntity<InstanceGroupV
     private RecoveryMode getRecoveryModeParam(HostGroupType hostGroupType) {
         String argumentName = String.join("", hostGroupType.getName(), RECOVERY_MODE);
         String argumentValue = getTestParameter().getWithDefault(argumentName, MANUAL);
-        if (argumentValue.equals(AUTO)) {
-            return RecoveryMode.AUTO;
-        } else {
-            return RecoveryMode.MANUAL;
-        }
+        return argumentValue.equals(AUTO) ? RecoveryMode.AUTO : RecoveryMode.MANUAL;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/mock/DefaultModel.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/mock/DefaultModel.java
@@ -47,6 +47,10 @@ public class DefaultModel extends MockModel {
         saltMock.addSaltMappings();
     }
 
+    public SPIMock getSpiMock() {
+        return spiMock;
+    }
+
     public AmbariMock getAmbariMock() {
         return ambariMock;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/mock/model/SPIMock.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/mock/model/SPIMock.java
@@ -1,21 +1,20 @@
 package com.sequenceiq.it.cloudbreak.newway.mock.model;
 
-import static com.sequenceiq.it.cloudbreak.newway.Mock.gson;
-import static com.sequenceiq.it.spark.ITResponse.MOCK_ROOT;
-
-import java.util.List;
-import java.util.Map;
-
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudVmMetaDataStatus;
 import com.sequenceiq.it.cloudbreak.newway.mock.AbstractModelMock;
 import com.sequenceiq.it.cloudbreak.newway.mock.DefaultModel;
+import com.sequenceiq.it.spark.DynamicRouteStack;
 import com.sequenceiq.it.spark.spi.CloudMetaDataStatuses;
 import com.sequenceiq.it.spark.spi.CloudVmInstanceStatuses;
-
 import spark.Service;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.sequenceiq.it.spark.ITResponse.MOCK_ROOT;
 
 public class SPIMock extends AbstractModelMock {
 
@@ -25,32 +24,38 @@ public class SPIMock extends AbstractModelMock {
 
     public static final String CLOUD_METADATA_STATUSES = "/cloud_metadata_statuses";
 
+    private DynamicRouteStack dynamicRouteStack;
+
     public SPIMock(Service sparkService, DefaultModel defaultModel) {
         super(sparkService, defaultModel);
+        dynamicRouteStack = new DynamicRouteStack(sparkService, defaultModel);
     }
 
     public void addSPIEndpoints() {
-        Service sparkService = getSparkService();
         Map<String, CloudVmMetaDataStatus> instanceMap = getDefaultModel().getInstanceMap();
-        postMockProviderMetadataStatus(sparkService, instanceMap);
-        postMockProviderInstanceStatus(sparkService, instanceMap);
-        postMockProviderTerminateInstance(sparkService, instanceMap);
+        postMockProviderMetadataStatus(instanceMap);
+        postMockProviderInstanceStatus(instanceMap);
+        postMockProviderTerminateInstance(instanceMap);
     }
 
-    private void postMockProviderTerminateInstance(Service sparkService, Map<String, CloudVmMetaDataStatus> instanceMap) {
-        sparkService.post(MOCK_ROOT + TERMINATE_INSTANCES, (request, response) -> {
+    public DynamicRouteStack getDynamicRouteStack() {
+        return dynamicRouteStack;
+    }
+
+    private void postMockProviderTerminateInstance(Map<String, CloudVmMetaDataStatus> instanceMap) {
+        dynamicRouteStack.post(MOCK_ROOT + TERMINATE_INSTANCES, (request, response) -> {
             List<CloudInstance> cloudInstances = new Gson().fromJson(request.body(), new TypeToken<List<CloudInstance>>() {
             }.getType());
             cloudInstances.forEach(cloudInstance -> getDefaultModel().terminateInstance(instanceMap, cloudInstance.getInstanceId()));
             return null;
-        }, gson()::toJson);
+        });
     }
 
-    private void postMockProviderInstanceStatus(Service sparkService, Map<String, CloudVmMetaDataStatus> instanceMap) {
-        sparkService.post(MOCK_ROOT + CLOUD_INSTANCE_STATUSES, new CloudVmInstanceStatuses(instanceMap), gson()::toJson);
+    private void postMockProviderInstanceStatus(Map<String, CloudVmMetaDataStatus> instanceMap) {
+        dynamicRouteStack.post(MOCK_ROOT + CLOUD_INSTANCE_STATUSES, new CloudVmInstanceStatuses(instanceMap));
     }
 
-    private void postMockProviderMetadataStatus(Service sparkService, Map<String, CloudVmMetaDataStatus> instanceMap) {
-        sparkService.post(MOCK_ROOT + CLOUD_METADATA_STATUSES, new CloudMetaDataStatuses(instanceMap), gson()::toJson);
+    private void postMockProviderMetadataStatus(Map<String, CloudVmMetaDataStatus> instanceMap) {
+        dynamicRouteStack.post(MOCK_ROOT + CLOUD_METADATA_STATUSES, new CloudMetaDataStatuses(instanceMap));
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/AbstractIntegrationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/AbstractIntegrationTest.java
@@ -37,6 +37,8 @@ public abstract class AbstractIntegrationTest extends AbstractTestNGSpringContex
 
     protected static final Map<String, String> STACK_FAILED = Map.of("status", "AVAILABLE", "clusterStatus", "CREATE_FAILED");
 
+    protected static final Map<String, String> STACK_STOPPED = Map.of("status", "STOPPED", "clusterStatus", "STOPPED");
+
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractIntegrationTest.class);
 
     @Value("${integrationtest.cleanup.cleanupBeforeStart:false}")

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/ClusterStopTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/ClusterStopTest.java
@@ -1,0 +1,97 @@
+package com.sequenceiq.it.cloudbreak.newway.testcase;
+
+import static com.sequenceiq.cloudbreak.cloud.model.InstanceStatus.STARTED;
+import static com.sequenceiq.cloudbreak.cloud.model.InstanceStatus.STOPPED;
+import static com.sequenceiq.it.cloudbreak.newway.Mock.gson;
+import static com.sequenceiq.it.spark.ITResponse.MOCK_ROOT;
+import static java.lang.String.format;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static javax.ws.rs.core.Response.Status.OK;
+
+import javax.inject.Inject;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.sequenceiq.it.cloudbreak.newway.RandomNameCreator;
+import com.sequenceiq.it.cloudbreak.newway.Stack;
+import com.sequenceiq.it.cloudbreak.newway.StackEntity;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.mock.model.SPIMock;
+import com.sequenceiq.it.spark.StatefulRoute;
+import com.sequenceiq.it.spark.spi.CloudVmInstanceStatuses;
+
+import spark.Route;
+
+public class ClusterStopTest extends AbstractIntegrationTest {
+
+    private static final String TEST_CONTEXT = "testContext";
+
+    private static final String CLOUD_INSTANCE_STATUSES = MOCK_ROOT + SPIMock.CLOUD_INSTANCE_STATUSES;
+
+    @Inject
+    private RandomNameCreator creator;
+
+    @BeforeMethod
+    public void beforeMethod(Object[] data) {
+        TestContext testContext = (TestContext) data[0];
+        createDefaultUser(testContext);
+        createDefaultCredential(testContext);
+        createDefaultImageCatalog(testContext);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tear(Object[] data) {
+        ((TestContext) data[0]).cleanupTestContextEntity();
+    }
+
+    @Test(dataProvider = TEST_CONTEXT)
+    public void testClusterStop(TestContext testContext) {
+        String clusterName = creator.getRandomNameForMock();
+        mockAmbari(testContext, clusterName);
+        mockSpi(testContext);
+        testContext
+                .given(StackEntity.class).valid().withName(clusterName)
+                .when(Stack.postV2())
+                .await(STACK_AVAILABLE)
+                .when(Stack.stopV2())
+                .await(STACK_STOPPED)
+                .validate();
+    }
+
+    private void mockAmbari(TestContext testContext, String clusterName) {
+        Route passAmbari = (request, response) -> {
+            response.type(TEXT_PLAIN);
+            response.status(OK.getStatusCode());
+            response.body(format("{\"href\":\"%s\",\"Requests\":{\"id\":12,\"status\":\"Accepted\"}}", request.url()));
+            return "";
+        };
+
+        testContext.getModel().getAmbariMock().getDynamicRouteStack().clearPost(format("/api/v1/clusters/%s/*", clusterName));
+        testContext.getModel().getAmbariMock().getDynamicRouteStack().put(format("/api/v1/clusters/%s/*", clusterName), passAmbari);
+    }
+
+    private void mockSpi(TestContext testContext) {
+        StatefulRoute okState = (request, response, model) -> {
+            String resultJson = gson().toJson(new CloudVmInstanceStatuses(model.getInstanceMap()).createCloudVmInstanceStatuses());
+            response.body(resultJson);
+            response.type(TEXT_PLAIN);
+            response.status(OK.getStatusCode());
+            return "";
+        };
+
+        StatefulRoute stoppedStateSpi = (request, response, model) -> {
+            String resultJson = gson().toJson(new CloudVmInstanceStatuses(model.getInstanceMap()).createCloudVmInstanceStatuses());
+            response.body(resultJson.replaceAll(STARTED.name(), STOPPED.name()));
+            response.type(TEXT_PLAIN);
+            response.status(OK.getStatusCode());
+            return "";
+        };
+
+        testContext.getModel().getSpiMock().getDynamicRouteStack().clearPost(CLOUD_INSTANCE_STATUSES);
+        testContext.getModel().getSpiMock().getDynamicRouteStack().post(CLOUD_INSTANCE_STATUSES, okState);
+        testContext.getModel().getSpiMock().getDynamicRouteStack().post(CLOUD_INSTANCE_STATUSES, stoppedStateSpi);
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/KerberosTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/KerberosTest.java
@@ -1,0 +1,327 @@
+package com.sequenceiq.it.cloudbreak.newway.testcase;
+
+import static com.sequenceiq.it.cloudbreak.newway.cloud.HostGroupType.MASTER;
+import static com.sequenceiq.it.cloudbreak.newway.context.RunningParameter.key;
+import static com.sequenceiq.it.cloudbreak.newway.mock.model.SaltMock.SALT_RUN;
+import static com.sequenceiq.it.spark.ITResponse.AMBARI_API_ROOT;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static javax.ws.rs.core.Response.Status.OK;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.ws.rs.BadRequestException;
+
+import org.springframework.http.HttpMethod;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.sequenceiq.cloudbreak.api.model.KerberosRequest;
+import com.sequenceiq.it.cloudbreak.newway.Blueprint;
+import com.sequenceiq.it.cloudbreak.newway.BlueprintEntity;
+import com.sequenceiq.it.cloudbreak.newway.RandomNameCreator;
+import com.sequenceiq.it.cloudbreak.newway.Stack;
+import com.sequenceiq.it.cloudbreak.newway.StackEntity;
+import com.sequenceiq.it.cloudbreak.newway.assertion.AssertionV2;
+import com.sequenceiq.it.cloudbreak.newway.assertion.MockVerification;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.AmbariEntity;
+import com.sequenceiq.it.cloudbreak.newway.entity.ClusterEntity;
+import com.sequenceiq.it.cloudbreak.newway.entity.InstanceGroupEntity;
+
+import spark.Route;
+
+public class KerberosTest extends AbstractIntegrationTest {
+
+    private static final String TEST_CONTEXT = "testContext";
+
+    private static final String LDAP_SYNC_PATH = "/api/v1/ldap_sync_events";
+
+    private static final String SALT_HIGHSTATE = "state.highstate";
+
+    private static final String BLUEPRINT_TEXT = "{\"Blueprints\":{\"blueprint_name\":\"ownbp\",\"stack_name\":\"HDF\",\"stack_version\":\"3.2\"},\"settings\""
+            + ":[{\"recovery_settings\":[]},{\"service_settings\":[]},{\"component_settings\":[]}],\"configurations\":[],\"host_groups\":[{\"name\":\"master\","
+            + "\"configurations\":[],\"components\":[{\"name\":\"METRICS_MONITOR\"},{\"name\":\"METRICS_COLLECTOR\"},{\"name\":\"ZOOKEEPER_CLIENT\"}],"
+            + "\"cardinality\":\"1\"}]}";
+
+    @Inject
+    private RandomNameCreator creator;
+
+    @BeforeMethod
+    public void beforeMethod(Object[] data) {
+        TestContext testContext = (TestContext) data[0];
+        createDefaultUser(testContext);
+        createDefaultCredential(testContext);
+        createDefaultImageCatalog(testContext);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tear(Object[] data) {
+        ((TestContext) data[0]).cleanupTestContextEntity();
+    }
+
+    @Test(dataProvider = "dataProviderForTest")
+    public void testClusterCreationWithValidKerberos(TestContext testContext, String blueprintName, KerberosTestData testData) {
+        mockAmbariBlueprintPassLdapSync(testContext);
+        testContext
+                .given(BlueprintEntity.class).valid().withName(blueprintName).withAmbariBlueprint(BLUEPRINT_TEXT)
+                .when(Blueprint.postV2())
+                .given("master", InstanceGroupEntity.class).valid().withHostGroup(MASTER).withNodeCount(1)
+                .given(StackEntity.class)
+                .withInstanceGroups("master")
+                .withCluster(new ClusterEntity(testContext)
+                        .valid()
+                        .withAmbariRequest(new AmbariEntity(testContext)
+                                .valid()
+                                .withKerberos(testData.getRequest())
+                                .withBlueprintName(blueprintName)
+                                .withEnableSecurity(true)))
+                .when(Stack.postV2())
+                .await(STACK_AVAILABLE)
+                .then(testData.getAssertions())
+                .validate();
+    }
+
+    @Test(dataProvider = TEST_CONTEXT)
+    public void testClusterCreationAttemptWithKerberosWhenDescriptorIsAnInvalidJson(TestContext testContext) {
+        mockAmbariBlueprintPassLdapSync(testContext);
+        String blueprintName = creator.getRandomNameForMock();
+        KerberosRequest request = KerberosTestData.CUSTOM.getRequest();
+        request.setDescriptor("{\"kerberos-env\":{\"properties\":{\"kdc_type\":\"mit-kdc\",\"kdc_hosts\":\"kdc-host-value\",\"admin_server_host\""
+                + ":\"admin-server-host-value\",\"realm\":\"realm-value\"}}");
+        testContext
+                .given(BlueprintEntity.class).valid().withName(blueprintName).withAmbariBlueprint(BLUEPRINT_TEXT)
+                .when(Blueprint.postV2())
+                .given("master", InstanceGroupEntity.class).valid().withHostGroup(MASTER).withNodeCount(1)
+                .given(StackEntity.class)
+                .withInstanceGroups("master")
+                .withCluster(new ClusterEntity(testContext)
+                        .valid()
+                        .withAmbariRequest(new AmbariEntity(testContext)
+                                .valid()
+                                .withKerberos(request)
+                                .withBlueprintName(blueprintName)
+                                .withEnableSecurity(true)))
+                .when(Stack.postV2(), key("badRequest"))
+                .except(BadRequestException.class, key("badRequest"))
+                .validate();
+    }
+
+    @Test(dataProvider = TEST_CONTEXT)
+    public void testClusterCreationAttemptWithKerberosWhenDescriptorDoesNotContainsAllTheRequiredFields(TestContext testContext) {
+        mockAmbariBlueprintPassLdapSync(testContext);
+        String blueprintName = creator.getRandomNameForMock();
+        KerberosRequest request = KerberosTestData.CUSTOM.getRequest();
+        request.setDescriptor("{\"kerberos-env\":{\"properties\":{\"kdc_type\":\"mit-kdc\",\"kdc_hosts\":\"kdc-host-value\"}}}");
+        testContext
+                .given(BlueprintEntity.class).valid().withName(blueprintName).withAmbariBlueprint(BLUEPRINT_TEXT)
+                .when(Blueprint.postV2())
+                .given("master", InstanceGroupEntity.class).valid().withHostGroup(MASTER).withNodeCount(1)
+                .given(StackEntity.class)
+                .withInstanceGroups("master")
+                .withCluster(new ClusterEntity(testContext)
+                        .valid()
+                        .withAmbariRequest(new AmbariEntity(testContext)
+                                .valid()
+                                .withKerberos(request)
+                                .withBlueprintName(blueprintName)
+                                .withEnableSecurity(true)))
+                .when(Stack.postV2(), key("badRequest"))
+                .except(BadRequestException.class, key("badRequest"))
+                .validate();
+    }
+
+    @Test(dataProvider = TEST_CONTEXT)
+    public void testClusterCreationAttemptWithKerberosWhenKrb5ConfIsNotAValidJson(TestContext testContext) {
+        mockAmbariBlueprintPassLdapSync(testContext);
+        String blueprintName = creator.getRandomNameForMock();
+        KerberosRequest request = KerberosTestData.CUSTOM.getRequest();
+        request.setKrb5Conf("{");
+        testContext
+                .given(BlueprintEntity.class).valid().withName(blueprintName).withAmbariBlueprint(BLUEPRINT_TEXT)
+                .when(Blueprint.postV2())
+                .given("master", InstanceGroupEntity.class).valid().withHostGroup(MASTER).withNodeCount(1)
+                .given(StackEntity.class)
+                .withInstanceGroups("master")
+                .withCluster(new ClusterEntity(testContext)
+                        .valid()
+                        .withAmbariRequest(new AmbariEntity(testContext)
+                                .valid()
+                                .withKerberos(request)
+                                .withBlueprintName(blueprintName)
+                                .withEnableSecurity(true)))
+                .when(Stack.postV2(), key("badRequest"))
+                .except(BadRequestException.class, key("badRequest"))
+                .validate();
+    }
+
+    @DataProvider(name = "dataProviderForTest")
+    public Object[][] provide() {
+        return new Object[][]{
+                {applicationContext.getBean(TestContext.class), creator.getRandomNameForMock(), KerberosTestData.CB_MANAGED},
+                {applicationContext.getBean(TestContext.class), creator.getRandomNameForMock(), KerberosTestData.EXISTING_AD},
+                {applicationContext.getBean(TestContext.class), creator.getRandomNameForMock(), KerberosTestData.EXISTING_MIT},
+                {applicationContext.getBean(TestContext.class), creator.getRandomNameForMock(), KerberosTestData.CUSTOM}
+        };
+    }
+
+    private void mockAmbariBlueprintPassLdapSync(TestContext testContext) {
+        Route customResponse2 = (request, response) -> {
+            if (LDAP_SYNC_PATH.equals(request.url())) {
+                response.type(TEXT_PLAIN);
+                response.status(OK.getStatusCode());
+            }
+            return "";
+        };
+        testContext.getModel().getAmbariMock().getDynamicRouteStack().clearPost(LDAP_SYNC_PATH);
+        testContext.getModel().getAmbariMock().getDynamicRouteStack().post(LDAP_SYNC_PATH, customResponse2);
+    }
+
+    private enum KerberosTestData {
+
+        CB_MANAGED {
+            @Override
+            public List<AssertionV2<StackEntity>> getAssertions() {
+                List<AssertionV2<StackEntity>> verifications = new LinkedList<>();
+                verifications.add(blueprintPostToAmbariContains(getRequest().getMasterKey()).exactTimes(0));
+                verifications.add(blueprintPostToAmbariContains(getRequest().getPassword()).exactTimes(0));
+                verifications.add(blueprintPostToAmbariContains(getRequest().getAdmin()).exactTimes(0));
+                verifications.add(blueprintPostToAmbariContains("KERBEROS_CLIENT").exactTimes(1));
+                verifications.add(MockVerification.verify(HttpMethod.POST, SALT_RUN).bodyContains(SALT_HIGHSTATE).exactTimes(2));
+                verifications.addAll(verifyCloudbreakUserHasSentToCreate());
+                return verifications;
+            }
+
+            @Override
+            public KerberosRequest getRequest() {
+                KerberosRequest request = new KerberosRequest();
+                request.setTcpAllowed(false);
+                request.setMasterKey("masterKey");
+                request.setAdmin("kerberosAdmin");
+                request.setPassword("kerberosPassw0rd");
+                return request;
+            }
+        },
+
+        EXISTING_AD {
+            @Override
+            public List<AssertionV2<StackEntity>> getAssertions() {
+                List<AssertionV2<StackEntity>> verifications = new LinkedList<>();
+                verifications.add(blueprintPostToAmbariContains(getRequest().getPassword()).exactTimes(0));
+                verifications.add(blueprintPostToAmbariContains(getRequest().getPrincipal()).exactTimes(0));
+                verifications.add(blueprintPostToAmbariContains(getRequest().getUrl()).exactTimes(1));
+                verifications.add(blueprintPostToAmbariContains(getRequest().getAdminUrl()).exactTimes(1));
+                verifications.add(blueprintPostToAmbariContains(getRequest().getLdapUrl()).exactTimes(1));
+                verifications.add(blueprintPostToAmbariContains(getRequest().getContainerDn()).exactTimes(1));
+                verifications.add(blueprintPostToAmbariContains("active-directory").exactTimes(1));
+                verifications.add(blueprintPostToAmbariContains("KERBEROS_CLIENT").exactTimes(1));
+                verifications.add(blueprintPostToAmbariContains("realm").exactTimes(1));
+                verifications.add(blueprintPostToAmbariContains("kdc_type").exactTimes(1));
+                verifications.add(blueprintPostToAmbariContains("kdc_hosts").exactTimes(1));
+                verifications.add(blueprintPostToAmbariContains("admin_server_host").exactTimes(1));
+                verifications.add(blueprintPostToAmbariContains("encryption_types").exactTimes(1));
+                verifications.add(blueprintPostToAmbariContains("ldap_url").exactTimes(1));
+                verifications.add(blueprintPostToAmbariContains("container_dn").exactTimes(1));
+                verifications.add(blueprintPostToAmbariContains("KERBEROS_CLIENT").exactTimes(1));
+                verifications.add(MockVerification.verify(HttpMethod.POST, SALT_RUN).bodyContains(SALT_HIGHSTATE).exactTimes(2));
+                verifications.addAll(verifyCloudbreakUserHasSentToCreate());
+                return verifications;
+            }
+
+            @Override
+            public KerberosRequest getRequest() {
+                KerberosRequest request = new KerberosRequest();
+                request.setTcpAllowed(true);
+                request.setPrincipal("admin/principal");
+                request.setPassword("kerberosPassword");
+                request.setUrl("someurl.com");
+                request.setAdminUrl("admin.url.com");
+                request.setRealm("realm");
+                request.setLdapUrl("otherurl.com");
+                request.setContainerDn("{}");
+                return request;
+            }
+        },
+
+        EXISTING_MIT {
+            @Override
+            public List<AssertionV2<StackEntity>> getAssertions() {
+                List<AssertionV2<StackEntity>> verifications = new LinkedList<>();
+                verifications.add(blueprintPostToAmbariContains(getRequest().getRealm().toUpperCase()).exactTimes(1));
+                verifications.add(blueprintPostToAmbariContains(getRequest().getPassword()).exactTimes(0));
+                verifications.add(blueprintPostToAmbariContains(getRequest().getAdminUrl()).exactTimes(1));
+                verifications.add(blueprintPostToAmbariContains(getRequest().getUrl()).exactTimes(1));
+                verifications.add(blueprintPostToAmbariContains("mit-kdc").exactTimes(1));
+                verifications.add(blueprintPostToAmbariContains("realm").exactTimes(1));
+                verifications.add(blueprintPostToAmbariContains("KERBEROS_CLIENT").exactTimes(1));
+                verifications.add(MockVerification.verify(HttpMethod.POST, SALT_RUN).bodyContains(SALT_HIGHSTATE).exactTimes(2));
+                verifications.addAll(verifyCloudbreakUserHasSentToCreate());
+                return verifications;
+            }
+
+            @Override
+            public KerberosRequest getRequest() {
+                KerberosRequest request = new KerberosRequest();
+                request.setTcpAllowed(true);
+                request.setPrincipal("kerberosPrincipal");
+                request.setPassword("kerberosPassword");
+                request.setUrl("kerberosproviderurl.com");
+                request.setAdminUrl("kerberosadminurl.com");
+                request.setRealm("kerbRealm");
+                return request;
+            }
+        },
+
+        CUSTOM {
+            @Override
+            public List<AssertionV2<StackEntity>> getAssertions() {
+                List<AssertionV2<StackEntity>> verifications = new LinkedList<>();
+                verifications.add(blueprintPostToAmbariContains("kdc_type").exactTimes(1));
+                verifications.add(blueprintPostToAmbariContains("mit-kdc").exactTimes(1));
+                verifications.add(blueprintPostToAmbariContains("kdc_hosts").exactTimes(1));
+                verifications.add(blueprintPostToAmbariContains("kdc-host-value").exactTimes(1));
+                verifications.add(blueprintPostToAmbariContains("admin_server_host").exactTimes(1));
+                verifications.add(blueprintPostToAmbariContains("admin-server-host-value").exactTimes(1));
+                verifications.add(blueprintPostToAmbariContains("realm").exactTimes(1));
+                verifications.add(blueprintPostToAmbariContains("realm-value").exactTimes(1));
+                verifications.add(blueprintPostToAmbariContains("KERBEROS_CLIENT").exactTimes(1));
+                verifications.add(MockVerification.verify(HttpMethod.POST, SALT_RUN).bodyContains(SALT_HIGHSTATE).exactTimes(2));
+                verifications.addAll(verifyCloudbreakUserHasSentToCreate());
+                return verifications;
+            }
+
+            @Override
+            public KerberosRequest getRequest() {
+                KerberosRequest request = new KerberosRequest();
+                request.setTcpAllowed(true);
+                request.setPrincipal("kerberosPrincipal");
+                request.setPassword("kerberosPassword");
+                request.setDescriptor("{\"kerberos-env\":{\"properties\":{\"kdc_type\":\"mit-kdc\",\"kdc_hosts\":\"kdc-host-value\",\"admin_server_host\":"
+                        + "\"admin-server-host-value\",\"realm\":\"realm-value\"}}}");
+                request.setKrb5Conf("{}");
+                return request;
+            }
+        };
+
+        public abstract List<AssertionV2<StackEntity>> getAssertions();
+
+        public abstract KerberosRequest getRequest();
+
+        private static MockVerification blueprintPostToAmbariContains(String content) {
+            return MockVerification.verify(HttpMethod.POST, "/api/v1/blueprints/").bodyContains(content);
+        }
+
+        private static List<AssertionV2<StackEntity>> verifyCloudbreakUserHasSentToCreate() {
+            return List.of(
+                    MockVerification.verify(HttpMethod.POST, AMBARI_API_ROOT + "/users").bodyContains("\"Users/active\": true"),
+                    MockVerification.verify(HttpMethod.POST, AMBARI_API_ROOT + "/users").bodyContains("\"Users/admin\": true"),
+                    MockVerification.verify(HttpMethod.POST, AMBARI_API_ROOT + "/users").bodyContains("\"Users/user_name\": \"cloudbreak\""),
+                    MockVerification.verify(HttpMethod.POST, AMBARI_API_ROOT + "/users").bodyContains("Users/password"));
+        }
+
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/RecipeTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/RecipeTest.java
@@ -1,0 +1,155 @@
+package com.sequenceiq.it.cloudbreak.newway.testcase;
+
+import static com.sequenceiq.cloudbreak.api.model.RecipeType.POST_AMBARI_START;
+import static com.sequenceiq.cloudbreak.api.model.RecipeType.POST_CLUSTER_INSTALL;
+import static com.sequenceiq.cloudbreak.api.model.RecipeType.PRE_AMBARI_START;
+import static com.sequenceiq.cloudbreak.api.model.RecipeType.PRE_TERMINATION;
+import static com.sequenceiq.it.cloudbreak.newway.cloud.HostGroupType.COMPUTE;
+import static com.sequenceiq.it.cloudbreak.newway.cloud.HostGroupType.WORKER;
+import static com.sequenceiq.it.cloudbreak.newway.mock.model.SaltMock.SALT_RUN;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpMethod;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.sequenceiq.cloudbreak.api.model.RecipeType;
+import com.sequenceiq.it.cloudbreak.newway.LdapConfig;
+import com.sequenceiq.it.cloudbreak.newway.LdapConfigEntity;
+import com.sequenceiq.it.cloudbreak.newway.RandomNameCreator;
+import com.sequenceiq.it.cloudbreak.newway.Recipe;
+import com.sequenceiq.it.cloudbreak.newway.RecipeEntity;
+import com.sequenceiq.it.cloudbreak.newway.Stack;
+import com.sequenceiq.it.cloudbreak.newway.StackEntity;
+import com.sequenceiq.it.cloudbreak.newway.action.StackScalePostAction;
+import com.sequenceiq.it.cloudbreak.newway.assertion.MockVerification;
+import com.sequenceiq.it.cloudbreak.newway.cloud.HostGroupType;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.ClusterEntity;
+import com.sequenceiq.it.cloudbreak.newway.entity.InstanceGroupEntity;
+
+public class RecipeTest extends AbstractIntegrationTest {
+
+    private static final String WORKER_ID = "ig";
+
+    private static final String COMPUTE_ID = "ig";
+
+    private static final String TEST_CONTEXT = "testContext";
+
+    private static final String HIGHSTATE = "state.highstate";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RecipeTest.class);
+
+    private static final String RECIPE_CONTENT = String.format("#!/bin/bash%necho ALMAA");
+
+    @Inject
+    private RandomNameCreator creator;
+
+    @BeforeMethod
+    public void beforeMethod(Object[] data) {
+        TestContext testContext = (TestContext) data[0];
+        createDefaultUser(testContext);
+        createDefaultCredential(testContext);
+        createDefaultImageCatalog(testContext);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tear(Object[] data) {
+        ((TestContext) data[0]).cleanupTestContextEntity();
+    }
+
+    @Test(dataProvider = "dataProviderForNonPreTerminationRecipeTypes")
+    public void testRecipeNotPreTerminationHasGotHighStateOnCluster(TestContext testContext, HostGroupType hostGroup, int nodeCount,
+                    RecipeType type, int executionTime) {
+        LOGGER.debug("testing recipe execution for type: {}", type.name());
+        String recipeName = creator.getRandomNameForMock();
+        testContext
+                .given(RecipeEntity.class).withName(recipeName).withContent(RECIPE_CONTENT).withRecipeType(type)
+                .when(Recipe.postV2())
+                .given(WORKER_ID, InstanceGroupEntity.class).withHostGroup(hostGroup).withNodeCount(nodeCount).withRecipes(recipeName)
+                .given(StackEntity.class).replaceInstanceGroups(WORKER_ID)
+                .when(Stack.postV2())
+                .await(STACK_AVAILABLE)
+                .then(MockVerification.verify(HttpMethod.POST, SALT_RUN).bodyContains(HIGHSTATE).exactTimes(executionTime))
+                .validate();
+    }
+
+    @Test(dataProvider = TEST_CONTEXT)
+    public void testRecipePreTerminationRecipeHasGotHighStateOnCluster(TestContext testContext) {
+        String recipeName = creator.getRandomNameForMock();
+        testContext
+                .given(RecipeEntity.class).withName(recipeName).withContent(RECIPE_CONTENT).withRecipeType(PRE_TERMINATION)
+                .when(Recipe.postV2())
+                .given(WORKER_ID, InstanceGroupEntity.class).withHostGroup(WORKER).withNodeCount(1).withRecipes(recipeName)
+                .given(StackEntity.class).replaceInstanceGroups(WORKER_ID)
+                .when(Stack.postV2())
+                .await(STACK_AVAILABLE)
+                .then(MockVerification.verify(HttpMethod.POST, SALT_RUN).bodyContains(HIGHSTATE).exactTimes(2))
+                .when(Stack.deleteV2())
+                .await(STACK_DELETED)
+                .then(MockVerification.verify(HttpMethod.POST, SALT_RUN).bodyContains(HIGHSTATE).exactTimes(3))
+                .validate();
+    }
+
+    @Test(dataProvider = TEST_CONTEXT, description = "Post Ambari start recipes executed when LDAP config is present, because later the LDAP sync is "
+            + "hooked for this salt state in the top.sls")
+    public void testWhenThereIsNoRecipeButLdapHasAttachedThenThePostAmbariRecipeShouldRunWhichResultThreeHighStateCall(TestContext testContext) {
+        String ldapName = creator.getRandomNameForMock();
+        testContext
+                .given(LdapConfigEntity.class).withName(ldapName)
+                .when(LdapConfig.postV2())
+                .given(StackEntity.class).withCluster(new ClusterEntity(testContext).valid().withLdapConfigName(ldapName))
+                .when(Stack.postV2())
+                .await(STACK_AVAILABLE)
+                .then(MockVerification.verify(HttpMethod.POST, SALT_RUN).bodyContains(HIGHSTATE).exactTimes(3))
+                .validate();
+    }
+
+    @Test(dataProvider = TEST_CONTEXT)
+    public void testWhenClusterGetUpscaledThenPostClusterInstallRecipeShouldBeExecuted(TestContext testContext) {
+        String recipeName = creator.getRandomNameForMock();
+        testContext
+                .given(RecipeEntity.class).withName(recipeName).withContent(RECIPE_CONTENT).withRecipeType(POST_CLUSTER_INSTALL)
+                .when(Recipe.postV2())
+                .given(WORKER_ID, InstanceGroupEntity.class).withHostGroup(WORKER).withNodeCount(1).withRecipes(recipeName)
+                .given(StackEntity.class).replaceInstanceGroups(WORKER_ID)
+                .when(Stack.postV2())
+                .await(STACK_AVAILABLE)
+                .when(StackScalePostAction.valid().withDesiredCount(2))
+                .await(STACK_AVAILABLE)
+                .then(MockVerification.verify(HttpMethod.POST, SALT_RUN).bodyContains(HIGHSTATE).exactTimes(4))
+                .validate();
+    }
+
+    @Test(dataProvider = TEST_CONTEXT)
+    public void testWhenRecipeProvidedToHostGroupAndAnotherHostgroupGetUpscaledThenThereIsNoFurtherRecipeExecutionOnTheNewNodeBesideTheDefaultOnes(
+            TestContext testContext) {
+        String recipeName = creator.getRandomNameForMock();
+        testContext
+                .given(RecipeEntity.class).withName(recipeName).withContent(RECIPE_CONTENT).withRecipeType(POST_AMBARI_START)
+                .when(Recipe.postV2())
+                .given(COMPUTE_ID, InstanceGroupEntity.class).withHostGroup(COMPUTE).withNodeCount(1).withRecipes(recipeName)
+                .given(StackEntity.class).replaceInstanceGroups(COMPUTE_ID)
+                .when(Stack.postV2())
+                .await(STACK_AVAILABLE)
+                .when(StackScalePostAction.valid().withDesiredCount(2))
+                .await(STACK_AVAILABLE)
+                .then(MockVerification.verify(HttpMethod.POST, SALT_RUN).bodyContains(HIGHSTATE).exactTimes(5))
+                .validate();
+    }
+
+    @DataProvider(name = "dataProviderForNonPreTerminationRecipeTypes")
+    public Object[][] getData() {
+        return new Object[][]{
+                {applicationContext.getBean(TestContext.class), WORKER, 1, PRE_AMBARI_START, 3},
+                {applicationContext.getBean(TestContext.class), WORKER, 1, POST_AMBARI_START, 3},
+                {applicationContext.getBean(TestContext.class), WORKER, 1, POST_CLUSTER_INSTALL, 2}
+        };
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/RecoveryItTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/RecoveryItTest.java
@@ -1,0 +1,83 @@
+package com.sequenceiq.it.cloudbreak.newway.testcase;
+
+import com.sequenceiq.cloudbreak.common.type.HostMetadataState;
+import com.sequenceiq.it.cloudbreak.newway.Stack;
+import com.sequenceiq.it.cloudbreak.newway.StackEntity;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.InstanceGroupEntity;
+import com.sequenceiq.it.spark.StatefulRoute;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static com.sequenceiq.cloudbreak.common.type.HostMetadataState.HEALTHY;
+import static com.sequenceiq.cloudbreak.common.type.HostMetadataState.UNHEALTHY;
+import static com.sequenceiq.it.cloudbreak.newway.cloud.HostGroupType.WORKER;
+
+public class RecoveryItTest extends AbstractIntegrationTest {
+
+    private static final String WORKER_ID = "ig";
+
+    private static final String TEST_CONTEXT = "testContext";
+
+    private static final String HOSTS = "/api/v1/hosts";
+
+    @BeforeMethod
+    public void beforeMethod(Object[] data) {
+        TestContext testContext = (TestContext) data[0];
+
+        createDefaultUser(testContext);
+        createDefaultCredential(testContext);
+        createDefaultImageCatalog(testContext);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tear(Object[] data) {
+        ((TestContext) data[0]).cleanupTestContextEntity();
+    }
+
+    @Test(dataProvider = TEST_CONTEXT, enabled = false)
+    public void testWhenSyncTellsNodesAreUnhealthyThenClusterStatusHaveToChange(TestContext testContext) {
+        String stackName = getNameGenerator().getRandomNameForMock();
+        mockAmbari(testContext);
+        testContext
+                .given(WORKER_ID, InstanceGroupEntity.class).withHostGroup(WORKER).withNodeCount(1)
+                .given(StackEntity.class).withName(stackName).replaceInstanceGroups(WORKER_ID)
+                .when(Stack.postV2())
+                .await(STACK_AVAILABLE)
+                .when(Stack.sync())
+                .await(STACK_FAILED)
+                .validate();
+    }
+
+    private void mockAmbari(TestContext testContext) {
+
+        testContext.getModel().getAmbariMock().getDynamicRouteStack().clearPost(HOSTS);
+        modifyStatusResponses(testContext, UNHEALTHY, 2);
+        modifyStatusResponses(testContext, HEALTHY, 1);
+    }
+
+    private void modifyStatusResponses(TestContext testContext, HostMetadataState state, int quantity) {
+        for (int i = 0; i < quantity; i++) {
+            testContext.getModel().getAmbariMock().getDynamicRouteStack().post(HOSTS, createHostResponseForAmbariWithStatus(state));
+        }
+    }
+
+    private StatefulRoute createHostResponseForAmbariWithStatus(HostMetadataState overridedStatus) {
+        return (request, response, model) -> {
+            response.type("text/plain");
+            response.status(200);
+            /*List<Map<String, ?>> itemList = new ArrayList<>();
+            for (Entry<String, CloudVmMetaDataStatus> stringCloudVmMetaDataStatusEntry : model.getInstanceMap().entrySet()) {
+                CloudVmMetaDataStatus status = stringCloudVmMetaDataStatusEntry.getValue();
+                if (InstanceStatus.STARTED == status.getCloudVmInstanceStatus().getStatus()) {
+                    Hosts hosts = new Hosts(Collections.singletonList(HostNameUtil
+                            .generateHostNameByIp(status.getMetaData().getPrivateIp())), overridedStatus.name());
+                    itemList.add(Collections.singletonMap("Hosts", hosts));
+                }
+            }*/
+            return "";
+        };
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/SharedServiceTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/SharedServiceTest.java
@@ -1,0 +1,383 @@
+package com.sequenceiq.it.cloudbreak.newway.testcase;
+
+import static com.sequenceiq.it.cloudbreak.newway.cloud.HostGroupType.MASTER;
+import static com.sequenceiq.it.cloudbreak.newway.context.RunningParameter.key;
+import static java.lang.String.format;
+import static java.util.List.of;
+
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+import javax.ws.rs.BadRequestException;
+
+import org.springframework.http.HttpMethod;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.sequenceiq.cloudbreak.api.model.DirectoryType;
+import com.sequenceiq.cloudbreak.api.model.ldap.LdapConfigRequest;
+import com.sequenceiq.cloudbreak.api.model.rds.RDSConfigJson;
+import com.sequenceiq.cloudbreak.api.model.rds.RDSConfigRequest;
+import com.sequenceiq.cloudbreak.api.model.rds.RdsType;
+import com.sequenceiq.cloudbreak.api.model.v2.CloudStorageRequest;
+import com.sequenceiq.cloudbreak.api.model.v2.StorageLocationRequest;
+import com.sequenceiq.cloudbreak.api.model.v2.filesystem.AdlsCloudStorageParameters;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.it.cloudbreak.newway.Blueprint;
+import com.sequenceiq.it.cloudbreak.newway.BlueprintEntity;
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.LdapConfig;
+import com.sequenceiq.it.cloudbreak.newway.LdapConfigEntity;
+import com.sequenceiq.it.cloudbreak.newway.RandomNameCreator;
+import com.sequenceiq.it.cloudbreak.newway.RdsConfig;
+import com.sequenceiq.it.cloudbreak.newway.RdsConfigEntity;
+import com.sequenceiq.it.cloudbreak.newway.Stack;
+import com.sequenceiq.it.cloudbreak.newway.StackEntity;
+import com.sequenceiq.it.cloudbreak.newway.assertion.AssertionV2;
+import com.sequenceiq.it.cloudbreak.newway.assertion.MockVerification;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.AmbariEntity;
+import com.sequenceiq.it.cloudbreak.newway.entity.ClusterEntity;
+import com.sequenceiq.it.cloudbreak.newway.entity.InstanceGroupEntity;
+
+public class SharedServiceTest extends AbstractIntegrationTest {
+
+    private static final String TEST_CONTEXT = "testContext";
+
+    private static final String SHARED_SERVICE_TAG = "shared_services_ready";
+
+    private static final String VALID_DL_BP = "{\"Blueprints\":{\"blueprint_name\":\"ownbp\",\"stack_name\":\"HDP\",\"stack_version\":\"2.6\"},\"settings\""
+            + ":[{\"recovery_settings\":[]},{\"service_settings\":[]},{\"component_settings\":[]}],\"configurations\":[],\"host_groups\":[{\"name\":\"master\""
+            + ",\"configurations\":[],\"components\":[{\"name\":\"HIVE_METASTORE\"},{\"name\":\"HIVE_CLIENT\"},{\"name\":\"RANGER_ADMIN\"}],\"cardinality\":\"1"
+            + "\"}]}";
+
+    private static final String HIVE = "hive";
+
+    private static final String RANGER = "ranger";
+
+    private static final String BAD_REQUEST_KEY = "badRequest";
+
+    private static final String RDS_KEY = "rdsConfigNames";
+
+    private static final String LDAP_KEY = "ldapConfigName";
+
+    @Inject
+    private RandomNameCreator creator;
+
+    @BeforeMethod
+    public void beforeMethod(Object[] data) {
+        TestContext testContext = (TestContext) data[0];
+        createDefaultUser(testContext);
+        createDefaultCredential(testContext);
+        createDefaultImageCatalog(testContext);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tear(Object[] data) {
+        ((TestContext) data[0]).cleanupTestContextEntity();
+    }
+
+    @Test(dataProvider = TEST_CONTEXT)
+    public void testCreateDatalakeCluster(TestContext testContext) {
+        String hiveRdsName = creator.getRandomNameForMock();
+        String rangerRdsName = creator.getRandomNameForMock();
+        String ldapName = creator.getRandomNameForMock();
+        String blueprintName = creator.getRandomNameForMock();
+        RDSConfigRequest hiveRds = rdsRequest(RdsType.HIVE, hiveRdsName);
+        RDSConfigRequest rangerRds = rdsRequest(RdsType.RANGER, rangerRdsName);
+        testContext
+                .given(HIVE, RdsConfigEntity.class).withRequest(hiveRds)
+                .when(RdsConfig.postV2())
+                .given(RANGER, RdsConfigEntity.class).withRequest(rangerRds)
+                .when(RdsConfig.postV2())
+                .given(LdapConfigEntity.class).withRequest(ldapRequest(ldapName))
+                .when(LdapConfig.postV2())
+                .given(BlueprintEntity.class).withName(blueprintName).withTag(of(SHARED_SERVICE_TAG), of(true)).withAmbariBlueprint(VALID_DL_BP)
+                .when(Blueprint.postV2())
+                .given(MASTER.name(), InstanceGroupEntity.class).valid().withHostGroup(MASTER).withNodeCount(1)
+                .given(StackEntity.class)
+                .withInstanceGroups(MASTER.name())
+                .withCluster(datalakeReadyCluster(testContext, hiveRdsName, rangerRdsName, ldapName, blueprintName, cloudStorage()))
+                .capture(SharedServiceTest::rdsConfigNamesFromRequest, key(RDS_KEY))
+                .capture(SharedServiceTest::ldapNameFromRequest, key(LDAP_KEY))
+                .when(Stack.postV2())
+                .await(STACK_AVAILABLE)
+                .verify(SharedServiceTest::rdsConfigNamesFromResponse, key(RDS_KEY))
+                .verify(SharedServiceTest::ldapNameFromResponse, key(LDAP_KEY))
+                .then(SharedServiceTest::checkBlueprintTaggedWithSharedService)
+                .then(cloudStorageParametersHasPassedToAmbariBlueprint())
+                .then(ldapParametersHasPassedToAmbariBlueprint(ldapName))
+                .then(rdsParametersHasPassedToAmbariBlueprint(hiveRds, rangerRds))
+                .validate();
+    }
+
+    @Test(dataProvider = TEST_CONTEXT)
+    public void testCreateDatalakeClusterWithMoreHostgroupThanSpecifiedInBlueprint(TestContext testContext) {
+        String hiveRdsName = creator.getRandomNameForMock();
+        String rangerRdsName = creator.getRandomNameForMock();
+        String ldapName = creator.getRandomNameForMock();
+        String blueprintName = creator.getRandomNameForMock();
+        CloudStorageRequest cloudStorage = cloudStorage();
+        testContext
+                .given(HIVE, RdsConfigEntity.class).valid().withType(RdsType.HIVE.name()).withName(hiveRdsName)
+                .when(RdsConfig.postV2())
+                .given(RANGER, RdsConfigEntity.class).valid().withType(RdsType.RANGER.name()).withName(rangerRdsName)
+                .when(RdsConfig.postV2())
+                .given(LdapConfigEntity.class).withName(ldapName)
+                .when(LdapConfig.postV2())
+                .given(BlueprintEntity.class).withName(blueprintName).withTag(of(SHARED_SERVICE_TAG), of(true)).withAmbariBlueprint(VALID_DL_BP)
+                .when(Blueprint.postV2())
+                .given(StackEntity.class)
+                .withCluster(datalakeReadyCluster(testContext, hiveRdsName, rangerRdsName, ldapName, blueprintName, cloudStorage))
+                .when(Stack.postV2(), key(BAD_REQUEST_KEY))
+                .except(BadRequestException.class, key(BAD_REQUEST_KEY))
+                .validate();
+    }
+
+    @Test(dataProvider = TEST_CONTEXT)
+    public void testCreateDatalakeClusterWithoutLdap(TestContext testContext) {
+        String hiveRdsName = creator.getRandomNameForMock();
+        String rangerRdsName = creator.getRandomNameForMock();
+        String blueprintName = creator.getRandomNameForMock();
+        CloudStorageRequest cloudStorage = cloudStorage();
+        testContext
+                .given(HIVE, RdsConfigEntity.class).valid().withType(RdsType.HIVE.name()).withName(hiveRdsName)
+                .when(RdsConfig.postV2())
+                .given(RANGER, RdsConfigEntity.class).valid().withType(RdsType.RANGER.name()).withName(rangerRdsName)
+                .when(RdsConfig.postV2())
+                .given(BlueprintEntity.class).withName(blueprintName).withTag(of(SHARED_SERVICE_TAG), of(true)).withAmbariBlueprint(VALID_DL_BP)
+                .when(Blueprint.postV2())
+                .given(MASTER.name(), InstanceGroupEntity.class).valid().withHostGroup(MASTER).withNodeCount(1)
+                .given(StackEntity.class)
+                .withInstanceGroups(MASTER.name())
+                .withCluster(datalakeReadyCluster(testContext, hiveRdsName, rangerRdsName, null, blueprintName, cloudStorage))
+                .when(Stack.postV2(), key(BAD_REQUEST_KEY))
+                .except(BadRequestException.class, key(BAD_REQUEST_KEY))
+                .validate();
+    }
+
+    @Test(dataProvider = TEST_CONTEXT)
+    public void testCreateDatalakeClusterWithOnlyOneRdsWhichIsHive(TestContext testContext) {
+        String hiveRdsName = creator.getRandomNameForMock();
+        String ldapName = creator.getRandomNameForMock();
+        String blueprintName = creator.getRandomNameForMock();
+        CloudStorageRequest cloudStorage = cloudStorage();
+        testContext
+                .given(HIVE, RdsConfigEntity.class).valid().withType(RdsType.HIVE.name()).withName(hiveRdsName)
+                .when(RdsConfig.postV2())
+                .given(BlueprintEntity.class).withName(blueprintName).withTag(of(SHARED_SERVICE_TAG), of(true)).withAmbariBlueprint(VALID_DL_BP)
+                .when(Blueprint.postV2())
+                .given(LdapConfigEntity.class).withName(ldapName)
+                .when(LdapConfig.postV2())
+                .given(MASTER.name(), InstanceGroupEntity.class).valid().withHostGroup(MASTER).withNodeCount(1)
+                .given(StackEntity.class)
+                .withInstanceGroups(MASTER.name())
+                .withCluster(datalakeReadyCluster(testContext, hiveRdsName, null, ldapName, blueprintName, cloudStorage))
+                .when(Stack.postV2(), key(BAD_REQUEST_KEY))
+                .except(BadRequestException.class, key(BAD_REQUEST_KEY))
+                .validate();
+    }
+
+    @Test(dataProvider = TEST_CONTEXT)
+    public void testCreateDatalakeClusterWithOnlyOneRdsWhichIsRanger(TestContext testContext) {
+        String rangerRdsName = creator.getRandomNameForMock();
+        String ldapName = creator.getRandomNameForMock();
+        String blueprintName = creator.getRandomNameForMock();
+        CloudStorageRequest cloudStorage = cloudStorage();
+        testContext
+                .given(RANGER, RdsConfigEntity.class).valid().withType(RdsType.RANGER.name()).withName(rangerRdsName)
+                .when(RdsConfig.postV2())
+                .given(BlueprintEntity.class).withName(blueprintName).withTag(of(SHARED_SERVICE_TAG), of(true)).withAmbariBlueprint(VALID_DL_BP)
+                .when(Blueprint.postV2())
+                .given(LdapConfigEntity.class).withName(ldapName)
+                .when(LdapConfig.postV2())
+                .given(MASTER.name(), InstanceGroupEntity.class).valid().withHostGroup(MASTER).withNodeCount(1)
+                .given(StackEntity.class)
+                .withInstanceGroups(MASTER.name())
+                .withCluster(datalakeReadyCluster(testContext, null, rangerRdsName, ldapName, blueprintName, cloudStorage))
+                .when(Stack.postV2(), key(BAD_REQUEST_KEY))
+                .except(BadRequestException.class, key(BAD_REQUEST_KEY))
+                .validate();
+    }
+
+    @Test(dataProvider = TEST_CONTEXT)
+    public void testCreateDatalakeClusterWithoutRds(TestContext testContext) {
+        String ldapName = creator.getRandomNameForMock();
+        String blueprintName = creator.getRandomNameForMock();
+        CloudStorageRequest cloudStorage = cloudStorage();
+        testContext
+                .given(BlueprintEntity.class).withName(blueprintName).withTag(of(SHARED_SERVICE_TAG), of(true)).withAmbariBlueprint(VALID_DL_BP)
+                .when(Blueprint.postV2())
+                .given(LdapConfigEntity.class).withName(ldapName)
+                .when(LdapConfig.postV2())
+                .given(MASTER.name(), InstanceGroupEntity.class).valid().withHostGroup(MASTER).withNodeCount(1)
+                .given(StackEntity.class)
+                .withInstanceGroups(MASTER.name())
+                .withCluster(datalakeReadyCluster(testContext, null, null, ldapName, blueprintName, cloudStorage))
+                .when(Stack.postV2(), key(BAD_REQUEST_KEY))
+                .except(BadRequestException.class, key(BAD_REQUEST_KEY))
+                .validate();
+    }
+
+    @Test(dataProvider = TEST_CONTEXT)
+    public void testCreateDatalakeClusterWithoutRdsAndLdap(TestContext testContext) {
+        String blueprintName = creator.getRandomNameForMock();
+        CloudStorageRequest cloudStorage = cloudStorage();
+        testContext
+                .given(BlueprintEntity.class).withName(blueprintName).withTag(of(SHARED_SERVICE_TAG), of(true)).withAmbariBlueprint(VALID_DL_BP)
+                .when(Blueprint.postV2())
+                .given(MASTER.name(), InstanceGroupEntity.class).valid().withHostGroup(MASTER).withNodeCount(1)
+                .given(StackEntity.class)
+                .withInstanceGroups(MASTER.name())
+                .withCluster(datalakeReadyCluster(testContext, null, null, null, blueprintName, cloudStorage))
+                .when(Stack.postV2(), key(BAD_REQUEST_KEY))
+                .except(BadRequestException.class, key(BAD_REQUEST_KEY))
+                .validate();
+    }
+
+    private CloudStorageRequest cloudStorage() {
+        AdlsCloudStorageParameters adls = new AdlsCloudStorageParameters();
+        CloudStorageRequest csr = new CloudStorageRequest();
+        csr.setLocations(Set.of(storageLocation()));
+        adls.setCredential("value");
+        adls.setAccountName("some");
+        adls.setClientId("other");
+        adls.setTenantId("here");
+        csr.setAdls(adls);
+        return csr;
+    }
+
+    private StorageLocationRequest storageLocation() {
+        StorageLocationRequest storageLocation = new StorageLocationRequest();
+        storageLocation.setValue("TheValueOfGivePropertyForStorageLocation");
+        storageLocation.setPropertyName("NameOfThisProperty");
+        storageLocation.setPropertyFile("SomePropertyHere");
+        return storageLocation;
+    }
+
+    private ClusterEntity datalakeReadyCluster(TestContext testContext, String hiveRdsName, String rangerRdsName, String ldapName, String blueprintName,
+                    CloudStorageRequest cloudStorage) {
+        ClusterEntity cluster = new ClusterEntity(testContext)
+                .valid()
+                .withRdsConfigNames(createSetOfNotNulls(hiveRdsName, rangerRdsName))
+                .withAmbariRequest(new AmbariEntity(testContext).valid().withBlueprintName(blueprintName));
+        if (ldapName != null) {
+            cluster.withLdapConfigName(ldapName);
+        }
+        if (cloudStorage != null) {
+            cluster.withCloudStorage(cloudStorage);
+        }
+        return cluster;
+    }
+
+    private Set<String> createSetOfNotNulls(String... elements) {
+        Set<String> toReturn = new LinkedHashSet<>();
+        for (String element : elements) {
+            if (element != null) {
+                toReturn.add(element);
+            }
+        }
+        return toReturn;
+    }
+
+    private static StackEntity checkBlueprintTaggedWithSharedService(TestContext testContext, StackEntity stack, CloudbreakClient cloudbreakClient) {
+        Map<String, Object> blueprintTags = stack.getResponse().getCluster().getBlueprint().getTags();
+        if (!blueprintTags.containsKey(SHARED_SERVICE_TAG) || blueprintTags.get(SHARED_SERVICE_TAG) == null
+                || !(blueprintTags.get(SHARED_SERVICE_TAG) instanceof Boolean)
+                || !((Boolean) blueprintTags.get(SHARED_SERVICE_TAG))) {
+            throw new TestFailException("shared service tag has not passed properly (or at all) to the blueprint");
+        }
+        return stack;
+    }
+
+    private List<AssertionV2<StackEntity>> cloudStorageParametersHasPassedToAmbariBlueprint() {
+        List<AssertionV2<StackEntity>> verifications = new LinkedList<>();
+        verifications.add(blueprintPostToAmbariContains(cloudStorage().getAdls().getAccountName()));
+        verifications.add(blueprintPostToAmbariContains(cloudStorage().getAdls().getClientId()));
+        verifications.add(blueprintPostToAmbariContains(cloudStorage().getAdls().getCredential()));
+        return verifications;
+    }
+
+    private List<AssertionV2<StackEntity>> ldapParametersHasPassedToAmbariBlueprint(String ldapName) {
+        List<AssertionV2<StackEntity>> verifications = new LinkedList<>();
+        verifications.add(blueprintPostToAmbariContains(ldapRequest(ldapName).getUserDnPattern()));
+        verifications.add(blueprintPostToAmbariContains(ldapRequest(ldapName).getBindPassword()));
+        verifications.add(blueprintPostToAmbariContains(ldapRequest(ldapName).getBindDn()));
+        verifications.add(blueprintPostToAmbariContains(ldapRequest(ldapName).getServerHost()));
+        verifications.add(blueprintPostToAmbariContains(ldapRequest(ldapName).getUserSearchBase()));
+        verifications.add(blueprintPostToAmbariContains(ldapRequest(ldapName).getGroupSearchBase()));
+        verifications.add(blueprintPostToAmbariContains(ldapRequest(ldapName).getGroupNameAttribute()));
+        verifications.add(blueprintPostToAmbariContains(ldapRequest(ldapName).getServerHost()));
+        return verifications;
+    }
+
+    private List<AssertionV2<StackEntity>> rdsParametersHasPassedToAmbariBlueprint(RDSConfigRequest hive, RDSConfigRequest ranger) {
+        List<AssertionV2<StackEntity>> verifications = new LinkedList<>();
+        verifications.add(blueprintPostToAmbariContains("ranger_privelege_user_jdbc_url"));
+        verifications.add(blueprintPostToAmbariContains(ranger.getConnectionURL()));
+        verifications.add(blueprintPostToAmbariContains("javax.jdo.option.ConnectionURL"));
+        verifications.add(blueprintPostToAmbariContains(hive.getConnectionURL()));
+        verifications.add(blueprintPostToAmbariContains("org.apache.hadoop.fs.adl.AdlFileSystem"));
+        return verifications;
+    }
+
+    private LdapConfigRequest ldapRequest(String name) {
+        LdapConfigRequest request = new LdapConfigRequest();
+        request.setGroupMemberAttribute("memberAttribute");
+        request.setUserNameAttribute("userNameAttribute");
+        request.setGroupNameAttribute("nameAttribute");
+        request.setGroupObjectClass("groupObjectClass");
+        request.setGroupSearchBase("groupSearchBase");
+        request.setUserObjectClass("userObjectClass");
+        request.setDirectoryType(DirectoryType.LDAP);
+        request.setUserSearchBase("userSearchBase");
+        request.setUserDnPattern("userDnPattern");
+        request.setBindPassword("bindPassword");
+        request.setDescription("descrition");
+        request.setAdminGroup("group");
+        request.setServerHost("host");
+        request.setBindDn("bindDn");
+        request.setDomain("domain");
+        request.setProtocol("http");
+        request.setServerPort(1234);
+        request.setName(name);
+        return request;
+    }
+
+    private RDSConfigRequest rdsRequest(RdsType type, String name) {
+        RDSConfigRequest request = new RDSConfigRequest();
+        request.setConnectionURL(format("jdbc:postgresql://somedb.com:5432/%s-mydb", type.name().toLowerCase()));
+        request.setConnectionPassword("password");
+        request.setConnectionUserName("someuser");
+        request.setType(type.name());
+        request.setName(name);
+        return request;
+    }
+
+    private MockVerification blueprintPostToAmbariContains(String content) {
+        return MockVerification.verify(HttpMethod.POST, "/api/v1/blueprints/").bodyContains(content);
+    }
+
+    private static Set<String> rdsConfigNamesFromResponse(StackEntity entity) {
+        return entity.getResponse().getCluster().getRdsConfigs().stream().map(RDSConfigJson::getName).collect(Collectors.toSet());
+    }
+
+    private static Set<String> rdsConfigNamesFromRequest(StackEntity entity) {
+        return entity.getRequest().getCluster().getRdsConfigNames();
+    }
+
+    private static String ldapNameFromRequest(StackEntity entity) {
+        return entity.getRequest().getCluster().getLdapConfigName();
+    }
+
+    private static String ldapNameFromResponse(StackEntity entity) {
+        return entity.getResponse().getCluster().getLdapConfig().getName();
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/WorkspaceTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/WorkspaceTest.java
@@ -1,23 +1,43 @@
 package com.sequenceiq.it.cloudbreak.newway.testcase;
 
-import static com.sequenceiq.it.cloudbreak.newway.context.RunningParameter.key;
-
-import javax.ws.rs.ForbiddenException;
-
+import com.sequenceiq.it.cloudbreak.newway.Blueprint;
+import com.sequenceiq.it.cloudbreak.newway.BlueprintEntity;
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakTest;
+import com.sequenceiq.it.cloudbreak.newway.Credential;
+import com.sequenceiq.it.cloudbreak.newway.CredentialEntity;
+import com.sequenceiq.it.cloudbreak.newway.ImageCatalog;
+import com.sequenceiq.it.cloudbreak.newway.ImageCatalogEntity;
+import com.sequenceiq.it.cloudbreak.newway.LdapConfig;
+import com.sequenceiq.it.cloudbreak.newway.LdapConfigEntity;
+import com.sequenceiq.it.cloudbreak.newway.ProxyConfig;
+import com.sequenceiq.it.cloudbreak.newway.ProxyConfigEntity;
+import com.sequenceiq.it.cloudbreak.newway.Recipe;
+import com.sequenceiq.it.cloudbreak.newway.RecipeEntity;
+import com.sequenceiq.it.cloudbreak.newway.Stack;
+import com.sequenceiq.it.cloudbreak.newway.StackEntity;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.sequenceiq.it.cloudbreak.newway.CloudbreakTest;
-import com.sequenceiq.it.cloudbreak.newway.Stack;
-import com.sequenceiq.it.cloudbreak.newway.StackEntity;
-import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import javax.ws.rs.ForbiddenException;
+
+import static com.sequenceiq.it.cloudbreak.newway.context.RunningParameter.key;
 
 public class WorkspaceTest extends AbstractIntegrationTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(WorkspaceTest.class);
+
+    private static final String DATA_PROVIDER = "testContext";
+
+    private static final String FORBIDDEN_KEY = "forbiddenGetByName";
+
+    private static final String BLUEPRINT_TEXT = "{\"Blueprints\":{\"blueprint_name\":\"ownbp\",\"stack_name\":\"HDF\",\"stack_version\":\"3.2\"},\"settings\""
+            + ":[{\"recovery_settings\":[]},{\"service_settings\":[]},{\"component_settings\":[]}],\"configurations\":[],\"host_groups\":[{\"name\":\"master\","
+            + "\"configurations\":[],\"components\":[{\"name\":\"METRICS_MONITOR\"},{\"name\":\"METRICS_COLLECTOR\"},{\"name\":\"ZOOKEEPER_CLIENT\"}],"
+            + "\"cardinality\":\"1\"}]}";
 
     @BeforeMethod
     public void beforeMethod(Object[] data) {
@@ -27,24 +47,91 @@ public class WorkspaceTest extends AbstractIntegrationTest {
         createSecondUser(testContext);
         createDefaultCredential(testContext);
         createDefaultImageCatalog(testContext);
-
-        testContext.given(StackEntity.class)
-                .when(Stack.postV2())
-                .await(STACK_AVAILABLE);
     }
 
     @AfterMethod(alwaysRun = true)
     public void tear(Object[] data) {
-        TestContext testContext = (TestContext) data[0];
-        testContext.cleanupTestContextEntity();
+        ((TestContext) data[0]).cleanupTestContextEntity();
     }
 
-    @Test(dataProvider = "testContext", enabled = false)
+    @Test(dataProvider = DATA_PROVIDER, enabled = false)
     public void testCreateAStackAndGetOtherUser(TestContext testContext) {
         testContext
                 .given(StackEntity.class)
-                .when(Stack::getByName, key("forbiddenGetByName").withWho(CloudbreakTest.SECOND_USER).withLogError(false))
-                .except(ForbiddenException.class, key("forbiddenGetByName"))
+                .when(Stack.postV2())
+                .await(STACK_AVAILABLE)
+                .when(Stack::getByName, key(FORBIDDEN_KEY).withWho(CloudbreakTest.SECOND_USER).withLogError(false))
+                .except(ForbiddenException.class, key(FORBIDDEN_KEY))
                 .validate();
     }
+
+    @Test(dataProvider = DATA_PROVIDER, enabled = false)
+    public void testCreateACredentialAndGetOtherUser(TestContext testContext) {
+        testContext
+                .given(CredentialEntity.class)
+                .when(Credential::getByName, key(FORBIDDEN_KEY).withWho(CloudbreakTest.SECOND_USER).withLogError(false))
+                .except(ForbiddenException.class, key(FORBIDDEN_KEY))
+                .validate();
+    }
+
+    @Test(dataProvider = DATA_PROVIDER, enabled = false)
+    public void testCreateABlueprintAndGetOtherUser(TestContext testContext) {
+        testContext
+                .given(BlueprintEntity.class).withAmbariBlueprint(BLUEPRINT_TEXT)
+                .when(Blueprint.postV2())
+                .when(Blueprint::getByName, key(FORBIDDEN_KEY).withWho(CloudbreakTest.SECOND_USER).withLogError(false))
+                .except(ForbiddenException.class, key(FORBIDDEN_KEY))
+                .validate();
+    }
+
+    @Test(dataProvider = DATA_PROVIDER, enabled = false)
+    public void testCreateARecipeAndGetOtherUser(TestContext testContext) {
+        testContext
+                .given(RecipeEntity.class)
+                .when(Recipe.postV2())
+                .when(Recipe::getByName, key(FORBIDDEN_KEY).withWho(CloudbreakTest.SECOND_USER).withLogError(false))
+                .except(ForbiddenException.class, key(FORBIDDEN_KEY))
+                .validate();
+    }
+
+    @Test(dataProvider = DATA_PROVIDER, enabled = false)
+    public void testCreateAnLdapAndGetOtherUser(TestContext testContext) {
+        testContext
+                .given(LdapConfigEntity.class)
+                .when(LdapConfig.postV2())
+                .when(LdapConfig::getByName, key(FORBIDDEN_KEY).withWho(CloudbreakTest.SECOND_USER).withLogError(false))
+                .except(ForbiddenException.class, key(FORBIDDEN_KEY))
+                .validate();
+    }
+
+    @Test(dataProvider = DATA_PROVIDER, enabled = false)
+    public void testCreateAnImageCatalogWithImagesAndGetOtherUser(TestContext testContext) {
+        testContext
+                .given(ImageCatalogEntity.class)
+                .when(ImageCatalog.postV2())
+                .when(ImageCatalog::getByNameAndImages, key(FORBIDDEN_KEY).withWho(CloudbreakTest.SECOND_USER).withLogError(false))
+                .except(ForbiddenException.class, key(FORBIDDEN_KEY))
+                .validate();
+    }
+
+    @Test(dataProvider = DATA_PROVIDER, enabled = false)
+    public void testCreateAnImageCatalogWithoutImagesAndGetOtherUser(TestContext testContext) {
+        testContext
+                .given(ImageCatalogEntity.class)
+                .when(ImageCatalog.postV2())
+                .when(ImageCatalog::getByNameWithoutImages, key(FORBIDDEN_KEY).withWho(CloudbreakTest.SECOND_USER).withLogError(false))
+                .except(ForbiddenException.class, key(FORBIDDEN_KEY))
+                .validate();
+    }
+
+    @Test(dataProvider = DATA_PROVIDER, enabled = false)
+    public void testCreateAProxyConfigAndGetOtherUser(TestContext testContext) {
+        testContext
+                .given(ProxyConfigEntity.class)
+                .when(ProxyConfig.postV2())
+                .when(ProxyConfig::getByName, key(FORBIDDEN_KEY).withWho(CloudbreakTest.SECOND_USER).withLogError(false))
+                .except(ForbiddenException.class, key(FORBIDDEN_KEY))
+                .validate();
+    }
+
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/wait/WaitUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/wait/WaitUtil.java
@@ -1,22 +1,20 @@
 package com.sequenceiq.it.cloudbreak.newway.wait;
 
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.ws.rs.ForbiddenException;
-
+import com.sequenceiq.cloudbreak.api.endpoint.v3.StackV3Endpoint;
+import com.sequenceiq.it.cloudbreak.WaitResult;
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v3.StackV3Endpoint;
-import com.sequenceiq.it.cloudbreak.WaitResult;
-import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import javax.ws.rs.ForbiddenException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Component
 public class WaitUtil {
@@ -54,7 +52,7 @@ public class WaitUtil {
             throw new RuntimeException(builder.toString());
         } else if (waitResult == WaitResult.TIMEOUT) {
             throw new RuntimeException("Timeout happened");
-        } else {
+        } else if (!"DELETE_COMPLETED".equals(desiredStatuses.get("status"))) {
             Map<String, Object> statusByNameInWorkspace = cloudbreakClient.getCloudbreakClient()
                     .stackV3Endpoint().getStatusByNameInWorkspace(cloudbreakClient.getWorkspaceId(), stackName);
             if (statusByNameInWorkspace != null) {
@@ -92,6 +90,7 @@ public class WaitUtil {
                             .filter(entry -> "DELETE_COMPLETED".equals(entry.getValue()))
                             .map(Map.Entry::getKey)
                             .forEach(statusPath -> currentStatuses.put(statusPath, "DELETE_COMPLETED"));
+                    break;
                 }
                 continue;
             }

--- a/integration-test/src/main/java/com/sequenceiq/it/spark/spi/CloudVmInstanceStatuses.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/spark/spi/CloudVmInstanceStatuses.java
@@ -17,7 +17,7 @@ public class CloudVmInstanceStatuses extends ITResponse {
         this.instanceMap = instanceMap;
     }
 
-    private List<CloudVmInstanceStatus> createCloudVmInstanceStatuses() {
+    public List<CloudVmInstanceStatus> createCloudVmInstanceStatuses() {
         List<CloudVmInstanceStatus> cloudVmInstanceStatuses = new ArrayList<>();
         for (Entry<String, CloudVmMetaDataStatus> stringCloudVmMetaDataStatusEntry : instanceMap.entrySet()) {
             cloudVmInstanceStatuses.add(stringCloudVmMetaDataStatusEntry.getValue().getCloudVmInstanceStatus());

--- a/integration-test/src/main/resources/testsuites/v2/mock/clustermocktestset.yaml
+++ b/integration-test/src/main/resources/testsuites/v2/mock/clustermocktestset.yaml
@@ -1,6 +1,12 @@
 name: "mock-cluster-tests"
+# parallel: classes
+# threadCount: 1
 tests:
   - name: "mockclusters"
     classes:
       - com.sequenceiq.it.cloudbreak.newway.testcase.TerminationTest
       - com.sequenceiq.it.cloudbreak.newway.testcase.UpscaleTest
+      - com.sequenceiq.it.cloudbreak.newway.testcase.ClusterStopTest
+      - com.sequenceiq.it.cloudbreak.newway.testcase.KerberosTest
+      - com.sequenceiq.it.cloudbreak.newway.testcase.RecipeTest
+      - com.sequenceiq.it.cloudbreak.newway.testcase.SharedServiceTest


### PR DESCRIPTION
# Additional (mock) integration test

### Cluster creation – attempt – with/for:
### Recipe
- Pre-Ambari start
- Post-Ambari start
- Post-Cluster-Install
- Pre-Termination
- With attached Ldap but without recipe (checking highstate call of the default Post-Ambari recipe when ldap attached)
- Recipe added to 'X' hostgroup and 'Y' hostgroup upscaled (the additional recipe of 'X' host group will not be executed)
### Kerberos
- Cloudbreak managed
- Existing Active Directory
- Existing MIT
- Custom
- Descriptor invalid json (Custom)
- Descriptor does not contains all of its required fields (Custom)
- Krb5Conf is not a waild json (Custom)
### Shared service
- Datalake cluster creation with attached Ldap and both Hive and Ranger external database
- Datalake cluster creation attempt when there are more hostgroup provided in the cluster request than the amount of hostgroup defined in the given blueprint
- Datalake cluster with Hive and Ranger external database but without LDAP
- Datalake cluster with LDAP but with just Hive external database
- Datalake cluster with LDAP but with just Ranger external database
- Datalake cluster with only LDAP
- Datalake cluster without LDAP and external database
### Start/Stop
- Stop
### Workspace (right now these tests are done but disabled until the complete CAAS integration)
- Checking resource permission for two user when they're not operating in the same Workspace
  * Blueprint
  * Recipe
  * Authentication Configuration (LDAP)
  * Image catalog (with two slightly different approach)
  * Proxy configuration
  * Credential
## In addition
- `BlueprintValidationException` has mapped from `InternalServerError` to `BadRequestException`
- New validation for `StackRequest` for the case when the Stack has a shared service ready blueprint. If so now we check for the required database and authentication configurations such as LDAP and Hive external database
  * unit tests