### PR TITLE
CB-99 exclude all transient dependencies from CB lib and use a global…

### DIFF
--- a/cluster-ambari/build.gradle
+++ b/cluster-ambari/build.gradle
@@ -10,7 +10,6 @@ repositories {
   maven { url "https://cloudbreak-maven.s3.amazonaws.com/releases" }
   maven { url "https://repo.spring.io/release" }
   maven { url "https://plugins.gradle.org/m2/" }
-  maven { url "https://repository.cloudera.com/artifactory/cloudera-repos" }
 }
 
 jar {

--- a/cluster-api/build.gradle
+++ b/cluster-api/build.gradle
@@ -10,7 +10,6 @@ repositories {
   maven { url "https://cloudbreak-maven.s3.amazonaws.com/releases" }
   maven { url "https://repo.spring.io/release" }
   maven { url "https://plugins.gradle.org/m2/" }
-  maven { url "https://repository.cloudera.com/artifactory/cloudera-repos" }
 }
 
 jar {

--- a/cluster-cm/build.gradle
+++ b/cluster-cm/build.gradle
@@ -10,7 +10,6 @@ repositories {
   maven { url "https://cloudbreak-maven.s3.amazonaws.com/releases" }
   maven { url "https://repo.spring.io/release" }
   maven { url "https://plugins.gradle.org/m2/" }
-  maven { url "https://repository.cloudera.com/artifactory/cloudera-repos" }
 }
 
 jar {
@@ -18,8 +17,8 @@ jar {
 }
 
 dependencies {
-  compile (group: 'com.cloudera.api.swagger',           name: 'cloudera-manager-api-swagger',version: '6.1.0') {
-    exclude group: 'com.squareup.okio', module: 'okio'
+  compile (group: 'com.cloudera.api',           name: 'cloudera-manager-api',version: cmClientVersion) {
+    transitive = false
   }
   compile project(':cluster-api')
   compile project(':template-manager-cmtemplate')

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -139,9 +139,6 @@ dependencyManagement {
     dependency group: 'org.springframework.security.oauth', name: 'spring-security-oauth2',      version: springOauthVersion
     dependency group: 'org.springframework',                name: 'spring-context-support',      version: springFrameworkVersion
 
-    dependency (group: 'com.cloudera.api.swagger',           name: 'cloudera-manager-api-swagger',version: '6.1.0') {
-        exclude 'com.squareup.okio:okio'
-    }
     dependency group: 'com.google.code.gson',               name: 'gson',                        version: '2.6.2'
     dependency group: 'org.codehaus.groovy',                name: 'groovy-all',                  version: '2.5.0'
     dependency group: 'org.freemarker',                     name: 'freemarker',                  version: freemarkerVersion

--- a/datalake/build.gradle
+++ b/datalake/build.gradle
@@ -15,7 +15,6 @@ repositories {
   maven { url "https://cloudbreak-maven.s3.amazonaws.com/releases" }
   maven { url "https://repo.spring.io/release" }
   maven { url "https://plugins.gradle.org/m2/" }
-  maven { url "https://repository.cloudera.com/artifactory/cloudera-repos" }
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,5 +31,6 @@ hadoopVersion=2.7.1
 mapstructVersion=1.2.0.Final
 postgreSQLVersion=42.2.1
 httpClientVersion=4.5.7
+cmClientVersion=6.1.0
 
 repoUrl=http://repo.hortonworks.com/content/repositories/releases/

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -97,7 +97,9 @@ dependencies {
     exclude group: "velocity"
   }
   compile group: 'com.google.code.findbugs',      name: 'annotations',                    version: '3.0.1'
-  compile group: 'com.cloudera.api.swagger',      name: 'cloudera-manager-api-swagger',   version: '6.1.0'
+  compile (group: 'com.cloudera.api',           name: 'cloudera-manager-api',version: cmClientVersion) {
+    transitive = false
+  }
   runtime group: 'com.google.inject',             name: 'guice',                          version: '3.0'
   runtime group: 'javax.xml.bind',                name: 'jaxb-api', version: '2.3.0'
 }

--- a/template-manager-cmtemplate/build.gradle
+++ b/template-manager-cmtemplate/build.gradle
@@ -14,7 +14,9 @@ dependencies {
   compile("com.sequenceiq:${ambariClientName}:${ambariClientVersion}") {
     exclude group: 'org.slf4j'
   }
-  compile (group: 'com.cloudera.api.swagger',           name: 'cloudera-manager-api-swagger',version: '6.1.0')
+  compile (group: 'com.cloudera.api',           name: 'cloudera-manager-api',version: cmClientVersion) {
+    transitive = false
+  }
   compile group: 'com.github.jknack',             name: 'handlebars',                     version: '4.0.6'
 
   compile project(':orchestrator-api')


### PR DESCRIPTION
I made this change as private builds does not have jars built with -swagger postfix so if we want to validate patches we would constantly rename the dependencies. This new dependency also uses the swagger as you can see I haven't changed any of the import path, but these jars are available for private and public builds also. 