### PR TITLE
CB-1837 Add redbeams DBStack and associated entities

### DIFF
--- a/redbeams/src/main/java/com/sequenceiq/redbeams/domain/stack/DBStack.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/domain/stack/DBStack.java
@@ -1,0 +1,129 @@
+package com.sequenceiq.redbeams.domain.stack;
+
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.common.json.JsonToString;
+
+import java.util.Map;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+import javax.persistence.ManyToOne;
+import javax.persistence.MapKeyColumn;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+
+@Entity
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"name", "environment_id"}))
+public class DBStack {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "dbstack_generator")
+    @SequenceGenerator(name = "dbstack_generator", sequenceName = "dbstack_id_seq", allocationSize = 1)
+    private Long id;
+
+    private String name;
+
+    private String displayName;
+
+    @Column(length = 1000000, columnDefinition = "TEXT")
+    private String description;
+
+    @ManyToOne
+    private Network network;
+
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    private DatabaseServer databaseServer;
+
+    @Convert(converter = JsonToString.class)
+    @Column(columnDefinition = "TEXT")
+    private Json tags;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @MapKeyColumn(name = "key")
+    @Column(name = "value", columnDefinition = "TEXT", length = 100000)
+    private Map<String, String> parameters;
+
+    @Column(nullable = false, name = "environment_id")
+    private String environmentId;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Network getNetwork() {
+        return network;
+    }
+
+    public void setNetwork(Network network) {
+        this.network = network;
+    }
+
+    public DatabaseServer getDatabaseServer() {
+        return databaseServer;
+    }
+
+    public void setDatabaseServer(DatabaseServer databaseServer) {
+        this.databaseServer = databaseServer;
+    }
+
+    public Json getTags() {
+        return tags;
+    }
+
+    public void setTags(Json tags) {
+        this.tags = tags;
+    }
+
+    public Map<String, String> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(Map<String, String> parameters) {
+        this.parameters = parameters;
+    }
+
+    public String getEnvironmentId() {
+        return environmentId;
+    }
+
+    public void setEnvironmentId(String environment) {
+        this.environmentId = environment;
+    }
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/domain/stack/DatabaseServer.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/domain/stack/DatabaseServer.java
@@ -1,0 +1,152 @@
+package com.sequenceiq.redbeams.domain.stack;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.common.json.JsonToString;
+import com.sequenceiq.cloudbreak.service.secret.SecretValue;
+import com.sequenceiq.cloudbreak.service.secret.domain.Secret;
+import com.sequenceiq.cloudbreak.service.secret.domain.SecretToString;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+
+@Entity
+@Table
+public class DatabaseServer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "databaseserver_generator")
+    @SequenceGenerator(name = "databaseserver_generator", sequenceName = "databaseserver_id_seq", allocationSize = 1)
+    private Long id;
+
+    private String name;
+
+    @Column(length = 1000000, columnDefinition = "TEXT")
+    private String description;
+
+    private String instanceType;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private DatabaseVendor databaseVendor;
+
+    private Long storageSize;
+
+    @Convert(converter = SecretToString.class)
+    @SecretValue
+    @Column(nullable = false)
+    private Secret rootUserName = Secret.EMPTY;
+
+    @Convert(converter = SecretToString.class)
+    @SecretValue
+    @Column(nullable = false)
+    private Secret rootPassword = Secret.EMPTY;
+
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "securitygroup_id", referencedColumnName = "id")
+    private SecurityGroup securityGroup;
+
+    @Convert(converter = JsonToString.class)
+    @Column(columnDefinition = "TEXT")
+    private Json attributes;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getInstanceType() {
+        return instanceType;
+    }
+
+    public void setInstanceType(String instanceType) {
+        this.instanceType = instanceType;
+    }
+
+    public DatabaseVendor getDatabaseVendor() {
+        return databaseVendor;
+    }
+
+    public void setDatabaseVendor(DatabaseVendor databaseVendor) {
+        this.databaseVendor = databaseVendor;
+    }
+
+    public Long getStorageSize() {
+        return storageSize;
+    }
+
+    public void setStorageSize(Long storageSize) {
+        this.storageSize = storageSize;
+    }
+
+    public String getRootUserName() {
+        return rootUserName.getRaw();
+    }
+
+    public String getRootUserNameSecret() {
+        return rootUserName.getSecret();
+    }
+
+    public void setRootUserName(String rootUserName) {
+        this.rootUserName = new Secret(rootUserName);
+    }
+
+    public String getRootPassword() {
+        return rootPassword.getRaw();
+    }
+
+    public String getRootPasswordSecret() {
+        return rootPassword.getSecret();
+    }
+
+    public void setRootPassword(String rootPassword) {
+        this.rootPassword = new Secret(rootPassword);
+    }
+
+    public SecurityGroup getSecurityGroup() {
+        return securityGroup;
+    }
+
+    public void setSecurityGroup(SecurityGroup securityGroup) {
+        this.securityGroup = securityGroup;
+    }
+
+    public Json getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Json attributes) {
+        this.attributes = attributes;
+    }
+
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/domain/stack/Network.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/domain/stack/Network.java
@@ -1,0 +1,65 @@
+package com.sequenceiq.redbeams.domain.stack;
+
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.common.json.JsonToString;
+
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+
+@Entity
+@Table
+public class Network {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "network_generator")
+    @SequenceGenerator(name = "network_generator", sequenceName = "network_id_seq", allocationSize = 1)
+    private Long id;
+
+    private String name;
+
+    @Column(length = 1000000, columnDefinition = "TEXT")
+    private String description;
+
+    @Convert(converter = JsonToString.class)
+    @Column(columnDefinition = "TEXT")
+    private Json attributes;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Json getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Json attributes) {
+        this.attributes = attributes;
+    }
+
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/domain/stack/SecurityGroup.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/domain/stack/SecurityGroup.java
@@ -1,0 +1,106 @@
+package com.sequenceiq.redbeams.domain.stack;
+
+import java.util.HashSet;
+import java.util.Set;
+
+// import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+// import javax.persistence.EnumType;
+// import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+
+// import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ResourceStatus;
+
+@Entity
+@Table
+public class SecurityGroup {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "securitygroup_generator")
+    @SequenceGenerator(name = "securitygroup_generator", sequenceName = "securitygroup_id_seq", allocationSize = 1)
+    private Long id;
+
+    private String name;
+
+    @Column(length = 1000000, columnDefinition = "TEXT")
+    private String description;
+
+    // @Enumerated(EnumType.STRING)
+    // private ResourceStatus status;
+
+    // @OneToMany(mappedBy = "securityGroup", cascade = {CascadeType.REMOVE, CascadeType.PERSIST}, orphanRemoval = true, fetch = FetchType.EAGER)
+    // private Set<SecurityRule> securityRules = new HashSet<>();
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @Column(name = "securitygroupid_value")
+    private Set<String> securityGroupIds = new HashSet<>();
+
+    // private String cloudPlatform;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    // public ResourceStatus getStatus() {
+    //     return status;
+    // }
+
+    // public void setStatus(ResourceStatus status) {
+    //     this.status = status;
+    // }
+
+    // public Set<SecurityRule> getSecurityRules() {
+    //     return securityRules;
+    // }
+
+    // public void setSecurityRules(Set<SecurityRule> securityRules) {
+    //     this.securityRules = securityRules;
+    // }
+
+    // public String getFirstSecurityGroupId() {
+    //     return securityGroupIds == null || securityGroupIds.isEmpty() ? null : securityGroupIds.iterator().next();
+    // }
+
+    public Set<String> getSecurityGroupIds() {
+        return securityGroupIds;
+    }
+
+    public void setSecurityGroupIds(Set<String> securityGroupIds) {
+        this.securityGroupIds = securityGroupIds;
+    }
+
+    // public String getCloudPlatform() {
+    //     return cloudPlatform;
+    // }
+
+    // public void setCloudPlatform(String cloudPlatform) {
+    //     this.cloudPlatform = cloudPlatform;
+    // }
+}

