### PR TITLE
[CB-1321] Support host group substitution

### DIFF
--- a/core-model/src/test/java/com/sequenceiq/cloudbreak/TestUtil.java
+++ b/core-model/src/test/java/com/sequenceiq/cloudbreak/TestUtil.java
@@ -305,7 +305,7 @@ public class TestUtil {
         instanceMetaData.setAmbariServer(ambariServer);
         instanceMetaData.setConsulServer(true);
         instanceMetaData.setSshPort(22);
-        instanceMetaData.setDiscoveryFQDN("test-" + instanceGroupId + '-' + serverNumber);
+        instanceMetaData.setDiscoveryFQDN("test-" + instanceGroup.getGroupName() + "-" + instanceGroupId + '-' + serverNumber);
         instanceMetaData.setInstanceId("test-" + instanceGroupId + '-' + serverNumber);
         instanceMetaData.setPrivateIp("1.1." + instanceGroupId + '.' + serverNumber);
         instanceMetaData.setPublicIp("2.2." + instanceGroupId + '.' + serverNumber);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/stack/instance/InstanceMetaDataToInstanceMetaDataJsonConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/stack/instance/InstanceMetaDataToInstanceMetaDataJsonConverterTest.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.converter.stack.instance;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
@@ -28,10 +29,14 @@ public class InstanceMetaDataToInstanceMetaDataJsonConverterTest extends Abstrac
     @Test
     public void testConvert() {
         // GIVEN
+        InstanceMetaData source = getSource();
+
         // WHEN
-        InstanceMetaDataV4Response result = underTest.convert(getSource());
+        InstanceMetaDataV4Response result = underTest.convert(source);
+
         // THEN
-        assertEquals("test-1-1", result.getDiscoveryFQDN());
+        assertNotNull(result);
+        assertEquals("test-" + source.getInstanceGroupName() + "-1-1", result.getDiscoveryFQDN());
         assertTrue(result.getAmbariServer());
         assertAllFieldsNotNull(result, List.of("state"));
     }

--- a/template-manager-blueprint/src/test/java/com/sequenceiq/cloudbreak/blueprint/template/TemplateProcessorTest.java
+++ b/template-manager-blueprint/src/test/java/com/sequenceiq/cloudbreak/blueprint/template/TemplateProcessorTest.java
@@ -24,6 +24,7 @@ import com.sequenceiq.cloudbreak.cloud.model.AmbariDatabase;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.domain.json.Json;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject.Builder;
 import com.sequenceiq.cloudbreak.template.TemplateProcessor;
@@ -66,6 +67,7 @@ public class TemplateProcessorTest {
                 .withBlueprintView(new BlueprintView(testBlueprint, blueprintStackInfo.getVersion(),
                         blueprintStackInfo.getType(), ambariBlueprintTextProcessor))
                 .withFixInputs(properties)
+                .withHostgroups(cluster.getHostGroups())
                 .build();
 
         String result = underTest.process(testBlueprint, templatePreparationObject, Maps.newHashMap());
@@ -76,6 +78,10 @@ public class TemplateProcessorTest {
         assertTrue(result.contains("jdbc:postgresql://10.1.1.1:5432/ranger"));
         assertTrue(result.contains("cn=users,dc=example,dc=org"));
         assertTrue(result.contains("ldap://localhost:389"));
+        assertTrue(result.contains("\"hive.metastore.uris\": \"thrift://test-master-1-1:9083,thrift://test-master-1-2:9083\""));
+        assertTrue(result.contains("\"worker_hosts\": \"test-worker-1-1;test-worker-1-2\""));
+        assertTrue(result.contains("\"single_gateway_host\": \"test-gateway-1-1\""));
+        assertTrue(result.contains("\"gateway_https_url\": \"https://test-gateway-1-1\""));
         assertFalse(result.contains("cloud-storage-present"));
     }
 
@@ -299,6 +305,13 @@ public class TemplateProcessorTest {
         rdsConfigSet.add(hiveRds);
         rdsConfigSet.add(rdsConfig(DatabaseType.RANGER.name().toLowerCase()));
         cluster.setRdsConfigs(rdsConfigSet);
+
+        Set<HostGroup> hostGroups = new HashSet<>();
+        hostGroups.add(TestUtil.hostGroup("master", 2));
+        hostGroups.add(TestUtil.hostGroup("worker", 2));
+        hostGroups.add(TestUtil.hostGroup("gateway", 1));
+        cluster.setHostGroups(hostGroups);
+
         return cluster;
     }
 

--- a/template-manager-blueprint/src/test/resources/blueprints-jackson/bp-mustache-test.bp
+++ b/template-manager-blueprint/src/test/resources/blueprints-jackson/bp-mustache-test.bp
@@ -29,10 +29,18 @@
     ],
     "configurations": [
       {
+        "host-group-test": {
+          "hive.metastore.uris": "{{{format-join host_groups.master format="thrift://%s:9083" sep=","}}}",
+          "worker_hosts": "{{{format-join host_groups.worker sep=";"}}}",
+          "single_gateway_host": "{{{ host_groups.gateway }}}",
+          "gateway_https_url": "{{{format-join host_groups.gateway format="https://%s" }}}"
+        }
+      },
+      {
         "nifi-ambari-ssl-config": {
           "content": "{{{ hdf.nodeEntities }}}",
           "nifi.initial.admin.identity": "{{{ general.userName }}}"
-        },
+        }
       },
       {
         "total-custom-rds-conf": {

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessorTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessorTest.java
@@ -32,7 +32,6 @@ public class CmTemplateProcessorTest {
 
     @Test
     public void testAddServiceConfigs() {
-        getBlueprintText("input/clouderamanager.bp");
         underTest = new CmTemplateProcessor(getBlueprintText("input/clouderamanager.bp"));
         List<ApiClusterTemplateConfig> configs = new ArrayList<>();
         configs.add(new ApiClusterTemplateConfig().name("hive_metastore_database_type").variable("hive-hive_metastore_database_type"));
@@ -48,7 +47,6 @@ public class CmTemplateProcessorTest {
 
     @Test
     public void testAddRoleConfigs() {
-        getBlueprintText("input/clouderamanager.bp");
         underTest = new CmTemplateProcessor(getBlueprintText("input/clouderamanager.bp"));
         Map<String, List<ApiClusterTemplateConfig>> configs = new HashMap<>();
         configs.put("hdfs-NAMENODE-BASE", List.of(new ApiClusterTemplateConfig().name("dfs_name_dir_list").variable("master_NAMENODE")));
@@ -70,7 +68,6 @@ public class CmTemplateProcessorTest {
 
     @Test
     public void testAddRoleConfigsWithNoMatchinRefName() {
-        getBlueprintText("input/clouderamanager.bp");
         underTest = new CmTemplateProcessor(getBlueprintText("input/clouderamanager.bp"));
         Map<String, List<ApiClusterTemplateConfig>> configs = new HashMap<>();
         configs.put("hdfs-NAMENODE-nomatch", List.of(new ApiClusterTemplateConfig().name("dfs_name_dir_list").variable("master_NAMENODE")));
@@ -90,7 +87,6 @@ public class CmTemplateProcessorTest {
 
     @Test
     public void testAddRoleConfigsWithExistingConfig() {
-        getBlueprintText("input/clouderamanager.bp");
         underTest = new CmTemplateProcessor(getBlueprintText("input/clouderamanager-existing-conf.bp"));
         Map<String, List<ApiClusterTemplateConfig>> configs = new HashMap<>();
         configs.put("hdfs-NAMENODE-BASE", List.of(new ApiClusterTemplateConfig().name("dfs_name_dir_list").variable("master_NAMENODE")));
@@ -119,7 +115,6 @@ public class CmTemplateProcessorTest {
 
     @Test
     public void testIsRoleTypePresentInServiceWithSingleRole() {
-        getBlueprintText("input/clouderamanager.bp");
         underTest = new CmTemplateProcessor(getBlueprintText("input/clouderamanager.bp"));
 
         boolean present = underTest.isRoleTypePresentInService("HDFS", List.of("NAMENODE"));
@@ -129,7 +124,6 @@ public class CmTemplateProcessorTest {
 
     @Test
     public void testIsRoleTypePresentInServiceWithMultipleRole() {
-        getBlueprintText("input/clouderamanager.bp");
         underTest = new CmTemplateProcessor(getBlueprintText("input/clouderamanager.bp"));
 
         boolean present = underTest.isRoleTypePresentInService("HDFS", List.of("DATANODE", "NAMENODE"));
@@ -139,7 +133,6 @@ public class CmTemplateProcessorTest {
 
     @Test
     public void testIsRoleTypePresentInServiceWithFakeRole() {
-        getBlueprintText("input/clouderamanager.bp");
         underTest = new CmTemplateProcessor(getBlueprintText("input/clouderamanager.bp"));
 
         boolean present = underTest.isRoleTypePresentInService("HDFS", List.of("MYROLE"));
@@ -149,7 +142,6 @@ public class CmTemplateProcessorTest {
 
     @Test
     public void testAddInstantiatorWithBaseRoles() {
-        getBlueprintText("input/clouderamanager.bp");
         underTest = new CmTemplateProcessor(getBlueprintText("input/clouderamanager.bp"));
         ClouderaManagerRepo clouderaManagerRepoDetails = new ClouderaManagerRepo();
         clouderaManagerRepoDetails.setVersion(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_6_3_0.getVersion());
@@ -170,7 +162,6 @@ public class CmTemplateProcessorTest {
 
     @Test
     public void testAddInstantiatorWithoutBaseRoles() {
-        getBlueprintText("input/clouderamanager.bp");
         underTest = new CmTemplateProcessor(getBlueprintText("input/clouderamanager-custom-ref.bp"));
         ClouderaManagerRepo clouderaManagerRepoDetails = new ClouderaManagerRepo();
         clouderaManagerRepoDetails.setVersion(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_6_3_0.getVersion());

--- a/template-manager-cmtemplate/src/test/resources/input/clouderamanager-fixparam.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/clouderamanager-fixparam.bp
@@ -27,6 +27,14 @@
         {
           "name": "default_fs_name",
           "value": "hdfs"
+        },
+        {
+          "name": "kdc_hosts",
+          "value": "{{{ host_groups.master }}}"
+        },
+        {
+          "name": "atlas.kafka.bootstrap.servers",
+          "value": "{{{format-join host_groups.master format="%s:2189"}}}"
         }
       ]
     },

--- a/template-manager-cmtemplate/src/test/resources/output/clouderamanager-fixparam.bp
+++ b/template-manager-cmtemplate/src/test/resources/output/clouderamanager-fixparam.bp
@@ -27,6 +27,14 @@
         {
           "name": "default_fs_name",
           "value": "hdfs"
+        },
+        {
+          "name": "kdc_hosts",
+          "value": "host1,host2"
+        },
+        {
+          "name": "atlas.kafka.bootstrap.servers",
+          "value": "host1:2189,host2:2189"
         }
       ]
     },

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/FormatJoinHelper.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/FormatJoinHelper.java
@@ -1,0 +1,51 @@
+package com.sequenceiq.cloudbreak.template;
+
+import static java.util.stream.Collectors.joining;
+
+import java.util.Collection;
+import java.util.function.Function;
+
+import com.github.jknack.handlebars.Helper;
+import com.github.jknack.handlebars.Options;
+
+/**
+ * Joins a collection of items after substituting each into a string format pattern.
+ *
+ * For example:
+ *
+ * <pre>
+ * {{format-join list format="https://%s" sep=";"}}
+ * </pre>
+ *
+ * If {@code list} is the list @{code ['cloudera.com', 'example.com', 'github.com']}, the output will be
+ * the string @{code "https://cloudera.com,https://example.com,https://github.com"}.
+ *
+ * Both format and separator are optional.
+ * The default separator is {@code ","}.
+ * If no format string is given, items are simply joined.
+ */
+public class FormatJoinHelper implements Helper<Collection<?>> {
+
+    public static final String NAME = "format-join";
+
+    static final FormatJoinHelper INSTANCE = new FormatJoinHelper();
+
+    @Override
+    public Object apply(Collection<?> context, Options options) {
+        if (context == null || context.isEmpty()) {
+            return "";
+        }
+
+        String separator = options.hash("sep", ",");
+        String format = options.hash("format", null);
+
+        Function<Object, String> formatter = format != null
+                ? each -> String.format(format, each)
+                : Object::toString;
+
+        return context.stream()
+                .map(formatter)
+                .collect(joining(separator));
+    }
+
+}

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/HandleBarModelKey.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/HandleBarModelKey.java
@@ -16,6 +16,7 @@ public enum HandleBarModelKey {
     BLUEPRINT("blueprint"),
     HDF("hdf"),
     GENERAL("general"),
+    HOST_GROUPS("host_groups"),
     STACK_VERSION("stack_version");
 
     private final String modelKey;

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/HandlebarUtils.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/HandlebarUtils.java
@@ -20,6 +20,7 @@ public final class HandlebarUtils {
         handlebars.registerHelper(ComponentPresentedHelper.NAME, ComponentPresentedHelper.INSTANCE);
         handlebars.registerHelper(NoEscapeHelper.NAME, NoEscapeHelper.INSTANCE);
         handlebars.registerHelper(IfNullHelper.NAME, IfNullHelper.INSTANCE);
+        handlebars.registerHelper(FormatJoinHelper.NAME, FormatJoinHelper.INSTANCE);
         handlebars.registerHelperMissing((context, options) -> options.fn.text());
         return handlebars;
     }

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/TemplateModelContextBuilder.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/TemplateModelContextBuilder.java
@@ -1,11 +1,15 @@
 package com.sequenceiq.cloudbreak.template;
 
+import static java.util.stream.Collectors.toMap;
+
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.SortedSet;
 
 import com.sequenceiq.cloudbreak.domain.KerberosConfig;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
@@ -18,6 +22,7 @@ import com.sequenceiq.cloudbreak.template.views.BlueprintView;
 import com.sequenceiq.cloudbreak.template.views.GatewayView;
 import com.sequenceiq.cloudbreak.template.views.GeneralClusterConfigsView;
 import com.sequenceiq.cloudbreak.template.views.HdfConfigView;
+import com.sequenceiq.cloudbreak.template.views.HostgroupView;
 import com.sequenceiq.cloudbreak.template.views.LdapView;
 import com.sequenceiq.cloudbreak.template.views.RdsView;
 import com.sequenceiq.cloudbreak.template.views.SharedServiceConfigsView;
@@ -49,6 +54,8 @@ public class TemplateModelContextBuilder {
     private Map<String, Object> customInputs = new HashMap<>();
 
     private Map<String, Object> fixInputs = new HashMap<>();
+
+    private Map<String, SortedSet<String>> hostGroups = Collections.emptyMap();
 
     public TemplateModelContextBuilder withGeneralClusterConfigs(GeneralClusterConfigs generalClusterConfigs) {
         generalClusterConfigsView = new GeneralClusterConfigsView(generalClusterConfigs);
@@ -126,6 +133,14 @@ public class TemplateModelContextBuilder {
         return this;
     }
 
+    public TemplateModelContextBuilder withHostgroupViews(Set<HostgroupView> hostgroupViews) {
+        if (hostgroupViews != null) {
+            hostGroups = hostgroupViews.stream()
+                .collect(toMap(HostgroupView::getName, HostgroupView::getHosts));
+        }
+        return this;
+    }
+
     public TemplateModelContextBuilder withComponents(Set<String> components) {
         this.components = components;
         return this;
@@ -157,6 +172,7 @@ public class TemplateModelContextBuilder {
         templateModelContext.put(HandleBarModelKey.BLUEPRINT.modelKey(), blueprintView);
         templateModelContext.put(HandleBarModelKey.HDF.modelKey(), hdfConfigs.orElse(null));
         templateModelContext.put(HandleBarModelKey.GENERAL.modelKey(), generalClusterConfigsView);
+        templateModelContext.put(HandleBarModelKey.HOST_GROUPS.modelKey(), hostGroups);
         ModelConverterUtils.deepMerge(templateModelContext, ModelConverterUtils.convert(customInputs));
         ModelConverterUtils.deepMerge(templateModelContext, ModelConverterUtils.convert(fixInputs));
         templateModelContext.put(HandleBarModelKey.STACK_VERSION.modelKey(), "{{stack_version}}");

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/TemplatePreparationObject.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/TemplatePreparationObject.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.sequenceiq.cloudbreak.domain.KerberosConfig;
 import com.sequenceiq.cloudbreak.domain.LdapConfig;
@@ -12,6 +13,7 @@ import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.gateway.Gateway;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.template.filesystem.BaseFileSystemConfigurationsView;
 import com.sequenceiq.cloudbreak.template.model.GeneralClusterConfigs;
 import com.sequenceiq.cloudbreak.template.model.HdfConfigs;
@@ -159,8 +161,11 @@ public class TemplatePreparationObject {
                 InstanceGroup instanceGroup = hostGroup.getConstraint().getInstanceGroup();
                 if (instanceGroup != null) {
                     int volumeCount = instanceGroup.getTemplate() == null ? 1 : instanceGroup.getTemplate().getVolumeCount();
+                    Set<String> fqdns = instanceGroup.getAllInstanceMetaData().stream()
+                            .map(InstanceMetaData::getDiscoveryFQDN)
+                            .collect(Collectors.toSet());
                     hostgroupViews.add(new HostgroupView(hostGroup.getName(), volumeCount,
-                            instanceGroup.getInstanceGroupType(), instanceGroup.getNodeCount()));
+                            instanceGroup.getInstanceGroupType(), fqdns));
                 } else {
                     hostgroupViews.add(new HostgroupView(hostGroup.getName()));
                 }

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/TemplateProcessor.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/TemplateProcessor.java
@@ -59,6 +59,7 @@ public class TemplateProcessor {
                 .withComponents(source.getBlueprintView().getComponents())
                 .withGateway(source.getGatewayView())
                 .withBlueprintView(source.getBlueprintView())
+                .withHostgroupViews(source.getHostgroupViews())
                 .withRdsConfigs(source.getRdsConfigs())
                 .withFileSystemConfigs(source.getFileSystemConfigurationView().orElse(null))
                 .withCustomInputs(source.getCustomInputs())

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/views/HostgroupView.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/views/HostgroupView.java
@@ -1,5 +1,10 @@
 package com.sequenceiq.cloudbreak.template.views;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceGroupType;
 
 public class HostgroupView {
@@ -14,12 +19,31 @@ public class HostgroupView {
 
     private final Integer nodeCount;
 
+    private final SortedSet<String> hosts;
+
+    public HostgroupView(String name, int volumeCount, InstanceGroupType instanceGroupType, Collection<String> hosts) {
+        this.name = name;
+        this.volumeCount = volumeCount;
+        instanceGroupConfigured = true;
+        this.instanceGroupType = instanceGroupType;
+        this.hosts = hosts != null
+            ? Collections.unmodifiableSortedSet(new TreeSet<>(hosts) {
+                    @Override
+                    public String toString() {
+                        return String.join(",", this);
+                    }
+                })
+            : Collections.emptySortedSet();
+        nodeCount = this.hosts.size();
+    }
+
     public HostgroupView(String name, int volumeCount, InstanceGroupType instanceGroupType, Integer nodeCount) {
         this.name = name;
         this.volumeCount = volumeCount;
         instanceGroupConfigured = true;
         this.instanceGroupType = instanceGroupType;
         this.nodeCount = nodeCount;
+        hosts = Collections.emptySortedSet();
     }
 
     public HostgroupView(String name) {
@@ -28,6 +52,7 @@ public class HostgroupView {
         instanceGroupConfigured = false;
         instanceGroupType = InstanceGroupType.CORE;
         nodeCount = 0;
+        hosts = Collections.emptySortedSet();
     }
 
     public String getName() {
@@ -48,5 +73,9 @@ public class HostgroupView {
 
     public Integer getNodeCount() {
         return nodeCount;
+    }
+
+    public SortedSet<String> getHosts() {
+        return hosts;
     }
 }

--- a/template-manager-core/src/test/java/com/sequenceiq/cloudbreak/template/FormatJoinHelperTest.java
+++ b/template-manager-core/src/test/java/com/sequenceiq/cloudbreak/template/FormatJoinHelperTest.java
@@ -1,0 +1,54 @@
+package com.sequenceiq.cloudbreak.template;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.github.jknack.handlebars.Options;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FormatJoinHelperTest {
+
+    @Mock
+    private Options options;
+
+    @Test
+    public void formatsEachItem() {
+        Collection<?> items = Arrays.asList("A", "B");
+        separatorIs(";");
+        formatStringIs("prefix:%s:suffix");
+
+        assertEquals("prefix:A:suffix;prefix:B:suffix", FormatJoinHelper.INSTANCE.apply(items, options));
+    }
+
+    @Test
+    public void noSeparatorForSingleItem() {
+        Collection<?> items = Collections.singleton("host");
+        separatorIs(",");
+        formatStringIs("http://%s:8080");
+
+        assertEquals("http://host:8080", FormatJoinHelper.INSTANCE.apply(items, options));
+    }
+
+    @Test
+    public void emptyResultForNoItems() {
+        assertEquals("", FormatJoinHelper.INSTANCE.apply(Collections.emptySet(), options));
+    }
+
+    private void formatStringIs(String format) {
+        when(options.hash("format", null)).thenReturn(format);
+    }
+
+    private void separatorIs(String separator) {
+        when(options.hash("sep", ",")).thenReturn(separator);
+    }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Introduce support for generic host group substitution in Cloudbreak templates.

1. Hosts that belong to a host group are available using `{{{ host_group.<host_group> }}}`.  For example `{{{ host_group.master }}}` is replaced with `master1,master2` if this host group contains the hosts `master1` and `master2`.
2. To accomodate the need to add some protocol and port for each host, a new custom Handlebars.java helper is implemented.  For example
   ```
   {{{format-join host_group.master format="thrift://%s:9083"}}}
   ```
   is replaced with
   ```
   thrift://master1:9083,thrift://master2:9083
   ```
   Separator can be changed, too, but defaults to `,`.

## How was this patch tested?

Adjusted existing unit tests for template processing, and added a new one for the custom helper.