### PR TITLE
CB-1814. add instance id to gateway config.

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/TlsSecurityService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/TlsSecurityService.java
@@ -103,7 +103,7 @@ public class TlsSecurityService {
         SaltSecurityConfig saltSecurityConfig = securityConfig.getSaltSecurityConfig();
         String saltSignPrivateKeyB64 = saltSecurityConfig.getSaltSignPrivateKey();
         return new GatewayConfig(connectionIp, gatewayInstance.getPublicIpWrapper(), gatewayInstance.getPrivateIp(), gatewayInstance.getDiscoveryFQDN(),
-                gatewayPort, conf.getServerCert(), conf.getClientCert(), conf.getClientKey(),
+                gatewayPort, gatewayInstance.getInstanceId(), conf.getServerCert(), conf.getClientCert(), conf.getClientKey(),
                 saltClientConfig.getSaltPassword(), saltClientConfig.getSaltBootPassword(), saltClientConfig.getSignatureKeyPem(),
                 knoxGatewayEnabled, InstanceMetadataType.GATEWAY_PRIMARY.equals(gatewayInstance.getInstanceMetadataType()),
                 new String(decodeBase64(saltSignPrivateKeyB64)), new String(decodeBase64(saltSecurityConfig.getSaltSignPublicKey())));

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapperErrorHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapperErrorHandlerTest.java
@@ -113,7 +113,7 @@ public class ClusterBootstrapperErrorHandlerTest {
         thrown.expectMessage("invalide.nodecount");
 
         underTest.terminateFailedNodes(null, orchestrator, TestUtil.stack(),
-                new GatewayConfig("10.0.0.1", "198.0.0.1", "10.0.0.1", 8443, false), prepareNodes(stack));
+                new GatewayConfig("10.0.0.1", "198.0.0.1", "10.0.0.1", 8443, "instanceId", false), prepareNodes(stack));
     }
 
     @Test
