### PR TITLE
CB-1339 missing volume templates migrator

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/config/generator/OfflineStateGenerator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/config/generator/OfflineStateGenerator.java
@@ -341,6 +341,11 @@ public class OfflineStateGenerator {
         }
 
         @Override
+        public Set<Stack> findAllAliveWithInstanceGroups() {
+            return null;
+        }
+
+        @Override
         public Set<Stack> findAllAliveWithNoWorkspaceOrUser() {
             return null;
         }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/init/CloudbreakCleanupService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/init/CloudbreakCleanupService.java
@@ -29,6 +29,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
 import com.sequenceiq.cloudbreak.common.service.TransactionService.TransactionExecutionException;
+import com.sequenceiq.cloudbreak.startup.MissingVolumeTemplatesMigrator;
 import com.sequenceiq.flow.core.Flow2Handler;
 import com.sequenceiq.flow.core.FlowLogService;
 import com.sequenceiq.cloudbreak.core.flow2.service.ReactorFlowManager;
@@ -91,6 +92,9 @@ public class CloudbreakCleanupService implements ApplicationListener<ContextRefr
     @Inject
     private GovCloudFlagMigrator govCloudFlagMigrator;
 
+    @Inject
+    private MissingVolumeTemplatesMigrator missingVolumeTemplatesMigrator;
+
     private final List<Status> syncRequiredStates = Arrays.asList(UPDATE_REQUESTED, UPDATE_IN_PROGRESS, WAIT_FOR_SYNC, START_IN_PROGRESS, STOP_IN_PROGRESS);
 
     @Override
@@ -105,6 +109,7 @@ public class CloudbreakCleanupService implements ApplicationListener<ContextRefr
             triggerSyncs(stacksToSync, clustersToSync);
             cloudbreakFlowLogService.purgeTerminatedStacksFlowLogs();
             govCloudFlagMigrator.run();
