### PR TITLE
CB-1612. Enable process auto-restart by default

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CentralCmTemplateUpdater.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CentralCmTemplateUpdater.java
@@ -37,6 +37,9 @@ public class CentralCmTemplateUpdater implements BlueprintUpdater {
     @Inject
     private CmTemplateComponentConfigProcessor cmTemplateComponentConfigProcessor;
 
+    @Inject
+    private CmTemplateConfigInjectors cmTemplateConfigInjectors;
+
     public ApiClusterTemplate getCmTemplate(TemplatePreparationObject source, Map<String, List<Map<String, String>>> hostGroupMappings,
             ClouderaManagerRepo clouderaManagerRepoDetails, List<ClouderaManagerProduct> clouderaManagerProductDetails, String sdxContextName) {
         try {
@@ -74,6 +77,7 @@ public class CentralCmTemplateUpdater implements BlueprintUpdater {
         processor.addInstantiator(clouderaManagerRepoDetails, source, sdxContextName);
         processor.addHosts(hostGroupMappings);
         cmTemplateComponentConfigProcessor.process(processor, source);
+        cmTemplateConfigInjectors.process(processor, source);
     }
 
     private void updateCmTemplateRepoDetails(CmTemplateProcessor cmTemplateProcessor, ClouderaManagerRepo clouderaManagerRepoDetails,

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateConfigInjector.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateConfigInjector.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.cloudbreak.cmtemplate;
+
+import java.util.List;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.cloudera.api.swagger.model.ApiClusterTemplateRoleConfigGroup;
+import com.cloudera.api.swagger.model.ApiClusterTemplateService;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+
+public interface CmTemplateConfigInjector {
+
+    default List<ApiClusterTemplateConfig> getServiceConfigs(
+            ApiClusterTemplateService service,
+            TemplatePreparationObject source
+    ) {
+        return List.of();
+    }
+
+    default List<ApiClusterTemplateConfig> getRoleConfigs(
+            ApiClusterTemplateRoleConfigGroup roleConfigGroup,
+            ApiClusterTemplateService service,
+            TemplatePreparationObject source
+    ) {
+        return List.of();
+    }
+
+    default void addServiceConfigs(
+            ApiClusterTemplateService service,
+            CmTemplateProcessor processor,
+            TemplatePreparationObject source
+    ) {
+        processor.mergeServiceConfigs(service, getServiceConfigs(service, source));
+    }
+
+    default void addRoleConfigs(
+            ApiClusterTemplateRoleConfigGroup roleConfigGroup,
+            ApiClusterTemplateService service,
+            CmTemplateProcessor processor,
+            TemplatePreparationObject source
+    ) {
+        processor.mergeRoleConfigs(roleConfigGroup, getRoleConfigs(roleConfigGroup, service, source));
+    }
+
+}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateConfigInjectors.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateConfigInjectors.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.cloudbreak.cmtemplate;
+
+import static java.util.Optional.ofNullable;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateRoleConfigGroup;
+import com.cloudera.api.swagger.model.ApiClusterTemplateService;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+
+@Component
+public class CmTemplateConfigInjectors {
+
+    @Inject
+    private List<CmTemplateConfigInjector> injectors;
+
+    public void process(CmTemplateProcessor processor, TemplatePreparationObject source) {
+        List<ApiClusterTemplateService> services = ofNullable(processor.getTemplate().getServices()).orElse(List.of());
+        for (CmTemplateConfigInjector injector : injectors) {
+            for (ApiClusterTemplateService service : services) {
+                injector.addServiceConfigs(service, processor, source);
+
+                Iterable<ApiClusterTemplateRoleConfigGroup> roleConfigGroups = ofNullable(service.getRoleConfigGroups()).orElse(List.of());
+                for (ApiClusterTemplateRoleConfigGroup roleConfigGroup : roleConfigGroups) {
+                    injector.addRoleConfigs(roleConfigGroup, service, processor, source);
+                }
+            }
+        }
+    }
+
+}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessor.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessor.java
@@ -205,14 +205,18 @@ public class CmTemplateProcessor implements BlueprintTextProcessor {
         getServiceByType(serviceType).ifPresent(service -> mergeServiceConfigs(service, configs));
     }
 
-    private void mergeServiceConfigs(ApiClusterTemplateService service, List<ApiClusterTemplateConfig> configs) {
+    public void mergeServiceConfigs(ApiClusterTemplateService service, List<ApiClusterTemplateConfig> newConfigs) {
+        if (newConfigs.isEmpty()) {
+            return;
+        }
+
         if (ofNullable(service.getServiceConfigs()).orElse(List.of()).isEmpty()) {
-            setServiceConfigs(service, configs);
+            setServiceConfigs(service, newConfigs);
             return;
         }
 
         Map<String, ApiClusterTemplateConfig> configMap = mapByName(service.getServiceConfigs());
-        configs.forEach(config -> configMap.putIfAbsent(config.getName(), config));
+        newConfigs.forEach(config -> configMap.putIfAbsent(config.getName(), config));
         setServiceConfigs(service, configMap.values());
     }
 
@@ -241,7 +245,11 @@ public class CmTemplateProcessor implements BlueprintTextProcessor {
         }
     }
 
-    private void mergeRoleConfigs(ApiClusterTemplateRoleConfigGroup configGroup, List<ApiClusterTemplateConfig> newConfigs) {
+    public void mergeRoleConfigs(ApiClusterTemplateRoleConfigGroup configGroup, List<ApiClusterTemplateConfig> newConfigs) {
+        if (newConfigs.isEmpty()) {
+            return;
+        }
+
         if (ofNullable(configGroup.getConfigs()).orElse(List.of()).isEmpty()) {
             setRoleConfigs(configGroup, newConfigs);
             return;

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ProcessAutoRestartInjector.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ProcessAutoRestartInjector.java
@@ -1,0 +1,57 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.stereotype.Component;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.cloudera.api.swagger.model.ApiClusterTemplateRoleConfigGroup;
+import com.cloudera.api.swagger.model.ApiClusterTemplateService;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateConfigInjector;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.hdfs.HdfsRoles;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive.HiveRoles;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.ranger.RangerRoles;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.yarn.YarnRoles;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+
+@Component
+public class ProcessAutoRestartInjector implements CmTemplateConfigInjector {
+
+    private static final Set<String> SERVICES = Set.of(
+            "ATLAS",
+            "HBASE",
+            HdfsRoles.HDFS,
+            HiveRoles.HIVE,
+            "LIVY",
+            RangerRoles.RANGER,
+            "SOLR",
+            "SPARK_ON_YARN",
+            YarnRoles.YARN,
+            "ZEPPELIN"
+    );
+
+    private static final Set<String> IGNORED_ROLES = Set.of(
+            "GATEWAY", HdfsRoles.BALANCER
+    );
+
+    private final ApiClusterTemplateConfig autoRestartConfig = config("process_auto_restart", Boolean.TRUE.toString());
+
+    private final List<ApiClusterTemplateConfig> configs = List.of(autoRestartConfig);
+
+    @Override
+    public List<ApiClusterTemplateConfig> getRoleConfigs(
+            ApiClusterTemplateRoleConfigGroup roleConfigGroup,
+            ApiClusterTemplateService service,
+            TemplatePreparationObject source
+    ) {
+        return shouldAutoRestart(service.getServiceType(), roleConfigGroup.getRoleType()) ? configs : List.of();
+    }
+
+    private boolean shouldAutoRestart(String service, String roleType) {
+        return SERVICES.contains(service) && !IGNORED_ROLES.contains(roleType);
+    }
+
+}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hdfs/HdfsRoles.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hdfs/HdfsRoles.java
@@ -12,6 +12,8 @@ public class HdfsRoles {
 
     public static final String JOURNALNODE = "JOURNALNODE";
 
+    public static final String BALANCER = "BALANCER";
+
     private HdfsRoles() { }
 
 }

--- a/template-manager-cmtemplate/src/test/resources/output/namenode-ha-injected.bp
+++ b/template-manager-cmtemplate/src/test/resources/output/namenode-ha-injected.bp
@@ -1,0 +1,157 @@
+{
+  "cdhVersion": "6.1.0",
+  "displayName": "simple_template",
+  "cmVersion": "6.1.0",
+  "repositories": [
+    "https://archive.cloudera.com/cdh6/{latest_supported}/parcels/"
+  ],
+  "products": [
+    {
+      "version": "6.1.0-1.cdh6.1.0.p0.770702",
+      "product": "CDH"
+    }
+  ],
+  "services": [
+    {
+      "refName": "zookeeper",
+      "serviceType": "ZOOKEEPER",
+      "serviceConfigs": [
+        {
+          "name": "service_config_name",
+          "value": "service_config_value"
+        }
+      ],
+      "roleConfigGroups": [
+        {
+          "refName": "zookeeper-SERVER-BASE",
+          "roleType": "SERVER",
+          "configs": [
+            {
+              "name": "role_config_name",
+              "value": "role_config_value"
+            }
+          ],
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "hdfs",
+      "serviceType": "HDFS",
+      "serviceConfigs": [
+        {
+          "name": "service_config_name",
+          "value": "service_config_value"
+        }
+      ],
+      "roleConfigGroups": [
+        {
+          "refName": "hdfs-NAMENODE-BASE",
+          "roleType": "NAMENODE",
+          "configs": [
+            {
+              "name": "role_config_name",
+              "value": "role_config_value"
+            }
+          ],
+          "base": true
+        },
+        {
+          "refName": "hdfs-DATANODE-BASE",
+          "roleType": "DATANODE",
+          "configs": [
+            {
+              "name": "role_config_name",
+              "value": "role_config_value"
+            }
+          ],
+          "base": true
+        },
+        {
+          "refName": "hdfs-JOURNALNODE-BASE",
+          "roleType": "JOURNALNODE",
+          "configs": [
+            {
+              "name": "role_config_name",
+              "value": "role_config_value"
+            }
+          ],
+          "base": true
+        },
+        {
+          "refName": "hdfs-FAILOVERCONTROLLER-BASE",
+          "roleType": "FAILOVERCONTROLLER",
+          "configs": [
+            {
+              "name": "role_config_name",
+              "value": "role_config_value"
+            }
+          ],
+          "base": true
+        },
+        {
+          "refName": "hdfs-BALANCER-BASE",
+          "roleType": "BALANCER",
+          "configs": [
+            {
+              "name": "role_config_name",
+              "value": "role_config_value"
+            }
+          ],
+          "base": true
+        }
+      ]
+    }
+  ],
+  "hostTemplates": [
+    {
+      "refName": "master",
+      "cardinality": 2,
+      "roleConfigGroupsRefNames": [
+        "hdfs-NAMENODE-BASE"
+      ]
+    },
+    {
+      "refName": "quorum",
+      "cardinality": 3,
+      "roleConfigGroupsRefNames": [
+        "zookeeper-SERVER-BASE"
+      ]
+    },
+    {
+      "refName": "gateway",
+      "cardinality": 1,
+      "roleConfigGroupsRefNames": [
+        "hdfs-BALANCER-BASE"
+      ]
+    },
+    {
+      "refName": "worker",
+      "cardinality": 3,
+      "roleConfigGroupsRefNames": [
+        "hdfs-DATANODE-BASE"
+      ]
+    }
+  ],
+  "instantiator": {
+    "clusterName": "testcluster",
+    "hosts": [
+      {
+        "hostName": "host3",
+        "hostTemplateRefName": "worker"
+      },
+      {
+        "hostName": "host4",
+        "hostTemplateRefName": "worker"
+      },
+      {
+        "hostName": "host1",
+        "hostTemplateRefName": "master"
+      },
+      {
+        "hostName": "host2",
+        "hostTemplateRefName": "master"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Automatically inject `process_auto_restart: true` into configs for all roles which are currently tested with this feature.

(The framework can also be used for example to "globally" override log directory thresholds to percentage values.)

## How was this patch tested?

Added unit test.  Deployed clusters using Data Engineering HA, Data Science and SDX templates.