### PR TITLE
[CB-984] Sync CM with CB

### DIFF
--- a/cluster-ambari/src/main/java/com/sequenceiq/cloudbreak/ambari/AmbariAdapter.java
+++ b/cluster-ambari/src/main/java/com/sequenceiq/cloudbreak/ambari/AmbariAdapter.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sequenceiq.ambari.client.AmbariClient;
 import com.sequenceiq.cloudbreak.cluster.status.ClusterStatus;
+import com.sequenceiq.cloudbreak.cluster.status.ClusterStatusResult;
 
 @Component
 public class AmbariAdapter {
@@ -103,23 +104,4 @@ public class AmbariAdapter {
         }
     }
 
-    public static class ClusterStatusResult {
-
-        private final ClusterStatus clusterStatus;
-
-        private final String componentsInStatus;
-
-        ClusterStatusResult(ClusterStatus clusterStatus, String componentsInStatus) {
-            this.clusterStatus = clusterStatus;
-            this.componentsInStatus = componentsInStatus;
-        }
-
-        public ClusterStatus getClusterStatus() {
-            return clusterStatus;
-        }
-
-        public String getComponentsInStatus() {
-            return componentsInStatus;
-        }
-    }
 }

--- a/cluster-ambari/src/main/java/com/sequenceiq/cloudbreak/ambari/AmbariClusterModificationService.java
+++ b/cluster-ambari/src/main/java/com/sequenceiq/cloudbreak/ambari/AmbariClusterModificationService.java
@@ -51,7 +51,6 @@ import com.sequenceiq.cloudbreak.cloud.scheduler.CancellationException;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterModificationService;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterConnectorPollingResultChecker;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterException;
-import com.sequenceiq.cloudbreak.cluster.status.ClusterStatus;
 import com.sequenceiq.cloudbreak.domain.KerberosConfig;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
@@ -103,9 +102,6 @@ public class AmbariClusterModificationService implements ClusterModificationServ
 
     @Inject
     private Retry retry;
-
-    @Inject
-    private AmbariClusterStatusFactory clusterStatusFactory;
 
     @Inject
     private AmbariRepositoryVersionService ambariRepositoryVersionService;
@@ -400,10 +396,6 @@ public class AmbariClusterModificationService implements ClusterModificationServ
         if (!errors.isEmpty()) {
             throw errors.poll();
         }
-    }
-
-    public ClusterStatus getStatus(boolean blueprintPresent) {
-        return clusterStatusFactory.createClusterStatus(stack, clientConfig, blueprintPresent);
     }
 
     @Override

--- a/cluster-ambari/src/main/java/com/sequenceiq/cloudbreak/ambari/AmbariClusterSetupService.java
+++ b/cluster-ambari/src/main/java/com/sequenceiq/cloudbreak/ambari/AmbariClusterSetupService.java
@@ -29,12 +29,12 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.ambari.client.AmbariClient;
-import com.sequenceiq.cloudbreak.ambari.AmbariAdapter.ClusterStatusResult;
 import com.sequenceiq.cloudbreak.ambari.flow.AmbariOperationService;
 import com.sequenceiq.cloudbreak.client.HttpClientConfig;
 import com.sequenceiq.cloudbreak.cloud.scheduler.CancellationException;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterSetupService;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterConnectorPollingResultChecker;
+import com.sequenceiq.cloudbreak.cluster.status.ClusterStatusResult;
 import com.sequenceiq.cloudbreak.clusterdefinition.CentralClusterDefinitionUpdater;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
