### PR TITLE
CB-877 change the IPA admin group to admins as ipausers is not posix …

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/config/LdapConfigRegisterService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/config/LdapConfigRegisterService.java
@@ -18,7 +18,7 @@ import com.sequenceiq.freeipa.ldap.LdapConfigService;
 @Service
 public class LdapConfigRegisterService extends AbstractConfigRegister {
 
-    public static final String ADMIN_GROUP = "ipausers";
+    public static final String ADMIN_GROUP = "admins";
 
     public static final String BIND_DN = "uid=admin,cn=users,cn=accounts";
 

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerUserSyncRoleConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerUserSyncRoleConfigProvider.java
@@ -29,7 +29,7 @@ public class RangerUserSyncRoleConfigProvider extends AbstractRoleConfigProvider
         String adminGroup = source.getLdapConfig().map(LdapView::getAdminGroup).orElse("*");
         return List.of(
                 config(ROLE_SAFETY_VALVE, ConfigUtils.getSafetyValveProperty(RANGER_USERSYNC_UNIX_BACKEND, "nss")),
-                config(ROLE_ASSIGNMENT_RULES, "ROLE_SYS_ADMIN:g:" + adminGroup));
+                config(ROLE_ASSIGNMENT_RULES, "&ROLE_SYS_ADMIN:g:" + adminGroup));
     }
 
     @Override


### PR DESCRIPTION
With this change whenever you log in to CM UI you'll have only read-access rights. Without this change, Ranger group mapping does not work. If you grant admins group in IPA it will work for CM and Ranger as well.