### PR TITLE
CB-1395 Fix connection URL for Postgres server

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/database/DatabaseCommon.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/database/DatabaseCommon.java
@@ -61,6 +61,11 @@ public class DatabaseCommon {
         }
         int port = Integer.parseInt(portString);
         Optional<String> database = Optional.ofNullable(matcher.group(DATABASE_GROUP));
+
+        if ("postgresql".equals(vendorDriverId) && !database.isPresent()) {
+            throw new IllegalArgumentException("PostgreSQL connection URLs require a database");
+        }
+
         return new JdbcConnectionUrlFields(vendorDriverId, host, port, database);
     }
 
@@ -75,6 +80,9 @@ public class DatabaseCommon {
                 url = String.format("jdbc:postgresql://%s:%d/", fields.getHost(), fields.getPort());
                 if (fields.getDatabase().isPresent()) {
                     url += fields.getDatabase().get();
+                } else {
+                    // PostgreSQL requires a database for connecting; this is a suitable default
+                    url += "postgres";
                 }
                 break;
             case "mysql":

--- a/common/src/test/java/com/sequenceiq/cloudbreak/util/DatabaseCommonTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/util/DatabaseCommonTest.java
@@ -31,6 +31,8 @@ public class DatabaseCommonTest {
 
     private static final String POSTGRES_URL_WITHOUT_DATABASE = "jdbc:postgresql://test.eu-west-1.rds.amazonaws.com:5432/";
 
+    private static final String POSTGRES_URL_WITH_POSTGRES_DATABASE = POSTGRES_URL_WITHOUT_DATABASE + "postgres";
+
     private static final String POSTGRES_URL = POSTGRES_URL_WITHOUT_DATABASE + "hivedb";
 
     private static final String POSTGRES_URL_WITH_HYPHENATED_DATABASE_NAME = POSTGRES_URL_WITHOUT_DATABASE + "hive-db-";
@@ -117,12 +119,9 @@ public class DatabaseCommonTest {
 
     @Test
     public void testPostgresNoDatabaseParsing() {
-        JdbcConnectionUrlFields fields = databaseCommon.parseJdbcConnectionUrl(POSTGRES_URL_WITHOUT_DATABASE);
-        assertThat(fields.getVendorDriverId()).isEqualTo("postgresql");
-        assertThat(fields.getHost()).isEqualTo("test.eu-west-1.rds.amazonaws.com");
-        assertThat(fields.getPort()).isEqualTo(5432);
-        assertThat(fields.getHostAndPort()).isEqualTo("test.eu-west-1.rds.amazonaws.com:5432");
-        assertThat(fields.getDatabase().isPresent()).isFalse();
+        thrown.expect(IllegalArgumentException.class);
+
+        databaseCommon.parseJdbcConnectionUrl(POSTGRES_URL_WITHOUT_DATABASE);
     }
 
     @Test
@@ -138,7 +137,7 @@ public class DatabaseCommonTest {
     @Test
     public void testPostgresConnectionUrlWithoutDatabase() {
         String url = databaseCommon.getJdbcConnectionUrl("postgresql", "test.eu-west-1.rds.amazonaws.com", 5432, Optional.empty());
-        assertThat(url).isEqualTo(POSTGRES_URL_WITHOUT_DATABASE);
+        assertThat(url).isEqualTo(POSTGRES_URL_WITH_POSTGRES_DATABASE);
     }
 
     @Test


### PR DESCRIPTION
PostgreSQL always requires a database as part of a JDBC connection URL.
So, the general connection URL for PostgreSQL database servers is now
defined as the URL for the "postgres" database that should always exist.
This allows connection to PostgreSQL for server-level operations, such
as database creation and deletion.