### PR TITLE
[WIP] CB-25. Java 11 support.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/openjdk:10-jdk
+      - image: circleci/openjdk:11-jdk
     steps:
       - checkout
       - restore_cache:
@@ -26,7 +26,7 @@ jobs:
 
   code-quality-check-checkstyle-test:
     docker:
-      - image: circleci/openjdk:10-jdk
+      - image: circleci/openjdk:11-jdk
     environment:
       _JAVA_OPTIONS: "-Xmx2048m"
     steps:
@@ -50,7 +50,7 @@ jobs:
 
   code-quality-check-checkstyle-main:
     docker:
-      - image: circleci/openjdk:10-jdk
+      - image: circleci/openjdk:11-jdk
     environment:
       _JAVA_OPTIONS: "-Xmx2048m"
     steps:
@@ -74,7 +74,7 @@ jobs:
 
   code-quality-check-spotbugs-main:
     docker:
-      - image: circleci/openjdk:10-jdk
+      - image: circleci/openjdk:11-jdk
     environment:
       _JAVA_OPTIONS: "-Xmx2048m"
     steps:
@@ -98,7 +98,7 @@ jobs:
 
   code-quality-check-spotbugs-test:
     docker:
-      - image: circleci/openjdk:10-jdk
+      - image: circleci/openjdk:11-jdk
     environment:
       _JAVA_OPTIONS: "-Xmx2048m"
     steps:
@@ -124,7 +124,7 @@ jobs:
     environment:
       CC_TEST_REPORTER_ID: CC_TEST_REPORTER_ID
     docker:
-      - image: circleci/openjdk:10-jdk
+      - image: circleci/openjdk:11-jdk
     environment:
       _JAVA_OPTIONS: "-Xmx2048m"
     steps:

