### PR TITLE
[CB-1388] CM started before pre-ambari-start recipe

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/init.sls
@@ -15,9 +15,4 @@ replace_server_host:
     - name: /etc/cloudera-scm-agent/config.ini
     - pattern: "server_host=.*"
     - repl: "server_host=cluster-manager.{{ metadata.cluster_domain }}"
-    - unless: cat /etc/cloudera-scm-agent/config.ini | grep server_host=host-10-0-0-3.openstacklocal
-
-start_agent:
-  service.running:
-    - enable: True
-    - name: cloudera-scm-agent
+    - unless: cat /etc/cloudera-scm-agent/config.ini | grep 'server_host="cluster-manager.{{ metadata.cluster_domain }}"'

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/start.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/start.sls
@@ -1,0 +1,4 @@
+start_agent:
+  service.running:
+    - enable: True
+    - name: cloudera-scm-agent

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/init.sls
@@ -7,11 +7,6 @@ install-cloudera-manager-server:
       - cloudera-manager-agent
       - cloudera-manager-server
 
-init-cloudera-manager-db:
-  cmd.run:
-    - name: /opt/cloudera/cm/schema/scm_prepare_database.sh -h {{ cloudera_manager.cloudera_manager_database.host }} {{ cloudera_manager.cloudera_manager_database.subprotocol }} {{ cloudera_manager.cloudera_manager_database.databaseName }} {{ cloudera_manager.cloudera_manager_database.connectionUserName }} {{ cloudera_manager.cloudera_manager_database.connectionPassword }} && echo $(date +%Y-%m-%d:%H:%M:%S) >>  /var/import-certificate_success
-    - unless: test -f /var/log/init-cloudera-manager-db-executed
-
 {% if salt['pillar.get']('ldap', None) != None and salt['pillar.get']('ldap:local', None) == None %}
 
 /etc/cloudera-scm-server/ldap.settings:
@@ -31,11 +26,6 @@ cloudera_manager_setup_ldap:
     - unless: grep "CMF_SERVER_ARGS=\"-i /etc/cloudera-scm-server/ldap.settings\"" /etc/default/cloudera-scm-server
 
 {% endif %}
-
-start_server:
-  service.running:
-    - enable: True
-    - name: cloudera-scm-server
 
 {% if salt['pillar.get']('cloudera-manager:license', None) != None %}
 

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/start.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/start.sls
@@ -1,0 +1,11 @@
+{%- from 'cloudera/manager/settings.sls' import cloudera_manager with context %}
+
+init-cloudera-manager-db:
+  cmd.run:
+    - name: /opt/cloudera/cm/schema/scm_prepare_database.sh -h {{ cloudera_manager.cloudera_manager_database.host }} {{ cloudera_manager.cloudera_manager_database.subprotocol }} {{ cloudera_manager.cloudera_manager_database.databaseName }} {{ cloudera_manager.cloudera_manager_database.connectionUserName }} {{ cloudera_manager.cloudera_manager_database.connectionPassword }} && echo $(date +%Y-%m-%d:%H:%M:%S) >> /var/log/init-cloudera-manager-db-executed
+    - unless: test -f /var/log/init-cloudera-manager-db-executed
+
+start_server:
+  service.running:
+    - enable: True
+    - name: cloudera-scm-server

--- a/orchestrator-salt/src/main/resources/salt/salt/top.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/top.sls
@@ -84,7 +84,12 @@ base:
 
   'roles:manager_server':
     - match: grain
+    - cloudera.manager.start
     - nginx.init
+
+  'roles:manager_agent':
+    - match: grain
+    - cloudera.agent.start
 
   'roles:ambari_server_standby':
     - match: grain


### PR DESCRIPTION
## What changes were proposed in this pull request?

Extract `start` step from `cloudera.manager` and `cloudera.agent` salt scripts.  Run these after `pre-ambari-start` step.

Plus:

 * fix `server_host` value in `unless` condition of `replace_server_host`
 * fix marker file for `init-cloudera-manager-db`

## How was this patch tested?

Deployed a simple ZK cluster with 2 host groups.  Verified that pre-ambari-start recipe is executed after CM install, but before CM start, both on the server host and on agent-only hosts.