### PR TITLE
CB-150 add default CM DL template with HMS

### DIFF
--- a/cloud-common/src/main/resources/application.yml
+++ b/cloud-common/src/main/resources/application.yml
@@ -120,6 +120,9 @@ cb:
     defaultLifeTime: -1
 
   clusterdefinition:
+    cm:
+      defaults: >
+                CDH 6.1 - Data Lake: Hive Metastore=cdh6-shared-services;
     ambari:
       defaults: >
                 EDW-ETL: Apache Hive, Apache Spark 2=hdp26-etl-edw-spark2;
@@ -237,14 +240,14 @@ cb:
         repo:
           stack:
             repoid: CDH
-            redhat7: https://archive.cloudera.com/cdh6/{latest_supported}/parcels/
+            redhat7: https://archive.cloudera.com/cdh6/6.1.0/parcels/
       "[6.1.1]":
         version: 6.1.1-1.cdh6.1.1.p0.875250
         minCM: 6.1
         repo:
           stack:
             repoid: CDH
-            redhat7: https://archive.cloudera.com/cdh6/{latest_supported}/parcels/
+            redhat7: https://archive.cloudera.com/cdh6/6.1.1/parcels/
 
   ambari:
     entries:

--- a/core/src/main/java/com/sequenceiq/cloudbreak/init/clusterdefinition/ClusterDefinitionLoaderService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/init/clusterdefinition/ClusterDefinitionLoaderService.java
@@ -26,10 +26,10 @@ public class ClusterDefinitionLoaderService {
     private static final Logger LOGGER = LoggerFactory.getLogger(ClusterDefinitionLoaderService.class);
 
     @Inject
-    private DefaultAmbariBlueprintCache defaultAmbariBlueprintCache;
+    private DefaulClusterDefinitionCache defaulClusterDefinitionCache;
 
     public boolean addingDefaultClusterDefinitionsAreNecessaryForTheUser(Collection<ClusterDefinition> clusterDefinitions) {
-        Map<String, ClusterDefinition> defaultBlueprints = defaultAmbariBlueprintCache.defaultBlueprints();
+        Map<String, ClusterDefinition> defaultBlueprints = defaulClusterDefinitionCache.defaultBlueprints();
         for (ClusterDefinition clusterDefinitionFromDatabase : clusterDefinitions) {
             ClusterDefinition defaultClusterDefinition = defaultBlueprints.get(clusterDefinitionFromDatabase.getName());
             if (mustUpdateTheExistingClusterDefinition(clusterDefinitionFromDatabase, defaultClusterDefinition)) {
@@ -93,7 +93,7 @@ public class ClusterDefinitionLoaderService {
     private Set<ClusterDefinition> updateDefaultClusterDefinitions(Iterable<ClusterDefinition> clusterDefinitions, Workspace workspace) {
         Set<ClusterDefinition> resultList = new HashSet<>();
         LOGGER.debug("Updating default cluster definitions which are contains text modifications.");
-        Map<String, ClusterDefinition> defaultBlueprints = defaultAmbariBlueprintCache.defaultBlueprints();
+        Map<String, ClusterDefinition> defaultBlueprints = defaulClusterDefinitionCache.defaultBlueprints();
         for (ClusterDefinition clusterDefinitionFromDatabase : clusterDefinitions) {
             ClusterDefinition defaultClusterDefinition = defaultBlueprints.get(clusterDefinitionFromDatabase.getName());
             if (defaultClusterDefinitionExistInTheCache(defaultClusterDefinition)
@@ -129,7 +129,7 @@ public class ClusterDefinitionLoaderService {
     private Map<String, ClusterDefinition> collectDeviationOfExistingAndDefaultClusterDefinitions(Iterable<ClusterDefinition> clusterDefinitions) {
         LOGGER.debug("Collecting cluster definitions which are missing from the defaults.");
         Map<String, ClusterDefinition> diff = new HashMap<>();
-        for (Entry<String, ClusterDefinition> stringClusterDefinitionEntry : defaultAmbariBlueprintCache.defaultBlueprints().entrySet()) {
+        for (Entry<String, ClusterDefinition> stringClusterDefinitionEntry : defaulClusterDefinitionCache.defaultBlueprints().entrySet()) {
             boolean contains = false;
             for (ClusterDefinition clusterDefinition : clusterDefinitions) {
                 if (isRegisteregClusterDefinitionAndDefaultIsTheSame(stringClusterDefinitionEntry, clusterDefinition)) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/init/clusterdefinition/DefaulClusterDefinitionCache.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/init/clusterdefinition/DefaulClusterDefinitionCache.java
@@ -19,15 +19,15 @@ import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clusterdefinition.requests.ClusterDefinitionV4Request;
-import com.sequenceiq.cloudbreak.converter.v4.clusterdefinition.ClusterDefinitionV4RequestToClusterDefinitionConverter;
 import com.sequenceiq.cloudbreak.clusterdefinition.utils.AmbariBlueprintUtils;
+import com.sequenceiq.cloudbreak.converter.v4.clusterdefinition.ClusterDefinitionV4RequestToClusterDefinitionConverter;
 import com.sequenceiq.cloudbreak.domain.ClusterDefinition;
 import com.sequenceiq.cloudbreak.domain.json.Json;
 
 @Service
-public class DefaultAmbariBlueprintCache {
+public class DefaulClusterDefinitionCache {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultAmbariBlueprintCache.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaulClusterDefinitionCache.class);
 
     private final Map<String, ClusterDefinition> defaultBlueprints = new HashMap<>();
 
@@ -36,6 +36,9 @@ public class DefaultAmbariBlueprintCache {
 
     @Value("#{'${cb.clusterdefinition.ambari.internal:}'.split(';')}")
     private List<String> internalBlueprints;
+
+    @Value("#{'${cb.clusterdefinition.cm.defaults:}'.split(';')}")
+    private List<String> releasedCMClusterDefinitions;
 
     @Inject
     private AmbariBlueprintUtils ambariBlueprintUtils;
@@ -76,7 +79,8 @@ public class DefaultAmbariBlueprintCache {
     }
 
     private List<String> blueprints() {
-        return Stream.concat(releasedBlueprints.stream().filter(StringUtils::isNoneBlank),
-                internalBlueprints.stream().filter(StringUtils::isNoneBlank)).collect(Collectors.toList());
+        return Stream.concat(
+                Stream.concat(releasedBlueprints.stream(), internalBlueprints.stream()), releasedCMClusterDefinitions.stream()
+        ).filter(StringUtils::isNoneBlank).collect(Collectors.toList());
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/SharedServiceValidator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/SharedServiceValidator.java
@@ -8,10 +8,14 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.cluster.ClusterV4Request;
 import com.sequenceiq.cloudbreak.controller.validation.ValidationResult;
+import com.sequenceiq.cloudbreak.controller.validation.ValidationResult.ValidationResultBuilder;
+import com.sequenceiq.cloudbreak.domain.ClusterDefinition;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.domain.view.StackView;
 import com.sequenceiq.cloudbreak.domain.workspace.Workspace;
+import com.sequenceiq.cloudbreak.service.clusterdefinition.ClusterDefinitionService;
 import com.sequenceiq.cloudbreak.service.rdsconfig.RdsConfigService;
 
 @Component
@@ -23,16 +27,24 @@ public class SharedServiceValidator {
     @Inject
     private StackViewService stackViewService;
 
+    @Inject
+    private ClusterDefinitionService clusterDefinitionService;
+
     public ValidationResult checkSharedServiceStackRequirements(StackV4Request request, Workspace workspace) {
-        ValidationResult.ValidationResultBuilder resultBuilder = ValidationResult.builder();
+        ValidationResultBuilder resultBuilder = ValidationResult.builder();
         if (request.getSharedService() != null) {
-            checkCloudPlatform(request, workspace.getId(), resultBuilder);
-            checkSharedServiceRequirements(request, workspace, resultBuilder);
+            Long wsId = workspace.getId();
+            checkCloudPlatform(request, wsId, resultBuilder);
+            ClusterV4Request clusterReq = request.getCluster();
+            ClusterDefinition clusterDefinition = clusterDefinitionService.getByNameForWorkspaceId(clusterReq.getAmbari().getClusterDefinitionName(), wsId);
+            if (clusterDefinitionService.isAmbariBlueprint(clusterDefinition)) {
+                checkSharedServiceRequirements(request, workspace, resultBuilder);
+            }
         }
         return resultBuilder.build();
     }
 
-    private void checkCloudPlatform(StackV4Request request, Long workspaceId, ValidationResult.ValidationResultBuilder resultBuilder) {
+    private void checkCloudPlatform(StackV4Request request, Long workspaceId, ValidationResultBuilder resultBuilder) {
         StackView datalakeStack = stackViewService.findByName(request.getSharedService().getDatalakeName(), workspaceId);
         if (datalakeStack == null) {
             resultBuilder.error("Datalake stack with the requested name (in sharedService/sharedClusterName field) was not found.");
@@ -46,7 +58,7 @@ public class SharedServiceValidator {
         }
     }
 
-    private void checkSharedServiceRequirements(StackV4Request request, Workspace workspace, ValidationResult.ValidationResultBuilder resultBuilder) {
+    private void checkSharedServiceRequirements(StackV4Request request, Workspace workspace, ValidationResultBuilder resultBuilder) {
         if (!hasConfiguredLdap(request)) {
             resultBuilder.error("Shared service stack should have LDAP configured.");
         }

--- a/core/src/main/resources/defaults/blueprints/cdh6-shared-services.bp
+++ b/core/src/main/resources/defaults/blueprints/cdh6-shared-services.bp
@@ -1,0 +1,119 @@
+{
+  "tags": {
+    "shared_services_ready": true
+  },
+  "description": "CM managed CDH Data Lake",
+  "blueprint": {
+    "cdhVersion": "6.1.1",
+    "displayName": "simple_template",
+    "cmVersion": "6.1.0",
+    "repositories": [
+      "https://archive.cloudera.com/cdh6/6.1.1/parcels/"
+    ],
+    "products": [
+      {
+        "version": "6.1.1-1.cdh6.1.1.p0.875250",
+        "product": "CDH"
+      }
+    ],
+    "services": [
+      {
+        "refName": "zookeeper",
+        "serviceType": "ZOOKEEPER",
+        "roleConfigGroups": [
+          {
+            "refName": "zookeeper-SERVER-BASE",
+            "roleType": "SERVER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "hdfs",
+        "serviceType": "HDFS",
+        "roleConfigGroups": [
+          {
+            "refName": "hdfs-NAMENODE-BASE",
+            "roleType": "NAMENODE",
+            "base": true
+          },
+          {
+            "refName": "hdfs-SECONDARYNAMENODE-BASE",
+            "roleType": "SECONDARYNAMENODE",
+            "base": true
+          },
+          {
+            "refName": "hdfs-DATANODE-BASE",
+            "roleType": "DATANODE",
+            "base": true
+          },
+          {
+            "refName": "hdfs-BALANCER-BASE",
+            "roleType": "BALANCER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "yarn",
+        "serviceType": "YARN",
+        "roleConfigGroups": [
+          {
+            "refName": "yarn-RESOURCEMANAGER-BASE",
+            "roleType": "RESOURCEMANAGER",
+            "base": true
+          },
+          {
+            "refName": "yarn-NODEMANAGER-BASE",
+            "roleType": "NODEMANAGER",
+            "base": true
+          },
+          {
+            "refName": "yarn-JOBHISTORY-BASE",
+            "roleType": "JOBHISTORY",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "hive",
+        "serviceType": "HIVE",
+        "roleConfigGroups": [
+          {
+            "refName": "hive-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          },
+          {
+            "refName": "hive-HIVESERVER2-BASE",
+            "roleType": "HIVESERVER2",
+            "base": true
+          },
+          {
+            "refName": "hive-HIVEMETASTORE-BASE",
+            "roleType": "HIVEMETASTORE",
+            "base": true
+          }
+        ]
+      }
+    ],
+    "hostTemplates": [
+      {
+        "refName": "master",
+        "roleConfigGroupsRefNames": [
+          "hdfs-BALANCER-BASE",
+          "hdfs-NAMENODE-BASE",
+          "hdfs-SECONDARYNAMENODE-BASE",
+          "hdfs-DATANODE-BASE",
+          "hive-GATEWAY-BASE",
+          "hive-HIVEMETASTORE-BASE",
+          "hive-HIVESERVER2-BASE",
+          "yarn-JOBHISTORY-BASE",
+          "yarn-RESOURCEMANAGER-BASE",
+          "yarn-NODEMANAGER-BASE",
+          "zookeeper-SERVER-BASE"
+        ]
+      }
+    ]
+  }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverterTest.java
@@ -48,7 +48,6 @@ import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.domain.workspace.User;
 import com.sequenceiq.cloudbreak.domain.workspace.Workspace;
 import com.sequenceiq.cloudbreak.service.AuthenticatedUserService;
-import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.cloudbreak.service.CloudbreakRestRequestThreadLocalService;
 import com.sequenceiq.cloudbreak.service.account.PreferencesService;
 import com.sequenceiq.cloudbreak.service.credential.CredentialService;
@@ -123,7 +122,7 @@ public class StackV4RequestToStackConverterTest extends AbstractJsonConverterTes
     }
 
     @Test
-    public void testConvert() throws CloudbreakException {
+    public void testConvert() {
         initMocks();
         ReflectionTestUtils.setField(underTest, "defaultRegions", "AWS:eu-west-2");
         StackV4Request request = getRequest("stack.json");
@@ -161,7 +160,7 @@ public class StackV4RequestToStackConverterTest extends AbstractJsonConverterTes
     }
 
     @Test
-    public void testConvertWithLoginUserName() throws CloudbreakException {
+    public void testConvertWithLoginUserName() {
         initMocks();
         ReflectionTestUtils.setField(underTest, "defaultRegions", "AWS:eu-west-2");
         given(defaultCostTaggingService.prepareDefaultTags(any(CloudbreakUser.class), anyMap(), anyString())).willReturn(new HashMap<>());

--- a/core/src/test/java/com/sequenceiq/cloudbreak/init/clusterdefinition/DefaulClusterDefinitionCacheTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/init/clusterdefinition/DefaulClusterDefinitionCacheTest.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -20,13 +19,13 @@ import org.powermock.reflect.Whitebox;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clusterdefinition.requests.ClusterDefinitionV4Request;
-import com.sequenceiq.cloudbreak.converter.v4.clusterdefinition.ClusterDefinitionV4RequestToClusterDefinitionConverter;
 import com.sequenceiq.cloudbreak.clusterdefinition.utils.AmbariBlueprintUtils;
+import com.sequenceiq.cloudbreak.converter.v4.clusterdefinition.ClusterDefinitionV4RequestToClusterDefinitionConverter;
 import com.sequenceiq.cloudbreak.domain.ClusterDefinition;
 import com.sequenceiq.cloudbreak.util.JsonUtil;
 
 @RunWith(MockitoJUnitRunner.class)
-public class DefaultAmbariBlueprintCacheTest {
+public class DefaulClusterDefinitionCacheTest {
 
     @Mock
     private AmbariBlueprintUtils ambariBlueprintUtils;
@@ -35,28 +34,16 @@ public class DefaultAmbariBlueprintCacheTest {
     private ClusterDefinitionV4RequestToClusterDefinitionConverter converter;
 
     @InjectMocks
-    private DefaultAmbariBlueprintCache underTest;
-
-    @Before
-    public void setup() throws IOException {
-
-        ClusterDefinition bp1 = new ClusterDefinition();
-        bp1.setName("bp1");
-
-        JsonNode bpText = JsonUtil.readTree("{\"inputs\":[],\"blueprint\":{\"Blueprints\":{\"blueprint_name\":\"bp1\"}}}");
-
-        when(ambariBlueprintUtils.isBlueprintNamePreConfigured(anyString(), any())).thenReturn(true);
-        when(ambariBlueprintUtils.convertStringToJsonNode(any())).thenReturn(bpText);
-        when(converter.convert(any(ClusterDefinitionV4Request.class))).thenReturn(bp1);
-
-        underTest.defaultBlueprints().clear();
-    }
+    private DefaulClusterDefinitionCache underTest;
 
     @Test
     public void testEmptyValues() {
         // GIVEN
+        underTest.defaultBlueprints().clear();
+
         Whitebox.setInternalState(underTest, "releasedBlueprints", Collections.singletonList(""));
         Whitebox.setInternalState(underTest, "internalBlueprints", Collections.singletonList(" "));
+        Whitebox.setInternalState(underTest, "releasedCMClusterDefinitions", Collections.singletonList(" "));
 
         // WHEN
         underTest.loadBlueprintsFromFile();
@@ -67,18 +54,41 @@ public class DefaultAmbariBlueprintCacheTest {
     }
 
     @Test
-    public void testOnlyReleasedBps() {
+    public void testOnlyReleasedBps() throws IOException {
         // GIVEN
+        ClusterDefinition bp1 = new ClusterDefinition();
+        bp1.setName("bp1");
+        String bp1JsonString = "{\"inputs\":[],\"blueprint\":{\"Blueprints\":{\"blueprint_name\":\"bp1\"}}}";
+        JsonNode bpText1 = JsonUtil.readTree(bp1JsonString);
+        when(ambariBlueprintUtils.convertStringToJsonNode(any())).thenReturn(bpText1);
+
+        ClusterDefinition bp2 = new ClusterDefinition();
+        bp2.setName("bp2");
+        String bp2JsonString = "{\"inputs\":[],\"blueprint\":{\"Blueprints\":{\"blueprint_name\":\"bp2\"}}}";
+        JsonNode bpText2 = JsonUtil.readTree(bp2JsonString);
+        when(ambariBlueprintUtils.convertStringToJsonNode(any())).thenReturn(bpText2);
+
+        when(ambariBlueprintUtils.isBlueprintNamePreConfigured(anyString(), any())).thenReturn(true);
         Whitebox.setInternalState(underTest, "releasedBlueprints", Collections.singletonList("Description1=bp1"));
         Whitebox.setInternalState(underTest, "internalBlueprints", Collections.singletonList(" "));
+        Whitebox.setInternalState(underTest, "releasedCMClusterDefinitions", Collections.singletonList("Description2=bp2"));
+
+        when(converter.convert(any(ClusterDefinitionV4Request.class))).thenAnswer(invocation -> {
+            ClusterDefinitionV4Request request = invocation.getArgument(0);
+            if ("Description1".equalsIgnoreCase(request.getName())) {
+                return bp1;
+            }
+            return bp2;
+        });
 
         // WHEN
         underTest.loadBlueprintsFromFile();
         Map<String, ClusterDefinition> defaultBlueprints = underTest.defaultBlueprints();
 
         // WHEN
-        assertEquals(1L, defaultBlueprints.size());
+        assertEquals(2L, defaultBlueprints.size());
         assertEquals("Description1", defaultBlueprints.get("bp1").getDescription());
+        assertEquals("Description2", defaultBlueprints.get("bp2").getDescription());
     }
 
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/clusterdefinition/ClusterDefinitionLoaderServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/clusterdefinition/ClusterDefinitionLoaderServiceTest.java
@@ -21,7 +21,7 @@ import com.sequenceiq.cloudbreak.common.model.user.CloudbreakUser;
 import com.sequenceiq.cloudbreak.domain.ClusterDefinition;
 import com.sequenceiq.cloudbreak.domain.workspace.Workspace;
 import com.sequenceiq.cloudbreak.init.clusterdefinition.ClusterDefinitionLoaderService;
-import com.sequenceiq.cloudbreak.init.clusterdefinition.DefaultAmbariBlueprintCache;
+import com.sequenceiq.cloudbreak.init.clusterdefinition.DefaulClusterDefinitionCache;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ClusterDefinitionLoaderServiceTest {
@@ -49,10 +49,10 @@ public class ClusterDefinitionLoaderServiceTest {
     private ClusterDefinitionLoaderService underTest;
 
     @Mock
-    private DefaultAmbariBlueprintCache blueprintCache;
+    private DefaulClusterDefinitionCache blueprintCache;
 
     @Mock
-    private DefaultAmbariBlueprintCache defaultAmbariBlueprintCache;
+    private DefaulClusterDefinitionCache defaulClusterDefinitionCache;
 
     @Mock
     private Workspace workspace;
@@ -61,7 +61,7 @@ public class ClusterDefinitionLoaderServiceTest {
     public void testBlueprintLoaderWhenTheUserWhenUserHaveAllTheDefaultBlueprintThenItShouldReturnWithFalse() {
         Set<ClusterDefinition> clusterDefinitions = generateDatabaseData(3);
         Map<String, ClusterDefinition> defaultBlueprints = generateCacheData(3);
-        when(defaultAmbariBlueprintCache.defaultBlueprints()).thenReturn(defaultBlueprints);
+        when(defaulClusterDefinitionCache.defaultBlueprints()).thenReturn(defaultBlueprints);
 
         boolean addingDefaultBlueprintsAreNecessaryForTheUser = underTest.addingDefaultClusterDefinitionsAreNecessaryForTheUser(clusterDefinitions);
 
@@ -72,7 +72,7 @@ public class ClusterDefinitionLoaderServiceTest {
     public void testBlueprintLoaderWhenTheUserIsANewOneInTheNewWorkspaceThenItShouldReturnWithTrue() {
         Set<ClusterDefinition> clusterDefinitions = generateDatabaseData(0);
         Map<String, ClusterDefinition> defaultBlueprints = generateCacheData(2);
-        when(defaultAmbariBlueprintCache.defaultBlueprints()).thenReturn(defaultBlueprints);
+        when(defaulClusterDefinitionCache.defaultBlueprints()).thenReturn(defaultBlueprints);
 
         boolean addingDefaultBlueprintsAreNecessaryForTheUser = underTest.addingDefaultClusterDefinitionsAreNecessaryForTheUser(clusterDefinitions);
 
@@ -83,7 +83,7 @@ public class ClusterDefinitionLoaderServiceTest {
     public void testBlueprintLoaderWhenTheUserIsANewOneInTheExistingWorkspaceThenItShouldReturnWithTrue() {
         Set<ClusterDefinition> clusterDefinitions = generateDatabaseData(1);
         Map<String, ClusterDefinition> defaultBlueprints = generateCacheData(2);
-        when(defaultAmbariBlueprintCache.defaultBlueprints()).thenReturn(defaultBlueprints);
+        when(defaulClusterDefinitionCache.defaultBlueprints()).thenReturn(defaultBlueprints);
 
         boolean addingDefaultBlueprintsAreNecessaryForTheUser = underTest.addingDefaultClusterDefinitionsAreNecessaryForTheUser(clusterDefinitions);
 
@@ -94,7 +94,7 @@ public class ClusterDefinitionLoaderServiceTest {
     public void testBlueprintLoaderWhenTheUserHasAllDefaultBlueprintButOneOfItWasChangeThenItShouldReturnWithTrue() {
         Set<ClusterDefinition> clusterDefinitions = generateDatabaseData(3);
         Map<String, ClusterDefinition> defaultBlueprints = generateCacheData(3, 1);
-        when(defaultAmbariBlueprintCache.defaultBlueprints()).thenReturn(defaultBlueprints);
+        when(defaulClusterDefinitionCache.defaultBlueprints()).thenReturn(defaultBlueprints);
 
         boolean addingDefaultBlueprintsAreNecessaryForTheUser = underTest.addingDefaultClusterDefinitionsAreNecessaryForTheUser(clusterDefinitions);
 
@@ -105,7 +105,7 @@ public class ClusterDefinitionLoaderServiceTest {
     public void testLoadBlueprintsForTheSpecifiedUserWhenOneNewDefaultExistThenRepositoryShouldUpdateOnlyOneBlueprint() {
         Set<ClusterDefinition> clusterDefinitions = generateDatabaseData(3);
         Map<String, ClusterDefinition> defaultBlueprints = generateCacheData(3, 1);
-        when(defaultAmbariBlueprintCache.defaultBlueprints()).thenReturn(defaultBlueprints);
+        when(defaulClusterDefinitionCache.defaultBlueprints()).thenReturn(defaultBlueprints);
 
         Collection<ClusterDefinition> resultSet = underTest.loadClusterDEfinitionsForTheWorkspace(clusterDefinitions, workspace, this::mockSave);
 
@@ -116,7 +116,7 @@ public class ClusterDefinitionLoaderServiceTest {
     public void testLoadBlueprintsForTheSpecifiedUserIsNewOneAndNoDefaultBlueprintAddedThenAllDefaultShouldBeAdd() {
         Set<ClusterDefinition> clusterDefinitions = generateDatabaseData(0);
         Map<String, ClusterDefinition> defaultBlueprints = generateCacheData(3);
-        when(defaultAmbariBlueprintCache.defaultBlueprints()).thenReturn(defaultBlueprints);
+        when(defaulClusterDefinitionCache.defaultBlueprints()).thenReturn(defaultBlueprints);
 
         Collection<ClusterDefinition> resultSet = underTest.loadClusterDEfinitionsForTheWorkspace(clusterDefinitions, workspace, this::mockSave);
 
@@ -127,7 +127,7 @@ public class ClusterDefinitionLoaderServiceTest {
     public void testLoadBlueprintsForTheSpecifiedUserWhenEveryDefaultExistThenRepositoryShouldNotUpdateAnything() {
         Set<ClusterDefinition> clusterDefinitions = generateDatabaseData(3);
         Map<String, ClusterDefinition> defaultBlueprints = generateCacheData(3);
-        when(defaultAmbariBlueprintCache.defaultBlueprints()).thenReturn(defaultBlueprints);
+        when(defaulClusterDefinitionCache.defaultBlueprints()).thenReturn(defaultBlueprints);
 
         Collection<ClusterDefinition> resultSet = underTest.loadClusterDEfinitionsForTheWorkspace(clusterDefinitions, workspace, this::mockSave);
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/SharedServiceValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/SharedServiceValidatorTest.java
@@ -7,7 +7,9 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.junit.Test;
@@ -20,11 +22,14 @@ import com.google.common.collect.Sets;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.cluster.ClusterV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.cluster.ambari.AmbariV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.cluster.sharedservice.SharedServiceV4Request;
 import com.sequenceiq.cloudbreak.controller.validation.ValidationResult;
+import com.sequenceiq.cloudbreak.domain.ClusterDefinition;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.domain.view.StackView;
 import com.sequenceiq.cloudbreak.domain.workspace.Workspace;
+import com.sequenceiq.cloudbreak.service.clusterdefinition.ClusterDefinitionService;
 import com.sequenceiq.cloudbreak.service.rdsconfig.RdsConfigService;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -48,6 +53,9 @@ public class SharedServiceValidatorTest {
     @Mock
     private StackViewService stackViewService;
 
+    @Mock
+    private ClusterDefinitionService clusterDefinitionService;
+
     @InjectMocks
     private SharedServiceValidator underTest;
 
@@ -57,6 +65,8 @@ public class SharedServiceValidatorTest {
         when(stackViewService.findByName(eq(DATALAKE_NAME), anyLong())).thenReturn(getStackView());
         when(rdsConfigService.getByNameForWorkspace(eq(RANGER_DB_NAME), any())).thenReturn(getDatabase(RANGER_TYPE_STRING));
         when(rdsConfigService.getByNameForWorkspace(eq(HIVE_DB_NAME), any())).thenReturn(getDatabase(HIVE_TYPE_STRING));
+        when(clusterDefinitionService.getByNameForWorkspaceId(anyString(), anyLong())).thenReturn(mock(ClusterDefinition.class));
+        when(clusterDefinitionService.isAmbariBlueprint(any())).thenReturn(true);
 
         ValidationResult validationResult = underTest.checkSharedServiceStackRequirements(stackRequest, getWorkspace());
 
@@ -69,6 +79,8 @@ public class SharedServiceValidatorTest {
         when(stackViewService.findByName(eq(DATALAKE_NAME), anyLong())).thenReturn(getStackView());
         when(rdsConfigService.getByNameForWorkspace(eq(RANGER_DB_NAME), any())).thenReturn(getDatabase(RANGER_TYPE_STRING));
         when(rdsConfigService.getByNameForWorkspace(eq(HIVE_DB_NAME), any())).thenReturn(null);
+        when(clusterDefinitionService.getByNameForWorkspaceId(anyString(), anyLong())).thenReturn(mock(ClusterDefinition.class));
+        when(clusterDefinitionService.isAmbariBlueprint(any())).thenReturn(true);
 
         ValidationResult validationResult = underTest.checkSharedServiceStackRequirements(stackRequest, getWorkspace());
 
@@ -83,6 +95,8 @@ public class SharedServiceValidatorTest {
         when(stackViewService.findByName(eq(DATALAKE_NAME), anyLong())).thenReturn(getStackView());
         when(rdsConfigService.getByNameForWorkspace(eq(HIVE_DB_NAME), any())).thenReturn(getDatabase(HIVE_TYPE_STRING));
         when(rdsConfigService.getByNameForWorkspace(eq(RANGER_DB_NAME), any())).thenReturn(null);
+        when(clusterDefinitionService.getByNameForWorkspaceId(anyString(), anyLong())).thenReturn(mock(ClusterDefinition.class));
+        when(clusterDefinitionService.isAmbariBlueprint(any())).thenReturn(true);
 
         ValidationResult validationResult = underTest.checkSharedServiceStackRequirements(stackRequest, getWorkspace());
 
@@ -98,6 +112,8 @@ public class SharedServiceValidatorTest {
         when(stackViewService.findByName(eq(DATALAKE_NAME), anyLong())).thenReturn(getStackView());
         when(rdsConfigService.getByNameForWorkspace(eq(RANGER_DB_NAME), any())).thenReturn(getDatabase(RANGER_TYPE_STRING));
         when(rdsConfigService.getByNameForWorkspace(eq(HIVE_DB_NAME), any())).thenReturn(getDatabase(HIVE_TYPE_STRING));
+        when(clusterDefinitionService.getByNameForWorkspaceId(anyString(), anyLong())).thenReturn(mock(ClusterDefinition.class));
+        when(clusterDefinitionService.isAmbariBlueprint(any())).thenReturn(true);
 
         ValidationResult validationResult = underTest.checkSharedServiceStackRequirements(stackRequest, getWorkspace());
 
@@ -116,6 +132,9 @@ public class SharedServiceValidatorTest {
         ClusterV4Request clusterRequest = new ClusterV4Request();
         clusterRequest.setDatabases(Sets.newHashSet(RANGER_DB_NAME, HIVE_DB_NAME));
         clusterRequest.setLdapName(ldapName);
+        AmbariV4Request ambariRequest = new AmbariV4Request();
+        ambariRequest.setClusterDefinitionName("test-blueprint");
+        clusterRequest.setAmbari(ambariRequest);
         StackV4Request stackRequest = new StackV4Request();
         stackRequest.setSharedService(new SharedServiceV4Request());
         stackRequest.getSharedService().setDatalakeName(DATALAKE_NAME);


### PR DESCRIPTION
This PR allows to launch a CDH based simple data lake with a default template (HMS) (which contains more services than it should, but this can be polished later). It also allows to attach a simple WL cluster by connecting the HMS databases. No Ldap, Kerberos, Cloud storage support. Also in case of CM there is no data lake resource collection (basically we do not collect any config from CM, but we might never need to if the shared data context will be implemented).