### PR TITLE
CB-1676 Update redbeams CRN handling

### DIFF
--- a/redbeams/src/main/java/com/sequenceiq/redbeams/RedbeamsApplication.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/RedbeamsApplication.java
@@ -8,7 +8,9 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @EnableSwagger2
 @SpringBootApplication(scanBasePackages = {"com.sequenceiq.redbeams",
+        "com.sequenceiq.cloudbreak.auth",
         "com.sequenceiq.cloudbreak.auth.altus",
+        "com.sequenceiq.cloudbreak.auth.filter",
         "com.sequenceiq.cloudbreak.auth.security",
         "com.sequenceiq.cloudbreak.security",
         "com.sequenceiq.cloudbreak.api.util",

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/repository/DatabaseConfigRepository.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/repository/DatabaseConfigRepository.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import javax.transaction.Transactional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
 import com.sequenceiq.cloudbreak.workspace.repository.check.CheckPermissionsByReturnValue;
@@ -18,11 +19,15 @@ public interface DatabaseConfigRepository extends JpaRepository<DatabaseConfig, 
 
     // TODO check if checkPermission still works
     @CheckPermissionsByReturnValue(action = ResourceAction.READ)
+    @Query("SELECT d FROM DatabaseConfig d WHERE d.environmentId = :environmentId "
+        + "AND (d.name = :name OR d.resourceCrn = :name)")
     Optional<DatabaseConfig> findByEnvironmentIdAndName(String environmentId, String name);
 
     @CheckPermissionsByReturnValue(action = ResourceAction.READ)
     Set<DatabaseConfig> findByEnvironmentId(String environmentId);
 
     @CheckPermissionsByReturnValue(action = ResourceAction.READ)
+    @Query("SELECT d FROM DatabaseConfig d WHERE d.environmentId = :environmentId "
+        + "AND (d.name IN :names OR d.resourceCrn IN :names)")
     Set<DatabaseConfig> findAllByEnvironmentIdAndNameIn(String environmentId, Set<String> names);
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/repository/DatabaseServerConfigRepository.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/repository/DatabaseServerConfigRepository.java
@@ -7,6 +7,7 @@ import javax.transaction.Transactional;
 import javax.transaction.Transactional.TxType;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
 import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
@@ -16,10 +17,14 @@ import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
 @Transactional(TxType.REQUIRED)
 public interface DatabaseServerConfigRepository extends JpaRepository<DatabaseServerConfig, Long> {
 
-    Set<DatabaseServerConfig> findAllByWorkspaceIdAndEnvironmentId(Long workspaceId, String environmentId);
+    Set<DatabaseServerConfig> findByWorkspaceIdAndEnvironmentId(Long workspaceId, String environmentId);
 
+    @Query("SELECT s FROM DatabaseServerConfig s WHERE s.workspaceId = :workspaceId AND s.environmentId = :environmentId "
+        + "AND (s.name = :name OR s.resourceCrn = :name)")
     Optional<DatabaseServerConfig> findByNameAndWorkspaceIdAndEnvironmentId(String name, Long workspaceId, String environmentId);
 
+    @Query("SELECT s FROM DatabaseServerConfig s WHERE s.workspaceId = :workspaceId AND s.environmentId = :environmentId "
+        + "AND (s.name IN :names OR s.resourceCrn IN :names)")
     Set<DatabaseServerConfig> findByNameInAndWorkspaceIdAndEnvironmentId(Set<String> names, Long workspaceId, String environmentId);
 
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigService.java
@@ -70,7 +70,7 @@ public class DatabaseServerConfigService extends AbstractArchivistService<Databa
             throw new IllegalArgumentException("No environmentId supplied.");
         }
 
-        return repository.findAllByWorkspaceIdAndEnvironmentId(workspaceId, environmentId);
+        return repository.findByWorkspaceIdAndEnvironmentId(workspaceId, environmentId);
     }
 
     public DatabaseServerConfig create(DatabaseServerConfig resource, Long workspaceId) {

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/service/crn/CrnServiceTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/service/crn/CrnServiceTest.java
@@ -1,18 +1,45 @@
 package com.sequenceiq.redbeams.service.crn;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.redbeams.domain.DatabaseConfig;
 import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
 
 public class CrnServiceTest {
 
-    private static final String RESOURCE_ID = "resourceId";
+    private static final String TEST_ACCOUNT_ID = "accountId";
 
-    private final CrnService crnService = new CrnService();
+    private static final String TEST_USER_ID = "bob";
+
+    private static final Crn CRN = Crn.builder()
+        .setService(Crn.Service.IAM)
+        .setAccountId(TEST_ACCOUNT_ID)
+        .setResourceType(Crn.ResourceType.USER)
+        .setResource(TEST_USER_ID)
+        .build();
+
+    @InjectMocks
+    private CrnService crnService;
+
+    @Mock
+    private ThreadBasedUserCrnProvider threadBasedUserCrnProvider;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+
+        // the provider should really store this as a CRN
+        when(threadBasedUserCrnProvider.getUserCrn()).thenReturn(CRN.toString());
+    }
 
     @Test
     public void testCreateCrnDatabaseConfig() {
@@ -20,6 +47,7 @@ public class CrnServiceTest {
         Crn crn = crnService.createCrn(resource);
 
         assertEquals(Crn.Service.REDBEAMS, crn.getService());
+        assertEquals(CRN.getAccountId(), crn.getAccountId());
         assertEquals(Crn.ResourceType.DATABASE, crn.getResourceType());
     }
 
@@ -29,6 +57,7 @@ public class CrnServiceTest {
         Crn crn = crnService.createCrn(resource);
 
         assertEquals(Crn.Service.REDBEAMS, crn.getService());
+        assertEquals(CRN.getAccountId(), crn.getAccountId());
         assertEquals(Crn.ResourceType.DATABASE_SERVER, crn.getResourceType());
     }
 

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigServiceTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigServiceTest.java
@@ -85,7 +85,7 @@ public class DatabaseServerConfigServiceTest {
 
     @Test
     public void testFindAll() {
-        when(repository.findAllByWorkspaceIdAndEnvironmentId(0L, "myenv")).thenReturn(Collections.singleton(server));
+        when(repository.findByWorkspaceIdAndEnvironmentId(0L, "myenv")).thenReturn(Collections.singleton(server));
 
         Set<DatabaseServerConfig> servers = underTest.findAll(0L, "myenv", false);
 


### PR DESCRIPTION
Two changes:

* The account ID present in the authenticated user's CRN is used when
  constructing new CRNs for databases and database servers.
* API calls which specify the "name" of a database or database server
  may use either the name itself or the CRN.