### PR TITLE
[BUG-116943] Upscaling with multiple nodes installs components on only one newly created node

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ambari/AmbariClusterModificationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ambari/AmbariClusterModificationService.java
@@ -9,7 +9,6 @@ import static com.sequenceiq.cloudbreak.service.cluster.ambari.AmbariMessages.AM
 import static com.sequenceiq.cloudbreak.service.cluster.ambari.AmbariMessages.AMBARI_CLUSTER_UPSCALE_FAILED;
 import static com.sequenceiq.cloudbreak.service.cluster.ambari.AmbariOperationType.STOP_AMBARI_PROGRESS_STATE;
 import static com.sequenceiq.cloudbreak.service.cluster.ambari.AmbariOperationType.UPSCALE_AMBARI_PROGRESS_STATE;
-import static com.sequenceiq.cloudbreak.service.cluster.ambari.AmbariRepositoryVersionService.AMBARI_VERSION_2_7_0_0;
 import static com.sequenceiq.cloudbreak.service.cluster.ambari.HostGroupAssociationBuilder.FQDN;
 import static java.util.Collections.singletonMap;
 
@@ -76,9 +75,6 @@ public class AmbariClusterModificationService implements ClusterModificationServ
 
     @Inject
     private CloudbreakEventService eventService;
-
-    @Inject
-    private AmbariRepositoryVersionService ambariRepositoryVersionService;
 
     @Inject
     private AmbariPollingServiceProvider ambariPollingServiceProvider;
@@ -189,12 +185,6 @@ public class AmbariClusterModificationService implements ClusterModificationServ
                     .collect(Collectors.toMap(association -> association.get(FQDN), association ->
                             association.get("rack") != null ? association.get("rack") : "/default-rack"));
             int upscaleRequestCode = ambariClient.addHostsAndRackInfoWithBlueprint(blueprintName, hostGroup.getName(), hostsWithRackInfo);
-            String ambariServerVersion = ambariClient.ambariServerVersion();
-            if (!ambariRepositoryVersionService.isVersionNewerOrEqualThanLimited(() -> ambariServerVersion, AMBARI_VERSION_2_7_0_0)) {
-                for (String host : hosts) {
-                    ambariClient.updateRack(host, hostsWithRackInfo.get(host));
-                }
-            }
             return singletonMap("UPSCALE_REQUEST", upscaleRequestCode);
         } catch (HttpResponseException e) {
             if ("Conflict".equals(e.getMessage())) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ambari/AmbariClusterModificationServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ambari/AmbariClusterModificationServiceTest.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.service.cluster.ambari;
 import static com.sequenceiq.cloudbreak.service.cluster.ambari.AmbariOperationType.UPSCALE_AMBARI_PROGRESS_STATE;
 import static com.sequenceiq.cloudbreak.service.cluster.ambari.HostGroupAssociationBuilder.FQDN;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -121,8 +122,7 @@ public class AmbariClusterModificationServiceTest {
         rackMap.put("host2", "myrack");
 
         verify(ambariClient, times(1)).addHostsAndRackInfoWithBlueprint(eq(cluster.getBlueprint().getName()), eq(hostGroup.getName()), eq(rackMap));
-        verify(ambariClient, times(1)).updateRack("host1", "myrack");
-        verify(ambariClient, times(1)).updateRack("host2", "myrack");
+        verify(ambariClient, never()).updateRack(anyString(), anyString());
     }
 
     @Test
@@ -168,7 +168,7 @@ public class AmbariClusterModificationServiceTest {
         rackMap.put("host2", "myrack");
 
         verify(ambariClient, times(1)).addHostsAndRackInfoWithBlueprint(eq(cluster.getBlueprint().getName()), eq(hostGroup.getName()), eq(rackMap));
-        verify(ambariClient, never()).updateRack("host1", "myrack");
+        verify(ambariClient, never()).updateRack(anyString(), anyString());
     }
 
     @Test
@@ -212,6 +212,6 @@ public class AmbariClusterModificationServiceTest {
         rackMap.put("host2", "/default-rack");
 
         verify(ambariClient, times(1)).addHostsAndRackInfoWithBlueprint(eq(cluster.getBlueprint().getName()), eq(hostGroup.getName()), eq(rackMap));
-        verify(ambariClient, never()).updateRack("host1", "myrack");
+        verify(ambariClient, never()).updateRack(anyString(), anyString());
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.configureondemand=true
 org.gradle.jvmargs=-Xmx2048m
 
 ambariClientName=ambari-client
-ambariClientVersion=2.4.77
+ambariClientVersion=2.4.80
 springBootVersion=2.0.3.RELEASE
 springOauthVersion=2.1.0.RELEASE
 awsSdkVersion=1.11.273


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ambari 2.6.x ignores `rack_info` provided in scale request, thus a [workaround](https://github.com/hortonworks/cloudbreak/blob/46afac34d4c460e78c83786c3a573ee6e8228eb6/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ambari/AmbariClusterModificationService.java#L192-L197) was introduced earlier to explicitly set the rack info in a separate request.  This causes a problem: the scale request may not have created all hosts yet by the time the rack update is processed.  All such hosts will be left in uninstalled state by Ambari.

ambari-rest-client [was fixed](https://github.com/hortonworks/ambari-rest-client/pull/158) to make the explicit rack update unnecessary.  This change removes it from Cloudbreak and upgrades to the new ambari-rest-client version.

## How was this patch tested?

Updated unit test.