### PR TITLE
BUG-115844 Add revised workload blueprints to Cloudbreak

### DIFF
--- a/cloud-common/src/main/resources/application.yml
+++ b/cloud-common/src/main/resources/application.yml
@@ -132,7 +132,11 @@ cb:
                 HDP 3.0 - Data Science: Apache Spark 2, Apache Zeppelin=hdp30-data-science-spark2;
                 HDP 3.0 - EDW-Analytics: Apache Hive 2 LLAP, Apache Zeppelin=hdp30-edw-analytics;
                 HDP 3.0 - Data Lake: Apache Ranger, Apache Hive Metastore=hdp30-shared-services;
-                HDP 3.0 - Data Lake: Apache Ranger, Apache Atlas, Infrastructure Services=hdp30-shared-services-v2
+                HDP 3.0 - Data Lake: Apache Ranger, Apache Atlas, Infrastructure Services=hdp30-shared-services-v2;
+                HDP 3.0 - Data Science Attached: Apache Spark 2, Apache Zeppelin=hdp30-data-science-spark2-attached-v2;
+                HDP 3.0 - Data Science Standalone: Apache Spark 2, Apache Zeppelin=hdp30-data-science-spark2-standalone-v2;
+                HDP 3.0 - EDW-Analytics Attached: Apache Hive 3 LLAP=hdp30-edw-analytics-attached-v2;
+                HDP 3.0 - EDW-Analytics Standalone: Apache Hive 3 LLAP=hdp30-edw-analytics-standalone-v2
   clustertemplate.defaults:
   template.defaults: minviable-gcp,minviable-azure-managed-disks,minviable-aws
   custom.user.data: |

