### PR TITLE
CB-438 Send JSON response for constraint violations

### DIFF
--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/json/ValidationResult.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/json/ValidationResult.java
@@ -5,6 +5,8 @@ import java.util.Map;
 
 public class ValidationResult {
 
+    static final String MESSAGE_SEPARATOR = "; ";
+
     private Map<String, String> validationErrors = new HashMap<>();
 
     public Map<String, String> getValidationErrors() {
@@ -12,11 +14,18 @@ public class ValidationResult {
     }
 
     public void setValidationErrors(Map<String, String> validationErrors) {
-        this.validationErrors = validationErrors;
+        this.validationErrors.putAll(validationErrors);
+    }
+
+    public void setValidationError(String field, String message) {
+        validationErrors.put(field, message);
     }
 
     public void addValidationError(String field, String message) {
-        validationErrors.put(field, message);
+        if (validationErrors.containsKey(field)) {
+            message = validationErrors.get(field) + MESSAGE_SEPARATOR + message;
+        }
+        setValidationError(field, message);
     }
 
 }

--- a/cloud-common/src/test/java/com/sequenceiq/cloudbreak/json/ValidationResultTest.java
+++ b/cloud-common/src/test/java/com/sequenceiq/cloudbreak/json/ValidationResultTest.java
@@ -1,0 +1,42 @@
+package com.sequenceiq.cloudbreak.json;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ValidationResultTest {
+
+    private static final Map<String, String> TEST_ERRORS = ImmutableMap.of("field1", "message1", "field2", "message2");
+
+    private ValidationResult result;
+
+    @Before
+    public void setup() {
+        result = new ValidationResult();
+        result.setValidationErrors(TEST_ERRORS);
+    }
+
+    @Test
+    public void testGetErrors() {
+        Assert.assertEquals(TEST_ERRORS, result.getValidationErrors());
+    }
+
+    @Test
+    public void testSetSingleError() {
+        result.setValidationError("field1", "newMessage1");
+        Map<String, String> expectedMap = ImmutableMap.of("field1", "newMessage1", "field2", "message2");
+        Assert.assertEquals(expectedMap, result.getValidationErrors());
+    }
+
+    @Test
+    public void testAddSingleError() {
+        result.addValidationError("field1", "newMessage1");
+        Map<String, String> expectedMap = ImmutableMap.of("field1", "message1; newMessage1", "field2", "message2");
+        Assert.assertEquals(expectedMap, result.getValidationErrors());
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/mapper/ConstraintViolationExceptionMapper.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/mapper/ConstraintViolationExceptionMapper.java
@@ -1,13 +1,12 @@
 package com.sequenceiq.cloudbreak.controller.mapper;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 import javax.ws.rs.core.Response.Status;
 
 import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.json.ValidationResult;
 
 @Component
 public class ConstraintViolationExceptionMapper extends SendNotificationExceptionMapper<ConstraintViolationException> {
@@ -27,11 +26,13 @@ public class ConstraintViolationExceptionMapper extends SendNotificationExceptio
 
     @Override
     protected Object getEntity(ConstraintViolationException exception) {
-        List<String> result = new ArrayList<>();
-        for (ConstraintViolation<?> violation : exception.getConstraintViolations()) {
-            result.add(violation.getPropertyPath() + ": " + violation.getInvalidValue() + ", error: " + violation.getMessage());
-        }
-        return String.join("\n", result);
+        ValidationResult validationResult = new ValidationResult();
+        exception.getConstraintViolations()
+                .forEach(violation -> {
+                    String propertyPath = violation.getPropertyPath() != null ? violation.getPropertyPath().toString() : "";
+                    validationResult.addValidationError(propertyPath, violation.getMessage());
+                    });
+        return validationResult;
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/ClusterTemplateTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/ClusterTemplateTest.java
@@ -167,8 +167,8 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
     public void testCreateInvalidNameClusterTemplate(TestContext testContext) {
         testContext.given(ClusterTemplateEntity.class).withName(ILLEGAL_CT_NAME)
                 .when(new ClusterTemplateV4CreateAction(), key("illegalCtName"))
-                .expect(BadRequestException.class, key("illegalCtName").withExpectedMessage("post.arg1.name: Illegal template name ;, error: "
-                        + "The length of the cluster template's name has to be in range of 1 to 100 and should not contain semicolon"))
+                .expect(BadRequestException.class, key("illegalCtName").withExpectedMessage("\"post.arg1.name\":"
+                        + "\"The length of the cluster template's name has to be in range of 1 to 100 and should not contain semicolon\""))
                 .validate();
     }
 
@@ -187,8 +187,8 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
     public void testCreateInvalidShortNameClusterTemplate(TestContext testContext) {
         testContext.given(ClusterTemplateEntity.class).withName("sh")
                 .when(new ClusterTemplateV4CreateAction(), key("illegalCtName"))
-                .expect(BadRequestException.class, key("illegalCtName").withExpectedMessage("post.arg1.name: sh, error: "
-                        + "The length of the cluster's name has to be in range of 5 to 40"))
+                .expect(BadRequestException.class, key("illegalCtName").withExpectedMessage("\"post.arg1.name\":"
+                        + "\"The length of the cluster's name has to be in range of 5 to 40\""))
                 .validate();
     }
 
@@ -212,8 +212,8 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
                 .when(Environment::post)
                 .given(ClusterTemplateEntity.class).withDescription(invalidLongDescripton)
                 .when(new ClusterTemplateV4CreateAction(), key("longCtDescription"))
-                .expect(BadRequestException.class, key("longCtDescription").withExpectedMessage("post.arg1.description: "
-                        + invalidLongDescripton + ", error: size must be between 0 and 1000"))
+                .expect(BadRequestException.class, key("longCtDescription").withExpectedMessage("\"post.arg1.description\":"
+                        + "\"size must be between 0 and 1000\""))
                 .validate();
     }
 
@@ -221,7 +221,7 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
     public void testCreateEmptyStackTemplateClusterTemplateException(TestContext testContext) {
         testContext.given(ClusterTemplateEntity.class).withoutStackTemplate()
                 .when(new ClusterTemplateV4CreateAction(), key("emptyStack"))
-                .expect(BadRequestException.class, key("emptyStack").withExpectedMessage("post.arg1.stackTemplate: null, error: must not be null"))
+                .expect(BadRequestException.class, key("emptyStack").withExpectedMessage("\"post.arg1.stackTemplate\":\"must not be null\""))
                 .validate();
     }
 
@@ -232,9 +232,9 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
                 .when(new ClusterTemplateV4CreateAction(), key("nullTemplateName"))
                 .given(ClusterTemplateEntity.class).withName("")
                 .when(new ClusterTemplateV4CreateAction(), key("emptyTemplateName").withSkipOnFail(false))
-                .expect(BadRequestException.class, key("nullTemplateName").withExpectedMessage("post.arg1.name: null, error: must not be null"))
+                .expect(BadRequestException.class, key("nullTemplateName").withExpectedMessage("\"post.arg1.name\":\"must not be null\""))
                 .expect(BadRequestException.class, key("emptyTemplateName")
-                        .withExpectedMessage("post.arg1.name: , error: The length of the cluster's name has to be in range of 5 to 40"))
+                        .withExpectedMessage("\"post.arg1.name\":\"The length of the cluster's name has to be in range of 5 to 40\""))
                 .validate();
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/CredentialTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/CredentialTest.java
@@ -115,14 +115,14 @@ public class CredentialTest extends AbstractIntegrationTest {
     public Object[][] provideInvalidAttributes() {
         return new Object[][]{
                 {getBean(MockedTestContext.class), longStringGeneratorUtil.stringGenerator(101),
-                        " The length of the credential's name has to be in range of 5 to 100"},
+                        "\"post.arg1.name\":\"The length of the credential's name has to be in range of 5 to 100\""},
                 {getBean(MockedTestContext.class), "abc",
-                        " The length of the credential's name has to be in range of 5 to 100"},
+                        "\"post.arg1.name\":\"The length of the credential's name has to be in range of 5 to 100\""},
                 {getBean(MockedTestContext.class), "a-@#$%|:&*;",
-                        " The name of the credential can only contain lowercase alphanumeric characters and "
-                                + "hyphens and has start with an alphanumeric character"},
+                        "\"post.arg1.name\":\"The name of the credential can only contain lowercase alphanumeric characters and "
+                                + "hyphens and has start with an alphanumeric character\""},
                 {getBean(MockedTestContext.class), null,
-                        "error: must not be null"}
+                        "\"post.arg1.name\":\"must not be null\""}
         };
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/DatabaseTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/DatabaseTest.java
@@ -29,7 +29,7 @@ public class DatabaseTest extends AbstractIntegrationTest {
 
     private static final String DB_TYPE_PROVIDER = "databaseTypeTestProvider";
 
-    private static final String INVALID_ATTRIBUTE_PROVIDER = "databaseInvalidAttirbutesTestProvider";
+    private static final String INVALID_ATTRIBUTE_PROVIDER = "databaseInvalidAttributesTestProvider";
 
     private static final String DATABASE_PROTOCOL = "jdbc:postgresql://";
 
@@ -174,9 +174,9 @@ public class DatabaseTest extends AbstractIntegrationTest {
                         DATABASE_PROTOCOL + DATABASE_HOST_PORT_DB, "The database's name can only contain lowercase alphanumeric characters and "
                         + "hyphens and has start with an alphanumeric character"},
                 {getBean(TEST_CONTEXT_CLASS), getNameGenerator().getRandomNameForResource(), null, DATABASE_PASSWORD,
-                        DATABASE_PROTOCOL + DATABASE_HOST_PORT_DB, "connectionUserName: null, error: must not be null"},
+                        DATABASE_PROTOCOL + DATABASE_HOST_PORT_DB, "\".*connectionUserName\":\"must not be null\""},
                 {getBean(TEST_CONTEXT_CLASS), getNameGenerator().getRandomNameForResource(), DATABASE_USERNAME, null,
-                        DATABASE_PROTOCOL + DATABASE_HOST_PORT_DB, "connectionPassword: null, error: must not be null"},
+                        DATABASE_PROTOCOL + DATABASE_HOST_PORT_DB, "\".*connectionPassword\":\"must not be null\""},
                 {getBean(TEST_CONTEXT_CLASS), getNameGenerator().getRandomNameForResource(), DATABASE_USERNAME, DATABASE_PASSWORD,
                         DATABASE_HOST_PORT_DB, "Unsupported database type"}
         };

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/ImageCatalogTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/ImageCatalogTest.java
@@ -124,7 +124,7 @@ public class ImageCatalogTest extends AbstractIntegrationTest {
                 .withUrl(invalidURL)
                 .when(new ImageCatalogPostAction(), RunningParameter.key("ImageCatalogPostAction"))
                 .expect(BadRequestException.class, RunningParameter.key("ImageCatalogPostAction")
-                        .withExpectedMessage(".* " + invalidURL + ", error: A valid image catalog must be available on the given URL"))
+                        .withExpectedMessage(".*A valid image catalog must be available on the given URL.*"))
                 .validate();
     }
 
