### PR TITLE
CB-29 Implement multi-delete API for recipes

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/recipes/RecipeV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/recipes/RecipeV4Endpoint.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.api.endpoint.v4.recipes;
 
+import java.util.Set;
+
 import javax.validation.Valid;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -13,6 +15,7 @@ import javax.ws.rs.core.MediaType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.recipes.requests.RecipeV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.recipes.responses.RecipeV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.recipes.responses.RecipeV4Responses;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.recipes.responses.RecipeViewV4Responses;
 import com.sequenceiq.cloudbreak.doc.ContentType;
 import com.sequenceiq.cloudbreak.doc.ControllerDescription;
 import com.sequenceiq.cloudbreak.doc.Notes;
@@ -31,7 +34,7 @@ public interface RecipeV4Endpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = RecipeOpDescription.LIST_BY_WORKSPACE, produces = ContentType.JSON, notes = Notes.RECIPE_NOTES,
             nickname = "listRecipesByWorkspace")
-    RecipeV4Responses list(@PathParam("workspaceId") Long workspaceId);
+    RecipeViewV4Responses list(@PathParam("workspaceId") Long workspaceId);
 
     @GET
     @Path("{name}")
@@ -53,6 +56,13 @@ public interface RecipeV4Endpoint {
     @ApiOperation(value = RecipeOpDescription.DELETE_BY_NAME_IN_WORKSPACE, produces = ContentType.JSON, notes = Notes.RECIPE_NOTES,
             nickname = "deleteRecipeInWorkspace")
     RecipeV4Response delete(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name);
+
+    @DELETE
+    @Path("")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = RecipeOpDescription.DELETE_MULTIPLE_BY_NAME_IN_WORKSPACE, produces = ContentType.JSON,
+            notes = Notes.RECIPE_NOTES, nickname = "deleteRecipesInWorkspace")
+    RecipeV4Responses deleteMultiple(@PathParam("workspaceId") Long workspaceId, Set<String> names);
 
     @GET
     @Path("{name}/request")

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/recipes/responses/RecipeViewV4Responses.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/recipes/responses/RecipeViewV4Responses.java
@@ -8,12 +8,12 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.common.responses.GeneralCollect
 import io.swagger.annotations.ApiModel;
 
 @ApiModel
-public class RecipeV4Responses extends GeneralCollectionV4Response<RecipeV4Response> {
-    public RecipeV4Responses(Set<RecipeV4Response> responses) {
+public class RecipeViewV4Responses extends GeneralCollectionV4Response<RecipeViewV4Response> {
+    public RecipeViewV4Responses(Set<RecipeViewV4Response> responses) {
         super(responses);
     }
 
-    public RecipeV4Responses() {
+    public RecipeViewV4Responses() {
         super(Sets.newHashSet());
     }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
@@ -93,6 +93,7 @@ public class OperationDescriptions {
         public static final String GET_BY_NAME_IN_WORKSPACE = "get recipe by name in workspace";
         public static final String CREATE_IN_WORKSPACE = "create recipe in workspace";
         public static final String DELETE_BY_NAME_IN_WORKSPACE = "delete recipe by name in workspace";
+        public static final String DELETE_MULTIPLE_BY_NAME_IN_WORKSPACE = "delete multiple recipes by name in workspace";
     }
 
     public static class WorkspaceOpDescription {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/RecipesV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/RecipesV4Controller.java
@@ -13,6 +13,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.recipes.requests.RecipeV4Reques
 import com.sequenceiq.cloudbreak.api.endpoint.v4.recipes.responses.RecipeV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.recipes.responses.RecipeV4Responses;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.recipes.responses.RecipeViewV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.recipes.responses.RecipeViewV4Responses;
 import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
 import com.sequenceiq.cloudbreak.common.type.ResourceEvent;
 import com.sequenceiq.cloudbreak.domain.Recipe;
@@ -32,9 +33,9 @@ public class RecipesV4Controller extends NotificationController implements Recip
     private ConverterUtil converterUtil;
 
     @Override
-    public RecipeV4Responses list(Long workspaceId) {
+    public RecipeViewV4Responses list(Long workspaceId) {
         Set<RecipeView> allViewByWorkspaceId = recipeService.findAllViewByWorkspaceId(workspaceId);
-        return new RecipeV4Responses(converterUtil.convertAllAsSet(allViewByWorkspaceId, RecipeViewV4Response.class));
+        return new RecipeViewV4Responses(converterUtil.convertAllAsSet(allViewByWorkspaceId, RecipeViewV4Response.class));
     }
 
     @Override
@@ -55,6 +56,13 @@ public class RecipesV4Controller extends NotificationController implements Recip
         Recipe deleted = recipeService.deleteByNameFromWorkspace(name, workspaceId);
         notify(ResourceEvent.RECIPE_DELETED);
         return converterUtil.convert(deleted, RecipeV4Response.class);
+    }
+
+    @Override
+    public RecipeV4Responses deleteMultiple(Long workspaceId, Set<String> names) {
+        Set<Recipe> deleted = recipeService.deleteMultipleByNameFromWorkspace(names, workspaceId);
+        notify(ResourceEvent.RECIPE_DELETED);
+        return new RecipeV4Responses(converterUtil.convertAllAsSet(deleted, RecipeV4Response.class));
     }
 
     @Override


### PR DESCRIPTION
The v4 recipe API is updated with a new endpoint for deleting multiple
recipes at once. The endpoint is called with a DELETE HTTP method, and
the body of the method is a JSON list of the names of the recipes to
delete.

The existing RecipeV4Responses class is reworked to store a collection
of RecipeV4Response objects, and the new RecipeViewV4Responses class
takes its place.