--- a/redbeams/src/main/resources/schema/app/20190614194213_CB-1837_Add_redbeams_stack_entities.sql
+++ b/redbeams/src/main/resources/schema/app/20190614194213_CB-1837_Add_redbeams_stack_entities.sql
@@ -1,0 +1,115 @@
+-- // CB-1837 Add redbeams stack entities
+-- Migration SQL that makes the change goes here.
+
+CREATE TABLE network
+(
+    id BIGINT NOT NULL,
+    name VARCHAR(255),
+    description TEXT,
+    attributes TEXT,
+    PRIMARY KEY (id)
+);
+
+CREATE SEQUENCE network_id_seq START WITH 1 INCREMENT BY 1 NO MINVALUE NO MAXVALUE CACHE 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS network_id_idx ON network(id);
+CREATE INDEX IF NOT EXISTS network_name_idx ON network(name);
+
+CREATE TABLE securitygroup
+(
+    id BIGINT NOT NULL,
+    name VARCHAR(255),
+    description TEXT,
+    PRIMARY KEY (id)
+);
+
+CREATE SEQUENCE securitygroup_id_seq START WITH 1 INCREMENT BY 1 NO MINVALUE NO MAXVALUE CACHE 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS securitygroup_id_idx ON securitygroup(id);
+CREATE INDEX IF NOT EXISTS securitygroup_name_idx ON securitygroup(name);
+
+CREATE TABLE securitygroup_securitygroupids (
+    securitygroup_id bigint NOT NULL REFERENCES securitygroup (id),
+    securitygroupid_value text
+);
+
+CREATE TABLE databaseserver
+(
+    id BIGINT NOT NULL,
+    name VARCHAR(255),
+    description TEXT,
+    instancetype VARCHAR(255),
+    databasevendor VARCHAR(255),
+    storagesize BIGINT,
+    rootusername VARCHAR(255) NOT NULL,
+    rootpassword VARCHAR(255) NOT NULL,
+    securitygroup_id BIGINT REFERENCES securitygroup (id),
+    attributes TEXT,
+    PRIMARY KEY (id)
+);
+
+CREATE SEQUENCE databaseserver_id_seq START WITH 1 INCREMENT BY 1 NO MINVALUE NO MAXVALUE CACHE 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS databaseserver_id_idx ON databaseserver(id);
+CREATE INDEX IF NOT EXISTS databaseserver_name_idx ON databaseserver(name);
+
+CREATE TABLE dbstack
+(
+    id BIGINT NOT NULL,
+    name VARCHAR(255),
+    displayname VARCHAR(255),
+    description TEXT,
+    network_id BIGINT REFERENCES network (id),
+    databaseserver_id BIGINT REFERENCES databaseserver (id),
+    tags TEXT,
+    environment_id TEXT,
+    PRIMARY KEY (id)
+);
+
+CREATE SEQUENCE dbstack_id_seq START WITH 1 INCREMENT BY 1 NO MINVALUE NO MAXVALUE CACHE 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS dbstack_id_idx ON dbstack(id);
+CREATE INDEX IF NOT EXISTS dbstack_name_idx ON dbstack(name);
+
+CREATE TABLE dbstack_parameters
+(
+    dbstack_id BIGINT NOT NULL REFERENCES dbstack (id),
+    key VARCHAR(255) NOT NULL,
+    value text,
+    PRIMARY KEY (dbstack_id, key)
+);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+DROP TABLE dbstack_parameters;
+
+DROP INDEX IF EXISTS dbstack_name_idx;
+DROP INDEX IF EXISTS dbstack_id_idx;
+
+DROP SEQUENCE IF EXISTS dbstack_id_seq;
+
+DROP TABLE dbstack;
+
+DROP INDEX IF EXISTS databaseserver_name_idx;
+DROP INDEX IF EXISTS databaseserver_id_idx;
+
+DROP SEQUENCE IF EXISTS databaseserver_id_seq;
+
+DROP TABLE databaseserver;
+
+DROP TABLE securitygroup_securitygroupids;
+
+DROP INDEX IF EXISTS securitygroup_name_idx;
+DROP INDEX IF EXISTS securitygroup_id_idx;
+
+DROP SEQUENCE IF EXISTS securitygroup_id_seq;
+
+DROP TABLE securitygroup;
+
+DROP INDEX IF EXISTS network_name_idx;
+DROP INDEX IF EXISTS network_id_idx;
+
+DROP SEQUENCE IF EXISTS network_id_seq;
+
+DROP TABLE network;

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/domain/DatabaseServerConfigTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/domain/DatabaseServerConfigTest.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.redbeams.model;
+package com.sequenceiq.redbeams.domain;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -16,8 +16,6 @@ import com.sequenceiq.cloudbreak.common.database.DatabaseCommon;
 import com.sequenceiq.cloudbreak.workspace.resource.WorkspaceResource;
 import com.sequenceiq.redbeams.TestData;
 import com.sequenceiq.redbeams.api.endpoint.v4.ResourceStatus;
