### PR TITLE
CB-1816. Add CCM endpoint infrastructure.

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/AbstractServiceFamily.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/AbstractServiceFamily.java
@@ -1,0 +1,55 @@
+package com.sequenceiq.cloudbreak.ccm.endpoint;
+
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Abstract service family implementation.
+ *
+ * @param <T> the type of service endpoint used by the family
+ */
+public abstract class AbstractServiceFamily<T extends ServiceEndpoint> implements ServiceFamily<T> {
+
+    /**
+     * The default port for the service.
+     */
+    private final int defaultPort;
+
+    /**
+     * The optional known service identifier for tunneling.
+     */
+    private final KnownServiceIdentifier knownServiceIdentifier;
+
+    /**
+     * Creates an abstract service family with the specified parameters.
+     *
+     * @param defaultPort the default port for the service
+     */
+    public AbstractServiceFamily(int defaultPort) {
+        this(defaultPort, null);
+    }
+
+    /**
+     * Creates an abstract service family with the specified parameters.
+     *
+     * @param defaultPort            the default port for the service
+     * @param knownServiceIdentifier the optional known service identifier for tunneling
+     */
+    protected AbstractServiceFamily(int defaultPort, @Nullable KnownServiceIdentifier knownServiceIdentifier) {
+        this.defaultPort = defaultPort;
+        this.knownServiceIdentifier = knownServiceIdentifier;
+    }
+
+    @Override
+    public int getDefaultPort() {
+        return defaultPort;
+    }
+
+    @Nonnull
+    @Override
+    public Optional<KnownServiceIdentifier> getKnownServiceIdentifier() {
+        return Optional.ofNullable(knownServiceIdentifier);
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/BaseServiceEndpoint.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/BaseServiceEndpoint.java
@@ -1,0 +1,129 @@
+package com.sequenceiq.cloudbreak.ccm.endpoint;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Base class for service endpoint implementations.
+ */
+public class BaseServiceEndpoint implements ServiceEndpoint, Serializable {
+
+    /**
+     * The dummy port for URI construction.
+     */
+    private static final int DUMMY_PORT = -1;
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The host endpoint.
+     */
+    private final HostEndpoint hostEndpoint;
+
+    /**
+     * The optional port.
+     */
+    private final Integer port;
+
+    /**
+     * The optional URI for connecting to the endpoint.
+     */
+    private final URI uri;
+
+    /**
+     * Creates a base service endpoint with the specified parameters.
+     *
+     * @param hostEndpoint the host endpoint
+     */
+    public BaseServiceEndpoint(@Nonnull HostEndpoint hostEndpoint) {
+        this(hostEndpoint, null, null);
+    }
+
+    /**
+     * Creates a base service endpoint with the specified parameters.
+     *
+     * @param hostEndpoint the host endpoint
+     * @param port         the optional port
+     * @param uri          the optional URI
+     */
+    public BaseServiceEndpoint(@Nonnull HostEndpoint hostEndpoint, @Nullable Integer port, @Nullable URI uri) {
+        this.hostEndpoint =
+                Objects.requireNonNull(hostEndpoint, "hostEndpoint is null");
+        this.port = port;
+        this.uri = uri;
+    }
+
+    /**
+     * Returns a default URI for the specified parameters.
+     *
+     * @param scheme       the scheme
+     * @param hostEndpoint the host endpoint
+     * @param port         the optional port
+     * @return a default URI for the specified parameters
+     */
+    protected static URI getDefaultURI(@Nonnull String scheme, @Nonnull HostEndpoint hostEndpoint, @Nullable Integer port) {
+        try {
+            return new URI(Objects.requireNonNull(scheme, "scheme is null"), null,
+                    Objects.requireNonNull(hostEndpoint, "hostEndpoint is null").getHostAddressString(),
+                    (port == null) ? DUMMY_PORT : port, null, null, null);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Cannot build URI for scheme: " + scheme + ", hostEndpoint: " + hostEndpoint + ", port: " + port, e);
+        }
+    }
+
+    @Override
+    public HostEndpoint getHostEndpoint() {
+        return hostEndpoint;
+    }
+
+    @Override
+    public Optional<Integer> getPort() {
+        return Optional.ofNullable(port);
+    }
+
+    @Override
+    public Optional<URI> getURI() {
+        return Optional.ofNullable(uri);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        BaseServiceEndpoint that = (BaseServiceEndpoint) o;
+
+        if (!hostEndpoint.equals(that.hostEndpoint)) {
+            return false;
+        }
+        if (!Objects.equals(port, that.port)) {
+            return false;
+        }
+        return Objects.equals(uri, that.uri);
+
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(hostEndpoint, port, uri);
+    }
+
+    @Override
+    public String toString() {
+        return "BaseServiceEndpoint{"
+                + "hostEndpoint=" + hostEndpoint
+                + ((port == null) ? "" : ", port=" + port)
+                + ((uri == null) ? "" : ", uri=" + uri)
+                + '}';
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/DirectServiceEndpointFinder.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/DirectServiceEndpointFinder.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.cloudbreak.ccm.endpoint;
+
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+
+/**
+ * An endpoint finder that returns an endpoint based on a direct connection to the target instance on the
+ * default port for the requested service family.
+ */
+public class DirectServiceEndpointFinder implements ServiceEndpointFinder {
+
+    @Nonnull
+    @Override
+    public <T extends ServiceEndpoint> T getServiceEndpoint(@Nonnull ServiceEndpointRequest<T> serviceEndpointRequest) {
+
+        final Optional<HostEndpoint> hostEndpoint = serviceEndpointRequest.getTargetInstance().getHostEndpoint();
+        if (!hostEndpoint.isPresent()) {
+            throw new IllegalArgumentException("No host endpoint provided");
+        }
+
+        ServiceFamily<T> serviceFamily = serviceEndpointRequest.getServiceFamily();
+
+        return serviceFamily.getServiceEndpoint(hostEndpoint.get(), serviceFamily.getDefaultPort());
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/HostEndpoint.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/HostEndpoint.java
@@ -1,0 +1,108 @@
+package com.sequenceiq.cloudbreak.ccm.endpoint;
+
+import java.io.Serializable;
+import java.net.InetAddress;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a host endpoint.
+ */
+@Immutable
+public class HostEndpoint implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The host address string.
+     */
+    private final String hostAddressString;
+
+    /**
+     * The optional resolved host address.
+     */
+    private final InetAddress hostAddress;
+
+    /**
+     * Creates a host endpoint with the specified parameters.
+     *
+     * @param hostAddressString the host address string
+     */
+    public HostEndpoint(@Nonnull String hostAddressString) {
+        this(hostAddressString, null);
+    }
+
+    /**
+     * Creates a host endpoint with the specified parameters.
+     *
+     * @param hostAddressString the host address string
+     * @param hostAddress       the optional resolved host address
+     */
+    @JsonCreator
+    public HostEndpoint(
+            @Nonnull @JsonProperty("hostAddressString") String hostAddressString,
+            @Nullable @JsonProperty("hostAddress") InetAddress hostAddress) {
+        this.hostAddressString =
+                Objects.requireNonNull(hostAddressString, "hostAddressString is null");
+        this.hostAddress = hostAddress;
+    }
+
+    /**
+     * Returns the host address string.
+     *
+     * @return the host address string
+     */
+    @Nonnull
+    public String getHostAddressString() {
+        return hostAddressString;
+    }
+
+    /**
+     * Returns the optional resolved host address.
+     *
+     * @return the optional resolved host address
+     */
+    @Nonnull
+    public Optional<InetAddress> getHostAddress() {
+        return Optional.ofNullable(hostAddress);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        HostEndpoint that = (HostEndpoint) o;
+
+        if (!hostAddressString.equals(that.hostAddressString)) {
+            return false;
+        }
+        return Objects.equals(hostAddress, that.hostAddress);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = hostAddressString.hashCode();
+        result = 31 * result + ((hostAddress == null) ? 0 : hostAddress.hashCode());
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "HostEndpoint{"
+                + "hostAddressString='" + hostAddressString + '\''
+                + ((hostAddress == null) ? "" : ", hostAddress=" + hostAddress)
+                + '}';
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/HttpsServiceEndpoint.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/HttpsServiceEndpoint.java
@@ -1,0 +1,53 @@
+package com.sequenceiq.cloudbreak.ccm.endpoint;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * HTTPS endpoint.
+ */
+public class HttpsServiceEndpoint extends BaseServiceEndpoint {
+
+    /**
+     * The URI scheme.
+     */
+    public static final String SCHEME = "https";
+
+    /**
+     * The default HTTPS port.
+     */
+    public static final int DEFAULT_HTTPS_PORT = 443;
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Creates an HTTPS endpoint with the specified parameters.
+     *
+     * @param hostEndpoint the host endpoint
+     */
+    public HttpsServiceEndpoint(@Nonnull HostEndpoint hostEndpoint) {
+        this(hostEndpoint, (Integer) null);
+    }
+
+    /**
+     * Creates an HTTPS endpoint with the specified parameters.
+     *
+     * @param hostEndpoint the host endpoint
+     * @param portString   the port string
+     */
+    public HttpsServiceEndpoint(@Nonnull HostEndpoint hostEndpoint, @Nullable String portString) {
+        this(hostEndpoint, (portString == null) ? null : Integer.valueOf(portString));
+    }
+
+    /**
+     * Creates an HTTPS endpoint with the specified parameters.
+     *
+     * @param hostEndpoint the host endpoint
+     * @param port         the optional port
+     */
+    public HttpsServiceEndpoint(@Nonnull HostEndpoint hostEndpoint, @Nullable Integer port) {
+        super(hostEndpoint,
+                (port != null) ? port : DEFAULT_HTTPS_PORT,
+                getDefaultURI(SCHEME, hostEndpoint, port));
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/KnownServiceIdentifier.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/KnownServiceIdentifier.java
@@ -1,0 +1,17 @@
+package com.sequenceiq.cloudbreak.ccm.endpoint;
+
+/**
+ * Identifiers for known services.
+ */
+public enum KnownServiceIdentifier {
+
+    /**
+     * A service identifier for the nginx web server that runs on gateway nodes.
+     */
+    GATEWAY,
+
+    /**
+     * A service identifier for the Apache Knox proxy server that runs on gateway nodes.
+     */
+    KNOX;
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/ServiceEndpoint.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/ServiceEndpoint.java
@@ -1,0 +1,83 @@
+package com.sequenceiq.cloudbreak.ccm.endpoint;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Represents a service endpoint.
+ */
+public interface ServiceEndpoint {
+
+    /**
+     * Returns the host endpoint.
+     *
+     * @return the host endpoint
+     */
+    @Nonnull
+    HostEndpoint getHostEndpoint();
+
+    /**
+     * Returns the optional port.
+     *
+     * @return the optional port
+     */
+    @Nonnull
+    Optional<Integer> getPort();
+
+    /**
+     * Returns the optional URI.
+     *
+     * @return the optional URI
+     */
+    @Nonnull
+    Optional<URI> getURI();
+
+    /**
+     * Returns a string representation of this service endpoint consisting of
+     * the host address or address string optionally followed by a colon and the
+     * the service port.
+     *
+     * @return a string representation of this service endpoint consisting of the
+     * host address or address string optionally followed by a colon and the
+     * service port
+     */
+    @Nonnull
+    default String asHostWithOptionalPort() {
+        return asHostWithOptionalPort(null);
+    }
+
+    /**
+     * Returns a string representation of this service endpoint consisting of
+     * the host address or address string optionally followed by a colon and the
+     * service port or the specified default port.
+     *
+     * @param defaultPort the default port if no port is specified in the endpoint
+     * @return a string representation of this service endpoint consisting of the
+     * host address or address string optionally followed by a colon and the
+     * service port
+     */
+    @Nonnull
+    default String asHostWithOptionalPort(@Nullable Integer defaultPort) {
+        StringBuilder buf = new StringBuilder();
+        HostEndpoint hostEndpoint = getHostEndpoint();
+        Optional<InetAddress> optionalHostAddress = hostEndpoint.getHostAddress();
+        if (optionalHostAddress.isPresent()) {
+            buf.append(optionalHostAddress.get().getHostAddress());
+        } else {
+            buf.append(hostEndpoint.getHostAddressString());
+        }
+        Optional<Integer> optionalPort = getPort();
+        if (optionalPort.isPresent()) {
+            buf.append(':');
+            buf.append(optionalPort.get());
+        } else if (defaultPort != null) {
+            buf.append(':');
+            buf.append(defaultPort);
+        }
+        return buf.toString();
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/ServiceEndpointFinder.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/ServiceEndpointFinder.java
@@ -1,0 +1,22 @@
+package com.sequenceiq.cloudbreak.ccm.endpoint;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Lookup service for service endpoints.
+ */
+public interface ServiceEndpointFinder {
+
+    /**
+     * Returns the service endpoint for the specified request.
+     *
+     * @param serviceEndpointRequest the service endpoint request
+     * @return the service endpoint for the specified request, which contains a host, port, and optional URI for reaching
+     * the service, possibly through an intermediary such as an SSH tunnel
+     * @throws ServiceEndpointLookupException if an exception occurs
+     * @throws InterruptedException           if the lookup is interrupted
+     */
+    @Nonnull
+    <T extends ServiceEndpoint> T getServiceEndpoint(@Nonnull ServiceEndpointRequest<T> serviceEndpointRequest)
+            throws ServiceEndpointLookupException, InterruptedException;
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/ServiceEndpointLookupException.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/ServiceEndpointLookupException.java
@@ -1,0 +1,78 @@
+package com.sequenceiq.cloudbreak.ccm.endpoint;
+
+/**
+ * Exception for service endpoint lookup failures.
+ */
+public class ServiceEndpointLookupException extends Exception {
+
+    /**
+     * Whether the exception represents a transient condition.
+     */
+    private final boolean retryable;
+
+    /**
+     * Creates a service endpoint lookup exception.
+     *
+     * @param retryable whether the exception represents a transient condition
+     */
+    public ServiceEndpointLookupException(boolean retryable) {
+        this.retryable = retryable;
+    }
+
+    /**
+     * Creates a service endpoint lookup exception with the specified parameters.
+     *
+     * @param message   the message
+     * @param retryable whether the exception represents a transient condition
+     */
+    public ServiceEndpointLookupException(String message, boolean retryable) {
+        super(message);
+        this.retryable = retryable;
+    }
+
+    /**
+     * Creates a service endpoint lookup exception with the specified parameters.
+     *
+     * @param message   the message
+     * @param cause     the cause
+     * @param retryable whether the exception represents a transient condition
+     */
+    public ServiceEndpointLookupException(String message, Throwable cause, boolean retryable) {
+        super(message, cause);
+        this.retryable = retryable;
+    }
+
+    /**
+     * Creates a service endpoint lookup exception with the specified parameters.
+     *
+     * @param cause     the cause
+     * @param retryable whether the exception represents a transient condition
+     */
+    public ServiceEndpointLookupException(Throwable cause, boolean retryable) {
+        super(cause);
+        this.retryable = retryable;
+    }
+
+    /**
+     * Creates a service endpoint lookup exception with the specified parameters.
+     *
+     * @param message            the message
+     * @param cause              the cause
+     * @param enableSuppression  whether suppression is enabled
+     * @param writableStackTrace whether the stack trace should be writable
+     * @param retryable          whether the exception represents a transient condition
+     */
+    public ServiceEndpointLookupException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace, boolean retryable) {
+        super(message, cause, enableSuppression, writableStackTrace);
+        this.retryable = retryable;
+    }
+
+    /**
+     * \Returns whether the exception represents a transient condition.
+     *
+     * @return whether the exception represents a transient condition
+     */
+    public boolean isRetryable() {
+        return retryable;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/ServiceEndpointRequest.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/ServiceEndpointRequest.java
@@ -1,0 +1,114 @@
+package com.sequenceiq.cloudbreak.ccm.endpoint;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Request for looking up service endpoints.
+ */
+public interface ServiceEndpointRequest<T extends ServiceEndpoint> {
+
+    /**
+     * The default amount of time to wait to fulfill a request, in seconds.
+     */
+    int DEFAULT_WAIT_DURATION_SEC = 30;
+
+    /**
+     * The default polling interval, in milliseconds.
+     */
+    long DEFAULT_POLLING_INTERVAL_MS = 1000L;
+
+    /**
+     * Returns a default service endpoint request for the specified target service.
+     *
+     * @param targetInstanceId the target instance ID
+     * @param hostEndpoint     the optional host endpoint
+     * @param serviceFamily    the service family
+     * @param <T>              the type of endpoint
+     * @return a default service endpoint request for the specified target service
+     */
+    @Nonnull
+    static <T extends ServiceEndpoint> ServiceEndpointRequest<T> createDefaultServiceEndpointRequest(
+            @Nonnull String targetInstanceId, @Nullable HostEndpoint hostEndpoint, @Nonnull ServiceFamily<T> serviceFamily) {
+
+        return new ServiceEndpointRequest<T>() {
+
+            @Override
+            public TargetInstance getTargetInstance() {
+                return new TargetInstance() {
+                    @Nonnull
+                    @Override
+                    public String getTargetInstanceId() {
+                        return targetInstanceId;
+                    }
+
+                    @Nonnull
+                    @Override
+                    public Optional<HostEndpoint> getHostEndpoint() {
+                        return Optional.ofNullable(hostEndpoint);
+                    }
+                };
+            }
+
+            @Override
+            public ServiceFamily<T> getServiceFamily() {
+                return serviceFamily;
+            }
+
+            @Override
+            public Optional<ZonedDateTime> getWaitUntilTime() {
+                return Optional.of(ZonedDateTime.now().plusSeconds(DEFAULT_WAIT_DURATION_SEC));
+            }
+
+            @Override
+            public long getPollingIntervalInMs() {
+                return DEFAULT_POLLING_INTERVAL_MS;
+            }
+        };
+    }
+
+    /**
+     * Returns the target instance.
+     *
+     * @return the target instance
+     */
+    TargetInstance getTargetInstance();
+
+    /**
+     * Returns the service family.
+     *
+     * @return the service family
+     */
+    ServiceFamily<T> getServiceFamily();
+
+    /**
+     * An optional datetime after which the lookup attempt should fail.
+     *
+     * @return the optional timeout
+     */
+    default Optional<ZonedDateTime> getWaitUntilTime() {
+        return Optional.empty();
+    }
+
+    /**
+     * Returns the default polling interval in milliseconds.
+     *
+     * @return the default polling interval in milliseconds
+     */
+    default long getPollingIntervalInMs() {
+        return DEFAULT_POLLING_INTERVAL_MS;
+    }
+
+    /**
+     * Returns whether the lookup should only allow direct access to the target service.
+     *
+     * @return whether the lookup should only allow direct access to the target service
+     */
+    // JSA TODO This is a workaround until we can turn reverse SSH lookup on and off in the environment
+    default boolean isDirectAccessRequired() {
+        return false;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/ServiceFamilies.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/ServiceFamilies.java
@@ -1,0 +1,39 @@
+package com.sequenceiq.cloudbreak.ccm.endpoint;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Provides utilities for dealing with service families.
+ */
+public class ServiceFamilies {
+
+    /**
+     * The service family for nginx web servers on gateways.
+     */
+    public static final ServiceFamily<HttpsServiceEndpoint> GATEWAY =
+            new AbstractServiceFamily<>(9443, KnownServiceIdentifier.GATEWAY) {
+                @Nonnull
+                @Override
+                public HttpsServiceEndpoint getServiceEndpoint(@Nonnull HostEndpoint hostEndpoint, int port) {
+                    return new HttpsServiceEndpoint(hostEndpoint, port);
+                }
+            };
+
+    /**
+     * The service family for Apache Knox proxy servers.
+     */
+    public static final ServiceFamily<HttpsServiceEndpoint> KNOX =
+            new AbstractServiceFamily<>(8443, KnownServiceIdentifier.KNOX) {
+                @Nonnull
+                @Override
+                public HttpsServiceEndpoint getServiceEndpoint(@Nonnull HostEndpoint hostEndpoint, int port) {
+                    return new HttpsServiceEndpoint(hostEndpoint, port);
+                }
+            };
+
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private ServiceFamilies() {
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/ServiceFamily.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/ServiceFamily.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.cloudbreak.ccm.endpoint;
+
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Represents a family of services.
+ *
+ * @param <T> the type of service endpoint used by the family
+ */
+public interface ServiceFamily<T extends ServiceEndpoint> {
+
+    /**
+     * Returns the default port for the service.
+     *
+     * @return the default port for the service
+     */
+    int getDefaultPort();
+
+    /**
+     * Returns the optional known service identifier for tunneling.
+     *
+     * @return the optional known service identifier for tunneling
+     */
+    @Nonnull
+    Optional<KnownServiceIdentifier> getKnownServiceIdentifier();
+
+    /**
+     * Returns a service endpoint for the service.
+     *
+     * @param hostEndpoint the host endpoint
+     * @param port         the port
+     * @return a service endpoint for the service
+     */
+    @Nonnull
+    T getServiceEndpoint(@Nonnull HostEndpoint hostEndpoint, int port);
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/TargetInstance.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/TargetInstance.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.cloudbreak.ccm.endpoint;
+
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Represents a target instance where a service is running.
+ */
+public interface TargetInstance {
+
+    /**
+     * Returns the unique identifier for the target instance.
+     *
+     * @return the unique identifier for the target instance
+     */
+    @Nonnull
+    String getTargetInstanceId();
+
+    /**
+     * The optional host endpoint for the target.
+     *
+     * @return the optional host endpoint for the target
+     */
+    @Nonnull
+    default Optional<HostEndpoint> getHostEndpoint() {
+        return Optional.empty();
+    }
+}

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/model/GatewayConfig.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/model/GatewayConfig.java
@@ -1,5 +1,17 @@
 package com.sequenceiq.cloudbreak.orchestrator.model;
 
+import java.util.Objects;
+
+import javax.annotation.Nonnull;
+
+import com.sequenceiq.cloudbreak.ccm.endpoint.HostEndpoint;
+import com.sequenceiq.cloudbreak.ccm.endpoint.HttpsServiceEndpoint;
+import com.sequenceiq.cloudbreak.ccm.endpoint.ServiceEndpoint;
+import com.sequenceiq.cloudbreak.ccm.endpoint.ServiceEndpointFinder;
+import com.sequenceiq.cloudbreak.ccm.endpoint.ServiceEndpointLookupException;
+import com.sequenceiq.cloudbreak.ccm.endpoint.ServiceEndpointRequest;
+import com.sequenceiq.cloudbreak.ccm.endpoint.ServiceFamilies;
+
 public class GatewayConfig {
 
     // Used by cloudbreak to connect the cluster
@@ -60,6 +72,16 @@ public class GatewayConfig {
         this.primary = primary;
         this.saltSignPrivateKey = saltSignPrivateKey;
         this.saltSignPublicKey = saltSignPublicKey;
+    }
+
+    private GatewayConfig(GatewayConfig gatewayConfig, @Nonnull ServiceEndpoint serviceEndpoint) {
+        this(serviceEndpoint.getHostEndpoint().getHostAddressString(), gatewayConfig.publicAddress, gatewayConfig.privateAddress,
+                gatewayConfig.hostname, Objects.requireNonNull(serviceEndpoint.getPort().orElse(null), "serviceEndpoint port unspecified"),
+                gatewayConfig.instanceId,
+                gatewayConfig.serverCert, gatewayConfig.clientCert, gatewayConfig.clientKey,
+                gatewayConfig.saltPassword, gatewayConfig.saltBootPassword, gatewayConfig.signatureKey,
+                gatewayConfig.knoxGatewayEnabled, gatewayConfig.primary,
+                gatewayConfig.saltSignPrivateKey, gatewayConfig.saltSignPublicKey);
     }
 
     public String getConnectionAddress() {
@@ -126,7 +148,47 @@ public class GatewayConfig {
         return saltSignPublicKey;
     }
 
-    @Override
+    /**
+     * Returns a gateway config for the nginx service on the gateway.
+     * The returned gateway config is identical to this one, except that
+     * its connection address and gateway port (and hence gateway URL)
+     * are determined using the specified service endpoint finder.
+     *
+     * @param serviceEndpointFinder  the service endpoint finder
+     * @return a gateway config for the nginx service on the gateway
+     * @throws ServiceEndpointLookupException if an exception occurs looking up the endpoint
+     * @throws InterruptedException           if the lookup is interrupted
+     */
+    public GatewayConfig getGatewayConfig(ServiceEndpointFinder serviceEndpointFinder)
+            throws ServiceEndpointLookupException, InterruptedException {
+        return new GatewayConfig(this, getServiceEndpoint(serviceEndpointFinder));
+    }
+
+    /**
+     * Returns a service endpoint for the nginx service on the gateway.
+     *
+     * @param serviceEndpointFinder  the service endpoint finder
+     * @return a service endpoint for the nginx service on the gateway
+     * @throws ServiceEndpointLookupException if an exception occurs looking up the endpoint
+     * @throws InterruptedException           if the lookup is interrupted
+     */
+    private HttpsServiceEndpoint getServiceEndpoint(ServiceEndpointFinder serviceEndpointFinder)
+            throws ServiceEndpointLookupException, InterruptedException {
+        ServiceEndpointRequest<HttpsServiceEndpoint> serviceEndpointRequest =
+                createServiceEndpointRequest();
+        return serviceEndpointFinder.getServiceEndpoint(serviceEndpointRequest);
+    }
+
+    /**
+     * Creates a service endpoint request for connecting to the nginx service on the gateway.
+     *
+     * @return a service endpoint request for connecting to the specified service on the gateway
+     */
+    private ServiceEndpointRequest<HttpsServiceEndpoint> createServiceEndpointRequest() {
+        return ServiceEndpointRequest.createDefaultServiceEndpointRequest(
+                instanceId, new HostEndpoint(connectionAddress), ServiceFamilies.GATEWAY);
+    }
+
     public String toString() {
         StringBuilder sb = new StringBuilder("GatewayConfig{");
         sb.append("connectionAddress='").append(connectionAddress).append('\'');


### PR DESCRIPTION
With these changes, CB has classes representing the various
CCM domain objects and finder functionality.

Additionally, the gateway config and salt orchestrator have
been modified to use a service endpoint finder instead of
always connecting directly to the nginx server on the gateway
node.
