### PR TITLE
CB-750. Multiple deletion for various resources.

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/clustertemplate/ClusterTemplateV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/clustertemplate/ClusterTemplateV4Endpoint.java
@@ -15,12 +15,15 @@ import javax.ws.rs.core.MediaType;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.requests.ClusterTemplateV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.responses.ClusterTemplateV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.responses.ClusterTemplateV4Responses;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.responses.ClusterTemplateViewV4Responses;
 import com.sequenceiq.cloudbreak.doc.ControllerDescription;
 import com.sequenceiq.cloudbreak.doc.OperationDescriptions.ClusterTemplateOpDescription;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+
+import java.util.Set;
 
 @Path("/v4/{workspaceId}/cluster_templates")
 @Consumes(MediaType.APPLICATION_JSON)
@@ -53,4 +56,11 @@ public interface ClusterTemplateV4Endpoint {
     @ApiOperation(value = ClusterTemplateOpDescription.DELETE_BY_NAME_IN_WORKSPACE, produces = JSON, notes = CLUSTER_TEMPLATE_NOTES,
             nickname = "deleteClusterTemplateInWorkspace")
     ClusterTemplateV4Response delete(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name);
+
+    @DELETE
+    @Path("")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = ClusterTemplateOpDescription.DELETE_MULTIPLE_BY_NAME_IN_WORKSPACE, produces = JSON, notes = CLUSTER_TEMPLATE_NOTES,
+            nickname = "deleteClusterTemplatesInWorkspace")
+    ClusterTemplateV4Responses deleteMultiple(@PathParam("workspaceId") Long workspaceId, Set<String> names);
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/clustertemplate/responses/ClusterTemplateV4Responses.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/clustertemplate/responses/ClusterTemplateV4Responses.java
@@ -1,0 +1,20 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.responses;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.responses.GeneralCollectionV4Response;
+
+import io.swagger.annotations.ApiModel;
+
+@ApiModel
+public class ClusterTemplateV4Responses extends GeneralCollectionV4Response<ClusterTemplateV4Response> {
+
+    public ClusterTemplateV4Responses(Set<ClusterTemplateV4Response> responses) {
+        super(responses);
+    }
+
+    public ClusterTemplateV4Responses() {
+        super(new HashSet<>());
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/credentials/CredentialV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/credentials/CredentialV4Endpoint.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.api.endpoint.v4.credentials;
 
+import java.util.Set;
+
 import javax.validation.Valid;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -58,6 +60,13 @@ public interface CredentialV4Endpoint {
     @ApiOperation(value = CredentialOpDescription.DELETE_BY_NAME_IN_WORKSPACE, produces = ContentType.JSON, notes = Notes.CREDENTIAL_NOTES,
             nickname = "deleteCredentialInWorkspace", httpMethod = "DELETE")
     CredentialV4Response delete(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name);
+
+    @DELETE
+    @Path("")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = CredentialOpDescription.DELETE_MULTIPLE_BY_NAME_IN_WORKSPACE, produces = ContentType.JSON, notes = Notes.CREDENTIAL_NOTES,
+            nickname = "deleteCredentialsInWorkspace", httpMethod = "DELETE")
+    CredentialV4Responses deleteMultiple(@PathParam("workspaceId") Long workspaceId, Set<String> names);
 
     @PUT
     @Path("")

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/database/DatabaseV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/database/DatabaseV4Endpoint.java
@@ -28,6 +28,8 @@ import com.sequenceiq.cloudbreak.doc.OperationDescriptions.DatabaseOpDescription
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 
+import java.util.Set;
+
 @Path("/v4/{workspaceId}/databases")
 @Consumes(MediaType.APPLICATION_JSON)
 @Api(value = "/v4/{workspaceId}/databases", description = ControllerDescription.DATABASES_V4_DESCRIPTION, protocols = "http,https")
@@ -61,6 +63,13 @@ public interface DatabaseV4Endpoint {
     @ApiOperation(value = DatabaseOpDescription.DELETE_BY_NAME_IN_WORKSPACE, produces = ContentType.JSON, notes = Notes.DATABASE_NOTES,
             nickname = "deleteDatabaseInWorkspace")
     DatabaseV4Response delete(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name);
+
+    @DELETE
+    @Path("")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = DatabaseOpDescription.DELETE_MULTIPLE_BY_NAME_IN_WORKSPACE, produces = ContentType.JSON, notes = Notes.DATABASE_NOTES,
+            nickname = "deleteDatabasesInWorkspace")
+    DatabaseV4Responses deleteMultiple(@PathParam("workspaceId") Long workspaceId, Set<String> names);
 
     @GET
     @Path("{name}/request")

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/ImageCatalogV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/ImageCatalogV4Endpoint.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog;
 
 import static com.sequenceiq.cloudbreak.doc.Notes.IMAGE_CATALOG_NOTES;
 
+import java.util.Set;
+
 import javax.validation.Valid;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -60,6 +62,13 @@ public interface ImageCatalogV4Endpoint {
     @ApiOperation(value = ImageCatalogOpDescription.DELETE_BY_NAME_IN_WORKSPACE, produces = ContentType.JSON, notes = IMAGE_CATALOG_NOTES,
             nickname = "deleteImageCatalogInWorkspace")
     ImageCatalogV4Response delete(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name);
+
+    @DELETE
+    @Path("")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = ImageCatalogOpDescription.DELETE_MULTIPLE_BY_NAME_IN_WORKSPACE, produces = ContentType.JSON, notes = IMAGE_CATALOG_NOTES,
+            nickname = "deleteImageCatalogsInWorkspace")
+    ImageCatalogV4Responses deleteMultiple(@PathParam("workspaceId") Long workspaceId, Set<String> names);
 
     @PUT
     @Path("")

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/kerberos/KerberosConfigV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/kerberos/KerberosConfigV4Endpoint.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.api.endpoint.v4.kerberos;
 
+import java.util.Set;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
@@ -16,6 +18,7 @@ import javax.ws.rs.core.MediaType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.EnvironmentNames;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.kerberos.requests.KerberosV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.kerberos.responses.KerberosV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.kerberos.responses.KerberosV4Responses;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.kerberos.responses.KerberosViewV4Responses;
 import com.sequenceiq.cloudbreak.doc.ContentType;
 import com.sequenceiq.cloudbreak.doc.ControllerDescription;
@@ -58,6 +61,13 @@ public interface KerberosConfigV4Endpoint {
     @ApiOperation(value = KerberosOpDescription.DELETE_BY_NAME_IN_WORKSPACE, produces = ContentType.JSON,
             notes = Notes.KERBEROS_CONFIG_NOTES, nickname = "deleteKerberosConfigInWorkspace")
     KerberosV4Response delete(@PathParam("workspaceId") Long workspaceId,  @PathParam("name") String name);
+
+    @DELETE
+    @Path("")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = KerberosOpDescription.DELETE_MULTIPLE_BY_NAME_IN_WORKSPACE, produces = ContentType.JSON,
+            notes = Notes.KERBEROS_CONFIG_NOTES, nickname = "deleteKerberosConfigsInWorkspace")
+    KerberosV4Responses deleteMultiple(@PathParam("workspaceId") Long workspaceId, Set<String> names);
 
     @PUT
     @Path("{name}/attach")

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/kerberos/responses/KerberosV4Responses.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/kerberos/responses/KerberosV4Responses.java
@@ -1,0 +1,20 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.kerberos.responses;
+
+import java.util.Set;
+
+import com.google.common.collect.Sets;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.responses.GeneralCollectionV4Response;
+
+import io.swagger.annotations.ApiModel;
+
+@ApiModel
+public class KerberosV4Responses extends GeneralCollectionV4Response<KerberosV4Response> {
+
+    public KerberosV4Responses(Set<KerberosV4Response> responses) {
+        super(responses);
+    }
+
+    public KerberosV4Responses() {
+        super(Sets.newHashSet());
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/kubernetes/KubernetesV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/kubernetes/KubernetesV4Endpoint.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.api.endpoint.v4.kubernetes;
 
+import java.util.Set;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
@@ -65,6 +67,13 @@ public interface KubernetesV4Endpoint {
     @ApiOperation(value = KubernetesConfigOpDescription.DELETE_BY_NAME_IN_WORKSPACE, produces = ContentType.JSON, notes = Notes.KUBERNETESCONFIG_NOTES,
             nickname = "deleteKubernetesConfigInWorkspace")
     KubernetesV4Response delete(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name);
+
+    @DELETE
+    @Path("")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = KubernetesConfigOpDescription.DELETE_MULTIPLE_BY_NAME_IN_WORKSPACE, produces = ContentType.JSON, notes = Notes.KUBERNETESCONFIG_NOTES,
+            nickname = "deleteKubernetesConfigsInWorkspace")
+    KubernetesV4Responses deleteMultiple(@PathParam("workspaceId") Long workspaceId, Set<String> names);
 
     @PUT
     @Path("{name}/attach")

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/ldaps/LdapConfigV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/ldaps/LdapConfigV4Endpoint.java
@@ -27,6 +27,8 @@ import com.sequenceiq.cloudbreak.doc.OperationDescriptions.LdapConfigOpDescripti
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 
+import java.util.Set;
+
 @Path("/v4/{workspaceId}/ldaps")
 @Consumes(MediaType.APPLICATION_JSON)
 @Api(value = "/v4/{workspaceId}/ldaps", description = ControllerDescription.LDAP_V4_CONFIG_DESCRIPTION, protocols = "http,https")
@@ -58,8 +60,15 @@ public interface LdapConfigV4Endpoint {
     @Path("{name}")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = LdapConfigOpDescription.DELETE_BY_NAME_IN_WORKSPACE, produces = ContentType.JSON, notes = Notes.LDAP_CONFIG_NOTES,
-            nickname = "deleteLdapConfigsInWorkspace")
+            nickname = "deleteLdapConfigInWorkspace")
     LdapV4Response delete(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String ldapConfigName);
+
+    @DELETE
+    @Path("")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = LdapConfigOpDescription.DELETE_MULTIPLE_BY_NAME_IN_WORKSPACE, produces = ContentType.JSON, notes = Notes.LDAP_CONFIG_NOTES,
+            nickname = "deleteLdapConfigsInWorkspace")
+    LdapV4Responses deleteMultiple(@PathParam("workspaceId") Long workspaceId, Set<String> ldapConfigNames);
 
     @POST
     @Path("test")

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/mpacks/ManagementPackV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/mpacks/ManagementPackV4Endpoint.java
@@ -21,6 +21,8 @@ import com.sequenceiq.cloudbreak.doc.OperationDescriptions.ManagementPackOpDescr
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 
+import java.util.Set;
+
 @Path("/v4/{workspaceId}/mpacks")
 @Consumes(MediaType.APPLICATION_JSON)
 @Api(value = "/v4/{workspaceId}/mpacks", description = ControllerDescription.MANAGEMENT_PACK_V4_DESCRIPTION, protocols = "http,https")
@@ -53,4 +55,11 @@ public interface ManagementPackV4Endpoint {
     @ApiOperation(value = ManagementPackOpDescription.DELETE_BY_NAME_IN_WORKSPACE, produces = ContentType.JSON, notes = Notes.MANAGEMENT_PACK_NOTES,
             nickname = "deleteManagementPackInWorkspace")
     ManagementPackV4Response deleteInWorkspace(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name);
+
+    @DELETE
+    @Path("")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = ManagementPackOpDescription.DELETE_MULTIPLE_BY_NAME_IN_WORKSPACE, produces = ContentType.JSON, notes = Notes.MANAGEMENT_PACK_NOTES,
+            nickname = "deleteManagementPacksInWorkspace")
+    ManagementPackV4Responses deleteMultipleInWorkspace(@PathParam("workspaceId") Long workspaceId, Set<String> names);
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/proxies/ProxyV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/proxies/ProxyV4Endpoint.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.api.endpoint.v4.proxies;
 
+import java.util.Set;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
@@ -34,7 +36,7 @@ public interface ProxyV4Endpoint {
     @Path("")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = ProxyConfigOpDescription.LIST_BY_WORKSPACE, produces = ContentType.JSON, notes = Notes.PROXY_CONFIG_NOTES,
-            nickname = "listProxyconfigsByWorkspace")
+            nickname = "listProxyConfigsByWorkspace")
     ProxyV4Responses list(@PathParam("workspaceId") Long workspaceId, @QueryParam("environment") String environment,
             @QueryParam("attachGlobal") Boolean attachGlobal);
 
@@ -42,22 +44,29 @@ public interface ProxyV4Endpoint {
     @Path("{name}")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = ProxyConfigOpDescription.GET_BY_NAME_IN_WORKSPACE, produces = ContentType.JSON, notes = Notes.PROXY_CONFIG_NOTES,
-            nickname = "getProxyconfigInWorkspace")
+            nickname = "getProxyConfigInWorkspace")
     ProxyV4Response get(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name);
 
     @POST
     @Path("")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = ProxyConfigOpDescription.CREATE_IN_WORKSPACE, produces = ContentType.JSON, notes = Notes.PROXY_CONFIG_NOTES,
