### PR TITLE
BUG-112926 Add mutually exclusive non-null check to repair request

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/annotations/IgnorePojoValidation.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/annotations/IgnorePojoValidation.java
@@ -1,0 +1,13 @@
+package com.sequenceiq.cloudbreak.api.model.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE })
+public @interface IgnorePojoValidation {
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/annotations/MutuallyExclusiveNotNull.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/annotations/MutuallyExclusiveNotNull.java
@@ -11,7 +11,7 @@ import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 import javax.validation.Payload;
 
-@Target( { ElementType.TYPE })
+@Target({ ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = MutuallyExclusiveNotNull.MutuallyExclusiveNotNullValidator.class)
 public @interface MutuallyExclusiveNotNull {
@@ -24,7 +24,7 @@ public @interface MutuallyExclusiveNotNull {
 
     @IgnorePojoValidation
     class MutuallyExclusiveNotNullValidator implements ConstraintValidator<MutuallyExclusiveNotNull, Object> {
-        String[] fieldNames;
+        private String[] fieldNames;
 
         @Override
         public void initialize(MutuallyExclusiveNotNull constraintAnnotation) {
@@ -40,6 +40,7 @@ public @interface MutuallyExclusiveNotNull {
             try {
                 for (String fieldName : fieldNames) {
                     Field field = value.getClass().getDeclaredField(fieldName);
+                    field.setAccessible(true);
                     Object fieldValue = field.get(value);
                     if (fieldValue != null) {
                         if (!hasNotNull) {

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/stack/cluster/ClusterRepairNodeRequest.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/stack/cluster/ClusterRepairNodeRequest.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.api.model.stack.cluster;
 
 import java.util.List;
 
+import javax.validation.constraints.NotEmpty;
+
 import com.sequenceiq.cloudbreak.doc.ModelDescriptions.RepairClusterNodeRequest;
 
 import io.swagger.annotations.ApiModel;
@@ -13,6 +15,7 @@ public class ClusterRepairNodeRequest {
     @ApiModelProperty(RepairClusterNodeRequest.DELETE_VOLUMES)
     private boolean deleteVolumes;
 
+    @NotEmpty
     @ApiModelProperty(RepairClusterNodeRequest.IDS)
     private List<String> ids;
 

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/stack/cluster/ClusterRepairRequest.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/stack/cluster/ClusterRepairRequest.java
@@ -2,16 +2,16 @@ package com.sequenceiq.cloudbreak.api.model.stack.cluster;
 
 import java.util.List;
 
-import javax.validation.constraints.NotNull;
-
+import com.sequenceiq.cloudbreak.api.model.annotations.MutuallyExclusiveNotNull;
 import com.sequenceiq.cloudbreak.doc.ModelDescriptions.RepairClusterRequest;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
 @ApiModel
+@MutuallyExclusiveNotNull(fieldNames = {"hostGroups", "nodes"})
 public class ClusterRepairRequest {
-    @NotNull
+
     @ApiModelProperty(value = RepairClusterRequest.HOSTGROUPS, required = true)
     private List<String> hostGroups;
 

--- a/core-api/src/test/java/com/sequenceiq/cloudbreak/api/model/annotations/MutuallyExclusiveNotNullValidatorTest.java
+++ b/core-api/src/test/java/com/sequenceiq/cloudbreak/api/model/annotations/MutuallyExclusiveNotNullValidatorTest.java
@@ -1,0 +1,62 @@
+package com.sequenceiq.cloudbreak.api.model.annotations;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MutuallyExclusiveNotNullValidatorTest {
+
+    private static Validator validator;
+
+    @BeforeClass
+    public static void setUpClass() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    public void pass1() {
+        DummyClass dummyObject = new DummyClass("a", null);
+        Set<ConstraintViolation<DummyClass>> violations = validator.validate(dummyObject);
+        Assert.assertTrue(violations.isEmpty());
+    }
+
+    @Test
+    public void pass2() {
+        DummyClass dummyObject = new DummyClass(null, "b");
+        Set<ConstraintViolation<DummyClass>> violations = validator.validate(dummyObject);
+        Assert.assertTrue(violations.isEmpty());
+    }
+
+    @Test
+    public void fail_both_null() {
+        DummyClass dummyObject = new DummyClass(null, null);
+        Set<ConstraintViolation<DummyClass>> violations = validator.validate(dummyObject);
+        Assert.assertFalse(violations.isEmpty());
+    }
+
+    @Test
+    public void fail_both_nonnull() {
+        DummyClass dummyObject = new DummyClass("a", "b");
+        Set<ConstraintViolation<DummyClass>> violations = validator.validate(dummyObject);
+        Assert.assertFalse(violations.isEmpty());
+    }
+
+    @MutuallyExclusiveNotNull(fieldNames = {"a", "b"})
+    static class DummyClass {
+        String a;
+        String b;
+
+        DummyClass(String a, String b) {
+            this.a = a;
+            this.b = b;
+        }
+    }
+}

--- a/core-api/src/test/java/com/sequenceiq/cloudbreak/api/model/annotations/MutuallyExclusiveNotNullValidatorTest.java
+++ b/core-api/src/test/java/com/sequenceiq/cloudbreak/api/model/annotations/MutuallyExclusiveNotNullValidatorTest.java
@@ -11,6 +11,8 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 public class MutuallyExclusiveNotNullValidatorTest {
 
     private static Validator validator;
@@ -36,14 +38,14 @@ public class MutuallyExclusiveNotNullValidatorTest {
     }
 
     @Test
-    public void fail_both_null() {
+    public void failBothNull() {
         DummyClass dummyObject = new DummyClass(null, null);
         Set<ConstraintViolation<DummyClass>> violations = validator.validate(dummyObject);
         Assert.assertFalse(violations.isEmpty());
     }
 
     @Test
-    public void fail_both_nonnull() {
+    public void failBothNonNull() {
         DummyClass dummyObject = new DummyClass("a", "b");
         Set<ConstraintViolation<DummyClass>> violations = validator.validate(dummyObject);
         Assert.assertFalse(violations.isEmpty());
@@ -51,8 +53,12 @@ public class MutuallyExclusiveNotNullValidatorTest {
 
     @MutuallyExclusiveNotNull(fieldNames = {"a", "b"})
     static class DummyClass {
-        String a;
-        String b;
+
+        @SuppressFBWarnings("URF_UNREAD_FIELD")
+        private String a;
+
+        @SuppressFBWarnings("URF_UNREAD_FIELD")
+        private String b;
 
         DummyClass(String a, String b) {
             this.a = a;

--- a/core-api/src/test/java/com/sequenceiq/cloudbreak/utils/ModelTest.java
+++ b/core-api/src/test/java/com/sequenceiq/cloudbreak/utils/ModelTest.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.utils;
 
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.junit.Test;
 
@@ -16,6 +17,7 @@ import com.openpojo.validation.rule.impl.NoStaticExceptFinalRule;
 import com.openpojo.validation.rule.impl.SetterMustExistRule;
 import com.openpojo.validation.test.impl.GetterTester;
 import com.openpojo.validation.test.impl.SetterTester;
+import com.sequenceiq.cloudbreak.api.model.annotations.IgnorePojoValidation;
 import com.sequenceiq.cloudbreak.api.model.annotations.Immutable;
 import com.sequenceiq.cloudbreak.api.model.annotations.TransformGetterType;
 import com.sequenceiq.cloudbreak.api.model.annotations.TransformSetterType;
@@ -24,8 +26,11 @@ public class ModelTest {
 
     private static final String DOMAIN_PACKAGE = "com.sequenceiq.cloudbreak.api.model";
 
+    private static final Pattern TESTCLASS_NAME_PATTERN = Pattern.compile("^\\S+?Test(?:\\$\\S+)?$");
+
     private static final PojoClassFilter BASE_CLASS_FILTER = pojoClass -> !pojoClass.isEnum() && !pojoClass.isAbstract()
-            && !pojoClass.getName().endsWith("Test");
+            && pojoClass.getAnnotation(IgnorePojoValidation.class) == null
+            && !TESTCLASS_NAME_PATTERN.matcher(pojoClass.getName()).matches();
 
     private static final PojoClassFilter POJO_CLASS_FILTER = new FilterChain(BASE_CLASS_FILTER,
             pojoClass -> pojoClass.getAnnotation(Immutable.class) == null


### PR DESCRIPTION
As the repair request can be used for 1. host group repair 2. individual node repair but these 2 lists are mutually exclusive, the validation had to be altered.
Also, made the node ID list mandatory, e.g. not null and not emtpy.
Added test cases for the validator.