### PR TITLE
CB-1778: Create SDX blueprint to handle medium scale

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx-medium-ha.bp
@@ -10,45 +10,57 @@
       {
         "refName": "master",
         "roleConfigGroupsRefNames": [
-          "atlas-ATLAS_SERVER-BASE",
-          "hbase-MASTER-BASE",
           "hbase-REGIONSERVER-BASE",
+          "hbase-MASTER-BASE",
           "hdfs-DATANODE-BASE",
           "hdfs-FAILOVERCONTROLLER-BASE",
           "hdfs-JOURNALNODE-BASE",
           "hdfs-NAMENODE-1",
           "hive-HIVEMETASTORE-BASE",
-          "kafka-GATEWAY-BASE",
-          "kafka-KAFKA_BROKER-BASE",
-          "ranger-RANGER_ADMIN-BASE",
-          "ranger-RANGER_USERSYNC-BASE",
           "solr-SOLR_SERVER-BASE",
+          "zookeeper-SERVER-BASE"
+        ]
+      },
+      {
+        "refName": "master2",
+        "roleConfigGroupsRefNames": [
+          "hdfs-BALANCER-BASE",
+          "hbase-REGIONSERVER-BASE",
+          "hbase-MASTER-BASE",
+          "hdfs-DATANODE-BASE",
+          "hdfs-FAILOVERCONTROLLER-BASE",
+          "hdfs-JOURNALNODE-BASE",
+          "hdfs-NAMENODE-2",
           "zookeeper-SERVER-BASE"
         ]
       },
       {
         "refName": "alpha",
         "roleConfigGroupsRefNames": [
+          "ranger-RANGER_ADMIN-BASE",
+          "ranger-RANGER_USERSYNC-BASE",
           "atlas-ATLAS_SERVER-1",
-          "hbase-MASTER-BASE",
-          "hbase-REGIONSERVER-BASE",
           "hdfs-DATANODE-BASE",
-          "hdfs-JOURNALNODE-BASE",
           "knox-KNOX_GATEWAY-BASE",
           "ranger-RANGER_TAGSYNC-BASE",
+          "kafka-KAFKA_BROKER-BASE",
+          "zookeeper-SERVER-BASE",
+          "hdfs-JOURNALNODE-BASE"
+        ]
+      },
+      {
+        "refName": "alpha2",
+        "roleConfigGroupsRefNames": [
+          "kafka-GATEWAY-BASE",
+          "atlas-ATLAS_SERVER-BASE",
+          "kafka-KAFKA_BROKER-BASE",
           "zookeeper-SERVER-BASE"
         ]
       },
       {
         "refName": "beta",
         "roleConfigGroupsRefNames": [
-          "hbase-MASTER-BASE",
-          "hbase-REGIONSERVER-BASE",
-          "hdfs-BALANCER-BASE",
           "hdfs-DATANODE-BASE",
-          "hdfs-FAILOVERCONTROLLER-BASE",
-          "hdfs-JOURNALNODE-BASE",
-          "hdfs-NAMENODE-2",
           "zookeeper-SERVER-BASE"
         ]
       },
@@ -72,7 +84,7 @@
             "configs": [
               {
                 "name": "atlas_kafka_bootstrap_servers",
-                "value": "{{{format-join host_groups.master format='%s:9092' }}}"
+                "value": "{{{ format-join host_groups.alpha format='%s:9092' }}},{{{ format-join host_groups.alpha2 format='%s:9092' }}}"
               }
             ]
           },
@@ -83,7 +95,7 @@
             "configs": [
               {
                 "name": "atlas_kafka_bootstrap_servers",
-                "value": "{{{format-join host_groups.master format='%s:9092' }}}"
+                "value": "{{{ format-join host_groups.alpha format='%s:9092' }}},{{{ format-join host_groups.alpha2 format='%s:9092' }}}"
               }
             ]
           }
@@ -194,7 +206,7 @@
               },
               {
                 "name": "namenode_config_safety_valve",
-                "value": "\n        <property>\n          <name>dfs.namenode.redundancy.considerLoad</name>\n          <value>false</value>\n        </property>"
+                "value": "\n <property>\n <name>dfs.namenode.redundancy.considerLoad</name>\n <value>false</value>\n </property>"
               },
               {
                 "name": "dfs_https_port",
@@ -399,15 +411,15 @@
             ]
           },
           {
-            "refName": "knox-IDBROKER-BASE",
-            "roleType": "IDBROKER",
             "base": true,
             "configs": [
               {
                 "name": "idbroker_master_secret",
                 "value": "cloudera1"
               }
-            ]
+            ],
+            "refName": "knox-IDBROKER-BASE",
+            "roleType": "IDBROKER"
           }
         ]
       }

--- a/core/src/main/resources/defaults/blueprints/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx.bp
@@ -2,7 +2,7 @@
   "tags": {
     "shared_services_ready": true
   },
-  "description": "CDP 1.0 Shared Data Experience template with Atlas, HMS, Ranger and other services they are dependent on",
+  "description": "CDP 1.0 SDX template with Atlas, HMS, Ranger and other services they are dependent on",
   "blueprint": {
     "cdhVersion": "7.0.0",
     "displayName": "datalake",


### PR DESCRIPTION
We need to have an SDX blueprint for HA deployment to handle the medium load. Idea is to have three blueprints for SDX
1. SDX Lite Duty
2. SDX Lite Duty -HA
3. SDX Medium Duty -HA
Scope of this Jira to get an initial version and make improvements as we go.

Made sure that cloudbreak is able to set up a CM cluster using the blueprint.