### PR TITLE
CDPCP-146. Add API to set user password in FreeIPA

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/client/FreeIpaApiClient.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/client/FreeIpaApiClient.java
@@ -2,7 +2,7 @@ package com.sequenceiq.freeipa.api.client;
 
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.FreeIpaV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.freeipa.test.ClientTestV1Endpoint;
-import com.sequenceiq.freeipa.api.v1.freeipa.user.UsersyncV1Endpoint;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.UserV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.kerberos.KerberosConfigV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.ldap.LdapConfigV1Endpoint;
 
@@ -13,7 +13,7 @@ public interface FreeIpaApiClient {
 
     KerberosConfigV1Endpoint getKerberosConfigV1Endpoint();
 
-    UsersyncV1Endpoint getUsersyncV1Endpoint();
+    UserV1Endpoint getUsersyncV1Endpoint();
 
     ClientTestV1Endpoint getClientTestV1Endpoint();
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/client/FreeIpaApiUserCrnClient.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/client/FreeIpaApiUserCrnClient.java
@@ -5,7 +5,7 @@ import javax.ws.rs.client.WebTarget;
 import com.sequenceiq.cloudbreak.client.AbstractUserCrnServiceEndpoint;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.FreeIpaV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.freeipa.test.ClientTestV1Endpoint;
-import com.sequenceiq.freeipa.api.v1.freeipa.user.UsersyncV1Endpoint;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.UserV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.kerberos.KerberosConfigV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.ldap.LdapConfigV1Endpoint;
 
@@ -30,8 +30,8 @@ public class FreeIpaApiUserCrnClient extends AbstractUserCrnServiceEndpoint impl
     }
 
     @Override
