### PR TITLE
CB-1169 Hive metastore storage location is invalid for ADLS gen2

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/services/filesystem/FileSystemType.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/services/filesystem/FileSystemType.java
@@ -14,7 +14,7 @@ public enum FileSystemType {
 
     ADLS(AdlsFileSystem.class, "adl", "{{{ accountName }}}.azuredatalakestore.net/{{{ storageName }}}"),
 
-    ADLS_GEN_2(AdlsGen2FileSystem.class, "abfs", "{{{ storageName }}}@{{{ accountName }}}.blob.core.windows.net"),
+    ADLS_GEN_2(AdlsGen2FileSystem.class, "abfs", "{{{ storageName }}}@{{{ accountName }}}.dfs.core.windows.net"),
 
     S3(S3FileSystem.class, "s3a", "{{{ storageName }}}");
 


### PR DESCRIPTION
After merge rc-2.9 this change was missing: ADSL gen2 filesystem location was incorrectly referenced.
Closes CB-1169