### PR TITLE
upgrade NodeJS to avoid syntax error in sultans

### DIFF
--- a/auth/Dockerfile
+++ b/auth/Dockerfile
@@ -1,8 +1,8 @@
-FROM gliderlabs/alpine:3.1
+FROM gliderlabs/alpine:3.6
 MAINTAINER SequenceIQ
 
 ENV SL_SERVER_PORT 3001
-RUN apk-install curl nodejs bash git
+RUN apk-install curl nodejs nodejs-npm bash git
 EXPOSE 3001
 ADD . /sultans
 RUN cd /sultans && npm install


### PR DESCRIPTION
Fix to avoid SyntaxError in Sultans:
```
sultans/node_modules/request/node_modules/tough-cookie/node_modules/ip-regex/index.js:3
const word = '[a-fA-F\\d:]';
^^^^^
SyntaxError: Use of const in strict mode.
    at Module._compile (module.js:439:25)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/sultans/node_modules/request/node_modules/tough-cookie/lib/cookie.js:34:15)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
```