### PR TITLE
Fix IT Makefile syntax error

### DIFF
--- a/integration-test/Makefile
+++ b/integration-test/Makefile
@@ -18,10 +18,10 @@ download-jar-from-s3:
 	curl ${REPO_URL}/com/sequenceiq/cloudbreak/$(VERSION)/cloudbreak-$(VERSION).jar -o ../core/build/libs/cloudbreak.jar --create-dirs
 	curl ${REPO_URL}/com/sequenceiq/environment/$(VERSION)/environment-$(VERSION).jar -o ../environment/build/libs/environment.jar --create-dirs
 	curl ${REPO_URL}/com/sequenceiq/redbeams/$(VERSION)/redbeams-$(VERSION).jar -o ../redbeams/build/libs/redbeams.jar --create-dirs
-    curl ${REPO_URL}/com/sequenceiq/datalake/$(VERSION)/datalake-$(VERSION).jar -o ../datalake/build/libs/datalake.jar --create-dirs
-    curl ${REPO_URL}/com/sequenceiq/freeipa/$(VERSION)/freeipa-$(VERSION).jar -o ../freeipa/build/libs/freeipa.jar --create-dirs
-    curl ${REPO_URL}/com/sequenceiq/periscope/$(VERSION)/periscope-$(VERSION).jar -o ../autoscale/build/libs/periscope.jar --create-dirs
-    curl ${REPO_URL}/com/sequenceiq/mock-caas/$(VERSION)/mock-caas-$(VERSION).jar -o ../mock-caas/build/libs/mock-caas.jar --create-dirs
+	curl ${REPO_URL}/com/sequenceiq/datalake/$(VERSION)/datalake-$(VERSION).jar -o ../datalake/build/libs/datalake.jar --create-dirs
+	curl ${REPO_URL}/com/sequenceiq/freeipa/$(VERSION)/freeipa-$(VERSION).jar -o ../freeipa/build/libs/freeipa.jar --create-dirs
+	curl ${REPO_URL}/com/sequenceiq/periscope/$(VERSION)/periscope-$(VERSION).jar -o ../autoscale/build/libs/periscope.jar --create-dirs
+	curl ${REPO_URL}/com/sequenceiq/mock-caas/$(VERSION)/mock-caas-$(VERSION).jar -o ../mock-caas/build/libs/mock-caas.jar --create-dirs
 	curl ${REPO_URL}/com/sequenceiq/cloudbreak-integration-test/$(VERSION)/cloudbreak-integration-test-$(VERSION).jar -o ../integration-test/build/libs/cloudbreak-integration-test.jar --create-dirs
 
 download-cbd:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix integration test error: https://circleci.com/gh/hortonworks/cloudbreak/64547

```
$ cd integration-test && make -n without-build
Makefile:21: *** missing separator.  Stop.
```

## How was this patch tested?

```
$ cd integration-test && make -n without-build
./scripts/download-cbd.sh
./scripts/create-image.sh
./scripts/create-cloudbreak-context.sh
./scripts/docker-compose.sh
./scripts/stop-containers.sh
./scripts/check-results.sh
```