### PR TITLE
BUG-116007 persist ObjectId of the created Azure App in case of inter…

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/interactivelogin/AzureInteractiveLoginStatusCheckerTask.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/interactivelogin/AzureInteractiveLoginStatusCheckerTask.java
@@ -113,6 +113,7 @@ public class AzureInteractiveLoginStatusCheckerTask extends PollBooleanStateTask
                     extendedCloudCredential.putParameter("accessKey", application.getAppId());
                     extendedCloudCredential.putParameter("secretKey", application.getAzureApplicationCreationView().getAppSecret());
                     extendedCloudCredential.putParameter("spDisplayName", sp.displayName());
+                    extendedCloudCredential.putParameter("appObjectId", application.getObjectId());
 
                     armInteractiveLoginStatusCheckerContext.getCredentialNotifier().createCredential(getAuthenticatedContext().getCloudContext(),
                             extendedCloudCredential);

--- a/cloud-azure/src/main/resources/definitions/azure-credential.json
+++ b/cloud-azure/src/main/resources/definitions/azure-credential.json
@@ -45,6 +45,12 @@
       "type": "Boolean",
       "optional": true,
       "sensitive": false
+    },
+    {
+      "name": "appObjectId",
+      "type": "String",
+      "optional": true,
+      "sensitive": false
     }
   ]
 }


### PR DESCRIPTION
@doktoric 
Please implement the UI to be able to handle the previously created code grant flow credentials that doesn't contain the new "appObjectId" field as parameter.