### PR TITLE
RMP-12922 : Introduce HDF-3.3.0.0 messaging management (kafka) into c…

### DIFF
--- a/cloud-common/src/main/resources/application.yml
+++ b/cloud-common/src/main/resources/application.yml
@@ -124,7 +124,7 @@ cb:
                 EDW-Analytics: Apache Hive 2 LLAP, Apache Zeppelin=hdp26-edw-analytics;
                 Data Science: Apache Spark 2, Apache Zeppelin=hdp26-data-science-spark2;
                 Flow Management: Apache NiFi, Apache NiFi Registry=hdf32-flow-management;
-                Messaging Management: Apache Kafka=hdf32-messaging-kafka;
+                HDF-3.3 Messaging Management: Apache Kafka=hdf33-messaging-kafka;
                 Messaging Management: Apache Kafka, Schema Registry=hdf32-messaging-kafka-registry;
                 Data Lake: Apache Ranger, Apache Atlas, Apache Hive Metastore=hdp26-shared-services;
                 Data Lake: Apache Ranger, Apache Hive Metastore HA=hdp26-shared-services-ha
@@ -399,6 +399,47 @@ cb:
             amazonlinux2:
               - mpackUrl: http://public-repo-1.hortonworks.com/HDF/amazonlinux2/3.x/updates/3.2.0.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.2.0.0-520.tar.gz
                 stackDefault: true
+
+      3.3:
+        version: 3.3.0.0-165
+        min-ambari: 2.7
+        repo:
+          stack:
+            repoid: HDF-3.3
+            redhat7: http://public-repo-1.hortonworks.com/HDF/centos7/3.x/updates/3.3.0.0
+            debian9: http://public-repo-1.hortonworks.com/HDF/debian9/3.x/updates/3.3.0.0
+            ubuntu16: http://public-repo-1.hortonworks.com/HDF/ubuntu16/3.x/updates/3.3.0.0
+            sles12: http://public-repo-1.hortonworks.com/HDF/sles12/3.x/updates/3.3.0.0
+            amazonlinux2: http://public-repo-1.hortonworks.com/HDF/amazonlinux2/3.x/updates/3.3.0.0
+            repository-version: 3.3.0.0-165
+            vdf-redhat7: http://public-repo-1.hortonworks.com/HDF/centos7/3.x/updates/3.3.0.0/HDF-3.3.0.0-165.xml
+            vdf-debian9: http://public-repo-1.hortonworks.com/HDF/debian9/3.x/updates/3.3.0.0/HDF-3.3.0.0-165.xml
+            vdf-ubuntu16: http://public-repo-1.hortonworks.com/HDF/ubuntu16/3.x/updates/3.3.0.0/HDF-3.3.0.0-165.xml
+            vdf-sles12: http://public-repo-1.hortonworks.com/HDF/sles12/3.x/updates/3.3.0.0/HDF-3.3.0.0-165.xml
+            vdf-amazonlinux2: http://public-repo-1.hortonworks.com/HDF/amazonlinux2/3.x/updates/3.3.0.0/HDF-3.3.0.0-165.xml
+          util:
+            repoid: HDP-UTILS-1.1.0.22
+            redhat7: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/centos7
+            debian9: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/debian9
+            ubuntu16: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/ubuntu16
+            sles12: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/sles12
+            amazonlinux2: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/amazonlinux2
+          mpacks:
+            redhat7:
+            - mpackUrl: http://public-repo-1.hortonworks.com/HDF/centos7/3.x/updates/3.3.0.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.3.0.0-165.tar.gz
+              stackDefault: true
+            debian9:
+            - mpackUrl: http://public-repo-1.hortonworks.com/HDF/debian9/3.x/updates/3.3.0.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.3.0.0-165.tar.gz
+              stackDefault: true
+            ubuntu16:
+            - mpackUrl: http://public-repo-1.hortonworks.com/HDF/ubuntu16/3.x/updates/3.3.0.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.3.0.0-165.tar.gz
+              stackDefault: true
+            sles12:
+            - mpackUrl: http://public-repo-1.hortonworks.com/HDF/sles12/3.x/updates/3.3.0.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.3.0.0-165.tar.gz
+              stackDefault: true
+            amazonlinux2:
+            - mpackUrl: http://public-repo-1.hortonworks.com/HDF/amazonlinux2/3.x/updates/3.3.0.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.3.0.0-165.tar.gz
+              stackDefault: true
   smartsense.configure: false
   smartsense.enabled: true
   smartsense.id.pattern: A-9990%s-C-%s

--- a/core/src/main/resources/defaults/blueprints/hdf33-messaging-kafka.bp
+++ b/core/src/main/resources/defaults/blueprints/hdf33-messaging-kafka.bp
@@ -1,0 +1,65 @@
+{
+  "description": "Useful for messaging management with Apache Kafka",
+  "blueprint":
+  {
+      "Blueprints": {
+        "blueprint_name": "hdf33-messaging-management",
+        "stack_name": "HDF",
+        "stack_version": "3.3"
+      },
+      "configurations": [
+        {
+          "ams-grafana-env": {
+            "metrics_grafana_password": "admin"
+          }
+        }
+      ],
+      "host_groups": [
+        {
+          "name": "Services",
+          "components": [
+            {
+              "name": "METRICS_COLLECTOR"
+            },
+            {
+              "name": "METRICS_MONITOR"
+            },
+            {
+              "name": "METRICS_GRAFANA"
+            },
+            {
+              "name": "ZOOKEEPER_CLIENT"
+            }
+          ],
+          "cardinality": "1"
+        },
+        {
+          "name": "Messaging",
+          "components": [
+            {
+              "name": "KAFKA_BROKER"
+            },
+            {
+              "name": "METRICS_MONITOR"
+            },
+            {
+              "name": "ZOOKEEPER_CLIENT"
+            }
+          ],
+          "cardinality": "3+"
+        },
+        {
+          "name": "ZooKeeper",
+          "components": [
+            {
+              "name": "ZOOKEEPER_SERVER"
+            },
+            {
+              "name": "ZOOKEEPER_CLIENT"
+            }
+          ],
+          "cardinality": "3+"
+        }
+      ]
+  }
+}


### PR DESCRIPTION
…loudbreak

Introduce HDF-3.3 stack/repo info into cloudbreak. Also including a new default blueprint for hdf33-messaging-management : Kafka.

I tested with given blueprints in cloud.eng.hortonworks and it works.