### PR TITLE
BUG-105449 Git ignore .env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /build
 /bin
+.env
 .settings
 .project
 .classpath


### PR DESCRIPTION
Different 3rd parties for bash are supporting to load environment variables per directory, and all of them are support `.env` file. Would be nice to ignore them.