@@ -152,7 +152,7 @@ public class ImageCatalogTest extends AbstractIntegrationTest {
                 .withUrl(INVALID_IMAGECATALOG_JSON_URL)
                 .when(new ImageCatalogPostAction(), RunningParameter.key("ImageCatalogPostAction"))
                 .expect(BadRequestException.class, RunningParameter.key("ImageCatalogPostAction")
-                        .withExpectedMessage(".*" + INVALID_IMAGECATALOG_JSON_URL + ", error: A valid image catalog must be available on the given URL.*"))
+                        .withExpectedMessage(".*A valid image catalog must be available on the given URL.*"))
                 .validate();
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/KubernetesTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/testcase/mock/KubernetesTest.java
@@ -23,7 +23,7 @@ public class KubernetesTest extends AbstractIntegrationTest {
 
     private static final String BAD_REQUEST_KEY = "badRequest";
 
-    private static final String INVALID_ATTRIBUTE_PROVIDER = "kubernetesInvalidAttirbutesTestProvider";
+    private static final String INVALID_ATTRIBUTE_PROVIDER = "kubernetesInvalidAttributesTestProvider";
 
     private static final String KUBERNETES_CONTENT = "content";
 
@@ -105,13 +105,14 @@ public class KubernetesTest extends AbstractIntegrationTest {
     public Object[][] provideInvalidAttributes() {
         return new Object[][]{
                 {getBean(TestContext.class), longStringGeneratorUtil.stringGenerator(101), KUBERNETES_CONTENT,
-                        " The length of the config's name has to be in range of 5 to 100"},
+                        "\"post.arg1.name\":\"The length of the config's name has to be in range of 5 to 100\""},
                 {getBean(TestContext.class), "abc", KUBERNETES_CONTENT,
-                        " The length of the config's name has to be in range of 5 to 100"},
+                        "\"post.arg1.name\":\"The length of the config's name has to be in range of 5 to 100\""},
                 {getBean(TestContext.class), "a-@#$%|:&*;", KUBERNETES_CONTENT,
-                        " The config's name can only contain lowercase alphanumeric characters and hyphens and has start with an alphanumeric character"},
+                        "\"post.arg1.name\":\"The config's name can only contain lowercase alphanumeric characters "
+                        + "and hyphens and has start with an alphanumeric character\""},
                 {getBean(TestContext.class), getNameGenerator().getRandomNameForResource(), null,
-                        "post.arg1.content: null, error: must not be null"}
+                        "\"post.arg1.content\":\"must not be null\""}
         };
     }
 }


### PR DESCRIPTION
The core ConstraintViolationExceptionMapper class was returning a plain
string as a response, but to be valid for JSON-producing endpoints, it
should return JSON. It now does, in a manner identical to the same
mapper in periscope.