### PR TITLE
BUG-116321 adjust Ambari and HDP versions in order to use blueprints

### DIFF
--- a/cloud-common/src/main/resources/application.yml
+++ b/cloud-common/src/main/resources/application.yml
@@ -234,21 +234,21 @@ cb:
             baseurl: http://public-repo-1.hortonworks.com/ambari/sles12/2.x/updates/2.6.2.2
             gpgkey: http://public-repo-1.hortonworks.com/ambari/sles12/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
       2.7:
-        version: 2.7.1.0
+        version: 2.7.100.0-255
         repo:
           redhat7:
-            baseurl: http://public-repo-1.hortonworks.com/ambari/centos7/2.x/updates/2.7.1.0
-            gpgkey: http://public-repo-1.hortonworks.com/ambari/centos7/2.x/updates/2.7.1.0/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
+            baseurl: http://s3.amazonaws.com/dev.hortonworks.com/ambari/centos7/2.x/BUILDS/2.7.100.0-255
+            gpgkey: http://s3.amazonaws.com/dev.hortonworks.com/ambari/centos7/2.x/BUILDS/2.7.100.0-255/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
           debian9:
-            baseurl: http://public-repo-1.hortonworks.com/ambari/debian9/2.x/updates/2.7.1.0
+            baseurl: http://s3.amazonaws.com/dev.hortonworks.com/ambari/debian9/2.x/BUILDS/2.7.100.0-255
           ubuntu16:
-            baseurl: http://public-repo-1.hortonworks.com/ambari/ubuntu16/2.x/updates/2.7.1.0
+            baseurl: http://s3.amazonaws.com/dev.hortonworks.com/ambari/ubuntu16/2.x/BUILDS/2.7.100.0-255
           sles12:
-            baseurl: http://public-repo-1.hortonworks.com/ambari/sles12/2.x/updates/2.7.1.0
-            gpgkey: http://public-repo-1.hortonworks.com/ambari/sles12/2.x/updates/2.7.1.0/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
+            baseurl: http://s3.amazonaws.com/dev.hortonworks.com/ambari/sles12/2.x/BUILDS/2.7.100.0-255
+            gpgkey: http://s3.amazonaws.com/dev.hortonworks.com/ambari/sles12/2.x/BUILDS/2.7.100.0-255/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
           amazonlinux2:
-            baseurl: http://public-repo-1.hortonworks.com/ambari/amazonlinux2/2.x/updates/2.7.1.0
-            gpgkey: http://public-repo-1.hortonworks.com/ambari/amazonlinux2/2.x/updates/2.7.1.0/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
+            baseurl: http://s3.amazonaws.com/dev.hortonworks.com/ambari/amazonlinux2/2.x/BUILDS/2.7.100.0-255
+            gpgkey: http://s3.amazonaws.com/dev.hortonworks.com/ambari/amazonlinux2/2.x/BUILDS/2.7.100.0-255/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
     database:
       port: 5432
       user: ambari
@@ -306,22 +306,22 @@ cb:
             ubuntu16: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/ubuntu16
             sles12: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/sles12
       3.0:
-        version: 3.0.1.0
+        version: 3.0.100.0
         minAmbari: 2.7
         repo:
           stack:
             repoid: HDP-3.0
-            redhat7: http://public-repo-1.hortonworks.com/HDP/centos7/3.x/updates/3.0.1.0
-            debian9: http://public-repo-1.hortonworks.com/HDP/debian9/3.x/updates/3.0.1.0
-            ubuntu16: http://public-repo-1.hortonworks.com/HDP/ubuntu16/3.x/updates/3.0.1.0
-            sles12: http://public-repo-1.hortonworks.com/HDP/sles12/3.x/updates/3.0.1.0
-            amazonlinux2: http://public-repo-1.hortonworks.com/HDP/amazonlinux2/3.x/updates/3.0.1.0
-            repository-version: 3.0.1.0-187
-            vdf-redhat7: http://public-repo-1.hortonworks.com/HDP/centos7/3.x/updates/3.0.1.0/HDP-3.0.1.0-187.xml
-            vdf-debian9: http://public-repo-1.hortonworks.com/HDP/debian9/3.x/updates/3.0.1.0/HDP-3.0.1.0-187.xml
-            vdf-ubuntu16: http://public-repo-1.hortonworks.com/HDP/ubuntu16/3.x/updates/3.0.1.0/HDP-3.0.1.0-187.xml
-            vdf-sles12: http://public-repo-1.hortonworks.com/HDP/sles12/3.x/updates/3.0.1.0/HDP-3.0.1.0-187.xml
-            vdf-amazonlinux2: http://public-repo-1.hortonworks.com/HDP/amazonlinux2/3.x/updates/3.0.1.0/HDP-3.0.1.0-187.xml
+            redhat7: http://s3.amazonaws.com/dev.hortonworks.com/HDP/centos7/3.x/BUILDS/3.0.100.0-171
+            debian9: http://s3.amazonaws.com/dev.hortonworks.com/HDP/debian9/3.x/BUILDS/3.0.100.0-171
+            ubuntu16: http://s3.amazonaws.com/dev.hortonworks.com/HDP/ubuntu16/3.x/BUILDS/3.0.100.0-171
+            sles12: http://s3.amazonaws.com/dev.hortonworks.com/HDP/sles12/3.x/BUILDS/3.0.100.0-171
+            amazonlinux2: http://s3.amazonaws.com/dev.hortonworks.com/HDP/amazonlinux2/3.x/BUILDS/3.0.100.0-171
+            repository-version: 3.0.100.0-171
+            vdf-redhat7: http://s3.amazonaws.com/dev.hortonworks.com/HDP/centos7/3.x/BUILDS/3.0.100.0-171/HDP-3.0.100.0-171.xml
+            vdf-debian9: http://s3.amazonaws.com/dev.hortonworks.com/HDP/debian9/3.x/BUILDS/3.0.100.0-171/HDP-3.0.100.0-171.xml
+            vdf-ubuntu16: http://s3.amazonaws.com/dev.hortonworks.com/HDP/ubuntu16/3.x/BUILDS/3.0.100.0-171/HDP-3.0.100.0-171.xml
+            vdf-sles12: http://s3.amazonaws.com/dev.hortonworks.com/HDP/sles12/3.x/BUILDS/3.0.100.0-171/HDP-3.0.100.0-171.xml
+            vdf-amazonlinux2: http://s3.amazonaws.com/dev.hortonworks.com/HDP/amazonlinux2/3.x/BUILDS/3.0.100.0-171/HDP-3.0.100.0-171.xml
           util:
             repoid: HDP-UTILS-1.1.0.22
             redhat7: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/centos7


### PR DESCRIPTION
HDP & Ambari versions are increased to use new hdp3 blueprints
HDP 3.0.100.0-171
Ambari 2.7.100.0-255

Closes 116321