### PR TITLE
CB-1557. CDH 6.2 cluster creation fails on Hive metastore config

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdh6-data-science.bp
+++ b/core/src/main/resources/defaults/blueprints/cdh6-data-science.bp
@@ -107,28 +107,6 @@
       {
         "refName": "hive",
         "serviceType": "HIVE",
-        "serviceConfigs": [
-          {
-            "name": "hive_metastore_database_password",
-            "variable": "hive-hive_metastore_database_password"
-          },
-          {
-            "name": "hive_metastore_database_port",
-            "variable": "hive-hive_metastore_database_port"
-          },
-          {
-            "name": "hive_metastore_database_host",
-            "variable": "hive-hive_metastore_database_host"
-          },
-          {
-            "name": "hive_metastore_database_type",
-            "variable": "hive-hive_metastore_database_type"
-          },
-          {
-            "name": "hive_metastore_database_name",
-            "variable": "hive-hive_metastore_database_name"
-          }
-        ],
         "roleConfigGroups": [
           {
             "refName": "hive-GATEWAY-BASE",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove leftover Hive Metastore DB variables from CDH 6.2 template.  They are no longer assigned any value since #4996.  The problem is that the variable references are not overwritten by generated config values since #5030.

## How was this patch tested?

Deployed CDH 6.2 cluster.