### PR TITLE
BUG-115316 handle plain text responses with no warning

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/rest/StructuredEventFilter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/rest/StructuredEventFilter.java
@@ -260,16 +260,9 @@ public class StructuredEventFilter implements WriterInterceptor, ContainerReques
         }
     }
 
-    private void extendRestParamsFromResponse(Map<String, String> params, CharSequence responseBody) {
+    protected void extendRestParamsFromResponse(Map<String, String> params, CharSequence responseBody) {
         if (responseBody != null && isResourceIdIsAbsentOrNull(params)) {
-            String resourceId = null;
-            try {
-                JsonNode jsonNode = JsonUtil.readTree(responseBody.toString());
-                JsonNode idNode = jsonNode.path("id");
-                resourceId = idNode.asText();
-            } catch (IOException e) {
-                LOGGER.warn("Parsing of ID from JSON response failed", e);
-            }
+            String resourceId = extractResourceIdFromJson(responseBody);
             if (StringUtils.isEmpty(resourceId)) {
                 Matcher matcher = extendRestParamsFromResponsePattern.matcher(responseBody);
                 if (matcher.find() && matcher.groupCount() >= 1) {
@@ -281,6 +274,24 @@ public class StructuredEventFilter implements WriterInterceptor, ContainerReques
                 params.put(RESOURCE_ID, resourceId);
             }
         }
+    }
+
+    private String extractResourceIdFromJson(CharSequence responseBody) {
+        String resourceId = null;
+        try {
+            if (JsonUtil.isValid(responseBody.toString())) {
+                JsonNode jsonNode = JsonUtil.readTree(responseBody.toString());
+                JsonNode idNode = jsonNode.path("id");
+                if (idNode.isMissingNode()) {
+                    LOGGER.warn("Response was a JSON but no ID available");
+                } else {
+                    resourceId = idNode.asText();
+                }
+            }
+        } catch (IOException e) {
+            LOGGER.error("Json parsing failed for ", e);
+        }
+        return resourceId;
     }
 
     private boolean isResourceIdIsAbsentOrNull(Map<String, String> params) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/structuredevent/rest/StructuredEventFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/structuredevent/rest/StructuredEventFilterTest.java
@@ -1,0 +1,45 @@
+package com.sequenceiq.cloudbreak.structuredevent.rest;
+
+import static com.sequenceiq.cloudbreak.structuredevent.rest.urlparsers.RestUrlParser.RESOURCE_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+public class StructuredEventFilterTest {
+
+    private StructuredEventFilter underTest = new StructuredEventFilter();
+
+    @Test
+    public void testResourceIdParsingWhenValidJsonIsReturned() {
+        Map<String, String> params = new HashMap<>();
+        underTest.extendRestParamsFromResponse(params, "{\"id\": \"12345\"}");
+        assertEquals(params.get(RESOURCE_ID), "12345", "Should find resourceId in valid JSON response");
+    }
+
+    @Test
+    public void testResourceIdParsingWhenNonJson() {
+        Map<String, String> params = new HashMap<>();
+        underTest.extendRestParamsFromResponse(params, "\"id\":12345 Something other written here");
+        assertEquals(params.get(RESOURCE_ID), "12345", "Should find resourceId in response");
+    }
+
+    @Test
+    public void testResourceIdParsingWhenJsonButNoId() {
+        Map<String, String> params = new HashMap<>();
+        underTest.extendRestParamsFromResponse(params, "{\"message\": \"Error happened and responding with JSON\"}");
+        assertTrue(params.isEmpty(), "No ResourceId is present in responseBody");
+    }
+
+    @Test
+    public void testResourceIdParsingWhenPlainTextResponse() {
+        Map<String, String> params = Collections.emptyMap();
+        underTest.extendRestParamsFromResponse(params,
+                "The recipe's name can only contain lowercase alphanumeric characters and hyphens and has start with an alphanumeric character");
+        assertTrue(params.isEmpty(), "No ResourceId is present in responseBody");
+    }
+}


### PR DESCRIPTION
When trying to parse resourceId from non JSON responses like BadRequestResponses various Exception have appeared in logsearch.
- com.fasterxml.jackson.core.io.JsonEOFException: Unexpected end-of-input in field name
- com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'createInWorkspace': was expecting ('true', 'false' or 'null')
- now we'll log cases when there is a valid JSON but without an ID. Also in those cases we does not provide RESOURCE_ID as emptyString