### PR TITLE
CB-1837 Augment cloud-api for db servers; add RDS CFT

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/ResourceConnector.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/ResourceConnector.java
@@ -8,6 +8,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.cloudbreak.cloud.model.TlsInfo;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
 import com.sequenceiq.cloudbreak.common.type.AdjustmentType;
@@ -57,6 +58,26 @@ public interface ResourceConnector<R> {
      */
     List<CloudResourceStatus> launch(AuthenticatedContext authenticatedContext, CloudStack stack, PersistenceNotifier persistenceNotifier,
             AdjustmentType adjustmentType, Long threshold) throws Exception;
+
+    /**
+     * Launches a database stack on a cloud platform. The stack consists of the following resources:
+     * - a single database server instance
+     * - depending on the platform, other associated, required resources (e.g., a DB subnet group for RDS)
+     * <br>
+     * This method initiates infrastructure creation on the cloud platform and returns a list of
+     * {@link CloudResourceStatus} values, one for each created resource. The caller does not need
+     * to wait/block until infrastructure creation is finished, but can return immediately and use
+     * {@link #check(AuthenticatedContext, List)} method to check regularly whether the
+     * infrastructure and all resources have been created or not.
+     *
+     * @param authenticatedContext the authenticated context which holds the client object
+     * @param stack                contains the full description of infrastructure
+     * @param persistenceNotifier  notifier for when a resource is allocated on the cloud platfrom
+     * @return the status of resources allocated on the cloud platform
+     * @throws Exception in case of any error
+     */
+    List<CloudResourceStatus> launchDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack, PersistenceNotifier persistenceNotifier)
+            throws Exception;
 
     /**
      * Invoked to check whether the resources have already reached a StatusGroup.PERMANENT state.
@@ -155,4 +176,12 @@ public interface ResourceConnector<R> {
      * @throws TemplatingDoesNotSupportedException if template not supported by provider
      */
     String getStackTemplate() throws TemplatingDoesNotSupportedException;
