### PR TITLE
RMP-12797 setting source and target compatibility for structuredevents

### DIFF
--- a/structuredevent-model/build.gradle
+++ b/structuredevent-model/build.gradle
@@ -1,5 +1,10 @@
 apply plugin: 'java'
 
+
+//Required for telemetry Spark queries with smartsense datalake
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
 repositories {
     mavenLocal()
     mavenCentral()
@@ -14,5 +19,4 @@ jar {
 dependencies {
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
     testCompile group: 'junit',                     name: 'junit',                          version: junitVersion
-
 }


### PR DESCRIPTION
-We plan to reuse structured event models for Spark queries, sadly Smartsense datalake is running on java 8, so we enforce source+target compatibility in gradle.
- Verified bytecode with `javap -verbose` and returned
major version: 52