### PR TITLE
CB-1518. Implement component-related logic for CM templates

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/blueprint/ComponentLocatorService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/blueprint/ComponentLocatorService.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.service.blueprint;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -51,7 +52,7 @@ public class ComponentLocatorService {
         BlueprintTextProcessor processor = isAmbariBlueprint(cluster) ? ambariBlueprintProcessorFactory.get(blueprintText)
                 : cmTemplateProcessorFactory.get(blueprintText);
         for (HostGroup hg : hostGroupService.getByCluster(cluster.getId())) {
-            Set<String> hgComponents = processor.getComponentsInHostGroup(hg.getName());
+            Set<String> hgComponents = new HashSet<>(processor.getComponentsInHostGroup(hg.getName()));
             hgComponents.retainAll(componentNames);
             fillList(fqdn, result, hg, hgComponents);
         }
@@ -66,7 +67,7 @@ public class ComponentLocatorService {
             Collection<String> componentNames, Function<InstanceMetaData, String> fqdn) {
         Map<String, List<String>> result = new HashMap<>();
         for (HostGroup hg : hostGroupService.getByCluster(clusterId)) {
-            Set<String> hgComponents = blueprintTextProcessor.getComponentsInHostGroup(hg.getName());
+            Set<String> hgComponents = new HashSet<>(blueprintTextProcessor.getComponentsInHostGroup(hg.getName()));
             hgComponents.retainAll(componentNames);
             fillList(fqdn, result, hg, hgComponents);
         }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/blueprint/ComponentLocatorServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/blueprint/ComponentLocatorServiceTest.java
@@ -5,7 +5,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.when;
 
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -25,6 +24,7 @@ import com.google.common.collect.Maps;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.ExposedService;
 import com.sequenceiq.cloudbreak.blueprint.AmbariBlueprintProcessorFactory;
 import com.sequenceiq.cloudbreak.blueprint.AmbariBlueprintTextProcessor;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessorFactory;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.domain.Constraint;
@@ -33,13 +33,15 @@ import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.service.hostgroup.HostGroupService;
-import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ComponentLocatorServiceTest {
 
     @Mock
     private AmbariBlueprintTextProcessor ambariBlueprintTextProcessor;
+
+    @Mock
+    private CmTemplateProcessor cmTemplateProcessor;
 
     @Mock
     private HostGroupService hostGroupService;
@@ -49,9 +51,6 @@ public class ComponentLocatorServiceTest {
 
     @Mock
     private CmTemplateProcessorFactory cmTemplateProcessorFactory;
-
-    @Mock
-    private InstanceMetaDataService instanceMetaDataService;
 
     @Mock
     private BlueprintService blueprintService;
@@ -69,8 +68,8 @@ public class ComponentLocatorServiceTest {
         HostGroup hg1 = createHostGroup("hg1", 0L, "myhost1", "10.0.140.69");
         HostGroup hg2 = createHostGroup("hg2", 1L, "myhost2", "10.0.140.70");
 
-        Set<String> hg1Components = set("RESOURCEMANAGER", "Service1", "HIVE_SERVER");
-        Set<String> hg2Components = set("NAMENODE", "Service2", "Service3");
+        Set<String> hg1Components = Set.of("RESOURCEMANAGER", "Service1", "HIVE_SERVER");
+        Set<String> hg2Components = Set.of("NAMENODE", "Service2", "Service3");
 
         when(hostGroupService.getByCluster(nullable(Long.class))).thenReturn(ImmutableSet.of(hg1, hg2));
         when(ambariBlueprintTextProcessor.getComponentsInHostGroup(eq("hg1"))).thenReturn(hg1Components);
@@ -96,11 +95,6 @@ public class ComponentLocatorServiceTest {
         return hg;
     }
 
-    @SafeVarargs
-    private final <T> Set<T> set(T... array) {
-        return new HashSet<>(Arrays.asList(array));
-    }
-
     @Test
     public void getComponentLocation() {
         when(blueprintService.isAmbariBlueprint(any())).thenReturn(true);
@@ -112,6 +106,24 @@ public class ComponentLocatorServiceTest {
 
         Map<String, List<String>> result = underTest.getComponentLocation(cluster, new HashSet<>(ExposedService.getAllServiceNameForAmbari()));
         Assert.assertEquals(3L, result.size());
+        Assert.assertEquals(expected, result);
+    }
+
+    @Test
+    public void getComponentLocationCM() {
+        when(blueprintService.isAmbariBlueprint(any())).thenReturn(false);
+        when(cmTemplateProcessorFactory.get(nullable(String.class))).thenReturn(cmTemplateProcessor);
+        when(cmTemplateProcessor.getComponentsInHostGroup(eq("hg1"))).thenReturn(Set.of("RESOURCEMANAGER", "Service1", "HIVESERVER2"));
+        when(cmTemplateProcessor.getComponentsInHostGroup(eq("hg2"))).thenReturn(Set.of("NAMENODE", "Service2", "Service3"));
+
+        Map<String, List<String>> expected = Map.of(
+                "RESOURCEMANAGER", ImmutableList.of("myhost1"),
+                "HIVESERVER2", ImmutableList.of("myhost1"),
+                "NAMENODE", ImmutableList.of("myhost2")
+        );
+
+        Map<String, List<String>> result = underTest.getComponentLocation(cluster, new HashSet<>(ExposedService.getAllServiceNameForCM()));
+
         Assert.assertEquals(expected, result);
     }
 

--- a/template-manager-blueprint/src/main/java/com/sequenceiq/cloudbreak/blueprint/AmbariBlueprintTextProcessor.java
+++ b/template-manager-blueprint/src/main/java/com/sequenceiq/cloudbreak/blueprint/AmbariBlueprintTextProcessor.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.blueprint;
 
+import static java.util.stream.Collectors.toSet;
+
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
@@ -12,7 +14,6 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -27,6 +28,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.MissingNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 import com.sequenceiq.cloudbreak.template.BlueprintProcessingException;
 import com.sequenceiq.cloudbreak.template.processor.BlueprintTextProcessor;
 import com.sequenceiq.cloudbreak.template.processor.ClusterManagerType;
@@ -38,7 +40,6 @@ import com.sequenceiq.cloudbreak.template.processor.configuration.SiteConfigurat
 import com.sequenceiq.cloudbreak.template.processor.configuration.SiteSettingsConfigurations;
 import com.sequenceiq.cloudbreak.template.processor.kerberos.KerberosDescriptorService;
 import com.sequenceiq.cloudbreak.template.processor.kerberos.KerberosServiceConfiguration;
-import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 
 public class AmbariBlueprintTextProcessor implements BlueprintTextProcessor {
 
@@ -208,12 +209,12 @@ public class AmbariBlueprintTextProcessor implements BlueprintTextProcessor {
     }
 
     public Set<String> getAllComponents() {
-        return getComponentsByHostGroup().entrySet()
-                .stream()
+        return getComponentsByHostGroup().entrySet().stream()
                 .flatMap(entry -> entry.getValue().stream())
-                .collect(Collectors.toSet());
+                .collect(toSet());
     }
 
+    @Override
     public Set<String> getComponentsInHostGroup(String hostGroup) {
         Set<String> services = new HashSet<>();
         ArrayNode hostGroupsNode = getArrayFromObjectNodeByPath(blueprint, HOST_GROUPS_NODE);

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/model/ServiceComponent.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/model/ServiceComponent.java
@@ -1,0 +1,68 @@
+package com.sequenceiq.cloudbreak.template.model;
+
+import java.util.Objects;
+
+import javax.annotation.Nonnull;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+public class ServiceComponent implements Comparable<ServiceComponent> {
+
+    private static final String UNKNOWN_SERVICE = "";
+
+    private final Pair<String, String> serviceComponent;
+
+    private ServiceComponent(String service, String component) {
+        serviceComponent = Pair.of(service, component);
+    }
+
+    /**
+     * Factory method for CM.
+     */
+    public static ServiceComponent of(String service, String component) {
+        return new ServiceComponent(service, component);
+    }
+
+    /**
+     * Factory method for Ambari.
+     */
+    public static ServiceComponent of(String component) {
+        return new ServiceComponent(UNKNOWN_SERVICE, component);
+    }
+
+    public String getService() {
+        return serviceComponent.getLeft();
+    }
+
+    public String getComponent() {
+        return serviceComponent.getRight();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        ServiceComponent other = (ServiceComponent) obj;
+        return Objects.equals(serviceComponent, other.serviceComponent);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(serviceComponent);
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toString(serviceComponent);
+    }
+
+    @Override
+    public int compareTo(@Nonnull ServiceComponent other) {
+        return serviceComponent.compareTo(other.serviceComponent);
+    }
+}

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/processor/BlueprintTextProcessor.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/processor/BlueprintTextProcessor.java
@@ -32,4 +32,5 @@ public interface BlueprintTextProcessor {
     String asText();
 
     Set<String> getComponentsInHostGroup(String name);
+
 }

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/views/BlueprintView.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/views/BlueprintView.java
@@ -19,17 +19,20 @@ public class BlueprintView {
 
     private Set<String> components;
 
-    private BlueprintTextProcessor processor;
+    private final BlueprintTextProcessor processor;
+
+    private final Map<String, Set<String>> componentsByHostGroup;
 
     public BlueprintView(String blueprintText, String version, String type, BlueprintTextProcessor processor) {
         this.blueprintText = blueprintText;
         this.type = type;
         this.version = version;
         this.processor = processor;
-        components = prepareComponents(blueprintText);
+        componentsByHostGroup = processor.getComponentsByHostGroup();
+        components = prepareComponents();
     }
 
-    private Set<String> prepareComponents(String blueprintText) {
+    private Set<String> prepareComponents() {
         Set<String> result = new HashSet<>();
         try {
             Map<String, Set<String>> componentsByHostGroup = processor.getComponentsByHostGroup();
@@ -76,6 +79,10 @@ public class BlueprintView {
         this.components = components;
     }
 
+    public Map<String, Set<String>> getComponentsByHostGroup() {
+        return componentsByHostGroup;
+    }
+
     @VisibleForTesting
     public BlueprintTextProcessor getProcessor() {
         return processor;
@@ -100,5 +107,4 @@ public class BlueprintView {
     public int hashCode() {
         return Objects.hash(blueprintText, version, type, components);
     }
-
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Implement some missing component-related functions for CM templates.  This is needed to streamline HA template logic.

## How was this patch tested?

Unit tests.