### PR TITLE
CB-1816. Add CCM endpoint infrastructure.

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/AbstractServiceFamily.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/AbstractServiceFamily.java
@@ -1,0 +1,55 @@
+package com.sequenceiq.cloudbreak.ccm.endpoint;
+
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Abstract service family implementation.
+ *
+ * @param <T> the type of service endpoint used by the family
+ */
+public abstract class AbstractServiceFamily<T extends ServiceEndpoint> implements ServiceFamily<T> {
+
+    /**
+     * The default port for the service.
+     */
+    private final int defaultPort;
+
+    /**
+     * The optional known service identifier for tunneling.
+     */
+    private final KnownServiceIdentifier knownServiceIdentifier;
+
+    /**
+     * Creates an abstract service family with the specified parameters.
+     *
+     * @param defaultPort the default port for the service
+     */
+    public AbstractServiceFamily(int defaultPort) {
+        this(defaultPort, null);
+    }
+
+    /**
+     * Creates an abstract service family with the specified parameters.
+     *
+     * @param defaultPort            the default port for the service
+     * @param knownServiceIdentifier the optional known service identifier for tunneling
+     */
+    protected AbstractServiceFamily(int defaultPort, @Nullable KnownServiceIdentifier knownServiceIdentifier) {
+        this.defaultPort = defaultPort;
+        this.knownServiceIdentifier = knownServiceIdentifier;
+    }
+
+    @Override
+    public int getDefaultPort() {
+        return defaultPort;
+    }
+
+    @Nonnull
+    @Override
+    public Optional<KnownServiceIdentifier> getKnownServiceIdentifier() {
+        return Optional.ofNullable(knownServiceIdentifier);
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/BaseServiceEndpoint.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/BaseServiceEndpoint.java
@@ -1,0 +1,129 @@
+package com.sequenceiq.cloudbreak.ccm.endpoint;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Base class for service endpoint implementations.
+ */
+public class BaseServiceEndpoint implements ServiceEndpoint, Serializable {
+
+    /**
+     * The dummy port for URI construction.
+     */
+    private static final int DUMMY_PORT = -1;
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The host endpoint.
+     */
+    private final HostEndpoint hostEndpoint;
+
+    /**
+     * The optional port.
+     */
+    private final Integer port;
+
+    /**
+     * The optional URI for connecting to the endpoint.
+     */
+    private final URI uri;
+
+    /**
+     * Creates a base service endpoint with the specified parameters.
+     *
+     * @param hostEndpoint the host endpoint
+     */
+    public BaseServiceEndpoint(@Nonnull HostEndpoint hostEndpoint) {
+        this(hostEndpoint, null, null);
+    }
+
+    /**
+     * Creates a base service endpoint with the specified parameters.
+     *
+     * @param hostEndpoint the host endpoint
+     * @param port         the optional port
+     * @param uri          the optional URI
+     */
+    public BaseServiceEndpoint(@Nonnull HostEndpoint hostEndpoint, @Nullable Integer port, @Nullable URI uri) {
+        this.hostEndpoint =
+                Objects.requireNonNull(hostEndpoint, "hostEndpoint is null");
+        this.port = port;
+        this.uri = uri;
+    }
+
+    /**
+     * Returns a default URI for the specified parameters.
+     *
+     * @param scheme       the scheme
+     * @param hostEndpoint the host endpoint
+     * @param port         the optional port
+     * @return a default URI for the specified parameters
+     */
+    protected static URI getDefaultURI(@Nonnull String scheme, @Nonnull HostEndpoint hostEndpoint, @Nullable Integer port) {
+        try {
+            return new URI(Objects.requireNonNull(scheme, "scheme is null"), null,
+                    Objects.requireNonNull(hostEndpoint, "hostEndpoint is null").getHostAddressString(),
+                    (port == null) ? DUMMY_PORT : port, null, null, null);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Cannot build URI for scheme: " + scheme + ", hostEndpoint: " + hostEndpoint + ", port: " + port, e);
+        }
+    }
+
+    @Override
+    public HostEndpoint getHostEndpoint() {
+        return hostEndpoint;
+    }
+
+    @Override
+    public Optional<Integer> getPort() {
+        return Optional.ofNullable(port);
+    }
+
+    @Override
+    public Optional<URI> getURI() {
+        return Optional.ofNullable(uri);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        BaseServiceEndpoint that = (BaseServiceEndpoint) o;
+
+        if (!hostEndpoint.equals(that.hostEndpoint)) {
+            return false;
+        }
+        if (!Objects.equals(port, that.port)) {
+            return false;
+        }
+        return Objects.equals(uri, that.uri);
+
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(hostEndpoint, port, uri);
+    }
+
+    @Override
+    public String toString() {
+        return "BaseServiceEndpoint{"
+                + "hostEndpoint=" + hostEndpoint
+                + ((port == null) ? "" : ", port=" + port)
+                + ((uri == null) ? "" : ", uri=" + uri)
+                + '}';
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/DirectServiceEndpointFinder.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/DirectServiceEndpointFinder.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.cloudbreak.ccm.endpoint;
+
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+
+/**
+ * An endpoint finder that returns an endpoint based on a direct connection to the target instance on the
+ * default port for the requested service family.
+ */
+public class DirectServiceEndpointFinder implements ServiceEndpointFinder {
+
+    @Nonnull
+    @Override
+    public <T extends ServiceEndpoint> T getServiceEndpoint(@Nonnull ServiceEndpointRequest<T> serviceEndpointRequest) {
+
+        final Optional<HostEndpoint> hostEndpoint = serviceEndpointRequest.getTargetInstance().getHostEndpoint();
+        if (!hostEndpoint.isPresent()) {
+            throw new IllegalArgumentException("No host endpoint provided");
+        }
+
+        ServiceFamily<T> serviceFamily = serviceEndpointRequest.getServiceFamily();
+        int port = serviceEndpointRequest.getPort().orElse(serviceFamily.getDefaultPort());
+
+        return serviceFamily.getServiceEndpoint(hostEndpoint.get(), port);
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/HostEndpoint.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/HostEndpoint.java
@@ -1,0 +1,108 @@
+package com.sequenceiq.cloudbreak.ccm.endpoint;
+
+import java.io.Serializable;
+import java.net.InetAddress;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a host endpoint.
+ */
+@Immutable
+public class HostEndpoint implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The host address string.
+     */
+    private final String hostAddressString;
+
+    /**
+     * The optional resolved host address.
+     */
+    private final InetAddress hostAddress;
+
+    /**
+     * Creates a host endpoint with the specified parameters.
+     *
+     * @param hostAddressString the host address string
+     */
+    public HostEndpoint(@Nonnull String hostAddressString) {
+        this(hostAddressString, null);
+    }
+
+    /**
+     * Creates a host endpoint with the specified parameters.
+     *
+     * @param hostAddressString the host address string
+     * @param hostAddress       the optional resolved host address
+     */
+    @JsonCreator
+    public HostEndpoint(
+            @Nonnull @JsonProperty("hostAddressString") String hostAddressString,
+            @Nullable @JsonProperty("hostAddress") InetAddress hostAddress) {
+        this.hostAddressString =
+                Objects.requireNonNull(hostAddressString, "hostAddressString is null");
+        this.hostAddress = hostAddress;
+    }
+
+    /**
+     * Returns the host address string.
+     *
+     * @return the host address string
+     */
+    @Nonnull
+    public String getHostAddressString() {
+        return hostAddressString;
+    }
+
+    /**
+     * Returns the optional resolved host address.
+     *
+     * @return the optional resolved host address
+     */
+    @Nonnull
+    public Optional<InetAddress> getHostAddress() {
+        return Optional.ofNullable(hostAddress);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        HostEndpoint that = (HostEndpoint) o;
+
+        if (!hostAddressString.equals(that.hostAddressString)) {
+            return false;
+        }
+        return Objects.equals(hostAddress, that.hostAddress);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = hostAddressString.hashCode();
+        result = 31 * result + ((hostAddress == null) ? 0 : hostAddress.hashCode());
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "HostEndpoint{"
+                + "hostAddressString='" + hostAddressString + '\''
+                + ((hostAddress == null) ? "" : ", hostAddress=" + hostAddress)
+                + '}';
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/HttpsServiceEndpoint.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/HttpsServiceEndpoint.java
@@ -1,0 +1,53 @@
+package com.sequenceiq.cloudbreak.ccm.endpoint;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * HTTPS endpoint.
+ */
+public class HttpsServiceEndpoint extends BaseServiceEndpoint {
+
+    /**
+     * The URI scheme.
+     */
+    public static final String SCHEME = "https";
+
+    /**
+     * The default HTTPS port.
+     */
+    public static final int DEFAULT_HTTPS_PORT = 443;
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Creates an HTTPS endpoint with the specified parameters.
+     *
+     * @param hostEndpoint the host endpoint
+     */
+    public HttpsServiceEndpoint(@Nonnull HostEndpoint hostEndpoint) {
+        this(hostEndpoint, (Integer) null);
+    }
+
+    /**
+     * Creates an HTTPS endpoint with the specified parameters.
+     *
+     * @param hostEndpoint the host endpoint
+     * @param portString   the port string
+     */
+    public HttpsServiceEndpoint(@Nonnull HostEndpoint hostEndpoint, @Nullable String portString) {
+        this(hostEndpoint, (portString == null) ? null : Integer.valueOf(portString));
+    }
+
+    /**
+     * Creates an HTTPS endpoint with the specified parameters.
+     *
+     * @param hostEndpoint the host endpoint
+     * @param port         the optional port
+     */
+    public HttpsServiceEndpoint(@Nonnull HostEndpoint hostEndpoint, @Nullable Integer port) {
+        super(hostEndpoint,
+                (port != null) ? port : DEFAULT_HTTPS_PORT,
+                getDefaultURI(SCHEME, hostEndpoint, port));
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/KnownServiceIdentifier.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/KnownServiceIdentifier.java
@@ -1,0 +1,17 @@
+package com.sequenceiq.cloudbreak.ccm.endpoint;
+
+/**
+ * Identifiers for known services.
+ */
+public enum KnownServiceIdentifier {
+
+    /**
+     * A service identifier for the nginx web server that runs on gateway nodes.
+     */
+    GATEWAY,
+
+    /**
+     * A service identifier for the Apache Knox proxy server that runs on gateway nodes.
+     */
+    KNOX;
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/ServiceEndpoint.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/ServiceEndpoint.java
@@ -1,0 +1,83 @@
+package com.sequenceiq.cloudbreak.ccm.endpoint;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Represents a service endpoint.
+ */
+public interface ServiceEndpoint {
+
+    /**
+     * Returns the host endpoint.
+     *
+     * @return the host endpoint
+     */
+    @Nonnull
+    HostEndpoint getHostEndpoint();
+
+    /**
+     * Returns the optional port.
+     *
+     * @return the optional port
+     */
+    @Nonnull
+    Optional<Integer> getPort();
+
+    /**
+     * Returns the optional URI.
+     *
+     * @return the optional URI
+     */
+    @Nonnull
+    Optional<URI> getURI();
+
+    /**
+     * Returns a string representation of this service endpoint consisting of
+     * the host address or address string optionally followed by a colon and the
+     * the service port.
+     *
+     * @return a string representation of this service endpoint consisting of the
+     * host address or address string optionally followed by a colon and the
+     * service port
+     */
+    @Nonnull
+    default String asHostWithOptionalPort() {
+        return asHostWithOptionalPort(null);
+    }
+
+    /**
+     * Returns a string representation of this service endpoint consisting of
+     * the host address or address string optionally followed by a colon and the
+     * service port or the specified default port.
+     *
+     * @param defaultPort the default port if no port is specified in the endpoint
+     * @return a string representation of this service endpoint consisting of the
+     * host address or address string optionally followed by a colon and the
+     * service port
+     */
+    @Nonnull
+    default String asHostWithOptionalPort(@Nullable Integer defaultPort) {
+        StringBuilder buf = new StringBuilder();
+        HostEndpoint hostEndpoint = getHostEndpoint();
+        Optional<InetAddress> optionalHostAddress = hostEndpoint.getHostAddress();
+        if (optionalHostAddress.isPresent()) {
+            buf.append(optionalHostAddress.get().getHostAddress());
+        } else {
+            buf.append(hostEndpoint.getHostAddressString());
+        }
+        Optional<Integer> optionalPort = getPort();
+        if (optionalPort.isPresent()) {
+            buf.append(':');
+            buf.append(optionalPort.get());
+        } else if (defaultPort != null) {
+            buf.append(':');
+            buf.append(defaultPort);
+        }
+        return buf.toString();
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/ServiceEndpointFinder.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/ServiceEndpointFinder.java
@@ -1,0 +1,22 @@
+package com.sequenceiq.cloudbreak.ccm.endpoint;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Lookup service for service endpoints.
+ */
+public interface ServiceEndpointFinder {
+
+    /**
+     * Returns the service endpoint for the specified request.
+     *
+     * @param serviceEndpointRequest the service endpoint request
+     * @return the service endpoint for the specified request, which contains a host, port, and optional URI for reaching
+     * the service, possibly through an intermediary such as an SSH tunnel
+     * @throws ServiceEndpointLookupException if an exception occurs
+     * @throws InterruptedException           if the lookup is interrupted
+     */
+    @Nonnull
+    <T extends ServiceEndpoint> T getServiceEndpoint(@Nonnull ServiceEndpointRequest<T> serviceEndpointRequest)
+            throws ServiceEndpointLookupException, InterruptedException;
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/ServiceEndpointLookupException.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/ServiceEndpointLookupException.java
@@ -1,0 +1,78 @@
+package com.sequenceiq.cloudbreak.ccm.endpoint;
+
+/**
+ * Exception for service endpoint lookup failures.
+ */
+public class ServiceEndpointLookupException extends Exception {
+
+    /**
+     * Whether the exception represents a transient condition.
+     */
+    private final boolean retryable;
+
+    /**
+     * Creates a service endpoint lookup exception.
+     *
+     * @param retryable whether the exception represents a transient condition
+     */
+    public ServiceEndpointLookupException(boolean retryable) {
+        this.retryable = retryable;
+    }
+
+    /**
+     * Creates a service endpoint lookup exception with the specified parameters.
+     *
+     * @param message   the message
+     * @param retryable whether the exception represents a transient condition
+     */
+    public ServiceEndpointLookupException(String message, boolean retryable) {
+        super(message);
+        this.retryable = retryable;
+    }
+
+    /**
+     * Creates a service endpoint lookup exception with the specified parameters.
+     *
+     * @param message   the message
+     * @param cause     the cause
+     * @param retryable whether the exception represents a transient condition
+     */
+    public ServiceEndpointLookupException(String message, Throwable cause, boolean retryable) {
+        super(message, cause);
+        this.retryable = retryable;
+    }
+
+    /**
+     * Creates a service endpoint lookup exception with the specified parameters.
+     *
+     * @param cause     the cause
+     * @param retryable whether the exception represents a transient condition
+     */
+    public ServiceEndpointLookupException(Throwable cause, boolean retryable) {
+        super(cause);
+        this.retryable = retryable;
+    }
+
+    /**
+     * Creates a service endpoint lookup exception with the specified parameters.
+     *
+     * @param message            the message
+     * @param cause              the cause
+     * @param enableSuppression  whether suppression is enabled
+     * @param writableStackTrace whether the stack trace should be writable
+     * @param retryable          whether the exception represents a transient condition
+     */
+    public ServiceEndpointLookupException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace, boolean retryable) {
+        super(message, cause, enableSuppression, writableStackTrace);
+        this.retryable = retryable;
+    }
+
+    /**
+     * \Returns whether the exception represents a transient condition.
+     *
+     * @return whether the exception represents a transient condition
+     */
+    public boolean isRetryable() {
+        return retryable;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/ServiceEndpointRequest.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/ServiceEndpointRequest.java
@@ -1,0 +1,129 @@
+package com.sequenceiq.cloudbreak.ccm.endpoint;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Request for looking up service endpoints.
+ */
+public interface ServiceEndpointRequest<T extends ServiceEndpoint> {
+
+    /**
+     * The default amount of time to wait to fulfill a request, in seconds.
+     */
+    int DEFAULT_WAIT_DURATION_SEC = 30;
+
+    /**
+     * The default polling interval, in milliseconds.
+     */
+    long DEFAULT_POLLING_INTERVAL_MS = 1000L;
+
+    /**
+     * Returns a default service endpoint request for the specified target service.
+     *
+     * @param targetInstanceId the target instance ID
+     * @param hostEndpoint     the optional host endpoint
+     * @param port             the optional port
+     * @param serviceFamily    the service family
+     * @param <T>              the type of endpoint
+     * @return a default service endpoint request for the specified target service
+     */
+    @Nonnull
+    static <T extends ServiceEndpoint> ServiceEndpointRequest<T> createDefaultServiceEndpointRequest(
+            @Nonnull String targetInstanceId, @Nullable HostEndpoint hostEndpoint, @Nullable Integer port, @Nonnull ServiceFamily<T> serviceFamily) {
+
+        return new ServiceEndpointRequest<T>() {
+
+            @Override
+            public TargetInstance getTargetInstance() {
+                return new TargetInstance() {
+                    @Nonnull
+                    @Override
+                    public String getTargetInstanceId() {
+                        return targetInstanceId;
+                    }
+
+                    @Nonnull
+                    @Override
+                    public Optional<HostEndpoint> getHostEndpoint() {
+                        return Optional.ofNullable(hostEndpoint);
+                    }
+                };
+            }
+
+            @Override
+            public ServiceFamily<T> getServiceFamily() {
+                return serviceFamily;
+            }
+
+            @Override
+            public Optional<Integer> getPort() {
+                return Optional.ofNullable(port);
+            }
+
+            @Override
+            public Optional<ZonedDateTime> getWaitUntilTime() {
+                return Optional.of(ZonedDateTime.now().plusSeconds(DEFAULT_WAIT_DURATION_SEC));
+            }
+
+            @Override
+            public long getPollingIntervalInMs() {
+                return DEFAULT_POLLING_INTERVAL_MS;
+            }
+        };
+    }
+
+    /**
+     * Returns the target instance.
+     *
+     * @return the target instance
+     */
+    TargetInstance getTargetInstance();
+
+    /**
+     * Returns the service family.
+     *
+     * @return the service family
+     */
+    ServiceFamily<T> getServiceFamily();
+
+    /**
+     * Returns the optional port.
+     *
+     * @return the optional port
+     */
+    default Optional<Integer> getPort() {
+        return Optional.empty();
+    }
+
+    /**
+     * An optional datetime after which the lookup attempt should fail.
+     *
+     * @return the optional timeout
+     */
+    default Optional<ZonedDateTime> getWaitUntilTime() {
+        return Optional.empty();
+    }
+
+    /**
+     * Returns the default polling interval in milliseconds.
+     *
+     * @return the default polling interval in milliseconds
+     */
+    default long getPollingIntervalInMs() {
+        return DEFAULT_POLLING_INTERVAL_MS;
+    }
+
+    /**
+     * Returns whether the lookup should only allow direct access to the target service.
+     *
+     * @return whether the lookup should only allow direct access to the target service
+     */
+    // JSA TODO This is a workaround until we can turn reverse SSH lookup on and off in the environment
+    default boolean isDirectAccessRequired() {
+        return false;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/ServiceFamilies.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/ServiceFamilies.java
@@ -1,0 +1,39 @@
+package com.sequenceiq.cloudbreak.ccm.endpoint;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Provides utilities for dealing with service families.
+ */
+public class ServiceFamilies {
+
+    /**
+     * The service family for nginx web servers on gateways.
+     */
+    public static final ServiceFamily<HttpsServiceEndpoint> GATEWAY =
+            new AbstractServiceFamily<>(9443, KnownServiceIdentifier.GATEWAY) {
+                @Nonnull
+                @Override
+                public HttpsServiceEndpoint getServiceEndpoint(@Nonnull HostEndpoint hostEndpoint, int port) {
+                    return new HttpsServiceEndpoint(hostEndpoint, port);
+                }
+            };
+
+    /**
+     * The service family for Apache Knox proxy servers.
+     */
+    public static final ServiceFamily<HttpsServiceEndpoint> KNOX =
+            new AbstractServiceFamily<>(8443, KnownServiceIdentifier.KNOX) {
+                @Nonnull
+                @Override
+                public HttpsServiceEndpoint getServiceEndpoint(@Nonnull HostEndpoint hostEndpoint, int port) {
+                    return new HttpsServiceEndpoint(hostEndpoint, port);
+                }
+            };
+
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private ServiceFamilies() {
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/ServiceFamily.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/ServiceFamily.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.cloudbreak.ccm.endpoint;
+
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Represents a family of services.
+ *
+ * @param <T> the type of service endpoint used by the family
+ */
+public interface ServiceFamily<T extends ServiceEndpoint> {
+
+    /**
+     * Returns the default port for the service.
+     *
+     * @return the default port for the service
+     */
+    int getDefaultPort();
+
+    /**
+     * Returns the optional known service identifier for tunneling.
+     *
+     * @return the optional known service identifier for tunneling
+     */
+    @Nonnull
+    Optional<KnownServiceIdentifier> getKnownServiceIdentifier();
+
+    /**
+     * Returns a service endpoint for the service.
+     *
+     * @param hostEndpoint the host endpoint
+     * @param port         the port
+     * @return a service endpoint for the service
+     */
+    @Nonnull
+    T getServiceEndpoint(@Nonnull HostEndpoint hostEndpoint, int port);
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/TargetInstance.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/endpoint/TargetInstance.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.cloudbreak.ccm.endpoint;
+
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Represents a target instance where a service is running.
+ */
+public interface TargetInstance {
+
+    /**
+     * Returns the unique identifier for the target instance.
+     *
+     * @return the unique identifier for the target instance
+     */
+    @Nonnull
+    String getTargetInstanceId();
+
+    /**
+     * The optional host endpoint for the target.
+     *
+     * @return the optional host endpoint for the target
+     */
+    @Nonnull
+    default Optional<HostEndpoint> getHostEndpoint() {
+        return Optional.empty();
+    }
+}

--- a/common/src/test/java/com/sequenceiq/cloudbreak/ccm/endpoint/DirectServiceEndpointFinderTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/ccm/endpoint/DirectServiceEndpointFinderTest.java
@@ -1,0 +1,70 @@
+package com.sequenceiq.cloudbreak.ccm.endpoint;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.junit.Test;
+
+/**
+ * Tests {@link DirectServiceEndpointFinder}
+ */
+public class DirectServiceEndpointFinderTest {
+
+    /**
+     * Verifies that the direct service endpoint finder acts as a passthrough,
+     * whether port is specified or not.
+     */
+    @Test
+    public void testGetServiceEndpoint() {
+        String hostAddressString = randomHostname();
+
+        verifyGetServiceEndpoint(hostAddressString, RandomUtils.nextInt(1, 65535));
+        verifyGetServiceEndpoint(hostAddressString, null);
+    }
+
+    private void verifyGetServiceEndpoint(String hostAddressString, Integer port) {
+        DirectServiceEndpointFinder endpointFinder = new DirectServiceEndpointFinder();
+
+        ServiceEndpointRequest<HttpsServiceEndpoint> serviceEndpointRequest = createServiceEndpointRequest(hostAddressString, port);
+
+        verifyGetServiceEndpoint(endpointFinder, serviceEndpointRequest, hostAddressString, port);
+    }
+
+    private ServiceEndpointRequest<HttpsServiceEndpoint> createServiceEndpointRequest(String hostAddressString, Integer port) {
+        String targetInstanceId = RandomStringUtils.random(10);
+        HostEndpoint hostEndpoint = mock(HostEndpoint.class);
+        when(hostEndpoint.getHostAddressString()).thenReturn(hostAddressString);
+        int randomValue = RandomUtils.nextInt(0, 2);
+        ServiceFamily<HttpsServiceEndpoint> serviceFamily = (randomValue == 0) ? ServiceFamilies.GATEWAY : ServiceFamilies.KNOX;
+        return ServiceEndpointRequest.createDefaultServiceEndpointRequest(targetInstanceId, hostEndpoint, port, serviceFamily);
+    }
+
+    private void verifyGetServiceEndpoint(DirectServiceEndpointFinder endpointFinder,
+            ServiceEndpointRequest<HttpsServiceEndpoint> serviceEndpointRequest, String hostAddressString, Integer port) {
+        ServiceEndpoint serviceEndpoint =
+                endpointFinder.getServiceEndpoint(serviceEndpointRequest);
+        assertEquals(hostAddressString, serviceEndpoint.getHostEndpoint().getHostAddressString());
+        Optional<Integer> expectedPort =
+                Optional.ofNullable(port).or(() -> Optional.of(serviceEndpointRequest.getServiceFamily().getDefaultPort()));
+        assertEquals(expectedPort, serviceEndpoint.getPort());
+    }
+
+    private String randomHostname() {
+        StringBuilder buf = new StringBuilder(randomHostnameComponent());
+        for (int i = 0; i < RandomUtils.nextInt(0, 3); i++) {
+            buf.append('.');
+            buf.append(randomHostnameComponent());
+        }
+        return buf.toString();
+    }
+
+    private String randomHostnameComponent() {
+        return RandomStringUtils.random(1, 32, 127, true, false)
+                + RandomStringUtils.random(9, 32, 127, true, true);
+    }
+}

--- a/orchestrator-api/build.gradle
+++ b/orchestrator-api/build.gradle
@@ -18,4 +18,17 @@ dependencies {
     compile group: 'com.fasterxml.jackson.core',    name: 'jackson-databind',               version: jacksonVersion
     compile group: 'org.apache.commons',            name: 'commons-lang3',                  version: apacheCommonsLangVersion
 
+
+    testCompile group: 'org.hamcrest',              name: 'hamcrest-all',                   version: '1.3'
+
+    testCompile (group: 'org.powermock',             name: 'powermock-module-junit4',        version: powermockVersion)
+    testCompile (group: 'org.powermock',             name: 'powermock-api-mockito2',          version: powermockVersion) {
+        exclude group: 'org.hamcrest'
+    }
+    testCompile (group: 'org.mockito',               name: 'mockito-core',                    version: mockitoVersion) {
+        exclude group: 'org.hamcrest'
+    }
+    testCompile (group: 'junit',                    name: 'junit',                          version: junitVersion) {
+        exclude group: 'org.hamcrest'
+    }
 }

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/model/GatewayConfig.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/model/GatewayConfig.java
@@ -1,5 +1,17 @@
 package com.sequenceiq.cloudbreak.orchestrator.model;
 
+import java.util.Objects;
+
+import javax.annotation.Nonnull;
+
+import com.sequenceiq.cloudbreak.ccm.endpoint.HostEndpoint;
+import com.sequenceiq.cloudbreak.ccm.endpoint.HttpsServiceEndpoint;
+import com.sequenceiq.cloudbreak.ccm.endpoint.ServiceEndpoint;
+import com.sequenceiq.cloudbreak.ccm.endpoint.ServiceEndpointFinder;
+import com.sequenceiq.cloudbreak.ccm.endpoint.ServiceEndpointLookupException;
+import com.sequenceiq.cloudbreak.ccm.endpoint.ServiceEndpointRequest;
+import com.sequenceiq.cloudbreak.ccm.endpoint.ServiceFamilies;
+
 public class GatewayConfig {
 
     // Used by cloudbreak to connect the cluster
@@ -62,6 +74,16 @@ public class GatewayConfig {
         this.saltSignPublicKey = saltSignPublicKey;
     }
 
+    private GatewayConfig(GatewayConfig gatewayConfig, @Nonnull ServiceEndpoint serviceEndpoint) {
+        this(serviceEndpoint.getHostEndpoint().getHostAddressString(), gatewayConfig.publicAddress, gatewayConfig.privateAddress,
+                gatewayConfig.hostname, Objects.requireNonNull(serviceEndpoint.getPort().orElse(null), "serviceEndpoint port unspecified"),
+                gatewayConfig.instanceId,
+                gatewayConfig.serverCert, gatewayConfig.clientCert, gatewayConfig.clientKey,
+                gatewayConfig.saltPassword, gatewayConfig.saltBootPassword, gatewayConfig.signatureKey,
+                gatewayConfig.knoxGatewayEnabled, gatewayConfig.primary,
+                gatewayConfig.saltSignPrivateKey, gatewayConfig.saltSignPublicKey);
+    }
+
     public String getConnectionAddress() {
         return connectionAddress;
     }
@@ -76,6 +98,10 @@ public class GatewayConfig {
 
     public String getHostname() {
         return hostname;
+    }
+
+    public Integer getGatewayPort() {
+        return gatewayPort;
     }
 
     public String getGatewayUrl() {
@@ -126,7 +152,47 @@ public class GatewayConfig {
         return saltSignPublicKey;
     }
 
-    @Override
+    /**
+     * Returns a gateway config for the nginx service on the gateway.
+     * The returned gateway config is identical to this one, except that
+     * its connection address and gateway port (and hence gateway URL)
+     * are determined using the specified service endpoint finder.
+     *
+     * @param serviceEndpointFinder  the service endpoint finder
+     * @return a gateway config for the nginx service on the gateway
+     * @throws ServiceEndpointLookupException if an exception occurs looking up the endpoint
+     * @throws InterruptedException           if the lookup is interrupted
+     */
+    public GatewayConfig getGatewayConfig(ServiceEndpointFinder serviceEndpointFinder)
+            throws ServiceEndpointLookupException, InterruptedException {
+        return new GatewayConfig(this, getServiceEndpoint(serviceEndpointFinder));
+    }
+
+    /**
+     * Returns a service endpoint for the nginx service on the gateway.
+     *
+     * @param serviceEndpointFinder  the service endpoint finder
+     * @return a service endpoint for the nginx service on the gateway
+     * @throws ServiceEndpointLookupException if an exception occurs looking up the endpoint
+     * @throws InterruptedException           if the lookup is interrupted
+     */
+    private ServiceEndpoint getServiceEndpoint(ServiceEndpointFinder serviceEndpointFinder)
+            throws ServiceEndpointLookupException, InterruptedException {
+        ServiceEndpointRequest<HttpsServiceEndpoint> serviceEndpointRequest =
+                createServiceEndpointRequest();
+        return serviceEndpointFinder.getServiceEndpoint(serviceEndpointRequest);
+    }
+
+    /**
+     * Creates a service endpoint request for connecting to the nginx service on the gateway.
+     *
+     * @return a service endpoint request for connecting to the specified service on the gateway
+     */
+    private ServiceEndpointRequest<HttpsServiceEndpoint> createServiceEndpointRequest() {
+        return ServiceEndpointRequest.createDefaultServiceEndpointRequest(
+                instanceId, new HostEndpoint(connectionAddress), gatewayPort, ServiceFamilies.GATEWAY);
+    }
+
     public String toString() {
         StringBuilder sb = new StringBuilder("GatewayConfig{");
         sb.append("connectionAddress='").append(connectionAddress).append('\'');

--- a/orchestrator-api/src/test/java/com/sequenceiq/cloudbreak/orchestrator/model/GatewayConfigTest.java
+++ b/orchestrator-api/src/test/java/com/sequenceiq/cloudbreak/orchestrator/model/GatewayConfigTest.java
@@ -1,0 +1,118 @@
+package com.sequenceiq.cloudbreak.orchestrator.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.junit.Test;
+
+import com.sequenceiq.cloudbreak.ccm.endpoint.HostEndpoint;
+import com.sequenceiq.cloudbreak.ccm.endpoint.ServiceEndpoint;
+import com.sequenceiq.cloudbreak.ccm.endpoint.ServiceEndpointFinder;
+import com.sequenceiq.cloudbreak.ccm.endpoint.ServiceEndpointLookupException;
+
+/**
+ * Tests {@link GatewayConfig}.
+ */
+public class GatewayConfigTest {
+
+    @Test
+    public void testGetGatewayConfig() throws ServiceEndpointLookupException, InterruptedException {
+        GatewayConfig gatewayConfig = createGatewayConfig(false);
+        verifyGetGatewayConfigWithPassthroughEndpointFinder(gatewayConfig);
+        verifyGetGatewayConfigWithLookupEndpointFinder(gatewayConfig);
+
+        gatewayConfig = createGatewayConfig(true);
+        verifyGetGatewayConfigWithPassthroughEndpointFinder(gatewayConfig);
+        verifyGetGatewayConfigWithLookupEndpointFinder(gatewayConfig);
+    }
+
+    private void verifyGetGatewayConfigWithPassthroughEndpointFinder(GatewayConfig gatewayConfig) throws ServiceEndpointLookupException, InterruptedException {
+        // Set up mock passthrough service endpoint finder
+        ServiceEndpointFinder serviceEndpointFinder = mockServiceEndpointFinder(gatewayConfig.getConnectionAddress(), gatewayConfig.getGatewayPort());
+
+        // Verify that the endpoint gateway config respects the connection address and port of the original gateway config
+        GatewayConfig endpointGatewayConfig = gatewayConfig.getGatewayConfig(serviceEndpointFinder);
+        verifyMatch(gatewayConfig, endpointGatewayConfig, null, null);
+    }
+
+    private void verifyGetGatewayConfigWithLookupEndpointFinder(GatewayConfig gatewayConfig) throws ServiceEndpointLookupException, InterruptedException {
+        // Set up mock service endpoint finder
+        String connectionAddress = RandomStringUtils.random(10);
+        Integer gatewayPort = RandomUtils.nextInt();
+        ServiceEndpointFinder serviceEndpointFinder = mockServiceEndpointFinder(connectionAddress, gatewayPort);
+
+        // Verify that the endpoint gateway config respects the address and port returned by the service endpoint finder
+        GatewayConfig endpointGatewayConfig = gatewayConfig.getGatewayConfig(serviceEndpointFinder);
+        verifyMatch(gatewayConfig, endpointGatewayConfig, connectionAddress, gatewayPort);
+    }
+
+    private GatewayConfig createGatewayConfig(boolean longConstructor) {
+        String connectionAddress = RandomStringUtils.randomAscii(10);
+        String publicAddress = RandomStringUtils.random(10);
+        String privateAddress = RandomStringUtils.random(10);
+        int randomPort = RandomUtils.nextInt(0, 65535);
+        Integer gatewayPort = (randomPort == 0) ? null : randomPort;
+        String instanceId = RandomStringUtils.random(10);
+        int randomValue = RandomUtils.nextInt(0, 3);
+        Boolean knoxGatewayEnabled = (randomValue == 0) ? null : (randomValue == 1) ? Boolean.TRUE : Boolean.FALSE;
+        if (longConstructor) {
+            String hostname = RandomStringUtils.random(10);
+            String serverCert = RandomStringUtils.random(10);
+            String clientCert = RandomStringUtils.random(10);
+            String clientKey = RandomStringUtils.random(10);
+            String saltPassword = RandomStringUtils.random(10);
+            String saltBootPassword = RandomStringUtils.random(10);
+            String signatureKey = RandomStringUtils.random(10);
+            boolean primary = RandomUtils.nextBoolean();
+            String saltSignPrivateKey = RandomStringUtils.random(10);
+            String saltSignPublicKey = RandomStringUtils.random(10);
+            return new GatewayConfig(connectionAddress, publicAddress, privateAddress, hostname, gatewayPort, instanceId,
+                    serverCert, clientCert, clientKey, saltPassword, saltBootPassword, signatureKey, knoxGatewayEnabled,
+                    primary, saltSignPrivateKey, saltSignPublicKey);
+        } else {
+            return new GatewayConfig(connectionAddress, publicAddress, privateAddress, gatewayPort, instanceId, knoxGatewayEnabled);
+        }
+    }
+
+    private ServiceEndpointFinder mockServiceEndpointFinder(String connectionAddress, Integer gatewayPort)
+            throws ServiceEndpointLookupException, InterruptedException {
+        ServiceEndpointFinder serviceEndpointFinder = mock(ServiceEndpointFinder.class);
+        ServiceEndpoint serviceEndpoint = mock(ServiceEndpoint.class);
+        HostEndpoint hostEndpoint = mock(HostEndpoint.class);
+        when(hostEndpoint.getHostAddressString()).thenReturn(connectionAddress);
+        when(serviceEndpoint.getHostEndpoint()).thenReturn(hostEndpoint);
+        when(serviceEndpoint.getPort()).thenReturn(Optional.ofNullable(gatewayPort));
+        when(serviceEndpointFinder.getServiceEndpoint(any())).thenReturn(serviceEndpoint);
+        return serviceEndpointFinder;
+    }
+
+    private void verifyMatch(GatewayConfig gatewayConfig, GatewayConfig endpointGatewayConfig, String endpointConnectionAddress, Integer endpointPort) {
+        String expectedConnectionAddress = (endpointConnectionAddress == null) ? gatewayConfig.getConnectionAddress() : endpointConnectionAddress;
+        Integer expectedGatewayPort = (endpointPort == null) ? gatewayConfig.getGatewayPort() : endpointPort;
+        String expectedGatewayUrl = String.format("https://%s:%d", expectedConnectionAddress, expectedGatewayPort);
+
+        assertEquals(expectedConnectionAddress, endpointGatewayConfig.getConnectionAddress());
+        assertEquals(gatewayConfig.getPublicAddress(), endpointGatewayConfig.getPublicAddress());
+        assertEquals(gatewayConfig.getPrivateAddress(), endpointGatewayConfig.getPrivateAddress());
+        assertEquals(gatewayConfig.getHostname(), endpointGatewayConfig.getHostname());
+        assertEquals(expectedGatewayPort, endpointGatewayConfig.getGatewayPort());
+        assertEquals(expectedGatewayUrl, endpointGatewayConfig.getGatewayUrl());
+        assertEquals(gatewayConfig.getInstanceId(), endpointGatewayConfig.getInstanceId());
+        assertEquals(gatewayConfig.getServerCert(), endpointGatewayConfig.getServerCert());
+        assertEquals(gatewayConfig.getClientCert(), endpointGatewayConfig.getClientCert());
+        assertEquals(gatewayConfig.getClientKey(), endpointGatewayConfig.getClientKey());
+        assertEquals(gatewayConfig.getSaltPassword(), endpointGatewayConfig.getSaltPassword());
+        assertEquals(gatewayConfig.getSaltBootPassword(), endpointGatewayConfig.getSaltBootPassword());
+        assertEquals(gatewayConfig.getSignatureKey(), endpointGatewayConfig.getSignatureKey());
+        assertEquals(gatewayConfig.getKnoxGatewayEnabled(), endpointGatewayConfig.getKnoxGatewayEnabled());
+        assertEquals(gatewayConfig.isPrimary(), endpointGatewayConfig.isPrimary());
+        assertEquals(gatewayConfig.getSaltSignPrivateKey(), endpointGatewayConfig.getSaltSignPrivateKey());
+        assertEquals(gatewayConfig.getSaltSignPublicKey(), endpointGatewayConfig.getSaltSignPublicKey());
+    }
+}

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
@@ -29,6 +29,7 @@ import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
@@ -40,6 +41,9 @@ import org.springframework.util.StringUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Sets;
 import com.sequenceiq.cloudbreak.common.type.RecipeExecutionPhase;
+import com.sequenceiq.cloudbreak.ccm.endpoint.DirectServiceEndpointFinder;
+import com.sequenceiq.cloudbreak.ccm.endpoint.ServiceEndpointFinder;
+import com.sequenceiq.cloudbreak.ccm.endpoint.ServiceEndpointLookupException;
 import com.sequenceiq.cloudbreak.orchestrator.OrchestratorBootstrap;
 import com.sequenceiq.cloudbreak.orchestrator.OrchestratorBootstrapRunner;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
@@ -107,6 +111,9 @@ public class SaltOrchestrator implements HostOrchestrator {
     @Value("${rest.debug}")
     private boolean restDebug;
 
+    @Autowired(required = false)
+    private ServiceEndpointFinder serviceEndpointFinder = new DirectServiceEndpointFinder();
+
     private ExitCriteria exitCriteria;
 
     @Override
@@ -120,7 +127,7 @@ public class SaltOrchestrator implements HostOrchestrator {
         LOGGER.debug("Start SaltBootstrap on nodes: {}", targets);
         GatewayConfig primaryGateway = getPrimaryGatewayConfig(allGatewayConfigs);
         Set<String> gatewayTargets = getGatewayPrivateIps(allGatewayConfigs);
-        try (SaltConnector sc = new SaltConnector(primaryGateway, restDebug)) {
+        try (SaltConnector sc = createSaltConnector(primaryGateway)) {
             uploadSaltConfig(sc, gatewayTargets, exitModel);
             Set<String> allTargets = targets.stream().map(Node::getPrivateIp).collect(Collectors.toSet());
             uploadSignKey(sc, primaryGateway, gatewayTargets, allTargets, exitModel);
@@ -140,7 +147,7 @@ public class SaltOrchestrator implements HostOrchestrator {
         GatewayConfig primaryGateway = getPrimaryGatewayConfig(allGateway);
         Set<String> allTargets = nodes.stream().map(Node::getPrivateIp).collect(Collectors.toSet());
         Compound allHosts = new Compound(nodes.stream().map(Node::getHostname).collect(Collectors.toSet()), CompoundType.HOST);
-        try (SaltConnector sc = new SaltConnector(primaryGateway, restDebug)) {
+        try (SaltConnector sc = createSaltConnector(primaryGateway)) {
             uploadMountScriptsAndMakeThemExecutable(nodes, exitModel, allTargets, allHosts, sc);
 
             SaltStates.runCommandOnHosts(sc, allHosts, "(cd " + SRV_SALT_DISK + ";./" + DISK_INITIALIZE + ')');
@@ -216,7 +223,7 @@ public class SaltOrchestrator implements HostOrchestrator {
         GatewayConfig primaryGateway = getPrimaryGatewayConfig(allGatewayConfigs);
         Set<String> gatewayTargets = allGatewayConfigs.stream().filter(gc -> targets.stream().anyMatch(n -> gc.getPrivateAddress().equals(n.getPrivateIp())))
                 .map(GatewayConfig::getPrivateAddress).collect(Collectors.toSet());
-        try (SaltConnector sc = new SaltConnector(primaryGateway, restDebug)) {
+        try (SaltConnector sc = createSaltConnector(primaryGateway)) {
             if (!gatewayTargets.isEmpty()) {
                 uploadSaltConfig(sc, gatewayTargets, stateConfigZip, exitModel);
             }
@@ -239,7 +246,7 @@ public class SaltOrchestrator implements HostOrchestrator {
         GatewayConfig primaryGateway = getPrimaryGatewayConfig(allGateway);
         Set<String> gatewayTargets = getGatewayPrivateIps(allGateway);
         String ambariServerAddress = primaryGateway.getPrivateAddress();
-        try (SaltConnector sc = new SaltConnector(primaryGateway, restDebug)) {
+        try (SaltConnector sc = createSaltConnector(primaryGateway)) {
             OrchestratorBootstrap hostSave = new PillarSave(sc, gatewayTargets, allNodes);
             Callable<Boolean> saltPillarRunner = runner(hostSave, exitCriteria, exitModel);
             saltPillarRunner.call();
@@ -291,7 +298,7 @@ public class SaltOrchestrator implements HostOrchestrator {
             throws CloudbreakOrchestratorFailedException {
         GatewayConfig primaryGateway = getPrimaryGatewayConfig(allGateway);
         Set<String> gatewayTargets = getGatewayPrivateIps(allGateway);
-        try (SaltConnector sc = new SaltConnector(primaryGateway, restDebug)) {
+        try (SaltConnector sc = createSaltConnector(primaryGateway)) {
             OrchestratorBootstrap hostSave = new PillarSave(sc, gatewayTargets, allNodes);
             Callable<Boolean> saltPillarRunner = runner(hostSave, exitCriteria, exitModel);
             saltPillarRunner.call();
@@ -355,7 +362,7 @@ public class SaltOrchestrator implements HostOrchestrator {
             throws CloudbreakOrchestratorException {
         LOGGER.debug("Run Services on nodes: {}", allNodes);
         GatewayConfig primaryGateway = getPrimaryGatewayConfig(allGateway);
-        try (SaltConnector sc = new SaltConnector(primaryGateway, restDebug)) {
+        try (SaltConnector sc = createSaltConnector(primaryGateway)) {
             Set<String> all = allNodes.stream().map(Node::getPrivateIp).collect(Collectors.toSet());
             // YARN/SALT MAGIC: If you remove 'get role grains' before highstate, then highstate can run with defective roles,
             // so it can happen that 'ambari_agent' role will be missing on some nodes. Please do not delete only if you know what you are doing.
@@ -401,7 +408,7 @@ public class SaltOrchestrator implements HostOrchestrator {
             ExitCriteriaModel exitCriteriaModel) throws CloudbreakOrchestratorException {
         LOGGER.debug("Change primary gateway: {}", formerGateway);
         String ambariServerAddress = newPrimaryGateway.getPrivateAddress();
-        try (SaltConnector sc = new SaltConnector(newPrimaryGateway, restDebug)) {
+        try (SaltConnector sc = createSaltConnector(newPrimaryGateway)) {
             SaltStates.stopMinions(sc, Collections.singletonMap(formerGateway.getHostname(), formerGateway.getPrivateAddress()));
 
             // change ambari_server_standby role to ambari_server
@@ -418,7 +425,7 @@ public class SaltOrchestrator implements HostOrchestrator {
             // remove minion key from all remaining gateway nodes
             for (GatewayConfig gatewayConfig : allGatewayConfigs) {
                 if (!gatewayConfig.getHostname().equals(formerGateway.getHostname())) {
-                    try (SaltConnector sc1 = new SaltConnector(gatewayConfig, restDebug)) {
+                    try (SaltConnector sc1 = createSaltConnector(gatewayConfig)) {
                         LOGGER.debug("Removing minion key '{}' from gateway '{}'", formerGateway.getHostname(), gatewayConfig.getHostname());
                         sc1.wheel("key.delete", Collections.singleton(formerGateway.getHostname()), Object.class);
                     } catch (Exception ex) {
@@ -444,7 +451,7 @@ public class SaltOrchestrator implements HostOrchestrator {
     @Override
     public void resetAmbari(GatewayConfig gatewayConfig, Set<String> target, Set<Node> allNodes, ExitCriteriaModel exitCriteriaModel)
             throws CloudbreakOrchestratorException {
-        try (SaltConnector saltConnector = new SaltConnector(gatewayConfig, restDebug)) {
+        try (SaltConnector saltConnector = createSaltConnector(gatewayConfig)) {
             BaseSaltJobRunner baseSaltJobRunner = new BaseSaltJobRunner(target, allNodes) {
                 @Override
                 public String submit(SaltConnector saltConnector) {
@@ -463,7 +470,7 @@ public class SaltOrchestrator implements HostOrchestrator {
     @Override
     public void stopAmbariOnMaster(GatewayConfig gatewayConfig, Set<Node> allNodes, ExitCriteriaModel exitCriteriaModel)
             throws CloudbreakOrchestratorException {
-        try (SaltConnector saltConnector = new SaltConnector(gatewayConfig, restDebug)) {
+        try (SaltConnector saltConnector = createSaltConnector(gatewayConfig)) {
             Set<String> master = Set.of(gatewayConfig.getPrivateAddress());
             runSaltCommand(saltConnector, new GrainAddRunner(master, allNodes, "ambari_single_master_repair_stop"), exitCriteriaModel);
             runNewService(saltConnector, new HighStateRunner(master, allNodes), exitCriteriaModel);
@@ -476,7 +483,7 @@ public class SaltOrchestrator implements HostOrchestrator {
     @Override
     public void startAmbariOnMaster(GatewayConfig gatewayConfig, Set<Node> allNodes, ExitCriteriaModel exitCriteriaModel)
             throws CloudbreakOrchestratorException {
-        try (SaltConnector saltConnector = new SaltConnector(gatewayConfig, restDebug)) {
+        try (SaltConnector saltConnector = createSaltConnector(gatewayConfig)) {
             Set<String> master = Set.of(gatewayConfig.getPrivateAddress());
             runSaltCommand(saltConnector, new GrainRemoveRunner(master, allNodes, "ambari_single_master_repair_stop"), exitCriteriaModel);
             runNewService(saltConnector, new HighStateRunner(master, allNodes), exitCriteriaModel);
@@ -490,7 +497,7 @@ public class SaltOrchestrator implements HostOrchestrator {
     @Override
     public void upgradeAmbari(GatewayConfig gatewayConfig, Set<String> target, Set<Node> allNodes, SaltConfig pillarConfig,
             ExitCriteriaModel exitCriteriaModel) throws CloudbreakOrchestratorException {
-        try (SaltConnector sc = new SaltConnector(gatewayConfig, restDebug)) {
+        try (SaltConnector sc = createSaltConnector(gatewayConfig)) {
             for (Entry<String, SaltPillarProperties> propertiesEntry : pillarConfig.getServicePillarConfig().entrySet()) {
                 OrchestratorBootstrap pillarSave = new PillarSave(sc, Sets.newHashSet(gatewayConfig.getPrivateAddress()), propertiesEntry.getValue());
                 Callable<Boolean> saltPillarRunner = runner(pillarSave, exitCriteria, exitCriteriaModel);
@@ -519,7 +526,7 @@ public class SaltOrchestrator implements HostOrchestrator {
         LOGGER.debug("Tear down hosts: {},", privateIPsByFQDN);
         LOGGER.debug("Gateway config for tear down: {}", allGatewayConfigs);
         GatewayConfig primaryGateway = getPrimaryGatewayConfig(allGatewayConfigs);
-        try (SaltConnector saltConnector = new SaltConnector(primaryGateway, restDebug)) {
+        try (SaltConnector saltConnector = createSaltConnector(primaryGateway)) {
             SaltStates.stopMinions(saltConnector, privateIPsByFQDN);
         } catch (Exception e) {
             LOGGER.info("Error occurred during salt minion tear down", e);
@@ -528,7 +535,7 @@ public class SaltOrchestrator implements HostOrchestrator {
         List<GatewayConfig> liveGateways = allGatewayConfigs.stream()
                 .filter(gw -> !privateIPsByFQDN.values().contains(gw.getPrivateAddress())).collect(Collectors.toList());
         for (GatewayConfig gatewayConfig : liveGateways) {
-            try (SaltConnector sc = new SaltConnector(gatewayConfig, restDebug)) {
+            try (SaltConnector sc = createSaltConnector(gatewayConfig)) {
                 sc.wheel("key.delete", privateIPsByFQDN.keySet(), Object.class);
                 removeDeadSaltMinions(gatewayConfig);
             } catch (Exception e) {
@@ -540,7 +547,7 @@ public class SaltOrchestrator implements HostOrchestrator {
 
     public Map<String, Map<String, String>> getPackageVersionsFromAllHosts(GatewayConfig gateway, String... packages)
             throws CloudbreakOrchestratorFailedException {
-        try (SaltConnector saltConnector = new SaltConnector(gateway, restDebug)) {
+        try (SaltConnector saltConnector = createSaltConnector(gateway)) {
             return SaltStates.getPackageVersions(saltConnector, packages);
         } catch (RuntimeException e) {
             LOGGER.info("Error occurred during determine package versions: " + Arrays.deepToString(packages), e);
@@ -549,7 +556,7 @@ public class SaltOrchestrator implements HostOrchestrator {
     }
 
     public Map<String, String> runCommandOnAllHosts(GatewayConfig gateway, String command) throws CloudbreakOrchestratorFailedException {
-        try (SaltConnector saltConnector = new SaltConnector(gateway, restDebug)) {
+        try (SaltConnector saltConnector = createSaltConnector(gateway)) {
             return SaltStates.runCommand(saltConnector, command);
         } catch (RuntimeException e) {
             LOGGER.info("Error occurred during command execution: " + command, e);
@@ -559,7 +566,7 @@ public class SaltOrchestrator implements HostOrchestrator {
 
     @Override
     public Map<String, JsonNode> getGrainOnAllHosts(GatewayConfig gateway, String grain) throws CloudbreakOrchestratorFailedException {
-        try (SaltConnector saltConnector = new SaltConnector(gateway, restDebug)) {
+        try (SaltConnector saltConnector = createSaltConnector(gateway)) {
             return SaltStates.getGrains(saltConnector, grain);
         } catch (RuntimeException e) {
             LOGGER.info("Error occurred during get grain execution: " + grain, e);
@@ -568,7 +575,7 @@ public class SaltOrchestrator implements HostOrchestrator {
     }
 
     private void removeDeadSaltMinions(GatewayConfig gateway) throws CloudbreakOrchestratorFailedException {
-        try (SaltConnector saltConnector = new SaltConnector(gateway, restDebug)) {
+        try (SaltConnector saltConnector = createSaltConnector(gateway)) {
             MinionStatusSaltResponse minionStatusSaltResponse = SaltStates.collectNodeStatus(saltConnector);
             List<String> downNodes = minionStatusSaltResponse.downMinions();
             if (downNodes != null && !downNodes.isEmpty()) {
@@ -588,7 +595,7 @@ public class SaltOrchestrator implements HostOrchestrator {
                 .findFirst()
                 .orElseThrow(() -> new CloudbreakOrchestratorFailedException("Primary gateway not found"));
         Set<String> gatewayTargets = getGatewayPrivateIps(allGatewayConfigs);
-        try (SaltConnector sc = new SaltConnector(primaryGateway, restDebug)) {
+        try (SaltConnector sc = createSaltConnector(primaryGateway)) {
             OrchestratorBootstrap scriptPillarSave = new PillarSave(sc, gatewayTargets, recipes, calculateRecipeExecutionTimeout());
             Callable<Boolean> saltPillarRunner = runner(scriptPillarSave, exitCriteria, exitModel);
             saltPillarRunner.call();
@@ -676,7 +683,7 @@ public class SaltOrchestrator implements HostOrchestrator {
     @Override
     public void stopClusterManagerAgent(GatewayConfig gatewayConfig, Set<Node> nodes, ExitCriteriaModel exitCriteriaModel, boolean adJoinable,
             boolean ipaJoinable) throws CloudbreakOrchestratorFailedException {
-        try (SaltConnector sc = new SaltConnector(gatewayConfig, restDebug)) {
+        try (SaltConnector sc = createSaltConnector(gatewayConfig)) {
             LOGGER.debug("Applying role 'cloudera_manager_agent_stop' on nodes: [{}]", nodes);
             Set<String> targets = nodes.stream().map(Node::getPrivateIp).collect(Collectors.toSet());
             runSaltCommand(sc, new GrainAddRunner(targets, nodes, "roles", "cloudera_manager_agent_stop", CompoundType.IP), exitCriteriaModel);
@@ -705,7 +712,7 @@ public class SaltOrchestrator implements HostOrchestrator {
 
     public void leaveDomain(GatewayConfig gatewayConfig, Set<Node> allNodes, String roleToRemove, String roleToAdd, ExitCriteriaModel exitCriteriaModel)
             throws CloudbreakOrchestratorFailedException {
-        try (SaltConnector sc = new SaltConnector(gatewayConfig, restDebug)) {
+        try (SaltConnector sc = createSaltConnector(gatewayConfig)) {
             Set<String> targets = allNodes.stream().map(Node::getPrivateIp).collect(Collectors.toSet());
             runSaltCommand(sc, new GrainAddRunner(targets, allNodes, "roles", roleToAdd, CompoundType.IP), exitCriteriaModel);
             runSaltCommand(sc, new GrainRemoveRunner(targets, allNodes, "roles", roleToRemove, CompoundType.IP), exitCriteriaModel);
@@ -730,7 +737,7 @@ public class SaltOrchestrator implements HostOrchestrator {
 
     @Override
     public boolean isBootstrapApiAvailable(GatewayConfig gatewayConfig) {
-        try (SaltConnector saltConnector = new SaltConnector(gatewayConfig, restDebug)) {
+        try (SaltConnector saltConnector = createSaltConnector(gatewayConfig)) {
             if (saltConnector.health().getStatusCode() == HttpStatus.OK.value()) {
                 return true;
             }
@@ -747,7 +754,7 @@ public class SaltOrchestrator implements HostOrchestrator {
 
     @Override
     public Map<String, String> getMembers(GatewayConfig gatewayConfig, List<String> privateIps) throws CloudbreakOrchestratorException {
-        try (SaltConnector saltConnector = new SaltConnector(gatewayConfig, restDebug)) {
+        try (SaltConnector saltConnector = createSaltConnector(gatewayConfig)) {
             return saltConnector.members(privateIps);
         }
     }
@@ -786,7 +793,7 @@ public class SaltOrchestrator implements HostOrchestrator {
     @SuppressFBWarnings("REC_CATCH_EXCEPTION")
     private void executeRecipes(GatewayConfig gatewayConfig, Set<Node> allNodes, ExitCriteriaModel exitCriteriaModel, RecipeExecutionPhase phase)
             throws CloudbreakOrchestratorFailedException {
-        try (SaltConnector sc = new SaltConnector(gatewayConfig, restDebug)) {
+        try (SaltConnector sc = createSaltConnector(gatewayConfig)) {
             // add 'recipe' grain to all nodes
             Set<String> targets = allNodes.stream().map(Node::getPrivateIp).collect(Collectors.toSet());
             runSaltCommand(sc, new GrainAddRunner(targets, allNodes, "recipes", phase.value(), CompoundType.IP), exitCriteriaModel);
@@ -880,6 +887,14 @@ public class SaltOrchestrator implements HostOrchestrator {
         } catch (Exception e) {
             LOGGER.info("Error occurred during file distribute to gateway nodes", e);
             throw new CloudbreakOrchestratorFailedException(e);
+        }
+    }
+
+    private SaltConnector createSaltConnector(GatewayConfig gatewayConfig) {
+        try {
+            return new SaltConnector(gatewayConfig.getGatewayConfig(serviceEndpointFinder), restDebug);
+        } catch (ServiceEndpointLookupException | InterruptedException e) {
+            throw new RuntimeException("Cannot determine service endpoint for gateway: " + gatewayConfig, e);
         }
     }
 }


### PR DESCRIPTION
With these changes, CB has classes representing the various
CCM domain objects and finder functionality.

Additionally, the gateway config and salt orchestrator have
been modified to use a service endpoint finder instead of
always connecting directly to the nginx server on the gateway
node.
