### PR TITLE
CB-723 Simplify get stacks for autoscale query

### DIFF
--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/projection/AutoscaleStack.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/projection/AutoscaleStack.java
@@ -1,0 +1,36 @@
+package com.sequenceiq.cloudbreak.domain.projection;
+
+import com.sequenceiq.cloudbreak.api.model.Status;
+import com.sequenceiq.cloudbreak.api.model.stack.instance.InstanceGroupType;
+import com.sequenceiq.cloudbreak.api.model.stack.instance.InstanceMetadataType;
+
+public interface AutoscaleStack {
+
+    Long getId();
+
+    String getName();
+
+    String getOwner();
+
+    Integer getGatewayPort();
+
+    Long getCreated();
+
+    Status getStackStatus();
+
+    String getCloudbreakAmbariUser();
+
+    String getCloudbreakAmbariPassword();
+
+    Status getClusterStatus();
+
+    InstanceGroupType getInstanceGroupType();
+
+    InstanceMetadataType getInstanceMetadataType();
+
+    String getPublicIp();
+
+    String getPrivateIp();
+
+    Boolean getUsePrivateIpToTls();
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/stack/AutoscaleStackToAutoscaleStackResponseJsonConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/stack/AutoscaleStackToAutoscaleStackResponseJsonConverter.java
@@ -6,18 +6,17 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.model.AutoscaleStackResponse;
 import com.sequenceiq.cloudbreak.converter.AbstractConversionServiceAwareConverter;
-import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.projection.AutoscaleStack;
 import com.sequenceiq.cloudbreak.service.GatewayConfigService;
 
 @Component
-public class StackToAutoscaleStackResponseJsonConverter extends AbstractConversionServiceAwareConverter<Stack, AutoscaleStackResponse> {
+public class AutoscaleStackToAutoscaleStackResponseJsonConverter extends AbstractConversionServiceAwareConverter<AutoscaleStack, AutoscaleStackResponse> {
 
     @Inject
     private GatewayConfigService gatewayConfigService;
 
     @Override
-    public AutoscaleStackResponse convert(Stack source) {
+    public AutoscaleStackResponse convert(AutoscaleStack source) {
         AutoscaleStackResponse result = new AutoscaleStackResponse();
         result.setStackId(source.getId());
         result.setName(source.getName());
@@ -25,15 +24,14 @@ public class StackToAutoscaleStackResponseJsonConverter extends AbstractConversi
         result.setAccount(source.getOwner());
         result.setGatewayPort(source.getGatewayPort());
         result.setCreated(source.getCreated());
-        result.setStatus(source.getStatus());
+        result.setStatus(source.getStackStatus());
 
-        if (source.getCluster() != null) {
-            Cluster cluster = source.getCluster();
+        if (source.getClusterStatus() != null) {
             String gatewayIp = gatewayConfigService.getPrimaryGatewayIp(source);
             result.setAmbariServerIp(gatewayIp);
-            result.setUserName(cluster.getCloudbreakAmbariUser());
-            result.setPassword(cluster.getCloudbreakAmbariPassword());
-            result.setClusterStatus(cluster.getStatus());
+            result.setUserName(source.getCloudbreakAmbariUser());
+            result.setPassword(source.getCloudbreakAmbariPassword());
+            result.setClusterStatus(source.getClusterStatus());
         }
         return result;
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/config/generator/OfflineStateGenerator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/config/generator/OfflineStateGenerator.java
@@ -62,6 +62,7 @@ import com.sequenceiq.cloudbreak.core.flow2.stack.upscale.StackUpscaleConfig;
 import com.sequenceiq.cloudbreak.domain.Credential;
 import com.sequenceiq.cloudbreak.domain.FlexSubscription;
 import com.sequenceiq.cloudbreak.domain.Network;
+import com.sequenceiq.cloudbreak.domain.projection.AutoscaleStack;
 import com.sequenceiq.cloudbreak.domain.workspace.Workspace;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.ha.CloudbreakNodeConfig;
@@ -346,7 +347,7 @@ public class OfflineStateGenerator {
         }
 
         @Override
-        public Set<Stack> findAliveOnes() {
+        public Set<AutoscaleStack> findAliveOnes() {
             return null;
         }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/GatewayConfigService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/GatewayConfigService.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import javax.inject.Inject;
 
@@ -9,9 +10,10 @@ import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.client.SaltClientConfig;
 import com.sequenceiq.cloudbreak.controller.exception.NotFoundException;
-import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.domain.SecurityConfig;
+import com.sequenceiq.cloudbreak.domain.projection.AutoscaleStack;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 
 @Service
@@ -43,6 +45,14 @@ public class GatewayConfigService {
     public String getPrimaryGatewayIp(Stack stack) {
         InstanceMetaData gatewayInstance = stack.getPrimaryGatewayInstance();
         return gatewayInstance == null ? null : getGatewayIp(stack, gatewayInstance);
+    }
+
+    public String getPrimaryGatewayIp(AutoscaleStack stack) {
+        String gatewayIP = Optional.ofNullable(stack.getPublicIp()).orElse(stack.getPrivateIp());
+        if (stack.getUsePrivateIpToTls()) {
+            gatewayIP = stack.getPrivateIp();
+        }
+        return gatewayIP;
     }
 
     public String getGatewayIp(Stack stack, InstanceMetaData gatewayInstance) {


### PR DESCRIPTION
Hibernate was slow to hydrate entities. Simplified the query to select only the necessary columns and records and created a projection interface for ease of use.