### PR TITLE
avoid output redirection for pip install

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/init.sls
@@ -8,7 +8,7 @@ install-cloudera-manager-agent:
 
 install-psycopg2:
   cmd.run:
-    - name: pip install --upgrade psycopg2>=2.5.4
+    - name: pip install --upgrade 'psycopg2>=2.5.4'
 
 replace_server_host:
   file.replace:


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the following command `>=2.5.4` is treated as output redirection instead of the intended version constraint for `pip`:

https://github.com/hortonworks/cloudbreak/blob/98c5c269d2a14122f616326d8d969a9d0bde5a43/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/init.sls#L11

The result:

```
$ cat /root/\=2.5.4
Collecting psycopg2
  Downloading https://files.pythonhosted.org/packages/51/89/7490c48abf2ea89b65140c3c77023f7ea623031389a8e0cd0788c1625b06/psycopg2-2.7.7-cp27-cp27mu-manylinux1_x86_64.whl (2.7MB)
Installing collected packages: psycopg2
  Found existing installation: psycopg2 2.5.1
    Uninstalling psycopg2-2.5.1:
      Successfully uninstalled psycopg2-2.5.1
Successfully installed psycopg2-2.7.7
```

## How was this patch tested?

Ran `pip install --upgrade "psycopg2>=2.5.4"` manually to verify that `pip` gets the version number.