### PR TITLE
CB-1394. Fix compile error in ClouderaManagerMgmtSetupServiceTest

### DIFF
--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerMgmtSetupServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerMgmtSetupServiceTest.java
@@ -11,8 +11,8 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 
 import com.cloudera.api.swagger.model.ApiConfig;
+import com.sequenceiq.cloudbreak.common.database.DatabaseCommon;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
-import com.sequenceiq.cloudbreak.validation.DatabaseCommon;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 


### PR DESCRIPTION
Fix:

```
> Task :cluster-cm:compileTestJava FAILED
cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerMgmtSetupServiceTest.java:15: error: cannot find symbol
import com.sequenceiq.cloudbreak.validation.DatabaseCommon;
```