### PR TITLE
CB-1494. Stack converter creates Ambari blueprint view

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/StackToTemplatePreparationObjectConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/StackToTemplatePreparationObjectConverter.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.cloud.model.StackInputs;
 import com.sequenceiq.cloudbreak.cloud.model.component.StackRepoDetails;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
-import com.sequenceiq.cloudbreak.blueprint.AmbariBlueprintViewProvider;
+import com.sequenceiq.cloudbreak.service.blueprint.BlueprintViewProvider;
 import com.sequenceiq.cloudbreak.blueprint.GeneralClusterConfigsProvider;
 import com.sequenceiq.cloudbreak.blueprint.nifi.HdfConfigProvider;
 import com.sequenceiq.cloudbreak.blueprint.sharedservice.SharedServiceConfigsViewProvider;
@@ -68,7 +68,7 @@ public class StackToTemplatePreparationObjectConverter extends AbstractConversio
     private SharedServiceConfigsViewProvider sharedServiceConfigProvider;
 
     @Inject
-    private AmbariBlueprintViewProvider ambariBlueprintViewProvider;
+    private BlueprintViewProvider blueprintViewProvider;
 
     @Inject
     private DatalakeResourcesService datalakeResourcesService;
@@ -106,7 +106,7 @@ public class StackToTemplatePreparationObjectConverter extends AbstractConversio
                     .withGateway(gateway, gatewaySignKey)
                     .withCustomInputs(stackInputs.getCustomInputs() == null ? new HashMap<>() : stackInputs.getCustomInputs())
                     .withFixInputs(fixInputs)
-                    .withBlueprintView(ambariBlueprintViewProvider.getBlueprintView(cluster.getBlueprint()))
+                    .withBlueprintView(blueprintViewProvider.getBlueprintView(cluster.getBlueprint()))
                     .withStackRepoDetailsHdpVersion(stackRepoDetailsHdpVersion)
                     .withFileSystemConfigurationView(fileSystemConfigurationView)
                     .withGeneralClusterConfigs(generalClusterConfigsProvider.generalClusterConfigs(source, cluster))

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToTemplatePreparationObjectConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToTemplatePreparationObjectConverter.java
@@ -34,7 +34,7 @@ import com.sequenceiq.cloudbreak.domain.view.EnvironmentView;
 import com.sequenceiq.cloudbreak.service.CloudbreakRestRequestThreadLocalService;
 import com.sequenceiq.cloudbreak.service.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.service.blueprint.BlueprintService;
-import com.sequenceiq.cloudbreak.service.blueprint.BlueprintTextProcessorFactory;
+import com.sequenceiq.cloudbreak.service.blueprint.BlueprintViewProvider;
 import com.sequenceiq.cloudbreak.service.credential.CredentialPrerequisiteService;
 import com.sequenceiq.cloudbreak.service.credential.CredentialService;
 import com.sequenceiq.cloudbreak.service.datalake.DatalakeResourcesService;
@@ -118,7 +118,7 @@ public class StackV4RequestToTemplatePreparationObjectConverter extends Abstract
     private DatalakeConfigApiConnector datalakeConfigApiConnector;
 
     @Inject
