### PR TITLE
BUG-115518 Add revised HDP3 infra/shared services blueprint

### DIFF
--- a/cloud-common/src/main/resources/application.yml
+++ b/cloud-common/src/main/resources/application.yml
@@ -131,7 +131,8 @@ cb:
      internal: >
                 HDP 3.0 - Data Science: Apache Spark 2, Apache Zeppelin=hdp30-data-science-spark2;
                 HDP 3.0 - EDW-Analytics: Apache Hive 2 LLAP, Apache Zeppelin=hdp30-edw-analytics;
-                HDP 3.0 - Data Lake: Apache Ranger, Apache Hive Metastore=hdp30-shared-services
+                HDP 3.0 - Data Lake: Apache Ranger=hdp30-shared-services;
+                HDP 3.0 - Data Lake: Apache Ranger, Apache Atlas, Infrastructure Services=hdp30-shared-services-v2
   clustertemplate.defaults:
   template.defaults: minviable-gcp,minviable-azure-managed-disks,minviable-aws
   custom.user.data: |

--- a/core/src/main/resources/defaults/blueprints/hdp30-shared-services-v2.bp
+++ b/core/src/main/resources/defaults/blueprints/hdp30-shared-services-v2.bp
@@ -1,0 +1,179 @@
+{
+  "tags": {
+    "shared_services_ready": true
+  },
+  "blueprint": {
+    "Blueprints": {
+      "blueprint_name": "hdp30-shared-services-v2",
+      "stack_name": "HDP",
+      "stack_version": "3.0"
+    },
+    "settings": [
+      {
+        "recovery_settings": []
+      },
+      {
+        "service_settings": [
+          {
+            "name": "HIVE",
+            "credential_store_enabled": "false"
+          }
+        ]
+      },
+      {
+        "component_settings": []
+      }
+    ],
+    "configurations": [
+      {
+        "yarn-site": {
+          "yarn.timeline-service.entity-group-fs-store.active-dir": "file:///hadoopfs/fs1/ats/active",
+          "yarn.timeline-service.entity-group-fs-store.done-dir": "file:///hadoopfs/fs1/ats/done",
+          "yarn.log-aggregation.file-formats": "TFile",
+          "yarn.resourcemanager.cluster-id": "{{{ general.uuid }}}"
+        }
+      },
+      {
+        "yarn-env": {
+          "apptimelineserver_heapsize": "1024m"
+        }
+      },
+      {
+        "yarn-hbase-site": {
+          "hbase.wal.dir": "file:///hadoopfs/fs1/apps/yarn-hbase/wal-data/",
+          "hbase.unsafe.stream.capability.enforce": "false"
+        }
+      },
+      {
+        "yarn-hbase-env": {
+          "is_hbase_system_service_launch": "false",
+          "use_external_hbase": "false",
+          "yarn_hbase_master_memory": "1024",
+          "yarn_hbase_regionserver_memory": "1024"
+        }
+      },
+      {
+        "hbase-site": {
+          "hbase.wal.dir": "file:///hadoopfs/fs1/hbase-atlas-wal-data/",
+          "hbase.bulkload.staging.dir": "file:///hadoopfs/fs1/apps/hbase-atlas/staging",
+          "hbase.unsafe.stream.capability.enforce" : "false"
+        }
+      },
+      {
+        "hbase-env": {
+          "hbase_regionserver_heapsize": "1024",
+          "hbase_master_heapsize": "1024"
+        }
+      },
+      {
+        "core-site": {
+          "fs.trash.interval": "4320",
+          "hadoop.proxyuser.yarn.hosts": "*"
+        }
+      },
+      {
+        "ams-site": {
+          "timeline.metrics.support.multiple.clusters": "true"
+        }
+      },
+      {
+        "ams-hbase-site": {
+          "hbase.wal.dir": "file:///hadoopfs/fs1/ams-hbase/wal-data/"
+        }
+      },
+      {
+        "anonymization-conf": {
+          "security.anonymization.max.heap": "1024"
+        }
+      },
+      {
+        "hst-agent-conf": {
+          "security.anonymization.max.heap": "1024"
+        }
+      },
+      {
+        "hst-server-conf": {
+          "server.max.heap": "1024"
+        }
+      }
+    ],
+    "host_groups": [
+      {
+        "name": "master",
+        "configurations": [],
+        "components": [
+          {
+            "name": "HDFS_CLIENT"
+          },
+          {
+            "name": "ZOOKEEPER_CLIENT"
+          },
+          {
+            "name": "ZOOKEEPER_SERVER"
+          },
+          {
+            "name": "INFRA_SOLR_CLIENT"
+          },
+          {
+            "name": "RANGER_TAGSYNC"
+          },
+          {
+            "name": "RANGER_USERSYNC"
+          },
+          {
+            "name": "RANGER_ADMIN"
+          },
+          {
+            "name": "INFRA_SOLR"
+          },
+          {
+              "name": "KAFKA_BROKER"
+          },
+          {
+              "name": "ATLAS_SERVER"
+          },
+          {
+              "name": "ATLAS_CLIENT"
+          },
+          {
+              "name": "HBASE_REGIONSERVER"
+          },
+          {
+              "name": "HBASE_MASTER"
+          },
+          {
+              "name": "HBASE_CLIENT"
+          },
+          {
+            "name": "LOGSEARCH_SERVER"
+          },
+          {
+            "name": "METRICS_COLLECTOR"
+          },
+          {
+            "name": "METRICS_MONITOR"
+          },
+          {
+            "name": "METRICS_GRAFANA"
+          },
+          {
+            "name": "SPARK2_JOBHISTORYSERVER"
+          },
+          {
+            "name": "APP_TIMELINE_SERVER"
+          },
+          {
+            "name": "TIMELINE_READER"
+          },
+          {
+            "name": "HST_SERVER"
+          },
+          {
+            "name": "HST_AGENT"
+          }
+        ],
+        "cardinality": "1"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This can't be launched via the UI yet. Thought the first part of the cloud storage changes would be enough, but that wasn't the case.

Template for this: https://github.com/hortonworks/dp-demo-utils/blob/master/cumulus-poc/templates/template_infra_krb.json
Everything under https://github.com/hortonworks/dp-demo-utils/blob/master/cumulus-poc/templates/template_infra_krb.json#L87
was added manually. (Some of the properties above were manually modified, but a bug exists to track the problem there)