### PR TITLE
CB-1695 Create db-specific users in redbeams

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/database/DatabaseCommon.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/database/DatabaseCommon.java
@@ -2,6 +2,10 @@ package com.sequenceiq.cloudbreak.common.database;
 
 import static java.util.Objects.requireNonNull;
 
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -103,6 +107,23 @@ public class DatabaseCommon {
                 throw new UnsupportedOperationException("Don't know how to form a connection URL for JDBC driver " + fields.getVendorDriverId());
         }
         return url;
+    }
+
+    /**
+     * Executes several SQL statements. Statements are not wrapped in a
+     * transaction, so do that if it's important.
+     *
+     * @param  statement    SQL statement for working with a database
+     * @param  sqlStrings   list of SQL statements to execute
+     * @return              corresponding list of update counts
+     * @throws SQLException if any statement fails
+     */
+    public List<Integer> executeUpdates(Statement statement, List<String> sqlStrings) throws SQLException {
+        List<Integer> rowCounts = new ArrayList<>(sqlStrings.size());
+        for (String sqlString : sqlStrings) {
+            rowCounts.add(statement.executeUpdate(sqlString));
+        }
+        return rowCounts;
     }
 
     public static class JdbcConnectionUrlFields {

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/domain/DatabaseServerConfig.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/domain/DatabaseServerConfig.java
@@ -274,9 +274,12 @@ public class DatabaseServerConfig implements ArchivableResource, CrnResource {
      * @param databaseName the name of the database
      * @param type         the type of the database
      * @param status       the resource status of the database
+     * @param userName     the username for the user associated with the database
+     * @param password     the password for the user associated with the database
      * @return a DatabaseConfig
      */
-    public DatabaseConfig createDatabaseConfig(String databaseName, String type, ResourceStatus status) {
+    public DatabaseConfig createDatabaseConfig(String databaseName, String type, ResourceStatus status,
+        String userName, String password) {
         DatabaseConfig databaseConfig = new DatabaseConfig();
 
         databaseConfig.setDatabaseVendor(databaseVendor);
@@ -285,8 +288,8 @@ public class DatabaseServerConfig implements ArchivableResource, CrnResource {
         databaseConfig.setConnectionURL(new DatabaseCommon().getJdbcConnectionUrl(databaseVendor.jdbcUrlDriverId(),
             host, port, Optional.of(databaseName)));
         databaseConfig.setConnectionDriver(connectionDriver);
-        databaseConfig.setConnectionUserName(connectionUserName.getRaw());
-        databaseConfig.setConnectionPassword(connectionPassword.getRaw());
+        databaseConfig.setConnectionUserName(userName);
+        databaseConfig.setConnectionPassword(password);
         databaseConfig.setStatus(status);
         databaseConfig.setType(type);
         databaseConfig.setConnectorJarUrl(connectorJarUrl);


### PR DESCRIPTION
When creating a new database on a server, redbeams now also creates a
new user with all privileges to the server. Likewise, when deleting a
database on a server, redbeams also deletes the corresponding user.
(Database commands are only tested on PostgreSQL for now.)

The user for a new database gets a random ten-character alphabetic
username and a random UUID for a password. (Future work could do a
better job of username generation, to ensure that an existing user
isn't reused by chance.) If, somehow, the user for a database is the
same as the root user for the server, redbeams does not remove the user
account from the server along with the database.

Transaction processing for these operations in redbeams has been
adjusted, so that only the SQL commands for database and user handling
occur within a transaction, Updates in redbeams's database itself are
not part of the transaction. Therefore:

* If database creation on the server fails, a new database entity is
  not saved in redbeams's database.
* If database creation on the server succeeds, but saving its entity
  in redbeam's database fails, the database on the server remains,
  orphaned.
* If database deletion in redbeams's database fails, the database
  remains on the server.
* If database deletion in redbeams's database succeeds, but deleting the
  database on the server fails, the database on the server remains,
  orphaned.