### PR TITLE
BUG-116969 after merge 2.9tests are failing

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/CloudbreakUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/CloudbreakUtil.java
@@ -55,7 +55,7 @@ public class CloudbreakUtil {
     }
 
     @SuppressFBWarnings("ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD")
-    @Value("${integrationtest.testsuite.pollingInterval}")
+    @Value("${integrationtest.testsuite.pollingInterval:10000}")
     public void setPollingInterval(int pollingInterval) {
         this.pollingInterval = pollingInterval;
     }

--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -142,6 +142,7 @@ integrationtest:
 
     testsuite:
         threadPoolSize: 3
+        pollingInterval: 10000
         skipRemainingTestsAfterOneFailed: true
         cleanUpOnFailure: true
 


### PR DESCRIPTION
Merge removed pollingIntervall from application.yml (integration-test)
Closes 116969