### PR TITLE
Bug 114428 configure additional cloud storage locations during dl setup   step 1

### DIFF
--- a/template-manager-blueprint/src/main/resources/definitions/cloud-storage-location-specification.json
+++ b/template-manager-blueprint/src/main/resources/definitions/cloud-storage-location-specification.json
@@ -1,9 +1,89 @@
 {
   "entries": [
     {
+      "propertyName": "zeppelin.notebook.dir",
+      "propertyFile": "zeppelin-site",
+      "description": "The root directory where Zeppelin notebook directories are saved",
+      "defaultPath": "{{{ defaultPath }}}/spark/zeppelin/notebook",
+      "propertyDisplayName": "Zeppelin Notebooks Root Directory",
+      "relatedService": "ZEPPELIN_MASTER",
+      "requiredForAttachedCluster": false,
+      "supportedStorages": ["ADLS", "WASB", "S3", "GCS", "ADLS_GEN_2"]
+    },
+    {
+      "propertyName": "tez.history.logging.proto-base-dir",
+      "propertyFile": "tez-site",
+      "description": "The directory into which Tez history data will be written when proto history logging service is used",
+      "defaultPath": "{{{ defaultPath }}}/apps/hive/ewarehouse/tablespace/external/hive/sys.db/query_data",
+      "propertyDisplayName": "Tez Proto History Logs",
+      "relatedService": "TEZ_CLIENT",
+      "requiredForAttachedCluster": false,
+      "supportedStorages": ["ADLS", "WASB", "S3", "GCS", "ADLS_GEN_2"]
+    },
+    {
+      "propertyName": "yarn.nodemanager.remote-app-log-dir",
+      "propertyFile": "yarn-site",
+      "description": "This is the directory where aggregated application logs should be stored by YARN NodeManager",
+      "defaultPath": "{{{ defaultPath }}}/yarn-app-logs",
+      "propertyDisplayName": "YARN Application Logs",
+      "relatedService": "NODEMANAGER",
+      "requiredForAttachedCluster": false,
+      "supportedStorages": ["ADLS", "WASB", "S3", "GCS", "ADLS_GEN_2"]
+    },
+    {
+      "propertyName": "hbase.rootdir",
+      "propertyFile": "yarn-hbase-site",
+      "description": "The directory shared by region servers and into which YARN App Timeline Server HBase persists",
+      "defaultPath": "{{{ defaultPath }}}/yarn-hbase/data",
+      "propertyDisplayName": "YARN HBase Root Directory",
+      "relatedService": "APP_TIMELINE_SERVER",
+      "requiredForAttachedCluster": false,
+      "supportedStorages": ["ADLS", "WASB", "S3", "GCS", "ADLS_GEN_2"]
+    },
+    {
+      "propertyName": "spark.eventLog.dir",
+      "propertyFile": "spark2-defaults",
+      "description": "The directory into which Spark events are logged",
+      "defaultPath": "{{{ defaultPath }}}/spark2-history",
+      "propertyDisplayName": "Spark Event Logs",
+      "relatedService": "SPARK2_CLIENT",
+      "requiredForAttachedCluster": false,
+      "supportedStorages": ["ADLS", "WASB", "S3", "GCS", "ADLS_GEN_2"]
+    },
+    {
+      "propertyName": "spark.history.fs.logDirectory",
+      "propertyFile": "spark2-defaults",
+      "description": "The directory containing application event logs to load into Spark History Server",
+      "defaultPath": "{{{ defaultPath }}}/spark2-history",
+      "propertyDisplayName": "Spark History Log Source",
+      "relatedService": "SPARK2_JOBHISTORYSERVER",
+      "requiredForAttachedCluster": false,
+      "supportedStorages": ["ADLS", "WASB", "S3", "GCS", "ADLS_GEN_2"]
+    },
+    {
+      "propertyName": "spark.sql.warehouse.dir",
+      "propertyFile": "spark2-defaults",
+      "description": "Spark SQL stores the table data for managed tables in the warehouse directory",
+      "defaultPath": "{{{ defaultPath }}}/apps/spark/warehouse",
+      "propertyDisplayName": "Spark SQL Warehouse Directory",
+      "relatedService": "SPARK2_CLIENT",
+      "requiredForAttachedCluster": false,
+      "supportedStorages": ["ADLS", "WASB", "S3", "GCS", "ADLS_GEN_2"]
+    },
+    {
+      "propertyName": "hbase.rootdir",
+      "propertyFile": "ams-hbase-site",
+      "description": "The directory shared by region servers and into which Ambari Metrics System HBase persists",
+      "defaultPath": "{{{ defaultPath }}}/ams-hbase/data",
+      "propertyDisplayName": "Ambari Metrics System HBase Root Directory",
+      "relatedService": "METRICS_COLLECTOR",
+      "requiredForAttachedCluster": false,
+      "supportedStorages": ["ADLS", "WASB", "S3", "GCS", "ADLS_GEN_2"]
+    },
+    {
       "propertyName": "hive.metastore.warehouse.dir",
       "propertyFile": "hive-site",
-      "description": "Hive stores the table data for managed tables in the Hive warehouse directory",
+      "description": "Hive stores the table data for managed tables in the warehouse directory",
       "defaultPath": "{{{ defaultPath }}}/apps/hive/warehouse",
       "propertyDisplayName": "Hive Warehouse Directory",
       "relatedService": "HIVE_METASTORE",
@@ -11,10 +91,20 @@
       "supportedStorages": ["ADLS", "WASB", "S3", "GCS", "ADLS_GEN_2"]
     },
     {
+      "propertyName": "hive.metastore.warehouse.external.dir",
+      "propertyFile": "hive-site",
+      "description": "Hive stores the table data for external managed tables in the warehouse directory",
+      "defaultPath": "{{{ defaultPath }}}/apps/hive/ewarehouse/tablespace/external/hive",
+      "propertyDisplayName": "Hive Warehouse Directory For External Tables",
+      "relatedService": "HIVE_METASTORE",
+      "requiredForAttachedCluster": false,
+      "supportedStorages": ["ADLS", "WASB", "S3", "GCS", "ADLS_GEN_2"]
+    },
+    {
       "propertyName": "xasecure.audit.destination.hdfs.dir",
       "propertyFile": "ranger-env",
-      "description": "This is the Directory where audit logs should be stored",
-      "defaultPath": "{{{ defaultPath }}}/apps/ranger/audit/{{{ clusterName }}}",
+      "description": "This is the directory where audit logs should be stored",
+      "defaultPath": "{{{ defaultPath }}}/apps/ranger/audit",
       "propertyDisplayName": "Ranger Audit Logs",
       "relatedService": "RANGER_ADMIN",
       "requiredForAttachedCluster": false,
@@ -23,8 +113,8 @@
     {
       "propertyName": "xasecure.audit.destination.hdfs.dir",
       "propertyFile": "ranger-hive-audit",
-      "description": "This is the Directory where audit logs should be stored",
-      "defaultPath": "{{{ defaultPath }}}/apps/ranger/audit/{{{ clusterName }}}",
+      "description": "This is the directory where audit logs should be stored",
+      "defaultPath": "{{{ defaultPath }}}/apps/ranger/audit",
       "propertyDisplayName": "Ranger Audit Logs For Hive",
       "relatedService": "HIVE_SERVER",
       "requiredForAttachedCluster": true,
@@ -33,7 +123,7 @@
     {
       "propertyName": "hbase.rootdir",
       "propertyFile": "hbase-site",
-      "description": "The directory shared by region servers and into which HBase persists.",
+      "description": "The directory shared by region servers and into which HBase persists",
       "defaultPath": "{{{ defaultPath }}}/apps/hbase/data",
       "propertyDisplayName": "HBase Root Directory",
       "relatedService": "HBASE_MASTER",

--- a/template-manager-blueprint/src/test/java/com/sequenceiq/cloudbreak/blueprint/filesystem/query/FileSystemConfigQueryServiceTest.java
+++ b/template-manager-blueprint/src/test/java/com/sequenceiq/cloudbreak/blueprint/filesystem/query/FileSystemConfigQueryServiceTest.java
@@ -44,6 +44,10 @@ public class FileSystemConfigQueryServiceTest {
 
     private static final String STORAGE_NAME = "hwx-remote";
 
+    private static final String HIVE_METASTORE_WAREHOUSE_DIR = "hive.metastore.warehouse.dir";
+
+    private static final String HIVE_METASTORE_WAREHOUSE_EXTERNAL_DIR = "hive.metastore.warehouse.external.dir";
+
     @Mock
     private CloudbreakResourceReaderService cloudbreakResourceReaderService;
 
@@ -71,16 +75,20 @@ public class FileSystemConfigQueryServiceTest {
                 .build();
         Set<ConfigQueryEntry> bigCluster = underTest.queryParameters(fileSystemConfigQueryObject);
 
-        Assert.assertEquals(2L, bigCluster.size());
+        Assert.assertEquals(3L, bigCluster.size());
 
-        Optional<ConfigQueryEntry> hiveMetastore = serviceEntry(bigCluster, HIVE_METASTORE);
+        Optional<ConfigQueryEntry> hiveMetastore = serviceEntry(bigCluster, HIVE_METASTORE, HIVE_METASTORE_WAREHOUSE_DIR);
+        Optional<ConfigQueryEntry> hiveMetastoreExternal = serviceEntry(bigCluster, HIVE_METASTORE, HIVE_METASTORE_WAREHOUSE_EXTERNAL_DIR);
         Optional<ConfigQueryEntry> rangerAdmin = serviceEntry(bigCluster, RANGER_ADMIN);
 
         Assert.assertTrue(hiveMetastore.isPresent());
+        Assert.assertTrue(hiveMetastoreExternal.isPresent());
         Assert.assertTrue(rangerAdmin.isPresent());
 
         Assert.assertEquals("default-account-name.azuredatalakestore.net/hwx-remote/apps/hive/warehouse", hiveMetastore.get().getDefaultPath());
-        Assert.assertEquals("default-account-name.azuredatalakestore.net/hwx-remote/apps/ranger/audit/bigCluster", rangerAdmin.get().getDefaultPath());
+        Assert.assertEquals("default-account-name.azuredatalakestore.net/hwx-remote/apps/hive/ewarehouse/tablespace/external/hive",
+                hiveMetastoreExternal.get().getDefaultPath());
+        Assert.assertEquals("default-account-name.azuredatalakestore.net/hwx-remote/apps/ranger/audit", rangerAdmin.get().getDefaultPath());
     }
 
     @Test
@@ -98,16 +106,20 @@ public class FileSystemConfigQueryServiceTest {
                 .build();
         Set<ConfigQueryEntry> bigCluster = underTest.queryParameters(fileSystemConfigQueryObject);
 
-        Assert.assertEquals(2L, bigCluster.size());
+        Assert.assertEquals(3L, bigCluster.size());
 
-        Optional<ConfigQueryEntry> hiveMetastore = serviceEntry(bigCluster, HIVE_METASTORE);
+        Optional<ConfigQueryEntry> hiveMetastore = serviceEntry(bigCluster, HIVE_METASTORE, HIVE_METASTORE_WAREHOUSE_DIR);
+        Optional<ConfigQueryEntry> hiveMetastoreExternal = serviceEntry(bigCluster, HIVE_METASTORE, HIVE_METASTORE_WAREHOUSE_EXTERNAL_DIR);
         Optional<ConfigQueryEntry> rangerAdmin = serviceEntry(bigCluster, RANGER_ADMIN);
 
         Assert.assertTrue(hiveMetastore.isPresent());
+        Assert.assertTrue(hiveMetastoreExternal.isPresent());
         Assert.assertTrue(rangerAdmin.isPresent());
 
         Assert.assertEquals("default-account-name.azuredatalakestore.net/hwx-remote/apps/hive/warehouse", hiveMetastore.get().getDefaultPath());
-        Assert.assertEquals("default-account-name.azuredatalakestore.net/hwx-remote/apps/ranger/audit/bigCluster", rangerAdmin.get().getDefaultPath());
+        Assert.assertEquals("default-account-name.azuredatalakestore.net/hwx-remote/apps/hive/ewarehouse/tablespace/external/hive",
+                hiveMetastoreExternal.get().getDefaultPath());
+        Assert.assertEquals("default-account-name.azuredatalakestore.net/hwx-remote/apps/ranger/audit", rangerAdmin.get().getDefaultPath());
     }
 
     @Test
@@ -128,11 +140,11 @@ public class FileSystemConfigQueryServiceTest {
 
         Assert.assertFalse(hiveMetastore.isPresent());
         Assert.assertTrue(rangerAdmin.isPresent());
-        Assert.assertEquals("default-account-name.azuredatalakestore.net/hwx-remote/apps/ranger/audit/bigCluster", rangerAdmin.get().getDefaultPath());
+        Assert.assertEquals("default-account-name.azuredatalakestore.net/hwx-remote/apps/ranger/audit", rangerAdmin.get().getDefaultPath());
     }
 
     @Test
-    public void testWhenOnlyHiveMetastoreIsPresentedAndAttachedClusterThenShouldReturnWithOnlyRangerAdminConfigs() {
+    public void testWhenOnlyHiveMetastoreIsPresentedAndAttachedClusterThenShouldReturnWithBothHiveMetastoreAndRangerAdminConfigs() {
         prepareBlueprintProcessorFactoryMock(HIVE_METASTORE);
         FileSystemConfigQueryObject fileSystemConfigQueryObject = Builder.builder()
                 .withStorageName(STORAGE_NAME)
@@ -143,17 +155,21 @@ public class FileSystemConfigQueryServiceTest {
                 .build();
         Set<ConfigQueryEntry> bigCluster = underTest.queryParameters(fileSystemConfigQueryObject);
 
-        Assert.assertEquals(2L, bigCluster.size());
+        Assert.assertEquals(3L, bigCluster.size());
 
-        Optional<ConfigQueryEntry> hiveMetastore = serviceEntry(bigCluster, HIVE_METASTORE);
+        Optional<ConfigQueryEntry> hiveMetastore = serviceEntry(bigCluster, HIVE_METASTORE, HIVE_METASTORE_WAREHOUSE_DIR);
+        Optional<ConfigQueryEntry> hiveMetastoreExternal = serviceEntry(bigCluster, HIVE_METASTORE, HIVE_METASTORE_WAREHOUSE_EXTERNAL_DIR);
         Optional<ConfigQueryEntry> hiveServerRangerAdmin = serviceEntry(bigCluster, HIVE_SERVER);
 
         Assert.assertTrue(hiveMetastore.isPresent());
+        Assert.assertTrue(hiveMetastoreExternal.isPresent());
         Assert.assertTrue(hiveServerRangerAdmin.isPresent());
-        Assert.assertEquals("default-account-name.azuredatalakestore.net/hwx-remote/apps/ranger/audit/bigCluster",
+        Assert.assertEquals("default-account-name.azuredatalakestore.net/hwx-remote/apps/ranger/audit",
                 hiveServerRangerAdmin.get().getDefaultPath());
         Assert.assertEquals("default-account-name.azuredatalakestore.net/hwx-remote/apps/hive/warehouse",
                 hiveMetastore.get().getDefaultPath());
+        Assert.assertEquals("default-account-name.azuredatalakestore.net/hwx-remote/apps/hive/ewarehouse/tablespace/external/hive",
+                hiveMetastoreExternal.get().getDefaultPath());
     }
 
     @Test
@@ -167,14 +183,18 @@ public class FileSystemConfigQueryServiceTest {
                 .build();
         Set<ConfigQueryEntry> bigCluster = underTest.queryParameters(fileSystemConfigQueryObject);
 
-        Assert.assertEquals(1L, bigCluster.size());
+        Assert.assertEquals(2L, bigCluster.size());
 
-        Optional<ConfigQueryEntry> hiveMetastore = serviceEntry(bigCluster, HIVE_METASTORE);
+        Optional<ConfigQueryEntry> hiveMetastore = serviceEntry(bigCluster, HIVE_METASTORE, HIVE_METASTORE_WAREHOUSE_DIR);
+        Optional<ConfigQueryEntry> hiveMetastoreExternal = serviceEntry(bigCluster, HIVE_METASTORE, HIVE_METASTORE_WAREHOUSE_EXTERNAL_DIR);
         Optional<ConfigQueryEntry> rangerAdmin = serviceEntry(bigCluster, RANGER_ADMIN);
 
         Assert.assertTrue(hiveMetastore.isPresent());
+        Assert.assertTrue(hiveMetastoreExternal.isPresent());
         Assert.assertFalse(rangerAdmin.isPresent());
         Assert.assertEquals("default-account-name.azuredatalakestore.net/hwx-remote/apps/hive/warehouse", hiveMetastore.get().getDefaultPath());
+        Assert.assertEquals("default-account-name.azuredatalakestore.net/hwx-remote/apps/hive/ewarehouse/tablespace/external/hive",
+                hiveMetastoreExternal.get().getDefaultPath());
     }
 
     @Test
@@ -199,6 +219,11 @@ public class FileSystemConfigQueryServiceTest {
 
     private Optional<ConfigQueryEntry> serviceEntry(Set<ConfigQueryEntry> configQueryEntries, String serviceName) {
         return configQueryEntries.stream().filter(b -> b.getRelatedService().equals(serviceName)).findFirst();
+    }
+
+    private Optional<ConfigQueryEntry> serviceEntry(Set<ConfigQueryEntry> configQueryEntries, String serviceName, String propertyName) {
+        return configQueryEntries.stream().filter(b -> b.getRelatedService().equals(serviceName)).filter(b -> b.getPropertyName().equals(propertyName))
+                .findFirst();
     }
 
     private void prepareBlueprintProcessorFactoryMock(String... services) {


### PR DESCRIPTION
Initial installment of Cloudbreak UI settings for additional cloud storage locations. At the moment, the following services are covered:

- YARN NM app logs
- YARN ATS
- SHS
- AMS

More changes are expected to come. In particular:
- Locations for LogSearch and Zeppelin are still missing
- `requiredForAttachedCluster` and `relatedService` settings need to be double-checked
- Extra `clusterName` suffix might need to be removed in certain cases
- Better wording for descriptions or more appropriate paths

Open issues (to be covered in a separate PR):
- Adding location inheritance to Cloudbreak (attached WL inheriting certain locations from the DL)
- Finetuning `defaultPath` expansion so that it does not necessarily contain any clusterName (or if it does, it contains the name of the DL in case of an attached WL)
- Where / when to set `core-site / fs.defaultFS` if it is supposed to point to a cloud location