### PR TITLE
CB-1521. Retrieve root certificate from ipa server

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
@@ -34,12 +34,19 @@ public interface FreeIpaV1Endpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = FreeIpaOperationDescriptions.GET_BY_ENVID, produces = ContentType.JSON, notes = FreeIpaNotes.FREEIPA_NOTES,
             nickname = "getFreeIpaByEnvironmentV1")
-    DescribeFreeIpaResponse describe(@QueryParam("environment") String environmentId);
+    DescribeFreeIpaResponse describe(@QueryParam("environment") String environmentCrn);
+
+    @GET
+    @Path("ca.crt")
+    @Produces(MediaType.TEXT_PLAIN)
+    @ApiOperation(value = FreeIpaOperationDescriptions.GET_ROOTCERTIFICATE_BY_ENVID, produces = ContentType.TEXT_PLAIN, notes = FreeIpaNotes.FREEIPA_NOTES,
+            nickname = "getFreeIpaRootCertificateByEnvironmentV1")
+    String getRootCertificate(@QueryParam("environment") String environmentCrn);
 
     @DELETE
     @Path("")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = FreeIpaOperationDescriptions.DELETE_BY_ENVID, produces = ContentType.JSON, notes = FreeIpaNotes.FREEIPA_NOTES,
             nickname = "deleteFreeIpaByEnvironmentV1")
