### PR TITLE
CB-1500 set password for Knox even if gateway is not enabled

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxGatewayConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxGatewayConfigProvider.java
@@ -44,6 +44,8 @@ public class KnoxGatewayConfigProvider extends AbstractRoleConfigConfigProvider 
                 if (gateway != null) {
                     config.add(config(KNOX_MASTER_SECRET, gateway.getMasterSecret()));
                     config.add(config(GATEWAY_PATH, gateway.getPath()));
+                } else {
+                    config.add(config(KNOX_MASTER_SECRET, source.getGeneralClusterConfigs().getPassword()));
                 }
                 return config;
             default:


### PR DESCRIPTION
Use the cluster password if gateway is not enabled, but Knox GW role is present in the blueprint. 