-import com.sequenceiq.redbeams.domain.DatabaseConfig;
-import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
 
 public class DatabaseServerConfigTest {
 

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/domain/stack/DBStackTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/domain/stack/DBStackTest.java
@@ -1,0 +1,60 @@
+package com.sequenceiq.redbeams.domain.stack;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableMap;
+import com.sequenceiq.cloudbreak.common.json.Json;
+
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class DBStackTest {
+
+    private static final Network NETWORK = new Network();
+
+    private static final DatabaseServer SERVER = new DatabaseServer();
+
+    private static final Json TAGS = new Json("{}");
+
+    private static final Map PARAMETERS = ImmutableMap.of("foo", "bar");
+
+    private DBStack dbStack;
+
+    @Before
+    public void setUp() throws Exception {
+        dbStack = new DBStack();
+    }
+
+    @Test
+    public void testGettersAndSetters() {
+        dbStack.setId(1L);
+        assertEquals(1L, dbStack.getId().longValue());
+
+        dbStack.setName("mydbstack");
+        assertEquals("mydbstack", dbStack.getName());
+
+        dbStack.setDisplayName("My DB Stack");
+        assertEquals("My DB Stack", dbStack.getDisplayName());
+
+        dbStack.setDescription("mine not yours");
+        assertEquals("mine not yours", dbStack.getDescription());
+
+        dbStack.setNetwork(NETWORK);
+        assertEquals(NETWORK, dbStack.getNetwork());
+
+        dbStack.setDatabaseServer(SERVER);
+        assertEquals(SERVER, dbStack.getDatabaseServer());
+
+        dbStack.setTags(TAGS);
+        assertEquals(TAGS, dbStack.getTags());
+
+        dbStack.setParameters(PARAMETERS);
+        assertEquals(PARAMETERS, dbStack.getParameters());
+
+        dbStack.setEnvironmentId("myenv");
+        assertEquals("myenv", dbStack.getEnvironmentId());
+    }
+
+}

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/domain/stack/DatabaseServerTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/domain/stack/DatabaseServerTest.java
@@ -1,0 +1,57 @@
+package com.sequenceiq.redbeams.domain.stack;
+
+import static org.junit.Assert.assertEquals;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
+import com.sequenceiq.cloudbreak.common.json.Json;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class DatabaseServerTest {
+
+    private static final SecurityGroup SECURITY_GROUP = new SecurityGroup();
+
+    private static final Json ATTRIBUTES = new Json("{}");
+
+    private DatabaseServer server;
+
+    @Before
+    public void setUp() throws Exception {
+        server = new DatabaseServer();
+    }
+
+    @Test
+    public void testGettersAndSetters() {
+        server.setId(1L);
+        assertEquals(1L, server.getId().longValue());
+
+        server.setName("myserver");
+        assertEquals("myserver", server.getName());
+
+        server.setDescription("mine not yours");
+        assertEquals("mine not yours", server.getDescription());
+
+        server.setInstanceType("db.m3.medium");
+        assertEquals("db.m3.medium", server.getInstanceType());
+
+        server.setDatabaseVendor(DatabaseVendor.POSTGRES);
+        assertEquals(DatabaseVendor.POSTGRES, server.getDatabaseVendor());
+
+        server.setStorageSize(50L);
+        assertEquals(50L, server.getStorageSize().longValue());
+
+        server.setRootUserName("root");
+        assertEquals("root", server.getRootUserName());
+
+        server.setRootPassword("cloudera");
+        assertEquals("cloudera", server.getRootPassword());
+
+        server.setSecurityGroup(SECURITY_GROUP);
+        assertEquals(SECURITY_GROUP, server.getSecurityGroup());
+
+        server.setAttributes(ATTRIBUTES);
+        assertEquals(ATTRIBUTES, server.getAttributes());
+    }
+
+}

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/domain/stack/NetworkTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/domain/stack/NetworkTest.java
@@ -1,0 +1,36 @@
+package com.sequenceiq.redbeams.domain.stack;
+
+import static org.junit.Assert.assertEquals;
+
+import com.sequenceiq.cloudbreak.common.json.Json;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class NetworkTest {
+
+    private static final Json ATTRIBUTES = new Json("{}");
+
+    private Network network;
+
+    @Before
+    public void setUp() throws Exception {
+        network = new Network();
+    }
+
+    @Test
+    public void testGettersAndSetters() {
+        network.setId(1L);
+        assertEquals(1L, network.getId().longValue());
+
+        network.setName("mynetwork");
+        assertEquals("mynetwork", network.getName());
+
+        network.setDescription("mine not yours");
+        assertEquals("mine not yours", network.getDescription());
+
+        network.setAttributes(ATTRIBUTES);
+        assertEquals(ATTRIBUTES, network.getAttributes());
+    }
+
+}

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/domain/stack/SecurityGroupTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/domain/stack/SecurityGroupTest.java
@@ -1,0 +1,36 @@
+package com.sequenceiq.redbeams.domain.stack;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class SecurityGroupTest {
+
+    private static final Set SECURITY_GROUP_IDS = Set.of("id1", "id2", "id3");
+
+    private SecurityGroup group;
+
+    @Before
+    public void setUp() throws Exception {
+        group = new SecurityGroup();
+    }
+
+    @Test
+    public void testGettersAndSetters() {
+        group.setId(1L);
+        assertEquals(1L, group.getId().longValue());
+
+        group.setName("mygroup");
+        assertEquals("mygroup", group.getName());
+
+        group.setDescription("mine not yours");
+        assertEquals("mine not yours", group.getDescription());
+
+        group.setSecurityGroupIds(SECURITY_GROUP_IDS);
+        assertEquals(SECURITY_GROUP_IDS, group.getSecurityGroupIds());
+    }
+
+}


### PR DESCRIPTION
New entity classes represent the creation of a new database server. The
top-level DBStack object represents one creation request. It is
comprised of a network description, a database server description, and
general top-level information. The lower-level Network, DatabaseServer,
and Security entities store more detailed information. Network and
Security are based on similar entity classes in the core Cloudbreak
service. All of the entities might end up with more fields in the near
future as the logic for performing database creation develops.

A database migration for establishing the entities in the redbeams
database is included.