### PR TITLE
Image id can be taken from the request

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/ImageService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/ImageService.java
@@ -47,8 +47,7 @@ public class ImageService {
         Image image = new Image();
         image.setStack(stack);
         image.setUserdata(userData);
-        //FIXME remove hardcoded image name
-        image.setImageName("ami-0a21cab39fdfb6b1a");
+        image.setImageName(imageRequest.getId());
         imageRepository.save(image);
     }
 


### PR DESCRIPTION
One line change for setting image from request and removal of hard-coded image id. 
Until there is a plan to have Images 

`"image": {
        "catalog": "string", 
        "id": "ami-0a21cab39fdfb6b1a", 
        "os": "string"
    }, `

`BUILD SUCCESSFUL in 14m 4s
390 actionable tasks: 388 executed, 2 up-to-date`

@keyki @lacikaaa @handavid 