### PR TITLE
BUG-116076 Set additional kerberos-env configs to generate auth_to_local

### DIFF
--- a/template-manager-blueprint/src/main/java/com/sequenceiq/cloudbreak/blueprint/kerberos/KerberosBlueprintService.java
+++ b/template-manager-blueprint/src/main/java/com/sequenceiq/cloudbreak/blueprint/kerberos/KerberosBlueprintService.java
@@ -72,6 +72,7 @@ public class KerberosBlueprintService implements BlueprintComponentConfigProvide
                 .put("kdc_hosts", kdcHosts)
                 .put("admin_server_host", kdcAdminHost)
                 .put("encryption_types", "aes des3-cbc-sha1 rc4 des-cbc-md5")
+                .put("include_all_components_in_auth_to_local_rules", "true")
                 .put("ldap_url", ldapUrl == null ? "" : ldapUrl)
                 .put("container_dn", containerDn == null ? "" : containerDn);
         if (kerberosConfig.getType() == KerberosType.FREEIPA) {

--- a/template-manager-blueprint/src/test/resources/blueprints-jackson/bp-kerberized-test.bp
+++ b/template-manager-blueprint/src/test/resources/blueprints-jackson/bp-kerberized-test.bp
@@ -22,6 +22,7 @@
                     "case_insensitive_username_rules": "true",
                     "container_dn": "",
                     "encryption_types": "enc_types.bp",
+                    "include_all_components_in_auth_to_local_rules": "true",
                     "install_packages": false,
                     "kdc_hosts": "kdc_host.bp",
                     "kdc_type": "mit-kdc",

--- a/template-manager-blueprint/src/test/resources/blueprints-jackson/bp-not-kerberized-existing-expected.bp
+++ b/template-manager-blueprint/src/test/resources/blueprints-jackson/bp-not-kerberized-existing-expected.bp
@@ -23,6 +23,7 @@
                     "kdc_hosts": "url.conf",
                     "admin_server_host": "adminUrl.conf",
                     "encryption_types": "aes des3-cbc-sha1 rc4 des-cbc-md5",
+                    "include_all_components_in_auth_to_local_rules": "true",
                     "ldap_url": "ldapUrl.conf",
                     "container_dn": "containerDn.conf"
                 }

--- a/template-manager-blueprint/src/test/resources/module-test/outputs/kerberos.bp
+++ b/template-manager-blueprint/src/test/resources/module-test/outputs/kerberos.bp
@@ -61,6 +61,7 @@
           "kdc_hosts": "fqdn.loal.com",
           "realm": "LOAL.COM",
           "encryption_types": "aes des3-cbc-sha1 rc4 des-cbc-md5",
+          "include_all_components_in_auth_to_local_rules": "true",
           "admin_server_host": "fqdn.loal.com",
           "ldap_url": "",
           "container_dn": ""


### PR DESCRIPTION
Tested this on a local deploy. The auth_to_local rules are generated properly with the change.