@@ -148,7 +148,7 @@ public class ClusterBootstrapperErrorHandlerTest {
             return Optional.empty();
         });
         underTest.terminateFailedNodes(null, orchestrator, TestUtil.stack(),
-                new GatewayConfig("10.0.0.1", "198.0.0.1", "10.0.0.1", 8443, false), prepareNodes(stack));
+                new GatewayConfig("10.0.0.1", "198.0.0.1", "10.0.0.1", 8443, "instanceId", false), prepareNodes(stack));
 
         verify(eventService, times(4)).fireCloudbreakEvent(anyLong(), anyString(), nullable(String.class));
         verify(instanceGroupService, times(3)).save(any(InstanceGroup.class));

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/flow/PreTerminationStateExecutorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/flow/PreTerminationStateExecutorTest.java
@@ -57,7 +57,7 @@ public class PreTerminationStateExecutorTest {
         cluster = spy(new Cluster());
         stack.setCluster(cluster);
         when(hostOrchestratorResolver.get(anyString())).thenReturn(hostOrchestrator);
-        when(gatewayConfigService.getPrimaryGatewayConfig(stack)).thenReturn(new GatewayConfig("a", "a", "a", 1, false));
+        when(gatewayConfigService.getPrimaryGatewayConfig(stack)).thenReturn(new GatewayConfig("a", "a", "a", 1, "a", false));
     }
 
     @Test

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/TlsSecurityService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/TlsSecurityService.java
@@ -88,7 +88,7 @@ public class TlsSecurityService {
         SaltSecurityConfig saltSecurityConfig = securityConfig.getSaltSecurityConfig();
         String saltSignPrivateKeyB64 = saltSecurityConfig.getSaltSignPrivateKey();
         return new GatewayConfig(connectionIp, gatewayInstance.getPublicIpWrapper(), gatewayInstance.getPrivateIp(), gatewayInstance.getDiscoveryFQDN(),
-                gatewayPort, conf.getServerCert(), conf.getClientCert(), conf.getClientKey(),
+                gatewayPort, gatewayInstance.getInstanceId(), conf.getServerCert(), conf.getClientCert(), conf.getClientKey(),
                 saltClientConfig.getSaltPassword(), saltClientConfig.getSaltBootPassword(), saltClientConfig.getSignatureKeyPem(),
                 knoxGatewayEnabled, InstanceMetadataType.GATEWAY_PRIMARY.equals(gatewayInstance.getInstanceMetadataType()),
                 new String(decodeBase64(saltSignPrivateKeyB64)), new String(decodeBase64(saltSecurityConfig.getSaltSignPublicKey())));

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/model/GatewayConfig.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/model/GatewayConfig.java
@@ -19,6 +19,8 @@ public class GatewayConfig {
 
     private final Integer gatewayPort;
 
+    private final String instanceId;
+
     private final String saltPassword;
 
     private final String saltBootPassword;
@@ -34,19 +36,20 @@ public class GatewayConfig {
     private final String saltSignPublicKey;
 
     public GatewayConfig(String connectionAddress, String publicAddress, String privateAddress,
-            Integer gatewayPort, Boolean knoxGatewayEnabled) {
+            Integer gatewayPort, String instanceId, Boolean knoxGatewayEnabled) {
         this(connectionAddress, publicAddress, privateAddress, null, gatewayPort,
-                null, null, null, null, null, null, knoxGatewayEnabled, true, null, null);
+                instanceId, null, null, null, null, null, null, knoxGatewayEnabled, true, null, null);
     }
 
     public GatewayConfig(String connectionAddress, String publicAddress, String privateAddress, String hostname,
-            Integer gatewayPort, String serverCert, String clientCert, String clientKey, String saltPassword, String saltBootPassword,
+            Integer gatewayPort, String instanceId, String serverCert, String clientCert, String clientKey, String saltPassword, String saltBootPassword,
             String signatureKey, Boolean knoxGatewayEnabled, boolean primary, String saltSignPrivateKey, String saltSignPublicKey) {
         this.connectionAddress = connectionAddress;
         this.publicAddress = publicAddress;
         this.privateAddress = privateAddress;
         this.hostname = hostname;
         this.gatewayPort = gatewayPort;
+        this.instanceId = instanceId;
         this.serverCert = serverCert;
         this.clientCert = clientCert;
         this.clientKey = clientKey;
@@ -77,6 +80,10 @@ public class GatewayConfig {
 
     public String getGatewayUrl() {
         return String.format("https://%s:%d", connectionAddress, gatewayPort);
+    }
+
+    public String getInstanceId() {
+        return instanceId;
     }
 
     public String getServerCert() {
@@ -127,6 +134,7 @@ public class GatewayConfig {
         sb.append(", privateAddress='").append(privateAddress).append('\'');
         sb.append(", hostname='").append(hostname).append('\'');
         sb.append(", gatewayPort=").append(gatewayPort);
+        sb.append(", instanceId=").append(instanceId);
         sb.append(", knoxGatewayEnabled=").append(knoxGatewayEnabled);
         sb.append(", primary=").append(primary);
         sb.append('}');

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestratorTest.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestratorTest.java
@@ -94,7 +94,7 @@ public class SaltOrchestratorTest {
 
     @Before
     public void setUp() throws Exception {
-        gatewayConfig = new GatewayConfig("1.1.1.1", "10.0.0.1", "172.16.252.43", "10-0-0-1", 9443, "servercert", "clientcert", "clientkey",
+        gatewayConfig = new GatewayConfig("1.1.1.1", "10.0.0.1", "172.16.252.43", "10-0-0-1", 9443, "instanceid", "servercert", "clientcert", "clientkey",
                 "saltpasswd", "saltbootpassword", "signkey", false, true, "privatekey", "publickey");
         targets = new HashSet<>();
         targets.add(new Node("10.0.0.1", "1.1.1.1", "10-0-0-1.example.com", "hg"));

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/SaltBootstrapTest.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/SaltBootstrapTest.java
@@ -46,7 +46,7 @@ public class SaltBootstrapTest {
     public void setUp() {
         saltConnector = mock(SaltConnector.class);
         gatewayConfig = new GatewayConfig("1.1.1.1", "10.0.0.1", "172.16.252.43",
-                "10-0-0-1.example.com", 9443, "serverCert", "clientCert", "clientKey",
+                "10-0-0-1.example.com", 9443, "instanceId", "serverCert", "clientCert", "clientKey",
                 "saltpasswd", "saltbootpassword", "signkey", false, true, null, null);
 
         GenericResponse response = new GenericResponse();


### PR DESCRIPTION
With these changes, the provider-specific instance id has been
propagated to the gateway config, in preparation for its use as a unique identifier by the CCM registration/lookup process.
