### PR TITLE
BUG-116567 Wait for instances to be terminated

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/task/AwsInstanceTerminatedStatusCheckerTask.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/task/AwsInstanceTerminatedStatusCheckerTask.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.cloudbreak.cloud.aws.task;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+
+import com.amazonaws.services.ec2.AmazonEC2Client;
+import com.amazonaws.services.ec2.model.DescribeInstanceStatusRequest;
+import com.amazonaws.services.ec2.model.DescribeInstanceStatusResult;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.task.PollBooleanStateTask;
+
+@Component(AwsInstanceTerminatedStatusCheckerTask.NAME)
+@Scope("prototype")
+public class AwsInstanceTerminatedStatusCheckerTask extends PollBooleanStateTask {
+    public static final String NAME = "awsInstanceTerminatedStatusCheckerTask";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsInstanceTerminatedStatusCheckerTask.class);
+
+    private final String instanceId;
+
+    private final AmazonEC2Client ec2Client;
+
+    public AwsInstanceTerminatedStatusCheckerTask(AuthenticatedContext authenticatedContext, String instanceId, AmazonEC2Client ec2Client) {
+        super(authenticatedContext, true);
+        this.instanceId = instanceId;
+        this.ec2Client = ec2Client;
+    }
+
+    @Override
+    protected Boolean doCall() {
+        LOGGER.debug("Checking if AWS instance '{}' is terminated.", instanceId);
+        DescribeInstanceStatusResult result = ec2Client.describeInstanceStatus(new DescribeInstanceStatusRequest().withInstanceIds(instanceId));
+        return CollectionUtils.isEmpty(result.getInstanceStatuses()) || "terminated".equals(result.getInstanceStatuses().get(0).getInstanceState().getName());
+    }
+}

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/task/AwsPollTaskFactory.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/task/AwsPollTaskFactory.java
@@ -48,6 +48,10 @@ public class AwsPollTaskFactory {
         return createPollTask(CreateSnapshotReadyStatusCheckerTask.NAME, authenticatedContext, snapshotId, ec2Client);
     }
 
+    public PollTask<Boolean> newInstanceTerminationStatusCheckerTask(AuthenticatedContext authenticatedContext, String instanceId, AmazonEC2Client ec2Client) {
+        return createPollTask(AwsInstanceTerminatedStatusCheckerTask.NAME, authenticatedContext, instanceId, ec2Client);
+    }
+
     public PollTask<Boolean> newAMICopyStatusCheckerTask(AuthenticatedContext authenticatedContext, Collection<String> imageIds, AmazonEC2Client client) {
         return createPollTask(AMICopyStatusCheckerTask.NAME, authenticatedContext, imageIds, client);
     }


### PR DESCRIPTION
Sometimes instance termination takes a very long time on AWS. Cloudbreak before stepped to the next flow step right after it sent the termination request to AWS. In the event of slow instance termination, flow execution reached the disk reattach step, but the disks were still attached to the instance under termination, which caused an error.

Implemented a poller, which waits for the instance to be terminated, before moving forward. The downside of this, is it makes flows, which include instance termination slower, depending on AWS performance.