### PR TITLE
CDPD-1220. Hive on MR does not start

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-mart.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-mart.bp
@@ -71,7 +71,7 @@
             "configs": [
               {
                 "name": "hs2_execution_engine",
-                "value": "mr"
+                "value": "spark"
               }
             ],
             "base": true
@@ -111,6 +111,22 @@
         ]
       },
       {
+        "refName": "spark_on_yarn",
+        "serviceType": "SPARK_ON_YARN",
+        "roleConfigGroups": [
+          {
+            "refName": "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+            "roleType": "SPARK_YARN_HISTORY_SERVER",
+            "base": true
+          },
+          {
+            "refName": "spark_on_yarn-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          }
+        ]
+      },
+      {
         "refName": "impala",
         "serviceType": "IMPALA",
         "roleConfigGroups": [
@@ -135,6 +151,7 @@
     "hostTemplates": [
       {
         "refName": "master",
+        "cardinality": 1,
         "roleConfigGroupsRefNames": [
           "hdfs-BALANCER-BASE",
           "hdfs-NAMENODE-BASE",
@@ -147,23 +164,28 @@
           "impala-CATALOGSERVER-BASE",
           "impala-STATESTORE-BASE",
           "oozie-OOZIE_SERVER-BASE",
+          "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
           "yarn-JOBHISTORY-BASE",
           "yarn-RESOURCEMANAGER-BASE"
         ]
       },
       {
         "refName": "worker",
+        "cardinality": 1,
         "roleConfigGroupsRefNames": [
           "hdfs-DATANODE-BASE",
           "hive-GATEWAY-BASE",
           "impala-IMPALAD-BASE",
+          "spark_on_yarn-GATEWAY-BASE",
           "yarn-NODEMANAGER-WORKER"
         ]
       },
       {
         "refName": "compute",
+        "cardinality": 0,
         "roleConfigGroupsRefNames": [
           "hive-GATEWAY-BASE",
+          "spark_on_yarn-GATEWAY-BASE",
           "yarn-NODEMANAGER-COMPUTE"
         ]
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Replace `mr` execution engine with `spark` in Data Mart template, because HiveServer2 fails to start due to: `IllegalArgumentException: mr execution engine is not supported`.
2. Specify `cardinality`.

## How was this patch tested?

Deployed cluster, verified HiveServer2 is up and running.