### PR TITLE
DISTX-138. Provide default values for HA-related configs

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha.bp
@@ -32,20 +32,6 @@
           {
             "refName": "hdfs-NAMENODE-BASE",
             "roleType": "NAMENODE",
-            "configs": [
-              {
-                "name": "autofailover_enabled",
-                "value": "true"
-              },
-              {
-                "name": "dfs_federation_namenode_nameservice",
-                "value": "ns1"
-              },
-              {
-                "name": "dfs_namenode_quorum_journal_name",
-                "value": "ns1"
-              }
-            ],
             "base": true
           },
           {

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessor.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessor.java
@@ -216,7 +216,7 @@ public class CmTemplateProcessor implements BlueprintTextProcessor {
         setServiceConfigs(service, configMap.values());
     }
 
-    private Map<String, ApiClusterTemplateConfig> mapByName(Collection<ApiClusterTemplateConfig> configs) {
+    public Map<String, ApiClusterTemplateConfig> mapByName(Collection<ApiClusterTemplateConfig> configs) {
         return configs.stream()
                 .collect(toMap(
                         ApiClusterTemplateConfig::getName,

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hdfs/HdfsVolumeConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hdfs/HdfsVolumeConfigProviderTest.java
@@ -12,15 +12,22 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.google.common.collect.Sets;
 import com.sequenceiq.cloudbreak.common.type.InstanceGroupType;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject.Builder;
+import com.sequenceiq.cloudbreak.template.views.BlueprintView;
 import com.sequenceiq.cloudbreak.template.views.HostgroupView;
 import com.sequenceiq.cloudbreak.util.FileReaderUtils;
 
 @RunWith(MockitoJUnitRunner.class)
 public class HdfsVolumeConfigProviderTest {
+
+    private static final Set<String> NN_BASE_PROPERTIES = Set.of("dfs_name_dir_list");
+
+    private static final Set<String> NN_HA_PROPERTIES =
+        Set.of("autofailover_enabled", "dfs_federation_namenode_nameservice", "dfs_namenode_quorum_journal_name");
 
     private final HdfsRoleConfigConfigProvider underTest = new HdfsRoleConfigConfigProvider();
 
@@ -35,9 +42,12 @@ public class HdfsVolumeConfigProviderTest {
     public void testGetRoleConfigsWithSingleRolesPerHostGroup() {
         HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, 1);
         HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, 2);
-        TemplatePreparationObject preparationObject = Builder.builder().withHostgroupViews(Set.of(master, worker)).build();
         String inputJson = getBlueprintText("input/clouderamanager.bp");
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+        TemplatePreparationObject preparationObject = Builder.builder()
+                .withHostgroupViews(Set.of(master, worker))
+                .withBlueprintView(new BlueprintView(inputJson, "CDP", "1.0", cmTemplateProcessor))
+                .build();
 
         Map<String, List<ApiClusterTemplateConfig>> roleConfigs = underTest.getRoleConfigs(cmTemplateProcessor, preparationObject);
 
@@ -61,9 +71,12 @@ public class HdfsVolumeConfigProviderTest {
     public void testGetRoleConfigsWithSingleRolesPerHostGroupWithCustomRefNames() {
         HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, 1);
         HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, 2);
-        TemplatePreparationObject preparationObject = Builder.builder().withHostgroupViews(Set.of(master, worker)).build();
         String inputJson = getBlueprintText("input/clouderamanager-custom-ref.bp");
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+        TemplatePreparationObject preparationObject = Builder.builder()
+                .withHostgroupViews(Set.of(master, worker))
+                .withBlueprintView(new BlueprintView(inputJson, "CDP", "1.0", cmTemplateProcessor))
+                .build();
 
         Map<String, List<ApiClusterTemplateConfig>> roleConfigs = underTest.getRoleConfigs(cmTemplateProcessor, preparationObject);
 
@@ -84,9 +97,12 @@ public class HdfsVolumeConfigProviderTest {
     public void testGetRoleConfigsWithOneHostGroupZeroAttachedVolumes() {
         HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, 1);
         HostgroupView worker = new HostgroupView("worker", 0, InstanceGroupType.CORE, 2);
-        TemplatePreparationObject preparationObject = Builder.builder().withHostgroupViews(Set.of(master, worker)).build();
         String inputJson = getBlueprintText("input/clouderamanager.bp");
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+        TemplatePreparationObject preparationObject = Builder.builder()
+                .withHostgroupViews(Set.of(master, worker))
+                .withBlueprintView(new BlueprintView(inputJson, "CDP", "1.0", cmTemplateProcessor))
+                .build();
 
         Map<String, List<ApiClusterTemplateConfig>> roleConfigs = underTest.getRoleConfigs(cmTemplateProcessor, preparationObject);
 
@@ -112,9 +128,12 @@ public class HdfsVolumeConfigProviderTest {
     public void testGetRoleConfigsWithAllHostGroupZeroAttachedVolumes() {
         HostgroupView master = new HostgroupView("master", 0, InstanceGroupType.GATEWAY, 1);
         HostgroupView worker = new HostgroupView("worker", 0, InstanceGroupType.CORE, 2);
-        TemplatePreparationObject preparationObject = Builder.builder().withHostgroupViews(Set.of(master, worker)).build();
         String inputJson = getBlueprintText("input/clouderamanager.bp");
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+        TemplatePreparationObject preparationObject = Builder.builder()
+                .withHostgroupViews(Set.of(master, worker))
+                .withBlueprintView(new BlueprintView(inputJson, "CDP", "1.0", cmTemplateProcessor))
+                .build();
 
         Map<String, List<ApiClusterTemplateConfig>> roleConfigs = underTest.getRoleConfigs(cmTemplateProcessor, preparationObject);
 
@@ -140,9 +159,12 @@ public class HdfsVolumeConfigProviderTest {
     public void testGetRoleConfigsWithNoNNOrDNInAnyHostGroup() {
         HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, 1);
         HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, 2);
-        TemplatePreparationObject preparationObject = Builder.builder().withHostgroupViews(Set.of(master, worker)).build();
         String inputJson = getBlueprintText("input/clouderamanager-no-nn-dn.bp");
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+        TemplatePreparationObject preparationObject = Builder.builder()
+                .withHostgroupViews(Set.of(master, worker))
+                .withBlueprintView(new BlueprintView(inputJson, "CDP", "1.0", cmTemplateProcessor))
+                .build();
 
         Map<String, List<ApiClusterTemplateConfig>> roleConfigs = underTest.getRoleConfigs(cmTemplateProcessor, preparationObject);
 
@@ -154,9 +176,12 @@ public class HdfsVolumeConfigProviderTest {
         HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, 1);
         HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, 2);
         HostgroupView compute = new HostgroupView("compute", 3, InstanceGroupType.CORE, 2);
-        TemplatePreparationObject preparationObject = Builder.builder().withHostgroupViews(Set.of(master, worker, compute)).build();
         String inputJson = getBlueprintText("input/clouderamanager-3hg-same-DN-role.bp");
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+        TemplatePreparationObject preparationObject = Builder.builder()
+                .withHostgroupViews(Set.of(master, worker, compute))
+                .withBlueprintView(new BlueprintView(inputJson, "CDP", "1.0", cmTemplateProcessor))
+                .build();
 
         Map<String, List<ApiClusterTemplateConfig>> roleConfigs = underTest.getRoleConfigs(cmTemplateProcessor, preparationObject);
 
@@ -173,9 +198,12 @@ public class HdfsVolumeConfigProviderTest {
         HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, 1);
         HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, 2);
         HostgroupView compute = new HostgroupView("compute", 3, InstanceGroupType.CORE, 2);
-        TemplatePreparationObject preparationObject = Builder.builder().withHostgroupViews(Set.of(master, worker, compute)).build();
         String inputJson = getBlueprintText("input/clouderamanager-3hg-different-DN-role.bp");
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+        TemplatePreparationObject preparationObject = Builder.builder()
+                .withHostgroupViews(Set.of(master, worker, compute))
+                .withBlueprintView(new BlueprintView(inputJson, "CDP", "1.0", cmTemplateProcessor))
+                .build();
 
         Map<String, List<ApiClusterTemplateConfig>> roleConfigs = underTest.getRoleConfigs(cmTemplateProcessor, preparationObject);
 
@@ -204,9 +232,12 @@ public class HdfsVolumeConfigProviderTest {
         HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, 1);
         HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, 2);
         HostgroupView compute = new HostgroupView("compute", 0, InstanceGroupType.CORE, 2);
-        TemplatePreparationObject preparationObject = Builder.builder().withHostgroupViews(Set.of(master, worker, compute)).build();
         String inputJson = getBlueprintText("input/clouderamanager-3hg-different-DN-role.bp");
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+        TemplatePreparationObject preparationObject = Builder.builder()
+                .withHostgroupViews(Set.of(master, worker, compute))
+                .withBlueprintView(new BlueprintView(inputJson, "CDP", "1.0", cmTemplateProcessor))
+                .build();
 
         Map<String, List<ApiClusterTemplateConfig>> roleConfigs = underTest.getRoleConfigs(cmTemplateProcessor, preparationObject);
 
@@ -226,6 +257,27 @@ public class HdfsVolumeConfigProviderTest {
         assertEquals("/hadoopfs/root1/datanode", computeDN.get(0).getValue());
         assertEquals("dfs_datanode_failed_volumes_tolerated", computeDN.get(1).getName());
         assertEquals("0", computeDN.get(1).getValue());
+    }
+
+    @Test
+    public void testNameNodeHA() {
+        HostgroupView gateway = new HostgroupView("gateway", 1, InstanceGroupType.GATEWAY, 1);
+        HostgroupView master = new HostgroupView("master", 0, InstanceGroupType.CORE, 2);
+        HostgroupView quorum = new HostgroupView("quorum", 0, InstanceGroupType.CORE, 3);
+        HostgroupView worker = new HostgroupView("worker", 0, InstanceGroupType.CORE, 3);
+        String inputJson = getBlueprintText("input/namenode-ha.bp");
+        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+        TemplatePreparationObject preparationObject = Builder.builder()
+                .withHostgroupViews(Set.of(gateway, master, quorum, worker))
+                .withBlueprintView(new BlueprintView(inputJson, "CDP", "1.0", cmTemplateProcessor))
+                .build();
+
+        Map<String, List<ApiClusterTemplateConfig>> roleConfigs = underTest.getRoleConfigs(cmTemplateProcessor, preparationObject);
+
+        List<ApiClusterTemplateConfig> namenodeConfigs = roleConfigs.get("hdfs-NAMENODE-BASE");
+        Map<String, ApiClusterTemplateConfig> configMap = cmTemplateProcessor.mapByName(namenodeConfigs);
+        assertEquals(Sets.union(NN_BASE_PROPERTIES, NN_HA_PROPERTIES), configMap.keySet());
+        assertEquals("true", configMap.get("autofailover_enabled").getValue());
     }
 
     private String getBlueprintText(String path) {

--- a/template-manager-cmtemplate/src/test/resources/input/namenode-ha.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/namenode-ha.bp
@@ -1,0 +1,88 @@
+{
+  "cdhVersion": "6.1.0",
+  "displayName": "simple_template",
+  "cmVersion": "6.1.0",
+  "repositories": [
+    "https://archive.cloudera.com/cdh6/{latest_supported}/parcels/"
+  ],
+  "products": [
+    {
+      "version": "6.1.0-1.cdh6.1.0.p0.770702",
+      "product": "CDH"
+    }
+  ],
+  "services": [
+    {
+      "refName": "zookeeper",
+      "serviceType": "ZOOKEEPER",
+      "roleConfigGroups": [
+        {
+          "refName": "zookeeper-SERVER-BASE",
+          "roleType": "SERVER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "hdfs",
+      "serviceType": "HDFS",
+      "roleConfigGroups": [
+        {
+          "refName": "hdfs-NAMENODE-BASE",
+          "roleType": "NAMENODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-DATANODE-BASE",
+          "roleType": "DATANODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-JOURNALNODE-BASE",
+          "roleType": "JOURNALNODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-FAILOVERCONTROLLER-BASE",
+          "roleType": "FAILOVERCONTROLLER",
+          "base": true
+        },
+        {
+          "refName": "hdfs-BALANCER-BASE",
+          "roleType": "BALANCER",
+          "base": true
+        }
+      ]
+    }
+  ],
+  "hostTemplates": [
+    {
+      "refName": "master",
+      "cardinality": 2,
+      "roleConfigGroupsRefNames": [
+        "hdfs-NAMENODE-BASE"
+      ]
+    },
+    {
+      "refName": "quorum",
+      "cardinality": 3,
+      "roleConfigGroupsRefNames": [
+        "zookeeper-SERVER-BASE"
+      ]
+    },
+    {
+      "refName": "gateway",
+      "cardinality": 1,
+      "roleConfigGroupsRefNames": [
+        "hdfs-BALANCER-BASE"
+      ]
+    },
+    {
+      "refName": "worker",
+      "cardinality": 3,
+      "roleConfigGroupsRefNames": [
+        "hdfs-DATANODE-BASE"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Move properties required for NameNode HA to the config provider from the template.  The goal is to avoid having to specify them in all HA templates.  `autofailover_enabled` should always be `true`.  The name for nameservice and journal are sensible defaults, but can be overridden in the template if needed.  The properties are injected only for HA template (more than one NameNode).

## How was this patch tested?

Deployed both non-HA and HA clusters.

Unit test.