### PR TITLE
CB-1353. Need trial license for Management Service

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerLdapService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerLdapService.java
@@ -4,14 +4,13 @@ import java.util.Optional;
 
 import javax.inject.Inject;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.cloudera.api.swagger.AuthRolesResourceApi;
-import com.cloudera.api.swagger.ClouderaManagerResourceApi;
 import com.cloudera.api.swagger.ExternalUserMappingsResourceApi;
+import com.cloudera.api.swagger.client.ApiClient;
 import com.cloudera.api.swagger.client.ApiException;
 import com.cloudera.api.swagger.model.ApiAuthRoleMetadata;
 import com.cloudera.api.swagger.model.ApiAuthRoleMetadataList;
@@ -19,7 +18,6 @@ import com.cloudera.api.swagger.model.ApiAuthRoleRef;
 import com.cloudera.api.swagger.model.ApiExternalUserMapping;
 import com.cloudera.api.swagger.model.ApiExternalUserMappingList;
 import com.cloudera.api.swagger.model.ApiExternalUserMappingType;
-import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
 import com.sequenceiq.cloudbreak.client.HttpClientConfig;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerClientFactory;
 import com.sequenceiq.cloudbreak.domain.LdapConfig;
@@ -35,29 +33,20 @@ public class ClouderaManagerLdapService {
     private ClouderaManagerClientFactory clouderaManagerClientFactory;
 
     @Inject
-    private GrpcUmsClient umsClient;
+    private ClouderaManagerLicenseService licenseService;
 
     public void setupLdap(Stack stack, Cluster cluster, HttpClientConfig clientConfig) throws ApiException {
         LdapConfig ldapConfig = cluster.getLdapConfig();
-        ClouderaManagerResourceApi clouderaManagerResourceApi = clouderaManagerClientFactory.getClouderaManagerResourceApi(stack, cluster, clientConfig);
-
-        // Begin the Cloudera Manager trial only if UMS is not enabled. Otherwise, we'll be using a
-        // license from UMS.
-        String userCrn = stack.getCreator().getUserCrn();
-        if (!umsClient.isUmsUsable(userCrn) || StringUtils.isEmpty(
-                umsClient.getAccountDetails(userCrn, userCrn, Optional.empty()).getClouderaManagerLicenseKey())) {
-            LOGGER.info("Enabling trial license.");
-            clouderaManagerResourceApi.beginTrial();
-        } else {
-            LOGGER.info("UMS detected and license key available, skipping trial license.");
-        }
 
         if (ldapConfig != null) {
+            ApiClient client = clouderaManagerClientFactory.getClient(stack, cluster, clientConfig);
+            licenseService.beginTrialIfNeeded(stack.getCreator(), client);
+
             LOGGER.debug("Setup LDAP on ClouderaManager API for stack: {}", stack.getId());
             LdapView ldapView = new LdapView(ldapConfig, ldapConfig.getBindDn(), ldapConfig.getBindPassword());
             ExternalUserMappingsResourceApi externalUserMappingsResourceApi =
-                    clouderaManagerClientFactory.getExternalUserMappingsResourceApi(stack, cluster, clientConfig);
-            AuthRolesResourceApi authRolesResourceApi = clouderaManagerClientFactory.getAuthRolesResourceApi(stack, cluster, clientConfig);
+                    clouderaManagerClientFactory.getExternalUserMappingsResourceApi(client);
+            AuthRolesResourceApi authRolesResourceApi = clouderaManagerClientFactory.getAuthRolesResourceApi(client);
             ApiAuthRoleMetadataList roleMetadataList = authRolesResourceApi.readAuthRolesMetadata(null);
             if (roleMetadataList.getItems() != null) {
                 Optional<ApiAuthRoleMetadata> roleMetadata = roleMetadataList.getItems().stream().filter(rm -> rm.getRole().equals("ROLE_ADMIN")).findFirst();

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerLicenseService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerLicenseService.java
@@ -1,0 +1,64 @@
+package com.sequenceiq.cloudbreak.cm;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.Response;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.cloudera.api.swagger.client.ApiClient;
+import com.cloudera.api.swagger.client.ApiException;
+import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
+import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerClientFactory;
+import com.sequenceiq.cloudbreak.workspace.model.User;
+
+@Service
+public class ClouderaManagerLicenseService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerLicenseService.class);
+
+    @Inject
+    private ClouderaManagerClientFactory clouderaManagerClientFactory;
+
+    @Inject
+    private GrpcUmsClient umsClient;
+
+    public void beginTrialIfNeeded(User user, ApiClient apiClient) throws ApiException {
+        // Begin the Cloudera Manager trial only if UMS is not enabled. Otherwise, we'll be using a
+        // license from UMS.
+        if (needTrialLicense(user.getUserCrn())) {
+            beginTrial(apiClient);
+        } else {
+            LOGGER.info("UMS detected and license key available, skipping trial license.");
+        }
+    }
+
+    private void beginTrial(ApiClient apiClient) throws ApiException {
+        LOGGER.info("Enabling trial license.");
+
+        try {
+            clouderaManagerClientFactory.getClouderaManagerResourceApi(apiClient).beginTrial();
+        } catch (ApiException e) {
+            if (trialAlreadyStarted(e)) {
+                LOGGER.info("Already had enabled trial license.");
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    private static boolean trialAlreadyStarted(ApiException e) {
+        return e.getCode() == Response.Status.BAD_REQUEST.getStatusCode()
+                && e.getResponseBody().contains("Trial has been used.");
+    }
+
+    private boolean needTrialLicense(String userCrn) {
+        return !umsClient.isUmsUsable(userCrn)
+                || StringUtils.isEmpty(umsClient.getAccountDetails(userCrn, userCrn, Optional.empty()).getClouderaManagerLicenseKey());
+    }
+
+}

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerMgmtSetupService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerMgmtSetupService.java
@@ -78,6 +78,9 @@ public class ClouderaManagerMgmtSetupService {
     @Inject
     private ClouderaManagerPollingServiceProvider clouderaManagerPollingServiceProvider;
 
+    @Inject
+    private ClouderaManagerLicenseService licenseService;
+
     /**
      * Sets up the management services using the given Cloudera Manager client.
      *
@@ -89,6 +92,8 @@ public class ClouderaManagerMgmtSetupService {
      */
     public void setupMgmtServices(Stack stack, ApiClient client, ApiHostRef cmHostRef, Set<RDSConfig> rdsConfigs)
             throws ApiException {
+        licenseService.beginTrialIfNeeded(stack.getCreator(), client);
+
         ClouderaManagerResourceApi clouderaManagerResourceApi = new ClouderaManagerResourceApi(client);
         MgmtServiceResourceApi mgmtServiceResourceApi = new MgmtServiceResourceApi(client);
         MgmtRolesResourceApi mgmtRolesResourceApi = new MgmtRolesResourceApi(client);

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/client/ClouderaManagerClientFactory.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/client/ClouderaManagerClientFactory.java
@@ -44,10 +44,6 @@ public class ClouderaManagerClientFactory {
         return clouderaManagerClientProvider.getClouderaManagerClient(clientConfig, stack.getGatewayPort(), username, password);
     }
 
-    public ClouderaManagerResourceApi getClouderaManagerResourceApi(Stack stack, Cluster cluster, HttpClientConfig clientConfig) {
-        return getClouderaManagerResourceApi(getClient(stack, cluster, clientConfig));
-    }
-
     public ClouderaManagerResourceApi getClouderaManagerResourceApi(ApiClient apiClient) {
         return new ClouderaManagerResourceApi(apiClient);
     }
@@ -56,16 +52,12 @@ public class ClouderaManagerClientFactory {
         return new MgmtServiceResourceApi(apiClient);
     }
 
-    public ExternalUserMappingsResourceApi getExternalUserMappingsResourceApi(Stack stack, Cluster cluster, HttpClientConfig clientConfig) {
-        return new ExternalUserMappingsResourceApi(getClient(stack, cluster, clientConfig));
+    public ExternalUserMappingsResourceApi getExternalUserMappingsResourceApi(ApiClient client) {
+        return new ExternalUserMappingsResourceApi(client);
     }
 
-    public AuthRolesResourceApi getAuthRolesResourceApi(Stack stack, Cluster cluster, HttpClientConfig clientConfig) {
-        return new AuthRolesResourceApi(getClient(stack, cluster, clientConfig));
-    }
-
-    public ClustersResourceApi getClustersResourceApi(Stack stack, Cluster cluster, HttpClientConfig clientConfig) {
-        return getClustersResourceApi(getClient(stack, cluster, clientConfig));
+    public AuthRolesResourceApi getAuthRolesResourceApi(ApiClient client) {
+        return new AuthRolesResourceApi(client);
     }
 
     public ClustersResourceApi getClustersResourceApi(ApiClient apiClient) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

CM/CDH cluster creation fails in certain test environments due to using test license.  The change here is to start the trial period if Management Service is being setup.  The logic is extracted from LDAP setup service.

## How was this patch tested?

Tested actual cluster deployment.  Also tested that duplicate "begin trial" requests are handled (to account for multiple independent services that require the trial).