### PR TITLE
CB-1772 Handle and generate request ID in redbeams

### DIFF
--- a/redbeams/src/main/java/com/sequenceiq/redbeams/authorization/PermissionCheckingUtils.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/authorization/PermissionCheckingUtils.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.redbeams.authorization;
 
+import com.sequenceiq.redbeams.service.ThreadBasedRequestIdProvider;
+
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
@@ -20,6 +22,9 @@ import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
 public class PermissionCheckingUtils {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PermissionCheckingUtils.class);
+
+    @Inject
+    private ThreadBasedRequestIdProvider threadBasedRequestIdProvider;
 
     @Inject
     private GrpcUmsClient grpcUmsClient;
@@ -49,7 +54,9 @@ public class PermissionCheckingUtils {
             String resourceCrn = ((CrnResource) resource).getResourceCrn().toString();
 
             LOGGER.info("Checking permissions on " + resourceCrn + " for user " + userCrn);
-            if (!grpcUmsClient.checkRight(userCrn, action.name(), resourceCrn, "notyet")) {
+            String requestId = threadBasedRequestIdProvider.getRequestId();
+            LOGGER.debug("- tracking with request ID {}", requestId);
+            if (!grpcUmsClient.checkRight(userCrn, action.name(), resourceCrn, requestId)) {
                 deniedResourceCrns.add(resourceCrn);
             }
         }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/AppConfig.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/AppConfig.java
@@ -4,10 +4,12 @@ import java.io.IOException;
 import java.security.Security;
 
 import javax.annotation.PostConstruct;
+import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.ResourceLoaderAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,12 +19,23 @@ import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import com.sequenceiq.cloudbreak.concurrent.MDCCleanerTaskDecorator;
+import com.sequenceiq.redbeams.filter.RequestIdFilter;
+import com.sequenceiq.redbeams.filter.RequestIdGeneratingFilter;
+import com.sequenceiq.redbeams.service.ThreadBasedRequestIdProvider;
 
 @Configuration
 @EnableRetry
 public class AppConfig implements ResourceLoaderAware {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AppConfig.class);
+
+    // from com.sequenceiq.cloudbreak.auth.filter.AuthFilterConfiguration
+    // redbeams should probably control this itself
+    // private static final int BEAN_ORDER_CRN_FILTER = 0;
+
+    private static final int BEAN_ORDER_REQUEST_ID_GENERATING_FILTER = 100;
+
+    private static final int BEAN_ORDER_REQUEST_ID_FILTER = 110;
 
     @Value("${redbeams.etc.config.dir}")
     private String etcConfigDir;
@@ -93,6 +106,9 @@ public class AppConfig implements ResourceLoaderAware {
     // @Inject
     // private List<EnvironmentNetworkValidator> environmentNetworkValidators;
 
+    @Inject
+    private ThreadBasedRequestIdProvider threadBasedRequestIdProvider;
+
     private ResourceLoader resourceLoader;
 
     @PostConstruct
@@ -138,6 +154,24 @@ public class AppConfig implements ResourceLoaderAware {
     //     registration.setName("turnOnStackUnderOperationService");
     //     return registration;
     // }
+
+    @Bean
+    public FilterRegistrationBean<RequestIdGeneratingFilter> requestIdGeneratingFilterRegistrationBean() {
+        FilterRegistrationBean<RequestIdGeneratingFilter> registrationBean = new FilterRegistrationBean<>();
+        RequestIdGeneratingFilter filter = new RequestIdGeneratingFilter();
+        registrationBean.setFilter(filter);
+        registrationBean.setOrder(BEAN_ORDER_REQUEST_ID_GENERATING_FILTER);
+        return registrationBean;
+    }
+
+    @Bean
+    public FilterRegistrationBean<RequestIdFilter> requestIdFilterRegistrationBean() {
+        FilterRegistrationBean<RequestIdFilter> registrationBean = new FilterRegistrationBean<>();
+        RequestIdFilter filter = new RequestIdFilter(threadBasedRequestIdProvider);
+        registrationBean.setFilter(filter);
+        registrationBean.setOrder(BEAN_ORDER_REQUEST_ID_FILTER);
+        return registrationBean;
+    }
 
     // @Bean
     // public Map<String, ContainerOrchestrator> containerOrchestrators() {

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/filter/RequestIdFilter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/filter/RequestIdFilter.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.redbeams.filter;
+
+import com.sequenceiq.redbeams.service.ThreadBasedRequestIdProvider;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * A filter that sets the value of the request ID header in a thread-local.
+ */
+public class RequestIdFilter extends OncePerRequestFilter {
+
+    private final ThreadBasedRequestIdProvider threadBasedRequestIdProvider;
+
+    public RequestIdFilter(ThreadBasedRequestIdProvider threadBasedRequestIdProvider) {
+        this.threadBasedRequestIdProvider = threadBasedRequestIdProvider;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+        String requestId = request.getHeader("x-cdp-request-id");
+        threadBasedRequestIdProvider.setRequestId(requestId);
+        filterChain.doFilter(request, response);
+        threadBasedRequestIdProvider.removeRequestId();
+    }
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/filter/RequestIdGeneratingFilter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/filter/RequestIdGeneratingFilter.java
@@ -1,0 +1,78 @@
+package com.sequenceiq.redbeams.filter;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.UUID;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * A filter that generates a new request ID and sets it as a request header,
+ * but only if a request ID is not already present.
+ */
+public class RequestIdGeneratingFilter extends OncePerRequestFilter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RequestIdGeneratingFilter.class);
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+        HttpServletRequestWrapper wrapper = new RequestIdHeaderInjectingHttpRequestWrapper(request);
+        filterChain.doFilter(wrapper, response);
+    }
+
+    @VisibleForTesting
+    static class RequestIdHeaderInjectingHttpRequestWrapper extends HttpServletRequestWrapper {
+
+        @VisibleForTesting
+        static final String REQUEST_ID_HEADER = "x-cdp-request-id";
+
+        private final String requestId;
+
+        private final boolean generatedRequestId;
+
+        RequestIdHeaderInjectingHttpRequestWrapper(HttpServletRequest request) {
+            super(request);
+
+            String requestIdHeader = request.getHeader(REQUEST_ID_HEADER);
+            generatedRequestId = StringUtils.isEmpty(requestIdHeader);
+            if (generatedRequestId) {
+                requestId = UUID.randomUUID().toString();
+                LOGGER.info("No request ID in request, created one: {}", requestId);
+            } else {
+                requestId = requestIdHeader;
+            }
+        }
+
+        @Override
+        public String getHeader(String name) {
+            return REQUEST_ID_HEADER.equals(name) ? requestId : super.getHeader(name);
+        }
+
+        @Override
+        public Enumeration<String> getHeaderNames() {
+            List<String> names = Collections.list(super.getHeaderNames());
+            if (generatedRequestId) {
+                names.add(REQUEST_ID_HEADER);
+            }
+            return Collections.enumeration(names);
+        }
+
+        @Override
+        public Enumeration<String> getHeaders(String name) {
+            return REQUEST_ID_HEADER.equals(name) ? Collections.enumeration(List.of(requestId)) : super.getHeaders(name);
+        }
+    }
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/ThreadBasedRequestIdProvider.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/ThreadBasedRequestIdProvider.java
@@ -1,0 +1,24 @@
+package com.sequenceiq.redbeams.service;
+
+import javax.annotation.Nullable;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class ThreadBasedRequestIdProvider {
+
+    private static final ThreadLocal<String> REQUEST_ID = new ThreadLocal<>();
+
+    @Nullable
+    public String getRequestId() {
+        return REQUEST_ID.get();
+    }
+
+    public void setRequestId(String requestId) {
+        REQUEST_ID.set(requestId);
+    }
+
+    public void removeRequestId() {
+        REQUEST_ID.remove();
+    }
+}

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/authorization/PermissionCheckingUtilsTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/authorization/PermissionCheckingUtilsTest.java
@@ -1,7 +1,5 @@
 package com.sequenceiq.redbeams.authorization;
 
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -10,6 +8,7 @@ import com.google.common.collect.ImmutableSet;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
 import com.sequenceiq.redbeams.domain.DatabaseConfig;
+import com.sequenceiq.redbeams.service.ThreadBasedRequestIdProvider;
 
 import java.util.Optional;
 
@@ -25,11 +24,16 @@ public class PermissionCheckingUtilsTest {
 
     private static final String USER_CRN = "crn:altus:iam:us-west-1:cloudera:user:bob@cloudera.com";
 
+    private static final String REQUEST_ID = "requestId1";
+
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
     @InjectMocks
     private PermissionCheckingUtils underTest;
+
+    @Mock
+    private ThreadBasedRequestIdProvider threadBasedRequestIdProvider;
 
     @Mock
     private GrpcUmsClient grpcUmsClient;
@@ -41,6 +45,8 @@ public class PermissionCheckingUtilsTest {
     @Before
     public void setUp() {
         initMocks(this);
+
+        when(threadBasedRequestIdProvider.getRequestId()).thenReturn(REQUEST_ID);
 
         db = new DatabaseConfig();
         db.setId(1L);
@@ -60,18 +66,18 @@ public class PermissionCheckingUtilsTest {
 
     @Test
     public void testCheckPermissionsByTargetSinglePass() {
-        when(grpcUmsClient.checkRight(eq(USER_CRN), eq(ResourceAction.READ.name()), eq(db.getResourceCrn().toString()), any(String.class)))
+        when(grpcUmsClient.checkRight(USER_CRN, ResourceAction.READ.name(), db.getResourceCrn().toString(), REQUEST_ID))
             .thenReturn(true);
 
         underTest.checkPermissionsByTarget(db, USER_CRN, ResourceAction.READ);
 
-        verify(grpcUmsClient).checkRight(eq(USER_CRN), eq(ResourceAction.READ.name()), eq(db.getResourceCrn().toString()), any(String.class));
+        verify(grpcUmsClient).checkRight(USER_CRN, ResourceAction.READ.name(), db.getResourceCrn().toString(), REQUEST_ID);
     }
 
     @Test
     public void testCheckPermissionsByTargetSingleFail() {
         thrown.expect(AccessDeniedException.class);
-        when(grpcUmsClient.checkRight(eq(USER_CRN), eq(ResourceAction.READ.name()), eq(db.getResourceCrn().toString()), any(String.class)))
+        when(grpcUmsClient.checkRight(USER_CRN, ResourceAction.READ.name(), db.getResourceCrn().toString(), REQUEST_ID))
             .thenReturn(false);
 
         underTest.checkPermissionsByTarget(db, USER_CRN, ResourceAction.READ);
@@ -79,18 +85,18 @@ public class PermissionCheckingUtilsTest {
 
     @Test
     public void testCheckPermissionsByTargetSingleOptionalPass() {
-        when(grpcUmsClient.checkRight(eq(USER_CRN), eq(ResourceAction.READ.name()), eq(db.getResourceCrn().toString()), any(String.class)))
+        when(grpcUmsClient.checkRight(USER_CRN, ResourceAction.READ.name(), db.getResourceCrn().toString(), REQUEST_ID))
             .thenReturn(true);
 
         underTest.checkPermissionsByTarget(Optional.of(db), USER_CRN, ResourceAction.READ);
 
-        verify(grpcUmsClient).checkRight(eq(USER_CRN), eq(ResourceAction.READ.name()), eq(db.getResourceCrn().toString()), any(String.class));
+        verify(grpcUmsClient).checkRight(USER_CRN, ResourceAction.READ.name(), db.getResourceCrn().toString(), REQUEST_ID);
     }
 
     @Test
     public void testCheckPermissionsByTargetSingleOptionalFail() {
         thrown.expect(AccessDeniedException.class);
-        when(grpcUmsClient.checkRight(eq(USER_CRN), eq(ResourceAction.READ.name()), eq(db.getResourceCrn().toString()), any(String.class)))
+        when(grpcUmsClient.checkRight(USER_CRN, ResourceAction.READ.name(), db.getResourceCrn().toString(), REQUEST_ID))
             .thenReturn(false);
 
         underTest.checkPermissionsByTarget(Optional.of(db), USER_CRN, ResourceAction.READ);
@@ -103,23 +109,23 @@ public class PermissionCheckingUtilsTest {
 
     @Test
     public void testCheckPermissionsByTargetLeelooDallasMultiPass() {
-        when(grpcUmsClient.checkRight(eq(USER_CRN), eq(ResourceAction.READ.name()), eq(db.getResourceCrn().toString()), any(String.class)))
+        when(grpcUmsClient.checkRight(USER_CRN, ResourceAction.READ.name(), db.getResourceCrn().toString(), REQUEST_ID))
             .thenReturn(true);
-        when(grpcUmsClient.checkRight(eq(USER_CRN), eq(ResourceAction.READ.name()), eq(db2.getResourceCrn().toString()), any(String.class)))
+        when(grpcUmsClient.checkRight(USER_CRN, ResourceAction.READ.name(), db2.getResourceCrn().toString(), REQUEST_ID))
             .thenReturn(true);
 
         underTest.checkPermissionsByTarget(ImmutableSet.of(db, db2), USER_CRN, ResourceAction.READ);
 
-        verify(grpcUmsClient).checkRight(eq(USER_CRN), eq(ResourceAction.READ.name()), eq(db.getResourceCrn().toString()), any(String.class));
-        verify(grpcUmsClient).checkRight(eq(USER_CRN), eq(ResourceAction.READ.name()), eq(db2.getResourceCrn().toString()), any(String.class));
+        verify(grpcUmsClient).checkRight(USER_CRN, ResourceAction.READ.name(), db.getResourceCrn().toString(), REQUEST_ID);
+        verify(grpcUmsClient).checkRight(USER_CRN, ResourceAction.READ.name(), db2.getResourceCrn().toString(), REQUEST_ID);
     }
 
     @Test
     public void testCheckPermissionsByTargetMultiFail() {
         thrown.expect(AccessDeniedException.class);
-        when(grpcUmsClient.checkRight(eq(USER_CRN), eq(ResourceAction.READ.name()), eq(db.getResourceCrn().toString()), any(String.class)))
+        when(grpcUmsClient.checkRight(USER_CRN, ResourceAction.READ.name(), db.getResourceCrn().toString(), REQUEST_ID))
             .thenReturn(false);
-        when(grpcUmsClient.checkRight(eq(USER_CRN), eq(ResourceAction.READ.name()), eq(db2.getResourceCrn().toString()), any(String.class)))
+        when(grpcUmsClient.checkRight(USER_CRN, ResourceAction.READ.name(), db2.getResourceCrn().toString(), REQUEST_ID))
             .thenReturn(true);
 
         underTest.checkPermissionsByTarget(ImmutableSet.of(db, db2), USER_CRN, ResourceAction.READ);

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/filter/RequestIdFilterTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/filter/RequestIdFilterTest.java
@@ -1,0 +1,58 @@
+package com.sequenceiq.redbeams.filter;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import com.sequenceiq.redbeams.service.ThreadBasedRequestIdProvider;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+
+public class RequestIdFilterTest {
+
+    private static final String REQUEST_ID = "requestId1";
+
+    private RequestIdFilter underTest;
+
+    @Mock
+    private ThreadBasedRequestIdProvider threadBasedRequestIdProvider;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+
+        underTest = new RequestIdFilter(threadBasedRequestIdProvider);
+    }
+
+    @Test
+    public void testDoFilterInternal() throws IOException, ServletException {
+        when(request.getHeader("x-cdp-request-id")).thenReturn(REQUEST_ID);
+
+        underTest.doFilterInternal(request, response, filterChain);
+
+        InOrder inOrder = inOrder(threadBasedRequestIdProvider, filterChain);
+        inOrder.verify(threadBasedRequestIdProvider).setRequestId(REQUEST_ID);
+        inOrder.verify(filterChain).doFilter(request, response);
+        inOrder.verify(threadBasedRequestIdProvider).removeRequestId();
+    }
+
+}

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/filter/RequestIdGeneratingFilterTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/filter/RequestIdGeneratingFilterTest.java
@@ -1,0 +1,125 @@
+package com.sequenceiq.redbeams.filter;
+
+import static com.sequenceiq.redbeams.filter.RequestIdGeneratingFilter.RequestIdHeaderInjectingHttpRequestWrapper.REQUEST_ID_HEADER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import com.sequenceiq.redbeams.filter.RequestIdGeneratingFilter.RequestIdHeaderInjectingHttpRequestWrapper;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+
+public class RequestIdGeneratingFilterTest {
+
+    private static final String REQUEST_ID = "requestId1";
+
+    private RequestIdGeneratingFilter underTest;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+
+        underTest = new RequestIdGeneratingFilter();
+    }
+
+    @Test
+    public void testDoFilterInternal() throws IOException, ServletException {
+        underTest.doFilterInternal(request, response, filterChain);
+
+        ArgumentCaptor<HttpServletRequest> captor = ArgumentCaptor.forClass(HttpServletRequest.class);
+        verify(filterChain).doFilter(captor.capture(), eq(response));
+
+        HttpServletRequest wrapper = captor.getValue();
+        assertTrue(wrapper instanceof RequestIdHeaderInjectingHttpRequestWrapper);
+        assertEquals(request, ((RequestIdHeaderInjectingHttpRequestWrapper) wrapper).getRequest());
+    }
+
+    @Test
+    public void testWrapperInjecting() {
+        when(request.getHeader(REQUEST_ID_HEADER)).thenReturn(null);
+        when(request.getHeader("foo")).thenReturn("bar");
+        when(request.getHeader("x")).thenReturn(null);
+        when(request.getHeaderNames()).thenReturn(Collections.enumeration(List.of("foo")));
+        when(request.getHeaders("foo")).thenReturn(Collections.enumeration(List.of("bar")));
+        when(request.getHeaders("x")).thenReturn(Collections.emptyEnumeration());
+
+        HttpServletRequest wrapper = new RequestIdHeaderInjectingHttpRequestWrapper(request);
+
+        String generatedRequestId = wrapper.getHeader(REQUEST_ID_HEADER);
+        assertNotNull(generatedRequestId);
+        assertNotEquals("bar", generatedRequestId);
+        assertEquals("bar", wrapper.getHeader("foo"));
+        assertNull(wrapper.getHeader("x"));
+
+        List<String> headerNames = Collections.list(wrapper.getHeaderNames());
+        assertTrue(headerNames.contains(REQUEST_ID_HEADER));
+        assertTrue(headerNames.contains("foo"));
+        assertFalse(headerNames.contains("x"));
+
+        List<String> headerValues = Collections.list(wrapper.getHeaders(REQUEST_ID_HEADER));
+        assertEquals(List.of(generatedRequestId), headerValues);
+        headerValues = Collections.list(wrapper.getHeaders("foo"));
+        assertEquals(List.of("bar"), headerValues);
+        headerValues = Collections.list(wrapper.getHeaders("x"));
+        assertTrue(headerValues.isEmpty());
+    }
+
+    @Test
+    public void testWrapperNotInjecting() {
+        when(request.getHeader(REQUEST_ID_HEADER)).thenReturn(REQUEST_ID);
+        when(request.getHeader("foo")).thenReturn("bar");
+        when(request.getHeader("x")).thenReturn(null);
+        when(request.getHeaderNames()).thenReturn(Collections.enumeration(List.of(REQUEST_ID_HEADER, "foo")));
+        when(request.getHeaders(REQUEST_ID_HEADER)).thenReturn(Collections.enumeration(List.of(REQUEST_ID)));
+        when(request.getHeaders("foo")).thenReturn(Collections.enumeration(List.of("bar")));
+        when(request.getHeaders("x")).thenReturn(Collections.emptyEnumeration());
+
+        HttpServletRequest wrapper = new RequestIdHeaderInjectingHttpRequestWrapper(request);
+
+        String requestId = wrapper.getHeader(REQUEST_ID_HEADER);
+        assertEquals(REQUEST_ID, requestId);
+        assertEquals("bar", wrapper.getHeader("foo"));
+        assertNull(wrapper.getHeader("x"));
+
+        List<String> headerNames = Collections.list(wrapper.getHeaderNames());
+        assertTrue(headerNames.contains(REQUEST_ID_HEADER));
+        assertTrue(headerNames.contains("foo"));
+        assertFalse(headerNames.contains("x"));
+
+        List<String> headerValues = Collections.list(wrapper.getHeaders(REQUEST_ID_HEADER));
+        assertEquals(List.of(requestId), headerValues);
+        headerValues = Collections.list(wrapper.getHeaders("foo"));
+        assertEquals(List.of("bar"), headerValues);
+        headerValues = Collections.list(wrapper.getHeaders("x"));
+        assertTrue(headerValues.isEmpty());
+    }
+
+}


### PR DESCRIPTION
Two new web filters in redbeams deal with request IDs.

* RequestIdGeneratingFilter looks for an x-cdp-request-id header in an
  incoming request and, if absent, generates one with a random UUID for
  a value. This ensures that every request has a request ID.
* RequestIdFilter saves the request ID in the x-cdp-request-id header in
  a thread-local variable hosted by ThreadBasedRequestIdProvider. This
  makes the request ID available to business logic.

PermissionCheckingUtils gets the request ID from the thread-local
provider to pass in UMS calls, instead of the former stub value.

The redbeams AppConfig class registers the two new web filters. The
generating filter is ordered first, so that the other filter can see
the request ID it might generate.

Unlike other services, this request ID handling is not coupled with
logging. (See MDCContextFilter elsewhere to compare). However, later
work can still extract the request ID, generated or not, to include in
the MDC.