### PR TITLE
CB-484 unit tests for gcp/aws encryption

### DIFF
--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverterTest.java
@@ -737,7 +737,7 @@ public class StackToCloudStackConverterTest {
     }
 
     @Test
-    public void testBuildInstanceTemplateWithGcpEncryptionAttributes() throws Exception {
+    public void testBuildInstanceTemplateWithEncryptionAttributes() throws Exception {
         Template template = new Template();
         template.setVolumeCount(0);
         template.setAttributes(new Json(Map.of("keyEncryptionMethod", "RAW", "type", "CUSTOM")));

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverterTest.java
@@ -735,4 +735,21 @@ public class StackToCloudStackConverterTest {
         assertEquals("value", instanceTemplate.getParameters().get("someAttr"));
         assertEquals("value", instanceTemplate.getParameters().get("otherAttr"));
     }
+
+    @Test
+    public void testBuildInstanceTemplateWithGcpEncryptionAttributes() throws Exception {
+        Template template = new Template();
+        template.setVolumeCount(0);
+        template.setAttributes(new Json(Map.of("keyEncryptionMethod", "RAW", "type", "CUSTOM")));
+        template.setSecretAttributes(new Json(Map.of("key", "myKey")).getValue());
+
+        InstanceTemplate instanceTemplate = underTest.buildInstanceTemplate(
+                template, "name", 0L, InstanceStatus.CREATE_REQUESTED, "instanceImageId");
+
+        Map<String, Object> parameters = instanceTemplate.getParameters();
+        assertNotNull(parameters);
+        assertEquals("RAW", parameters.get("keyEncryptionMethod"));
+        assertEquals("CUSTOM", parameters.get("type"));
+        assertEquals("myKey", parameters.get("key"));
+    }
 }


### PR DESCRIPTION
This PR adds tests when we convert the requests to entities and entities to dtos. Gcp side of the encryption is already covered: https://github.com/hortonworks/cloudbreak/blob/master/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilderTest.java#L326-L358