### PR TITLE
CB-688. README additions for Linux development.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,14 @@ As of now this document is focusing on setting up your development environment o
 
 As a prerequisite you need to have Java 10 installed. You can get it from [here](https://jdk.java.net/10/).
 
-You'll need [Docker for mac](https://docs.docker.com/docker-for-mac/install/) too.
+You'll need Docker. For Mac, use [Docker for mac](https://docs.docker.com/docker-for-mac/install/).
+
+## Obtaining the Docker Bridge Address (Linux Only)
+
+The Docker bridge can be found by listing the networks docker is aware of and inspecting the docker default, which for me is "bridge."
+You can find that by running `docker inspect bridge` and looking under the section "Gateway." It's possible that your setup is 
+different and "bridge" may not be the docker network that is being used in your setup. At this point, I would look at your Linux's
+network devices and verify.
 
 ## Cloudbreak Deployer
 
@@ -81,6 +88,17 @@ If everything went well then Cloudbreak will be available on http://localhost. F
 
 The deployer has generated a `certs` directory under `cbd-local` directory which will be needed later on to set up IDEA properly.
 
+### Linux differences and obtaining the docker bridge address
+
+The profile section needs two extra configuration options:
+
+```
+export PUBLIC_IP=127.0.0.1
+export CB_LOCAL_DEV_BIND_ADDR=<DOCKER_BRIDGE_ADDRESS>
+```
+
+As cbd is unable to determine these automatically. Please refer to the section above for determining the docker bridge address.
+
 ## IDEA
 
 ### Check out the Cloudbreak repository
@@ -117,12 +135,11 @@ IntelliJ IDEA -> Preferences -> Editor -> Inspections -> Settings icon -> Import
 
 ### Running cloudbreak in IDEA
 
-
 To launch the Cloudbreak application execute the `com.sequenceiq.cloudbreak.CloudbreakApplication` class  (Set 'Use classpath of module' to `core_main`) with the following VM options:
 ```
 -Dcb.client.id=cloudbreak
 -Dcb.client.secret=CB_SECRET_GENERATED_BY_CBD
--Dcb.db.port.5432.tcp.addr=localhost
+-Dcb.db.port.5432.tcp.addr=<DB_ADDRESS>
 -Dcb.db.port.5432.tcp.port=5432
 -Dcb.identity.server.url=http://localhost:8089
 -Dspring.cloud.consul.host=YOUR_IP
@@ -131,6 +148,8 @@ To launch the Cloudbreak application execute the `com.sequenceiq.cloudbreak.Clou
 -Dvault.addr=localhost
 -Dvault.root.token=<TOKEN_FROM_PROFILE_FILE>
 ```
+
+The `-Dcb.db.port.5432.tcp.addr=<DB_ADDRESS>`, on Mac, should be set to `localhost`. On Linux, it should be set to the bridge address of Docker. Look above for information on how to retrieve that address.
 
 The `-Dcb.client.secret=CB_SECRET_GENERATED_BY_CBD` value has to be replaced with the value of UAA_DEFAULT_SECRET from the cdb-local/Profile file.
 The database migration scripts run automatically by Cloudbreak by default, this migration can be turned off with the `-Dcb.schema.migration.auto=false` VM option.
@@ -155,7 +174,7 @@ After having imported cloudbreak repo root you can launch Periscope application 
 -Dperiscope.client.id=periscope
 -Dperiscope.client.secret=PERISCOPE_SECRET_GENERATED_BY_CBD
 -Dperiscope.identity.server.url=http://localhost:8089
--Dperiscope.db.port.5432.tcp.addr=localhost
+-Dperiscope.db.port.5432.tcp.addr=<DB_ADDRESS>
 -Dperiscope.db.port.5432.tcp.port=5432
 -Dperiscope.cloudbreak.url=http://localhost:8080
 -Dserver.port=8085
@@ -163,6 +182,8 @@ After having imported cloudbreak repo root you can launch Periscope application 
 -Dvault.addr=localhost
 -Dvault.root.token=<TOKEN_FROM_PROFILE_FILE>
 ````
+
+The `-Dcb.db.port.5432.tcp.addr=<DB_ADDRESS>`, on Mac, should be set to `localhost`. On Linux, it should be set to the bridge address of Docker. Look above for information on how to retrieve that address.
 
 The -Dperiscope.client.secret=PERISCOPE_SECRET_GENERATED_BY_CBD value has to be replaced with the value of UAA_DEFAULT_SECRET from the cdb-local/Profile file.
 
@@ -184,7 +205,7 @@ To run Cloudbreak from command line, you have to list the JVM parameters from ab
 ```
 ./gradlew :core:buildInfo :core:bootRun -PjvmArgs="-Dcb.client.id=cloudbreak \
 -Dcb.client.secret=CB_SECRET_GENERATED_BY_CBD \
--Dcb.db.port.5432.tcp.addr=localhost \
+-Dcb.db.port.5432.tcp.addr=<DB_ADDRESS> \
 -Dcb.db.port.5432.tcp.port=5432 \
 -Dcb.identity.server.url=http://localhost:8089 \
 -Dcb.schema.scripts.location=$(pwd)/core/src/main/resources/schema
@@ -194,6 +215,8 @@ To run Cloudbreak from command line, you have to list the JVM parameters from ab
 -Dvault.root.token=<TOKEN_FROM_PROFILE_FILE>
 -Dspring.config.location=$(pwd)/cloud-common/src/main/resources/application.yml,$(pwd)/core/build/resources/main/application.properties"
 ```
+
+The `-Dcb.db.port.5432.tcp.addr=<DB_ADDRESS>`, on Mac, should be set to `localhost`. On Linux, it should be set to the bridge address of Docker. Look above for information on how to retrieve that address.
 
 The `-Dcb.client.secret=CB_SECRET_GENERATED_BY_CBD` value has to be replaced with the value of UAA_DEFAULT_SECRET from the cdb-local/Profile file.
 
@@ -206,7 +229,7 @@ To run periscope from command line you have to run the below gradle command with
 ./gradlew :autoscale:bootRun -PjvmArgs="-Dperiscope.client.id=periscope \
 -Dperiscope.client.secret=CB_SECRET_GENERATED_BY_CBD \
 -Dperiscope.identity.server.url=http://localhost:8089 \
--Dperiscope.db.port.5432.tcp.addr=localhost \
+-Dperiscope.db.port.5432.tcp.addr=<DB_ADDRESS> \
 -Dperiscope.db.port.5432.tcp.port=5432 \
 -Dperiscope.cloudbreak.url=http://localhost:8080 \
 -Dperiscope.schema.scripts.location=$(pwd)/autoscale/src/main/resources/schema
@@ -216,6 +239,8 @@ To run periscope from command line you have to run the below gradle command with
 -Dvault.root.token=<TOKEN_FROM_PROFILE_FILE>
 -Dspring.config.location=$(pwd)/autoscale/src/main/resources/application.yml,$(pwd)/autoscale/build/resources/main/application.properties"
 ```` 
+
+The `-Dcb.db.port.5432.tcp.addr=<DB_ADDRESS>`, on Mac, should be set to `localhost`. On Linux, it should be set to the bridge address of Docker. Look above for information on how to retrieve that address.
 
 The `-Dcb.client.secret=CB_SECRET_GENERATED_BY_CBD` value has to be replaced with the value of UAA_DEFAULT_SECRET from the cdb-local/Profile file.
 


### PR DESCRIPTION
Additions have been made to the README.md to clarify some things
necessary specific to Linux development.

Note: This is pretty minor -- a lot of the changes made recently have made it nicer to work on Linux, since the Mac experience and the Linux experience are closer together.