### PR TITLE
CB-1174 Implement redbeams existing database server API

### DIFF
--- a/redbeams-api/build.gradle
+++ b/redbeams-api/build.gradle
@@ -34,6 +34,7 @@ dependencies {
   testCompile group: 'junit',                     name: 'junit',                          version: junitVersion
 
   compile project(':cloud-common')
+  compile project(':secret-engine')
 }
 
 

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/DatabaseServerV4Endpoint.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/DatabaseServerV4Endpoint.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.redbeams.api.endpoint.v4.databaseserver;
 
+import java.util.Set;
+
 import javax.validation.Valid;
 //import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
@@ -13,9 +15,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
-//
-import com.sequenceiq.cloudbreak.doc.ContentType;
-//import com.sequenceiq.redbeams.api.endpoint.v4.common.EnvironmentIds;
+
 //import com.sequenceiq.redbeams.api.endpoint.v4.database.requests.DatabaseTestV4Request;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.DatabaseServerV4Request;
 //import com.sequenceiq.redbeams.api.endpoint.v4.database.responses.DatabaseTestV4Response;
@@ -30,58 +30,58 @@ import io.swagger.annotations.ApiOperation;
 
 //import java.util.Set;
 
-@Path("/v4/{workspaceId}/databaseservers")
+@Path("/v4/databaseservers")
 @Consumes(MediaType.APPLICATION_JSON)
-@Api(value = "/v4/{workspaceId}/databaseservers", description = ControllerDescriptions.DATABASE_SERVER_V4_DESCRIPTION, protocols = "http,https")
+@Api(value = "/v4/databaseservers", description = ControllerDescriptions.DATABASE_SERVER_V4_DESCRIPTION, protocols = "http,https")
 public interface DatabaseServerV4Endpoint {
 
     @GET
     @Path("")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = DatabaseServerOpDescription.LIST_BY_WORKSPACE, produces = ContentType.JSON, notes = Notes.DATABASE_SERVER_NOTES,
-        nickname = "listDatabasesServersByWorkspace")
-    DatabaseServerV4Responses list(@PathParam("workspaceId") Long workspaceId, @QueryParam("environmentId") String environmentId,
+    @ApiOperation(value = DatabaseServerOpDescription.LIST, produces = MediaType.APPLICATION_JSON, notes = Notes.DATABASE_SERVER_NOTES,
+        nickname = "listDatabasesServers")
+    DatabaseServerV4Responses list(@QueryParam("environmentId") String environmentId,
         @QueryParam("attachGlobal") @DefaultValue("false") Boolean attachGlobal);
 
     @GET
     @Path("{name}")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = DatabaseServerOpDescription.GET_BY_NAME_IN_WORKSPACE, produces = ContentType.JSON, notes = Notes.DATABASE_SERVER_NOTES,
-        nickname = "getDatabaseServerInWorkspace")
-    DatabaseServerV4Response get(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name);
+    @ApiOperation(value = DatabaseServerOpDescription.GET_BY_NAME, produces = MediaType.APPLICATION_JSON, notes = Notes.DATABASE_SERVER_NOTES,
+        nickname = "getDatabaseServer")
+    DatabaseServerV4Response get(@PathParam("name") String name);
 
     @POST
     @Path("register")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = DatabaseServerOpDescription.REGISTER_IN_WORKSPACE, produces = ContentType.JSON, notes = Notes.DATABASE_SERVER_NOTES,
-        nickname = "registerDatabaseServerInWorkspace")
-    DatabaseServerV4Response register(@PathParam("workspaceId") Long workspaceId, @Valid DatabaseServerV4Request request);
+    @ApiOperation(value = DatabaseServerOpDescription.REGISTER, produces = MediaType.APPLICATION_JSON, notes = Notes.DATABASE_SERVER_NOTES,
+        nickname = "registerDatabaseServer")
+    DatabaseServerV4Response register(@Valid DatabaseServerV4Request request);
 
     @DELETE
     @Path("{name}")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = DatabaseServerOpDescription.DELETE_BY_NAME_IN_WORKSPACE, produces = ContentType.JSON, notes = Notes.DATABASE_SERVER_NOTES,
-        nickname = "deleteDatabaseServerInWorkspace")
-    DatabaseServerV4Response delete(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name);
+    @ApiOperation(value = DatabaseServerOpDescription.DELETE_BY_NAME, produces = MediaType.APPLICATION_JSON, notes = Notes.DATABASE_SERVER_NOTES,
+        nickname = "deleteDatabaseServer")
+    DatabaseServerV4Response delete(@PathParam("name") String name);
 
-//    @DELETE
-//    @Path("")
-//    @Produces(MediaType.APPLICATION_JSON)
-//    @ApiOperation(value = DatabaseOpDescription.DELETE_MULTIPLE_BY_NAME_IN_WORKSPACE, produces = ContentType.JSON, notes = Notes.DATABASE_NOTES,
-//            nickname = "deleteDatabasesInWorkspace")
-//    DatabaseV4Responses deleteMultiple(@PathParam("workspaceId") Long workspaceId, Set<String> names);
-//
+    @DELETE
+    @Path("")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = DatabaseServerOpDescription.DELETE_MULTIPLE_BY_NAME, produces = MediaType.APPLICATION_JSON, notes = Notes.DATABASE_SERVER_NOTES,
+            nickname = "deleteMultipleDatabaseServers")
+    DatabaseServerV4Responses deleteMultiple(Set<String> names);
+
 //    @GET
 //    @Path("{name}/request")
 //    @Produces(MediaType.APPLICATION_JSON)
-//    @ApiOperation(value = DatabaseOpDescription.GET_REQUEST_IN_WORKSPACE, produces = ContentType.JSON, notes = Notes.DATABASE_NOTES,
+//    @ApiOperation(value = DatabaseOpDescription.GET_REQUEST_IN_WORKSPACE, produces = MediaType.APPLICATION_JSON, notes = Notes.DATABASE_NOTES,
 //            nickname = "getDatabaseRequestFromNameInWorkspace")
 //    DatabaseV4Request getRequest(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name);
 //
 //    @POST
 //    @Path("test")
 //    @Produces(MediaType.APPLICATION_JSON)
-//    @ApiOperation(value = DatabaseOpDescription.POST_CONNECTION_TEST, produces = ContentType.JSON, notes = Notes.DATABASE_NOTES,
+//    @ApiOperation(value = DatabaseOpDescription.POST_CONNECTION_TEST, produces = MediaType.APPLICATION_JSON, notes = Notes.DATABASE_NOTES,
 //            nickname = "testDatabaseConnectionInWorkspace")
 //    DatabaseTestV4Response test(@PathParam("workspaceId") Long workspaceId, @Valid DatabaseTestV4Request databaseTestV4Request);
 //
