### PR TITLE
CB-1433. Remove hard-coded password from SDX template

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/cluster/ClusterV4Request.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/cluster/ClusterV4Request.java
@@ -40,7 +40,11 @@ public class ClusterV4Request implements JsonEntity {
     private String userName;
 
     @NotNull
-    @Size(max = 100, min = 5, message = "The length of the password has to be in range of 5 to 100")
+    @Pattern.List({
+            @Pattern(regexp = "^.*[a-zA-Z].*$", message = "The password should contain at least one letter."),
+            @Pattern(regexp = "^.*[0-9].*$", message = "The password should contain at least one number.")
+    })
+    @Size(max = 100, min = 8, message = "The length of the password has to be in range of 8 to 100")
     @ApiModelProperty(value = StackModelDescription.PASSWORD, required = true)
     private String password;
 

--- a/core-api/src/test/resources/api-compatibility/StackV4Request_v2.10.0.json
+++ b/core-api/src/test/resources/api-compatibility/StackV4Request_v2.10.0.json
@@ -83,7 +83,7 @@
   "flexId": 0,
   "cluster": {
     "userName": "string",
-    "password": "string",
+    "password": "string123",
     "emailNeeded": false,
     "emailTo": "string",
     "ldapConfigName": "string",

--- a/core/src/main/resources/defaults/blueprints/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx.bp
@@ -28,11 +28,11 @@
           },
           {
             "name": "rangeradmin_user_password",
-            "value": "Admin123!"
+            "value": "{{{ general.password }}}"
           },
           {
             "name": "rangertagsync_user_password",
-            "value": "Admin123!"
+            "value": "{{{ general.password }}}"
           },
           {
             "name": "solr_service",
@@ -40,11 +40,11 @@
           },
           {
             "name": "rangerusersync_user_password",
-            "value": "Admin123!"
+            "value": "{{{ general.password }}}"
           },
           {
             "name": "keyadmin_user_password",
-            "value": "Admin123!"
+            "value": "{{{ general.password }}}"
           }
         ],
         "roleConfigGroups": [

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CentralCmTemplateUpdaterTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CentralCmTemplateUpdaterTest.java
@@ -74,6 +74,7 @@ public class CentralCmTemplateUpdaterTest {
         when(templatePreparationObject.getGeneralClusterConfigs()).thenReturn(generalClusterConfigs);
         when(templatePreparationObject.getRdsConfigs()).thenReturn(getRdsConfigs());
         when(generalClusterConfigs.getClusterName()).thenReturn("testcluster");
+        when(generalClusterConfigs.getPassword()).thenReturn("Admin123!");
         clouderaManagerRepo = new ClouderaManagerRepo();
         clouderaManagerRepo.setVersion("6.1.0");
         ReflectionTestUtils.setField(cmTemplateComponentConfigProcessor, "cmTemplateComponentConfigProviderList", cmTemplateComponentConfigProviders);

--- a/template-manager-cmtemplate/src/test/resources/input/clouderamanager.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/clouderamanager.bp
@@ -152,6 +152,16 @@
       ]
     },
     {
+      "refName": "ranger",
+      "serviceType": "RANGER",
+      "serviceConfigs": [
+        {
+          "name": "rangeradmin_user_password",
+          "value": "{{{ general.password }}}"
+        }
+      ]
+    },
+    {
       "refName": "impala",
       "serviceType": "IMPALA",
       "roleConfigGroups": [

--- a/template-manager-cmtemplate/src/test/resources/output/clouderamanager.bp
+++ b/template-manager-cmtemplate/src/test/resources/output/clouderamanager.bp
@@ -178,6 +178,16 @@
       ]
     },
     {
+      "refName": "ranger",
+      "serviceType": "RANGER",
+      "serviceConfigs": [
+        {
+          "name": "rangeradmin_user_password",
+          "value": "Admin123!"
+        }
+      ]
+    },
+    {
       "refName": "impala",
       "serviceType": "IMPALA",
       "roleConfigGroups": [


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use master password in SDX template instead of hard-coded one.

## How was this patch tested?

Adjusted unit test.  Still have to test actual cluster deployment.