### PR TITLE
CB-1193 generate IPA service account per cluster

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,11 +170,14 @@ subprojects {
     maven { url "https://repo.spring.io/release" }
     maven { url "https://plugins.gradle.org/m2/" }
     maven {
-      credentials {
+      authentication {
+        basic(BasicAuthentication)
+      }
+      credentials(PasswordCredentials) {
         username "$cmPrivateRepoUser"
         password "$cmPrivateRepoPassword"
       }
-      url "https://repository.cloudera.com/cloudera/list/cm-private/" 
+      url "https://repository.cloudera.com/cloudera/list/cm-private/"
     }
   }
 }

--- a/orchestrator-salt/src/main/resources/salt/pillar/top.sls
+++ b/orchestrator-salt/src/main/resources/salt/pillar/top.sls
@@ -24,6 +24,10 @@ base:
     - match: compound
     - sssd.ipa
 
+  'G@roles:ipa_leave':
+    - match: compound
+    - sssd.ipa
+
   'roles:gateway':
     - match: grain
     - gateway.init

--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/ipa-leave.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/ipa-leave.sls
@@ -1,3 +1,28 @@
+{%- from 'sssd/settings.sls' import ipa with context %}
+
+{%- if "manager_server" in grains.get('roles', []) %}
+
+create_remove_cm_sa_script:
+  file.managed:
+    - name: /opt/salt/scripts/remove_cm_sa.sh
+    - source: salt://sssd/template/remove_cm_sa.j2
+    - makedirs: True
+    - template: jinja
+    - context:
+        ipa: {{ ipa }}
+    - mode: 755
+
+remove_cm_service_account:
+  cmd.run:
+    - name: sh /opt/salt/scripts/remove_cm_sa.sh 2>&1 | tee -a /var/log/remove_cm_sa.log && exit ${PIPESTATUS[0]}
+    - env:
+        - password: {{salt['pillar.get']('sssd-ipa:password')}}
+    - onlyif: ls /etc/cloudera-scm-server/cmf.keytab
+    - require:
+      - file: create_remove_cm_sa_script
+
+{%- endif %}
+
 leave-ipa:
   cmd.run:
     - name: ipa host-del {{ salt['grains.get']('fqdn') }} --updatedns && ipa-client-install --uninstall -U

--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/settings.sls
@@ -1,11 +1,13 @@
 {% set server = salt['pillar.get']('sssd-ipa:server') %}
 {% set principal = salt['pillar.get']('sssd-ipa:principal') %}
 {% set realm = salt['pillar.get']('sssd-ipa:realm') %}
+{% set cluster_name = salt['pillar.get']('cluster:name') %}
 
 {% set ipa = {} %}
 {% do ipa.update({
     'server': server,
     'principal': principal,
-    'realm': realm
+    'realm': realm,
+    'cluster_name': cluster_name
 }) %}
 

--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/template/generate_cm_keytab.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/template/generate_cm_keytab.j2
@@ -7,15 +7,27 @@ echo "$password" | kinit {{ ipa.principal }}
 
 set -x
 
+SA_NAME=krbbind-{{ ipa.cluster_name }}
+ROLE_NAME=hadoopadminrole-{{ ipa.cluster_name }}
+
+# Generate per-cluster krbbind Service Account
+ipa user-add "$SA_NAME" --first=service --last=account
+ipa role-add "$ROLE_NAME"
+ipa role-add-privilege "$ROLE_NAME" --privileges="Service Administrators"
+ipa role-add-member "$ROLE_NAME" --users="$SA_NAME"
+
 # generate keytab for user krbbind
-ipa-getkeytab -s {{ ipa.server }} -p krbbind -k /etc/cloudera-scm-server/cmf.keytab
+ipa-getkeytab -s {{ ipa.server }} -p "$SA_NAME" -k /etc/cloudera-scm-server/cmf.keytab
 chown cloudera-scm:cloudera-scm /etc/cloudera-scm-server/cmf.keytab
 chmod 600 /etc/cloudera-scm-server/cmf.keytab
 
 # tell CM which principal to use to connect to IPA
-echo "krbbind@{{ ipa.realm|upper }}" > /etc/cloudera-scm-server/cmf.principal
+echo "${SA_NAME}@{{ ipa.realm|upper }}" > /etc/cloudera-scm-server/cmf.principal
 chown cloudera-scm:cloudera-scm /etc/cloudera-scm-server/cmf.principal
 
 # temporary HACK until CM side of the script is fixed
 sed -i "s/ipa env host/ipa env server/g" /opt/cloudera/cm/bin/gen_credentials_ipa.sh
 sed -i '/MAX_RENEW_LIFE=.*/a MAX_RENEW_LIFE=0' /opt/cloudera/cm/bin/gen_credentials_ipa.sh
+
+# Destroy the admin krbtgt
+kdestroy

--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/template/remove_cm_sa.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/template/remove_cm_sa.j2
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+# auth to remove the Service Account
+echo "$password" | kinit {{ ipa.principal }}
+
+set -x
+
+SA_NAME=krbbind-{{ ipa.cluster_name }}
+ROLE_NAME=hadoopadminrole-{{ ipa.cluster_name }}
+
+# Remove per-cluster krbbind Service Account
+ipa user-del "$SA_NAME"
+ipa role-del "$ROLE_NAME"
+
+# Remove CM keytab
+rm -f /etc/cloudera-scm-server/cmf.keytab


### PR DESCRIPTION
CB needs to generate a keytab for CM so CM can create the principals for the different services. However, using the same global service account makes the already generated keytabs invalid. To avoid such errors we need to generate a SA per cluster and once the cluster is terminated remove the corresponding SA as well from IPA.