### PR TITLE
CB-1536. Recommend default instance counts and cluster manager group

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/GatewayRecommendation.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/GatewayRecommendation.java
@@ -1,0 +1,41 @@
+package com.sequenceiq.cloudbreak.cloud.model;
+
+import java.util.Objects;
+import java.util.Set;
+
+public class GatewayRecommendation {
+
+    private final Set<String> hostGroups;
+
+    public GatewayRecommendation(Set<String> hostGroups) {
+        this.hostGroups = Set.copyOf(hostGroups);
+    }
+
+    public Set<String> getHostGroups() {
+        return hostGroups;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (null == obj || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        GatewayRecommendation other = (GatewayRecommendation) obj;
+
+        return Objects.equals(hostGroups, other.hostGroups);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(hostGroups);
+    }
+
+    @Override
+    public String toString() {
+        return "GatewayRecommendation" + hostGroups;
+    }
+}

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/InstanceCount.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/InstanceCount.java
@@ -1,0 +1,72 @@
+package com.sequenceiq.cloudbreak.cloud.model;
+
+import java.util.Objects;
+
+public class InstanceCount {
+
+    public static final InstanceCount ZERO_OR_MORE = atLeast(0);
+
+    public static final InstanceCount ONE_OR_MORE = atLeast(1);
+
+    public static final InstanceCount EXACTLY_ONE = exactly(1);
+
+    private Integer minimumCount;
+
+    private Integer maximumCount;
+
+    private InstanceCount(Integer minimumCount, Integer maximumCount) {
+        this.minimumCount = minimumCount;
+        this.maximumCount = maximumCount;
+    }
+
+    public static InstanceCount of(Integer minimumCount, Integer maximumCount) {
+        return new InstanceCount(minimumCount, maximumCount);
+    }
+
+    public static InstanceCount atLeast(Integer minimumCount) {
+        return of(minimumCount, Integer.MAX_VALUE);
+    }
+
+    public static InstanceCount exactly(Integer count) {
+        return of(count, count);
+    }
+
+    public Integer getMinimumCount() {
+        return minimumCount;
+    }
+
+    public Integer getMaximumCount() {
+        return maximumCount;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (null == obj || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        InstanceCount other = (InstanceCount) obj;
+
+        return Objects.equals(minimumCount, other.minimumCount)
+                && Objects.equals(maximumCount, other.maximumCount);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(minimumCount, maximumCount);
+    }
+
+    @Override
+    public String toString() {
+        if (Objects.equals(minimumCount, maximumCount)) {
+            return Objects.toString(minimumCount);
+        }
+        if (maximumCount == Integer.MAX_VALUE) {
+            return minimumCount + "+";
+        }
+        return minimumCount + "-" + maximumCount;
+    }
+}

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/PlatformRecommendation.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/PlatformRecommendation.java
@@ -12,10 +12,22 @@ public class PlatformRecommendation {
 
     private DiskTypes diskTypes;
 
-    public PlatformRecommendation(Map<String, VmType> recommendations, Set<VmType> virtualMachines, DiskTypes diskTypes) {
+    private Map<String, InstanceCount> instanceCounts;
+
+    private GatewayRecommendation gatewayRecommendation;
+
+    public PlatformRecommendation(
+            Map<String, VmType> recommendations,
+            Set<VmType> virtualMachines,
+            DiskTypes diskTypes,
+            Map<String, InstanceCount> instanceCounts,
+            GatewayRecommendation gatewayRecommendation
+    ) {
         this.recommendations = recommendations;
         this.virtualMachines = virtualMachines;
         this.diskTypes = diskTypes;
+        this.instanceCounts = instanceCounts;
+        this.gatewayRecommendation = gatewayRecommendation;
     }
 
     public Map<String, VmType> getRecommendations() {
@@ -40,5 +52,13 @@ public class PlatformRecommendation {
 
     public void setDiskTypes(DiskTypes diskTypes) {
         this.diskTypes = diskTypes;
+    }
+
+    public Map<String, InstanceCount> getInstanceCounts() {
+        return instanceCounts;
+    }
+
+    public GatewayRecommendation getGatewayRecommendation() {
+        return gatewayRecommendation;
     }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/blueprint/responses/RecommendationV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/blueprint/responses/RecommendationV4Response.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.JsonEntity;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses.DiskV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses.GatewayRecommendationV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses.InstanceCountV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.VmTypeV4Response;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -20,13 +22,25 @@ public class RecommendationV4Response implements JsonEntity {
 
     private Set<DiskV4Response> diskResponses;
 
+    private Map<String, InstanceCountV4Response> instanceCounts;
+
+    private GatewayRecommendationV4Response gatewayRecommendation;
+
     public RecommendationV4Response() {
     }
 
-    public RecommendationV4Response(Map<String, VmTypeV4Response> recommendations, Set<VmTypeV4Response> virtualMachines, Set<DiskV4Response> diskResponses) {
+    public RecommendationV4Response(
+            Map<String, VmTypeV4Response> recommendations,
+            Set<VmTypeV4Response> virtualMachines,
+            Set<DiskV4Response> diskResponses,
+            Map<String, InstanceCountV4Response> instanceCounts,
+            GatewayRecommendationV4Response gatewayRecommendation
+    ) {
         this.recommendations = recommendations;
         this.virtualMachines = virtualMachines;
         this.diskResponses = diskResponses;
+        this.instanceCounts = instanceCounts;
+        this.gatewayRecommendation = gatewayRecommendation;
     }
 
     public Map<String, VmTypeV4Response> getRecommendations() {
@@ -51,5 +65,13 @@ public class RecommendationV4Response implements JsonEntity {
 
     public void setDiskResponses(Set<DiskV4Response> diskResponses) {
         this.diskResponses = diskResponses;
+    }
+
+    public Map<String, InstanceCountV4Response> getInstanceCounts() {
+        return instanceCounts;
+    }
+
+    public GatewayRecommendationV4Response getGatewayRecommendation() {
+        return gatewayRecommendation;
     }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/connector/responses/GatewayRecommendationV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/connector/responses/GatewayRecommendationV4Response.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses;
+
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.JsonEntity;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GatewayRecommendationV4Response implements JsonEntity {
+
+    private Set<String> hostGroups;
+
+    public GatewayRecommendationV4Response(Set<String> hostGroups) {
+        this.hostGroups = hostGroups;
+    }
+
+    public Set<String> getHostGroups() {
+        return hostGroups;
+    }
+
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/connector/responses/InstanceCountV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/connector/responses/InstanceCountV4Response.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.JsonEntity;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class InstanceCountV4Response implements JsonEntity {
+
+    private Integer minimumCount;
+
+    private Integer maximumCount;
+
+    public InstanceCountV4Response(Integer minimumCount, Integer maximumCount) {
+        this.minimumCount = minimumCount;
+        this.maximumCount = maximumCount;
+    }
+
+    public Integer getMinimumCount() {
+        return minimumCount;
+    }
+
+    public Integer getMaximumCount() {
+        return maximumCount;
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/clustertemplate/PlatformRecommendationToPlatformRecommendationV4ResponseConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/clustertemplate/PlatformRecommendationToPlatformRecommendationV4ResponseConverter.java
@@ -5,12 +5,15 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.blueprint.responses.RecommendationV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses.DiskV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses.GatewayRecommendationV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses.InstanceCountV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.VmTypeV4Response;
 import com.sequenceiq.cloudbreak.cloud.model.DiskType;
 import com.sequenceiq.cloudbreak.cloud.model.DisplayName;
@@ -42,6 +45,17 @@ public class PlatformRecommendationToPlatformRecommendationV4ResponseConverter
                 }
             }
         }
-        return new RecommendationV4Response(result, vmTypes, diskResponses);
+
+        Map<String, InstanceCountV4Response> instanceCounts = new TreeMap<>();
+        source.getInstanceCounts().forEach((hostGroupName, instanceCount) ->
+                instanceCounts.put(hostGroupName, new InstanceCountV4Response(
+                        instanceCount.getMinimumCount(),
+                        instanceCount.getMaximumCount()
+                ))
+        );
+
+        GatewayRecommendationV4Response gateway = new GatewayRecommendationV4Response(source.getGatewayRecommendation().getHostGroups());
+
+        return new RecommendationV4Response(result, vmTypes, diskResponses, instanceCounts, gateway);
     }
 }

--- a/template-manager-blueprint/src/test/resources/blueprints-jackson/test-bp-cardinality.bp
+++ b/template-manager-blueprint/src/test/resources/blueprints-jackson/test-bp-cardinality.bp
@@ -1,0 +1,38 @@
+{
+  "host_groups": [
+    {
+      "name": "master",
+      "components": [ ],
+      "cardinality": "2"
+    },
+    {
+      "name": "worker",
+      "components": [ ],
+      "cardinality": "3+"
+    },
+    {
+      "name": "compute",
+      "components": [ ],
+      "cardinality": "0+"
+    },
+    {
+      "name": "gateway",
+      "components": [ ],
+      "cardinality": "0-1"
+    },
+    {
+      "name": "no_cardinality",
+      "components": [ ]
+    },
+    {
+      "name": "invalid_cardinality",
+      "components": [ ],
+      "cardinality": "123asdf"
+    }
+  ],
+  "Blueprints": {
+    "blueprint_name": "multi-node-hdfs-yarn",
+    "stack_name": "HDP",
+    "stack_version": "2.3"
+  }
+}

--- a/template-manager-blueprint/src/test/resources/blueprints-jackson/test-bp-gateway.bp
+++ b/template-manager-blueprint/src/test/resources/blueprints-jackson/test-bp-gateway.bp
@@ -1,0 +1,24 @@
+{
+  "host_groups": [
+    {
+      "name": "master",
+      "components": [ { "name": "AMBARI_SERVER" } ],
+      "cardinality": "2"
+    },
+    {
+      "name": "worker",
+      "components": [ ],
+      "cardinality": "3+"
+    },
+    {
+      "name": "compute",
+      "components": [ ],
+      "cardinality": "0+"
+    }
+  ],
+  "Blueprints": {
+    "blueprint_name": "multi-node-hdfs-yarn",
+    "stack_name": "HDP",
+    "stack_version": "2.3"
+  }
+}

--- a/template-manager-cmtemplate/src/test/resources/input/namenode-ha-no-gateway.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/namenode-ha-no-gateway.bp
@@ -1,0 +1,81 @@
+{
+  "cdhVersion": "6.1.0",
+  "displayName": "simple_template",
+  "cmVersion": "6.1.0",
+  "repositories": [
+    "https://archive.cloudera.com/cdh6/{latest_supported}/parcels/"
+  ],
+  "products": [
+    {
+      "version": "6.1.0-1.cdh6.1.0.p0.770702",
+      "product": "CDH"
+    }
+  ],
+  "services": [
+    {
+      "refName": "zookeeper",
+      "serviceType": "ZOOKEEPER",
+      "roleConfigGroups": [
+        {
+          "refName": "zookeeper-SERVER-BASE",
+          "roleType": "SERVER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "hdfs",
+      "serviceType": "HDFS",
+      "roleConfigGroups": [
+        {
+          "refName": "hdfs-NAMENODE-BASE",
+          "roleType": "NAMENODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-DATANODE-BASE",
+          "roleType": "DATANODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-JOURNALNODE-BASE",
+          "roleType": "JOURNALNODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-FAILOVERCONTROLLER-BASE",
+          "roleType": "FAILOVERCONTROLLER",
+          "base": true
+        },
+        {
+          "refName": "hdfs-BALANCER-BASE",
+          "roleType": "BALANCER",
+          "base": true
+        }
+      ]
+    }
+  ],
+  "hostTemplates": [
+    {
+      "refName": "master",
+      "cardinality": 2,
+      "roleConfigGroupsRefNames": [
+        "hdfs-NAMENODE-BASE"
+      ]
+    },
+    {
+      "refName": "quorum",
+      "cardinality": 3,
+      "roleConfigGroupsRefNames": [
+        "zookeeper-SERVER-BASE"
+      ]
+    },
+    {
+      "refName": "worker",
+      "cardinality": 3,
+      "roleConfigGroupsRefNames": [
+        "hdfs-DATANODE-BASE"
+      ]
+    }
+  ]
+}

--- a/template-manager-cmtemplate/src/test/resources/input/namenode-ha-single-worker.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/namenode-ha-single-worker.bp
@@ -1,0 +1,81 @@
+{
+  "cdhVersion": "6.1.0",
+  "displayName": "simple_template",
+  "cmVersion": "6.1.0",
+  "repositories": [
+    "https://archive.cloudera.com/cdh6/{latest_supported}/parcels/"
+  ],
+  "products": [
+    {
+      "version": "6.1.0-1.cdh6.1.0.p0.770702",
+      "product": "CDH"
+    }
+  ],
+  "services": [
+    {
+      "refName": "zookeeper",
+      "serviceType": "ZOOKEEPER",
+      "roleConfigGroups": [
+        {
+          "refName": "zookeeper-SERVER-BASE",
+          "roleType": "SERVER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "hdfs",
+      "serviceType": "HDFS",
+      "roleConfigGroups": [
+        {
+          "refName": "hdfs-NAMENODE-BASE",
+          "roleType": "NAMENODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-DATANODE-BASE",
+          "roleType": "DATANODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-JOURNALNODE-BASE",
+          "roleType": "JOURNALNODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-FAILOVERCONTROLLER-BASE",
+          "roleType": "FAILOVERCONTROLLER",
+          "base": true
+        },
+        {
+          "refName": "hdfs-BALANCER-BASE",
+          "roleType": "BALANCER",
+          "base": true
+        }
+      ]
+    }
+  ],
+  "hostTemplates": [
+    {
+      "refName": "master",
+      "cardinality": 2,
+      "roleConfigGroupsRefNames": [
+        "hdfs-NAMENODE-BASE"
+      ]
+    },
+    {
+      "refName": "quorum",
+      "cardinality": 3,
+      "roleConfigGroupsRefNames": [
+        "zookeeper-SERVER-BASE"
+      ]
+    },
+    {
+      "refName": "worker",
+      "cardinality": 1,
+      "roleConfigGroupsRefNames": [
+        "hdfs-DATANODE-BASE"
+      ]
+    }
+  ]
+}

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/processor/BlueprintTextProcessor.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/processor/BlueprintTextProcessor.java
@@ -5,6 +5,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import com.sequenceiq.cloudbreak.cloud.model.GatewayRecommendation;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceCount;
 import com.sequenceiq.cloudbreak.template.processor.configuration.HostgroupConfigurations;
 import com.sequenceiq.cloudbreak.template.processor.configuration.SiteConfigurations;
 
@@ -33,4 +35,7 @@ public interface BlueprintTextProcessor {
 
     Set<String> getComponentsInHostGroup(String name);
 
+    Map<String, InstanceCount> getCardinalityByHostGroup();
+
+    GatewayRecommendation recommendGateway();
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add two new structures to the response of `/blueprints_util/recommendation` V4 endpoint:

1. `instanceCounts`: minimum and maximum number of hosts for each host group
2. `gatewayRecommendation`: set of host groups where the cluster manager server should be installed

Example:

```
{
  ...
  "instanceCounts": {
    "compute": {
      "minimumCount": 0,
      "maximumCount": 2147483647
    },
    "gateway": {
      "minimumCount": 1,
      "maximumCount": 1
    },
    "master": {
      "minimumCount": 2,
      "maximumCount": 2
    },
    "quorum": {
      "minimumCount": 3,
      "maximumCount": 2147483647
    },
    "worker": {
      "minimumCount": 1,
      "maximumCount": 2147483647
    }
  },
  "gatewayRecommendation": {
    "hostGroups": [
      "gateway"
    ]
  }
}
```

These are filled based on the following:

### Cardinality

1. Ambari: the following types of cardinality specification are handled in blueprints:
 * `N` ("exactly N")
 * `N+` ("at least N")
 * `N-M` ("between N and M")
2. CM: cluster templates can have a single numeric cardinality for each host group, which cannot describe ranges.  Thus the following rule of thumb is followed: cardinality `N` is translated to `N+` for most groups, except for `master*` and `gateway*` groups, for which `N` is considered "exactly N".
3. fallback: if cardinality is not specified, `1+` is assumed, except for `*compute*` host group, for which the default is `0+`.

### Gateway groups

1. Ambari: blueprint can explicitly include `AMBARI_SERVER` component in host groups.  These are the source of gateway group recommendations for Ambari.
2. CM: `gateway` or `master` host groups are recommended for CM server, but only if they have cardinality `1`.  Otherwise the first `1+` group is recommended.
3. fallback: `*master*` and `*gateway*` groups are recommended

## How was this patch tested?

New unit test cases.  Manually tested API requests.