### PR TITLE
Simplify CM template configuration

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/AbstractRoleConfigConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/AbstractRoleConfigConfigProvider.java
@@ -30,7 +30,7 @@ public abstract class AbstractRoleConfigConfigProvider implements CmTemplateComp
                         Optional<String> roleRefOpt = findRoleRef(cmTemplate.getTemplate(), hostTemplate, roleType);
                         if (roleRefOpt.isPresent()) {
                             List<ApiClusterTemplateConfig> roleConfigs = configs.computeIfAbsent(roleRefOpt.get(), v -> new ArrayList<>());
-                            List<ApiClusterTemplateConfig> roleConfig = getRoleConfig(roleType, hostGroupView);
+                            List<ApiClusterTemplateConfig> roleConfig = getRoleConfig(roleType, hostGroupView, templatePreparationObject);
                             setConfigs(roleConfigs, roleConfig);
                         }
                     }
@@ -95,10 +95,11 @@ public abstract class AbstractRoleConfigConfigProvider implements CmTemplateComp
         return roleConfigGroup.getRefName().equals(roleConfigGroupsRefName) && roleConfigGroup.getRoleType().equals(roleType);
     }
 
-    protected abstract List<ApiClusterTemplateConfig> getRoleConfig(String roleType, HostgroupView hostGroupView);
+    protected abstract List<ApiClusterTemplateConfig> getRoleConfig(String roleType, HostgroupView hostGroupView, TemplatePreparationObject source);
 
-    protected abstract List<ApiClusterTemplateVariable> getVariables(String roleType, HostgroupView hostgroupView,
-            TemplatePreparationObject templatePreparationObject);
+    protected List<ApiClusterTemplateVariable> getVariables(String roleType, HostgroupView hostgroupView, TemplatePreparationObject source) {
+        return List.of();
+    }
 
     public String getRoleTypeVariableName(String hostGroup, String roleType, String propertyKey) {
         return String.format("%s_%s_%s", hostGroup, roleType.toLowerCase(), propertyKey);

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ConfigUtils.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ConfigUtils.java
@@ -1,0 +1,30 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders;
+
+import java.util.Optional;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
+import com.sequenceiq.cloudbreak.domain.RDSConfig;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+
+public class ConfigUtils {
+
+    private ConfigUtils() { }
+
+    /**
+     * Convenience method for creating an {@link ApiClusterTemplateConfig} with a value.
+     *
+     * @param name config name
+     * @param value config value
+     * @return config object
+     */
+    public static ApiClusterTemplateConfig config(String name, String value) {
+        return new ApiClusterTemplateConfig().name(name).value(value);
+    }
+
+    public static Optional<RDSConfig> getFirstRDSConfigOptional(TemplatePreparationObject source, DatabaseType databaseType) {
+        return source.getRdsConfigs().stream()
+                .filter(rds -> databaseType.name().equalsIgnoreCase(rds.getType()))
+                .findFirst();
+    }
+}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hdfs/HdfsRoleConfigConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hdfs/HdfsRoleConfigConfigProvider.java
@@ -1,16 +1,15 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.hdfs;
 
-import java.util.ArrayList;
-import java.util.Arrays;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static com.sequenceiq.cloudbreak.template.VolumeUtils.buildVolumePathStringZeroVolumeHandled;
+
 import java.util.List;
 
 import org.springframework.stereotype.Component;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
-import com.cloudera.api.swagger.model.ApiClusterTemplateVariable;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRoleConfigConfigProvider;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
-import com.sequenceiq.cloudbreak.template.VolumeUtils;
 import com.sequenceiq.cloudbreak.template.views.HostgroupView;
 
 @Component
@@ -24,71 +23,37 @@ public class HdfsRoleConfigConfigProvider extends AbstractRoleConfigConfigProvid
 
     private static final String FAILED_VOLUMES_TOLERATED = "dfs_datanode_failed_volumes_tolerated";
 
-    private static final String NUM_FAILED_VOLUMES_TOLERATED = "0";
+    private static final Integer NUM_FAILED_VOLUMES_TOLERATED = 0;
 
     @Override
-    protected List<ApiClusterTemplateConfig> getRoleConfig(String roleType, HostgroupView hostGroupView) {
-        List<ApiClusterTemplateConfig> roleConfigs = new ArrayList<>();
-
+    protected List<ApiClusterTemplateConfig> getRoleConfig(String roleType, HostgroupView hostGroupView, TemplatePreparationObject source) {
         switch (roleType) {
-            case "DATANODE":
-                String dataDir = getRoleTypeVariableName(hostGroupView.getName(), roleType, DFS_DATA_DIRS);
-                roleConfigs.add(new ApiClusterTemplateConfig().name(DFS_DATA_DIRS).variable(dataDir));
-                String tolerate = getRoleTypeVariableName(hostGroupView.getName(), roleType, FAILED_VOLUMES_TOLERATED);
-                roleConfigs.add(new ApiClusterTemplateConfig().name(FAILED_VOLUMES_TOLERATED).variable(tolerate));
-                break;
-            case "NAMENODE":
-                String nameDir = getRoleTypeVariableName(hostGroupView.getName(), roleType, DFS_NAME_DIRS);
-                roleConfigs.add(new ApiClusterTemplateConfig().name(DFS_NAME_DIRS).variable(nameDir));
-                break;
-            case "SECONDARYNAMENODE":
-                String checkDir = getRoleTypeVariableName(hostGroupView.getName(), roleType, DFS_CHECK_DIRS);
-                roleConfigs.add(new ApiClusterTemplateConfig().name(DFS_CHECK_DIRS).variable(checkDir));
-                break;
+            case HdfsRoles.DATANODE:
+                return List.of(
+                        config(DFS_DATA_DIRS, buildVolumePathStringZeroVolumeHandled(hostGroupView.getVolumeCount(), "datanode")),
+                        config(FAILED_VOLUMES_TOLERATED, NUM_FAILED_VOLUMES_TOLERATED.toString())
+                );
+            case HdfsRoles.NAMENODE:
+                return List.of(
+                        config(DFS_NAME_DIRS, buildVolumePathStringZeroVolumeHandled(hostGroupView.getVolumeCount(), "namenode"))
+                );
+            case HdfsRoles.SECONDARYNAMENODE:
+                return List.of(
+                        config(DFS_CHECK_DIRS, buildVolumePathStringZeroVolumeHandled(hostGroupView.getVolumeCount(), "namesecondary"))
+                );
             default:
-                break;
+                return List.of();
         }
-
-        return roleConfigs;
-    }
-
-    @Override
-    protected List<ApiClusterTemplateVariable> getVariables(String roleType, HostgroupView hostGroupView, TemplatePreparationObject templatePreparationObject) {
-        List<ApiClusterTemplateVariable> variables = new ArrayList<>();
-
-        switch (roleType) {
-            case "DATANODE":
-                String dataDirVar = getRoleTypeVariableName(hostGroupView.getName(), roleType, DFS_DATA_DIRS);
-                String dataDirs = VolumeUtils.buildVolumePathStringZeroVolumeHandled(hostGroupView.getVolumeCount(), "datanode");
-                variables.add(new ApiClusterTemplateVariable().name(dataDirVar).value(dataDirs));
-                String tolerate = getRoleTypeVariableName(hostGroupView.getName(), roleType, FAILED_VOLUMES_TOLERATED);
-                variables.add(new ApiClusterTemplateVariable().name(tolerate).value(NUM_FAILED_VOLUMES_TOLERATED));
-                break;
-            case "NAMENODE":
-                String nameDirVar = getRoleTypeVariableName(hostGroupView.getName(), roleType, DFS_NAME_DIRS);
-                String nameDirs = VolumeUtils.buildVolumePathStringZeroVolumeHandled(hostGroupView.getVolumeCount(), "namenode");
-                variables.add(new ApiClusterTemplateVariable().name(nameDirVar).value(nameDirs));
-                break;
-            case "SECONDARYNAMENODE":
-                String checkDirVar = getRoleTypeVariableName(hostGroupView.getName(), roleType, DFS_CHECK_DIRS);
-                String checkDirs = VolumeUtils.buildVolumePathStringZeroVolumeHandled(hostGroupView.getVolumeCount(), "namesecondary");
-                variables.add(new ApiClusterTemplateVariable().name(checkDirVar).value(checkDirs));
-                break;
-            default:
-                break;
-        }
-
-        return variables;
     }
 
     @Override
     public String getServiceType() {
-        return "HDFS";
+        return HdfsRoles.HDFS;
     }
 
     @Override
     public List<String> getRoleTypes() {
-        return Arrays.asList("NAMENODE", "DATANODE", "SECONDARYNAMENODE");
+        return List.of(HdfsRoles.NAMENODE, HdfsRoles.DATANODE, HdfsRoles.SECONDARYNAMENODE);
     }
 
 }

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hdfs/HdfsRoles.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hdfs/HdfsRoles.java
@@ -1,0 +1,15 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.hdfs;
+
+public class HdfsRoles {
+
+    public static final String HDFS = "HDFS";
+
+    public static final String DATANODE = "DATANODE";
+
+    public static final String NAMENODE = "NAMENODE";
+
+    public static final String SECONDARYNAMENODE = "SECONDARYNAMENODE";
+
+    private HdfsRoles() { }
+
+}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveMetastoreConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveMetastoreConfigProvider.java
@@ -1,18 +1,18 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive;
 
-import java.util.ArrayList;
-import java.util.Collections;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+
 import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
-import com.cloudera.api.swagger.model.ApiClusterTemplateVariable;
 import com.google.common.base.Preconditions;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateComponentConfigProvider;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.views.RdsView;
@@ -22,39 +22,27 @@ public class HiveMetastoreConfigProvider implements CmTemplateComponentConfigPro
 
     @Override
     public List<ApiClusterTemplateConfig> getServiceConfigs(TemplatePreparationObject templatePreparationObject) {
-        List<ApiClusterTemplateConfig> result = new ArrayList<>();
-        result.add(new ApiClusterTemplateConfig().name("hive_metastore_database_password").variable("hive-hive_metastore_database_password"));
-        result.add(new ApiClusterTemplateConfig().name("hive_metastore_database_port").variable("hive-hive_metastore_database_port"));
-        result.add(new ApiClusterTemplateConfig().name("hive_metastore_database_host").variable("hive-hive_metastore_database_host"));
-        result.add(new ApiClusterTemplateConfig().name("hive_metastore_database_type").variable("hive-hive_metastore_database_type"));
-        result.add(new ApiClusterTemplateConfig().name("hive_metastore_database_name").variable("hive-hive_metastore_database_name"));
-        result.add(new ApiClusterTemplateConfig().name("hive_metastore_database_user").variable("hive-hive_metastore_database_user"));
-        return result;
-    }
-
-    @Override
-    public List<ApiClusterTemplateVariable> getServiceConfigVariables(TemplatePreparationObject source) {
-        List<ApiClusterTemplateVariable> result = new ArrayList<>();
-        Optional<RDSConfig> rdsConfigOptional = getFirstRDSConfigOptional(source);
+        Optional<RDSConfig> rdsConfigOptional = getFirstRDSConfigOptional(templatePreparationObject);
         Preconditions.checkArgument(rdsConfigOptional.isPresent());
         RdsView hiveView = new RdsView(rdsConfigOptional.get());
-        result.add(new ApiClusterTemplateVariable().name("hive-hive_metastore_database_host").value(hiveView.getHost()));
-        result.add(new ApiClusterTemplateVariable().name("hive-hive_metastore_database_port").value(hiveView.getPort()));
-        result.add(new ApiClusterTemplateVariable().name("hive-hive_metastore_database_name").value(hiveView.getDatabaseName()));
-        result.add(new ApiClusterTemplateVariable().name("hive-hive_metastore_database_type").value(hiveView.getSubprotocol()));
-        result.add(new ApiClusterTemplateVariable().name("hive-hive_metastore_database_password").value(hiveView.getConnectionPassword()));
-        result.add(new ApiClusterTemplateVariable().name("hive-hive_metastore_database_user").value(hiveView.getConnectionUserName()));
-        return result;
+        return List.of(
+                config("hive_metastore_database_host", hiveView.getHost()),
+                config("hive_metastore_database_name", hiveView.getDatabaseName()),
+                config("hive_metastore_database_password", hiveView.getConnectionPassword()),
+                config("hive_metastore_database_port", hiveView.getPort()),
+                config("hive_metastore_database_type", hiveView.getSubprotocol()),
+                config("hive_metastore_database_user", hiveView.getConnectionUserName())
+        );
     }
 
     @Override
     public String getServiceType() {
-        return "HIVE";
+        return HiveRoles.HIVE;
     }
 
     @Override
     public List<String> getRoleTypes() {
-        return Collections.singletonList("HIVEMETASTORE");
+        return List.of(HiveRoles.HIVEMETASTORE);
     }
 
     @Override
@@ -63,6 +51,7 @@ public class HiveMetastoreConfigProvider implements CmTemplateComponentConfigPro
     }
 
     private Optional<RDSConfig> getFirstRDSConfigOptional(TemplatePreparationObject source) {
-        return source.getRdsConfigs().stream().filter(rds -> DatabaseType.HIVE.name().equalsIgnoreCase(rds.getType())).findFirst();
+        return ConfigUtils.getFirstRDSConfigOptional(source, DatabaseType.HIVE);
     }
