### PR TITLE
CB-1616. Handle undefined cluster template variables

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CentralCmTemplateUpdater.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CentralCmTemplateUpdater.java
@@ -44,6 +44,7 @@ public class CentralCmTemplateUpdater implements BlueprintUpdater {
             ClouderaManagerRepo clouderaManagerRepoDetails, List<ClouderaManagerProduct> clouderaManagerProductDetails, String sdxContextName) {
         try {
             CmTemplateProcessor processor = getCmTemplateProcessor(source);
+            processor.removeDanglingVariableReferences();
             updateCmTemplateRepoDetails(processor, clouderaManagerRepoDetails, clouderaManagerProductDetails);
             updateCmTemplateConfiguration(processor, clouderaManagerRepoDetails, source, hostGroupMappings, sdxContextName);
             return processor.getTemplate();

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CentralCmTemplateUpdaterTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CentralCmTemplateUpdaterTest.java
@@ -106,6 +106,13 @@ public class CentralCmTemplateUpdaterTest {
     }
 
     @Test
+    public void danglingVariableReferencesAreRemoved() {
+        when(blueprintView.getBlueprintText()).thenReturn(getBlueprintText("input/clouderamanager-variables.bp"));
+        ApiClusterTemplate generated = generator.getCmTemplate(templatePreparationObject, getHostgroupMappings(), clouderaManagerRepo, null, null);
+        Assert.assertEquals(new CmTemplateProcessor(getBlueprintText("output/clouderamanager-variables.bp")).getTemplate(), generated);
+    }
+
+    @Test
     public void configsAreInjected() {
         List<ApiClusterTemplateConfig> serviceConfigs = List.of(config("service_config_name", "service_config_value"));
         List<ApiClusterTemplateConfig> roleConfigs = List.of(config("role_config_name", "role_config_value"));

--- a/template-manager-cmtemplate/src/test/resources/input/clouderamanager-custom_cluster_name.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/clouderamanager-custom_cluster_name.bp
@@ -1,0 +1,6 @@
+{
+  "cdhVersion": "7.0.0",
+  "instantiator": {
+    "clusterName": "kusztom"
+  }
+}

--- a/template-manager-cmtemplate/src/test/resources/input/clouderamanager-variables.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/clouderamanager-variables.bp
@@ -1,0 +1,273 @@
+{
+  "cdhVersion": "6.1.0",
+  "displayName": "simple_template",
+  "cmVersion": "6.1.0",
+  "repositories": [
+    "https://archive.cloudera.com/cdh6/{latest_supported}/parcels/",
+    "https://archive.cloudera.com/cdh5/parcels/5.14/",
+    "https://archive.cloudera.com/accumulo-c5/parcels/latest/",
+    "https://archive.cloudera.com/kafka/parcels/latest/",
+    "http://archive.cloudera.com/kudu/parcels/latest/",
+    "https://archive.cloudera.com/spark/parcels/latest/",
+    "https://archive.cloudera.com/sqoop-teradata-connector1/latest/",
+    "https://archive.cloudera.com/sqoop-netezza-connector1/latest/",
+    "https://archive.cloudera.com/sqoop-connectors/parcels/latest/"
+  ],
+  "products": [
+    {
+      "version": "6.1.0-1.cdh6.1.0.p0.770702",
+      "product": "CDH"
+    }
+  ],
+  "services": [
+    {
+      "refName": "isilon",
+      "serviceType": "ISILON",
+      "serviceConfigs": [
+        {
+          "name": "default_fs_name",
+          "value": "hdfs"
+        }
+      ]
+    },
+    {
+      "refName": "zookeeper",
+      "serviceType": "ZOOKEEPER",
+      "serviceConfigs": [
+        {
+          "name": "fake_service_config",
+          "variable": "does_not_exist"
+        }
+      ],
+      "roleConfigGroups": [
+        {
+          "refName": "zookeeper-SERVER-BASE",
+          "roleType": "SERVER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "hdfs",
+      "serviceType": "HDFS",
+      "roleConfigGroups": [
+        {
+          "refName": "hdfs-NAMENODE-BASE",
+          "roleType": "NAMENODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-SECONDARYNAMENODE-BASE",
+          "roleType": "SECONDARYNAMENODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-DATANODE-BASE",
+          "roleType": "DATANODE"
+        },
+        {
+          "refName": "hdfs-BALANCER-BASE",
+          "roleType": "BALANCER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "kafka",
+      "serviceType": "KAFKA",
+      "roleConfigGroups": [
+        {
+          "refName": "kafka-KAFKA_BROKER-BASE",
+          "roleType": "KAFKA_BROKER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "hbase",
+      "serviceType": "HBASE",
+      "roleConfigGroups": [
+        {
+          "refName": "hbase-REGIONSERVER-BASE",
+          "roleType": "REGIONSERVER",
+          "base": true
+        },
+        {
+          "refName": "hbase-MASTER-BASE",
+          "roleType": "MASTER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "yarn",
+      "serviceType": "YARN",
+      "roleConfigGroups": [
+        {
+          "refName": "yarn-RESOURCEMANAGER-BASE",
+          "roleType": "RESOURCEMANAGER",
+          "base": true
+        },
+        {
+          "refName": "yarn-NODEMANAGER-BASE",
+          "roleType": "NODEMANAGER",
+          "base": false
+        },
+        {
+          "refName": "yarn-JOBHISTORY-BASE",
+          "roleType": "JOBHISTORY",
+          "configs": [
+            {
+              "name": "fake_config",
+              "variable": "dangling_variable_reference"
+            }
+          ],
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "spark_on_yarn",
+      "serviceType": "SPARK_ON_YARN",
+      "roleConfigGroups": [
+        {
+          "refName": "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+          "roleType": "SPARK_YARN_HISTORY_SERVER",
+          "base": true
+        },
+        {
+          "refName": "spark_on_yarn-GATEWAY-BASE",
+          "roleType": "GATEWAY",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "hive",
+      "serviceType": "HIVE",
+      "serviceConfigs": [
+        {
+          "name": "hive_metastore_database_password",
+          "variable": "hive-hive_metastore_database_password"
+        },
+        {
+          "name": "hive_metastore_database_port",
+          "variable": "hive-hive_metastore_database_port"
+        },
+        {
+          "name": "hive_metastore_database_host",
+          "variable": "hive-hive_metastore_database_host"
+        },
+        {
+          "name": "hive_metastore_database_type",
+          "variable": "hive-hive_metastore_database_type"
+        },
+        {
+          "name": "hive_metastore_database_name",
+          "variable": "hive-hive_metastore_database_name"
+        }
+      ],
+      "roleConfigGroups": [
+        {
+          "refName": "hive-GATEWAY-BASE",
+          "roleType": "GATEWAY",
+          "base": true
+        },
+        {
+          "refName": "hive-HIVESERVER2-BASE",
+          "roleType": "HIVESERVER2",
+          "base": true
+        },
+        {
+          "refName": "hive-HIVEMETASTORE-BASE",
+          "roleType": "HIVEMETASTORE",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "ranger",
+      "serviceType": "RANGER",
+      "serviceConfigs": [
+        {
+          "name": "rangeradmin_user_password",
+          "value": "{{{ general.password }}}"
+        }
+      ]
+    },
+    {
+      "refName": "impala",
+      "serviceType": "IMPALA",
+      "serviceConfigs": [
+        {
+          "name": "fake_service_config",
+          "variable": "does_not_exist"
+        },
+        {
+          "name": "other_service_config",
+          "variable": "variable_with_value"
+        }
+      ],
+      "roleConfigGroups": [
+        {
+          "refName": "impala-IMPALAD-BASE",
+          "roleType": "IMPALAD",
+          "base": true
+        },
+        {
+          "refName": "impala-STATESTORE-BASE",
+          "roleType": "STATESTORE",
+          "base": true
+        },
+        {
+          "refName": "impala-CATALOGSERVER-BASE",
+          "roleType": "CATALOGSERVER",
+          "base": true
+        }
+      ]
+    }
+  ],
+  "hostTemplates": [
+    {
+      "refName": "master",
+      "cardinality": 1,
+      "roleConfigGroupsRefNames": [
+        "hbase-MASTER-BASE",
+        "hdfs-BALANCER-BASE",
+        "hdfs-NAMENODE-BASE",
+        "hdfs-SECONDARYNAMENODE-BASE",
+        "hive-GATEWAY-BASE",
+        "hive-HIVEMETASTORE-BASE",
+        "hive-HIVESERVER2-BASE",
+        "impala-CATALOGSERVER-BASE",
+        "impala-STATESTORE-BASE",
+        "kafka-KAFKA_BROKER-BASE",
+        "spark_on_yarn-GATEWAY-BASE",
+        "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+        "yarn-JOBHISTORY-BASE",
+        "yarn-RESOURCEMANAGER-BASE",
+        "zookeeper-SERVER-BASE"
+      ]
+    },
+    {
+      "refName": "worker",
+      "cardinality": 1,
+      "roleConfigGroupsRefNames": [
+        "hbase-REGIONSERVER-BASE",
+        "hdfs-DATANODE-BASE",
+        "hive-GATEWAY-BASE",
+        "impala-IMPALAD-BASE",
+        "spark_on_yarn-GATEWAY-BASE",
+        "yarn-NODEMANAGER-BASE"
+      ]
+    }
+  ],
+  "instantiator": {
+    "variables": [
+      {
+        "name": "variable_with_value",
+        "value": "some_value"
+      }
+    ]
+  }
+}

--- a/template-manager-cmtemplate/src/test/resources/output/clouderamanager-variables.bp
+++ b/template-manager-cmtemplate/src/test/resources/output/clouderamanager-variables.bp
@@ -1,0 +1,290 @@
+{
+  "cdhVersion": "6.1.0",
+  "displayName": "simple_template",
+  "cmVersion": "6.1.0",
+  "repositories": [
+    "https://archive.cloudera.com/cdh6/{latest_supported}/parcels/",
+    "https://archive.cloudera.com/cdh5/parcels/5.14/",
+    "https://archive.cloudera.com/accumulo-c5/parcels/latest/",
+    "https://archive.cloudera.com/kafka/parcels/latest/",
+    "http://archive.cloudera.com/kudu/parcels/latest/",
+    "https://archive.cloudera.com/spark/parcels/latest/",
+    "https://archive.cloudera.com/sqoop-teradata-connector1/latest/",
+    "https://archive.cloudera.com/sqoop-netezza-connector1/latest/",
+    "https://archive.cloudera.com/sqoop-connectors/parcels/latest/"
+  ],
+  "products": [
+    {
+      "version": "6.1.0-1.cdh6.1.0.p0.770702",
+      "product": "CDH"
+    }
+  ],
+  "services": [
+    {
+      "refName": "isilon",
+      "serviceType": "ISILON",
+      "serviceConfigs": [
+        {
+          "name": "default_fs_name",
+          "value": "hdfs"
+        }
+      ]
+    },
+    {
+      "refName": "zookeeper",
+      "serviceType": "ZOOKEEPER",
+      "roleConfigGroups": [
+        {
+          "refName": "zookeeper-SERVER-BASE",
+          "roleType": "SERVER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "hdfs",
+      "serviceType": "HDFS",
+      "roleConfigGroups": [
+        {
+          "refName": "hdfs-NAMENODE-BASE",
+          "roleType": "NAMENODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-SECONDARYNAMENODE-BASE",
+          "roleType": "SECONDARYNAMENODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-DATANODE-BASE",
+          "roleType": "DATANODE"
+        },
+        {
+          "refName": "hdfs-BALANCER-BASE",
+          "roleType": "BALANCER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "kafka",
+      "serviceType": "KAFKA",
+      "roleConfigGroups": [
+        {
+          "refName": "kafka-KAFKA_BROKER-BASE",
+          "roleType": "KAFKA_BROKER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "hbase",
+      "serviceType": "HBASE",
+      "roleConfigGroups": [
+        {
+          "refName": "hbase-REGIONSERVER-BASE",
+          "roleType": "REGIONSERVER",
+          "base": true
+        },
+        {
+          "refName": "hbase-MASTER-BASE",
+          "roleType": "MASTER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "yarn",
+      "serviceType": "YARN",
+      "roleConfigGroups": [
+        {
+          "refName": "yarn-RESOURCEMANAGER-BASE",
+          "roleType": "RESOURCEMANAGER",
+          "base": true
+        },
+        {
+          "refName": "yarn-NODEMANAGER-BASE",
+          "roleType": "NODEMANAGER",
+          "base": false
+        },
+        {
+          "refName": "yarn-JOBHISTORY-BASE",
+          "roleType": "JOBHISTORY",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "spark_on_yarn",
+      "serviceType": "SPARK_ON_YARN",
+      "roleConfigGroups": [
+        {
+          "refName": "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+          "roleType": "SPARK_YARN_HISTORY_SERVER",
+          "base": true
+        },
+        {
+          "refName": "spark_on_yarn-GATEWAY-BASE",
+          "roleType": "GATEWAY",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "hive",
+      "serviceType": "HIVE",
+      "serviceConfigs": [
+        {
+          "name": "hive_metastore_database_host",
+          "value": "cluster.test.com"
+        },
+        {
+          "name": "hive_metastore_database_name",
+          "value": "hive"
+        },
+        {
+          "name": "hive_metastore_database_password",
+          "value": "password"
+        },
+        {
+          "name": "hive_metastore_database_port",
+          "value": "5432"
+        },
+        {
+          "name": "hive_metastore_database_type",
+          "value": "postgresql"
+        },
+        {
+          "name": "hive_metastore_database_user",
+          "value": "user"
+        }
+      ],
+      "roleConfigGroups": [
+        {
+          "refName": "hive-GATEWAY-BASE",
+          "roleType": "GATEWAY",
+          "base": true
+        },
+        {
+          "refName": "hive-HIVESERVER2-BASE",
+          "roleType": "HIVESERVER2",
+          "base": true
+        },
+        {
+          "refName": "hive-HIVEMETASTORE-BASE",
+          "roleType": "HIVEMETASTORE",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "ranger",
+      "serviceType": "RANGER",
+      "serviceConfigs": [
+        {
+          "name": "rangeradmin_user_password",
+          "value": "Admin123!"
+        }
+      ]
+    },
+    {
+      "refName": "impala",
+      "serviceType": "IMPALA",
+      "serviceConfigs": [
+        {
+          "name": "other_service_config",
+          "variable": "variable_with_value"
+        }
+      ],
+      "roleConfigGroups": [
+        {
+          "refName": "impala-IMPALAD-BASE",
+          "roleType": "IMPALAD",
+          "base": true
+        },
+        {
+          "refName": "impala-STATESTORE-BASE",
+          "roleType": "STATESTORE",
+          "base": true
+        },
+        {
+          "refName": "impala-CATALOGSERVER-BASE",
+          "roleType": "CATALOGSERVER",
+          "base": true
+        }
+      ]
+    }
+  ],
+  "hostTemplates": [
+    {
+      "refName": "master",
+      "cardinality": 1,
+      "roleConfigGroupsRefNames": [
+        "hbase-MASTER-BASE",
+        "hdfs-BALANCER-BASE",
+        "hdfs-NAMENODE-BASE",
+        "hdfs-SECONDARYNAMENODE-BASE",
+        "hive-GATEWAY-BASE",
+        "hive-HIVEMETASTORE-BASE",
+        "hive-HIVESERVER2-BASE",
+        "impala-CATALOGSERVER-BASE",
+        "impala-STATESTORE-BASE",
+        "kafka-KAFKA_BROKER-BASE",
+        "spark_on_yarn-GATEWAY-BASE",
+        "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+        "yarn-JOBHISTORY-BASE",
+        "yarn-RESOURCEMANAGER-BASE",
+        "zookeeper-SERVER-BASE"
+      ]
+    },
+    {
+      "refName": "worker",
+      "cardinality": 1,
+      "roleConfigGroupsRefNames": [
+        "hbase-REGIONSERVER-BASE",
+        "hdfs-DATANODE-BASE",
+        "hive-GATEWAY-BASE",
+        "impala-IMPALAD-BASE",
+        "spark_on_yarn-GATEWAY-BASE",
+        "yarn-NODEMANAGER-BASE"
+      ]
+    }
+  ],
+  "instantiator": {
+    "clusterName": "testcluster",
+    "hosts": [
+      {
+        "hostName": "host3",
+        "hostTemplateRefName": "worker"
+      },
+      {
+        "hostName": "host4",
+        "hostTemplateRefName": "worker"
+      },
+      {
+        "hostName": "host1",
+        "hostTemplateRefName": "master"
+      },
+      {
+        "hostName": "host2",
+        "hostTemplateRefName": "master"
+      }
+    ],
+    "variables": [
+      {
+        "name": "variable_with_value",
+        "value": "some_value"
+      }
+    ],
+    "roleConfigGroups": [
+      {
+        "rcgRefName": "hdfs-DATANODE-BASE",
+        "name": null
+      },
+      {
+        "rcgRefName": "yarn-NODEMANAGER-BASE",
+        "name": null
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove configurations that reference undefined variables before further processing the cluster template.  This way leftover references are handled gracefully, while ensuring that users can define variables and reference them.

## How was this patch tested?

Added unit test.  Deployed cluster with both kind of variables (valid and invalid).