### PR TITLE
DISTX-186. Improve user sync behavior

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/config/UmsClientConfig.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/config/UmsClientConfig.java
@@ -5,11 +5,18 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class UmsClientConfig {
+    @Value("${altus.ums.client.list_groups_page_size:100}")
+    private int listGroupsPageSize;
+
     @Value("${altus.ums.client.list_users_page_size:100}")
     private int listUsersPageSize;
 
     @Value("${altus.ums.client.list_machine_users_page_size:100}")
     private int listMachineUsersPageSize;
+
+    public int getListGroupsPageSize() {
+        return listGroupsPageSize;
+    }
 
     public int getListUsersPageSize() {
         return listUsersPageSize;

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/User.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/User.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.freeipa.api.v1.freeipa.user.model;
 
 import java.util.Objects;
-import java.util.Set;
 
 import javax.validation.constraints.NotNull;
 
@@ -27,9 +26,6 @@ public class User {
     @ApiModelProperty(value = UserModelDescriptions.USER_LASTNAME, required = true)
     private String lastName;
 
-    @ApiModelProperty(value = UserModelDescriptions.USER_GROUPS)
-    private Set<String> groups;
-
     public String getName() {
         return name;
     }
@@ -52,14 +48,6 @@ public class User {
 
     public void setLastName(String lastName) {
         this.lastName = lastName;
-    }
-
-    public Set<String> getGroups() {
-        return groups;
-    }
-
-    public void setGroups(Set<String> groups) {
-        this.groups = groups;
     }
 
     @Override
@@ -88,7 +76,6 @@ public class User {
                 + "name='" + name + '\''
                 + ", firstName='" + firstName + '\''
                 + ", lastName='" + lastName + '\''
-                + ", groups=" + groups
                 + '}';
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/UserV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/UserV1Controller.java
@@ -42,13 +42,16 @@ public class UserV1Controller implements UserV1Endpoint {
     public SynchronizeUserResponse synchronizeUser(SynchronizeUserRequest request) {
         String userCrn = checkUserCrn();
         LOGGER.debug("synchronizeUser() requested for user {}", userCrn);
+        String accountId = crnService.getCurrentAccountId();
 
-        return userService.synchronizeUser(userCrn);
+        return userService.synchronizeUser(accountId, userCrn, userCrn);
     }
 
     @Override
     public SynchronizeAllUsersResponse synchronizeAllUsers(SynchronizeAllUsersRequest request) {
-        return userService.synchronizeAllUsers(request);
+        String userCrn = checkUserCrn();
+        String accountId = crnService.getCurrentAccountId();
+        return userService.synchronizeAllUsers(accountId, userCrn, request);
     }
 
     @Override
@@ -61,8 +64,9 @@ public class UserV1Controller implements UserV1Endpoint {
         try {
             String userCrn = checkUserCrn();
             LOGGER.debug("setPassword() requested for user {}", userCrn);
+            String accountId = crnService.getCurrentAccountId();
 
-            return passwordService.setPassword(userCrn, request.getPassword());
+            return passwordService.setPassword(accountId, userCrn, request.getPassword());
         } catch (Exception e) {
             LOGGER.error("setPassword caught exception. rethrowing", e);
             throw e;
@@ -73,7 +77,7 @@ public class UserV1Controller implements UserV1Endpoint {
     public CreateUsersResponse createUsers(CreateUsersRequest request) {
         try {
             String accountId = crnService.getCurrentAccountId();
-            userService.createUsers(request, accountId);
+            userService.createUsers(accountId, request);
         } catch (Exception e) {
             LOGGER.error("Failed to create users", e);
             throw new RuntimeException(e);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/FreeIpaPostInstallService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/FreeIpaPostInstallService.java
@@ -9,11 +9,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.freeipa.client.FreeIpaClient;
+import com.sequenceiq.freeipa.client.model.Permission;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.service.stack.StackService;
 import com.sequenceiq.freeipa.service.user.UserService;
-import com.sequenceiq.freeipa.client.model.Permission;
 
 @Service
 public class FreeIpaPostInstallService {
@@ -34,6 +35,9 @@ public class FreeIpaPostInstallService {
     @Inject
     private StackService stackService;
 
+    @Inject
+    private ThreadBasedUserCrnProvider threadBasedUserCrnProvider;
+
     public void postInstallFreeIpa(Long stackId) throws Exception {
         LOGGER.debug("Performing post-install configuration for stack {}", stackId);
         Stack stack = stackService.getStackById(stackId);
@@ -47,6 +51,7 @@ public class FreeIpaPostInstallService {
             LOGGER.debug("Set maximum username length to {}", MAX_USERNAME_LENGTH);
             freeIpaClient.setUsernameLength(MAX_USERNAME_LENGTH);
         }
-        userService.syncAllUserForStack(stack);
+
+        userService.syncAllUserForStack(threadBasedUserCrnProvider.getAccountId(), threadBasedUserCrnProvider.getUserCrn(), stack);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/PasswordService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/PasswordService.java
@@ -40,8 +40,7 @@ public class PasswordService {
     @Inject
     private GrpcUmsClient umsClient;
 
-    public SetPasswordResponse setPassword(String userCrn, String password) {
-        String accountId = crnService.getCurrentAccountId();
+    public SetPasswordResponse setPassword(String accountId, String userCrn, String password) {
         String userId = getUserIdFromUserCrn(userCrn);
 
         LOGGER.debug("setting password for user {} in account {}", userCrn, accountId);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/UmsUsersStateProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/UmsUsersStateProvider.java
@@ -2,10 +2,8 @@ package com.sequenceiq.freeipa.service.user;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -13,127 +11,47 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
-import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetRightsResponse;
 import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
-import com.sequenceiq.freeipa.api.v1.freeipa.user.model.Group;
-import com.sequenceiq.freeipa.api.v1.freeipa.user.model.User;
-import com.sequenceiq.freeipa.service.user.model.UsersState;
-import com.sequenceiq.freeipa.util.CrnService;
+import com.sequenceiq.freeipa.service.user.model.UmsState;
 
 @Service
 public class UmsUsersStateProvider {
     private static final Logger LOGGER = LoggerFactory.getLogger(UmsUsersStateProvider.class);
 
     @Inject
-    private ThreadBasedUserCrnProvider threadBaseUserCrnProvider;
-
-    @Inject
-    private CrnService crnService;
-
-    @Inject
     private GrpcUmsClient umsClient;
 
-    public User getUser(String userCrn, String environmentCrn) {
-        final String actorCrn = threadBaseUserCrnProvider.getUserCrn();
+    public UmsState getUmsState(String accountId, String actorCrn) {
+        UmsState.Builder umsStateBuilder = new UmsState.Builder();
+        umsClient.listAllUsers(actorCrn, accountId, Optional.empty())
+                .forEach(u -> umsStateBuilder.addUser(u, umsClient.getRightsForUser(actorCrn, u.getCrn(), null, Optional.empty())));
 
-        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.User user =
-                umsClient.getUserDetails(actorCrn, userCrn, Optional.empty());
-        return umsUserToUser(actorCrn, user, environmentCrn);
+        umsClient.listAllMachineUsers(actorCrn, accountId, Optional.empty())
+                .forEach(u -> umsStateBuilder.addMachineUser(u, umsClient.getRightsForUser(actorCrn, u.getCrn(), null, Optional.empty())));
+
+        umsClient.listAllGroups(actorCrn, accountId, Optional.empty())
+                .forEach(g -> umsStateBuilder.addGroup(g));
+
+        return umsStateBuilder.build();
     }
 
-    public UsersState getUsersState(String environmentCrn) {
-        final String actorCrn = threadBaseUserCrnProvider.getUserCrn();
-        final String accountId = crnService.getCurrentAccountId();
+    public UmsState getUserFilteredUmsState(String accountId, String actorCrn, Set<String> userCrns) {
+        // TODO allow filtering on machine users as well once that's exposed in the API
+        UmsState.Builder umsStateBuilder = new UmsState.Builder();
 
-        List<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.User> users =
-                umsClient.listUsers(actorCrn, accountId, Optional.empty());
-        LOGGER.info("Found {} users", users.size());
-        List<User> convertedUsers = users.stream()
-                .map(user -> umsUserToUser(actorCrn, user, environmentCrn))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+        Set<String> groupCrns = new HashSet<>();
 
-        List<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.MachineUser> machineUsers =
-                umsClient.listMachineUsers(actorCrn, accountId, Optional.empty());
-        LOGGER.info("Found {} machine users", machineUsers.size());
-        List<User> convertedMachineUsers = machineUsers.stream()
-                .map(machineUser -> umsMachineUserToUser(actorCrn, machineUser, environmentCrn))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+        umsClient.listUsers(actorCrn, accountId, List.copyOf(userCrns), Optional.empty())
+                .forEach(u -> {
+                    GetRightsResponse rights = umsClient.getRightsForUser(actorCrn, u.getCrn(), null, Optional.empty());
+                    umsStateBuilder.addUser(u, rights);
+                    groupCrns.addAll(rights.getGroupCrnList());
+                });
 
-        Set<User> allUsers = new HashSet<>();
-        allUsers.addAll(convertedUsers);
-        allUsers.addAll(convertedMachineUsers);
+        umsClient.listGroups(actorCrn, accountId, List.copyOf(groupCrns), Optional.empty())
+                .forEach(g -> umsStateBuilder.addGroup(g));
 
-        Set<Group> groups = allUsers.stream()
-                .map(User::getGroups)
-                .flatMap(Set::stream)
-                .map(this::fromGroupName)
-                .collect(Collectors.toSet());
-
-        return new UsersState(groups, allUsers);
-    }
-
-    private User umsUserToUser(String actorCrn, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.User umsUser, String environmentCrn) {
-        Set<String> groups = getGroupsForUser(actorCrn, umsUser.getCrn(), environmentCrn);
-        if (groups.isEmpty()) {
-            return null;
-        }
-
-        User user = new User();
-        // TODO Use workloadUsername once the UMS proto is updated
-        user.setName(getUsernameFromEmail(umsUser));
-        // TODO improve handling if names are missing
-        user.setFirstName(getOrDefault(umsUser.getFirstName(), "None"));
-        user.setLastName(getOrDefault(umsUser.getLastName(), "None"));
-        user.setGroups(groups);
-        return user;
-    }
-
-    private String getOrDefault(String value, String other) {
-        return (value == null || value.isBlank()) ? other : value;
-    }
-
-    private String getUsernameFromEmail(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.User umsUser) {
-        // TODO replace this code with workloadUsername in DISTX-184
-        return umsUser.getEmail().split("@")[0];
-    }
-
-    private User umsMachineUserToUser(String actorCrn,
-            com.cloudera.thunderhead.service.usermanagement.UserManagementProto.MachineUser umsMachineUser, String environmentCrn) {
-        Set<String> groups = getGroupsForUser(actorCrn, umsMachineUser.getCrn(), environmentCrn);
-        if (groups.isEmpty()) {
-            return null;
-        }
-
-        User user = new User();
-        // TODO Use workloadUsername once the UMS proto is updated
-        user.setName(umsMachineUser.getMachineUserName());
-        // TODO what should the appropriate first and last name be for machine users?
-        user.setFirstName("Machine");
-        user.setLastName("User");
-        user.setGroups(groups);
-        return user;
-    }
-
-    private Set<String> getGroupsForUser(String actorCrn, String userCrn, String environmentCrn) {
-        // TODO do we care about '*' rights?
-        return new HashSet<>(
-                umsClient.getGroupsForUser(actorCrn, userCrn, environmentCrn, Optional.empty())
-                        .stream()
-                        .map(this::getGroupNameFromGroupCrn)
-                        .collect(Collectors.toSet()));
-    }
-
-    private String getGroupNameFromGroupCrn(String groupCrn) {
-        Crn crn = Crn.safeFromString(groupCrn);
-        return crn.getResource().split("/")[0];
-    }
-
-    private Group fromGroupName(String groupName) {
-        Group group = new Group();
-        group.setName(groupName);
-        return group;
+        return umsStateBuilder.build();
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/UserService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/UserService.java
@@ -2,10 +2,8 @@ package com.sequenceiq.freeipa.service.user;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -16,8 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-import com.google.common.collect.Sets;
-import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.google.common.collect.Multimap;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.CreateUsersRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.Group;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizationStatus;
@@ -31,9 +28,10 @@ import com.sequenceiq.freeipa.client.model.RPCResponse;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.service.FreeIpaClientFactory;
 import com.sequenceiq.freeipa.service.stack.StackService;
+import com.sequenceiq.freeipa.service.user.model.SyncStatusDetail;
+import com.sequenceiq.freeipa.service.user.model.UmsState;
 import com.sequenceiq.freeipa.service.user.model.UsersState;
 import com.sequenceiq.freeipa.service.user.model.UsersStateDifference;
-import com.sequenceiq.freeipa.util.CrnService;
 
 @Service
 public class UserService {
@@ -47,137 +45,119 @@ public class UserService {
     private FreeIpaClientFactory freeIpaClientFactory;
 
     @Inject
-    private ThreadBasedUserCrnProvider threadBaseUserCrnProvider;
-
-    @Inject
-    private CrnService crnService;
-
-    @Inject
     private UmsUsersStateProvider umsUsersStateProvider;
 
     @Inject
     private FreeIpaUsersStateProvider freeIpaUsersStateProvider;
 
-    public SynchronizeUserResponse synchronizeUser(String userCrn) {
-        String accountId = crnService.getCurrentAccountId();
-
+    public SynchronizeUserResponse synchronizeUser(String accountId, String actorCrn, String userCrn) {
         LOGGER.debug("Syncing user {} in account {}", userCrn, accountId);
-
-        List<Stack> stacks = stackService.getAllByAccountId(accountId);
-
-        if (stacks.isEmpty()) {
-            throw new IllegalArgumentException("No stacks found for accountId " + accountId);
-        }
+        List<SyncStatusDetail> statuses = synchronizeUsers(accountId, actorCrn, null, Set.of(userCrn));
 
         List<String> success = new ArrayList<>();
         Map<String, String> failure = new HashMap<>();
-
-        for (Stack stack : stacks) {
-            try {
-                LOGGER.debug("Syncing {} to Environment {}", userCrn, stack.getEnvironmentCrn());
-                User umsUser = umsUsersStateProvider.getUser(userCrn, stack.getEnvironmentCrn());
-                Optional<User> ipaUserOptional = freeIpaUsersStateProvider.getUser(umsUser.getName(), stack);
-
-                FreeIpaClient freeIpaClient = freeIpaClientFactory.getFreeIpaClientForStack(stack);
-
-                Set<String> groupsToAdd;
-                Set<String> groupsToRemove;
-
-                // TODO check rights and deactivate user if no rights for this environment
-                if (ipaUserOptional.isEmpty()) {
-                    addUsers(freeIpaClient, Set.of(umsUser));
-                    groupsToAdd = umsUser.getGroups();
-                    groupsToRemove = Set.of();
-                } else {
-                    User ipaUser = ipaUserOptional.get();
-                    groupsToAdd = Sets.difference(umsUser.getGroups(), ipaUser.getGroups());
-                    groupsToRemove = Sets.difference(ipaUser.getGroups(), umsUser.getGroups());
-                }
-
-                Set<String> usernameSet = Set.of(umsUser.getName());
-                Map<String, Set<String>> groupAddMapping = new HashMap<>(groupsToAdd.size());
-                groupsToAdd.forEach(g -> groupAddMapping.put(g, usernameSet));
-                addUsersToGroups(freeIpaClient, groupAddMapping);
-
-                Map<String, Set<String>> groupRemoveMapping = new HashMap<>(groupsToRemove.size());
-                groupsToRemove.forEach(g -> groupRemoveMapping.put(g, usernameSet));
-                removeUsersFromGroups(freeIpaClient, groupRemoveMapping);
-
-                success.add(stack.getEnvironmentCrn());
-            } catch (Exception e) {
-                LOGGER.warn("Failed to synchronize environment {}", stack.getEnvironmentCrn());
-                failure.put(stack.getEnvironmentCrn(), e.getLocalizedMessage());
+        statuses.forEach(status -> {
+            switch (status.getStatus()) {
+                case COMPLETED:
+                    success.add(status.getEnvironmentCrn());
+                    break;
+                case FAILED:
+                    failure.put(status.getEnvironmentCrn(), status.getDetails());
+                    break;
+                default:
+                    failure.put(status.getEnvironmentCrn(), "Unknown status");
+                    break;
             }
-        }
+        });
         return new SynchronizeUserResponse(success, failure);
     }
 
-    public SynchronizeAllUsersResponse synchronizeAllUsers(SynchronizeAllUsersRequest request) {
-        String accountId = crnService.getCurrentAccountId();
+    public SynchronizeAllUsersResponse synchronizeAllUsers(String accountId, String actorCrn, SynchronizeAllUsersRequest request) {
+        synchronizeUsers(accountId, actorCrn, request.getEnvironments(), request.getUsers());
+
+        // TODO properly return values
+        return new SynchronizeAllUsersResponse(UUID.randomUUID().toString(), SynchronizationStatus.RUNNING,
+                null, null);
+    }
+
+    private List<SyncStatusDetail> synchronizeUsers(String accountId, String actorCrn, Set<String> environmentsFilter, Set<String> userCrnFilter) {
+        boolean filterUsers = userCrnFilter != null && !userCrnFilter.isEmpty();
+
+        // TODO allow filtering on machine users as well
+
         List<Stack> stacks = stackService.getAllByAccountId(accountId);
         LOGGER.debug("Found {} stacks for account {}", stacks.size(), accountId);
-        Set<String> environmentsFilter = request.getEnvironments();
-        if (!environmentsFilter.isEmpty()) {
+        if (environmentsFilter != null && !environmentsFilter.isEmpty()) {
             stacks = stacks.stream()
                     .filter(stack -> environmentsFilter.contains(stack.getEnvironmentCrn()))
                     .collect(Collectors.toList());
         }
+        UmsState umsState = filterUsers ? umsUsersStateProvider.getUserFilteredUmsState(accountId, actorCrn, userCrnFilter)
+                : umsUsersStateProvider.getUmsState(accountId, actorCrn);
 
-        stacks.forEach(this::syncAllUserForStack);
+        Set<String> userIdFilter = filterUsers ? umsState.getUsernamesFromCrns(userCrnFilter)
+                : Set.of();
 
-        return new SynchronizeAllUsersResponse(UUID.randomUUID().toString(), SynchronizationStatus.FAILED,
-                null, null);
-    }
+        List<SyncStatusDetail> statuses = stacks.stream()
+                .map(stack -> synchronizeStack(stack, umsState, userIdFilter))
+                .collect(Collectors.toList());
 
-    public void syncAllUserForStack(Stack stack) {
-        // TODO improve exception handling
-        try {
-            LOGGER.info("Syncing Environment {}", stack.getEnvironmentCrn());
-            // TODO filter by users in request
-            UsersState umsUsersState = umsUsersStateProvider.getUsersState(stack.getEnvironmentCrn());
-            LOGGER.debug("UMS UsersState = {}", umsUsersState);
-            // TODO filter by users in request
-            UsersState ipaUsersState = freeIpaUsersStateProvider.getUsersState(stack);
-            LOGGER.debug("IPA UsersState = {}", ipaUsersState);
-            // TODO calculate group membership changes. this currently only picks up group membership for added users
-            UsersStateDifference stateDifference = UsersStateDifference.fromUmsAndIpaUsersStates(umsUsersState, ipaUsersState);
-            LOGGER.debug("State Difference = {}", stateDifference);
-            FreeIpaClient freeIpaClient = freeIpaClientFactory.getFreeIpaClientForStack(stack);
-            addGroups(freeIpaClient, stateDifference.getGroupsToAdd());
-            addUsers(freeIpaClient, stateDifference.getUsersToAdd());
-            // TODO remove/deactivate groups/users
-        } catch (Exception e) {
-            LOGGER.warn("Failed to synchronize environment {}", stack.getEnvironmentCrn());
-        }
+        return statuses;
     }
 
     public SynchronizeAllUsersResponse getSynchronizeUsersStatus(String syncId) {
-        return new SynchronizeAllUsersResponse(syncId, SynchronizationStatus.FAILED,
+        return new SynchronizeAllUsersResponse(syncId, SynchronizationStatus.RUNNING,
                 null, null);
     }
 
-    public void createUsers(CreateUsersRequest request, String accountId) throws Exception {
-        LOGGER.info("UserService.synchronizeAllUsers() called");
+    public void createUsers(String accountId, CreateUsersRequest request) throws Exception {
+        // TODO remove this method and API when we are happy w/ user sync
+        LOGGER.info("UserService.createUsers() called");
 
         Stack stack = stackService.getByEnvironmentCrnAndAccountId(request.getEnvironmentCrn(), accountId);
 
         FreeIpaClient freeIpaClient = freeIpaClientFactory.getFreeIpaClientForStack(stack);
-
-        // TODO improve exception handling. e.g., group or user add will fail if group or user already exists
-        // TODO batch calls for improved performance. i.e., get all members of each group so we call groupAddMember once per group. investigate batch api
 
         addGroups(freeIpaClient, request.getGroups());
 
         Set<User> users = request.getUsers();
         addUsers(freeIpaClient, users);
 
-        addUsersToGroups(freeIpaClient, getGroupUserMapping(users));
-
-        // TODO remove users from groups that are not specified
-        // TODO remove groups that are not specified
-        // TODO remove/disable users
-
         LOGGER.info("Done!");
+    }
+
+    public SyncStatusDetail syncAllUserForStack(String accountId, String actorCrn, Stack stack) {
+        UmsState umsState = umsUsersStateProvider.getUmsState(accountId, actorCrn);
+        return synchronizeStack(stack, umsState, Set.of());
+    }
+
+    private SyncStatusDetail synchronizeStack(Stack stack, UmsState umsState, Set<String> userIdFilter) {
+        // TODO improve exception handling
+        String environmentCrn = stack.getEnvironmentCrn();
+        try {
+            LOGGER.info("Syncing Environment {}", environmentCrn);
+            UsersState umsUsersState = umsState.getUsersState(environmentCrn);
+            LOGGER.debug("UMS UsersState = {}", umsUsersState);
+
+            FreeIpaClient freeIpaClient = freeIpaClientFactory.getFreeIpaClientForStack(stack);
+            UsersState ipaUsersState = userIdFilter.isEmpty() ? freeIpaUsersStateProvider.getUsersState(freeIpaClient)
+                    : freeIpaUsersStateProvider.getFilteredUsersState(freeIpaClient, userIdFilter);
+            LOGGER.debug("IPA UsersState = {}", ipaUsersState);
+
+            UsersStateDifference stateDifference = UsersStateDifference.fromUmsAndIpaUsersStates(umsUsersState, ipaUsersState);
+            LOGGER.debug("State Difference = {}", stateDifference);
+
+            addGroups(freeIpaClient, stateDifference.getGroupsToAdd());
+            addUsers(freeIpaClient, stateDifference.getUsersToAdd());
+            addUsersToGroups(freeIpaClient, stateDifference.getGroupMembershipToAdd());
+
+            // TODO remove/deactivate groups/users/group membership
+
+            return SyncStatusDetail.succeed(environmentCrn, "TODO- collect detail info");
+        } catch (Exception e) {
+            LOGGER.warn("Failed to synchronize environment {}", stack.getEnvironmentCrn());
+            return SyncStatusDetail.fail(environmentCrn, e.getLocalizedMessage());
+        }
     }
 
     private void addGroups(FreeIpaClient freeIpaClient, Set<Group> groups) throws FreeIpaClientException {
@@ -210,49 +190,37 @@ public class UserService {
         }
     }
 
-    private void addUsersToGroups(FreeIpaClient freeIpaClient, Map<String, Set<String>> groupMapping) throws FreeIpaClientException {
-        for (Map.Entry<String, Set<String>> entry : groupMapping.entrySet()) {
-            LOGGER.debug("adding users {} to group {}", entry.getValue(), entry.getKey());
+    private void addUsersToGroups(FreeIpaClient freeIpaClient, Multimap<String, String> groupMapping) throws FreeIpaClientException {
+        LOGGER.debug("adding users to groups: {}", groupMapping);
+        for (String group : groupMapping.keySet()) {
+            Set<String> users = Set.copyOf(groupMapping.get(group));
+            LOGGER.debug("adding users {} to group {}", users, group);
+
             try {
                 // TODO specialize response object
-                RPCResponse<Object> groupAddMember = freeIpaClient.groupAddMembers(entry.getKey(), entry.getValue());
+                RPCResponse<Object> groupAddMember = freeIpaClient.groupAddMembers(group, users);
                 LOGGER.debug("Success: {}", groupAddMember.getResult());
             } catch (FreeIpaClientException e) {
                 // TODO propagate this information out to API
-                LOGGER.error("Failed to add users {} to group {}", entry.getValue(), entry.getKey(), e);
+                LOGGER.error("Failed to add {} to group", users, group, e);
             }
         }
     }
 
-    private void removeUsersFromGroups(FreeIpaClient freeIpaClient, Map<String, Set<String>> groupMapping) throws FreeIpaClientException {
-        for (Map.Entry<String, Set<String>> entry : groupMapping.entrySet()) {
-            LOGGER.debug("removing users {} from group {}", entry.getValue(), entry.getKey());
+    private void removeUsersFromGroups(FreeIpaClient freeIpaClient, Multimap<String, String> groupMapping) throws FreeIpaClientException {
+        for (String group : groupMapping.keySet()) {
+            Set<String> users = Set.copyOf(groupMapping.get(group));
+            LOGGER.debug("removing users {} to group {}", users, group);
+
             try {
                 // TODO specialize response object
-                RPCResponse<Object> groupRemoveMember = freeIpaClient.groupRemoveMembers(entry.getKey(), entry.getValue());
-                LOGGER.debug("Success: {}", groupRemoveMember.getResult());
+                RPCResponse<Object> groupRemoveMembers = freeIpaClient.groupRemoveMembers(group, users);
+                LOGGER.debug("Success: {}", groupRemoveMembers.getResult());
             } catch (FreeIpaClientException e) {
                 // TODO propagate this information out to API
-                LOGGER.error("Failed to remove users {} from group {}", entry.getValue(), entry.getKey(), e);
+                LOGGER.error("Failed to add {} to group", users, group, e);
             }
         }
-    }
-
-    private Map<String, Set<String>> getGroupUserMapping(Set<User> users) {
-        Map<String, Set<String>> mapping = new HashMap<>();
-
-        for (User user : users) {
-            String username = user.getName();
-            for (String group : user.getGroups()) {
-                Set<String> members = mapping.get(group);
-                if (members == null) {
-                    members = new HashSet<>();
-                    mapping.put(group, members);
-                }
-                members.add(username);
-            }
-        }
-        return mapping;
     }
 
     private String generateRandomPassword() {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/model/SyncStatusDetail.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/model/SyncStatusDetail.java
@@ -1,0 +1,40 @@
+package com.sequenceiq.freeipa.service.user.model;
+
+import static java.util.Objects.requireNonNull;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizationStatus;
+
+public class SyncStatusDetail {
+
+    private String environmentCrn;
+
+    private SynchronizationStatus status;
+
+    private String details;
+
+    public SyncStatusDetail(String environmentCrn, SynchronizationStatus status, String details) {
+        this.environmentCrn = requireNonNull(environmentCrn);
+        this.status = requireNonNull(status);
+        this.details = requireNonNull(details);
+    }
+
+    public String getEnvironmentCrn() {
+        return environmentCrn;
+    }
+
+    public SynchronizationStatus getStatus() {
+        return status;
+    }
+
+    public String getDetails() {
+        return details;
+    }
+
+    public static SyncStatusDetail fail(String environmentCrn, String failureMessage) {
+        return new SyncStatusDetail(environmentCrn, SynchronizationStatus.FAILED, failureMessage);
+    }
+
+    public static SyncStatusDetail succeed(String environmentCrn, String details) {
+        return new SyncStatusDetail(environmentCrn, SynchronizationStatus.COMPLETED, details);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/model/UmsState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/model/UmsState.java
@@ -1,0 +1,138 @@
+package com.sequenceiq.freeipa.service.user.model;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetRightsResponse;
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.Group;
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.MachineUser;
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.User;
+
+public class UmsState {
+    private Map<String, Group> groupMap;
+
+    private Map<String, User> userMap;
+
+    private Map<String, GetRightsResponse> userRightsMap;
+
+    private Map<String, MachineUser> machineUserMap;
+
+    private Map<String, GetRightsResponse> machineUserRightsMap;
+
+    public UmsState(Map<String, Group> groupMap, Map<String, User> userMap, Map<String, GetRightsResponse> userRightsMap,
+            Map<String, MachineUser> machineUserMap, Map<String, GetRightsResponse> machineUserRightsMap) {
+        this.groupMap = requireNonNull(groupMap);
+        this.userMap = requireNonNull(userMap);
+        this.userRightsMap = requireNonNull(userRightsMap);
+        this.machineUserMap = requireNonNull(machineUserMap);
+        this.machineUserRightsMap = requireNonNull(machineUserRightsMap);
+    }
+
+    public UsersState getUsersState(String environmentCrn) {
+        UsersState.Builder builder = new UsersState.Builder();
+
+        Map<String, com.sequenceiq.freeipa.api.v1.freeipa.user.model.Group> crnToGroup = new HashMap<>(groupMap.size());
+        groupMap.entrySet()
+                .forEach(e -> {
+                    com.sequenceiq.freeipa.api.v1.freeipa.user.model.Group group = umsGroupToGroup(e.getValue());
+                    crnToGroup.put(e.getKey(), group);
+                    builder.addGroup(group);
+                });
+
+        // TODO filter users by environment rights
+        userMap.entrySet()
+                .forEach(e -> {
+                    com.sequenceiq.freeipa.api.v1.freeipa.user.model.User user = umsUserToUser(e.getValue());
+                    builder.addUser(user);
+                    userRightsMap.get(e.getKey()).getGroupCrnList()
+                            .forEach(crn -> builder.addMemberToGroup(crnToGroup.get(crn).getName(), user.getName()));
+                });
+
+        // TODO filter machine users by environment rights
+        machineUserMap.entrySet()
+                .forEach(e -> {
+                    com.sequenceiq.freeipa.api.v1.freeipa.user.model.User user = umsMachineUserToUser(e.getValue());
+                    builder.addUser(user);
+                    machineUserRightsMap.get(e.getKey()).getGroupCrnList()
+                            .forEach(crn -> builder.addMemberToGroup(crnToGroup.get(crn).getName(), user.getName()));
+                });
+
+        return builder.build();
+    }
+
+    public Set<String> getUsernamesFromCrns(Set<String> userCrns) {
+        return userCrns.stream()
+                .map(crn -> getUsernameFromEmail(userMap.get(crn)))
+                .collect(Collectors.toSet());
+    }
+
+    private com.sequenceiq.freeipa.api.v1.freeipa.user.model.User umsUserToUser(User umsUser) {
+        com.sequenceiq.freeipa.api.v1.freeipa.user.model.User user = new com.sequenceiq.freeipa.api.v1.freeipa.user.model.User();
+        // TODO Use workloadUsername once the UMS proto is updated in DISTX-184
+        user.setName(getUsernameFromEmail(umsUser));
+        user.setFirstName(getOrDefault(umsUser.getFirstName(), "None"));
+        user.setLastName(getOrDefault(umsUser.getLastName(), "None"));
+        return user;
+    }
+
+    private String getOrDefault(String value, String other) {
+        return (value == null || value.isBlank()) ? other : value;
+    }
+
+    private String getUsernameFromEmail(User umsUser) {
+        // TODO replace this code with workloadUsername in DISTX-184
+        return umsUser.getEmail().split("@")[0];
+    }
+
+    private com.sequenceiq.freeipa.api.v1.freeipa.user.model.User umsMachineUserToUser(MachineUser umsMachineUser) {
+        com.sequenceiq.freeipa.api.v1.freeipa.user.model.User user = new com.sequenceiq.freeipa.api.v1.freeipa.user.model.User();
+        // TODO Use workloadUsername once the UMS proto is updated in DISTX-184
+        user.setName(umsMachineUser.getMachineUserName());
+        // TODO what should the appropriate first and last name be for machine users?
+        user.setFirstName("Machine");
+        user.setLastName("User");
+        return user;
+    }
+
+    private com.sequenceiq.freeipa.api.v1.freeipa.user.model.Group umsGroupToGroup(Group umsGroup) {
+        com.sequenceiq.freeipa.api.v1.freeipa.user.model.Group group = new com.sequenceiq.freeipa.api.v1.freeipa.user.model.Group();
+        group.setName(umsGroup.getGroupName());
+        return group;
+    }
+
+    public static class Builder {
+        private Map<String, Group> groupMap = new HashMap<>();
+
+        private Map<String, User> userMap = new HashMap<>();
+
+        private Map<String, GetRightsResponse> userRightsMap = new HashMap<>();
+
+        private Map<String, MachineUser> machineUserMap = new HashMap<>();
+
+        private Map<String, GetRightsResponse> machineUserRightsMap = new HashMap<>();
+
+        public void addGroup(Group group) {
+            groupMap.put(group.getCrn(), group);
+        }
+
+        public void addUser(User user, GetRightsResponse rights) {
+            String userCrn = user.getCrn();
+            userMap.put(userCrn, user);
+            userRightsMap.put(userCrn, rights);
+        }
+
+        public void addMachineUser(MachineUser machineUser, GetRightsResponse rights) {
+            String machineUserCrn = machineUser.getCrn();
+            machineUserMap.put(machineUserCrn, machineUser);
+            machineUserRightsMap.put(machineUserCrn, rights);
+        }
+
+        public UmsState build() {
+            return new UmsState(groupMap, userMap, userRightsMap, machineUserMap, machineUserRightsMap);
+        }
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/model/UsersState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/user/model/UsersState.java
@@ -2,8 +2,11 @@ package com.sequenceiq.freeipa.service.user.model;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.HashSet;
 import java.util.Set;
 
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.Group;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.User;
 
@@ -12,9 +15,12 @@ public class UsersState {
 
     private Set<User> users;
 
-    public UsersState(Set<Group> groups, Set<User> users) {
+    private Multimap<String, String> groupMembership;
+
+    public UsersState(Set<Group> groups, Set<User> users, Multimap<String, String> groupMembership) {
         this.groups = requireNonNull(groups);
         this.users = requireNonNull(users);
+        this.groupMembership = requireNonNull(groupMembership);
     }
 
     public Set<Group> getGroups() {
@@ -25,11 +31,40 @@ public class UsersState {
         return users;
     }
 
+    public Multimap<String, String> getGroupMembership() {
+        return groupMembership;
+    }
+
     @Override
     public String toString() {
         return "UsersState{"
                 + "groups=" + groups
                 + ", users=" + users
+                + ", groupMembership=" + groupMembership
                 + '}';
+    }
+
+    public static class Builder {
+        private Set<Group> groups = new HashSet<>();
+
+        private Set<User> users = new HashSet<>();
+
+        private Multimap<String, String> groupMembership = HashMultimap.create();
+
+        public void addGroup(Group group) {
+            groups.add(group);
+        }
+
+        public void addUser(User user) {
+            users.add(user);
+        }
+
+        public void addMemberToGroup(String group, String user) {
+            groupMembership.put(group, user);
+        }
+
+        public UsersState build() {
+            return new UsersState(groups, users, groupMembership);
+        }
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/controller/UserV1ControllerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/controller/UserV1ControllerTest.java
@@ -45,20 +45,25 @@ public class UserV1ControllerTest {
     @Test
     void synchronizeUser() {
         when(threadBaseUserCrnProvider.getUserCrn()).thenReturn(USER_CRN);
+        when(crnService.getCurrentAccountId()).thenReturn(ACCOUNT_ID);
+
         SynchronizeUserRequest request = mock(SynchronizeUserRequest.class);
 
         underTest.synchronizeUser(request);
 
-        verify(userService, times(1)).synchronizeUser(USER_CRN);
+        verify(userService, times(1)).synchronizeUser(ACCOUNT_ID, USER_CRN, USER_CRN);
     }
 
     @Test
     void synchronizeAllUsers() {
+        when(threadBaseUserCrnProvider.getUserCrn()).thenReturn(USER_CRN);
+        when(crnService.getCurrentAccountId()).thenReturn(ACCOUNT_ID);
+
         SynchronizeAllUsersRequest request = mock(SynchronizeAllUsersRequest.class);
 
         underTest.synchronizeAllUsers(request);
 
-        verify(userService, times(1)).synchronizeAllUsers(request);
+        verify(userService, times(1)).synchronizeAllUsers(ACCOUNT_ID, USER_CRN, request);
     }
 
     @Test
@@ -73,22 +78,25 @@ public class UserV1ControllerTest {
     @Test
     void setPassword() {
         when(threadBaseUserCrnProvider.getUserCrn()).thenReturn(USER_CRN);
+        when(crnService.getCurrentAccountId()).thenReturn(ACCOUNT_ID);
+
         String password = "password";
         SetPasswordRequest request = mock(SetPasswordRequest.class);
         when(request.getPassword()).thenReturn(password);
 
         underTest.setPassword(request);
 
-        verify(passwordService, times(1)).setPassword(USER_CRN, password);
+        verify(passwordService, times(1)).setPassword(ACCOUNT_ID, USER_CRN, password);
     }
 
     @Test
     void createUsers() throws Exception {
         when(crnService.getCurrentAccountId()).thenReturn(ACCOUNT_ID);
+
         CreateUsersRequest request = mock(CreateUsersRequest.class);
 
         underTest.createUsers(request);
 
-        verify(userService, times(1)).createUsers(request, ACCOUNT_ID);
+        verify(userService, times(1)).createUsers(ACCOUNT_ID, request);
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/user/FreeIpaUsersStateProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/user/FreeIpaUsersStateProviderTest.java
@@ -41,8 +41,6 @@ class FreeIpaUsersStateProviderTest {
 
     @Test
     void testGetUserState() throws Exception {
-        when(freeIpaClientFactory.getFreeIpaClientForStack(stack)).thenReturn(freeIpaClient);
-
         List<String> user1GroupNames = List.of("group1", "group2");
         List<String> user2GroupNames = List.of("group2", "group3", FreeIpaUsersStateProvider.IPA_ONLY_GROUPS.get(0));
         List<String> ipaOnlyUserGroupNames = List.of("dont_include");
@@ -65,7 +63,7 @@ class FreeIpaUsersStateProviderTest {
         when(freeIpaClient.userFindAll()).thenReturn(usersFindAll);
         when(freeIpaClient.groupFindAll()).thenReturn(groupsFindAll);
 
-        UsersState ipaState = underTest.getUsersState(stack);
+        UsersState ipaState = underTest.getUsersState(freeIpaClient);
 
         Set<String> expectedUsers = users.keySet().stream()
                 .filter(user -> !FreeIpaUsersStateProvider.IPA_ONLY_USERS.contains(user))
@@ -98,7 +96,6 @@ class FreeIpaUsersStateProviderTest {
         assertEquals(user.getName(), ipaUser.getUid());
         assertEquals(user.getLastName(), ipaUser.getSn());
         assertEquals(user.getFirstName(), ipaUser.getGivenname());
-        assertEquals(user.getGroups(), Set.copyOf(ipaUser.getMemberOfGroup()));
     }
 
     @Test


### PR DESCRIPTION
User sync behavior has changed in the following ways:
  - All groups are retrieved from UMS instead of only those that
    users are members of
  - All users are added to IPA instead of only those that are members
    of a group
  - Users are retrieved a single time from the UMS instead of
    repeatedly for each environment
  - A user filter was implemented to allow sync of specified users
  - Group membership is calculated and compared between UMS and IPA
  - Users are added to groups in IPA

Other minor changes were:
  - account and actor crn are retrieved in the controller layer
    and passed in to the UserService rather than retrieved in
    the UmsUsersStateProvider

This commit does not remove or deactivate users, nor does it
remove users from groups.
