### PR TITLE
CB-706. Increase timeout of testPopWhenReplacementNeeded

### DIFF
--- a/cloud-common/src/test/java/com/sequenceiq/cloudbreak/util/FixedSizePreloadCacheTest.java
+++ b/cloud-common/src/test/java/com/sequenceiq/cloudbreak/util/FixedSizePreloadCacheTest.java
@@ -20,13 +20,13 @@ public class FixedSizePreloadCacheTest {
     }
 
     @Test
-    public void testPopWhenReplacementNeeded() throws InterruptedException {
+    public void testPopWhenReplacementNeeded() {
         Iterator<String> items = Arrays.asList("a", "b", "c").iterator();
         FixedSizePreloadCache<String> cache = new FixedSizePreloadCache<>(1, items::next);
 
         assertEquals("a", cache.pop());
         Awaitility.await()
-                .atMost(1, TimeUnit.SECONDS)
+                .atMost(10, TimeUnit.SECONDS)
                 .until(() -> cache.size() == 1);
         assertEquals("b", cache.pop());
     }


### PR DESCRIPTION
Increase timeout, trying to avoid intermittent failure of `FixedSizePreloadCacheTest.testPopWhenReplacementNeeded` (failed 2 out of 20 times recently).