@@ -89,7 +89,7 @@ public interface DatabaseServerV4Endpoint {
 //    @Path("{name}/attach")
 //    @Produces(MediaType.APPLICATION_JSON)
 //    @Consumes(MediaType.APPLICATION_JSON)
-//    @ApiOperation(value = DatabaseOpDescription.ATTACH_TO_ENVIRONMENTS, produces = ContentType.JSON, notes = Notes.DATABASE_NOTES,
+//    @ApiOperation(value = DatabaseOpDescription.ATTACH_TO_ENVIRONMENTS, produces = MediaType.APPLICATION_JSON, notes = Notes.DATABASE_NOTES,
 //            nickname = "attachDatabaseToEnvironments")
 //    DatabaseV4Response attach(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name,
 //        @Valid @NotNull EnvironmentNames environmentNames);
@@ -98,7 +98,7 @@ public interface DatabaseServerV4Endpoint {
 //    @Path("{name}/detach")
 //    @Produces(MediaType.APPLICATION_JSON)
 //    @Consumes(MediaType.APPLICATION_JSON)
-//    @ApiOperation(value = DatabaseOpDescription.DETACH_FROM_ENVIRONMENTS, produces = ContentType.JSON, notes = Notes.DATABASE_NOTES,
+//    @ApiOperation(value = DatabaseOpDescription.DETACH_FROM_ENVIRONMENTS, produces = MediaType.APPLICATION_JSON, notes = Notes.DATABASE_NOTES,
 //            nickname = "detachDatabaseFromEnvironments")
 //    DatabaseV4Response detach(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name,
 //        @Valid @NotNull EnvironmentNames environmentNames);

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/responses/DatabaseServerV4Response.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/responses/DatabaseServerV4Response.java
@@ -4,12 +4,11 @@ package com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.common.responses.SecretV4Response;
+import com.sequenceiq.secret.model.SecretResponse;
 // import com.sequenceiq.cloudbreak.api.endpoint.v4.workspace.responses.WorkspaceResourceV4Response;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.base.DatabaseServerV4Base;
 import com.sequenceiq.redbeams.doc.ModelDescriptions;
 import com.sequenceiq.redbeams.doc.ModelDescriptions.DatabaseServer;
-// import com.sequenceiq.cloudbreak.doc.ModelDescriptions.RDSConfigModelDescription;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -21,13 +20,6 @@ public class DatabaseServerV4Response extends DatabaseServerV4Base {
     @ApiModelProperty(ModelDescriptions.ID)
     private Long id;
 
-    // FIXME
-    // @ApiModelProperty(ModelDescriptions.WORKSPACE_OF_THE_RESOURCE)
-    // private WorkspaceResourceV4Response workspace;
-
-    // @ApiModelProperty(RDSConfigModelDescription.CLUSTER_NAMES)
-    // private Set<String> clusterNames;
-
     @ApiModelProperty(value = DatabaseServer.DATABASE_VENDOR_DISPLAY_NAME, required = true)
     private String databaseVendorDisplayName;
 
@@ -35,10 +27,10 @@ public class DatabaseServerV4Response extends DatabaseServerV4Base {
     private String connectionDriver;
 
     @ApiModelProperty(DatabaseServer.CONNECTION_USER_NAME)
-    private SecretV4Response connectionUserName;
+    private SecretResponse connectionUserName;
 
     @ApiModelProperty(DatabaseServer.CONNECTION_PASSWORD)
-    private SecretV4Response connectionPassword;
+    private SecretResponse connectionPassword;
 
     @ApiModelProperty(ModelDescriptions.CREATION_DATE)
     private Long creationDate;
@@ -67,19 +59,19 @@ public class DatabaseServerV4Response extends DatabaseServerV4Base {
         this.connectionDriver = connectionDriver;
     }
 
-    public SecretV4Response getConnectionUserName() {
+    public SecretResponse getConnectionUserName() {
         return connectionUserName;
     }
 
-    public void setConnectionUserName(SecretV4Response connectionUserName) {
+    public void setConnectionUserName(SecretResponse connectionUserName) {
         this.connectionUserName = connectionUserName;
     }
 
-    public SecretV4Response getConnectionPassword() {
+    public SecretResponse getConnectionPassword() {
         return connectionPassword;
     }
 
-    public void setConnectionPassword(SecretV4Response connectionPassword) {
+    public void setConnectionPassword(SecretResponse connectionPassword) {
         this.connectionPassword = connectionPassword;
     }
 
@@ -90,20 +82,4 @@ public class DatabaseServerV4Response extends DatabaseServerV4Base {
     public void setCreationDate(Long creationDate) {
         this.creationDate = creationDate;
     }
-
-    // public Set<String> getClusterNames() {
-    //     return clusterNames;
-    // }
-
-    // public void setClusterNames(Set<String> clusterNames) {
-    //     this.clusterNames = clusterNames;
-    // }
-
-    // public WorkspaceResourceV4Response getWorkspace() {
-    //     return workspace;
-    // }
-
-    // public void setWorkspace(WorkspaceResourceV4Response workspace) {
-    //     this.workspace = workspace;
-    // }
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/ModelDescriptions.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/ModelDescriptions.java
@@ -3,8 +3,6 @@ package com.sequenceiq.redbeams.doc;
 public final class ModelDescriptions {
 
     public static final String ID = "ID of the resource";
-    // public static final String WORKSPACE_OF_THE_RESOURCE = "workspace of the resource";
-    // public static final String WORKSPACE_ID = "Workspace ID of the resource";
     public static final String DESCRIPTION = "Description of the resource";
     public static final String CREATION_DATE = "Creation date / time of the resource, in epoch milliseconds";
     public static final String ENVIRONMENT_ID = "ID of the environment of the resource";

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/OperationDescriptions.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/OperationDescriptions.java
@@ -1,28 +1,6 @@
 package com.sequenceiq.redbeams.doc;
 
 public final class OperationDescriptions {
-    // public static class BlueprintOpDescription {
-    //     public static final String GET_BY_NAME = "retrieve validation request by blueprint name";
-    //     public static final String LIST_BY_WORKSPACE = "list blueprints for the given workspace";
-    //     public static final String GET_BY_NAME_IN_WORKSPACE = "get blueprint by name in workspace";
-    //     public static final String CREATE_IN_WORKSPACE = "create blueprint in workspace";
-    //     public static final String DELETE_BY_NAME_IN_WORKSPACE = "delete blueprint by name in workspace";
-    //     public static final String DELETE_MULTIPLE_BY_NAME_IN_WORKSPACE = "delete multiple blueprints by name in workspace";
-    // }
-
-    // public static class CredentialOpDescription {
-    //     public static final String PUT_IN_WORKSPACE = "modify public credential resource in workspace";
-    //     public static final String INTERACTIVE_LOGIN = "interactive login";
-    //     public static final String INIT_CODE_GRANT_FLOW = "start a credential creation with Oauth2 Authorization Code Grant flow";
-    //     public static final String INIT_CODE_GRANT_FLOW_ON_EXISTING = "Reinitialize Oauth2 Authorization Code Grant flow on an existing credential";
-    //     public static final String AUTHORIZE_CODE_GRANT_FLOW = "Authorize Oauth2 Authorization Code Grant flow";
-    //     public static final String LIST_BY_WORKSPACE = "list credentials for the given workspace";
-    //     public static final String GET_BY_NAME_IN_WORKSPACE = "get credential by name in workspace";
-    //     public static final String CREATE_IN_WORKSPACE = "create credential in workspace";
-    //     public static final String DELETE_BY_NAME_IN_WORKSPACE = "delete credential by name in workspace";
-    //     public static final String DELETE_MULTIPLE_BY_NAME_IN_WORKSPACE = "delete multiple credentials by name in workspace";
-    //     public static final String GET_PREREQUISTIES_BY_CLOUD_PROVIDER = "get credential prerequisites for cloud platform";
-    // }
 
     public static final class DatabaseOpDescription {
         public static final String POST_CONNECTION_TEST = "test RDS connectivity";
@@ -41,11 +19,11 @@ public final class OperationDescriptions {
 
     public static final class DatabaseServerOpDescription {
         // public static final String POST_CONNECTION_TEST = "test RDS connectivity";
-        public static final String LIST_BY_WORKSPACE = "list database servers for the given workspace";
-        public static final String GET_BY_NAME_IN_WORKSPACE = "get a database server by name in workspace";
-        public static final String REGISTER_IN_WORKSPACE = "register a database server in workspace";
-        public static final String DELETE_BY_NAME_IN_WORKSPACE = "deregister or terminate a database server by name in workspace";
-        public static final String DELETE_MULTIPLE_BY_NAME_IN_WORKSPACE = "deregister or terminate multiple database servers by name in workspace";
+        public static final String LIST = "list database servers";
+        public static final String GET_BY_NAME = "get a database server by name";
+        public static final String REGISTER = "register a database server";
+        public static final String DELETE_BY_NAME = "deregister or terminate a database server by name";
+        public static final String DELETE_MULTIPLE_BY_NAME = "deregister or terminate multiple database servers by name";
         // public static final String GET_REQUEST_IN_WORKSPACE = "get request in workspace";
         // public static final String ATTACH_TO_ENVIRONMENTS = "attach RDS resource to environemnts";
         // public static final String DETACH_FROM_ENVIRONMENTS = "detach RDS resource from environemnts";

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/responses/DatabaseServerV4ResponseTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/responses/DatabaseServerV4ResponseTest.java
@@ -2,7 +2,7 @@ package com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses;
 
 import static org.junit.Assert.assertEquals;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.common.responses.SecretV4Response;
+import com.sequenceiq.secret.model.SecretResponse;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -27,13 +27,13 @@ public class DatabaseServerV4ResponseTest {
         response.setConnectionDriver("postgresql.jar");
         assertEquals("postgresql.jar", response.getConnectionDriver());
 
-        SecretV4Response username = new SecretV4Response("engine", "username");
+        SecretResponse username = new SecretResponse("engine", "username");
         response.setConnectionUserName(username);
-        verifyEqualSecretV4Responses(username, response.getConnectionUserName());
+        verifyEqualSecretResponses(username, response.getConnectionUserName());
 
-        SecretV4Response password = new SecretV4Response("engine", "password");
+        SecretResponse password = new SecretResponse("engine", "password");
         response.setConnectionPassword(password);
-        verifyEqualSecretV4Responses(password, response.getConnectionPassword());
+        verifyEqualSecretResponses(password, response.getConnectionPassword());
 
         long now = System.currentTimeMillis();
         response.setCreationDate(now);
@@ -41,7 +41,7 @@ public class DatabaseServerV4ResponseTest {
 
     }
 
-    private static void verifyEqualSecretV4Responses(SecretV4Response expected, SecretV4Response actual) {
+    private static void verifyEqualSecretResponses(SecretResponse expected, SecretResponse actual) {
         assertEquals(expected.getEnginePath(), actual.getEnginePath());
         assertEquals(expected.getSecretPath(), actual.getSecretPath());
     }

--- a/redbeams-model/build.gradle
+++ b/redbeams-model/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     compile project(':cloud-common')
     compile project(':core-api')
     compile project(':workspace-authorization')
+    compile project(':secret-engine')
     compile group: 'org.hibernate.javax.persistence',   name: 'hibernate-jpa-2.1-api',  version: '1.0.0.Final'
     compile group: 'org.apache.commons',                name: 'commons-lang3',          version: apacheCommonsLangVersion
     compile group: 'com.google.code.findbugs',          name: 'annotations',            version: '3.0.1'

--- a/redbeams-model/src/main/java/com/sequenceiq/redbeams/domain/DatabaseServerConfig.java
+++ b/redbeams-model/src/main/java/com/sequenceiq/redbeams/domain/DatabaseServerConfig.java
@@ -16,10 +16,10 @@ import org.hibernate.annotations.Where;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ResourceStatus;
-import com.sequenceiq.cloudbreak.aspect.secret.SecretValue;
-import com.sequenceiq.cloudbreak.domain.Secret;
-import com.sequenceiq.cloudbreak.domain.SecretToString;
 import com.sequenceiq.cloudbreak.workspace.resource.WorkspaceResource;
+import com.sequenceiq.secret.SecretValue;
+import com.sequenceiq.secret.domain.Secret;
+import com.sequenceiq.secret.domain.SecretToString;
 
 @Entity
 @Where(clause = "archived = false")

--- a/redbeams/build.gradle
+++ b/redbeams/build.gradle
@@ -18,6 +18,7 @@ repositories {
 }
 
 dependencies {
+  implementation     group: 'com.google.guava',          name: 'guava'
   implementation     group: 'com.google.code.gson',      name: 'gson'
   implementation     group: 'dnsjava',                   name: 'dnsjava'
   implementation     group: 'io.micrometer',             name: 'micrometer-core'
@@ -41,9 +42,12 @@ dependencies {
     exclude group: 'junit'
   }
   testImplementation group: 'org.junit.jupiter',         name: 'junit-jupiter-api'
+  testImplementation group: 'org.mockito',               name: 'mockito-core'
   testRuntime        group: 'org.junit.jupiter',         name: 'junit-jupiter-engine'
+  testRuntime        group: 'org.junit.vintage',         name: 'junit-vintage-engine'
 
   constraints {
+    implementation     group: 'com.google.guava',          name: 'guava',                          version: guavaVersion
     implementation     group: 'com.google.code.gson',      name: 'gson',                           version: '2.6.2'
     implementation     group: 'dnsjava',                   name: 'dnsjava',                        version: '2.1.7'
     implementation     group: 'io.micrometer',             name: 'micrometer-core',                version: micrometerVersion
@@ -65,10 +69,13 @@ dependencies {
     implementation     group: 'org.springframework.boot',  name: 'spring-boot-starter-data-jpa',   version: springBootVersion
     testImplementation group: 'org.springframework.boot',  name: 'spring-boot-starter-test',       version: springBootVersion
     testImplementation group: 'org.junit.jupiter',         name: 'junit-jupiter-api',              version: junitJupiterVersion
+    testImplementation group: 'org.mockito',               name: 'mockito-core',                   version: mockitoVersion
     testRuntime        group: 'org.junit.jupiter',         name: 'junit-jupiter-engine',           version: junitJupiterVersion
+    testRuntime        group: 'org.junit.vintage',         name: 'junit-vintage-engine',           version: junitJupiterVersion
   }
 
   compile project(':cloud-common')
+  compile project(':secret-engine')
   compile project(':common')
   compile project(':auth-connector')
   compile project(':core-api')
@@ -105,7 +112,9 @@ bootJar {
 }
 
 test{
-  useJUnitPlatform()
+  useJUnitPlatform {
+    includeEngines 'junit-jupiter', 'junit-vintage'
+  }
 }
 
 task execute(type: JavaExec) {

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/RedbeamsApplication.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/RedbeamsApplication.java
@@ -13,7 +13,11 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
     "com.sequenceiq.cloudbreak.api.util",
     "com.sequenceiq.cloudbreak.conf",
     "com.sequenceiq.cloudbreak.config",
-    "com.sequenceiq.cloudbreak.cache.common" },
+    "com.sequenceiq.cloudbreak.cache.common",
+    "com.sequenceiq.secret.service",
+    "com.sequenceiq.secret.vault",
+    "com.sequenceiq.cloudbreak.common.service",
+    "com.sequenceiq.cloudbreak.common.dbmigration" },
     exclude = WebMvcMetricsAutoConfiguration.class)
 public class RedbeamsApplication {
 

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/aspect/SecretAspects.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/aspect/SecretAspects.java
@@ -1,0 +1,55 @@
+package com.sequenceiq.redbeams.aspect;
+
+import javax.inject.Inject;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.secret.service.SecretAspectService;
+
+@Component
+@Aspect
+public class SecretAspects {
+
+    @Inject
+    private SecretAspectService secretAspectService;
+
+    @Pointcut("execution(public * com.sequenceiq.redbeams.repository..*.save(..)) ")
+    public void onRepositorySave() {
+    }
+
+    @Pointcut("execution(public void com.sequenceiq.redbeams.repository..*.delete(..)) ")
+    public void onRepositoryDelete() {
+    }
+
+    @Pointcut("execution(public * com.sequenceiq.redbeams.repository..*.saveAll(..)) ")
+    public void onRepositorySaveAll() {
+    }
+
+    @Pointcut("execution(public void com.sequenceiq.redbeams.repository..*.deleteAll(..)) ")
+    public void onRepositoryDeleteAll() {
+    }
+
+    @Around("onRepositorySave()")
+    public Object proceedOnRepositorySave(ProceedingJoinPoint proceedingJoinPoint) {
+        return secretAspectService.proceedSave(proceedingJoinPoint);
+    }
+
+    @Around("onRepositoryDelete()")
+    public Object proceedOnRepositoryDelete(ProceedingJoinPoint proceedingJoinPoint) {
+        return secretAspectService.proceedDelete(proceedingJoinPoint);
+    }
+
+    @Around("onRepositorySaveAll()")
+    public Object proceedOnRepositorySaveAll(ProceedingJoinPoint proceedingJoinPoint) {
+        return secretAspectService.proceedSave(proceedingJoinPoint);
+    }
+
+    @Around("onRepositoryDeleteAll()")
+    public Object proceedOnRepositoryDeleteAll(ProceedingJoinPoint proceedingJoinPoint) {
+        return secretAspectService.proceedDelete(proceedingJoinPoint);
+    }
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/DatabaseConfig.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/DatabaseConfig.java
@@ -118,8 +118,7 @@ public class DatabaseConfig {
     public EntityManagerFactory entityManagerFactory() throws SQLException {
         LocalContainerEntityManagerFactoryBean entityManagerFactory = new LocalContainerEntityManagerFactoryBean();
 
-        // FIXME: redbeams - yep, need to move, or else tables missing for all the other domain objects!
-        entityManagerFactory.setPackagesToScan("com.sequenceiq");
+        entityManagerFactory.setPackagesToScan("com.sequenceiq.redbeams");
         entityManagerFactory.setDataSource(dataSource());
 
         entityManagerFactory.setJpaVendorAdapter(jpaVendorAdapter());

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/controller/mapper/NotFoundExceptionMapper.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/controller/mapper/NotFoundExceptionMapper.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.redbeams.controller.mapper;
+
+import javax.ws.rs.core.Response.Status;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.exception.NotFoundException;
+
+@Component
+public class NotFoundExceptionMapper extends BaseExceptionMapper<NotFoundException> {
+
+    @Override
+    Status getResponseStatus() {
+        return Status.NOT_FOUND;
+    }
+
+    @Override
+    Class<NotFoundException> getExceptionType() {
+        return NotFoundException.class;
+    }
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/converter/StringToSecretResponseConverter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/converter/StringToSecretResponseConverter.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.redbeams.converter;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.converter.AbstractConversionServiceAwareConverter;
+import com.sequenceiq.secret.model.SecretResponse;
+import com.sequenceiq.secret.service.SecretService;
+
+@Component
+public class StringToSecretResponseConverter extends AbstractConversionServiceAwareConverter<String, SecretResponse> {
+
+    @Inject
+    private SecretService secretService;
+
+    @Override
+    public SecretResponse convert(String source) {
+        return secretService.convertToExternal(source);
+    }
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/converter/v4/databaseserver/DatabaseServerConfigToDatabaseServerV4RequestConverter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/converter/v4/databaseserver/DatabaseServerConfigToDatabaseServerV4RequestConverter.java
@@ -1,0 +1,30 @@
+package com.sequenceiq.redbeams.converter.v4.databaseserver;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.converter.AbstractConversionServiceAwareConverter;
+import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.DatabaseServerV4Request;
+import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
+
+@Component
+public class DatabaseServerConfigToDatabaseServerV4RequestConverter
+    extends AbstractConversionServiceAwareConverter<DatabaseServerConfig, DatabaseServerV4Request> {
+
+    @Override
+    public DatabaseServerV4Request convert(DatabaseServerConfig source) {
+        DatabaseServerV4Request request = new DatabaseServerV4Request();
+        request.setName(source.getName());
+        request.setDescription(source.getDescription());
+        request.setHost(source.getHost());
+        request.setPort(source.getPort());
+
+        request.setDatabaseVendor(source.getDatabaseVendor().databaseType());
+        request.setConnectionUserName("REDACTED");
+        request.setConnectionPassword("REDACTED");
+        request.setConnectorJarUrl(source.getConnectorJarUrl());
+
+        request.setEnvironmentId(source.getEnvironmentId());
+
+        return request;
+    }
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/converter/v4/databaseserver/DatabaseServerConfigToDatabaseServerV4ResponseConverter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/converter/v4/databaseserver/DatabaseServerConfigToDatabaseServerV4ResponseConverter.java
@@ -1,0 +1,36 @@
+package com.sequenceiq.redbeams.converter.v4.databaseserver;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.converter.AbstractConversionServiceAwareConverter;
+import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerV4Response;
+import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
+import com.sequenceiq.secret.model.SecretResponse;
+
+@Component
+public class DatabaseServerConfigToDatabaseServerV4ResponseConverter
+    extends AbstractConversionServiceAwareConverter<DatabaseServerConfig, DatabaseServerV4Response> {
+
+    @Override
+    public DatabaseServerV4Response convert(DatabaseServerConfig source) {
+        DatabaseServerV4Response response = new DatabaseServerV4Response();
+        response.setId(source.getId());
+        response.setName(source.getName());
+        response.setDescription(source.getDescription());
+        response.setHost(source.getHost());
+        response.setPort(source.getPort());
+
+        response.setDatabaseVendor(source.getDatabaseVendor().databaseType());
+        response.setDatabaseVendorDisplayName(source.getDatabaseVendor().displayName());
+        response.setConnectionDriver(source.getConnectionDriver());
+        response.setConnectionUserName(getConversionService().convert(source.getConnectionUserNameSecret(), SecretResponse.class));
+        response.setConnectionPassword(getConversionService().convert(source.getConnectionPasswordSecret(), SecretResponse.class));
+        response.setConnectorJarUrl(source.getConnectorJarUrl());
+
+        response.setCreationDate(source.getCreationDate());
+
+        response.setEnvironmentId(source.getEnvironmentId());
+
+        return response;
+    }
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/converter/v4/databaseserver/DatabaseServerV4RequestToDatabaseServerConfigConverter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/converter/v4/databaseserver/DatabaseServerV4RequestToDatabaseServerConfigConverter.java
@@ -1,0 +1,62 @@
+package com.sequenceiq.redbeams.converter.v4.databaseserver;
+
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.google.common.base.Strings;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ResourceStatus;
+import com.sequenceiq.cloudbreak.converter.AbstractConversionServiceAwareConverter;
+import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.DatabaseServerV4Request;
+import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
+
+@Component
+public class DatabaseServerV4RequestToDatabaseServerConfigConverter
+    extends AbstractConversionServiceAwareConverter<DatabaseServerV4Request, DatabaseServerConfig> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseServerV4RequestToDatabaseServerConfigConverter.class);
+
+    @Override
+    public DatabaseServerConfig convert(DatabaseServerV4Request source) {
+        DatabaseServerConfig server = new DatabaseServerConfig();
+        if (Strings.isNullOrEmpty(source.getName())) {
+            server.setName(generateName());
+        } else {
+            server.setName(source.getName());
+        }
+        server.setDescription(source.getDescription());
+        server.setHost(source.getHost());
+        server.setPort(source.getPort());
+
+        DatabaseVendor databaseVendor = DatabaseVendor.fromValue(source.getDatabaseVendor());
+        server.setDatabaseVendor(databaseVendor);
+        server.setConnectionDriver(databaseVendor.connectionDriver());
+        server.setConnectionUserName(source.getConnectionUserName());
+        server.setConnectionPassword(source.getConnectionPassword());
+
+        server.setCreationDate(System.currentTimeMillis());
+        server.setResourceStatus(ResourceStatus.USER_MANAGED);
+
+        if (server.getDatabaseVendor() != DatabaseVendor.POSTGRES && Strings.isNullOrEmpty(source.getConnectorJarUrl())) {
+            String msg = String.format("The 'connectorJarUrl' field needs to be specified for database vendor '%s'.", server.getDatabaseVendor());
+            LOGGER.info(msg);
+            // FIXME: should this fail?
+        }
+        server.setConnectorJarUrl(source.getConnectorJarUrl());
+
+        server.setArchived(false);
+        server.setDeletionTimestamp(null);
+
+        server.setEnvironmentId(source.getEnvironmentId());
+
+        return server;
+    }
+
+    // Sorry, MissingResourceNameGenerator seems like overkill
+    private static String generateName() {
+        return String.format("dbsvr-%s", UUID.randomUUID().toString());
+    }
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/repository/DatabaseServerConfigRepository.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/repository/DatabaseServerConfigRepository.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.redbeams.repository;
 
+import java.util.Optional;
 import java.util.Set;
 
 import javax.transaction.Transactional;
@@ -20,5 +21,9 @@ public interface DatabaseServerConfigRepository extends CrudRepository<DatabaseS
             + " s.workspaceId = :workspaceId AND s.environmentId = :environmentId"
             + " AND s.resourceStatus = 'USER_MANAGED'")
     Set<DatabaseServerConfig> findAllByWorkspaceIdAndEnvironmentId(Long workspaceId, String environmentId);
+
+    Optional<DatabaseServerConfig> findByNameAndWorkspaceId(String name, Long workspaceId);
+
+    Set<DatabaseServerConfig> findByNameInAndWorkspaceId(Set<String> names, Long workspaceId);
 
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/DummyMetricService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/DummyMetricService.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.redbeams.service;
+
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.common.metrics.MetricService;
+import com.sequenceiq.cloudbreak.common.metrics.type.Metric;
+
+@Service
+public class DummyMetricService implements MetricService {
+
+    @Override
+    public void submit(Metric metric, double value) {
+    }
+
+    @Override
+    public void submit(Metric metric, double value, Map<String, String> labels) {
+    }
+
+    @Override
+    public void initMicrometerMetricCounter(Metric metric) {
+    }
+
+    @Override
+    public void incrementMetricCounter(Metric metric) {
+    }
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigService.java
@@ -1,13 +1,22 @@
 package com.sequenceiq.redbeams.service.dbserverconfig;
 
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
+import org.hibernate.exception.ConstraintViolationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
+import com.google.common.collect.Sets;
+import com.sequenceiq.cloudbreak.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.exception.NotFoundException;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.cloudbreak.workspace.resource.WorkspaceResource;
 import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
 import com.sequenceiq.redbeams.repository.DatabaseServerConfigRepository;
 
@@ -23,4 +32,74 @@ public class DatabaseServerConfigService {
         return repository.findAllByWorkspaceIdAndEnvironmentId(workspaceId, environmentId);
     }
 
+    public DatabaseServerConfig create(DatabaseServerConfig resource, Long workspaceId) {
+        // FIXME? Currently no checks if logged-in user has access to workspace
+        // Compare with AbstractWorkspaceAwareResourceService
+        try {
+            MDCBuilder.buildMdcContext(resource);
+            // prepareCreation(resource);
+            resource.setWorkspaceId(workspaceId);
+            return repository.save(resource);
+        } catch (AccessDeniedException e) {
+            ConstraintViolationException cve = null;
+            for (Throwable t = e.getCause(); t != null; t = t.getCause()) {
+                if (t instanceof ConstraintViolationException) {
+                    cve = (ConstraintViolationException) t;
+                    break;
+                }
+            }
+            if (cve != null) {
+                String message = String.format("%s already exists with name '%s' in workspace %d",
+                        resource().getShortName(), resource.getName(), resource.getWorkspaceId());
+                throw new BadRequestException(message, e);
+            }
+            throw e;
+        }
+    }
+
+    public DatabaseServerConfig getByNameInWorkspace(Long workspaceId, String name) {
+        Optional<DatabaseServerConfig> resourceOpt = repository.findByNameAndWorkspaceId(name, workspaceId);
+        if (resourceOpt.isEmpty()) {
+            throw new NotFoundException(String.format("No %s found with name '%s'", resource().getShortName(), name));
+        }
+        MDCBuilder.buildMdcContext(resourceOpt.get());
+        return resourceOpt.get();
+    }
+
+    public DatabaseServerConfig deleteByNameInWorkspace(Long workspaceId, String name) {
+        DatabaseServerConfig resource = getByNameInWorkspace(workspaceId, name);
+        return delete(resource);
+    }
+
+    DatabaseServerConfig delete(DatabaseServerConfig resource) {
+        LOGGER.debug("Deleting {} with name: {}", resource().getReadableName(), resource.getName());
+        MDCBuilder.buildMdcContext(resource);
+        // prepareDeletion(resource);
+        repository.delete(resource);
+        return resource;
+    }
+
+    public Set<DatabaseServerConfig> deleteMultipleByNameInWorkspace(Long workspaceId, Set<String> names) {
+        Set<DatabaseServerConfig> resources = getByNamesInWorkspace(workspaceId, names);
+        return resources.stream()
+            .map(r -> delete(r))
+            .collect(Collectors.toSet());
+    }
+
+    Set<DatabaseServerConfig> getByNamesInWorkspace(Long workspaceId, Set<String> names) {
+        Set<DatabaseServerConfig> resources = repository.findByNameInAndWorkspaceId(names, workspaceId);
+        Set<String> notFound = Sets.difference(names,
+                resources.stream().map(DatabaseServerConfig::getName).collect(Collectors.toSet()));
+
+        if (!notFound.isEmpty()) {
+            throw new NotFoundException(String.format("No %s(s) found with name(s) %s", resource().getShortName(),
+                    notFound.stream().map(name -> '\'' + name + '\'').collect(Collectors.joining(", "))));
+        }
+
+        return resources;
+    }
+
+    public WorkspaceResource resource() {
+        return WorkspaceResource.DATABASE_SERVER;
+    }
 }

--- a/redbeams/src/main/resources/application.yml
+++ b/redbeams/src/main/resources/application.yml
@@ -46,6 +46,10 @@ cert:
   validation: true
   ignorePreValidation: false
 
+secret:
+  application: cb/shared
+  engine: "com.sequenceiq.secret.vault.VaultKvV2Engine"
+
 vault:
   addr: vault.service.consul
   port: 8200

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4ControllerTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4ControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
+import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.DatabaseServerV4Request;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerV4Response;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerV4Responses;
 import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
@@ -22,7 +23,7 @@ import org.mockito.Mock;
 public class DatabaseServerV4ControllerTest {
 
     @InjectMocks
-    private DatabaseServerV4Controller controller;
+    private DatabaseServerV4Controller underTest;
 
     @Mock
     private DatabaseServerConfigService service;
@@ -32,9 +33,13 @@ public class DatabaseServerV4ControllerTest {
 
     private DatabaseServerConfig server;
 
+    private DatabaseServerConfig server2;
+
+    private DatabaseServerV4Request request;
+
     private DatabaseServerV4Response response;
 
-    private Set<DatabaseServerV4Response> responseSet;
+    private DatabaseServerV4Response response2;
 
     @Before
     public void setUp() {
@@ -42,23 +47,84 @@ public class DatabaseServerV4ControllerTest {
 
         server = new DatabaseServerConfig();
         server.setId(1L);
+        server.setName("myserver");
+
+        server2 = new DatabaseServerConfig();
+        server2.setId(2L);
+        server2.setName("myotherserver");
+
+        request = new DatabaseServerV4Request();
+        request.setName("myserver");
 
         response = new DatabaseServerV4Response();
         response.setId(1L);
+        response.setName("myserver");
 
-        responseSet = new HashSet<>();
-        responseSet.add(response);
+        response2 = new DatabaseServerV4Response();
+        response2.setId(2L);
+        response2.setName("myotherserver");
     }
 
     @Test
     public void testList() {
         Set<DatabaseServerConfig> serverSet = Collections.singleton(server);
-        when(service.findAllInWorkspaceAndEnvironment(0L, "myenvironment", Boolean.TRUE)).thenReturn(serverSet);
+        when(service.findAllInWorkspaceAndEnvironment(DatabaseServerV4Controller.DEFAULT_WORKSPACE, "myenvironment", Boolean.TRUE)).thenReturn(serverSet);
+        Set<DatabaseServerV4Response> responseSet = Collections.singleton(response);
         when(converterUtil.convertAllAsSet(serverSet, DatabaseServerV4Response.class)).thenReturn(responseSet);
 
-        DatabaseServerV4Responses responses = controller.list(0L, "myenvironment", Boolean.TRUE);
+        DatabaseServerV4Responses responses = underTest.list("myenvironment", Boolean.TRUE);
 
         assertEquals(1, responses.getResponses().size());
         assertEquals(response.getId(), responses.getResponses().iterator().next().getId());
+    }
+
+    @Test
+    public void testGet() {
+        when(service.getByNameInWorkspace(DatabaseServerV4Controller.DEFAULT_WORKSPACE, "myserver")).thenReturn(server);
+        when(converterUtil.convert(server, DatabaseServerV4Response.class)).thenReturn(response);
+
+        DatabaseServerV4Response response = underTest.get("myserver");
+
+        assertEquals(1L, response.getId().longValue());
+    }
+
+    @Test
+    public void testRegister() {
+        when(converterUtil.convert(request, DatabaseServerConfig.class)).thenReturn(server);
+        when(service.create(server, DatabaseServerV4Controller.DEFAULT_WORKSPACE)).thenReturn(server);
+        when(converterUtil.convert(server, DatabaseServerV4Response.class)).thenReturn(response);
+
+        DatabaseServerV4Response response = underTest.register(request);
+
+        assertEquals(1L, response.getId().longValue());
+    }
+
+    @Test
+    public void testDelete() {
+        when(service.deleteByNameInWorkspace(DatabaseServerV4Controller.DEFAULT_WORKSPACE, "myserver")).thenReturn(server);
+        when(converterUtil.convert(server, DatabaseServerV4Response.class)).thenReturn(response);
+
+        DatabaseServerV4Response response = underTest.delete("myserver");
+
+        assertEquals(1L, response.getId().longValue());
+    }
+
+    @Test
+    public void testDeleteMultiple() {
+        Set<String> nameSet = new HashSet<>();
+        nameSet.add(server.getName());
+        nameSet.add(server2.getName());
+        Set<DatabaseServerConfig> serverSet = new HashSet<>();
+        serverSet.add(server);
+        serverSet.add(server2);
+        when(service.deleteMultipleByNameInWorkspace(DatabaseServerV4Controller.DEFAULT_WORKSPACE, nameSet)).thenReturn(serverSet);
+        Set<DatabaseServerV4Response> responseSet = new HashSet<>();
+        responseSet.add(response);
+        responseSet.add(response2);
+        when(converterUtil.convertAllAsSet(serverSet, DatabaseServerV4Response.class)).thenReturn(responseSet);
+
+        DatabaseServerV4Responses responses = underTest.deleteMultiple(nameSet);
+
+        assertEquals(2, responses.getResponses().size());
     }
 }

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/converter/v4/databaseserver/DatabaseServerConfigToDatabaseServerV4RequestConverterTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/converter/v4/databaseserver/DatabaseServerConfigToDatabaseServerV4RequestConverterTest.java
@@ -1,0 +1,48 @@
+package com.sequenceiq.redbeams.converter.v4.databaseserver;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
+import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.DatabaseServerV4Request;
+import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
+
+public class DatabaseServerConfigToDatabaseServerV4RequestConverterTest {
+
+    private DatabaseServerConfigToDatabaseServerV4RequestConverter converter;
+
+    @Before
+    public void setUp() {
+        converter = new DatabaseServerConfigToDatabaseServerV4RequestConverter();
+    }
+
+    @Test
+    public void testConversion() {
+        DatabaseServerConfig server = new DatabaseServerConfig();
+        server.setName("myserver");
+        server.setDescription("mine not yours");
+        server.setHost("myserver.db.example.com");
+        server.setPort(5432);
+        server.setDatabaseVendor(DatabaseVendor.POSTGRES);
+        server.setConnectionUserName("root");
+        server.setConnectionPassword("cloudera");
+        server.setConnectorJarUrl("http://drivers.example.com/postgresql.jar");
+        server.setEnvironmentId("myenvironment");
+
+        DatabaseServerV4Request request = converter.convert(server);
+
+        assertEquals(server.getName(), request.getName());
+        assertEquals(server.getDescription(), request.getDescription());
+        assertEquals(server.getHost(), request.getHost());
+        assertEquals(server.getPort(), request.getPort());
+        assertEquals(server.getDatabaseVendor().databaseType(), request.getDatabaseVendor());
+        assertNotEquals(server.getConnectionUserName(), request.getConnectionUserName());
+        assertNotEquals(server.getConnectionPassword(), request.getConnectionPassword());
+        assertEquals(server.getConnectorJarUrl(), request.getConnectorJarUrl());
+        assertEquals(server.getEnvironmentId(), request.getEnvironmentId());
+    }
+
+}

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/converter/v4/databaseserver/DatabaseServerConfigToDatabaseServerV4ResponseConverterTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/converter/v4/databaseserver/DatabaseServerConfigToDatabaseServerV4ResponseConverterTest.java
@@ -1,0 +1,70 @@
+package com.sequenceiq.redbeams.converter.v4.databaseserver;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.core.convert.ConversionService;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
+import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerV4Response;
+import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
+import com.sequenceiq.secret.model.SecretResponse;
+
+public class DatabaseServerConfigToDatabaseServerV4ResponseConverterTest {
+
+    @Mock
+    private ConversionService conversionService;
+
+    @InjectMocks
+    private DatabaseServerConfigToDatabaseServerV4ResponseConverter converter;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+    }
+
+    @Test
+    public void testConversion() {
+        DatabaseServerConfig server = new DatabaseServerConfig();
+        server.setId(1L);
+        server.setName("myserver");
+        server.setDescription("mine not yours");
+        server.setHost("myserver.db.example.com");
+        server.setPort(5432);
+        server.setDatabaseVendor(DatabaseVendor.POSTGRES);
+        server.setConnectionUserName("root");
+        server.setConnectionPassword("cloudera");
+        server.setConnectorJarUrl("http://drivers.example.com/postgresql.jar");
+        server.setCreationDate(System.currentTimeMillis());
+        server.setEnvironmentId("myenvironment");
+
+        when(conversionService.convert(any(), any())).thenReturn(new SecretResponse());
+
+        DatabaseServerV4Response response = converter.convert(server);
+
+        verify(conversionService, times(2)).convert(any(), any());
+
+        assertEquals(server.getId(), response.getId());
+        assertEquals(server.getName(), response.getName());
+        assertEquals(server.getDescription(), response.getDescription());
+        assertEquals(server.getHost(), response.getHost());
+        assertEquals(server.getPort(), response.getPort());
+        assertEquals(server.getDatabaseVendor().databaseType(), response.getDatabaseVendor());
+        assertEquals(server.getDatabaseVendor().displayName(), response.getDatabaseVendorDisplayName());
+        assertNotNull(response.getConnectionUserName());
+        assertNotNull(response.getConnectionPassword());
+        assertEquals(server.getConnectorJarUrl(), response.getConnectorJarUrl());
+        assertEquals(server.getCreationDate(), response.getCreationDate());
+        assertEquals(server.getEnvironmentId(), response.getEnvironmentId());
+    }
+
+}

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/converter/v4/databaseserver/DatabaseServerV4RequestToDatabaseServerConfigConverterTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/converter/v4/databaseserver/DatabaseServerV4RequestToDatabaseServerConfigConverterTest.java
@@ -1,0 +1,46 @@
+package com.sequenceiq.redbeams.converter.v4.databaseserver;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.DatabaseServerV4Request;
+import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
+
+public class DatabaseServerV4RequestToDatabaseServerConfigConverterTest {
+
+    private DatabaseServerV4RequestToDatabaseServerConfigConverter converter;
+
+    @Before
+    public void setUp() {
+        converter = new DatabaseServerV4RequestToDatabaseServerConfigConverter();
+    }
+
+    @Test
+    public void testConversion() {
+        DatabaseServerV4Request request = new DatabaseServerV4Request();
+        request.setName("myserver");
+        request.setDescription("mine not yours");
+        request.setHost("myserver.db.example.com");
+        request.setPort(5432);
+        request.setDatabaseVendor("postgres");
+        request.setConnectionUserName("root");
+        request.setConnectionPassword("cloudera");
+        request.setConnectorJarUrl("http://drivers.example.com/postgresql.jar");
+        request.setEnvironmentId("myenvironment");
+
+        DatabaseServerConfig server = converter.convert(request);
+
+        assertEquals(request.getName(), server.getName());
+        assertEquals(request.getDescription(), server.getDescription());
+        assertEquals(request.getHost(), server.getHost());
+        assertEquals(request.getPort(), server.getPort());
+        assertEquals(request.getDatabaseVendor(), server.getDatabaseVendor().databaseType());
+        assertEquals(request.getConnectionUserName(), server.getConnectionUserName());
+        assertEquals(request.getConnectionPassword(), server.getConnectionPassword());
+        assertEquals(request.getConnectorJarUrl(), server.getConnectorJarUrl());
+        assertEquals(request.getEnvironmentId(), server.getEnvironmentId());
+    }
+
+}

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigServiceTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigServiceTest.java
@@ -1,29 +1,45 @@
 package com.sequenceiq.redbeams.service.dbserverconfig;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+import com.sequenceiq.cloudbreak.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.exception.NotFoundException;
 import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
 import com.sequenceiq.redbeams.repository.DatabaseServerConfigRepository;
 
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
+import org.hibernate.exception.ConstraintViolationException;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.springframework.security.access.AccessDeniedException;
 
 public class DatabaseServerConfigServiceTest {
 
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
     @InjectMocks
-    private DatabaseServerConfigService service;
+    private DatabaseServerConfigService underTest;
 
     @Mock
     private DatabaseServerConfigRepository repository;
 
     private DatabaseServerConfig server;
+
+    private DatabaseServerConfig server2;
 
     @Before
     public void setUp() {
@@ -31,15 +47,128 @@ public class DatabaseServerConfigServiceTest {
 
         server = new DatabaseServerConfig();
         server.setId(1L);
+        server.setName("myserver");
+
+        server2 = new DatabaseServerConfig();
+        server2.setId(2L);
+        server.setName("myotherserver");
     }
 
     @Test
     public void testFindAllInWorkspaceAndEnvironment() {
         when(repository.findAllByWorkspaceIdAndEnvironmentId(0L, "myenvironment")).thenReturn(Collections.singleton(server));
 
-        Set<DatabaseServerConfig> servers = service.findAllInWorkspaceAndEnvironment(0L, "myenvironment", false);
+        Set<DatabaseServerConfig> servers = underTest.findAllInWorkspaceAndEnvironment(0L, "myenvironment", false);
 
         assertEquals(1, servers.size());
         assertEquals(1L, servers.iterator().next().getId().longValue());
+    }
+
+    @Test
+    public void testCreateSuccess() {
+        server.setWorkspaceId(-1L);
+        when(repository.save(server)).thenReturn(server);
+
+        DatabaseServerConfig createdServer = underTest.create(server, 0L);
+
+        assertEquals(server, createdServer);
+        assertEquals(0L, createdServer.getWorkspaceId().longValue());
+    }
+
+    @Test
+    public void testCreateAlreadyExists() {
+        thrown.expect(BadRequestException.class);
+
+        AccessDeniedException e = new AccessDeniedException("no way", mock(ConstraintViolationException.class));
+        when(repository.save(server)).thenThrow(e);
+
+        underTest.create(server, 0L);
+    }
+
+    @Test
+    public void testCreateFailure() {
+        thrown.expect(AccessDeniedException.class);
+
+        AccessDeniedException e = new AccessDeniedException("no way");
+        when(repository.save(server)).thenThrow(e);
+
+        underTest.create(server, 0L);
+    }
+
+    @Test
+    public void testGetByNameInWorkspaceFound() {
+        when(repository.findByNameAndWorkspaceId(server.getName(), 0L)).thenReturn(Optional.of(server));
+
+        DatabaseServerConfig foundServer = underTest.getByNameInWorkspace(0L, server.getName());
+
+        assertEquals(server, foundServer);
+    }
+
+    @Test
+    public void testGetByNameInWorkspaceNotFound() {
+        thrown.expect(NotFoundException.class);
+
+        when(repository.findByNameAndWorkspaceId(server.getName(), 0L)).thenReturn(Optional.empty());
+
+        underTest.getByNameInWorkspace(0L, server.getName());
+    }
+
+    @Test
+    public void testDeleteByNameInWorkspaceFound() {
+        when(repository.findByNameAndWorkspaceId(server.getName(), 0L)).thenReturn(Optional.of(server));
+
+        DatabaseServerConfig deletedServer = underTest.deleteByNameInWorkspace(0L, server.getName());
+
+        assertEquals(server, deletedServer);
+        verify(repository).delete(server);
+    }
+
+    @Test
+    public void testDeleteByNameInWorkspaceNotFound() {
+        thrown.expect(NotFoundException.class);
+
+        when(repository.findByNameAndWorkspaceId(server.getName(), 0L)).thenReturn(Optional.empty());
+
+        try {
+            underTest.deleteByNameInWorkspace(0L, server.getName());
+        } finally {
+            verify(repository, never()).delete(server);
+        }
+    }
+
+    @Test
+    public void testDeleteMultipleByNameInWorkspaceFound() {
+        Set<String> nameSet = new HashSet<>();
+        nameSet.add(server.getName());
+        nameSet.add(server2.getName());
+        Set<DatabaseServerConfig> serverSet = new HashSet<>();
+        serverSet.add(server);
+        serverSet.add(server2);
+        when(repository.findByNameInAndWorkspaceId(nameSet, 0L)).thenReturn(serverSet);
+
+        Set<DatabaseServerConfig> deletedServerSet = underTest.deleteMultipleByNameInWorkspace(0L, nameSet);
+
+        assertEquals(2, deletedServerSet.size());
+        verify(repository).delete(server);
+        verify(repository).delete(server2);
+    }
+
+    @Test
+    public void testDeleteMultipleByNameInWorkspaceNotFound() {
+        thrown.expect(NotFoundException.class);
+
+        Set<String> nameSet = new HashSet<>();
+        nameSet.add(server.getName());
+        nameSet.add(server2.getName());
+        Set<DatabaseServerConfig> serverSet = new HashSet<>();
+        serverSet.add(server);
+        when(repository.findByNameInAndWorkspaceId(nameSet, 0L)).thenReturn(serverSet);
+
+        try {
+            underTest.deleteMultipleByNameInWorkspace(0L, nameSet);
+        } finally {
+            verify(repository, never()).delete(server);
+            verify(repository, never()).delete(server2);
+        }
     }
 }


### PR DESCRIPTION
The redbeams service now supports the following operations on existing
database servers:

* registration (creation)
* deregistration (deletion)
* multiple deregistration
* retrieval
* listing

The two primary pieces of work to enable this, beyond the business logic
to perform the operations:

* Several converters are added for converting between the internal
  DatabaseServerConfig model class and corresponding request and
  response objects at the API level. Additionally,
  StringToSecretV4ResponseConverter is brought in, since it is needed
  for converting to database server API response objects.
* The SecretAspects aspect is copied in to enable redbeams to access
  the vault service, where database server connection usernames and
  passwords are kept.

The API response converters are also needed for the existing list API
endpoint to function, but before this, it wasn't possible to add
database servers, so it didn't matter until now.

The base API path for database server operations no longer includes a
workspace ID. However, internally, an ID is still tracked, but unused
for now.

A few other changes catch redbeams up to refactorings done elsewhere.