### PR TITLE
CB-1456 - following packaging convention

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/configuration/EndpointConfig.java
+++ b/environment/src/main/java/com/sequenceiq/environment/configuration/EndpointConfig.java
@@ -11,7 +11,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StringUtils;
 
 import com.sequenceiq.environment.api.EnvironmentApi;
-import com.sequenceiq.environment.credential.controller.CredentialV1Controller;
+import com.sequenceiq.environment.credential.v1.CredentialV1Controller;
 import com.sequenceiq.environment.environment.v1.EnvironmentV1Controller;
 import com.sequenceiq.environment.exception.mapper.DefaultExceptionMapper;
 import com.sequenceiq.environment.exception.mapper.WebApplicaitonExceptionMapper;

--- a/environment/src/main/java/com/sequenceiq/environment/credential/exception/MissingParameterException.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/exception/MissingParameterException.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.environment.definition;
+package com.sequenceiq.environment.credential.exception;
 
 public class MissingParameterException extends RuntimeException {
 

--- a/environment/src/main/java/com/sequenceiq/environment/credential/service/ResourceDefinitionService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/service/ResourceDefinitionService.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.environment.definition;
+package com.sequenceiq.environment.credential.service;
 
 import javax.inject.Inject;
 

--- a/environment/src/main/java/com/sequenceiq/environment/credential/service/ServiceProviderCredentialAdapter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/service/ServiceProviderCredentialAdapter.java
@@ -27,8 +27,8 @@ import com.sequenceiq.cloudbreak.cloud.model.CredentialStatus;
 import com.sequenceiq.cloudbreak.cloud.model.ExtendedCloudCredential;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.service.OperationException;
-import com.sequenceiq.environment.credential.converter.CredentialToCloudCredentialConverter;
-import com.sequenceiq.environment.credential.converter.CredentialToExtendedCloudCredentialConverter;
+import com.sequenceiq.environment.credential.v1.converter.CredentialToCloudCredentialConverter;
+import com.sequenceiq.environment.credential.v1.converter.CredentialToExtendedCloudCredentialConverter;
 import com.sequenceiq.environment.credential.domain.Credential;
 import com.sequenceiq.flow.reactor.ErrorHandlerAwareReactorEventFactory;
 

--- a/environment/src/main/java/com/sequenceiq/environment/credential/v1/CredentialV1Controller.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/v1/CredentialV1Controller.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.environment.credential.controller;
+package com.sequenceiq.environment.credential.v1;
 
 import java.util.Map;
 import java.util.Set;
@@ -18,7 +18,7 @@ import com.sequenceiq.environment.api.v1.credential.model.request.CredentialRequ
 import com.sequenceiq.environment.api.v1.credential.model.response.CredentialResponse;
 import com.sequenceiq.environment.api.v1.credential.model.response.CredentialResponses;
 import com.sequenceiq.environment.api.v1.credential.model.response.InteractiveCredentialResponse;
-import com.sequenceiq.environment.credential.converter.CredentialToCredentialV1ResponseConverter;
+import com.sequenceiq.environment.credential.v1.converter.CredentialToCredentialV1ResponseConverter;
 import com.sequenceiq.environment.credential.domain.Credential;
 import com.sequenceiq.environment.credential.service.CredentialService;
 import com.sequenceiq.notification.NotificationController;

--- a/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/AwsCredentialV1ParametersToAwsCredentialAttributesConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/AwsCredentialV1ParametersToAwsCredentialAttributesConverter.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.environment.credential.converter;
+package com.sequenceiq.environment.credential.v1.converter;
 
 import org.springframework.stereotype.Component;
 

--- a/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/AzureCredentialV1ParametersToAzureCredentialAttributesConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/AzureCredentialV1ParametersToAzureCredentialAttributesConverter.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.environment.credential.converter;
+package com.sequenceiq.environment.credential.v1.converter;
 
 import org.springframework.stereotype.Component;
 

--- a/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/CredentialToCloudCredentialConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/CredentialToCloudCredentialConverter.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.environment.credential.converter;
+package com.sequenceiq.environment.credential.v1.converter;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 

--- a/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/CredentialToCredentialV1ResponseConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/CredentialToCredentialV1ResponseConverter.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.environment.credential.converter;
+package com.sequenceiq.environment.credential.v1.converter;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/CredentialToExtendedCloudCredentialConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/CredentialToExtendedCloudCredentialConverter.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.environment.credential.converter;
+package com.sequenceiq.environment.credential.v1.converter;
 
 import javax.inject.Inject;
 

--- a/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/CredentialV1RequestToCredentialConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/CredentialV1RequestToCredentialConverter.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.environment.credential.converter;
+package com.sequenceiq.environment.credential.v1.converter;
 
 import javax.inject.Inject;
 

--- a/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/CumulusCredentialV1ParametersToCumulusCredentialAttributesConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/CumulusCredentialV1ParametersToCumulusCredentialAttributesConverter.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.environment.credential.converter;
+package com.sequenceiq.environment.credential.v1.converter;
 
 import org.springframework.stereotype.Component;
 

--- a/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/GcpCredentialV1ParametersToGcpCredentialAttributesConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/GcpCredentialV1ParametersToGcpCredentialAttributesConverter.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.environment.credential.converter;
+package com.sequenceiq.environment.credential.v1.converter;
 
 import org.springframework.stereotype.Component;
 

--- a/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/MockCredentialV1ParametersToMockCredentialAttributesConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/MockCredentialV1ParametersToMockCredentialAttributesConverter.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.environment.credential.converter;
+package com.sequenceiq.environment.credential.v1.converter;
 
 import org.springframework.stereotype.Component;
 

--- a/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/OpenStackCredentialV1ParametersToOpenStackCredentialAttributesConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/OpenStackCredentialV1ParametersToOpenStackCredentialAttributesConverter.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.environment.credential.converter;
+package com.sequenceiq.environment.credential.v1.converter;
 
 import org.springframework.stereotype.Component;
 

--- a/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/YarnCredentialV1ParametersToAwsYarnAttributesConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/YarnCredentialV1ParametersToAwsYarnAttributesConverter.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.environment.credential.converter;
+package com.sequenceiq.environment.credential.v1.converter;
 
 import org.springframework.stereotype.Component;
 

--- a/environment/src/main/java/com/sequenceiq/environment/credential/validation/definition/CredentialDefinitionService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/validation/definition/CredentialDefinitionService.java
@@ -12,8 +12,8 @@ import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
 import com.sequenceiq.cloudbreak.util.JsonUtil;
-import com.sequenceiq.environment.definition.MissingParameterException;
-import com.sequenceiq.environment.definition.ResourceDefinitionService;
+import com.sequenceiq.environment.credential.exception.MissingParameterException;
+import com.sequenceiq.environment.credential.service.ResourceDefinitionService;
 
 @Service
 public class CredentialDefinitionService {

--- a/environment/src/main/java/com/sequenceiq/environment/platformresource/CloudParameterService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/platformresource/CloudParameterService.java
@@ -69,7 +69,7 @@ import com.sequenceiq.cloudbreak.cloud.model.VmRecommendations;
 import com.sequenceiq.cloudbreak.service.OperationException;
 import com.sequenceiq.environment.GetCloudParameterException;
 import com.sequenceiq.environment.credential.domain.Credential;
-import com.sequenceiq.environment.credential.converter.CredentialToExtendedCloudCredentialConverter;
+import com.sequenceiq.environment.credential.v1.converter.CredentialToExtendedCloudCredentialConverter;
 import com.sequenceiq.flow.reactor.ErrorHandlerAwareReactorEventFactory;
 
 import reactor.bus.Event;


### PR DESCRIPTION
Moving controller and converters to the v1 package - because these are directly depending on the v1 api. Other classes should not depend on the v1 api - this should be fixed later by adding DTOs.