### PR TITLE
CB-1771 - Fixed UMS Host property key

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/config/UmsConfig.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/config/UmsConfig.java
@@ -9,10 +9,10 @@ import io.netty.util.internal.StringUtil;
 @Configuration
 public class UmsConfig {
 
-    @Value("${altus.ums.host:}")
+    @Value("${global.ums.host:}")
     private String endpoint;
 
-    @Value("${altus.ums.port:8982}")
+    @Value("${cdpdemoapp.env.ums.port:8982}")
     private int port;
 
     public String getEndpoint() {


### PR DESCRIPTION
Updated UMS Host property key. 

`Deprecated Gradle features were used in this build, making it incompatible with Gradle 6.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/5.4.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 16m 46s
411 actionable tasks: 409 executed, 2 up-to-date`

@keyki @akanto @doktoric @lacikaaa @handavid  - if there is any issue, please revert this commit. My local builds are successful. 