### PR TITLE
RMP-12456 : Wire Up WL Cluster to send metrics to DL

### DIFF
--- a/template-manager-blueprint/src/main/resources/blueprints/configurations/metrics_monitor/services.json
+++ b/template-manager-blueprint/src/main/resources/blueprints/configurations/metrics_monitor/services.json
@@ -1,0 +1,3 @@
+{
+  "services": ["METRICS_MONITOR"]
+}

--- a/template-manager-blueprint/src/main/resources/blueprints/configurations/metrics_monitor/shared_service.handlebars
+++ b/template-manager-blueprint/src/main/resources/blueprints/configurations/metrics_monitor/shared_service.handlebars
@@ -1,0 +1,9 @@
+{
+{{{#if-true sharedService.attachedCluster}}}
+  "cluster-env": {
+    "properties": {
+      "metrics_collector_external_hosts": "{{{ sharedService.datalakeAmbariFqdn }}}"
+    }
+  }
+{{{/if-true}}}
+}

--- a/template-manager-blueprint/src/main/resources/blueprints/configurations/yarn_client/services.json
+++ b/template-manager-blueprint/src/main/resources/blueprints/configurations/yarn_client/services.json
@@ -1,0 +1,3 @@
+{
+  "services": ["YARN_CLIENT"]
+}

--- a/template-manager-blueprint/src/main/resources/blueprints/configurations/yarn_client/shared_service.handlebars
+++ b/template-manager-blueprint/src/main/resources/blueprints/configurations/yarn_client/shared_service.handlebars
@@ -1,0 +1,18 @@
+{
+{{{#if-true sharedService.attachedCluster}}}
+  "yarn-site": {
+    "properties_attributes": {},
+    "properties": {
+      "yarn.timeline-service.reader.webapp.address": "{{{ sharedService.datalakeAmbariFqdn }}}:8198",
+      "yarn.timeline-service.reader.webapp.https.address": "{{{ sharedService.datalakeAmbariFqdn }}}:8199",
+      "yarn.log.server.web-service.url": "{{{ sharedService.datalakeAmbariFqdn }}}:8198/ws/v2/applicationlog"
+    }
+  },
+  "yarn-hbase-site": {
+    "properties_attributes": {},
+    "properties": {
+      "hbase.zookeeper.quorum": "{{{ sharedService.datalakeAmbariFqdn }}}"
+    }
+  }
+{{{/if-true}}}
+}

--- a/template-manager-blueprint/src/test/java/com/sequenceiq/cloudbreak/blueprint/BlueprintSegmentReaderTest.java
+++ b/template-manager-blueprint/src/test/java/com/sequenceiq/cloudbreak/blueprint/BlueprintSegmentReaderTest.java
@@ -39,7 +39,7 @@ public class BlueprintSegmentReaderTest {
         Map<ServiceName, TemplateFiles> kerberosDescriptorFiles = underTest.collectAllKerberosDescriptorFile();
 
         Assert.assertEquals(3L, configFiles.size());
-        Assert.assertEquals(24L, serviceFiles.size());
+        Assert.assertEquals(26L, serviceFiles.size());
         Assert.assertEquals(1L, settingsFiles.size());
         Assert.assertEquals(1L, kerberosDescriptorFiles.size());
     }

--- a/template-manager-blueprint/src/test/java/com/sequenceiq/cloudbreak/blueprint/template/HandlebarTemplateTest.java
+++ b/template-manager-blueprint/src/test/java/com/sequenceiq/cloudbreak/blueprint/template/HandlebarTemplateTest.java
@@ -224,6 +224,14 @@ public class HandlebarTemplateTest {
                 {"blueprints/configurations/dp_profiler/global.handlebars", "configurations/dp_profiler/profiler.json",
                         objectWithoutEverything()},
 
+                // METRICS_MONITOR
+                {"blueprints/configurations/metrics_monitor/shared_service.handlebars", "configurations/metrics_monitor/metrics-monitor.json",
+                        sSConfigWhenMetricsMonitorInWLThenShouldReturnWithMetricsCollectorConfig()},
+
+                // YARN_CLIENT
+                {"blueprints/configurations/yarn_client/shared_service.handlebars", "configurations/yarn_client/yarn-client.json",
+                        sSConfigWhenMetricsMonitorInWLThenShouldReturnWithMetricsCollectorConfig()},
+
                 // RANGER_ADMIN
                 {"blueprints/configurations/ranger/gateway.handlebars", "configurations/ranger/enable-gateway.json",
                         enabledGateway()},
@@ -665,6 +673,16 @@ public class HandlebarTemplateTest {
         return new TemplateModelContextBuilder()
                 .withSharedServiceConfigs(attachedClusterSharedServiceConfig().get())
                 .withFixInputs(fixInputs)
+                .build();
+    }
+
+    private static Object sSConfigWhenMetricsMonitorInWLThenShouldReturnWithMetricsCollectorConfig() {
+
+        SharedServiceConfigsView sharedServiceConfigsView = attachedClusterSharedServiceConfig().get();
+        sharedServiceConfigsView.setDatalakeAmbariFqdn("ambarifqdn");
+
+        return new TemplateModelContextBuilder()
+                .withSharedServiceConfigs(sharedServiceConfigsView)
                 .build();
     }
 

--- a/template-manager-blueprint/src/test/resources/handlebar/configurations/metrics_monitor/metrics-monitor.json
+++ b/template-manager-blueprint/src/test/resources/handlebar/configurations/metrics_monitor/metrics-monitor.json
@@ -1,0 +1,9 @@
+{
+
+  "cluster-env": {
+    "properties": {
+      "metrics_collector_external_hosts": "ambarifqdn"
+    }
+  }
+
+}

--- a/template-manager-blueprint/src/test/resources/handlebar/configurations/yarn_client/yarn-client.json
+++ b/template-manager-blueprint/src/test/resources/handlebar/configurations/yarn_client/yarn-client.json
@@ -1,0 +1,18 @@
+{
+
+  "yarn-site": {
+    "properties_attributes": {},
+    "properties": {
+      "yarn.timeline-service.reader.webapp.address": "ambarifqdn:8198",
+      "yarn.timeline-service.reader.webapp.https.address": "ambarifqdn:8199",
+      "yarn.log.server.web-service.url": "ambarifqdn:8198/ws/v2/applicationlog"
+    }
+  },
+  "yarn-hbase-site": {
+    "properties_attributes": {},
+    "properties": {
+      "hbase.zookeeper.quorum": "ambarifqdn"
+    }
+  }
+
+}


### PR DESCRIPTION
RMP-12456 : Wire Up WL Cluster to send metrics to DL
- Configured Blueprint Shared Services template to wire up METRICS_MONITOR and YARN_CLIENT in WL Clusters.
