### PR TITLE
DISTX-192. Add Oozie to Data Engineering HA template

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha.bp
@@ -124,6 +124,17 @@
         ]
       },
       {
+        "refName": "oozie",
+        "serviceType": "OOZIE",
+        "roleConfigGroups": [
+          {
+            "refName": "oozie-OOZIE_SERVER-BASE",
+            "roleType": "OOZIE_SERVER",
+            "base": true
+          }
+        ]
+      },
+      {
         "refName": "spark_on_yarn",
         "serviceType": "SPARK_ON_YARN",
         "roleConfigGroups": [
@@ -217,6 +228,7 @@
           "hive-GATEWAY-BASE",
           "hms-GATEWAY-BASE",
           "livy-LIVY_SERVER-BASE",
+          "oozie-OOZIE_SERVER-BASE",
           "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
           "tez-GATEWAY-BASE",
           "yarn-JOBHISTORY-BASE",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add Oozie to the Data Engineering HA template.  Oozie supports HA, but CM requires a load balancer to be manually set up for that. The load balancer will be added later, so Oozie is not HA yet in this template.

## How was this patch tested?

Deployed HA cluster using the template.