### PR TITLE
DISTX-39. Fix cleanup failure if delete happens too early.

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterService.java
@@ -595,7 +595,7 @@ public class ClusterService {
                 Telemetry telemetry = componentConfigProviderService.getTelemetry(stackId);
                 try {
                     clusterApiConnectors.getConnector(stack).clusterModificationService().cleanupCluster(telemetry);
-                } catch (CloudbreakException e) {
+                } catch (Exception e) {
                     LOGGER.error("Cluster specific cleanup failed.", e);
                 }
                 return stack;


### PR DESCRIPTION
If during cluster install, cleanup task can fail through creating cluster modification bean (as CM client cannot be created yet)
that is just a quick fix , a cluster related cleanup is not a fatal one, so just catching and logging the error.

With a longer term solution (not too long term ... I mean like next week) is to create an another interface for ClusterApi that can be called without creating CM client or just call the cleanup if a specific cluster state is satisfied