+
 }

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveRoles.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveRoles.java
@@ -1,0 +1,13 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive;
+
+public class HiveRoles {
+
+    public static final String HIVEMETASTORE = "HIVEMETASTORE";
+
+    public static final String HIVE = "HIVE";
+
+    public static final String HIVESERVER2 = "HIVESERVER2";
+
+    private HiveRoles() { }
+
+}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveServer2RoleConfigConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveServer2RoleConfigConfigProvider.java
@@ -1,13 +1,12 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive;
 
-import java.util.ArrayList;
-import java.util.Collections;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+
 import java.util.List;
 
 import org.springframework.stereotype.Component;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
-import com.cloudera.api.swagger.model.ApiClusterTemplateVariable;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRoleConfigConfigProvider;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
@@ -17,45 +16,27 @@ import com.sequenceiq.cloudbreak.template.views.HostgroupView;
 public class HiveServer2RoleConfigConfigProvider extends AbstractRoleConfigConfigProvider {
 
     @Override
-    protected List<ApiClusterTemplateConfig> getRoleConfig(String roleType, HostgroupView hostGroupView) {
-        List<ApiClusterTemplateConfig> roleConfigs = new ArrayList<>();
-
+    protected List<ApiClusterTemplateConfig> getRoleConfig(String roleType, HostgroupView hostGroupView, TemplatePreparationObject source) {
         switch (roleType) {
-            case "HIVESERVER2":
-                roleConfigs.add(new ApiClusterTemplateConfig().name("hive_hs2_config_safety_valve").variable("hive-hive_server2_wm_namespace"));
-                break;
+            case HiveRoles.HIVESERVER2:
+                String uuid = source.getGeneralClusterConfigs().getUuid();
+                String safetyValveValue = "<property><name>hive.server2.wm.namespace</name><value>" + uuid + "</value></property>";
+                return List.of(
+                        config("hive_hs2_config_safety_valve", safetyValveValue)
+                );
             default:
-                break;
+                return List.of();
         }
-
-        return roleConfigs;
-    }
-
-    @Override
-    protected List<ApiClusterTemplateVariable> getVariables(String roleType, HostgroupView hostGroupView, TemplatePreparationObject templatePreparationObject) {
-        List<ApiClusterTemplateVariable> variables = new ArrayList<>();
-
-        switch (roleType) {
-            case "HIVESERVER2":
-                String uuid = templatePreparationObject.getGeneralClusterConfigs().getUuid();
-                variables.add(new ApiClusterTemplateVariable().name("hive-hive_server2_wm_namespace")
-                        .value("<property><name>hive.server2.wm.namespace</name><value>" + uuid + "</value></property>"));
-                break;
-            default:
-                break;
-        }
-
-        return variables;
     }
 
     @Override
     public String getServiceType() {
-        return "HIVE";
+        return HiveRoles.HIVE;
     }
 
     @Override
     public List<String> getRoleTypes() {
-        return Collections.singletonList("HIVESERVER2");
+        return List.of(HiveRoles.HIVESERVER2);
     }
 
     @Override

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/oozie/OozieRoleConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/oozie/OozieRoleConfigProvider.java
@@ -1,18 +1,18 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.oozie;
 
-import java.util.ArrayList;
-import java.util.Collections;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+
 import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
-import com.cloudera.api.swagger.model.ApiClusterTemplateVariable;
 import com.google.common.base.Preconditions;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRoleConfigConfigProvider;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.views.HostgroupView;
@@ -32,75 +32,32 @@ public class OozieRoleConfigProvider extends AbstractRoleConfigConfigProvider {
     private static final String OOZIE_DATABASE_PASSWORD = "oozie_database_password";
 
     @Override
-    protected List<ApiClusterTemplateConfig> getRoleConfig(String roleType, HostgroupView hostGroupView) {
-        List<ApiClusterTemplateConfig> roleConfigs = new ArrayList<>();
-
+    protected List<ApiClusterTemplateConfig> getRoleConfig(String roleType, HostgroupView hostGroupView, TemplatePreparationObject source) {
         switch (roleType) {
-            case "OOZIE_SERVER":
-                String databaseHost = getRoleTypeVariableName(hostGroupView.getName(), roleType, OOZIE_DATABASE_HOST);
-                roleConfigs.add(new ApiClusterTemplateConfig().name(OOZIE_DATABASE_HOST).variable(databaseHost));
-
-                String databaseName = getRoleTypeVariableName(hostGroupView.getName(), roleType, OOZIE_DATABASE_NAME);
-                roleConfigs.add(new ApiClusterTemplateConfig().name(OOZIE_DATABASE_NAME).variable(databaseName));
-
-                String databaseType = getRoleTypeVariableName(hostGroupView.getName(), roleType, OOZIE_DATABASE_TYPE);
-                roleConfigs.add(new ApiClusterTemplateConfig().name(OOZIE_DATABASE_TYPE).variable(databaseType));
-
-                String databaseUser = getRoleTypeVariableName(hostGroupView.getName(), roleType, OOZIE_DATABASE_USER);
-                roleConfigs.add(new ApiClusterTemplateConfig().name(OOZIE_DATABASE_USER).variable(databaseUser));
-
-                String databasePassword = getRoleTypeVariableName(hostGroupView.getName(), roleType, OOZIE_DATABASE_PASSWORD);
-                roleConfigs.add(new ApiClusterTemplateConfig().name(OOZIE_DATABASE_PASSWORD).variable(databasePassword));
-
-                break;
-            default:
-                break;
-        }
-
-        return roleConfigs;
-    }
-
-    @Override
-    protected List<ApiClusterTemplateVariable> getVariables(String roleType, HostgroupView hostGroupView, TemplatePreparationObject templatePreparationObject) {
-        List<ApiClusterTemplateVariable> variables = new ArrayList<>();
-
-        switch (roleType) {
-            case "OOZIE_SERVER":
-                Optional<RDSConfig> rdsConfigOptional = getFirstRDSConfigOptional(templatePreparationObject);
+            case OozieRoles.OOZIE_SERVER:
+                Optional<RDSConfig> rdsConfigOptional = getFirstRDSConfigOptional(source);
                 Preconditions.checkArgument(rdsConfigOptional.isPresent());
                 RdsView oozieRdsView = new RdsView(rdsConfigOptional.get());
-
-                String databaseHostVar = getRoleTypeVariableName(hostGroupView.getName(), roleType, OOZIE_DATABASE_HOST);
-                variables.add(new ApiClusterTemplateVariable().name(databaseHostVar).value(oozieRdsView.getHost()));
-
-                String databaseNameVar = getRoleTypeVariableName(hostGroupView.getName(), roleType, OOZIE_DATABASE_NAME);
-                variables.add(new ApiClusterTemplateVariable().name(databaseNameVar).value(oozieRdsView.getDatabaseName()));
-
-                String databaseTypeVar = getRoleTypeVariableName(hostGroupView.getName(), roleType, OOZIE_DATABASE_TYPE);
-                variables.add(new ApiClusterTemplateVariable().name(databaseTypeVar).value(oozieRdsView.getSubprotocol()));
-
-                String databaseUserVar = getRoleTypeVariableName(hostGroupView.getName(), roleType, OOZIE_DATABASE_USER);
-                variables.add(new ApiClusterTemplateVariable().name(databaseUserVar).value(oozieRdsView.getConnectionUserName()));
-
-                String databasePasswordVar = getRoleTypeVariableName(hostGroupView.getName(), roleType, OOZIE_DATABASE_PASSWORD);
-                variables.add(new ApiClusterTemplateVariable().name(databasePasswordVar).value(oozieRdsView.getConnectionPassword()));
-
-                break;
+                return List.of(
+                        config(OOZIE_DATABASE_HOST, oozieRdsView.getHost()),
+                        config(OOZIE_DATABASE_NAME, oozieRdsView.getDatabaseName()),
+                        config(OOZIE_DATABASE_TYPE, oozieRdsView.getSubprotocol()),
+                        config(OOZIE_DATABASE_USER, oozieRdsView.getConnectionUserName()),
+                        config(OOZIE_DATABASE_PASSWORD, oozieRdsView.getConnectionPassword())
+                );
             default:
-                break;
+                return List.of();
         }
-
-        return variables;
     }
 
     @Override
     public String getServiceType() {
-        return "OOZIE";
+        return OozieRoles.OOZIE;
     }
 
     @Override
     public List<String> getRoleTypes() {
-        return Collections.singletonList("OOZIE_SERVER");
+        return List.of(OozieRoles.OOZIE_SERVER);
     }
 
     @Override
@@ -109,6 +66,6 @@ public class OozieRoleConfigProvider extends AbstractRoleConfigConfigProvider {
     }
 
     private Optional<RDSConfig> getFirstRDSConfigOptional(TemplatePreparationObject source) {
-        return source.getRdsConfigs().stream().filter(rds -> DatabaseType.OOZIE.name().equalsIgnoreCase(rds.getType())).findFirst();
+        return ConfigUtils.getFirstRDSConfigOptional(source, DatabaseType.OOZIE);
     }
 }

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/oozie/OozieRoles.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/oozie/OozieRoles.java
@@ -1,0 +1,11 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.oozie;
+
+public class OozieRoles {
+
+    public static final String OOZIE = "OOZIE";
+
+    public static final String OOZIE_SERVER = "OOZIE_SERVER";
+
+    private OozieRoles() { }
+
+}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerRoles.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerRoles.java
@@ -1,0 +1,11 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.ranger;
+
+public class RangerRoles {
+
+    public static final String RANGER_ADMIN = "RANGER_ADMIN";
+
+    public static final String RANGER = "RANGER";
+
+    private RangerRoles() { }
+
+}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/yarn/YarnRoleConfigConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/yarn/YarnRoleConfigConfigProvider.java
@@ -1,15 +1,15 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.yarn;
 
-import java.util.ArrayList;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static com.sequenceiq.cloudbreak.template.VolumeUtils.buildVolumePathStringZeroVolumeHandled;
+
 import java.util.List;
 
 import org.springframework.stereotype.Component;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
-import com.cloudera.api.swagger.model.ApiClusterTemplateVariable;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRoleConfigConfigProvider;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
-import com.sequenceiq.cloudbreak.template.VolumeUtils;
 import com.sequenceiq.cloudbreak.template.views.HostgroupView;
 
 @Component
@@ -20,52 +20,25 @@ public class YarnRoleConfigConfigProvider extends AbstractRoleConfigConfigProvid
     private static final String NODE_LOG_DIRS = "yarn_nodemanager_log_dirs";
 
     @Override
-    protected List<ApiClusterTemplateConfig> getRoleConfig(String roleType, HostgroupView hostGroupView) {
-        List<ApiClusterTemplateConfig> roleConfigs = new ArrayList<>();
-
+    protected List<ApiClusterTemplateConfig> getRoleConfig(String roleType, HostgroupView hostGroupView, TemplatePreparationObject source) {
         switch (roleType) {
-            case "NODEMANAGER":
-                String localDirs = getRoleTypeVariableName(hostGroupView.getName(), roleType, NODE_LOCAL_DIRS);
-                roleConfigs.add(new ApiClusterTemplateConfig().name(NODE_LOCAL_DIRS).variable(localDirs));
-
-                String logDirs = getRoleTypeVariableName(hostGroupView.getName(), roleType, NODE_LOG_DIRS);
-                roleConfigs.add(new ApiClusterTemplateConfig().name(NODE_LOG_DIRS).variable(logDirs));
-                break;
+            case YarnRoles.NODEMANAGER:
+                return List.of(
+                        config(NODE_LOCAL_DIRS, buildVolumePathStringZeroVolumeHandled(hostGroupView.getVolumeCount(), "nodemanager")),
+                        config(NODE_LOG_DIRS, buildVolumePathStringZeroVolumeHandled(hostGroupView.getVolumeCount(), "nodemanager/log"))
+                );
             default:
-                break;
+                return List.of();
         }
-
-        return roleConfigs;
-    }
-
-    @Override
-    protected List<ApiClusterTemplateVariable> getVariables(String roleType, HostgroupView hostGroupView, TemplatePreparationObject templatePreparationObject) {
-        List<ApiClusterTemplateVariable> variables = new ArrayList<>();
-
-        switch (roleType) {
-            case "NODEMANAGER":
-                String localDirVar = getRoleTypeVariableName(hostGroupView.getName(), roleType, NODE_LOCAL_DIRS);
-                String localDirs = VolumeUtils.buildVolumePathStringZeroVolumeHandled(hostGroupView.getVolumeCount(), "nodemanager");
-                variables.add(new ApiClusterTemplateVariable().name(localDirVar).value(localDirs));
-
-                String logDirVar = getRoleTypeVariableName(hostGroupView.getName(), roleType, NODE_LOG_DIRS);
-                String logDirs = VolumeUtils.buildVolumePathStringZeroVolumeHandled(hostGroupView.getVolumeCount(), "nodemanager/log");
-                variables.add(new ApiClusterTemplateVariable().name(logDirVar).value(logDirs));
-                break;
-            default:
-                break;
-        }
-
-        return variables;
     }
 
     @Override
     public String getServiceType() {
-        return "YARN";
+        return YarnRoles.YARN;
     }
 
     @Override
     public List<String> getRoleTypes() {
-        return List.of("NODEMANAGER");
+        return List.of(YarnRoles.NODEMANAGER);
     }
 }

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/yarn/YarnRoles.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/yarn/YarnRoles.java
@@ -1,0 +1,11 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.yarn;
+
+public class YarnRoles {
+
+    public static final String NODEMANAGER = "NODEMANAGER";
+
+    public static final String YARN = "YARN";
+
+    private YarnRoles() { }
+
+}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/generator/dependencies/ServiceDependencyMatrixService.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/generator/dependencies/ServiceDependencyMatrixService.java
@@ -30,7 +30,7 @@ public class ServiceDependencyMatrixService {
         Dependencies dependencies = new Dependencies();
         Set<String> deps = new HashSet<>();
         for (String service : services) {
-            for (ServiceConfig serviceInformation : resolver.serviceInformations()) {
+            for (ServiceConfig serviceInformation : resolver.serviceConfigs()) {
                 if (service.toUpperCase().equals(serviceInformation.getName())) {
                     for (String dependency : serviceInformation.getDependencies()) {
                         deps.add(dependency.toUpperCase());

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/generator/support/SupportedVersionService.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/generator/support/SupportedVersionService.java
@@ -29,7 +29,7 @@ public class SupportedVersionService {
             supportedVersion.setVersion(key.getVersion());
             SupportedServices supportedServices = new SupportedServices();
             for (String serviceName : value) {
-                for (ServiceConfig serviceInformation : resolver.serviceInformations()) {
+                for (ServiceConfig serviceInformation : resolver.serviceConfigs()) {
                     if (serviceInformation.getName().equals(serviceName)) {
                         SupportedService supportedService = new SupportedService();
                         supportedService.setName(serviceInformation.getName());

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/generator/template/GeneratedCmTemplateService.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/generator/template/GeneratedCmTemplateService.java
@@ -67,7 +67,7 @@ public class GeneratedCmTemplateService {
     private Set<ServiceConfig> collectServiceConfigs(Set<String> services) {
         Set<ServiceConfig> serviceConfigs = new HashSet<>();
         for (String service : services) {
-            for (ServiceConfig serviceInformation : resolver.serviceInformations()) {
+            for (ServiceConfig serviceInformation : resolver.serviceConfigs()) {
                 if (serviceInformation.getName().equals(service.toUpperCase())) {
                     serviceConfigs.add(serviceInformation);
                 }

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CentralCmTemplateUpdaterTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CentralCmTemplateUpdaterTest.java
@@ -93,7 +93,7 @@ public class CentralCmTemplateUpdaterTest {
     public void getCmTemplate() {
         when(blueprintView.getBlueprintText()).thenReturn(getBlueprintText("input/clouderamanager.bp"));
         ApiClusterTemplate generated = generator.getCmTemplate(templatePreparationObject, getHostgroupMappings(), clouderaManagerRepo, null);
-        Assert.assertEquals(new CmTemplateProcessor(getBlueprintText("output/clouderamanager.bp")).getTemplate(), generated);
+        Assert.assertEquals(new CmTemplateProcessor(getBlueprintText("output/clouderamanager.bp")).getTemplate().toString(), generated.toString());
     }
 
     @Test
@@ -114,8 +114,8 @@ public class CentralCmTemplateUpdaterTest {
     public void getCmTemplateWithoutHosts() {
         when(blueprintView.getBlueprintText()).thenReturn(getBlueprintText("input/clouderamanager-without-hosts.bp"));
         String generated = generator.getBlueprintText(templatePreparationObject);
-        Assert.assertEquals(new CmTemplateProcessor(getBlueprintText("output/clouderamanager-without-hosts.bp")).getTemplate(),
-                new CmTemplateProcessor(generated).getTemplate());
+        Assert.assertEquals(new CmTemplateProcessor(getBlueprintText("output/clouderamanager-without-hosts.bp")).getTemplate().toString(),
+                new CmTemplateProcessor(generated).getTemplate().toString());
     }
 
     private String getBlueprintText(String path) {

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/ClusterTemplateGeneratorServiceTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/ClusterTemplateGeneratorServiceTest.java
@@ -41,7 +41,7 @@ class ClusterTemplateGeneratorServiceTest {
         Set<String> services = Set.of("HDFS", "HIVE");
         ServiceDependencyMatrix dependentServices = new ServiceDependencyMatrix();
         Dependencies dependencies = new Dependencies();
-        dependencies.setServices(Set.of("ZOOKEPER"));
+        dependencies.setServices(Set.of("ZOOKEEPER"));
         dependentServices.setDependencies(dependencies);
 
         when(serviceDependencyMatrixService.collectServiceDependencyMatrix(services, "CDH", "6.1.1"))
@@ -50,7 +50,7 @@ class ClusterTemplateGeneratorServiceTest {
         underTest.generateTemplateByServices(services, "CDH-6.1.1");
 
         verify(generatedCMTemplateService).prepareClouderaManagerTemplate(captor.capture(), anyString(), anyString(), anyString());
-        Set<String> expectedServicesArgument = Set.of("HDFS", "HIVE", "ZOOKEPER");
+        Set<String> expectedServicesArgument = Set.of("HDFS", "HIVE", "ZOOKEEPER");
         Assertions.assertEquals(expectedServicesArgument, captor.getValue());
     }
 }

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hdfs/HdfsVolumeConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hdfs/HdfsVolumeConfigProviderTest.java
@@ -3,7 +3,6 @@ package com.sequenceiq.cloudbreak.cmtemplate.configproviders.hdfs;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -13,7 +12,6 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
-import com.cloudera.api.swagger.model.ApiClusterTemplateVariable;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceGroupType;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
@@ -45,15 +43,18 @@ public class HdfsVolumeConfigProviderTest {
 
         List<ApiClusterTemplateConfig> masterNN = roleConfigs.get("hdfs-NAMENODE-BASE");
         List<ApiClusterTemplateConfig> workerDN = roleConfigs.get("hdfs-DATANODE-BASE");
+        List<ApiClusterTemplateConfig> masterSN = roleConfigs.get("hdfs-SECONDARYNAMENODE-BASE");
 
         assertEquals(2, workerDN.size());
         assertEquals("dfs_data_dir_list", workerDN.get(0).getName());
-        assertEquals("worker_datanode_dfs_data_dir_list", workerDN.get(0).getVariable());
+        assertEquals("/hadoopfs/fs1/datanode,/hadoopfs/fs2/datanode", workerDN.get(0).getValue());
         assertEquals("dfs_datanode_failed_volumes_tolerated", workerDN.get(1).getName());
-        assertEquals("worker_datanode_dfs_datanode_failed_volumes_tolerated", workerDN.get(1).getVariable());
+        assertEquals("0", workerDN.get(1).getValue());
         assertEquals(1, masterNN.size());
         assertEquals("dfs_name_dir_list", masterNN.get(0).getName());
-        assertEquals("master_namenode_dfs_name_dir_list", masterNN.get(0).getVariable());
+        assertEquals("/hadoopfs/fs1/namenode", masterNN.get(0).getValue());
+        assertEquals("fs_checkpoint_dir_list", masterSN.get(0).getName());
+        assertEquals("/hadoopfs/fs1/namesecondary", masterSN.get(0).getValue());
     }
 
     @Test
@@ -71,12 +72,12 @@ public class HdfsVolumeConfigProviderTest {
 
         assertEquals(2, workerDN.size());
         assertEquals("dfs_data_dir_list", workerDN.get(0).getName());
-        assertEquals("worker_datanode_dfs_data_dir_list", workerDN.get(0).getVariable());
+        assertEquals("/hadoopfs/fs1/datanode,/hadoopfs/fs2/datanode", workerDN.get(0).getValue());
         assertEquals("dfs_datanode_failed_volumes_tolerated", workerDN.get(1).getName());
-        assertEquals("worker_datanode_dfs_datanode_failed_volumes_tolerated", workerDN.get(1).getVariable());
+        assertEquals("0", workerDN.get(1).getValue());
         assertEquals(1, masterNN.size());
         assertEquals("dfs_name_dir_list", masterNN.get(0).getName());
-        assertEquals("master_namenode_dfs_name_dir_list", masterNN.get(0).getVariable());
+        assertEquals("/hadoopfs/fs1/namenode", masterNN.get(0).getValue());
     }
 
     @Test
@@ -98,13 +99,13 @@ public class HdfsVolumeConfigProviderTest {
         assertEquals(1, masterSN.size());
         assertEquals(2, workerDN.size());
         assertEquals("dfs_name_dir_list", masterNN.get(0).getName());
-        assertEquals("master_namenode_dfs_name_dir_list", masterNN.get(0).getVariable());
+        assertEquals("/hadoopfs/fs1/namenode", masterNN.get(0).getValue());
         assertEquals("fs_checkpoint_dir_list", masterSN.get(0).getName());
-        assertEquals("master_secondarynamenode_fs_checkpoint_dir_list", masterSN.get(0).getVariable());
+        assertEquals("/hadoopfs/fs1/namesecondary", masterSN.get(0).getValue());
         assertEquals("dfs_data_dir_list", workerDN.get(0).getName());
-        assertEquals("worker_datanode_dfs_data_dir_list", workerDN.get(0).getVariable());
+        assertEquals("/hadoopfs/root1/datanode", workerDN.get(0).getValue());
         assertEquals("dfs_datanode_failed_volumes_tolerated", workerDN.get(1).getName());
-        assertEquals("worker_datanode_dfs_datanode_failed_volumes_tolerated", workerDN.get(1).getVariable());
+        assertEquals("0", workerDN.get(1).getValue());
     }
 
     @Test
@@ -126,13 +127,13 @@ public class HdfsVolumeConfigProviderTest {
         assertEquals(1, masterSN.size());
         assertEquals(2, workerDN.size());
         assertEquals("dfs_name_dir_list", masterNN.get(0).getName());
-        assertEquals("master_namenode_dfs_name_dir_list", masterNN.get(0).getVariable());
+        assertEquals("/hadoopfs/root1/namenode", masterNN.get(0).getValue());
         assertEquals("fs_checkpoint_dir_list", masterSN.get(0).getName());
-        assertEquals("master_secondarynamenode_fs_checkpoint_dir_list", masterSN.get(0).getVariable());
+        assertEquals("/hadoopfs/root1/namesecondary", masterSN.get(0).getValue());
         assertEquals("dfs_data_dir_list", workerDN.get(0).getName());
-        assertEquals("worker_datanode_dfs_data_dir_list", workerDN.get(0).getVariable());
+        assertEquals("/hadoopfs/root1/datanode", workerDN.get(0).getValue());
         assertEquals("dfs_datanode_failed_volumes_tolerated", workerDN.get(1).getName());
-        assertEquals("worker_datanode_dfs_datanode_failed_volumes_tolerated", workerDN.get(1).getVariable());
+        assertEquals("0", workerDN.get(1).getValue());
     }
 
     @Test
@@ -164,7 +165,7 @@ public class HdfsVolumeConfigProviderTest {
         assertEquals(3, roleConfigs.size());
         assertEquals(1, masterNN.size());
         assertEquals("dfs_name_dir_list", masterNN.get(0).getName());
-        assertEquals("master_namenode_dfs_name_dir_list", masterNN.get(0).getVariable());
+        assertEquals("/hadoopfs/fs1/namenode", masterNN.get(0).getValue());
     }
 
     @Test
@@ -184,17 +185,17 @@ public class HdfsVolumeConfigProviderTest {
 
         assertEquals(2, workerDN.size());
         assertEquals("dfs_data_dir_list", workerDN.get(0).getName());
-        assertEquals("worker_datanode_dfs_data_dir_list", workerDN.get(0).getVariable());
+        assertEquals("/hadoopfs/fs1/datanode,/hadoopfs/fs2/datanode", workerDN.get(0).getValue());
         assertEquals("dfs_datanode_failed_volumes_tolerated", workerDN.get(1).getName());
-        assertEquals("worker_datanode_dfs_datanode_failed_volumes_tolerated", workerDN.get(1).getVariable());
+        assertEquals("0", workerDN.get(1).getValue());
         assertEquals(1, masterNN.size());
         assertEquals("dfs_name_dir_list", masterNN.get(0).getName());
-        assertEquals("master_namenode_dfs_name_dir_list", masterNN.get(0).getVariable());
+        assertEquals("/hadoopfs/fs1/namenode", masterNN.get(0).getValue());
         assertEquals(2, computeDN.size());
         assertEquals("dfs_data_dir_list", computeDN.get(0).getName());
-        assertEquals("compute_datanode_dfs_data_dir_list", computeDN.get(0).getVariable());
+        assertEquals("/hadoopfs/fs1/datanode,/hadoopfs/fs2/datanode,/hadoopfs/fs3/datanode", computeDN.get(0).getValue());
         assertEquals("dfs_datanode_failed_volumes_tolerated", computeDN.get(1).getName());
-        assertEquals("compute_datanode_dfs_datanode_failed_volumes_tolerated", computeDN.get(1).getVariable());
+        assertEquals("0", computeDN.get(1).getValue());
 
     }
 
@@ -215,201 +216,16 @@ public class HdfsVolumeConfigProviderTest {
 
         assertEquals(2, workerDN.size());
         assertEquals("dfs_data_dir_list", workerDN.get(0).getName());
-        assertEquals("worker_datanode_dfs_data_dir_list", workerDN.get(0).getVariable());
+        assertEquals("/hadoopfs/fs1/datanode,/hadoopfs/fs2/datanode", workerDN.get(0).getValue());
         assertEquals("dfs_datanode_failed_volumes_tolerated", workerDN.get(1).getName());
-        assertEquals("worker_datanode_dfs_datanode_failed_volumes_tolerated", workerDN.get(1).getVariable());
+        assertEquals("0", workerDN.get(1).getValue());
         assertEquals(1, masterNN.size());
         assertEquals("dfs_name_dir_list", masterNN.get(0).getName());
-        assertEquals("master_namenode_dfs_name_dir_list", masterNN.get(0).getVariable());
         assertEquals(2, computeDN.size());
-        assertTrue(computeDN.stream().map(ApiClusterTemplateConfig::getName).anyMatch("dfs_data_dir_list"::equals));
-        assertEquals("compute_datanode_dfs_data_dir_list", computeDN.stream().filter(conf -> "dfs_data_dir_list".equals(conf.getName()))
-                .findFirst().get().getVariable());
-        assertTrue(computeDN.stream().map(ApiClusterTemplateConfig::getName).anyMatch("dfs_datanode_failed_volumes_tolerated"::equals));
-        assertEquals("compute_datanode_dfs_datanode_failed_volumes_tolerated", computeDN.stream()
-                .filter(conf -> "dfs_datanode_failed_volumes_tolerated".equals(conf.getName()))
-                .findFirst().get().getVariable());
-    }
-
-    @Test
-    public void testGetRoleConfigVariables() {
-        HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, 1);
-        HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, 2);
-        TemplatePreparationObject preparationObject = Builder.builder().withHostgroupViews(Set.of(master, worker)).build();
-        String inputJson = getBlueprintText("input/clouderamanager.bp");
-        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
-
-        List<ApiClusterTemplateVariable> roleVariables = underTest.getRoleConfigVariables(cmTemplateProcessor, preparationObject);
-
-        roleVariables.sort(Comparator.comparing(ApiClusterTemplateVariable::getName));
-        ApiClusterTemplateVariable masterNN = roleVariables.get(0);
-        ApiClusterTemplateVariable masterSN = roleVariables.get(1);
-        ApiClusterTemplateVariable workerDN = roleVariables.get(2);
-        ApiClusterTemplateVariable workerDNFailedVolumes = roleVariables.get(3);
-
-        assertEquals(4, roleVariables.size());
-        assertEquals("master_namenode_dfs_name_dir_list", masterNN.getName());
-        assertEquals("/hadoopfs/fs1/namenode", masterNN.getValue());
-        assertEquals("master_secondarynamenode_fs_checkpoint_dir_list", masterSN.getName());
-        assertEquals("/hadoopfs/fs1/namesecondary", masterSN.getValue());
-        assertEquals("worker_datanode_dfs_data_dir_list", workerDN.getName());
-        assertEquals("/hadoopfs/fs1/datanode,/hadoopfs/fs2/datanode", workerDN.getValue());
-        assertEquals("worker_datanode_dfs_datanode_failed_volumes_tolerated", workerDNFailedVolumes.getName());
-        assertEquals("0", workerDNFailedVolumes.getValue());
-    }
-
-    @Test
-    public void testGetRoleConfigVariablesWithOneHostGroupZeroAttachedVolumes() {
-        HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, 1);
-        HostgroupView worker = new HostgroupView("worker", 0, InstanceGroupType.CORE, 2);
-        TemplatePreparationObject preparationObject = Builder.builder().withHostgroupViews(Set.of(master, worker)).build();
-        String inputJson = getBlueprintText("input/clouderamanager.bp");
-        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
-
-        List<ApiClusterTemplateVariable> roleVariables = underTest.getRoleConfigVariables(cmTemplateProcessor, preparationObject);
-
-        roleVariables.sort(Comparator.comparing(ApiClusterTemplateVariable::getName));
-        ApiClusterTemplateVariable masterNN = roleVariables.get(0);
-        ApiClusterTemplateVariable masterSN = roleVariables.get(1);
-        ApiClusterTemplateVariable workerDN = roleVariables.get(2);
-        ApiClusterTemplateVariable workerFailedVolumes = roleVariables.get(3);
-
-        assertEquals(4, roleVariables.size());
-        assertEquals("master_namenode_dfs_name_dir_list", masterNN.getName());
-        assertEquals("/hadoopfs/fs1/namenode", masterNN.getValue());
-        assertEquals("master_secondarynamenode_fs_checkpoint_dir_list", masterSN.getName());
-        assertEquals("/hadoopfs/fs1/namesecondary", masterSN.getValue());
-        assertEquals("worker_datanode_dfs_data_dir_list", workerDN.getName());
-        assertEquals("/hadoopfs/root1/datanode", workerDN.getValue());
-        assertEquals("worker_datanode_dfs_datanode_failed_volumes_tolerated", workerFailedVolumes.getName());
-        assertEquals("0", workerFailedVolumes.getValue());
-    }
-
-    @Test
-    public void testGetRoleConfigVariablesWithAllHostGroupZeroAttachedVolumes() {
-        HostgroupView master = new HostgroupView("master", 0, InstanceGroupType.GATEWAY, 1);
-        HostgroupView worker = new HostgroupView("worker", 0, InstanceGroupType.CORE, 2);
-        TemplatePreparationObject preparationObject = Builder.builder().withHostgroupViews(Set.of(master, worker)).build();
-        String inputJson = getBlueprintText("input/clouderamanager.bp");
-        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
-
-        List<ApiClusterTemplateVariable> roleVariables = underTest.getRoleConfigVariables(cmTemplateProcessor, preparationObject);
-
-        roleVariables.sort(Comparator.comparing(ApiClusterTemplateVariable::getName));
-        ApiClusterTemplateVariable masterNN = roleVariables.get(0);
-        ApiClusterTemplateVariable masterSN = roleVariables.get(1);
-        ApiClusterTemplateVariable workerDN = roleVariables.get(2);
-        ApiClusterTemplateVariable workerFailedVolumes = roleVariables.get(3);
-
-        assertEquals(4, roleVariables.size());
-        assertEquals("master_namenode_dfs_name_dir_list", masterNN.getName());
-        assertEquals("/hadoopfs/root1/namenode", masterNN.getValue());
-        assertEquals("master_secondarynamenode_fs_checkpoint_dir_list", masterSN.getName());
-        assertEquals("/hadoopfs/root1/namesecondary", masterSN.getValue());
-        assertEquals("worker_datanode_dfs_data_dir_list", workerDN.getName());
-        assertEquals("/hadoopfs/root1/datanode", workerDN.getValue());
-        assertEquals("worker_datanode_dfs_datanode_failed_volumes_tolerated", workerFailedVolumes.getName());
-        assertEquals("0", workerFailedVolumes.getValue());
-    }
-
-    @Test
-    public void testGetRoleConfigVariablesWithCustomRefNames() {
-        HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, 1);
-        HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, 2);
-        TemplatePreparationObject preparationObject = Builder.builder().withHostgroupViews(Set.of(master, worker)).build();
-        String inputJson = getBlueprintText("input/clouderamanager-custom-ref.bp");
-        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
-
-        List<ApiClusterTemplateVariable> roleVariables = underTest.getRoleConfigVariables(cmTemplateProcessor, preparationObject);
-
-        roleVariables.sort(Comparator.comparing(ApiClusterTemplateVariable::getName));
-        ApiClusterTemplateVariable masterNN = roleVariables.get(0);
-        ApiClusterTemplateVariable masterSN = roleVariables.get(1);
-        ApiClusterTemplateVariable workerDN = roleVariables.get(2);
-        ApiClusterTemplateVariable workerDNFailedVolumes = roleVariables.get(3);
-
-        assertEquals(4, roleVariables.size());
-        assertEquals("master_namenode_dfs_name_dir_list", masterNN.getName());
-        assertEquals("/hadoopfs/fs1/namenode", masterNN.getValue());
-        assertEquals("master_secondarynamenode_fs_checkpoint_dir_list", masterSN.getName());
-        assertEquals("/hadoopfs/fs1/namesecondary", masterSN.getValue());
-        assertEquals("worker_datanode_dfs_data_dir_list", workerDN.getName());
-        assertEquals("/hadoopfs/fs1/datanode,/hadoopfs/fs2/datanode", workerDN.getValue());
-        assertEquals("worker_datanode_dfs_datanode_failed_volumes_tolerated", workerDNFailedVolumes.getName());
-        assertEquals("0", workerDNFailedVolumes.getValue());
-    }
-
-    @Test
-    public void testGetRoleConfigVariablesWithNoNNOrDNInAnyHostGroup() {
-        HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, 1);
-        HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, 2);
-        TemplatePreparationObject preparationObject = Builder.builder().withHostgroupViews(Set.of(master, worker)).build();
-        String inputJson = getBlueprintText("input/clouderamanager-no-nn-dn.bp");
-        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
-
-        List<ApiClusterTemplateVariable> roleVariables = underTest.getRoleConfigVariables(cmTemplateProcessor, preparationObject);
-
-        assertTrue(roleVariables.isEmpty());
-    }
-
-    @Test
-    public void testGetRoleConfigVariablesWithDifferentDataNodeRoleForMultipleGroups() {
-        HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, 1);
-        HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, 2);
-        HostgroupView compute = new HostgroupView("compute", 3, InstanceGroupType.CORE, 2);
-        TemplatePreparationObject preparationObject = Builder.builder().withHostgroupViews(Set.of(master, worker, compute)).build();
-        String inputJson = getBlueprintText("input/clouderamanager-3hg-different-DN-role.bp");
-        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
-
-        List<ApiClusterTemplateVariable> roleVariables = underTest.getRoleConfigVariables(cmTemplateProcessor, preparationObject);
-
-        roleVariables.sort(Comparator.comparing(ApiClusterTemplateVariable::getName));
-        ApiClusterTemplateVariable computeDN = roleVariables.get(0);
-        ApiClusterTemplateVariable computeVolTolerate = roleVariables.get(1);
-        ApiClusterTemplateVariable masterNN = roleVariables.get(2);
-        ApiClusterTemplateVariable masterSN = roleVariables.get(3);
-        ApiClusterTemplateVariable workerDN = roleVariables.get(4);
-
-        assertEquals("master_namenode_dfs_name_dir_list", masterNN.getName());
-        assertEquals("/hadoopfs/fs1/namenode", masterNN.getValue());
-        assertEquals("master_secondarynamenode_fs_checkpoint_dir_list", masterSN.getName());
-        assertEquals("/hadoopfs/fs1/namesecondary", masterSN.getValue());
-        assertEquals("worker_datanode_dfs_data_dir_list", workerDN.getName());
-        assertEquals("/hadoopfs/fs1/datanode,/hadoopfs/fs2/datanode", workerDN.getValue());
-        assertEquals("compute_datanode_dfs_data_dir_list", computeDN.getName());
-        assertEquals("/hadoopfs/fs1/datanode,/hadoopfs/fs2/datanode,/hadoopfs/fs3/datanode", computeDN.getValue());
-        assertEquals("compute_datanode_dfs_datanode_failed_volumes_tolerated", computeVolTolerate.getName());
-        assertEquals("0", computeVolTolerate.getValue());
-    }
-
-    @Test
-    public void testGetRoleConfigVariablesWithDifferentDataNodeRoleForMultipleGroupsNoComputeDisks() {
-        HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, 1);
-        HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, 2);
-        HostgroupView compute = new HostgroupView("compute", 0, InstanceGroupType.CORE, 2);
-        TemplatePreparationObject preparationObject = Builder.builder().withHostgroupViews(Set.of(master, worker, compute)).build();
-        String inputJson = getBlueprintText("input/clouderamanager-3hg-different-DN-role.bp");
-        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
-
-        List<ApiClusterTemplateVariable> roleVariables = underTest.getRoleConfigVariables(cmTemplateProcessor, preparationObject);
-
-        roleVariables.sort(Comparator.comparing(ApiClusterTemplateVariable::getName));
-        ApiClusterTemplateVariable computeDN = roleVariables.get(0);
-        ApiClusterTemplateVariable computeFailedVolumes = roleVariables.get(1);
-        ApiClusterTemplateVariable masterNN = roleVariables.get(2);
-        ApiClusterTemplateVariable masterSN = roleVariables.get(3);
-        ApiClusterTemplateVariable workerDN = roleVariables.get(4);
-
-        assertEquals("master_namenode_dfs_name_dir_list", masterNN.getName());
-        assertEquals("/hadoopfs/fs1/namenode", masterNN.getValue());
-        assertEquals("master_secondarynamenode_fs_checkpoint_dir_list", masterSN.getName());
-        assertEquals("/hadoopfs/fs1/namesecondary", masterSN.getValue());
-        assertEquals("worker_datanode_dfs_data_dir_list", workerDN.getName());
-        assertEquals("/hadoopfs/fs1/datanode,/hadoopfs/fs2/datanode", workerDN.getValue());
-        assertEquals("compute_datanode_dfs_data_dir_list", computeDN.getName());
-        assertEquals("/hadoopfs/root1/datanode", computeDN.getValue());
-        assertEquals("compute_datanode_dfs_datanode_failed_volumes_tolerated", computeFailedVolumes.getName());
-        assertEquals("0", computeFailedVolumes.getValue());
+        assertEquals("dfs_data_dir_list", computeDN.get(0).getName());
+        assertEquals("/hadoopfs/root1/datanode", computeDN.get(0).getValue());
+        assertEquals("dfs_datanode_failed_volumes_tolerated", computeDN.get(1).getName());
+        assertEquals("0", computeDN.get(1).getValue());
     }
 
     private String getBlueprintText(String path) {

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveServer2ConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveServer2ConfigProviderTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -14,7 +13,6 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
-import com.cloudera.api.swagger.model.ApiClusterTemplateVariable;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceGroupType;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
@@ -40,24 +38,11 @@ public class HiveServer2ConfigProviderTest {
 
         assertEquals(1, hiveserver2.size());
         assertEquals("hive_hs2_config_safety_valve", hiveserver2.get(0).getName());
-        assertEquals("hive-hive_server2_wm_namespace", hiveserver2.get(0).getVariable());
-    }
-
-    @Test
-    public void testGetRoleConfigVariables() {
-        TemplatePreparationObject preparationObject = getTemplatePreparationObject();
-        String inputJson = getBlueprintText("input/clouderamanager.bp");
-        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
-
-        List<ApiClusterTemplateVariable> roleVariables = underTest.getRoleConfigVariables(cmTemplateProcessor, preparationObject);
-
-        roleVariables.sort(Comparator.comparing(ApiClusterTemplateVariable::getName));
-        ApiClusterTemplateVariable hiveserver2Namespace = roleVariables.get(0);
-
-        assertEquals(1, roleVariables.size());
-        assertEquals("hive-hive_server2_wm_namespace", hiveserver2Namespace.getName());
-        assertEquals("<property><name>hive.server2.wm.namespace</name><value>" + preparationObject.getGeneralClusterConfigs().getUuid() + "</value></property>",
-                hiveserver2Namespace.getValue());
+        String expected = "<property><name>hive.server2.wm.namespace</name><value>"
+                + preparationObject.getGeneralClusterConfigs().getUuid()
+                + "</value></property>";
+        assertEquals(expected,
+                hiveserver2.get(0).getValue());
     }
 
     @Test

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/oozie/OozieRoleConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/oozie/OozieRoleConfigProviderTest.java
@@ -2,7 +2,6 @@ package com.sequenceiq.cloudbreak.cmtemplate.configproviders.oozie;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -12,7 +11,6 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
-import com.cloudera.api.swagger.model.ApiClusterTemplateVariable;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceGroupType;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
@@ -37,50 +35,19 @@ public class OozieRoleConfigProviderTest {
 
         assertEquals(5, oozieServer.size());
         assertEquals("oozie_database_host", oozieServer.get(0).getName());
-        assertEquals("master_oozie_server_oozie_database_host", oozieServer.get(0).getVariable());
+        assertEquals("testhost", oozieServer.get(0).getValue());
 
         assertEquals("oozie_database_name", oozieServer.get(1).getName());
-        assertEquals("master_oozie_server_oozie_database_name", oozieServer.get(1).getVariable());
+        assertEquals("ooziedb", oozieServer.get(1).getValue());
 
         assertEquals("oozie_database_type", oozieServer.get(2).getName());
-        assertEquals("master_oozie_server_oozie_database_type", oozieServer.get(2).getVariable());
+        assertEquals("postgresql", oozieServer.get(2).getValue());
 
         assertEquals("oozie_database_user", oozieServer.get(3).getName());
-        assertEquals("master_oozie_server_oozie_database_user", oozieServer.get(3).getVariable());
+        assertEquals("testuser", oozieServer.get(3).getValue());
 
         assertEquals("oozie_database_password", oozieServer.get(4).getName());
-        assertEquals("master_oozie_server_oozie_database_password", oozieServer.get(4).getVariable());
-    }
-
-    @Test
-    public void testGetRoleConfigVariables() {
-        TemplatePreparationObject preparationObject = getTemplatePreparationObject();
-        String inputJson = getBlueprintText("input/clouderamanager-db-config.bp");
-        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
-
-        List<ApiClusterTemplateVariable> roleVariables = underTest.getRoleConfigVariables(cmTemplateProcessor, preparationObject);
-        roleVariables.sort(Comparator.comparing(ApiClusterTemplateVariable::getName));
-
-        assertEquals(5, roleVariables.size());
-        ApiClusterTemplateVariable databaseHost = roleVariables.get(0);
-        assertEquals("master_oozie_server_oozie_database_host", databaseHost.getName());
-        assertEquals("testhost", databaseHost.getValue());
-
-        ApiClusterTemplateVariable databaseName = roleVariables.get(1);
-        assertEquals("master_oozie_server_oozie_database_name", databaseName.getName());
-        assertEquals("ooziedb", databaseName.getValue());
-
-        ApiClusterTemplateVariable databasePassword = roleVariables.get(2);
-        assertEquals("master_oozie_server_oozie_database_password", databasePassword.getName());
-        assertEquals("testpassword", databasePassword.getValue());
-
-        ApiClusterTemplateVariable databaseType = roleVariables.get(3);
-        assertEquals("master_oozie_server_oozie_database_type", databaseType.getName());
-        assertEquals("postgresql", databaseType.getValue());
-
-        ApiClusterTemplateVariable databaseUser = roleVariables.get(4);
-        assertEquals("master_oozie_server_oozie_database_user", databaseUser.getName());
-        assertEquals("testuser", databaseUser.getValue());
+        assertEquals("testpassword", oozieServer.get(4).getValue());
     }
 
     private TemplatePreparationObject getTemplatePreparationObject() {

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/yarn/YarnVolumeConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/yarn/YarnVolumeConfigProviderTest.java
@@ -2,7 +2,6 @@ package com.sequenceiq.cloudbreak.cmtemplate.configproviders.yarn;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -12,7 +11,6 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
-import com.cloudera.api.swagger.model.ApiClusterTemplateVariable;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceGroupType;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
@@ -39,51 +37,28 @@ public class YarnVolumeConfigProviderTest {
 
         assertEquals(2, workerNM.size());
         assertEquals("yarn_nodemanager_local_dirs", workerNM.get(0).getName());
-        assertEquals("worker_nodemanager_yarn_nodemanager_local_dirs", workerNM.get(0).getVariable());
+        assertEquals("/hadoopfs/fs1/nodemanager,/hadoopfs/fs2/nodemanager", workerNM.get(0).getValue());
         assertEquals("yarn_nodemanager_log_dirs", workerNM.get(1).getName());
-        assertEquals("worker_nodemanager_yarn_nodemanager_log_dirs", workerNM.get(1).getVariable());
+        assertEquals("/hadoopfs/fs1/nodemanager/log,/hadoopfs/fs2/nodemanager/log", workerNM.get(1).getValue());
     }
 
     @Test
-    public void testGetRoleConfigVariables() {
-        HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, 1);
-        HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, 2);
-        TemplatePreparationObject preparationObject = Builder.builder().withHostgroupViews(Set.of(master, worker)).build();
-        String inputJson = getBlueprintText("input/clouderamanager.bp");
-        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
-
-        List<ApiClusterTemplateVariable> roleVariables = underTest.getRoleConfigVariables(cmTemplateProcessor, preparationObject);
-
-        roleVariables.sort(Comparator.comparing(ApiClusterTemplateVariable::getName));
-        ApiClusterTemplateVariable workerLocal = roleVariables.get(0);
-        ApiClusterTemplateVariable workerLog = roleVariables.get(1);
-
-        assertEquals(2, roleVariables.size());
-        assertEquals("worker_nodemanager_yarn_nodemanager_local_dirs", workerLocal.getName());
-        assertEquals("/hadoopfs/fs1/nodemanager,/hadoopfs/fs2/nodemanager", workerLocal.getValue());
-        assertEquals("worker_nodemanager_yarn_nodemanager_log_dirs", workerLog.getName());
-        assertEquals("/hadoopfs/fs1/nodemanager/log,/hadoopfs/fs2/nodemanager/log", workerLog.getValue());
-    }
-
-    @Test
-    public void testGetRoleConfigVariablesWithZeroDisks() {
+    public void testGetRoleConfigsWithZeroDisks() {
         HostgroupView master = new HostgroupView("master", 0, InstanceGroupType.GATEWAY, 1);
         HostgroupView worker = new HostgroupView("worker", 0, InstanceGroupType.CORE, 2);
         TemplatePreparationObject preparationObject = Builder.builder().withHostgroupViews(Set.of(master, worker)).build();
         String inputJson = getBlueprintText("input/clouderamanager.bp");
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
 
-        List<ApiClusterTemplateVariable> roleVariables = underTest.getRoleConfigVariables(cmTemplateProcessor, preparationObject);
+        Map<String, List<ApiClusterTemplateConfig>> roleConfigs = underTest.getRoleConfigs(cmTemplateProcessor, preparationObject);
 
-        roleVariables.sort(Comparator.comparing(ApiClusterTemplateVariable::getName));
-        ApiClusterTemplateVariable workerLocal = roleVariables.get(0);
-        ApiClusterTemplateVariable workerLog = roleVariables.get(1);
+        List<ApiClusterTemplateConfig> workerNM = roleConfigs.get("yarn-NODEMANAGER-BASE");
 
-        assertEquals(2, roleVariables.size());
-        assertEquals("worker_nodemanager_yarn_nodemanager_local_dirs", workerLocal.getName());
-        assertEquals("/hadoopfs/root1/nodemanager", workerLocal.getValue());
-        assertEquals("worker_nodemanager_yarn_nodemanager_log_dirs", workerLog.getName());
-        assertEquals("/hadoopfs/root1/nodemanager/log", workerLog.getValue());
+        assertEquals(2, workerNM.size());
+        assertEquals("yarn_nodemanager_local_dirs", workerNM.get(0).getName());
+        assertEquals("/hadoopfs/root1/nodemanager", workerNM.get(0).getValue());
+        assertEquals("yarn_nodemanager_log_dirs", workerNM.get(1).getName());
+        assertEquals("/hadoopfs/root1/nodemanager/log", workerNM.get(1).getValue());
     }
 
     private String getBlueprintText(String path) {

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/generator/configuration/CmTemplateGeneratorConfigurationResolverTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/generator/configuration/CmTemplateGeneratorConfigurationResolverTest.java
@@ -30,7 +30,7 @@ public class CmTemplateGeneratorConfigurationResolverTest {
     @Test
     public void testThatAllFileIsReadableShouldVerifyThatFileCountMatch() {
         Map<StackVersion, Set<String>> stackVersionSetMap = underTest.cdhConfigurations();
-        Set<ServiceConfig> serviceConfigs = underTest.serviceInformations();
+        Set<ServiceConfig> serviceConfigs = underTest.serviceConfigs();
 
         Assert.assertEquals(1L, stackVersionSetMap.size());
         Assert.assertEquals(13L, serviceConfigs.size());

--- a/template-manager-cmtemplate/src/test/resources/output/clouderamanager-without-hosts.bp
+++ b/template-manager-cmtemplate/src/test/resources/output/clouderamanager-without-hosts.bp
@@ -136,28 +136,28 @@
       "serviceType": "HIVE",
       "serviceConfigs": [
         {
-          "name": "hive_metastore_database_password",
-          "variable": "hive-hive_metastore_database_password"
-        },
-        {
-          "name": "hive_metastore_database_port",
-          "variable": "hive-hive_metastore_database_port"
-        },
-        {
           "name": "hive_metastore_database_host",
-          "variable": "hive-hive_metastore_database_host"
-        },
-        {
-          "name": "hive_metastore_database_type",
-          "variable": "hive-hive_metastore_database_type"
+          "value": "cluster.test.com"
         },
         {
           "name": "hive_metastore_database_name",
-          "variable": "hive-hive_metastore_database_name"
+          "value": "hive"
+        },
+        {
+          "name": "hive_metastore_database_password",
+          "value": "password"
+        },
+        {
+          "name": "hive_metastore_database_port",
+          "value": "5432"
+        },
+        {
+          "name": "hive_metastore_database_type",
+          "value": "postgresql"
         },
         {
           "name": "hive_metastore_database_user",
-          "variable": "hive-hive_metastore_database_user"
+          "value": "user"
         }
       ],
       "roleConfigGroups": [
@@ -236,32 +236,6 @@
     }
   ],
   "instantiator": {
-    "clusterName": "testcluster",
-    "variables": [
-      {
-        "name": "hive-hive_metastore_database_host",
-        "value": "cluster.test.com"
-      },
-      {
-        "name": "hive-hive_metastore_database_port",
-        "value": "5432"
-      },
-      {
-        "name": "hive-hive_metastore_database_name",
-        "value": "hive"
-      },
-      {
-        "name": "hive-hive_metastore_database_type",
-        "value": "postgresql"
-      },
-      {
-        "name": "hive-hive_metastore_database_password",
-        "value": "password"
-      },
-      {
-        "name": "hive-hive_metastore_database_user",
-        "value": "user"
-      }
-    ]
+    "clusterName": "testcluster"
   }
 }

--- a/template-manager-cmtemplate/src/test/resources/output/clouderamanager.bp
+++ b/template-manager-cmtemplate/src/test/resources/output/clouderamanager.bp
@@ -135,28 +135,28 @@
       "serviceType": "HIVE",
       "serviceConfigs": [
         {
-          "name": "hive_metastore_database_password",
-          "variable": "hive-hive_metastore_database_password"
-        },
-        {
-          "name": "hive_metastore_database_port",
-          "variable": "hive-hive_metastore_database_port"
-        },
-        {
           "name": "hive_metastore_database_host",
-          "variable": "hive-hive_metastore_database_host"
-        },
-        {
-          "name": "hive_metastore_database_type",
-          "variable": "hive-hive_metastore_database_type"
+          "value": "cluster.test.com"
         },
         {
           "name": "hive_metastore_database_name",
-          "variable": "hive-hive_metastore_database_name"
+          "value": "hive"
+        },
+        {
+          "name": "hive_metastore_database_password",
+          "value": "password"
+        },
+        {
+          "name": "hive_metastore_database_port",
+          "value": "5432"
+        },
+        {
+          "name": "hive_metastore_database_type",
+          "value": "postgresql"
         },
         {
           "name": "hive_metastore_database_user",
-          "variable": "hive-hive_metastore_database_user"
+          "value": "user"
         }
       ],
       "roleConfigGroups": [
@@ -252,32 +252,6 @@
       {
         "hostName": "host2",
         "hostTemplateRefName": "master"
-      }
-    ],
-    "variables": [
-      {
-        "name": "hive-hive_metastore_database_host",
-        "value": "cluster.test.com"
-      },
-      {
-        "name": "hive-hive_metastore_database_port",
-        "value": "5432"
-      },
-      {
-        "name": "hive-hive_metastore_database_name",
-        "value": "hive"
-      },
-      {
-        "name": "hive-hive_metastore_database_type",
-        "value": "postgresql"
-      },
-      {
-        "name": "hive-hive_metastore_database_password",
-        "value": "password"
-      },
-      {
-        "name": "hive-hive_metastore_database_user",
-        "value": "user"
       }
     ],
     "roleConfigGroups": [


### PR DESCRIPTION
## What changes were proposed in this pull request?

Refactor config providers a bit:

 * eliminate indirection (`name` -> `variable` -> `value`) since it seems unnecessary for generated templates
 * extract service and role names to constants
 * less verbose config item creation (`config` utility function)

Plus:

 * remove unused `ResourceLoader` from `CmTemplateGeneratorConfigurationResolver`
 * rename `serviceInformations` to `serviceConfigs` to be consistent with the type `ServiceConfig`

## How was this patch tested?

Adjusted unit tests.

Deployed workload and data lake clusters.