### PR TITLE
CB-1427. Only one DB per type is allowed

### DIFF
--- a/core-model/src/test/java/com/sequenceiq/cloudbreak/TestUtil.java
+++ b/core-model/src/test/java/com/sequenceiq/cloudbreak/TestUtil.java
@@ -643,7 +643,7 @@ public class TestUtil {
     public static RDSConfig rdsConfig(DatabaseType databaseType, DatabaseVendor databaseVendor) {
         RDSConfig rdsConfig = new RDSConfig();
         rdsConfig.setId(generateUniqueId());
-        rdsConfig.setName(databaseType.name());
+        rdsConfig.setName(databaseType.name() + rdsConfig.getId());
         rdsConfig.setConnectionPassword("iamsoosecure");
         rdsConfig.setConnectionUserName("heyitsme");
         if (databaseVendor == DatabaseVendor.ORACLE12 || databaseVendor == DatabaseVendor.ORACLE11) {
@@ -666,16 +666,7 @@ public class TestUtil {
     }
 
     public static RDSConfig rdsConfig(DatabaseType databaseType) {
-        RDSConfig rdsConfig = new RDSConfig();
-        rdsConfig.setId(generateUniqueId());
-        rdsConfig.setName(databaseType.name());
-        rdsConfig.setConnectionPassword("iamsoosecure");
-        rdsConfig.setConnectionUserName("heyitsme");
-        rdsConfig.setConnectionURL("jdbc:postgresql://10.1.1.1:5432/" + databaseType.name().toLowerCase());
-        rdsConfig.setType(databaseType.name());
-        rdsConfig.setConnectionDriver("org.postgresql.Driver");
-        rdsConfig.setDatabaseEngine(DatabaseVendor.POSTGRES);
-        return rdsConfig;
+        return rdsConfig(databaseType, DatabaseVendor.POSTGRES);
     }
 
     private static void setGatewayTopology(Gateway gateway) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/validation/rds/RdsConfigValidator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/validation/rds/RdsConfigValidator.java
@@ -1,20 +1,23 @@
 package com.sequenceiq.cloudbreak.controller.validation.rds;
 
-import java.util.HashMap;
-import java.util.HashSet;
+import static java.util.stream.Collectors.counting;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toCollection;
+
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 
 import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.cluster.ClusterV4Request;
-import com.sequenceiq.cloudbreak.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
+import com.sequenceiq.cloudbreak.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.service.rdsconfig.RdsConfigService;
 import com.sequenceiq.cloudbreak.workspace.model.User;
 import com.sequenceiq.cloudbreak.workspace.model.Workspace;
-import com.sequenceiq.cloudbreak.service.rdsconfig.RdsConfigService;
 
 @Component
 public class RdsConfigValidator {
@@ -23,26 +26,18 @@ public class RdsConfigValidator {
     private RdsConfigService rdsConfigService;
 
     public void validateRdsConfigs(ClusterV4Request request, User user, Workspace workspace) {
-        Map<String, Integer> typeCountMap = new HashMap<>();
-        Set<String> multipleTypes = new HashSet<>();
         if (request.getDatabases() != null) {
-            for (String rdsConfigName : request.getDatabases()) {
-                RDSConfig rdsConfig = rdsConfigService.getByNameForWorkspace(rdsConfigName, workspace);
-                increaseCount(rdsConfig.getType(), typeCountMap, multipleTypes);
+            Set<String> multipleTypes = request.getDatabases().stream()
+                    .map(rdsConfigName -> rdsConfigService.getByNameForWorkspace(rdsConfigName, workspace))
+                    .collect(groupingBy(RDSConfig::getType, counting()))
+                    .entrySet().stream()
+                    .filter(e -> e.getValue() > 1L)
+                    .map(Map.Entry::getKey)
+                    .collect(toCollection(TreeSet::new));
+            if (!multipleTypes.isEmpty()) {
+                throw new BadRequestException("Multiple databases are defined for the following types: "
+                        + String.join(",", multipleTypes));
             }
-        }
-        if (!multipleTypes.isEmpty()) {
-            throw new BadRequestException("Mutliple Rds are defined for the following types: "
-                    + String.join(",", multipleTypes));
-        }
-    }
-
-    private void increaseCount(String type, Map<String, Integer> typeCountMap, Set<String> multipleTypes) {
-        Integer count = typeCountMap.get(type);
-        count = count == null ? 1 : count + 1;
-        typeCountMap.put(type, count);
-        if (count > 1) {
-            multipleTypes.add(type);
         }
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/controller/validation/rds/RdsConfigValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/controller/validation/rds/RdsConfigValidatorTest.java
@@ -1,0 +1,76 @@
+package com.sequenceiq.cloudbreak.controller.validation.rds;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.sequenceiq.cloudbreak.TestUtil;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.cluster.ClusterV4Request;
+import com.sequenceiq.cloudbreak.domain.RDSConfig;
+import com.sequenceiq.cloudbreak.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.service.rdsconfig.RdsConfigService;
+import com.sequenceiq.cloudbreak.workspace.model.Workspace;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RdsConfigValidatorTest {
+
+    @InjectMocks
+    private RdsConfigValidator subject = new RdsConfigValidator();
+
+    @Mock
+    private RdsConfigService rdsConfigService;
+
+    @Mock
+    private Workspace workspace;
+
+    @Test
+    public void acceptsNoDatabases() {
+        ClusterV4Request request = requestWithDatabases();
+
+        subject.validateRdsConfigs(request, null, workspace);
+    }
+
+    @Test
+    public void acceptsMultipleDatabasesOfDifferentType() {
+        ClusterV4Request request = requestWithDatabases(DatabaseType.HIVE, DatabaseType.HUE, DatabaseType.RANGER);
+
+        subject.validateRdsConfigs(request, null, workspace);
+    }
+
+    @Test
+    public void rejectsMultipleDatabasesOfSameType() {
+        ClusterV4Request request = requestWithDatabases(DatabaseType.HIVE, DatabaseType.HUE, DatabaseType.HIVE, DatabaseType.RANGER, DatabaseType.RANGER);
+
+        BadRequestException exception = assertThrows(BadRequestException.class, () -> subject.validateRdsConfigs(request, null, workspace));
+        assertTrue(exception.getMessage().contains("HIVE"));
+        assertFalse(exception.getMessage().contains("HUE"));
+        assertTrue(exception.getMessage().contains("RANGER"));
+    }
+
+    private ClusterV4Request requestWithDatabases(DatabaseType... databaseTypes) {
+        List<RDSConfig> rdsConfigs = Arrays.stream(databaseTypes)
+                .map(TestUtil::rdsConfig)
+                .collect(toList());
+
+        rdsConfigs.forEach(each -> when(rdsConfigService.getByNameForWorkspace(each.getName(), workspace)).thenReturn(each));
+
+        ClusterV4Request request = new ClusterV4Request();
+        request.setDatabases(rdsConfigs.stream().map(RDSConfig::getName).collect(toSet()));
+
+        return request;
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v2/StackV4RequestToTemplatePreparationObjectConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v2/StackV4RequestToTemplatePreparationObjectConverterTest.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.converter.v2;
 
+import static com.sequenceiq.cloudbreak.TestUtil.rdsConfig;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -29,6 +30,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.core.convert.ConversionService;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.cluster.ClusterV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.cluster.ambari.AmbariV4Request;
@@ -244,10 +246,9 @@ public class StackV4RequestToTemplatePreparationObjectConverterTest {
     public void testConvertWhenClusterHasSomeRdsConfigNamesThenTheSameAmountOfRdsConfigShouldBeStored() {
         Set<String> rdsConfigNames = createRdsConfigNames();
         when(cluster.getDatabases()).thenReturn(rdsConfigNames);
-        long id = 0;
+        int i = 0;
         for (String rdsConfigName : rdsConfigNames) {
-            RDSConfig rdsConfig = new RDSConfig();
-            rdsConfig.setId(id++);
+            RDSConfig rdsConfig = rdsConfig(DatabaseType.values()[i++]);
             when(rdsConfigService.getByNameForWorkspace(rdsConfigName, workspace)).thenReturn(rdsConfig);
         }
         TemplatePreparationObject result = underTest.convert(source);

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/AbstractRdsRoleConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/AbstractRdsRoleConfigProvider.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.getRdsConfigOfType;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.domain.RDSConfig;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.cloudbreak.template.views.RdsView;
+
+public abstract class AbstractRdsRoleConfigProvider extends AbstractRoleConfigProvider {
+
+    protected abstract DatabaseType dbType();
+
+    @Override
+    public boolean isConfigurationNeeded(CmTemplateProcessor cmTemplateProcessor, TemplatePreparationObject source) {
+        return getRdsConfig(source) != null
+                && super.isConfigurationNeeded(cmTemplateProcessor, source);
+    }
+
+    protected RDSConfig getRdsConfig(TemplatePreparationObject source) {
+        return getRdsConfigOfType(dbType(), source);
+    }
+
+    protected RdsView getRdsView(TemplatePreparationObject source) {
+        return new RdsView(getRdsConfig(source));
+    }
+
+}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ConfigUtils.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ConfigUtils.java
@@ -48,10 +48,8 @@ public class ConfigUtils {
         return new ApiClusterTemplateVariable().name(name).value(value);
     }
 
-    public static Optional<RDSConfig> getFirstRDSConfigOptional(TemplatePreparationObject source, DatabaseType databaseType) {
-        return source.getRdsConfigs().stream()
-                .filter(rds -> databaseType.name().equalsIgnoreCase(rds.getType()))
-                .findFirst();
+    public static RDSConfig getRdsConfigOfType(DatabaseType databaseType, TemplatePreparationObject source) {
+        return source.getRdsConfig(databaseType);
     }
 
     public static Optional<StorageLocationView> getStorageLocationForServiceProperty(TemplatePreparationObject source, String serviceProperty) {

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hue/HueConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hue/HueConfigProvider.java
@@ -2,21 +2,19 @@ package com.sequenceiq.cloudbreak.cmtemplate.configproviders.hue;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
 import com.cloudera.api.swagger.model.ApiClusterTemplateVariable;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
-import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateComponentConfigProvider;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
-import com.sequenceiq.cloudbreak.domain.RDSConfig;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRdsRoleConfigProvider;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.views.RdsView;
 
 @Component
-public class HueConfigProvider implements CmTemplateComponentConfigProvider {
+public class HueConfigProvider extends AbstractRdsRoleConfigProvider {
 
     private static final String HUE_DATABASE_HOST = "hue-hue_database_host";
 
@@ -31,7 +29,7 @@ public class HueConfigProvider implements CmTemplateComponentConfigProvider {
     private static final String HUE_DATABASE_PASSWORD = "hue-hue_database_password";
 
     @Override
-    public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject templatePreparationObject) {
+    public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject source) {
         List<ApiClusterTemplateConfig> result = new ArrayList<>();
         result.add(new ApiClusterTemplateConfig().name("database_host").variable(HUE_DATABASE_HOST));
         result.add(new ApiClusterTemplateConfig().name("database_port").variable(HUE_DATABASE_PORT));
@@ -45,7 +43,7 @@ public class HueConfigProvider implements CmTemplateComponentConfigProvider {
     @Override
     public List<ApiClusterTemplateVariable> getServiceConfigVariables(TemplatePreparationObject source) {
         List<ApiClusterTemplateVariable> result = new ArrayList<>();
-        RdsView hueRdsView = new RdsView(getFirstRDSConfigOptional(source).get());
+        RdsView hueRdsView = getRdsView(source);
         result.add(new ApiClusterTemplateVariable().name(HUE_DATABASE_HOST).value(hueRdsView.getHost()));
         result.add(new ApiClusterTemplateVariable().name(HUE_DATABASE_PORT).value(hueRdsView.getPort()));
         result.add(new ApiClusterTemplateVariable().name(HUE_DATABASE_NAME).value(hueRdsView.getDatabaseName()));
@@ -66,11 +64,12 @@ public class HueConfigProvider implements CmTemplateComponentConfigProvider {
     }
 
     @Override
-    public boolean isConfigurationNeeded(CmTemplateProcessor cmTemplateProcessor, TemplatePreparationObject source) {
-        return getFirstRDSConfigOptional(source).isPresent() && cmTemplateProcessor.isRoleTypePresentInService(getServiceType(), getRoleTypes());
+    protected DatabaseType dbType() {
+        return DatabaseType.HUE;
     }
 
-    private Optional<RDSConfig> getFirstRDSConfigOptional(TemplatePreparationObject source) {
-        return source.getRdsConfigs().stream().filter(rds -> DatabaseType.HUE.name().equalsIgnoreCase(rds.getType())).findFirst();
+    @Override
+    protected List<ApiClusterTemplateConfig> getRoleConfigs(String roleType, TemplatePreparationObject source) {
+        return List.of();
     }
 }

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/oozie/OozieRoleConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/oozie/OozieRoleConfigProvider.java
@@ -3,22 +3,17 @@ package com.sequenceiq.cloudbreak.cmtemplate.configproviders.oozie;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
-import com.google.common.base.Preconditions;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
-import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
-import com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRoleConfigProvider;
-import com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils;
-import com.sequenceiq.cloudbreak.domain.RDSConfig;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRdsRoleConfigProvider;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.views.RdsView;
 
 @Component
-public class OozieRoleConfigProvider extends AbstractRoleConfigProvider {
+public class OozieRoleConfigProvider extends AbstractRdsRoleConfigProvider {
 
     private static final String OOZIE_DATABASE_HOST = "oozie_database_host";
 
@@ -34,9 +29,7 @@ public class OozieRoleConfigProvider extends AbstractRoleConfigProvider {
     protected List<ApiClusterTemplateConfig> getRoleConfigs(String roleType, TemplatePreparationObject source) {
         switch (roleType) {
             case OozieRoles.OOZIE_SERVER:
-                Optional<RDSConfig> rdsConfigOptional = getFirstRDSConfigOptional(source);
-                Preconditions.checkArgument(rdsConfigOptional.isPresent());
-                RdsView oozieRdsView = new RdsView(rdsConfigOptional.get());
+                RdsView oozieRdsView = getRdsView(source);
                 return List.of(
                         config(OOZIE_DATABASE_HOST, oozieRdsView.getHost()),
                         config(OOZIE_DATABASE_NAME, oozieRdsView.getDatabaseName()),
@@ -60,11 +53,7 @@ public class OozieRoleConfigProvider extends AbstractRoleConfigProvider {
     }
 
     @Override
-    public boolean isConfigurationNeeded(CmTemplateProcessor cmTemplateProcessor, TemplatePreparationObject source) {
-        return getFirstRDSConfigOptional(source).isPresent() && cmTemplateProcessor.isRoleTypePresentInService(getServiceType(), getRoleTypes());
-    }
-
-    private Optional<RDSConfig> getFirstRDSConfigOptional(TemplatePreparationObject source) {
-        return ConfigUtils.getFirstRDSConfigOptional(source, DatabaseType.OOZIE);
+    protected DatabaseType dbType() {
+        return DatabaseType.OOZIE;
     }
 }

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CentralCmTemplateUpdaterTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CentralCmTemplateUpdaterTest.java
@@ -25,7 +25,7 @@ import com.cloudera.api.swagger.model.ApiClusterTemplate;
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
 import com.cloudera.api.swagger.model.ApiClusterTemplateRoleConfigGroup;
 import com.cloudera.api.swagger.model.ApiClusterTemplateService;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
+import com.sequenceiq.cloudbreak.TestUtil;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive.HiveMetastoreConfigProvider;
@@ -70,9 +70,6 @@ public class CentralCmTemplateUpdaterTest {
     @Mock
     private GeneralClusterConfigs generalClusterConfigs;
 
-    @Mock
-    private RDSConfig rdsConfig;
-
     private ClouderaManagerRepo clouderaManagerRepo;
 
     @Before
@@ -82,7 +79,9 @@ public class CentralCmTemplateUpdaterTest {
         when(templatePreparationObject.getBlueprintView()).thenReturn(blueprintView);
         when(templatePreparationObject.getHostgroupViews()).thenReturn(toHostgroupViews(getHostgroupMappings()));
         when(templatePreparationObject.getGeneralClusterConfigs()).thenReturn(generalClusterConfigs);
-        when(templatePreparationObject.getRdsConfigs()).thenReturn(getRdsConfigs());
+        RDSConfig rdsConfig = TestUtil.rdsConfig(DatabaseType.HIVE);
+        when(templatePreparationObject.getRdsConfigs()).thenReturn(Set.of(rdsConfig));
+        when(templatePreparationObject.getRdsConfig(DatabaseType.HIVE)).thenReturn(rdsConfig);
         when(generalClusterConfigs.getClusterName()).thenReturn("testcluster");
         when(generalClusterConfigs.getPassword()).thenReturn("Admin123!");
         clouderaManagerRepo = new ClouderaManagerRepo();
@@ -183,13 +182,4 @@ public class CentralCmTemplateUpdaterTest {
         return result;
     }
 
-    private Set<RDSConfig> getRdsConfigs() {
-        RDSConfig config = new RDSConfig();
-        config.setConnectionURL("jdbc:postgresql://cluster.test.com:5432/hive");
-        config.setDatabaseEngine(DatabaseVendor.POSTGRES);
-        config.setType(DatabaseType.HIVE.name());
-        config.setConnectionUserName("user");
-        config.setConnectionPassword("password");
-        return Set.of(config);
-    }
 }

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/AbstractRdsRoleConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/AbstractRdsRoleConfigProviderTest.java
@@ -1,0 +1,82 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders;
+
+import static com.sequenceiq.cloudbreak.TestUtil.rdsConfig;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.domain.RDSConfig;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+
+class AbstractRdsRoleConfigProviderTest {
+
+    private AbstractRdsRoleConfigProvider subject = new AbstractRdsRoleConfigProvider() {
+        @Override
+        protected DatabaseType dbType() {
+            return DatabaseType.RANGER;
+        }
+
+        @Override
+        protected List<ApiClusterTemplateConfig> getRoleConfigs(String roleType, TemplatePreparationObject source) {
+            return List.of();
+        }
+
+        @Override
+        public String getServiceType() {
+            return "service";
+        }
+
+        @Override
+        public List<String> getRoleTypes() {
+            return List.of("role1", "role2");
+        }
+    };
+
+    @Mock
+    private CmTemplateProcessor templateProcessor;
+
+    @Mock
+    private TemplatePreparationObject source;
+
+    @BeforeEach
+    void setup() {
+        initMocks(this);
+    }
+
+    @Test
+    void configurationNeededIfRdsConfigAndRoleBothPresent() {
+        RDSConfig rdsConfig = rdsConfig(DatabaseType.RANGER);
+        when(source.getRdsConfig(DatabaseType.RANGER)).thenReturn(rdsConfig);
+        when(templateProcessor.isRoleTypePresentInService(subject.getServiceType(), subject.getRoleTypes())).thenReturn(Boolean.TRUE);
+
+        assertTrue(subject.isConfigurationNeeded(templateProcessor, source));
+    }
+
+    @Test
+    void configurationNotNeededIfRoleAbsent() {
+        RDSConfig rdsConfig = rdsConfig(DatabaseType.RANGER);
+        when(source.getRdsConfig(DatabaseType.RANGER)).thenReturn(rdsConfig);
+        when(templateProcessor.isRoleTypePresentInService(subject.getServiceType(), subject.getRoleTypes())).thenReturn(Boolean.FALSE);
+
+        assertFalse(subject.isConfigurationNeeded(templateProcessor, source));
+    }
+
+    @Test
+    void configurationNotNeededIfRdsConfigAbsent() {
+        when(source.getRdsConfig(DatabaseType.RANGER)).thenReturn(null);
+        when(templateProcessor.isRoleTypePresentInService(subject.getServiceType(), subject.getRoleTypes())).thenReturn(Boolean.TRUE);
+
+        assertFalse(subject.isConfigurationNeeded(templateProcessor, source));
+    }
+
+}

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerRoleConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerRoleConfigProviderTest.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.cmtemplate.configproviders.ranger;
 
 import static com.sequenceiq.cloudbreak.TestUtil.rdsConfig;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 
 import java.util.Collections;
@@ -83,7 +84,7 @@ public class RangerRoleConfigProviderTest {
 
     }
 
-    @Test(expected = CloudbreakServiceException.class)
+    @Test
     public void testGetEmptyRoleConfigs() {
         HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, 1);
         HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, 2);
@@ -95,15 +96,10 @@ public class RangerRoleConfigProviderTest {
         String inputJson = getBlueprintText("input/clouderamanager-db-config.bp");
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
 
-        try {
-            underTest.getRoleConfigs(cmTemplateProcessor, preparationObject);
-        } catch (CloudbreakServiceException cse) {
-            assertEquals("Ranger database has not been provided for RANGER_ADMIN component", cse.getMessage());
-            throw cse;
-        }
+        assertFalse(underTest.isConfigurationNeeded(cmTemplateProcessor, preparationObject));
     }
 
-    @Test(expected = CloudbreakServiceException.class)
+    @Test(expected = IllegalStateException.class)
     public void testRoleConfigsForMultipleDb() {
         HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, 1);
         HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, 2);

--- a/template-manager-cmtemplate/src/test/resources/output/clouderamanager-variables.bp
+++ b/template-manager-cmtemplate/src/test/resources/output/clouderamanager-variables.bp
@@ -136,7 +136,7 @@
       "serviceConfigs": [
         {
           "name": "hive_metastore_database_host",
-          "value": "cluster.test.com"
+          "value": "10.1.1.1"
         },
         {
           "name": "hive_metastore_database_name",
@@ -144,7 +144,7 @@
         },
         {
           "name": "hive_metastore_database_password",
-          "value": "password"
+          "value": "iamsoosecure"
         },
         {
           "name": "hive_metastore_database_port",
@@ -156,7 +156,7 @@
         },
         {
           "name": "hive_metastore_database_user",
-          "value": "user"
+          "value": "heyitsme"
         }
       ],
       "roleConfigGroups": [

--- a/template-manager-cmtemplate/src/test/resources/output/clouderamanager-without-hosts.bp
+++ b/template-manager-cmtemplate/src/test/resources/output/clouderamanager-without-hosts.bp
@@ -137,7 +137,7 @@
       "serviceConfigs": [
         {
           "name": "hive_metastore_database_host",
-          "value": "cluster.test.com"
+          "value": "10.1.1.1"
         },
         {
           "name": "hive_metastore_database_name",
@@ -145,7 +145,7 @@
         },
         {
           "name": "hive_metastore_database_password",
-          "value": "password"
+          "value": "iamsoosecure"
         },
         {
           "name": "hive_metastore_database_port",
@@ -157,7 +157,7 @@
         },
         {
           "name": "hive_metastore_database_user",
-          "value": "user"
+          "value": "heyitsme"
         }
       ],
       "roleConfigGroups": [

--- a/template-manager-cmtemplate/src/test/resources/output/clouderamanager.bp
+++ b/template-manager-cmtemplate/src/test/resources/output/clouderamanager.bp
@@ -136,7 +136,7 @@
       "serviceConfigs": [
         {
           "name": "hive_metastore_database_host",
-          "value": "cluster.test.com"
+          "value": "10.1.1.1"
         },
         {
           "name": "hive_metastore_database_name",
@@ -144,7 +144,7 @@
         },
         {
           "name": "hive_metastore_database_password",
-          "value": "password"
+          "value": "iamsoosecure"
         },
         {
           "name": "hive_metastore_database_port",
@@ -156,7 +156,7 @@
         },
         {
           "name": "hive_metastore_database_user",
-          "value": "user"
+          "value": "heyitsme"
         }
       ],
       "roleConfigGroups": [

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/TemplatePreparationObject.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/TemplatePreparationObject.java
@@ -5,9 +5,11 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.domain.Template;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.gateway.Gateway;
@@ -15,13 +17,13 @@ import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.dto.KerberosConfig;
+import com.sequenceiq.cloudbreak.dto.LdapView;
 import com.sequenceiq.cloudbreak.template.filesystem.BaseFileSystemConfigurationsView;
 import com.sequenceiq.cloudbreak.template.model.GeneralClusterConfigs;
 import com.sequenceiq.cloudbreak.template.model.HdfConfigs;
 import com.sequenceiq.cloudbreak.template.views.BlueprintView;
 import com.sequenceiq.cloudbreak.template.views.GatewayView;
 import com.sequenceiq.cloudbreak.template.views.HostgroupView;
-import com.sequenceiq.cloudbreak.dto.LdapView;
 import com.sequenceiq.cloudbreak.template.views.SharedServiceConfigsView;
 
 public class TemplatePreparationObject {
@@ -32,7 +34,7 @@ public class TemplatePreparationObject {
 
     private final BlueprintView blueprintView;
 
-    private final Set<RDSConfig> rdsConfigs;
+    private final Map<String, RDSConfig> rdsConfigs;
 
     private final Set<HostgroupView> hostgroupViews;
 
@@ -53,7 +55,10 @@ public class TemplatePreparationObject {
     private final Map<String, Object> fixInputs;
 
     private TemplatePreparationObject(Builder builder) {
-        rdsConfigs = builder.rdsConfigs;
+        rdsConfigs = builder.rdsConfigs.stream().collect(Collectors.toMap(
+                rdsConfig -> rdsConfig.getType().toLowerCase(),
+                Function.identity()
+        ));
         hostgroupViews = builder.hostgroupViews;
         stackRepoDetailsHdpVersion = builder.stackRepoDetailsHdpVersion;
         ldapConfig = builder.ldapConfig;
@@ -76,7 +81,11 @@ public class TemplatePreparationObject {
     }
 
     public Set<RDSConfig> getRdsConfigs() {
-        return rdsConfigs;
+        return Set.copyOf(rdsConfigs.values());
+    }
+
+    public RDSConfig getRdsConfig(DatabaseType type) {
+        return rdsConfigs.get(type.name().toLowerCase());
     }
 
     public Set<HostgroupView> getHostgroupViews() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

RDS configs in the stack request are already validated, rejecting requests with multiple database of the same type.  This change adds some unit test for the validator.

Since duplicates are rejected, we can collect `RDSConfig`s into a map by type, and eliminate `getFirstRDSConfigOptional`, which had two problems:
1. it returned "some" config of the given database type (didn't fail on duplicates)
2. used linear search

Also extracted a common base class for DB-related config providers to get rid of some code duplication.

## How was this patch tested?

Added unit test, deployed various clusters.