### PR TITLE
BUG-116614 typo in the e2e test blueprint name

### DIFF
--- a/integration-test/src/main/resources/testsuites/clusterostestset.yaml
+++ b/integration-test/src/main/resources/testsuites/clusterostestset.yaml
@@ -43,7 +43,7 @@ tests:
     parameters:
       clusterName: aws-ubuntu-datasci
       provider: aws
-      blueprintName: "HDP 3.0 - Data Science: Apache Spark 2, Apache Zeppelinn"
+      blueprintName: "HDP 3.0 - Data Science: Apache Spark 2, Apache Zeppelin"
       imageos: ubuntu16
       instancegroupName: worker
     classes:


### PR DESCRIPTION
OS related tests contain blueprint name with type
Closes 116614