### PR TITLE
BUG-115743: Set properties while attaching kafka cluster to Ranger in DL

### DIFF
--- a/template-manager-blueprint/src/main/resources/blueprints/configurations/kafka_broker/shared_service.handlebars
+++ b/template-manager-blueprint/src/main/resources/blueprints/configurations/kafka_broker/shared_service.handlebars
@@ -1,0 +1,37 @@
+{
+{{{#if-true sharedService.attachedCluster}}}
+
+  "cluster-env": {
+    "properties": {
+      "enable_external_ranger":"true"
+    }
+  },
+  "kafka-broker": {
+    "properties": {
+      "authorizer.class.name": "org.apache.ranger.authorization.kafka.authorizer.RangerKafkaAuthorizer"
+    }
+  },
+  "ranger-kafka-plugin-properties": {
+    "properties": {
+      "ranger-kafka-plugin-enabled": "Yes",
+      "external_ranger_admin_username": "admin",
+      "external_ranger_admin_password": "{{{ sharedService.rangerAdminPassword }}}",
+      "external_admin_username": "admin",
+      "external_admin_password": "{{{ sharedService.rangerAdminPassword }}}"
+    }
+  },
+  "ranger-kafka-audit": {
+    "properties": {
+      "xasecure.audit.destination.solr": "true",
+      "xasecure.audit.destination.solr.zookeepers":"{{{ ranger.audit.solr.zookeepers }}}"
+    }
+  },
+  "ranger-kafka-security":{
+    "properties": {
+      "ranger.plugin.kafka.policy.rest.url": "http://{{{ sharedService.rangerAdminHost }}}:{{{ sharedService.rangerAdminPort }}}",
+      "ranger.plugin.kafka.service.name":"{{{ general.clusterName }}}_kafka",
+      "ranger.plugin.kafka.policy.cache.dir":"/etc/ranger/{{{ general.clusterName }}}/policycache"
+    }
+  }
+{{{/if-true}}}
+}

--- a/template-manager-blueprint/src/test/java/com/sequenceiq/cloudbreak/blueprint/template/HandlebarTemplateTest.java
+++ b/template-manager-blueprint/src/test/java/com/sequenceiq/cloudbreak/blueprint/template/HandlebarTemplateTest.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import com.sequenceiq.cloudbreak.domain.KerberosConfig;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,6 +35,7 @@ import com.sequenceiq.cloudbreak.api.model.DatabaseVendor;
 import com.sequenceiq.cloudbreak.api.model.ExecutorType;
 import com.sequenceiq.cloudbreak.api.model.rds.RdsType;
 import com.sequenceiq.cloudbreak.common.model.OrchestratorType;
+import com.sequenceiq.cloudbreak.domain.KerberosConfig;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.template.HandlebarUtils;
 import com.sequenceiq.cloudbreak.template.TemplateModelContextBuilder;
@@ -231,11 +231,15 @@ public class HandlebarTemplateTest {
 
                 // METRICS_MONITOR
                 {"blueprints/configurations/metrics_monitor/shared_service.handlebars", "configurations/metrics_monitor/metrics-monitor.json",
-                        sSConfigWhenMetricsMonitorInWLThenShouldReturnWithMetricsCollectorConfig()},
+                        sSConfigWhenAttachedWLThenShouldReturnWithAttachedWLConfig()},
 
                 // YARN_CLIENT
                 {"blueprints/configurations/yarn_client/shared_service.handlebars", "configurations/yarn_client/yarn-client.json",
-                        sSConfigWhenMetricsMonitorInWLThenShouldReturnWithMetricsCollectorConfig()},
+                        sSConfigWhenAttachedWLThenShouldReturnWithAttachedWLConfig()},
+
+                // KAFKA_BROKER
+                {"blueprints/configurations/kafka_broker/shared_service.handlebars", "configurations/kafka_broker/shared-service-attached.json",
+                        sSConfigWhenAttachedWLThenShouldReturnWithAttachedWLConfig()},
 
                 // LOGSEARCH_LOGFEEDER
                 {"blueprints/configurations/logsearch_logfeeder/cloud_storage.handlebars", "configurations/logsearch_logfeeder/logsearch-logfeeder-empty.json",
@@ -729,7 +733,7 @@ public class HandlebarTemplateTest {
                 .build();
     }
 
-    private static Object sSConfigWhenMetricsMonitorInWLThenShouldReturnWithMetricsCollectorConfig() {
+    private static Object sSConfigWhenAttachedWLThenShouldReturnWithAttachedWLConfig() {
         SharedServiceConfigsView sharedServiceConfigsView = attachedClusterSharedServiceConfig().get();
         sharedServiceConfigsView.setDatalakeAmbariFqdn("ambarifqdn");
 

--- a/template-manager-blueprint/src/test/resources/handlebar/configurations/kafka_broker/shared-service-attached.json
+++ b/template-manager-blueprint/src/test/resources/handlebar/configurations/kafka_broker/shared-service-attached.json
@@ -1,0 +1,37 @@
+{
+
+
+  "cluster-env": {
+    "properties": {
+      "enable_external_ranger":"true"
+    }
+  },
+  "kafka-broker": {
+    "properties": {
+      "authorizer.class.name": "org.apache.ranger.authorization.kafka.authorizer.RangerKafkaAuthorizer"
+    }
+  },
+  "ranger-kafka-plugin-properties": {
+    "properties": {
+      "ranger-kafka-plugin-enabled": "Yes",
+      "external_ranger_admin_username": "admin",
+      "external_ranger_admin_password": "cloudbreak123!",
+      "external_admin_username": "admin",
+      "external_admin_password": "cloudbreak123!"
+    }
+  },
+  "ranger-kafka-audit": {
+    "properties": {
+      "xasecure.audit.destination.solr": "true",
+      "xasecure.audit.destination.solr.zookeepers":"{{{ranger.audit.solr.zookeepers}}}"
+    }
+  },
+  "ranger-kafka-security":{
+    "properties": {
+      "ranger.plugin.kafka.policy.rest.url": "http://1.1.1.1:6080",
+      "ranger.plugin.kafka.service.name":"{{{general.clusterName}}}_kafka",
+      "ranger.plugin.kafka.policy.cache.dir":"/etc/ranger/{{{general.clusterName}}}/policycache"
+    }
+  }
+
+}


### PR DESCRIPTION
Initialize ranger properties while attaching Kafka cluster to Ranger in DL.
Closes #BUG-115743