### PR TITLE
CB-1837 Augment cloud-api with database support

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/DatabaseEngine.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/DatabaseEngine.java
@@ -1,0 +1,5 @@
+package com.sequenceiq.cloudbreak.cloud.model;
+
+public enum DatabaseEngine {
+    POSTGRESQL
+}

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/DatabaseServer.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/DatabaseServer.java
@@ -1,0 +1,93 @@
+package com.sequenceiq.cloudbreak.cloud.model;
+
+import com.sequenceiq.cloudbreak.cloud.model.generic.DynamicModel;
+
+import java.util.Map;
+
+public class DatabaseServer extends DynamicModel {
+
+    private final String serverId;
+
+    private final String flavor;
+
+    private final DatabaseEngine engine;
+
+    private final String rootUserName;
+
+    private final String rootPassword;
+
+    private final long storageSize;
+
+    private final Security security;
+
+    private final InstanceStatus status;
+
+    public DatabaseServer(String serverId, String flavor, DatabaseEngine engine, String rootUserName, String rootPassword,
+            long storageSize, Security security, InstanceStatus status) {
+        this.serverId = serverId;
+        this.flavor = flavor;
+        this.engine = engine;
+        this.rootUserName = rootUserName;
+        this.rootPassword = rootPassword;
+        this.storageSize = storageSize;
+        this.security = security;
+        this.status = status;
+    }
+
+    public DatabaseServer(String serverId, String flavor, DatabaseEngine engine, String rootUserName, String rootPassword,
+            long storageSize, Security security, InstanceStatus status, Map<String, Object> parameters) {
+        this.serverId = serverId;
+        this.flavor = flavor;
+        this.engine = engine;
+        this.rootUserName = rootUserName;
+        this.rootPassword = rootPassword;
+        this.storageSize = storageSize;
+        this.security = security;
+        this.status = status;
+    }
+
+    public String getServerId() {
+        return serverId;
+    }
+
+    public String getFlavor() {
+        return flavor;
+    }
+
+    public DatabaseEngine getEngine() {
+        return engine;
+    }
+
+    public String getRootUserName() {
+        return rootUserName;
+    }
+
+    public String getRootPassword() {
+        return rootPassword;
+    }
+
+    public long getStorageSize() {
+        return storageSize;
+    }
+
+    public Security getSecurity() {
+        return security;
+    }
+
+    public InstanceStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String toString() {
+        return "DatabaseServer{"
+                + "serverId='" + serverId + '\''
+                + ", flavor='" + flavor + '\''
+                + ", engine='" + engine + '\''
+                + ", rootUserName='" + rootUserName + '\''
+                + ", storageSize=" + storageSize
+                + ", security=" + security
+                + ", status=" + status
+                + '}';
+    }
+}

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/DatabaseStack.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/DatabaseStack.java
@@ -1,0 +1,49 @@
+package com.sequenceiq.cloudbreak.cloud.model;
+
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+
+public class DatabaseStack {
+
+    private final Network network;
+
+    private final DatabaseServer databaseServer;
+
+    private final String template;
+
+    private final Map<String, String> tags;
+
+    public DatabaseStack(Network network, DatabaseServer databaseServer, Map<String, String> tags, String template) {
+        this.network = network;
+        this.databaseServer = databaseServer;
+        this.tags = ImmutableMap.copyOf(tags);
+        this.template = template;
+    }
+
+    public Network getNetwork() {
+        return network;
+    }
+
+    public DatabaseServer getDatabaseServer() {
+        return databaseServer;
+    }
+
+    public String getTemplate() {
+        return template;
+    }
+
+    public Map<String, String> getTags() {
+        return tags;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("DatabaseStack{");
+        sb.append("network=").append(network);
+        sb.append(", databaseServer=").append(databaseServer);
+        sb.append('}');
+        return sb.toString();
+    }
+
+}

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/common/type/ResourceType.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/common/type/ResourceType.java
@@ -14,6 +14,8 @@ public enum ResourceType {
     AWS_LAUNCHCONFIGURATION,
     AWS_VOLUMESET,
     AWS_INSTANCE,
+    RDS_INSTANCE,
+    RDS_DB_SUBNET_GROUP,
 
     // OPENSTACK
     HEAT_STACK(CommonResourceType.TEMPLATE),


### PR DESCRIPTION
Additions to cloud-api lay the groundwork for database server creation
in cloud providers via template.  The new DatabaseStack class
corresponds to the existing CloudStack class, but is intended to
represent the resources for a database server and supporting resources.