-            nickname = "createProxyconfigInWorkspace")
+            nickname = "createProxyConfigInWorkspace")
     ProxyV4Response post(@PathParam("workspaceId") Long workspaceId, @Valid ProxyV4Request request);
 
     @DELETE
     @Path("{name}")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = ProxyConfigOpDescription.DELETE_BY_NAME_IN_WORKSPACE, produces = ContentType.JSON, notes = Notes.PROXY_CONFIG_NOTES,
-            nickname = "deleteProxyconfigInWorkspace")
+            nickname = "deleteProxyConfigInWorkspace")
     ProxyV4Response delete(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name);
+
+    @DELETE
+    @Path("")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = ProxyConfigOpDescription.DELETE_MULTIPLE_BY_NAME_IN_WORKSPACE, produces = ContentType.JSON, notes = Notes.PROXY_CONFIG_NOTES,
+            nickname = "deleteProxyConfigsInWorkspace")
+    ProxyV4Responses deleteMultiple(@PathParam("workspaceId") Long workspaceId, Set<String> names);
 
     @PUT
     @Path("{name}/attach")

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
@@ -20,6 +20,7 @@ public class OperationDescriptions {
         public static final String GET_BY_NAME_IN_WORKSPACE = "get credential by name in workspace";
         public static final String CREATE_IN_WORKSPACE = "create credential in workspace";
         public static final String DELETE_BY_NAME_IN_WORKSPACE = "delete credential by name in workspace";
+        public static final String DELETE_MULTIPLE_BY_NAME_IN_WORKSPACE = "delete multiple credentials by name in workspace";
         public static final String GET_PREREQUISTIES_BY_CLOUD_PROVIDER = "get credential prerequisites for cloud platform";
     }
 
