### PR TITLE
Skip upload to Code Climate for forked PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
           command: JACOCO_SOURCE_PATH=core/src/main/java ./cc-test-reporter format-coverage ./core/build/reports/jacoco/test/jacocoTestReport.xml --input-type jacoco
       - run:
           name: Upload code climate report
-          command: ./cc-test-reporter upload-coverage -r $CC_TEST_REPORTER_ID
+          command: if [[ -n "${CC_TEST_REPORTER_ID}" ]]; then ./cc-test-reporter upload-coverage -r $CC_TEST_REPORTER_ID; else echo "Skipping upload-coverage"; fi
           when: on_success
       - run:
           name: Save test results


### PR DESCRIPTION
CircleCI `unit-test` tries to upload coverage to Code Climate.

https://github.com/hortonworks/cloudbreak/blob/41f5c96f5e9f9832f2fc7baf3f81902ae638056e/.circleci/config.yml#L149-L152

For PRs opened from forks this results in the following error due to empty `CC_TEST_REPORTER_ID`:

```
./cc-test-reporter upload-coverage -r $CC_TEST_REPORTER_ID

Error: flag needs an argument: 'r' in -r
```