### PR TITLE
CB-1654 Include environment ID fully in redbeams API

### DIFF
--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/database/DatabaseV4Endpoint.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/database/DatabaseV4Endpoint.java
@@ -5,9 +5,9 @@ import static com.sequenceiq.redbeams.doc.OperationDescriptions.DatabaseOpDescri
 import java.util.Set;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
-import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -37,8 +37,7 @@ public interface DatabaseV4Endpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = DatabaseOpDescription.LIST, produces = MediaType.APPLICATION_JSON, notes = Notes.DATABASE_NOTES,
             nickname = "listDatabases")
-    DatabaseV4Responses list(@QueryParam("environment") String environment,
-            @QueryParam("attachGlobal") @DefaultValue("false") Boolean attachGlobal);
+    DatabaseV4Responses list(@NotNull @QueryParam("environmentId") String environmentId);
 
     @POST
     @Path("")
@@ -59,28 +58,28 @@ public interface DatabaseV4Endpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = DatabaseOpDescription.GET_BY_NAME, produces = MediaType.APPLICATION_JSON, notes = Notes.DATABASE_NOTES,
             nickname = "getDatabase")
-    DatabaseV4Response get(@PathParam("name") String name);
+    DatabaseV4Response get(@NotNull @QueryParam("environmentId") String environmentId, @PathParam("name") String name);
 
     @DELETE
     @Path("/{name}")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = DatabaseOpDescription.DELETE_BY_NAME, produces = MediaType.APPLICATION_JSON, notes = Notes.DATABASE_NOTES,
             nickname = "deleteDatabase")
-    DatabaseV4Response delete(@QueryParam("environmentCrn") String environmentCrn, @PathParam("name") String name);
+    DatabaseV4Response delete(@NotNull @QueryParam("environmentId") String environmentId, @PathParam("name") String name);
 
     @DELETE
     @Path("")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = DatabaseOpDescription.DELETE_MULTIPLE_BY_NAME, produces = MediaType.APPLICATION_JSON, notes = Notes.DATABASE_NOTES,
-            nickname = "deleteDatabases")
-    DatabaseV4Responses deleteMultiple(@QueryParam("environmentCrn") String environmentCrn, Set<String> names);
+            nickname = "deleteMultipleDatabases")
+    DatabaseV4Responses deleteMultiple(@NotNull @QueryParam("environmentId") String environmentId, Set<String> names);
 
-    @GET
-    @Path("/{name}/request")
-    @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = DatabaseOpDescription.GET_REQUEST, produces = MediaType.APPLICATION_JSON, notes = Notes.DATABASE_NOTES,
-            nickname = "getDatabaseRequestFromName")
-    DatabaseV4Request getRequest(@PathParam("name") String name);
+    // @GET
+    // @Path("/{name}/request")
+    // @Produces(MediaType.APPLICATION_JSON)
+    // @ApiOperation(value = DatabaseOpDescription.GET_REQUEST, produces = MediaType.APPLICATION_JSON, notes = Notes.DATABASE_NOTES,
+    //         nickname = "getDatabaseRequestFromName")
+    // DatabaseV4Request getRequest(@PathParam("name") String name);
 
     @POST
     @Path("/test")
