### PR TITLE
CDPCP-300. Set password for user from crn

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/UserV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/UserV1Endpoint.java
@@ -4,7 +4,6 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
@@ -39,10 +38,10 @@ public interface UserV1Endpoint {
     SynchronizeUsersResponse getStatus(@QueryParam("id") String syncId);
 
     @POST
-    @Path("/{username}/password")
+    @Path("/password")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = UserOperationDescriptions.SET_PASSWORD, notes = UserNotes.USER_NOTES, produces = ContentType.JSON, nickname = "setPasswordV1")
-    SetPasswordResponse setPassword(@PathParam("username") String username, SetPasswordRequest request);
+    SetPasswordResponse setPassword(SetPasswordRequest request);
 
     @POST
     @Path("create")

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/controller/UserV1ControllerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/controller/UserV1ControllerTest.java
@@ -11,6 +11,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.CreateUsersRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SetPasswordRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeUsersRequest;
@@ -23,6 +24,8 @@ public class UserV1ControllerTest {
 
     private static final String ACCOUNT_ID = "accountId";
 
+    private static final String USER_CRN = ":crn:altus:iam:us-west-1:9d74eee4-1cad-45d7-b645-7ccf9edbb73d:user:59cbfafb-999b-4df9-81e2-aa00a88382e9";
+
     @InjectMocks
     private UserV1Controller underTest;
 
@@ -34,6 +37,9 @@ public class UserV1ControllerTest {
 
     @Mock
     private CrnService crnService;
+
+    @Mock
+    private ThreadBasedUserCrnProvider threadBaseUserCrnProvider;
 
     @Test
     void synchronizeUsers() {
@@ -55,14 +61,14 @@ public class UserV1ControllerTest {
 
     @Test
     void setPassword() {
-        String username = "username";
+        when(threadBaseUserCrnProvider.getUserCrn()).thenReturn(USER_CRN);
         String password = "password";
         SetPasswordRequest request = mock(SetPasswordRequest.class);
         when(request.getPassword()).thenReturn(password);
 
-        underTest.setPassword(username, request);
+        underTest.setPassword(request);
 
-        verify(passwordService, times(1)).setPassword(username, password);
+        verify(passwordService, times(1)).setPassword(USER_CRN, password);
     }
 
     @Test


### PR DESCRIPTION
This change removes the username from the set password endpoint.
Instead, the calling user crn will be used to retrieve the
user id from the UMS so users can only set their own password.
