### PR TITLE
DISTX-39. Use objects for telemetry attributes

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/Logging.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/Logging.java
@@ -3,8 +3,6 @@ package com.sequenceiq.cloudbreak.cloud.model;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 
-import java.util.Map;
-
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -17,11 +15,11 @@ public class Logging {
 
     private final LoggingOutputType outputType;
 
-    private final Map<String, Object> attributes;
+    private final LoggingAttributesHolder attributes;
 
     public Logging(@JsonProperty("enabled") boolean enabled,
             @JsonProperty("output") LoggingOutputType outputType,
-            @JsonProperty("attributes") Map<String, Object> attributes) {
+            @JsonProperty("attributes") LoggingAttributesHolder attributes) {
         this.enabled = enabled;
         this.outputType = outputType;
         this.attributes = attributes;
@@ -35,7 +33,7 @@ public class Logging {
         return outputType;
     }
 
-    public Map<String, Object> getAttributes() {
+    public LoggingAttributesHolder getAttributes() {
         return attributes;
     }
 }

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/LoggingAttributesHolder.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/LoggingAttributesHolder.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.cloudbreak.cloud.model;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.cloud.model.logging.CommonLoggingAttributes;
+import com.sequenceiq.cloudbreak.cloud.model.logging.S3LoggingAttributes;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class LoggingAttributesHolder implements Serializable {
+
+    @JsonProperty("common")
+    private CommonLoggingAttributes commonAttributes;
+
+    @JsonProperty("s3")
+    private S3LoggingAttributes s3Attributes;
+
+    public CommonLoggingAttributes getCommonAttributes() {
+        return commonAttributes;
+    }
+
+    public void setCommonAttributes(CommonLoggingAttributes commonAttributes) {
+        this.commonAttributes = commonAttributes;
+    }
+
+    public S3LoggingAttributes getS3Attributes() {
+        return s3Attributes;
+    }
+
+    public void setS3Attributes(S3LoggingAttributes s3Attributes) {
+        this.s3Attributes = s3Attributes;
+    }
+}

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/WorkloadAnalytics.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/WorkloadAnalytics.java
@@ -3,8 +3,6 @@ package com.sequenceiq.cloudbreak.cloud.model;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 
-import java.util.Map;
-
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -22,13 +20,13 @@ public class WorkloadAnalytics {
 
     private final String privateKey;
 
-    private final Map<String, Object> attributes;
+    private final WorkloadAnalyticsAttributesHolder attributes;
 
     public WorkloadAnalytics(@JsonProperty("enabled") boolean enabled,
             @JsonProperty("databusEndpoint") String databusEndpoint,
             @JsonProperty("accessKey") String accessKey,
             @JsonProperty("privateKey") String privateKey,
-            @JsonProperty("attributes") Map<String, Object> attributes) {
+            @JsonProperty("attributes") WorkloadAnalyticsAttributesHolder attributes) {
         this.enabled = enabled;
         this.databusEndpoint = databusEndpoint;
         this.accessKey = accessKey;
@@ -52,7 +50,7 @@ public class WorkloadAnalytics {
         return privateKey;
     }
 
-    public Map<String, Object> getAttributes() {
+    public WorkloadAnalyticsAttributesHolder getAttributes() {
         return attributes;
     }
 }

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/WorkloadAnalyticsAttributesHolder.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/WorkloadAnalyticsAttributesHolder.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.cloudbreak.cloud.model;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class WorkloadAnalyticsAttributesHolder implements Serializable {
+
+    private String sdxId;
+
+    private String sdxName;
+
+    public String getSdxId() {
+        return sdxId;
+    }
+
+    public void setSdxId(String sdxId) {
+        this.sdxId = sdxId;
+    }
+
+    public String getSdxName() {
+        return sdxName;
+    }
+
+    public void setSdxName(String sdxName) {
+        this.sdxName = sdxName;
+    }
+}

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/logging/CommonLoggingAttributes.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/logging/CommonLoggingAttributes.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.cloudbreak.cloud.model.logging;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CommonLoggingAttributes implements Serializable {
+
+    private final String user;
+
+    private final String group;
+
+    public CommonLoggingAttributes(@JsonProperty("user") String user,
+            @JsonProperty("group") String group) {
+        this.user = user;
+        this.group = group;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public String getGroup() {
+        return group;
+    }
+}

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/logging/S3LoggingAttributes.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/logging/S3LoggingAttributes.java
@@ -1,0 +1,41 @@
+package com.sequenceiq.cloudbreak.cloud.model.logging;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class S3LoggingAttributes implements Serializable {
+
+    private final String bucket;
+
+    private final String basePath;
+
+    private final Integer partitionIntervalMin;
+
+    public S3LoggingAttributes(@JsonProperty("bucket") String bucket,
+            @JsonProperty("basePath") String basePath,
+            @JsonProperty("partitionIntervalMin") Integer partitionIntervalMin) {
+        this.bucket = bucket;
+        this.basePath = basePath;
+        this.partitionIntervalMin = partitionIntervalMin;
+    }
+
+    public String getBucket() {
+        return bucket;
+    }
+
+    public String getBasePath() {
+        return basePath;
+    }
+
+    public Integer getPartitionIntervalMin() {
+        return partitionIntervalMin;
+    }
+}

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerMgmtTelemetryService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerMgmtTelemetryService.java
@@ -28,6 +28,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.auth.altus.model.AltusCredential;
 import com.sequenceiq.cloudbreak.cloud.model.Telemetry;
 import com.sequenceiq.cloudbreak.cloud.model.WorkloadAnalytics;
+import com.sequenceiq.cloudbreak.cloud.model.WorkloadAnalyticsAttributesHolder;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 
 @Service
@@ -69,10 +70,6 @@ public class ClouderaManagerMgmtTelemetryService {
     private static final String TELEMETRY_UPLOAD_LOGS = "telemetry.upload.job.logs";
 
     private static final String TELEMETRY_WA_DEFAULT_CLUSTER_TYPE = "DISTROX";
-
-    private static final String ATTRIBUE_SDX_ID = "sdxId";
-
-    private static final String ATTRIBUTE_SDX_NAME = "sdxName";
 
     @Value("${altus.databus.endpoint:}")
     private String databusEndpoint;
@@ -167,11 +164,10 @@ public class ClouderaManagerMgmtTelemetryService {
     void enrichWithSdxData(String sdxContext, Stack stack, WorkloadAnalytics wa, Map<String, String> telemetrySafetyValveMap) {
         final String sdxId;
         final String sdxName;
-        Map<String, Object> attributes = wa.getAttributes();
-        if (attributes != null && attributes.get(ATTRIBUE_SDX_ID) != null
-                && attributes.get(ATTRIBUTE_SDX_NAME) != null) {
-            sdxId = attributes.get(ATTRIBUE_SDX_ID).toString();
-            sdxName = attributes.get(ATTRIBUTE_SDX_NAME).toString();
+        WorkloadAnalyticsAttributesHolder attributes = wa.getAttributes();
+        if (attributes != null && StringUtils.isNoneEmpty(attributes.getSdxId(), attributes.getSdxName())) {
+            sdxId = attributes.getSdxId();
+            sdxName = attributes.getSdxName();
         } else {
             sdxName = String.format("%s-%s", stack.getCluster().getName(), stack.getCluster().getId().toString());
             sdxId = UUID.nameUUIDFromBytes(sdxName.getBytes()).toString();

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerMgmtTelemetryServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerMgmtTelemetryServiceTest.java
@@ -27,6 +27,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.auth.altus.model.AltusCredential;
 import com.sequenceiq.cloudbreak.cloud.model.Telemetry;
 import com.sequenceiq.cloudbreak.cloud.model.WorkloadAnalytics;
+import com.sequenceiq.cloudbreak.cloud.model.WorkloadAnalyticsAttributesHolder;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 
@@ -194,10 +195,10 @@ public class ClouderaManagerMgmtTelemetryServiceTest {
     public void testEnrichWithSdxDataWithProvidedSdxData() {
         // GIVEN
         Map<String, String> safetyValveMap = new HashMap<>();
-        Map<String, Object> sdxDataMap = new HashMap<>();
-        sdxDataMap.put("sdxId", "mySdxId");
-        sdxDataMap.put("sdxName", "mySdxName");
-        WorkloadAnalytics wa = new WorkloadAnalytics(true, "customEndpoint", null, null, sdxDataMap);
+        WorkloadAnalyticsAttributesHolder attributesHolder = new WorkloadAnalyticsAttributesHolder();
+        attributesHolder.setSdxId("mySdxId");
+        attributesHolder.setSdxName("mySdxName");
+        WorkloadAnalytics wa = new WorkloadAnalytics(true, "customEndpoint", null, null, attributesHolder);
         // WHEN
         underTest.enrichWithSdxData(null, null, wa, safetyValveMap);
         // THEN

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/LoggingV4Base.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/LoggingV4Base.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.telemetry.TelemetryComponentParams;
+import com.sequenceiq.cloudbreak.cloud.model.LoggingAttributesHolder;
 import com.sequenceiq.cloudbreak.cloud.model.LoggingOutputType;
 import com.sequenceiq.cloudbreak.doc.ModelDescriptions;
 
@@ -17,11 +18,22 @@ public class LoggingV4Base extends TelemetryComponentParams {
     @ApiModelProperty(ModelDescriptions.StackModelDescription.TELEMETRY_LOGGING_OUTPUT_TYPE)
     private LoggingOutputType output;
 
+    @ApiModelProperty(ModelDescriptions.StackModelDescription.TELEMETRY_COMPONENT_ATTRIBUTES)
+    private LoggingAttributesHolder attributes;
+
     public LoggingOutputType getOutput() {
         return output;
     }
 
     public void setOutput(LoggingOutputType output) {
         this.output = output;
+    }
+
+    public LoggingAttributesHolder getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(LoggingAttributesHolder attributes) {
+        this.attributes = attributes;
     }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/WorkloadAnalyticsV4Base.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/WorkloadAnalyticsV4Base.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.telemetry.TelemetryComponentParams;
+import com.sequenceiq.cloudbreak.cloud.model.WorkloadAnalyticsAttributesHolder;
 import com.sequenceiq.cloudbreak.doc.ModelDescriptions;
 
 import io.swagger.annotations.ApiModel;
@@ -16,11 +17,22 @@ public class WorkloadAnalyticsV4Base extends TelemetryComponentParams {
     @ApiModelProperty(ModelDescriptions.StackModelDescription.TELEMETRY_WA_DATABUS_ENDPOINT)
     private String databusEndpoint;
 
+    @ApiModelProperty(ModelDescriptions.StackModelDescription.TELEMETRY_COMPONENT_ATTRIBUTES)
+    private WorkloadAnalyticsAttributesHolder attributes;
+
     public String getDatabusEndpoint() {
         return databusEndpoint;
     }
 
     public void setDatabusEndpoint(String databusEndpoint) {
         this.databusEndpoint = databusEndpoint;
+    }
+
+    public WorkloadAnalyticsAttributesHolder getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(WorkloadAnalyticsAttributesHolder attributes) {
+        this.attributes = attributes;
     }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/telemetry/TelemetryComponentParams.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/telemetry/TelemetryComponentParams.java
@@ -1,7 +1,5 @@
 package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.telemetry;
 
-import java.util.Map;
-
 import com.sequenceiq.cloudbreak.api.endpoint.v4.JsonEntity;
 import com.sequenceiq.cloudbreak.doc.ModelDescriptions;
 
@@ -12,22 +10,11 @@ public class TelemetryComponentParams implements JsonEntity {
     @ApiModelProperty(ModelDescriptions.StackModelDescription.TELEMETRY_COMPONENT_ENABLED)
     private boolean enabled;
 
-    @ApiModelProperty(ModelDescriptions.StackModelDescription.TELEMETRY_COMPONENT_ATTRIBUTES)
-    private Map<String, Object> attributes;
-
     public boolean isEnabled() {
         return enabled;
     }
 
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
-    }
-
-    public Map<String, Object> getAttributes() {
-        return attributes;
-    }
-
-    public void setAttributes(Map<String, Object> attributes) {
-        this.attributes = attributes;
     }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
@@ -192,7 +192,7 @@ public class ModelDescriptions {
         public static final String TELEMETRY = "stack related telemetry settings";
         public static final String TELEMETRY_LOGGING = "stack related telemetry - logging settings";
         public static final String TELEMETRY_COMPONENT_ENABLED = "enable telemetry component";
-        public static final String TELEMETRY_COMPONENT_ATTRIBUTES = "stack related telemetry dynamic component settings";
+        public static final String TELEMETRY_COMPONENT_ATTRIBUTES = "stack related telemetry component attributes";
         public static final String TELEMETRY_LOGGING_OUTPUT_TYPE = "telemetry - logging output type";
         public static final String TELEMETRY_WA = "stack related telemetry - workload analytics settings";
         public static final String TELEMETRY_WA_DATABUS_ENDPOINT = "telemetry - workload altus service (databus) endpoint url";

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecorator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecorator.java
@@ -1,16 +1,25 @@
 package com.sequenceiq.cloudbreak.core.bootstrap.service.host.decorator;
 
 import static java.util.Collections.singletonMap;
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
+
+import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.cloud.model.Logging;
+import com.sequenceiq.cloudbreak.cloud.model.LoggingAttributesHolder;
 import com.sequenceiq.cloudbreak.cloud.model.LoggingOutputType;
 import com.sequenceiq.cloudbreak.cloud.model.Telemetry;
+import com.sequenceiq.cloudbreak.cloud.model.logging.CommonLoggingAttributes;
+import com.sequenceiq.cloudbreak.cloud.model.logging.S3LoggingAttributes;
 import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
+import com.sequenceiq.cloudbreak.service.CloudbreakServiceException;
 
 /**
  * Decorate fluentd related salt pillar configs (in order to ship daemon logs to cloud storage)
@@ -34,7 +43,39 @@ public class TelemetryDecorator {
 
     private static final String TD_AGENT_GROUP_DEFAULT = "root";
 
+    // Right now it is built-in, add a way to override log folder configuration
+    // if custom log locations will be supported by the cluster template with CB deploy
+    private static final String LOGS_FOLDER_PREFIX_DEFAULT = "/var/log";
+
     private static final Integer PARTITION_INTERVAL_MIN_DEFAULT = 5;
+
+    private static final String CLUSTER_TYPE_DISTROX = "distrox";
+
+    private static final String CLUSTER_TYPE_SDX = "sdx";
+
+    private static final String CLUSTER_LOG_PREFIX = "cluster-logs";
+
+    private static final String FLUENT_ENABLED_PROPERTY = "enabled";
+
+    private static final String FLUENT_USER_PROPERTY = "user";
+
+    private static final String FLUENT_GROUP_PROPERTY = "group";
+
+    private static final String FLUENT_PROVIDER_PREFIX_PROPERTY = "providerPrefix";
+
+    private static final String FLUENT_SERVER_LOG_PREFIX_PROPERTY = "serverLogFolderPrefix";
+
+    private static final String FLUENT_AGENT_LOG_PREFIX_PROPERTY = "agentLogFolderPrefix";
+
+    private static final String FLUENT_SERVICE_LOG_PREFIX_PROPERTY = "serviceLogFolderPrefix";
+
+    private static final String[] S3_SCHEME_PREFIXES = {"s3://", "s3a://", "s3n://"};
+
+    private static final String S3_PARTITION_INTERVAL_PROPERTY = "partitionIntervalMin";
+
+    private static final String S3_LOG_ARCHIVE_BUCKET_PROPERTY = "s3LogArchiveBucketName";
+
+    private static final String S3_LOG_FOLDER_NAME_PROPERTY = "s3LogFolderName";
 
     private final Map<String, SaltPillarProperties> servicePillar;
 
@@ -56,22 +97,108 @@ public class TelemetryDecorator {
 
     private void fillFluentConfigs(Logging logging, Map<String, Object> fluentConfig,
             String clusterName, StackType stackType) {
-        Map<String, Object> attributes = logging.getAttributes();
-        if (LoggingOutputType.S3.equals(logging.getOutputType())) {
-            fluentConfig.put("enabled", true);
-            fluentConfig.put("user", attributes.getOrDefault("user", TD_AGENT_USER_DEFAULT));
-            fluentConfig.put("group", attributes.getOrDefault("group", TD_AGENT_GROUP_DEFAULT));
-            fluentConfig.put("partitionIntervalMin", attributes.getOrDefault("partitionIntervalMin", PARTITION_INTERVAL_MIN_DEFAULT));
-            fluentConfig.put("providerPrefix", "s3");
-            fluentConfig.put("s3LogArchiveBucketName", attributes.get("s3LogArchiveBucketName"));
-            String clusterType = "distrox";
-            if (StackType.DATALAKE.equals(stackType)) {
-                clusterType = "sdx";
+        LoggingAttributesHolder attributes = logging.getAttributes();
+        if (attributes != null) {
+            String user = TD_AGENT_USER_DEFAULT;
+            String group = TD_AGENT_GROUP_DEFAULT;
+            CommonLoggingAttributes common = attributes.getCommonAttributes();
+            if (common != null) {
+                if (StringUtils.isNotEmpty(common.getUser())) {
+                    user = common.getUser();
+                }
+                if (StringUtils.isNotEmpty(common.getGroup())) {
+                    group = common.getGroup();
+                }
             }
-            String defaultLogFolder = Paths.get("cluster-logs", clusterType, clusterName).toString();
-            fluentConfig.put("s3LogFolderName", attributes.getOrDefault("s3LogFolderName", defaultLogFolder));
+            fluentConfig.put(FLUENT_USER_PROPERTY, user);
+            fluentConfig.put(FLUENT_GROUP_PROPERTY, group);
+
+            fluentConfig.put(FLUENT_SERVER_LOG_PREFIX_PROPERTY, LOGS_FOLDER_PREFIX_DEFAULT);
+            fluentConfig.put(FLUENT_AGENT_LOG_PREFIX_PROPERTY, LOGS_FOLDER_PREFIX_DEFAULT);
+            fluentConfig.put(FLUENT_SERVICE_LOG_PREFIX_PROPERTY, LOGS_FOLDER_PREFIX_DEFAULT);
+            fluentConfig.put(FLUENT_ENABLED_PROPERTY, true);
+
+            if (LoggingOutputType.S3.equals(logging.getOutputType()) && attributes.getS3Attributes() != null) {
+                S3LoggingAttributes s3Attributes = attributes.getS3Attributes();
+                fluentConfig.put(FLUENT_PROVIDER_PREFIX_PROPERTY, "s3");
+                fluentConfig.put(S3_PARTITION_INTERVAL_PROPERTY, defaultIfNull(s3Attributes.getPartitionIntervalMin(), PARTITION_INTERVAL_MIN_DEFAULT));
+                calculateS3BucketAndLogFolder(clusterName, stackType, s3Attributes, fluentConfig);
+            } else {
+                fluentConfig.put(FLUENT_ENABLED_PROPERTY, false);
+            }
             servicePillar.put("fluent",
                     new SaltPillarProperties("/fluent/init.sls", singletonMap("fluent", fluentConfig)));
+        }
+    }
+
+    @VisibleForTesting
+    void calculateS3BucketAndLogFolder(String clusterName, StackType stackType,
+            S3LoggingAttributes attributes, Map<String, Object> fluentConfig) {
+        String bucket = attributes.getBucket();
+        String basePath = attributes.getBasePath();
+        BucketFolderPrefixPair bucketFolderPrefixPair = generateBucketFolderPrefixPair(bucket, basePath);
+
+        String clusterType = CLUSTER_TYPE_DISTROX;
+        if (StackType.DATALAKE.equals(stackType)) {
+            clusterType = CLUSTER_TYPE_SDX;
+        }
+        String s3LogFolderName = Paths.get(CLUSTER_LOG_PREFIX, clusterType, clusterName).toString();
+        if (StringUtils.isNotEmpty(bucketFolderPrefixPair.getFolderPrefix())) {
+            s3LogFolderName = Paths.get(bucketFolderPrefixPair.getFolderPrefix(), clusterType, clusterName).toString();
+        }
+
+        fluentConfig.put(S3_LOG_ARCHIVE_BUCKET_PROPERTY, bucketFolderPrefixPair.getBucket());
+        fluentConfig.put(S3_LOG_FOLDER_NAME_PROPERTY, s3LogFolderName);
+    }
+
+    private BucketFolderPrefixPair generateBucketFolderPrefixPair(String bucket, String basePath) {
+        if (StringUtils.isNoneEmpty(bucket, basePath)) {
+            Path bucketPath = getPathWithoutSchemePrefixes(bucket, S3_SCHEME_PREFIXES);
+            String[] splittedBucket = bucketPath.toString().split("/", 2);
+            return new BucketFolderPrefixPair(splittedBucket[0], basePath);
+        } else if (StringUtils.isNotEmpty(bucket)) {
+            Path path = getPathWithoutSchemePrefixes(bucket, S3_SCHEME_PREFIXES);
+            String[] splitted = path.toString().split("/");
+            return new BucketFolderPrefixPair(splitted[0], null);
+        } else if (StringUtils.isNotEmpty(basePath)) {
+            Path path = getPathWithoutSchemePrefixes(basePath, S3_SCHEME_PREFIXES);
+            String[] splitted = path.toString().split("/", 2);
+            if (splitted.length < 2) {
+                return new BucketFolderPrefixPair(splitted[0], null);
+            }
+            return new BucketFolderPrefixPair(splitted[0], splitted[1]);
+        }
+        throw new CloudbreakServiceException("Bucket and / or basePath parameters are missing for S3 attributes");
+    }
+
+    private Path getPathWithoutSchemePrefixes(String input, String... schemePrefixes) {
+        for (String schemePrefix : schemePrefixes) {
+            if (input.startsWith(schemePrefix)) {
+                String[] splitted = input.split(schemePrefix);
+                if (splitted.length > 1) {
+                    return Paths.get(splitted[1]);
+                }
+            }
+        }
+        return Paths.get(input);
+    }
+
+    private static class BucketFolderPrefixPair {
+        private final String bucket;
+
+        private final String folderPrefix;
+
+        BucketFolderPrefixPair(String bucket, String folderPrefix) {
+            this.bucket = bucket;
+            this.folderPrefix = folderPrefix;
+        }
+
+        String getBucket() {
+            return bucket;
+        }
+
+        String getFolderPrefix() {
+            return folderPrefix;
         }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterService.java
@@ -593,11 +593,15 @@ public class ClusterService {
         try {
             transactionService.required(() -> {
                 Stack stack = stackService.getByIdWithListsInTransaction(stackId);
-                Telemetry telemetry = componentConfigProviderService.getTelemetry(stackId);
-                try {
-                    clusterApiConnectors.getConnector(stack).clusterModificationService().cleanupCluster(telemetry);
-                } catch (Exception e) {
-                    LOGGER.error("Cluster specific cleanup failed.", e);
+                if (StringUtils.isEmpty(stack.getCluster().getAmbariIp())) {
+                    LOGGER.debug("Cluster server IP was not set before, cleanup cluster operation can be skipped.");
+                } else {
+                    Telemetry telemetry = componentConfigProviderService.getTelemetry(stackId);
+                    try {
+                        clusterApiConnectors.getConnector(stack).clusterModificationService().cleanupCluster(telemetry);
+                    } catch (CloudbreakException e) {
+                        LOGGER.error("Cluster specific cleanup failed.", e);
+                    }
                 }
                 return stack;
             });

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecoratorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecoratorTest.java
@@ -1,0 +1,158 @@
+package com.sequenceiq.cloudbreak.core.bootstrap.service.host.decorator;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.cloud.model.Logging;
+import com.sequenceiq.cloudbreak.cloud.model.LoggingAttributesHolder;
+import com.sequenceiq.cloudbreak.cloud.model.LoggingOutputType;
+import com.sequenceiq.cloudbreak.cloud.model.Telemetry;
+import com.sequenceiq.cloudbreak.cloud.model.logging.S3LoggingAttributes;
+import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
+import com.sequenceiq.cloudbreak.service.CloudbreakServiceException;
+
+public class TelemetryDecoratorTest {
+
+    private TelemetryDecorator underTest;
+
+    private Map<String, SaltPillarProperties> servicePillar;
+
+    @Before
+    public void setUp() {
+        servicePillar = new HashMap<>();
+        underTest = new TelemetryDecorator(servicePillar);
+    }
+
+    @Test
+    public void testS3Decorate() {
+        // GIVEN
+        String clusterName = "cl1";
+        LoggingAttributesHolder attributes = new LoggingAttributesHolder();
+        S3LoggingAttributes s3Attributes = new S3LoggingAttributes(
+                "mybucket", "cluster-logs/custom", 5);
+        attributes.setS3Attributes(s3Attributes);
+        Logging logging = new Logging(true, LoggingOutputType.S3, attributes);
+        Telemetry telemetry = new Telemetry(logging, null);
+        // WHEN
+        underTest.decoratePillar(telemetry, clusterName, StackType.WORKLOAD);
+        // THEN
+        Map<String, Object> results = createMapFromFluentPillars(servicePillar);
+        assertEquals(results.get("providerPrefix"), "s3");
+        assertEquals(results.get("s3LogArchiveBucketName"), "mybucket");
+        assertEquals(results.get("s3LogFolderName"), "cluster-logs/custom/distrox/cl1");
+        assertEquals(results.get("enabled"), true);
+    }
+
+    @Test
+    public void testS3DecorateWithDatalake() {
+        // GIVEN
+        String clusterName = "cl1";
+        LoggingAttributesHolder attributes = new LoggingAttributesHolder();
+        S3LoggingAttributes s3Attributes = new S3LoggingAttributes(
+                "mybucket", "cluster-logs/custom", 5);
+        attributes.setS3Attributes(s3Attributes);
+        Logging logging = new Logging(true, LoggingOutputType.S3, attributes);
+        Telemetry telemetry = new Telemetry(logging, null);
+        // WHEN
+        underTest.decoratePillar(telemetry, clusterName, StackType.DATALAKE);
+        // THEN
+        Map<String, Object> results = createMapFromFluentPillars(servicePillar);
+        assertEquals(results.get("providerPrefix"), "s3");
+        assertEquals(results.get("s3LogArchiveBucketName"), "mybucket");
+        assertEquals(results.get("s3LogFolderName"), "cluster-logs/custom/sdx/cl1");
+        assertEquals(results.get("enabled"), true);
+    }
+
+    @Test
+    public void testS3DecorateWithDefaultPath() {
+        // GIVEN
+        String clusterName = "cl1";
+        LoggingAttributesHolder attributes = new LoggingAttributesHolder();
+        S3LoggingAttributes s3Attributes = new S3LoggingAttributes(
+                "mybucket", null, 5);
+        attributes.setS3Attributes(s3Attributes);
+        Logging logging = new Logging(true, LoggingOutputType.S3, attributes);
+        Telemetry telemetry = new Telemetry(logging, null);
+        // WHEN
+        underTest.decoratePillar(telemetry, clusterName, StackType.WORKLOAD);
+        // THEN
+        Map<String, Object> results = createMapFromFluentPillars(servicePillar);
+        assertEquals(results.get("providerPrefix"), "s3");
+        assertEquals(results.get("s3LogArchiveBucketName"), "mybucket");
+        assertEquals(results.get("s3LogFolderName"), "cluster-logs/distrox/cl1");
+        assertEquals(results.get("enabled"), true);
+    }
+
+    @Test
+    public void testS3DecorateWitoutS3Attributes() {
+        // GIVEN
+        String clusterName = "cl1";
+        LoggingAttributesHolder attributes = new LoggingAttributesHolder();
+        Logging logging = new Logging(true, LoggingOutputType.S3, attributes);
+        Telemetry telemetry = new Telemetry(logging, null);
+        // WHEN
+        underTest.decoratePillar(telemetry, clusterName, StackType.WORKLOAD);
+        // THEN
+        Map<String, Object> results = createMapFromFluentPillars(servicePillar);
+        assertEquals(results.get("enabled"), false);
+    }
+
+    @Test
+    public void testS3DecorateWithFullPathBucket() {
+        // GIVEN
+        S3LoggingAttributes s3Attributes = new S3LoggingAttributes(
+                "s3://mybucket/cluster-logs/my/path", null, 5);
+        Map<String, Object> results = new HashMap<>();
+        // WHEN
+        underTest.calculateS3BucketAndLogFolder("cl1", StackType.WORKLOAD, s3Attributes, results);
+        // THEN
+        assertEquals(results.get("s3LogArchiveBucketName"), "mybucket");
+        assertEquals(results.get("s3LogFolderName"), "cluster-logs/distrox/cl1");
+    }
+
+    @Test
+    public void testS3DecorateWithFullBasePathOnly() {
+        // GIVEN
+        S3LoggingAttributes s3Attributes = new S3LoggingAttributes(
+                null, "s3://mybucket/cluster-logs", 5);
+        Map<String, Object> results = new HashMap<>();
+        // WHEN
+        underTest.calculateS3BucketAndLogFolder("cl1", StackType.WORKLOAD, s3Attributes, results);
+        // THEN
+        assertEquals(results.get("s3LogArchiveBucketName"), "mybucket");
+        assertEquals(results.get("s3LogFolderName"), "cluster-logs/distrox/cl1");
+    }
+
+    @Test
+    public void testS3DecorateWithFullPathBucketWithS3A() {
+        // GIVEN
+        S3LoggingAttributes s3Attributes = new S3LoggingAttributes(
+                null, "s3a://mybucket/cluster-logs", 5);
+        Map<String, Object> results = new HashMap<>();
+        // WHEN
+        underTest.calculateS3BucketAndLogFolder("cl1", StackType.WORKLOAD, s3Attributes, results);
+        // THEN
+        assertEquals(results.get("s3LogArchiveBucketName"), "mybucket");
+        assertEquals(results.get("s3LogFolderName"), "cluster-logs/distrox/cl1");
+    }
+
+    @Test(expected = CloudbreakServiceException.class)
+    public void testS3DecorateWithoutProperAttributes() {
+        // GIVEN
+        S3LoggingAttributes s3Attributes = new S3LoggingAttributes(
+                null, null, 5);
+        Map<String, Object> results = new HashMap<>();
+        // WHEN
+        underTest.calculateS3BucketAndLogFolder("cl1", StackType.WORKLOAD, s3Attributes, results);
+    }
+
+    private Map<String, Object> createMapFromFluentPillars(Map<String, SaltPillarProperties> servicePillar) {
+        return (Map<String, Object>) servicePillar.get("fluent").getProperties().get("fluent");
+    }
+}

--- a/orchestrator-salt/src/main/resources/salt/pillar/fluent/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/pillar/fluent/init.sls
@@ -2,6 +2,9 @@ fluent:
   enabled: false
   user: root
   group: root
+  serverLogFolderPrefix: /var/log
+  agentLogFolderPrefix: /var/log
+  serviceLogFolderPrefix: /var/log
   providerPrefix: "stdout"
   partitionIntervalMin: 5
   s3LogArchiveBucketName:

--- a/orchestrator-salt/src/main/resources/salt/salt/fluent/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/fluent/init.sls
@@ -1,5 +1,72 @@
 {%- from 'fluent/settings.sls' import fluent with context %}
+{% set os = salt['grains.get']('os') %}
+{% set osmajorrelease = salt['grains.get']('osmajorrelease') %}
+
 {% if fluent.enabled %}
+
+{% if not salt['file.directory_exists' ]('/etc/td-agent') %}
+{% if os == "RedHat" or os == "CentOS" %}
+install_fluentd_yum:
+  cmd.run:
+    - name: curl -L https://toolbelt.treasuredata.com/sh/install-redhat-td-agent3.sh | sh
+{% elif os == "Ubuntu" %}
+  {% if osmajorrelease | int == 18 %}
+install_fluentd_ubuntu18:
+  cmd.run:
+    - name: curl -L https://toolbelt.treasuredata.com/sh/install-ubuntu-bionic-td-agent3.sh | sh
+  {% elif osmajorrelease | int == 16 %}
+install_fluentd_ubuntu16:
+  cmd.run:
+    - name: curl -L https://toolbelt.treasuredata.com/sh/install-ubuntu-xenial-td-agent3.sh | sh
+  {% elif osmajorrelease | int == 14 %}
+install_fluentd_ubuntu14:
+  cmd.run:
+    - name: curl -L https://toolbelt.treasuredata.com/sh/install-ubuntu-trusty-td-agent3.sh | sh
+  {% else %}
+warning_fluentd_ubuntu:
+  cmd.run:
+    - name: echo "Warning - Fluentd install is not supported for this Ubuntu OS version ({{ os }})"
+  {% endif %}
+{% elif os == "Debian" %}
+  {% if osmajorrelease | int == 9 %}
+install_fluentd_debian9:
+  cmd.run:
+    - name: curl -L https://toolbelt.treasuredata.com/sh/install-debian-stretch-td-agent3.sh | sh
+  {% elif osmajorrelease | int == 8 %}
+install_fluentd_debian8:
+  cmd.run:
+    - name: curl -L https://toolbelt.treasuredata.com/sh/install-debian-jessie-td-agent3.sh | sh
+  {% else %}
+warning_fluentd_debian:
+  cmd.run:
+    - name: echo "Warning - Fluentd install is not supported for this Debian OS version ({{ os }})"
+  {% endif %}
+{% elif os == "SLES" %}
+warning_fluentd_suse:
+  cmd.run:
+    - name: echo "Warning - Fluentd install is not supported yet for Suse ({{ os }})"
+{% elif os == "Amazon" %}
+{% if osmajorrelease | int == 2 %}
+install_fluentd_amazon2:
+  cmd.run:
+    - name: curl -L https://toolbelt.treasuredata.com/sh/install-amazon2-td-agent3.sh | sh
+{% elif osmajorrelease | int == 1 %}
+install_fluentd_amazon1:
+  cmd.run:
+    - name: curl -L https://toolbelt.treasuredata.com/sh/install-amazon1-td-agent3.sh | sh
+{% endif %}
+{% else %}
+warning_fluentd_os:
+  cmd.run:
+    - name: echo "Warning - Fluentd install is not supported for this OS type ({{ os }})"
+{% endif %}
+install_fluentd_plugins:
+  cmd.run:
+    - name: /opt/td-agent/embedded/bin/fluent-gem install fluent-plugin-cloudwatch-logs
+    - onlyif: test -d /opt/td-agent/embedded/bin/
+
+{% endif %}
+
 /etc/td-agent/pos:
   file.directory:
     - name: /etc/td-agent/pos

--- a/orchestrator-salt/src/main/resources/salt/salt/fluent/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/fluent/settings.sls
@@ -11,6 +11,9 @@
 {% endif %}
 {% set fluent_user = salt['pillar.get']('fluent:user') %}
 {% set fluent_group = salt['pillar.get']('fluent:group') %}
+{% set server_log_folder_prefix = salt['pillar.get']('fluent:serverLogFolderPrefix') %}
+{% set agent_log_folder_prefix = salt['pillar.get']('fluent:agentLogFolderPrefix') %}
+{% set service_log_folder_prefix = salt['pillar.get']('fluent:serviceLogFolderPrefix') %}
 {% set provider_prefix = salt['pillar.get']('fluent:providerPrefix') %}
 {% set s3_log_bucket = salt['pillar.get']('fluent:s3LogArchiveBucketName') %}
 {% set s3_log_folder = salt['pillar.get']('fluent:s3LogFolderName') %}
@@ -18,6 +21,9 @@
 
 {% do fluent.update({
     "is_systemd" : is_systemd,
+    "serverLogFolderPrefix": server_log_folder_prefix,
+    "agentLogFolderPrefix": agent_log_folder_prefix,
+    "serviceLogFolderPrefix": service_log_folder_prefix,
     "enabled": fluent_enabled,
     "user": fluent_user,
     "group": fluent_group,

--- a/orchestrator-salt/src/main/resources/salt/salt/fluent/template/td-agent.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/fluent/template/td-agent.conf.j2
@@ -27,7 +27,7 @@
 <source>
   @type tail
   format none
-  path /var/log/cloudera-scm-server/cloudera-scm-server.log
+  path {{fluent.serverLogFolderPrefix}}/cloudera-scm-server/cloudera-scm-server.log
   pos_file /var/log/td-agent/pos/cloudera-scm-server.log.pos
   tag {{fluent.providerPrefix}}.cloudera-scm-server-log
   read_from_head true
@@ -35,7 +35,7 @@
 <source>
   @type tail
   format none
-  path /var/log/cloudera-scm-server/cloudera-scm-server.out
+  path {{fluent.serverLogFolderPrefix}}/cloudera-scm-server/cloudera-scm-server.out
   pos_file /var/log/td-agent/pos/cloudera-scm-server-out.log.pos
   tag {{fluent.providerPrefix}}.cloudera-scm-server-out
   read_from_head true
@@ -43,7 +43,7 @@
 <source>
   @type tail
   format none
-  path /var/log/cloudera-scm-agent/cloudera-scm-agent.log
+  path {{fluent.agentLogFolderPrefix}}/cloudera-scm-agent/cloudera-scm-agent.log
   pos_file /var/log/td-agent/pos/cloudera-scm-agent.log.pos
   tag {{fluent.providerPrefix}}.cloudera-scm-agent-log
   read_from_head true
@@ -51,7 +51,7 @@
 <source>
   @type tail
   format none
-  path /var/log/cloudera-scm-agent/cloudera-scm-agent*.out
+  path {{fluent.agentLogFolderPrefix}}/cloudera-scm-agent/cloudera-scm-agent*.out
   pos_file /var/log/td-agent/pos/cloudera-scm-agent-out.log.pos
   tag {{fluent.providerPrefix}}.cloudera-scm-agent-out
   read_from_head true
@@ -123,7 +123,7 @@
 <source>
   @type tail
   format none
-  path /var/log/*/*cmf*-YARN*-NODEMANAGER*.log.out
+  path /var/log/*/*cmf*-yarn*-NODEMANAGER*.log.out
   pos_file /var/log/td-agent/pos/cmf-yarn-nodemanager-out.log.pos
   tag {{fluent.providerPrefix}}.YARN-NODEMANAGER
   read_from_head true


### PR DESCRIPTION
Use objects instead of dynamic attributes for log settings:
that: 
```json
"attributes" : {
   "xxx",
   "yyy"
}
```
will look like this:
```json
"output": "s3",
"attributes" : {
 "s3": {
   "xxx",
   "yyy"
  }
}
```

Also adding some cleanups:
- extend decorator a bit to handle situations when bucket or basePath is defined with s3, s3a or s3n scheme
- install td-agent on the nodes in case of missing from the image (it is installed by default in cloudbreak-images, but that can be useful if the package is missing)
- do not skip cluster cleanup on any errors, it can be skipped if cluster IP was calculated (before)
- add some more UTs