--- a/core/src/main/resources/defaults/blueprints/hdp30-data-science-spark2-attached-v2.bp
+++ b/core/src/main/resources/defaults/blueprints/hdp30-data-science-spark2-attached-v2.bp
@@ -1,0 +1,203 @@
+{
+  "description": "Useful for data science with Spark and Zeppelin",
+  "blueprint": {
+    "Blueprints": {
+      "stack_name": "HDP",
+      "stack_version": "3.0",
+      "blueprint_name": "hdp30-data-science-spark2-attached-v2"
+    },
+    "settings": [
+      {
+        "recovery_settings": []
+      },
+      {
+        "service_settings": [
+          {
+            "name": "HIVE",
+            "credential_store_enabled": "true"
+          }
+        ]
+      },
+      {
+        "component_settings": []
+      }
+    ],
+    "configurations": [
+      {
+        "zeppelin-site": {
+          "properties_attributes": {},
+          "properties": {
+            "zeppelin.hadoop.localfs.override": "false"
+          }
+        }
+      },
+      {
+        "livy2-conf": {
+          "properties_attributes": {},
+          "properties": {
+            "livy.superusers": "knox,zeppelin"
+          }
+        }
+      },
+      {
+        "yarn-site": {
+          "properties_attributes": {},
+          "properties": {
+            "yarn.acl.enable": "true",
+            "hadoop.registry.dns.enabled": "false",
+            "yarn.log-aggregation.fs-support-append": "false",
+            "yarn.log-aggregation.file-formats": "TFile",
+            "yarn.timeline-service.versions" : "2.0f",
+            "yarn.resourcemanager.cluster-id" : "{{{ general.uuid }}}",
+            "yarn.log-aggregation-status.time-out.ms": "1200000"
+          }
+        }
+      },
+      {
+        "yarn-hbase-site": {
+          "properties_attributes": {},
+          "properties": {
+            "hbase.zookeeper.property.clientPort": "2181",
+            "hbase.client.retries.number": "10"
+          }
+        }
+      },
+      {
+        "yarn-hbase-env": {
+          "properties_attributes": {},
+          "properties": {
+            "use_external_hbase": "true",
+            "is_hbase_system_service_launch": "false"
+          }
+        }
+      },  
+      {
+        "cluster-env": {
+          "properties_attributes": {},
+          "properties": {
+            "metrics_collector_external_port": "6188"
+          }
+        }
+      },
+      {
+        "anonymization-conf": {
+          "security.anonymization.max.heap": "1024"
+        }
+      },
+      {
+        "hst-agent-conf": {
+          "security.anonymization.max.heap": "1024"
+        }
+      },
+      {
+        "hst-server-conf": {
+          "server.max.heap": "1024"
+        }
+      }
+    ],
+    "host_groups": [
+      {
+        "name": "master",
+        "configurations": [],
+        "components": [
+          {
+            "name": "YARN_CLIENT"
+          },
+          {
+            "name": "HDFS_CLIENT"
+          },
+          {
+            "name": "SPARK2_CLIENT"
+          },
+          {
+            "name": "HIVE_METASTORE"
+          },
+          {
+            "name": "NAMENODE"
+          },
+          {
+            "name": "ZEPPELIN_MASTER"
+          },
+          {
+            "name": "ZOOKEEPER_CLIENT"
+          },
+          {
+            "name": "SECONDARY_NAMENODE"
+          },
+          {
+            "name": "ZOOKEEPER_SERVER"
+          },
+          {
+            "name": "AMBARI_SERVER"
+          },
+          {
+            "name": "LIVY2_SERVER"
+          },
+          {
+            "name": "HIVE_CLIENT"
+          },
+          {
+            "name": "RESOURCEMANAGER"
+          },
+          {
+            "name": "METRICS_MONITOR"
+          },
+          {
+            "name": "HST_SERVER"
+          },
+          {
+            "name": "HST_AGENT"
+          }
+        ],
+        "cardinality": "1"
+      },
+      {
+        "name": "worker",
+        "configurations": [],
+        "components": [
+          {
+            "name": "HIVE_CLIENT"
+          },
+          {
+            "name": "SPARK2_CLIENT"
+          },
+          {
+            "name": "DATANODE"
+          },
+          {
+            "name": "METRICS_MONITOR"
+          },
+          {
+            "name": "NODEMANAGER"
+          },
+          {
+            "name": "HST_AGENT"
+          }
+        ],
+        "cardinality": "1+"
+      },
+      {
+        "name": "compute",
+        "configurations": [],
+        "components": [
+          {
+            "name": "HIVE_CLIENT"
+          },
+          {
+            "name": "SPARK2_CLIENT"
+          },
+          {
+            "name": "METRICS_MONITOR"
+          },
+          {
+            "name": "NODEMANAGER"
+          },
+          {
+            "name": "HST_AGENT"
+          }
+        ],
+        "cardinality": "1+"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/blueprints/hdp30-data-science-spark2-standalone-v2.bp
+++ b/core/src/main/resources/defaults/blueprints/hdp30-data-science-spark2-standalone-v2.bp
@@ -1,0 +1,202 @@
+{
+  "description": "Useful for data science with Spark and Zeppelin",
+  "blueprint": {
+    "Blueprints": {
+      "stack_name": "HDP",
+      "stack_version": "3.0",
+      "blueprint_name": "hdp30-data-science-spark2-standalone-v2"
+    },
+    "settings": [
+      {
+        "recovery_settings": []
+      },
+      {
+        "service_settings": [
+          {
+            "name": "HIVE",
+            "credential_store_enabled": "true"
+          }
+        ]
+      },
+      {
+        "component_settings": []
+      }
+    ],
+    "configurations": [
+      {
+        "zeppelin-site": {
+          "properties_attributes": {},
+          "properties": {
+            "zeppelin.hadoop.localfs.override": "false"
+          }
+        }
+      },
+      {
+        "livy2-conf": {
+          "properties_attributes": {},
+          "properties": {
+            "livy.superusers": "knox,zeppelin"
+          }
+        }
+      },
+      {
+        "yarn-site": {
+          "yarn.acl.enable": "true",
+          "hadoop.registry.dns.enabled": "false",
+          "yarn.log-aggregation.fs-support-append": "false",
+          "yarn.log-aggregation.file-formats": "TFile",
+          "yarn.timeline-service.versions" : "2.0f",
+          "yarn.resourcemanager.cluster-id" : "{{{ general.uuid }}}",
+          "yarn.log-aggregation-status.time-out.ms": "1200000"
+        }
+      },
+      {
+        "yarn-env": {
+          "apptimelineserver_heapsize": "1024m"
+        }
+      },
+      {
+        "yarn-hbase-env": {
+          "is_hbase_system_service_launch": "false",
+          "use_external_hbase": "false",
+          "yarn_hbase_master_memory": "1024",
+          "yarn_hbase_regionserver_memory": "1024"
+        }
+      },
+      {
+        "anonymization-conf": {
+          "security.anonymization.max.heap": "1024"
+        }
+      },
+      {
+        "hst-agent-conf": {
+          "security.anonymization.max.heap": "1024"
+        }
+      },
+      {
+        "hst-server-conf": {
+          "server.max.heap": "1024"
+        }
+      }
+    ],
+    "host_groups": [
+      {
+        "name": "master",
+        "configurations": [],
+        "components": [
+          {
+            "name": "YARN_CLIENT"
+          },
+          {
+            "name": "HDFS_CLIENT"
+          },
+          {
+            "name": "METRICS_MONITOR"
+          },
+          {
+            "name": "METRICS_GRAFANA"
+          },
+          {
+            "name": "METRICS_COLLECTOR"
+          },
+          {
+            "name": "SPARK2_JOBHISTORYSERVER"
+          },
+          {
+            "name": "SPARK2_CLIENT"
+          },
+          {
+            "name": "HIVE_METASTORE"
+          },
+          {
+            "name": "NAMENODE"
+          },
+          {
+            "name": "ZEPPELIN_MASTER"
+          },
+          {
+            "name": "ZOOKEEPER_CLIENT"
+          },
+          {
+            "name": "TIMELINE_READER"
+          },
+          {
+            "name": "SECONDARY_NAMENODE"
+          },
+          {
+            "name": "ZOOKEEPER_SERVER"
+          },
+          {
+            "name": "AMBARI_SERVER"
+          },
+          {
+            "name": "LIVY2_SERVER"
+          },
+          {
+            "name": "APP_TIMELINE_SERVER"
+          },
+          {
+            "name": "HIVE_CLIENT"
+          },
+          {
+            "name": "RESOURCEMANAGER"
+          },
+          {
+            "name": "HST_SERVER"
+          },
+          {
+            "name": "HST_AGENT"
+          }
+        ],
+        "cardinality": "1"
+      },
+      {
+        "name": "worker",
+        "configurations": [],
+        "components": [
+          {
+            "name": "HIVE_CLIENT"
+          },
+          {
+            "name": "SPARK2_CLIENT"
+          },
+          {
+            "name": "DATANODE"
+          },
+          {
+            "name": "METRICS_MONITOR"
+          },
+          {
+            "name": "NODEMANAGER"
+          },
+          {
+            "name": "HST_AGENT"
+          }
+        ],
+        "cardinality": "1+"
+      },
+      {
+        "name": "compute",
+        "configurations": [],
+        "components": [
+          {
+            "name": "HIVE_CLIENT"
+          },
+          {
+            "name": "SPARK2_CLIENT"
+          },
+          {
+            "name": "METRICS_MONITOR"
+          },
+          {
+            "name": "NODEMANAGER"
+          },
+          {
+            "name": "HST_AGENT"
+          }
+        ],
+        "cardinality": "1+"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/blueprints/hdp30-edw-analytics-attached-v2.bp
+++ b/core/src/main/resources/defaults/blueprints/hdp30-edw-analytics-attached-v2.bp
@@ -1,0 +1,230 @@
+{
+  "description": "Useful for EDW analytics using Hive LLAP",
+  "blueprint": {
+    "Blueprints": {
+      "blueprint_name": "hdp30-edw-analytics-attached-v2",
+      "stack_name": "HDP",
+      "stack_version": "3.0"
+    },
+    "settings": [
+      {
+        "recovery_settings": []
+      },
+      {
+        "service_settings": [
+          {
+            "name": "HIVE",
+            "credential_store_enabled": "false"
+          }
+        ]
+      },
+      {
+        "component_settings": []
+      }
+    ],
+    "configurations": [
+      {
+        "hive-interactive-env": {
+          "enable_hive_interactive": "true"
+        }
+      },
+      {
+        "hive-interactive-site": {
+          "hive.exec.orc.split.strategy": "BI",
+          "hive.stats.fetch.bitvector": "true",
+          "hive.metastore.rawstore.impl": "org.apache.hadoop.hive.metastore.cache.CachedStore"
+        }
+      },
+      {
+        "hive-site": {
+          "hive.exec.compress.output": "true",
+          "hive.merge.mapfiles": "true",
+          "hive.server2.tez.initialize.default.sessions": "true",
+          "hive.server2.transport.mode": "http"
+        }
+      },
+      {
+        "hive-atlas-application.properties": {
+          "enable.external.atlas.for.hive": "true"
+        }
+      },
+      {
+        "mapred-site": {
+          "mapreduce.job.reduce.slowstart.completedmaps": "0.7",
+          "mapreduce.map.output.compress": "true",
+          "mapreduce.output.fileoutputformat.compress": "true"
+        }
+      },
+      {
+        "tez-site": {
+          "tez.runtime.shuffle.parallel.copies": "4",
+          "tez.runtime.enable.final-merge.in.output": "false",
+          "tez.am.am-rm.heartbeat.interval-ms.max": "3100"
+        }
+      },
+      {
+        "core-site": {
+          "fs.trash.interval": "4331"
+        }
+      },
+      {
+        "hdfs-site": {
+          "dfs.namenode.safemode.threshold-pct": "0.99"
+        }
+      },
+      {
+        "yarn-site": {
+          "properties_attributes": {},
+          "properties": {
+            "yarn.acl.enable": "true",
+            "hadoop.registry.dns.enabled": "false",
+            "yarn.log-aggregation.fs-support-append": "false",
+            "yarn.log-aggregation.file-formats": "TFile",
+            "yarn.timeline-service.versions" : "2.0f",
+            "yarn.resourcemanager.cluster-id" : "{{{ general.uuid }}}",
+            "yarn.log-aggregation-status.time-out.ms": "1200000"
+          }
+        }
+      },
+      {
+        "yarn-hbase-site": {
+          "properties_attributes": {},
+          "properties": {
+            "hbase.zookeeper.property.clientPort": "2181",
+            "hbase.client.retries.number": "10"
+          }
+        }
+      },
+      {
+        "yarn-hbase-env": {
+          "properties_attributes": {},
+          "properties": {
+            "use_external_hbase": "true",
+            "is_hbase_system_service_launch": "false"
+          }
+        }
+      },  
+      {
+        "cluster-env": {
+          "properties_attributes": {},
+          "properties": {
+            "metrics_collector_external_port": "6188"
+          }
+        }
+      },
+      {
+        "anonymization-conf": {
+          "security.anonymization.max.heap": "1024"
+        }
+      },
+      {
+        "hst-agent-conf": {
+          "security.anonymization.max.heap": "1024"
+        }
+      },
+      {
+        "hst-server-conf": {
+          "server.max.heap": "1024"
+        }
+      }
+    ],
+    "host_groups": [
+      {
+        "name": "master",
+        "configurations": [],
+        "components": [
+          {
+            "name": "HDFS_CLIENT"
+          },
+          {
+            "name": "HISTORYSERVER"
+          },
+          {
+            "name": "HIVE_CLIENT"
+          },
+          {
+            "name": "HIVE_METASTORE"
+          },
+          {
+            "name": "HIVE_SERVER_INTERACTIVE"
+          },
+          {
+            "name": "MAPREDUCE2_CLIENT"
+          },
+          {
+            "name": "METRICS_MONITOR"
+          },
+          {
+            "name": "NAMENODE"
+          },
+          {
+            "name": "RESOURCEMANAGER"
+          },
+          {
+            "name": "SECONDARY_NAMENODE"
+          },
+          {
+            "name": "TEZ_CLIENT"
+          },
+          {
+            "name": "YARN_CLIENT"
+          },
+          {
+            "name": "ZOOKEEPER_CLIENT"
+          },
+          {
+            "name": "ZOOKEEPER_SERVER"
+          },
+          {
+            "name": "HST_SERVER"
+          },
+          {
+            "name": "HST_AGENT"
+          }
+        ],
+        "cardinality": "1"
+      },
+      {
+        "name": "worker",
+        "configurations": [],
+        "components": [
+          {
+            "name": "HIVE_CLIENT"
+          },
+          {
+            "name": "DATANODE"
+          },
+          {
+            "name": "METRICS_MONITOR"
+          },
+          {
+            "name": "NODEMANAGER"
+          },
+          {
+            "name": "HST_AGENT"
+          }
+        ],
+        "cardinality": "1+"
+      },
+      {
+        "name": "compute",
+        "configurations": [],
+        "components": [
+          {
+            "name": "HIVE_CLIENT"
+          },
+          {
+            "name": "METRICS_MONITOR"
+          },
+          {
+            "name": "NODEMANAGER"
+          },
+          {
+            "name": "HST_AGENT"
+          }
+        ],
+        "cardinality": "1+"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/blueprints/hdp30-edw-analytics-standalone-v2.bp
+++ b/core/src/main/resources/defaults/blueprints/hdp30-edw-analytics-standalone-v2.bp
@@ -1,0 +1,221 @@
+{
+  "description": "Useful for EDW analytics using Hive LLAP",
+  "blueprint": {
+    "Blueprints": {
+      "blueprint_name": "hdp30-edw-analytics-standalone-v2",
+      "stack_name": "HDP",
+      "stack_version": "3.0"
+    },
+    "settings": [
+      {
+        "recovery_settings": []
+      },
+      {
+        "service_settings": [
+          {
+            "name": "HIVE",
+            "credential_store_enabled": "false"
+          }
+        ]
+      },
+      {
+        "component_settings": []
+      }
+    ],
+    "configurations": [
+      {
+        "hive-interactive-env": {
+          "enable_hive_interactive": "true"
+        }
+      },
+      {
+        "hive-interactive-site": {
+          "hive.exec.orc.split.strategy": "BI",
+          "hive.stats.fetch.bitvector": "true",
+          "hive.metastore.rawstore.impl": "org.apache.hadoop.hive.metastore.cache.CachedStore"
+        }
+      },
+      {
+        "hive-site": {
+          "hive.exec.compress.output": "true",
+          "hive.merge.mapfiles": "true",
+          "hive.server2.tez.initialize.default.sessions": "true",
+          "hive.server2.transport.mode": "http"
+        }
+      },
+      {
+        "mapred-site": {
+          "mapreduce.job.reduce.slowstart.completedmaps": "0.7",
+          "mapreduce.map.output.compress": "true",
+          "mapreduce.output.fileoutputformat.compress": "true"
+        }
+      },
+      {
+        "tez-site": {
+          "tez.runtime.shuffle.parallel.copies": "4",
+          "tez.runtime.enable.final-merge.in.output": "false",
+          "tez.am.am-rm.heartbeat.interval-ms.max": "3100"
+        }
+      },
+      {
+        "core-site": {
+          "fs.trash.interval": "4331"
+        }
+      },
+      {
+        "hdfs-site": {
+          "dfs.namenode.safemode.threshold-pct": "0.99"
+        }
+      },
+      {
+        "yarn-site": {
+          "yarn.acl.enable": "true",
+          "hadoop.registry.dns.enabled": "false",
+          "yarn.log-aggregation.fs-support-append": "false",
+          "yarn.timeline-service.versions" : "2.0f",
+          "yarn.log-aggregation.file-formats": "TFile",
+          "yarn.resourcemanager.cluster-id": "{{{ general.uuid }}}",
+          "yarn.log-aggregation-status.time-out.ms": "1200000"
+        }
+      },
+      {
+        "yarn-env": {
+          "apptimelineserver_heapsize": "1024m"
+        }
+      },
+      {
+        "yarn-hbase-env": {
+          "is_hbase_system_service_launch": "false",
+          "use_external_hbase": "false",
+          "yarn_hbase_master_memory": "1024",
+          "yarn_hbase_regionserver_memory": "1024"
+        }
+      },
+      {
+        "anonymization-conf": {
+          "security.anonymization.max.heap": "1024"
+        }
+      },
+      {
+        "hst-agent-conf": {
+          "security.anonymization.max.heap": "1024"
+        }
+      },
+      {
+        "hst-server-conf": {
+          "server.max.heap": "1024"
+        }
+      }
+    ],
+    "host_groups": [
+      {
+        "name": "master",
+        "configurations": [],
+        "components": [
+          {
+            "name": "APP_TIMELINE_SERVER"
+          },
+          {
+            "name": "TIMELINE_READER"
+          },
+          {
+            "name": "HDFS_CLIENT"
+          },
+          {
+            "name": "HISTORYSERVER"
+          },
+          {
+            "name": "HIVE_CLIENT"
+          },
+          {
+            "name": "HIVE_METASTORE"
+          },
+          {
+            "name": "HIVE_SERVER_INTERACTIVE"
+          },
+          {
+            "name": "MAPREDUCE2_CLIENT"
+          },
+          {
+            "name": "METRICS_COLLECTOR"
+          },
+          {
+            "name": "METRICS_MONITOR"
+          },
+          {
+            "name": "METRICS_GRAFANA"
+          },
+          {
+            "name": "NAMENODE"
+          },
+          {
+            "name": "RESOURCEMANAGER"
+          },
+          {
+            "name": "SECONDARY_NAMENODE"
+          },
+          {
+            "name": "TEZ_CLIENT"
+          },
+          {
+            "name": "YARN_CLIENT"
+          },
+          {
+            "name": "ZOOKEEPER_CLIENT"
+          },
+          {
+            "name": "ZOOKEEPER_SERVER"
+          },
+          {
+            "name": "HST_SERVER"
+          },
+          {
+            "name": "HST_AGENT"
+          }
+        ],
+        "cardinality": "1"
+      },
+      {
+        "name": "worker",
+        "configurations": [],
+        "components": [
+          {
+            "name": "HIVE_CLIENT"
+          },
+          {
+            "name": "DATANODE"
+          },
+          {
+            "name": "METRICS_MONITOR"
+          },
+          {
+            "name": "NODEMANAGER"
+          },
+          {
+            "name": "HST_AGENT"
+          }
+        ],
+        "cardinality": "1+"
+      },
+      {
+        "name": "compute",
+        "configurations": [],
+        "components": [
+          {
+            "name": "HIVE_CLIENT"
+          },
+          {
+            "name": "METRICS_MONITOR"
+          },
+          {
+            "name": "NODEMANAGER"
+          },
+          {
+            "name": "HST_AGENT"
+          }
+        ],
+        "cardinality": "1+"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/blueprints/hdp30-shared-services-v2.bp
+++ b/core/src/main/resources/defaults/blueprints/hdp30-shared-services-v2.bp
@@ -8,13 +8,13 @@
       "stack_name": "HDP",
       "stack_version": "3.0"
     },
-  "settings": [
-    {
-      "recovery_settings": []
-    },
-    {
-      "component_settings": []
-    }
+    "settings": [
+      {
+        "recovery_settings": []
+      },
+      {
+        "component_settings": []
+      }
     ],
     "configurations": [
       {
@@ -40,6 +40,7 @@
       {
         "yarn-hbase-site": {
           "hbase.wal.dir": "file:///hadoopfs/fs1/apps/yarn-hbase/wal-data/",
+          "hbase.rootdir": "file:///hadoopfs/fs1/apps/yarn-hbase/data/",
           "hbase.unsafe.stream.capability.enforce": "false"
         }
       },
@@ -54,6 +55,7 @@
       {
         "hbase-site": {
           "hbase.wal.dir": "file:///hadoopfs/fs1/hbase-atlas-wal-data/",
+          "hbase.rootdir": "file:///hadoopfs/fs1/hbase-atlas-data",
           "hbase.unsafe.stream.capability.enforce" : "false"
         }
       },
@@ -70,7 +72,13 @@
       },
       {
         "ams-hbase-site": {
-          "hbase.wal.dir": "file:///hadoopfs/fs1/apps/ams-hbase/wal-data/"
+          "hbase.wal.dir": "file:///hadoopfs/fs1/apps/ams-hbase/wal-data/",
+          "hbase.rootdir": "file:///hadoopfs/fs1/apps/ams-hbase/data"
+        }
+      },
+      {
+        "kafka-broker": {
+          "log.dirs": "file:///hadoopfs/fs1/kafka-logs"
         }
       },
       {
@@ -89,13 +97,13 @@
         }
       }
     ],
-      "host_groups": [
-        {
-          "name": "master",
-          "configurations": [],
-          "components": [
-            {
-              "name": "HDFS_CLIENT"
+    "host_groups": [
+      {
+        "name": "master",
+        "configurations": [],
+        "components": [
+          {
+            "name": "HDFS_CLIENT"
           },
           {
             "name": "ZOOKEEPER_CLIENT"


### PR DESCRIPTION
@doktoric  - Apologies, but posting this again with separation between attached and standalone clusters.

I tried looking at doing this separation - will send over a mail separately with potential logic.
Needs access to 
`return (In-Built BluePrint && HDP && HDP_VERSION in 3.0.100 && !AttachedToDatalake)`
- Whether the blueprint is In-Built or not (Could not figure out how to find this)
- Whether HDP (Likely already available)
- HDP Version (Likely already available)
- Whether attaching to Datalake (May not be available in the BlueprintComponentConfigProvider Interface, but looking at the code - think this can be made available.

My trying to make biggish changes to Cloudbreak at this point is extremely inefficient. When I was looking at the code, and added some logging, the initial impression I got was that this isn't invoked at all. (For whatever reason a lot of logging that I add does not show up).

Anyway - could you please commit the change as is for now, and this can be worked on post Dec 20th (which is next year). Alternately, I'm going to need your help to make the change if it's trivial. It's highly unlikely that I'll be able to make the change in the next 2 days for some upcoming demo.