### PR TITLE
CB-28 Define multi-delete API for cluster defs

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/clusterdefinition/ClusterDefinitionV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/clusterdefinition/ClusterDefinitionV4Endpoint.java
@@ -3,6 +3,8 @@ package com.sequenceiq.cloudbreak.api.endpoint.v4.clusterdefinition;
 import static com.sequenceiq.cloudbreak.doc.ContentType.JSON;
 import static com.sequenceiq.cloudbreak.doc.Notes.CLUSTER_DEFINITION_NOTES;
 
+import java.util.Set;
+
 import javax.validation.Valid;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -16,6 +18,7 @@ import javax.ws.rs.core.MediaType;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clusterdefinition.requests.ClusterDefinitionV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clusterdefinition.responses.ClusterDefinitionV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.clusterdefinition.responses.ClusterDefinitionV4Responses;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clusterdefinition.responses.ClusterDefinitionV4ViewResponses;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clusterdefinition.responses.RecommendationV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.ParametersQueryV4Response;
@@ -60,6 +63,13 @@ public interface ClusterDefinitionV4Endpoint {
     @ApiOperation(value = ClusterDefinitionOpDescription.DELETE_BY_NAME_IN_WORKSPACE, produces = JSON, notes = CLUSTER_DEFINITION_NOTES,
             nickname = "deleteClusterDefinitionInWorkspace")
     ClusterDefinitionV4Response delete(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name);
+
+    @DELETE
+    @Path("")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = ClusterDefinitionOpDescription.DELETE_MULTIPLE_BY_NAME_IN_WORKSPACE, produces = JSON,
+            notes = CLUSTER_DEFINITION_NOTES, nickname = "deleteClusterDefinitionsInWorkspace")
+    ClusterDefinitionV4Responses deleteMultiple(@PathParam("workspaceId") Long workspaceId, Set<String> names);
 
     @GET
     @Path("{name}/request")

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/clusterdefinition/responses/ClusterDefinitionV4Responses.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/clusterdefinition/responses/ClusterDefinitionV4Responses.java
@@ -1,0 +1,20 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.clusterdefinition.responses;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.responses.GeneralCollectionV4Response;
+
+import io.swagger.annotations.ApiModel;
+
+@ApiModel
+public class ClusterDefinitionV4Responses extends GeneralCollectionV4Response<ClusterDefinitionV4Response> {
+
+    public ClusterDefinitionV4Responses(Set<ClusterDefinitionV4Response> responses) {
+        super(responses);
+    }
+
+    public ClusterDefinitionV4Responses() {
+        super(new HashSet<>());
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
@@ -7,6 +7,7 @@ public class OperationDescriptions {
         public static final String GET_BY_NAME_IN_WORKSPACE = "get cluster definition by name in workspace";
         public static final String CREATE_IN_WORKSPACE = "create cluster definition in workspace";
         public static final String DELETE_BY_NAME_IN_WORKSPACE = "delete cluster definition by name in workspace";
+        public static final String DELETE_MULTIPLE_BY_NAME_IN_WORKSPACE = "delete multiple cluster definitions by name in workspace";
     }
 
     public static class CredentialOpDescription {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/ClusterDefinitionV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/ClusterDefinitionV4Controller.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Controller;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clusterdefinition.ClusterDefinitionV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clusterdefinition.requests.ClusterDefinitionV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clusterdefinition.responses.ClusterDefinitionV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.clusterdefinition.responses.ClusterDefinitionV4Responses;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clusterdefinition.responses.ClusterDefinitionV4ViewResponse;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clusterdefinition.responses.ClusterDefinitionV4ViewResponses;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clusterdefinition.responses.RecommendationV4Response;
@@ -62,6 +63,13 @@ public class ClusterDefinitionV4Controller extends NotificationController implem
         ClusterDefinition deleted = clusterDefinitionService.deleteByNameFromWorkspace(name, workspaceId);
         notify(ResourceEvent.CLUSTER_DEFINITION_DELETED);
         return converterUtil.convert(deleted, ClusterDefinitionV4Response.class);
+    }
+
+    @Override
+    public ClusterDefinitionV4Responses deleteMultiple(Long workspaceId, Set<String> names) {
+        Set<ClusterDefinition> deleted = clusterDefinitionService.deleteMultipleByNameFromWorkspace(names, workspaceId);
+        notify(ResourceEvent.CLUSTER_DEFINITION_DELETED);
+        return new ClusterDefinitionV4Responses(converterUtil.convertAllAsSet(deleted, ClusterDefinitionV4Response.class));
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/AbstractWorkspaceAwareResourceService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/AbstractWorkspaceAwareResourceService.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.service;
 
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
@@ -105,8 +106,21 @@ public abstract class AbstractWorkspaceAwareResourceService<T extends WorkspaceA
     }
 
     @Override
+    public Set<T> delete(Set<T> resources) {
+        return resources.stream()
+                .map(r -> delete(r))
+                .collect(Collectors.toSet());
+    }
+
+    @Override
     public T deleteByNameFromWorkspace(String name, Long workspaceId) {
         T toBeDeleted = getByNameForWorkspaceId(name, workspaceId);
+        return delete(toBeDeleted);
+    }
+
+    @Override
+    public Set<T> deleteMultipleByNameFromWorkspace(Set<String> names, Long workspaceId) {
+        Set<T> toBeDeleted = names.stream().map(n -> getByNameForWorkspaceId(n, workspaceId)).collect(Collectors.toSet());
         return delete(toBeDeleted);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/workspace/WorkspaceAwareResourceService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/workspace/WorkspaceAwareResourceService.java
@@ -25,7 +25,11 @@ public interface WorkspaceAwareResourceService<T extends WorkspaceAwareResource>
 
     T delete(T resource);
 
+    Set<T> delete(Set<T> resources);
+
     T deleteByNameFromWorkspace(String name, Long workspaceId);
+
+    Set<T> deleteMultipleByNameFromWorkspace(Set<String> names, Long workspaceId);
 
     WorkspaceResource resource();
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/AbstractWorkspaceAwareResourceServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/AbstractWorkspaceAwareResourceServiceTest.java
@@ -1,0 +1,111 @@
+package com.sequenceiq.cloudbreak.service;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.sequenceiq.cloudbreak.authorization.WorkspaceResource;
+import com.sequenceiq.cloudbreak.domain.workspace.Workspace;
+import com.sequenceiq.cloudbreak.domain.workspace.WorkspaceAwareResource;
+import com.sequenceiq.cloudbreak.repository.workspace.WorkspaceResourceRepository;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AbstractWorkspaceAwareResourceServiceTest {
+
+    @Mock
+    private AbstractWorkspaceAwareResourceService<TestWorkspaceAwareResource> underTest;
+
+    @Mock
+    private Workspace workspace;
+
+    @Mock
+    private WorkspaceResourceRepository<TestWorkspaceAwareResource, Long> testRepository;
+
+    @Before
+    public void setup() {
+        // The mock service is the object under test. Mock methods of the abstract
+        // class that are not under test here.
+        when(underTest.repository()).thenReturn(testRepository);
+        when(underTest.resource()).thenReturn(WorkspaceResource.ALL);
+
+        // Have the mock call the real methods in the abstract class that are
+        // under test.
+        when(underTest.delete(any(TestWorkspaceAwareResource.class))).thenCallRealMethod();
+        when(underTest.delete(any(Set.class))).thenCallRealMethod();
+    }
+
+    @Test
+    public void testDelete() {
+        TestWorkspaceAwareResource r = new TestWorkspaceAwareResource(1L, workspace, "name1");
+
+        underTest.delete(r);
+
+        verify(underTest).prepareDeletion(r);
+        verify(underTest.repository()).delete(r);
+    }
+
+    @Test
+    public void testMultiDelete() {
+        TestWorkspaceAwareResource r1 = new TestWorkspaceAwareResource(1L, workspace, "name1");
+        TestWorkspaceAwareResource r2 = new TestWorkspaceAwareResource(2L, workspace, "name2");
+
+        underTest.delete(ImmutableSet.of(r1, r2));
+
+        verify(underTest).prepareDeletion(r1);
+        verify(underTest).prepareDeletion(r2);
+        verify(underTest.repository()).delete(r1);
+        verify(underTest.repository()).delete(r2);
+    }
+
+    private static class TestWorkspaceAwareResource implements WorkspaceAwareResource {
+
+        private Long id;
+
+        private Workspace workspace;
+
+        private String name;
+
+        private TestWorkspaceAwareResource(Long id, Workspace workspace, String name) {
+            this.id = id;
+            this.workspace = workspace;
+            this.name = name;
+        }
+
+        @Override
+        public Long getId() {
+            return id;
+        }
+
+        @Override
+        public Workspace getWorkspace() {
+            return workspace;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public void setWorkspace(Workspace workspace) {
+            this.workspace = workspace;
+        }
+
+        @Override
+        public WorkspaceResource getResource() {
+            return WorkspaceResource.ALL;
+        }
+
+    }
+
+}


### PR DESCRIPTION
WorkspaceAwareResourceService and its abstract implementation now
support deleting multiple resources at a time. Resources, or the names
of them, are provided in sets, so deletion order is not specified.

A new unit test for AbstractWorkspaceAwareResourceService tests out
the delete and multi-delete methods.

The v4 cluster definition API is updated to make use of this new support
and features a new endpoint for deleting multiple cluster definitions at
once. The endpoint is called with a DELETE HTTP method, and the body of
the method is a JSON list of the names of the cluster definitions to
delete.