-    public UsersyncV1Endpoint getUsersyncV1Endpoint() {
-        return getEndpoint(UsersyncV1Endpoint.class);
+    public UserV1Endpoint getUsersyncV1Endpoint() {
+        return getEndpoint(UserV1Endpoint.class);
     }
 
     @Override

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/UserV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/UserV1Endpoint.java
@@ -4,9 +4,13 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import com.sequenceiq.freeipa.api.v1.freeipa.user.doc.UsersyncOperationDescriptions;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SetPasswordRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SetPasswordResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeUsersRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeUsersResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeUsersStatus;
@@ -15,19 +19,25 @@ import com.sequenceiq.service.api.doc.ContentType;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 
-@Path("/v1/freeipa/usersync")
+@Path("/v1/freeipa/user")
 @Consumes(MediaType.APPLICATION_JSON)
-@Api(value = "/v1/freeipa/usersync", description = "Synchronize users to FreeIPA", protocols = "http,https")
-public interface UsersyncV1Endpoint {
+@Api(value = "/v1/freeipa/user", description = "Synchronize users to FreeIPA", protocols = "http,https")
+public interface UserV1Endpoint {
     @POST
-    @Path("")
+    @Path("sync")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Synchronize users to FreeIPA", produces = ContentType.JSON, nickname = "synchronizeUsersV1")
+    @ApiOperation(value = UsersyncOperationDescriptions.SYNC, produces = ContentType.JSON, nickname = "synchronizeUsersV1")
     SynchronizeUsersResponse synchronizeUsers(SynchronizeUsersRequest request);
 
     @GET
-    @Path("")
+    @Path("sync")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Get status of latest synchronization", produces = ContentType.JSON, nickname = "getSyncUsersStatusV1")
     SynchronizeUsersStatus getStatus();
+
+    @POST
+    @Path("/{username}/password")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = UsersyncOperationDescriptions.SET_PASSWORD, produces = ContentType.JSON, nickname = "setPasswordV1")
+    SetPasswordResponse setPassword(@PathParam("username") String username, SetPasswordRequest request);
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/doc/UserModelDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/doc/UserModelDescriptions.java
@@ -1,9 +1,7 @@
 package com.sequenceiq.freeipa.api.v1.freeipa.user.doc;
 
-public class UsersyncModelDescriptions {
-    // TODO use the FreeIpaModelDescriptions where available
-    public static final String ENVIRONMENT_NAME = "name of the environment";
-    public static final String STACK_NAME = "name of the stack";
+public class UserModelDescriptions {
+
     public static final String USERSYNC_GROUPS = "groups to sync";
     public static final String USERSYNC_USERS = "users to sync";
     public static final String GROUP_NAME = "name of the group";
@@ -12,7 +10,9 @@ public class UsersyncModelDescriptions {
     public static final String USER_LASTNAME = "last name of the user";
     public static final String USER_PASSWORD = "the user's password";
     public static final String USER_GROUPS = "the user's groups";
+    public static final String SUCCESS_ENVIRONMENTNAME = "environment names where operation succeeded";
+    public static final String FAILURE_ENVIRONMENTNAME = "environment names where operation failed";
 
-    private UsersyncModelDescriptions() {
+    private UserModelDescriptions() {
     }
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/doc/UsersyncOperationDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/doc/UsersyncOperationDescriptions.java
@@ -1,0 +1,9 @@
+package com.sequenceiq.freeipa.api.v1.freeipa.user.doc;
+
+public final class UsersyncOperationDescriptions {
+    public static final String SYNC = "Synchronizes Groups and Users to the FreeIPA servers";
+    public static final String SET_PASSWORD = "Sets the user's password in the FreeIPA servers";
+
+    private UsersyncOperationDescriptions() {
+    }
+}

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SetPasswordRequest.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SetPasswordRequest.java
@@ -1,22 +1,19 @@
 package com.sequenceiq.freeipa.api.v1.freeipa.user.model;
 
-import javax.validation.constraints.NotNull;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.doc.UserModelDescriptions;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
-@ApiModel("GroupV1")
+@ApiModel("SetPasswordV1Request")
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class Group {
+public class SetPasswordRequest {
 
-    @NotNull
-    @ApiModelProperty(value = UserModelDescriptions.GROUP_NAME, required = true)
-    private String name;
+    @ApiModelProperty(value = UserModelDescriptions.USER_PASSWORD)
+    private String password;
 
-    public String getName() {
-        return name;
+    public String getPassword() {
+        return password;
     }
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SetPasswordResponse.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SetPasswordResponse.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.freeipa.api.v1.freeipa.user.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.doc.UserModelDescriptions;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel("SetPasswordV1Response")
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SetPasswordResponse {
+
+    @ApiModelProperty(value = UserModelDescriptions.SUCCESS_ENVIRONMENTNAME)
+    private final List<String> success;
+
+    @ApiModelProperty(value = UserModelDescriptions.FAILURE_ENVIRONMENTNAME)
+    private final List<String> failure;
+
+    public SetPasswordResponse(List<String> success, List<String> failure) {
+        this.success = success;
+        this.failure = failure;
+    }
+
+    public List<String> getSuccess() {
+        return success;
+    }
+
+    public List<String> getFailure() {
+        return failure;
+    }
+}

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SynchronizeUsersRequest.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SynchronizeUsersRequest.java
@@ -6,7 +6,8 @@ import java.util.Set;
 import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.sequenceiq.freeipa.api.v1.freeipa.user.doc.UsersyncModelDescriptions;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.doc.FreeIpaModelDescriptions;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.doc.UserModelDescriptions;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -15,20 +16,20 @@ import io.swagger.annotations.ApiModelProperty;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SynchronizeUsersRequest {
     @NotNull
-    @ApiModelProperty(value = UsersyncModelDescriptions.ENVIRONMENT_NAME, required = true)
+    @ApiModelProperty(value = FreeIpaModelDescriptions.ENVIRONMENT_ID, required = true)
     private String environmentName;
 
     // TODO: figure out whether we need a separate name since we are expecting one freeipa per environment.
     // We currently retrieve stacks from the repository by environment and name and then
     // get the freeipa from the stack.
     @NotNull
-    @ApiModelProperty(value = UsersyncModelDescriptions.STACK_NAME, required = true)
+    @ApiModelProperty(value = FreeIpaModelDescriptions.FREEIPA_NAME, required = true)
     private String name;
 
-    @ApiModelProperty(value = UsersyncModelDescriptions.USERSYNC_GROUPS)
+    @ApiModelProperty(value = UserModelDescriptions.USERSYNC_GROUPS)
     private Set<Group> groups = new HashSet<>();
 
-    @ApiModelProperty(value = UsersyncModelDescriptions.USERSYNC_USERS)
+    @ApiModelProperty(value = UserModelDescriptions.USERSYNC_USERS)
     private Set<User> users = new HashSet<>();
 
     public String getEnvironmentName() {

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/User.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/User.java
@@ -5,7 +5,7 @@ import java.util.Set;
 import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.sequenceiq.freeipa.api.v1.freeipa.user.doc.UsersyncModelDescriptions;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.doc.UserModelDescriptions;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -15,22 +15,18 @@ import io.swagger.annotations.ApiModelProperty;
 public class User {
 
     @NotNull
-    @ApiModelProperty(value = UsersyncModelDescriptions.USER_NAME, required = true)
+    @ApiModelProperty(value = UserModelDescriptions.USER_NAME, required = true)
     private String name;
 
     @NotNull
-    @ApiModelProperty(value = UsersyncModelDescriptions.USER_FIRSTNAME, required = true)
+    @ApiModelProperty(value = UserModelDescriptions.USER_FIRSTNAME, required = true)
     private String firstName;
 
     @NotNull
-    @ApiModelProperty(value = UsersyncModelDescriptions.USER_LASTNAME, required = true)
+    @ApiModelProperty(value = UserModelDescriptions.USER_LASTNAME, required = true)
     private String lastName;
 
-    // TODO make this secret
-    @ApiModelProperty(value = UsersyncModelDescriptions.USER_PASSWORD)
-    private String password;
-
-    @ApiModelProperty(value = UsersyncModelDescriptions.USERSYNC_GROUPS)
+    @ApiModelProperty(value = UserModelDescriptions.USER_GROUPS)
     private Set<String> groups;
 
     public String getName() {
@@ -43,10 +39,6 @@ public class User {
 
     public String getLastName() {
         return lastName;
-    }
-
-    public String getPassword() {
-        return password;
     }
 
     public Set<String> getGroups() {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/EndpointConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/EndpointConfig.java
@@ -15,7 +15,7 @@ import org.springframework.util.StringUtils;
 import com.sequenceiq.freeipa.api.FreeIpaApi;
 import com.sequenceiq.freeipa.controller.ClientTestV1Controller;
 import com.sequenceiq.freeipa.controller.FreeIpaV1Controller;
-import com.sequenceiq.freeipa.controller.UsersyncV1Controller;
+import com.sequenceiq.freeipa.controller.UserV1Controller;
 import com.sequenceiq.freeipa.controller.mapper.DefaultExceptionMapper;
 import com.sequenceiq.freeipa.controller.mapper.WebApplicaitonExceptionMapper;
 
@@ -28,7 +28,7 @@ import io.swagger.jaxrs.config.SwaggerContextService;
 public class EndpointConfig extends ResourceConfig {
 
     private static final List<Class<?>> CONTROLLERS = List.of(
-            UsersyncV1Controller.class, ClientTestV1Controller.class, FreeIpaV1Controller.class);
+            UserV1Controller.class, ClientTestV1Controller.class, FreeIpaV1Controller.class);
 
     private static final String VERSION_UNAVAILABLE = "unspecified";
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/UserV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/UserV1Controller.java
@@ -6,19 +6,25 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
 
-import com.sequenceiq.freeipa.api.v1.freeipa.user.UsersyncV1Endpoint;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.UserV1Endpoint;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SetPasswordRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SetPasswordResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeUsersRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeUsersResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeUsersStatus;
-import com.sequenceiq.freeipa.service.user.UsersyncService;
+import com.sequenceiq.freeipa.service.user.PasswordService;
+import com.sequenceiq.freeipa.service.user.UserService;
 
 @Controller
-public class UsersyncV1Controller implements UsersyncV1Endpoint {
+public class UserV1Controller implements UserV1Endpoint {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(UsersyncV1Controller.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserV1Controller.class);
 
     @Inject
-    private UsersyncService usersyncService;
+    private UserService userService;
+
+    @Inject
+    private PasswordService passwordService;
 
     @Override
     public SynchronizeUsersResponse synchronizeUsers(SynchronizeUsersRequest request) {
@@ -26,9 +32,9 @@ public class UsersyncV1Controller implements UsersyncV1Endpoint {
 
         String accountId = "test_account";
         try {
-            usersyncService.synchronizeUsers(accountId, request);
+            userService.synchronizeUsers(accountId, request);
         } catch (Exception e) {
-            LOGGER.error("failed to synchronizeUsers()", e);
+            LOGGER.error("Failed to synchronizeUsers()", e);
             throw new RuntimeException(e);
         }
 
@@ -39,5 +45,14 @@ public class UsersyncV1Controller implements UsersyncV1Endpoint {
     public SynchronizeUsersStatus getStatus() {
         LOGGER.info("getStatus()");
         return new SynchronizeUsersStatus("Hello getStatus()!");
+    }
+
+    @Override
+    public SetPasswordResponse setPassword(String username, SetPasswordRequest request) {
+        LOGGER.info("setPassword() requested for user {}", username);
+
+        String accountId = "test_account";
+
+        return passwordService.setPassword(accountId, username, request.getPassword());
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/user/event/FreeIpaClientRequest.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/user/event/FreeIpaClientRequest.java
@@ -1,0 +1,61 @@
+package com.sequenceiq.freeipa.flow.freeipa.user.event;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.TimeUnit;
+
+import org.reactivestreams.Subscriber;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+
+import reactor.rx.Promise;
+import reactor.rx.Promises;
+
+public class FreeIpaClientRequest<T> implements Selectable {
+
+    private final Long stackId;
+
+    private final Promise<T> result;
+
+    public FreeIpaClientRequest(Long stackId) {
+        this.stackId = requireNonNull(stackId);
+        result = Promises.prepare();
+    }
+
+    public static String selector(Class<?> clazz) {
+        return clazz.getSimpleName().toUpperCase();
+    }
+
+    @Override
+    public String selector() {
+        return selector(getClass());
+    }
+
+    @Override
+    public Long getResourceId() {
+        return stackId;
+    }
+
+    public Subscriber<T> getResult() {
+        return result;
+    }
+
+    public T await() throws InterruptedException {
+        return await(1, TimeUnit.HOURS);
+    }
+
+    public T await(long timeout, TimeUnit unit) throws InterruptedException {
+        T result = this.result.await(timeout, unit);
+        if (result == null) {
+            throw new InterruptedException("Operation timed out, couldn't retrieve result");
+        }
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "FreeIpaRequest{"
+                + "stackId=" + stackId
+                + '}';
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/user/event/FreeIpaClientResult.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/user/event/FreeIpaClientResult.java
@@ -1,0 +1,73 @@
+package com.sequenceiq.freeipa.flow.freeipa.user.event;
+
+import com.sequenceiq.cloudbreak.cloud.event.model.EventStatus;
+import com.sequenceiq.cloudbreak.common.event.Payload;
+
+public class FreeIpaClientResult<R extends FreeIpaClientRequest<?>> implements Payload {
+
+    private EventStatus status;
+
+    private String statusReason;
+
+    private Exception errorDetails;
+
+    private R request;
+
+    public FreeIpaClientResult(R request) {
+        init(EventStatus.OK, null, null, request);
+    }
+
+    public FreeIpaClientResult(String statusReason, Exception errorDetails, R request) {
+        init(EventStatus.FAILED, statusReason, errorDetails, request);
+    }
+
+    protected void init(EventStatus status, String statusReason, Exception errorDetails, R request) {
+        this.status = status;
+        this.statusReason = statusReason;
+        this.errorDetails = errorDetails;
+        this.request = request;
+    }
+
+    public static String selector(Class<?> clazz) {
+        return clazz.getSimpleName().toUpperCase();
+    }
+
+    public static String failureSelector(Class<?> clazz) {
+        return clazz.getSimpleName().toUpperCase() + "_ERROR";
+    }
+
+    public String selector() {
+        return status == EventStatus.OK ? selector(getClass()) : failureSelector(getClass());
+    }
+
+    public EventStatus getStatus() {
+        return status;
+    }
+
+    public String getStatusReason() {
+        return statusReason;
+    }
+
+    public Exception getErrorDetails() {
+        return errorDetails;
+    }
+
+    public R getRequest() {
+        return request;
+    }
+
+    @Override
+    public String toString() {
+        return "FreeIpaResult{"
+                + "status=" + status
+                + ", statusReason='" + statusReason + '\''
+                + ", errorDetails=" + errorDetails
+                + ", request=" + request
+                + '}';
+    }
+
+    @Override
+    public Long getResourceId() {
+        return request.getResourceId();
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/user/event/SetPasswordRequest.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/user/event/SetPasswordRequest.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.freeipa.flow.freeipa.user.event;
+
+public class SetPasswordRequest extends FreeIpaClientRequest<SetPasswordResult> {
+
+    private final String environment;
+
+    private final String username;
+
+    private final String password;
+
+    public SetPasswordRequest(Long stackId, String environment, String username, String password) {
+        super(stackId);
+        this.environment = environment;
+        this.username = username;
+        this.password = password;
+    }
+
+    public String getEnvironment() {
+        return environment;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String toString() {
+        return "SetPasswordRequest{"
+                + "stackId='" + getResourceId() + '\''
+                + "environment='" + environment + '\''
+                + "username='" + username + '\''
+                + '}';
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/user/event/SetPasswordResult.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/user/event/SetPasswordResult.java
@@ -1,0 +1,12 @@
+package com.sequenceiq.freeipa.flow.freeipa.user.event;
+
+public class SetPasswordResult extends FreeIpaClientResult<SetPasswordRequest> {
+
+    public SetPasswordResult(SetPasswordRequest request) {
+        super(request);
+    }
+
+    public SetPasswordResult(String statusReason, Exception errorDetails, SetPasswordRequest request) {
+        super(statusReason, errorDetails, request);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/user/handler/SetPasswordHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/user/handler/SetPasswordHandler.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.freeipa.flow.freeipa.user.handler;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.flow.event.EventSelectorUtil;
+import com.sequenceiq.flow.reactor.api.handler.EventHandler;
+import com.sequenceiq.freeipa.client.FreeIpaClient;
+import com.sequenceiq.freeipa.flow.freeipa.user.event.SetPasswordRequest;
+import com.sequenceiq.freeipa.flow.freeipa.user.event.SetPasswordResult;
+import com.sequenceiq.freeipa.service.FreeIpaClientFactory;
+
+import reactor.bus.Event;
+
+@Component
+public class SetPasswordHandler implements EventHandler<SetPasswordRequest> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SetPasswordHandler.class);
+
+    @Inject
+    private FreeIpaClientFactory freeIpaClientFactory;
+
+    @Override
+    public String selector() {
+        return EventSelectorUtil.selector(SetPasswordRequest.class);
+    }
+
+    @Override
+    public void accept(Event<SetPasswordRequest> setPasswordRequestEvent) {
+        SetPasswordRequest request = setPasswordRequestEvent.getData();
+        LOGGER.info("SetPasswordHandler accepting request {}", request);
+        try {
+            FreeIpaClient freeIpaClient = freeIpaClientFactory.getFreeIpaClientForStackId(request.getResourceId());
+            freeIpaClient.userSetPassword(request.getUsername(), request.getPassword());
+        } catch (Exception e) {
+            request.getResult().onError(e);
+        }
+        SetPasswordResult result = new SetPasswordResult(request);
+        request.getResult().onNext(result);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/repository/StackRepository.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/repository/StackRepository.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.freeipa.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import javax.transaction.Transactional;
@@ -24,4 +25,6 @@ public interface StackRepository extends CrudRepository<Stack, Long> {
 
     @Query("SELECT s FROM Stack s WHERE s.environment = :environment")
     Optional<Stack> findByEnvironment(@Param("environment") String environment);
+
+    List<Stack> findByAccountId(@Param("accountId") String accountId);
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.freeipa.service.stack;
 
+import java.util.List;
+
 import javax.inject.Inject;
 
 import org.springframework.stereotype.Service;
@@ -34,5 +36,9 @@ public class StackService {
     public Stack getByEnvironmentCrn(String environmentCrn) {
         return stackRepository.findByEnvironment(environmentCrn)
                 .orElseThrow(() -> new NotFoundException(String.format("Stack by environment [%s] not found", environmentCrn)));
+    }
+
+    public List<Stack> getAllByAccountId(String accountId) {
+        return stackRepository.findByAccountId(accountId);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/PasswordService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/PasswordService.java
@@ -1,0 +1,79 @@
+package com.sequenceiq.freeipa.service.user;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cloud.event.model.EventStatus;
+import com.sequenceiq.cloudbreak.service.OperationException;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SetPasswordResponse;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.flow.freeipa.user.event.SetPasswordRequest;
+import com.sequenceiq.freeipa.flow.freeipa.user.event.SetPasswordResult;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+import reactor.bus.Event;
+import reactor.bus.EventBus;
+
+@Service
+public class PasswordService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PasswordService.class);
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private EventBus eventBus;
+
+    public SetPasswordResponse setPassword(String accountId, String username, String password) {
+        LOGGER.debug("setting password for user {} in account {}", username, accountId);
+
+        List<Stack> stacks = stackService.getAllByAccountId(accountId);
+
+        if (stacks.isEmpty()) {
+            throw new IllegalArgumentException("No stacks found for accountId " + accountId);
+        }
+
+        List<SetPasswordRequest> requests = new ArrayList<>();
+        for (Stack stack : stacks) {
+            requests.add(triggerSetPassword(stack, stack.getEnvironment(), username, password));
+        }
+
+        List<String> success = new ArrayList<>();
+        List<String> failure = new ArrayList<>();
+
+        for (SetPasswordRequest request : requests) {
+            try {
+                waitSetPassword(request);
+                success.add(request.getEnvironment());
+            } catch (OperationException e) {
+                LOGGER.debug("Failed to set password for user {} in environment {}", username, request.getEnvironment());
+                failure.add(request.getEnvironment());
+            } catch (InterruptedException e) {
+                LOGGER.error("Interrupted while setting passwords for user {} in account {}", username, accountId);
+                throw new OperationException(e);
+            }
+        }
+
+        return new SetPasswordResponse(success, failure);
+    }
+
+    private SetPasswordRequest triggerSetPassword(Stack stack, String environment, String username, String password) {
+        SetPasswordRequest request = new SetPasswordRequest(stack.getId(), environment, username, password);
+        eventBus.notify(request.selector(), new Event<>(request));
+        return request;
+    }
+
+    private void waitSetPassword(SetPasswordRequest request) throws InterruptedException {
+        SetPasswordResult result = request.await();
+        if (result.getStatus().equals(EventStatus.FAILED)) {
+            throw new OperationException(result.getErrorDetails());
+        }
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/UserService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/UserService.java
@@ -22,9 +22,9 @@ import com.sequenceiq.freeipa.service.FreeIpaClientFactory;
 import com.sequenceiq.freeipa.service.stack.StackService;
 
 @Service
-public class UsersyncService {
+public class UserService {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(UsersyncService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserService.class);
 
     @Inject
     private StackService stackService;
@@ -33,7 +33,7 @@ public class UsersyncService {
     private FreeIpaClientFactory freeIpaClientFactory;
 
     public void synchronizeUsers(String accountId, SynchronizeUsersRequest request) throws Exception {
-        LOGGER.info("UsersyncService.synchronizeUsers() called");
+        LOGGER.info("UserService.synchronizeUsers() called");
 
         Stack stack = stackService.getByAccountIdEnvironmentAndName(accountId, request.getEnvironmentName(), request.getName());
 
@@ -73,8 +73,6 @@ public class UsersyncService {
             RPCResponse<com.sequenceiq.freeipa.client.model.User> userAdd = freeIpaClient.userAdd(
                     username, user.getFirstName(), user.getLastName());
 
-            RPCResponse<Object> userSetPassword = freeIpaClient.userSetPassword(username, user.getPassword());
-
             LOGGER.debug("Success: {}", userAdd.getResult());
         }
     }
@@ -104,4 +102,5 @@ public class UsersyncService {
         }
         return mapping;
     }
+
 }


### PR DESCRIPTION
This commit adds an endpoint that sets a user's password in the
freeipa server. The API call is currently wired directly to the
service implementation and executed synchronously. The actual
set password activities will take time and will be executed
through the EventBus.

As part of this change, the API path for usersync has been changed
/v1/freeipa/user/sync -- performs usersync
/v1/freeipa/user/{username}/password -- sets password for user

A getAllByAccountId method was added to the StackService to retrieve all stacks for a
given accountId because we want to set the password in all environments.
