### PR TITLE
CB-1676 Implement UMS-based permission checks in redbeams

### DIFF
--- a/redbeams/src/main/java/com/sequenceiq/redbeams/aspect/CheckPermissionsAspects.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/aspect/CheckPermissionsAspects.java
@@ -1,0 +1,30 @@
+package com.sequenceiq.redbeams.aspect;
+
+import javax.inject.Inject;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.redbeams.authorization.PermissionCheckerService;
+
+@Component
+@Aspect
+public class CheckPermissionsAspects {
+
+    @Inject
+    private PermissionCheckerService permissionCheckerService;
+
+    @Pointcut("execution(public * com.sequenceiq.redbeams.repository..*.*(..)) ")
+    public void allRepositories() {
+    }
+
+    @Around("allRepositories()")
+    // CHECKSTYLE:OFF
+    public Object hasPermission(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+    // CHECKSTYLE:ON
+        return permissionCheckerService.hasPermission(proceedingJoinPoint);
+    }
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/authorization/CheckPermissionsByReturnValue.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/authorization/CheckPermissionsByReturnValue.java
@@ -1,0 +1,13 @@
+package com.sequenceiq.redbeams.authorization;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface CheckPermissionsByReturnValue {
+
+    ResourceAction action() default ResourceAction.READ;
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/authorization/CheckPermissionsByTarget.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/authorization/CheckPermissionsByTarget.java
@@ -1,0 +1,15 @@
+package com.sequenceiq.redbeams.authorization;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface CheckPermissionsByTarget {
+
+    ResourceAction action() default ResourceAction.READ;
+
+    int targetIndex();
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/authorization/CrnResource.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/authorization/CrnResource.java
@@ -1,0 +1,15 @@
+package com.sequenceiq.redbeams.authorization;
+
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
+
+/**
+ * A resource that can be referenced by CRN. This is important for authorization
+ * checks on entities which can be represented by CRN.
+ */
+public interface CrnResource {
+
+    String getAccountId();
+
+    Crn getResourceCrn();
+
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/authorization/DisableCheckPermissions.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/authorization/DisableCheckPermissions.java
@@ -1,0 +1,11 @@
+package com.sequenceiq.redbeams.authorization;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface DisableCheckPermissions {
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/authorization/DisabledPermissionChecker.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/authorization/DisabledPermissionChecker.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.redbeams.authorization;
+
+import java.lang.annotation.Annotation;
+
+import javax.inject.Inject;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DisabledPermissionChecker implements PermissionChecker<DisableCheckPermissions> {
+
+    @Inject
+    private PermissionCheckingUtils permissionCheckingUtils;
+
+    @Override
+    public <T extends Annotation> Object checkPermissions(T rawMethodAnnotation, String userCrn,
+            ProceedingJoinPoint proceedingJoinPoint, MethodSignature methodSignature) throws Throwable {
+        return permissionCheckingUtils.proceed(proceedingJoinPoint, methodSignature);
+    }
+
+    @Override
+    public Class<DisableCheckPermissions> supportedAnnotation() {
+        return DisableCheckPermissions.class;
+    }
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/authorization/PermissionChecker.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/authorization/PermissionChecker.java
@@ -1,0 +1,16 @@
+package com.sequenceiq.redbeams.authorization;
+
+import java.lang.annotation.Annotation;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+
+public interface PermissionChecker<T extends Annotation> {
+
+    // CHECKSTYLE:OFF
+    <T extends Annotation> Object checkPermissions(T rawMethodAnnotation, String userCrn, ProceedingJoinPoint proceedingJoinPoint,
+            MethodSignature methodSignature) throws Throwable;
+    // CHECKSTYLE:ON
+
+    Class<T> supportedAnnotation();
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/authorization/PermissionCheckerService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/authorization/PermissionCheckerService.java
@@ -1,0 +1,109 @@
+package com.sequenceiq.redbeams.authorization;
+
+import static java.lang.String.format;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+
+import java.lang.annotation.Annotation;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PermissionCheckerService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PermissionCheckerService.class);
+
+    private static final List<Class<? extends Annotation>> POSSIBLE_METHOD_ANNOTATIONS = List.of(CheckPermissionsByTarget.class,
+            CheckPermissionsByReturnValue.class, DisableCheckPermissions.class);
+
+    @Inject
+    @VisibleForTesting
+    List<PermissionChecker<? extends Annotation>> permissionCheckers;
+
+    @VisibleForTesting
+    SecurityContext testSecurityContext;
+
+    @Inject
+    private PermissionCheckingUtils permissionCheckingUtils;
+
+    @Inject
+    private ThreadBasedUserCrnProvider threadBasedUserCrnProvider;
+
+    private final Map<Class<? extends Annotation>, PermissionChecker<? extends Annotation>> permissionCheckerMap = new HashMap<>();
+
+    @PostConstruct
+    public void populatePermissionCheckerMap() {
+        permissionCheckers.forEach(permissionChecker -> permissionCheckerMap.put(permissionChecker.supportedAnnotation(), permissionChecker));
+    }
+
+    // CHECKSTYLE:OFF
+    public Object hasPermission(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+    // CHECKSTYLE:ON
+        MethodSignature methodSignature = (MethodSignature) proceedingJoinPoint.getSignature();
+        Authentication auth;
+        if (testSecurityContext != null) {
+            auth = testSecurityContext.getAuthentication();
+        } else {
+            auth = SecurityContextHolder.getContext().getAuthentication();
+        }
+        if (auth == null) {
+            return permissionCheckingUtils.proceed(proceedingJoinPoint, methodSignature);
+        }
+
+        // Class<?> repositoryClass = proceedingJoinPoint.getTarget().getClass();
+
+        List<? extends Annotation> annotations = POSSIBLE_METHOD_ANNOTATIONS.stream()
+                .map(c -> methodSignature.getMethod().getAnnotation(c))
+                .collect(Collectors.toList());
+
+        Annotation methodAnnotation = validateNumberOfAnnotations(methodSignature, annotations).orElse(null);
+        if (methodAnnotation == null) {
+            LOGGER.debug("Permission check not present on {}", methodSignature.getName());
+            return permissionCheckingUtils.proceed(proceedingJoinPoint, methodSignature);
+        }
+        if (methodAnnotation instanceof DisableCheckPermissions) {
+            LOGGER.debug("Permission check disabled on {}", methodSignature.getName());
+            return permissionCheckingUtils.proceed(proceedingJoinPoint, methodSignature);
+        }
+
+        String userCrn = threadBasedUserCrnProvider.getUserCrn();
+        if (userCrn == null) {
+            throw new AccessDeniedException("User CRN is not available, cannot authorize access");
+        }
+        PermissionChecker<? extends Annotation> permissionChecker = permissionCheckerMap.get(methodAnnotation.annotationType());
+        return permissionChecker.checkPermissions(methodAnnotation, userCrn, proceedingJoinPoint, methodSignature);
+    }
+
+    private Optional<Annotation> validateNumberOfAnnotations(MethodSignature methodSignature, List<? extends Annotation> annotations) {
+        annotations = annotations.stream().filter(Objects::nonNull).collect(Collectors.toList());
+        if (annotations.isEmpty()) {
+            // OK to not be annotated
+            return Optional.empty();
+        } else if (annotations.size() > 1) {
+            String annotationsMessage = annotations.stream()
+                    .map(a -> a.getClass().getSimpleName())
+                    .collect(Collectors.joining(",\n"));
+            throw new IllegalStateException(format("Only one of these annotations can be added to method: %s", annotationsMessage));
+        }
+        return Optional.of(annotations.iterator().next());
+    }
+
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/authorization/PermissionCheckingUtils.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/authorization/PermissionCheckingUtils.java
@@ -1,0 +1,80 @@
+package com.sequenceiq.redbeams.authorization;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
+
+@Component
+public class PermissionCheckingUtils {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PermissionCheckingUtils.class);
+
+    @Inject
+    private GrpcUmsClient grpcUmsClient;
+
+    public void checkPermissionsByTarget(Object target, String userCrn, ResourceAction action) {
+        if (target == null) {
+            return;
+        }
+        Iterable<?> targets = target instanceof Iterable ? (Iterable<?>) target : Collections.singleton(target);
+
+        Set<String> deniedResourceCrns = new HashSet<>();
+        for (Object targetObj : targets) {
+            Object resource;
+            if (targetObj instanceof Optional) {
+                Optional<?> optionalTargetObj = (Optional<?>) targetObj;
+                if (!optionalTargetObj.isPresent()) {
+                    continue;
+                }
+                resource = optionalTargetObj.get();
+            } else {
+                resource = targetObj;
+            }
+            if (!(resource instanceof CrnResource)) {
+                throw new IllegalStateException("Target is of type " + targetObj.getClass().getName()
+                    + " which is not a CrnResource, cannot perform authorization check");
+            }
+            String resourceCrn = ((CrnResource) resource).getResourceCrn().toString();
+
+            LOGGER.info("Checking permissions on " + resourceCrn + " for user " + userCrn);
+            if (!grpcUmsClient.checkRight(userCrn, action.name(), resourceCrn, "notyet")) {
+                deniedResourceCrns.add(resourceCrn);
+            }
+        }
+
+        if (!deniedResourceCrns.isEmpty()) {
+            throw new AccessDeniedException(String.format("You lack %s permission to resource(s): %s", action.name(),
+                String.join(", ", deniedResourceCrns)));
+        }
+    }
+
+    void validateIndex(int index, int length, String indexName) {
+        if (index >= length) {
+            throw new IllegalArgumentException(
+                    String.format("The %s [%s] cannot be bigger than or equal to the method's argument count [%s]", indexName, index, length));
+        }
+    }
+
+    // CHECKSTYLE:OFF
+    public Object proceed(ProceedingJoinPoint proceedingJoinPoint, MethodSignature methodSignature) throws Throwable {
+    // CHECKSTYLE:ON
+        Object result = proceedingJoinPoint.proceed();
+        if (result == null) {
+            LOGGER.debug("Return value is null, method signature: {}", methodSignature.toLongString());
+        }
+        return result;
+    }
+
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/authorization/ResourceAction.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/authorization/ResourceAction.java
@@ -1,0 +1,7 @@
+package com.sequenceiq.redbeams.authorization;
+
+public enum ResourceAction {
+    READ,
+    WRITE,
+    MANAGE
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/authorization/ReturnValuePermissionChecker.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/authorization/ReturnValuePermissionChecker.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.redbeams.authorization;
+
+import java.lang.annotation.Annotation;
+
+import javax.inject.Inject;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ReturnValuePermissionChecker implements PermissionChecker<CheckPermissionsByReturnValue> {
+
+    @Inject
+    private PermissionCheckingUtils permissionCheckingUtils;
+
+    @Override
+    public <T extends Annotation> Object checkPermissions(T rawMethodAnnotation, String userCrn,
+            ProceedingJoinPoint proceedingJoinPoint, MethodSignature methodSignature) throws Throwable {
+        CheckPermissionsByReturnValue methodAnnotation = (CheckPermissionsByReturnValue) rawMethodAnnotation;
+        ResourceAction action = methodAnnotation.action();
+        Object result = permissionCheckingUtils.proceed(proceedingJoinPoint, methodSignature);
+        permissionCheckingUtils.checkPermissionsByTarget(result, userCrn, action);
+        return result;
+    }
+
+    @Override
+    public Class<CheckPermissionsByReturnValue> supportedAnnotation() {
+        return CheckPermissionsByReturnValue.class;
+    }
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/authorization/TargetPermissionChecker.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/authorization/TargetPermissionChecker.java
@@ -1,0 +1,42 @@
+package com.sequenceiq.redbeams.authorization;
+
+import java.lang.annotation.Annotation;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TargetPermissionChecker implements PermissionChecker<CheckPermissionsByTarget> {
+
+    @Inject
+    private PermissionCheckingUtils permissionCheckingUtils;
+
+    @Override
+    public <T extends Annotation> Object checkPermissions(T rawMethodAnnotation, String userCrn,
+            ProceedingJoinPoint proceedingJoinPoint, MethodSignature methodSignature) throws Throwable {
+
+        CheckPermissionsByTarget methodAnnotation = (CheckPermissionsByTarget) rawMethodAnnotation;
+        int targetIndex = methodAnnotation.targetIndex();
+        int length = proceedingJoinPoint.getArgs().length;
+        permissionCheckingUtils.validateIndex(targetIndex, length, "targetIndex");
+        Object target = proceedingJoinPoint.getArgs()[targetIndex];
+        if (target instanceof Optional) {
+            Optional<?> targetOpt = (Optional<?>) target;
+            if (!targetOpt.isPresent()) {
+                return permissionCheckingUtils.proceed(proceedingJoinPoint, methodSignature);
+            }
+            target = targetOpt.get();
+        }
+        permissionCheckingUtils.checkPermissionsByTarget(target, userCrn, methodAnnotation.action());
+        return permissionCheckingUtils.proceed(proceedingJoinPoint, methodSignature);
+    }
+
+    @Override
+    public Class<CheckPermissionsByTarget> supportedAnnotation() {
+        return CheckPermissionsByTarget.class;
+    }
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/domain/DatabaseConfig.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/domain/DatabaseConfig.java
@@ -23,12 +23,13 @@ import com.sequenceiq.cloudbreak.service.secret.SecretValue;
 import com.sequenceiq.cloudbreak.service.secret.domain.Secret;
 import com.sequenceiq.cloudbreak.service.secret.domain.SecretToString;
 import com.sequenceiq.redbeams.api.endpoint.v4.ResourceStatus;
+import com.sequenceiq.redbeams.authorization.CrnResource;
 import com.sequenceiq.redbeams.converter.CrnConverter;
 
 @Entity
 @Where(clause = "archived = false")
 @Table(uniqueConstraints = @UniqueConstraint(columnNames = {"name", "deletionTimestamp", "environment_id"}))
-public class DatabaseConfig implements ArchivableResource {
+public class DatabaseConfig implements ArchivableResource, CrnResource {
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO, generator = "databaseconfig_generator")
@@ -95,10 +96,12 @@ public class DatabaseConfig implements ArchivableResource {
         return id;
     }
 
+    @Override
     public String getAccountId() {
         return accountId;
     }
 
+    @Override
     public Crn getResourceCrn() {
         return resourceCrn;
     }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/domain/DatabaseServerConfig.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/domain/DatabaseServerConfig.java
@@ -24,6 +24,7 @@ import com.sequenceiq.cloudbreak.service.secret.domain.Secret;
 import com.sequenceiq.cloudbreak.service.secret.domain.SecretToString;
 import com.sequenceiq.cloudbreak.workspace.resource.WorkspaceResource;
 import com.sequenceiq.redbeams.api.endpoint.v4.ResourceStatus;
+import com.sequenceiq.redbeams.authorization.CrnResource;
 import com.sequenceiq.redbeams.converter.CrnConverter;
 
 import java.util.Optional;
@@ -32,7 +33,7 @@ import java.util.Set;
 @Entity
 @Where(clause = "archived = false")
 @Table(uniqueConstraints = @UniqueConstraint(columnNames = {"name", "deletionTimestamp", "environmentId"}))
-public class DatabaseServerConfig implements ArchivableResource {
+public class DatabaseServerConfig implements ArchivableResource, CrnResource {
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO, generator = "databaseserverconfig_generator")
@@ -107,6 +108,7 @@ public class DatabaseServerConfig implements ArchivableResource {
         this.id = id;
     }
 
+    @Override
     public String getAccountId() {
         return accountId;
     }
@@ -115,6 +117,7 @@ public class DatabaseServerConfig implements ArchivableResource {
         this.accountId = accountId;
     }
 
+    @Override
     public Crn getResourceCrn() {
         return resourceCrn;
     }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/repository/DatabaseConfigRepository.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/repository/DatabaseConfigRepository.java
@@ -9,15 +9,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
-import com.sequenceiq.cloudbreak.workspace.repository.check.CheckPermissionsByReturnValue;
-import com.sequenceiq.cloudbreak.workspace.resource.ResourceAction;
+import com.sequenceiq.redbeams.authorization.CheckPermissionsByReturnValue;
+import com.sequenceiq.redbeams.authorization.ResourceAction;
 import com.sequenceiq.redbeams.domain.DatabaseConfig;
 
 @EntityType(entityClass = DatabaseConfig.class)
 @Transactional(Transactional.TxType.REQUIRED)
 public interface DatabaseConfigRepository extends JpaRepository<DatabaseConfig, Long> {
 
-    // TODO check if checkPermission still works
     @CheckPermissionsByReturnValue(action = ResourceAction.READ)
     @Query("SELECT d FROM DatabaseConfig d WHERE d.environmentId = :environmentId "
         + "AND (d.name = :name OR d.resourceCrn = :name)")
@@ -30,4 +29,6 @@ public interface DatabaseConfigRepository extends JpaRepository<DatabaseConfig, 
     @Query("SELECT d FROM DatabaseConfig d WHERE d.environmentId = :environmentId "
         + "AND (d.name IN :names OR d.resourceCrn IN :names)")
     Set<DatabaseConfig> findAllByEnvironmentIdAndNameIn(String environmentId, Set<String> names);
+
+    // save does not require a permission check
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/repository/DatabaseServerConfigRepository.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/repository/DatabaseServerConfigRepository.java
@@ -10,6 +10,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
+import com.sequenceiq.redbeams.authorization.CheckPermissionsByReturnValue;
+import com.sequenceiq.redbeams.authorization.ResourceAction;
 import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
 
 // FIXME: Use DisabledBaseRepository when doing permissions
@@ -17,14 +19,18 @@ import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
 @Transactional(TxType.REQUIRED)
 public interface DatabaseServerConfigRepository extends JpaRepository<DatabaseServerConfig, Long> {
 
+    @CheckPermissionsByReturnValue(action = ResourceAction.READ)
     Set<DatabaseServerConfig> findByWorkspaceIdAndEnvironmentId(Long workspaceId, String environmentId);
 
+    @CheckPermissionsByReturnValue(action = ResourceAction.READ)
     @Query("SELECT s FROM DatabaseServerConfig s WHERE s.workspaceId = :workspaceId AND s.environmentId = :environmentId "
         + "AND (s.name = :name OR s.resourceCrn = :name)")
     Optional<DatabaseServerConfig> findByNameAndWorkspaceIdAndEnvironmentId(String name, Long workspaceId, String environmentId);
 
+    @CheckPermissionsByReturnValue(action = ResourceAction.READ)
     @Query("SELECT s FROM DatabaseServerConfig s WHERE s.workspaceId = :workspaceId AND s.environmentId = :environmentId "
         + "AND (s.name IN :names OR s.resourceCrn IN :names)")
     Set<DatabaseServerConfig> findByNameInAndWorkspaceIdAndEnvironmentId(Set<String> names, Long workspaceId, String environmentId);
 
+    // save does not require a permission check
 }

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/authorization/DisabledPermissionCheckerTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/authorization/DisabledPermissionCheckerTest.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.redbeams.authorization;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+public class DisabledPermissionCheckerTest {
+
+    @InjectMocks
+    private DisabledPermissionChecker underTest;
+
+    @Mock
+    private PermissionCheckingUtils permissionCheckingUtils;
+
+    @Mock
+    private ProceedingJoinPoint proceedingJoinPoint;
+
+    @Mock
+    private MethodSignature methodSignature;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+    }
+
+    @Test
+    // CHECKSTYLE:OFF
+    public void testCheckPermissions() throws Throwable {
+    // CHECKSTYLE:ON
+        when(permissionCheckingUtils.proceed(proceedingJoinPoint, methodSignature)).thenReturn("ok");
+
+        Object result = underTest.checkPermissions(null, "userCrn", proceedingJoinPoint, methodSignature);
+
+        assertEquals("ok", result);
+    }
+
+}

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/authorization/PermissionCheckerServiceTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/authorization/PermissionCheckerServiceTest.java
@@ -1,0 +1,94 @@
+package com.sequenceiq.redbeams.authorization;
+
+import static org.junit.Assert.assertEquals;
+// import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+
+import java.util.ArrayList;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.Before;
+// import org.junit.Rule;
+import org.junit.Test;
+// import org.junit.rules.ExpectedException;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+
+public class PermissionCheckerServiceTest {
+
+    // @Rule
+    // public ExpectedException thrown = ExpectedException.none();
+
+    @InjectMocks
+    private PermissionCheckerService underTest;
+
+    @Mock
+    private PermissionCheckingUtils permissionCheckingUtils;
+
+    @Mock
+    private ThreadBasedUserCrnProvider threadBasedUserCrnProvider;
+
+    @Mock
+    private TargetPermissionChecker permissionChecker;
+
+    @Mock
+    private SecurityContext securityContext;
+
+    @Mock
+    private Authentication springAuthentication;
+
+    @Mock
+    private ProceedingJoinPoint proceedingJoinPoint;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private MethodSignature methodSignature;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+
+        underTest.permissionCheckers = new ArrayList<>();
+        underTest.permissionCheckers.add(permissionChecker);
+        underTest.testSecurityContext = securityContext;
+
+        underTest.populatePermissionCheckerMap();
+
+        when(proceedingJoinPoint.getSignature()).thenReturn(methodSignature);
+    }
+
+    // Need more test methods here. I'm having trouble mocking MethodSignature.
+
+    // @Test
+    // public void testNoMethodAnnotation() throws Throwable {
+    //     when(securityContext.getAuthentication()).thenReturn(springAuthentication);
+    //     when(methodSignature.getMethod().getAnnotation(any())).thenReturn(null);
+    //     when(permissionCheckingUtils.proceed(proceedingJoinPoint, methodSignature)).thenReturn("ok");
+
+    //     Object result = underTest.hasPermission(proceedingJoinPoint);
+
+    //     assertEquals("ok", result);
+    //     verify(permissionCheckingUtils).proceed(proceedingJoinPoint, methodSignature);
+    // }
+
+    @Test
+    // CHECKSTYLE:OFF
+    public void testNoSpringAuthentication() throws Throwable {
+    // CHECKSTYLE:ON
+        when(securityContext.getAuthentication()).thenReturn(null);
+        when(permissionCheckingUtils.proceed(proceedingJoinPoint, methodSignature)).thenReturn("ok");
+
+        Object result = underTest.hasPermission(proceedingJoinPoint);
+
+        assertEquals("ok", result);
+        verify(permissionCheckingUtils).proceed(proceedingJoinPoint, methodSignature);
+    }
+
+}

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/authorization/PermissionCheckingUtilsTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/authorization/PermissionCheckingUtilsTest.java
@@ -1,0 +1,134 @@
+package com.sequenceiq.redbeams.authorization;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import com.google.common.collect.ImmutableSet;
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
+import com.sequenceiq.redbeams.domain.DatabaseConfig;
+
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.security.access.AccessDeniedException;
+
+public class PermissionCheckingUtilsTest {
+
+    private static final String USER_CRN = "crn:altus:iam:us-west-1:cloudera:user:bob@cloudera.com";
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @InjectMocks
+    private PermissionCheckingUtils underTest;
+
+    @Mock
+    private GrpcUmsClient grpcUmsClient;
+
+    private DatabaseConfig db;
+
+    private DatabaseConfig db2;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+
+        db = new DatabaseConfig();
+        db.setId(1L);
+        db.setName("mydb");
+        db.setResourceCrn(Crn.safeFromString("crn:altus:redbeams:us-west-1:cloudera:database:mydb"));
+
+        db2 = new DatabaseConfig();
+        db2.setId(2L);
+        db2.setName("mydb2");
+        db2.setResourceCrn(Crn.safeFromString("crn:altus:redbeams:us-west-1:cloudera:database:mydb2"));
+    }
+
+    @Test
+    public void testCheckPermissionsByTargetNull() {
+        underTest.checkPermissionsByTarget(null, USER_CRN, ResourceAction.READ);
+    }
+
+    @Test
+    public void testCheckPermissionsByTargetSinglePass() {
+        when(grpcUmsClient.checkRight(eq(USER_CRN), eq(ResourceAction.READ.name()), eq(db.getResourceCrn().toString()), any(String.class)))
+            .thenReturn(true);
+
+        underTest.checkPermissionsByTarget(db, USER_CRN, ResourceAction.READ);
+
+        verify(grpcUmsClient).checkRight(eq(USER_CRN), eq(ResourceAction.READ.name()), eq(db.getResourceCrn().toString()), any(String.class));
+    }
+
+    @Test
+    public void testCheckPermissionsByTargetSingleFail() {
+        thrown.expect(AccessDeniedException.class);
+        when(grpcUmsClient.checkRight(eq(USER_CRN), eq(ResourceAction.READ.name()), eq(db.getResourceCrn().toString()), any(String.class)))
+            .thenReturn(false);
+
+        underTest.checkPermissionsByTarget(db, USER_CRN, ResourceAction.READ);
+    }
+
+    @Test
+    public void testCheckPermissionsByTargetSingleOptionalPass() {
+        when(grpcUmsClient.checkRight(eq(USER_CRN), eq(ResourceAction.READ.name()), eq(db.getResourceCrn().toString()), any(String.class)))
+            .thenReturn(true);
+
+        underTest.checkPermissionsByTarget(Optional.of(db), USER_CRN, ResourceAction.READ);
+
+        verify(grpcUmsClient).checkRight(eq(USER_CRN), eq(ResourceAction.READ.name()), eq(db.getResourceCrn().toString()), any(String.class));
+    }
+
+    @Test
+    public void testCheckPermissionsByTargetSingleOptionalFail() {
+        thrown.expect(AccessDeniedException.class);
+        when(grpcUmsClient.checkRight(eq(USER_CRN), eq(ResourceAction.READ.name()), eq(db.getResourceCrn().toString()), any(String.class)))
+            .thenReturn(false);
+
+        underTest.checkPermissionsByTarget(Optional.of(db), USER_CRN, ResourceAction.READ);
+    }
+
+    @Test
+    public void testCheckPermissionsByTargetSingleOptionalEmptyPass() {
+        underTest.checkPermissionsByTarget(Optional.empty(), USER_CRN, ResourceAction.READ);
+    }
+
+    @Test
+    public void testCheckPermissionsByTargetLeelooDallasMultiPass() {
+        when(grpcUmsClient.checkRight(eq(USER_CRN), eq(ResourceAction.READ.name()), eq(db.getResourceCrn().toString()), any(String.class)))
+            .thenReturn(true);
+        when(grpcUmsClient.checkRight(eq(USER_CRN), eq(ResourceAction.READ.name()), eq(db2.getResourceCrn().toString()), any(String.class)))
+            .thenReturn(true);
+
+        underTest.checkPermissionsByTarget(ImmutableSet.of(db, db2), USER_CRN, ResourceAction.READ);
+
+        verify(grpcUmsClient).checkRight(eq(USER_CRN), eq(ResourceAction.READ.name()), eq(db.getResourceCrn().toString()), any(String.class));
+        verify(grpcUmsClient).checkRight(eq(USER_CRN), eq(ResourceAction.READ.name()), eq(db2.getResourceCrn().toString()), any(String.class));
+    }
+
+    @Test
+    public void testCheckPermissionsByTargetMultiFail() {
+        thrown.expect(AccessDeniedException.class);
+        when(grpcUmsClient.checkRight(eq(USER_CRN), eq(ResourceAction.READ.name()), eq(db.getResourceCrn().toString()), any(String.class)))
+            .thenReturn(false);
+        when(grpcUmsClient.checkRight(eq(USER_CRN), eq(ResourceAction.READ.name()), eq(db2.getResourceCrn().toString()), any(String.class)))
+            .thenReturn(true);
+
+        underTest.checkPermissionsByTarget(ImmutableSet.of(db, db2), USER_CRN, ResourceAction.READ);
+    }
+
+    @Test
+    public void testCheckPermissionsByTargetNoCrn() {
+        thrown.expect(IllegalStateException.class);
+
+        underTest.checkPermissionsByTarget("nope", USER_CRN, ResourceAction.READ);
+    }
+}

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/authorization/ReturnValuePermissionCheckerTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/authorization/ReturnValuePermissionCheckerTest.java
@@ -1,0 +1,69 @@
+package com.sequenceiq.redbeams.authorization;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.security.access.AccessDeniedException;
+
+public class ReturnValuePermissionCheckerTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @InjectMocks
+    private ReturnValuePermissionChecker underTest;
+
+    @Mock
+    private PermissionCheckingUtils permissionCheckingUtils;
+
+    @Mock
+    private CheckPermissionsByReturnValue annotation;
+
+    @Mock
+    private ProceedingJoinPoint proceedingJoinPoint;
+
+    @Mock
+    private MethodSignature methodSignature;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+    }
+
+    @Test
+    // CHECKSTYLE:OFF
+    public void testCheckPermissionsPass() throws Throwable {
+    // CHECKSTYLE:ON
+        when(annotation.action()).thenReturn(ResourceAction.READ);
+        when(permissionCheckingUtils.proceed(proceedingJoinPoint, methodSignature)).thenReturn("ok");
+
+        Object result = underTest.checkPermissions(annotation, "userCrn", proceedingJoinPoint, methodSignature);
+
+        assertEquals("ok", result);
+        verify(permissionCheckingUtils).checkPermissionsByTarget("ok", "userCrn", ResourceAction.READ);
+    }
+
+    @Test
+    // CHECKSTYLE:OFF
+    public void testCheckPermissionsFail() throws Throwable {
+    // CHECKSTYLE:ON
+        thrown.expect(AccessDeniedException.class);
+        when(annotation.action()).thenReturn(ResourceAction.READ);
+        when(permissionCheckingUtils.proceed(proceedingJoinPoint, methodSignature)).thenReturn("ok");
+        doThrow(new AccessDeniedException("nope")).when(permissionCheckingUtils).checkPermissionsByTarget("ok", "userCrn", ResourceAction.READ);
+
+        underTest.checkPermissions(annotation, "userCrn", proceedingJoinPoint, methodSignature);
+    }
+
+}

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/authorization/TargetPermissionCheckerTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/authorization/TargetPermissionCheckerTest.java
@@ -1,0 +1,136 @@
+package com.sequenceiq.redbeams.authorization;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.Optional;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.security.access.AccessDeniedException;
+
+public class TargetPermissionCheckerTest {
+
+    private static final Object[] ARGS = { "foo", "bar", "baz" };
+
+    private static final Object[] OPT_ARGS = { Optional.of("foo"), Optional.of("bar"), Optional.of("baz") };
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @InjectMocks
+    private TargetPermissionChecker underTest;
+
+    @Mock
+    private PermissionCheckingUtils permissionCheckingUtils;
+
+    @Mock
+    private CheckPermissionsByTarget annotation;
+
+    @Mock
+    private ProceedingJoinPoint proceedingJoinPoint;
+
+    @Mock
+    private MethodSignature methodSignature;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+    }
+
+    @Test
+    // CHECKSTYLE:OFF
+    public void testCheckPermissionsPass() throws Throwable {
+    // CHECKSTYLE:ON
+        when(proceedingJoinPoint.getArgs()).thenReturn(ARGS);
+        when(annotation.action()).thenReturn(ResourceAction.READ);
+        when(annotation.targetIndex()).thenReturn(1);
+        when(permissionCheckingUtils.proceed(proceedingJoinPoint, methodSignature)).thenReturn("ok");
+
+        Object result = underTest.checkPermissions(annotation, "userCrn", proceedingJoinPoint, methodSignature);
+
+        assertEquals("ok", result);
+        verify(permissionCheckingUtils).checkPermissionsByTarget("bar", "userCrn", ResourceAction.READ);
+        verify(permissionCheckingUtils).proceed(proceedingJoinPoint, methodSignature);
+    }
+
+    @Test
+    // CHECKSTYLE:OFF
+    public void testCheckPermissionsFail() throws Throwable {
+    // CHECKSTYLE:ON
+        thrown.expect(AccessDeniedException.class);
+        when(proceedingJoinPoint.getArgs()).thenReturn(ARGS);
+        when(annotation.action()).thenReturn(ResourceAction.READ);
+        when(annotation.targetIndex()).thenReturn(1);
+        when(permissionCheckingUtils.proceed(proceedingJoinPoint, methodSignature)).thenReturn("ok");
+        doThrow(new AccessDeniedException("nope")).when(permissionCheckingUtils).checkPermissionsByTarget("bar", "userCrn", ResourceAction.READ);
+
+        try {
+            underTest.checkPermissions(annotation, "userCrn", proceedingJoinPoint, methodSignature);
+        } finally {
+            verify(permissionCheckingUtils, never()).proceed(proceedingJoinPoint, methodSignature);
+        }
+    }
+
+    @Test
+    // CHECKSTYLE:OFF
+    public void testCheckPermissionsIndexValidation() throws Throwable {
+    // CHECKSTYLE:ON
+        thrown.expect(IllegalArgumentException.class);
+        when(proceedingJoinPoint.getArgs()).thenReturn(ARGS);
+        when(annotation.action()).thenReturn(ResourceAction.READ);
+        when(annotation.targetIndex()).thenReturn(ARGS.length + 1);
+        doThrow(new IllegalArgumentException()).when(permissionCheckingUtils).validateIndex(ARGS.length + 1, ARGS.length, "targetIndex");
+
+        try {
+            underTest.checkPermissions(annotation, "userCrn", proceedingJoinPoint, methodSignature);
+        } finally {
+            verify(permissionCheckingUtils, never()).proceed(proceedingJoinPoint, methodSignature);
+        }
+    }
+
+    @Test
+    // CHECKSTYLE:OFF
+    public void testCheckPermissionsPassOptional() throws Throwable {
+    // CHECKSTYLE:ON
+        when(proceedingJoinPoint.getArgs()).thenReturn(OPT_ARGS);
+        when(annotation.action()).thenReturn(ResourceAction.READ);
+        when(annotation.targetIndex()).thenReturn(1);
+        when(permissionCheckingUtils.proceed(proceedingJoinPoint, methodSignature)).thenReturn("ok");
+
+        Object result = underTest.checkPermissions(annotation, "userCrn", proceedingJoinPoint, methodSignature);
+
+        assertEquals("ok", result);
+        verify(permissionCheckingUtils).checkPermissionsByTarget("bar", "userCrn", ResourceAction.READ);
+        verify(permissionCheckingUtils).proceed(proceedingJoinPoint, methodSignature);
+    }
+
+    @Test
+    // CHECKSTYLE:OFF
+    public void testCheckPermissionsPassOptionalEmpty() throws Throwable {
+    // CHECKSTYLE:ON
+        when(proceedingJoinPoint.getArgs()).thenReturn(new Object[] { Optional.empty() });
+        when(annotation.action()).thenReturn(ResourceAction.READ);
+        when(annotation.targetIndex()).thenReturn(0);
+        when(permissionCheckingUtils.proceed(proceedingJoinPoint, methodSignature)).thenReturn("ok");
+
+        Object result = underTest.checkPermissions(annotation, "userCrn", proceedingJoinPoint, methodSignature);
+
+        assertEquals("ok", result);
+        verify(permissionCheckingUtils).proceed(proceedingJoinPoint, methodSignature);
+        verify(permissionCheckingUtils, never()).checkPermissionsByTarget(any(), eq("userCrn"), eq(ResourceAction.READ));
+    }
+
+}


### PR DESCRIPTION
The repository classes in redbeams now enforce READ permission checks on
database and database server entities. The permission framework is
implemented in a similar fashion to other Cloudbreak services (core and
environment, in particular), but uniquely enough to merit doing its own
thing.

Only the following three permission checks are supported, reduced from
those currently defined in core:

* disabled
* on return value
* on method argument ("target")

Each permission checker is composed of an annotation and corresponding
class containing the checking logic. Unlike the permission framework in
core, redbeams allows repository methods to have no annotation, which
means there is no permission check. Multiple annotations are still
prohibited.

CheckPermissionsAspects intercepts calls to the repository classes and
asks PermissionCheckerService to perform the necessary permission checks
for the calls. The service finds the annotation on the intercepted
method and calls the corresponding permission checker. The two
non-disabled checkers end up delegating to PermissionCheckingUtils,
which is where the grpc call to UMS happens.

Permission checks are based on the CRN of the user and the CRN of the
resource being accessed. Therefore, permission checks are only supported
on resources with CRNs, and the interface CrnResource marks those. A
resource wrapped in an Optional works, as does a collection of them (or
Optionals of them).

Currently, all database and database server repository methods are
annotated for permission checks. The save method is not, so right now,
any user may create a new entity.