@@ -85,6 +86,7 @@ public class OperationDescriptions {
         public static final String GET_BY_NAME_IN_WORKSPACE = "get cluster template by name in workspace";
         public static final String CREATE_IN_WORKSPACE = "create cluster template in workspace";
         public static final String DELETE_BY_NAME_IN_WORKSPACE = "delete cluster template by name in workspace";
+        public static final String DELETE_MULTIPLE_BY_NAME_IN_WORKSPACE = "delete multiple cluster templates by name in workspace";
     }
 
     public static class RecipeOpDescription {
@@ -137,6 +139,7 @@ public class OperationDescriptions {
         public static final String GET_BY_NAME_IN_WORKSPACE = "get LDAP config by name in workspace";
         public static final String CREATE_IN_WORKSPACE = "create LDAP config in workspace";
         public static final String DELETE_BY_NAME_IN_WORKSPACE = "delete LDAP config by name in workspace";
+        public static final String DELETE_MULTIPLE_BY_NAME_IN_WORKSPACE = "delete multiple LDAP configs by name in workspace";
         public static final String ATTACH_TO_ENVIRONMENTS = "attach ldap resource to environemnts";
         public static final String DETACH_FROM_ENVIRONMENTS = "detach ldap resource from environemnts";
     }
@@ -161,6 +164,7 @@ public class OperationDescriptions {
         public static final String GET_BY_NAME_IN_WORKSPACE = "get RDS config by name in workspace";
         public static final String CREATE_IN_WORKSPACE = "create RDS config in workspace";
         public static final String DELETE_BY_NAME_IN_WORKSPACE = "delete RDS config by name in workspace";
+        public static final String DELETE_MULTIPLE_BY_NAME_IN_WORKSPACE = "delete multiple RDS configs by name in workspace";
         public static final String GET_REQUEST_IN_WORKSPACE = "get request in workspace";
         public static final String ATTACH_TO_ENVIRONMENTS = "attach RDS resource to environemnts";
         public static final String DETACH_FROM_ENVIRONMENTS = "detach RDS resource from environemnts";
@@ -171,6 +175,7 @@ public class OperationDescriptions {
         public static final String GET_BY_NAME_IN_WORKSPACE = "get proxy configuration by name in workspace";
         public static final String CREATE_IN_WORKSPACE = "create proxy configuration in workspace";
         public static final String DELETE_BY_NAME_IN_WORKSPACE = "delete proxy configuration by name in workspace";
+        public static final String DELETE_MULTIPLE_BY_NAME_IN_WORKSPACE = "delete multiple proxy configurations by name in workspace";
         public static final String ATTACH_TO_ENVIRONMENTS = "attach proxy resource to environemnts";
         public static final String DETACH_FROM_ENVIRONMENTS = "detach proxy resource from environemnts";
         public static final String GET_REQUEST_BY_NAME = "get request by name";
@@ -191,6 +196,7 @@ public class OperationDescriptions {
         public static final String GET_BY_NAME_IN_WORKSPACE = "get management pack by name in workspace";
         public static final String CREATE_IN_WORKSPACE = "create management pack in workspace";
         public static final String DELETE_BY_NAME_IN_WORKSPACE = "delete management pack by name in workspace";
+        public static final String DELETE_MULTIPLE_BY_NAME_IN_WORKSPACE = "delete multiple management packs by name in workspace";
     }
 
     public static class KubernetesConfigOpDescription {
@@ -199,6 +205,7 @@ public class OperationDescriptions {
         public static final String CREATE_IN_WORKSPACE = "create Kubernetes config in workspace";
         public static final String PUT_IN_WORKSPACE = "modify Kubernetes config in workspace";
         public static final String DELETE_BY_NAME_IN_WORKSPACE = "delete Kubernetes config by name in workspace";
+        public static final String DELETE_MULTIPLE_BY_NAME_IN_WORKSPACE = "delete multiple Kubernetes configs by name in workspace";
         public static final String ATTACH_TO_ENVIRONMENTS = "attach Kubernetes resource to environemnts";
         public static final String DETACH_FROM_ENVIRONMENTS = "detach Kubernetes resource from environemnts";
     }
@@ -233,6 +240,7 @@ public class OperationDescriptions {
         public static final String GET_BY_NAME_IN_WORKSPACE = "get image catalog by name in workspace";
         public static final String CREATE_IN_WORKSPACE = "create image catalog in workspace";
         public static final String DELETE_BY_NAME_IN_WORKSPACE = "delete image catalog by name in workspace";
+        public static final String DELETE_MULTIPLE_BY_NAME_IN_WORKSPACE = "delete multiple image catalogs by name in workspace";
     }
 
     public static class SecurityRuleOpDescription {
@@ -267,6 +275,7 @@ public class OperationDescriptions {
         public static final String GET_BY_NAME_IN_WORKSPACE = "get kerberos config by name in workspace";
         public static final String CREATE_IN_WORKSPACE = "create kerberos config in workspace";
         public static final String DELETE_BY_NAME_IN_WORKSPACE = "delete kerberos config by name in workspace";
+        public static final String DELETE_MULTIPLE_BY_NAME_IN_WORKSPACE = "delete multiple kerberos configs by name in workspace";
         public static final String ATTACH_TO_ENVIRONMENTS = "attach kerberos config to environemnts";
         public static final String DETACH_FROM_ENVIRONMENTS = "detach kerberos config from environemnts";
         public static final String GET_REQUEST = "get request by name";

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/ClusterTemplateV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/ClusterTemplateV4Controller.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Controller;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.ClusterTemplateV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.requests.ClusterTemplateV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.responses.ClusterTemplateV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.responses.ClusterTemplateV4Responses;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.responses.ClusterTemplateViewV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.responses.ClusterTemplateViewV4Responses;
 import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
@@ -77,5 +78,11 @@ public class ClusterTemplateV4Controller extends NotificationController implemen
     public ClusterTemplateV4Response delete(Long workspaceId, String name) {
         ClusterTemplate clusterTemplate = clusterTemplateService.delete(name, workspaceId);
         return converterUtil.convert(clusterTemplate, ClusterTemplateV4Response.class);
+    }
+
+    @Override
+    public ClusterTemplateV4Responses deleteMultiple(Long workspaceId, Set<String> names) {
+        Set<ClusterTemplate> clusterTemplates = clusterTemplateService.deleteMultipleByNameFromWorkspace(names, workspaceId);
+        return new ClusterTemplateV4Responses(converterUtil.convertAllAsSet(clusterTemplates, ClusterTemplateV4Response.class));
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/CredentialV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/CredentialV4Controller.java
@@ -60,6 +60,13 @@ public class CredentialV4Controller extends NotificationController implements Cr
     }
 
     @Override
+    public CredentialV4Responses deleteMultiple(Long workspaceId, Set<String> names) {
+        Set<Credential> deleted = credentialService.deleteMultipleByNameFromWorkspace(names, workspaceId);
+        notify(ResourceEvent.CREDENTIAL_DELETED);
+        return new CredentialV4Responses(converterUtil.convertAllAsSet(deleted, CredentialV4Response.class));
+    }
+
+    @Override
     public CredentialV4Response put(Long workspaceId, CredentialV4Request credentialRequest) {
         return converterUtil.convert(credentialService.updateByWorkspaceId(
                 workspaceId, converterUtil.convert(credentialRequest, Credential.class)), CredentialV4Response.class);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/DatabaseV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/DatabaseV4Controller.java
@@ -59,6 +59,13 @@ public class DatabaseV4Controller extends NotificationController implements Data
     }
 
     @Override
+    public DatabaseV4Responses deleteMultiple(Long workspaceId, Set<String> names) {
+        Set<RDSConfig> deleted = databaseService.deleteMultipleByNameFromWorkspace(names, workspaceId);
+        notify(ResourceEvent.LDAP_DELETED);
+        return new DatabaseV4Responses(converterUtil.convertAllAsSet(deleted, DatabaseV4Response.class));
+    }
+
+    @Override
     public DatabaseTestV4Response test(Long workspaceId, DatabaseTestV4Request databaseTestV4Request) {
         RDSConfig rdsConfig = converterUtil.convert(databaseTestV4Request.getDatabase(), RDSConfig.class);
         String connectionResult = databaseService.testRdsConnection(workspaceId, databaseTestV4Request.getExistingDatabaseName(), rdsConfig);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/ImageCatalogV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/ImageCatalogV4Controller.java
@@ -64,6 +64,13 @@ public class ImageCatalogV4Controller extends NotificationController implements 
     }
 
     @Override
+    public ImageCatalogV4Responses deleteMultiple(Long workspaceId, Set<String> names) {
+        Set<ImageCatalog> deleted = imageCatalogService.deleteMultiple(workspaceId, names);
+        notify(ResourceEvent.IMAGE_CATALOG_DELETED);
+        return new ImageCatalogV4Responses(converterUtil.convertAllAsSet(deleted, ImageCatalogV4Response.class));
+    }
+
+    @Override
     public ImageCatalogV4Response update(Long workspaceId, UpdateImageCatalogV4Request request) {
         ImageCatalog imageCatalog = imageCatalogService.update(workspaceId, converterUtil.convert(request, ImageCatalog.class));
         return converterUtil.convert(imageCatalog, ImageCatalogV4Response.class);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/KerberosConfigV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/KerberosConfigV4Controller.java
@@ -13,6 +13,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.common.EnvironmentNames;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.kerberos.KerberosConfigV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.kerberos.requests.KerberosV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.kerberos.responses.KerberosV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.kerberos.responses.KerberosV4Responses;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.kerberos.responses.KerberosViewV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.kerberos.responses.KerberosViewV4Responses;
 import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
@@ -55,6 +56,12 @@ public class KerberosConfigV4Controller extends NotificationController implement
     public KerberosV4Response delete(Long workspaceId, String name) {
         KerberosConfig deleted = kerberosService.deleteByNameFromWorkspace(name, workspaceId);
         return converterUtil.convert(deleted, KerberosV4Response.class);
+    }
+
+    @Override
+    public KerberosV4Responses deleteMultiple(Long workspaceId, Set<String> names) {
+        Set<KerberosConfig> deleted = kerberosService.deleteMultipleByNameFromWorkspace(names, workspaceId);
+        return new KerberosV4Responses(converterUtil.convertAllAsSet(deleted, KerberosV4Response.class));
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/KubernetesV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/KubernetesV4Controller.java
@@ -67,6 +67,13 @@ public class KubernetesV4Controller extends NotificationController implements Ku
     }
 
     @Override
+    public KubernetesV4Responses deleteMultiple(Long workspaceId, Set<String> names) {
+        Set<KubernetesConfig> deleted = kubernetesConfigService.deleteMultipleByNameFromWorkspace(names, workspaceId);
+        notify(ResourceEvent.KUBERNETES_CONFIG_DELETED);
+        return new KubernetesV4Responses(converterUtil.convertAllAsSet(deleted, KubernetesV4Response.class));
+    }
+
+    @Override
     public KubernetesV4Response attach(Long workspaceId, String name, EnvironmentNames environmentNames) {
         return kubernetesConfigService.attachToEnvironmentsAndConvert(name, environmentNames.getEnvironmentNames(), workspaceId, KubernetesV4Response.class);
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/LdapV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/LdapV4Controller.java
@@ -61,6 +61,13 @@ public class LdapV4Controller extends NotificationController implements LdapConf
     }
 
     @Override
+    public LdapV4Responses deleteMultiple(Long workspaceId, Set<String> names) {
+        Set<LdapConfig> deleted = ldapConfigService.deleteMultipleByNameFromWorkspace(names, workspaceId);
+        notify(ResourceEvent.LDAP_DELETED);
+        return new LdapV4Responses(converterUtil.convertAllAsSet(deleted, LdapV4Response.class));
+    }
+
+    @Override
     public LdapTestV4Response test(Long workspaceId, LdapTestV4Request ldapValidationRequest) {
         LdapTestV4Response ldapTestV4Response = new LdapTestV4Response();
         ldapTestV4Response.setResult(ldapConfigService.testConnection(workspaceId,

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/ManagementPackV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/ManagementPackV4Controller.java
@@ -18,6 +18,8 @@ import com.sequenceiq.cloudbreak.service.mpack.ManagementPackService;
 import com.sequenceiq.cloudbreak.service.user.UserService;
 import com.sequenceiq.cloudbreak.util.WorkspaceEntityType;
 
+import java.util.Set;
+
 @Controller
 @WorkspaceEntityType(ManagementPack.class)
 public class ManagementPackV4Controller extends NotificationController implements ManagementPackV4Endpoint {
@@ -59,5 +61,12 @@ public class ManagementPackV4Controller extends NotificationController implement
         ManagementPack deleted = mpackService.deleteByNameFromWorkspace(name, workspaceId);
         notify(ResourceEvent.MANAGEMENT_PACK_DELETED);
         return converterUtil.convert(deleted, ManagementPackV4Response.class);
+    }
+
+    @Override
+    public ManagementPackV4Responses deleteMultipleInWorkspace(Long workspaceId, Set<String> names) {
+        Set<ManagementPack> deleted = mpackService.deleteMultipleByNameFromWorkspace(names, workspaceId);
+        notify(ResourceEvent.MANAGEMENT_PACK_DELETED);
+        return new ManagementPackV4Responses(converterUtil.convertAllAsSet(deleted, ManagementPackV4Response.class));
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/ProxyV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/ProxyV4Controller.java
@@ -59,6 +59,13 @@ public class ProxyV4Controller extends NotificationController implements ProxyV4
     }
 
     @Override
+    public ProxyV4Responses deleteMultiple(Long workspaceId, Set<String> names) {
+        Set<ProxyConfig> deleted = proxyConfigService.deleteMultipleByNameFromWorkspace(names, workspaceId);
+        notify(ResourceEvent.PROXY_CONFIG_DELETED);
+        return new ProxyV4Responses(converterUtil.convertAllAsSet(deleted, ProxyV4Response.class));
+    }
+
+    @Override
     public ProxyV4Response attach(Long workspaceId, String name, EnvironmentNames environmentNames) {
         return proxyConfigService.attachToEnvironmentsAndConvert(name, environmentNames.getEnvironmentNames(),
                 workspaceId, ProxyV4Response.class);


### PR DESCRIPTION
Credentials, image catalog, Kerberos configurations, Kubernetes
configurations, proxy configurations, cluster templates, authentication,
database configurations, and management packs all have the ability to
delete multiple resources.

Note: I verified that the new endpoints show up in swagger.json, but I need to work on testing them more thoroughly.