--- a/autoscale/build.gradle
+++ b/autoscale/build.gradle
@@ -67,7 +67,7 @@ dependencyManagement {
         dependencySet (group: 'org.powermock', version: powermockVersion) {
             entry 'powermock-module-junit4'
             entry('powermock-api-mockito2') {
-                exclude group: 'org.hamcrest'
+                exclude group: 'org.hamcrest', name: '*'
             }
         }
 
@@ -90,7 +90,7 @@ dependencyManagement {
         dependency group: 'org.mybatis',                        name: 'mybatis-migrations',        version: '3.2.0'
         dependency group: 'org.mockito',                        name: 'mockito-core',              version: mockitoVersion
         dependency group: 'com.openpojo',                       name: 'openpojo',                  version: '0.8.10'
-        dependency group: 'org.ow2.asm',                        name: 'asm',                       version: '6.2'
+        dependency group: 'org.ow2.asm',                        name: 'asm',                       version: '7.0'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
 
 plugins {
   id 'org.ajoberstar.grgit' version '2.1.0'
-  id "com.github.spotbugs" version "1.6.2"
+  id "com.github.spotbugs" version "1.6.10"
 }
 
 if (project.hasProperty("reckon.scope")) {
@@ -58,8 +58,8 @@ subprojects {
   apply plugin: 'jacoco'
 
 
-  sourceCompatibility = 10
-  targetCompatibility = 10
+  sourceCompatibility = 11
+  targetCompatibility = 11
 
   configurations {
     deployerJars
@@ -83,13 +83,13 @@ subprojects {
   }
 
   spotbugs {
-    toolVersion = "3.1.7"
+    toolVersion = "3.1.11"
     excludeFilter = file("$rootProject.projectDir/config/spotbugs/excludeFilter.xml")
     effort = "min"
   }
 
   jacoco {
-    toolVersion = "0.8.2"
+    toolVersion = "0.8.3"
     reportsDir = file("$buildDir/reports/jacoco")
   }
 

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/AwsComponentTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/AwsComponentTest.java
@@ -45,7 +45,7 @@ import com.sequenceiq.cloudbreak.util.FreeMarkerTemplateUtils;
 import freemarker.template.TemplateException;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = AwsTestContext.class)
+@SpringBootTest(classes = AwsTestContext.class, properties = "spring.main.allow-bean-definition-overriding=true")
 public abstract class AwsComponentTest {
 
     @Configuration

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/AwsLaunchTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/AwsLaunchTest.java
@@ -83,7 +83,7 @@ import com.sequenceiq.cloudbreak.util.FreeMarkerTemplateUtils;
         @MockBean(AwsCreateStackStatusCheckerTask.class),
 //        @MockBean(Aws)
 })
-public class AwsLauchTest extends AwsComponentTest {
+public class AwsLaunchTest extends AwsComponentTest {
 
     private static final String LOGIN_USER_NAME = "loginusername";
 

--- a/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/AbstractComponentTest.java
+++ b/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/AbstractComponentTest.java
@@ -13,7 +13,8 @@ import reactor.bus.Event;
 import reactor.bus.EventBus;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest(classes = TestApplicationContext.class)
+@SpringBootTest(classes = TestApplicationContext.class,
+        properties = "spring.main.allow-bean-definition-overriding=true")
 public abstract class AbstractComponentTest<T> {
 
     @Inject

--- a/config/spotbugs/excludeFilter.xml
+++ b/config/spotbugs/excludeFilter.xml
@@ -20,6 +20,10 @@
         <Bug pattern="OBL_UNSATISFIED_OBLIGATION" />
     </Match>
     <Match>
+        <!-- False positive: https://github.com/spotbugs/spotbugs/issues/756 -->
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+    </Match>
+    <Match>
         <Class name="~.*MapperImpl$"/>
     </Match>
     <Match>

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -100,17 +100,19 @@ dependencyManagement {
     dependencySet(group: 'org.powermock', version: powermockVersion) {
       entry 'powermock-module-junit4'
       entry('powermock-api-mockito2') {
-        exclude group: 'org.hamcrest'
+        exclude group: 'org.hamcrest', name: '*'
       }
     }
 
     dependency (group: 'org.springframework.statemachine',  name: 'spring-statemachine-core',    version: '1.0.1.RELEASE') {
-      exclude group: 'org.springframework'
+      exclude group: 'org.springframework', name: '*'
     }
 
     dependency (group: 'com.google.oauth-client',           name: 'google-oauth-client-jetty',   version: '1.22.0') {
-      exclude module: 'servlet-api'
+      exclude group: '*', name: 'servlet-api'
     }
+
+    dependency group: 'org.testng',                         name: 'testng',                      version: testNgVersion
 
     dependencySet(group: 'org.junit.jupiter', version: '5.2.0') {
       entry 'junit-jupiter-api'
@@ -242,6 +244,7 @@ dependencies {
   testCompile group: 'com.jayway.restassured',   name: 'json-path'
   testCompile group: 'com.h2database',           name: 'h2'
   testCompile group: 'org.mockito',              name: 'mockito-junit-jupiter'
+  testCompile group: 'org.testng',               name: 'testng'
   testCompile group: 'org.junit.vintage',        name: 'junit-vintage-engine'
   testCompile group: 'org.junit.jupiter',        name: 'junit-jupiter-api'
   testRuntime group: 'org.junit.jupiter',        name: 'junit-jupiter-engine'

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/WorkspaceAwareUtilV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/WorkspaceAwareUtilV4Controller.java
@@ -3,8 +3,8 @@ package com.sequenceiq.cloudbreak.controller.v4;
 import javax.inject.Inject;
 
 import org.springframework.stereotype.Controller;
-import org.testng.collections.Sets;
 
+import com.google.common.collect.Sets;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.WorkspaceAwareUtilV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.ExposedServiceV4Responses;
 import com.sequenceiq.cloudbreak.service.ServiceEndpointCollector;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/image/update/PackageVersionChecker.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/image/update/PackageVersionChecker.java
@@ -15,8 +15,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-import org.testng.collections.Lists;
 
+import com.google.common.collect.Lists;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.core.flow2.CheckResult;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/image/update/StackImageUpdateService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/image/update/StackImageUpdateService.java
@@ -12,9 +12,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import org.testng.collections.Lists;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.collect.Lists;
 import com.sequenceiq.cloudbreak.cloud.VersionComparator;
 import com.sequenceiq.cloudbreak.cloud.event.model.EventStatus;
 import com.sequenceiq.cloudbreak.cloud.model.CloudbreakDetails;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/CloudResourceAdvisor.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/CloudResourceAdvisor.java
@@ -15,9 +15,9 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import org.testng.collections.Maps;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
 import com.sequenceiq.cloudbreak.blueprint.BlueprintProcessorFactory;
 import com.sequenceiq.cloudbreak.blueprint.validation.StackServiceComponentDescriptors;
 import com.sequenceiq.cloudbreak.cloud.model.CloudVmTypes;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/CredentialV4RequestToCredentialConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/CredentialV4RequestToCredentialConverterTest.java
@@ -15,8 +15,8 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.testng.collections.Maps;
 
+import com.google.common.collect.Maps;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.credentials.parameters.aws.AwsCredentialV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.credentials.requests.CredentialV4Request;
 import com.sequenceiq.cloudbreak.controller.validation.credential.CredentialValidator;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/credential/RsaPublicKeyValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/credential/RsaPublicKeyValidatorTest.java
@@ -57,7 +57,7 @@ public class RsaPublicKeyValidatorTest {
     @Test
     public void inValidPublicKeyWillFailWhenTooShortBody() {
         thrown.expect(BadRequestException.class);
-        thrown.expectMessage("detailed message: 3");
+        thrown.expectMessage("detailed message: Index 3 out of bounds for length 3");
         openSshPublicKeyValidator.validate(
                         "ssh-rsa AAAA sequence-eu"
         );

--- a/docker-autoscale/Dockerfile
+++ b/docker-autoscale/Dockerfile
@@ -1,4 +1,4 @@
-FROM hortonworks/hwx_openjdk:10-jdk-slim
+FROM hortonworks/hwx_openjdk:11-jdk-slim
 MAINTAINER info@hortonworks.com
 
 # REPO URL to download jar

--- a/docker-cloudbreak/Dockerfile
+++ b/docker-cloudbreak/Dockerfile
@@ -1,4 +1,4 @@
-FROM hortonworks/hwx_openjdk:10-jdk-slim
+FROM hortonworks/hwx_openjdk:11-jdk-slim
 MAINTAINER info@hortonworks.com
 
 # REPO URL to download jar

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx2048m
 
 ambariClientName=ambari-client
 ambariClientVersion=2.4.80
-springBootVersion=2.0.3.RELEASE
+springBootVersion=2.1.3.RELEASE
 springOauthVersion=2.1.0.RELEASE
 awsSdkVersion=1.11.273
 azureSdkVersion=1.17.0
@@ -20,6 +20,7 @@ jasyptVersion=1.9.2
 apacheCommonsLangVersion=3.8.1
 mockitoVersion=2.21.0
 powermockVersion=2.0.0-beta.5
+testNgVersion=6.9.10
 junitVersion=4.12
 junitJupiterVersion=5.4.0
 jerseyCoreVersion=2.26

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -84,7 +84,7 @@ dependencies {
   compile group:  'org.springframework',          name: 'spring-context-support',         version: springFrameworkVersion
   compile group:  'org.apache.velocity',          name: 'velocity',                       version: '1.7'
   compile group:  'com.hierynomus',               name: 'sshj',                           version: '0.15.0'
-  compile group:  'org.testng',                   name: 'testng',                         version: '6.9.10'
+  compile group:  'org.testng',                   name: 'testng',                         version: testNgVersion
   compile group:  'javax.el',                     name: 'javax.el-api',                   version: '3.0.0'
   compile group:  'org.apache.commons',           name: 'commons-lang3',                  version: '3.4'
   compile group: 'org.pacesys.openstack4j.connectors', name: 'openstack4j-jersey2',       version: '3.1.0-jersey26_v4fix'

--- a/integration-test/docker-compose_template.yml
+++ b/integration-test/docker-compose_template.yml
@@ -4,7 +4,7 @@ mock-caas:
   volumes:
   - ../mock-caas/build/libs/mock-caas.jar:/mock-caas.jar
   command: java -jar /mock-caas.jar
-  image: openjdk:10-jdk
+  image: openjdk:11-jdk
   environment:
     - SERVICE_NAME=caas-mock
 test:
@@ -56,7 +56,7 @@ test:
     - INTEGRATIONTEST_PROXYCONFIG_PROXYPASSWORD
     - AWS_ACCESS_KEY_ID
     - AWS_SECRET_ACCESS_KEY
-  image: openjdk:10-jdk
+  image: openjdk:11-jdk
 swagger-diff:
   dns:
   volumes:

--- a/integration-test/scripts/docker-build.sh
+++ b/integration-test/scripts/docker-build.sh
@@ -2,6 +2,6 @@
 
 : ${ADDITIONAL_DOCKER_BUILD_COMMAND:=""}
 
-docker pull openjdk:10-jdk
+docker pull openjdk:11-jdk
 echo -e "\n\033[1;96m--- build cloudbreak in docker container\033[0m\n"
-docker run -i --rm $ADDITIONAL_DOCKER_BUILD_COMMAND -v $(pwd)/../:/tmp/prj:rw openjdk:10-jdk /tmp/prj/gradlew -b /tmp/prj/build.gradle clean build -x test
+docker run -i --rm $ADDITIONAL_DOCKER_BUILD_COMMAND -v $(pwd)/../:/tmp/prj:rw openjdk:11-jdk /tmp/prj/gradlew -b /tmp/prj/build.gradle clean build -x test

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/logsearch/UrlParameters.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/logsearch/UrlParameters.java
@@ -7,12 +7,12 @@ import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testng.collections.Maps;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Joiner;
+import com.google.common.collect.Maps;
 
 public class UrlParameters {
 

--- a/mock-caas/Dockerfile
+++ b/mock-caas/Dockerfile
@@ -1,4 +1,4 @@
-FROM hortonworks/hwx_openjdk:10-jdk-slim
+FROM hortonworks/hwx_openjdk:11-jdk-slim
 MAINTAINER info@hortonworks.com
 
 # REPO URL to download jar


### PR DESCRIPTION
Java 11 is now supported by Cloudbreak.

Notes:

As my first Cloudbreak commit, I'm sure I'm missing a bunch of stuff here, specifically in regards to the Docker image generation and proper testing. I wanted to put this out there to get some initial feedback and any other thoughts on things that I need to do.

I'm not expecting this to be merged as is.