### PR TITLE
DISTX-112. Update user sync API

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/test/ClientTestV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/test/ClientTestV1Endpoint.java
@@ -19,6 +19,6 @@ public interface ClientTestV1Endpoint {
     @GET
     @Path("{id}/{name}")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Creates FreeIPA instance", produces = ContentType.JSON, nickname = "userShowV1")
+    @ApiOperation(value = "Retrieves user information", produces = ContentType.JSON, nickname = "userShowV1")
     String userShow(@PathParam("id") Long id, @PathParam("name") String name);
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/UserV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/UserV1Endpoint.java
@@ -6,14 +6,17 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
-import com.sequenceiq.freeipa.api.v1.freeipa.user.doc.UsersyncOperationDescriptions;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.doc.UserNotes;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.doc.UserOperationDescriptions;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.CreateUsersRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.CreateUsersResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SetPasswordRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SetPasswordResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeUsersRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeUsersResponse;
-import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeUsersStatus;
 import com.sequenceiq.service.api.doc.ContentType;
 
 import io.swagger.annotations.Api;
@@ -26,18 +29,24 @@ public interface UserV1Endpoint {
     @POST
     @Path("sync")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = UsersyncOperationDescriptions.SYNC, produces = ContentType.JSON, nickname = "synchronizeUsersV1")
+    @ApiOperation(value = UserOperationDescriptions.SYNC, notes = UserNotes.USER_NOTES, produces = ContentType.JSON, nickname = "synchronizeUsersV1")
     SynchronizeUsersResponse synchronizeUsers(SynchronizeUsersRequest request);
 
     @GET
     @Path("sync")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Get status of latest synchronization", produces = ContentType.JSON, nickname = "getSyncUsersStatusV1")
-    SynchronizeUsersStatus getStatus();
+    @ApiOperation(value = UserOperationDescriptions.SYNC_STATUS, notes = UserNotes.USER_NOTES, produces = ContentType.JSON, nickname = "getSyncUsersStatusV1")
+    SynchronizeUsersResponse getStatus(@QueryParam("id") String syncId);
 
     @POST
     @Path("/{username}/password")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = UsersyncOperationDescriptions.SET_PASSWORD, produces = ContentType.JSON, nickname = "setPasswordV1")
+    @ApiOperation(value = UserOperationDescriptions.SET_PASSWORD, notes = UserNotes.USER_NOTES, produces = ContentType.JSON, nickname = "setPasswordV1")
     SetPasswordResponse setPassword(@PathParam("username") String username, SetPasswordRequest request);