+
+    /**
+     * Gets the cloud platform related database stack template.
+     *
+     * @return the platform related database stack template
+     * @throws TemplatingDoesNotSupportedException if templating is not supported by provider
+     */
+    String getDBStackTemplate() throws TemplatingDoesNotSupportedException;
 }

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/DatabaseServer.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/DatabaseServer.java
@@ -36,6 +36,7 @@ public class DatabaseServer extends DynamicModel {
 
     public DatabaseServer(String serverId, String flavor, DatabaseEngine engine, String rootUserName, String rootPassword,
             long storageSize, Security security, InstanceStatus status, Map<String, Object> parameters) {
+        super(parameters);
         this.serverId = serverId;
         this.flavor = flavor;
         this.engine = engine;

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnector.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnector.java
@@ -22,6 +22,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.cloudbreak.cloud.model.Network;
 import com.sequenceiq.cloudbreak.cloud.model.TlsInfo;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
@@ -54,6 +55,9 @@ public class AwsResourceConnector implements ResourceConnector<Object> {
     @Value("${cb.aws.cf.template.new.path:}")
     private String awsCloudformationTemplatePath;
 
+    @Value("${cb.aws.cf.template.newdb.path:}")
+    private String awsDbCloudformationTemplatePath;
+
     @Inject
     private AwsLaunchService awsLaunchService;
 
@@ -73,6 +77,12 @@ public class AwsResourceConnector implements ResourceConnector<Object> {
     public List<CloudResourceStatus> launch(AuthenticatedContext ac, CloudStack stack, PersistenceNotifier resourceNotifier,
             AdjustmentType adjustmentType, Long threshold) throws Exception {
         return awsLaunchService.launch(ac, stack, resourceNotifier, adjustmentType, threshold);
+    }
+
+    @Override
+    public List<CloudResourceStatus> launchDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
+            PersistenceNotifier persistenceNotifier) {
+        throw new UnsupportedOperationException("Database server launch is not supported for " + getClass().getName());
     }
 
     private boolean deployingToSameVPC(AwsNetworkView awsNetworkView, boolean existingVPC) {
@@ -123,6 +133,15 @@ public class AwsResourceConnector implements ResourceConnector<Object> {
     public String getStackTemplate() {
         try {
             return freemarkerConfiguration.getTemplate(awsCloudformationTemplatePath, "UTF-8").toString();
+        } catch (IOException e) {
+            throw new CloudConnectorException("can't get freemarker template", e);
+        }
+    }
+
+    @Override
+    public String getDBStackTemplate() {
+        try {
+            return freemarkerConfiguration.getTemplate(awsDbCloudformationTemplatePath, "UTF-8").toString();
         } catch (IOException e) {
             throw new CloudConnectorException("can't get freemarker template", e);
         }

--- a/cloud-aws/src/main/resources/templates/aws-cf-dbstack.ftl
+++ b/cloud-aws/src/main/resources/templates/aws-cf-dbstack.ftl
@@ -1,0 +1,123 @@
+<#setting number_format="computer">
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+
+  "Description" : "Deploys an RDS instance and associated DB subnet group on AWS.",
+
+  "Parameters" : {
+
+    "AllocatedStorageParameter": {
+        "Type": "Number",
+        "Default": 10,
+        "Description": "Allocated storage, in GB",
+        "MinValue": 10
+    },
+    "BackupRetentionPeriodParameter": {
+        "Type": "Number",
+        "Default": 3,
+        "Description": "Backup retention period, in days",
+        "MinValue": 0,
+        "MaxValue": 8
+    },
+    "DBInstanceClassParameter": {
+        "Type": "String",
+        "Default": "db.t3.medium",
+        "Description": "DB instance class"
+    },
+    "DBInstanceIdentifierParameter": {
+        "Type": "String",
+        "Description": "DB instance identifier",
+        "AllowedPattern": "[A-Za-z][A-Za-z0-9-]*",
+        "MinLength": 1,
+        "MaxLength": 63
+    },
+    "DBSubnetGroupNameParameter": {
+        "Type": "String",
+        "Description": "DB subnet group name"
+    },
+    "DBSubnetGroupSubnetIdsParameter": {
+        "Type": "List<AWS::EC2::Subnet::Id>",
+        "Description": "DB subnet group subnet IDs"
+    },
+    "EngineParameter": {
+        "Type": "String",
+        "Default": "postgres",
+        "Description": "Engine",
+        "AllowedValues": [ "postgres" ]
+    },
+    "EngineVersionParameter": {
+        "Type": "String",
+        "Default": "10.6",
+        "Description": "Engine version",
+        "MinLength": 1,
+        "MaxLength": 64
+    },
+    "MasterUsernameParameter": {
+        "Type": "String",
+        "Description": "Master username",
+        "AllowedPattern": "[A-Za-z][A-Za-z0-9]+",
+        "MinLength": 1,
+        "MaxLength": 16
+    },
+    "MasterUserPasswordParameter": {
+        "Type": "String",
+        "Description": "Master user password",
+        "MinLength": 8,
+        "MaxLength": 30
+    },
+    "VPCSecurityGroupsParameter": {
+        "Type": "List<AWS::EC2::SecurityGroup::Id>",
+        "Description": "VPC security groups"
+    },
+
+    "StackOwner" : {
+      "Description" : "The instances will have this parameter as an Owner tag.",
+      "Type" : "String",
+      "MinLength": "1",
+      "MaxLength": "50"
+    }
+  },
+
+  "Resources" : {
+
+        "DBSubnetGroup": {
+            "Type": "AWS::RDS::DBSubnetGroup",
+            "Properties": {
+                "DBSubnetGroupDescription": { "Fn::Sub": "DB subnet group for ${r"${DBInstanceIdentifierParameter}"}" },
+                "DBSubnetGroupName": { "Ref": "DBSubnetGroupNameParameter" },
+                "SubnetIds": { "Ref": "DBSubnetGroupSubnetIdsParameter" },
+                "Tags": [
+                    { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
+                    { "Key" : "cb-resource-type", "Value" : "${database_resource}" },
+                    { "Key" : "owner", "Value" : { "Ref" : "StackOwner" } }
+                ]
+            }
+        },
+        "DBInstance": {
+            "Type": "AWS::RDS::DBInstance",
+            "Properties": {
+                "AllocatedStorage": { "Ref": "AllocatedStorageParameter" },
+                "BackupRetentionPeriod": { "Ref": "BackupRetentionPeriodParameter" },
+                "DBInstanceClass": { "Ref": "DBInstanceClassParameter" },
+                "DBInstanceIdentifier": { "Ref": "DBInstanceIdentifierParameter" },
+                "DBSubnetGroupName": { "Ref": "DBSubnetGroup" },
+                "Engine": { "Ref": "EngineParameter" },
+                "EngineVersion": { "Ref": "EngineVersionParameter" },
+                "MasterUserPassword": { "Ref": "MasterUserPasswordParameter" },
+                "MasterUsername": { "Ref": "MasterUsernameParameter" },
+                "MultiAZ": true,
+                "StorageEncrypted": true,
+                "Tags": [
+                    { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
+                    { "Key" : "cb-resource-type", "Value" : "${database_resource}" },
+                    { "Key" : "owner", "Value" : { "Ref" : "StackOwner" } }
+                ],
+                "VPCSecurityGroups": { "Ref": "VPCSecurityGroupsParameter" }
+            }
+        }
+  },
+  "Outputs" : {
+      "CreatedDBInstance": { "Ref": "DBInstance" },
+      "CreatedDBSubnetGroup": { "Ref": "DBSubnetGroup" }
+  }
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
@@ -44,11 +44,13 @@ import com.sequenceiq.cloudbreak.cloud.azure.view.AzureStorageView;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.exception.TemplatingDoesNotSupportedException;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource.Builder;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.Network;
 import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
@@ -155,6 +157,12 @@ public class AzureResourceConnector implements ResourceConnector<Map<String, Map
         List<CloudResourceStatus> resources = check(ac, Collections.singletonList(cloudResource));
         LOGGER.debug("Launched resources: {}", resources);
         return resources;
+    }
+
+    @Override
+    public List<CloudResourceStatus> launchDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
+        PersistenceNotifier persistenceNotifier) {
+        throw new UnsupportedOperationException("Database server launch is not supported for " + getClass().getName());
     }
 
     @Override
@@ -438,6 +446,11 @@ public class AzureResourceConnector implements ResourceConnector<Map<String, Map
     @Override
     public String getStackTemplate() {
         return azureTemplateBuilder.getTemplateString();
+    }
+
+    @Override
+    public String getDBStackTemplate() throws TemplatingDoesNotSupportedException {
+        throw new TemplatingDoesNotSupportedException();
     }
 
     private AzureStackView getAzureStack(AzureCredentialView azureCredentialView, CloudStack cloudStack,

--- a/cloud-common/src/main/resources/application.yml
+++ b/cloud-common/src/main/resources/application.yml
@@ -118,6 +118,7 @@ cb:
     external.id: provision-ambari
     role.session.name: hadoop-provisioning
     cf.template.new.path: templates/aws-cf-stack.ftl
+    cf.template.newdb.path: templates/aws-cf-dbstack.ftl
     default.inbound.security.group:
     vpc:
 

--- a/cloud-cumulus-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/cumulus/yarn/CumulusYarnResourceConnector.java
+++ b/cloud-cumulus-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/cumulus/yarn/CumulusYarnResourceConnector.java
@@ -31,6 +31,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource.Builder;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.TlsInfo;
@@ -65,6 +66,12 @@ public class CumulusYarnResourceConnector implements ResourceConnector<Object> {
         CloudResource yarnService = new Builder().type(CUMULUS_YARN_SERVICE).name(service.getName()).build();
         persistenceNotifier.notifyAllocation(yarnService, authenticatedContext.getCloudContext());
         return check(authenticatedContext, Collections.singletonList(yarnService));
+    }
+
+    @Override
+    public List<CloudResourceStatus> launchDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
+        PersistenceNotifier persistenceNotifier) {
+        throw new UnsupportedOperationException("Database server launch is not supported for " + getClass().getName());
     }
 
     @Override
@@ -206,6 +213,11 @@ public class CumulusYarnResourceConnector implements ResourceConnector<Object> {
 
     @Override
     public String getStackTemplate() throws TemplatingDoesNotSupportedException {
+        throw new TemplatingDoesNotSupportedException();
+    }
+
+    @Override
+    public String getDBStackTemplate() throws TemplatingDoesNotSupportedException {
         throw new TemplatingDoesNotSupportedException();
     }
 }

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpResourceConnector.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpResourceConnector.java
@@ -59,6 +59,11 @@ public class GcpResourceConnector extends AbstractResourceConnector {
     }
 
     @Override
+    public String getDBStackTemplate() throws TemplatingDoesNotSupportedException {
+        throw new TemplatingDoesNotSupportedException();
+    }
+
+    @Override
     public List<CloudResourceStatus> upscale(AuthenticatedContext auth, CloudStack stack, List<CloudResource> resources) {
         CloudContext cloudContext = auth.getCloudContext();
         Platform platform = cloudContext.getPlatform();

--- a/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockResourceConnector.java
+++ b/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockResourceConnector.java
@@ -19,6 +19,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource.Builder;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.TlsInfo;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
@@ -47,6 +48,25 @@ public class MockResourceConnector implements ResourceConnector<Object> {
                 cloudResourceStatuses.add(new CloudResourceStatus(cloudResource, CREATED));
             }
         }
+        return cloudResourceStatuses;
+    }
+
+    @Override
+    public List<CloudResourceStatus> launchDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
+        PersistenceNotifier persistenceNotifier) {
+        List<CloudResourceStatus> cloudResourceStatuses = new ArrayList<>();
+        // for (Group group : stack.getGroups()) {
+        //     for (int i = 0; i < group.getInstancesSize(); i++) {
+        //         CloudResource cloudResource = new Builder()
+        //                 .type(ResourceType.MOCK_INSTANCE)
+        //                 .status(CommonStatus.CREATED)
+        //                 .name("cloudinstance" + cloudResourceStatuses.size())
+        //                 .reference("")
+        //                 .persistent(true)
+        //                 .build();
+        //         cloudResourceStatuses.add(new CloudResourceStatus(cloudResource, CREATED));
+        //     }
+        // }
         return cloudResourceStatuses;
     }
 
@@ -119,6 +139,11 @@ public class MockResourceConnector implements ResourceConnector<Object> {
 
     @Override
     public String getStackTemplate() throws TemplatingDoesNotSupportedException {
+        throw new TemplatingDoesNotSupportedException();
+    }
+
+    @Override
+    public String getDBStackTemplate() throws TemplatingDoesNotSupportedException {
         throw new TemplatingDoesNotSupportedException();
     }
 }

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/heat/OpenStackResourceConnector.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/heat/OpenStackResourceConnector.java
@@ -25,11 +25,13 @@ import org.springframework.stereotype.Service;
 import com.sequenceiq.cloudbreak.cloud.ResourceConnector;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.exception.TemplatingDoesNotSupportedException;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource.Builder;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
@@ -115,6 +117,12 @@ public class OpenStackResourceConnector implements ResourceConnector<Object> {
         }
         LOGGER.debug("Launched resources: {}", resources);
         return resources;
+    }
+
+    @Override
+    public List<CloudResourceStatus> launchDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
+        PersistenceNotifier persistenceNotifier) {
+        throw new UnsupportedOperationException("Database server launch is not supported for " + getClass().getName());
     }
 
     private List<CloudResource> collectResources(AuthenticatedContext authenticatedContext, PersistenceNotifier notifier, Stack heatStack, CloudStack stack,
@@ -340,6 +348,11 @@ public class OpenStackResourceConnector implements ResourceConnector<Object> {
     @Override
     public String getStackTemplate() {
         return heatTemplateBuilder.getTemplate();
+    }
+
+    @Override
+    public String getDBStackTemplate() throws TemplatingDoesNotSupportedException {
+        throw new TemplatingDoesNotSupportedException();
     }
 
     @Override

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/nativ/OpenStackNativeResourceConnector.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/nativ/OpenStackNativeResourceConnector.java
@@ -27,6 +27,11 @@ public class OpenStackNativeResourceConnector extends AbstractResourceConnector 
     }
 
     @Override
+    public String getDBStackTemplate() throws TemplatingDoesNotSupportedException {
+        throw new TemplatingDoesNotSupportedException();
+    }
+
+    @Override
     protected List<CloudResource> collectProviderSpecificResources(List<CloudResource> resources, List<CloudInstance> vms) {
         return Collections.emptyList();
     }

--- a/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/AbstractResourceConnector.java
+++ b/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/AbstractResourceConnector.java
@@ -15,6 +15,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
@@ -72,6 +73,12 @@ public abstract class AbstractResourceConnector implements ResourceConnector<Lis
         cloudResourceStatuses.addAll(computeStatuses);
 
         return cloudResourceStatuses;
+    }
+
+    @Override
+    public List<CloudResourceStatus> launchDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
+        PersistenceNotifier persistenceNotifier) {
+        throw new UnsupportedOperationException("Database server launch is not supported for " + getClass().getName());
     }
 
     @Override

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnResourceConnector.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnResourceConnector.java
@@ -32,6 +32,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource.Builder;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
@@ -90,6 +91,12 @@ public class YarnResourceConnector implements ResourceConnector<Object> {
         CloudResource yarnApplication = new Builder().type(YARN_APPLICATION).name(applicationName).build();
         persistenceNotifier.notifyAllocation(yarnApplication, authenticatedContext.getCloudContext());
         return check(authenticatedContext, Collections.singletonList(yarnApplication));
+    }
+
+    @Override
+    public List<CloudResourceStatus> launchDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
+        PersistenceNotifier persistenceNotifier) {
+        throw new UnsupportedOperationException("Database server launch is not supported for " + getClass().getName());
     }
 
     private void createApplication(YarnClient yarnClient, CreateApplicationRequest createApplicationRequest) throws MalformedURLException {
@@ -244,6 +251,11 @@ public class YarnResourceConnector implements ResourceConnector<Object> {
 
     @Override
     public String getStackTemplate() throws TemplatingDoesNotSupportedException {
+        throw new TemplatingDoesNotSupportedException();
+    }
+
+    @Override
+    public String getDBStackTemplate() throws TemplatingDoesNotSupportedException {
         throw new TemplatingDoesNotSupportedException();
     }
 

--- a/environment/src/main/resources/application.yml
+++ b/environment/src/main/resources/application.yml
@@ -113,6 +113,7 @@ cb:
     external.id: provision-ambari
     role.session.name: hadoop-provisioning
     cf.template.new.path: templates/aws-cf-stack.ftl
+    cf.template.newdb.path: templates/aws-cf-dbstack.ftl
     default.inbound.security.group:
     vpc:
   arm:

--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -120,6 +120,7 @@ cb:
     external.id: provision-ambari
     role.session.name: hadoop-provisioning
     cf.template.new.path: templates/aws-cf-stack.ftl
+    cf.template.newdb.path: templates/aws-cf-dbstack.ftl
     default.inbound.security.group:
     vpc:
 

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/converter/spi/DBStackToDatabaseStackConverter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/converter/spi/DBStackToDatabaseStackConverter.java
@@ -1,0 +1,103 @@
+package com.sequenceiq.redbeams.converter.spi;
+
+import static com.sequenceiq.cloudbreak.cloud.model.InstanceStatus.CREATE_REQUESTED;
+// import static com.sequenceiq.cloudbreak.cloud.model.InstanceStatus.DELETE_REQUESTED;
+
+import com.google.common.collect.Maps;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseEngine;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseServer;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.Network;
+import com.sequenceiq.cloudbreak.cloud.model.Security;
+import com.sequenceiq.cloudbreak.cloud.model.StackTags;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.exception.BadRequestException;
+import com.sequenceiq.redbeams.domain.stack.DBStack;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DBStackToDatabaseStackConverter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DBStackToDatabaseStackConverter.class);
+
+    public DatabaseStack convert(DBStack dbStack) {
+        Network network = buildNetwork(dbStack);
+        DatabaseServer databaseServer = buildDatabaseServer(dbStack);
+        // FIXME need to retrieve template
+        return new DatabaseStack(network, databaseServer, getUserDefinedTags(dbStack), null);
+    }
+
+    private Network buildNetwork(DBStack dbStack) {
+        com.sequenceiq.redbeams.domain.stack.Network dbStackNetwork = dbStack.getNetwork();
+        if (dbStackNetwork == null) {
+            return null;
+        }
+        Json attributes = dbStackNetwork.getAttributes();
+        Map<String, Object> params = attributes == null ? Collections.emptyMap() : attributes.getMap();
+        return new Network(null, params);
+    }
+
+    private DatabaseServer buildDatabaseServer(DBStack dbStack) {
+        com.sequenceiq.redbeams.domain.stack.DatabaseServer dbStackDatabaseServer = dbStack.getDatabaseServer();
+        if (dbStackDatabaseServer == null) {
+            return null;
+        }
+
+        String serverId = dbStackDatabaseServer.getName();
+        String flavor = dbStackDatabaseServer.getInstanceType();
+        DatabaseEngine engine;
+        switch (dbStackDatabaseServer.getDatabaseVendor()) {
+            case POSTGRES:
+                engine = DatabaseEngine.POSTGRESQL;
+                break;
+            case MYSQL:
+            case MARIADB:
+            case MSSQL:
+            case ORACLE11:
+            case ORACLE12:
+            case SQLANYWHERE:
+            default:
+                throw new BadRequestException("Unsupported database vendor " + dbStackDatabaseServer.getDatabaseVendor());
+        }
+        String username = dbStackDatabaseServer.getRootUserName();
+        String password = dbStackDatabaseServer.getRootPassword();
+        Long storageSize = dbStackDatabaseServer.getStorageSize();
+        Security security = new Security(Collections.emptyList(), dbStackDatabaseServer.getSecurityGroup().getSecurityGroupIds());
+        // TODO / FIXME converter caller decides this?
+        InstanceStatus status = CREATE_REQUESTED;
+
+        Json attributes = dbStackDatabaseServer.getAttributes();
+        Map<String, Object> params = attributes == null ? Collections.emptyMap() : attributes.getMap();
+
+        return new DatabaseServer(serverId, flavor, engine, username, password, storageSize, security, status, params);
+    }
+
+    private Map<String, String> getUserDefinedTags(DBStack dbStack) {
+        Map<String, String> result = Maps.newHashMap();
+        try {
+            if (dbStack.getTags() != null) {
+                StackTags stackTag = dbStack.getTags().get(StackTags.class);
+                Map<String, String> userDefined = stackTag.getUserDefinedTags();
+                Map<String, String> defaultTags = stackTag.getDefaultTags();
+                if (defaultTags != null) {
+                    result.putAll(defaultTags);
+                }
+                if (userDefined != null) {
+                    result.putAll(userDefined);
+                }
+            }
+        } catch (IOException e) {
+            LOGGER.warn("Failed to read JSON tags, skipping", e);
+        }
+        return result;
+    }
+
+}

