### PR TITLE
CB-1395 Implement database deletion on server

### DIFF
--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/ResourceStatus.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/ResourceStatus.java
@@ -1,0 +1,13 @@
+package com.sequenceiq.redbeams.api.endpoint.v4;
+
+public enum ResourceStatus {
+    UNKNOWN,
+    /**
+     * Redbeams is managing / owns the resource.
+     */
+    SERVICE_MANAGED,
+    /**
+     * The user is managing / owns the resource.
+     */
+    USER_MANAGED
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/database/DatabaseV4Controller.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/database/DatabaseV4Controller.java
@@ -51,7 +51,8 @@ public class DatabaseV4Controller implements DatabaseV4Endpoint {
 
     @Override
     public DatabaseV4Response get(String environmentId, String name) {
-        return new DatabaseV4Response();
+        DatabaseConfig databaseConfig = databaseConfigService.get(name, environmentId);
+        return redbeamsConverterUtil.convert(databaseConfig, DatabaseV4Response.class);
     }
 
     @Override

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/converter/database/DatabaseV4RequestToDatabaseConfigConverter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/converter/database/DatabaseV4RequestToDatabaseConfigConverter.java
@@ -9,9 +9,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ResourceStatus;
 import com.sequenceiq.cloudbreak.common.service.Clock;
 import com.sequenceiq.cloudbreak.converter.AbstractConversionServiceAwareConverter;
+import com.sequenceiq.redbeams.api.endpoint.v4.ResourceStatus;
 import com.sequenceiq.redbeams.api.endpoint.v4.database.request.DatabaseV4Request;
 import com.sequenceiq.redbeams.api.util.DatabaseVendorUtil;
 import com.sequenceiq.redbeams.domain.DatabaseConfig;

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/converter/v4/databaseserver/DatabaseServerV4RequestToDatabaseServerConfigConverter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/converter/v4/databaseserver/DatabaseServerV4RequestToDatabaseServerConfigConverter.java
@@ -8,8 +8,8 @@ import org.springframework.stereotype.Component;
 
 import com.google.common.base.Strings;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ResourceStatus;
 import com.sequenceiq.cloudbreak.converter.AbstractConversionServiceAwareConverter;
+import com.sequenceiq.redbeams.api.endpoint.v4.ResourceStatus;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.DatabaseServerV4Request;
 import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
 

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/domain/DatabaseConfig.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/domain/DatabaseConfig.java
@@ -7,7 +7,9 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
+import javax.persistence.JoinColumn;
 import javax.persistence.Id;
+import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
@@ -15,12 +17,12 @@ import javax.persistence.UniqueConstraint;
 import org.hibernate.annotations.Where;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ResourceStatus;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.common.archive.ArchivableResource;
 import com.sequenceiq.cloudbreak.service.secret.SecretValue;
 import com.sequenceiq.cloudbreak.service.secret.domain.Secret;
 import com.sequenceiq.cloudbreak.service.secret.domain.SecretToString;
+import com.sequenceiq.redbeams.api.endpoint.v4.ResourceStatus;
 import com.sequenceiq.redbeams.converter.CrnConverter;
 
 @Entity
@@ -85,6 +87,10 @@ public class DatabaseConfig implements ArchivableResource {
     @Column(nullable = false, name = "environment_id")
     private String environmentId;
 
+    @ManyToOne(optional = true)
+    @JoinColumn(name = "server_id", nullable = true)
+    private DatabaseServerConfig server;
+
     public Long getId() {
         return id;
     }
@@ -133,10 +139,6 @@ public class DatabaseConfig implements ArchivableResource {
         return status;
     }
 
-    public boolean isUserManaged() {
-        return status == ResourceStatus.USER_MANAGED;
-    }
-
     public String getType() {
         return type;
     }
@@ -155,6 +157,10 @@ public class DatabaseConfig implements ArchivableResource {
 
     public String getEnvironmentId() {
         return environmentId;
+    }
+
+    public DatabaseServerConfig getServer() {
+        return server;
     }
 
     public void setId(Long id) {
@@ -227,5 +233,9 @@ public class DatabaseConfig implements ArchivableResource {
 
     public void setEnvironmentId(String environment) {
         this.environmentId = environment;
+    }
+
+    public void setServer(DatabaseServerConfig server) {
+        this.server = server;
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/exception/RedbeamsException.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/exception/RedbeamsException.java
@@ -1,0 +1,30 @@
+package com.sequenceiq.redbeams.exception;
+
+import java.util.Objects;
+
+public class RedbeamsException extends RuntimeException {
+
+    public RedbeamsException(String message) {
+        super(message);
+    }
+
+    public RedbeamsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o instanceof RedbeamsException) {
+            return getMessage().equals(((Throwable) o).getMessage());
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getMessage());
+    }
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigService.java
@@ -31,6 +31,7 @@ import com.sequenceiq.cloudbreak.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.cloudbreak.workspace.resource.WorkspaceResource;
+import com.sequenceiq.redbeams.api.endpoint.v4.ResourceStatus;
 import com.sequenceiq.redbeams.domain.DatabaseConfig;
 import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
 import com.sequenceiq.redbeams.repository.DatabaseServerConfigRepository;
@@ -174,7 +175,7 @@ public class DatabaseServerConfigService extends AbstractArchivistService<Databa
                     createResult.append("created");
 
                     DatabaseConfig newDatabaseConfig =
-                            databaseServerConfig.createDatabaseConfig(databaseName, databaseType);
+                            databaseServerConfig.createDatabaseConfig(databaseName, databaseType, ResourceStatus.SERVICE_MANAGED);
                     databaseConfigService.register(newDatabaseConfig);
 
                 } else {

--- a/redbeams/src/main/resources/schema/app/20190604193436_CB-1395_Link_databases_and_database_servers.sql
+++ b/redbeams/src/main/resources/schema/app/20190604193436_CB-1395_Link_databases_and_database_servers.sql
@@ -1,0 +1,9 @@
+-- // CB-1395 Link databases and database servers
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE databaseconfig ADD COLUMN server_id bigint REFERENCES databaseserverconfig(id);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE databaseconfig DROP COLUMN server_id;

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/controller/v4/database/DatabaseV4ControllerTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/controller/v4/database/DatabaseV4ControllerTest.java
@@ -1,0 +1,154 @@
+package com.sequenceiq.redbeams.controller.v4.database;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
+// import com.sequenceiq.redbeams.api.endpoint.v4.database.request.DatabaseTestV4Request;
+import com.sequenceiq.redbeams.api.endpoint.v4.database.request.DatabaseV4Request;
+// import com.sequenceiq.redbeams.api.endpoint.v4.database.responses.DatabaseTestV4Response;
+import com.sequenceiq.redbeams.api.endpoint.v4.database.responses.DatabaseV4Response;
+import com.sequenceiq.redbeams.api.endpoint.v4.database.responses.DatabaseV4Responses;
+import com.sequenceiq.redbeams.domain.DatabaseConfig;
+import com.sequenceiq.redbeams.service.dbconfig.DatabaseConfigService;
+
+import java.util.Collections;
+// import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+public class DatabaseV4ControllerTest {
+
+    @InjectMocks
+    private DatabaseV4Controller underTest;
+
+    @Mock
+    private DatabaseConfigService service;
+
+    @Mock
+    private ConverterUtil converterUtil;
+
+    private DatabaseConfig db;
+
+    private DatabaseConfig db2;
+
+    private DatabaseV4Request request;
+
+    private DatabaseV4Response response;
+
+    private DatabaseV4Response response2;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+
+        db = new DatabaseConfig();
+        db.setId(1L);
+        db.setName("mydb");
+
+        db2 = new DatabaseConfig();
+        db2.setId(2L);
+        db2.setName("myotherdb");
+
+        request = new DatabaseV4Request();
+        request.setName("mydb");
+
+        response = new DatabaseV4Response();
+        response.setName("mydb");
+
+        response2 = new DatabaseV4Response();
+        response2.setName("myotherdb");
+    }
+
+    @Test
+    public void testList() {
+        Set<DatabaseConfig> dbSet = Collections.singleton(db);
+        when(service.findAll("myenvironment")).thenReturn(dbSet);
+        Set<DatabaseV4Response> responseSet = Collections.singleton(response);
+        when(converterUtil.convertAllAsSet(dbSet, DatabaseV4Response.class)).thenReturn(responseSet);
+
+        DatabaseV4Responses responses = underTest.list("myenvironment");
+
+        assertEquals(1, responses.getResponses().size());
+        assertEquals(response.getName(), responses.getResponses().iterator().next().getName());
+    }
+
+    @Test
+    public void testGet() {
+        when(service.get("mydb", "myenvironment")).thenReturn(db);
+        when(converterUtil.convert(db, DatabaseV4Response.class)).thenReturn(response);
+
+        DatabaseV4Response response = underTest.get("myenvironment", "mydb");
+
+        assertEquals(db.getName(), response.getName());
+    }
+
+    @Test
+    public void testRegister() {
+        when(converterUtil.convert(request, DatabaseConfig.class)).thenReturn(db);
+        when(service.register(db)).thenReturn(db);
+        when(converterUtil.convert(db, DatabaseV4Response.class)).thenReturn(response);
+
+        DatabaseV4Response response = underTest.register(request);
+
+        assertEquals(db.getName(), response.getName());
+    }
+
+    // @Test
+    // public void testDelete() {
+    //     when(service.deleteByNameInWorkspace(DatabaseV4Controller.DEFAULT_WORKSPACE, "id",  "mydb")).thenReturn(db);
+    //     when(converterUtil.convert(db, DatabaseV4Response.class)).thenReturn(response);
+
+    //     DatabaseV4Response response = underTest.delete("id", "mydb");
+
+    //     assertEquals(1L, response.getId().longValue());
+    // }
+
+    // @Test
+    // public void testDeleteMultiple() {
+    //     Set<String> nameSet = new HashSet<>();
+    //     nameSet.add(db.getName());
+    //     nameSet.add(db2.getName());
+    //     Set<DatabaseConfig> dbSet = new HashSet<>();
+    //     dbSet.add(db);
+    //     dbSet.add(db2);
+    //     when(service.deleteMultipleByNameInWorkspace(DatabaseV4Controller.DEFAULT_WORKSPACE, "id", nameSet)).thenReturn(dbSet);
+    //     Set<DatabaseV4Response> responseSet = new HashSet<>();
+    //     responseSet.add(response);
+    //     responseSet.add(response2);
+    //     when(converterUtil.convertAllAsSet(dbSet, DatabaseV4Response.class)).thenReturn(responseSet);
+
+    //     DatabaseV4Responses responses = underTest.deleteMultiple("id", nameSet);
+
+    //     assertEquals(2, responses.getResponses().size());
+    // }
+
+    // @Test
+    // public void testTestWithName() {
+    //     when(service.testConnection(DatabaseV4Controller.DEFAULT_WORKSPACE, "id", "mydb")).thenReturn("yeahhh");
+    //     DatabaseServerTestV4Request testRequest = new DatabaseServerTestV4Request();
+    //     testRequest.setEnvironmentId("id");
+    //     testRequest.setExistingDatabaseServerName("mydb");
+
+    //     DatabaseServerTestV4Response response = underTest.test(testRequest);
+
+    //     assertEquals("yeahhh", response.getResult());
+    // }
+
+    // @Test
+    // public void testTestWithServer() {
+    //     when(converterUtil.convert(request, DatabaseConfig.class)).thenReturn(db);
+    //     when(service.testConnection(db)).thenReturn("okayyy");
+    //     DatabaseServerTestV4Request testRequest = new DatabaseServerTestV4Request();
+    //     testRequest.setDatabaseServer(request);
+
+    //     DatabaseServerTestV4Response response = underTest.test(testRequest);
+
+    //     assertEquals("okayyy", response.getResult());
+    // }
+}

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/converter/database/DatabaseConfigToDatabaseV4ResponseConverterTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/converter/database/DatabaseConfigToDatabaseV4ResponseConverterTest.java
@@ -57,7 +57,6 @@ public class DatabaseConfigToDatabaseV4ResponseConverterTest {
         databaseConfig.setResourceCrn(CRN);
         databaseConfig.setDescription(DESCRIPTION);
         databaseConfig.setCreationDate(CREATION_DATE);
-//        databaseConfig.setStatus(ResourceStatus.USER_MANAGED);
         databaseConfig.setConnectionDriver(CONNECTION_DRIVER);
         databaseConfig.setConnectionUserName("userName");
         databaseConfig.setConnectionPassword("password");
@@ -73,7 +72,6 @@ public class DatabaseConfigToDatabaseV4ResponseConverterTest {
         assertEquals(CRN.toString(), response.getCrn());
         assertEquals(DESCRIPTION, response.getDescription());
         assertEquals(CREATION_DATE, response.getCreationDate().longValue());
-//        assertEquals(ResourceStatus.USER_MANAGED.toString(), response.ge);
         assertEquals(CONNECTION_DRIVER, response.getConnectionDriver());
         assertNotNull(response.getConnectionPassword());
         assertNotNull(response.getConnectionUserName());

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/converter/database/DatabaseV4RequestToDatabaseConfigConverterTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/converter/database/DatabaseV4RequestToDatabaseConfigConverterTest.java
@@ -17,6 +17,7 @@ import org.mockito.MockitoAnnotations;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
 import com.sequenceiq.cloudbreak.common.converter.MissingResourceNameGenerator;
 import com.sequenceiq.cloudbreak.common.service.Clock;
+import com.sequenceiq.redbeams.api.endpoint.v4.ResourceStatus;
 import com.sequenceiq.redbeams.api.endpoint.v4.database.request.DatabaseV4Request;
 import com.sequenceiq.redbeams.api.util.DatabaseVendorUtil;
 import com.sequenceiq.redbeams.domain.DatabaseConfig;
@@ -80,6 +81,7 @@ public class DatabaseV4RequestToDatabaseConfigConverterTest {
         assertEquals(CONNECTION_USERNAME, databaseConfig.getConnectionUserName().getRaw());
         assertEquals(CONNECTOR_JAR_URL, databaseConfig.getConnectorJarUrl());
         assertEquals(DatabaseVendor.POSTGRES, databaseConfig.getDatabaseVendor());
+        assertEquals(ResourceStatus.USER_MANAGED, databaseConfig.getStatus());
         verify(databaseVendorUtil).getVendorByJdbcUrl(request);
         verify(missingResourceNameGenerator, never()).generateName(any());
     }

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/converter/v4/databaseserver/DatabaseServerV4RequestToDatabaseServerConfigConverterTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/converter/v4/databaseserver/DatabaseServerV4RequestToDatabaseServerConfigConverterTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.sequenceiq.redbeams.api.endpoint.v4.ResourceStatus;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.DatabaseServerV4Request;
 import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
 
@@ -41,6 +42,7 @@ public class DatabaseServerV4RequestToDatabaseServerConfigConverterTest {
         assertEquals(request.getConnectionPassword(), server.getConnectionPassword());
         assertEquals(request.getConnectorJarUrl(), server.getConnectorJarUrl());
         assertEquals(request.getEnvironmentId(), server.getEnvironmentId());
+        assertEquals(ResourceStatus.USER_MANAGED, server.getResourceStatus());
     }
 
 }

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/model/DatabaseServerConfigTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/model/DatabaseServerConfigTest.java
@@ -9,10 +9,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ResourceStatus;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.workspace.resource.WorkspaceResource;
 import com.sequenceiq.redbeams.TestData;
+import com.sequenceiq.redbeams.api.endpoint.v4.ResourceStatus;
 import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
 
 public class DatabaseServerConfigTest {
@@ -67,8 +67,8 @@ public class DatabaseServerConfigTest {
         config.setCreationDate(now);
         assertEquals(now, config.getCreationDate().longValue());
 
-        config.setResourceStatus(ResourceStatus.DEFAULT);
-        assertEquals(ResourceStatus.DEFAULT, config.getResourceStatus());
+        config.setResourceStatus(ResourceStatus.SERVICE_MANAGED);
+        assertEquals(ResourceStatus.SERVICE_MANAGED, config.getResourceStatus());
 
         config.setConnectorJarUrl("http://drivers.example.com/postgresql.jar");
         assertEquals("http://drivers.example.com/postgresql.jar", config.getConnectorJarUrl());

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigServiceTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigServiceTest.java
@@ -80,7 +80,7 @@ public class DatabaseServerConfigServiceTest {
 
         server2 = new DatabaseServerConfig();
         server2.setId(2L);
-        server.setName("myotherserver");
+        server2.setName("myotherserver");
     }
 
     @Test


### PR DESCRIPTION
Redbeams now has the ability to delete databases existing on PostgreSQL
database servers, as long as redbeams itself created it in the first
place.

Redbeams uses a new ResourceStatus enum to more clearly mark databases
as either service-managed (created by redbeams) or user-managed (created
outside redbeams). Handling of this status field for databases is
updated, so that it is set properly depending on the provenance of a new
database.

Implementing this requires the establishment of a one-to-many
relationship between databases and the servers they run on. Only
databases created by redbeams have this linkage in place.

As a bonus, the database get operation is now available in the API.