### PR TITLE
CB-1174 Add environments to database servers, and more

### DIFF
--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/DatabaseServerV4Endpoint.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/DatabaseServerV4Endpoint.java
@@ -15,7 +15,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 //
 import com.sequenceiq.cloudbreak.doc.ContentType;
-//import com.sequenceiq.redbeams.api.endpoint.v4.common.EnvironmentNames;
+//import com.sequenceiq.redbeams.api.endpoint.v4.common.EnvironmentIds;
 //import com.sequenceiq.redbeams.api.endpoint.v4.database.requests.DatabaseTestV4Request;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.DatabaseServerV4Request;
 //import com.sequenceiq.redbeams.api.endpoint.v4.database.responses.DatabaseTestV4Response;
@@ -40,7 +40,7 @@ public interface DatabaseServerV4Endpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = DatabaseServerOpDescription.LIST_BY_WORKSPACE, produces = ContentType.JSON, notes = Notes.DATABASE_SERVER_NOTES,
         nickname = "listDatabasesServersByWorkspace")
-    DatabaseServerV4Responses list(@PathParam("workspaceId") Long workspaceId, @QueryParam("environment") String environment,
+    DatabaseServerV4Responses list(@PathParam("workspaceId") Long workspaceId, @QueryParam("environmentId") String environmentId,
         @QueryParam("attachGlobal") @DefaultValue("false") Boolean attachGlobal);
 
     @GET

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/base/DatabaseServerV4Base.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/base/DatabaseServerV4Base.java
@@ -1,8 +1,5 @@
 package com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.base;
 
-// import java.util.HashSet;
-// import java.util.Set;
-
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
@@ -38,11 +35,15 @@ public abstract class DatabaseServerV4Base implements JsonEntity {
     @ApiModelProperty(value = DatabaseServer.PORT, required = true)
     private Integer port;
 
+    @NotNull
+    @ApiModelProperty(value = DatabaseServer.DATABASE_VENDOR, required = true)
+    private String databaseVendor;
+
     @ApiModelProperty(DatabaseServer.CONNECTOR_JAR_URL)
     private String connectorJarUrl;
 
-    // @ApiModelProperty(ModelDescriptions.ENVIRONMENTS)
-    // private Set<String> environments = new HashSet<>();
+    @ApiModelProperty(value = ModelDescriptions.ENVIRONMENT_ID, required = true)
+    private String environmentId;
 
     public String getName() {
         return name;
@@ -76,6 +77,14 @@ public abstract class DatabaseServerV4Base implements JsonEntity {
         this.port = port;
     }
 
+    public String getDatabaseVendor() {
+        return databaseVendor;
+    }
+
+    public void setDatabaseVendor(String databaseVendor) {
+        this.databaseVendor = databaseVendor;
+    }
+
     public String getConnectorJarUrl() {
         return connectorJarUrl;
     }
@@ -84,11 +93,11 @@ public abstract class DatabaseServerV4Base implements JsonEntity {
         this.connectorJarUrl = connectorJarUrl;
     }
 
-// public Set<String> getEnvironments() {
-//     return environments;
-// }
+    public String getEnvironmentId() {
+        return environmentId;
+    }
 
-// public void setEnvironments(Set<String> environments) {
-//     this.environments = environments == null ? new HashSet<>() : environments;
-// }
+    public void setEnvironmentId(String environmentId) {
+        this.environmentId = environmentId;
+    }
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/DatabaseServerV4Request.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/DatabaseServerV4Request.java
@@ -15,11 +15,6 @@ import io.swagger.annotations.ApiModelProperty;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DatabaseServerV4Request extends DatabaseServerV4Base {
 
-    // FIXME maybe move to base
-    @NotNull
-    @ApiModelProperty(value = DatabaseServer.DATABASE_VENDOR, required = true)
-    private String databaseVendor;
-
     @NotNull
     @ApiModelProperty(value = DatabaseServer.CONNECTION_USER_NAME, required = true)
     private String connectionUserName;
@@ -30,14 +25,6 @@ public class DatabaseServerV4Request extends DatabaseServerV4Base {
 
     // @ApiModelProperty(Database.ORACLE)
     // private OracleParameters oracle;
-
-    public String getDatabaseVendor() {
-        return databaseVendor;
-    }
-
-    public void setDatabaseVendor(String databaseVendor) {
-        this.databaseVendor = databaseVendor;
-    }
 
     public String getConnectionUserName() {
         return connectionUserName;

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/responses/DatabaseServerV4Response.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/responses/DatabaseServerV4Response.java
@@ -28,10 +28,6 @@ public class DatabaseServerV4Response extends DatabaseServerV4Base {
     // @ApiModelProperty(RDSConfigModelDescription.CLUSTER_NAMES)
     // private Set<String> clusterNames;
 
-    // FIXME maybe move to base
-    @ApiModelProperty(value = DatabaseServer.DATABASE_VENDOR, required = true)
-    private String databaseVendor;
-
     @ApiModelProperty(value = DatabaseServer.DATABASE_VENDOR_DISPLAY_NAME, required = true)
     private String databaseVendorDisplayName;
 
@@ -53,14 +49,6 @@ public class DatabaseServerV4Response extends DatabaseServerV4Base {
 
     public void setId(Long id) {
         this.id = id;
-    }
-
-    public String getDatabaseVendor() {
-        return databaseVendor;
-    }
-
-    public void setDatabaseVendor(String databaseVendor) {
-        this.databaseVendor = databaseVendor;
     }
 
     public String getDatabaseVendorDisplayName() {

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/ModelDescriptions.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/ModelDescriptions.java
@@ -2,11 +2,12 @@ package com.sequenceiq.redbeams.doc;
 
 public final class ModelDescriptions {
 
-    public static final String ID = "id of the resource";
+    public static final String ID = "ID of the resource";
     // public static final String WORKSPACE_OF_THE_RESOURCE = "workspace of the resource";
     // public static final String WORKSPACE_ID = "Workspace ID of the resource";
     public static final String DESCRIPTION = "Description of the resource";
-    public static final String CREATION_DATE = "creation date / time of the resource, in epoch milliseconds";
+    public static final String CREATION_DATE = "Creation date / time of the resource, in epoch milliseconds";
+    public static final String ENVIRONMENT_ID = "ID of the environment of the resource";
 
     // public static class Database {
     //     public static final String CONNECTION_URL = "JDBC connection URL in the form of jdbc:<db-type>://<address>:<port>/<db>";

--- a/redbeams-model/src/main/java/com/sequenceiq/redbeams/domain/DatabaseServerConfig.java
+++ b/redbeams-model/src/main/java/com/sequenceiq/redbeams/domain/DatabaseServerConfig.java
@@ -1,22 +1,13 @@
 package com.sequenceiq.redbeams.domain;
 
-//import java.util.HashSet;
-//import java.util.Set;
-
-//import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-//import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-//import javax.persistence.JoinColumn;
-//import javax.persistence.JoinTable;
-//import javax.persistence.ManyToMany;
-// import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
@@ -29,23 +20,17 @@ import com.sequenceiq.cloudbreak.aspect.secret.SecretValue;
 import com.sequenceiq.cloudbreak.domain.Secret;
 import com.sequenceiq.cloudbreak.domain.SecretToString;
 import com.sequenceiq.cloudbreak.workspace.resource.WorkspaceResource;
-//import com.sequenceiq.cloudbreak.domain.environment.EnvironmentAwareResource;
-//import com.sequenceiq.cloudbreak.domain.view.EnvironmentView;
-// import com.sequenceiq.cloudbreak.domain.workspace.Workspace;
-// import com.sequenceiq.cloudbreak.domain.workspace.WorkspaceAwareResource;
 
 @Entity
 @Where(clause = "archived = false")
 @Table(uniqueConstraints = @UniqueConstraint(columnNames = {"workspace_id", "name"}))
-public class DatabaseServerConfig implements ProvisionEntity, /* EnvironmentAwareResource, WorkspaceAwareResource, */ ArchivableResource {
+public class DatabaseServerConfig implements ProvisionEntity, ArchivableResource {
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO, generator = "databaseserverconfig_generator")
     @SequenceGenerator(name = "databaseserverconfig_generator", sequenceName = "databaseserverconfig_id_seq", allocationSize = 1)
     private Long id;
 
-    // @ManyToOne
-    // private Workspace workspace;
     @Column(name = "workspace_id", nullable = false)
     private Long workspaceId;
 
@@ -87,16 +72,15 @@ public class DatabaseServerConfig implements ProvisionEntity, /* EnvironmentAwar
     @Column
     private String connectorJarUrl;
 
+    @Column
     private boolean archived;
 
+    @Column
     private Long deletionTimestamp = -1L;
 
-    // might go away / change, since environments are not stored in redbeams
-    // @ManyToMany(cascade = CascadeType.MERGE, fetch = FetchType.EAGER)
-    // @JoinTable(name = "env_databaseserver", joinColumns = @JoinColumn(name = "databaseserverid"), inverseJoinColumns = @JoinColumn(name = "envid"))
-    // private Set<EnvironmentView> environments = new HashSet<>();
+    @Column(nullable = false)
+    private String environmentId;
 
-    //@Override
     public Long getId() {
         return id;
     }
@@ -113,12 +97,10 @@ public class DatabaseServerConfig implements ProvisionEntity, /* EnvironmentAwar
         this.workspaceId = workspaceId;
     }
 
-    //@Override
     public WorkspaceResource getResource() {
         return WorkspaceResource.DATABASE_SERVER;
     }
 
-    // @Override
     public String getName() {
         return name;
     }
@@ -230,21 +212,19 @@ public class DatabaseServerConfig implements ProvisionEntity, /* EnvironmentAwar
 
     @Override
     public void setArchived(boolean archived) {
-        this.archived = true;
+        this.archived = archived;
     }
 
     @Override
     public void unsetRelationsToEntitiesToBeDeleted() {
     }
 
-    // @Override
-    // public Set<EnvironmentView> getEnvironments() {
-    //     return environments;
-    // }
+    public String getEnvironmentId() {
+        return environmentId;
+    }
 
-    // @Override
-    // public void setEnvironments(Set<EnvironmentView> environments) {
-    //     this.environments = environments;
-    // }
+    public void setEnvironmentId(String environmentId) {
+        this.environmentId = environmentId;
+    }
 
 }

--- a/redbeams-model/src/test/java/com/sequenceiq/redbeams/domain/DatabaseServerConfigTest.java
+++ b/redbeams-model/src/test/java/com/sequenceiq/redbeams/domain/DatabaseServerConfigTest.java
@@ -6,12 +6,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ResourceStatus;
-//import com.sequenceiq.cloudbreak.domain.view.EnvironmentView;
-// import com.sequenceiq.cloudbreak.domain.workspace.Workspace;
 import com.sequenceiq.cloudbreak.workspace.resource.WorkspaceResource;
-
-// import java.util.Collections;
-// import java.util.Set;
 
 import org.hibernate.annotations.Where;
 import org.junit.Before;
@@ -19,20 +14,10 @@ import org.junit.Test;
 
 public class DatabaseServerConfigTest {
 
-    // private Workspace workspace;
-
-    // private EnvironmentView environmentView;
-
     private DatabaseServerConfig config;
 
     @Before
     public void setUp() {
-        // workspace = new Workspace();
-        // workspace.setId(1L);
-
-        // environmentView = new EnvironmentView();
-        // environmentView.setId(1L);
-
         config = new DatabaseServerConfig();
     }
 
@@ -84,9 +69,8 @@ public class DatabaseServerConfigTest {
         config.setArchived(true);
         assertTrue(config.isArchived());
 
-        // Set<EnvironmentView> environments = Collections.singleton(environmentView);
-        // config.setEnvironments(environments);
-        // assertEquals(environments, config.getEnvironments());
+        config.setEnvironmentId("myenvironment");
+        assertEquals("myenvironment", config.getEnvironmentId());
     }
 
     @Test

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4Controller.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4Controller.java
@@ -28,8 +28,8 @@ public class DatabaseServerV4Controller implements DatabaseServerV4Endpoint {
     private ConverterUtil converterUtil;
 
     @Override
-    public DatabaseServerV4Responses list(Long workspaceId, String environment, Boolean attachGlobal) {
-        Set<DatabaseServerConfig> all = databaseServerConfigService.findAllInWorkspaceAndEnvironment(workspaceId, environment, attachGlobal);
+    public DatabaseServerV4Responses list(Long workspaceId, String environmentId, Boolean attachGlobal) {
+        Set<DatabaseServerConfig> all = databaseServerConfigService.findAllInWorkspaceAndEnvironment(workspaceId, environmentId, attachGlobal);
         return new DatabaseServerV4Responses(converterUtil.convertAllAsSet(all, DatabaseServerV4Response.class));
     }
 

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/repository/DatabaseServerConfigRepository.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/repository/DatabaseServerConfigRepository.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import javax.transaction.Transactional;
 import javax.transaction.Transactional.TxType;
 
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
 import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
@@ -15,6 +16,9 @@ import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
 @Transactional(TxType.REQUIRED)
 public interface DatabaseServerConfigRepository extends CrudRepository<DatabaseServerConfig, Long> {
 
-    Set<DatabaseServerConfig> findAllByWorkspaceId(Long workspaceId);
+    @Query("SELECT s FROM DatabaseServerConfig s WHERE"
+            + " s.workspaceId = :workspaceId AND s.environmentId = :environmentId"
+            + " AND s.resourceStatus = 'USER_MANAGED'")
+    Set<DatabaseServerConfig> findAllByWorkspaceIdAndEnvironmentId(Long workspaceId, String environmentId);
 
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigService.java
@@ -19,8 +19,8 @@ public class DatabaseServerConfigService {
     @Inject
     private DatabaseServerConfigRepository repository;
 
-    public Set<DatabaseServerConfig> findAllInWorkspaceAndEnvironment(Long workspaceId, String environment, Boolean attachGlobal) {
-        return repository.findAllByWorkspaceId(workspaceId);
+    public Set<DatabaseServerConfig> findAllInWorkspaceAndEnvironment(Long workspaceId, String environmentId, Boolean attachGlobal) {
+        return repository.findAllByWorkspaceIdAndEnvironmentId(workspaceId, environmentId);
     }
 
 }

--- a/redbeams/src/main/resources/schema/app/20190508131601_CB-1174_database_server_config_env.sql
+++ b/redbeams/src/main/resources/schema/app/20190508131601_CB-1174_database_server_config_env.sql
@@ -1,0 +1,19 @@
+-- CB-1174 database server config environment IDs
+
+ALTER TABLE ONLY databaseserverconfig ADD CONSTRAINT uk_databaseserverconfig_deletiondate_workspace UNIQUE (name, deletionTimestamp, workspace_id);
+
+ALTER TABLE databaseserverconfig ADD COLUMN environmentid VARCHAR(255);
+
+UPDATE databaseserverconfig SET environmentid = 'unknown' WHERE environmentid IS NULL;
+
+ALTER TABLE databaseserverconfig ALTER COLUMN environmentid SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS databaseserverconfig_environmentid_idx ON databaseserverconfig(environmentid);
+
+-- //@UNDO
+
+DROP INDEX IF EXISTS databaseserverconfig_environmentid_idx;
+
+ALTER TABLE databaseserverconfig DROP COLUMN environmentid;
+
+ALTER TABLE ONLY databaseserverconfig DROP CONSTRAINT IF EXISTS uk_databaseserverconfig_deletiondate_workspace;


### PR DESCRIPTION
A database server entity in redbeams is now associated with one or more
environment IDs. The list API is connected up properly so that the
environment ID query parameter matters.

Other useful changes:

- The query for finding all database server entities is expanded to
include the environment ID as a criterion. The query is not fully tested
yet to see what happens if no environment ID is specified.
- The database vendor property for database server API models is
refactored into the base model class.
- The databaseserverconfig table gets a new constraint pertaining to
archiving.
- Many commented-out lines, left tentatively in place, are cleaned up.
(There are still plenty more in redbeams to dispose of later.)