### PR TITLE
BUG-115806 Yarn log server URL and BUG-114296  CloudBreak needs to configure a unique cluster Id 

### DIFF
--- a/template-manager-blueprint/src/main/resources/blueprints/configurations/yarn_client/shared_service.handlebars
+++ b/template-manager-blueprint/src/main/resources/blueprints/configurations/yarn_client/shared_service.handlebars
@@ -5,7 +5,8 @@
     "properties": {
       "yarn.timeline-service.reader.webapp.address": "{{{ sharedService.datalakeAmbariFqdn }}}:8198",
       "yarn.timeline-service.reader.webapp.https.address": "{{{ sharedService.datalakeAmbariFqdn }}}:8199",
-      "yarn.log.server.web-service.url": "{{{ sharedService.datalakeAmbariFqdn }}}:8198/ws/v2/applicationlog"
+      "yarn.log.server.web-service.url": "http://{{{ sharedService.datalakeAmbariFqdn }}}:8198/ws/v2/applicationlog",
+      "yarn.resourcemanager.cluster-id": "{{{ general.uuid }}}"
     }
   },
   "yarn-hbase-site": {

--- a/template-manager-blueprint/src/test/resources/handlebar/configurations/yarn_client/yarn-client.json
+++ b/template-manager-blueprint/src/test/resources/handlebar/configurations/yarn_client/yarn-client.json
@@ -5,7 +5,8 @@
     "properties": {
       "yarn.timeline-service.reader.webapp.address": "ambarifqdn:8198",
       "yarn.timeline-service.reader.webapp.https.address": "ambarifqdn:8199",
-      "yarn.log.server.web-service.url": "ambarifqdn:8198/ws/v2/applicationlog"
+      "yarn.log.server.web-service.url": "http://ambarifqdn:8198/ws/v2/applicationlog",
+      "yarn.resourcemanager.cluster-id": "{{{general.uuid}}}"
     }
   },
   "yarn-hbase-site": {


### PR DESCRIPTION
Changes to fix below issues.
BUG-115806 : Yarn log server URL wiring is missing the protocol
BUG-114296 : CloudBreak needs to configure a unique cluster Id for each workload cluster



Closes #BUG-115806
Closes #BUG-114296