-    void delete(@QueryParam("environment") String environmentId);
+    void delete(@QueryParam("environment") String environmentCrn);
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaOperationDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaOperationDescriptions.java
@@ -3,6 +3,7 @@ package com.sequenceiq.freeipa.api.v1.freeipa.stack.doc;
 public final class FreeIpaOperationDescriptions {
     public static final String CREATE = "Create FreeIpa stack";
     public static final String GET_BY_ENVID = "Get FreeIPA stack by envid";
+    public static final String GET_ROOTCERTIFICATE_BY_ENVID = "Get FreeIPA root certificate by envid";
     public static final String DELETE_BY_ENVID = "Delete FreeIPA stack by envid";
 
     private FreeIpaOperationDescriptions() {

--- a/freeipa-api/src/main/java/com/sequenceiq/service/api/doc/ContentType.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/service/api/doc/ContentType.java
@@ -6,6 +6,8 @@ public class ContentType {
 
     public static final String JSON = "application/json";
 
+    public static final String TEXT_PLAIN = "text/plain";
+
     private ContentType() {
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
@@ -12,6 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.googlecode.jsonrpc4j.JsonRpcHttpClient;
+import com.sequenceiq.freeipa.client.model.Ca;
 import com.sequenceiq.freeipa.client.model.RPCResponse;
 import com.sequenceiq.freeipa.client.model.User;
 
@@ -156,6 +157,13 @@ public class FreeIpaClient {
                 "user", users
         );
         return invoke("group_add_member", flags, params, Object.class);
+    }
+
+    public String getRootCertificate() throws FreeIpaClientException {
+        List<String> flags = List.of("ipa");
+        Map<String, Object> params = Map.of();
+        RPCResponse<Ca> response = invoke("ca_show", flags, params, Ca.class);
+        return response.getResult().getCertificate();
     }
 
     public <T> RPCResponse<T> invoke(String method, List<String> flags, Map<String, Object> params, Type resultType) throws FreeIpaClientException {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/client/model/Ca.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/client/model/Ca.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.freeipa.client.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Ca {
+    private String certificate;
+
+    public String getCertificate() {
+        return certificate;
+    }
+
+    public void setCertificate(String certificate) {
+        this.certificate = certificate;
+    }
+
+    @Override
+    public String toString() {
+        return "Ca{"
+                + "certificate='" + certificate + '\''
+                + '}';
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaV1Controller.java
@@ -11,6 +11,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.describe.DescribeFreeIp
 import com.sequenceiq.freeipa.service.stack.FreeIpaCreationService;
 import com.sequenceiq.freeipa.service.stack.FreeIpaDeletionService;
 import com.sequenceiq.freeipa.service.stack.FreeIpaDescribeService;
+import com.sequenceiq.freeipa.service.stack.FreeIpaRootCertificateService;
 
 @Controller
 public class FreeIpaV1Controller implements FreeIpaV1Endpoint {
@@ -24,6 +25,9 @@ public class FreeIpaV1Controller implements FreeIpaV1Endpoint {
     @Inject
     private FreeIpaDescribeService freeIpaDescribeService;
 
+    @Inject
+    private FreeIpaRootCertificateService freeIpaRootCertificateService;
+
     @Override
     public DescribeFreeIpaResponse create(@Valid CreateFreeIpaRequest request) {
         // TODO parse account from header
@@ -32,8 +36,17 @@ public class FreeIpaV1Controller implements FreeIpaV1Endpoint {
     }
 
     @Override
-    public DescribeFreeIpaResponse describe(String environmentId) {
-        return freeIpaDescribeService.describe(environmentId);
+    public DescribeFreeIpaResponse describe(String environmentCrn) {
+        return freeIpaDescribeService.describe(environmentCrn);
+    }
+
+    @Override
+    public String getRootCertificate(String environmentCrn) {
+        try {
+            return freeIpaRootCertificateService.getRootCertificate(environmentCrn);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaRootCertificateService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaRootCertificateService.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.freeipa.service.stack;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.freeipa.client.FreeIpaClient;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.FreeIpaClientFactory;
+
+@Service
+public class FreeIpaRootCertificateService {
+
+    private static final String BEGIN_CERTIFICATE = "-----BEGIN CERTIFICATE-----";
+
+    private static final String END_CERTIFICATE = "-----END CERTIFICATE-----";
+
+    @Inject
+    private FreeIpaClientFactory freeIpaClientFactory;
+
+    @Inject
+    private StackService stackService;
+
+    public String getRootCertificate(String environmentCrn) throws Exception {
+        Stack stack = stackService.getByEnvironmentCrn(environmentCrn);
+        FreeIpaClient client = freeIpaClientFactory.getFreeIpaClientForStack(stack);
+
+        return convertToPemFormat(client.getRootCertificate());
+    }
+
+    private String convertToPemFormat(String certificate) {
+        return String.join("\n",
+                BEGIN_CERTIFICATE,
+                String.join("\n",
+                        certificate.split("(?<=\\G.{64})")),
+                END_CERTIFICATE);
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/controller/FreeIpaV1ControllerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/controller/FreeIpaV1ControllerTest.java
@@ -14,6 +14,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.create.CreateFreeIpaReq
 import com.sequenceiq.freeipa.service.stack.FreeIpaCreationService;
 import com.sequenceiq.freeipa.service.stack.FreeIpaDeletionService;
 import com.sequenceiq.freeipa.service.stack.FreeIpaDescribeService;
+import com.sequenceiq.freeipa.service.stack.FreeIpaRootCertificateService;
 
 @ExtendWith(MockitoExtension.class)
 class FreeIpaV1ControllerTest {
@@ -32,6 +33,9 @@ class FreeIpaV1ControllerTest {
     @Mock
     private FreeIpaDescribeService describeService;
 
+    @Mock
+    private FreeIpaRootCertificateService rootCertificateService;
+
     @Test
     void create() {
         CreateFreeIpaRequest freeIpaRequest = new CreateFreeIpaRequest();
@@ -43,6 +47,12 @@ class FreeIpaV1ControllerTest {
     @Test
     void describe() {
         assertNull(underTest.describe(ENVIRONMENT_CRN));
+    }
+
+    @Test
+    void getRootCertificate() throws Exception {
+        underTest.getRootCertificate(ENVIRONMENT_CRN);
+        verify(rootCertificateService, times(1)).getRootCertificate(ENVIRONMENT_CRN);
     }
 
     @Test


### PR DESCRIPTION
/v1/freeipa/ca.crt?{environmentCrn} endpoint added to FreeIpaV1Endpoint.
This endpoint uses the FreeIpaClient to retrieve the root certificate
from the IPA server. The certificate is returned Base64 encoded. This
code re-formats the certificate into PEM format before returning it to
the caller.