### PR TITLE
BUG-115160. Set additional Atlas settings when attaching to a kerberized cluser. BUG-115662. Enable ranger audit logging to solr

### DIFF
--- a/cloud-common/src/main/resources/application.yml
+++ b/cloud-common/src/main/resources/application.yml
@@ -518,6 +518,10 @@ serviceDescriptorDefinitionMap:
     blueprintParamKeys:
       - atlas.rest.address
       - atlas.kafka.bootstrap.servers
+      - atlas.kafka.security.protocol
+      - atlas.jaas.KafkaClient.option.serviceName
+      - atlas.kafka.sasl.kerberos.service.name
+      - atlas.kafka.zookeeper.connect
   YARN:
     serviceName: YARN
     blueprintParamKeys:

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/sharedservice/SharedServiceConfigProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/sharedservice/SharedServiceConfigProvider.java
@@ -137,6 +137,10 @@ public class SharedServiceConfigProvider {
         datalakeProperties.add("ranger.audit.solr.zookeepers");
         datalakeProperties.add("atlas.rest.address");
         datalakeProperties.add("atlas.kafka.bootstrap.servers");
+        datalakeProperties.add("atlas.kafka.security.protocol");
+        datalakeProperties.add("atlas.jaas.KafkaClient.option.serviceName");
+        datalakeProperties.add("atlas.kafka.sasl.kerberos.service.name");
+        datalakeProperties.add("atlas.kafka.zookeeper.connect");
         datalakeProperties.add("ranger_admin_username");
         datalakeProperties.add("policymgr_external_url");
     }

--- a/template-manager-blueprint/src/main/resources/blueprints/configurations/hive_server/shared_service.handlebars
+++ b/template-manager-blueprint/src/main/resources/blueprints/configurations/hive_server/shared_service.handlebars
@@ -24,6 +24,12 @@
       "ranger.plugin.hive.service.name":"{{{ remoteClusterName }}}_hive"
     }
   },