--- a/redbeams/src/main/resources/application.yml
+++ b/redbeams/src/main/resources/application.yml
@@ -105,6 +105,7 @@ cb:
     external.id: provision-ambari
     role.session.name: hadoop-provisioning
     cf.template.new.path: templates/aws-cf-stack.ftl
+    cf.template.newdb.path: templates/aws-cf-dbstack.ftl
     default.inbound.security.group:
     vpc:
 
@@ -519,4 +520,3 @@ cb:
         pkgName: ambari-agent
         prewarmed: true
 altus.ums.host: localhost
-

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/converter/spi/DBStackToDatabaseStackConverterTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/converter/spi/DBStackToDatabaseStackConverterTest.java
@@ -1,0 +1,115 @@
+package com.sequenceiq.redbeams.converter.spi;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseEngine;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.redbeams.domain.stack.DBStack;
+import com.sequenceiq.redbeams.domain.stack.DatabaseServer;
+import com.sequenceiq.redbeams.domain.stack.Network;
+import com.sequenceiq.redbeams.domain.stack.SecurityGroup;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+
+public class DBStackToDatabaseStackConverterTest {
+
+    private static final String NETWORK_ATTRIBUTES = "{ \"foo\": \"bar\" }";
+
+    private static final String DATABASE_SERVER_ATTRIBUTES = "{ \"this\": \"that\" }";
+
+    private static final String STACK_TAGS = "{ \"userDefinedTags\": { \"ukey1\" : \"uvalue1\", \"key1\": \"value1\" }, "
+                                            + " \"defaultTags\": { \"dkey1\" : \"dvalue1\", \"key1\": \"shadowed\" } }";
+
+    private DBStack dbStack;
+
+    @InjectMocks
+    private DBStackToDatabaseStackConverter underTest;
+
+    @Before
+    public void setUp() {
+        // the converter will probably get mocks soon
+        initMocks(this);
+
+        dbStack = new DBStack();
+        dbStack.setId(1L);
+        dbStack.setName("mystack");
+        dbStack.setDisplayName("My Stack");
+        dbStack.setDescription("my stack");
+        dbStack.setEnvironmentId("myenv");
+    }
+
+    @Test
+    public void testConversionNormal() {
+        Network network = new Network();
+        network.setAttributes(new Json(NETWORK_ATTRIBUTES));
+        dbStack.setNetwork(network);
+
+        DatabaseServer server = new DatabaseServer();
+        server.setName("myserver");
+        server.setInstanceType("db.m3.medium");
+        server.setDatabaseVendor(DatabaseVendor.POSTGRES);
+        server.setRootUserName("root");
+        server.setRootPassword("cloudera");
+        server.setStorageSize(50L);
+        SecurityGroup securityGroup = new SecurityGroup();
+        Set<String> securityGroupIds = new HashSet<>();
+        securityGroupIds.add("sg-1234");
+        securityGroup.setSecurityGroupIds(securityGroupIds);
+        server.setSecurityGroup(securityGroup);
+        server.setAttributes(new Json(DATABASE_SERVER_ATTRIBUTES));
+        dbStack.setDatabaseServer(server);
+
+        dbStack.setTags(new Json(STACK_TAGS));
+
+        DatabaseStack convertedStack = underTest.convert(dbStack);
+
+        assertEquals(1, convertedStack.getNetwork().getParameters().size());
+        assertEquals("bar", convertedStack.getNetwork().getParameters().get("foo"));
+
+        assertEquals("myserver", convertedStack.getDatabaseServer().getServerId());
+        assertEquals("db.m3.medium", convertedStack.getDatabaseServer().getFlavor());
+        assertEquals(DatabaseEngine.POSTGRESQL, convertedStack.getDatabaseServer().getEngine());
+        assertEquals("root", convertedStack.getDatabaseServer().getRootUserName());
+        assertEquals("cloudera", convertedStack.getDatabaseServer().getRootPassword());
+        assertEquals(50L, convertedStack.getDatabaseServer().getStorageSize());
+        assertEquals(List.of("sg-1234"), convertedStack.getDatabaseServer().getSecurity().getCloudSecurityIds());
+        // FIXME test instanceStatus
+        assertEquals(1, convertedStack.getDatabaseServer().getParameters().size());
+        assertEquals("that", convertedStack.getDatabaseServer().getParameters().get("this"));
+
+        // FIXME test template
+
+        Map<String, String> tags = convertedStack.getTags();
+        assertEquals(3, tags.size());
+        assertEquals("uvalue1", tags.get("ukey1"));
+        assertEquals("dvalue1", tags.get("dkey1"));
+        assertEquals("value1", tags.get("key1"));
+    }
+
+    @Test
+    public void testConversionEmpty() {
+        dbStack.setNetwork(null);
+        dbStack.setDatabaseServer(null);
+        dbStack.setTags(null);
+        dbStack.setParameters(null);
+
+        DatabaseStack convertedStack = underTest.convert(dbStack);
+
+        assertNull(convertedStack.getNetwork());
+        assertNull(convertedStack.getDatabaseServer());
+        // FIXME test template
+        assertEquals(0, convertedStack.getTags().size());
+    }
+
+}


### PR DESCRIPTION
The ResourceConnector cloud-api interface gains two new methods:
launchDatabaseServer for launching a new database server in a cloud
provider, and getDBStackTemplate for getting the Freemarker template to
be used to build an RDS instance. The methods are mostly stubbed out in
ResourceConnector implementations, except for AwsResourceConnector. In
that implementation, the template contents are loaded from a file as
expected, but the launch method is still stubbed out, for now.

The contents of that Freemarker template for creation of an RDS instance
and associated DB subnet are now available. The template is much simpler
than the existing one for clusters, and is driven by a somewhat large
number of parameters.

The new DBStackToDatabaseStackConverter class converts from the redbeams
DBStack entity, and its family of related entities, to the cloud-api
DatabaseStack model object, and its family of related objects. The
converter forms the starting data for the ResourceConnector to initiate
launch.

Lastly, a bug in the cloud-api DatabaseServer class is fixed.