### PR TITLE
CB-1458. Accept built-in blueprint in request

### DIFF
--- a/template-manager-blueprint/src/main/java/com/sequenceiq/cloudbreak/blueprint/utils/BlueprintUtils.java
+++ b/template-manager-blueprint/src/main/java/com/sequenceiq/cloudbreak/blueprint/utils/BlueprintUtils.java
@@ -24,6 +24,8 @@ public class BlueprintUtils {
 
     public static final String CDH_VERSION_JSON_NODE_TEXT = "cdhVersion";
 
+    private static final String BLUEPRINT_NODE = "blueprint";
+
     @Inject
     private JsonHelper jsonHelper;
 
@@ -73,6 +75,16 @@ public class BlueprintUtils {
 
     public boolean isAmbariBlueprint(JsonNode blueprint) {
         return blueprint.path(CDH_VERSION_JSON_NODE_TEXT).isMissingNode() && blueprint.path(BLUEPRINTS_JSON_NODE_TEXT).isContainerNode();
+    }
+
+    public boolean isBuiltinBlueprint(JsonNode root) {
+        JsonNode blueprint = getBuiltinBlueprintContent(root);
+        return blueprint != null
+                && (isClouderaManagerClusterTemplate(blueprint) || isAmbariBlueprint(blueprint));
+    }
+
+    public JsonNode getBuiltinBlueprintContent(JsonNode root) {
+        return root.get(BLUEPRINT_NODE);
     }
 
     public String getBlueprintName(JsonNode root) {

--- a/template-manager-blueprint/src/test/java/com/sequenceiq/cloudbreak/blueprint/utils/AmbariBlueprintUtilsTest.java
+++ b/template-manager-blueprint/src/test/java/com/sequenceiq/cloudbreak/blueprint/utils/AmbariBlueprintUtilsTest.java
@@ -147,4 +147,32 @@ public class AmbariBlueprintUtilsTest {
     public void testIsValidHostGroupNameWithMaster() {
         assertTrue(underTest.isValidHostGroupName("master"));
     }
+
+    @Test
+    public void builtinBlueprintConsideredBuiltin() throws Exception {
+        String text = FileReaderUtils.readFileFromClasspath("defaults/blueprints/cdp.bp");
+        JsonNode json = new JsonHelper().createJsonFromString(text);
+
+        assertTrue(underTest.isBuiltinBlueprint(json));
+    }
+
+    @Test
+    public void otherBlueprintNotConsideredBuiltin() throws Exception {
+        String text = FileReaderUtils.readFileFromClasspath("blueprints-jackson/test-bp-without-config-block.bp");
+        JsonNode json = new JsonHelper().createJsonFromString(text);
+
+        assertFalse(underTest.isBuiltinBlueprint(json));
+    }
+
+    @Test
+    public void emptyBlueprintIsNotBuiltin() {
+        JsonNode json = new JsonHelper().createJsonFromString("{}");
+        assertFalse(underTest.isBuiltinBlueprint(json));
+    }
+
+    @Test
+    public void blueprintWithEmptyContentIsNotBuiltin() {
+        JsonNode json = new JsonHelper().createJsonFromString("{ \"blueprint\": { } }");
+        assertFalse(underTest.isBuiltinBlueprint(json));
+    }
 }

--- a/template-manager-blueprint/src/test/resources/defaults/blueprints/cdp.bp
+++ b/template-manager-blueprint/src/test/resources/defaults/blueprints/cdp.bp
@@ -1,0 +1,10 @@
+{
+  "tags": {
+    "shared_services_ready": true
+  },
+  "description": "desc",
+  "blueprint": {
+    "cdhVersion": "7.0.0",
+    "displayName": "datalake"
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

[Default blueprints](https://github.com/hortonworks/cloudbreak/tree/master/core/src/main/resources/defaults/blueprints) have an additional layer of data on top of the content accepted for user-managed blueprints.  This causes confusion when trying to submit customised built-in blueprints, especially given the not too helpful error message:

```
ERROR: status code: 400, message: null
```

This change lets users submit both raw regular and built-in blueprints.  The latter is accepted if the embedded `"blueprint": { ... }` structure is valid as Ambari or CM blueprint.

Tags, description and any other data from the external structure are ignored and still need to be set "manually" in the request.

## How was this patch tested?

Added unit test.  Tested creation of valid and invalid blueprints via CLI.  Checked created valid blueprints on UI.