### PR TITLE
int test and e2e test fixes

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/IntegrationTestApp.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/IntegrationTestApp.java
@@ -70,7 +70,7 @@ public class IntegrationTestApp implements CommandLineRunner {
     @Value("${integrationtest.threadCount:2}")
     private int threadCount;
 
-    @Value("${integrationtest.parallel:METHODS}")
+    @Value("${integrationtest.parallel:FALSE}")
     private String parallel;
 
     @Inject

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/wait/WaitUtilForMultipleStatuses.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/newway/wait/WaitUtilForMultipleStatuses.java
@@ -20,9 +20,11 @@ import com.sequenceiq.it.cloudbreak.newway.CloudbreakClient;
 
 @Component
 public class WaitUtilForMultipleStatuses {
-    private static final Logger LOGGER = LoggerFactory.getLogger(WaitUtil.class);
 
-    private static final int MAX_RETRY = 360;
+    private static final Logger LOGGER = LoggerFactory.getLogger(WaitUtilForMultipleStatuses.class);
+
+    @Value("${integrationtest.testsuite.maxRetry:720}")
+    private int maxRetry;
 
     @Value("${integrationtest.testsuite.pollingInterval:1000}")
     private long pollingInterval;
@@ -87,7 +89,7 @@ public class WaitUtilForMultipleStatuses {
         Map<String, Status> currentStatuses = new HashMap<>();
 
         int retryCount = 0;
-        while (!checkStatuses(currentStatuses, desiredStatuses) && !checkFailedStatuses(currentStatuses) && retryCount < MAX_RETRY) {
+        while (!checkStatuses(currentStatuses, desiredStatuses) && !checkFailedStatuses(currentStatuses) && retryCount < maxRetry) {
             LOGGER.info("Waiting for status(es) {}, stack id: {}, current status(es) {} ...", desiredStatuses, stackName, currentStatuses);
 
             sleep();
@@ -119,7 +121,7 @@ public class WaitUtilForMultipleStatuses {
                 || checkNotExpectedDelete(currentStatuses, desiredStatuses)) {
             waitResult = WaitResult.FAILED;
             LOGGER.info("Desired status(es) are {} for {} but status(es) are {}", desiredStatuses, stackName, currentStatuses);
-        } else if (retryCount == MAX_RETRY) {
+        } else if (retryCount == maxRetry) {
             waitResult = WaitResult.TIMEOUT;
             LOGGER.info("Timeout: Desired tatus(es) are {} for {} but status(es) are {}", desiredStatuses, stackName, currentStatuses);
         } else {


### PR DESCRIPTION
- disabling parallel execution for integration tests
- increasing timeout for e2e tests