### PR TITLE
DISTX-197. Implement telemetry on env side

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/util/TelemetryMergerUtil.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/util/TelemetryMergerUtil.java
@@ -1,0 +1,63 @@
+package com.sequenceiq.cloudbreak.converter.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.cloud.model.Logging;
+import com.sequenceiq.cloudbreak.cloud.model.Telemetry;
+import com.sequenceiq.cloudbreak.cloud.model.WorkloadAnalytics;
+import com.sequenceiq.environment.api.v1.environment.model.response.LoggingResponse;
+import com.sequenceiq.environment.api.v1.environment.model.response.TelemetryResponse;
+import com.sequenceiq.environment.api.v1.environment.model.response.WorkloadAnalyticsResponse;
+
+public class TelemetryMergerUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TelemetryMergerUtil.class);
+
+    private TelemetryMergerUtil() {
+    }
+
+    /**
+     * Merge environment and stack telemetry settings.
+     * Stack level telemetry settings should override the environment level one.
+     * @param envTelemetryResponse Environment level (global) telemetry settings
+     * @param stackTelemetry Stack (cluster) level telemetry settings
+     * @return final telemetry settings
+     */
+    public static Telemetry mergeGlobalAndStackLevelTelemetry(TelemetryResponse envTelemetryResponse, Telemetry stackTelemetry) {
+        final Telemetry envTelemetry = createEnvTelemetry(envTelemetryResponse);
+        return createStackTelemetry(stackTelemetry, envTelemetry.getLogging(), envTelemetry.getWorkloadAnalytics());
+    }
+
+    private static Telemetry createEnvTelemetry(TelemetryResponse envTelemetry) {
+        Logging logging = null;
+        WorkloadAnalytics workloadAnalytics = null;
+        if (envTelemetry != null) {
+            if (envTelemetry.getLogging() != null) {
+                LOGGER.debug("Found global (environment) telemetry (logging) settings.");
+                LoggingResponse loggingResponse = envTelemetry.getLogging();
+                logging = new Logging(loggingResponse.isEnabled(), loggingResponse.getOutput(), loggingResponse.getAttributes());
+            }
+            if (envTelemetry.getWorkloadAnalytics() != null) {
+                LOGGER.debug("Found global (environment) telemetry (workload analytics) settings.");
+                WorkloadAnalyticsResponse waResponse = envTelemetry.getWorkloadAnalytics();
+                workloadAnalytics = new WorkloadAnalytics(waResponse.isEnabled(), waResponse.getDatabusEndpoint(), null, null, waResponse.getAttributes());
+            }
+        }
+        return new Telemetry(logging, workloadAnalytics);
+    }
+
+    private static Telemetry createStackTelemetry(Telemetry stackTelemetry, Logging logging, WorkloadAnalytics workloadAnalytics) {
+        if (stackTelemetry != null) {
+            if (stackTelemetry.getLogging() != null) {
+                LOGGER.debug("Found stack level telemetry (logging) settings. It will override enviroment level telemetry configs.");
+                logging = stackTelemetry.getLogging();
+            }
+            if (stackTelemetry.getWorkloadAnalytics() != null) {
+                LOGGER.debug("Found stack level telemetry (workload analytics) settings. It will override enviroment level telemetry configs.");
+                workloadAnalytics = stackTelemetry.getWorkloadAnalytics();
+            }
+        }
+        return new Telemetry(logging, workloadAnalytics);
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/util/TelemetryMergerUtilTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/util/TelemetryMergerUtilTest.java
@@ -1,0 +1,64 @@
+package com.sequenceiq.cloudbreak.converter.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.sequenceiq.cloudbreak.cloud.model.Logging;
+import com.sequenceiq.cloudbreak.cloud.model.LoggingOutputType;
+import com.sequenceiq.cloudbreak.cloud.model.Telemetry;
+import com.sequenceiq.cloudbreak.cloud.model.WorkloadAnalytics;
+import com.sequenceiq.environment.api.v1.environment.model.response.LoggingResponse;
+import com.sequenceiq.environment.api.v1.environment.model.response.TelemetryResponse;
+
+public class TelemetryMergerUtilTest {
+
+    @Test
+    public void testMergeGlobalAndStackLevelTelemetry() {
+        // GIVEN
+        TelemetryResponse envTelemetry = new TelemetryResponse();
+        LoggingResponse loggingResponse = new LoggingResponse();
+        loggingResponse.setEnabled(true);
+        loggingResponse.setOutput(LoggingOutputType.S3);
+        envTelemetry.setLogging(loggingResponse);
+        Telemetry stackTelemetry = new Telemetry(
+                null,
+                new WorkloadAnalytics(true, null, null, null, null)
+        );
+        // WHEN
+        Telemetry result = TelemetryMergerUtil.mergeGlobalAndStackLevelTelemetry(envTelemetry, stackTelemetry);
+        // THEN
+        assertTrue(result.getLogging().isEnabled());
+        assertTrue(result.getWorkloadAnalytics().isEnabled());
+    }
+
+    @Test
+    public void testMergeGlobalAndStackLevelTelemetryOverrideLogging() {
+        // GIVEN
+        TelemetryResponse envTelemetry = new TelemetryResponse();
+        LoggingResponse loggingResponse = new LoggingResponse();
+        loggingResponse.setEnabled(true);
+        loggingResponse.setOutput(LoggingOutputType.S3);
+        envTelemetry.setLogging(loggingResponse);
+        Telemetry stackTelemetry = new Telemetry(
+                new Logging(true, LoggingOutputType.WASB, null),
+                null
+        );
+        // WHEN
+        Telemetry result = TelemetryMergerUtil.mergeGlobalAndStackLevelTelemetry(envTelemetry, stackTelemetry);
+        // THEN
+        assertEquals(LoggingOutputType.WASB, result.getLogging().getOutputType());
+    }
+
+    @Test
+    public void testMergeGlobalAndStackLevelTelemetryWithNulls() {
+        // GIVEN
+        // WHEN
+        Telemetry result = TelemetryMergerUtil.mergeGlobalAndStackLevelTelemetry(null, null);
+        // THEN
+        assertNull(result.getLogging());
+        assertNull(result.getWorkloadAnalytics());
+    }
+}

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
@@ -28,6 +28,14 @@ public class EnvironmentModelDescription {
     public static final String LATITUDE = "Location latitude of the environment.";
     public static final String LOCATION_DISPLAY_NAME = "Display name of the location of the environment.";
     public static final String NETWORK = "Network related specifics of the environment.";
+    public static final String TELEMETRY = "Telemetry related specifics of the environment.";
+    public static final String TELEMETRY_LOGGING = "Logging related specifics of the environment.";
+    public static final String TELEMETRY_WORKLOAD_ANALYTICS = "Workload analytics related specifics of the environment.";
+    public static final String TELEMETRY_LOGGING_OUTPUT_TYPE = "Logging output type of the environment";
+    public static final String TELEMETRY_LOGGING_ATTRIBUTES = "Logging component specific attributes of the environment";
+    public static final String TELEMETRY_FEATURE_ENABLED = "Enable telemetry component feature of the environment";
+    public static final String TELEMETRY_WA_DATABUS_ENDPOINT = "Databus endpoint for workload analytics (environment)";
+    public static final String TELEMETRY_WA_ATTRIBUTES = "Workload analytics attributes of the environment";
 
     public static final String CREDENTIAL_RESPONSE = "Credential of the environment.";
     public static final String PROXY_CONFIGS_RESPONSE = "Proxy configurations in the environment.";

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/base/CommonTelemetryFields.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/base/CommonTelemetryFields.java
@@ -1,0 +1,19 @@
+package com.sequenceiq.environment.api.v1.environment.model.base;
+
+import com.sequenceiq.environment.api.doc.environment.EnvironmentModelDescription;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public abstract class CommonTelemetryFields {
+
+    @ApiModelProperty(EnvironmentModelDescription.TELEMETRY_FEATURE_ENABLED)
+    private boolean enabled;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/base/LoggingBase.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/base/LoggingBase.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.environment.api.v1.environment.model.base;
+
+import com.sequenceiq.cloudbreak.cloud.model.LoggingAttributesHolder;
+import com.sequenceiq.cloudbreak.cloud.model.LoggingOutputType;
+import com.sequenceiq.environment.api.doc.environment.EnvironmentModelDescription;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public abstract class LoggingBase extends CommonTelemetryFields {
+    @ApiModelProperty(EnvironmentModelDescription.TELEMETRY_LOGGING_OUTPUT_TYPE)
+    private LoggingOutputType output;
+
+    @ApiModelProperty(EnvironmentModelDescription.TELEMETRY_LOGGING_ATTRIBUTES)
+    private LoggingAttributesHolder attributes;
+
+    public LoggingOutputType getOutput() {
+        return output;
+    }
+
+    public void setOutput(LoggingOutputType output) {
+        this.output = output;
+    }
+
+    public LoggingAttributesHolder getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(LoggingAttributesHolder attributes) {
+        this.attributes = attributes;
+    }
+}

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/base/WorkloadAnalyticsBase.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/base/WorkloadAnalyticsBase.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.environment.api.v1.environment.model.base;
+
+import com.sequenceiq.cloudbreak.cloud.model.WorkloadAnalyticsAttributesHolder;
+import com.sequenceiq.environment.api.doc.environment.EnvironmentModelDescription;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class WorkloadAnalyticsBase extends CommonTelemetryFields {
+
+    @ApiModelProperty(EnvironmentModelDescription.TELEMETRY_WA_DATABUS_ENDPOINT)
+    private String databusEndpoint;
+
+    @ApiModelProperty(EnvironmentModelDescription.TELEMETRY_WA_ATTRIBUTES)
+    private WorkloadAnalyticsAttributesHolder attributes;
+
+    public String getDatabusEndpoint() {
+        return databusEndpoint;
+    }
+
+    public void setDatabusEndpoint(String databusEndpoint) {
+        this.databusEndpoint = databusEndpoint;
+    }
+
+    public WorkloadAnalyticsAttributesHolder getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(WorkloadAnalyticsAttributesHolder attributes) {
+        this.attributes = attributes;
+    }
+}

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/EnvironmentEditRequest.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/EnvironmentEditRequest.java
@@ -31,6 +31,9 @@ public class EnvironmentEditRequest {
     @ApiModelProperty(EnvironmentModelDescription.AUTHENTICATION)
     private @Valid EnvironmentAuthenticationRequest authentication;
 
+    @ApiModelProperty(EnvironmentModelDescription.TELEMETRY)
+    private TelemetryRequest telemetry;
+
     public String getDescription() {
         return description;
     }
@@ -69,5 +72,13 @@ public class EnvironmentEditRequest {
 
     public void setAuthentication(EnvironmentAuthenticationRequest authentication) {
         this.authentication = authentication;
+    }
+
+    public TelemetryRequest getTelemetry() {
+        return telemetry;
+    }
+
+    public void setTelemetry(TelemetryRequest telemetry) {
+        this.telemetry = telemetry;
     }
 }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/EnvironmentRequest.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/EnvironmentRequest.java
@@ -43,6 +43,9 @@ public class EnvironmentRequest extends EnvironmentBaseRequest implements Creden
     @ApiModelProperty(EnvironmentModelDescription.NETWORK)
     private EnvironmentNetworkRequest network;
 
+    @ApiModelProperty(EnvironmentModelDescription.TELEMETRY)
+    private TelemetryRequest telemetry;
+
     @ApiModelProperty(EnvironmentModelDescription.CLOUD_PLATFORM)
     private String cloudPlatform;
 
@@ -90,6 +93,14 @@ public class EnvironmentRequest extends EnvironmentBaseRequest implements Creden
 
     public void setLocation(LocationRequest location) {
         this.location = location;
+    }
+
+    public TelemetryRequest getTelemetry() {
+        return telemetry;
+    }
+
+    public void setTelemetry(TelemetryRequest telemetry) {
+        this.telemetry = telemetry;
     }
 
     public EnvironmentNetworkRequest getNetwork() {

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/LoggingRequest.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/LoggingRequest.java
@@ -1,0 +1,9 @@
+package com.sequenceiq.environment.api.v1.environment.model.request;
+
+import com.sequenceiq.environment.api.v1.environment.model.base.LoggingBase;
+
+import io.swagger.annotations.ApiModel;
+
+@ApiModel(value = "LoggingV1Request")
+public class LoggingRequest extends LoggingBase {
+}

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/TelemetryRequest.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/TelemetryRequest.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.environment.api.v1.environment.model.request;
+
+import com.sequenceiq.environment.api.doc.environment.EnvironmentModelDescription;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel(value = "TelemetryV1Request")
+public class TelemetryRequest {
+
+    @ApiModelProperty(EnvironmentModelDescription.TELEMETRY_LOGGING)
+    private LoggingRequest logging;
+
+    @ApiModelProperty(EnvironmentModelDescription.TELEMETRY_WORKLOAD_ANALYTICS)
+    private WorkloadAnalyticsRequest workloadAnalytics;
+
+    public LoggingRequest getLogging() {
+        return logging;
+    }
+
+    public void setLogging(LoggingRequest logging) {
+        this.logging = logging;
+    }
+
+    public WorkloadAnalyticsRequest getWorkloadAnalytics() {
+        return workloadAnalytics;
+    }
+
+    public void setWorkloadAnalytics(WorkloadAnalyticsRequest workloadAnalytics) {
+        this.workloadAnalytics = workloadAnalytics;
+    }
+}

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/WorkloadAnalyticsRequest.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/WorkloadAnalyticsRequest.java
@@ -1,0 +1,9 @@
+package com.sequenceiq.environment.api.v1.environment.model.request;
+
+import com.sequenceiq.environment.api.v1.environment.model.base.WorkloadAnalyticsBase;
+
+import io.swagger.annotations.ApiModel;
+
+@ApiModel(value = "WorkloadAnalyticsV1Request")
+public class WorkloadAnalyticsRequest extends WorkloadAnalyticsBase {
+}

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/DetailedEnvironmentResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/DetailedEnvironmentResponse.java
@@ -31,6 +31,8 @@ public class DetailedEnvironmentResponse extends EnvironmentBaseResponse {
 
         private EnvironmentNetworkResponse network;
 
+        private TelemetryResponse telemetry;
+
         private EnvironmentStatus environmentStatus;
 
         private String statusReason;
@@ -86,6 +88,11 @@ public class DetailedEnvironmentResponse extends EnvironmentBaseResponse {
             return this;
         }
 
+        public Builder withTelemetry(TelemetryResponse telemetry) {
+            this.telemetry = telemetry;
+            return this;
+        }
+
         public Builder withEnvironmentStatus(EnvironmentStatus environmentStatus) {
             this.environmentStatus = environmentStatus;
             return this;
@@ -126,6 +133,7 @@ public class DetailedEnvironmentResponse extends EnvironmentBaseResponse {
             detailedEnvironmentResponse.setStatusReason(statusReason);
             detailedEnvironmentResponse.setCreated(created);
             detailedEnvironmentResponse.setAuthentication(authentication);
+            detailedEnvironmentResponse.setTelemetry(telemetry);
             return detailedEnvironmentResponse;
         }
     }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentBaseResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentBaseResponse.java
@@ -36,6 +36,9 @@ public abstract class EnvironmentBaseResponse {
     @ApiModelProperty(EnvironmentModelDescription.LOCATION)
     private LocationResponse location;
 
+    @ApiModelProperty(EnvironmentModelDescription.TELEMETRY)
+    private TelemetryResponse telemetry;
+
     @ApiModelProperty(EnvironmentModelDescription.NETWORK)
     private EnvironmentNetworkResponse network;
 
@@ -103,6 +106,14 @@ public abstract class EnvironmentBaseResponse {
 
     public void setLocation(LocationResponse location) {
         this.location = location;
+    }
+
+    public TelemetryResponse getTelemetry() {
+        return telemetry;
+    }
+
+    public void setTelemetry(TelemetryResponse telemetry) {
+        this.telemetry = telemetry;
     }
 
     public EnvironmentNetworkResponse getNetwork() {

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/LoggingResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/LoggingResponse.java
@@ -1,0 +1,9 @@
+package com.sequenceiq.environment.api.v1.environment.model.response;
+
+import com.sequenceiq.environment.api.v1.environment.model.base.LoggingBase;
+
+import io.swagger.annotations.ApiModel;
+
+@ApiModel(value = "LoggingV1Response")
+public class LoggingResponse extends LoggingBase {
+}

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/SimpleEnvironmentResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/SimpleEnvironmentResponse.java
@@ -28,6 +28,8 @@ public class SimpleEnvironmentResponse extends EnvironmentBaseResponse {
 
         private LocationResponse location;
 
+        private TelemetryResponse telemetry;
+
         private EnvironmentNetworkResponse network;
 
         private EnvironmentStatus environmentStatus;
@@ -66,6 +68,11 @@ public class SimpleEnvironmentResponse extends EnvironmentBaseResponse {
 
         public Builder withCredential(CredentialResponse credentialResponse) {
             this.credentialResponse = credentialResponse;
+            return this;
+        }
+
+        public Builder withTelemetry(TelemetryResponse telemetry) {
+            this.telemetry = telemetry;
             return this;
         }
 
@@ -113,6 +120,7 @@ public class SimpleEnvironmentResponse extends EnvironmentBaseResponse {
             simpleEnvironmentResponse.setCreateFreeIpa(createFreeIpa);
             simpleEnvironmentResponse.setStatusReason(statusReason);
             simpleEnvironmentResponse.setCreated(created);
+            simpleEnvironmentResponse.setTelemetry(telemetry);
             return simpleEnvironmentResponse;
         }
     }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/TelemetryResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/TelemetryResponse.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.environment.api.v1.environment.model.response;
+
+import io.swagger.annotations.ApiModel;
+
+@ApiModel(value = "TelemetryV1Response")
+public class TelemetryResponse {
+
+    private LoggingResponse logging;
+
+    private WorkloadAnalyticsResponse workloadAnalytics;
+
+    public LoggingResponse getLogging() {
+        return logging;
+    }
+
+    public void setLogging(LoggingResponse logging) {
+        this.logging = logging;
+    }
+
+    public WorkloadAnalyticsResponse getWorkloadAnalytics() {
+        return workloadAnalytics;
+    }
+
+    public void setWorkloadAnalytics(WorkloadAnalyticsResponse workloadAnalytics) {
+        this.workloadAnalytics = workloadAnalytics;
+    }
+}

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/WorkloadAnalyticsResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/WorkloadAnalyticsResponse.java
@@ -1,0 +1,9 @@
+package com.sequenceiq.environment.api.v1.environment.model.response;
+
+import com.sequenceiq.environment.api.v1.environment.model.base.WorkloadAnalyticsBase;
+
+import io.swagger.annotations.ApiModel;
+
+@ApiModel(value = "WorkloadAnalyticsV1Response")
+public class WorkloadAnalyticsResponse extends WorkloadAnalyticsBase {
+}

--- a/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/TelemetryApiConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/TelemetryApiConverter.java
@@ -1,0 +1,82 @@
+package com.sequenceiq.environment.credential.v1.converter;
+
+import java.io.IOException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.model.Logging;
+import com.sequenceiq.cloudbreak.cloud.model.Telemetry;
+import com.sequenceiq.cloudbreak.cloud.model.WorkloadAnalytics;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.environment.api.v1.environment.model.request.LoggingRequest;
+import com.sequenceiq.environment.api.v1.environment.model.request.TelemetryRequest;
+import com.sequenceiq.environment.api.v1.environment.model.request.WorkloadAnalyticsRequest;
+import com.sequenceiq.environment.api.v1.environment.model.response.LoggingResponse;
+import com.sequenceiq.environment.api.v1.environment.model.response.TelemetryResponse;
+import com.sequenceiq.environment.api.v1.environment.model.response.WorkloadAnalyticsResponse;
+
+@Component
+public class TelemetryApiConverter {
+
+    public Telemetry convert(TelemetryRequest request) {
+        Telemetry telemetry = null;
+        if (request != null) {
+            Logging logging = null;
+            WorkloadAnalytics wa = null;
+            if (request.getLogging() != null) {
+                LoggingRequest loggingRequest = request.getLogging();
+                logging = new Logging(
+                        loggingRequest.isEnabled(),
+                        loggingRequest.getOutput(),
+                        loggingRequest.getAttributes());
+            }
+            if (request.getWorkloadAnalytics() != null) {
+                WorkloadAnalyticsRequest waRequest = request.getWorkloadAnalytics();
+                wa = new WorkloadAnalytics(waRequest.isEnabled(), waRequest.getDatabusEndpoint(),
+                        null, null, waRequest.getAttributes());
+            }
+            telemetry = new Telemetry(logging, wa);
+        }
+        return telemetry;
+    }
+
+    public TelemetryResponse convertFromJson(Json json) {
+        if (json != null && StringUtils.isNotEmpty(json.getValue())) {
+            Telemetry telemetry = null;
+            try {
+                telemetry = json.get(Telemetry.class);
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Telemetry JSON is not valid", e);
+            }
+            return convert(telemetry);
+        }
+        return null;
+    }
+
+    public TelemetryResponse convert(Telemetry telemetry) {
+        TelemetryResponse response = null;
+        if (telemetry != null) {
+            LoggingResponse loggingResponse = null;
+            WorkloadAnalyticsResponse waResponse = null;
+            if (telemetry.getLogging() != null) {
+                Logging logging = telemetry.getLogging();
+                loggingResponse = new LoggingResponse();
+                loggingResponse.setAttributes(logging.getAttributes());
+                loggingResponse.setOutput(logging.getOutputType());
+                loggingResponse.setEnabled(logging.isEnabled());
+            }
+            if (telemetry.getWorkloadAnalytics() != null) {
+                WorkloadAnalytics wa = telemetry.getWorkloadAnalytics();
+                waResponse = new WorkloadAnalyticsResponse();
+                waResponse.setEnabled(wa.isEnabled());
+                waResponse.setAttributes(wa.getAttributes());
+                waResponse.setDatabusEndpoint(wa.getDatabusEndpoint());
+            }
+            response = new TelemetryResponse();
+            response.setLogging(loggingResponse);
+            response.setWorkloadAnalytics(waResponse);
+        }
+        return response;
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/domain/Environment.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/domain/Environment.java
@@ -55,6 +55,10 @@ public class Environment implements AuthResource {
     @Column(columnDefinition = "TEXT", nullable = false)
     private Json regions;
 
+    @Convert(converter = JsonToString.class)
+    @Column(columnDefinition = "TEXT")
+    private Json telemetry;
+
     @Column(nullable = false)
     private String location;
 
@@ -218,6 +222,14 @@ public class Environment implements AuthResource {
 
     public void setNetwork(BaseNetwork network) {
         this.network = network;
+    }
+
+    public Json getTelemetry() {
+        return telemetry;
+    }
+
+    public void setTelemetry(Json telemetry) {
+        this.telemetry = telemetry;
     }
 
     @Override

--- a/environment/src/main/java/com/sequenceiq/environment/environment/domain/EnvironmentView.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/domain/EnvironmentView.java
@@ -36,6 +36,10 @@ public class EnvironmentView extends CompactView implements AuthResource {
     @Column(columnDefinition = "TEXT", nullable = false)
     private Json regions;
 
+    @Convert(converter = JsonToString.class)
+    @Column(columnDefinition = "TEXT")
+    private Json telemetry;
+
     @ManyToOne
     @JoinColumn(nullable = false)
     private Credential credential;
@@ -77,6 +81,14 @@ public class EnvironmentView extends CompactView implements AuthResource {
 
     public Set<Region> getRegionSet() {
         return JsonUtil.jsonToType(regions.getValue(), new EmptyTypeReference<>());
+    }
+
+    public Json getTelemetry() {
+        return telemetry;
+    }
+
+    public void setTelemetry(Json telemetry) {
+        this.telemetry = telemetry;
     }
 
     public String getCloudPlatform() {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentCreationDto.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentCreationDto.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import org.apache.commons.collections4.CollectionUtils;
 
+import com.sequenceiq.cloudbreak.cloud.model.Telemetry;
 import com.sequenceiq.environment.api.v1.environment.model.request.CredentialAwareEnvRequest;
 import com.sequenceiq.environment.network.dto.NetworkDto;
 
@@ -32,13 +33,15 @@ public class EnvironmentCreationDto {
 
     private final AuthenticationDto authentication;
 
+    private final Telemetry telemetry;
+
     private final Long created;
 
     //CHECKSTYLE:OFF
     public EnvironmentCreationDto(String name, String description, String cloudPlatform, String accountId,
             LocationDto location, NetworkDto network, CredentialAwareEnvRequest credential,
             Set<String> regions, Set<String> proxyNames, boolean createFreeIpa, AuthenticationDto authentication,
-            Long created) {
+            Long created, Telemetry telemetry) {
         //CHECKSTYLE:ON
         this.name = name;
         this.description = description;
@@ -60,6 +63,7 @@ public class EnvironmentCreationDto {
             this.proxyNames = proxyNames;
         }
         this.authentication = authentication;
+        this.telemetry = telemetry;
     }
 
     public String getName() {
@@ -98,6 +102,10 @@ public class EnvironmentCreationDto {
         return credential;
     }
 
+    public Telemetry getTelemetry() {
+        return telemetry;
+    }
+
     public boolean isCreateFreeIpa() {
         return createFreeIpa;
     }
@@ -128,6 +136,8 @@ public class EnvironmentCreationDto {
         private Set<String> regions;
 
         private Set<String> proxyNames;
+
+        private Telemetry telemetry;
 
         private boolean createFreeIpa = true;
 
@@ -202,9 +212,14 @@ public class EnvironmentCreationDto {
             return this;
         }
 
+        public Builder withTelemetry(Telemetry telemetry) {
+            this.telemetry = telemetry;
+            return this;
+        }
+
         public EnvironmentCreationDto build() {
             return new EnvironmentCreationDto(name, description, cloudPlatform, accountId,
-                    location, network, credential, regions, proxyNames, createFreeIpa, authentication, created);
+                    location, network, credential, regions, proxyNames, createFreeIpa, authentication, created, telemetry);
         }
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentDto.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentDto.java
@@ -30,6 +30,8 @@ public class EnvironmentDto implements Payload {
 
     private Json regions;
 
+    private Json telemetry;
+
     private boolean archived;
 
     private Long deletionTimestamp = -1L;
@@ -119,6 +121,14 @@ public class EnvironmentDto implements Payload {
 
     public void setRegions(Json regions) {
         this.regions = regions;
+    }
+
+    public Json getTelemetry() {
+        return telemetry;
+    }
+
+    public void setTelemetry(Json telemetry) {
+        this.telemetry = telemetry;
     }
 
     public boolean isArchived() {
@@ -236,6 +246,8 @@ public class EnvironmentDto implements Payload {
 
         private Json regions;
 
+        private Json telemetry;
+
         private boolean archived;
 
         private Long deletionTimestamp = -1L;
@@ -295,6 +307,11 @@ public class EnvironmentDto implements Payload {
 
         public Builder withRegions(Json regions) {
             this.regions = regions;
+            return this;
+        }
+
+        public Builder withTelemetry(Json telemetry) {
+            this.telemetry = telemetry;
             return this;
         }
 
@@ -366,6 +383,7 @@ public class EnvironmentDto implements Payload {
             environmentDto.setDescription(description);
             environmentDto.setCredential(credential);
             environmentDto.setCloudPlatform(cloudPlatform);
+            environmentDto.setTelemetry(telemetry);
             environmentDto.setRegions(regions);
             environmentDto.setArchived(archived);
             environmentDto.setDeletionTimestamp(deletionTimestamp);

--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentDtoConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentDtoConverter.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.environment.CloudPlatform;
 import com.sequenceiq.environment.environment.EnvironmentStatus;
 import com.sequenceiq.environment.environment.domain.Environment;
@@ -35,6 +36,7 @@ public class EnvironmentDtoConverter {
                 .withDeletionTimestamp(environment.getDeletionTimestamp())
                 .withLocationDto(environmentToLocationDto(environment))
                 .withRegions(environment.getRegions())
+                .withTelemetry(environment.getTelemetry())
                 .withEnvironmentStatus(environment.getStatus())
                 .withCreator(environment.getCreator())
                 .withCreateFreeIpa(environment.isCreateFreeIpa())
@@ -59,6 +61,9 @@ public class EnvironmentDtoConverter {
         environment.setLatitude(creationDto.getLocation().getLatitude());
         environment.setLongitude(creationDto.getLocation().getLongitude());
         environment.setLocation(creationDto.getLocation().getName());
+        if (creationDto.getTelemetry() != null) {
+            environment.setTelemetry(new Json(creationDto.getTelemetry()));
+        }
         environment.setLocationDisplayName(creationDto.getLocation().getDisplayName());
         environment.setStatus(EnvironmentStatus.CREATION_INITIATED);
         environment.setCreateFreeIpa(creationDto.isCreateFreeIpa());

--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentEditDto.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentEditDto.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import org.apache.commons.collections4.CollectionUtils;
 
+import com.sequenceiq.cloudbreak.cloud.model.Telemetry;
 import com.sequenceiq.environment.network.dto.NetworkDto;
 
 public class EnvironmentEditDto {
@@ -14,6 +15,8 @@ public class EnvironmentEditDto {
     private final Set<String> regions;
 
     private final String accountId;
+
+    private final Telemetry telemetry;
 
     private LocationDto location;
 
@@ -27,7 +30,8 @@ public class EnvironmentEditDto {
             String accountId,
             LocationDto location,
             NetworkDto network,
-            AuthenticationDto authentication) {
+            AuthenticationDto authentication,
+            Telemetry telemetry) {
         this.description = description;
         this.accountId = accountId;
         if (CollectionUtils.isEmpty(regions)) {
@@ -38,6 +42,7 @@ public class EnvironmentEditDto {
         this.network = network;
         this.location = location;
         this.authentication = authentication;
+        this.telemetry = telemetry;
     }
 
     public String getDescription() {
@@ -68,6 +73,10 @@ public class EnvironmentEditDto {
         return authentication;
     }
 
+    public Telemetry getTelemetry() {
+        return telemetry;
+    }
+
     public static final class EnvironmentEditDtoBuilder {
         private String description;
 
@@ -80,6 +89,8 @@ public class EnvironmentEditDto {
         private NetworkDto network;
 
         private AuthenticationDto authentication;
+
+        private Telemetry telemetry;
 
         private EnvironmentEditDtoBuilder() {
         }
@@ -118,8 +129,13 @@ public class EnvironmentEditDto {
             return this;
         }
 
+        public EnvironmentEditDtoBuilder withTelemetry(Telemetry telemetry) {
+            this.telemetry = telemetry;
+            return this;
+        }
+
         public EnvironmentEditDto build() {
-            return new EnvironmentEditDto(description, regions, accountId, location, network, authentication);
+            return new EnvironmentEditDto(description, regions, accountId, location, network, authentication, telemetry);
         }
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/EnvironmentApiConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/EnvironmentApiConverter.java
@@ -21,6 +21,7 @@ import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentN
 import com.sequenceiq.environment.api.v1.environment.model.response.LocationResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.SimpleEnvironmentResponse;
 import com.sequenceiq.environment.credential.v1.converter.CredentialToCredentialV1ResponseConverter;
+import com.sequenceiq.environment.credential.v1.converter.TelemetryApiConverter;
 import com.sequenceiq.environment.environment.dto.AuthenticationDto;
 import com.sequenceiq.environment.environment.dto.EnvironmentChangeCredentialDto;
 import com.sequenceiq.environment.environment.dto.EnvironmentCreationDto;
@@ -41,12 +42,16 @@ public class EnvironmentApiConverter {
 
     private final CredentialToCredentialV1ResponseConverter credentialConverter;
 
+    private final TelemetryApiConverter telemetryApiConverter;
+
     public EnvironmentApiConverter(ThreadBasedUserCrnProvider threadBasedUserCrnProvider,
             RegionConverter regionConverter,
-            CredentialToCredentialV1ResponseConverter credentialConverter) {
+            CredentialToCredentialV1ResponseConverter credentialConverter,
+            TelemetryApiConverter telemetryApiConverter) {
         this.threadBasedUserCrnProvider = threadBasedUserCrnProvider;
         this.regionConverter = regionConverter;
         this.credentialConverter = credentialConverter;
+        this.telemetryApiConverter = telemetryApiConverter;
     }
 
     public EnvironmentCreationDto initCreationDto(EnvironmentRequest request) {
@@ -59,6 +64,7 @@ public class EnvironmentApiConverter {
                 .withCreated(System.currentTimeMillis())
                 .withCreateFreeIpa(request.getCreateFreeIpa() == null ? true : request.getCreateFreeIpa())
                 .withLocation(locationRequestToDto(request.getLocation()))
+                .withTelemetry(telemetryApiConverter.convert(request.getTelemetry()))
                 .withRegions(request.getRegions())
                 .withAuthentication(authenticationRequestToDto(request.getAuthentication()));
 
@@ -118,6 +124,7 @@ public class EnvironmentApiConverter {
                 .withAuthentication(authenticationToResponse(environmentDto.getAuthentication()))
                 .withStatusReason(environmentDto.getStatusReason())
                 .withCreated(environmentDto.getCreated())
+                .withTelemetry(telemetryApiConverter.convertFromJson(environmentDto.getTelemetry()))
                 .withRegions(regionConverter.convertRegions(environmentDto.getRegionSet()));
 
         NullUtil.doIfNotNull(environmentDto.getNetwork(), network -> builder.withNetwork(networkDtoToResponse(network)));
@@ -136,6 +143,7 @@ public class EnvironmentApiConverter {
                 .withCreateFreeIpa(environmentDto.isCreateFreeIpa())
                 .withStatusReason(environmentDto.getStatusReason())
                 .withCreated(environmentDto.getCreated())
+                .withTelemetry(telemetryApiConverter.convertFromJson(environmentDto.getTelemetry()))
                 .withRegions(regionConverter.convertRegions(environmentDto.getRegionSet()));
 
         NullUtil.doIfNotNull(environmentDto.getNetwork(), network -> builder.withNetwork(networkDtoToResponse(network)));
@@ -176,6 +184,7 @@ public class EnvironmentApiConverter {
         NullUtil.doIfNotNull(request.getNetwork(), network -> builder.withNetwork(networkRequestToDto(network)));
         NullUtil.doIfNotNull(request.getLocation(), location -> builder.withLocation(locationRequestToDto(location)));
         NullUtil.doIfNotNull(request.getAuthentication(), authentication -> builder.withAuthentication(authenticationRequestToDto(authentication)));
+        NullUtil.doIfNotNull(request.getTelemetry(), telemetryRequest -> builder.withTelemetry(telemetryApiConverter.convert(request.getTelemetry())));
         return builder.build();
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/network/v1/converter/EnvironmentBaseNetworkConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/v1/converter/EnvironmentBaseNetworkConverter.java
@@ -52,6 +52,7 @@ public abstract class EnvironmentBaseNetworkConverter implements EnvironmentNetw
         environmentView.setLocationDisplayName(environment.getLocationDisplayName());
         environmentView.setNetwork(environment.getNetwork());
         environmentView.setRegions(environment.getRegions());
+        environmentView.setTelemetry(environment.getTelemetry());
         return Collections.singleton(environmentView);
     }
 

--- a/environment/src/main/resources/schema/app/20190626141237_DISTX-197_add_telemetry.sql
+++ b/environment/src/main/resources/schema/app/20190626141237_DISTX-197_add_telemetry.sql
@@ -1,0 +1,9 @@
+-- // DISTX-197 Implement Logging/WXM request support on Env side
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE environment ADD COLUMN IF NOT EXISTS telemetry text;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE environment DROP COLUMN IF EXISTS telemetry;


### PR DESCRIPTION
- added telemetry request / response on env side
- save global telemetry settings on env side (nullable - dynamic)
- merge global env telemetry settings with the stack level one

UI changes should be added in the future for the env API

No request validation yet (will be added in another PR) - overall every new field is nullsafe right now, should not broke anything
I will be out until next Thursday so no hurry with merging this