### PR TITLE
CB-574 support CM anc CDH in stack matrix

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/ClouderaManagerRepo.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/ClouderaManagerRepo.java
@@ -1,0 +1,62 @@
+package com.sequenceiq.cloudbreak.cloud.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(Include.NON_NULL)
+public class ClouderaManagerRepo {
+
+    private Boolean predefined;
+
+    private String version;
+
+    private String baseUrl;
+
+    private String gpgKeyUrl;
+
+    public Boolean getPredefined() {
+        return predefined;
+    }
+
+    public void setPredefined(Boolean predefined) {
+        this.predefined = predefined;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    public String getGpgKeyUrl() {
+        return gpgKeyUrl;
+    }
+
+    public void setGpgKeyUrl(String gpgKeyUrl) {
+        this.gpgKeyUrl = gpgKeyUrl;
+    }
+
+    public Map<String, Object> asMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("predefined", predefined);
+        map.put("version", version);
+        map.put("baseUrl", baseUrl);
+        map.put("gpgKeyUrl", gpgKeyUrl);
+        return map;
+    }
+}

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/component/AmbariDefaultStackRepoDetails.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/component/AmbariDefaultStackRepoDetails.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class DefaultStackRepoDetails implements Serializable {
+public class AmbariDefaultStackRepoDetails implements Serializable {
 
     public static final String REPO_ID_TAG = "repoid";
 

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/component/ClouderaManagerDefaultStackRepoDetails.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/component/ClouderaManagerDefaultStackRepoDetails.java
@@ -1,0 +1,39 @@
+package com.sequenceiq.cloudbreak.cloud.model.component;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.StringJoiner;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ClouderaManagerDefaultStackRepoDetails implements Serializable {
+
+    private Map<String, String> stack;
+
+    private String cdhVersion;
+
+    public Map<String, String> getStack() {
+        return stack;
+    }
+
+    public void setStack(Map<String, String> stack) {
+        this.stack = stack;
+    }
+
+    public String getCdhVersion() {
+        return cdhVersion;
+    }
+
+    public void setCdhVersion(String cdhVersion) {
+        this.cdhVersion = cdhVersion;
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", ClouderaManagerDefaultStackRepoDetails.class.getSimpleName() + "[", "]")
+                .add("stack=" + stack)
+                .add("cdhVersion='" + cdhVersion + "'")
+                .toString();
+    }
+}

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/component/DefaultCDHEntries.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/component/DefaultCDHEntries.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.cloudbreak.cloud.model.component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@ConfigurationProperties("cb.cdh")
+@Component
+public class DefaultCDHEntries {
+
+    private Map<String, DefaultCDHInfo> entries = new HashMap<>();
+
+    public Map<String, DefaultCDHInfo> getEntries() {
+        return entries;
+    }
+
+    public void setEntries(Map<String, DefaultCDHInfo> entries) {
+        this.entries = entries;
+    }
+}

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/component/DefaultCDHInfo.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/component/DefaultCDHInfo.java
@@ -4,13 +4,13 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.sequenceiq.cloudbreak.cloud.model.Versioned;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class StackInfo implements Versioned {
+public class DefaultCDHInfo implements Versioned {
 
     private String version;
 
-    private AmbariDefaultStackRepoDetails repo;
+    private ClouderaManagerDefaultStackRepoDetails repo;
 
-    private String minAmbari;
+    private String minCM;
 
     @Override
     public String getVersion() {
@@ -21,22 +21,22 @@ public class StackInfo implements Versioned {
         this.version = version;
     }
 
-    public String getMinAmbari() {
-        return minAmbari;
+    public String getMinCM() {
+        return minCM;
     }
 
-    public void setMinAmbari(String minAmbari) {
-        this.minAmbari = minAmbari;
+    public void setMinCM(String minCM) {
+        this.minCM = minCM;
     }
 
-    public AmbariDefaultStackRepoDetails getRepo() {
+    public ClouderaManagerDefaultStackRepoDetails getRepo() {
         if (repo != null) {
-            repo.setHdpVersion(version);
+            repo.setCdhVersion(version);
         }
         return repo;
     }
 
-    public void setRepo(AmbariDefaultStackRepoDetails repo) {
+    public void setRepo(ClouderaManagerDefaultStackRepoDetails repo) {
         this.repo = repo;
     }
 
@@ -45,7 +45,7 @@ public class StackInfo implements Versioned {
         return "StackInfo{"
                 + "version='" + version + '\''
                 + ", repo=" + repo
-                + ", minAmbari=" + minAmbari
+                + ", minCM=" + minCM
                 + '}';
     }
 }

--- a/cloud-common/src/main/resources/application.yml
+++ b/cloud-common/src/main/resources/application.yml
@@ -224,20 +224,19 @@ cb:
       6.1:
         version: 6.1.0
         repo:
-          redhat6:
-            baseurl: https://archive.cloudera.com/cm6/6.1.0/redhat6/yum/
-            gpgkey: https://archive.cloudera.com/cm6/6.1.0/redhat6/yum/RPM-GPG-KEY-cloudera
           redhat7:
             baseurl: https://archive.cloudera.com/cm6/6.1.0/redhat7/yum/
             gpgkey: https://archive.cloudera.com/cm6/6.1.0/redhat7/yum/RPM-GPG-KEY-cloudera
-          amazonlinux2:
-            baseurl: https://archive.cloudera.com/cm6/6.1.0/redhat7/yum/
-            gpgkey: https://archive.cloudera.com/cm6/6.1.0/redhat7/yum/RPM-GPG-KEY-cloudera
-          sles12:
-            baseurl: https://archive.cloudera.com/cm6/6.1.0/sles12/yum/
-            gpgkey: https://archive.cloudera.com/cm6/6.1.0/sles12/yum/RPM-GPG-KEY-cloudera
-          ubuntu16:
-            baseurl: https://archive.cloudera.com/cm6/6.1.0/ubuntu1604/apt/
+
+  cdh:
+    entries:
+      "[6.1.0]":
+        version: 6.1.0-1.cdh6.1.0.p0.770702
+        minCM: 6.1
+        repo:
+          stack:
+            repoid: CDH
+            redhat7: https://archive.cloudera.com/cdh6/{latest_supported}/parcels/
 
   ambari:
     entries:

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/responses/AmbariStackRepoDetailsV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/responses/AmbariStackRepoDetailsV4Response.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.JsonEntity;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class StackRepoDetailsV4Response implements JsonEntity {
+public class AmbariStackRepoDetailsV4Response implements JsonEntity {
 
     @JsonProperty("stack")
     private Map<String, String> stack = new HashMap<>();

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/responses/ClouderaManagerStackRepoDetailsV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/responses/ClouderaManagerStackRepoDetailsV4Response.java
@@ -1,0 +1,24 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.JsonEntity;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ClouderaManagerStackRepoDetailsV4Response implements JsonEntity {
+
+    @JsonProperty("stack")
+    private Map<String, String> stack = new HashMap<>();
+
+    public Map<String, String> getStack() {
+        return stack;
+    }
+
+    public void setStack(Map<String, String> stack) {
+        this.stack = stack;
+    }
+
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/responses/StackDetailsV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/responses/StackDetailsV4Response.java
@@ -14,7 +14,7 @@ public class StackDetailsV4Response implements JsonEntity {
     private String version;
 
     @JsonProperty
-    private StackRepoDetailsV4Response repository;
+    private AmbariStackRepoDetailsV4Response repository;
 
     private Map<String, List<ManagementPackV4Entry>> mpacks = new HashMap<>();
 
@@ -26,11 +26,11 @@ public class StackDetailsV4Response implements JsonEntity {
         this.version = version;
     }
 
-    public StackRepoDetailsV4Response getRepository() {
+    public AmbariStackRepoDetailsV4Response getRepository() {
         return repository;
     }
 
-    public void setRepository(StackRepoDetailsV4Response repository) {
+    public void setRepository(AmbariStackRepoDetailsV4Response repository) {
         this.repository = repository;
     }
 

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/cluster/clouderamanager/ClouderaManagerRepositoryV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/cluster/clouderamanager/ClouderaManagerRepositoryV4Response.java
@@ -1,0 +1,15 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.cluster.clouderamanager;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.cluster.ambari.RepositoryV4Response;
+
+import io.swagger.annotations.ApiModel;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(Include.NON_NULL)
+public class ClouderaManagerRepositoryV4Response extends RepositoryV4Response {
+
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/util/responses/AmbariStackDescriptorV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/util/responses/AmbariStackDescriptorV4Response.java
@@ -4,15 +4,15 @@ import java.util.List;
 import java.util.Map;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ManagementPackV4Entry;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.StackRepoDetailsV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.AmbariStackRepoDetailsV4Response;
 
-public class StackDescriptorV4Response {
+public class AmbariStackDescriptorV4Response {
 
     private String version;
 
     private String minAmbari;
 
-    private StackRepoDetailsV4Response repository;
+    private AmbariStackRepoDetailsV4Response repository;
 
     private Map<String, List<ManagementPackV4Entry>> mpacks;
 
@@ -34,11 +34,11 @@ public class StackDescriptorV4Response {
         this.minAmbari = minAmbari;
     }
 
-    public StackRepoDetailsV4Response getRepository() {
+    public AmbariStackRepoDetailsV4Response getRepository() {
         return repository;
     }
 
-    public void setRepository(StackRepoDetailsV4Response repository) {
+    public void setRepository(AmbariStackRepoDetailsV4Response repository) {
         this.repository = repository;
     }
 

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/util/responses/ClouderaManagerInfoV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/util/responses/ClouderaManagerInfoV4Response.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses;
+
+import java.util.Map;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.cluster.clouderamanager.ClouderaManagerRepositoryV4Response;
+
+public class ClouderaManagerInfoV4Response {
+
+    private String version;
+
+    private Map<String, ClouderaManagerRepositoryV4Response> repository;
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public Map<String, ClouderaManagerRepositoryV4Response> getRepository() {
+        return repository;
+    }
+
+    public void setRepository(Map<String, ClouderaManagerRepositoryV4Response> repository) {
+        this.repository = repository;
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/util/responses/ClouderaManagerStackDescriptorV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/util/responses/ClouderaManagerStackDescriptorV4Response.java
@@ -1,0 +1,47 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ClouderaManagerStackRepoDetailsV4Response;
+
+public class ClouderaManagerStackDescriptorV4Response {
+
+    private String version;
+
+    private String minCM;
+
+    private ClouderaManagerStackRepoDetailsV4Response repository;
+
+    private ClouderaManagerInfoV4Response clouderaManager;
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getMinCM() {
+        return minCM;
+    }
+
+    public void setMinCM(String minCM) {
+        this.minCM = minCM;
+    }
+
+    public ClouderaManagerStackRepoDetailsV4Response getRepository() {
+        return repository;
+    }
+
+    public void setRepository(ClouderaManagerStackRepoDetailsV4Response repository) {
+        this.repository = repository;
+    }
+
+    public ClouderaManagerInfoV4Response getClouderaManager() {
+        return clouderaManager;
+    }
+
+    public void setClouderaManager(ClouderaManagerInfoV4Response clouderaManager) {
+        this.clouderaManager = clouderaManager;
+    }
+
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/util/responses/StackMatrixV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/util/responses/StackMatrixV4Response.java
@@ -4,23 +4,33 @@ import java.util.Map;
 
 public class StackMatrixV4Response {
 
-    private Map<String, StackDescriptorV4Response> hdp;
+    private Map<String, AmbariStackDescriptorV4Response> hdp;
 
-    private Map<String, StackDescriptorV4Response> hdf;
+    private Map<String, AmbariStackDescriptorV4Response> hdf;
 
-    public Map<String, StackDescriptorV4Response> getHdp() {
+    private Map<String, ClouderaManagerStackDescriptorV4Response> cdh;
+
+    public Map<String, AmbariStackDescriptorV4Response> getHdp() {
         return hdp;
     }
 
-    public void setHdp(Map<String, StackDescriptorV4Response> hdp) {
+    public void setHdp(Map<String, AmbariStackDescriptorV4Response> hdp) {
         this.hdp = hdp;
     }
 
-    public Map<String, StackDescriptorV4Response> getHdf() {
+    public Map<String, AmbariStackDescriptorV4Response> getHdf() {
         return hdf;
     }
 
-    public void setHdf(Map<String, StackDescriptorV4Response> hdf) {
+    public void setHdf(Map<String, AmbariStackDescriptorV4Response> hdf) {
         this.hdf = hdf;
+    }
+
+    public Map<String, ClouderaManagerStackDescriptorV4Response> getCdh() {
+        return cdh;
+    }
+
+    public void setCdh(Map<String, ClouderaManagerStackDescriptorV4Response> cdh) {
+        this.cdh = cdh;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/imagecatalog/ImagesToImagesV4ResponseConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/imagecatalog/ImagesToImagesV4ResponseConverter.java
@@ -15,7 +15,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImageV4R
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImagesV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ManagementPackV4Entry;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.StackDetailsV4Response;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.StackRepoDetailsV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.AmbariStackRepoDetailsV4Response;
 import com.sequenceiq.cloudbreak.cloud.model.AmbariRepo;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Images;
@@ -93,7 +93,7 @@ public class ImagesToImagesV4ResponseConverter extends AbstractConversionService
         List<StackDetailsV4Response> result = new ArrayList<>();
         for (StackInfo info : defaultStackInfos) {
             StackDetailsV4Response json = new StackDetailsV4Response();
-            StackRepoDetailsV4Response repoJson = new StackRepoDetailsV4Response();
+            AmbariStackRepoDetailsV4Response repoJson = new AmbariStackRepoDetailsV4Response();
             Map<String, String> stackRepo = info.getRepo().getStack();
             if (stackRepo != null) {
                 repoJson.setStack(stackRepo);
@@ -154,8 +154,8 @@ public class ImagesToImagesV4ResponseConverter extends AbstractConversionService
         return json;
     }
 
-    private StackRepoDetailsV4Response convertStackRepoDetailsToJson(StackRepoDetails repo) {
-        StackRepoDetailsV4Response json = new StackRepoDetailsV4Response();
+    private AmbariStackRepoDetailsV4Response convertStackRepoDetailsToJson(StackRepoDetails repo) {
+        AmbariStackRepoDetailsV4Response json = new AmbariStackRepoDetailsV4Response();
         json.setStack(new HashMap<>(repo.getStack()));
         json.setUtil(new HashMap<>(repo.getUtil()));
         return json;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cluster/clouderamanager/RepoDetailsToClouderaManagerRepositoryV4ResponseConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cluster/clouderamanager/RepoDetailsToClouderaManagerRepositoryV4ResponseConverter.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.cloudbreak.converter.v4.stacks.cluster.clouderamanager;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.cluster.clouderamanager.ClouderaManagerRepositoryV4Response;
+import com.sequenceiq.cloudbreak.cloud.model.component.RepositoryDetails;
+import com.sequenceiq.cloudbreak.converter.AbstractConversionServiceAwareConverter;
+
+@Component
+public class RepoDetailsToClouderaManagerRepositoryV4ResponseConverter
+        extends AbstractConversionServiceAwareConverter<RepositoryDetails, ClouderaManagerRepositoryV4Response> {
+
+    @Override
+    public ClouderaManagerRepositoryV4Response convert(RepositoryDetails source) {
+        ClouderaManagerRepositoryV4Response repoDetailsJson = new ClouderaManagerRepositoryV4Response();
+        repoDetailsJson.setBaseUrl(source.getBaseurl());
+        repoDetailsJson.setGpgKeyUrl(source.getGpgkey());
+        return repoDetailsJson;
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cluster/clouderamanager/RepositoryInfoToClouderaManagerInfoV4ResponseConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cluster/clouderamanager/RepositoryInfoToClouderaManagerInfoV4ResponseConverter.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.cloudbreak.converter.v4.stacks.cluster.clouderamanager;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.cluster.clouderamanager.ClouderaManagerRepositoryV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.ClouderaManagerInfoV4Response;
+import com.sequenceiq.cloudbreak.cloud.model.component.RepositoryDetails;
+import com.sequenceiq.cloudbreak.cloud.model.component.RepositoryInfo;
+import com.sequenceiq.cloudbreak.converter.AbstractConversionServiceAwareConverter;
+
+@Component
+public class RepositoryInfoToClouderaManagerInfoV4ResponseConverter
+        extends AbstractConversionServiceAwareConverter<RepositoryInfo, ClouderaManagerInfoV4Response> {
+
+    @Override
+    public ClouderaManagerInfoV4Response convert(RepositoryInfo source) {
+        ClouderaManagerInfoV4Response cmInfoJson = new ClouderaManagerInfoV4Response();
+        cmInfoJson.setVersion(source.getVersion());
+        cmInfoJson.setRepository(stringCMRepoDetailsMapToStringCMRepoDetailsJsonMap(source.getRepo()));
+        return cmInfoJson;
+    }
+
+    private Map<String, ClouderaManagerRepositoryV4Response> stringCMRepoDetailsMapToStringCMRepoDetailsJsonMap(Map<String, RepositoryDetails> map) {
+        if (map == null) {
+            return null;
+        }
+
+        Map<String, ClouderaManagerRepositoryV4Response> ret = new HashMap<>();
+        map.forEach((key, value) -> ret.put(key, getConversionService().convert(value, ClouderaManagerRepositoryV4Response.class)));
+        return ret;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cluster/clouderamanager/StackInfoToClouderaManagerStackDescriptorV4ResponseConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cluster/clouderamanager/StackInfoToClouderaManagerStackDescriptorV4ResponseConverter.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.cloudbreak.converter.v4.stacks.cluster.clouderamanager;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ClouderaManagerStackRepoDetailsV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.ClouderaManagerStackDescriptorV4Response;
+import com.sequenceiq.cloudbreak.cloud.model.component.ClouderaManagerDefaultStackRepoDetails;
+import com.sequenceiq.cloudbreak.cloud.model.component.DefaultCDHInfo;
+import com.sequenceiq.cloudbreak.converter.AbstractConversionServiceAwareConverter;
+
+@Component
+public class StackInfoToClouderaManagerStackDescriptorV4ResponseConverter
+        extends AbstractConversionServiceAwareConverter<DefaultCDHInfo, ClouderaManagerStackDescriptorV4Response> {
+
+    @Override
+    public ClouderaManagerStackDescriptorV4Response convert(DefaultCDHInfo source) {
+        ClouderaManagerStackDescriptorV4Response stackDescriptorV4 = new ClouderaManagerStackDescriptorV4Response();
+        stackDescriptorV4.setVersion(source.getVersion());
+        stackDescriptorV4.setMinCM(source.getMinCM());
+        stackDescriptorV4.setRepository(defaultStackRepoDetailsToStackRepoDetailsV4Response(source.getRepo()));
+        return stackDescriptorV4;
+    }
+
+    private ClouderaManagerStackRepoDetailsV4Response defaultStackRepoDetailsToStackRepoDetailsV4Response(
+            ClouderaManagerDefaultStackRepoDetails cmDefaultStackRepoDetails) {
+        if (cmDefaultStackRepoDetails == null) {
+            return null;
+        }
+        ClouderaManagerStackRepoDetailsV4Response cmStackRepoDetailsV4Response = new ClouderaManagerStackRepoDetailsV4Response();
+        cmStackRepoDetailsV4Response.setStack(cmDefaultStackRepoDetails.getStack());
+        return cmStackRepoDetailsV4Response;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cluster/gateway/StackInfoToAmbariStackDescriptorV4ResponseConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cluster/gateway/StackInfoToAmbariStackDescriptorV4ResponseConverter.java
@@ -8,22 +8,22 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ManagementPackV4Entry;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.StackRepoDetailsV4Response;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.StackDescriptorV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.AmbariStackRepoDetailsV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.AmbariStackDescriptorV4Response;
 import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
-import com.sequenceiq.cloudbreak.cloud.model.component.DefaultStackRepoDetails;
+import com.sequenceiq.cloudbreak.cloud.model.component.AmbariDefaultStackRepoDetails;
 import com.sequenceiq.cloudbreak.cloud.model.component.StackInfo;
 import com.sequenceiq.cloudbreak.converter.AbstractConversionServiceAwareConverter;
 
 @Component
-public class StackInfoToStackDescriptorV4ResponseConverter extends AbstractConversionServiceAwareConverter<StackInfo, StackDescriptorV4Response> {
+public class StackInfoToAmbariStackDescriptorV4ResponseConverter extends AbstractConversionServiceAwareConverter<StackInfo, AmbariStackDescriptorV4Response> {
 
     @Autowired
     private ConverterUtil converterUtil;
 
     @Override
-    public StackDescriptorV4Response convert(StackInfo source) {
-        StackDescriptorV4Response stackDescriptorV4 = new StackDescriptorV4Response();
+    public AmbariStackDescriptorV4Response convert(StackInfo source) {
+        AmbariStackDescriptorV4Response stackDescriptorV4 = new AmbariStackDescriptorV4Response();
 
         stackDescriptorV4.setVersion(source.getVersion());
         stackDescriptorV4.setMinAmbari(source.getMinAmbari());
@@ -38,14 +38,14 @@ public class StackInfoToStackDescriptorV4ResponseConverter extends AbstractConve
         return stackDescriptorV4;
     }
 
-    private StackRepoDetailsV4Response defaultStackRepoDetailsToStackRepoDetailsV4Response(DefaultStackRepoDetails defaultStackRepoDetails) {
-        if (defaultStackRepoDetails == null) {
+    private AmbariStackRepoDetailsV4Response defaultStackRepoDetailsToStackRepoDetailsV4Response(AmbariDefaultStackRepoDetails ambariDefaultStackRepoDetails) {
+        if (ambariDefaultStackRepoDetails == null) {
             return null;
         }
 
-        StackRepoDetailsV4Response stackRepoDetailsV4Response = new StackRepoDetailsV4Response();
-        stackRepoDetailsV4Response.setStack(defaultStackRepoDetails.getStack());
-        stackRepoDetailsV4Response.setUtil(defaultStackRepoDetails.getUtil());
-        return stackRepoDetailsV4Response;
+        AmbariStackRepoDetailsV4Response ambariStackRepoDetailsV4Response = new AmbariStackRepoDetailsV4Response();
+        ambariStackRepoDetailsV4Response.setStack(ambariDefaultStackRepoDetails.getStack());
+        ambariStackRepoDetailsV4Response.setUtil(ambariDefaultStackRepoDetails.getUtil());
+        return ambariStackRepoDetailsV4Response;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/ClusterCreationSetupService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/ClusterCreationSetupService.java
@@ -28,7 +28,7 @@ import com.google.common.collect.Sets;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.cluster.ClusterV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.cluster.ambari.ambarirepository.AmbariRepositoryV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.cluster.ambari.stackrepository.StackRepositoryV4Request;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.StackDescriptorV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.AmbariStackDescriptorV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.StackMatrixV4Response;
 import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
 import com.sequenceiq.cloudbreak.clusterdefinition.utils.AmbariBlueprintUtils;
@@ -40,7 +40,7 @@ import com.sequenceiq.cloudbreak.cloud.model.component.DefaultHDFEntries;
 import com.sequenceiq.cloudbreak.cloud.model.component.DefaultHDFInfo;
 import com.sequenceiq.cloudbreak.cloud.model.component.DefaultHDPEntries;
 import com.sequenceiq.cloudbreak.cloud.model.component.DefaultHDPInfo;
-import com.sequenceiq.cloudbreak.cloud.model.component.DefaultStackRepoDetails;
+import com.sequenceiq.cloudbreak.cloud.model.component.AmbariDefaultStackRepoDetails;
 import com.sequenceiq.cloudbreak.cloud.model.component.ManagementPackComponent;
 import com.sequenceiq.cloudbreak.cloud.model.component.StackInfo;
 import com.sequenceiq.cloudbreak.cloud.model.component.StackRepoDetails;
@@ -245,7 +245,7 @@ public class ClusterCreationSetupService {
         Image image = imageComponent.getAttributes().get(Image.class);
         StackMatrixV4Response stackMatrixV4Response = stackMatrixService.getStackMatrix();
         String stackMajorVersion = stackRepoDetails.getMajorHdpVersion();
-        Map<String, StackDescriptorV4Response> stackDescriptorMap;
+        Map<String, AmbariStackDescriptorV4Response> stackDescriptorMap;
 
         String stackType = stackRepoDetails.getStack().get(StackRepoDetails.REPO_ID_TAG);
         if (stackType.contains("-")) {
@@ -262,7 +262,7 @@ public class ClusterCreationSetupService {
                 LOGGER.warn("No stack descriptor map found for stacktype {}, using 'HDP'", stackType);
                 stackDescriptorMap = stackMatrixV4Response.getHdp();
         }
-        StackDescriptorV4Response stackDescriptorV4 = stackDescriptorMap.get(stackMajorVersion);
+        AmbariStackDescriptorV4Response stackDescriptorV4 = stackDescriptorMap.get(stackMajorVersion);
         if (stackDescriptorV4 != null) {
             boolean hasDefaultStackRepoUrlForOsType = stackDescriptorV4.getRepository().getStack().containsKey(image.getOsType());
             boolean hasDefaultAmbariRepoUrlForOsType = stackDescriptorV4.getAmbari().getRepository().containsKey(image.getOsType());
@@ -319,7 +319,7 @@ public class ClusterCreationSetupService {
                 StackRepoDetails stackRepoDetails = stackRepoDetailsConverter.convert(ambariStackDetails);
                 stackRepoDetailsJson = new Json(stackRepoDetails);
             } else {
-                DefaultStackRepoDetails stackRepoDetails = SerializationUtils.clone(defaultHDPInfo(clusterDefinition, request, workspace).getRepo());
+                AmbariDefaultStackRepoDetails stackRepoDetails = SerializationUtils.clone(defaultHDPInfo(clusterDefinition, request, workspace).getRepo());
                 String osType = getOsType(stackId);
                 StackRepoDetails repo = createStackRepoDetails(stackRepoDetails, osType);
                 Optional<String> vdfUrl = getVDFUrlByOsType(osType, stackRepoDetails);
@@ -350,7 +350,7 @@ public class ClusterCreationSetupService {
         }
     }
 
-    private StackRepoDetails createStackRepoDetails(DefaultStackRepoDetails stackRepoDetails, String osType) {
+    private StackRepoDetails createStackRepoDetails(AmbariDefaultStackRepoDetails stackRepoDetails, String osType) {
         StackRepoDetails repo = new StackRepoDetails();
         repo.setHdpVersion(stackRepoDetails.getHdpVersion());
         repo.setStack(stackRepoDetails.getStack());
@@ -436,7 +436,7 @@ public class ClusterCreationSetupService {
         return image.getOsType();
     }
 
-    private Optional<String> getVDFUrlByOsType(String osType, DefaultStackRepoDetails stackRepoDetails) {
+    private Optional<String> getVDFUrlByOsType(String osType, AmbariDefaultStackRepoDetails stackRepoDetails) {
         String vdfStackRepoKeyFilter = VDF_REPO_KEY_PREFIX;
         if (!StringUtils.isEmpty(osType)) {
             vdfStackRepoKeyFilter += osType;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/DefaultAmbariRepoService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/DefaultAmbariRepoService.java
@@ -14,7 +14,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.AmbariInfoV4Response;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.StackDescriptorV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.AmbariStackDescriptorV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.StackMatrixV4Response;
 import com.sequenceiq.cloudbreak.cloud.model.AmbariRepo;
 import com.sequenceiq.cloudbreak.cloud.model.component.RepositoryInfo;
@@ -49,7 +49,7 @@ public class DefaultAmbariRepoService {
 
     public AmbariRepo getDefault(String osType, String clusterType, String clusterVersion) {
         StackMatrixV4Response stackMatrixV4Response = stackMatrixService.getStackMatrix();
-        Map<String, StackDescriptorV4Response> stackDescriptorMap;
+        Map<String, AmbariStackDescriptorV4Response> stackDescriptorMap;
 
         if (clusterType != null) {
             switch (clusterType) {
@@ -67,12 +67,12 @@ public class DefaultAmbariRepoService {
         }
 
         if (stackDescriptorMap != null) {
-            Optional<Entry<String, StackDescriptorV4Response>> descriptorEntry = stackDescriptorMap.entrySet().stream()
+            Optional<Entry<String, AmbariStackDescriptorV4Response>> descriptorEntry = stackDescriptorMap.entrySet().stream()
                     .filter(stackDescriptorEntry ->
                             clusterVersion == null || clusterVersion.equals(stackDescriptorEntry.getKey()))
                     .max(Comparator.comparing(Entry::getKey));
             if (descriptorEntry.isPresent()) {
-                Entry<String, StackDescriptorV4Response> stackDescriptorEntry = descriptorEntry.get();
+                Entry<String, AmbariStackDescriptorV4Response> stackDescriptorEntry = descriptorEntry.get();
                 AmbariInfoV4Response ambariInfoJson = stackDescriptorEntry.getValue().getAmbari();
                 if (ambariInfoJson.getRepository().get(osType) != null) {
                     AmbariRepo ambariRepo = new AmbariRepo();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/DefaultClouderaManagerRepoService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/DefaultClouderaManagerRepoService.java
@@ -9,7 +9,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Service;
 
-import com.sequenceiq.cloudbreak.cloud.model.AmbariRepo;
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
 import com.sequenceiq.cloudbreak.cloud.model.component.RepositoryInfo;
 import com.sequenceiq.cloudbreak.service.exception.RepositoryCannotFoundException;
 
@@ -21,14 +21,14 @@ public class DefaultClouderaManagerRepoService {
 
     private Map<String, RepositoryInfo> entries = new HashMap<>();
 
-    public AmbariRepo getDefault(String osType) {
+    public ClouderaManagerRepo getDefault(String osType) {
         for (Entry<String, RepositoryInfo> clouderaManagerInfoEntry : entries.entrySet()) {
             RepositoryInfo clouderaManagerInfo = clouderaManagerInfoEntry.getValue();
             if (clouderaManagerInfo.getRepo().get(osType) == null) {
                 LOGGER.info("Missing Cloudera Manager ({}) repo information for os: {}", clouderaManagerInfo.getVersion(), osType);
                 continue;
             }
-            AmbariRepo repository = new AmbariRepo();
+            ClouderaManagerRepo repository = new ClouderaManagerRepo();
             repository.setPredefined(Boolean.FALSE);
             repository.setVersion(clouderaManagerInfo.getVersion());
             repository.setBaseUrl(clouderaManagerInfo.getRepo().get(osType).getBaseurl());

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/ClusterCreationSetupServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/ClusterCreationSetupServiceTest.java
@@ -30,7 +30,7 @@ import com.sequenceiq.cloudbreak.cloud.model.AmbariRepo;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.cloud.model.component.DefaultHDPEntries;
 import com.sequenceiq.cloudbreak.cloud.model.component.DefaultHDPInfo;
-import com.sequenceiq.cloudbreak.cloud.model.component.DefaultStackRepoDetails;
+import com.sequenceiq.cloudbreak.cloud.model.component.AmbariDefaultStackRepoDetails;
 import com.sequenceiq.cloudbreak.cloud.model.component.StackRepoDetails;
 import com.sequenceiq.cloudbreak.common.type.ComponentType;
 import com.sequenceiq.cloudbreak.controller.exception.BadRequestException;
@@ -120,7 +120,7 @@ public class ClusterCreationSetupServiceTest {
         when(ambariBlueprintUtils.getBlueprintStackVersion(any())).thenReturn(version);
         when(ambariBlueprintUtils.getBlueprintStackName(any())).thenReturn("HDP");
         DefaultHDPInfo defaultHDPInfo = new DefaultHDPInfo();
-        DefaultStackRepoDetails stackRepoDetails = new DefaultStackRepoDetails();
+        AmbariDefaultStackRepoDetails stackRepoDetails = new AmbariDefaultStackRepoDetails();
         stackRepoDetails.setHdpVersion(version);
         Map<String, String> stackRepo = new HashMap<>();
         stackRepo.put("centos7", "http://centos7-repo/" + version);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/DefaultAmbariRepoServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/DefaultAmbariRepoServiceTest.java
@@ -18,7 +18,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.cluster.ambari.ambarirepository.AmbariRepositoryV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.AmbariInfoV4Response;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.StackDescriptorV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.AmbariStackDescriptorV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.StackMatrixV4Response;
 import com.sequenceiq.cloudbreak.cloud.model.AmbariRepo;
 import com.sequenceiq.cloudbreak.cloud.model.component.RepositoryInfo;
@@ -38,8 +38,8 @@ public class DefaultAmbariRepoServiceTest {
         Map<String, RepositoryInfo> entries = new HashMap<>();
 
         StackMatrixV4Response stackMatrixV4Response = new StackMatrixV4Response();
-        Map<String, StackDescriptorV4Response> hdpMap = new HashMap<>();
-        Map<String, StackDescriptorV4Response> hdfMap = new HashMap<>();
+        Map<String, AmbariStackDescriptorV4Response> hdpMap = new HashMap<>();
+        Map<String, AmbariStackDescriptorV4Response> hdfMap = new HashMap<>();
 
         AmbariInfoV4Response ambariInfoJson26 = new AmbariInfoV4Response();
         ambariInfoJson26.setVersion("2.6");
@@ -49,17 +49,17 @@ public class DefaultAmbariRepoServiceTest {
         ambariInfoJson27.setVersion("2.7");
         ambariInfoJson27.setRepository(getAmbariRepoJson("2.7"));
 
-        StackDescriptorV4Response hdpDescriptor26 = new StackDescriptorV4Response();
+        AmbariStackDescriptorV4Response hdpDescriptor26 = new AmbariStackDescriptorV4Response();
         hdpDescriptor26.setAmbari(ambariInfoJson26);
         hdpMap.put("2.7", hdpDescriptor26);
 
-        StackDescriptorV4Response hdpDescriptor30 = new StackDescriptorV4Response();
+        AmbariStackDescriptorV4Response hdpDescriptor30 = new AmbariStackDescriptorV4Response();
         hdpDescriptor30.setAmbari(ambariInfoJson27);
         hdpMap.put("3.0", hdpDescriptor30);
 
         stackMatrixV4Response.setHdp(hdpMap);
 
-        StackDescriptorV4Response hdfDescriptor31 = new StackDescriptorV4Response();
+        AmbariStackDescriptorV4Response hdfDescriptor31 = new AmbariStackDescriptorV4Response();
         hdfDescriptor31.setAmbari(ambariInfoJson27);
         hdfMap.put("3.1", hdfDescriptor31);
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/DefaultClouderaManagerRepoServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/DefaultClouderaManagerRepoServiceTest.java
@@ -15,7 +15,7 @@ import org.mockito.InjectMocks;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.collect.Maps;
-import com.sequenceiq.cloudbreak.cloud.model.AmbariRepo;
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
 import com.sequenceiq.cloudbreak.cloud.model.component.RepositoryDetails;
 import com.sequenceiq.cloudbreak.cloud.model.component.RepositoryInfo;
 import com.sequenceiq.cloudbreak.service.exception.RepositoryCannotFoundException;
@@ -51,7 +51,7 @@ public class DefaultClouderaManagerRepoServiceTest {
 
     @Test
     public void testDefaultRepo() {
-        AmbariRepo repo = defaultClouderaManagerRepoService.getDefault("redhat7");
+        ClouderaManagerRepo repo = defaultClouderaManagerRepoService.getDefault("redhat7");
         assertNotNull(repo);
 
         repo = defaultClouderaManagerRepoService.getDefault("amazonlinux2");

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/StackMatrixServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/StackMatrixServiceTest.java
@@ -15,19 +15,26 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.StackRepoDetailsV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.AmbariStackRepoDetailsV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ClouderaManagerStackRepoDetailsV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.cluster.ambari.ambarirepository.AmbariRepositoryV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.cluster.clouderamanager.ClouderaManagerRepositoryV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.AmbariInfoV4Response;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.StackDescriptorV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.AmbariStackDescriptorV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.ClouderaManagerInfoV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.ClouderaManagerStackDescriptorV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.StackMatrixV4Response;
 import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
-import com.sequenceiq.cloudbreak.cloud.model.component.RepositoryInfo;
-import com.sequenceiq.cloudbreak.cloud.model.component.RepositoryDetails;
+import com.sequenceiq.cloudbreak.cloud.model.component.AmbariDefaultStackRepoDetails;
+import com.sequenceiq.cloudbreak.cloud.model.component.ClouderaManagerDefaultStackRepoDetails;
+import com.sequenceiq.cloudbreak.cloud.model.component.DefaultCDHEntries;
+import com.sequenceiq.cloudbreak.cloud.model.component.DefaultCDHInfo;
 import com.sequenceiq.cloudbreak.cloud.model.component.DefaultHDFEntries;
 import com.sequenceiq.cloudbreak.cloud.model.component.DefaultHDFInfo;
 import com.sequenceiq.cloudbreak.cloud.model.component.DefaultHDPEntries;
 import com.sequenceiq.cloudbreak.cloud.model.component.DefaultHDPInfo;
-import com.sequenceiq.cloudbreak.cloud.model.component.DefaultStackRepoDetails;
+import com.sequenceiq.cloudbreak.cloud.model.component.RepositoryDetails;
+import com.sequenceiq.cloudbreak.cloud.model.component.RepositoryInfo;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StackMatrixServiceTest {
@@ -39,7 +46,13 @@ public class StackMatrixServiceTest {
     private DefaultHDPEntries defaultHDPEntries;
 
     @Mock
+    private DefaultCDHEntries defaultCDHEntries;
+
+    @Mock
     private DefaultAmbariRepoService defaultAmbariRepoService;
+
+    @Mock
+    private DefaultClouderaManagerRepoService defaultClouderaManagerRepoService;
 
     @Mock
     private ConverterUtil converterUtil;
@@ -81,12 +94,20 @@ public class StackMatrixServiceTest {
     @Test
     public void getStackMatrixWithoutAmbari() {
         setupStackEntries();
+
         when(converterUtil.convert(any(RepositoryInfo.class), eq(AmbariInfoV4Response.class))).thenReturn(new AmbariInfoV4Response());
+        when(converterUtil.convert(any(RepositoryInfo.class), eq(ClouderaManagerInfoV4Response.class))).thenReturn(new ClouderaManagerInfoV4Response());
 
         StackMatrixV4Response stackMatrixV4Response = stackMatrixService.getStackMatrix();
 
         assertEquals(2L, stackMatrixV4Response.getHdf().size());
         assertEquals(3L, stackMatrixV4Response.getHdp().size());
+        assertEquals(1L, stackMatrixV4Response.getCdh().size());
+
+        assertEquals("6.1", stackMatrixV4Response.getCdh().get("6.1.0").getMinCM());
+        assertEquals("6.1.0-1.cdh6.1.0.p0.770702", stackMatrixV4Response.getCdh().get("6.1.0").getVersion());
+        assertNull(stackMatrixV4Response.getCdh().get("6.1.0").getClouderaManager().getRepository());
+        assertNull(stackMatrixV4Response.getCdh().get("6.1.0").getClouderaManager().getVersion());
 
         assertEquals("2.6", stackMatrixV4Response.getHdf().get("3.1").getMinAmbari());
         assertEquals("3.1.2.0", stackMatrixV4Response.getHdf().get("3.1").getVersion());
@@ -114,11 +135,11 @@ public class StackMatrixServiceTest {
 
         DefaultHDFInfo threeOneHdfInfo = getDefaultHDFInfo("2.6", "3.1.2.0");
         hdfEntries.put("3.1", threeOneHdfInfo);
-        when(converterUtil.convert(threeOneHdfInfo, StackDescriptorV4Response.class)).thenReturn(getStackDescriptorResponse("2.6", "3.1.2.0"));
+        when(converterUtil.convert(threeOneHdfInfo, AmbariStackDescriptorV4Response.class)).thenReturn(getStackDescriptorResponse("2.6", "3.1.2.0"));
 
         DefaultHDFInfo threeTwoHdfInfo = getDefaultHDFInfo("2.7", "3.2.4.1");
         hdfEntries.put("3.2", threeTwoHdfInfo);
-        when(converterUtil.convert(threeTwoHdfInfo, StackDescriptorV4Response.class)).thenReturn(getStackDescriptorResponse("2.7", "3.2.4.1"));
+        when(converterUtil.convert(threeTwoHdfInfo, AmbariStackDescriptorV4Response.class)).thenReturn(getStackDescriptorResponse("2.7", "3.2.4.1"));
 
         when(defaultHDFEntries.getEntries()).thenReturn(hdfEntries);
 
@@ -126,17 +147,26 @@ public class StackMatrixServiceTest {
 
         DefaultHDPInfo twoSixHdpInfo = getDefaultHDPInfo("2.5", "2.6.5.0");
         hdpEntries.put("2.6", twoSixHdpInfo);
-        when(converterUtil.convert(twoSixHdpInfo, StackDescriptorV4Response.class)).thenReturn(getStackDescriptorResponse("2.5", "2.6.5.0"));
+        when(converterUtil.convert(twoSixHdpInfo, AmbariStackDescriptorV4Response.class)).thenReturn(getStackDescriptorResponse("2.5", "2.6.5.0"));
 
         DefaultHDPInfo threeZeroHdpInfo = getDefaultHDPInfo("2.7", "3.0.1.0");
         hdpEntries.put("3.0", threeZeroHdpInfo);
-        when(converterUtil.convert(threeZeroHdpInfo, StackDescriptorV4Response.class)).thenReturn(getStackDescriptorResponse("2.7", "3.0.1.0"));
+        when(converterUtil.convert(threeZeroHdpInfo, AmbariStackDescriptorV4Response.class)).thenReturn(getStackDescriptorResponse("2.7", "3.0.1.0"));
 
         DefaultHDPInfo threeOneHdpInfo = getDefaultHDPInfo("2.7", "3.1.8.0");
         hdpEntries.put("3.1", threeOneHdpInfo);
-        when(converterUtil.convert(threeOneHdpInfo, StackDescriptorV4Response.class)).thenReturn(getStackDescriptorResponse("2.7", "3.1.8.0"));
+        when(converterUtil.convert(threeOneHdpInfo, AmbariStackDescriptorV4Response.class)).thenReturn(getStackDescriptorResponse("2.7", "3.1.8.0"));
 
         when(defaultHDPEntries.getEntries()).thenReturn(hdpEntries);
+
+        Map<String, DefaultCDHInfo> cdhEntries = new HashMap<>();
+
+        DefaultCDHInfo cdhInfo = getDefaultCDHInfo("6.1", "6.1.0-1.cdh6.1.0.p0.770702");
+        cdhEntries.put("6.1.0", cdhInfo);
+        when(converterUtil.convert(cdhInfo, ClouderaManagerStackDescriptorV4Response.class))
+                .thenReturn(getCMStackDescriptorResponse("6.1", "6.1.0-1.cdh6.1.0.p0.770702"));
+
+        when(defaultCDHEntries.getEntries()).thenReturn(cdhEntries);
     }
 
     private void setupAmbariEntries() {
@@ -164,6 +194,13 @@ public class StackMatrixServiceTest {
         return twoFiveAmbariInfo;
     }
 
+    private RepositoryInfo getClouderaManagerInfo(String version) {
+        RepositoryInfo cmInfo = new RepositoryInfo();
+        cmInfo.setVersion(version);
+        cmInfo.setRepo(getCMRepo(version));
+        return cmInfo;
+    }
+
     private Map<String, RepositoryDetails> getAmbariRepo(String version) {
         Map<String, RepositoryDetails> ambariRepo = new HashMap<>();
 
@@ -180,11 +217,29 @@ public class StackMatrixServiceTest {
         return ambariRepo;
     }
 
+    private Map<String, RepositoryDetails> getCMRepo(String version) {
+        Map<String, RepositoryDetails> cmRepo = new HashMap<>();
+
+        RepositoryDetails redhat7RepositoryDetails = new RepositoryDetails();
+        redhat7RepositoryDetails.setBaseurl("http://redhat7-base/" + version);
+        redhat7RepositoryDetails.setGpgkey("http://redhat7-gpg/" + version);
+        cmRepo.put("redhat7", redhat7RepositoryDetails);
+
+        return cmRepo;
+    }
+
     private AmbariInfoV4Response getAmbariInfoResponse(String version) {
         AmbariInfoV4Response ambariInfoV4Response = new AmbariInfoV4Response();
         ambariInfoV4Response.setVersion(version);
         ambariInfoV4Response.setRepository(getAmbariRepositoryResponse(version));
         return ambariInfoV4Response;
+    }
+
+    private ClouderaManagerInfoV4Response getClouderaManagerInfoResponse(String version) {
+        ClouderaManagerInfoV4Response cmResponse = new ClouderaManagerInfoV4Response();
+        cmResponse.setVersion(version);
+        cmResponse.setRepository(getClouderaManagerRepositoryResponse(version));
+        return cmResponse;
     }
 
     private Map<String, AmbariRepositoryV4Response> getAmbariRepositoryResponse(String version) {
@@ -205,6 +260,26 @@ public class StackMatrixServiceTest {
         return ambariRepoResponse;
     }
 
+    private Map<String, ClouderaManagerRepositoryV4Response> getClouderaManagerRepositoryResponse(String version) {
+        Map<String, ClouderaManagerRepositoryV4Response> response = new HashMap<>();
+
+        ClouderaManagerRepositoryV4Response redhat7RepoResponse = new ClouderaManagerRepositoryV4Response();
+        redhat7RepoResponse.setVersion(version);
+        redhat7RepoResponse.setBaseUrl("http://redhat7-base/" + version);
+        redhat7RepoResponse.setGpgKeyUrl("http://redhat7-gpg/" + version);
+        response.put("redhat7", redhat7RepoResponse);
+
+        return response;
+    }
+
+    private DefaultCDHInfo getDefaultCDHInfo(String minCM, String version) {
+        DefaultCDHInfo defaultCDHInfo = new DefaultCDHInfo();
+        defaultCDHInfo.setMinCM(minCM);
+        defaultCDHInfo.setVersion(version);
+        defaultCDHInfo.setRepo(getCMStackRepoDetails(version));
+        return defaultCDHInfo;
+    }
+
     private DefaultHDFInfo getDefaultHDFInfo(String minAmbari, String version) {
         DefaultHDFInfo defaultHDFInfo = new DefaultHDFInfo();
         defaultHDFInfo.setMinAmbari(minAmbari);
@@ -221,8 +296,15 @@ public class StackMatrixServiceTest {
         return defaultHDPInfo;
     }
 
-    private DefaultStackRepoDetails getStackRepoDetails(String version) {
-        DefaultStackRepoDetails stackRepoDetails = new DefaultStackRepoDetails();
+    private ClouderaManagerDefaultStackRepoDetails getCMStackRepoDetails(String version) {
+        ClouderaManagerDefaultStackRepoDetails stackRepoDetails = new ClouderaManagerDefaultStackRepoDetails();
+        stackRepoDetails.setCdhVersion(version);
+        stackRepoDetails.setStack(getStackRepo(version));
+        return stackRepoDetails;
+    }
+
+    private AmbariDefaultStackRepoDetails getStackRepoDetails(String version) {
+        AmbariDefaultStackRepoDetails stackRepoDetails = new AmbariDefaultStackRepoDetails();
         stackRepoDetails.setHdpVersion(version);
         stackRepoDetails.setStack(getStackRepo(version));
         stackRepoDetails.setUtil(getUtilRepo(version));
@@ -243,19 +325,33 @@ public class StackMatrixServiceTest {
         return utilRepo;
     }
 
-    private StackDescriptorV4Response getStackDescriptorResponse(String minAmbari, String version) {
-        StackDescriptorV4Response stackDescriptorV4Response = new StackDescriptorV4Response();
-        stackDescriptorV4Response.setMinAmbari(minAmbari);
+    private AmbariStackDescriptorV4Response getStackDescriptorResponse(String minAmbari, String version) {
+        AmbariStackDescriptorV4Response ambariStackDescriptorV4Response = new AmbariStackDescriptorV4Response();
+        ambariStackDescriptorV4Response.setMinAmbari(minAmbari);
+        ambariStackDescriptorV4Response.setVersion(version);
+        ambariStackDescriptorV4Response.setRepository(getStackRepoDetailsResponse(version));
+        return ambariStackDescriptorV4Response;
+    }
+
+    private ClouderaManagerStackDescriptorV4Response getCMStackDescriptorResponse(String minCM, String version) {
+        ClouderaManagerStackDescriptorV4Response stackDescriptorV4Response = new ClouderaManagerStackDescriptorV4Response();
+        stackDescriptorV4Response.setMinCM(minCM);
         stackDescriptorV4Response.setVersion(version);
-        stackDescriptorV4Response.setRepository(getStackRepoDetailsResponse(version));
+        stackDescriptorV4Response.setRepository(getCMStackRepoDetailsResponse(version));
         return stackDescriptorV4Response;
     }
 
-    private StackRepoDetailsV4Response getStackRepoDetailsResponse(String version) {
-        StackRepoDetailsV4Response stackRepoDetailsV4Response = new StackRepoDetailsV4Response();
-        stackRepoDetailsV4Response.setStack(getStackRepo(version));
-        stackRepoDetailsV4Response.setUtil(getUtilRepo(version));
-        return stackRepoDetailsV4Response;
+    private AmbariStackRepoDetailsV4Response getStackRepoDetailsResponse(String version) {
+        AmbariStackRepoDetailsV4Response ambariStackRepoDetailsV4Response = new AmbariStackRepoDetailsV4Response();
+        ambariStackRepoDetailsV4Response.setStack(getStackRepo(version));
+        ambariStackRepoDetailsV4Response.setUtil(getUtilRepo(version));
+        return ambariStackRepoDetailsV4Response;
+    }
+
+    private ClouderaManagerStackRepoDetailsV4Response getCMStackRepoDetailsResponse(String version) {
+        ClouderaManagerStackRepoDetailsV4Response cmStackRepoDetailsV4Response = new ClouderaManagerStackRepoDetailsV4Response();
+        cmStackRepoDetailsV4Response.setStack(getStackRepo(version));
+        return cmStackRepoDetailsV4Response;
     }
 
 }


### PR DESCRIPTION
The stack matrix response is extended with the following section:
```
  "cdh": {
    "6.1.0": {
      "version": "6.1.0-1.cdh6.1.0.p0.770702",
      "minCM": "6.1",
      "repository": {
        "stack": {
          "repoid": "CDH",
          "redhat7": "https://archive.cloudera.com/cdh6/{latest_supported}/parcels/"
        }
      },
      "clouderaManager": {
        "version": "6.1.0",
        "repository": {
          "redhat7": {
            "baseUrl": "https://archive.cloudera.com/cm6/6.1.0/redhat7/yum/",
            "gpgKeyUrl": "https://archive.cloudera.com/cm6/6.1.0/redhat7/yum/RPM-GPG-KEY-cloudera"
          }
        }
      }
    }
  }
```
The actual values are not in use on the backend as the repo info is part of the cluster definition which we will need to extend. This is the min requirement to make the CM work with the stack matrix.