### PR TITLE
CB-1761. Validate node counts in CM cluster request

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/InstanceCount.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/InstanceCount.java
@@ -69,4 +69,18 @@ public class InstanceCount {
         }
         return minimumCount + "-" + maximumCount;
     }
+
+    public boolean isAcceptable(int count) {
+        return minimumCount <= count && count <= maximumCount;
+    }
+
+    /**
+     * Logic from UI.
+     */
+    public static InstanceCount fallbackInstanceCountRecommendation(String hostGroup) {
+        return hostGroup.contains("compute")
+                ? ZERO_OR_MORE
+                : ONE_OR_MORE;
+    }
+
 }

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/cluster/host/HostGroup.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/cluster/host/HostGroup.java
@@ -139,4 +139,8 @@ public class HostGroup implements ProvisionEntity {
         }
         return hostNames;
     }
+
+    public int getHostCount() {
+        return getConstraint().getHostCount();
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/blueprint/BlueprintService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/blueprint/BlueprintService.java
@@ -25,29 +25,28 @@ import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ResourceStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
-import com.sequenceiq.cloudbreak.workspace.resource.WorkspaceResource;
 import com.sequenceiq.cloudbreak.blueprint.AmbariBlueprintProcessorFactory;
 import com.sequenceiq.cloudbreak.blueprint.CentralBlueprintParameterQueryService;
 import com.sequenceiq.cloudbreak.blueprint.utils.BlueprintUtils;
-import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
 import com.sequenceiq.cloudbreak.common.type.APIResourceType;
-import com.sequenceiq.cloudbreak.exception.BadRequestException;
-import com.sequenceiq.cloudbreak.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.view.BlueprintView;
-import com.sequenceiq.cloudbreak.workspace.model.User;
-import com.sequenceiq.cloudbreak.workspace.model.Workspace;
+import com.sequenceiq.cloudbreak.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.init.blueprint.BlueprintLoaderService;
 import com.sequenceiq.cloudbreak.repository.BlueprintRepository;
 import com.sequenceiq.cloudbreak.repository.BlueprintViewRepository;
-import com.sequenceiq.cloudbreak.workspace.repository.workspace.WorkspaceResourceRepository;
 import com.sequenceiq.cloudbreak.service.AbstractWorkspaceAwareResourceService;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
 import com.sequenceiq.cloudbreak.template.filesystem.FileSystemConfigQueryObject;
 import com.sequenceiq.cloudbreak.template.filesystem.FileSystemConfigQueryObject.Builder;
 import com.sequenceiq.cloudbreak.template.filesystem.query.ConfigQueryEntry;
 import com.sequenceiq.cloudbreak.template.processor.configuration.SiteConfigurations;
+import com.sequenceiq.cloudbreak.workspace.model.User;
+import com.sequenceiq.cloudbreak.workspace.model.Workspace;
+import com.sequenceiq.cloudbreak.workspace.repository.workspace.WorkspaceResourceRepository;
+import com.sequenceiq.cloudbreak.workspace.resource.WorkspaceResource;
 
 @Service
 public class BlueprintService extends AbstractWorkspaceAwareResourceService<Blueprint> {
@@ -196,7 +195,7 @@ public class BlueprintService extends AbstractWorkspaceAwareResourceService<Blue
     }
 
     public String getBlueprintVariant(Blueprint blueprint) {
-        return isAmbariBlueprint(blueprint) ? ClusterApi.AMBARI : ClusterApi.CLOUDERA_MANAGER;
+        return blueprintUtils.getBlueprintVariant(blueprint.getBlueprintText());
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/blueprint/BlueprintValidatorFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/blueprint/BlueprintValidatorFactory.java
@@ -1,0 +1,40 @@
+package com.sequenceiq.cloudbreak.service.blueprint;
+
+import static com.sequenceiq.cloudbreak.cluster.api.ClusterApi.AMBARI;
+import static com.sequenceiq.cloudbreak.cluster.api.ClusterApi.CLOUDERA_MANAGER;
+
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.NotImplementedException;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.blueprint.utils.BlueprintUtils;
+import com.sequenceiq.cloudbreak.blueprint.validation.AmbariBlueprintValidator;
+import com.sequenceiq.cloudbreak.template.validation.BlueprintValidator;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateValidator;
+import com.sequenceiq.cloudbreak.domain.Blueprint;
+
+@Component
+public class BlueprintValidatorFactory {
+
+    @Inject
+    private BlueprintUtils blueprintUtils;
+
+    @Inject
+    private AmbariBlueprintValidator ambariBlueprintValidator;
+
+    @Inject
+    private CmTemplateValidator cmTemplateValidator;
+
+    public BlueprintValidator createBlueprintValidator(Blueprint blueprint) {
+        String variant = blueprintUtils.getBlueprintVariant(blueprint.getBlueprintText());
+        switch (variant) {
+            case AMBARI:
+                return ambariBlueprintValidator;
+            case CLOUDERA_MANAGER:
+                return cmTemplateValidator;
+            default:
+                throw new NotImplementedException("BlueprintValidator for " + variant);
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/decorator/ClusterDecorator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/decorator/ClusterDecorator.java
@@ -19,10 +19,10 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.ExposedService;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.cluster.ClusterV4Request;
 import com.sequenceiq.cloudbreak.aspect.Measure;
 import com.sequenceiq.cloudbreak.blueprint.AmbariBlueprintTextProcessor;
-import com.sequenceiq.cloudbreak.blueprint.validation.AmbariBlueprintValidator;
+import com.sequenceiq.cloudbreak.template.validation.BlueprintValidator;
+import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.domain.LdapConfig;
-import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.gateway.ExposedServices;
@@ -30,6 +30,7 @@ import com.sequenceiq.cloudbreak.domain.stack.cluster.gateway.Gateway;
 import com.sequenceiq.cloudbreak.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.service.AmbariHaComponentFilter;
 import com.sequenceiq.cloudbreak.service.blueprint.BlueprintService;
+import com.sequenceiq.cloudbreak.service.blueprint.BlueprintValidatorFactory;
 import com.sequenceiq.cloudbreak.service.ldapconfig.LdapConfigService;
 import com.sequenceiq.cloudbreak.service.rdsconfig.RdsConfigService;
 import com.sequenceiq.cloudbreak.service.sharedservice.SharedServiceConfigProvider;
@@ -45,7 +46,7 @@ public class ClusterDecorator {
     private BlueprintService blueprintService;
 
     @Inject
-    private AmbariBlueprintValidator ambariBlueprintValidator;
+    private BlueprintValidatorFactory blueprintValidatorFactory;
 
     @Inject
     private RdsConfigService rdsConfigService;
@@ -78,8 +79,9 @@ public class ClusterDecorator {
     }
 
     private void validateBlueprintIfRequired(Cluster subject, ClusterV4Request request, Stack stack) {
-        if (blueprintService.isAmbariBlueprint(subject.getBlueprint()) && request.getValidateBlueprint()) {
-            ambariBlueprintValidator.validateBlueprintForStack(subject, subject.getBlueprint(), subject.getHostGroups(), stack.getInstanceGroups());
+        if (request.getValidateBlueprint()) {
+            BlueprintValidator blueprintValidator = blueprintValidatorFactory.createBlueprintValidator(subject.getBlueprint());
+            blueprintValidator.validateBlueprintForStack(subject.getBlueprint(), subject.getHostGroups(), stack.getInstanceGroups());
         }
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/CloudResourceAdvisor.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/CloudResourceAdvisor.java
@@ -144,18 +144,9 @@ public class CloudResourceAdvisor {
     private Map<String, InstanceCount> recommendInstanceCounts(BlueprintTextProcessor blueprintProcessor) {
         Map<String, InstanceCount> cardinality = new TreeMap<>(blueprintProcessor.getCardinalityByHostGroup());
         for (String hostGroup : blueprintProcessor.getComponentsByHostGroup().keySet()) {
-            cardinality.computeIfAbsent(hostGroup, this::fallbackInstanceCountRecommendation);
+            cardinality.computeIfAbsent(hostGroup, InstanceCount::fallbackInstanceCountRecommendation);
         }
         return cardinality;
-    }
-
-    /**
-     * Logic from UI.
-     */
-    private InstanceCount fallbackInstanceCountRecommendation(String hostGroup) {
-        return hostGroup.contains("compute")
-                ? InstanceCount.ZERO_OR_MORE
-                : InstanceCount.ONE_OR_MORE;
     }
 
     private Blueprint getBlueprint(String blueprintName, Long workspaceId) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/AmbariClusterHostServiceTypeTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/AmbariClusterHostServiceTypeTest.java
@@ -40,6 +40,7 @@ import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostMetadata;
 import com.sequenceiq.cloudbreak.repository.cluster.ClusterRepository;
 import com.sequenceiq.cloudbreak.service.TlsSecurityService;
 import com.sequenceiq.cloudbreak.service.blueprint.BlueprintService;
+import com.sequenceiq.cloudbreak.service.blueprint.BlueprintValidatorFactory;
 import com.sequenceiq.cloudbreak.service.hostgroup.HostGroupService;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
@@ -76,6 +77,9 @@ public class AmbariClusterHostServiceTypeTest {
     private StatusToPollGroupConverter statusToPollGroupConverter;
 
     @Mock
+    private BlueprintValidatorFactory blueprintValidatorFactory;
+
+    @Mock
     private AmbariBlueprintValidator ambariBlueprintValidator;
 
     @Mock
@@ -93,6 +97,7 @@ public class AmbariClusterHostServiceTypeTest {
         when(stackService.getById(anyLong())).thenReturn(stack);
         when(stackService.getByIdWithListsInTransaction(anyLong())).thenReturn(stack);
         when(blueprintService.isAmbariBlueprint(any(Blueprint.class))).thenReturn(Boolean.TRUE);
+        when(blueprintValidatorFactory.createBlueprintValidator(any())).thenReturn(ambariBlueprintValidator);
     }
 
     @Test

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/decorator/ClusterDecoratorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/decorator/ClusterDecoratorTest.java
@@ -22,15 +22,16 @@ import com.sequenceiq.cloudbreak.controller.validation.rds.RdsConnectionValidato
 import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
-import com.sequenceiq.cloudbreak.workspace.model.User;
-import com.sequenceiq.cloudbreak.workspace.model.Workspace;
 import com.sequenceiq.cloudbreak.service.AmbariHaComponentFilter;
-import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
 import com.sequenceiq.cloudbreak.service.blueprint.BlueprintService;
+import com.sequenceiq.cloudbreak.service.blueprint.BlueprintValidatorFactory;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
 import com.sequenceiq.cloudbreak.service.ldapconfig.LdapConfigService;
 import com.sequenceiq.cloudbreak.service.rdsconfig.RdsConfigService;
 import com.sequenceiq.cloudbreak.service.sharedservice.SharedServiceConfigProvider;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.workspace.model.User;
+import com.sequenceiq.cloudbreak.workspace.model.Workspace;
 
 public class ClusterDecoratorTest {
 
@@ -39,6 +40,9 @@ public class ClusterDecoratorTest {
 
     @Mock
     private BlueprintService blueprintService;
+
+    @Mock
+    private BlueprintValidatorFactory blueprintValidatorFactory;
 
     @Mock
     private AmbariBlueprintValidator ambariBlueprintValidator;
@@ -73,6 +77,7 @@ public class ClusterDecoratorTest {
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
+        when(blueprintValidatorFactory.createBlueprintValidator(any())).thenReturn(ambariBlueprintValidator);
     }
 
     @Test

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentDatalakeClusterTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentDatalakeClusterTest.java
@@ -1,7 +1,5 @@
 package com.sequenceiq.it.cloudbreak.testcase.mock;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -16,7 +14,6 @@ import com.sequenceiq.it.cloudbreak.client.DatabaseTestClient;
 import com.sequenceiq.it.cloudbreak.client.EnvironmentTestClient;
 import com.sequenceiq.it.cloudbreak.client.LdapTestClient;
 import com.sequenceiq.it.cloudbreak.client.StackTestClient;
-import com.sequenceiq.it.cloudbreak.cloud.HostGroupType;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.RunningParameter;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
@@ -65,7 +62,7 @@ public class EnvironmentDatalakeClusterTest extends AbstractIntegrationTest {
             given = "Create datalake cluster and then delete",
             when = "create cluster and if available then delete",
             then = "the cluster should work")
-    public void testCreateDalalakeDelete(TestContext testContext) {
+    public void testCreateDatalakeDelete(TestContext testContext) {
         String hivedb = resourcePropertyProvider().getName();
         String rangerdb = resourcePropertyProvider().getName();
         Set<String> rdsList = createDatalakeResources(testContext, hivedb, rangerdb);
@@ -81,7 +78,7 @@ public class EnvironmentDatalakeClusterTest extends AbstractIntegrationTest {
 
                 .given(StackTestDto.class).withPlacement("placement")
                 .withEnvironment(EnvironmentTestDto.class)
-                .withInstanceGroupsEntity(setInstanceGroup(testContext))
+                .withInstanceGroupsEntity(InstanceGroupTestDto.defaultHostGroup(testContext))
 
                 .when(stackTestClient.createV4())
                 .when(stackTestClient.deleteV4(), RunningParameter.withoutLogError())
@@ -99,7 +96,7 @@ public class EnvironmentDatalakeClusterTest extends AbstractIntegrationTest {
             given = "Create datalake cluster and then delete resources",
             when = "create cluster and then delete resources",
             then = "the resource deletion does not work because the resources attached to the cluster")
-    public void testCreateDalalakeDeleteFails(TestContext testContext) {
+    public void testCreateDatalakeDeleteFails(TestContext testContext) {
         String forbiddenKey = resourcePropertyProvider().getName();
         String hivedb = resourcePropertyProvider().getName();
         String rangerdb = resourcePropertyProvider().getName();
@@ -114,7 +111,7 @@ public class EnvironmentDatalakeClusterTest extends AbstractIntegrationTest {
                 .given("placement", PlacementSettingsTestDto.class)
                 .given(StackTestDto.class).withPlacement("placement")
                 .withEnvironment(EnvironmentTestDto.class)
-                .withInstanceGroupsEntity(setInstanceGroup(testContext))
+                .withInstanceGroupsEntity(InstanceGroupTestDto.defaultHostGroup(testContext))
                 .when(stackTestClient.createV4())
                 .deleteGiven(LdapTestDto.class, ldapTestClient.deleteV4(), RunningParameter.key(forbiddenKey))
                 .deleteGiven(DatabaseTestDto.class, databaseTestClient.deleteV4(), RunningParameter.key(forbiddenKey))
@@ -167,7 +164,7 @@ public class EnvironmentDatalakeClusterTest extends AbstractIntegrationTest {
     @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
     @Description(
             given = "Create datalake cluster and workload",
-            when = "call create cluster with datalake and wiht workload config",
+            when = "call create cluster with datalake and with workload config",
             then = "will work fine")
     public void testSameEnvironmentInDatalakeAndWorkload(TestContext testContext) {
         String dlName = resourcePropertyProvider().getName();
@@ -195,7 +192,7 @@ public class EnvironmentDatalakeClusterTest extends AbstractIntegrationTest {
                 .withName(resourcePropertyProvider().getName())
                 .withPlacement("placement")
                 .withEnvironment(EnvironmentTestDto.class)
-                .withInstanceGroupsEntity(setInstanceGroup(testContext))
+                .withInstanceGroupsEntity(InstanceGroupTestDto.defaultHostGroup(testContext))
                 .when(stackTestClient.createV4())
                 .validate();
     }
@@ -214,12 +211,5 @@ public class EnvironmentDatalakeClusterTest extends AbstractIntegrationTest {
         rdsSet.add(hiveDb);
         rdsSet.add(rangerDb);
         return rdsSet;
-    }
-
-    private Collection<InstanceGroupTestDto> setInstanceGroup(TestContext testContext) {
-        Collection<InstanceGroupTestDto> instanceGroupTestDto = new ArrayList<>();
-        InstanceGroupTestDto ig = InstanceGroupTestDto.hostGroup(testContext, HostGroupType.MASTER);
-        instanceGroupTestDto.add(ig);
-        return instanceGroupTestDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/KerberosConfigTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/KerberosConfigTest.java
@@ -23,10 +23,14 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.kerberos.requests.AmbariKerbero
 import com.sequenceiq.cloudbreak.api.endpoint.v4.kerberos.requests.FreeIPAKerberosDescriptor;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.kerberos.requests.KerberosV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.kerberos.requests.MITKerberosDescriptor;
+import com.sequenceiq.it.cloudbreak.assertion.Assertion;
 import com.sequenceiq.it.cloudbreak.assertion.MockVerification;
 import com.sequenceiq.it.cloudbreak.client.KerberosTestClient;
 import com.sequenceiq.it.cloudbreak.client.StackTestClient;
 import com.sequenceiq.it.cloudbreak.cloud.HostGroupType;
+import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
+import com.sequenceiq.it.cloudbreak.context.TestCaseDescription;
 import com.sequenceiq.it.cloudbreak.dto.AmbariTestDto;
 import com.sequenceiq.it.cloudbreak.dto.ClusterTestDto;
 import com.sequenceiq.it.cloudbreak.dto.InstanceGroupTestDto;
@@ -34,13 +38,8 @@ import com.sequenceiq.it.cloudbreak.dto.kerberos.KerberosTestDto;
 import com.sequenceiq.it.cloudbreak.dto.stack.StackTestDto;
 import com.sequenceiq.it.cloudbreak.mock.model.ClouderaManagerMock;
 import com.sequenceiq.it.cloudbreak.mock.model.SaltMock;
-import com.sequenceiq.it.cloudbreak.assertion.Assertion;
-import com.sequenceiq.it.cloudbreak.client.BlueprintTestClient;
-import com.sequenceiq.it.cloudbreak.context.Description;
-import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
-import com.sequenceiq.it.cloudbreak.context.TestCaseDescription;
-import com.sequenceiq.it.cloudbreak.testcase.AbstractIntegrationTest;
 import com.sequenceiq.it.cloudbreak.spark.DynamicRouteStack;
+import com.sequenceiq.it.cloudbreak.testcase.AbstractIntegrationTest;
 
 import spark.Route;
 
@@ -49,14 +48,6 @@ public class KerberosConfigTest extends AbstractIntegrationTest {
     private static final String LDAP_SYNC_PATH = "/api/v1/ldap_sync_events";
 
     private static final String SALT_HIGHSTATE = "state.highstate";
-
-    private static final String BLUEPRINT_TEXT = "{\"Blueprints\":{\"blueprint_name\":\"ownbp\",\"stack_name\":\"HDF\",\"stack_version\":\"3.2\"},"
-            + "\"settings\":[{\"recovery_settings\":[]},{\"service_settings\":[]},{\"component_settings\":[]}],\"configurations\":[],\"host_groups\":[{\"name\""
-            + ":\"master\",\"configurations\":[],\"components\":[{\"name\":\"METRICS_MONITOR\"},{\"name\":\"METRICS_COLLECTOR\"},{\"name\":"
-            + "\"ZOOKEEPER_CLIENT\"}],\"cardinality\":\"1\"}]}";
-
-    @Inject
-    private BlueprintTestClient blueprintTestClient;
 
     @Inject
     private KerberosTestClient kerberosTestClient;
@@ -86,7 +77,7 @@ public class KerberosConfigTest extends AbstractIntegrationTest {
                 .given(ClusterTestDto.class)
                 .withKerberos(request.getName())
                 .given(StackTestDto.class)
-                .withInstanceGroups("master")
+                .withInstanceGroupsEntity(InstanceGroupTestDto.defaultHostGroup(testContext))
                 .when(stackTestClient.createV4())
                 .await(STACK_AVAILABLE)
                 .then(testData.getAssertions())
@@ -107,7 +98,7 @@ public class KerberosConfigTest extends AbstractIntegrationTest {
                 .given(ClusterTestDto.class)
                 .withKerberos(null)
                 .given(StackTestDto.class)
-                .withInstanceGroups("master")
+                .withInstanceGroupsEntity(InstanceGroupTestDto.defaultHostGroup(testContext))
                 .when(stackTestClient.createV4())
                 .await(STACK_AVAILABLE)
                 .validate();
@@ -134,7 +125,7 @@ public class KerberosConfigTest extends AbstractIntegrationTest {
                 .withKerberos("")
                 .withAmbari(testContext.given(AmbariTestDto.class))
                 .given(StackTestDto.class)
-                .withInstanceGroups("master")
+                .withInstanceGroupsEntity(InstanceGroupTestDto.defaultHostGroup(testContext))
                 .when(stackTestClient.createV4(), key("badRequest"))
                 .expect(BadRequestException.class, key("badRequest"))
                 .validate();

--- a/template-manager-blueprint/src/main/java/com/sequenceiq/cloudbreak/blueprint/utils/BlueprintUtils.java
+++ b/template-manager-blueprint/src/main/java/com/sequenceiq/cloudbreak/blueprint/utils/BlueprintUtils.java
@@ -12,10 +12,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
+import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.json.JsonHelper;
 import com.sequenceiq.cloudbreak.util.FileReaderUtils;
-import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 
 @Component
 public class BlueprintUtils {
@@ -59,6 +60,10 @@ public class BlueprintUtils {
 
     public boolean isValidHostGroupName(String hostGroupName) {
         return StringUtils.isNotEmpty(hostGroupName) && validHostGroupNamePattern.matcher(hostGroupName).matches();
+    }
+
+    public String getBlueprintVariant(String blueprint) {
+        return isAmbariBlueprint(blueprint) ? ClusterApi.AMBARI : ClusterApi.CLOUDERA_MANAGER;
     }
 
     public boolean isClouderaManagerClusterTemplate(String text) {

--- a/template-manager-blueprint/src/main/java/com/sequenceiq/cloudbreak/blueprint/validation/AmbariBlueprintValidator.java
+++ b/template-manager-blueprint/src/main/java/com/sequenceiq/cloudbreak/blueprint/validation/AmbariBlueprintValidator.java
@@ -8,7 +8,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -18,33 +17,28 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Maps;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
-import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.template.validation.BlueprintServiceComponent;
 import com.sequenceiq.cloudbreak.template.validation.BlueprintValidationException;
+import com.sequenceiq.cloudbreak.template.validation.BlueprintValidator;
+import com.sequenceiq.cloudbreak.template.validation.BlueprintValidatorUtil;
 
 @Component
-public class AmbariBlueprintValidator {
-
-    private static final String KNOX = "KNOX_GATEWAY";
+public class AmbariBlueprintValidator implements BlueprintValidator {
 
     private ObjectMapper objectMapper = new ObjectMapper();
 
     @Inject
     private StackServiceComponentDescriptors stackServiceComponentDescs;
 
-    public void validateBlueprintForStack(Blueprint blueprint, Set<HostGroup> hostGroups, Collection<InstanceGroup> instanceGroups)
-            throws BlueprintValidationException {
-        validateBlueprintForStack(null, blueprint, hostGroups, instanceGroups);
-    }
-
-    public void validateBlueprintForStack(Cluster cluster, Blueprint blueprint, Collection<HostGroup> hostGroups,
-            Collection<InstanceGroup> instanceGroups) {
+    @Override
+    public void validateBlueprintForStack(Blueprint blueprint, Set<HostGroup> hostGroups, Collection<InstanceGroup> instanceGroups) {
         try {
             JsonNode hostGroupsNode = getHostGroupNode(blueprint);
-            validateHostGroups(hostGroupsNode, hostGroups, instanceGroups);
-            Map<String, HostGroup> hostGroupMap = createHostGroupMap(hostGroups);
+            BlueprintValidatorUtil.validateHostGroupsMatch(hostGroups, getHostGroupsFromBlueprint(hostGroupsNode));
+            BlueprintValidatorUtil.validateInstanceGroups(hostGroups, instanceGroups);
+            Map<String, HostGroup> hostGroupMap = BlueprintValidatorUtil.createHostGroupMap(hostGroups);
             Map<String, BlueprintServiceComponent> blueprintServiceComponentMap = Maps.newHashMap();
             for (JsonNode hostGroupNode : hostGroupsNode) {
                 validateHostGroup(hostGroupNode, hostGroupMap, blueprintServiceComponentMap);
@@ -55,7 +49,7 @@ public class AmbariBlueprintValidator {
         }
     }
 
-    public JsonNode getHostGroupNode(Blueprint blueprint) throws IOException {
+    private JsonNode getHostGroupNode(Blueprint blueprint) throws IOException {
         JsonNode blueprintJsonTree = createJsonTree(blueprint);
         return blueprintJsonTree.get("host_groups");
     }
@@ -65,35 +59,11 @@ public class AmbariBlueprintValidator {
         return objectMapper.readTree(blueprintText);
     }
 
-    private void validateHostGroups(JsonNode hostGroupsNode, Collection<HostGroup> hostGroups, Collection<InstanceGroup> instanceGroups) {
-        Set<String> hostGroupsInRequest = getHostGroupsFromRequest(hostGroups);
-        Set<String> hostGroupsInBlueprint = getHostGroupsFromBlueprint(hostGroupsNode);
-
-        if (!hostGroupsInRequest.containsAll(hostGroupsInBlueprint) || !hostGroupsInBlueprint.containsAll(hostGroupsInRequest)) {
-            throw new BlueprintValidationException("The host groups in the validation [" + String.join(",", hostGroupsInBlueprint) + "] "
-                    + "must match the hostgroups in the request [" + String.join(",", hostGroupsInRequest) + "].");
-        }
-
-        if (!instanceGroups.isEmpty()) {
-            Collection<String> instanceGroupNames = new HashSet<>();
-            for (HostGroup hostGroup : hostGroups) {
-                String instanceGroupName = hostGroup.getConstraint().getInstanceGroup().getGroupName();
-                if (instanceGroupNames.contains(instanceGroupName)) {
-                    throw new BlueprintValidationException(String.format(
-                            "Instance group '%s' is assigned to more than one hostgroup.", instanceGroupName));
-                }
-                instanceGroupNames.add(instanceGroupName);
-            }
-            if (instanceGroups.size() < hostGroupsInRequest.size()) {
-                throw new BlueprintValidationException("Each host group must have an instance group");
-            }
-        }
-    }
-
+    @Override
     public void validateHostGroupScalingRequest(Blueprint blueprint, HostGroup hostGroup, Integer adjustment) {
         try {
             JsonNode hostGroupsNode = getHostGroupNode(blueprint);
-            Map<String, HostGroup> hostGroupMap = createHostGroupMap(Collections.singleton(hostGroup));
+            Map<String, HostGroup> hostGroupMap = BlueprintValidatorUtil.createHostGroupMap(Collections.singleton(hostGroup));
             for (JsonNode hostGroupNode : hostGroupsNode) {
                 if (hostGroup.getName().equals(hostGroupNode.get("name").asText())) {
                     validateHostGroup(hostGroupNode, hostGroupMap, new HashMap<>(), adjustment);
@@ -105,10 +75,6 @@ public class AmbariBlueprintValidator {
         }
     }
 
-    private Set<String> getHostGroupsFromRequest(Collection<HostGroup> hostGroup) {
-        return hostGroup.stream().map(HostGroup::getName).collect(Collectors.toSet());
-    }
-
     private Set<String> getHostGroupsFromBlueprint(JsonNode hostGroupsNode) {
         Set<String> hostGroupsInBlueprint = new HashSet<>();
         Iterator<JsonNode> hostGroups = hostGroupsNode.elements();
@@ -116,14 +82,6 @@ public class AmbariBlueprintValidator {
             hostGroupsInBlueprint.add(hostGroups.next().get("name").asText());
         }
         return hostGroupsInBlueprint;
-    }
-
-    public Map<String, HostGroup> createHostGroupMap(Iterable<HostGroup> hostGroups) {
-        Map<String, HostGroup> groupMap = Maps.newHashMap();
-        for (HostGroup hostGroup : hostGroups) {
-            groupMap.put(hostGroup.getName(), hostGroup);
-        }
-        return groupMap;
     }
 
     private void validateHostGroup(JsonNode hostGroupNode, Map<String, HostGroup> hostGroupMap,
@@ -145,11 +103,11 @@ public class AmbariBlueprintValidator {
         return hostGroupNode.get("name").asText();
     }
 
-    public HostGroup getHostGroup(Map<String, HostGroup> hostGroupMap, String hostGroupName) {
+    private HostGroup getHostGroup(Map<String, HostGroup> hostGroupMap, String hostGroupName) {
         return hostGroupMap.get(hostGroupName);
     }
 
-    public JsonNode getComponentsNode(JsonNode hostGroupNode) {
+    private JsonNode getComponentsNode(JsonNode hostGroupNode) {
         return hostGroupNode.get("components");
     }
 

--- a/template-manager-blueprint/src/test/java/com/sequenceiq/cloudbreak/blueprint/validation/AmbariBlueprintValidatorTest.java
+++ b/template-manager-blueprint/src/test/java/com/sequenceiq/cloudbreak/blueprint/validation/AmbariBlueprintValidatorTest.java
@@ -104,7 +104,7 @@ public class AmbariBlueprintValidatorTest {
         JsonNode blueprintJsonTree = createJsonTree();
         BDDMockito.given(objectMapper.readTree(BLUEPRINT_STRING)).willReturn(blueprintJsonTree);
         thrown.expect(BlueprintValidationException.class);
-        thrown.expectMessage(Matchers.startsWith("The host groups in the validation"));
+        thrown.expectMessage(Matchers.containsString("host groups are missing"));
         // WHEN
         underTest.validateBlueprintForStack(blueprint, hostGroups, instanceGroups);
         // THEN throw exception
@@ -132,11 +132,11 @@ public class AmbariBlueprintValidatorTest {
         Blueprint blueprint = createBlueprint();
         Set<InstanceGroup> instanceGroups = createInstanceGroups();
         Set<HostGroup> hostGroups = createHostGroups(instanceGroups);
-        instanceGroups.add(createInstanceGroup("gateway", 0L, 1));
+        hostGroups.add(createHostGroup(GROUP4, createInstanceGroup(GROUP4, 0L, 1)));
         JsonNode blueprintJsonTree = createJsonTreeWithTooMuchGroup();
         BDDMockito.given(objectMapper.readTree(BLUEPRINT_STRING)).willReturn(blueprintJsonTree);
         thrown.expect(BlueprintValidationException.class);
-        thrown.expectMessage(Matchers.startsWith("The host groups in the validation"));
+        thrown.expectMessage(Matchers.containsString("Each host group must have"));
         // WHEN
         underTest.validateBlueprintForStack(blueprint, hostGroups, instanceGroups);
         // THEN throw exception
@@ -151,7 +151,7 @@ public class AmbariBlueprintValidatorTest {
         JsonNode blueprintJsonTree = createJsonTreeWithNotEnoughGroup();
         BDDMockito.given(objectMapper.readTree(BLUEPRINT_STRING)).willReturn(blueprintJsonTree);
         thrown.expect(BlueprintValidationException.class);
-        thrown.expectMessage(Matchers.startsWith("The host groups in the validation"));
+        thrown.expectMessage(Matchers.startsWith("Unknown host groups are present"));
         // WHEN
         underTest.validateBlueprintForStack(blueprint, hostGroups, instanceGroups);
         // THEN throw exception
@@ -307,7 +307,7 @@ public class AmbariBlueprintValidatorTest {
         return groups;
     }
 
-    private HostGroup createHostGroup(String groupName, InstanceGroup instanceGroup) {
+    public static HostGroup createHostGroup(String groupName, InstanceGroup instanceGroup) {
         HostGroup group = new HostGroup();
         group.setName(groupName);
         Constraint constraint = new Constraint();

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessor.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessor.java
@@ -132,8 +132,9 @@ public class CmTemplateProcessor implements BlueprintTextProcessor {
     public Map<String, InstanceCount> getCardinalityByHostGroup() {
         Map<String, InstanceCount> result = new TreeMap<>();
         for (ApiClusterTemplateHostTemplate group : Optional.ofNullable(cmTemplate.getHostTemplates()).orElse(List.of())) {
-            recommendInstanceCount(group.getRefName(), group.getCardinality())
-                    .ifPresent(recommendedCount -> result.put(group.getRefName(), recommendedCount));
+            InstanceCount recommendedCount = recommendInstanceCount(group.getRefName(), group.getCardinality())
+                    .orElse(InstanceCount.fallbackInstanceCountRecommendation(group.getRefName()));
+            result.put(group.getRefName(), recommendedCount);
         }
         return result;
     }

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateValidator.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateValidator.java
@@ -1,0 +1,39 @@
+package com.sequenceiq.cloudbreak.cmtemplate;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.NotImplementedException;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.model.InstanceCount;
+import com.sequenceiq.cloudbreak.domain.Blueprint;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.template.validation.BlueprintValidator;
+import com.sequenceiq.cloudbreak.template.validation.BlueprintValidatorUtil;
+
+@Component
+public class CmTemplateValidator implements BlueprintValidator {
+
+    @Inject
+    private CmTemplateProcessorFactory processorFactory;
+
+    @Override
+    public void validateBlueprintForStack(Blueprint blueprint, Set<HostGroup> hostGroups, Collection<InstanceGroup> instanceGroups) {
+        CmTemplateProcessor templateProcessor = processorFactory.get(blueprint.getBlueprintText());
+        Map<String, InstanceCount> blueprintHostGroupCardinality = templateProcessor.getCardinalityByHostGroup();
+
+        BlueprintValidatorUtil.validateHostGroupsMatch(hostGroups, blueprintHostGroupCardinality.keySet());
+        BlueprintValidatorUtil.validateInstanceGroups(hostGroups, instanceGroups);
+        BlueprintValidatorUtil.validateHostGroupCardinality(hostGroups, blueprintHostGroupCardinality);
+    }
+
+    @Override
+    public void validateHostGroupScalingRequest(Blueprint blueprint, HostGroup hostGroup, Integer adjustment) {
+        throw new NotImplementedException("Scale request validation for CM");
+    }
+}

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessorTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessorTest.java
@@ -405,6 +405,15 @@ public class CmTemplateProcessorTest {
         );
         assertEquals(expected, underTest.getCardinalityByHostGroup());
 
+        underTest = new CmTemplateProcessor(getBlueprintText("input/cdp-data-mart.bp"));
+
+        expected = Map.of(
+                "master", InstanceCount.EXACTLY_ONE,
+                "worker", InstanceCount.ONE_OR_MORE,
+                "compute", InstanceCount.ZERO_OR_MORE
+        );
+        assertEquals(expected, underTest.getCardinalityByHostGroup());
+
         underTest = new CmTemplateProcessor(getBlueprintText("input/namenode-ha.bp"));
 
         expected = Map.of(

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateValidatorTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateValidatorTest.java
@@ -1,0 +1,79 @@
+package com.sequenceiq.cloudbreak.cmtemplate;
+
+import static com.sequenceiq.cloudbreak.TestUtil.hostGroup;
+import static java.util.stream.Collectors.toSet;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Collection;
+import java.util.Set;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.sequenceiq.cloudbreak.domain.Blueprint;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.template.validation.BlueprintValidationException;
+import com.sequenceiq.cloudbreak.util.FileReaderUtils;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CmTemplateValidatorTest {
+
+    @InjectMocks
+    private CmTemplateValidator subject = new CmTemplateValidator();
+
+    @Spy
+    @SuppressFBWarnings(value = "URF_UNREAD_FIELD", justification = "Injected by Mockito")
+    private CmTemplateProcessorFactory templateProcessorFactory = new CmTemplateProcessorFactory();
+
+    @Test
+    public void validWithZeroComputeNodesWhenCardinalityUnspecified() {
+        Blueprint blueprint = new Blueprint();
+        blueprint.setBlueprintText(FileReaderUtils.readFileFromClasspathQuietly("input/cdp-data-mart-no-cardinality.bp"));
+        Set<HostGroup> hostGroups = Set.of(
+                hostGroup("master", 1),
+                hostGroup("worker", 3),
+                hostGroup("compute", 0)
+        );
+        Collection<InstanceGroup> instanceGroups = hostGroups.stream()
+                .map(hg -> hg.getConstraint().getInstanceGroup())
+                .collect(toSet());
+        subject.validateBlueprintForStack(blueprint, hostGroups, instanceGroups);
+    }
+
+    @Test
+    public void validWithZeroComputeNodes() {
+        Blueprint blueprint = new Blueprint();
+        blueprint.setBlueprintText(FileReaderUtils.readFileFromClasspathQuietly("input/cdp-data-mart.bp"));
+        Set<HostGroup> hostGroups = Set.of(
+                hostGroup("master", 1),
+                hostGroup("worker", 3),
+                hostGroup("compute", 0)
+        );
+        Collection<InstanceGroup> instanceGroups = hostGroups.stream()
+                .map(hg -> hg.getConstraint().getInstanceGroup())
+                .collect(toSet());
+        subject.validateBlueprintForStack(blueprint, hostGroups, instanceGroups);
+    }
+
+    @Test
+    public void invalidWithoutComputeHostGroup() {
+        Blueprint blueprint = new Blueprint();
+        blueprint.setBlueprintText(FileReaderUtils.readFileFromClasspathQuietly("input/cdp-data-mart.bp"));
+        Set<HostGroup> hostGroups = Set.of(
+                hostGroup("master", 1),
+                hostGroup("worker", 3)
+        );
+        Collection<InstanceGroup> instanceGroups = hostGroups.stream()
+                .map(hg -> hg.getConstraint().getInstanceGroup())
+                .collect(toSet());
+
+        assertThrows(BlueprintValidationException.class, () -> subject.validateBlueprintForStack(blueprint, hostGroups, instanceGroups));
+    }
+
+}

--- a/template-manager-cmtemplate/src/test/resources/input/cdp-data-mart-no-cardinality.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/cdp-data-mart-no-cardinality.bp
@@ -1,0 +1,169 @@
+{
+  "cdhVersion": "7.0.0",
+  "displayName": "datamart",
+  "services": [
+    {
+      "refName": "hdfs",
+      "serviceType": "HDFS",
+      "roleConfigGroups": [
+        {
+          "refName": "hdfs-NAMENODE-BASE",
+          "roleType": "NAMENODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-SECONDARYNAMENODE-BASE",
+          "roleType": "SECONDARYNAMENODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-DATANODE-BASE",
+          "roleType": "DATANODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-BALANCER-BASE",
+          "roleType": "BALANCER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "yarn",
+      "serviceType": "YARN",
+      "roleConfigGroups": [
+        {
+          "refName": "yarn-RESOURCEMANAGER-BASE",
+          "roleType": "RESOURCEMANAGER",
+          "base": true
+        },
+        {
+          "refName": "yarn-NODEMANAGER-WORKER",
+          "roleType": "NODEMANAGER",
+          "base": false
+        },
+        {
+          "refName": "yarn-NODEMANAGER-COMPUTE",
+          "roleType": "NODEMANAGER",
+          "base": false
+        },
+        {
+          "refName": "yarn-JOBHISTORY-BASE",
+          "roleType": "JOBHISTORY",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "hive",
+      "serviceType": "HIVE",
+      "roleConfigGroups": [
+        {
+          "refName": "hive-GATEWAY-BASE",
+          "roleType": "GATEWAY",
+          "base": true
+        },
+        {
+          "refName": "hive-HIVESERVER2-BASE",
+          "roleType": "HIVESERVER2",
+          "configs": [
+            {
+              "name": "hs2_execution_engine",
+              "value": "mr"
+            }
+          ],
+          "base": true
+        },
+        {
+          "refName": "hive-HIVEMETASTORE-BASE",
+          "roleType": "HIVEMETASTORE",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "hue",
+      "serviceType": "HUE",
+      "roleConfigGroups": [
+        {
+          "refName": "hue-HUE_SERVER-BASE",
+          "roleType": "HUE_SERVER",
+          "base": true
+        },
+        {
+          "refName": "hue-HUE_LOAD_BALANCER-BASE",
+          "roleType": "HUE_LOAD_BALANCER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "oozie",
+      "serviceType": "OOZIE",
+      "roleConfigGroups": [
+        {
+          "refName": "oozie-OOZIE_SERVER-BASE",
+          "roleType": "OOZIE_SERVER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "impala",
+      "serviceType": "IMPALA",
+      "roleConfigGroups": [
+        {
+          "refName": "impala-IMPALAD-BASE",
+          "roleType": "IMPALAD",
+          "base": true
+        },
+        {
+          "refName": "impala-STATESTORE-BASE",
+          "roleType": "STATESTORE",
+          "base": true
+        },
+        {
+          "refName": "impala-CATALOGSERVER-BASE",
+          "roleType": "CATALOGSERVER",
+          "base": true
+        }
+      ]
+    }
+  ],
+  "hostTemplates": [
+    {
+      "refName": "master",
+      "roleConfigGroupsRefNames": [
+        "hdfs-BALANCER-BASE",
+        "hdfs-NAMENODE-BASE",
+        "hdfs-SECONDARYNAMENODE-BASE",
+        "hive-GATEWAY-BASE",
+        "hive-HIVEMETASTORE-BASE",
+        "hive-HIVESERVER2-BASE",
+        "hue-HUE_LOAD_BALANCER-BASE",
+        "hue-HUE_SERVER-BASE",
+        "impala-CATALOGSERVER-BASE",
+        "impala-STATESTORE-BASE",
+        "oozie-OOZIE_SERVER-BASE",
+        "yarn-JOBHISTORY-BASE",
+        "yarn-RESOURCEMANAGER-BASE"
+      ]
+    },
+    {
+      "refName": "worker",
+      "roleConfigGroupsRefNames": [
+        "hdfs-DATANODE-BASE",
+        "hive-GATEWAY-BASE",
+        "impala-IMPALAD-BASE",
+        "yarn-NODEMANAGER-WORKER"
+      ]
+    },
+    {
+      "refName": "compute",
+      "roleConfigGroupsRefNames": [
+        "hive-GATEWAY-BASE",
+        "yarn-NODEMANAGER-COMPUTE"
+      ]
+    }
+  ]
+}

--- a/template-manager-cmtemplate/src/test/resources/input/cdp-data-mart.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/cdp-data-mart.bp
@@ -1,0 +1,172 @@
+{
+  "cdhVersion": "7.0.0",
+  "displayName": "datamart",
+  "services": [
+    {
+      "refName": "hdfs",
+      "serviceType": "HDFS",
+      "roleConfigGroups": [
+        {
+          "refName": "hdfs-NAMENODE-BASE",
+          "roleType": "NAMENODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-SECONDARYNAMENODE-BASE",
+          "roleType": "SECONDARYNAMENODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-DATANODE-BASE",
+          "roleType": "DATANODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-BALANCER-BASE",
+          "roleType": "BALANCER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "yarn",
+      "serviceType": "YARN",
+      "roleConfigGroups": [
+        {
+          "refName": "yarn-RESOURCEMANAGER-BASE",
+          "roleType": "RESOURCEMANAGER",
+          "base": true
+        },
+        {
+          "refName": "yarn-NODEMANAGER-WORKER",
+          "roleType": "NODEMANAGER",
+          "base": false
+        },
+        {
+          "refName": "yarn-NODEMANAGER-COMPUTE",
+          "roleType": "NODEMANAGER",
+          "base": false
+        },
+        {
+          "refName": "yarn-JOBHISTORY-BASE",
+          "roleType": "JOBHISTORY",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "hive",
+      "serviceType": "HIVE",
+      "roleConfigGroups": [
+        {
+          "refName": "hive-GATEWAY-BASE",
+          "roleType": "GATEWAY",
+          "base": true
+        },
+        {
+          "refName": "hive-HIVESERVER2-BASE",
+          "roleType": "HIVESERVER2",
+          "configs": [
+            {
+              "name": "hs2_execution_engine",
+              "value": "mr"
+            }
+          ],
+          "base": true
+        },
+        {
+          "refName": "hive-HIVEMETASTORE-BASE",
+          "roleType": "HIVEMETASTORE",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "hue",
+      "serviceType": "HUE",
+      "roleConfigGroups": [
+        {
+          "refName": "hue-HUE_SERVER-BASE",
+          "roleType": "HUE_SERVER",
+          "base": true
+        },
+        {
+          "refName": "hue-HUE_LOAD_BALANCER-BASE",
+          "roleType": "HUE_LOAD_BALANCER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "oozie",
+      "serviceType": "OOZIE",
+      "roleConfigGroups": [
+        {
+          "refName": "oozie-OOZIE_SERVER-BASE",
+          "roleType": "OOZIE_SERVER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "impala",
+      "serviceType": "IMPALA",
+      "roleConfigGroups": [
+        {
+          "refName": "impala-IMPALAD-BASE",
+          "roleType": "IMPALAD",
+          "base": true
+        },
+        {
+          "refName": "impala-STATESTORE-BASE",
+          "roleType": "STATESTORE",
+          "base": true
+        },
+        {
+          "refName": "impala-CATALOGSERVER-BASE",
+          "roleType": "CATALOGSERVER",
+          "base": true
+        }
+      ]
+    }
+  ],
+  "hostTemplates": [
+    {
+      "refName": "master",
+      "cardinality": 1,
+      "roleConfigGroupsRefNames": [
+        "hdfs-BALANCER-BASE",
+        "hdfs-NAMENODE-BASE",
+        "hdfs-SECONDARYNAMENODE-BASE",
+        "hive-GATEWAY-BASE",
+        "hive-HIVEMETASTORE-BASE",
+        "hive-HIVESERVER2-BASE",
+        "hue-HUE_LOAD_BALANCER-BASE",
+        "hue-HUE_SERVER-BASE",
+        "impala-CATALOGSERVER-BASE",
+        "impala-STATESTORE-BASE",
+        "oozie-OOZIE_SERVER-BASE",
+        "yarn-JOBHISTORY-BASE",
+        "yarn-RESOURCEMANAGER-BASE"
+      ]
+    },
+    {
+      "refName": "worker",
+      "cardinality": 1,
+      "roleConfigGroupsRefNames": [
+        "hdfs-DATANODE-BASE",
+        "hive-GATEWAY-BASE",
+        "impala-IMPALAD-BASE",
+        "yarn-NODEMANAGER-WORKER"
+      ]
+    },
+    {
+      "refName": "compute",
+      "cardinality": 0,
+      "roleConfigGroupsRefNames": [
+        "hive-GATEWAY-BASE",
+        "yarn-NODEMANAGER-COMPUTE"
+      ]
+    }
+  ]
+}

--- a/template-manager-core/build.gradle
+++ b/template-manager-core/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 
     testCompile group: 'org.springframework.boot',  name: 'spring-boot-starter',            version: springBootVersion
     testCompile group: 'org.springframework.boot',  name: 'spring-boot-starter-test',       version: springBootVersion
+    testCompile group: 'org.junit.jupiter',         name: 'junit-jupiter-api',              version: junitJupiterVersion
     testCompile (group: 'junit', name: 'junit', version: junitVersion) {
         exclude group: 'org.hamcrest'
     }

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/validation/BlueprintValidator.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/validation/BlueprintValidator.java
@@ -1,0 +1,18 @@
+package com.sequenceiq.cloudbreak.template.validation;
+
+import java.util.Collection;
+import java.util.Set;
+
+import com.sequenceiq.cloudbreak.domain.Blueprint;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+
+public interface BlueprintValidator {
+
+    void validateBlueprintForStack(Blueprint blueprint, Set<HostGroup> hostGroups, Collection<InstanceGroup> instanceGroups)
+            throws BlueprintValidationException;
+
+    void validateHostGroupScalingRequest(Blueprint blueprint, HostGroup hostGroup, Integer adjustment)
+            throws BlueprintValidationException;
+
+}

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/validation/BlueprintValidatorUtil.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/validation/BlueprintValidatorUtil.java
@@ -1,0 +1,74 @@
+package com.sequenceiq.cloudbreak.template.validation;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceCount;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+
+public class BlueprintValidatorUtil {
+
+    private BlueprintValidatorUtil() { }
+
+    public static void validateHostGroupsMatch(Set<HostGroup> hostGroupsInRequest, Set<String> hostGroupsInBlueprint) {
+        Set<String> hostGroupNamesInRequest = hostGroupsInRequest.stream().map(HostGroup::getName).collect(Collectors.toSet());
+        Set<String> missingFromRequest = Set.copyOf(Sets.difference(hostGroupsInBlueprint, hostGroupNamesInRequest));
+        Set<String> unknownHostGroups = Set.copyOf(Sets.difference(hostGroupNamesInRequest, hostGroupsInBlueprint));
+        if (!missingFromRequest.isEmpty()) {
+            throw new BlueprintValidationException("The following host groups are missing from the request: "
+                    + String.join(", ", missingFromRequest));
+        }
+        if (!unknownHostGroups.isEmpty()) {
+            throw new BlueprintValidationException("Unknown host groups are present in the request: "
+                    + String.join(", ", unknownHostGroups));
+        }
+    }
+
+    public static void validateInstanceGroups(Collection<HostGroup> hostGroups, Collection<InstanceGroup> instanceGroups) {
+        if (!instanceGroups.isEmpty()) {
+            Collection<String> instanceGroupNames = new HashSet<>();
+            for (HostGroup hostGroup : hostGroups) {
+                String instanceGroupName = hostGroup.getConstraint().getInstanceGroup().getGroupName();
+                if (instanceGroupNames.contains(instanceGroupName)) {
+                    throw new BlueprintValidationException(String.format(
+                            "Instance group '%s' is assigned to more than one hostgroup.", instanceGroupName));
+                }
+                instanceGroupNames.add(instanceGroupName);
+            }
+            if (instanceGroups.size() < hostGroups.size()) {
+                throw new BlueprintValidationException("Each host group must have an instance group");
+            }
+        }
+    }
+
+    public static Map<String, HostGroup> createHostGroupMap(Iterable<HostGroup> hostGroups) {
+        Map<String, HostGroup> groupMap = Maps.newHashMap();
+        for (HostGroup hostGroup : hostGroups) {
+            groupMap.put(hostGroup.getName(), hostGroup);
+        }
+        return groupMap;
+    }
+
+    public static void validateHostGroupCardinality(Set<HostGroup> hostGroups, Map<String, InstanceCount> blueprintHostGroupCardinality) {
+        List<String> failures = new LinkedList<>();
+        for (HostGroup hostGroup : hostGroups) {
+            InstanceCount requiredCount = blueprintHostGroupCardinality.get(hostGroup.getName());
+            int count = hostGroup.getHostCount();
+            if (!requiredCount.isAcceptable(count)) {
+                failures.add(String.format("(group: '%s', required: %s, actual: %d)", hostGroup.getName(), requiredCount, count));
+            }
+        }
+        if (!failures.isEmpty()) {
+            throw new BlueprintValidationException("Node count for the following host groups does not meet requirements: "
+                    + String.join(", ", failures));
+        }
+    }
+}

--- a/template-manager-core/src/test/java/com/sequenceiq/cloudbreak/template/validation/BlueprintValidatorUtilTest.java
+++ b/template-manager-core/src/test/java/com/sequenceiq/cloudbreak/template/validation/BlueprintValidatorUtilTest.java
@@ -1,0 +1,98 @@
+package com.sequenceiq.cloudbreak.template.validation;
+
+import static com.sequenceiq.cloudbreak.TestUtil.hostGroup;
+import static com.sequenceiq.cloudbreak.template.validation.BlueprintValidatorUtil.validateHostGroupCardinality;
+import static com.sequenceiq.cloudbreak.template.validation.BlueprintValidatorUtil.validateHostGroupsMatch;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+
+import com.sequenceiq.cloudbreak.cloud.model.InstanceCount;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
+
+public class BlueprintValidatorUtilTest {
+
+    @Test
+    public void rejectsMissingHostGroup() {
+        Set<HostGroup> request = Set.of(
+                hostGroup("master", 1),
+                hostGroup("worker", 2)
+        );
+        Map<String, InstanceCount> requirements = Map.of(
+                "master", InstanceCount.EXACTLY_ONE,
+                "worker", InstanceCount.atLeast(3),
+                "compute", InstanceCount.ZERO_OR_MORE
+        );
+
+        Exception e = assertThrows(BlueprintValidationException.class, () -> validateHostGroupsMatch(request, requirements.keySet()));
+        assertTrue(e.getMessage().contains("compute"));
+        Set.of("master", "worker").forEach(hostGroup -> assertFalse(e.getMessage().contains(hostGroup), hostGroup));
+    }
+
+    @Test
+    public void rejectsUnknownHostGroup() {
+        Set<HostGroup> request = Set.of(
+                hostGroup(">OK<", 1),
+                hostGroup("unknown", 2)
+        );
+        Map<String, InstanceCount> requirements = Map.of(
+                ">OK<", InstanceCount.ONE_OR_MORE
+        );
+
+        Exception e = assertThrows(BlueprintValidationException.class, () -> validateHostGroupsMatch(request, requirements.keySet()));
+        assertTrue(e.getMessage().contains("unknown"));
+        assertFalse(e.getMessage().contains(">OK<"));
+    }
+
+    @Test
+    public void rejectsTooFewNodes() {
+        Set<HostGroup> request = Set.of(
+                hostGroup("master", 1),
+                hostGroup("worker", 2)
+        );
+        Map<String, InstanceCount> requirements = Map.of(
+                "master", InstanceCount.EXACTLY_ONE,
+                "worker", InstanceCount.atLeast(3)
+        );
+
+        Exception e = assertThrows(BlueprintValidationException.class, () -> validateHostGroupCardinality(request, requirements));
+        assertTrue(e.getMessage().contains("worker"));
+        assertFalse(e.getMessage().contains("master"));
+    }
+
+    @Test
+    public void rejectsTooManyNodes() {
+        Set<HostGroup> request = Set.of(
+                hostGroup("master", 2),
+                hostGroup("worker", 4)
+        );
+        Map<String, InstanceCount> requirements = Map.of(
+                "master", InstanceCount.EXACTLY_ONE,
+                "worker", InstanceCount.atLeast(3)
+        );
+
+        Exception e = assertThrows(BlueprintValidationException.class, () -> validateHostGroupCardinality(request, requirements));
+        assertTrue(e.getMessage().contains("master"));
+        assertFalse(e.getMessage().contains("worker"));
+    }
+
+    @Test
+    public void acceptsNodeCountWithinLimits() {
+        Set<HostGroup> request = Set.of(
+                hostGroup("master", 2),
+                hostGroup("worker", 4)
+        );
+        Map<String, InstanceCount> requirements = Map.of(
+                "master", InstanceCount.of(1, 2),
+                "worker", InstanceCount.atLeast(3)
+        );
+
+        validateHostGroupCardinality(request, requirements);
+    }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Validate host groups in cluster creation request for CM.

 * no missing groups: all host groups in the template should be present in the request
 * no unknown groups: all host groups in the request should be defined in the template
 * cardinality: nodes requested for each host group should be within the range recommended based on cardinality of the template

Validation can be turned off by setting `.cluster.validateBlueprint` to `false` in the request.  However CLI has a bug that makes it impossible to turn off validation since version 964.

UI always turns off validation, cluster with invalid cardinality can still be created through it.

Validation for scaling requests is not implemented yet.

## How was this patch tested?

Tested that cluster creation requests invalid due to the above restrictions are rejected with the correct message when sent via CLI.

Examples:

```
ERROR: status code: 400, message: The following host groups are missing from the request: compute, gateway, quorum
ERROR: status code: 400, message: Unknown host groups are present in the request: unknown
ERROR: status code: 400, message: Node count for the following host groups does not meet requirements: (group: 'worker', required: 1+, actual: 0)
ERROR: status code: 400, message: Node count for the following host groups does not meet requirements: (group: 'master', required: 1, actual: 2)
```

Also verified that the same requests are accepted with `validateBlueprint: false` using older CLI.

Added unit test.