### PR TITLE
CB-722 Prevent creating multiple flow logs for the same state

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/flowlog/FlowLogService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/flowlog/FlowLogService.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.service.flowlog;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.Queue;
 
 import javax.inject.Inject;
@@ -81,7 +82,7 @@ public class FlowLogService {
     private FlowLog finalize(Long stackId, String flowId, String state) throws TransactionExecutionException {
         return transactionService.required(() -> {
             flowLogRepository.finalizeByFlowId(flowId);
-            updateLastFlowLogStatus(flowId, false);
+            updateLastFlowLogStatus(getLastFlowLog(flowId), false);
             FlowLog flowLog = new FlowLog(stackId, flowId, state, Boolean.TRUE, StateStatus.SUCCESSFUL);
             flowLog.setCloudbreakNodeId(cloudbreakNodeConfig.getId());
             return flowLogRepository.save(flowLog);
@@ -94,9 +95,27 @@ public class FlowLogService {
         flowChainLogRepository.save(chainLog);
     }
 
-    public void updateLastFlowLogStatus(String flowId, boolean failureEvent) {
+    public void updateLastFlowLogStatus(FlowLog lastFlowLog, boolean failureEvent) {
         StateStatus stateStatus = failureEvent ? StateStatus.FAILED : StateStatus.SUCCESSFUL;
-        FlowLog lastFlowLog = flowLogRepository.findFirstByFlowIdOrderByCreatedDesc(flowId);
         flowLogRepository.updateLastLogStatusInFlow(lastFlowLog.getId(), stateStatus);
+    }
+
+    public boolean repeatedFlowState(FlowLog lastFlowLog, String event) {
+        return lastFlowLog.getNextEvent().equalsIgnoreCase(event);
+    }
+
+    public void updateLastFlowLogPayload(FlowLog lastFlowLog, Payload payload, Map<Object, Object> variables) {
+        String payloadJson = JsonWriter.objectToJson(payload, writeOptions);
+        String variablesJson = JsonWriter.objectToJson(variables, writeOptions);
+        Optional.ofNullable(lastFlowLog)
+                .ifPresent(flowLog -> {
+                    flowLog.setPayload(payloadJson);
+                    flowLog.setVariables(variablesJson);
+                    flowLogRepository.save(flowLog);
+                });
+    }
+
+    public FlowLog getLastFlowLog(String flowId) {
+        return flowLogRepository.findFirstByFlowIdOrderByCreatedDesc(flowId);
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/Flow2HandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/Flow2HandlerTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -198,8 +199,8 @@ public class Flow2HandlerTest {
         event.setKey("KEY");
         underTest.accept(event);
         verify(flowConfigurationMap, times(1)).get(anyString());
-        verify(runningFlows, times(0)).put(any(Flow.class), isNull(String.class));
-        verify(flowLogService, times(0)).save(anyString(), anyString(), anyString(), any(Payload.class), anyMap(), any(), any(FlowState.class));
+        verify(runningFlows, never()).put(any(Flow.class), isNull(String.class));
+        verify(flowLogService, never()).save(anyString(), anyString(), anyString(), any(Payload.class), anyMap(), any(), any(FlowState.class));
     }
 
     @Test
@@ -216,12 +217,33 @@ public class Flow2HandlerTest {
     }
 
     @Test
+    public void testExistingFlowRepeatedState() {
+        BDDMockito.<FlowConfiguration<?>>given(flowConfigurationMap.get(any())).willReturn(flowConfig);
+        given(runningFlows.get(anyString())).willReturn(flow);
+        given(flow.getCurrentState()).willReturn(flowState);
+        given(flow.getFlowId()).willReturn(FLOW_ID);
+
+        Map<Object, Object> variables = Map.of("repeated", 2);
+        given(flow.getVariables()).willReturn(variables);
+
+        FlowLog lastFlowLog = new FlowLog();
+        lastFlowLog.setNextEvent("KEY");
+        given(flowLogService.getLastFlowLog(FLOW_ID)).willReturn(lastFlowLog);
+        given(flowLogService.repeatedFlowState(lastFlowLog, "KEY")).willReturn(true);
+        dummyEvent.setKey("KEY");
+        underTest.accept(dummyEvent);
+        verify(flowLogService, times(1))
+                .updateLastFlowLogPayload(lastFlowLog, payload, variables);
+        verify(flow, times(1)).sendEvent(eq("KEY"), any());
+    }
+
+    @Test
     public void testExistingFlowNotFound() {
         BDDMockito.<FlowConfiguration<?>>given(flowConfigurationMap.get(any())).willReturn(flowConfig);
         dummyEvent.setKey("KEY");
         underTest.accept(dummyEvent);
-        verify(flowLogService, times(0)).save(anyString(), anyString(), anyString(), any(Payload.class), anyMap(), any(), any(FlowState.class));
-        verify(flow, times(0)).sendEvent(anyString(), any());
+        verify(flowLogService, never()).save(anyString(), anyString(), anyString(), any(Payload.class), anyMap(), any(), any(FlowState.class));
+        verify(flow, never()).sendEvent(anyString(), any());
     }
 
     @Test
@@ -231,10 +253,10 @@ public class Flow2HandlerTest {
         underTest.accept(dummyEvent);
         verify(flowLogService, times(1)).close(anyLong(), eq(FLOW_ID));
         verify(runningFlows, times(1)).remove(eq(FLOW_ID));
-        verify(runningFlows, times(0)).get(eq(FLOW_ID));
-        verify(runningFlows, times(0)).put(any(Flow.class), isNull(String.class));
-        verify(flowChains, times(0)).removeFlowChain(anyString());
-        verify(flowChains, times(0)).triggerNextFlow(anyString());
+        verify(runningFlows, never()).get(eq(FLOW_ID));
+        verify(runningFlows, never()).put(any(Flow.class), isNull(String.class));
+        verify(flowChains, never()).removeFlowChain(anyString());
+        verify(flowChains, never()).triggerNextFlow(anyString());
     }
 
     @Test
@@ -245,9 +267,9 @@ public class Flow2HandlerTest {
         underTest.accept(dummyEvent);
         verify(flowLogService, times(1)).close(anyLong(), eq(FLOW_ID));
         verify(runningFlows, times(1)).remove(eq(FLOW_ID));
-        verify(runningFlows, times(0)).get(eq(FLOW_ID));
-        verify(runningFlows, times(0)).put(any(Flow.class), isNull(String.class));
-        verify(flowChains, times(0)).removeFlowChain(anyString());
+        verify(runningFlows, never()).get(eq(FLOW_ID));
+        verify(runningFlows, never()).put(any(Flow.class), isNull(String.class));
+        verify(flowChains, never()).removeFlowChain(anyString());
         verify(flowChains, times(1)).triggerNextFlow(eq(FLOW_CHAIN_ID));
     }
 
@@ -260,10 +282,10 @@ public class Flow2HandlerTest {
         underTest.accept(dummyEvent);
         verify(flowLogService, times(1)).close(anyLong(), eq(FLOW_ID));
         verify(runningFlows, times(1)).remove(eq(FLOW_ID));
-        verify(runningFlows, times(0)).get(eq(FLOW_ID));
-        verify(runningFlows, times(0)).put(any(Flow.class), isNull(String.class));
-        verify(flowChains, times(0)).removeFullFlowChain(anyString());
-        verify(flowChains, times(0)).triggerNextFlow(anyString());
+        verify(runningFlows, never()).get(eq(FLOW_ID));
+        verify(runningFlows, never()).put(any(Flow.class), isNull(String.class));
+        verify(flowChains, never()).removeFullFlowChain(anyString());
+        verify(flowChains, never()).triggerNextFlow(anyString());
     }
 
     @Test
@@ -276,10 +298,10 @@ public class Flow2HandlerTest {
         underTest.accept(dummyEvent);
         verify(flowLogService, times(1)).close(anyLong(), eq(FLOW_ID));
         verify(runningFlows, times(1)).remove(eq(FLOW_ID));
-        verify(runningFlows, times(0)).get(eq(FLOW_ID));
-        verify(runningFlows, times(0)).put(any(Flow.class), isNull(String.class));
+        verify(runningFlows, never()).get(eq(FLOW_ID));
+        verify(runningFlows, never()).put(any(Flow.class), isNull(String.class));
         verify(flowChains, times(1)).removeFullFlowChain(anyString());
-        verify(flowChains, times(0)).triggerNextFlow(anyString());
+        verify(flowChains, never()).triggerNextFlow(anyString());
     }
 
     @Test
@@ -325,7 +347,7 @@ public class Flow2HandlerTest {
         ArgumentCaptor<Payload> payloadCaptor = ArgumentCaptor.forClass(Payload.class);
 
         verify(flowChainHandler, times(1)).restoreFlowChain(FLOW_CHAIN_ID);
-        verify(flowLogService, times(0)).terminate(STACK_ID, FLOW_ID);
+        verify(flowLogService, never()).terminate(STACK_ID, FLOW_ID);
         verify(defaultRestartAction, times(1)).restart(eq(FLOW_ID), eq(FLOW_CHAIN_ID), eq(NEXT_EVENT), payloadCaptor.capture());
 
         Payload captorValue = payloadCaptor.getValue();
@@ -352,7 +374,7 @@ public class Flow2HandlerTest {
 
         verify(flowChainHandler, times(1)).restoreFlowChain(FLOW_CHAIN_ID);
         verify(flowLogService, times(1)).terminate(STACK_ID, FLOW_ID);
-        verify(defaultRestartAction, times(0)).restart(any(), any(), any(), any());
+        verify(defaultRestartAction, never()).restart(any(), any(), any(), any());
     }
 
     @Test
@@ -373,9 +395,9 @@ public class Flow2HandlerTest {
 
         underTest.restartFlow(FLOW_ID);
 
-        verify(flowChainHandler, times(0)).restoreFlowChain(FLOW_CHAIN_ID);
+        verify(flowChainHandler, never()).restoreFlowChain(FLOW_CHAIN_ID);
         verify(flowLogService, times(1)).terminate(STACK_ID, FLOW_ID);
-        verify(defaultRestartAction, times(0)).restart(any(), any(), any(), any());
+        verify(defaultRestartAction, never()).restart(any(), any(), any(), any());
     }
 
     private FlowLog createFlowLog(String flowChainId) {


### PR DESCRIPTION
The IMAGE_CHECK_STATE is a repeatable event. For every repetition the flow handler created a new flow log entry with the same nextState value. This prevented postgres to make use of indexes on the table because of the multiple identical records.

From now on, the flow handler will check if the last flow log has the same state as the next one, and if it does, then it will only update its payload and variable columns.