### PR TITLE
CB-1959. Default Ranger audit location is not HA-compatible

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateComponentConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateComponentConfigProvider.java
@@ -23,7 +23,7 @@ public interface CmTemplateComponentConfigProvider {
         return false;
     }
 
-    default List<ApiClusterTemplateConfig> getServiceConfigs(TemplatePreparationObject source) {
+    default List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject source) {
         return List.of();
     }
 

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateComponentConfigProviderProcessor.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateComponentConfigProviderProcessor.java
@@ -18,7 +18,8 @@ public class CmTemplateComponentConfigProviderProcessor {
         for (CmTemplateComponentConfigProvider provider : providers) {
             cmTemplateProcessor.extendTemplateWithAdditionalServices(provider.getAdditionalServices(cmTemplateProcessor, template));
             if (provider.isConfigurationNeeded(cmTemplateProcessor, template)) {
-                cmTemplateProcessor.addServiceConfigs(provider.getServiceType(), provider.getRoleTypes(), provider.getServiceConfigs(template));
+                cmTemplateProcessor.addServiceConfigs(provider.getServiceType(), provider.getRoleTypes(),
+                        provider.getServiceConfigs(cmTemplateProcessor, template));
                 cmTemplateProcessor.addVariables(provider.getServiceConfigVariables(template));
                 cmTemplateProcessor.addRoleConfigs(provider.getServiceType(), provider.getRoleConfigs(cmTemplateProcessor, template));
                 cmTemplateProcessor.addVariables(provider.getRoleConfigVariables(cmTemplateProcessor, template));

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessor.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessor.java
@@ -425,4 +425,14 @@ public class CmTemplateProcessor implements BlueprintTextProcessor {
         }
         return configs;
     }
+
+    public Optional<ApiClusterTemplateConfig> getRoleConfig(String serviceType, String roleType, String configName) {
+        return getServiceByType(serviceType).flatMap(
+                service -> Optional.ofNullable(service.getRoleConfigGroups()).orElseGet(List::of).stream()
+                        .filter(rcg -> Objects.equals(roleType, rcg.getRoleType()))
+                        .flatMap(rcg -> Optional.ofNullable(rcg.getConfigs()).orElseGet(List::of).stream())
+                        .filter(config -> configName.equals(config.getName()))
+                        .findAny()
+        );
+    }
 }

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ConfigUtils.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ConfigUtils.java
@@ -63,4 +63,5 @@ public class ConfigUtils {
     public static String getSafetyValveProperty(String key, String value) {
         return String.format(CM_SAFETY_VALVE_PROPERTY_FORMAT, key, value);
     }
+
 }

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hdfs/HdfsRoleConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hdfs/HdfsRoleConfigProvider.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.hdfs;
 
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static java.util.stream.Collectors.toSet;
 
 import java.util.List;
 import java.util.Set;
@@ -15,6 +16,8 @@ import com.sequenceiq.cloudbreak.template.views.HostgroupView;
 @Component
 public class HdfsRoleConfigProvider extends AbstractRoleConfigProvider {
 
+    public static final String DEFAULT_NAME_SERVICE = "ns1";
+
     private static final String FAILED_VOLUMES_TOLERATED = "dfs_datanode_failed_volumes_tolerated";
 
     private static final Integer NUM_FAILED_VOLUMES_TOLERATED = 0;
@@ -27,11 +30,11 @@ public class HdfsRoleConfigProvider extends AbstractRoleConfigProvider {
                         config(FAILED_VOLUMES_TOLERATED, NUM_FAILED_VOLUMES_TOLERATED.toString())
                 );
             case HdfsRoles.NAMENODE:
-                if (isHA(source)) {
+                if (isNamenodeHA(source)) {
                     return List.of(
                             config("autofailover_enabled", "true"),
-                            config("dfs_federation_namenode_nameservice", "ns1"),
-                            config("dfs_namenode_quorum_journal_name", "ns1")
+                            config("dfs_federation_namenode_nameservice", DEFAULT_NAME_SERVICE),
+                            config("dfs_namenode_quorum_journal_name", DEFAULT_NAME_SERVICE)
                     );
                 }
                 return List.of();
@@ -50,13 +53,16 @@ public class HdfsRoleConfigProvider extends AbstractRoleConfigProvider {
         return List.of(HdfsRoles.NAMENODE, HdfsRoles.DATANODE);
     }
 
-    private boolean isHA(TemplatePreparationObject source) {
-        Set<String> namenodeGroups = source.getBlueprintView().getProcessor()
-                .getHostGroupsWithComponent(HdfsRoles.NAMENODE);
-        return source.getHostgroupViews().stream()
-                .filter(hostGroup -> namenodeGroups.contains(hostGroup.getName()))
+    public static boolean isNamenodeHA(TemplatePreparationObject source) {
+        return source.getHostGroupsWithComponent(HdfsRoles.NAMENODE)
                 .mapToInt(HostgroupView::getNodeCount)
                 .sum() > 1;
+    }
+
+    public static Set<String> nameNodeFQDNs(TemplatePreparationObject source) {
+        return source.getHostGroupsWithComponent(HdfsRoles.NAMENODE)
+                .flatMap(hostGroup -> hostGroup.getHosts().stream())
+                .collect(toSet());
     }
 
 }

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveMetastoreConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveMetastoreConfigProvider.java
@@ -23,7 +23,7 @@ import com.sequenceiq.cloudbreak.template.views.RdsView;
 public class HiveMetastoreConfigProvider extends AbstractRoleConfigProvider {
 
     @Override
-    public List<ApiClusterTemplateConfig> getServiceConfigs(TemplatePreparationObject templatePreparationObject) {
+    public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject templatePreparationObject) {
         Optional<RDSConfig> rdsConfigOptional = getFirstRDSConfigOptional(templatePreparationObject);
         Preconditions.checkArgument(rdsConfigOptional.isPresent());
         RdsView hiveView = new RdsView(rdsConfigOptional.get());

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hue/HueConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hue/HueConfigProvider.java
@@ -31,7 +31,7 @@ public class HueConfigProvider implements CmTemplateComponentConfigProvider {
     private static final String HUE_DATABASE_PASSWORD = "hue-hue_database_password";
 
     @Override
-    public List<ApiClusterTemplateConfig> getServiceConfigs(TemplatePreparationObject templatePreparationObject) {
+    public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject templatePreparationObject) {
         List<ApiClusterTemplateConfig> result = new ArrayList<>();
         result.add(new ApiClusterTemplateConfig().name("database_host").variable(HUE_DATABASE_HOST));
         result.add(new ApiClusterTemplateConfig().name("database_port").variable(HUE_DATABASE_PORT));

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerCloudStorageServiceConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerCloudStorageServiceConfigProvider.java
@@ -3,7 +3,7 @@ package com.sequenceiq.cloudbreak.cmtemplate.configproviders.ranger;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
 
 import java.util.List;
-import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.stereotype.Component;
 
@@ -11,6 +11,8 @@ import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateComponentConfigProvider;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.hdfs.HdfsRoleConfigProvider;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.hdfs.HdfsRoles;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 
 @Component
@@ -19,11 +21,10 @@ public class RangerCloudStorageServiceConfigProvider implements CmTemplateCompon
     private static final String RANGER_HDFS_AUDIT_URL = "ranger_plugin_hdfs_audit_url";
 
     @Override
-    public List<ApiClusterTemplateConfig> getServiceConfigs(TemplatePreparationObject templatePreparationObject) {
+    public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject templatePreparationObject) {
         return ConfigUtils.getStorageLocationForServiceProperty(templatePreparationObject, RANGER_HDFS_AUDIT_URL)
                 .map(location -> List.of(config(RANGER_HDFS_AUDIT_URL, location.getValue())))
-                .orElse(List.of(config(RANGER_HDFS_AUDIT_URL,
-                        setDefaultRangerAuditUrl(templatePreparationObject))));
+                .orElseGet(() -> List.of(config(RANGER_HDFS_AUDIT_URL, getDefaultRangerAuditUrl(templateProcessor, templatePreparationObject))));
     }
 
     @Override
@@ -41,12 +42,19 @@ public class RangerCloudStorageServiceConfigProvider implements CmTemplateCompon
         return cmTemplateProcessor.isRoleTypePresentInService(getServiceType(), getRoleTypes());
     }
 
-    private String setDefaultRangerAuditUrl(TemplatePreparationObject templatePreparationObject) {
-        Optional<String> primaryGatewayInstanceDiscoveryFQDN = templatePreparationObject.getGeneralClusterConfigs().getPrimaryGatewayInstanceDiscoveryFQDN();
-        if (primaryGatewayInstanceDiscoveryFQDN.isPresent()) {
-            return "hdfs://" + primaryGatewayInstanceDiscoveryFQDN.get() + ":8020/ranger/audit";
-        } else {
-            return "";
+    private String getDefaultRangerAuditUrl(CmTemplateProcessor templateProcessor, TemplatePreparationObject templatePreparationObject) {
+        if (HdfsRoleConfigProvider.isNamenodeHA(templatePreparationObject)) {
+            String nameService = templateProcessor.getRoleConfig(HdfsRoles.HDFS, HdfsRoles.NAMENODE, "dfs_federation_namenode_nameservice")
+                    .map(ApiClusterTemplateConfig::getValue)
+                    .orElse(HdfsRoleConfigProvider.DEFAULT_NAME_SERVICE);
+            return "hdfs://" + nameService;
         }
+
+        Set<String> namenodeHosts = HdfsRoleConfigProvider.nameNodeFQDNs(templatePreparationObject);
+        if (namenodeHosts.size() == 1) {
+            return "hdfs://" + namenodeHosts.iterator().next();
+        }
+
+        return "";
     }
 }

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/yarn/YarnConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/yarn/YarnConfigProvider.java
@@ -20,7 +20,7 @@ public class YarnConfigProvider implements CmTemplateComponentConfigProvider {
             + "</value></property><property><name>hadoop.proxyuser.knox.hosts</name><value>*</value></property>";
 
     @Override
-    public List<ApiClusterTemplateConfig> getServiceConfigs(TemplatePreparationObject templatePreparationObject) {
+    public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject templatePreparationObject) {
         return List.of(
                 config("yarn_core_site_safety_valve",
                         KNOX_PROXY_USER_SETTINGS));

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hue/HueConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hue/HueConfigProviderTest.java
@@ -48,7 +48,7 @@ public class HueConfigProviderTest {
     @Test
     public void getServiceConfigs() {
         TemplatePreparationObject tpo = new Builder().build();
-        List<ApiClusterTemplateConfig> result = underTest.getServiceConfigs(tpo);
+        List<ApiClusterTemplateConfig> result = underTest.getServiceConfigs(null, tpo);
         Map<String, String> paramToVariable =
                 result.stream().collect(Collectors.toMap(ApiClusterTemplateConfig::getName, ApiClusterTemplateConfig::getVariable));
         assertThat(paramToVariable).containsOnly(

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerCloudStorageServiceConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerCloudStorageServiceConfigProviderTest.java
@@ -1,6 +1,9 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.ranger;
 
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,6 +15,8 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.hdfs.HdfsRoles;
 import com.sequenceiq.cloudbreak.common.type.InstanceGroupType;
 import com.sequenceiq.cloudbreak.common.type.filesystem.S3FileSystem;
 import com.sequenceiq.cloudbreak.domain.StorageLocation;
@@ -20,6 +25,7 @@ import com.sequenceiq.cloudbreak.template.TemplatePreparationObject.Builder;
 import com.sequenceiq.cloudbreak.template.filesystem.StorageLocationView;
 import com.sequenceiq.cloudbreak.template.filesystem.s3.S3FileSystemConfigurationsView;
 import com.sequenceiq.cloudbreak.template.model.GeneralClusterConfigs;
+import com.sequenceiq.cloudbreak.template.views.BlueprintView;
 import com.sequenceiq.cloudbreak.template.views.HostgroupView;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -29,8 +35,12 @@ public class RangerCloudStorageServiceConfigProviderTest {
 
     @Test
     public void testGetRangerCloudStorageServiceConfigs() {
-        TemplatePreparationObject preparationObject = getTemplatePreparationObject(true);
-        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(preparationObject);
+        CmTemplateProcessor templateProcessor = mock(CmTemplateProcessor.class);
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject(true)
+                .withBlueprintView(mock(BlueprintView.class))
+                .build();
+
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(templateProcessor, preparationObject);
 
         assertEquals(1, serviceConfigs.size());
         assertEquals("ranger_plugin_hdfs_audit_url", serviceConfigs.get(0).getName());
@@ -38,16 +48,45 @@ public class RangerCloudStorageServiceConfigProviderTest {
     }
 
     @Test
-    public void testGetRangerCloudStorageServiceConfigsWhenNoStorageProvided() {
-        TemplatePreparationObject preparationObject = getTemplatePreparationObject(false);
+    public void defaultRangerHdfsAuditUrlWithNamenodeHA() {
+        CmTemplateProcessor templateProcessor = mock(CmTemplateProcessor.class);
+        BlueprintView blueprintView = mock(BlueprintView.class);
+        when(blueprintView.getProcessor()).thenReturn(templateProcessor);
+        when(templateProcessor.getHostGroupsWithComponent(HdfsRoles.NAMENODE)).thenReturn(Set.of("master"));
+        when(templateProcessor.getRoleConfig(HdfsRoles.HDFS, HdfsRoles.NAMENODE, "dfs_federation_namenode_nameservice"))
+                .thenReturn(Optional.of(config("dfs_federation_namenode_nameservice", "ns")));
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject(false)
+                .withBlueprintView(blueprintView)
+                .build();
 
-        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(preparationObject);
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(templateProcessor, preparationObject);
+
         assertEquals(1, serviceConfigs.size());
+        assertEquals("ranger_plugin_hdfs_audit_url", serviceConfigs.get(0).getName());
+        assertEquals("hdfs://ns", serviceConfigs.get(0).getValue());
     }
 
-    private TemplatePreparationObject getTemplatePreparationObject(boolean includeLocations) {
-        HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, 1);
-        HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, 2);
+    @Test
+    public void defaultRangerHdfsAuditUrlWithSingleNamenode() {
+        CmTemplateProcessor templateProcessor = mock(CmTemplateProcessor.class);
+        BlueprintView blueprintView = mock(BlueprintView.class);
+        when(blueprintView.getProcessor()).thenReturn(templateProcessor);
+        when(templateProcessor.getHostGroupsWithComponent(HdfsRoles.NAMENODE)).thenReturn(Set.of("gateway"));
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject(false)
+                .withBlueprintView(blueprintView)
+                .build();
+
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(templateProcessor, preparationObject);
+
+        assertEquals(1, serviceConfigs.size());
+        assertEquals("ranger_plugin_hdfs_audit_url", serviceConfigs.get(0).getName());
+        assertEquals("hdfs://g", serviceConfigs.get(0).getValue());
+    }
+
+    private TemplatePreparationObject.Builder getTemplatePreparationObject(boolean includeLocations) {
+        HostgroupView gateway = new HostgroupView("gateway", 1, InstanceGroupType.GATEWAY, Set.of("g"));
+        HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.CORE, Set.of("m1", "m2"));
+        HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, Set.of("w1", "w2", "w3"));
 
         List<StorageLocationView> locations = new ArrayList<>();
 
@@ -62,8 +101,8 @@ public class RangerCloudStorageServiceConfigProviderTest {
 
         return Builder.builder()
                 .withFileSystemConfigurationView(fileSystemConfigurationsView)
-                .withHostgroupViews(Set.of(master, worker))
-                .withGeneralClusterConfigs(generalClusterConfigs).build();
+                .withHostgroupViews(Set.of(gateway, master, worker))
+                .withGeneralClusterConfigs(generalClusterConfigs);
     }
 
     protected StorageLocation getRangerAuditCloudStorageDir() {

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/TemplatePreparationObject.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/TemplatePreparationObject.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.domain.Template;
@@ -65,6 +66,13 @@ public class TemplatePreparationObject {
         sharedServiceConfigs = builder.sharedServiceConfigs;
         customInputs = builder.customInputs;
         fixInputs = builder.fixInputs;
+    }
+
+    public Stream<HostgroupView> getHostGroupsWithComponent(String component) {
+        Set<String> groups = getBlueprintView().getProcessor()
+                .getHostGroupsWithComponent(component);
+        return getHostgroupViews().stream()
+                .filter(hostGroup -> groups.contains(hostGroup.getName()));
     }
 
     public Set<RDSConfig> getRdsConfigs() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change improves the default Ranger audit location for HDFS to make it work in NameNode HA setup.

Also:
 * since `/ranger/audit` is appended by CM, we don't need to include it in the default value
 * use FQDN of NameNode, since it may be assigned to a host other than the one with CM
 * port can be omitted, CM will read from configs

## How was this patch tested?

Deployed clusters HA and non-HA clusters with:

 * default settings
  ```
  Successfully created HDFS directory hdfs://ns1/ranger/audit/hdfs.
  Successfully created HDFS directory hdfs://example.com/ranger/audit/hdfs.
  ```
 * custom audit location (specified in `ranger_plugin_hdfs_audit_url` in the blueprint)
  ```
  Successfully created HDFS directory hdfs://ns1/customdir/ranger/audit/hdfs.
  Successfully created HDFS directory hdfs://example.com/customdir/ranger/audit/ranger/audit/hdfs.
  ```
 * custom name service in HA case
  ```
  Successfully created HDFS directory hdfs://customns/ranger/audit/hdfs.
  ```