@@ -159,8 +159,9 @@ public class AmbariClusterSetupService implements ClusterSetupService {
     private String constructClusterFailedMessage(Long clusterId, AmbariClient ambariClient) {
         String ambariClusterInstallFailedMsg = cloudbreakMessagesService.getMessage(AMBARI_CLUSTER_INSTALL_FAILED.code());
         ClusterStatusResult clusterStatusResult = ambariAdapter.getClusterStatusHostComponentMap(ambariClient);
-        LOGGER.debug("There are not started services. Cluster: [{}], services: [{}]", clusterId, clusterStatusResult.getComponentsInStatus());
-        return String.format("%s Not started services: [%s]", ambariClusterInstallFailedMsg, clusterStatusResult.getComponentsInStatus());
+        String statusReason = clusterStatusResult.getStatusReason();
+        LOGGER.debug("There are not started services. Cluster: [{}], services: [{}]", clusterId, statusReason);
+        return String.format("%s Not started services: [%s]", ambariClusterInstallFailedMsg, statusReason);
     }
 
     @Override

--- a/cluster-ambari/src/main/java/com/sequenceiq/cloudbreak/ambari/status/AmbariClusterStatusService.java
+++ b/cluster-ambari/src/main/java/com/sequenceiq/cloudbreak/ambari/status/AmbariClusterStatusService.java
@@ -12,8 +12,10 @@ import org.springframework.stereotype.Service;
 
 import com.sequenceiq.ambari.client.AmbariClient;
 import com.sequenceiq.cloudbreak.ambari.AmbariClientFactory;
+import com.sequenceiq.cloudbreak.ambari.AmbariClusterStatusFactory;
 import com.sequenceiq.cloudbreak.client.HttpClientConfig;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterStatusService;
+import com.sequenceiq.cloudbreak.cluster.status.ClusterStatusResult;
 import com.sequenceiq.cloudbreak.common.type.HostMetadataState;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 
@@ -28,6 +30,9 @@ public class AmbariClusterStatusService implements ClusterStatusService {
     @Inject
     private AmbariClientFactory ambariClientFactory;
 
+    @Inject
+    private AmbariClusterStatusFactory clusterStatusFactory;
+
     private AmbariClient ambariClient;
 
     public AmbariClusterStatusService(Stack stack, HttpClientConfig clientConfig) {
@@ -38,6 +43,11 @@ public class AmbariClusterStatusService implements ClusterStatusService {
     @PostConstruct
     public void initAmbariClient() {
         ambariClient = ambariClientFactory.getAmbariClient(stack, stack.getCluster(), clientConfig);
+    }
+
+    @Override
+    public ClusterStatusResult getStatus(boolean blueprintPresent) {
+        return clusterStatusFactory.createClusterStatus(stack, clientConfig, blueprintPresent);
     }
 
     @Override

--- a/cluster-ambari/src/test/java/com/sequenceiq/cloudbreak/ambari/AmbariAdapterTest.java
+++ b/cluster-ambari/src/test/java/com/sequenceiq/cloudbreak/ambari/AmbariAdapterTest.java
@@ -14,8 +14,8 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.sequenceiq.ambari.client.AmbariClient;
-import com.sequenceiq.cloudbreak.ambari.AmbariAdapter.ClusterStatusResult;
 import com.sequenceiq.cloudbreak.cluster.status.ClusterStatus;
+import com.sequenceiq.cloudbreak.cluster.status.ClusterStatusResult;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AmbariAdapterTest {

--- a/cluster-ambari/src/test/java/com/sequenceiq/cloudbreak/ambari/status/AmbariClusterStatusFactoryTest.java
+++ b/cluster-ambari/src/test/java/com/sequenceiq/cloudbreak/ambari/status/AmbariClusterStatusFactoryTest.java
@@ -76,7 +76,7 @@ public class AmbariClusterStatusFactoryTest {
         // GIVEN
         BDDMockito.given(ambariClient.healthCheck()).willThrow(new RuntimeException());
         // WHEN
-        ClusterStatus actualResult = underTest.createClusterStatus(stack, clientConfig, true);
+        ClusterStatus actualResult = underTest.createClusterStatus(stack, clientConfig, true).getClusterStatus();
         // THEN
         Assert.assertEquals(ClusterStatus.AMBARISERVER_NOT_RUNNING, actualResult);
     }
@@ -88,7 +88,7 @@ public class AmbariClusterStatusFactoryTest {
         BDDMockito.given(ambariClient.getRequests("IN_PROGRESS", "PENDING")).willReturn(Collections.singletonMap("IN_PROGRESS",
                 Collections.singletonList(1)));
         // WHEN
-        ClusterStatus actualResult = underTest.createClusterStatus(stack, clientConfig, true);
+        ClusterStatus actualResult = underTest.createClusterStatus(stack, clientConfig, true).getClusterStatus();
         // THEN
         Assert.assertEquals(ClusterStatus.PENDING, actualResult);
     }
@@ -98,7 +98,7 @@ public class AmbariClusterStatusFactoryTest {
         // GIVEN
         BDDMockito.given(ambariClient.healthCheck()).willReturn("RUNNING");
         // WHEN
-        ClusterStatus actualResult = underTest.createClusterStatus(stack, clientConfig, false);
+        ClusterStatus actualResult = underTest.createClusterStatus(stack, clientConfig, false).getClusterStatus();
         // THEN
         Assert.assertEquals(ClusterStatus.AMBARISERVER_RUNNING, actualResult);
         Assert.assertEquals(Status.AVAILABLE, actualResult.getStackStatus());
@@ -111,7 +111,7 @@ public class AmbariClusterStatusFactoryTest {
         BDDMockito.given(ambariClient.healthCheck()).willReturn("RUNNING");
         BDDMockito.given(ambariClient.getHostComponentsStatesCategorized()).willReturn(createHostComponentsStates("INSTALLED"));
         // WHEN
-        ClusterStatus actualResult = underTest.createClusterStatus(stack, clientConfig, true);
+        ClusterStatus actualResult = underTest.createClusterStatus(stack, clientConfig, true).getClusterStatus();
         // THEN
         Assert.assertEquals(ClusterStatus.INSTALLED, actualResult);
         Assert.assertEquals(Status.AVAILABLE, actualResult.getStackStatus());
@@ -124,7 +124,7 @@ public class AmbariClusterStatusFactoryTest {
         BDDMockito.given(ambariClient.healthCheck()).willReturn("RUNNING");
         BDDMockito.given(ambariClient.getHostComponentsStatesCategorized()).willReturn(createHostComponentsStates("STARTED"));
         // WHEN
-        ClusterStatus actualResult = underTest.createClusterStatus(stack, clientConfig, true);
+        ClusterStatus actualResult = underTest.createClusterStatus(stack, clientConfig, true).getClusterStatus();
         // THEN
         Assert.assertEquals(ClusterStatus.STARTED, actualResult);
         Assert.assertEquals(Status.AVAILABLE, actualResult.getStackStatus());
@@ -137,7 +137,7 @@ public class AmbariClusterStatusFactoryTest {
         BDDMockito.given(ambariClient.healthCheck()).willReturn("RUNNING");
         BDDMockito.given(ambariClient.getHostComponentsStatesCategorized()).willReturn(createInstallingHostComponentsStates());
         // WHEN
-        ClusterStatus actualResult = underTest.createClusterStatus(stack, clientConfig, true);
+        ClusterStatus actualResult = underTest.createClusterStatus(stack, clientConfig, true).getClusterStatus();
         // THEN
         Assert.assertEquals(ClusterStatus.INSTALLING, actualResult);
     }
@@ -148,7 +148,7 @@ public class AmbariClusterStatusFactoryTest {
         BDDMockito.given(ambariClient.healthCheck()).willReturn("RUNNING");
         BDDMockito.given(ambariClient.getHostComponentsStatesCategorized()).willReturn(createInstalledAndStartedHostComponentsStates());
         // WHEN
-        ClusterStatus actualResult = underTest.createClusterStatus(stack, clientConfig, true);
+        ClusterStatus actualResult = underTest.createClusterStatus(stack, clientConfig, true).getClusterStatus();
         // THEN
         Assert.assertEquals(ClusterStatus.AMBIGUOUS, actualResult);
     }
@@ -159,7 +159,7 @@ public class AmbariClusterStatusFactoryTest {
         BDDMockito.given(ambariClient.healthCheck()).willReturn("RUNNING");
         BDDMockito.given(ambariClient.getHostComponentsStatesCategorized()).willReturn(createHostComponentsStates("Unsupported"));
         // WHEN
-        ClusterStatus actualResult = underTest.createClusterStatus(stack, clientConfig, true);
+        ClusterStatus actualResult = underTest.createClusterStatus(stack, clientConfig, true).getClusterStatus();
         // THEN
         Assert.assertEquals(ClusterStatus.AMBIGUOUS, actualResult);
     }
@@ -170,7 +170,7 @@ public class AmbariClusterStatusFactoryTest {
         BDDMockito.given(ambariClient.healthCheck()).willReturn("RUNNING");
         BDDMockito.given(ambariClient.getHostComponentsStatesCategorized()).willThrow(new RuntimeException());
         // WHEN
-        ClusterStatus actualResult = underTest.createClusterStatus(stack, clientConfig, true);
+        ClusterStatus actualResult = underTest.createClusterStatus(stack, clientConfig, true).getClusterStatus();
         // THEN
         Assert.assertEquals(ClusterStatus.UNKNOWN, actualResult);
     }

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
@@ -103,7 +103,7 @@ public interface ClusterApi {
     }
 
     default ClusterStatus getStatus(boolean blueprintPresent) {
-        return clusterModificationService().getStatus(blueprintPresent);
+        return clusterStatusService().getStatus(blueprintPresent).getClusterStatus();
     }
 
     default Map<String, HostMetadataState> getHostStatuses() {

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterModificationService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterModificationService.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import java.util.Set;
 
 import com.sequenceiq.cloudbreak.cloud.model.component.StackRepoDetails;
-import com.sequenceiq.cloudbreak.cluster.status.ClusterStatus;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostMetadata;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
@@ -19,8 +18,6 @@ public interface ClusterModificationService {
     void stopCluster() throws CloudbreakException;
 
     int startCluster(Set<HostMetadata> hostsInCluster) throws CloudbreakException;
-
-    ClusterStatus getStatus(boolean blueprintPresent);
 
     Map<String, String> getComponentsByCategory(String blueprintName, String hostGroupName);
 

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterStatusService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterStatusService.java
@@ -2,10 +2,19 @@ package com.sequenceiq.cloudbreak.cluster.api;
 
 import java.util.Map;
 
+import com.sequenceiq.cloudbreak.cluster.status.ClusterStatusResult;
 import com.sequenceiq.cloudbreak.common.type.HostMetadataState;
 
 public interface ClusterStatusService {
 
+    /**
+     * Determine cluster-level status based on service/component states.
+     */
+    ClusterStatusResult getStatus(boolean blueprintPresent);
+
+    /**
+     * Determine state of all hosts known by the Cluster Manager.
+     */
     Map<String, HostMetadataState> getHostStatuses();
 
     Map<String, String> getHostStatusesRaw();

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/status/ClusterStatus.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/status/ClusterStatus.java
@@ -1,27 +1,24 @@
 package com.sequenceiq.cloudbreak.cluster.status;
 
 import java.util.Arrays;
-import java.util.Optional;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 
 public enum ClusterStatus {
-    UNKNOWN(null, null, "Error happened during the communication with Ambari"),
-    AMBARISERVER_NOT_RUNNING(null, null, "Ambariserver is not running."),
-    AMBARISERVER_RUNNING(Status.AVAILABLE, null, "Ambari server is running."),
-    INSTALLING(Status.AVAILABLE, null, "Ambari server is running, services are being installed... [%s]"),
+    UNKNOWN(null, null, "Error happened during the communication with the Cluster Manager"),
+    AMBARISERVER_NOT_RUNNING(null, null, "The Cluster Manager server is not running."),
+    AMBARISERVER_RUNNING(Status.AVAILABLE, null, "The Cluster Manager server is running."),
+    INSTALLING(Status.AVAILABLE, null, "The Cluster Manager server is running, services are being installed... [%s]"),
     INSTALLED(Status.AVAILABLE, Status.STOPPED, "Services are installed but not running."),
-    INSTALL_FAILED(Status.AVAILABLE, null, "Ambari server is running, but the ambari installation has failed. [%s]"),
+    INSTALL_FAILED(Status.AVAILABLE, null, "The Cluster Manager server is running, but service installation has failed. [%s]"),
     STARTING(Status.AVAILABLE, Status.START_IN_PROGRESS, "Services are installed, starting... [%s]"),
     STARTED(Status.AVAILABLE, Status.AVAILABLE, "Services are installed and running."),
     STOPPING(Status.AVAILABLE, Status.STOP_IN_PROGRESS, "Services are installed, stopping... [%s]"),
-    PENDING(Status.AVAILABLE, null, "There are in progress or pending operations in Ambari. Wait them to be finsihed and try syncing later."),
+    PENDING(Status.AVAILABLE, null, "There are in progress or pending operations in the Cluster Manager. Wait them to be finished and try syncing later."),
     AMBIGUOUS(Status.AVAILABLE, Status.AVAILABLE,
-            "There are stopped and running Ambari services as well. [%s] Restart or stop all of them and try syncing later.");
+            "There are both stopped and running services. [%s] Restart or stop all of them and try syncing later.");
 
     private final String statusReason;
-
-    private String statusReasonArg;
 
     private final Status stackStatus;
 
@@ -31,15 +28,10 @@ public enum ClusterStatus {
         this.stackStatus = stackStatus;
         this.clusterStatus = clusterStatus;
         this.statusReason = statusReason;
-        statusReasonArg = "";
     }
 
     public String getStatusReason() {
-        return String.format(statusReason, statusReasonArg);
-    }
-
-    public void setStatusReasonArg(String statusReasonArg) {
-        this.statusReasonArg = Optional.ofNullable(statusReasonArg).orElse("");
+        return statusReason;
     }
 
     public Status getStackStatus() {

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/status/ClusterStatusResult.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/status/ClusterStatusResult.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.cloudbreak.cluster.status;
+
+public class ClusterStatusResult {
+
+    private final ClusterStatus clusterStatus;
+
+    private final String statusReasonArg;
+
+    private ClusterStatusResult(ClusterStatus clusterStatus) {
+        this(clusterStatus, null);
+    }
+
+    public ClusterStatusResult(ClusterStatus clusterStatus, String statusReasonArg) {
+        this.clusterStatus = clusterStatus;
+        this.statusReasonArg = statusReasonArg;
+    }
+
+    public static ClusterStatusResult of(ClusterStatus clusterStatus) {
+        return new ClusterStatusResult(clusterStatus);
+    }
+
+    public ClusterStatus getClusterStatus() {
+        return clusterStatus;
+    }
+
+    public String getStatusReason() {
+        return statusReasonArg != null
+                ? String.format(clusterStatus.getStatusReason(), statusReasonArg)
+                : clusterStatus.getStatusReason();
+    }
+}

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusService.java
@@ -1,16 +1,44 @@
 package com.sequenceiq.cloudbreak.cm;
 
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
 
+import com.cloudera.api.swagger.HostsResourceApi;
+import com.cloudera.api.swagger.RolesResourceApi;
+import com.cloudera.api.swagger.ServicesResourceApi;
 import com.cloudera.api.swagger.client.ApiClient;
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.model.ApiHealthCheck;
+import com.cloudera.api.swagger.model.ApiHealthSummary;
+import com.cloudera.api.swagger.model.ApiRole;
+import com.cloudera.api.swagger.model.ApiRoleState;
+import com.cloudera.api.swagger.model.ApiService;
+import com.cloudera.api.swagger.model.ApiServiceState;
+import com.google.common.collect.Sets;
 import com.sequenceiq.cloudbreak.client.HttpClientConfig;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterStatusService;
+import com.sequenceiq.cloudbreak.cluster.status.ClusterStatus;
+import com.sequenceiq.cloudbreak.cluster.status.ClusterStatusResult;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerClientFactory;
 import com.sequenceiq.cloudbreak.common.type.HostMetadataState;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
@@ -18,6 +46,33 @@ import com.sequenceiq.cloudbreak.domain.stack.Stack;
 @Service
 @Scope("prototype")
 public class ClouderaManagerClusterStatusService implements ClusterStatusService {
+
+    static final String HOST_SCM_HEALTH = "HOST_SCM_HEALTH";
+
+    static final String FULL_VIEW = "FULL";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerClusterStatusService.class);
+
+    private static final Set<ApiServiceState> IGNORED_SERVICE_STATES = Sets.immutableEnumSet(
+            ApiServiceState.NA,
+            ApiServiceState.HISTORY_NOT_AVAILABLE
+    );
+
+    private static final Set<ApiRoleState> IGNORED_ROLE_STATES = Sets.immutableEnumSet(
+            ApiRoleState.NA,
+            ApiRoleState.HISTORY_NOT_AVAILABLE
+    );
+
+    private static final Set<ClusterStatus> NON_PENDING_STATES = Sets.immutableEnumSet(
+            ClusterStatus.STARTED,
+            ClusterStatus.INSTALLED
+    );
+
+    private static final Set<ApiHealthSummary> IGNORED_HEALTH_SUMMARIES = Sets.immutableEnumSet(
+            ApiHealthSummary.DISABLED,
+            ApiHealthSummary.NOT_AVAILABLE,
+            ApiHealthSummary.HISTORY_NOT_AVAILABLE
+    );
 
     @Inject
     private ClouderaManagerClientFactory clouderaManagerClientFactory;
@@ -28,7 +83,7 @@ public class ClouderaManagerClusterStatusService implements ClusterStatusService
 
     private ApiClient client;
 
-    public ClouderaManagerClusterStatusService(Stack stack, HttpClientConfig clientConfig) {
+    ClouderaManagerClusterStatusService(Stack stack, HttpClientConfig clientConfig) {
         this.stack = stack;
         this.clientConfig = clientConfig;
     }
@@ -39,12 +94,203 @@ public class ClouderaManagerClusterStatusService implements ClusterStatusService
     }
 
     @Override
+    public ClusterStatusResult getStatus(boolean blueprintPresent) {
+        if (!isCMRunning()) {
+            return ClusterStatusResult.of(ClusterStatus.AMBARISERVER_NOT_RUNNING);
+        } else if (blueprintPresent) {
+            return determineClusterStatus(stack);
+        } else {
+            return ClusterStatusResult.of(ClusterStatus.AMBARISERVER_RUNNING);
+        }
+    }
+
+    @Override
     public Map<String, HostMetadataState> getHostStatuses() {
-        return null;
+        return convertHealthSummary(getHostHealthSummary(), ClouderaManagerClusterStatusService::healthSummaryToState);
     }
 
     @Override
     public Map<String, String> getHostStatusesRaw() {
-        return null;
+        return convertHealthSummary(getHostHealthSummary(), ApiHealthSummary::getValue);
+    }
+
+    private ClusterStatusResult determineClusterStatus(Stack stack) {
+        try {
+            Collection<ApiService> services = readServices(stack);
+            Map<ClusterStatus, List<String>> servicesByStatus = groupServicesByState(services);
+            Set<ClusterStatus> statuses = servicesByStatus.keySet();
+            if (hasPendingOperation(statuses)) {
+                return ClusterStatusResult.of(ClusterStatus.PENDING);
+            }
+            // service INSTALLED => all its roles are INSTALLED
+            if (isUniformStatus(statuses, ClusterStatus.INSTALLED)) {
+                return ClusterStatusResult.of(ClusterStatus.INSTALLED);
+            }
+            // service STARTED => at least one of its roles are STARTED, have to check role statuses
+            if (isUniformStatus(statuses, ClusterStatus.STARTED)) {
+                return determineClusterStatusFromRoles(stack, servicesByStatus.get(ClusterStatus.STARTED));
+            }
+            if (areStatesAmbiguous(statuses)) {
+                return new ClusterStatusResult(ClusterStatus.AMBIGUOUS, constructStatusMessage(servicesByStatus));
+            }
+
+            LOGGER.info("Failed to determine cluster status: {}", statuses);
+            return ClusterStatusResult.of(ClusterStatus.UNKNOWN);
+        } catch (RuntimeException | ApiException e) {
+            LOGGER.info("Failed to determine cluster status: {}", e.getMessage(), e);
+            return ClusterStatusResult.of(ClusterStatus.UNKNOWN);
+        }
+    }
+
+    private ClusterStatusResult determineClusterStatusFromRoles(Stack stack, Collection<String> apiServices) {
+        Map<ClusterStatus, List<String>> rolesByStatus = groupRolesByState(stack, apiServices);
+        Set<ClusterStatus> statuses = rolesByStatus.keySet();
+        if (hasPendingOperation(statuses)) {
+            return ClusterStatusResult.of(ClusterStatus.PENDING);
+        }
+        if (areStatesAmbiguous(statuses)) {
+            return new ClusterStatusResult(ClusterStatus.AMBIGUOUS, constructStatusMessage(rolesByStatus));
+        }
+        if (statuses.size() == 1) {
+            return ClusterStatusResult.of(statuses.iterator().next());
+        }
+
+        LOGGER.info("Failed to determine cluster status: {}", statuses);
+        return ClusterStatusResult.of(ClusterStatus.UNKNOWN);
+    }
+
+    private Collection<ApiService> readServices(Stack stack) throws ApiException {
+        ServicesResourceApi api = clouderaManagerClientFactory.getServicesResourceApi(client);
+        return api.readServices(stack.getCluster().getName(), FULL_VIEW).getItems();
+    }
+
+    private static Map<ClusterStatus, List<String>> groupServicesByState(Collection<ApiService> services) {
+        return services.stream()
+                .filter(service -> !IGNORED_SERVICE_STATES.contains(service.getServiceState()))
+                .collect(groupingBy(service -> toClusterStatus(service.getServiceState()),
+                        mapping(ApiService::getName, toList())));
+    }
+
+    private Map<ClusterStatus, List<String>> groupRolesByState(Stack stack, Collection<String> services) {
+        RolesResourceApi api = clouderaManagerClientFactory.getRolesResourceApi(client);
+        return services.stream()
+                .flatMap(service -> readRoles(api, stack, service))
+                .filter(role -> !IGNORED_ROLE_STATES.contains(role.getRoleState()))
+                .collect(groupingBy(role -> toClusterStatus(role.getRoleState()),
+                        mapping(ApiRole::getName, toList())));
+    }
+
+    // need to translate checked exception for usage in stream
+    private static Stream<ApiRole> readRoles(RolesResourceApi api, Stack stack, String service) {
+        try {
+            return api.readRoles(stack.getCluster().getName(), service, "", FULL_VIEW).getItems().stream();
+        } catch (ApiException e) {
+            String message = String.format("Failed to read roles of service %s %s", stack.getCluster().getName(), service);
+            LOGGER.warn(message, e);
+            throw new RuntimeException(message, e);
+        }
+    }
+
+    private boolean isCMRunning() {
+        try {
+            clouderaManagerClientFactory.getClouderaManagerResourceApi(client).getVersion();
+            return true;
+        } catch (ApiException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Collects summary of HOST_SCM_HEALTH check for each host.
+     * Currently this is the best indicator of host availability.
+     */
+    private Map<String, ApiHealthSummary> getHostHealthSummary() {
+        HostsResourceApi api = clouderaManagerClientFactory.getHostsResourceApi(client);
+        try {
+            return api.readHosts(FULL_VIEW).getItems().stream()
+                    .filter(host -> host.getHealthChecks() != null)
+                    .flatMap(host -> host.getHealthChecks().stream()
+                            .filter(check -> HOST_SCM_HEALTH.equals(check.getName()))
+                            .map(ApiHealthCheck::getSummary)
+                            .filter(healthSummary -> !IGNORED_HEALTH_SUMMARIES.contains(healthSummary))
+                            .map(healthSummary -> Pair.of(host.getHostname(), healthSummary))
+                    )
+                    .collect(toMap(Pair::getLeft, Pair::getRight));
+        } catch (ApiException e) {
+            LOGGER.info("Failed to get hosts from CM", e);
+            throw new RuntimeException("Failed to get hosts from CM due to: " + e.getMessage(), e);
+        }
+    }
+
+    private static boolean isUniformStatus(Set<ClusterStatus> statuses, ClusterStatus expectedStatus) {
+        return statuses.size() == 1 && statuses.contains(expectedStatus);
+    }
+
+    private static boolean areStatesAmbiguous(Set<ClusterStatus> states) {
+        return states.containsAll(NON_PENDING_STATES);
+    }
+
+    private static String constructStatusMessage(Map<ClusterStatus, List<String>> stateMap) {
+        return stateMap.entrySet().stream()
+                .map(e -> e.getKey() + ": " + String.join(", ", e.getValue()))
+                .collect(joining("; "));
+    }
+
+    private static boolean hasPendingOperation(Set<ClusterStatus> states) {
+        return states.contains(ClusterStatus.STARTING)
+                || states.contains(ClusterStatus.STOPPING);
+    }
+
+    private static ClusterStatus toClusterStatus(ApiServiceState state) {
+        switch (state) {
+            case STARTING:
+                return ClusterStatus.STARTING;
+            case STARTED:
+                return ClusterStatus.STARTED;
+            case STOPPING:
+                return ClusterStatus.STOPPING;
+            case STOPPED:
+                return ClusterStatus.INSTALLED;
+            case UNKNOWN:
+                return ClusterStatus.UNKNOWN;
+            default:
+                LOGGER.debug("Translated service state {} to status {}", state, ClusterStatus.UNKNOWN);
+                return ClusterStatus.UNKNOWN;
+        }
+    }
+
+    private static ClusterStatus toClusterStatus(ApiRoleState state) {
+        switch (state) {
+            case STARTING:
+                return ClusterStatus.STARTING;
+            case STARTED:
+                return ClusterStatus.STARTED;
+            case STOPPING:
+                return ClusterStatus.STOPPING;
+            case STOPPED:
+                return ClusterStatus.INSTALLED;
+            case UNKNOWN:
+                return ClusterStatus.UNKNOWN;
+            default:
+                LOGGER.debug("Translated role state {} to status {}", state, ClusterStatus.UNKNOWN);
+                return ClusterStatus.UNKNOWN;
+        }
+    }
+
+    private static HostMetadataState healthSummaryToState(ApiHealthSummary healthSummary) {
+        switch (healthSummary) {
+            case GOOD:
+            case CONCERNING:
+                return HostMetadataState.HEALTHY;
+            default:
+                LOGGER.debug("Translated health summary {} to state {}", healthSummary, HostMetadataState.UNHEALTHY);
+                return HostMetadataState.UNHEALTHY;
+        }
+    }
+
+    private static <T> Map<String, T> convertHealthSummary(Map<String, ApiHealthSummary> hostHealth, Function<ApiHealthSummary, T> converter) {
+        Map<String, T> result = new HashMap<>();
+        hostHealth.forEach((hostname, healthSummary) -> result.put(hostname, converter.apply(healthSummary)));
+        return result;
     }
 }

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
@@ -25,7 +25,6 @@ import com.sequenceiq.cloudbreak.client.HttpClientConfig;
 import com.sequenceiq.cloudbreak.cloud.model.component.StackRepoDetails;
 import com.sequenceiq.cloudbreak.cloud.scheduler.CancellationException;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterModificationService;
-import com.sequenceiq.cloudbreak.cluster.status.ClusterStatus;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerClientFactory;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollingServiceProvider;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
@@ -112,11 +111,6 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
             LOGGER.info("Couldn't start Cloudera Manager services", e);
             throw new ClouderaManagerOperationFailedException(e.getMessage(), e);
         }
-    }
-
-    @Override
-    public ClusterStatus getStatus(boolean blueprintPresent) {
-        return null;
     }
 
     @Override

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/client/ClouderaManagerClientFactory.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/client/ClouderaManagerClientFactory.java
@@ -8,6 +8,9 @@ import com.cloudera.api.swagger.AuthRolesResourceApi;
 import com.cloudera.api.swagger.ClouderaManagerResourceApi;
 import com.cloudera.api.swagger.ClustersResourceApi;
 import com.cloudera.api.swagger.ExternalUserMappingsResourceApi;
+import com.cloudera.api.swagger.HostsResourceApi;
+import com.cloudera.api.swagger.RolesResourceApi;
+import com.cloudera.api.swagger.ServicesResourceApi;
 import com.cloudera.api.swagger.client.ApiClient;
 import com.sequenceiq.cloudbreak.client.HttpClientConfig;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
@@ -54,5 +57,17 @@ public class ClouderaManagerClientFactory {
 
     public ClustersResourceApi getClustersResourceApi(ApiClient apiClient) {
         return new ClustersResourceApi(apiClient);
+    }
+
+    public HostsResourceApi getHostsResourceApi(ApiClient client) {
+        return new HostsResourceApi(client);
+    }
+
+    public ServicesResourceApi getServicesResourceApi(ApiClient client) {
+        return new ServicesResourceApi(client);
+    }
+
+    public RolesResourceApi getRolesResourceApi(ApiClient client) {
+        return new RolesResourceApi(client);
     }
 }

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusServiceTest.java
@@ -1,0 +1,269 @@
+package com.sequenceiq.cloudbreak.cm;
+
+import static com.sequenceiq.cloudbreak.cm.ClouderaManagerClusterStatusService.FULL_VIEW;
+import static com.sequenceiq.cloudbreak.cm.ClouderaManagerClusterStatusService.HOST_SCM_HEALTH;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.cloudera.api.swagger.ClouderaManagerResourceApi;
+import com.cloudera.api.swagger.HostsResourceApi;
+import com.cloudera.api.swagger.RolesResourceApi;
+import com.cloudera.api.swagger.ServicesResourceApi;
+import com.cloudera.api.swagger.client.ApiClient;
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.model.ApiHealthCheck;
+import com.cloudera.api.swagger.model.ApiHealthSummary;
+import com.cloudera.api.swagger.model.ApiHost;
+import com.cloudera.api.swagger.model.ApiHostList;
+import com.cloudera.api.swagger.model.ApiRole;
+import com.cloudera.api.swagger.model.ApiRoleList;
+import com.cloudera.api.swagger.model.ApiRoleState;
+import com.cloudera.api.swagger.model.ApiService;
+import com.cloudera.api.swagger.model.ApiServiceList;
+import com.cloudera.api.swagger.model.ApiServiceState;
+import com.cloudera.api.swagger.model.ApiVersionInfo;
+import com.google.common.collect.ImmutableMap;
+import com.sequenceiq.cloudbreak.client.HttpClientConfig;
+import com.sequenceiq.cloudbreak.cluster.status.ClusterStatus;
+import com.sequenceiq.cloudbreak.cluster.status.ClusterStatusResult;
+import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerClientFactory;
+import com.sequenceiq.cloudbreak.common.type.HostMetadataState;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+
+public class ClouderaManagerClusterStatusServiceTest {
+
+    private static final String CLUSTER_NAME = "clusterName";
+
+    private final HttpClientConfig clientConfig = new HttpClientConfig("1.2.3.4", null, null, null);
+
+    @Mock
+    private ApiClient client;
+
+    @Mock
+    private ClouderaManagerClientFactory clientFactory;
+
+    @Mock
+    private ClouderaManagerResourceApi cmApi;
+
+    @Mock
+    private ServicesResourceApi servicesApi;
+
+    @Mock
+    private RolesResourceApi rolesApi;
+
+    @Mock
+    private HostsResourceApi hostsApi;
+
+    @InjectMocks
+    private ClouderaManagerClusterStatusService subject;
+
+    @Before
+    public void init() {
+        Cluster cluster = new Cluster();
+        cluster.setName(CLUSTER_NAME);
+        Stack stack = new Stack();
+        stack.setName(CLUSTER_NAME);
+        stack.setCluster(cluster);
+
+        subject = new ClouderaManagerClusterStatusService(stack, clientConfig);
+
+        MockitoAnnotations.initMocks(this);
+
+        when(clientFactory.getClient(stack, cluster, clientConfig)).thenReturn(client);
+        when(clientFactory.getClouderaManagerResourceApi(client)).thenReturn(cmApi);
+        when(clientFactory.getServicesResourceApi(client)).thenReturn(servicesApi);
+        when(clientFactory.getRolesResourceApi(client)).thenReturn(rolesApi);
+        when(clientFactory.getHostsResourceApi(client)).thenReturn(hostsApi);
+    }
+
+    @Test
+    public void detectsStoppedClouderaManager() throws ApiException {
+        cmIsNotReachable();
+
+        assertEquals(ClusterStatus.AMBARISERVER_NOT_RUNNING, subject.getStatus(true).getClusterStatus());
+    }
+
+    @Test
+    public void reportsClouderaManagerRunningWhenClusterNotPresent() throws ApiException {
+        cmIsReachable();
+
+        assertEquals(ClusterStatus.AMBARISERVER_RUNNING, subject.getStatus(false).getClusterStatus());
+    }
+
+    @Test
+    public void reportsClusterStatusPendingWhenAnyServiceIsStarting() throws ApiException {
+        cmIsReachable();
+        servicesAre(
+            new ApiService().name("service1").serviceState(ApiServiceState.STARTING),
+            new ApiService().name("service2").serviceState(ApiServiceState.STARTED)
+        );
+
+        assertEquals(ClusterStatus.PENDING, subject.getStatus(true).getClusterStatus());
+    }
+
+    @Test
+    public void reportsClusterStoppedWhenAllServicesStopped() throws ApiException {
+        cmIsReachable();
+        servicesAre(
+                new ApiService().name("service1").serviceState(ApiServiceState.STOPPED),
+                new ApiService().name("service2").serviceState(ApiServiceState.STOPPED)
+        );
+
+        assertEquals(ClusterStatus.INSTALLED, subject.getStatus(true).getClusterStatus());
+    }
+
+    @Test
+    public void reportsClusterStartedWhenAllRolesAreStarted() throws ApiException {
+        cmIsReachable();
+        servicesAre(
+                new ApiService().name("service1").serviceState(ApiServiceState.STARTED),
+                new ApiService().name("service2").serviceState(ApiServiceState.STARTED)
+        );
+        rolesAre("service1",
+                new ApiRole().name("role 1.1").roleState(ApiRoleState.STARTED),
+                new ApiRole().name("role 1.2").roleState(ApiRoleState.STARTED)
+        );
+        rolesAre("service2",
+                new ApiRole().name("role 2.1").roleState(ApiRoleState.STARTED),
+                new ApiRole().name("role 2.2").roleState(ApiRoleState.STARTED)
+        );
+
+        assertEquals(ClusterStatus.STARTED, subject.getStatus(true).getClusterStatus());
+    }
+
+    @Test
+    public void ignoresServicesNA() throws ApiException {
+        cmIsReachable();
+        servicesAre(
+                new ApiService().name("service1").serviceState(ApiServiceState.STOPPED),
+                new ApiService().name("service2").serviceState(ApiServiceState.NA),
+                new ApiService().name("service3").serviceState(ApiServiceState.STOPPED)
+        );
+
+        assertEquals(ClusterStatus.INSTALLED, subject.getStatus(true).getClusterStatus());
+    }
+
+    @Test
+    public void reportsAmbiguousServiceStatus() throws ApiException {
+        cmIsReachable();
+        servicesAre(
+                new ApiService().name("service1").serviceState(ApiServiceState.STARTED),
+                new ApiService().name("service2").serviceState(ApiServiceState.STOPPED)
+        );
+
+        ClusterStatusResult statusResult = subject.getStatus(true);
+        assertEquals(ClusterStatus.AMBIGUOUS, statusResult.getClusterStatus());
+        String statusReason = statusResult.getStatusReason();
+        assertTrue(statusReason, statusReason.contains("STARTED: service1"));
+        assertTrue(statusReason, statusReason.contains("INSTALLED: service2"));
+    }
+
+    @Test
+    public void reportsAmbiguousRoleStatus() throws ApiException {
+        cmIsReachable();
+        servicesAre(
+                new ApiService().name("service1").serviceState(ApiServiceState.STARTED),
+                new ApiService().name("service2").serviceState(ApiServiceState.STARTED)
+        );
+        rolesAre("service1",
+                new ApiRole().name("role 1.1").roleState(ApiRoleState.STARTED),
+                new ApiRole().name("role 1.2").roleState(ApiRoleState.STOPPED)
+        );
+        rolesAre("service2",
+                new ApiRole().name("role 2.1").roleState(ApiRoleState.STARTED),
+                new ApiRole().name("role 2.2").roleState(ApiRoleState.STOPPED)
+        );
+
+        ClusterStatusResult statusResult = subject.getStatus(true);
+        assertEquals(ClusterStatus.AMBIGUOUS, statusResult.getClusterStatus());
+        String statusReason = statusResult.getStatusReason();
+        assertTrue(statusReason, statusReason.contains("STARTED: role 1.1, role 2.1"));
+        assertTrue(statusReason, statusReason.contains("INSTALLED: role 1.2, role 2.2"));
+    }
+
+    @Test
+    public void collectsHostHealthIfAvailable() throws ApiException {
+        hostsAre(
+                new ApiHost().hostname("host1").addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.GOOD)),
+                new ApiHost().hostname("host2").addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.CONCERNING)),
+                new ApiHost().hostname("host3").addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.BAD)),
+                new ApiHost().hostname("host4").addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.NOT_AVAILABLE)),
+                new ApiHost().hostname("host5").addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.HISTORY_NOT_AVAILABLE)),
+                new ApiHost().hostname("host6").addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.DISABLED))
+        );
+
+        Map<String, HostMetadataState> expected = ImmutableMap.of(
+                "host1", HostMetadataState.HEALTHY,
+                "host2", HostMetadataState.HEALTHY,
+                "host3", HostMetadataState.UNHEALTHY
+        );
+        Map<String, HostMetadataState> actual = new TreeMap<>(subject.getHostStatuses());
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void filtersAppropriateHealthCheckForHost() throws ApiException {
+        hostsAre(
+                new ApiHost().hostname("host")
+                        .addHealthChecksItem(new ApiHealthCheck().name("fake_check").summary(ApiHealthSummary.BAD))
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.CONCERNING))
+                        .addHealthChecksItem(new ApiHealthCheck().name("another").summary(ApiHealthSummary.BAD))
+        );
+
+        Map<String, HostMetadataState> expected = Collections.singletonMap("host", HostMetadataState.HEALTHY);
+        assertEquals(expected, subject.getHostStatuses());
+    }
+
+    @Test
+    public void ignoresHostsWithoutHealthChecks() throws ApiException {
+        hostsAre(new ApiHost().hostname("hostY"));
+
+        assertEquals(Collections.emptyMap(), subject.getHostStatuses());
+    }
+
+    @Test
+    public void ignoresHostsWithoutAppropriateHealthCheck() throws ApiException {
+        hostsAre(new ApiHost().hostname("hostY").addHealthChecksItem(new ApiHealthCheck().name("fake_check").summary(ApiHealthSummary.GOOD)));
+
+        assertEquals(Collections.emptyMap(), subject.getHostStatuses());
+    }
+
+    private void hostsAre(ApiHost... hosts) throws ApiException {
+        ApiHostList list = new ApiHostList().items(Arrays.asList(hosts));
+        when(hostsApi.readHosts(FULL_VIEW)).thenReturn(list);
+    }
+
+    private void servicesAre(ApiService... services) throws ApiException {
+        ApiServiceList serviceList = new ApiServiceList().items(Arrays.asList(services));
+        when(servicesApi.readServices(CLUSTER_NAME, FULL_VIEW)).thenReturn(serviceList);
+    }
+
+    private void rolesAre(String service, ApiRole... roles) throws ApiException {
+        ApiRoleList roleList = new ApiRoleList().items(Arrays.asList(roles));
+        when(rolesApi.readRoles(eq(CLUSTER_NAME), eq(service), anyString(), eq(FULL_VIEW))).thenReturn(roleList);
+    }
+
+    private void cmIsNotReachable() throws ApiException {
+        when(cmApi.getVersion()).thenThrow(new ApiException("CM is not reachable"));
+    }
+
+    private void cmIsReachable() throws ApiException {
+        when(cmApi.getVersion()).thenReturn(new ApiVersionInfo().version("1.2.3"));
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/flow/status/ClusterStatusUpdaterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/flow/status/ClusterStatusUpdaterTest.java
@@ -16,8 +16,9 @@ import org.mockito.MockitoAnnotations;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
-import com.sequenceiq.cloudbreak.cluster.api.ClusterModificationService;
+import com.sequenceiq.cloudbreak.cluster.api.ClusterStatusService;
 import com.sequenceiq.cloudbreak.cluster.status.ClusterStatus;
+import com.sequenceiq.cloudbreak.cluster.status.ClusterStatusResult;
 import com.sequenceiq.cloudbreak.domain.ClusterDefinition;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.StackStatus;
@@ -59,22 +60,22 @@ public class ClusterStatusUpdaterTest {
     private ClusterApi clusterApi;
 
     @Mock
-    private ClusterModificationService clusterModificationService;
+    private ClusterStatusService clusterStatusService;
 
     @Before
     public void setUp() {
         underTest = new ClusterStatusUpdater();
         MockitoAnnotations.initMocks(this);
         when(clusterApiConnectors.getConnector(any(Stack.class))).thenReturn(clusterApi);
-        when(clusterApi.clusterModificationService()).thenReturn(clusterModificationService);
-        when(clusterModificationService.getStatus(anyBoolean())).thenReturn(ClusterStatus.STARTED);
+        when(clusterApi.clusterStatusService()).thenReturn(clusterStatusService);
+        when(clusterStatusService.getStatus(anyBoolean())).thenReturn(ClusterStatusResult.of(ClusterStatus.STARTED));
     }
 
     @Test
     public void testUpdateClusterStatusShouldUpdateStackStatusWhenStackStatusChanged() {
         // GIVEN
         Stack stack = createStack(Status.AVAILABLE, Status.AVAILABLE);
-        when(clusterModificationService.getStatus(anyBoolean())).thenReturn(ClusterStatus.INSTALLED);
+        when(clusterStatusService.getStatus(anyBoolean())).thenReturn(ClusterStatusResult.of(ClusterStatus.INSTALLED));
         // WHEN
         underTest.updateClusterStatus(stack, stack.getCluster());
         // THEN
@@ -105,7 +106,7 @@ public class ClusterStatusUpdaterTest {
     public void testUpdateClusterStatusShouldUpdateStackStatusWhenMaintenanceModeIsEnabledButClusterIsStopped() {
         // GIVEN
         Stack stack = createStack(Status.AVAILABLE, Status.MAINTENANCE_MODE_ENABLED);
-        when(clusterModificationService.getStatus(anyBoolean())).thenReturn(ClusterStatus.INSTALLED);
+        when(clusterStatusService.getStatus(anyBoolean())).thenReturn(ClusterStatusResult.of(ClusterStatus.INSTALLED));
         // WHEN
         underTest.updateClusterStatus(stack, stack.getCluster());
         // THEN

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/repair/CandidateUnhealthyInstancesSelectorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/repair/CandidateUnhealthyInstancesSelectorTest.java
@@ -59,7 +59,7 @@ public class CandidateUnhealthyInstancesSelectorTest {
 
         Set<InstanceMetaData> candidateUnhealthyInstances = undertest.selectCandidateUnhealthyInstances(stack.getId());
 
-        assertEquals(2L, candidateUnhealthyInstances.size());
+        assertEquals(2, candidateUnhealthyInstances.size());
         assertTrue(candidateUnhealthyInstances.contains(imd1));
         assertTrue(candidateUnhealthyInstances.contains(imd2));
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Implement cluster sync for Cloudera Manager:

 * cluster status calculation based on service and role state
 * host status based on the host health check `HOST_SCM_HEALTH`

Notable changes:

 * Move the method `getStatus` from `ClusterModificationService` to `ClusterStatusService`
 * Eliminate mutable state (`statusReasonArg`) from the `enum ClusterStatus` by reusing `ClusterStatusResult` for this purpose (moved to `cluster-api`)
 * Refactor stream processing in `CandidateUnhealthyInstanceSelector` (trying to avoid mutating external state in `foreach`)

Note:

 * Health checks apparently require Cloudera Management Service
 * `CandidateUnhealthyInstanceSelector` has Ambari-specific status code that will need to account for corresponding status from CM

## How was this patch tested?

Tested "sync" on CDH cluster after install completed, and also after stopping some roles and services.

Installed CMS on the cluster, stopped a VM manually, triggered "sync", verified that the host has been marked as unhealthy.

Added unit tests.