### PR TITLE
CB-1248 Augment cloud-api for db server termination

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/ResourceConnector.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/ResourceConnector.java
@@ -102,6 +102,21 @@ public interface ResourceConnector<R> {
     List<CloudResourceStatus> terminate(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> cloudResources) throws Exception;
 
     /**
+     * Deletes the infrastructure for a database server from a cloud platform. This method initiates
+     * infrastructure deletion on the cloud platform and returns a list of {@link CloudResourceStatus}
+     * values, one for each terminated resource. The caller does not need to wait/block until
+     * infrastructure deletion is finished, but can return immediately and use
+     * {@link #check(AuthenticatedContext, List)} method to check regularly whether the infrastructure
+     * and all resources have been deleted or not.
+     *
+     * @param authenticatedContext the authenticated context which holds the client object
+     * @param stack                contains the full description of infrastructure
+     * @return the status of resources terminated on the cloud platform
+     * @throws Exception in case of any error
+     */
+    List<CloudResourceStatus> terminateDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack) throws Exception;
+
+    /**
      * Update of infrastructure on Cloud platform. (e.g change Security groups). It does not need to wait/block until the infrastructure update is
      * finished, but it can return immediately and the {@link #check(AuthenticatedContext, List)} method is invoked to check regularly whether the
      * infrastructure and all resources have already been updated or not.

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnector.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnector.java
@@ -103,6 +103,11 @@ public class AwsResourceConnector implements ResourceConnector<Object> {
     }
 
     @Override
+    public List<CloudResourceStatus> terminateDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack) {
+        throw new UnsupportedOperationException("Database server termination is not supported for " + getClass().getName());
+    }
+
+    @Override
     public List<CloudResourceStatus> update(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources) {
         return awsUpdateService.update(authenticatedContext, stack, resources);
     }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
@@ -248,6 +248,11 @@ public class AzureResourceConnector implements ResourceConnector<Map<String, Map
     }
 
     @Override
+    public List<CloudResourceStatus> terminateDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack) {
+        throw new UnsupportedOperationException("Database server termination is not supported for " + getClass().getName());
+    }
+
+    @Override
     public List<CloudResourceStatus> update(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources) {
         return new ArrayList<>();
     }

--- a/cloud-cumulus-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/cumulus/yarn/CumulusYarnResourceConnector.java
+++ b/cloud-cumulus-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/cumulus/yarn/CumulusYarnResourceConnector.java
@@ -147,6 +147,11 @@ public class CumulusYarnResourceConnector implements ResourceConnector<Object> {
     }
 
     @Override
+    public List<CloudResourceStatus> terminateDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack) {
+        throw new UnsupportedOperationException("Database server termination is not supported for " + getClass().getName());
+    }
+
+    @Override
     public List<CloudResourceStatus> update(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources) {
         return null;
     }

--- a/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockResourceConnector.java
+++ b/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockResourceConnector.java
@@ -81,6 +81,11 @@ public class MockResourceConnector implements ResourceConnector<Object> {
     }
 
     @Override
+    public List<CloudResourceStatus> terminateDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack) {
+        return new ArrayList<>();
+    }
+
+    @Override
     public List<CloudResourceStatus> update(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources) {
         return new ArrayList<>();
     }

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/heat/OpenStackResourceConnector.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/heat/OpenStackResourceConnector.java
@@ -277,6 +277,11 @@ public class OpenStackResourceConnector implements ResourceConnector<Object> {
         }
     }
 
+    @Override
+    public List<CloudResourceStatus> terminateDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack) {
+        throw new UnsupportedOperationException("Database server termination is not supported for " + getClass().getName());
+    }
+
     private void deleteKeyPair(AuthenticatedContext authenticatedContext, OSClient<?> client) {
         KeystoneCredentialView keystoneCredential = openStackClient.createKeystoneCredential(authenticatedContext);
         String keyPairName = keystoneCredential.getKeyPairName();

--- a/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/AbstractResourceConnector.java
+++ b/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/AbstractResourceConnector.java
@@ -104,6 +104,11 @@ public abstract class AbstractResourceConnector implements ResourceConnector<Lis
     }
 
     @Override
+    public List<CloudResourceStatus> terminateDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack) {
+        throw new UnsupportedOperationException("Database server termination is not supported for " + getClass().getName());
+    }
+
+    @Override
     public List<CloudResourceStatus> upscale(AuthenticatedContext auth, CloudStack stack, List<CloudResource> resources) {
         CloudContext cloudContext = auth.getCloudContext();
         Platform platform = cloudContext.getPlatform();

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnResourceConnector.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnResourceConnector.java
@@ -224,6 +224,11 @@ public class YarnResourceConnector implements ResourceConnector<Object> {
     }
 
     @Override
+    public List<CloudResourceStatus> terminateDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack) {
+        throw new UnsupportedOperationException("Database server termination is not supported for " + getClass().getName());
+    }
+
+    @Override
     public List<CloudResourceStatus> update(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources) {
         return null;
     }


### PR DESCRIPTION
The ResourceConnector cloud-api interface gains a new methods,
terminateDatabaseServer for terminating a previously allocated database
server in a cloud provider. The methods are stubbed out in
ResourceConnector implementations.