### PR TITLE
[CB-997] Cluster sync prevented by unsupported instance sync

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudInstance.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudInstance.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.cloud.model;
 
 import java.util.Map;
+import java.util.Objects;
 
 import com.sequenceiq.cloudbreak.cloud.model.generic.DynamicModel;
 
@@ -51,5 +52,26 @@ public class CloudInstance extends DynamicModel {
         sb.append(", authentication=").append(authentication);
         sb.append('}');
         return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        CloudInstance other = (CloudInstance) obj;
+        return Objects.equals(instanceId, other.instanceId)
+                && Objects.equals(template, other.template)
+                && Objects.equals(authentication, other.authentication)
+                && Objects.equals(getParameters(), other.getParameters());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getParameters(), instanceId, template, authentication);
     }
 }

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudVmInstanceStatus.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudVmInstanceStatus.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.cloud.model;
 
+import java.util.Objects;
+
 public class CloudVmInstanceStatus {
 
     private final CloudInstance cloudInstance;
@@ -37,5 +39,26 @@ public class CloudVmInstanceStatus {
                 + ", status=" + status
                 + ", statusReason='" + statusReason + '\''
                 + '}';
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        CloudVmInstanceStatus other = (CloudVmInstanceStatus) obj;
+
+        return Objects.equals(cloudInstance, other.cloudInstance)
+                && Objects.equals(status, other.status)
+                && Objects.equals(statusReason, other.statusReason);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), cloudInstance, status, statusReason);
     }
 }

--- a/cloud-cumulus-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/cumulus/yarn/CumulusYarnInstanceConnector.java
+++ b/cloud-cumulus-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/cumulus/yarn/CumulusYarnInstanceConnector.java
@@ -20,6 +20,7 @@ import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.cumulus.yarn.client.CumulusYarnClient;
 import com.sequenceiq.cloudbreak.cloud.cumulus.yarn.util.CumulusYarnContainerStatus;
 import com.sequenceiq.cloudbreak.cloud.cumulus.yarn.util.CumulusYarnResourceNameHelper;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudOperationNotSupportedException;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
@@ -60,7 +61,7 @@ public class CumulusYarnInstanceConnector implements InstanceConnector {
                             CumulusYarnContainerStatus.mapInstanceStatus(containerStateById.get(cloudInstance.getInstanceId()))))
                     .collect(Collectors.toList());
         } catch (ApiException e) {
-            throw new CloudOperationNotSupportedException("Couldn't get service state from Cumulus Yarn", e);
+            throw new CloudConnectorException("Couldn't get service state from Cumulus Yarn", e);
         }
     }
 

--- a/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/InstanceStateHandlerTest.java
+++ b/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/InstanceStateHandlerTest.java
@@ -1,0 +1,114 @@
+package com.sequenceiq.cloudbreak.cloud.handler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.sequenceiq.cloudbreak.cloud.event.resource.GetInstancesStateRequest;
+import com.sequenceiq.cloudbreak.cloud.event.resource.GetInstancesStateResult;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudOperationNotSupportedException;
+import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
+import com.sequenceiq.cloudbreak.cloud.model.CloudVmInstanceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
+
+import reactor.bus.Event;
+import reactor.bus.EventBus;
+
+public class InstanceStateHandlerTest {
+
+    @Mock
+    private InstanceStateQuery instanceStateQuery;
+
+    @Mock
+    private EventBus eventBus;
+
+    @InjectMocks
+    private InstanceStateHandler subject;
+
+    private Event<GetInstancesStateRequest> event;
+
+    private GetInstancesStateRequest<GetInstancesStateResult> request;
+
+    private List<CloudInstance> instances;
+
+    @Before
+    public void init() {
+        instances = Arrays.asList(
+                new CloudInstance("host1", null, null),
+                new CloudInstance("host2", null, null)
+        );
+        request = new GetInstancesStateRequest<>(null, null, instances);
+        event = new Event<>(request);
+
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void handlesInstanceStatusWhenAvailable() {
+        List<CloudVmInstanceStatus> allStarted = allInstancesInStatus(InstanceStatus.STARTED);
+        when(instanceStateQuery.getCloudVmInstanceStatuses(any(), any(), eq(instances)))
+                .thenReturn(allStarted);
+
+        subject.accept(event);
+
+        verifyResult(new GetInstancesStateResult(request, allStarted));
+    }
+
+    @Test
+    public void returnsUnknownStatusWhenUnsupported() {
+        when(instanceStateQuery.getCloudVmInstanceStatuses(any(), any(), eq(instances)))
+                .thenThrow(new CloudOperationNotSupportedException("No check on mock cloud"));
+
+        subject.accept(event);
+
+        verifyResult(new GetInstancesStateResult(request, allInstancesInStatus(InstanceStatus.UNKNOWN)));
+    }
+
+    @Test
+    public void returnsErrorWhenFailsToSync() {
+        String message = "Some error happened";
+        CloudConnectorException exception = new CloudConnectorException(message);
+        when(instanceStateQuery.getCloudVmInstanceStatuses(any(), any(), eq(instances)))
+                .thenThrow(exception);
+
+        subject.accept(event);
+
+        verifyResult(new GetInstancesStateResult("some message", exception, request));
+    }
+
+    private List<CloudVmInstanceStatus> allInstancesInStatus(InstanceStatus status) {
+        return instances.stream()
+                .map(instance -> new CloudVmInstanceStatus(instance, status))
+                .collect(Collectors.toList());
+    }
+
+    private void verifyResult(GetInstancesStateResult expectedResult) {
+        verify(eventBus).notify(eq(expectedResult.selector()), argThat(resultMatcher(event, expectedResult)));
+    }
+
+    private static ArgumentMatcher<Event<GetInstancesStateResult>> resultMatcher(
+            Event<GetInstancesStateRequest> sourceEvent,
+            GetInstancesStateResult expectedResult
+    ) {
+        return event -> Objects.equals(sourceEvent.getHeaders().asMap(), event.getHeaders().asMap())
+                && Objects.equals(expectedResult.getStatuses(), event.getData().getStatuses())
+                && Objects.equals(expectedResult.getStatus(), event.getData().getStatus())
+                && Objects.equals(expectedResult.getErrorDetails(), event.getData().getErrorDetails());
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackSyncService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackSyncService.java
@@ -154,7 +154,7 @@ public class StackSyncService {
         } else if (InstanceSyncState.STOPPED.equals(state)) {
             syncStoppedInstance(stack, counts, metaData);
         } else {
-            counts.put(InstanceSyncState.IN_PROGRESS, counts.get(InstanceSyncState.IN_PROGRESS) + 1);
+            counts.put(state, counts.get(state) + 1);
         }
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Mark instance state as `UNKNOWN` if a cloud provider does not support instance state check, instead of failing the whole flow chain.  The goal is to allow the chain to proceed to cluster manager sync.

## How was this patch tested?

Tested sync on a cluster deployed to Yarn.  CB synced with Ambari fine after reporting that it couldn't sync with some instances.  Tested both with Ambari running and stopped.