### PR TITLE
BUG-117886 generated recipes are not saved

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/recipe/OrchestratorRecipeExecutor.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/recipe/OrchestratorRecipeExecutor.java
@@ -189,6 +189,8 @@ class OrchestratorRecipeExecutor {
             for (RecipeModel recipeModel : hostGroupListEntry.getValue()) {
                 GeneratedRecipe generatedRecipe = new GeneratedRecipe();
                 generatedRecipe.setHostGroup(hostGroupListEntry.getKey());
+                generatedRecipe.setExtendedRecipe(recipeModel.getGeneratedScript());
+                generatedRecipe.setOriginalRecipe(recipeModel.getScript());
                 generatedRecipeService.save(generatedRecipe);
             }
         }


### PR DESCRIPTION
These 2 lines were excluded during the cherry pick resulting in persisting null's to the databases, when a cluster was launched with recipes. The issue was only visible on the UI once the recipes got generated. sodre's PR only fixed the View part.
Sadly we can't remove that fix for now, as these are alredy persisted to the database. 
Effect is probably the recipes didn't run at all.