### PR TITLE
DISTX-126. Sync users from UMS to IPA

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/config/UmsClientConfig.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/config/UmsClientConfig.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.cloudbreak.auth.altus.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class UmsClientConfig {
+    @Value("${altus.ums.client.list_users_page_size:100}")
+    private int listUsersPageSize;
+
+    @Value("${altus.ums.client.list_machine_users_page_size:100}")
+    private int listMachineUsersPageSize;
+
+    public int getListUsersPageSize() {
+        return listUsersPageSize;
+    }
+
+    public int getListMachineUsersPageSize() {
+        return listMachineUsersPageSize;
+    }
+}

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/Group.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/Group.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.freeipa.api.v1.freeipa.user.model;
 
+import java.util.Objects;
+
 import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -16,7 +18,38 @@ public class Group {
     @ApiModelProperty(value = UserModelDescriptions.GROUP_NAME, required = true)
     private String name;
 
+    public void setName(String name) {
+        this.name = name;
+    }
+
     public String getName() {
         return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Group other = (Group) o;
+
+        return Objects.equals(this.name, other.name);
+
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    @Override
+    public String toString() {
+        return "Group{"
+                + "name='" + name + '\''
+                + '}';
     }
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/User.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/User.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.freeipa.api.v1.freeipa.user.model;
 
+import java.util.Objects;
 import java.util.Set;
 
 import javax.validation.constraints.NotNull;
@@ -33,15 +34,61 @@ public class User {
         return name;
     }
 
+    public void setName(String name) {
+        this.name = name;
+    }
+
     public String getFirstName() {
         return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
     }
 
     public String getLastName() {
         return lastName;
     }
 
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
     public Set<String> getGroups() {
         return groups;
+    }
+
+    public void setGroups(Set<String> groups) {
+        this.groups = groups;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        User other = (User) o;
+        return Objects.equals(this.name, other.name)
+                && Objects.equals(this.firstName, other.firstName)
+                && Objects.equals(this.lastName, other.lastName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, firstName, lastName);
+    }
+
+    @Override
+    public String toString() {
+        return "User{"
+                + "name='" + name + '\''
+                + ", firstName='" + firstName + '\''
+                + ", lastName='" + lastName + '\''
+                + ", groups=" + groups
+                + '}';
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 
 import com.googlecode.jsonrpc4j.JsonRpcHttpClient;
 import com.sequenceiq.freeipa.client.model.Ca;
+import com.sequenceiq.freeipa.client.model.Group;
 import com.sequenceiq.freeipa.client.model.RPCResponse;
 import com.sequenceiq.freeipa.client.model.User;
 
@@ -35,24 +36,25 @@ public class FreeIpaClient {
         this.apiVersion = apiVersion;
     }
 
-    public RPCResponse<User> userShow(String user) throws FreeIpaClientException {
+    public User userShow(String user) throws FreeIpaClientException {
         List<String> flags = List.of(user);
         Map<String, Object> params = Map.of();
-        return invoke("user_show", flags, params, User.class);
+        return (User) invoke("user_show", flags, params, User.class).getResult();
     }
 
-    public RPCResponse<Set<User>> userFindAll() throws FreeIpaClientException {
+    public Set<User> userFindAll() throws FreeIpaClientException {
         List<String> flags = List.of();
         Map<String, Object> params = Map.of(
                 "sizelimit", 0,
-                "timelimit", 0
+                "timelimit", 0,
+                "all", true
         );
         ParameterizedType type = TypeUtils
                 .parameterize(Set.class, User.class);
-        return invoke("user_find", flags, params, type);
+        return (Set<User>) invoke("user_find", flags, params, type).getResult();
     }
 
-    public RPCResponse<User> userAdd(String user, String firstName, String lastName, String password) throws FreeIpaClientException {
+    public User userAdd(String user, String firstName, String lastName, String password) throws FreeIpaClientException {
         List<String> flags = List.of(user);
         Map<String, Object> params = Map.of(
                 "givenname", firstName,
@@ -60,7 +62,7 @@ public class FreeIpaClient {
                 "userpassword", password,
                 "setattr", "krbPasswordExpiration=20380101000000Z"
         );
-        return invoke("user_add", flags, params, User.class);
+        return (User) invoke("user_add", flags, params, User.class).getResult();
     }
 
     public void userSetPassword(String user, String password) throws FreeIpaClientException {
@@ -70,49 +72,18 @@ public class FreeIpaClient {
         userMod(user, "setattr", "krbPasswordExpiration=20380101000000Z");
     }
 
-    public RPCResponse<User> userMod(String user, String key, Object value) throws FreeIpaClientException {
+    public User userMod(String user, String key, Object value) throws FreeIpaClientException {
         List<String> flags = List.of(user);
         Map<String, Object> params = Map.of(
                 key, value
         );
-        return invoke("user_mod", flags, params, User.class);
+        return (User) invoke("user_mod", flags, params, User.class).getResult();
     }
 
-    // TODO unpack response into something meaningful
-    //ipa: INFO: Response: {
-    //    "error": null,
-    //    "id": 0,
-    //    "principal": "admin@IPATEST.LOCAL",
-    //    "result": {
-    //        "result": {
-    //            "cn": [
-    //                "testgrp1"
-    //            ],
-    //            "dn": "cn=testgrp1,cn=groups,cn=accounts,dc=ipatest,dc=local",
-    //            "gidnumber": [
-    //                "790600009"
-    //            ],
-    //            "ipauniqueid": [
-    //                "a5e6ca24-774f-11e9-abeb-02864e36b814"
-    //            ],
-    //            "objectclass": [
-    //                "top",
-    //                "groupofnames",
-    //                "nestedgroup",
-    //                "ipausergroup",
-    //                "ipaobject",
-    //                "posixgroup"
-    //            ]
-    //        },
-    //        "summary": "Added group \"testgrp1\"",
-    //        "value": "testgrp1"
-    //    },
-    //    "version": "4.6.4"
-    //}
-    public RPCResponse<Object> groupAdd(String group) throws FreeIpaClientException {
+    public Group groupAdd(String group) throws FreeIpaClientException {
         List<String> flags = List.of(group);
         Map<String, Object> params = Map.of();
-        return invoke("group_add", flags, params, Object.class);
+        return (Group) invoke("group_add", flags, params, Group.class).getResult();
     }
 
     // TODO unpack response into something meaningful
@@ -157,6 +128,18 @@ public class FreeIpaClient {
                 "user", users
         );
         return invoke("group_add_member", flags, params, Object.class);
+    }
+
+    public Set<Group> groupFindAll() throws FreeIpaClientException {
+        List<String> flags = List.of();
+        Map<String, Object> params = Map.of(
+                "sizelimit", 0,
+                "timelimit", 0,
+                "all", true
+        );
+        ParameterizedType type = TypeUtils
+                .parameterize(Set.class, Group.class);
+        return (Set<Group>) invoke("group_find", flags, params, type).getResult();
     }
 
     public String getRootCertificate() throws FreeIpaClientException {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/client/model/Group.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/client/model/Group.java
@@ -1,0 +1,42 @@
+package com.sequenceiq.freeipa.client.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.sequenceiq.freeipa.client.deserializer.ListFlatteningDeserializer;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Group {
+    @JsonDeserialize(using = ListFlatteningDeserializer.class)
+    private String cn;
+
+    private List<String> memberUser;
+
+    public String getCn() {
+        return cn;
+    }
+
+    public void setCn(String cn) {
+        this.cn = cn;
+    }
+
+    @JsonProperty("member_user")
+    public List<String> getMemberUser() {
+        return memberUser;
+    }
+
+    @JsonProperty("member_user")
+    public void setMemberUser(List<String> memberUser) {
+        this.memberUser = memberUser;
+    }
+
+    @Override
+    public String toString() {
+        return "Group{"
+                + "cn='" + cn + '\''
+                + "memberUser='" + memberUser + '\''
+                + '}';
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/client/model/User.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/client/model/User.java
@@ -17,6 +17,9 @@ public class User {
     @JsonDeserialize(using = ListFlatteningDeserializer.class)
     private String uid;
 
+    @JsonDeserialize(using = ListFlatteningDeserializer.class)
+    private String givenname;
+
     @JsonProperty(value = "memberof_group")
     private List<String> memberOfGroup;
 
@@ -44,6 +47,14 @@ public class User {
         this.uid = uid;
     }
 
+    public String getGivenname() {
+        return givenname;
+    }
+
+    public void setGivenname(String givenname) {
+        this.givenname = givenname;
+    }
+
     public List<String> getMemberOfGroup() {
         return memberOfGroup;
     }
@@ -58,6 +69,7 @@ public class User {
                 + "dn='" + dn + '\''
                 + ", sn='" + sn + '\''
                 + ", uid='" + uid + '\''
+                + ", givenname='" + givenname + '\''
                 + ", memberOfGroup=" + memberOfGroup
                 + '}';
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/ClientTestV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/ClientTestV1Controller.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Controller;
 
 import com.sequenceiq.freeipa.api.v1.freeipa.test.ClientTestV1Endpoint;
 import com.sequenceiq.freeipa.client.FreeIpaClient;
-import com.sequenceiq.freeipa.client.model.RPCResponse;
 import com.sequenceiq.freeipa.client.model.User;
 import com.sequenceiq.freeipa.service.FreeIpaClientFactory;
 
@@ -31,8 +30,7 @@ public class ClientTestV1Controller implements ClientTestV1Endpoint {
         }
 
         try {
-            RPCResponse<User> userShow = freeIpaClient.userShow(name);
-            User user = userShow.getResult();
+            User user = freeIpaClient.userShow(name);
             LOGGER.info("Groups: {}", user.getMemberOfGroup());
             LOGGER.info("Success: {}", user);
         } catch (Exception e) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/FreeIpaUsersStateProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/FreeIpaUsersStateProvider.java
@@ -1,0 +1,68 @@
+package com.sequenceiq.freeipa.service.user;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Service;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.Group;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.User;
+import com.sequenceiq.freeipa.client.FreeIpaClient;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.FreeIpaClientFactory;
+import com.sequenceiq.freeipa.service.user.model.UsersState;
+
+@Service
+public class FreeIpaUsersStateProvider {
+
+    // TODO add other Cloudera-managed users (e.g., Kerberos and LDAP users?)
+    @VisibleForTesting
+    static final List<String> IPA_ONLY_USERS = List.of("admin");
+
+    // TODO add other Cloudera-managed groups?
+    @VisibleForTesting
+    static final List<String> IPA_ONLY_GROUPS = List.of("admins", "editors", "ipausers", "trust admins");
+
+    @Inject
+    private FreeIpaClientFactory freeIpaClientFactory;
+
+    // TODO improve out exception handling
+    public UsersState getUsersState(Stack stack) throws Exception {
+        FreeIpaClient freeIpaClient = freeIpaClientFactory.getFreeIpaClientForStack(stack);
+
+        Set<User> users = freeIpaClient.userFindAll().stream()
+                .filter(user -> !IPA_ONLY_USERS.contains(user.getUid()))
+                .map(this::fromIpaUser)
+                .collect(Collectors.toSet());
+
+        Set<Group> groups = freeIpaClient.groupFindAll().stream()
+                .filter(group -> !IPA_ONLY_GROUPS.contains(group.getCn()))
+                .map(this::fromIpaGroup)
+                .collect(Collectors.toSet());
+
+        return new UsersState(groups, users);
+    }
+
+    @VisibleForTesting
+    User fromIpaUser(com.sequenceiq.freeipa.client.model.User ipaUser) {
+        User user = new User();
+        user.setName(ipaUser.getUid());
+        user.setFirstName(ipaUser.getGivenname());
+        user.setLastName(ipaUser.getSn());
+        user.setGroups(ipaUser.getMemberOfGroup().stream()
+                .filter(group -> !IPA_ONLY_GROUPS.contains(group))
+                .collect(Collectors.toSet()));
+        return user;
+    }
+
+    @VisibleForTesting
+    Group fromIpaGroup(com.sequenceiq.freeipa.client.model.Group ipaGroup) {
+        Group group = new Group();
+        group.setName(ipaGroup.getCn());
+        return group;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/UmsUsersStateProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/UmsUsersStateProvider.java
@@ -1,0 +1,130 @@
+package com.sequenceiq.freeipa.service.user;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.Group;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.User;
+import com.sequenceiq.freeipa.service.user.model.UsersState;
+import com.sequenceiq.freeipa.util.CrnService;
+
+@Service
+public class UmsUsersStateProvider {
+    private static final Logger LOGGER = LoggerFactory.getLogger(UmsUsersStateProvider.class);
+
+    @Inject
+    private ThreadBasedUserCrnProvider threadBaseUserCrnProvider;
+
+    @Inject
+    private CrnService crnService;
+
+    @Inject
+    private GrpcUmsClient umsClient;
+
+    public UsersState getUsersState(String environmentCrn) {
+        final String actorCrn = threadBaseUserCrnProvider.getUserCrn();
+        final String accountId = crnService.getCurrentAccountId();
+
+        List<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.User> users =
+                umsClient.listUsers(actorCrn, accountId, Optional.empty());
+        LOGGER.info("Found {} users", users.size());
+        List<User> convertedUsers = users.stream()
+                .map(user -> umsUserToUser(actorCrn, user, environmentCrn))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        List<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.MachineUser> machineUsers =
+                umsClient.listMachineUsers(actorCrn, accountId, Optional.empty());
+        LOGGER.info("Found {} machine users", machineUsers.size());
+        List<User> convertedMachineUsers = machineUsers.stream()
+                .map(machineUser -> umsMachineUserToUser(actorCrn, machineUser, environmentCrn))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        Set<User> allUsers = new HashSet<>();
+        allUsers.addAll(convertedUsers);
+        allUsers.addAll(convertedMachineUsers);
+
+        Set<Group> groups = allUsers.stream()
+                .map(User::getGroups)
+                .flatMap(Set::stream)
+                .map(this::fromGroupName)
+                .collect(Collectors.toSet());
+
+        return new UsersState(groups, allUsers);
+    }
+
+    private User umsUserToUser(String actorCrn, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.User umsUser, String environmentCrn) {
+        Set<String> groups = getGroupsForUser(actorCrn, umsUser.getCrn(), environmentCrn);
+        if (groups.isEmpty()) {
+            return null;
+        }
+
+        User user = new User();
+        // TODO Use workloadUsername once the UMS proto is updated
+        user.setName(getUsernameFromEmail(umsUser));
+        // TODO improve handling if names are missing
+        user.setFirstName(getOrDefault(umsUser.getFirstName(), "None"));
+        user.setLastName(getOrDefault(umsUser.getLastName(), "None"));
+        user.setGroups(groups);
+        return user;
+    }
+
+    private String getOrDefault(String value, String other) {
+        return (value == null || value.isBlank()) ? other : value;
+    }
+
+    private String getUsernameFromEmail(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.User umsUser) {
+        return umsUser.getEmail().split("@")[0];
+    }
+
+    private User umsMachineUserToUser(String actorCrn,
+            com.cloudera.thunderhead.service.usermanagement.UserManagementProto.MachineUser umsMachineUser, String environmentCrn) {
+        Set<String> groups = getGroupsForUser(actorCrn, umsMachineUser.getCrn(), environmentCrn);
+        if (groups.isEmpty()) {
+            return null;
+        }
+
+        User user = new User();
+        // TODO Use workloadUsername once the UMS proto is updated
+        user.setName(umsMachineUser.getMachineUserName());
+        // TODO what should the appropriate first and last name be for machine users?
+        user.setFirstName("Machine");
+        user.setLastName("User");
+        user.setGroups(groups);
+        return user;
+    }
+
+    private Set<String> getGroupsForUser(String actorCrn, String userCrn, String environmentCrn) {
+        // TODO do we care about '*' rights?
+        return new HashSet<>(
+                umsClient.getGroupsForUser(actorCrn, userCrn, environmentCrn, Optional.empty())
+                        .stream()
+                        .map(this::getGroupNameFromGroupCrn)
+                        .collect(Collectors.toSet()));
+    }
+
+    private String getGroupNameFromGroupCrn(String groupCrn) {
+        Crn crn = Crn.safeFromString(groupCrn);
+        return crn.getResource().split("/")[0];
+    }
+
+    private Group fromGroupName(String groupName) {
+        Group group = new Group();
+        group.setName(groupName);
+        return group;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/UserService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/UserService.java
@@ -2,9 +2,11 @@ package com.sequenceiq.freeipa.service.user;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -12,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.CreateUsersRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.Group;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizationStatus;
@@ -24,6 +27,9 @@ import com.sequenceiq.freeipa.client.model.RPCResponse;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.service.FreeIpaClientFactory;
 import com.sequenceiq.freeipa.service.stack.StackService;
+import com.sequenceiq.freeipa.service.user.model.UsersState;
+import com.sequenceiq.freeipa.service.user.model.UsersStateDifference;
+import com.sequenceiq.freeipa.util.CrnService;
 
 @Service
 public class UserService {
@@ -36,7 +42,50 @@ public class UserService {
     @Inject
     private FreeIpaClientFactory freeIpaClientFactory;
 
+    @Inject
+    private ThreadBasedUserCrnProvider threadBaseUserCrnProvider;
+
+    @Inject
+    private CrnService crnService;
+
+    @Inject
+    private UmsUsersStateProvider umsUsersStateProvider;
+
+    @Inject
+    private FreeIpaUsersStateProvider freeIpaUsersStateProvider;
+
     public SynchronizeUsersResponse synchronizeUsers(SynchronizeUsersRequest request) {
+        String accountId = crnService.getCurrentAccountId();
+        List<Stack> stacks = stackService.getAllByAccountId(accountId);
+        LOGGER.debug("Found {} stacks for account {}", stacks.size(), accountId);
+        Set<String> environmentsFilter = request.getEnvironments();
+        if (!environmentsFilter.isEmpty()) {
+            stacks = stacks.stream()
+                    .filter(stack -> environmentsFilter.contains(stack.getEnvironmentCrn()))
+                    .collect(Collectors.toList());
+        }
+        for (Stack stack : stacks) {
+            // TODO improve exception handling
+            try {
+                LOGGER.info("Syncing Environment {}", stack.getEnvironmentCrn());
+                // TODO filter by users in request
+                UsersState umsUsersState = umsUsersStateProvider.getUsersState(stack.getEnvironmentCrn());
+                LOGGER.debug("UMS UsersState = {}", umsUsersState);
+                // TODO filter by users in request
+                UsersState ipaUsersState = freeIpaUsersStateProvider.getUsersState(stack);
+                LOGGER.debug("IPA UsersState = {}", ipaUsersState);
+                // TODO calculate group membership changes. this currently only picks up group membership for added users
+                UsersStateDifference stateDifference = UsersStateDifference.fromUmsAndIpaUsersStates(umsUsersState, ipaUsersState);
+                LOGGER.debug("State Difference = {}", stateDifference);
+                FreeIpaClient freeIpaClient = freeIpaClientFactory.getFreeIpaClientForStack(stack);
+                addGroups(freeIpaClient, stateDifference.getGroupsToAdd());
+                addUsers(freeIpaClient, stateDifference.getUsersToAdd());
+                // TODO remove/deactivate groups/users
+            } catch (Exception e) {
+                LOGGER.warn("Failed to syncronize environment {}", stack.getEnvironmentCrn());
+            }
+        }
+
         return new SynchronizeUsersResponse(UUID.randomUUID().toString(), SynchronizationStatus.FAILED,
                 null, null);
     }
@@ -73,8 +122,13 @@ public class UserService {
     private void addGroups(FreeIpaClient freeIpaClient, Set<Group> groups) throws FreeIpaClientException {
         for (Group group : groups) {
             LOGGER.debug("adding group {}", group.getName());
-            RPCResponse<Object> groupAdd = freeIpaClient.groupAdd(group.getName());
-            LOGGER.debug("Success: {}", groupAdd.getResult());
+            try {
+                com.sequenceiq.freeipa.client.model.Group groupAdd = freeIpaClient.groupAdd(group.getName());
+                LOGGER.debug("Success: {}", groupAdd);
+            } catch (FreeIpaClientException e) {
+                // TODO propagate this information out to API
+                LOGGER.error("Failed to add group {}", group.getName(), e);
+            }
         }
     }
 
@@ -84,19 +138,28 @@ public class UserService {
 
             LOGGER.debug("adding user {}", username);
 
-            RPCResponse<com.sequenceiq.freeipa.client.model.User> userAdd = freeIpaClient.userAdd(
-                    username, user.getFirstName(), user.getLastName(), generateRandomPassword());
-
-            LOGGER.debug("Success: {}", userAdd.getResult());
+            try {
+                com.sequenceiq.freeipa.client.model.User userAdd = freeIpaClient.userAdd(
+                        username, user.getFirstName(), user.getLastName(), generateRandomPassword());
+                LOGGER.debug("Success: {}", userAdd);
+            } catch (FreeIpaClientException e) {
+                // TODO propagate this information out to API
+                LOGGER.error("Failed to add {}", username, e);
+            }
         }
     }
 
     private void addUsersToGroups(FreeIpaClient freeIpaClient, Map<String, Set<String>> groupMapping) throws FreeIpaClientException {
         for (Map.Entry<String, Set<String>> entry : groupMapping.entrySet()) {
             LOGGER.debug("adding users {} to group {}", entry.getValue(), entry.getKey());
-            // TODO specialize response object
-            RPCResponse<Object> groupAddMember = freeIpaClient.groupAddMembers(entry.getKey(), entry.getValue());
-            LOGGER.debug("Success: {}", groupAddMember.getResult());
+            try {
+                // TODO specialize response object
+                RPCResponse<Object> groupAddMember = freeIpaClient.groupAddMembers(entry.getKey(), entry.getValue());
+                LOGGER.debug("Success: {}", groupAddMember.getResult());
+            } catch (FreeIpaClientException e) {
+                // TODO propagate this information out to API
+                LOGGER.error("Failed to add users {} to group {}", entry.getValue(), entry.getKey(), e);
+            }
         }
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/model/UsersState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/model/UsersState.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.freeipa.service.user.model;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Set;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.Group;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.User;
+
+public class UsersState {
+    private Set<Group> groups;
+
+    private Set<User> users;
+
+    public UsersState(Set<Group> groups, Set<User> users) {
+        this.groups = requireNonNull(groups);
+        this.users = requireNonNull(users);
+    }
+
+    public Set<Group> getGroups() {
+        return groups;
+    }
+
+    public Set<User> getUsers() {
+        return users;
+    }
+
+    @Override
+    public String toString() {
+        return "UsersState{"
+                + "groups=" + groups
+                + ", users=" + users
+                + '}';
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/model/UsersStateDifference.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/model/UsersStateDifference.java
@@ -1,0 +1,83 @@
+package com.sequenceiq.freeipa.service.user.model;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.Group;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.User;
+
+public class UsersStateDifference {
+    private Set<Group> groupsToAdd;
+
+    private Set<User> usersToAdd;
+
+    private Set<Group> groupsToRemove;
+
+    private Set<User> usersToRemove;
+
+    private Multimap<Group, User> groupMembershipToAdd;
+
+    private Multimap<Group, User> groupMembershipToRemove;
+
+    public UsersStateDifference(Set<Group> groupsToAdd, Set<User> usersToAdd, Set<Group> groupsToRemove, Set<User> usersToRemove,
+            Multimap<Group, User> groupMembershipToAdd, Multimap<Group, User> groupMembershipToRemove) {
+        this.groupsToAdd = requireNonNull(groupsToAdd);
+        this.usersToAdd = requireNonNull(usersToAdd);
+        this.groupsToRemove = requireNonNull(groupsToRemove);
+        this.usersToRemove = requireNonNull(usersToRemove);
+        this.groupMembershipToAdd = requireNonNull(groupMembershipToAdd);
+        this.groupMembershipToRemove = requireNonNull(groupMembershipToRemove);
+    }
+
+    public Set<Group> getGroupsToAdd() {
+        return groupsToAdd;
+    }
+
+    public Set<User> getUsersToAdd() {
+        return usersToAdd;
+    }
+
+    public Set<Group> getGroupsToRemove() {
+        return groupsToRemove;
+    }
+
+    public Set<User> getUsersToRemove() {
+        return usersToRemove;
+    }
+
+    public Multimap<Group, User> getGroupMembershipToAdd() {
+        return groupMembershipToAdd;
+    }
+
+    public Multimap<Group, User> getGroupMembershipToRemove() {
+        return groupMembershipToRemove;
+    }
+
+    @Override
+    public String toString() {
+        return "UsersStateDifference{"
+                + "groupsToAdd=" + groupsToAdd
+                + ", usersToAdd=" + usersToAdd
+                + ", groupsToRemove=" + groupsToRemove
+                + ", usersToRemove=" + usersToRemove
+                + ", groupMembershipToAdd=" + groupMembershipToAdd
+                + ", groupMembershipToRemove=" + groupMembershipToRemove
+                + '}';
+    }
+
+    public static UsersStateDifference fromUmsAndIpaUsersStates(UsersState umsState, UsersState ipaState) {
+        return new UsersStateDifference(
+                Set.copyOf(Sets.difference(umsState.getGroups(), ipaState.getGroups())),
+                Set.copyOf(Sets.difference(umsState.getUsers(), ipaState.getUsers())),
+                Set.copyOf(Sets.difference(ipaState.getGroups(), umsState.getGroups())),
+                Set.copyOf(Sets.difference(ipaState.getUsers(), umsState.getUsers())),
+                // TODO calculate group membership changes
+                Multimaps.forMap(Map.of()),
+                Multimaps.forMap(Map.of()));
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/user/FreeIpaUsersStateProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/user/FreeIpaUsersStateProviderTest.java
@@ -1,0 +1,128 @@
+package com.sequenceiq.freeipa.service.user;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.Group;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.User;
+import com.sequenceiq.freeipa.client.FreeIpaClient;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.FreeIpaClientFactory;
+import com.sequenceiq.freeipa.service.user.model.UsersState;
+
+@ExtendWith(MockitoExtension.class)
+class FreeIpaUsersStateProviderTest {
+
+    @InjectMocks
+    FreeIpaUsersStateProvider underTest;
+
+    @Mock
+    private FreeIpaClientFactory freeIpaClientFactory;
+
+    @Mock
+    private Stack stack;
+
+    @Mock
+    private FreeIpaClient freeIpaClient;
+
+    @Test
+    void testGetUserState() throws Exception {
+        when(freeIpaClientFactory.getFreeIpaClientForStack(stack)).thenReturn(freeIpaClient);
+
+        List<String> user1GroupNames = List.of("group1", "group2");
+        List<String> user2GroupNames = List.of("group2", "group3", FreeIpaUsersStateProvider.IPA_ONLY_GROUPS.get(0));
+        List<String> ipaOnlyUserGroupNames = List.of("dont_include");
+        Map<String, List<String>> users = Map.of(
+                "user1", user1GroupNames,
+                "user2", user2GroupNames,
+                FreeIpaUsersStateProvider.IPA_ONLY_USERS.get(0), ipaOnlyUserGroupNames
+        );
+
+        Set<com.sequenceiq.freeipa.client.model.User> usersFindAll = users.entrySet().stream()
+                .map(entry -> createIpaUser(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toSet());
+
+        Set<com.sequenceiq.freeipa.client.model.Group> groupsFindAll = Stream.of(user1GroupNames.stream(),
+                user2GroupNames.stream(), FreeIpaUsersStateProvider.IPA_ONLY_GROUPS.stream())
+                .flatMap(groupName -> groupName)
+                .map(this::createIpaGroup)
+                .collect(Collectors.toSet());
+
+        when(freeIpaClient.userFindAll()).thenReturn(usersFindAll);
+        when(freeIpaClient.groupFindAll()).thenReturn(groupsFindAll);
+
+        UsersState ipaState = underTest.getUsersState(stack);
+
+        Set<String> expectedUsers = users.keySet().stream()
+                .filter(user -> !FreeIpaUsersStateProvider.IPA_ONLY_USERS.contains(user))
+                .collect(Collectors.toSet());
+
+        Set<String> expectedGroups = expectedUsers.stream()
+                .flatMap(user -> users.get(user).stream())
+                .filter(group -> !FreeIpaUsersStateProvider.IPA_ONLY_GROUPS.contains(group))
+                .collect(Collectors.toSet());
+
+        for (User user : ipaState.getUsers()) {
+            assertTrue(expectedUsers.contains(user.getName()));
+            expectedUsers.remove(user.getName());
+        }
+        assertTrue(expectedUsers.isEmpty());
+
+        for (Group group : ipaState.getGroups()) {
+            assertTrue(expectedGroups.contains(group.getName()));
+            expectedGroups.remove(group.getName());
+        }
+        assertTrue(expectedGroups.isEmpty());
+    }
+
+    @Test
+    void testFromIpaUser() {
+        com.sequenceiq.freeipa.client.model.User ipaUser = createIpaUser("uid", List.of("group1", "group2"));
+
+        User user = underTest.fromIpaUser(ipaUser);
+
+        assertEquals(user.getName(), ipaUser.getUid());
+        assertEquals(user.getLastName(), ipaUser.getSn());
+        assertEquals(user.getFirstName(), ipaUser.getGivenname());
+        assertEquals(user.getGroups(), Set.copyOf(ipaUser.getMemberOfGroup()));
+    }
+
+    @Test
+    void testFromIpaGroup() {
+        com.sequenceiq.freeipa.client.model.Group ipaGroup = createIpaGroup("cn");
+
+        Group group = underTest.fromIpaGroup(ipaGroup);
+
+        assertEquals(group.getName(), ipaGroup.getCn());
+    }
+
+    private com.sequenceiq.freeipa.client.model.User createIpaUser(String uid, List<String> memberOfGroup) {
+        com.sequenceiq.freeipa.client.model.User ipaUser = new com.sequenceiq.freeipa.client.model.User();
+        ipaUser.setUid(uid);
+        ipaUser.setDn(UUID.randomUUID().toString());
+        ipaUser.setSn(UUID.randomUUID().toString());
+        ipaUser.setGivenname(UUID.randomUUID().toString());
+        ipaUser.setMemberOfGroup(memberOfGroup);
+        return ipaUser;
+    }
+
+    private com.sequenceiq.freeipa.client.model.Group createIpaGroup(String cn) {
+        com.sequenceiq.freeipa.client.model.Group ipaGroup = new com.sequenceiq.freeipa.client.model.Group();
+        ipaGroup.setCn(cn);
+        return ipaGroup;
+    }
+}


### PR DESCRIPTION
This is the first cut at syncing users and groups from the UMS to
the IPA server. This includes the following changes:
- The UMS client was updated to list all users and retrieve rights
- The FMS retrieves the user and group state from the UMS
- The FMS retrieves the user and group state from the IPA
- The FMS calculates the difference between the state retrieved from
  the UMS compared to the IPA
- The FMS adds groups and users that exist in the UMS to the IPA.

The sync is currently run synchronously with the API call and the
API response is not yet populated.
