### PR TITLE
CB-1804. Inject `idbroker_master_secret`

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-sdx-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx-ha.bp
@@ -390,24 +390,12 @@
           {
             "base": true,
             "refName": "knox-KNOX_GATEWAY-BASE",
-            "roleType": "KNOX_GATEWAY",
-            "configs": [
-              {
-                "name": "gateway_master_secret",
-                "value": "cloudera1"
-              }
-            ]
+            "roleType": "KNOX_GATEWAY"
           },
           {
             "refName": "knox-IDBROKER-BASE",
             "roleType": "IDBROKER",
-            "base": true,
-            "configs": [
-              {
-                "name": "idbroker_master_secret",
-                "value": "cloudera1"
-              }
-            ]
+            "base": true
           }
         ]
       }

--- a/core/src/main/resources/defaults/blueprints/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx.bp
@@ -251,22 +251,10 @@
           {
             "base": true,
             "refName": "knox-KNOX_GATEWAY-BASE",
-            "roleType": "KNOX_GATEWAY",
-            "configs": [
-              {
-                "name": "gateway_master_secret",
-                "value": "{{{ general.password }}}"
-              }
-            ]
+            "roleType": "KNOX_GATEWAY"
           },
           {
             "base": true,
-            "configs": [
-              {
-                "name": "idbroker_master_secret",
-                "value": "{{{ general.password }}}"
-              }
-            ],
             "refName": "knox-IDBROKER-BASE",
             "roleType": "IDBROKER"
           }

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxRoles.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxRoles.java
@@ -1,0 +1,13 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.knox;
+
+public class KnoxRoles {
+
+    public static final String KNOX = "KNOX";
+
+    public static final String KNOX_GATEWAY = "KNOX_GATEWAY";
+
+    public static final String IDBROKER = "IDBROKER";
+
+    private KnoxRoles() { }
+
+}

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxGatewayConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxGatewayConfigProviderTest.java
@@ -1,9 +1,12 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.knox;
 
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -18,6 +21,7 @@ import com.sequenceiq.cloudbreak.common.type.InstanceGroupType;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.gateway.Gateway;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject.Builder;
+import com.sequenceiq.cloudbreak.template.model.GeneralClusterConfigs;
 import com.sequenceiq.cloudbreak.template.views.HostgroupView;
 import com.sequenceiq.cloudbreak.util.FileReaderUtils;
 
@@ -101,6 +105,52 @@ public class KnoxGatewayConfigProviderTest {
         Map<String, ApiClusterTemplateService> additionalServices = underTest.getAdditionalServices(cmTemplateProcessor, preparationObject);
 
         assertTrue(additionalServices.isEmpty());
+    }
+
+    @Test
+    public void roleConfigsWithGateway() {
+        HostgroupView any = mock(HostgroupView.class);
+        Gateway gateway = new Gateway();
+        gateway.setKnoxMasterSecret("admin");
+        gateway.setPath("/a/b/c");
+        TemplatePreparationObject source = Builder.builder().withGateway(gateway, "key").build();
+
+        assertEquals(
+                List.of(
+                        config("idbroker_master_secret", gateway.getKnoxMasterSecret())
+                ),
+                underTest.getRoleConfig(KnoxRoles.IDBROKER, any, source)
+        );
+        assertEquals(
+                List.of(
+                        config("gateway_master_secret", gateway.getKnoxMasterSecret()),
+                        config("gateway_path", gateway.getPath())
+                ),
+                underTest.getRoleConfig(KnoxRoles.KNOX_GATEWAY, any, source)
+        );
+        assertEquals(List.of(), underTest.getRoleConfig("NAMENODE", any, source));
+    }
+
+    @Test
+    public void roleConfigsWithoutGateway() {
+        HostgroupView any = mock(HostgroupView.class);
+        GeneralClusterConfigs gcc = new GeneralClusterConfigs();
+        gcc.setPassword("secret");
+        TemplatePreparationObject source = Builder.builder().withGeneralClusterConfigs(gcc).build();
+
+        assertEquals(
+                List.of(
+                        config("idbroker_master_secret", gcc.getPassword())
+                ),
+                underTest.getRoleConfig(KnoxRoles.IDBROKER, any, source)
+        );
+        assertEquals(
+                List.of(
+                        config("gateway_master_secret", gcc.getPassword())
+                ),
+                underTest.getRoleConfig(KnoxRoles.KNOX_GATEWAY, any, source)
+        );
+        assertEquals(List.of(), underTest.getRoleConfig("NAMENODE", any, source));
     }
 
     private String getBlueprintText(String path) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Inject gateway password (or cluster password if gateway is not enabled) as `idbroker_master_secret` in Knox role configs, similar to how `gateway_master_secret` is injected.

## How was this patch tested?

Added unit test.  Deployed SDX clusters of various flavors.