### PR TITLE
CB-1168 Fix cluster template multi-delete

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/ClusterTemplateV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/ClusterTemplateV4Controller.java
@@ -82,7 +82,7 @@ public class ClusterTemplateV4Controller extends NotificationController implemen
 
     @Override
     public ClusterTemplateV4Responses deleteMultiple(Long workspaceId, Set<String> names) {
-        Set<ClusterTemplate> clusterTemplates = clusterTemplateService.deleteMultipleByNameFromWorkspace(names, workspaceId);
+        Set<ClusterTemplate> clusterTemplates = clusterTemplateService.deleteMultiple(names, workspaceId);
         return new ClusterTemplateV4Responses(converterUtil.convertAllAsSet(clusterTemplates, ClusterTemplateV4Response.class));
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/template/ClusterTemplateService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/template/ClusterTemplateService.java
@@ -187,4 +187,8 @@ public class ClusterTemplateService extends AbstractWorkspaceAwareResourceServic
         stackTemplateService.delete(clusterTemplate.getStackTemplate());
         return clusterTemplate;
     }
+
+    public Set<ClusterTemplate> deleteMultiple(Set<String> names, Long workspaceId) {
+        return names.stream().map(name -> delete(name, workspaceId)).collect(Collectors.toSet());
+    }
 }


### PR DESCRIPTION
The multi-delete code for cluster templates now also deletes the stack
temmplate resident inside each template, to avoid API conversion
problems later.