+
+    @POST
+    @Path("create")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = UserOperationDescriptions.CREATE, notes = UserNotes.USER_NOTES, produces = ContentType.JSON, nickname = "createUsersV1")
+    CreateUsersResponse createUsers(CreateUsersRequest request);
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/doc/UserModelDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/doc/UserModelDescriptions.java
@@ -2,16 +2,22 @@ package com.sequenceiq.freeipa.api.v1.freeipa.user.doc;
 
 public class UserModelDescriptions {
 
-    public static final String USERSYNC_GROUPS = "groups to sync";
-    public static final String USERSYNC_USERS = "users to sync";
-    public static final String GROUP_NAME = "name of the group";
+    public static final String USERSYNC_ENVIRONMENTS = "Optional environments to sync";
+    public static final String USERSYNC_USERS = "Optional users to sync";
+    public static final String USERSYNC_ID = "User synchronization operation id";
+    public static final String USERSYNC_STATUS = "User synchronization operation status";
+    public static final String USERSYNC_STARTTIME = "User synchronization operation start time";
+    public static final String USERSYNC_ENDTIME = "User synchronization operation end time";
     public static final String USER_NAME = "name of the user";
+    public static final String SUCCESS_ENVIRONMENTNAME = "environment names where operation succeeded";
+    public static final String FAILURE_ENVIRONMENTNAME = "environment names where operation failed";
+    public static final String USERCREATE_GROUPS = "groups to create";
+    public static final String USERCREATE_USERS = "users to create";
+    public static final String GROUP_NAME = "name of the group";
     public static final String USER_FIRSTNAME = "first name of the user";
     public static final String USER_LASTNAME = "last name of the user";
     public static final String USER_PASSWORD = "the user's password";
     public static final String USER_GROUPS = "the user's groups";
-    public static final String SUCCESS_ENVIRONMENTNAME = "environment names where operation succeeded";
-    public static final String FAILURE_ENVIRONMENTNAME = "environment names where operation failed";
 
     private UserModelDescriptions() {
     }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/doc/UserNotes.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/doc/UserNotes.java
@@ -1,0 +1,8 @@
+package com.sequenceiq.freeipa.api.v1.freeipa.user.doc;
+
+public class UserNotes {
+    public static final String USER_NOTES = "User synchronization and management operations";
+
+    private UserNotes() {
+    }
+}

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/doc/UserOperationDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/doc/UserOperationDescriptions.java
@@ -1,0 +1,11 @@
+package com.sequenceiq.freeipa.api.v1.freeipa.user.doc;
+
+public final class UserOperationDescriptions {
+    public static final String SYNC = "Synchronizes Groups and Users to the FreeIPA servers";
+    public static final String SYNC_STATUS = "Gets the status of synchronization operation";
+    public static final String SET_PASSWORD = "Sets the user's password in the FreeIPA servers";
+    public static final String CREATE = "Creates Groups and Users in the FreeIPA servers";
+
+    private UserOperationDescriptions() {
+    }
+}

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/doc/UsersyncOperationDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/doc/UsersyncOperationDescriptions.java
@@ -1,9 +1,0 @@
-package com.sequenceiq.freeipa.api.v1.freeipa.user.doc;
-
-public final class UsersyncOperationDescriptions {
-    public static final String SYNC = "Synchronizes Groups and Users to the FreeIPA servers";
-    public static final String SET_PASSWORD = "Sets the user's password in the FreeIPA servers";
-
-    private UsersyncOperationDescriptions() {
-    }
-}

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/CreateUsersRequest.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/CreateUsersRequest.java
@@ -1,0 +1,39 @@
+package com.sequenceiq.freeipa.api.v1.freeipa.user.model;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.doc.FreeIpaModelDescriptions;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.doc.UserModelDescriptions;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel("CreateUsersV1Request")
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CreateUsersRequest {
+    @NotNull
+    @ApiModelProperty(value = FreeIpaModelDescriptions.ENVIRONMENT_ID, required = true)
+    private String environmentId;
+
+    @ApiModelProperty(value = UserModelDescriptions.USERCREATE_GROUPS)
+    private Set<Group> groups = new HashSet<>();
+
+    @ApiModelProperty(value = UserModelDescriptions.USERCREATE_USERS)
+    private Set<User> users = new HashSet<>();
+
+    public String getEnvironmentId() {
+        return environmentId;
+    }
+
+    public Set<Group> getGroups() {
+        return groups;
+    }
+
+    public Set<User> getUsers() {
+        return users;
+    }
+}

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/CreateUsersResponse.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/CreateUsersResponse.java
@@ -6,12 +6,12 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import io.swagger.annotations.ApiModel;
 
-@ApiModel("SynchronizeUsersV1Status")
+@ApiModel("CreateUsersV1Response")
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class SynchronizeUsersStatus {
+public class CreateUsersResponse {
     private final String value;
 
-    public SynchronizeUsersStatus(String value) {
+    public CreateUsersResponse(String value) {
         this.value = requireNonNull(value);
     }
 

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SynchronizationStatus.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SynchronizationStatus.java
@@ -1,0 +1,5 @@
+package com.sequenceiq.freeipa.api.v1.freeipa.user.model;
+
+public enum SynchronizationStatus {
+    RUNNING, COMPLETED, FAILED
+}

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SynchronizeUsersRequest.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SynchronizeUsersRequest.java
@@ -3,10 +3,7 @@ package com.sequenceiq.freeipa.api.v1.freeipa.user.model;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.validation.constraints.NotNull;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.doc.FreeIpaModelDescriptions;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.doc.UserModelDescriptions;
 
 import io.swagger.annotations.ApiModel;
@@ -15,36 +12,17 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel("SynchronizeUsersV1Request")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SynchronizeUsersRequest {
-    @NotNull
-    @ApiModelProperty(value = FreeIpaModelDescriptions.ENVIRONMENT_ID, required = true)
-    private String environmentName;
-
-    // TODO: figure out whether we need a separate name since we are expecting one freeipa per environment.
-    // We currently retrieve stacks from the repository by environment and name and then
-    // get the freeipa from the stack.
-    @NotNull
-    @ApiModelProperty(value = FreeIpaModelDescriptions.FREEIPA_NAME, required = true)
-    private String name;
-
-    @ApiModelProperty(value = UserModelDescriptions.USERSYNC_GROUPS)
-    private Set<Group> groups = new HashSet<>();
+    @ApiModelProperty(value = UserModelDescriptions.USERSYNC_ENVIRONMENTS)
+    private Set<String> environments = new HashSet<>();
 
     @ApiModelProperty(value = UserModelDescriptions.USERSYNC_USERS)
-    private Set<User> users = new HashSet<>();
+    private Set<String> users = new HashSet<>();
 
-    public String getEnvironmentName() {
-        return environmentName;
+    public Set<String> getEnvironments() {
+        return environments;
     }
 
-    public String getName() {
-        return name;
-    }
-
-    public Set<Group> getGroups() {
-        return groups;
-    }
-
-    public Set<User> getUsers() {
+    public Set<String> getUsers() {
         return users;
     }
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SynchronizeUsersResponse.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SynchronizeUsersResponse.java
@@ -3,19 +3,46 @@ package com.sequenceiq.freeipa.api.v1.freeipa.user.model;
 import static java.util.Objects.requireNonNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.doc.UserModelDescriptions;
 
 import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 
 @ApiModel("SynchronizeUsersV1Response")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SynchronizeUsersResponse {
-    private final String value;
+    @ApiModelProperty(value = UserModelDescriptions.USERSYNC_ID, required = true)
+    private final String id;
 
-    public SynchronizeUsersResponse(String value) {
-        this.value = requireNonNull(value);
+    @ApiModelProperty(value = UserModelDescriptions.USERSYNC_STATUS, required = true)
+    private final SynchronizationStatus status;
+
+    @ApiModelProperty(value = UserModelDescriptions.USERSYNC_STARTTIME)
+    private final String startTime;
+
+    @ApiModelProperty(value = UserModelDescriptions.USERSYNC_ENDTIME)
+    private final String endTime;
+
+    public SynchronizeUsersResponse(String id, SynchronizationStatus status, String startTime, String endTime) {
+        this.id = requireNonNull(id);
+        this.status = requireNonNull(status);
+        this.startTime = startTime;
+        this.endTime = endTime;
     }
 
-    public String getValue() {
-        return value;
+    public String getId() {
+        return id;
+    }
+
+    public SynchronizationStatus getStatus() {
+        return status;
+    }
+
+    public String getStartTime() {
+        return startTime;
+    }
+
+    public String getEndTime() {
+        return endTime;
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/UserV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/UserV1Controller.java
@@ -7,11 +7,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
 
 import com.sequenceiq.freeipa.api.v1.freeipa.user.UserV1Endpoint;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.CreateUsersRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.CreateUsersResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SetPasswordRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SetPasswordResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeUsersRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeUsersResponse;
-import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeUsersStatus;
 import com.sequenceiq.freeipa.service.user.PasswordService;
 import com.sequenceiq.freeipa.service.user.UserService;
 
@@ -28,31 +29,30 @@ public class UserV1Controller implements UserV1Endpoint {
 
     @Override
     public SynchronizeUsersResponse synchronizeUsers(SynchronizeUsersRequest request) {
-        LOGGER.info("synchronizeUsers() request = {}", request);
-
-        String accountId = "test_account";
-        try {
-            userService.synchronizeUsers(accountId, request);
-        } catch (Exception e) {
-            LOGGER.error("Failed to synchronizeUsers()", e);
-            throw new RuntimeException(e);
-        }
-
-        return new SynchronizeUsersResponse("Hello synchronizeUsers()!");
+        return userService.synchronizeUsers(request);
     }
 
     @Override
-    public SynchronizeUsersStatus getStatus() {
-        LOGGER.info("getStatus()");
-        return new SynchronizeUsersStatus("Hello getStatus()!");
+    public SynchronizeUsersResponse getStatus(String syncId) {
+        return userService.getSynchronizeUsersStatus(syncId);
     }
 
     @Override
     public SetPasswordResponse setPassword(String username, SetPasswordRequest request) {
-        LOGGER.info("setPassword() requested for user {}", username);
+        LOGGER.debug("setPassword() requested for user {}", username);
 
-        String accountId = "test_account";
+        return passwordService.setPassword(username, request.getPassword());
+    }
 
-        return passwordService.setPassword(accountId, username, request.getPassword());
+    @Override
+    public CreateUsersResponse createUsers(CreateUsersRequest request) {
+        try {
+            userService.createUsers(request);
+        } catch (Exception e) {
+            LOGGER.error("Failed to create users", e);
+            throw new RuntimeException(e);
+        }
+
+        return new CreateUsersResponse("Hello createUsers()!");
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/PasswordService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/PasswordService.java
@@ -16,6 +16,7 @@ import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.flow.freeipa.user.event.SetPasswordRequest;
 import com.sequenceiq.freeipa.flow.freeipa.user.event.SetPasswordResult;
 import com.sequenceiq.freeipa.service.stack.StackService;
+import com.sequenceiq.freeipa.util.UserCrnService;
 
 import reactor.bus.Event;
 import reactor.bus.EventBus;
@@ -31,7 +32,12 @@ public class PasswordService {
     @Inject
     private EventBus eventBus;
 
-    public SetPasswordResponse setPassword(String accountId, String username, String password) {
+    @Inject
+    private UserCrnService userCrnService;
+
+    public SetPasswordResponse setPassword(String username, String password) {
+        String accountId = userCrnService.getCurrentAccountId();
+
         LOGGER.debug("setting password for user {} in account {}", username, accountId);
 
         List<Stack> stacks = stackService.getAllByAccountId(accountId);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/UserService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/UserService.java
@@ -12,8 +12,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.CreateUsersRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.Group;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizationStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeUsersRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeUsersResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.User;
 import com.sequenceiq.freeipa.client.FreeIpaClient;
 import com.sequenceiq.freeipa.client.FreeIpaClientException;
@@ -33,10 +36,20 @@ public class UserService {
     @Inject
     private FreeIpaClientFactory freeIpaClientFactory;
 
-    public void synchronizeUsers(String accountId, SynchronizeUsersRequest request) throws Exception {
+    public SynchronizeUsersResponse synchronizeUsers(SynchronizeUsersRequest request) {
+        return new SynchronizeUsersResponse(UUID.randomUUID().toString(), SynchronizationStatus.FAILED,
+                null, null);
+    }
+
+    public SynchronizeUsersResponse getSynchronizeUsersStatus(String syncId) {
+        return new SynchronizeUsersResponse(syncId, SynchronizationStatus.FAILED,
+                null, null);
+    }
+
+    public void createUsers(CreateUsersRequest request) throws Exception {
         LOGGER.info("UserService.synchronizeUsers() called");
 
-        Stack stack = stackService.getByAccountIdEnvironmentAndName(accountId, request.getEnvironmentName(), request.getName());
+        Stack stack = stackService.getByEnvironmentCrn(request.getEnvironmentId());
 
         FreeIpaClient freeIpaClient = freeIpaClientFactory.getFreeIpaClientForStack(stack);
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/controller/UserV1ControllerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/controller/UserV1ControllerTest.java
@@ -1,0 +1,70 @@
+package com.sequenceiq.freeipa.controller;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.CreateUsersRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SetPasswordRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeUsersRequest;
+import com.sequenceiq.freeipa.service.user.PasswordService;
+import com.sequenceiq.freeipa.service.user.UserService;
+
+@ExtendWith(MockitoExtension.class)
+public class UserV1ControllerTest {
+
+    @InjectMocks
+    private UserV1Controller underTest;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private PasswordService passwordService;
+
+    @Test
+    void synchronizeUsers() {
+        SynchronizeUsersRequest request = mock(SynchronizeUsersRequest.class);
+
+        underTest.synchronizeUsers(request);
+
+        verify(userService, times(1)).synchronizeUsers(request);
+    }
+
+    @Test
+    void getStatus() {
+        String syncId = "testId";
+
+        underTest.getStatus(syncId);
+
+        verify(userService, times(1)).getSynchronizeUsersStatus(syncId);
+    }
+
+    @Test
+    void setPassword() {
+        String username = "username";
+        String password = "password";
+        SetPasswordRequest request = mock(SetPasswordRequest.class);
+        when(request.getPassword()).thenReturn(password);
+
+        underTest.setPassword(username, request);
+
+        verify(passwordService, times(1)).setPassword(username, password);
+    }
+
+    @Test
+    void createUsers() throws Exception {
+        CreateUsersRequest request = mock(CreateUsersRequest.class);
+
+        underTest.createUsers(request);
+
+        verify(userService, times(1)).createUsers(request);
+    }
+}


### PR DESCRIPTION
The existing user sync API has been moved to "create". This will
be left in place until the user sync API work is completed.

The user sync API has been changed to accept an optional set of
environments and users in anticipation of retrieving users from
the UMS instead of passing them in through the API. The environments
and users in the request will be used to narrow the scope of the
sync. e.g., if we want to sync only one environment or one user.

Minor improvements were made to API documentation and testing.