+            missingVolumeTemplatesMigrator.run();
         } catch (Exception e) {
             LOGGER.error("Clean up or the migration operations failed. Shutting down the node. ", e);
             ConfigurableApplicationContext applicationContext = (ConfigurableApplicationContext) event.getApplicationContext();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
@@ -104,6 +104,11 @@ public interface StackRepository extends WorkspaceResourceRepository<Stack, Long
     List<Stack> findAllAlive();
 
     @CheckPermissionsByReturnValue
+    @Query("SELECT s FROM Stack s LEFT JOIN FETCH s.resources LEFT JOIN FETCH s.instanceGroups ig "
+            + "WHERE s.terminated = null AND (s.type is not 'TEMPLATE' OR s.type is null)")
+    Set<Stack> findAllAliveWithInstanceGroups();
+
+    @CheckPermissionsByReturnValue
     @Query("SELECT s FROM Stack s WHERE s.terminated = null AND "
             + "(s.workspace = null OR s.creator = null) AND (s.type is not 'TEMPLATE' OR s.type is null)")
     Set<Stack> findAllAliveWithNoWorkspaceOrUser();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/VolumeTemplateRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/VolumeTemplateRepository.java
@@ -1,0 +1,16 @@
+package com.sequenceiq.cloudbreak.repository;
+
+import javax.transaction.Transactional;
+import javax.transaction.Transactional.TxType;
+
+import com.sequenceiq.cloudbreak.domain.VolumeTemplate;
+import com.sequenceiq.cloudbreak.workspace.repository.BaseRepository;
+import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
+import com.sequenceiq.cloudbreak.workspace.repository.HasPermission;
+
+@EntityType(entityClass = VolumeTemplate.class)
+@Transactional(TxType.REQUIRED)
+@HasPermission
+public interface VolumeTemplateRepository extends BaseRepository<VolumeTemplate, Long> {
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
@@ -604,6 +604,10 @@ public class StackService {
         return stackRepository.findAllAlive();
     }
 
+    public Set<Stack> getAllAliveWithInstanceGroups() {
+        return stackRepository.findAllAliveWithInstanceGroups();
+    }
+
     public List<Stack> getByStatuses(List<Status> statuses) {
         return stackRepository.findByStatuses(statuses);
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/startup/MissingVolumeTemplatesMigrator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/startup/MissingVolumeTemplatesMigrator.java
@@ -1,0 +1,151 @@
+package com.sequenceiq.cloudbreak.startup;
+
+import static com.sequenceiq.cloudbreak.cloud.model.Platform.platform;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.model.DiskTypes;
+import com.sequenceiq.cloudbreak.cloud.model.Platform;
+import com.sequenceiq.cloudbreak.cloud.model.PlatformDisks;
+import com.sequenceiq.cloudbreak.cloud.model.VmRecommendation;
+import com.sequenceiq.cloudbreak.cloud.model.VmRecommendations;
+import com.sequenceiq.cloudbreak.cloud.model.VolumeParameterType;
+import com.sequenceiq.cloudbreak.cloud.model.VolumeSetAttributes;
+import com.sequenceiq.cloudbreak.cluster.util.ResourceAttributeUtil;
+import com.sequenceiq.cloudbreak.domain.Resource;
+import com.sequenceiq.cloudbreak.domain.VolumeTemplate;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.repository.VolumeTemplateRepository;
+import com.sequenceiq.cloudbreak.service.stack.CloudParameterService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+
+@Component
+public class MissingVolumeTemplatesMigrator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MissingVolumeTemplatesMigrator.class);
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private ResourceAttributeUtil resourceAttributeUtil;
+
+    @Inject
+    private VolumeTemplateRepository volumeTemplateRepository;
+
+    @Inject
+    private CloudParameterService cloudParameterService;
+
+    private final AtomicBoolean finished = new AtomicBoolean(false);
+
+    public void run() {
+        try {
+            Set<Stack> liveStacks = stackService.getAllAliveWithInstanceGroups();
+            liveStacks.stream()
+                    .forEach(stack -> stack.getInstanceGroups().stream()
+                        .filter(ig -> ig.getTemplate().getVolumeTemplates().isEmpty())
+                        .forEach(ig -> addMountedVolumesToInstanceMetadata(stack, ig)));
+        } catch (Exception e) {
+            LOGGER.error("Exception during missing volumes migration: ", e);
+        }
+        finished.set(true);
+    }
+
+    private void addMountedVolumesToInstanceMetadata(Stack stack, InstanceGroup instanceGroup) {
+        List<Resource> diskResources = stack.getDiskResources();
+        Optional<Resource> resource = diskResources.stream()
+                .filter(diskResource -> diskResource.getInstanceGroup().contentEquals(instanceGroup.getGroupName()))
+                .findFirst();
+        if (resource.isPresent()) {
+            setVolumeTemplateForInstanceGroup(stack, instanceGroup, resource.get());
+        } else {
+            setDefaultVolumeTemplateForInstanceGroup(stack, instanceGroup);
+        }
+    }
+
+    private void setVolumeTemplateForInstanceGroup(Stack stack, InstanceGroup instanceGroup, Resource diskResource) {
+        Optional<VolumeSetAttributes> attributes = resourceAttributeUtil.getTypedAttributes(diskResource, VolumeSetAttributes.class);
+        if (attributes.isPresent()) {
+            VolumeSetAttributes volumeSetAttributes = attributes.get();
+            try {
+                Set<String> volumeTypes = volumeSetAttributes.getVolumes().stream().map(VolumeSetAttributes.Volume::getType).collect(Collectors.toSet());
+                volumeTypes.stream().forEach(volumeType -> createVolumeTemplate(volumeSetAttributes, instanceGroup, volumeType));
+                LOGGER.info("Added volumetemplate to template in instancegroup {} in stack {}", instanceGroup.getGroupName(), stack.getName());
+            } catch (Exception e) {
+                LOGGER.error("Exception occured during addition of volumetemplate to template in instancegroup "
+                        + diskResource.getInstanceGroup() + " in stack " + stack.getName(), e);
+            }
+        }
+    }
+
+    private void setDefaultVolumeTemplateForInstanceGroup(Stack stack, InstanceGroup instanceGroup) {
+        try {
+            VmRecommendations recommendations = cloudParameterService.getRecommendation(stack.cloudPlatform());
+            VmRecommendation recommendation = recommendations.getWorker();
+            PlatformDisks platformDisks = cloudParameterService.getDiskTypes();
+            Platform platform = platform(stack.cloudPlatform());
+            DiskTypes diskTypes = new DiskTypes(
+                    platformDisks.getDiskTypes().get(platform),
+                    platformDisks.getDefaultDisks().get(platform),
+                    platformDisks.getDiskMappings().get(platform),
+                    platformDisks.getDiskDisplayNames().get(platform));
+            VolumeParameterType volumeParameterType = VolumeParameterType.valueOf(recommendation.getVolumeType());
+            if (diskTypes.diskMapping().containsValue(volumeParameterType)) {
+                Optional<Map.Entry<String, VolumeParameterType>> recommendedVolumeName = diskTypes
+                        .diskMapping()
+                        .entrySet()
+                        .stream()
+                        .filter(entry -> volumeParameterType.equals(entry.getValue()))
+                        .findFirst();
+                if (recommendedVolumeName.isPresent()) {
+                    createDefaultVolumeTemplate(instanceGroup, recommendedVolumeName.get().getKey(),
+                            Math.toIntExact(recommendation.getVolumeCount()), Math.toIntExact(recommendation.getVolumeSizeGB()));
+                    LOGGER.info("Added default volumetemplate to template in instancegroup {} in stack {}", instanceGroup.getGroupName(), stack.getName());
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.error("Exception occured during addition of volumetemplate to template in instancegroup "
+                    + instanceGroup.getGroupName() + " in stack " + stack.getName(), e);
+        }
+    }
+
+    private void createVolumeTemplate(VolumeSetAttributes volumeSetAttributes, InstanceGroup instanceGroup, String volumeType) {
+        VolumeTemplate volumeTemplate = new VolumeTemplate();
+        volumeTemplate.setVolumeType(volumeType);
+        volumeTemplate.setVolumeSize(volumeSetAttributes.getVolumes().stream()
+                .filter(volume -> volume.getType().contentEquals(volumeType))
+                .findFirst()
+                .get()
+                .getSize());
+        volumeTemplate.setVolumeCount(Math.toIntExact(volumeSetAttributes.getVolumes().stream()
+                .filter(volume -> volume.getType().contentEquals(volumeType))
+                .count()));
+        volumeTemplate.setTemplate(instanceGroup.getTemplate());
+        volumeTemplateRepository.save(volumeTemplate);
+    }
+
+    private void createDefaultVolumeTemplate(InstanceGroup instanceGroup, String volumeType, Integer volumeCount, Integer volumeSize) {
+        VolumeTemplate volumeTemplate = new VolumeTemplate();
+        volumeTemplate.setVolumeType(volumeType);
+        volumeTemplate.setVolumeSize(volumeSize);
+        volumeTemplate.setVolumeCount(volumeCount);
+        volumeTemplate.setTemplate(instanceGroup.getTemplate());
+        volumeTemplateRepository.save(volumeTemplate);
+    }
+
+    public boolean isFinished() {
+        return finished.get();
+    }
+}


### PR DESCRIPTION
This is needed for environments where the wrong volume template SQL has already been executed before the fix (like on QA). 
Later we can delete it, but it was easier to do this with Java migration.