### PR TITLE
CB-1660. Workaround for Metastore Canary failure

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha.bp
@@ -80,12 +80,6 @@
           {
             "refName": "hms-HIVEMETASTORE-BASE",
             "roleType": "HIVEMETASTORE",
-            "configs": [
-              {
-                "name": "metastore_canary_health_enabled",
-                "value": "false"
-              }
-            ],
             "base": true
           }
         ]

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveMetastoreConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveMetastoreConfigProvider.java
@@ -10,15 +10,16 @@ import org.springframework.stereotype.Component;
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
 import com.google.common.base.Preconditions;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
-import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateComponentConfigProvider;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRoleConfigConfigProvider;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.cloudbreak.template.views.HostgroupView;
 import com.sequenceiq.cloudbreak.template.views.RdsView;
 
 @Component
-public class HiveMetastoreConfigProvider implements CmTemplateComponentConfigProvider {
+public class HiveMetastoreConfigProvider extends AbstractRoleConfigConfigProvider {
 
     @Override
     public List<ApiClusterTemplateConfig> getServiceConfigs(TemplatePreparationObject templatePreparationObject) {
@@ -48,6 +49,13 @@ public class HiveMetastoreConfigProvider implements CmTemplateComponentConfigPro
     @Override
     public boolean isConfigurationNeeded(CmTemplateProcessor cmTemplateProcessor, TemplatePreparationObject source) {
         return getFirstRDSConfigOptional(source).isPresent() && cmTemplateProcessor.isRoleTypePresentInService(getServiceType(), getRoleTypes());
+    }
+
+    @Override
+    protected List<ApiClusterTemplateConfig> getRoleConfig(String roleType, HostgroupView hostGroupView, TemplatePreparationObject source) {
+        return List.of(
+                config("metastore_canary_health_enabled", Boolean.FALSE.toString())
+        );
     }
 
     private Optional<RDSConfig> getFirstRDSConfigOptional(TemplatePreparationObject source) {

--- a/template-manager-cmtemplate/src/test/resources/output/clouderamanager-variables.bp
+++ b/template-manager-cmtemplate/src/test/resources/output/clouderamanager-variables.bp
@@ -173,6 +173,12 @@
         {
           "refName": "hive-HIVEMETASTORE-BASE",
           "roleType": "HIVEMETASTORE",
+          "configs": [
+            {
+              "name": "metastore_canary_health_enabled",
+              "value": "false"
+            }
+          ],
           "base": true
         }
       ]

--- a/template-manager-cmtemplate/src/test/resources/output/clouderamanager-without-hosts.bp
+++ b/template-manager-cmtemplate/src/test/resources/output/clouderamanager-without-hosts.bp
@@ -174,6 +174,12 @@
         {
           "refName": "hive-HIVEMETASTORE-BASE",
           "roleType": "HIVEMETASTORE",
+          "configs": [
+            {
+              "name": "metastore_canary_health_enabled",
+              "value": "false"
+            }
+          ],
           "base": true
         }
       ]

--- a/template-manager-cmtemplate/src/test/resources/output/clouderamanager.bp
+++ b/template-manager-cmtemplate/src/test/resources/output/clouderamanager.bp
@@ -173,6 +173,12 @@
         {
           "refName": "hive-HIVEMETASTORE-BASE",
           "roleType": "HIVEMETASTORE",
+          "configs": [
+            {
+              "name": "metastore_canary_health_enabled",
+              "value": "false"
+            }
+          ],
           "base": true
         }
       ]


### PR DESCRIPTION
## What changes were proposed in this pull request?

Temporarily disable Hive Metastore Canary health check until it is fixed.

## How was this patch tested?

Adjusted unit tests.  Deployed built-in SDX data lake, verified check is disabled.