### PR TITLE
CB-1452. Let existing config in template take precedence

### DIFF
--- a/template-manager-cmtemplate/src/test/resources/input/clouderamanager-existing-conf.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/clouderamanager-existing-conf.bp
@@ -44,6 +44,12 @@
     {
       "refName": "hdfs",
       "serviceType": "HDFS",
+      "serviceConfigs": [
+        {
+          "name": "redaction_policy_enabled",
+          "value": "false"
+        }
+      ],
       "roleConfigGroups": [
         {
           "refName": "hdfs-NAMENODE-BASE",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Prefer configuration defined in cluster template (blueprint) over configuration generated by code.

## How was this patch tested?

Adjusted unit test.  Deployed cluster with custom `dfs_datanode_failed_volumes_tolerated` setting.