### PR TITLE
CB-1272. Wrong location for some US West zones

### DIFF
--- a/cloud-aws/src/main/resources/definitions/aws-zone-coordinates.json
+++ b/cloud-aws/src/main/resources/definitions/aws-zone-coordinates.json
@@ -57,8 +57,8 @@
     {
       "name": "us-west-2",
       "displayName": "US West (Oregon)",
-      "latitude": "43.67216158",
-      "longitude": "-70.2455274"
+      "latitude": "45.5428",
+      "longitude": "-122.6544"
     },
     {
       "name": "ap-southeast-2",

--- a/cloud-azure/src/main/resources/definitions/azure-zone-coordinates.json
+++ b/cloud-azure/src/main/resources/definitions/azure-zone-coordinates.json
@@ -117,8 +117,8 @@
     },
     {
       "name": "West US 2",
-      "latitude": "38.89954938",
-      "longitude": "-77.00941858"
+      "latitude": "47.6076",
+      "longitude": "-122.3420"
     },
     {
       "name": "West India",

--- a/cloud-cumulus-yarn/src/main/resources/definitions/cumulus-yarn-zone-coordinates.json
+++ b/cloud-cumulus-yarn/src/main/resources/definitions/cumulus-yarn-zone-coordinates.json
@@ -117,8 +117,8 @@
     {
       "displayName": "Washington (West US)",
       "name": "Washington",
-      "latitude": "38.89954938",
-      "longitude": "-77.00941858"
+      "latitude": "47.6076",
+      "longitude": "-122.3420"
     },
     {
       "displayName": "Mumbai (West India)",

--- a/cloud-mock/src/main/resources/definitions/mock-zone-coordinates.json
+++ b/cloud-mock/src/main/resources/definitions/mock-zone-coordinates.json
@@ -117,8 +117,8 @@
     {
       "displayName": "Washington (West US)",
       "name": "Washington",
-      "latitude": "38.89954938",
-      "longitude": "-77.00941858"
+      "latitude": "47.6076",
+      "longitude": "-122.3420"
     },
     {
       "displayName": "Mumbai (West India)",

--- a/cloud-openstack/src/main/resources/definitions/openstack-zone-coordinates.json
+++ b/cloud-openstack/src/main/resources/definitions/openstack-zone-coordinates.json
@@ -117,8 +117,8 @@
     {
       "displayName": "Washington (West US)",
       "name": "Washington",
-      "latitude": "38.89954938",
-      "longitude": "-77.00941858"
+      "latitude": "47.6076",
+      "longitude": "-122.3420"
     },
     {
       "displayName": "Mumbai (West India)",

--- a/cloud-yarn/src/main/resources/definitions/yarn-zone-coordinates.json
+++ b/cloud-yarn/src/main/resources/definitions/yarn-zone-coordinates.json
@@ -117,8 +117,8 @@
     {
       "displayName": "Washington (West US)",
       "name": "Washington",
-      "latitude": "38.89954938",
-      "longitude": "-77.00941858"
+      "latitude": "47.6076",
+      "longitude": "-122.3420"
     },
     {
       "displayName": "Mumbai (West India)",


### PR DESCRIPTION
Fix the location of some US West zones:

 * Oregon: [old](https://www.openstreetmap.org/#map=8/43.676/-70.249) -> [new](https://www.openstreetmap.org/#map=8/45.543/-122.654)
 * Washington: [old](https://www.openstreetmap.org/#map=7/38.891/-77.014) -> [new](https://www.openstreetmap.org/#map=7/47.608/-122.342)