### PR TITLE
NPE at AmbariClusterModificationService.getStatus

### DIFF
--- a/cluster-ambari/src/main/java/com/sequenceiq/cloudbreak/ambari/AmbariClusterModificationService.java
+++ b/cluster-ambari/src/main/java/com/sequenceiq/cloudbreak/ambari/AmbariClusterModificationService.java
@@ -104,6 +104,7 @@ public class AmbariClusterModificationService implements ClusterModificationServ
     @Inject
     private Retry retry;
 
+    @Inject
     private AmbariClusterStatusFactory clusterStatusFactory;
 
     @Inject


### PR DESCRIPTION
Fix NPE, which occurs at `AmbariClusterModificationService#getStatus` during cluster sync.