### PR TITLE
CB-1286 create CM management user for shared access

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerSecurityService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerSecurityService.java
@@ -117,6 +117,7 @@ public class ClouderaManagerSecurityService implements ClusterSecurityService {
             if (oldAdminUser.isPresent()) {
                 Cluster cluster = stack.getCluster();
                 createNewUser(usersResourceApi, oldAdminUser.get().getAuthRoles(), cluster.getCloudbreakAmbariUser(), cluster.getCloudbreakAmbariPassword());
+                createNewUser(usersResourceApi, oldAdminUser.get().getAuthRoles(), cluster.getDpAmbariUser(), cluster.getDpAmbariPassword());
                 if ("admin".equals(cluster.getUserName())) {
                     ApiUser2 oldAdmin = oldAdminUser.get();
                     oldAdmin.setPassword(cluster.getPassword());

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/cluster/ClusterV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/cluster/ClusterV4Response.java
@@ -99,11 +99,11 @@ public class ClusterV4Response implements JsonEntity {
     @ApiModelProperty(ModelDescriptions.WORKSPACE_OF_THE_RESOURCE)
     private WorkspaceResourceV4Response workspace;
 
-    @ApiModelProperty(StackModelDescription.DP_AMBARI_USERNAME)
-    private SecretV4Response dpUser;
+    @ApiModelProperty(StackModelDescription.CM_MANAGEMENT_USERNAME)
+    private SecretV4Response cmMgmtUser;
 
-    @ApiModelProperty(StackModelDescription.DP_AMBARI_PASSWORD)
-    private SecretV4Response dpPassword;
+    @ApiModelProperty(StackModelDescription.CM_MANAGEMENT_PASSWORD)
+    private SecretV4Response cmMgmtPassword;
 
     @ApiModelProperty(ClusterModelDescription.BLUEPRINT)
     private BlueprintV4Response blueprint;
@@ -247,20 +247,20 @@ public class ClusterV4Response implements JsonEntity {
         this.uptime = uptime;
     }
 
-    public SecretV4Response getDpUser() {
-        return dpUser;
+    public SecretV4Response getCmMgmtUser() {
+        return cmMgmtUser;
     }
 
-    public void setDpUser(SecretV4Response dpUser) {
-        this.dpUser = dpUser;
+    public void setCmMgmtUser(SecretV4Response cmMgmtUser) {
+        this.cmMgmtUser = cmMgmtUser;
     }
 
-    public SecretV4Response getDpPassword() {
-        return dpPassword;
+    public SecretV4Response getCmMgmtPassword() {
+        return cmMgmtPassword;
     }
 
-    public void setDpPassword(SecretV4Response dpPassword) {
-        this.dpPassword = dpPassword;
+    public void setCmMgmtPassword(SecretV4Response cmMgmtPassword) {
+        this.cmMgmtPassword = cmMgmtPassword;
     }
 
     public WorkspaceResourceV4Response getWorkspace() {

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
@@ -171,8 +171,8 @@ public class ModelDescriptions {
         public static final String STATUS_REQUEST = "status of the scale request";
         public static final String SERVER_IP = "public ambari ip of the stack";
         public static final String SERVER_URL = "public ambari url";
-        public static final String DP_AMBARI_USERNAME = "ambari username for Dataplane";
-        public static final String DP_AMBARI_PASSWORD = "ambari password for Dataplane";
+        public static final String CM_MANAGEMENT_USERNAME = "CM username for shared usage";
+        public static final String CM_MANAGEMENT_PASSWORD = "CM password for shared usage";
         public static final String NETWORK_ID = "network resource id for the stack";
         public static final String CERTIFICATE = "server certificate used by the gateway";
         public static final String CLIENT_KEY = "client key used by the gateway";

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cluster/ClusterToClusterV4ResponseConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cluster/ClusterToClusterV4ResponseConverter.java
@@ -189,8 +189,8 @@ public class ClusterToClusterV4ResponseConverter extends AbstractConversionServi
 
     private void convertDpSecrets(Cluster source, ClusterV4Response response) {
         if (isNotEmpty(source.getDpAmbariUserSecret()) && isNotEmpty(source.getDpAmbariPasswordSecret())) {
-            response.setDpUser(getConversionService().convert(source.getDpAmbariUserSecret(), SecretV4Response.class));
-            response.setDpPassword(getConversionService().convert(source.getDpAmbariPasswordSecret(), SecretV4Response.class));
+            response.setCmMgmtUser(getConversionService().convert(source.getDpAmbariUserSecret(), SecretV4Response.class));
+            response.setCmMgmtPassword(getConversionService().convert(source.getDpAmbariPasswordSecret(), SecretV4Response.class));
         }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cluster/ClusterV4RequestToClusterConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cluster/ClusterV4RequestToClusterConverter.java
@@ -38,8 +38,8 @@ import com.sequenceiq.cloudbreak.converter.AbstractConversionServiceAwareConvert
 import com.sequenceiq.cloudbreak.converter.util.CloudStorageValidationUtil;
 import com.sequenceiq.cloudbreak.converter.v4.stacks.cluster.clouderamanager.ClouderaManagerProductV4RequestToClouderaManagerProductConverter;
 import com.sequenceiq.cloudbreak.converter.v4.stacks.cluster.clouderamanager.ClouderaManagerRepositoryV4RequestToClouderaManagerRepoConverter;
-import com.sequenceiq.cloudbreak.domain.ClusterAttributes;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
+import com.sequenceiq.cloudbreak.domain.ClusterAttributes;
 import com.sequenceiq.cloudbreak.domain.FileSystem;
 import com.sequenceiq.cloudbreak.domain.KerberosConfig;
 import com.sequenceiq.cloudbreak.domain.LdapConfig;
@@ -66,8 +66,8 @@ public class ClusterV4RequestToClusterConverter extends AbstractConversionServic
     @Value("${cb.ambari.username:cloudbreak}")
     private String ambariUserName;
 
-    @Value("${cb.ambari.dp.username:dpapps}")
-    private String dpUsername;
+    @Value("${cb.cm.mgmt.username:cmmgmt}")
+    private String cmMgmtUsername;
 
     @Inject
     private CloudStorageValidationUtil cloudStorageValidationUtil;
@@ -107,7 +107,7 @@ public class ClusterV4RequestToClusterConverter extends AbstractConversionServic
         }
         cluster.setCloudbreakAmbariUser(ambariUserName);
         cluster.setCloudbreakAmbariPassword(PasswordUtil.generatePassword());
-        cluster.setDpAmbariUser(dpUsername);
+        cluster.setDpAmbariUser(cmMgmtUsername);
         cluster.setDpAmbariPassword(PasswordUtil.generatePassword());
         cluster.setBlueprint(getBlueprint(source.getBlueprintName(), workspace));
         convertGateway(source, cluster);


### PR DESCRIPTION
Create a shared CM management user. I didn't rename the Entity fields, just the Response fileds, because in DB we still save all user/pass entries under cloudbreakAmbariUser etc..