+  "ranger-hive-audit": {
+    "properties": {
+      "xasecure.audit.destination.solr": "true"{{{#cp sharedService.datalakeComponents 'RANGER_ADMIN'}}},
+      "xasecure.audit.destination.solr.zookeepers": "{{{ ranger.audit.solr.zookeepers }}}"{{{/cp}}}
+    }
+  },
   "hive-env": {
     "properties": {
       "hive_security_authorization": "Ranger"{{{#cp sharedService.datalakeComponents 'ATLAS_SERVER'}}},
@@ -32,7 +38,11 @@
   }{{{#cp sharedService.datalakeComponents 'KAFKA_BROKER'}}},
   "hive-atlas-application.properties": {
     "properties": {
-      "atlas.kafka.bootstrap.servers": "{{{ atlas.kafka.bootstrap.servers }}}"
+      "atlas.kafka.bootstrap.servers": "{{{ atlas.kafka.bootstrap.servers }}}",
+      "atlas.kafka.security.protocol": "{{{ atlas.kafka.security.protocol }}}",
+      "atlas.jaas.KafkaClient.option.serviceName": "{{{ atlas.jaas.KafkaClient.option.serviceName }}}",
+      "atlas.kafka.sasl.kerberos.service.name": "{{{ atlas.kafka.sasl.kerberos.service.name }}}",
+      "atlas.kafka.zookeeper.connect": "{{{ atlas.kafka.zookeeper.connect }}}"
     }
   }{{{/cp}}}
 {{{/if-true}}}

--- a/template-manager-blueprint/src/main/resources/blueprints/configurations/hive_server_interactive/shared_service.handlebars
+++ b/template-manager-blueprint/src/main/resources/blueprints/configurations/hive_server_interactive/shared_service.handlebars
@@ -30,6 +30,12 @@
       "ranger.plugin.hive.service.name":"{{{ remoteClusterName }}}_hive"
     }
   },
+  "ranger-hive-audit": {
+    "properties": {
+      "xasecure.audit.destination.solr": "true"{{{#cp sharedService.datalakeComponents 'RANGER_ADMIN'}}},
+      "xasecure.audit.destination.solr.zookeepers": "{{{ ranger.audit.solr.zookeepers }}}"{{{/cp}}}
+    }
+  },
   "hive-env": {
     "properties": {
       "hive_security_authorization": "Ranger"{{{#cp sharedService.datalakeComponents 'ATLAS_SERVER'}}},
@@ -38,7 +44,11 @@
   }{{{#cp sharedService.datalakeComponents 'KAFKA_BROKER'}}},
   "hive-atlas-application.properties": {
     "properties": {
-      "atlas.kafka.bootstrap.servers": "{{{ atlas.kafka.bootstrap.servers }}}"
+      "atlas.kafka.bootstrap.servers": "{{{ atlas.kafka.bootstrap.servers }}}",
+      "atlas.kafka.security.protocol": "{{{ atlas.kafka.security.protocol }}}",
+      "atlas.jaas.KafkaClient.option.serviceName": "{{{ atlas.jaas.KafkaClient.option.serviceName }}}",
+      "atlas.kafka.sasl.kerberos.service.name": "{{{ atlas.kafka.sasl.kerberos.service.name }}}",
+      "atlas.kafka.zookeeper.connect": "{{{ atlas.kafka.zookeeper.connect }}}"
     }
   }{{{/cp}}}
 {{{/if-true}}}

--- a/template-manager-blueprint/src/test/java/com/sequenceiq/cloudbreak/blueprint/template/HandlebarTemplateTest.java
+++ b/template-manager-blueprint/src/test/java/com/sequenceiq/cloudbreak/blueprint/template/HandlebarTemplateTest.java
@@ -670,8 +670,15 @@ public class HandlebarTemplateTest {
         Map<String, Object> fixInputs = new HashMap<>();
         fixInputs.put("remoteClusterName", "datalake-1");
         fixInputs.put("policymgr_external_url", "10.1.1.1:6080");
+        fixInputs.put("ranger.audit.solr.zookeepers", "10.1.1.1:2181/infra-solr");
+
+        SharedServiceConfigsView sharedServiceConfigsView = attachedClusterSharedServiceConfig().get();
+        Set<String> objects = new HashSet<>();
+        objects.add("RANGER_ADMIN");
+        sharedServiceConfigsView.setDatalakeComponents(objects);
+
         return new TemplateModelContextBuilder()
-                .withSharedServiceConfigs(attachedClusterSharedServiceConfig().get())
+                .withSharedServiceConfigs(sharedServiceConfigsView)
                 .withFixInputs(fixInputs)
                 .build();
     }
@@ -692,12 +699,19 @@ public class HandlebarTemplateTest {
         fixInputs.put("policymgr_external_url", "10.1.1.1:6080");
         fixInputs.put("atlas.kafka.bootstrap.servers", "10.1.1.1:6667");
         fixInputs.put("atlas.rest.address", "http://10.1.1.1:21000");
+        fixInputs.put("atlas.kafka.security.protocol", "SASL_PLAINTEXT");
+        fixInputs.put("atlas.jaas.KafkaClient.option.serviceName", "kafka");
+        fixInputs.put("atlas.kafka.sasl.kerberos.service.name", "kafka");
+        fixInputs.put("atlas.kafka.zookeeper.connect", "10.1.1.1:2181");
+        fixInputs.put("ranger.audit.solr.zookeepers", "10.1.1.1:2181/infra-solr");
+
         SharedServiceConfigsView sharedServiceConfigsView = attachedClusterSharedServiceConfig().get();
         sharedServiceConfigsView.setDatalakeAmbariIp("10.1.1.1");
 
         Set<String> objects = new HashSet<>();
         objects.add("KAFKA_BROKER");
         objects.add("ATLAS_SERVER");
+        objects.add("RANGER_ADMIN");
         sharedServiceConfigsView.setDatalakeComponents(objects);
 
         return new TemplateModelContextBuilder()

--- a/template-manager-blueprint/src/test/resources/handlebar/configurations/hive_server/shared-service-atlas-attached.json
+++ b/template-manager-blueprint/src/test/resources/handlebar/configurations/hive_server/shared-service-atlas-attached.json
@@ -24,6 +24,12 @@
       "ranger.plugin.hive.service.name":"datalake-1_hive"
     }
   },
+  "ranger-hive-audit": {
+    "properties": {
+      "xasecure.audit.destination.solr": "true",
+      "xasecure.audit.destination.solr.zookeepers": "10.1.1.1:2181/infra-solr"
+    }
+  },
   "hive-env": {
     "properties": {
       "hive_security_authorization": "Ranger",
@@ -32,7 +38,11 @@
   },
   "hive-atlas-application.properties": {
     "properties": {
-      "atlas.kafka.bootstrap.servers": "10.1.1.1:6667"
+      "atlas.kafka.bootstrap.servers": "10.1.1.1:6667",
+      "atlas.kafka.security.protocol": "SASL_PLAINTEXT",
+      "atlas.jaas.KafkaClient.option.serviceName": "kafka",
+      "atlas.kafka.sasl.kerberos.service.name": "kafka",
+      "atlas.kafka.zookeeper.connect": "10.1.1.1:2181"
     }
   }
 

--- a/template-manager-blueprint/src/test/resources/handlebar/configurations/hive_server/shared-service-attached.json
+++ b/template-manager-blueprint/src/test/resources/handlebar/configurations/hive_server/shared-service-attached.json
@@ -23,6 +23,12 @@
       "ranger.plugin.hive.service.name":"datalake-1_hive"
     }
   },
+  "ranger-hive-audit": {
+    "properties": {
+      "xasecure.audit.destination.solr": "true",
+      "xasecure.audit.destination.solr.zookeepers": "10.1.1.1:2181/infra-solr"
+    }
+  },
   "hive-env": {
     "properties": {
       "hive_security_authorization": "Ranger"

--- a/template-manager-blueprint/src/test/resources/handlebar/configurations/hive_server_interactive/shared-service-atlas-attached.json
+++ b/template-manager-blueprint/src/test/resources/handlebar/configurations/hive_server_interactive/shared-service-atlas-attached.json
@@ -30,6 +30,12 @@
       "ranger.plugin.hive.service.name":"datalake-1_hive"
     }
   },
+  "ranger-hive-audit": {
+    "properties": {
+      "xasecure.audit.destination.solr": "true",
+      "xasecure.audit.destination.solr.zookeepers": "10.1.1.1:2181/infra-solr"
+    }
+  },
   "hive-env": {
     "properties": {
       "hive_security_authorization": "Ranger",
@@ -38,7 +44,11 @@
   },
   "hive-atlas-application.properties": {
     "properties": {
-      "atlas.kafka.bootstrap.servers": "10.1.1.1:6667"
+      "atlas.kafka.bootstrap.servers": "10.1.1.1:6667",
+      "atlas.kafka.security.protocol": "SASL_PLAINTEXT",
+      "atlas.jaas.KafkaClient.option.serviceName": "kafka",
+      "atlas.kafka.sasl.kerberos.service.name": "kafka",
+      "atlas.kafka.zookeeper.connect": "10.1.1.1:2181"
     }
   }
 

--- a/template-manager-blueprint/src/test/resources/handlebar/configurations/hive_server_interactive/shared-service-attached.json
+++ b/template-manager-blueprint/src/test/resources/handlebar/configurations/hive_server_interactive/shared-service-attached.json
@@ -29,6 +29,12 @@
       "ranger.plugin.hive.service.name":"datalake-1_hive"
     }
   },
+  "ranger-hive-audit": {
+    "properties": {
+      "xasecure.audit.destination.solr": "true",
+      "xasecure.audit.destination.solr.zookeepers": "10.1.1.1:2181/infra-solr"
+    }
+  },
   "hive-env": {
     "properties": {
       "hive_security_authorization": "Ranger"


### PR DESCRIPTION
Tested via a local deployment. Also noticed that CB seems to pick up DL properties from it's DB, rather than querying the DL cluster. Creating an improvement request for that.