### PR TITLE
CB-1169 Hive metastore storage location is invalid for ADLS gen2

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/filesystem/FileSystemType.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/filesystem/FileSystemType.java
@@ -14,7 +14,7 @@ public enum FileSystemType {
 
     ADLS(AdlsFileSystem.class, "adl", "{{{ accountName }}}.azuredatalakestore.net/{{{ storageName }}}"),
 
-    ADLS_GEN_2(AdlsGen2FileSystem.class, "abfs", "{{{ storageName }}}@{{{ accountName }}}.blob.core.windows.net"),
+    ADLS_GEN_2(AdlsGen2FileSystem.class, "abfs", "{{{ storageName }}}@{{{ accountName }}}.dfs.core.windows.net"),
 
     S3(S3FileSystem.class, "s3a", "{{{ storageName }}}/{{{ clusterName }}}");
 


### PR DESCRIPTION
When cluster is configured to use cloud storage on Azure, ADSL gen2 location was incorrect. dfs.core.windows.net instead of blob.core.windows.net

Closes CB-1169