-    private BlueprintTextProcessorFactory blueprintTextProcessorFactory;
+    private BlueprintViewProvider blueprintViewProvider;
 
     @Override
     public TemplatePreparationObject convert(StackV4Request source) {
@@ -136,9 +136,7 @@ public class StackV4RequestToTemplatePreparationObjectConverter extends Abstract
             BlueprintStackInfo blueprintStackInfo = stackInfoService.blueprintStackInfo(blueprintText);
             Set<HostgroupView> hostgroupViews = getHostgroupViews(source);
             Gateway gateway = source.getCluster().getGateway() == null ? null : getConversionService().convert(source, Gateway.class);
-            BlueprintView blueprintView = new BlueprintView(blueprint.getBlueprintText(),
-                    blueprintStackInfo.getVersion(), blueprintStackInfo.getType(),
-                    blueprintTextProcessorFactory.createBlueprintTextProcessor(blueprint.getBlueprintText()));
+            BlueprintView blueprintView = blueprintViewProvider.getBlueprintView(blueprint);
             GeneralClusterConfigs generalClusterConfigs = generalClusterConfigsProvider.generalClusterConfigs(source, cloudbreakUser.getEmail(),
                     blueprintService.getBlueprintVariant(blueprint));
             String bindDn = null;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/blueprint/BlueprintViewProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/blueprint/BlueprintViewProvider.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.cloudbreak.blueprint;
+package com.sequenceiq.cloudbreak.service.blueprint;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
@@ -12,15 +12,18 @@ import com.sequenceiq.cloudbreak.template.processor.BlueprintTextProcessor;
 import com.sequenceiq.cloudbreak.template.views.BlueprintView;
 
 @Component
-public class AmbariBlueprintViewProvider {
+public class BlueprintViewProvider {
 
     @Inject
     private StackInfoService stackInfoService;
 
+    @Inject
+    private BlueprintTextProcessorFactory blueprintTextProcessorFactory;
+
     public BlueprintView getBlueprintView(@Nonnull Blueprint blueprint) {
         String blueprintText = blueprint.getBlueprintText();
         BlueprintStackInfo blueprintStackInfo = stackInfoService.blueprintStackInfo(blueprintText);
-        BlueprintTextProcessor processor = new AmbariBlueprintTextProcessor(blueprintText);
+        BlueprintTextProcessor processor = blueprintTextProcessorFactory.createBlueprintTextProcessor(blueprintText);
         return new BlueprintView(blueprintText, blueprintStackInfo.getVersion(), blueprintStackInfo.getType(), processor);
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v2/StackV4RequestToTemplatePreparationObjectConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v2/StackV4RequestToTemplatePreparationObjectConverterTest.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.converter.v2;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -27,7 +28,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.core.convert.ConversionService;
 
-import com.sequenceiq.cloudbreak.common.type.InstanceGroupType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.cluster.ClusterV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.cluster.ambari.AmbariV4Request;
@@ -36,9 +36,9 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.cluster.storage.
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.environment.EnvironmentSettingsV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.InstanceGroupV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.template.InstanceTemplateV4Request;
-import com.sequenceiq.cloudbreak.blueprint.AmbariBlueprintTextProcessor;
 import com.sequenceiq.cloudbreak.blueprint.GeneralClusterConfigsProvider;
 import com.sequenceiq.cloudbreak.blueprint.utils.StackInfoService;
+import com.sequenceiq.cloudbreak.common.type.InstanceGroupType;
 import com.sequenceiq.cloudbreak.common.user.CloudbreakUser;
 import com.sequenceiq.cloudbreak.converter.util.CloudStorageValidationUtil;
 import com.sequenceiq.cloudbreak.converter.v4.stacks.StackV4RequestToTemplatePreparationObjectConverter;
@@ -49,11 +49,9 @@ import com.sequenceiq.cloudbreak.domain.KerberosConfig;
 import com.sequenceiq.cloudbreak.domain.LdapConfig;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.gateway.Gateway;
-import com.sequenceiq.cloudbreak.workspace.model.User;
-import com.sequenceiq.cloudbreak.workspace.model.Workspace;
 import com.sequenceiq.cloudbreak.service.CloudbreakRestRequestThreadLocalService;
 import com.sequenceiq.cloudbreak.service.blueprint.BlueprintService;
-import com.sequenceiq.cloudbreak.service.blueprint.BlueprintTextProcessorFactory;
+import com.sequenceiq.cloudbreak.service.blueprint.BlueprintViewProvider;
 import com.sequenceiq.cloudbreak.service.credential.CredentialService;
 import com.sequenceiq.cloudbreak.service.kerberos.KerberosConfigService;
 import com.sequenceiq.cloudbreak.service.ldapconfig.LdapConfigService;
@@ -66,6 +64,8 @@ import com.sequenceiq.cloudbreak.template.filesystem.FileSystemConfigurationProv
 import com.sequenceiq.cloudbreak.template.model.BlueprintStackInfo;
 import com.sequenceiq.cloudbreak.template.model.GeneralClusterConfigs;
 import com.sequenceiq.cloudbreak.template.views.BlueprintView;
+import com.sequenceiq.cloudbreak.workspace.model.User;
+import com.sequenceiq.cloudbreak.workspace.model.Workspace;
 
 public class StackV4RequestToTemplatePreparationObjectConverterTest {
 
@@ -154,7 +154,7 @@ public class StackV4RequestToTemplatePreparationObjectConverterTest {
     private KerberosConfigService kerberosConfigService;
 
     @Mock
-    private BlueprintTextProcessorFactory blueprintTextProcessorFactory;
+    private BlueprintViewProvider blueprintViewProvider;
 
     @Before
     public void setUp() {
@@ -173,7 +173,6 @@ public class StackV4RequestToTemplatePreparationObjectConverterTest {
         when(cloudbreakUser.getEmail()).thenReturn("test@hortonworks.com");
         when(workspaceService.get(anyLong(), eq(user))).thenReturn(workspace);
         when(credentialService.getByNameForWorkspace(TEST_CREDENTIAL_NAME, workspace)).thenReturn(credential);
-        when(blueprintTextProcessorFactory.createBlueprintTextProcessor(anyString())).thenReturn(new AmbariBlueprintTextProcessor(""));
     }
 
     @Test
@@ -269,12 +268,12 @@ public class StackV4RequestToTemplatePreparationObjectConverterTest {
         String stackType = "HDP";
         when(blueprintStackInfo.getVersion()).thenReturn(stackVersion);
         when(blueprintStackInfo.getType()).thenReturn(stackType);
-        BlueprintView expected = new BlueprintView(TEST_BLUEPRINT_TEXT, stackVersion, stackType,
-                new AmbariBlueprintTextProcessor(TEST_BLUEPRINT_TEXT));
+        BlueprintView expected = mock(BlueprintView.class);
+        when(blueprintViewProvider.getBlueprintView(blueprint)).thenReturn(expected);
 
         TemplatePreparationObject result = underTest.convert(source);
 
-        assertEquals(expected, result.getBlueprintView());
+        assertSame(expected, result.getBlueprintView());
     }
 
     @Test

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/blueprint/BlueprintViewProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/blueprint/BlueprintViewProviderTest.java
@@ -1,0 +1,73 @@
+package com.sequenceiq.cloudbreak.service.blueprint;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.sequenceiq.cloudbreak.blueprint.AmbariBlueprintTextProcessor;
+import com.sequenceiq.cloudbreak.blueprint.utils.StackInfoService;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.domain.Blueprint;
+import com.sequenceiq.cloudbreak.template.model.BlueprintStackInfo;
+import com.sequenceiq.cloudbreak.template.processor.BlueprintTextProcessor;
+import com.sequenceiq.cloudbreak.template.views.BlueprintView;
+
+public class BlueprintViewProviderTest {
+
+    private static final String TEST_BLUEPRINT_TEXT = "{}";
+
+    private static final String TEST_STACK_TYPE = "CDP";
+
+    private static final String TEST_STACK_VERSION = "1.0";
+
+    @InjectMocks
+    private BlueprintViewProvider subject;
+
+    @Mock
+    private BlueprintTextProcessorFactory blueprintTextProcessorFactory;
+
+    @Mock
+    private StackInfoService stackInfoService;
+
+    @Mock
+    private Blueprint blueprint;
+
+    @Mock
+    private BlueprintStackInfo blueprintStackInfo;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        when(blueprint.getBlueprintText()).thenReturn(TEST_BLUEPRINT_TEXT);
+        when(stackInfoService.blueprintStackInfo(TEST_BLUEPRINT_TEXT)).thenReturn(blueprintStackInfo);
+        when(blueprintStackInfo.getType()).thenReturn(TEST_STACK_TYPE);
+        when(blueprintStackInfo.getVersion()).thenReturn(TEST_STACK_VERSION);
+    }
+
+    @Test
+    public void usesAmbariBlueprintTextProcessor() {
+        testUsesProcessorFromFactory(new AmbariBlueprintTextProcessor(TEST_BLUEPRINT_TEXT));
+    }
+
+    @Test
+    public void usesCmTemplateProcessor() {
+        testUsesProcessorFromFactory(new CmTemplateProcessor(TEST_BLUEPRINT_TEXT));
+    }
+
+    private void testUsesProcessorFromFactory(BlueprintTextProcessor processor) {
+        when(blueprintTextProcessorFactory.createBlueprintTextProcessor(TEST_BLUEPRINT_TEXT)).thenReturn(processor);
+
+        BlueprintView blueprintView = subject.getBlueprintView(blueprint);
+
+        assertEquals(TEST_BLUEPRINT_TEXT, blueprintView.getBlueprintText());
+        assertEquals(TEST_STACK_TYPE, blueprintView.getType());
+        assertEquals(TEST_STACK_VERSION, blueprintView.getVersion());
+        assertSame(processor, blueprintView.getProcessor());
+    }
+}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessor.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessor.java
@@ -123,7 +123,8 @@ public class CmTemplateProcessor implements BlueprintTextProcessor {
     @Override
     public Map<String, Set<String>> getComponentsByHostGroup() {
         Map<String, Set<String>> result = new HashMap<>();
-        for (ApiClusterTemplateHostTemplate apiClusterTemplateHostTemplate : cmTemplate.getHostTemplates()) {
+        List<ApiClusterTemplateHostTemplate> hostTemplates = Optional.ofNullable(cmTemplate.getHostTemplates()).orElse(List.of());
+        for (ApiClusterTemplateHostTemplate apiClusterTemplateHostTemplate : hostTemplates) {
             Set<String> componentNames = new HashSet<>(apiClusterTemplateHostTemplate.getRoleConfigGroupsRefNames());
             result.put(apiClusterTemplateHostTemplate.getRefName(), componentNames);
         }

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/views/BlueprintView.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/views/BlueprintView.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.template.BlueprintProcessingException;
 import com.sequenceiq.cloudbreak.template.processor.BlueprintTextProcessor;
 
@@ -73,6 +74,11 @@ public class BlueprintView {
 
     public void setComponents(Set<String> components) {
         this.components = components;
+    }
+
+    @VisibleForTesting
+    public BlueprintTextProcessor getProcessor() {
+        return processor;
     }
 
     @Override


### PR DESCRIPTION
Leftover `AmbariBlueprintViewProvider` caused `BlueprintView` created for CM template to have no components.