### PR TITLE
CB-1653 Add account ID to database, expand CRN column

### DIFF
--- a/redbeams/src/main/java/com/sequenceiq/redbeams/converter/database/DatabaseConfigToDatabaseV4ResponseConverter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/converter/database/DatabaseConfigToDatabaseV4ResponseConverter.java
@@ -14,7 +14,7 @@ public class DatabaseConfigToDatabaseV4ResponseConverter extends AbstractConvers
     public DatabaseV4Response convert(DatabaseConfig source) {
         DatabaseV4Response json = new DatabaseV4Response();
         json.setName(source.getName());
-        json.setCrn(source.getCrn().toString());
+        json.setCrn(source.getResourceCrn().toString());
         json.setDescription(source.getDescription());
         json.setConnectionURL(source.getConnectionURL());
         json.setDatabaseEngine(source.getDatabaseVendor().name());

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/domain/DatabaseConfig.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/domain/DatabaseConfig.java
@@ -29,9 +29,12 @@ public class DatabaseConfig {
     @SequenceGenerator(name = "databaseconfig_generator", sequenceName = "databaseconfig_id_seq", allocationSize = 1)
     private Long id;
 
-    @Convert(converter = CrnConverter.class)
     @Column(nullable = false)
-    private Crn crn;
+    private String accountId;
+
+    @Convert(converter = CrnConverter.class)
+    @Column(name = "crn", nullable = false)
+    private Crn resourceCrn;
 
     @Column(nullable = false)
     private String name;
@@ -82,8 +85,12 @@ public class DatabaseConfig {
         return id;
     }
 
-    public Crn getCrn() {
-        return crn;
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public Crn getResourceCrn() {
+        return resourceCrn;
     }
 
     public String getName() {
@@ -146,8 +153,12 @@ public class DatabaseConfig {
         this.id = id;
     }
 
-    public void setCrn(Crn crn) {
-        this.crn = crn;
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
+    }
+
+    public void setResourceCrn(Crn resourceCrn) {
+        this.resourceCrn = resourceCrn;
     }
 
     public void setName(String name) {

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbconfig/DatabaseConfigService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbconfig/DatabaseConfigService.java
@@ -10,6 +10,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ResourceStatus;
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.common.service.Clock;
 import com.sequenceiq.cloudbreak.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
@@ -37,7 +38,9 @@ public class DatabaseConfigService {
             // prepareCreation(configToSave);
             configToSave.setStatus(ResourceStatus.USER_MANAGED);
             configToSave.setCreationDate(clock.getCurrentTimeMillis());
-            configToSave.setCrn(crnService.createCrn(configToSave));
+            Crn crn = crnService.createCrn(configToSave);
+            configToSave.setResourceCrn(crn);
+            configToSave.setAccountId(crn.getAccountId());
             return databaseConfigRepository.save(configToSave);
         } catch (AccessDeniedException | DataIntegrityViolationException e) {
             ConstraintViolationException cve = null;

--- a/redbeams/src/main/resources/schema/app/20190530170044_CB-1653_Adjust_database_CRN_storage.sql
+++ b/redbeams/src/main/resources/schema/app/20190530170044_CB-1653_Adjust_database_CRN_storage.sql
@@ -1,0 +1,22 @@
+-- // CB-1653 Adjust database CRN storage
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE databaseconfig ALTER COLUMN crn TYPE TEXT;
+
+ALTER TABLE databaseconfig ADD COLUMN accountid TEXT;
+
+UPDATE databaseconfig SET accountid = 'unknown' WHERE accountid IS NULL;
+
+ALTER TABLE databaseconfig ALTER COLUMN accountid SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS databaseconfig_accountid_idx ON databaseconfig(accountid);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+DROP INDEX IF EXISTS databaseconfig_accountid_idx;
+
+ALTER TABLE databaseconfig DROP COLUMN accountid;
+
+ALTER TABLE databaseconfig ALTER COLUMN crn TYPE VARCHAR(255);
+

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/converter/database/DatabaseConfigToDatabaseV4ResponseConverterTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/converter/database/DatabaseConfigToDatabaseV4ResponseConverterTest.java
@@ -54,7 +54,7 @@ public class DatabaseConfigToDatabaseV4ResponseConverterTest {
     public void testConvert() {
         DatabaseConfig databaseConfig = new DatabaseConfig();
         databaseConfig.setName(NAME);
-        databaseConfig.setCrn(CRN);
+        databaseConfig.setResourceCrn(CRN);
         databaseConfig.setDescription(DESCRIPTION);
         databaseConfig.setCreationDate(CREATION_DATE);
 //        databaseConfig.setStatus(ResourceStatus.USER_MANAGED);


### PR DESCRIPTION
Redbeams now stores the account ID from database CRNs in a separate,
indexed column. The existing "crn" column is migrated to a TEXT type to
ensure enough space to store an entire CRN.