### PR TITLE
upgrade NodeJS to avoid syntax error in web container

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,8 +1,8 @@
-FROM gliderlabs/alpine:3.1
+FROM gliderlabs/alpine:3.6
 MAINTAINER Hortonworks
 
 ENV ULU_SERVER_PORT 3000
-RUN apk-install curl nodejs bash git
+RUN apk-install curl nodejs nodejs-npm bash git
 EXPOSE 3000
 ADD . /uluwatu
 RUN bash -c 'cd /uluwatu && for i in {1..10}; do npm install && npm install -g bower && break || sleep 5; done && npm install && npm install -g bower'


### PR DESCRIPTION
Upgrade NodeJS and NPM version to avoid the following syntax error in Uluwatu:
```/uluwatu/node_modules/express/node_modules/debug/src/node.js:120
exports.inspectOpts = Object.keys(process.env).filter(key => {
                                                           ^
SyntaxError: Unexpected token >
    at Module._compile (module.js:439:25)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/uluwatu/node_modules/express/node_modules/debug/src/index.js:9:19)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)```