@@ -88,25 +87,4 @@ public interface DatabaseV4Endpoint {
     @ApiOperation(value = DatabaseOpDescription.POST_CONNECTION_TEST, produces = MediaType.APPLICATION_JSON, notes = Notes.DATABASE_NOTES,
             nickname = "testDatabaseConnection")
     DatabaseTestV4Response test(@Valid DatabaseTestV4Request databaseTestV4Request);
-
-    // TODO: current idea is: 1 db - 1 env. That is, we should not be able to attach it to multiple environments.
-//    @PUT
-//    @Path("{name}/attach")
-//    @Produces(MediaType.APPLICATION_JSON)
-//    @Consumes(MediaType.APPLICATION_JSON)
-//    @ApiOperation(value = OperationDescriptions.DatabaseOpDescription.ATTACH_TO_ENVIRONMENTS, produces = ContentType.JSON,
-//    notes = com.sequenceiq.cloudbreak.doc.Notes.DATABASE_NOTES,
-//            nickname = "attachDatabaseToEnvironments")
-//    DatabaseV4Response attach(@PathParam("name") String name,
-//            @Valid @NotNull EnvironmentNames environmentNames);
-//
-//    @PUT
-//    @Path("{name}/detach")
-//    @Produces(MediaType.APPLICATION_JSON)
-//    @Consumes(MediaType.APPLICATION_JSON)
-//    @ApiOperation(value = OperationDescriptions.DatabaseOpDescription.DETACH_FROM_ENVIRONMENTS, produces = ContentType.JSON,
-//    notes = com.sequenceiq.cloudbreak.doc.Notes.DATABASE_NOTES,
-//            nickname = "detachDatabaseFromEnvironments")
-//    DatabaseV4Response detach(@PathParam("name") String name,
-//            @Valid @NotNull EnvironmentNames environmentNames);
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/database/base/DatabaseV4Identifiers.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/database/base/DatabaseV4Identifiers.java
@@ -1,0 +1,45 @@
+package com.sequenceiq.redbeams.api.endpoint.v4.database.base;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.sequenceiq.redbeams.doc.ModelDescriptions;
+import com.sequenceiq.redbeams.doc.ModelDescriptions.Database;
+
+import io.swagger.annotations.ApiModelProperty;
+
+import java.io.Serializable;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DatabaseV4Identifiers implements Serializable {
+
+    @NotNull
+    @Size(max = 100, min = 5, message = "The length of the database's name must be between 5 to 100, inclusive")
+    @Pattern(regexp = "(^[a-z][-a-z0-9]*[a-z0-9]$)",
+            message = "The database's name may only contain lowercase characters, digits, and hyphens, and must start with an alphanumeric character")
+    @ApiModelProperty(value = Database.NAME, required = true)
+    private String name;
+
+    @NotNull
+    @ApiModelProperty(value = ModelDescriptions.ENVIRONMENT_ID, required = true)
+    private String environmentId;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEnvironmentId() {
+        return environmentId;
+    }
+
+    public void setEnvironmentId(String environmentId) {
+        this.environmentId = environmentId;
+    }
+
+}

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/database/request/DatabaseTestV4Request.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/database/request/DatabaseTestV4Request.java
@@ -1,33 +1,36 @@
 package com.sequenceiq.redbeams.api.endpoint.v4.database.request;
 
-import static com.sequenceiq.redbeams.doc.ModelDescriptions.Database;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.sequenceiq.cloudbreak.validation.ValidIfExactlyOneNonNull;
+import com.sequenceiq.redbeams.api.endpoint.v4.database.base.DatabaseV4Identifiers;
+import com.sequenceiq.redbeams.doc.ModelDescriptions.Database;
 
 import java.io.Serializable;
 
 import javax.validation.Valid;
-
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
 @ApiModel
 @JsonIgnoreProperties(ignoreUnknown = true)
+@ValidIfExactlyOneNonNull(fields = { "existingDatabase", "database" })
 public class DatabaseTestV4Request implements Serializable {
 
-    @ApiModelProperty(Database.NAME)
-    private String existingDatabaseName;
+    @Valid
+    @ApiModelProperty(Database.DATABASE_TEST_EXISTING_REQUEST)
+    private DatabaseV4Identifiers existingDatabase;
 
     @Valid
-    @ApiModelProperty(Database.DATABASE_REQUEST)
+    @ApiModelProperty(Database.DATABASE_TEST_NEW_REQUEST)
     private DatabaseV4Request database;
 
-    public String getExistingDatabaseName() {
-        return existingDatabaseName;
+    public DatabaseV4Identifiers getExistingDatabase() {
+        return existingDatabase;
     }
 
-    public void setExistingDatabaseName(String existingDatabaseName) {
-        this.existingDatabaseName = existingDatabaseName;
+    public void setExistingDatabase(DatabaseV4Identifiers existingDatabase) {
+        this.existingDatabase = existingDatabase;
     }
 
     public DatabaseV4Request getDatabase() {

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/DatabaseServerV4Endpoint.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/DatabaseServerV4Endpoint.java
@@ -3,6 +3,7 @@ package com.sequenceiq.redbeams.api.endpoint.v4.databaseserver;
 import java.util.Set;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
@@ -39,8 +40,8 @@ public interface DatabaseServerV4Endpoint {
     @Path("")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = DatabaseServerOpDescription.LIST, produces = MediaType.APPLICATION_JSON, notes = Notes.DATABASE_SERVER_NOTES,
-        nickname = "listDatabasesServers")
-    DatabaseServerV4Responses list(@QueryParam("environmentId") String environmentId,
+        nickname = "listDatabaseServers")
+    DatabaseServerV4Responses list(@NotNull @QueryParam("environmentId") String environmentId,
         @QueryParam("attachGlobal") @DefaultValue("false") Boolean attachGlobal);
 
     @GET
@@ -48,7 +49,7 @@ public interface DatabaseServerV4Endpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = DatabaseServerOpDescription.GET_BY_NAME, produces = MediaType.APPLICATION_JSON, notes = Notes.DATABASE_SERVER_NOTES,
         nickname = "getDatabaseServer")
-    DatabaseServerV4Response get(@QueryParam("environmentId") String environmentId, @PathParam("name") String name);
+    DatabaseServerV4Response get(@NotNull @QueryParam("environmentId") String environmentId, @PathParam("name") String name);
 
     @POST
     @Path("register")
@@ -62,14 +63,14 @@ public interface DatabaseServerV4Endpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = DatabaseServerOpDescription.DELETE_BY_NAME, produces = MediaType.APPLICATION_JSON, notes = Notes.DATABASE_SERVER_NOTES,
         nickname = "deleteDatabaseServer")
-    DatabaseServerV4Response delete(@QueryParam("environmentId") String environmentId, @PathParam("name") String name);
+    DatabaseServerV4Response delete(@NotNull @QueryParam("environmentId") String environmentId, @PathParam("name") String name);
 
     @DELETE
     @Path("")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = DatabaseServerOpDescription.DELETE_MULTIPLE_BY_NAME, produces = MediaType.APPLICATION_JSON, notes = Notes.DATABASE_SERVER_NOTES,
             nickname = "deleteMultipleDatabaseServers")
-    DatabaseServerV4Responses deleteMultiple(@QueryParam("environmentId") String environmentId, Set<String> names);
+    DatabaseServerV4Responses deleteMultiple(@NotNull @QueryParam("environmentId") String environmentId, Set<String> names);
 
 //    @GET
 //    @Path("{name}/request")

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/base/DatabaseServerV4Identifiers.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/base/DatabaseServerV4Identifiers.java
@@ -1,0 +1,45 @@
+package com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.base;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.sequenceiq.redbeams.doc.ModelDescriptions;
+import com.sequenceiq.redbeams.doc.ModelDescriptions.DatabaseServer;
+
+import io.swagger.annotations.ApiModelProperty;
+
+import java.io.Serializable;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DatabaseServerV4Identifiers implements Serializable {
+
+    @NotNull
+    @Size(max = 100, min = 5, message = "The length of the database server's name must be between 5 and 100, inclusive")
+    @Pattern(regexp = "(^[a-z][-a-z0-9]*[a-z0-9]$)",
+            message = "The database server's name may only contain lowercase letters, digits, and hyphens, and must start with an alphanumeric character")
+    @ApiModelProperty(value = DatabaseServer.NAME, required = true)
+    private String name;
+
+    @NotNull
+    @ApiModelProperty(value = ModelDescriptions.ENVIRONMENT_ID, required = true)
+    private String environmentId;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEnvironmentId() {
+        return environmentId;
+    }
+
+    public void setEnvironmentId(String environmentId) {
+        this.environmentId = environmentId;
+    }
+
+}

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/DatabaseServerTestV4Request.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/DatabaseServerTestV4Request.java
@@ -1,10 +1,8 @@
 package com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests;
 
-import static com.sequenceiq.redbeams.doc.ModelDescriptions.ENVIRONMENT_ID;
-import static java.util.Objects.requireNonNull;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.sequenceiq.cloudbreak.validation.ValidIfExactlyOneNonNull;
+import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.base.DatabaseServerV4Identifiers;
 import com.sequenceiq.redbeams.doc.ModelDescriptions.DatabaseServer;
 
 import io.swagger.annotations.ApiModel;
@@ -16,33 +14,23 @@ import javax.validation.Valid;
 
 @ApiModel
 @JsonIgnoreProperties(ignoreUnknown = true)
-@ValidIfExactlyOneNonNull(fields = { "existingDatabaseServerName", "databaseServer" })
+@ValidIfExactlyOneNonNull(fields = { "existingDatabaseServer", "databaseServer" })
 public class DatabaseServerTestV4Request implements Serializable {
 
-    @ApiModelProperty(ENVIRONMENT_ID)
-    private String environmentId;
-
-    @ApiModelProperty(DatabaseServer.NAME)
-    private String existingDatabaseServerName;
+    @Valid
+    @ApiModelProperty(DatabaseServer.DATABASE_SERVER_TEST_EXISTING_REQUEST)
+    private DatabaseServerV4Identifiers existingDatabaseServer;
 
     @Valid
-    @ApiModelProperty(DatabaseServer.DATABASE_SERVER_REQUEST)
+    @ApiModelProperty(DatabaseServer.DATABASE_SERVER_TEST_NEW_REQUEST)
     private DatabaseServerV4Request databaseServer;
 
-    public String getEnvironmentId() {
-        return environmentId;
+    public DatabaseServerV4Identifiers getExistingDatabaseServer() {
+        return existingDatabaseServer;
     }
 
-    public void setEnvironmentId(String environmentId) {
-        this.environmentId = requireNonNull(environmentId, "environmentId is null");
-    }
-
-    public String getExistingDatabaseServerName() {
-        return existingDatabaseServerName;
-    }
-
-    public void setExistingDatabaseServerName(String existingDatabaseServerName) {
-        this.existingDatabaseServerName = existingDatabaseServerName;
+    public void setExistingDatabaseServer(DatabaseServerV4Identifiers existingDatabaseServer) {
+        this.existingDatabaseServer = existingDatabaseServer;
     }
 
     public DatabaseServerV4Request getDatabaseServer() {

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/ModelDescriptions.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/ModelDescriptions.java
@@ -20,7 +20,8 @@ public final class ModelDescriptions {
         public static final String TYPE = "Type of database, aka the service name that will use the database like HIVE, DRUID, SUPERSET, RANGER, etc.";
         public static final String CONNECTOR_JAR_URL = "URL that points to the jar of the connection driver(connector)";
         public static final String DATABASE_CONNECTION_TEST_RESULT = "Result of database connection test";
-        public static final String DATABASE_REQUEST = "Unsaved database config to be tested for connectivity";
+        public static final String DATABASE_TEST_EXISTING_REQUEST = "Identifiers of saved database config to be tested for connectivity";
+        public static final String DATABASE_TEST_NEW_REQUEST = "Unsaved database config to be tested for connectivity";
         public static final String DATABASE_CREATE_RESULT = "Result of database creation";
     }
 
@@ -34,7 +35,8 @@ public final class ModelDescriptions {
         public static final String CONNECTOR_JAR_URL = "URL that points to the JAR of the connection driver (JDBC connector)";
         public static final String CONNECTION_USER_NAME = "User name for the administrative user of the database server";
         public static final String CONNECTION_PASSWORD = "Password for the administrative user of the database server";
-        public static final String DATABASE_SERVER_REQUEST = "Unsaved database server config to be tested for connectivity";
+        public static final String DATABASE_SERVER_TEST_EXISTING_REQUEST = "Identifiers of saved database server config to be tested for connectivity";
+        public static final String DATABASE_SERVER_TEST_NEW_REQUEST = "Unsaved database server config to be tested for connectivity";
         public static final String DATABASE_SERVER_CONNECTION_TEST_RESULT = "Result of database server connection test";
     }
 

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/database/base/DatabaseV4BaseTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/database/base/DatabaseV4BaseTest.java
@@ -1,0 +1,42 @@
+package com.sequenceiq.redbeams.api.endpoint.v4.database.base;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class DatabaseV4BaseTest {
+
+    private DatabaseV4Base base;
+
+    @Before
+    public void setUp() {
+        base = new DatabaseV4BaseTestImpl();
+    }
+
+    @Test
+    public void testGettersAndSetters() {
+        base.setName("mydb");
+        assertEquals("mydb", base.getName());
+
+        base.setDescription("mine not yours");
+        assertEquals("mine not yours", base.getDescription());
+
+        base.setConnectionURL("jdbc:postgresql://myserver.db.example.com:5432/mydb");
+        assertEquals("jdbc:postgresql://myserver.db.example.com:5432/mydb", base.getConnectionURL());
+
+        base.setType("hive");
+        assertEquals("hive", base.getType());
+
+        base.setConnectorJarUrl("http://drivers.example.com/postgresql.jar");
+        assertEquals("http://drivers.example.com/postgresql.jar", base.getConnectorJarUrl());
+
+        base.setEnvironmentId("myenvironment");
+        assertEquals("myenvironment", base.getEnvironmentId());
+
+    }
+
+    private static class DatabaseV4BaseTestImpl extends DatabaseV4Base {
+    }
+
+}

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/database/base/DatabaseV4IdentifiersTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/database/base/DatabaseV4IdentifiersTest.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.redbeams.api.endpoint.v4.database.base;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class DatabaseV4IdentifiersTest {
+
+    private DatabaseV4Identifiers ids;
+
+    @Before
+    public void setUp() {
+        ids = new DatabaseV4Identifiers();
+    }
+
+    @Test
+    public void testGettersAndSetters() {
+        ids.setName("mydb");
+        assertEquals("mydb", ids.getName());
+
+        ids.setEnvironmentId("myenvironment");
+        assertEquals("myenvironment", ids.getEnvironmentId());
+
+    }
+
+}

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/database/request/DatabaseTestV4RequestTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/database/request/DatabaseTestV4RequestTest.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.redbeams.api.endpoint.v4.database.request;
+
+import static org.junit.Assert.assertEquals;
+
+import com.sequenceiq.redbeams.api.endpoint.v4.database.base.DatabaseV4Identifiers;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class DatabaseTestV4RequestTest {
+
+    private DatabaseTestV4Request request;
+
+    @Before
+    public void setUp() {
+        request = new DatabaseTestV4Request();
+    }
+
+    @Test
+    public void testGettersAndSetters() {
+        DatabaseV4Identifiers identifiers = new DatabaseV4Identifiers();
+        request.setExistingDatabase(identifiers);
+        assertEquals(identifiers, request.getExistingDatabase());
+
+        DatabaseV4Request serverRequest = new DatabaseV4Request();
+        serverRequest.setName("mydb1");
+        request.setDatabase(serverRequest);
+        assertEquals("mydb1", request.getDatabase().getName());
+
+    }
+
+}

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/base/DatabaseServerV4IdentifiersTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/base/DatabaseServerV4IdentifiersTest.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.base;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class DatabaseServerV4IdentifiersTest {
+
+    private DatabaseServerV4Identifiers ids;
+
+    @Before
+    public void setUp() {
+        ids = new DatabaseServerV4Identifiers();
+    }
+
+    @Test
+    public void testGettersAndSetters() {
+        ids.setName("myserver");
+        assertEquals("myserver", ids.getName());
+
+        ids.setEnvironmentId("myenvironment");
+        assertEquals("myenvironment", ids.getEnvironmentId());
+
+    }
+
+}

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/DatabaseServerTestV4RequestTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/DatabaseServerTestV4RequestTest.java
@@ -2,6 +2,8 @@ package com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests;
 
 import static org.junit.Assert.assertEquals;
 
+import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.base.DatabaseServerV4Identifiers;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -16,8 +18,9 @@ public class DatabaseServerTestV4RequestTest {
 
     @Test
     public void testGettersAndSetters() {
-        request.setExistingDatabaseServerName("mydb1");
-        assertEquals("mydb1", request.getExistingDatabaseServerName());
+        DatabaseServerV4Identifiers identifiers = new DatabaseServerV4Identifiers();
+        request.setExistingDatabaseServer(identifiers);
+        assertEquals(identifiers, request.getExistingDatabaseServer());
 
         DatabaseServerV4Request serverRequest = new DatabaseServerV4Request();
         serverRequest.setName("mydb1");

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/database/DatabaseV4Controller.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/database/DatabaseV4Controller.java
@@ -24,7 +24,7 @@ import com.sequenceiq.redbeams.service.dbconfig.DatabaseConfigService;
 @Transactional(Transactional.TxType.NEVER)
 @WorkspaceEntityType(DatabaseConfig.class)
 @Component
-public class DatabaseV4Controller /*extends NotificationController */ implements DatabaseV4Endpoint {
+public class DatabaseV4Controller implements DatabaseV4Endpoint {
 
     @Inject
     private ConverterUtil redbeamsConverterUtil;
@@ -33,8 +33,8 @@ public class DatabaseV4Controller /*extends NotificationController */ implements
     private DatabaseConfigService databaseConfigService;
 
     @Override
-    public DatabaseV4Responses list(String environment, Boolean attachGlobal) {
-        return new DatabaseV4Responses(redbeamsConverterUtil.convertAllAsSet(databaseConfigService.list(environment),
+    public DatabaseV4Responses list(String environmentId) {
+        return new DatabaseV4Responses(redbeamsConverterUtil.convertAllAsSet(databaseConfigService.findAll(environmentId),
                         DatabaseV4Response.class));
     }
 
@@ -50,24 +50,24 @@ public class DatabaseV4Controller /*extends NotificationController */ implements
     }
 
     @Override
-    public DatabaseV4Response get(String name) {
+    public DatabaseV4Response get(String environmentId, String name) {
         return new DatabaseV4Response();
     }
 
     @Override
-    public DatabaseV4Response delete(String environmentCrn, String name) {
-        return redbeamsConverterUtil.convert(databaseConfigService.delete(name, environmentCrn), DatabaseV4Response.class);
+    public DatabaseV4Response delete(String environmentId, String name) {
+        return redbeamsConverterUtil.convert(databaseConfigService.delete(name, environmentId), DatabaseV4Response.class);
     }
 
     @Override
-    public DatabaseV4Responses deleteMultiple(String environmentCrn, Set<String> names) {
-        return new DatabaseV4Responses(redbeamsConverterUtil.convertAllAsSet(databaseConfigService.delete(names, environmentCrn), DatabaseV4Response.class));
+    public DatabaseV4Responses deleteMultiple(String environmentId, Set<String> names) {
+        return new DatabaseV4Responses(redbeamsConverterUtil.convertAllAsSet(databaseConfigService.delete(names, environmentId), DatabaseV4Response.class));
     }
 
-    @Override
-    public DatabaseV4Request getRequest(String name) {
-        return new DatabaseV4Request();
-    }
+    // @Override
+    // public DatabaseV4Request getRequest(String name) {
+    //     return new DatabaseV4Request();
+    // }
 
     @Override
     public DatabaseTestV4Response test(@Valid DatabaseTestV4Request databaseTestV4Request) {

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4Controller.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4Controller.java
@@ -34,13 +34,13 @@ public class DatabaseServerV4Controller implements DatabaseServerV4Endpoint {
 
     @Override
     public DatabaseServerV4Responses list(String environmentId, Boolean attachGlobal) {
-        Set<DatabaseServerConfig> all = databaseServerConfigService.findAllInWorkspaceAndEnvironment(DEFAULT_WORKSPACE, environmentId, attachGlobal);
+        Set<DatabaseServerConfig> all = databaseServerConfigService.findAll(DEFAULT_WORKSPACE, environmentId, attachGlobal);
         return new DatabaseServerV4Responses(converterUtil.convertAllAsSet(all, DatabaseServerV4Response.class));
     }
 
     @Override
     public DatabaseServerV4Response get(String environmentId, String name) {
-        DatabaseServerConfig server = databaseServerConfigService.getByNameInWorkspaceAndEnvironment(DEFAULT_WORKSPACE, environmentId, name);
+        DatabaseServerConfig server = databaseServerConfigService.getByName(DEFAULT_WORKSPACE, environmentId, name);
         return converterUtil.convert(server, DatabaseServerV4Response.class);
     }
 
@@ -54,7 +54,7 @@ public class DatabaseServerV4Controller implements DatabaseServerV4Endpoint {
     @Override
     public DatabaseServerV4Response delete(String environmentId, String name) {
         DatabaseServerConfig deleted =
-                databaseServerConfigService.deleteByNameInWorkspace(DEFAULT_WORKSPACE, environmentId, name);
+                databaseServerConfigService.deleteByName(DEFAULT_WORKSPACE, environmentId, name);
         //notify(ResourceEvent.DATABASE_SERVER_CONFIG_DELETED);
         return converterUtil.convert(deleted, DatabaseServerV4Response.class);
     }
@@ -62,7 +62,7 @@ public class DatabaseServerV4Controller implements DatabaseServerV4Endpoint {
     @Override
     public DatabaseServerV4Responses deleteMultiple(String environmentId, Set<String> names) {
         Set<DatabaseServerConfig> deleted =
-                databaseServerConfigService.deleteMultipleByNameInWorkspace(DEFAULT_WORKSPACE, environmentId, names);
+                databaseServerConfigService.deleteMultipleByName(DEFAULT_WORKSPACE, environmentId, names);
         //notify(ResourceEvent.DATABASE_SERVER_CONFIG_DELETED);
         return new DatabaseServerV4Responses(converterUtil.convertAllAsSet(deleted, DatabaseServerV4Response.class));
     }
@@ -70,9 +70,10 @@ public class DatabaseServerV4Controller implements DatabaseServerV4Endpoint {
     @Override
     public DatabaseServerTestV4Response test(DatabaseServerTestV4Request request) {
         String connectionResult;
-        if (request.getExistingDatabaseServerName() != null) {
-            connectionResult = databaseServerConfigService.testConnection(DEFAULT_WORKSPACE,
-                    request.getEnvironmentId(), request.getExistingDatabaseServerName());
+        if (request.getExistingDatabaseServer() != null) {
+            String name = request.getExistingDatabaseServer().getName();
+            String environmentId = request.getExistingDatabaseServer().getEnvironmentId();
+            connectionResult = databaseServerConfigService.testConnection(DEFAULT_WORKSPACE, environmentId, name);
         } else {
             DatabaseServerConfig server = converterUtil.convert(request.getDatabaseServer(), DatabaseServerConfig.class);
             connectionResult = databaseServerConfigService.testConnection(server);

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/repository/DatabaseConfigRepository.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/repository/DatabaseConfigRepository.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.redbeams.repository;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -22,7 +21,7 @@ public interface DatabaseConfigRepository extends JpaRepository<DatabaseConfig, 
     Optional<DatabaseConfig> findByEnvironmentIdAndName(String environmentId, String name);
 
     @CheckPermissionsByReturnValue(action = ResourceAction.READ)
-    List<DatabaseConfig> findByEnvironmentId(String environmentId);
+    Set<DatabaseConfig> findByEnvironmentId(String environmentId);
 
     @CheckPermissionsByReturnValue(action = ResourceAction.READ)
     Set<DatabaseConfig> findAllByEnvironmentIdAndNameIn(String environmentId, Set<String> names);

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/repository/DatabaseServerConfigRepository.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/repository/DatabaseServerConfigRepository.java
@@ -7,8 +7,6 @@ import javax.transaction.Transactional;
 import javax.transaction.Transactional.TxType;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
 import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
@@ -18,14 +16,9 @@ import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
 @Transactional(TxType.REQUIRED)
 public interface DatabaseServerConfigRepository extends JpaRepository<DatabaseServerConfig, Long> {
 
-    @Query("SELECT s FROM DatabaseServerConfig s WHERE"
-            + " s.workspaceId = :workspaceId AND s.environmentId = :environmentId"
-            + " AND s.resourceStatus = 'USER_MANAGED'")
-    Set<DatabaseServerConfig> findAllByWorkspaceIdAndEnvironmentId(@Param("workspaceId")Long workspaceId, @Param("environmentId")String environmentId);
+    Set<DatabaseServerConfig> findAllByWorkspaceIdAndEnvironmentId(Long workspaceId, String environmentId);
 
     Optional<DatabaseServerConfig> findByNameAndWorkspaceIdAndEnvironmentId(String name, Long workspaceId, String environmentId);
-
-    Optional<DatabaseServerConfig> findByNameAndEnvironmentId(String name, String  workspaceId);
 
     Set<DatabaseServerConfig> findByNameInAndWorkspaceIdAndEnvironmentId(Set<String> names, Long workspaceId, String environmentId);
 

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4ControllerTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4ControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
+import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.base.DatabaseServerV4Identifiers;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.DatabaseServerTestV4Request;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.DatabaseServerV4Request;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerTestV4Response;
@@ -50,10 +51,12 @@ public class DatabaseServerV4ControllerTest {
         server = new DatabaseServerConfig();
         server.setId(1L);
         server.setName("myserver");
+        server.setEnvironmentId("myenv");
 
         server2 = new DatabaseServerConfig();
         server2.setId(2L);
         server2.setName("myotherserver");
+        server2.setEnvironmentId("myenv");
 
         request = new DatabaseServerV4Request();
         request.setName("myserver");
@@ -70,11 +73,11 @@ public class DatabaseServerV4ControllerTest {
     @Test
     public void testList() {
         Set<DatabaseServerConfig> serverSet = Collections.singleton(server);
-        when(service.findAllInWorkspaceAndEnvironment(DatabaseServerV4Controller.DEFAULT_WORKSPACE, "myenvironment", Boolean.TRUE)).thenReturn(serverSet);
+        when(service.findAll(DatabaseServerV4Controller.DEFAULT_WORKSPACE, "myenv", Boolean.TRUE)).thenReturn(serverSet);
         Set<DatabaseServerV4Response> responseSet = Collections.singleton(response);
         when(converterUtil.convertAllAsSet(serverSet, DatabaseServerV4Response.class)).thenReturn(responseSet);
 
-        DatabaseServerV4Responses responses = underTest.list("myenvironment", Boolean.TRUE);
+        DatabaseServerV4Responses responses = underTest.list("myenv", Boolean.TRUE);
 
         assertEquals(1, responses.getResponses().size());
         assertEquals(response.getId(), responses.getResponses().iterator().next().getId());
@@ -82,10 +85,10 @@ public class DatabaseServerV4ControllerTest {
 
     @Test
     public void testGet() {
-        when(service.getByNameInWorkspaceAndEnvironment(DatabaseServerV4Controller.DEFAULT_WORKSPACE, "id", "myserver")).thenReturn(server);
+        when(service.getByName(DatabaseServerV4Controller.DEFAULT_WORKSPACE, "myenv", "myserver")).thenReturn(server);
         when(converterUtil.convert(server, DatabaseServerV4Response.class)).thenReturn(response);
 
-        DatabaseServerV4Response response = underTest.get("id", "myserver");
+        DatabaseServerV4Response response = underTest.get("myenv", "myserver");
 
         assertEquals(1L, response.getId().longValue());
     }
@@ -103,10 +106,10 @@ public class DatabaseServerV4ControllerTest {
 
     @Test
     public void testDelete() {
-        when(service.deleteByNameInWorkspace(DatabaseServerV4Controller.DEFAULT_WORKSPACE, "id",  "myserver")).thenReturn(server);
+        when(service.deleteByName(DatabaseServerV4Controller.DEFAULT_WORKSPACE, "myenv", "myserver")).thenReturn(server);
         when(converterUtil.convert(server, DatabaseServerV4Response.class)).thenReturn(response);
 
-        DatabaseServerV4Response response = underTest.delete("id", "myserver");
+        DatabaseServerV4Response response = underTest.delete("myenv", "myserver");
 
         assertEquals(1L, response.getId().longValue());
     }
@@ -119,23 +122,25 @@ public class DatabaseServerV4ControllerTest {
         Set<DatabaseServerConfig> serverSet = new HashSet<>();
         serverSet.add(server);
         serverSet.add(server2);
-        when(service.deleteMultipleByNameInWorkspace(DatabaseServerV4Controller.DEFAULT_WORKSPACE, "id", nameSet)).thenReturn(serverSet);
+        when(service.deleteMultipleByName(DatabaseServerV4Controller.DEFAULT_WORKSPACE, "myenv", nameSet)).thenReturn(serverSet);
         Set<DatabaseServerV4Response> responseSet = new HashSet<>();
         responseSet.add(response);
         responseSet.add(response2);
         when(converterUtil.convertAllAsSet(serverSet, DatabaseServerV4Response.class)).thenReturn(responseSet);
 
-        DatabaseServerV4Responses responses = underTest.deleteMultiple("id", nameSet);
+        DatabaseServerV4Responses responses = underTest.deleteMultiple("myenv", nameSet);
 
         assertEquals(2, responses.getResponses().size());
     }
 
     @Test
-    public void testTestWithName() {
-        when(service.testConnection(DatabaseServerV4Controller.DEFAULT_WORKSPACE, "id", "myserver")).thenReturn("yeahhh");
+    public void testTestWithIdentifiers() {
+        when(service.testConnection(DatabaseServerV4Controller.DEFAULT_WORKSPACE, "myenv", "myserver")).thenReturn("yeahhh");
+        DatabaseServerV4Identifiers testIdentifiers = new DatabaseServerV4Identifiers();
+        testIdentifiers.setName("myserver");
+        testIdentifiers.setEnvironmentId("myenv");
         DatabaseServerTestV4Request testRequest = new DatabaseServerTestV4Request();
-        testRequest.setEnvironmentId("id");
-        testRequest.setExistingDatabaseServerName("myserver");
+        testRequest.setExistingDatabaseServer(testIdentifiers);
 
         DatabaseServerTestV4Response response = underTest.test(testRequest);
 

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/service/dbconfig/DatabaseConfigServiceTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/service/dbconfig/DatabaseConfigServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -70,9 +71,25 @@ public class DatabaseConfigServiceTest {
     @InjectMocks
     private DatabaseConfigService underTest;
 
+    private DatabaseConfig db;
+
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
+
+        db = new DatabaseConfig();
+        db.setId(1L);
+        db.setName("mydb");
+    }
+
+    @Test
+    public void testFindAll() {
+        when(databaseConfigRepository.findByEnvironmentId("myenv")).thenReturn(Collections.singleton(db));
+
+        Set<DatabaseConfig> dbs = underTest.findAll("myenv");
+
+        assertEquals(1, dbs.size());
+        assertEquals(1L, dbs.iterator().next().getId().longValue());
     }
 
     @Test

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigServiceTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigServiceTest.java
@@ -84,10 +84,10 @@ public class DatabaseServerConfigServiceTest {
     }
 
     @Test
-    public void testFindAllInWorkspaceAndEnvironment() {
-        when(repository.findAllByWorkspaceIdAndEnvironmentId(0L, "myenvironment")).thenReturn(Collections.singleton(server));
+    public void testFindAll() {
+        when(repository.findAllByWorkspaceIdAndEnvironmentId(0L, "myenv")).thenReturn(Collections.singleton(server));
 
-        Set<DatabaseServerConfig> servers = underTest.findAllInWorkspaceAndEnvironment(0L, "myenvironment", false);
+        Set<DatabaseServerConfig> servers = underTest.findAll(0L, "myenv", false);
 
         assertEquals(1, servers.size());
         assertEquals(1L, servers.iterator().next().getId().longValue());
@@ -137,28 +137,28 @@ public class DatabaseServerConfigServiceTest {
     }
 
     @Test
-    public void testGetByNameInWorkspaceFound() {
-        when(repository.findByNameAndWorkspaceIdAndEnvironmentId(server.getName(), 0L, "id")).thenReturn(Optional.of(server));
+    public void testGetByNameFound() {
+        when(repository.findByNameAndWorkspaceIdAndEnvironmentId(server.getName(), 0L, "myenv")).thenReturn(Optional.of(server));
 
-        DatabaseServerConfig foundServer = underTest.getByNameInWorkspaceAndEnvironment(0L, "id", server.getName());
+        DatabaseServerConfig foundServer = underTest.getByName(0L, "myenv", server.getName());
 
         assertEquals(server, foundServer);
     }
 
     @Test
-    public void testGetByNameInWorkspaceNotFound() {
+    public void testGetByNameNotFound() {
         thrown.expect(NotFoundException.class);
 
-        when(repository.findByNameAndWorkspaceIdAndEnvironmentId(server.getName(), 0L, "id")).thenReturn(Optional.empty());
+        when(repository.findByNameAndWorkspaceIdAndEnvironmentId(server.getName(), 0L, "myenv")).thenReturn(Optional.empty());
 
-        underTest.getByNameInWorkspaceAndEnvironment(0L, "id", server.getName());
+        underTest.getByName(0L, "myenv", server.getName());
     }
 
     @Test
-    public void testDeleteByNameInWorkspaceFound() {
-        when(repository.findByNameAndWorkspaceIdAndEnvironmentId(server.getName(), 0L, "id")).thenReturn(Optional.of(server));
+    public void testDeleteByNameFound() {
+        when(repository.findByNameAndWorkspaceIdAndEnvironmentId(server.getName(), 0L, "myenv")).thenReturn(Optional.of(server));
 
-        DatabaseServerConfig deletedServer = underTest.deleteByNameInWorkspace(0L, "id", server.getName());
+        DatabaseServerConfig deletedServer = underTest.deleteByName(0L, "myenv", server.getName());
 
         assertEquals(server, deletedServer);
         assertTrue(deletedServer.isArchived());
@@ -166,29 +166,29 @@ public class DatabaseServerConfigServiceTest {
     }
 
     @Test
-    public void testDeleteByNameInWorkspaceNotFound() {
+    public void testDeleteByNameNotFound() {
         thrown.expect(NotFoundException.class);
 
-        when(repository.findByNameAndWorkspaceIdAndEnvironmentId(server.getName(), 0L, "id")).thenReturn(Optional.empty());
+        when(repository.findByNameAndWorkspaceIdAndEnvironmentId(server.getName(), 0L, "myenv")).thenReturn(Optional.empty());
 
         try {
-            underTest.deleteByNameInWorkspace(0L, "id", server.getName());
+            underTest.deleteByName(0L, "myenv", server.getName());
         } finally {
             verify(repository, never()).delete(server);
         }
     }
 
     @Test
-    public void testDeleteMultipleByNameInWorkspaceFound() {
+    public void testDeleteMultipleByNameFound() {
         Set<String> nameSet = new HashSet<>();
         nameSet.add(server.getName());
         nameSet.add(server2.getName());
         Set<DatabaseServerConfig> serverSet = new HashSet<>();
         serverSet.add(server);
         serverSet.add(server2);
-        when(repository.findByNameInAndWorkspaceIdAndEnvironmentId(nameSet, 0L, "id")).thenReturn(serverSet);
+        when(repository.findByNameInAndWorkspaceIdAndEnvironmentId(nameSet, 0L, "myenv")).thenReturn(serverSet);
 
-        Set<DatabaseServerConfig> deletedServerSet = underTest.deleteMultipleByNameInWorkspace(0L, "id", nameSet);
+        Set<DatabaseServerConfig> deletedServerSet = underTest.deleteMultipleByName(0L, "myenv", nameSet);
 
         assertEquals(2, deletedServerSet.size());
         assertThat(deletedServerSet, everyItem(hasProperty("archived", is(true))));
@@ -207,7 +207,7 @@ public class DatabaseServerConfigServiceTest {
     }
 
     @Test
-    public void testDeleteMultipleByNameInWorkspaceNotFound() {
+    public void testDeleteMultipleByNameNotFound() {
         thrown.expect(NotFoundException.class);
 
         Set<String> nameSet = new HashSet<>();
@@ -215,10 +215,10 @@ public class DatabaseServerConfigServiceTest {
         nameSet.add(server2.getName());
         Set<DatabaseServerConfig> serverSet = new HashSet<>();
         serverSet.add(server);
-        when(repository.findByNameInAndWorkspaceIdAndEnvironmentId(nameSet, 0L, "id")).thenReturn(serverSet);
+        when(repository.findByNameInAndWorkspaceIdAndEnvironmentId(nameSet, 0L, "myenv")).thenReturn(serverSet);
 
         try {
-            underTest.deleteMultipleByNameInWorkspace(0L, "id", nameSet);
+            underTest.deleteMultipleByName(0L, "myenv", nameSet);
         } finally {
             verify(repository, never()).delete(server);
             verify(repository, never()).delete(server2);
@@ -227,10 +227,10 @@ public class DatabaseServerConfigServiceTest {
 
     @Test
     public void testTestConnectionSuccess() {
-        when(repository.findByNameAndWorkspaceIdAndEnvironmentId(server.getName(), 0L, "id"))
+        when(repository.findByNameAndWorkspaceIdAndEnvironmentId(server.getName(), 0L, "myenv"))
                 .thenReturn(Optional.of(server));
 
-        String result = underTest.testConnection(0L, "id", server.getName());
+        String result = underTest.testConnection(0L, "myenv", server.getName());
 
         assertEquals("success", result);
         verify(connectionValidator).validate(eq(server), any(Errors.class));
@@ -238,7 +238,7 @@ public class DatabaseServerConfigServiceTest {
 
     @Test
     public void testTestConnectionFailure() {
-        when(repository.findByNameAndWorkspaceIdAndEnvironmentId(server.getName(), 0L, "id"))
+        when(repository.findByNameAndWorkspaceIdAndEnvironmentId(server.getName(), 0L, "myenv"))
                 .thenReturn(Optional.of(server));
         doAnswer(new Answer() {
             public Object answer(InvocationOnMock invocation) {
@@ -249,7 +249,7 @@ public class DatabaseServerConfigServiceTest {
             }
         }).when(connectionValidator).validate(eq(server), any(Errors.class));
 
-        String result = underTest.testConnection(0L, "id", server.getName());
+        String result = underTest.testConnection(0L, "myenv", server.getName());
 
         assertTrue(result.contains("epic fail"));
         assertTrue(result.contains("connectorJarUrl: bad jar"));


### PR DESCRIPTION
All redbeams API calls pertaining to databases and database servers now
require an environment ID, which may be either a CRN or name. Calls
where the environment ID is not passed as a JSON field get it from an
API query parameter, such that these resources are now scoped by
environment in the API.

Other changes:

* DatabaseConfigRepository.findByEnvironmentId now returns a set.
* DatabaseConfigService.list is renamed to findAll.
* DatabaseConfigService.get is implemented; this refactors delete logic
and forms the basis for the upcoming get API endpoint.
* DatabaseConfigService.delete for multiple databases now returns the
deleted entities, not the originally found ones.
* DatabaseV4BaseTest is introduced.
* Listing of database servers now include all of them, not just
USER_MANAGED ones.