### PR TITLE
CB-1365 Expand bean validation on DatabaseServerV4Base

### DIFF
--- a/core-api/build.gradle
+++ b/core-api/build.gradle
@@ -39,6 +39,7 @@ dependencies {
   compile group: 'org.springframework.security.oauth', name: 'spring-security-oauth2',    version: springOauthVersion
   compile group: 'org.springframework',           name: 'spring-aspects',                 version: springFrameworkVersion
   compile group: 'org.apache.commons',            name: 'commons-lang3',                  version: apacheCommonsLangVersion
+  compile group: 'commons-validator',             name: 'commons-validator',              version: apacheCommonsValidatorVersion
 
   testCompile group: 'org.mockito',               name: 'mockito-core',                   version: mockitoVersion
   testCompile group: 'org.springframework.boot',  name: 'spring-boot-starter',            version: springBootVersion

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/DatabaseVendorValidator.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/DatabaseVendorValidator.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.cloudbreak.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
+
+public class DatabaseVendorValidator implements ConstraintValidator<ValidDatabaseVendor, String> {
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        context.disableDefaultConstraintViolation();
+        if (value == null) {
+            return true;
+        }
+        if (value.isEmpty()) {
+            ValidatorUtil.addConstraintViolation(context, "Database vendor may not be empty");
+            return false;
+        }
+
+        try {
+            DatabaseVendor.fromValue(value);
+            return true;
+        } catch (UnsupportedOperationException e) {
+            ValidatorUtil.addConstraintViolation(context, value + " is not a valid database vendor");
+            return false;
+        }
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/UrlValidator.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/UrlValidator.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.cloudbreak.validation;
+
+import static org.apache.commons.validator.routines.UrlValidator.ALLOW_ALL_SCHEMES;
+import static org.apache.commons.validator.routines.UrlValidator.ALLOW_LOCAL_URLS;
+import static org.apache.commons.validator.routines.UrlValidator.NO_FRAGMENTS;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class UrlValidator implements ConstraintValidator<ValidUrl, String> {
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        context.disableDefaultConstraintViolation();
+        if (value == null) {
+            return true;
+        }
+        if (value.isEmpty()) {
+            ValidatorUtil.addConstraintViolation(context, "URL may not be empty");
+            return false;
+        }
+
+        long validatorOptions = ALLOW_ALL_SCHEMES + ALLOW_LOCAL_URLS + NO_FRAGMENTS;
+        org.apache.commons.validator.routines.UrlValidator commonsValidator = new org.apache.commons.validator.routines.UrlValidator(validatorOptions);
+        if (!commonsValidator.isValid(value)) {
+            ValidatorUtil.addConstraintViolation(context, value + " is not a valid URL");
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/ValidDatabaseVendor.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/ValidDatabaseVendor.java
@@ -1,0 +1,24 @@
+package com.sequenceiq.cloudbreak.validation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Documented
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = DatabaseVendorValidator.class)
+public @interface ValidDatabaseVendor {
+
+    String message() default "";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/ValidUrl.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/ValidUrl.java
@@ -1,0 +1,24 @@
+package com.sequenceiq.cloudbreak.validation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Documented
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = UrlValidator.class)
+public @interface ValidUrl {
+
+    String message() default "";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/ValidatorUtil.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/ValidatorUtil.java
@@ -13,4 +13,9 @@ public class ValidatorUtil {
                 .addConstraintViolation();
     }
 
+    public static ConstraintValidatorContext addConstraintViolation(ConstraintValidatorContext context, String message) {
+        return context.buildConstraintViolationWithTemplate(message)
+                .addConstraintViolation();
+    }
+
 }

--- a/core-api/src/test/java/com/sequenceiq/cloudbreak/validation/DatabaseVendorValidatorTest.java
+++ b/core-api/src/test/java/com/sequenceiq/cloudbreak/validation/DatabaseVendorValidatorTest.java
@@ -1,0 +1,62 @@
+package com.sequenceiq.cloudbreak.validation;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
+
+import javax.validation.ConstraintValidatorContext;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+public class DatabaseVendorValidatorTest {
+
+    private DatabaseVendorValidator underTest;
+
+    @Mock(answer = RETURNS_DEEP_STUBS)
+    private ConstraintValidatorContext context;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        when(context.buildConstraintViolationWithTemplate(any(String.class)).addConstraintViolation()).thenReturn(context);
+
+        underTest = new DatabaseVendorValidator();
+    }
+
+    @Test
+    public void testValid() {
+        assertTrue(underTest.isValid(DatabaseVendor.POSTGRES.databaseType(), context));
+
+        verify(context, never()).buildConstraintViolationWithTemplate(any(String.class));
+    }
+
+    @Test
+    public void testInvalid() {
+        assertFalse(underTest.isValid("foo", context));
+
+        verify(context).buildConstraintViolationWithTemplate(any(String.class));
+    }
+
+    @Test
+    public void testNullIsValid() {
+        assertTrue(underTest.isValid(null, context));
+
+        verify(context, never()).buildConstraintViolationWithTemplate(any(String.class));
+    }
+
+    @Test
+    public void testEmptyIsInvalid() {
+        assertFalse(underTest.isValid("", context));
+
+        verify(context).buildConstraintViolationWithTemplate(any(String.class));
+    }
+}

--- a/core-api/src/test/java/com/sequenceiq/cloudbreak/validation/UrlValidatorTest.java
+++ b/core-api/src/test/java/com/sequenceiq/cloudbreak/validation/UrlValidatorTest.java
@@ -1,0 +1,67 @@
+package com.sequenceiq.cloudbreak.validation;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import javax.validation.ConstraintValidatorContext;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+public class UrlValidatorTest {
+
+    private UrlValidator underTest;
+
+    @Mock(answer = RETURNS_DEEP_STUBS)
+    private ConstraintValidatorContext context;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        when(context.buildConstraintViolationWithTemplate(any(String.class)).addConstraintViolation()).thenReturn(context);
+
+        underTest = new UrlValidator();
+    }
+
+    @Test
+    public void testValid() {
+        assertTrue(underTest.isValid("https://www.cloudera.com/", context));
+
+        verify(context, never()).buildConstraintViolationWithTemplate(any(String.class));
+    }
+
+    @Test
+    public void testLocalUrlIsValid() {
+        assertTrue(underTest.isValid("http://localhost:7189/", context));
+
+        verify(context, never()).buildConstraintViolationWithTemplate(any(String.class));
+    }
+
+    @Test
+    public void testInvalid() {
+        assertFalse(underTest.isValid("foo", context));
+
+        verify(context).buildConstraintViolationWithTemplate(any(String.class));
+    }
+
+    @Test
+    public void testNullIsValid() {
+        assertTrue(underTest.isValid(null, context));
+
+        verify(context, never()).buildConstraintViolationWithTemplate(any(String.class));
+    }
+
+    @Test
+    public void testEmptyIsInvalid() {
+        assertFalse(underTest.isValid("", context));
+
+        verify(context).buildConstraintViolationWithTemplate(any(String.class));
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,7 @@ hibernateValidatorVersion=6.0.9.Final
 jasyptVersion=1.9.2
 apacheCommonsLangVersion=3.8.1
 apacheCommonsIoVersion=2.6
+apacheCommonsValidatorVersion=1.6
 mockitoVersion=2.21.0
 powermockVersion=2.0.0-beta.5
 junitVersion=4.12

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/base/DatabaseServerV4Base.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/base/DatabaseServerV4Base.java
@@ -6,18 +6,18 @@ import javax.validation.constraints.Size;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.JsonEntity;
+import com.sequenceiq.cloudbreak.validation.ValidDatabaseVendor;
+import com.sequenceiq.cloudbreak.validation.ValidUrl;
 import com.sequenceiq.redbeams.doc.ModelDescriptions;
 import com.sequenceiq.redbeams.doc.ModelDescriptions.DatabaseServer;
-// import com.sequenceiq.cloudbreak.validation.ValidRDSConfigJson;
 
 import io.swagger.annotations.ApiModelProperty;
 
-// @ValidRDSConfigJson
 @JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class DatabaseServerV4Base implements JsonEntity {
 
     @NotNull
-    @Size(max = 100, min = 5, message = "The length of the database servers's name has to be in range of 5 to 100")
+    @Size(max = 100, min = 5, message = "The length of the database server's name must be between 5 and 100, inclusive")
     @Pattern(regexp = "(^[a-z][-a-z0-9]*[a-z0-9]$)",
             message = "The database server's name may only contain lowercase letters, digits, and hyphens, and must start with an alphanumeric character")
     @ApiModelProperty(value = DatabaseServer.NAME, required = true)
@@ -36,12 +36,16 @@ public abstract class DatabaseServerV4Base implements JsonEntity {
     private Integer port;
 
     @NotNull
+    @ValidDatabaseVendor
     @ApiModelProperty(value = DatabaseServer.DATABASE_VENDOR, required = true)
     private String databaseVendor;
 
+    @Size(max = 150)
+    @ValidUrl
     @ApiModelProperty(DatabaseServer.CONNECTOR_JAR_URL)
     private String connectorJarUrl;
 
+    @NotNull
     @ApiModelProperty(value = ModelDescriptions.ENVIRONMENT_ID, required = true)
     private String environmentId;
 

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/DatabaseServerV4Request.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/DatabaseServerV4Request.java
@@ -5,12 +5,10 @@ import javax.validation.constraints.NotNull;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.base.DatabaseServerV4Base;
 import com.sequenceiq.redbeams.doc.ModelDescriptions.DatabaseServer;
-// import com.sequenceiq.cloudbreak.validation.externaldatabase.ValidRds;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
-// @ValidRds
 @ApiModel
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DatabaseServerV4Request extends DatabaseServerV4Base {

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/controller/mapper/ConstraintViolationExceptionMapper.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/controller/mapper/ConstraintViolationExceptionMapper.java
@@ -1,0 +1,51 @@
+package com.sequenceiq.redbeams.controller.mapper;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.ws.rs.core.Response.Status;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.json.ValidationResult;
+
+@Component
+public class ConstraintViolationExceptionMapper extends BaseExceptionMapper<ConstraintViolationException> {
+
+    @Override
+    protected String getErrorMessage(ConstraintViolationException exception) {
+        StringBuilder violations = new StringBuilder();
+        violations.append("Constraint violations:");
+        for (ConstraintViolation<?> constraintViolation : exception.getConstraintViolations()) {
+            violations.append('\n')
+                    .append(constraintViolation.getPropertyPath())
+                    .append(" - ")
+                    .append(constraintViolation.getMessage());
+        }
+        return violations.toString();
+    }
+
+    @Override
+    protected Object getEntity(ConstraintViolationException exception) {
+        ValidationResult validationResult = new ValidationResult();
+        exception.getConstraintViolations()
+                .forEach(violation -> {
+                        String propertyPath = violation.getPropertyPath() != null ? violation.getPropertyPath().toString() : "";
+                        String message = violation.getMessage();
+                        if (message != null && !message.isEmpty()) {
+                            validationResult.addValidationError(propertyPath, violation.getMessage());
+                        }
+                    });
+        return validationResult;
+    }
+
+    @Override
+    Status getResponseStatus() {
+        return Status.BAD_REQUEST;
+    }
+
+    @Override
+    Class<ConstraintViolationException> getExceptionType() {
+        return ConstraintViolationException.class;
+    }
+
+}


### PR DESCRIPTION
Bean validation for the JSON representation of database server data is
expanded to cover the database vendor and connector JAR URL fields,
through the application of two new validators: DatabaseVendorValidator
and UrlValidator. Constraint violations that arise from validation
failures are now properly mapped to API responses.