### PR TITLE
CB-1837 Add RDS instance creation to cloud-aws

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilder.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilder.java
@@ -18,6 +18,7 @@ import com.sequenceiq.cloudbreak.cloud.aws.view.AwsInstanceView;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+// import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.common.service.DefaultCostTaggingService;
 import com.sequenceiq.cloudbreak.common.type.InstanceGroupType;
@@ -83,6 +84,18 @@ public class CloudFormationTemplateBuilder {
         model.putAll(defaultCostTaggingService.prepareAllTagsForTemplate());
         try {
             String template = freeMarkerTemplateUtils.processTemplateIntoString(new Template("aws-template", context.template, freemarkerConfiguration), model);
+            return template.replaceAll("\\t|\\n| [\\s]+", "");
+        } catch (IOException | TemplateException e) {
+            throw new CloudConnectorException("Failed to process CloudFormation freemarker template", e);
+        }
+    }
+
+    public String build(RDSModelContext context) {
+        Map<String, Object> model = new HashMap<>();
+        model.putAll(defaultCostTaggingService.prepareAllTagsForTemplate());
+        try {
+            String template = freeMarkerTemplateUtils.processTemplateIntoString(new Template("aws-rds-template", context.template, freemarkerConfiguration),
+                                                                                model);
             return template.replaceAll("\\t|\\n| [\\s]+", "");
         } catch (IOException | TemplateException e) {
             throw new CloudConnectorException("Failed to process CloudFormation freemarker template", e);
@@ -193,6 +206,30 @@ public class CloudFormationTemplateBuilder {
 
         public ModelContext withEncryptedAMIByGroupName(Map<String, String> encryptedAMIByGroupName) {
             this.encryptedAMIByGroupName.putAll(encryptedAMIByGroupName);
+            return this;
+        }
+
+    }
+
+    public static class RDSModelContext {
+        // private AuthenticatedContext ac;
+
+        // private DatabaseStack stack;
+
+        private String template;
+
+        // public RDSModelContext withAuthenticatedContext(AuthenticatedContext ac) {
+        //     this.ac = ac;
+        //     return this;
+        // }
+
+        // public RDSModelContext withStack(DatabaseStack stack) {
+        //     this.stack = stack;
+        //     return this;
+        // }
+
+        public RDSModelContext withTemplate(String template) {
+            this.template = template;
             return this;
         }
 

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsLaunchService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsLaunchService.java
@@ -1,0 +1,155 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource;
+
+import static com.amazonaws.services.cloudformation.model.StackStatus.CREATE_COMPLETE;
+import static com.amazonaws.services.cloudformation.model.StackStatus.CREATE_FAILED;
+import static com.sequenceiq.cloudbreak.cloud.aws.connector.resource.AwsResourceConstants.ERROR_STATUSES;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.cloudformation.AmazonCloudFormationClient;
+import com.amazonaws.services.cloudformation.model.DescribeStacksRequest;
+import com.sequenceiq.cloudbreak.cloud.aws.AwsClient;
+import com.sequenceiq.cloudbreak.cloud.aws.AwsStackRequestHelper;
+import com.sequenceiq.cloudbreak.cloud.aws.CloudFormationStackUtil;
+import com.sequenceiq.cloudbreak.cloud.aws.CloudFormationTemplateBuilder;
+import com.sequenceiq.cloudbreak.cloud.aws.CloudFormationTemplateBuilder.RDSModelContext;
+import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonCloudFormationRetryClient;
+import com.sequenceiq.cloudbreak.cloud.aws.scheduler.AwsBackoffSyncPollingScheduler;
+import com.sequenceiq.cloudbreak.cloud.aws.task.AwsPollTaskFactory;
+import com.sequenceiq.cloudbreak.cloud.aws.view.AwsCredentialView;
+import com.sequenceiq.cloudbreak.cloud.aws.view.AwsNetworkView;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource.Builder;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
+import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
+import com.sequenceiq.cloudbreak.cloud.task.PollTask;
+import com.sequenceiq.cloudbreak.common.type.ResourceType;
+
+@Service
+public class AwsRdsLaunchService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsRdsLaunchService.class);
+
+    private static final String CREATED_DB_INSTANCE = "CreatedDBInstance";
+
+    private static final String CREATED_DB_SUBNET_GROUP = "CreatedDBSubnetGroup";
+
+    @Inject
+    private CloudFormationStackUtil cfStackUtil;
+
+    @Inject
+    private AwsClient awsClient;
+
+    // @Inject
+    // private AwsNetworkService awsNetworkService;
+
+    @Inject
+    private AwsBackoffSyncPollingScheduler<Boolean> awsBackoffSyncPollingScheduler;
+
+    @Inject
+    private CloudFormationTemplateBuilder cloudFormationTemplateBuilder;
+
+    @Inject
+    private AwsPollTaskFactory awsPollTaskFactory;
+
+    @Inject
+    private AwsStackRequestHelper awsStackRequestHelper;
+
+    @Inject
+    private AwsResourceConnector awsResourceConnector;
+
+    public List<CloudResourceStatus> launch(AuthenticatedContext ac, DatabaseStack stack, PersistenceNotifier resourceNotifier)
+            throws Exception {
+        String cFStackName = cfStackUtil.getCfStackName(ac);
+        AwsCredentialView credentialView = new AwsCredentialView(ac.getCloudCredential());
+        String regionName = ac.getCloudContext().getLocation().getRegion().value();
+        AmazonCloudFormationRetryClient cfRetryClient = awsClient.createCloudFormationRetryClient(credentialView, regionName);
+        AwsNetworkView awsNetworkView = new AwsNetworkView(stack.getNetwork());
+        try {
+            cfRetryClient.describeStacks(new DescribeStacksRequest().withStackName(cFStackName));
+            LOGGER.debug("Stack already exists: {}", cFStackName);
+        } catch (AmazonServiceException ignored) {
+            boolean existingVPC = awsNetworkView.isExistingVPC();
+            // all subnets desired for DB subnet group are in the stack
+            boolean existingSubnet = awsNetworkView.isExistingSubnet();
+            if (!existingVPC || !existingSubnet) {
+                throw new CloudConnectorException("Can only create RDS instance with existing subnets");
+            }
+            CloudResource cloudFormationStack = new Builder().type(ResourceType.CLOUDFORMATION_STACK).name(cFStackName).build();
+            resourceNotifier.notifyAllocation(cloudFormationStack, ac.getCloudContext());
+
+            RDSModelContext rdsModelContext = new RDSModelContext()
+                    // .withAuthenticatedContext(ac)
+                    // .withStack(stack)
+                    .withTemplate(stack.getTemplate());
+            String cfTemplate = cloudFormationTemplateBuilder.build(rdsModelContext);
+            LOGGER.debug("CloudFormationTemplate: {}", cfTemplate);
+            cfRetryClient.createStack(awsStackRequestHelper.createCreateStackRequest(ac, stack, cFStackName, cfTemplate));
+        }
+        LOGGER.debug("CloudFormation stack creation request sent with stack name: '{}' for stack: '{}'", cFStackName, ac.getCloudContext().getId());
+
+        AmazonCloudFormationClient cfClient = awsClient.createCloudFormationClient(credentialView, regionName);
+        // autoscaling client is unused by task!
+        PollTask<Boolean> task = awsPollTaskFactory.newAwsCreateStackStatusCheckerTask(ac, cfClient, null, CREATE_COMPLETE, CREATE_FAILED, ERROR_STATUSES,
+                cFStackName);
+        try {
+            awsBackoffSyncPollingScheduler.schedule(task);
+        } catch (RuntimeException e) {
+            throw new CloudConnectorException(e.getMessage(), e);
+        }
+
+        List<CloudResource> databaseResources = getCreatedOutputs(ac, stack, cFStackName, cfRetryClient, resourceNotifier);
+        // FIXME check does nothing?!
+        return awsResourceConnector.check(ac, databaseResources);
+    }
+
+    private List<CloudResource> getCreatedOutputs(AuthenticatedContext ac, DatabaseStack stack, String cFStackName, AmazonCloudFormationRetryClient client,
+            PersistenceNotifier resourceNotifier) {
+        List<CloudResource> resources = new ArrayList<>();
+
+        String dbInstanceId = getCreatedDBInstance(cFStackName, client);
+        CloudResource dbInstance = new Builder().type(ResourceType.RDS_INSTANCE).name(dbInstanceId).build();
+        resourceNotifier.notifyAllocation(dbInstance, ac.getCloudContext());
+        resources.add(dbInstance);
+
+        String dbSubnetGroupId = getCreatedDBSubnetGroup(cFStackName, client);
+        CloudResource dbSubnetGroup = new Builder().type(ResourceType.RDS_DB_SUBNET_GROUP).name(dbSubnetGroupId).build();
+        resourceNotifier.notifyAllocation(dbSubnetGroup, ac.getCloudContext());
+        resources.add(dbSubnetGroup);
+
+        return resources;
+    }
+
+    private String getCreatedDBInstance(String cFStackName, AmazonCloudFormationRetryClient client) {
+        Map<String, String> outputs = cfStackUtil.getOutputs(cFStackName, client);
+        if (outputs.containsKey(CREATED_DB_INSTANCE)) {
+            return outputs.get(CREATED_DB_INSTANCE);
+        } else {
+            String outputKeyNotFound = String.format("DB instance could not be found in the Cloudformation stack('%s') output.", cFStackName);
+            throw new CloudConnectorException(outputKeyNotFound);
+        }
+    }
+
+    private String getCreatedDBSubnetGroup(String cFStackName, AmazonCloudFormationRetryClient client) {
+        Map<String, String> outputs = cfStackUtil.getOutputs(cFStackName, client);
+        if (outputs.containsKey(CREATED_DB_SUBNET_GROUP)) {
+            return outputs.get(CREATED_DB_SUBNET_GROUP);
+        } else {
+            String outputKeyNotFound = String.format("DB subnet group could not be found in the Cloudformation stack('%s') output.", cFStackName);
+            throw new CloudConnectorException(outputKeyNotFound);
+        }
+    }
+
+}

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnector.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnector.java
@@ -62,6 +62,9 @@ public class AwsResourceConnector implements ResourceConnector<Object> {
     private AwsLaunchService awsLaunchService;
 
     @Inject
+    private AwsRdsLaunchService awsRdsLaunchService;
+
+    @Inject
     private AwsTerminateService awsTerminateService;
 
     @Inject
@@ -80,9 +83,9 @@ public class AwsResourceConnector implements ResourceConnector<Object> {
     }
 
     @Override
-    public List<CloudResourceStatus> launchDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
-            PersistenceNotifier persistenceNotifier) {
-        throw new UnsupportedOperationException("Database server launch is not supported for " + getClass().getName());
+    public List<CloudResourceStatus> launchDatabaseServer(AuthenticatedContext ac, DatabaseStack stack,
+            PersistenceNotifier persistenceNotifier) throws Exception {
+        return awsRdsLaunchService.launch(ac, stack, persistenceNotifier);
     }
 
     private boolean deployingToSameVPC(AwsNetworkView awsNetworkView, boolean existingVPC) {

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsNetworkView.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsNetworkView.java
@@ -2,19 +2,21 @@ package com.sequenceiq.cloudbreak.cloud.aws.view;
 
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
-import java.util.Arrays;
 import java.util.List;
 
-import com.google.common.collect.Lists;
+import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.cloud.model.Network;
 
 public class AwsNetworkView {
 
-    private static final String VPC = "vpcId";
+    @VisibleForTesting
+    static final String VPC = "vpcId";
 
-    private static final String IGW = "internetGatewayId";
+    @VisibleForTesting
+    static final String IGW = "internetGatewayId";
 
-    private static final String SUBNET = "subnetId";
+    @VisibleForTesting
+    static final String SUBNET = "subnetId";
 
     private final Network network;
 
@@ -39,11 +41,11 @@ public class AwsNetworkView {
     }
 
     public boolean isSubnetList() {
-        return getExistingSubnet().contains(",");
+        return isExistingSubnet() && getExistingSubnet().contains(",");
     }
 
     public List<String> getSubnetList() {
-        return isSubnetList() ? Arrays.asList(getExistingSubnet().split(",")) : Lists.newArrayList(getExistingSubnet());
+        return isSubnetList() ? List.of(getExistingSubnet().split(",")) : (isExistingSubnet() ? List.of(getExistingSubnet()) : List.of());
     }
 
     public String getExistingIGW() {

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsRdsDbSubnetGroupView.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsRdsDbSubnetGroupView.java
@@ -1,0 +1,16 @@
+package com.sequenceiq.cloudbreak.cloud.aws.view;
+
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseServer;
+
+public class AwsRdsDbSubnetGroupView {
+
+    private final DatabaseServer databaseServer;
+
+    public AwsRdsDbSubnetGroupView(DatabaseServer databaseServer) {
+        this.databaseServer = databaseServer;
+    }
+
+    public String getDBSubnetGroupName() {
+        return databaseServer.getServerId() != null ? "dsg-" + databaseServer.getServerId() : null;
+    }
+}

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsRdsInstanceView.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsRdsInstanceView.java
@@ -1,0 +1,66 @@
+package com.sequenceiq.cloudbreak.cloud.aws.view;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseServer;
+
+import java.util.List;
+
+public class AwsRdsInstanceView {
+
+    @VisibleForTesting
+    static final String BACKUP_RETENTION_PERIOD = "backupRetentionPeriod";
+
+    @VisibleForTesting
+    static final String ENGINE_VERSION = "engineVersion";
+
+    private final DatabaseServer databaseServer;
+
+    public AwsRdsInstanceView(DatabaseServer databaseServer) {
+        this.databaseServer = databaseServer;
+    }
+
+    public Long getAllocatedStorage() {
+        return databaseServer.getStorageSize();
+    }
+
+    public Integer getBackupRetentionPeriod() {
+        return databaseServer.getParameter(BACKUP_RETENTION_PERIOD, Integer.class);
+    }
+
+    public String getDBInstanceClass() {
+        return databaseServer.getFlavor();
+    }
+
+    public String getDBInstanceIdentifier() {
+        return databaseServer.getServerId();
+    }
+
+    public String getEngine() {
+        if (databaseServer.getEngine() == null) {
+            return null;
+        }
+        switch (databaseServer.getEngine()) {
+            case POSTGRESQL:
+                return "postgres";
+            default:
+                throw new IllegalStateException("Unsupported RDS engine " + databaseServer.getEngine());
+        }
+    }
+
+    public String getEngineVersion() {
+        return databaseServer.getStringParameter(ENGINE_VERSION);
+    }
+
+    public String getMasterUsername() {
+        return databaseServer.getRootUserName();
+    }
+
+    public String getMasterUserPassword() {
+        return databaseServer.getRootPassword();
+    }
+
+    public List<String> getVPCSecurityGroups() {
+        return databaseServer.getSecurity().getCloudSecurityIds();
+    }
+
+}

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsStackRequestHelperTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsStackRequestHelperTest.java
@@ -1,17 +1,18 @@
 package com.sequenceiq.cloudbreak.cloud.aws;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
 
-import org.junit.Assert;
+import java.util.Collection;
+
+import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import com.amazonaws.services.cloudformation.model.CreateStackRequest;
 import com.amazonaws.services.cloudformation.model.Tag;
@@ -24,12 +25,14 @@ import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.AvailabilityZone;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseServer;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.cloud.model.Location;
 import com.sequenceiq.cloudbreak.cloud.model.Network;
 import com.sequenceiq.cloudbreak.cloud.model.Region;
+import com.sequenceiq.cloudbreak.cloud.model.Security;
 
-@RunWith(MockitoJUnitRunner.class)
 public class AwsStackRequestHelperTest {
 
     @Mock
@@ -38,33 +41,87 @@ public class AwsStackRequestHelperTest {
     @Mock
     private AwsClient awsClient;
 
+    @Mock
+    private AuthenticatedContext authenticatedContext;
+
+    @Mock
+    private CloudContext cloudContext;
+
+    @Mock
+    private CloudStack cloudStack;
+
+    @Mock
+    private DatabaseStack databaseStack;
+
+    @Mock
+    private Image image;
+
+    @Mock
+    private Network network;
+
+    @Mock
+    private DatabaseServer databaseServer;
+
+    @Mock
+    private Security security;
+
+    @Mock
+    private AmazonEC2Client amazonEC2Client;
+
     @InjectMocks
     private AwsStackRequestHelper underTest;
 
-    @Test
-    public void testTegPreparationIsCalled() {
-        AuthenticatedContext authenticatedContext = mock(AuthenticatedContext.class);
-        CloudStack cloudStack = mock(CloudStack.class);
-        Image image = mock(Image.class);
-        CloudContext cloudContext = mock(CloudContext.class);
-        AmazonEC2Client amazonEC2Client = mock(AmazonEC2Client.class);
-        Network network = mock(Network.class);
+    @Before
+    public void setUp() {
+        initMocks(this);
+
+        when(authenticatedContext.getCloudContext()).thenReturn(cloudContext);
 
         when(cloudStack.getImage()).thenReturn(image);
-        when(authenticatedContext.getCloudContext()).thenReturn(cloudContext);
-        when(cloudContext.getLocation()).thenReturn(Location.location(Region.region("region"), new AvailabilityZone("az")));
+        when(cloudStack.getNetwork()).thenReturn(network);
+        when(databaseStack.getNetwork()).thenReturn(network);
+        when(databaseStack.getDatabaseServer()).thenReturn(databaseServer);
+
+        when(databaseServer.getSecurity()).thenReturn(security);
+
         when(awsClient.createAccess(any(AwsCredentialView.class), anyString())).thenReturn(amazonEC2Client);
+    }
+
+    @Test
+    public void testCreateCreateStackRequestForCloudStack() {
+        when(cloudContext.getLocation()).thenReturn(Location.location(Region.region("region"), new AvailabilityZone("az")));
         DescribeImagesResult imagesResult = new DescribeImagesResult();
         when(amazonEC2Client.describeImages(any(DescribeImagesRequest.class)))
                 .thenReturn(imagesResult.withImages(new com.amazonaws.services.ec2.model.Image()));
-        when(cloudStack.getNetwork()).thenReturn(network);
         when(network.getStringParameter(anyString())).thenReturn("");
-        when(awsTagPreparationService.prepareCloudformationTags(authenticatedContext, cloudStack.getTags())).thenReturn(Lists.newArrayList(new Tag()));
+
+        Collection<Tag> tags = Lists.newArrayList(new Tag().withKey("mytag").withValue("myvalue"));
+        when(awsTagPreparationService.prepareCloudformationTags(authenticatedContext, cloudStack.getTags())).thenReturn(tags);
 
         CreateStackRequest createStackRequest =
                 underTest.createCreateStackRequest(authenticatedContext, cloudStack, "stackName", "subnet", "template");
 
+        assertEquals("stackName", createStackRequest.getStackName());
+        assertEquals("template", createStackRequest.getTemplateBody());
+
         verify(awsTagPreparationService).prepareCloudformationTags(authenticatedContext, cloudStack.getTags());
-        Assert.assertFalse(createStackRequest.getTags().isEmpty());
+        assertEquals(tags, createStackRequest.getTags());
     }
+
+    @Test
+    public void testCreateCreateStackRequestForDatabaseStack() {
+        Collection<Tag> tags = Lists.newArrayList(new Tag().withKey("mytag").withValue("myvalue"));
+        when(awsTagPreparationService.prepareCloudformationTags(authenticatedContext, databaseStack.getTags())).thenReturn(tags);
+
+        CreateStackRequest createStackRequest =
+                underTest.createCreateStackRequest(authenticatedContext, databaseStack, "stackName", "template");
+
+        assertEquals("stackName", createStackRequest.getStackName());
+        assertEquals("template", createStackRequest.getTemplateBody());
+
+        verify(awsTagPreparationService).prepareCloudformationTags(authenticatedContext, cloudStack.getTags());
+        assertEquals(tags, createStackRequest.getTags());
+    }
+
+    // TODO: test getStackParameters
 }

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilderDBTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilderDBTest.java
@@ -1,0 +1,187 @@
+package com.sequenceiq.cloudbreak.cloud.aws;
+
+import static com.sequenceiq.cloudbreak.cloud.aws.TestConstants.LATEST_AWS_CLOUD_FORMATION_DB_TEMPLATE_PATH;
+import static java.util.Collections.emptyList;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.ui.freemarker.FreeMarkerConfigurationFactoryBean;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.Lists;
+import com.sequenceiq.cloudbreak.cloud.aws.CloudFormationTemplateBuilder.RDSModelContext;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.model.AvailabilityZone;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseEngine;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseServer;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.Location;
+import com.sequenceiq.cloudbreak.cloud.model.Network;
+import com.sequenceiq.cloudbreak.cloud.model.Region;
+import com.sequenceiq.cloudbreak.cloud.model.Security;
+import com.sequenceiq.cloudbreak.common.service.DefaultCostTaggingService;
+import com.sequenceiq.cloudbreak.common.type.CloudbreakResourceType;
+import com.sequenceiq.cloudbreak.util.FreeMarkerTemplateUtils;
+import com.sequenceiq.cloudbreak.common.json.JsonUtil;
+
+import freemarker.template.Configuration;
+
+@RunWith(Parameterized.class)
+public class CloudFormationTemplateBuilderDBTest {
+
+    private static final String V16 = "1.16";
+
+    private static final String USER_ID = "horton@hortonworks.com";
+
+    private static final Long WORKSPACE_ID = 1L;
+
+    private static final String CIDR = "10.0.0.0/16";
+
+    private static final int ROOT_VOLUME_SIZE = 17;
+
+    @Mock
+    private DefaultCostTaggingService defaultCostTaggingService;
+
+    @Mock
+    private FreeMarkerTemplateUtils freeMarkerTemplateUtils;
+
+    @InjectMocks
+    private CloudFormationTemplateBuilder cloudFormationTemplateBuilder;
+
+    private DatabaseStack databaseStack;
+
+    private RDSModelContext modelContext;
+
+    private String awsCloudFormationTemplate;
+
+    private AuthenticatedContext authenticatedContext;
+
+    private final String templatePath;
+
+    private final Map<String, String> defaultTags = new HashMap<>();
+
+    public CloudFormationTemplateBuilderDBTest(String templatePath) {
+        this.templatePath = templatePath;
+    }
+
+    @Parameters(name = "{0}")
+    public static Iterable<?> getTemplatesPath() {
+        List<String> templates = Lists.newArrayList(LATEST_AWS_CLOUD_FORMATION_DB_TEMPLATE_PATH);
+        File[] templateFiles = new File(CloudFormationTemplateBuilderDBTest.class.getClassLoader().getResource("dbtemplates").getPath()).listFiles();
+        List<String> olderTemplates = Arrays.stream(templateFiles).map(file -> {
+            String[] path = file.getPath().split("/");
+            return "templates/" + path[path.length - 1];
+        }).filter(s -> !s.contains(".keep")).collect(Collectors.toList());
+        templates.addAll(olderTemplates);
+        return templates;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+        FreeMarkerConfigurationFactoryBean factoryBean = new FreeMarkerConfigurationFactoryBean();
+        factoryBean.setPreferFileSystemAccess(false);
+        factoryBean.setTemplateLoaderPath("classpath:/");
+        factoryBean.afterPropertiesSet();
+        Configuration configuration = factoryBean.getObject();
+        ReflectionTestUtils.setField(cloudFormationTemplateBuilder, "freemarkerConfiguration", configuration);
+
+        when(freeMarkerTemplateUtils.processTemplateIntoString(any(), any())).thenCallRealMethod();
+
+        awsCloudFormationTemplate = configuration.getTemplate(templatePath, "UTF-8").toString();
+        authenticatedContext = authenticatedContext();
+
+        defaultTags.put(CloudbreakResourceType.DATABASE.templateVariable(), CloudbreakResourceType.DATABASE.key());
+        when(defaultCostTaggingService.prepareAllTagsForTemplate()).thenReturn(defaultTags);
+        databaseStack = createDefaultDatabaseStack(getDefaultDatabaseStackTags());
+    }
+
+    @Test
+    public void buildTestDBServer() throws IOException {
+        //WHEN
+        modelContext = new RDSModelContext()
+                // .withAuthenticatedContext(authenticatedContext)
+                // .withStack(databaseStack)
+                .withTemplate(awsCloudFormationTemplate);
+        String templateString = cloudFormationTemplateBuilder.build(modelContext);
+        //THEN
+        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        // FIXME this is apparently intentional, but it doesn't make sense
+        assertThat(templateString, not(containsString("testtagkey")));
+        assertThat(templateString, not(containsString("testtagvalue")));
+        JsonNode jsonNode = JsonUtil.readTree(templateString);
+        jsonNode.findValues("Tags").forEach(jsonNode1 -> {
+            assertTrue(jsonNode1.findValues("Key").stream().anyMatch(jsonNode2 -> "cb-resource-type".equals(jsonNode2.textValue())));
+        });
+    }
+
+    private AuthenticatedContext authenticatedContext() {
+        Location location = Location.location(Region.region("region"), AvailabilityZone.availabilityZone("az"));
+        CloudContext cloudContext = new CloudContext(5L, "name", "platform", "variant",
+                location, USER_ID, WORKSPACE_ID);
+        CloudCredential credential = new CloudCredential("crn", null);
+        return new AuthenticatedContext(cloudContext, credential);
+    }
+
+    private DatabaseStack createDefaultDatabaseStack(Map<String, String> tags) {
+        Network network = createDefaultNetwork();
+        DatabaseServer server = createDefaultDatabaseServer();
+        return new DatabaseStack(network, server, tags, null);
+    }
+
+    private Network createDefaultNetwork() {
+        return new Network(null, Map.of("subnetId", "subnet-123,subnet-456,subnet-789"));
+    }
+
+    private DatabaseServer createDefaultDatabaseServer() {
+        return new DatabaseServer("myserver", "db.m3.medium", DatabaseEngine.POSTGRESQL, "root", "cloudera", 50L,
+                createDefaultSecurity(), InstanceStatus.CREATE_REQUESTED,
+                Map.of("engineVersion", "1.2.3"));
+    }
+
+    private Map<String, String> getDefaultDatabaseStackTags() {
+        return Map.of("testtagkey", "testtagvalue");
+    }
+
+    private Security createDefaultSecurity() {
+        return new Security(emptyList(), getDefaultSecurityIds());
+    }
+
+    private List<String> getDefaultSecurityIds() {
+        return List.of("sg-1234");
+    }
+
+    private JsonNode getJsonNode(JsonNode node, String value) {
+        if (node == null) {
+            throw new RuntimeException("No Json node provided for seeking value!");
+        }
+        return Optional.ofNullable(node.findValue(value)).orElseThrow(() -> new RuntimeException("No value find in json with the name of: \"" + value + "\""));
+    }
+
+}

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/TestConstants.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/TestConstants.java
@@ -4,6 +4,8 @@ public class TestConstants {
 
     public static final String LATEST_AWS_CLOUD_FORMATION_TEMPLATE_PATH = "templates/aws-cf-stack.ftl";
 
+    public static final String LATEST_AWS_CLOUD_FORMATION_DB_TEMPLATE_PATH = "templates/aws-cf-dbstack.ftl";
+
     private TestConstants() {
     }
 }

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsNetworkViewTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsNetworkViewTest.java
@@ -1,0 +1,90 @@
+package com.sequenceiq.cloudbreak.cloud.aws.view;
+
+import static com.sequenceiq.cloudbreak.cloud.aws.view.AwsNetworkView.IGW;
+import static com.sequenceiq.cloudbreak.cloud.aws.view.AwsNetworkView.SUBNET;
+import static com.sequenceiq.cloudbreak.cloud.aws.view.AwsNetworkView.VPC;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import com.sequenceiq.cloudbreak.cloud.model.Network;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+public class AwsNetworkViewTest {
+
+    @Mock
+    private Network network;
+
+    private AwsNetworkView underTest;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+
+        underTest = new AwsNetworkView(network);
+    }
+
+    @Test
+    public void testVpc() {
+        when(network.getStringParameter(VPC)).thenReturn("vpc-123");
+        assertTrue(underTest.isExistingVPC());
+        assertEquals("vpc-123", underTest.getExistingVPC());
+    }
+
+    @Test
+    public void testNoVpc() {
+        when(network.getStringParameter(VPC)).thenReturn(null);
+        assertFalse(underTest.isExistingVPC());
+        assertNull(underTest.getExistingVPC());
+    }
+
+    @Test
+    public void testIgw() {
+        when(network.getStringParameter(IGW)).thenReturn("igw-123");
+        assertTrue(underTest.isExistingIGW());
+        assertEquals("igw-123", underTest.getExistingIGW());
+    }
+
+    @Test
+    public void testNoIgw() {
+        when(network.getStringParameter(IGW)).thenReturn(null);
+        assertFalse(underTest.isExistingIGW());
+        assertNull(underTest.getExistingIGW());
+    }
+
+    @Test
+    public void testSingleSubnet() {
+        when(network.getStringParameter(SUBNET)).thenReturn("subnet-123");
+        assertTrue(underTest.isExistingSubnet());
+        assertEquals("subnet-123", underTest.getExistingSubnet());
+        assertFalse(underTest.isSubnetList());
+        assertEquals(List.of("subnet-123"), underTest.getSubnetList());
+    }
+
+    @Test
+    public void testMultipleSubnet() {
+        when(network.getStringParameter(SUBNET)).thenReturn("subnet-123,subnet-456,subnet-789");
+        assertTrue(underTest.isExistingSubnet());
+        assertEquals("subnet-123,subnet-456,subnet-789", underTest.getExistingSubnet());
+        assertTrue(underTest.isSubnetList());
+        assertEquals(List.of("subnet-123", "subnet-456", "subnet-789"), underTest.getSubnetList());
+    }
+
+    @Test
+    public void testNoSubnet() {
+        when(network.getStringParameter(SUBNET)).thenReturn(null);
+        assertFalse(underTest.isExistingSubnet());
+        assertNull(underTest.getExistingSubnet());
+        assertFalse(underTest.isSubnetList());
+        assertEquals(List.of(), underTest.getSubnetList());
+    }
+
+}

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsRdsDbSubnetGroupViewTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsRdsDbSubnetGroupViewTest.java
@@ -1,0 +1,40 @@
+package com.sequenceiq.cloudbreak.cloud.aws.view;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseServer;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.Mock;
+
+public class AwsRdsDbSubnetGroupViewTest {
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private DatabaseServer server;
+
+    private AwsRdsDbSubnetGroupView underTest;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+
+        underTest = new AwsRdsDbSubnetGroupView(server);
+    }
+
+    @Test
+    public void testDBSubnetGroupName() {
+        when(server.getServerId()).thenReturn("myserver");
+        assertEquals("dsg-myserver", underTest.getDBSubnetGroupName());
+    }
+
+    @Test
+    public void testNoDBSubnetGroupName() {
+        when(server.getServerId()).thenReturn(null);
+        assertNull(underTest.getDBSubnetGroupName());
+    }
+}

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsRdsInstanceViewTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsRdsInstanceViewTest.java
@@ -1,0 +1,135 @@
+package com.sequenceiq.cloudbreak.cloud.aws.view;
+
+import static com.sequenceiq.cloudbreak.cloud.aws.view.AwsRdsInstanceView.BACKUP_RETENTION_PERIOD;
+import static com.sequenceiq.cloudbreak.cloud.aws.view.AwsRdsInstanceView.ENGINE_VERSION;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseEngine;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseServer;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.Mock;
+
+public class AwsRdsInstanceViewTest {
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private DatabaseServer server;
+
+    private AwsRdsInstanceView underTest;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+
+        underTest = new AwsRdsInstanceView(server);
+    }
+
+    @Test
+    public void testAllocatedStorage() {
+        when(server.getStorageSize()).thenReturn(50L);
+        assertEquals(50L, underTest.getAllocatedStorage().longValue());
+    }
+
+    @Test
+    public void testBackupRetentionPeriod() {
+        when(server.getParameter(BACKUP_RETENTION_PERIOD, Integer.class)).thenReturn(Integer.valueOf("3"));
+        assertEquals(3, underTest.getBackupRetentionPeriod().intValue());
+    }
+
+    @Test
+    public void testNoBackupRetentionPeriod() {
+        when(server.getParameter(BACKUP_RETENTION_PERIOD, Integer.class)).thenReturn(null);
+        assertNull(underTest.getBackupRetentionPeriod());
+    }
+
+    @Test
+    public void testDBInstanceClass() {
+        when(server.getFlavor()).thenReturn("db.m3.medium");
+        assertEquals("db.m3.medium", underTest.getDBInstanceClass());
+    }
+
+    @Test
+    public void testNoDBInstanceClass() {
+        when(server.getFlavor()).thenReturn(null);
+        assertNull(underTest.getDBInstanceClass());
+    }
+
+    @Test
+    public void testDBInstanceIdentifier() {
+        when(server.getServerId()).thenReturn("myserver");
+        assertEquals("myserver", underTest.getDBInstanceIdentifier());
+    }
+
+    @Test
+    public void testNoDBInstanceIdentifier() {
+        when(server.getServerId()).thenReturn(null);
+        assertNull(underTest.getDBInstanceIdentifier());
+    }
+
+    @Test
+    public void testMasterUsername() {
+        when(server.getRootUserName()).thenReturn("root");
+        assertEquals("root", underTest.getMasterUsername());
+    }
+
+    @Test
+    public void testEnginePostgres() {
+        when(server.getEngine()).thenReturn(DatabaseEngine.POSTGRESQL);
+        assertEquals("postgres", underTest.getEngine());
+    }
+
+    @Test
+    public void testNoEngine() {
+        when(server.getEngine()).thenReturn(null);
+        assertNull(underTest.getEngine());
+    }
+
+    @Test
+    public void testEngineVersion() {
+        when(server.getStringParameter(ENGINE_VERSION)).thenReturn("1.2.3");
+        assertEquals("1.2.3", underTest.getEngineVersion());
+    }
+
+    @Test
+    public void testNoEngineVersion() {
+        when(server.getStringParameter(ENGINE_VERSION)).thenReturn(null);
+        assertNull(underTest.getEngineVersion());
+    }
+
+    @Test
+    public void testNoMasterUsername() {
+        when(server.getRootUserName()).thenReturn(null);
+        assertNull(underTest.getMasterUsername());
+    }
+
+    @Test
+    public void testMasterUserPassword() {
+        when(server.getRootPassword()).thenReturn("cloudera");
+        assertEquals("cloudera", underTest.getMasterUserPassword());
+    }
+
+    @Test
+    public void testNoMasterUserPassword() {
+        when(server.getRootPassword()).thenReturn(null);
+        assertNull(underTest.getMasterUserPassword());
+    }
+
+    @Test
+    public void testVPCSecurityGroups() {
+        when(server.getSecurity().getCloudSecurityIds()).thenReturn(List.of("sg-123"));
+        assertEquals(List.of("sg-123"), underTest.getVPCSecurityGroups());
+    }
+
+    @Test
+    public void testNoVPCSecurityGroups() {
+        when(server.getSecurity().getCloudSecurityIds()).thenReturn(null);
+        assertNull(underTest.getVPCSecurityGroups());
+    }
+}

--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/common/type/CloudbreakResourceType.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/common/type/CloudbreakResourceType.java
@@ -8,7 +8,8 @@ public enum CloudbreakResourceType {
     SECURITY("securitygroup_resource", "securitygroup"),
     IP("ipaddress_resource", "ipaddress"),
     DISK("disk_resource", "disk"),
-    STORAGE("storage_resource", "storage");
+    STORAGE("storage_resource", "storage"),
+    DATABASE("database_resource", "database");
 
     private final String key;
     private final String templateVariable;

--- a/cloud-common/src/test/java/com/sequenceiq/cloudbreak/common/service/DefaultCostTaggingServiceTest.java
+++ b/cloud-common/src/test/java/com/sequenceiq/cloudbreak/common/service/DefaultCostTaggingServiceTest.java
@@ -42,7 +42,7 @@ public class DefaultCostTaggingServiceTest {
     @Test
     public void testPrepareAllTagsForTemplateShouldReturnAllResourceMap() {
         Map<String, String> result = underTest.prepareAllTagsForTemplate();
-        Assert.assertEquals(7L, result.size());
+        Assert.assertEquals(8L, result.size());
     }
 
     @Test


### PR DESCRIPTION
The cloud-aws module is augmented with most of the logic needed for
creating RDS instances. The core classes that have been modified or
added are:

* AwsResourceConnector - now delegates to the new AwsRdsLaunchService
  to create an RDS instance
* AwsRdsLaunchService - performs the RDS instance launch process:
  uses the following classes to create a CloudFormation template and
  creation request, then sends the request to AWS and polls for
  completion and outputs
* CloudFormationTemplateBuilder - builds the body of a CloudFormation
  template for a new RDS instance and DB subnet group from a context
* AwsStackRequestHelper - creates a CloudFormation stack creation
  request from a database stack, including setting the necessary
  template parameters

The actual CloudFormation template for new RDS instance, unlike the
one for new clusters, does not require much Freemarker processing at
this time, but that could change in the future.

Several views have been created or modified to codify interpreting the
general cloud-api model objects for RDS operations.

* AwsNetworkView - improved for better support for multiple subnets and
  avoidance of null pointer exceptions
* AwsRdsInstanceView - for locating RDS instance information
* AwsRdsDbSubnetGroupView - for locating DB subnet group information

Unit tests for much of the implementation work is included, but the
overall functionality has not yet been tested for real.