### PR TITLE
CB-716 make Ums user cacheable

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
@@ -10,6 +10,7 @@ import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
@@ -29,6 +30,7 @@ public class GrpcUmsClient {
         return UUID.randomUUID().toString();
     }
 
+    @Cacheable(cacheNames = "umsUserCache")
     public UserManagementProto.User getUserDetails(String actorCrn, String userCrn) {
         try (ManagedChannelWrapper channelWrapper = new ManagedChannelWrapper(
                 ManagedChannelBuilder.forAddress(umsConfig.getEndpoint(), umsConfig.getPort())

--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/cache/common/UmsUserCache.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/cache/common/UmsUserCache.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.cloudbreak.cache.common;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class UmsUserCache extends AbstractCacheDefinition {
+
+    private static final long MAX_ENTRIES = 1000L;
+
+    private static final long TTL_IN_SECONDS = 5L;
+
+    @Override
+    protected String getName() {
+        return "umsUserCache";
+    }
+
+    @Override
+    protected long getMaxEntries() {
+        return MAX_ENTRIES;
+    }
+
+    @Override
+    protected long getTimeToLiveSeconds() {
+        return TTL_IN_SECONDS;
+    }
+}


### PR DESCRIPTION
- remote UMS was slow, user should be cacheable.
- same as caas user before