### PR TITLE
BUG-116668 e2e test can't check ambari when cluster is kerberized

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/ClusterTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/ClusterTests.java
@@ -208,19 +208,18 @@ public class ClusterTests extends CloudbreakClusterTestConfiguration {
 
     @Test(dataProvider = "providername", priority = 40)
     public void testStartCluster(CloudProvider cloudProvider, String clusterName) throws Exception {
-        given(CloudbreakClient.created());
-        given(cloudProvider.aValidCredential());
-        given(cloudProvider.aValidStackCreated()
-                .withName(clusterName), "a stack is created");
-        given(StackOperationEntity.request());
-        when(StackOperationEntity.start());
-        when(Stack.get());
-        then(Stack.waitAndCheckClusterAndStackAvailabilityStatus(), "stack has been started");
-        then(Stack.checkClusterHasAmbariRunning(
-                getTestParameter().get(CloudProviderHelper.DEFAULT_AMBARI_PORT),
+        startClusterWithAmbariCredential(cloudProvider,
+                clusterName,
                 getTestParameter().get(CloudProviderHelper.DEFAULT_AMBARI_USER),
-                getTestParameter().get(CloudProviderHelper.DEFAULT_AMBARI_PASSWORD)),
-                "ambari check");
+                getTestParameter().get(CloudProviderHelper.DEFAULT_AMBARI_PASSWORD));
+    }
+
+    @Test(dataProvider = "providername", priority = 40)
+    public void testStartKerberizedCluster(CloudProvider cloudProvider, String clusterName) throws Exception {
+        startClusterWithAmbariCredential(cloudProvider,
+                clusterName,
+                AwsKerberos.USERNAME,
+                getTestParameter().get(AwsKerberos.AD_PASSWORD));
     }
 
     @Test(alwaysRun = true, dataProvider = "providername", priority = 50)
@@ -234,7 +233,7 @@ public class ClusterTests extends CloudbreakClusterTestConfiguration {
     }
 
     @Test(alwaysRun = true, dataProvider = "providername", priority = 50)
-    public void testTerminateKerberosCluster(CloudProvider cloudProvider, String clusterName) throws Exception {
+    public void testTerminateKerberizedCluster(CloudProvider cloudProvider, String clusterName) throws Exception {
         given(CloudbreakClient.created());
         given(cloudProvider.aValidCredential());
         given(cloudProvider.aValidStackCreated()
@@ -378,5 +377,21 @@ public class ClusterTests extends CloudbreakClusterTestConfiguration {
         }
         result = result.stream().sorted(Comparator.comparing(ImageResponse::getDate)).collect(Collectors.toList());
         return result.get(result.size() - 1).getUuid();
+    }
+
+    private void startClusterWithAmbariCredential(CloudProvider cloudProvider, String clusterName, String ambariUser, String ambariPassword) throws Exception {
+        given(CloudbreakClient.created());
+        given(cloudProvider.aValidCredential());
+        given(cloudProvider.aValidStackCreated()
+                .withName(clusterName), "a stack is created");
+        given(StackOperationEntity.request());
+        when(StackOperationEntity.start());
+        when(Stack.get());
+        then(Stack.waitAndCheckClusterAndStackAvailabilityStatus(), "stack has been started");
+        then(Stack.checkClusterHasAmbariRunning(
+                getTestParameter().get(CloudProviderHelper.DEFAULT_AMBARI_PORT),
+                ambariUser,
+                ambariPassword),
+                "ambari check");
     }
 }

--- a/integration-test/src/main/resources/testsuites/clusterawstestset.yaml
+++ b/integration-test/src/main/resources/testsuites/clusterawstestset.yaml
@@ -6,7 +6,7 @@ parameters:
   awsAvailabilityZone: eu-west-1a
   awsCredentialName: autotesting-clusters-aws
 listeners:
-  - com.sequenceiq.it.cloudbreak.newway.listener.FirstLastTestExecutionBehaviour
+  - com.sequenceiq.it.cloudbreakCredent.newway.listener.FirstLastTestExecutionBehaviour
   - com.sequenceiq.it.cloudbreak.newway.listener.GatekeeperBehaviour
   - com.sequenceiq.it.cloudbreak.newway.listener.StructuredEventsReporterOnFailingCluster
 tests:
@@ -57,8 +57,8 @@ tests:
         includedMethods:
           - testCreateHdfCluster
           - testStopCluster
-          - testStartCluster
-          - testTerminateKerberosCluster
+          - testStartKerberizedCluster
+          - testTerminateKerberizedCluster
   - name: "aws prewarm image datascience"
     preserveOrder: true
     parameters:
@@ -105,5 +105,5 @@ tests:
         includedMethods:
           - testCreateHdfCluster
           - testStopCluster
-          - testStartCluster
-          - testTerminateKerberosCluster
+          - testStartKerberizedCluster
+          - testTerminateKerberizedCluster


### PR DESCRIPTION
E2e tests could not check ambari status without credential for the kerberized cluster
Closes 116668