### PR TITLE
CB-372 – Connector v4 related integration test

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/accessconfig/PlatformAccessConfigsTestAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/accessconfig/PlatformAccessConfigsTestAction.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.it.cloudbreak.newway.action.accessconfig;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.accessconfig.PlatformAccessConfigsTestDto;
+
+public class PlatformAccessConfigsTestAction {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlatformAccessConfigsTestAction.class);
+
+    private PlatformAccessConfigsTestAction() {
+    }
+
+    public static PlatformAccessConfigsTestDto getAccessConfigs(TestContext testContext, PlatformAccessConfigsTestDto entity, CloudbreakClient client) {
+        String logInitMessage = "Obtaining access configs by credential";
+        LOGGER.info("{}", logInitMessage);
+        entity.setResponse(
+                client.getCloudbreakClient().connectorV4Endpoint().getAccessConfigs(
+                        client.getWorkspaceId(), entity.getCredentialName(), entity.getRegion(), entity.getPlatformVariant(), entity.getAvailabilityZone())
+        );
+        LOGGER.info("{} was successful", logInitMessage);
+        return entity;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/encryptionkeys/PlatformEncryptionKeysTestAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/encryptionkeys/PlatformEncryptionKeysTestAction.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.it.cloudbreak.newway.action.encryptionkeys;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.encryption.PlatformEncryptionKeysTestDto;
+
+public class PlatformEncryptionKeysTestAction {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlatformEncryptionKeysTestAction.class);
+
+    private PlatformEncryptionKeysTestAction() {
+    }
+
+    public static PlatformEncryptionKeysTestDto getEncryptionKeys(TestContext testContext, PlatformEncryptionKeysTestDto entity, CloudbreakClient client) {
+        String logInitMessage = "Obtaining encryption keys by credential";
+        LOGGER.info("{}", logInitMessage);
+        entity.setResponse(
+                client.getCloudbreakClient().connectorV4Endpoint().getEncryptionKeys(
+                        client.getWorkspaceId(), entity.getCredentialName(), entity.getRegion(), entity.getPlatformVariant(), entity.getAvailabilityZone())
+        );
+        LOGGER.info("{} was successful", logInitMessage);
+        return entity;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/gateway/PlatformGatewaysTestAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/gateway/PlatformGatewaysTestAction.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.it.cloudbreak.newway.action.gateway;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.gateway.PlatformGatewaysTestDto;
+
+public class PlatformGatewaysTestAction {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlatformGatewaysTestAction.class);
+
+    private PlatformGatewaysTestAction() {
+    }
+
+    public static PlatformGatewaysTestDto getGateways(TestContext testContext, PlatformGatewaysTestDto entity, CloudbreakClient client) {
+        String logInitMessage = "Obtaining gateways by credential";
+        LOGGER.info("{}", logInitMessage);
+        entity.setResponse(
+                client.getCloudbreakClient().connectorV4Endpoint().getGatewaysCredentialId(
+                        client.getWorkspaceId(), entity.getCredentialName(), entity.getRegion(), entity.getPlatformVariant(), entity.getAvailabilityZone())
+        );
+        LOGGER.info("{} was successful", logInitMessage);
+        return entity;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/ip/PlatformIpPoolsTestAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/ip/PlatformIpPoolsTestAction.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.it.cloudbreak.newway.action.ip;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.ip.PlatformIpPoolsTestDto;
+
+public class PlatformIpPoolsTestAction {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlatformIpPoolsTestAction.class);
+
+    private PlatformIpPoolsTestAction() {
+    }
+
+    public static PlatformIpPoolsTestDto getIpPools(TestContext testContext, PlatformIpPoolsTestDto entity, CloudbreakClient client) {
+        String logInitMessage = "Obtaining ip pools by credential";
+        LOGGER.info("{}", logInitMessage);
+        entity.setResponse(
+                client.getCloudbreakClient().connectorV4Endpoint().getIpPoolsCredentialId(
+                        client.getWorkspaceId(), entity.getCredentialName(), entity.getRegion(), entity.getPlatformVariant(), entity.getAvailabilityZone())
+        );
+        LOGGER.info("{} was successful", logInitMessage);
+        return entity;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/network/PlatformNetworksTestAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/network/PlatformNetworksTestAction.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.it.cloudbreak.newway.action.network;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.network.PlatformNetworksTestDto;
+
+public class PlatformNetworksTestAction {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlatformNetworksTestAction.class);
+
+    private PlatformNetworksTestAction() {
+    }
+
+    public static PlatformNetworksTestDto getPlatformNetworks(TestContext testContext, PlatformNetworksTestDto entity, CloudbreakClient client) {
+        String logInitMessage = "Obtaining networks by credential";
+        LOGGER.info("{}", logInitMessage);
+        entity.setResponse(
+                client.getCloudbreakClient().connectorV4Endpoint().getCloudNetworks(
+                        client.getWorkspaceId(), entity.getCredentialName(), entity.getRegion(), entity.getPlatformVariant(), entity.getAvailabilityZone())
+        );
+        LOGGER.info("{} was successful", logInitMessage);
+        return entity;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/platformdisk/PlatformDisksTestAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/platformdisk/PlatformDisksTestAction.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.it.cloudbreak.newway.action.platformdisk;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.disk.PlatformDiskTestDto;
+
+public class PlatformDisksTestAction {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlatformDisksTestAction.class);
+
+    private PlatformDisksTestAction() {
+    }
+
+    public static PlatformDiskTestDto getDiskTypes(TestContext testContext, PlatformDiskTestDto entity, CloudbreakClient client) {
+        String logInitMessage = "Obtaining disk types";
+        LOGGER.info("{}", logInitMessage);
+        entity.setResponse(client.getCloudbreakClient().connectorV4Endpoint().getDisktypes(client.getWorkspaceId()));
+        LOGGER.info("{} was successful", logInitMessage);
+        return entity;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/region/RegionTestAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/region/RegionTestAction.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.it.cloudbreak.newway.action.region;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.region.RegionTestDto;
+
+public class RegionTestAction {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RegionTestAction.class);
+
+    private RegionTestAction() {
+    }
+
+    public static RegionTestDto getRegions(TestContext testContext, RegionTestDto entity, CloudbreakClient client) {
+        String logInitMessage = "Obtaining regions by credential";
+        LOGGER.info("{}", logInitMessage);
+        entity.setResponse(
+                client.getCloudbreakClient().connectorV4Endpoint().getRegionsByCredential(
+                        client.getWorkspaceId(), entity.getCredentialName(), entity.getRegion(), entity.getPlatformVariant(), entity.getAvailabilityZone())
+        );
+        LOGGER.info("{} was successful", logInitMessage);
+        return entity;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/securitygroup/PlatformSecurityGroupsTestAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/securitygroup/PlatformSecurityGroupsTestAction.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.it.cloudbreak.newway.action.securitygroup;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.securitygroup.PlatformSecurityGroupsTestDto;
+
+public class PlatformSecurityGroupsTestAction {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlatformSecurityGroupsTestAction.class);
+
+    private PlatformSecurityGroupsTestAction() {
+    }
+
+    public static PlatformSecurityGroupsTestDto getSecurityGroups(TestContext testContext, PlatformSecurityGroupsTestDto entity, CloudbreakClient client) {
+        String logInitMessage = "Obtaining security groups by credential";
+        LOGGER.info("{}", logInitMessage);
+        entity.setResponse(
+                client.getCloudbreakClient().connectorV4Endpoint().getSecurityGroups(
+                        client.getWorkspaceId(), entity.getCredentialName(), entity.getRegion(), entity.getPlatformVariant(), entity.getAvailabilityZone())
+        );
+        LOGGER.info("{} was successful", logInitMessage);
+        return entity;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/sshkeys/PlatformSshKeysTestAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/sshkeys/PlatformSshKeysTestAction.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.it.cloudbreak.newway.action.sshkeys;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.sshkeys.PlatformSshKeysTestDto;
+
+public class PlatformSshKeysTestAction {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlatformSshKeysTestAction.class);
+
+    private PlatformSshKeysTestAction() {
+    }
+
+    public static PlatformSshKeysTestDto getSSHKeys(TestContext testContext, PlatformSshKeysTestDto entity, CloudbreakClient client) {
+        String logInitMessage = "Obtaining ssh keys by credential";
+        LOGGER.info("{}", logInitMessage);
+        entity.setResponse(
+                client.getCloudbreakClient().connectorV4Endpoint().getCloudSshKeys(
+                        client.getWorkspaceId(), entity.getCredentialName(), entity.getRegion(), entity.getPlatformVariant(), entity.getAvailabilityZone())
+        );
+        LOGGER.info("{} was successful", logInitMessage);
+        return entity;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/tagspecifications/TagSpecificationsTestAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/tagspecifications/TagSpecificationsTestAction.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.it.cloudbreak.newway.action.tagspecifications;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.tagspecifications.TagSpecificationsTestDto;
+
+public class TagSpecificationsTestAction {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TagSpecificationsTestAction.class);
+
+    private TagSpecificationsTestAction() {
+    }
+
+    public static TagSpecificationsTestDto getTagSpecifications(TestContext testContext, TagSpecificationsTestDto entity, CloudbreakClient client) {
+        String logInitMessage = "Obtaining tag specifications";
+        LOGGER.info("{}", logInitMessage);
+        entity.setResponse(client.getCloudbreakClient().connectorV4Endpoint().getTagSpecifications(client.getWorkspaceId()));
+        LOGGER.info("{} was successful", logInitMessage);
+        return entity;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/vmtypes/PlatformVmTypesTestAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/action/vmtypes/PlatformVmTypesTestAction.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.it.cloudbreak.newway.action.vmtypes;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.vmtypes.PlatformVmTypesTestDto;
+
+public class PlatformVmTypesTestAction {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlatformVmTypesTestAction.class);
+
+    private PlatformVmTypesTestAction() {
+    }
+
+    public static PlatformVmTypesTestDto getPlatformVmtypes(TestContext testContext, PlatformVmTypesTestDto entity, CloudbreakClient client) {
+        String logInitMessage = "Obtaining vm types by credential";
+        LOGGER.info("{}", logInitMessage);
+        entity.setResponse(
+                client.getCloudbreakClient().connectorV4Endpoint().getVmTypesByCredential(
+                        client.getWorkspaceId(), entity.getCredentialName(), entity.getRegion(), entity.getPlatformVariant(), entity.getAvailabilityZone())
+        );
+        LOGGER.info("{} was successful", logInitMessage);
+        return entity;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/entity/accessconfig/PlatformAccessConfigsTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/entity/accessconfig/PlatformAccessConfigsTestDto.java
@@ -1,0 +1,84 @@
+package com.sequenceiq.it.cloudbreak.newway.entity.accessconfig;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses.PlatformAccessConfigsV4Response;
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.Prototype;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.AbstractCloudbreakEntity;
+import com.sequenceiq.it.cloudbreak.newway.entity.CloudbreakEntity;
+
+@Prototype
+public class PlatformAccessConfigsTestDto extends AbstractCloudbreakEntity<Object, PlatformAccessConfigsV4Response, PlatformAccessConfigsTestDto> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlatformAccessConfigsTestDto.class);
+
+    private String credentialName;
+
+    private String region;
+
+    private String platformVariant;
+
+    private String availabilityZone;
+
+    protected PlatformAccessConfigsTestDto(TestContext testContext) {
+        super(null, testContext);
+    }
+
+    @Override
+    public CloudbreakEntity valid() {
+        return withPlatformVariant("mock")
+                .withRegion("mockRegion")
+                .withAvailabilityZone("mockAZ")
+                .withCredentialName("mock-credential");
+    }
+
+    public String getCredentialName() {
+        return credentialName;
+    }
+
+    public PlatformAccessConfigsTestDto withCredentialName(String credentialName) {
+        this.credentialName = credentialName;
+        return this;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public PlatformAccessConfigsTestDto withRegion(String region) {
+        this.region = region;
+        return this;
+    }
+
+    public String getPlatformVariant() {
+        return platformVariant;
+    }
+
+    public PlatformAccessConfigsTestDto withPlatformVariant(String platformVariant) {
+        this.platformVariant = platformVariant;
+        return this;
+    }
+
+    public String getAvailabilityZone() {
+        return availabilityZone;
+    }
+
+    public PlatformAccessConfigsTestDto withAvailabilityZone(String availabilityZone) {
+        this.availabilityZone = availabilityZone;
+        return this;
+    }
+
+    @Override
+    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
+        LOGGER.debug("this entry point does not have any clean up operation");
+    }
+
+    @Override
+    public int order() {
+        return 500;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/entity/disk/PlatformDiskTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/entity/disk/PlatformDiskTestDto.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.it.cloudbreak.newway.entity.disk;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses.PlatformDisksV4Response;
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.Prototype;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.AbstractCloudbreakEntity;
+import com.sequenceiq.it.cloudbreak.newway.entity.CloudbreakEntity;
+
+@Prototype
+public class PlatformDiskTestDto extends AbstractCloudbreakEntity<Object, PlatformDisksV4Response, PlatformDiskTestDto> {
+
+    protected PlatformDiskTestDto(TestContext testContext) {
+        super(null, testContext);
+    }
+
+    @Override
+    public CloudbreakEntity valid() {
+        return this;
+    }
+
+    @Override
+    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
+        LOGGER.debug("this entry point does not have any clean up operation");
+    }
+
+    @Override
+    public int order() {
+        return 500;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/entity/encryption/PlatformEncryptionKeysTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/entity/encryption/PlatformEncryptionKeysTestDto.java
@@ -1,0 +1,84 @@
+package com.sequenceiq.it.cloudbreak.newway.entity.encryption;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses.PlatformEncryptionKeysV4Response;
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.Prototype;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.AbstractCloudbreakEntity;
+import com.sequenceiq.it.cloudbreak.newway.entity.CloudbreakEntity;
+
+@Prototype
+public class PlatformEncryptionKeysTestDto extends AbstractCloudbreakEntity<Object, PlatformEncryptionKeysV4Response, PlatformEncryptionKeysTestDto> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlatformEncryptionKeysTestDto.class);
+
+    private String credentialName;
+
+    private String region;
+
+    private String platformVariant;
+
+    private String availabilityZone;
+
+    protected PlatformEncryptionKeysTestDto(TestContext testContext) {
+        super(null, testContext);
+    }
+
+    @Override
+    public CloudbreakEntity valid() {
+        return withPlatformVariant("mock")
+                .withRegion("mockRegion")
+                .withAvailabilityZone("mockAZ")
+                .withCredentialName("mock-credential");
+    }
+
+    public String getCredentialName() {
+        return credentialName;
+    }
+
+    public PlatformEncryptionKeysTestDto withCredentialName(String credentialName) {
+        this.credentialName = credentialName;
+        return this;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public PlatformEncryptionKeysTestDto withRegion(String region) {
+        this.region = region;
+        return this;
+    }
+
+    public String getPlatformVariant() {
+        return platformVariant;
+    }
+
+    public PlatformEncryptionKeysTestDto withPlatformVariant(String platformVariant) {
+        this.platformVariant = platformVariant;
+        return this;
+    }
+
+    public String getAvailabilityZone() {
+        return availabilityZone;
+    }
+
+    public PlatformEncryptionKeysTestDto withAvailabilityZone(String availabilityZone) {
+        this.availabilityZone = availabilityZone;
+        return this;
+    }
+
+    @Override
+    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
+        LOGGER.debug("this entry point does not have any clean up operation");
+    }
+
+    @Override
+    public int order() {
+        return 500;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/entity/gateway/PlatformGatewaysTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/entity/gateway/PlatformGatewaysTestDto.java
@@ -1,0 +1,84 @@
+package com.sequenceiq.it.cloudbreak.newway.entity.gateway;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses.PlatformGatewaysV4Response;
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.Prototype;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.AbstractCloudbreakEntity;
+import com.sequenceiq.it.cloudbreak.newway.entity.CloudbreakEntity;
+
+@Prototype
+public class PlatformGatewaysTestDto extends AbstractCloudbreakEntity<Object, PlatformGatewaysV4Response, PlatformGatewaysTestDto> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlatformGatewaysTestDto.class);
+
+    private String credentialName;
+
+    private String region;
+
+    private String platformVariant;
+
+    private String availabilityZone;
+
+    protected PlatformGatewaysTestDto(TestContext testContext) {
+        super(null, testContext);
+    }
+
+    @Override
+    public CloudbreakEntity valid() {
+        return withPlatformVariant("mock")
+                .withRegion("mockRegion")
+                .withAvailabilityZone("mockAZ")
+                .withCredentialName("mock-credential");
+    }
+
+    public String getCredentialName() {
+        return credentialName;
+    }
+
+    public PlatformGatewaysTestDto withCredentialName(String credentialName) {
+        this.credentialName = credentialName;
+        return this;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public PlatformGatewaysTestDto withRegion(String region) {
+        this.region = region;
+        return this;
+    }
+
+    public String getPlatformVariant() {
+        return platformVariant;
+    }
+
+    public PlatformGatewaysTestDto withPlatformVariant(String platformVariant) {
+        this.platformVariant = platformVariant;
+        return this;
+    }
+
+    public String getAvailabilityZone() {
+        return availabilityZone;
+    }
+
+    public PlatformGatewaysTestDto withAvailabilityZone(String availabilityZone) {
+        this.availabilityZone = availabilityZone;
+        return this;
+    }
+
+    @Override
+    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
+        LOGGER.debug("this entry point does not have any clean up operation");
+    }
+
+    @Override
+    public int order() {
+        return 500;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/entity/ip/PlatformIpPoolsTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/entity/ip/PlatformIpPoolsTestDto.java
@@ -1,0 +1,84 @@
+package com.sequenceiq.it.cloudbreak.newway.entity.ip;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses.PlatformIpPoolsV4Response;
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.Prototype;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.AbstractCloudbreakEntity;
+import com.sequenceiq.it.cloudbreak.newway.entity.CloudbreakEntity;
+
+@Prototype
+public class PlatformIpPoolsTestDto extends AbstractCloudbreakEntity<Object, PlatformIpPoolsV4Response, PlatformIpPoolsTestDto> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlatformIpPoolsTestDto.class);
+
+    private String credentialName;
+
+    private String region;
+
+    private String platformVariant;
+
+    private String availabilityZone;
+
+    protected PlatformIpPoolsTestDto(TestContext testContext) {
+        super(null, testContext);
+    }
+
+    @Override
+    public CloudbreakEntity valid() {
+        return withPlatformVariant("mock")
+                .withRegion("mockRegion")
+                .withAvailabilityZone("mockAZ")
+                .withCredentialName("mock-credential");
+    }
+
+    public String getCredentialName() {
+        return credentialName;
+    }
+
+    public PlatformIpPoolsTestDto withCredentialName(String credentialName) {
+        this.credentialName = credentialName;
+        return this;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public PlatformIpPoolsTestDto withRegion(String region) {
+        this.region = region;
+        return this;
+    }
+
+    public String getPlatformVariant() {
+        return platformVariant;
+    }
+
+    public PlatformIpPoolsTestDto withPlatformVariant(String platformVariant) {
+        this.platformVariant = platformVariant;
+        return this;
+    }
+
+    public String getAvailabilityZone() {
+        return availabilityZone;
+    }
+
+    public PlatformIpPoolsTestDto withAvailabilityZone(String availabilityZone) {
+        this.availabilityZone = availabilityZone;
+        return this;
+    }
+
+    @Override
+    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
+        LOGGER.debug("this entry point does not have any clean up operation");
+    }
+
+    @Override
+    public int order() {
+        return 500;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/entity/network/PlatformNetworksTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/entity/network/PlatformNetworksTestDto.java
@@ -1,0 +1,84 @@
+package com.sequenceiq.it.cloudbreak.newway.entity.network;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses.PlatformNetworksV4Response;
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.Prototype;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.AbstractCloudbreakEntity;
+import com.sequenceiq.it.cloudbreak.newway.entity.CloudbreakEntity;
+
+@Prototype
+public class PlatformNetworksTestDto extends AbstractCloudbreakEntity<Object, PlatformNetworksV4Response, PlatformNetworksTestDto> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlatformNetworksTestDto.class);
+
+    private String credentialName;
+
+    private String region;
+
+    private String platformVariant;
+
+    private String availabilityZone;
+
+    protected PlatformNetworksTestDto(TestContext testContext) {
+        super(null, testContext);
+    }
+
+    @Override
+    public CloudbreakEntity valid() {
+        return withPlatformVariant("mock")
+                .withRegion("mockRegion")
+                .withAvailabilityZone("mockAZ")
+                .withCredentialName("mock-credential");
+    }
+
+    public String getCredentialName() {
+        return credentialName;
+    }
+
+    public PlatformNetworksTestDto withCredentialName(String credentialName) {
+        this.credentialName = credentialName;
+        return this;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public PlatformNetworksTestDto withRegion(String region) {
+        this.region = region;
+        return this;
+    }
+
+    public String getPlatformVariant() {
+        return platformVariant;
+    }
+
+    public PlatformNetworksTestDto withPlatformVariant(String platformVariant) {
+        this.platformVariant = platformVariant;
+        return this;
+    }
+
+    public String getAvailabilityZone() {
+        return availabilityZone;
+    }
+
+    public PlatformNetworksTestDto withAvailabilityZone(String availabilityZone) {
+        this.availabilityZone = availabilityZone;
+        return this;
+    }
+
+    @Override
+    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
+        LOGGER.debug("this entry point does not have any clean up operation");
+    }
+
+    @Override
+    public int order() {
+        return 500;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/entity/region/RegionTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/entity/region/RegionTestDto.java
@@ -1,0 +1,84 @@
+package com.sequenceiq.it.cloudbreak.newway.entity.region;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses.RegionV4Response;
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.Prototype;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.AbstractCloudbreakEntity;
+import com.sequenceiq.it.cloudbreak.newway.entity.CloudbreakEntity;
+
+@Prototype
+public class RegionTestDto extends AbstractCloudbreakEntity<Object, RegionV4Response, RegionTestDto> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RegionTestDto.class);
+
+    private String credentialName;
+
+    private String region;
+
+    private String platformVariant;
+
+    private String availabilityZone;
+
+    protected RegionTestDto(TestContext testContext) {
+        super(null, testContext);
+    }
+
+    @Override
+    public CloudbreakEntity valid() {
+        return withPlatformVariant("mock")
+                .withRegion("mockRegion")
+                .withAvailabilityZone("mockAZ")
+                .withCredentialName("mock-credential");
+    }
+
+    public String getCredentialName() {
+        return credentialName;
+    }
+
+    public RegionTestDto withCredentialName(String credentialName) {
+        this.credentialName = credentialName;
+        return this;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public RegionTestDto withRegion(String region) {
+        this.region = region;
+        return this;
+    }
+
+    public String getPlatformVariant() {
+        return platformVariant;
+    }
+
+    public RegionTestDto withPlatformVariant(String platformVariant) {
+        this.platformVariant = platformVariant;
+        return this;
+    }
+
+    public String getAvailabilityZone() {
+        return availabilityZone;
+    }
+
+    public RegionTestDto withAvailabilityZone(String availabilityZone) {
+        this.availabilityZone = availabilityZone;
+        return this;
+    }
+
+    @Override
+    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
+        LOGGER.debug("this entry point does not have any clean up operation");
+    }
+
+    @Override
+    public int order() {
+        return 500;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/entity/securitygroup/PlatformSecurityGroupsTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/entity/securitygroup/PlatformSecurityGroupsTestDto.java
@@ -1,0 +1,84 @@
+package com.sequenceiq.it.cloudbreak.newway.entity.securitygroup;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses.PlatformSecurityGroupsV4Response;
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.Prototype;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.AbstractCloudbreakEntity;
+import com.sequenceiq.it.cloudbreak.newway.entity.CloudbreakEntity;
+
+@Prototype
+public class PlatformSecurityGroupsTestDto extends AbstractCloudbreakEntity<Object, PlatformSecurityGroupsV4Response, PlatformSecurityGroupsTestDto> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlatformSecurityGroupsTestDto.class);
+
+    private String credentialName;
+
+    private String region;
+
+    private String platformVariant;
+
+    private String availabilityZone;
+
+    protected PlatformSecurityGroupsTestDto(TestContext testContext) {
+        super(null, testContext);
+    }
+
+    @Override
+    public CloudbreakEntity valid() {
+        return withPlatformVariant("mock")
+                .withRegion("mockRegion")
+                .withAvailabilityZone("mockAZ")
+                .withCredentialName("mock-credential");
+    }
+
+    public String getCredentialName() {
+        return credentialName;
+    }
+
+    public PlatformSecurityGroupsTestDto withCredentialName(String credentialName) {
+        this.credentialName = credentialName;
+        return this;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public PlatformSecurityGroupsTestDto withRegion(String region) {
+        this.region = region;
+        return this;
+    }
+
+    public String getPlatformVariant() {
+        return platformVariant;
+    }
+
+    public PlatformSecurityGroupsTestDto withPlatformVariant(String platformVariant) {
+        this.platformVariant = platformVariant;
+        return this;
+    }
+
+    public String getAvailabilityZone() {
+        return availabilityZone;
+    }
+
+    public PlatformSecurityGroupsTestDto withAvailabilityZone(String availabilityZone) {
+        this.availabilityZone = availabilityZone;
+        return this;
+    }
+
+    @Override
+    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
+        LOGGER.debug("this entry point does not have any clean up operation");
+    }
+
+    @Override
+    public int order() {
+        return 500;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/entity/sshkeys/PlatformSshKeysTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/entity/sshkeys/PlatformSshKeysTestDto.java
@@ -1,0 +1,84 @@
+package com.sequenceiq.it.cloudbreak.newway.entity.sshkeys;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses.PlatformSshKeysV4Response;
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.Prototype;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.AbstractCloudbreakEntity;
+import com.sequenceiq.it.cloudbreak.newway.entity.CloudbreakEntity;
+
+@Prototype
+public class PlatformSshKeysTestDto extends AbstractCloudbreakEntity<Object, PlatformSshKeysV4Response, PlatformSshKeysTestDto> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlatformSshKeysTestDto.class);
+
+    private String credentialName;
+
+    private String region;
+
+    private String platformVariant;
+
+    private String availabilityZone;
+
+    protected PlatformSshKeysTestDto(TestContext testContext) {
+        super(null, testContext);
+    }
+
+    @Override
+    public CloudbreakEntity valid() {
+        return withPlatformVariant("mock")
+                .withRegion("mockRegion")
+                .withAvailabilityZone("mockAZ")
+                .withCredentialName("mock-credential");
+    }
+
+    public String getCredentialName() {
+        return credentialName;
+    }
+
+    public PlatformSshKeysTestDto withCredentialName(String credentialName) {
+        this.credentialName = credentialName;
+        return this;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public PlatformSshKeysTestDto withRegion(String region) {
+        this.region = region;
+        return this;
+    }
+
+    public String getPlatformVariant() {
+        return platformVariant;
+    }
+
+    public PlatformSshKeysTestDto withPlatformVariant(String platformVariant) {
+        this.platformVariant = platformVariant;
+        return this;
+    }
+
+    public String getAvailabilityZone() {
+        return availabilityZone;
+    }
+
+    public PlatformSshKeysTestDto withAvailabilityZone(String availabilityZone) {
+        this.availabilityZone = availabilityZone;
+        return this;
+    }
+
+    @Override
+    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
+        LOGGER.debug("this entry point does not have any clean up operation");
+    }
+
+    @Override
+    public int order() {
+        return 500;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/entity/tagspecifications/TagSpecificationsTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/entity/tagspecifications/TagSpecificationsTestDto.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.it.cloudbreak.newway.entity.tagspecifications;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses.TagSpecificationsV4Response;
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.Prototype;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.AbstractCloudbreakEntity;
+import com.sequenceiq.it.cloudbreak.newway.entity.CloudbreakEntity;
+
+@Prototype
+public class TagSpecificationsTestDto extends AbstractCloudbreakEntity<Object, TagSpecificationsV4Response, TagSpecificationsTestDto> {
+
+    protected TagSpecificationsTestDto(TestContext testContext) {
+        super(null, testContext);
+    }
+
+    @Override
+    public CloudbreakEntity valid() {
+        return this;
+    }
+
+    @Override
+    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
+        LOGGER.debug("this entry point does not have any clean up operation");
+    }
+
+    @Override
+    public int order() {
+        return 500;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/entity/vmtypes/PlatformVmTypesTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/entity/vmtypes/PlatformVmTypesTestDto.java
@@ -1,0 +1,84 @@
+package com.sequenceiq.it.cloudbreak.newway.entity.vmtypes;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses.PlatformVmtypesV4Response;
+import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.newway.Prototype;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.AbstractCloudbreakEntity;
+import com.sequenceiq.it.cloudbreak.newway.entity.CloudbreakEntity;
+
+@Prototype
+public class PlatformVmTypesTestDto extends AbstractCloudbreakEntity<Object, PlatformVmtypesV4Response, PlatformVmTypesTestDto> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlatformVmTypesTestDto.class);
+
+    private String credentialName;
+
+    private String region;
+
+    private String platformVariant;
+
+    private String availabilityZone;
+
+    protected PlatformVmTypesTestDto(TestContext testContext) {
+        super(null, testContext);
+    }
+
+    @Override
+    public CloudbreakEntity valid() {
+        return withPlatformVariant("mock")
+                .withRegion("mockRegion")
+                .withAvailabilityZone("mockAZ")
+                .withCredentialName("mock-credential");
+    }
+
+    public String getCredentialName() {
+        return credentialName;
+    }
+
+    public PlatformVmTypesTestDto withCredentialName(String credentialName) {
+        this.credentialName = credentialName;
+        return this;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public PlatformVmTypesTestDto withRegion(String region) {
+        this.region = region;
+        return this;
+    }
+
+    public String getPlatformVariant() {
+        return platformVariant;
+    }
+
+    public PlatformVmTypesTestDto withPlatformVariant(String platformVariant) {
+        this.platformVariant = platformVariant;
+        return this;
+    }
+
+    public String getAvailabilityZone() {
+        return availabilityZone;
+    }
+
+    public PlatformVmTypesTestDto withAvailabilityZone(String availabilityZone) {
+        this.availabilityZone = availabilityZone;
+        return this;
+    }
+
+    @Override
+    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
+        LOGGER.debug("this entry point does not have any clean up operation");
+    }
+
+    @Override
+    public int order() {
+        return 500;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/AccessConfigsTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/AccessConfigsTest.java
@@ -1,0 +1,59 @@
+package com.sequenceiq.it.cloudbreak.newway.testcase.mock;
+
+import static com.sequenceiq.it.cloudbreak.newway.context.RunningParameter.key;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.ForbiddenException;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.sequenceiq.it.cloudbreak.newway.action.accessconfig.PlatformAccessConfigsTestAction;
+import com.sequenceiq.it.cloudbreak.newway.action.credential.CredentialTestAction;
+import com.sequenceiq.it.cloudbreak.newway.context.MockedTestContext;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.accessconfig.PlatformAccessConfigsTestDto;
+import com.sequenceiq.it.cloudbreak.newway.entity.credential.CredentialTestDto;
+import com.sequenceiq.it.cloudbreak.newway.testcase.AbstractIntegrationTest;
+
+public class AccessConfigsTest extends AbstractIntegrationTest {
+
+    @BeforeMethod
+    public void beforeMethod(Object[] data) {
+        createDefaultUser((TestContext) data[0]);
+    }
+
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
+    public void testGetAccessConfigsByCredentialName(MockedTestContext testContext) {
+        String credentialName = getNameGenerator().getRandomNameForResource();
+        testContext
+                .given(CredentialTestDto.class)
+                .withName(credentialName)
+                .when(CredentialTestAction::create)
+                .given(PlatformAccessConfigsTestDto.class)
+                .withCredentialName(credentialName)
+                .when(PlatformAccessConfigsTestAction::getAccessConfigs);
+    }
+
+    @Test(dataProvider = "contextWithCredentialNameAndException")
+    public void testGetAccessConfigsByCredentialNameWhenCredentialIsInvalid(MockedTestContext testContext, String credentialName, String exceptionKey,
+            Class<Exception> exception) {
+        testContext
+                .given(PlatformAccessConfigsTestDto.class)
+                .withCredentialName(credentialName)
+                .when(PlatformAccessConfigsTestAction::getAccessConfigs, key(exceptionKey))
+                .expect(exception, key(exceptionKey))
+                .validate();
+    }
+
+    @DataProvider(name = "contextWithCredentialNameAndException")
+    public Object[][] provideInvalidAttributes() {
+        return new Object[][]{
+                {getBean(MockedTestContext.class), "", "badRequest", BadRequestException.class},
+                {getBean(MockedTestContext.class), null, "badRequest", BadRequestException.class},
+                {getBean(MockedTestContext.class), "andNowForSomethingCompletelyDifferent", "forbidden", ForbiddenException.class}
+        };
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/CredentialTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/CredentialTest.java
@@ -120,14 +120,14 @@ public class CredentialTest extends AbstractIntegrationTest {
     @DataProvider(name = INVALID_ATTRIBUTE_PROVIDER)
     public Object[][] provideInvalidAttributes() {
         return new Object[][]{
-                {applicationContext.getBean(MockedTestContext.class), longStringGeneratorUtil.stringGenerator(101),
+                {getBean(MockedTestContext.class), longStringGeneratorUtil.stringGenerator(101),
                         " The length of the credential's name has to be in range of 5 to 100"},
-                {applicationContext.getBean(MockedTestContext.class), "abc",
+                {getBean(MockedTestContext.class), "abc",
                         " The length of the credential's name has to be in range of 5 to 100"},
-                {applicationContext.getBean(MockedTestContext.class), "a-@#$%|:&*;",
+                {getBean(MockedTestContext.class), "a-@#$%|:&*;",
                         " The name of the credential can only contain lowercase alphanumeric characters and "
                                 + "hyphens and has start with an alphanumeric character"},
-                {applicationContext.getBean(MockedTestContext.class), null,
+                {getBean(MockedTestContext.class), null,
                         "error: must not be null"}
         };
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/DatabaseTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/DatabaseTest.java
@@ -160,7 +160,7 @@ public class DatabaseTest extends AbstractIntegrationTest {
         Object[][] objects = new Object[databaseTypeList.size()][2];
         databaseTypeList
                 .forEach(databaseType -> {
-                    objects[databaseTypeList.indexOf(databaseType)][0] = applicationContext.getBean(TEST_CONTEXT_CLASS);
+                    objects[databaseTypeList.indexOf(databaseType)][0] = getBean(TEST_CONTEXT_CLASS);
                     objects[databaseTypeList.indexOf(databaseType)][1] = databaseType;
                 });
         return objects;
@@ -169,18 +169,18 @@ public class DatabaseTest extends AbstractIntegrationTest {
     @DataProvider(name = INVALID_ATTRIBUTE_PROVIDER)
     public Object[][] provideInvalidAttributes() {
         return new Object[][]{
-                {applicationContext.getBean(TEST_CONTEXT_CLASS), longStringGeneratorUtil.stringGenerator(51), DATABASE_USERNAME, DATABASE_PASSWORD,
+                {getBean(TEST_CONTEXT_CLASS), longStringGeneratorUtil.stringGenerator(51), DATABASE_USERNAME, DATABASE_PASSWORD,
                         DATABASE_PROTOCOL + DATABASE_HOST_PORT_DB, "The length of the name has to be in range of 4 to 50"},
-                {applicationContext.getBean(TEST_CONTEXT_CLASS), "abc", DATABASE_USERNAME, DATABASE_PASSWORD,
+                {getBean(TEST_CONTEXT_CLASS), "abc", DATABASE_USERNAME, DATABASE_PASSWORD,
                         DATABASE_PROTOCOL + DATABASE_HOST_PORT_DB, "The length of the name has to be in range of 4 to 50"},
-                {applicationContext.getBean(TEST_CONTEXT_CLASS), "a-@#$%|:&*;", DATABASE_USERNAME, DATABASE_PASSWORD,
+                {getBean(TEST_CONTEXT_CLASS), "a-@#$%|:&*;", DATABASE_USERNAME, DATABASE_PASSWORD,
                         DATABASE_PROTOCOL + DATABASE_HOST_PORT_DB, "The database's name can only contain lowercase alphanumeric characters and "
                         + "hyphens and has start with an alphanumeric character"},
-                {applicationContext.getBean(TEST_CONTEXT_CLASS), getNameGenerator().getRandomNameForResource(), null, DATABASE_PASSWORD,
+                {getBean(TEST_CONTEXT_CLASS), getNameGenerator().getRandomNameForResource(), null, DATABASE_PASSWORD,
                         DATABASE_PROTOCOL + DATABASE_HOST_PORT_DB, "connectionUserName: null, error: must not be null"},
-                {applicationContext.getBean(TEST_CONTEXT_CLASS), getNameGenerator().getRandomNameForResource(), DATABASE_USERNAME, null,
+                {getBean(TEST_CONTEXT_CLASS), getNameGenerator().getRandomNameForResource(), DATABASE_USERNAME, null,
                         DATABASE_PROTOCOL + DATABASE_HOST_PORT_DB, "connectionPassword: null, error: must not be null"},
-                {applicationContext.getBean(TEST_CONTEXT_CLASS), getNameGenerator().getRandomNameForResource(), DATABASE_USERNAME, DATABASE_PASSWORD,
+                {getBean(TEST_CONTEXT_CLASS), getNameGenerator().getRandomNameForResource(), DATABASE_USERNAME, DATABASE_PASSWORD,
                         DATABASE_HOST_PORT_DB, "Unsupported database type"}
         };
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/DisksTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/DisksTest.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.it.cloudbreak.newway.testcase.mock;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.sequenceiq.it.cloudbreak.newway.action.platformdisk.PlatformDisksTestAction;
+import com.sequenceiq.it.cloudbreak.newway.context.MockedTestContext;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.disk.PlatformDiskTestDto;
+import com.sequenceiq.it.cloudbreak.newway.testcase.AbstractIntegrationTest;
+
+public class DisksTest extends AbstractIntegrationTest {
+
+    @BeforeMethod
+    public void beforeMethod(Object[] data) {
+        createDefaultUser((TestContext) data[0]);
+    }
+
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
+    public void testGetPlatformDisks(MockedTestContext testContext) {
+        testContext
+                .given(PlatformDiskTestDto.class)
+                .when(PlatformDisksTestAction::getDiskTypes);
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/EncryptionKeysTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/EncryptionKeysTest.java
@@ -1,0 +1,59 @@
+package com.sequenceiq.it.cloudbreak.newway.testcase.mock;
+
+import static com.sequenceiq.it.cloudbreak.newway.context.RunningParameter.key;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.ForbiddenException;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.sequenceiq.it.cloudbreak.newway.action.credential.CredentialTestAction;
+import com.sequenceiq.it.cloudbreak.newway.action.encryptionkeys.PlatformEncryptionKeysTestAction;
+import com.sequenceiq.it.cloudbreak.newway.context.MockedTestContext;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.credential.CredentialTestDto;
+import com.sequenceiq.it.cloudbreak.newway.entity.encryption.PlatformEncryptionKeysTestDto;
+import com.sequenceiq.it.cloudbreak.newway.testcase.AbstractIntegrationTest;
+
+public class EncryptionKeysTest extends AbstractIntegrationTest {
+
+    @BeforeMethod
+    public void beforeMethod(Object[] data) {
+        createDefaultUser((TestContext) data[0]);
+    }
+
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
+    public void testGetPlatformEncryptionKeysByCredentialName(MockedTestContext testContext) {
+        String credentialName = getNameGenerator().getRandomNameForResource();
+        testContext
+                .given(CredentialTestDto.class)
+                .withName(credentialName)
+                .when(CredentialTestAction::create)
+                .given(PlatformEncryptionKeysTestDto.class)
+                .withCredentialName(credentialName)
+                .when(PlatformEncryptionKeysTestAction::getEncryptionKeys);
+    }
+
+    @Test(dataProvider = "contextWithCredentialNameAndException")
+    public void testGetPlatformEncryptionKeysByCredentialNameWhenCredentialIsInvalid(MockedTestContext testContext, String credentialName, String exceptionKey,
+            Class<Exception> exception) {
+        testContext
+                .given(PlatformEncryptionKeysTestDto.class)
+                .withCredentialName(credentialName)
+                .when(PlatformEncryptionKeysTestAction::getEncryptionKeys, key(exceptionKey))
+                .expect(exception, key(exceptionKey))
+                .validate();
+    }
+
+    @DataProvider(name = "contextWithCredentialNameAndException")
+    public Object[][] provideInvalidAttributes() {
+        return new Object[][]{
+                {getBean(MockedTestContext.class), "", "badRequest", BadRequestException.class},
+                {getBean(MockedTestContext.class), null, "badRequest", BadRequestException.class},
+                {getBean(MockedTestContext.class), "andNowForSomethingCompletelyDifferent", "forbidden", ForbiddenException.class}
+        };
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/EnvironmentClusterTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/EnvironmentClusterTest.java
@@ -41,7 +41,7 @@ import com.sequenceiq.it.cloudbreak.newway.v3.StackActionV4;
 
 public class EnvironmentClusterTest extends AbstractIntegrationTest {
 
-    public static final String NEW_CREDENTIAL_KEY = "newCred";
+    private static final String NEW_CREDENTIAL_KEY = "newCred";
 
     private static final String FORBIDDEN_KEY = "forbiddenPost";
 
@@ -359,7 +359,7 @@ public class EnvironmentClusterTest extends AbstractIntegrationTest {
         return environment;
     }
 
-    protected static EnvironmentEntity checkNewCredentialAttachedToEnv(TestContext testContext,
+    private static EnvironmentEntity checkNewCredentialAttachedToEnv(TestContext testContext,
             EnvironmentEntity environment, CloudbreakClient cloudbreakClient) {
         String credentialName = environment.getResponse().getCredentialName();
         if (!credentialName.equals(testContext.get(NEW_CREDENTIAL_KEY).getName())) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/EnvironmentTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/EnvironmentTest.java
@@ -554,7 +554,7 @@ public class EnvironmentTest extends AbstractIntegrationTest {
                 .validate();
     }
 
-    protected static EnvironmentEntity checkCredentialAttachedToEnv(TestContext testContext, EnvironmentEntity environment, CloudbreakClient cloudbreakClient) {
+    private static EnvironmentEntity checkCredentialAttachedToEnv(TestContext testContext, EnvironmentEntity environment, CloudbreakClient cloudbreakClient) {
         String credentialName = environment.getResponse().getCredentialName();
         if (!credentialName.equals(testContext.get(CredentialTestDto.class).getName())) {
             throw new TestFailException("Credential is not attached to environment");
@@ -562,7 +562,7 @@ public class EnvironmentTest extends AbstractIntegrationTest {
         return environment;
     }
 
-    protected static EnvironmentEntity checkRdsAttachedToEnv(TestContext testContext, EnvironmentEntity environment, CloudbreakClient cloudbreakClient) {
+    static EnvironmentEntity checkRdsAttachedToEnv(TestContext testContext, EnvironmentEntity environment, CloudbreakClient cloudbreakClient) {
         Set<String> rdsConfigs = new HashSet<>();
         Set<DatabaseV4Response> rdsConfigResponseSet = environment.getResponse().getDatabases();
         for (DatabaseV4Response rdsConfigResponse : rdsConfigResponseSet) {
@@ -580,7 +580,7 @@ public class EnvironmentTest extends AbstractIntegrationTest {
         return checkRdsDetachedFromEnv(environment, rdsName);
     }
 
-    public static <T extends CloudbreakEntity> EnvironmentEntity checkRdsDetachedFromEnv(TestContext testContext,
+    static <T extends CloudbreakEntity> EnvironmentEntity checkRdsDetachedFromEnv(TestContext testContext,
             EnvironmentEntity environment, Class<T> rdsKey, CloudbreakClient cloudbreakClient) {
         String rdsName = testContext.get(rdsKey).getName();
         return checkRdsDetachedFromEnv(environment, rdsName);
@@ -597,7 +597,7 @@ public class EnvironmentTest extends AbstractIntegrationTest {
         return environment;
     }
 
-    protected static EnvironmentEntity checkLdapAttachedToEnv(TestContext testContext, EnvironmentEntity environment, CloudbreakClient cloudbreakClient) {
+    private static EnvironmentEntity checkLdapAttachedToEnv(TestContext testContext, EnvironmentEntity environment, CloudbreakClient cloudbreakClient) {
         Set<String> ldapConfigs = new HashSet<>();
         Set<LdapV4Response> ldapV4ResponseSet = environment.getResponse().getLdaps();
         for (LdapV4Response ldapV4Response : ldapV4ResponseSet) {
@@ -609,7 +609,7 @@ public class EnvironmentTest extends AbstractIntegrationTest {
         return environment;
     }
 
-    protected static EnvironmentEntity checkProxyAttachedToEnv(TestContext testContext, EnvironmentEntity environment, CloudbreakClient cloudbreakClient) {
+    private static EnvironmentEntity checkProxyAttachedToEnv(TestContext testContext, EnvironmentEntity environment, CloudbreakClient cloudbreakClient) {
         Set<String> proxyConfigs = new HashSet<>();
         Set<ProxyV4Response> proxyV4ResponseSet = environment.getResponse().getProxies();
         for (ProxyV4Response proxyV4Response : proxyV4ResponseSet) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/GatewaysTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/GatewaysTest.java
@@ -1,0 +1,59 @@
+package com.sequenceiq.it.cloudbreak.newway.testcase.mock;
+
+import static com.sequenceiq.it.cloudbreak.newway.context.RunningParameter.key;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.ForbiddenException;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.sequenceiq.it.cloudbreak.newway.action.credential.CredentialTestAction;
+import com.sequenceiq.it.cloudbreak.newway.action.gateway.PlatformGatewaysTestAction;
+import com.sequenceiq.it.cloudbreak.newway.context.MockedTestContext;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.credential.CredentialTestDto;
+import com.sequenceiq.it.cloudbreak.newway.entity.gateway.PlatformGatewaysTestDto;
+import com.sequenceiq.it.cloudbreak.newway.testcase.AbstractIntegrationTest;
+
+public class GatewaysTest extends AbstractIntegrationTest {
+
+    @BeforeMethod
+    public void beforeMethod(Object[] data) {
+        createDefaultUser((TestContext) data[0]);
+    }
+
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
+    public void testGetPlatformGatewaysByCredentialName(MockedTestContext testContext) {
+        String credentialName = getNameGenerator().getRandomNameForResource();
+        testContext
+                .given(CredentialTestDto.class)
+                .withName(credentialName)
+                .when(CredentialTestAction::create)
+                .given(PlatformGatewaysTestDto.class)
+                .withCredentialName(credentialName)
+                .when(PlatformGatewaysTestAction::getGateways);
+    }
+
+    @Test(dataProvider = "contextWithCredentialNameAndException")
+    public void testGetPlatformGatewaysByCredentialNameWhenCredentialIsInvalid(MockedTestContext testContext, String credentialName, String exceptionKey,
+            Class<Exception> exception) {
+        testContext
+                .given(PlatformGatewaysTestDto.class)
+                .withCredentialName(credentialName)
+                .when(PlatformGatewaysTestAction::getGateways, key(exceptionKey))
+                .expect(exception, key(exceptionKey))
+                .validate();
+    }
+
+    @DataProvider(name = "contextWithCredentialNameAndException")
+    public Object[][] provideInvalidAttributes() {
+        return new Object[][]{
+                {getBean(MockedTestContext.class), "", "badRequest", BadRequestException.class},
+                {getBean(MockedTestContext.class), null, "badRequest", BadRequestException.class},
+                {getBean(MockedTestContext.class), "andNowForSomethingCompletelyDifferent", "forbidden", ForbiddenException.class}
+        };
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/IpPoolsTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/IpPoolsTest.java
@@ -1,0 +1,59 @@
+package com.sequenceiq.it.cloudbreak.newway.testcase.mock;
+
+import static com.sequenceiq.it.cloudbreak.newway.context.RunningParameter.key;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.ForbiddenException;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.sequenceiq.it.cloudbreak.newway.action.credential.CredentialTestAction;
+import com.sequenceiq.it.cloudbreak.newway.action.ip.PlatformIpPoolsTestAction;
+import com.sequenceiq.it.cloudbreak.newway.context.MockedTestContext;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.credential.CredentialTestDto;
+import com.sequenceiq.it.cloudbreak.newway.entity.ip.PlatformIpPoolsTestDto;
+import com.sequenceiq.it.cloudbreak.newway.testcase.AbstractIntegrationTest;
+
+public class IpPoolsTest extends AbstractIntegrationTest {
+
+    @BeforeMethod
+    public void beforeMethod(Object[] data) {
+        createDefaultUser((TestContext) data[0]);
+    }
+
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
+    public void testGetIpPoolsByCredentialName(MockedTestContext testContext) {
+        String credentialName = getNameGenerator().getRandomNameForResource();
+        testContext
+                .given(CredentialTestDto.class)
+                .withName(credentialName)
+                .when(CredentialTestAction::create)
+                .given(PlatformIpPoolsTestDto.class)
+                .withCredentialName(credentialName)
+                .when(PlatformIpPoolsTestAction::getIpPools);
+    }
+
+    @Test(dataProvider = "contextWithCredentialNameAndException")
+    public void testGetIpPoolsByCredentialNameWhenCredentialIsInvalid(MockedTestContext testContext, String credentialName, String exceptionKey,
+            Class<Exception> exception) {
+        testContext
+                .given(PlatformIpPoolsTestDto.class)
+                .withCredentialName(credentialName)
+                .when(PlatformIpPoolsTestAction::getIpPools, key(exceptionKey))
+                .expect(exception, key(exceptionKey))
+                .validate();
+    }
+
+    @DataProvider(name = "contextWithCredentialNameAndException")
+    public Object[][] provideInvalidAttributes() {
+        return new Object[][]{
+                {getBean(MockedTestContext.class), "", "badRequest", BadRequestException.class},
+                {getBean(MockedTestContext.class), null, "badRequest", BadRequestException.class},
+                {getBean(MockedTestContext.class), "andNowForSomethingCompletelyDifferent", "forbidden", ForbiddenException.class}
+        };
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/KerberosTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/KerberosTest.java
@@ -180,10 +180,10 @@ public class KerberosTest extends AbstractIntegrationTest {
     @DataProvider(name = "dataProviderForTest")
     public Object[][] provide() {
         return new Object[][]{
-                {applicationContext.getBean(MockedTestContext.class), getNameGenerator().getRandomNameForResource(), KerberosTestData.FREEIPA},
-                {applicationContext.getBean(MockedTestContext.class), getNameGenerator().getRandomNameForResource(), KerberosTestData.ACTIVE_DIRECTORY},
-                {applicationContext.getBean(MockedTestContext.class), getNameGenerator().getRandomNameForResource(), KerberosTestData.MIT},
-                {applicationContext.getBean(MockedTestContext.class), getNameGenerator().getRandomNameForResource(), KerberosTestData.AMBARI_DESCRIPTOR}
+                {getBean(MockedTestContext.class), getNameGenerator().getRandomNameForResource(), KerberosTestData.FREEIPA},
+                {getBean(MockedTestContext.class), getNameGenerator().getRandomNameForResource(), KerberosTestData.ACTIVE_DIRECTORY},
+                {getBean(MockedTestContext.class), getNameGenerator().getRandomNameForResource(), KerberosTestData.MIT},
+                {getBean(MockedTestContext.class), getNameGenerator().getRandomNameForResource(), KerberosTestData.AMBARI_DESCRIPTOR}
         };
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/KubernetesTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/KubernetesTest.java
@@ -109,13 +109,13 @@ public class KubernetesTest extends AbstractIntegrationTest {
     @DataProvider(name = INVALID_ATTRIBUTE_PROVIDER)
     public Object[][] provideInvalidAttributes() {
         return new Object[][]{
-                {applicationContext.getBean(TestContext.class), longStringGeneratorUtil.stringGenerator(101), KUBERNETES_CONTENT,
+                {getBean(TestContext.class), longStringGeneratorUtil.stringGenerator(101), KUBERNETES_CONTENT,
                         " The length of the config's name has to be in range of 5 to 100"},
-                {applicationContext.getBean(TestContext.class), "abc", KUBERNETES_CONTENT,
+                {getBean(TestContext.class), "abc", KUBERNETES_CONTENT,
                         " The length of the config's name has to be in range of 5 to 100"},
-                {applicationContext.getBean(TestContext.class), "a-@#$%|:&*;", KUBERNETES_CONTENT,
+                {getBean(TestContext.class), "a-@#$%|:&*;", KUBERNETES_CONTENT,
                         " The config's name can only contain lowercase alphanumeric characters and hyphens and has start with an alphanumeric character"},
-                {applicationContext.getBean(TestContext.class), getNameGenerator().getRandomNameForResource(), null,
+                {getBean(TestContext.class), getNameGenerator().getRandomNameForResource(), null,
                         "post.arg1.content: null, error: must not be null"}
         };
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/MaintenanceModeTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/MaintenanceModeTest.java
@@ -19,7 +19,7 @@ import com.sequenceiq.it.cloudbreak.newway.v4.UpdateStackDataAction;
 
 public class MaintenanceModeTest extends AbstractIntegrationTest {
 
-    protected static final Map<String, Status> CLUSTER_MAINTENANCE_MODE = Map.of("status", Status.AVAILABLE, "clusterStatus", Status.MAINTENANCE_MODE_ENABLED);
+    private static final Map<String, Status> CLUSTER_MAINTENANCE_MODE = Map.of("status", Status.AVAILABLE, "clusterStatus", Status.MAINTENANCE_MODE_ENABLED);
 
     @BeforeMethod
     public void beforeMethod(Object[] data) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/NetworksTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/NetworksTest.java
@@ -1,0 +1,59 @@
+package com.sequenceiq.it.cloudbreak.newway.testcase.mock;
+
+import static com.sequenceiq.it.cloudbreak.newway.context.RunningParameter.key;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.ForbiddenException;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.sequenceiq.it.cloudbreak.newway.action.credential.CredentialTestAction;
+import com.sequenceiq.it.cloudbreak.newway.action.network.PlatformNetworksTestAction;
+import com.sequenceiq.it.cloudbreak.newway.context.MockedTestContext;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.credential.CredentialTestDto;
+import com.sequenceiq.it.cloudbreak.newway.entity.network.PlatformNetworksTestDto;
+import com.sequenceiq.it.cloudbreak.newway.testcase.AbstractIntegrationTest;
+
+public class NetworksTest extends AbstractIntegrationTest {
+
+    @BeforeMethod
+    public void beforeMethod(Object[] data) {
+        createDefaultUser((TestContext) data[0]);
+    }
+
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
+    public void testGetPlatformNetworksByCredentialName(MockedTestContext testContext) {
+        String credentialName = getNameGenerator().getRandomNameForResource();
+        testContext
+                .given(CredentialTestDto.class)
+                .withName(credentialName)
+                .when(CredentialTestAction::create)
+                .given(PlatformNetworksTestDto.class)
+                .withCredentialName(credentialName)
+                .when(PlatformNetworksTestAction::getPlatformNetworks);
+    }
+
+    @Test(dataProvider = "contextWithCredentialNameAndException")
+    public void testGetPlatformNetworksByCredentialNameWhenCredentialIsInvalid(MockedTestContext testContext, String credentialName, String exceptionKey,
+            Class<Exception> exception) {
+        testContext
+                .given(PlatformNetworksTestDto.class)
+                .withCredentialName(credentialName)
+                .when(PlatformNetworksTestAction::getPlatformNetworks, key(exceptionKey))
+                .expect(exception, key(exceptionKey))
+                .validate();
+    }
+
+    @DataProvider(name = "contextWithCredentialNameAndException")
+    public Object[][] provideInvalidAttributes() {
+        return new Object[][]{
+                {getBean(MockedTestContext.class), "", "badRequest", BadRequestException.class},
+                {getBean(MockedTestContext.class), null, "badRequest", BadRequestException.class},
+                {getBean(MockedTestContext.class), "andNowForSomethingCompletelyDifferent", "forbidden", ForbiddenException.class}
+        };
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/RecipeTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/RecipeTest.java
@@ -145,9 +145,9 @@ public class RecipeTest extends AbstractIntegrationTest {
     @DataProvider(name = "dataProviderForNonPreTerminationRecipeTypes")
     public Object[][] getData() {
         return new Object[][]{
-                {applicationContext.getBean(MockedTestContext.class), PRE_AMBARI_START, 3},
-                {applicationContext.getBean(MockedTestContext.class), POST_AMBARI_START, 3},
-                {applicationContext.getBean(MockedTestContext.class), POST_CLUSTER_INSTALL, 2}
+                {getBean(MockedTestContext.class), PRE_AMBARI_START, 3},
+                {getBean(MockedTestContext.class), POST_AMBARI_START, 3},
+                {getBean(MockedTestContext.class), POST_CLUSTER_INSTALL, 2}
         };
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/RegionTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/RegionTest.java
@@ -1,0 +1,59 @@
+package com.sequenceiq.it.cloudbreak.newway.testcase.mock;
+
+import static com.sequenceiq.it.cloudbreak.newway.context.RunningParameter.key;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.ForbiddenException;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.sequenceiq.it.cloudbreak.newway.action.credential.CredentialTestAction;
+import com.sequenceiq.it.cloudbreak.newway.action.region.RegionTestAction;
+import com.sequenceiq.it.cloudbreak.newway.context.MockedTestContext;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.credential.CredentialTestDto;
+import com.sequenceiq.it.cloudbreak.newway.entity.region.RegionTestDto;
+import com.sequenceiq.it.cloudbreak.newway.testcase.AbstractIntegrationTest;
+
+public class RegionTest extends AbstractIntegrationTest {
+
+    @BeforeMethod
+    public void beforeMethod(Object[] data) {
+        createDefaultUser((TestContext) data[0]);
+    }
+
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
+    public void testGetRegionsByCredentialName(MockedTestContext testContext) {
+        String credentialName = getNameGenerator().getRandomNameForResource();
+        testContext
+                .given(CredentialTestDto.class)
+                .withName(credentialName)
+                .when(CredentialTestAction::create)
+                .given(RegionTestDto.class)
+                .withCredentialName(credentialName)
+                .when(RegionTestAction::getRegions);
+    }
+
+    @Test(dataProvider = "contextWithCredentialNameAndException")
+    public void testGetRegionsByCredentialNameWhenCredentialIsInvalid(MockedTestContext testContext, String credentialName, String exceptionKey,
+            Class<Exception> exception) {
+        testContext
+                .given(RegionTestDto.class)
+                .withCredentialName(credentialName)
+                .when(RegionTestAction::getRegions, key(exceptionKey))
+                .expect(exception, key(exceptionKey))
+                .validate();
+    }
+
+    @DataProvider(name = "contextWithCredentialNameAndException")
+    public Object[][] provideInvalidAttributes() {
+        return new Object[][]{
+                {getBean(MockedTestContext.class), "", "badRequest", BadRequestException.class},
+                {getBean(MockedTestContext.class), null, "badRequest", BadRequestException.class},
+                {getBean(MockedTestContext.class), "andNowForSomethingCompletelyDifferent", "forbidden", ForbiddenException.class}
+        };
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/SSHKeysTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/SSHKeysTest.java
@@ -1,0 +1,59 @@
+package com.sequenceiq.it.cloudbreak.newway.testcase.mock;
+
+import static com.sequenceiq.it.cloudbreak.newway.context.RunningParameter.key;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.ForbiddenException;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.sequenceiq.it.cloudbreak.newway.action.credential.CredentialTestAction;
+import com.sequenceiq.it.cloudbreak.newway.action.sshkeys.PlatformSshKeysTestAction;
+import com.sequenceiq.it.cloudbreak.newway.context.MockedTestContext;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.credential.CredentialTestDto;
+import com.sequenceiq.it.cloudbreak.newway.entity.sshkeys.PlatformSshKeysTestDto;
+import com.sequenceiq.it.cloudbreak.newway.testcase.AbstractIntegrationTest;
+
+public class SSHKeysTest extends AbstractIntegrationTest {
+
+    @BeforeMethod
+    public void beforeMethod(Object[] data) {
+        createDefaultUser((TestContext) data[0]);
+    }
+
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
+    public void testGetSSHKeysByCredentialName(MockedTestContext testContext) {
+        String credentialName = getNameGenerator().getRandomNameForResource();
+        testContext
+                .given(CredentialTestDto.class)
+                .withName(credentialName)
+                .when(CredentialTestAction::create)
+                .given(PlatformSshKeysTestDto.class)
+                .withCredentialName(credentialName)
+                .when(PlatformSshKeysTestAction::getSSHKeys);
+    }
+
+    @Test(dataProvider = "contextWithCredentialNameAndException")
+    public void testGetSSHKeysByCredentialNameWhenCredentialIsInvalid(MockedTestContext testContext, String credentialName, String exceptionKey,
+            Class<Exception> exception) {
+        testContext
+                .given(PlatformSshKeysTestDto.class)
+                .withCredentialName(credentialName)
+                .when(PlatformSshKeysTestAction::getSSHKeys, key(exceptionKey))
+                .expect(exception, key(exceptionKey))
+                .validate();
+    }
+
+    @DataProvider(name = "contextWithCredentialNameAndException")
+    public Object[][] provideInvalidAttributes() {
+        return new Object[][]{
+                {getBean(MockedTestContext.class), "", "badRequest", BadRequestException.class},
+                {getBean(MockedTestContext.class), null, "badRequest", BadRequestException.class},
+                {getBean(MockedTestContext.class), "andNowForSomethingCompletelyDifferent", "forbidden", ForbiddenException.class}
+        };
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/SecurityGroupsTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/SecurityGroupsTest.java
@@ -1,0 +1,59 @@
+package com.sequenceiq.it.cloudbreak.newway.testcase.mock;
+
+import static com.sequenceiq.it.cloudbreak.newway.context.RunningParameter.key;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.ForbiddenException;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.sequenceiq.it.cloudbreak.newway.action.credential.CredentialTestAction;
+import com.sequenceiq.it.cloudbreak.newway.action.securitygroup.PlatformSecurityGroupsTestAction;
+import com.sequenceiq.it.cloudbreak.newway.context.MockedTestContext;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.credential.CredentialTestDto;
+import com.sequenceiq.it.cloudbreak.newway.entity.securitygroup.PlatformSecurityGroupsTestDto;
+import com.sequenceiq.it.cloudbreak.newway.testcase.AbstractIntegrationTest;
+
+public class SecurityGroupsTest extends AbstractIntegrationTest {
+
+    @BeforeMethod
+    public void beforeMethod(Object[] data) {
+        createDefaultUser((TestContext) data[0]);
+    }
+
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
+    public void testGetSecurityGroupsByCredentialName(MockedTestContext testContext) {
+        String credentialName = getNameGenerator().getRandomNameForResource();
+        testContext
+                .given(CredentialTestDto.class)
+                .withName(credentialName)
+                .when(CredentialTestAction::create)
+                .given(PlatformSecurityGroupsTestDto.class)
+                .withCredentialName(credentialName)
+                .when(PlatformSecurityGroupsTestAction::getSecurityGroups);
+    }
+
+    @Test(dataProvider = "contextWithCredentialNameAndException")
+    public void testGetSecurityGroupsByCredentialNameWhenCredentialIsInvalid(MockedTestContext testContext, String credentialName, String exceptionKey,
+            Class<Exception> exception) {
+        testContext
+                .given(PlatformSecurityGroupsTestDto.class)
+                .withCredentialName(credentialName)
+                .when(PlatformSecurityGroupsTestAction::getSecurityGroups, key(exceptionKey))
+                .expect(exception, key(exceptionKey))
+                .validate();
+    }
+
+    @DataProvider(name = "contextWithCredentialNameAndException")
+    public Object[][] provideInvalidAttributes() {
+        return new Object[][]{
+                {getBean(MockedTestContext.class), "", "badRequest", BadRequestException.class},
+                {getBean(MockedTestContext.class), null, "badRequest", BadRequestException.class},
+                {getBean(MockedTestContext.class), "andNowForSomethingCompletelyDifferent", "forbidden", ForbiddenException.class}
+        };
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/TagSpecificationsTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/TagSpecificationsTest.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.it.cloudbreak.newway.testcase.mock;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.sequenceiq.it.cloudbreak.newway.action.tagspecifications.TagSpecificationsTestAction;
+import com.sequenceiq.it.cloudbreak.newway.context.MockedTestContext;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.tagspecifications.TagSpecificationsTestDto;
+import com.sequenceiq.it.cloudbreak.newway.testcase.AbstractIntegrationTest;
+
+public class TagSpecificationsTest extends AbstractIntegrationTest {
+
+    @BeforeMethod
+    public void beforeMethod(Object[] data) {
+        createDefaultUser((TestContext) data[0]);
+    }
+
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
+    public void testGetTagSpecifications(MockedTestContext testContext) {
+        testContext
+                .given(TagSpecificationsTestDto.class)
+                .when(TagSpecificationsTestAction::getTagSpecifications);
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/VmTypesTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/VmTypesTest.java
@@ -1,0 +1,61 @@
+package com.sequenceiq.it.cloudbreak.newway.testcase.mock;
+
+import static com.sequenceiq.it.cloudbreak.newway.context.RunningParameter.key;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.ForbiddenException;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.sequenceiq.it.cloudbreak.newway.action.credential.CredentialTestAction;
+import com.sequenceiq.it.cloudbreak.newway.action.region.RegionTestAction;
+import com.sequenceiq.it.cloudbreak.newway.action.vmtypes.PlatformVmTypesTestAction;
+import com.sequenceiq.it.cloudbreak.newway.context.MockedTestContext;
+import com.sequenceiq.it.cloudbreak.newway.context.TestContext;
+import com.sequenceiq.it.cloudbreak.newway.entity.credential.CredentialTestDto;
+import com.sequenceiq.it.cloudbreak.newway.entity.region.RegionTestDto;
+import com.sequenceiq.it.cloudbreak.newway.entity.vmtypes.PlatformVmTypesTestDto;
+import com.sequenceiq.it.cloudbreak.newway.testcase.AbstractIntegrationTest;
+
+public class VmTypesTest extends AbstractIntegrationTest {
+
+    @BeforeMethod
+    public void beforeMethod(Object[] data) {
+        createDefaultUser((TestContext) data[0]);
+    }
+
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
+    public void testGetPlatformVmtypesByCredentialName(MockedTestContext testContext) {
+        String credentialName = getNameGenerator().getRandomNameForResource();
+        testContext
+                .given(CredentialTestDto.class)
+                .withName(credentialName)
+                .when(CredentialTestAction::create)
+                .given(PlatformVmTypesTestDto.class)
+                .withCredentialName(credentialName)
+                .when(PlatformVmTypesTestAction::getPlatformVmtypes);
+    }
+
+    @Test(dataProvider = "contextWithCredentialNameAndException")
+    public void testGetPlatformVmtypesByCredentialNameWhenCredentialIsInvalid(MockedTestContext testContext, String credentialName, String exceptionKey,
+            Class<Exception> exception) {
+        testContext
+                .given(RegionTestDto.class)
+                .withCredentialName(credentialName)
+                .when(RegionTestAction::getRegions, key(exceptionKey))
+                .expect(exception, key(exceptionKey))
+                .validate();
+    }
+
+    @DataProvider(name = "contextWithCredentialNameAndException")
+    public Object[][] provideInvalidAttributes() {
+        return new Object[][]{
+                {getBean(MockedTestContext.class), "", "badRequest", BadRequestException.class},
+                {getBean(MockedTestContext.class), null, "badRequest", BadRequestException.class},
+                {getBean(MockedTestContext.class), "andNowForSomethingCompletelyDifferent", "forbidden", ForbiddenException.class}
+        };
+    }
+
+}


### PR DESCRIPTION
- CB-372 – Connector v4 related integration test
- super small refactor
- getBean method in the `AbstractIntegrationTest.java` to lower the amount of warnings when accessing the applicationContext from the tests.