### PR TITLE
BUG-116615 Kerberos e2e test can't check ambari availability

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/ClusterTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/ClusterTests.java
@@ -83,8 +83,8 @@ public class ClusterTests extends CloudbreakClusterTestConfiguration {
                 "wait and check availability");
         then(Stack.checkClusterHasAmbariRunning(
                 getTestParameter().get(CloudProviderHelper.DEFAULT_AMBARI_PORT),
-                getTestParameter().get(CloudProviderHelper.DEFAULT_AMBARI_USER),
-                getTestParameter().get(CloudProviderHelper.DEFAULT_AMBARI_PASSWORD)),
+                AwsKerberos.USERNAME,
+                getTestParameter().get(AwsKerberos.AD_PASSWORD)),
                 "check ambari is running and components available");
     }
 


### PR DESCRIPTION
HDF kerberos test is failing due to test could not check ambari availability with default credentials
Closes 116615