### PR TITLE
CB-1006 Small enhancements for CM conf provider var handling & testing

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/AbstractRoleConfigConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/AbstractRoleConfigConfigProvider.java
@@ -52,7 +52,7 @@ public abstract class AbstractRoleConfigConfigProvider implements CmTemplateComp
                     for (String roleType : getRoleTypes()) {
                         Optional<String> roleRefOpt = findRoleRef(cmTemplate.getTemplate(), hostTemplate, roleType);
                         if (roleRefOpt.isPresent()) {
-                            result.addAll(getVariables(roleType, hostGroupView, templatePreparationObject));
+                            result.addAll(getRoleConfigVariable(roleType, hostGroupView, templatePreparationObject));
                         }
                     }
                 }
@@ -97,7 +97,7 @@ public abstract class AbstractRoleConfigConfigProvider implements CmTemplateComp
 
     protected abstract List<ApiClusterTemplateConfig> getRoleConfig(String roleType, HostgroupView hostGroupView, TemplatePreparationObject source);
 
-    protected List<ApiClusterTemplateVariable> getVariables(String roleType, HostgroupView hostgroupView, TemplatePreparationObject source) {
+    protected List<ApiClusterTemplateVariable> getRoleConfigVariable(String roleType, HostgroupView hostgroupView, TemplatePreparationObject source) {
         return List.of();
     }
 

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ConfigUtils.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ConfigUtils.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.cmtemplate.configproviders;
 import java.util.Optional;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.cloudera.api.swagger.model.ApiClusterTemplateVariable;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
@@ -22,9 +23,32 @@ public class ConfigUtils {
         return new ApiClusterTemplateConfig().name(name).value(value);
     }
 
+    /**
+     * Convenience method for creating an {@link ApiClusterTemplateConfig} with a variable.
+     *
+     * @param name config name
+     * @param variable config variable
+     * @return config object
+     */
+    public static ApiClusterTemplateConfig configVar(String name, String variable) {
+        return new ApiClusterTemplateConfig().name(name).variable(variable);
+    }
+
+    /**
+     * Convenience method for creating an {@link ApiClusterTemplateVariable}.
+     *
+     * @param name variable name
+     * @param value variable value
+     * @return variable object
+     */
+    public static ApiClusterTemplateVariable variable(String name, String value) {
+        return new ApiClusterTemplateVariable().name(name).value(value);
+    }
+
     public static Optional<RDSConfig> getFirstRDSConfigOptional(TemplatePreparationObject source, DatabaseType databaseType) {
         return source.getRdsConfigs().stream()
                 .filter(rds -> databaseType.name().equalsIgnoreCase(rds.getType()))
                 .findFirst();
     }
+
 }

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ConfigTestUtil.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ConfigTestUtil.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders;
+
+import static java.util.stream.Collectors.toMap;
+
+import java.util.List;
+import java.util.Map;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.cloudera.api.swagger.model.ApiClusterTemplateVariable;
+
+public class ConfigTestUtil {
+
+    private ConfigTestUtil() {
+
+    }
+
+    public static Map<String, String> getConfigNameToValueMap(List<ApiClusterTemplateConfig> configs) {
+        return configs.stream().filter(config -> config.getValue() != null)
+                .collect(toMap(ApiClusterTemplateConfig::getName, ApiClusterTemplateConfig::getValue));
+    }
+
+    public static Map<String, String> getConfigNameToVariableNameMap(List<ApiClusterTemplateConfig> configs) {
+        return configs.stream().filter(config -> config.getVariable() != null)
+                .collect(toMap(ApiClusterTemplateConfig::getName, ApiClusterTemplateConfig::getVariable));
+    }
+
+    public static Map<String, String> getVariableNameToValueMap(List<ApiClusterTemplateVariable> variables) {
+        return variables.stream().collect(toMap(ApiClusterTemplateVariable::getName, ApiClusterTemplateVariable::getValue));
+    }
+
+}

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/impala/ImpalaLdapConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/impala/ImpalaLdapConfigProviderTest.java
@@ -3,6 +3,9 @@ package com.sequenceiq.cloudbreak.cmtemplate.configproviders.impala;
 import static com.sequenceiq.cloudbreak.TestUtil.kerberosConfigFreeipa;
 import static com.sequenceiq.cloudbreak.TestUtil.kerberosConfigMit;
 import static com.sequenceiq.cloudbreak.TestUtil.ldapConfig;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigTestUtil.getConfigNameToValueMap;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigTestUtil.getConfigNameToVariableNameMap;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigTestUtil.getVariableNameToValueMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -11,7 +14,6 @@ import static org.mockito.Mockito.when;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -255,20 +257,6 @@ public class ImpalaLdapConfigProviderTest {
 
         boolean result = underTest.isConfigurationNeeded(templateProcessor, tpo);
         assertThat(result).isFalse();
-    }
-
-    private Map<String, String> getConfigNameToValueMap(List<ApiClusterTemplateConfig> configs) {
-        return configs.stream().filter(config -> config.getValue() != null)
-                .collect(Collectors.toMap(ApiClusterTemplateConfig::getName, ApiClusterTemplateConfig::getValue));
-    }
-
-    private Map<String, String> getConfigNameToVariableNameMap(List<ApiClusterTemplateConfig> configs) {
-        return configs.stream().filter(config -> config.getVariable() != null)
-                .collect(Collectors.toMap(ApiClusterTemplateConfig::getName, ApiClusterTemplateConfig::getVariable));
-    }
-
-    private Map<String, String> getVariableNameToValueMap(List<ApiClusterTemplateVariable> variables) {
-        return variables.stream().collect(Collectors.toMap(ApiClusterTemplateVariable::getName, ApiClusterTemplateVariable::getValue));
     }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Rename `AbstractRoleConfigConfigProvider.getVariables()` to `getRoleConfigVariable()`
  * Named by analogy of its counterpart `getRoleConfig()`
* Extend `ConfigUtils` with two additional convenience factory methods: `configVar()` and `variable()`
  * Will come handy when setting configs as variables as opposed to direct values
* Extract `Map` building logic from `ImpalaLdapConfigProviderTest` into the new `ConfigTestUtil`
  * Encourages code-reuse among similar unit tests

## How was this patch tested?

Adjusted unit tests.
