### PR TITLE
CB-597. Add Blueprints into CDH bp files.

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdh6-data-science.bp
+++ b/core/src/main/resources/defaults/blueprints/cdh6-data-science.bp
@@ -3,6 +3,10 @@
   "blueprint": {
     "cdhVersion": "6.1.1",
     "displayName": "datascience",
+    "Blueprints": {
+      "stack_name": "CDH",
+      "stack_version": "6.1.1"
+    },
     "services": [
       {
         "refName": "isilon",

--- a/core/src/main/resources/defaults/blueprints/cdh6-shared-services.bp
+++ b/core/src/main/resources/defaults/blueprints/cdh6-shared-services.bp
@@ -6,6 +6,10 @@
   "blueprint": {
     "cdhVersion": "6.1.1",
     "displayName": "datalake",
+    "Blueprints": {
+      "stack_name": "CDH",
+      "stack_version": "6.1.1"
+    },
     "services": [
       {
         "refName": "zookeeper",


### PR DESCRIPTION
The CLI will now properly display the stack name and stack version of
CDH cluster definitions.

Note: I'd appreciate any pointers to what tests I should add, and any other suggestions for this addition.