### PR TITLE
CB-1837. Register created databases.

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudResource.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudResource.java
@@ -1,7 +1,9 @@
 package com.sequenceiq.cloudbreak.cloud.model;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import com.google.common.base.Preconditions;
 import com.sequenceiq.cloudbreak.cloud.model.generic.DynamicModel;
@@ -90,6 +92,12 @@ public class CloudResource extends DynamicModel {
 
     public void setInstanceId(String instanceId) {
         this.instanceId = instanceId;
+    }
+
+    public static Optional<CloudResource> getResourceTypeFromList(ResourceType type, List<CloudResource> resources) {
+        return resources.stream()
+                .filter(resource -> resource.type == type)
+                .findFirst();
     }
 
     public static class Builder {

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/DatabaseServer.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/DatabaseServer.java
@@ -16,6 +16,8 @@ public class DatabaseServer extends DynamicModel {
 
     private final String rootPassword;
 
+    private final Integer port;
+
     private final long storageSize;
 
     private final Security security;
@@ -23,25 +25,27 @@ public class DatabaseServer extends DynamicModel {
     private final InstanceStatus status;
 
     public DatabaseServer(String serverId, String flavor, DatabaseEngine engine, String rootUserName, String rootPassword,
-            long storageSize, Security security, InstanceStatus status) {
+            Integer port, long storageSize, Security security, InstanceStatus status) {
         this.serverId = serverId;
         this.flavor = flavor;
         this.engine = engine;
         this.rootUserName = rootUserName;
         this.rootPassword = rootPassword;
+        this.port = port;
         this.storageSize = storageSize;
         this.security = security;
         this.status = status;
     }
 
     public DatabaseServer(String serverId, String flavor, DatabaseEngine engine, String rootUserName, String rootPassword,
-            long storageSize, Security security, InstanceStatus status, Map<String, Object> parameters) {
+            Integer port, long storageSize, Security security, InstanceStatus status, Map<String, Object> parameters) {
         super(parameters);
         this.serverId = serverId;
         this.flavor = flavor;
         this.engine = engine;
         this.rootUserName = rootUserName;
         this.rootPassword = rootPassword;
+        this.port = port;
         this.storageSize = storageSize;
         this.security = security;
         this.status = status;
@@ -67,6 +71,10 @@ public class DatabaseServer extends DynamicModel {
         return rootPassword;
     }
 
+    public Integer getPort() {
+        return port;
+    }
+
     public long getStorageSize() {
         return storageSize;
     }
@@ -86,6 +94,7 @@ public class DatabaseServer extends DynamicModel {
                 + ", flavor='" + flavor + '\''
                 + ", engine='" + engine + '\''
                 + ", rootUserName='" + rootUserName + '\''
+                + ", port='" + port + '\''
                 + ", storageSize=" + storageSize
                 + ", security=" + security
                 + ", status=" + status

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/common/type/ResourceType.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/common/type/ResourceType.java
@@ -15,6 +15,8 @@ public enum ResourceType {
     AWS_VOLUMESET,
     AWS_INSTANCE,
     RDS_INSTANCE,
+    RDS_HOSTNAME,
+    RDS_PORT,
     RDS_DB_SUBNET_GROUP,
 
     // OPENSTACK

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsStackRequestHelper.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsStackRequestHelper.java
@@ -5,6 +5,7 @@ import static java.util.Arrays.asList;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 
 import javax.inject.Inject;
@@ -120,7 +121,7 @@ public class AwsStackRequestHelper {
         AwsNetworkView awsNetworkView = new AwsNetworkView(stack.getNetwork());
         AwsRdsInstanceView awsRdsInstanceView = new AwsRdsInstanceView(stack.getDatabaseServer());
         AwsRdsDbSubnetGroupView awsRdsDbSubnetGroupView = new AwsRdsDbSubnetGroupView(stack.getDatabaseServer());
-        Collection<Parameter> parameters = new ArrayList<>(asList(
+        List<Parameter> parameters = new ArrayList<>(asList(
                 new Parameter().withParameterKey("AllocatedStorageParameter").withParameterValue(Objects.toString(awsRdsInstanceView.getAllocatedStorage())),
                 new Parameter().withParameterKey("BackupRetentionPeriodParameter")
                     .withParameterValue(Objects.toString(awsRdsInstanceView.getBackupRetentionPeriod())),
@@ -135,6 +136,13 @@ public class AwsStackRequestHelper {
                 new Parameter().withParameterKey("VPCSecurityGroupsParameter").withParameterValue(String.join(",", awsRdsInstanceView.getVPCSecurityGroups())),
                 new Parameter().withParameterKey("StackOwner").withParameterValue(String.valueOf(ac.getCloudContext().getUserName()))
         ));
+
+        // Add the port if it's been supplied
+        Integer port = stack.getDatabaseServer().getPort();
+        if (port != null) {
+            parameters.add(new Parameter().withParameterKey("PortParameter").withParameterValue(Objects.toString(port)));
+        }
+
         return parameters;
     }
 }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilder.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilder.java
@@ -93,6 +93,7 @@ public class CloudFormationTemplateBuilder {
     public String build(RDSModelContext context) {
         Map<String, Object> model = new HashMap<>();
         model.putAll(defaultCostTaggingService.prepareAllTagsForTemplate());
+        model.put("hasPort", context.hasPort);
         try {
             String template = freeMarkerTemplateUtils.processTemplateIntoString(new Template("aws-rds-template", context.template, freemarkerConfiguration),
                                                                                 model);
@@ -218,6 +219,8 @@ public class CloudFormationTemplateBuilder {
 
         private String template;
 
+        private boolean hasPort;
+
         // public RDSModelContext withAuthenticatedContext(AuthenticatedContext ac) {
         //     this.ac = ac;
         //     return this;
@@ -233,5 +236,9 @@ public class CloudFormationTemplateBuilder {
             return this;
         }
 
+        public RDSModelContext withHasPort(boolean hasPort) {
+            this.hasPort = hasPort;
+            return this;
+        }
     }
 }

--- a/cloud-aws/src/main/resources/templates/aws-cf-dbstack.ftl
+++ b/cloud-aws/src/main/resources/templates/aws-cf-dbstack.ftl
@@ -65,6 +65,14 @@
         "MinLength": 8,
         "MaxLength": 30
     },
+    <#if hasPort>
+    "PortParameter": {
+        "Type": "Number",
+        "Description": "Database port",
+        "MinValue": 0,
+        "MaxValue": 65355
+    },
+    </#if>
     "VPCSecurityGroupsParameter": {
         "Type": "List<AWS::EC2::SecurityGroup::Id>",
         "Description": "VPC security groups"
@@ -106,6 +114,9 @@
                 "MasterUserPassword": { "Ref": "MasterUserPasswordParameter" },
                 "MasterUsername": { "Ref": "MasterUsernameParameter" },
                 "MultiAZ": true,
+                <#if hasPort>
+                "Port": { "Ref": "PortParameter" },
+                </#if>
                 "StorageEncrypted": true,
                 "Tags": [
                     { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
@@ -117,6 +128,8 @@
         }
   },
   "Outputs" : {
+      "Hostname": { "Value" : { "Fn::GetAtt" : [ "DBInstance", "Endpoint.Address" ]} },
+      "Port": { "Value" : { "Fn::GetAtt" : [ "DBInstance", "Endpoint.Port" ]} },
       "CreatedDBInstance": { "Value": { "Ref": "DBInstance" } },
       "CreatedDBSubnetGroup": { "Value": { "Ref": "DBSubnetGroup" } }
   }

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilderDBTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilderDBTest.java
@@ -160,9 +160,9 @@ public class CloudFormationTemplateBuilderDBTest {
     }
 
     private DatabaseServer createDefaultDatabaseServer() {
-        return new DatabaseServer("myserver", "db.m3.medium", DatabaseEngine.POSTGRESQL, "root", "cloudera", 50L,
-                createDefaultSecurity(), InstanceStatus.CREATE_REQUESTED,
-                Map.of("engineVersion", "1.2.3"));
+        return new DatabaseServer("myserver", "db.m3.medium", DatabaseEngine.POSTGRESQL,
+            "root", "cloudera", 5432, 50L, createDefaultSecurity(),
+            InstanceStatus.CREATE_REQUESTED, Map.of("engineVersion", "1.2.3"));
     }
 
     private Map<String, String> getDefaultDatabaseStackTags() {

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/DatabaseServerV4Base.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/DatabaseServerV4Base.java
@@ -25,6 +25,9 @@ public class DatabaseServerV4Base extends ProviderParametersBase {
     @ApiModelProperty(DatabaseServerModelDescription.ROOT_USER_PASSWORD)
     private String rootUserPassword;
 
+    @ApiModelProperty(DatabaseServerModelDescription.PORT)
+    private Integer port;
+
     @ApiModelProperty(DatabaseServerModelDescription.AWS_PARAMETERS)
     private AwsDatabaseServerV4Parameters aws;
 
@@ -81,6 +84,14 @@ public class DatabaseServerV4Base extends ProviderParametersBase {
 
     public void setRootUserPassword(String rootUserPassword) {
         this.rootUserPassword = rootUserPassword;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+
+    public void setPort(Integer port) {
+        this.port = port;
     }
 
     @Override

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/ModelDescriptions.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/ModelDescriptions.java
@@ -70,6 +70,7 @@ public final class ModelDescriptions {
         public static final String STORAGE_SIZE = "Storage size of the database server, in GB";
         public static final String ROOT_USER_NAME = "Root user name of the database server";
         public static final String ROOT_USER_PASSWORD = "Root user password of the database server";
+        public static final String PORT = "Port for the database";
         public static final String AWS_PARAMETERS = "AWS-specific parameters of the specified database server";
         public static final String GCP_PARAMETERS = "GCP-specific parameters of the specified database server";
         public static final String AZURE_PARAMETERS = "Azure-specific parameters of the specified database server";

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4Controller.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4Controller.java
@@ -68,10 +68,10 @@ public class DatabaseServerV4Controller implements DatabaseServerV4Endpoint {
     @Override
     public DatabaseServerAllocationOutcomeV4Response create(AllocateDatabaseServerV4Request request) {
         DBStack dbStack = dbStackConverter.convert(request, threadBasedUserCrnProvider.getUserCrn());
-        DatabaseServerConfig server = redbeamsCreationService.launchDatabase(dbStack);
+        redbeamsCreationService.launchDatabase(dbStack);
         // FIXME the converter for this doesn't exist yet, and probably needs to convert something
         // more than just a DatabaseServerConfig
-        return converterUtil.convert(server, DatabaseServerAllocationOutcomeV4Response.class);
+        return new DatabaseServerAllocationOutcomeV4Response();
     }
 
     @Override

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/converter/spi/DBStackToDatabaseStackConverter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/converter/spi/DBStackToDatabaseStackConverter.java
@@ -68,6 +68,7 @@ public class DBStackToDatabaseStackConverter {
         }
         String username = dbStackDatabaseServer.getRootUserName();
         String password = dbStackDatabaseServer.getRootPassword();
+        Integer port = dbStackDatabaseServer.getPort();
         Long storageSize = dbStackDatabaseServer.getStorageSize();
         Security security = new Security(Collections.emptyList(), dbStackDatabaseServer.getSecurityGroup().getSecurityGroupIds());
         // TODO / FIXME converter caller decides this?
@@ -76,7 +77,7 @@ public class DBStackToDatabaseStackConverter {
         Json attributes = dbStackDatabaseServer.getAttributes();
         Map<String, Object> params = attributes == null ? Collections.emptyMap() : attributes.getMap();
 
-        return new DatabaseServer(serverId, flavor, engine, username, password, storageSize, security, status, params);
+        return new DatabaseServer(serverId, flavor, engine, username, password, port, storageSize, security, status, params);
     }
 
     private Map<String, String> getUserDefinedTags(DBStack dbStack) {

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverter.java
@@ -55,6 +55,8 @@ public class AllocateDatabaseServerV4RequestToDBStackConverter {
     private Clock clock;
 
     public DBStack convert(AllocateDatabaseServerV4Request source, String ownerCrnString) {
+        Crn ownerCrn = Crn.safeFromString(ownerCrnString);
+
         DBStack dbStack = new DBStack();
         dbStack.setName(source.getName());
         dbStack.setEnvironmentId(source.getEnvironmentId());
@@ -66,7 +68,7 @@ public class AllocateDatabaseServerV4RequestToDBStackConverter {
             dbStack.setNetwork(buildNetwork(source.getNetwork()));
         }
         if (source.getDatabaseServer() != null) {
-            dbStack.setDatabaseServer(buildDatabaseServer(source.getDatabaseServer(), source.getName()));
+            dbStack.setDatabaseServer(buildDatabaseServer(source.getDatabaseServer(), source.getName(), ownerCrn));
         }
 
         Map<String, Object> asMap = providerParameterCalculator.get(source).asMap();
@@ -76,7 +78,6 @@ public class AllocateDatabaseServerV4RequestToDBStackConverter {
             dbStack.setParameters(parameter);
         }
 
-        Crn ownerCrn = Crn.safeFromString(ownerCrnString);
         dbStack.setOwnerCrn(ownerCrn);
         dbStack.setTags(getTags(ownerCrn, dbStack.getCloudPlatform()));
 
@@ -118,8 +119,9 @@ public class AllocateDatabaseServerV4RequestToDBStackConverter {
         return network;
     }
 
-    private DatabaseServer buildDatabaseServer(DatabaseServerV4Request source, String name) {
+    private DatabaseServer buildDatabaseServer(DatabaseServerV4Request source, String name, Crn ownerCrn) {
         DatabaseServer server = new DatabaseServer();
+        server.setAccountId(ownerCrn.getAccountId());
         server.setName(generateDatabaseServerName());
         server.setInstanceType(source.getInstanceType());
         DatabaseVendor databaseVendor = DatabaseVendor.fromValue(source.getDatabaseVendor());
@@ -127,6 +129,7 @@ public class AllocateDatabaseServerV4RequestToDBStackConverter {
         server.setStorageSize(source.getStorageSize());
         server.setRootUserName(source.getRootUserName());
         server.setRootPassword(source.getRootUserPassword());
+        server.setPort(source.getPort());
         server.setSecurityGroup(buildSecurityGroup(source.getSecurityGroup()));
 
         Map<String, Object> parameters = providerParameterCalculator.get(source).asMap();

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/domain/stack/DatabaseServer.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/domain/stack/DatabaseServer.java
@@ -31,6 +31,9 @@ public class DatabaseServer implements AccountIdAwareResource {
     @SequenceGenerator(name = "databaseserver_generator", sequenceName = "databaseserver_id_seq", allocationSize = 1)
     private Long id;
 
+    @Column(nullable = false)
+    private String accountId;
+
     private String name;
 
     @Column(length = 1000000, columnDefinition = "TEXT")
@@ -58,6 +61,8 @@ public class DatabaseServer implements AccountIdAwareResource {
     @JoinColumn(name = "securitygroup_id", referencedColumnName = "id")
     private SecurityGroup securityGroup;
 
+    private Integer port;
+
     @Convert(converter = JsonToString.class)
     @Column(columnDefinition = "TEXT")
     private Json attributes;
@@ -68,6 +73,15 @@ public class DatabaseServer implements AccountIdAwareResource {
 
     public void setId(Long id) {
         this.id = id;
+    }
+
+    @Override
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
     }
 
     public String getName() {
@@ -142,16 +156,19 @@ public class DatabaseServer implements AccountIdAwareResource {
         this.securityGroup = securityGroup;
     }
 
+    public Integer getPort() {
+        return port;
+    }
+
+    public void setPort(Integer port) {
+        this.port = port;
+    }
+
     public Json getAttributes() {
         return attributes;
     }
 
     public void setAttributes(Json attributes) {
         this.attributes = attributes;
-    }
-
-    @Override
-    public String getAccountId() {
-        return null;
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/common/RedbeamsContext.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/common/RedbeamsContext.java
@@ -5,6 +5,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.flow.core.CommonContext;
 import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.redbeams.domain.stack.DBStack;
 
 public class RedbeamsContext extends CommonContext {
 
@@ -14,12 +15,15 @@ public class RedbeamsContext extends CommonContext {
 
     private final DatabaseStack databaseStack;
 
+    private final DBStack dbStack;
+
     public RedbeamsContext(FlowParameters flowParameters, CloudContext cloudContext, CloudCredential cloudCredential,
-        DatabaseStack databaseStack) {
+        DatabaseStack databaseStack, DBStack dbStack) {
         super(flowParameters);
         this.cloudContext = cloudContext;
         this.cloudCredential = cloudCredential;
         this.databaseStack = databaseStack;
+        this.dbStack = dbStack;
     }
 
     public CloudContext getCloudContext() {
@@ -32,5 +36,9 @@ public class RedbeamsContext extends CommonContext {
 
     public DatabaseStack getDatabaseStack() {
         return databaseStack;
+    }
+
+    public DBStack getDBStack() {
+        return dbStack;
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/AbstractRedbeamsProvisionAction.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/AbstractRedbeamsProvisionAction.java
@@ -71,7 +71,7 @@ public abstract class AbstractRedbeamsProvisionAction<P extends Payload>
         Credential credential = credentialService.getCredentialByEnvCrn(dbStack.getEnvironmentId());
         CloudCredential cloudCredential = credentialConverter.convert(credential);
         DatabaseStack databaseStack = databaseStackConverter.convert(dbStack);
-        return new RedbeamsContext(flowParameters, cloudContext, cloudCredential, databaseStack);
+        return new RedbeamsContext(flowParameters, cloudContext, cloudCredential, databaseStack, dbStack);
     }
 
     @Override

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/action/RedbeamsProvisionActions.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/action/RedbeamsProvisionActions.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.redbeams.flow.redbeams.provision.action;
 
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+import com.sequenceiq.cloudbreak.cloud.transform.ResourceLists;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.redbeams.flow.redbeams.common.RedbeamsContext;
 import com.sequenceiq.redbeams.flow.redbeams.common.RedbeamsEvent;
@@ -9,6 +11,9 @@ import com.sequenceiq.redbeams.flow.redbeams.provision.event.allocate.AllocateDa
 import com.sequenceiq.redbeams.flow.redbeams.provision.event.allocate.AllocateDatabaseServerSuccess;
 import com.sequenceiq.redbeams.flow.redbeams.provision.event.register.RegisterDatabaseServerRequest;
 import com.sequenceiq.redbeams.flow.redbeams.provision.event.register.RegisterDatabaseServerSuccess;
+
+import java.util.List;
+import java.util.Map;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -33,9 +38,16 @@ public class RedbeamsProvisionActions {
     public Action<?, ?> registerDatabase() {
         return new AbstractRedbeamsProvisionAction<>(AllocateDatabaseServerSuccess.class) {
 
+            private List<CloudResource> dbResources;
+
+            @Override
+            protected void prepareExecution(AllocateDatabaseServerSuccess payload, Map<Object, Object> variables) {
+                dbResources = ResourceLists.transform(payload.getResults());
+            }
+
             @Override
             protected Selectable createRequest(RedbeamsContext context) {
-                return new RegisterDatabaseServerRequest(0L);
+                return new RegisterDatabaseServerRequest(context.getCloudContext(), context.getDBStack(), dbResources);
             }
         };
     }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/event/register/RegisterDatabaseServerRequest.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/event/register/RegisterDatabaseServerRequest.java
@@ -1,12 +1,49 @@
 package com.sequenceiq.redbeams.flow.redbeams.provision.event.register;
 
+import com.google.common.collect.ImmutableList;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+import com.sequenceiq.redbeams.domain.stack.DBStack;
 import com.sequenceiq.redbeams.flow.redbeams.common.RedbeamsEvent;
+
+import java.util.List;
 
 /**
  * A request for registering a database server after allocation.
  */
 public class RegisterDatabaseServerRequest extends RedbeamsEvent {
-    public RegisterDatabaseServerRequest(Long resourceId) {
-        super(resourceId);
+
+    private final CloudContext cloudContext;
+
+    private final DBStack dbStack;
+
+    private final List<CloudResource> dbResources;
+
+    public RegisterDatabaseServerRequest(CloudContext cloudContext, DBStack dbStack,
+        List<CloudResource> dbResources) {
+        super(cloudContext != null ? cloudContext.getId() : null);
+        this.cloudContext = cloudContext;
+        this.dbStack = dbStack;
+        this.dbResources = ImmutableList.copyOf(dbResources);
+    }
+
+    public CloudContext getCloudContext() {
+        return cloudContext;
+    }
+
+    public DBStack getDBStack() {
+        return dbStack;
+    }
+
+    public List<CloudResource> getDbResources() {
+        return dbResources;
+    }
+
+    public String toString() {
+        return "RegisterDatabaseServerRequest{"
+                + "cloudContext=" + cloudContext
+                + ", dbStack=" + dbStack
+                + ", dbResources=" + dbResources
+                + '}';
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/handler/RegisterDatabaseServerHandler.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/handler/RegisterDatabaseServerHandler.java
@@ -1,11 +1,21 @@
 package com.sequenceiq.redbeams.flow.redbeams.provision.handler;
 
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.common.type.ResourceType;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.EventHandler;
-import com.sequenceiq.redbeams.flow.redbeams.common.RedbeamsEvent;
+import com.sequenceiq.redbeams.api.endpoint.v4.ResourceStatus;
+import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
+import com.sequenceiq.redbeams.domain.stack.DBStack;
+import com.sequenceiq.redbeams.domain.stack.DatabaseServer;
 import com.sequenceiq.redbeams.flow.redbeams.provision.event.register.RegisterDatabaseServerRequest;
 import com.sequenceiq.redbeams.flow.redbeams.provision.event.register.RegisterDatabaseServerSuccess;
+import com.sequenceiq.redbeams.repository.DatabaseServerConfigRepository;
+import com.sequenceiq.redbeams.service.crn.CrnService;
+
+import java.util.List;
+import java.util.Optional;
 
 import javax.inject.Inject;
 
@@ -21,8 +31,16 @@ public class RegisterDatabaseServerHandler implements EventHandler<RegisterDatab
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RegisterDatabaseServerHandler.class);
 
+    private static final long DEFAULT_WORKSPACE = 0L;
+
     @Inject
     private EventBus eventBus;
+
+    @Inject
+    private CrnService crnService;
+
+    @Inject
+    private DatabaseServerConfigRepository databaseServerConfigRepository;
 
     @Override
     public String selector() {
@@ -31,11 +49,44 @@ public class RegisterDatabaseServerHandler implements EventHandler<RegisterDatab
 
     @Override
     public void accept(Event<RegisterDatabaseServerRequest> event) {
-        RedbeamsEvent request = event.getData();
+        RegisterDatabaseServerRequest request = event.getData();
         Selectable response = new RegisterDatabaseServerSuccess(request.getResourceId());
+        DBStack dbStack = request.getDBStack();
+        List<CloudResource> dbResources = request.getDbResources();
 
-        // TODO: Actually allocate database servers
-        LOGGER.info("A database server would be registered here.");
+        DatabaseServer databaseServer = dbStack.getDatabaseServer();
+        DatabaseServerConfig dbServerConfig = new DatabaseServerConfig();
+
+        // TODO: Adjust workspace to something non-default when and if necessary
+        dbServerConfig.setWorkspaceId(DEFAULT_WORKSPACE);
+        dbServerConfig.setResourceStatus(ResourceStatus.SERVICE_MANAGED);
+        dbServerConfig.setAccountId(databaseServer.getAccountId());
+        dbServerConfig.setName(dbStack.getName());
+        dbServerConfig.setEnvironmentId(dbStack.getEnvironmentId());
+        // TODO: Since the postgres driver is built in, we don't have to worry about setting the driver info.
+        //       However, we'll need to address this when adding in new types of database servers.
+        //dbServerConfig.setConnectionDriver("POSTGRESQL");
+        //dbServerConfig.setConnectorJarUrl("");
+        dbServerConfig.setConnectionUserName(dbStack.getDatabaseServer().getRootUserName());
+        dbServerConfig.setConnectionPassword(dbStack.getDatabaseServer().getRootPassword());
+        dbServerConfig.setDatabaseVendor(dbStack.getDatabaseServer().getDatabaseVendor());
+        dbServerConfig.setPort(databaseServer.getPort());
+
+        Optional<CloudResource> dbHostname = CloudResource.getResourceTypeFromList(ResourceType.RDS_HOSTNAME, dbResources);
+        if (dbHostname.isEmpty()) {
+            throw new IllegalStateException("DB hostname not found for allocated database.");
+        }
+
+        Optional<CloudResource> dbPort = CloudResource.getResourceTypeFromList(ResourceType.RDS_PORT, dbResources);
+        if (dbPort.isEmpty()) {
+            throw new IllegalStateException("DB port not found for allocated database.");
+        }
+
+        dbServerConfig.setHost(dbHostname.get().getName());
+        dbServerConfig.setPort(Integer.parseInt(dbPort.get().getName()));
+        dbServerConfig.setResourceCrn(crnService.createCrn(dbServerConfig));
+
+        databaseServerConfigRepository.save(dbServerConfig);
 
         eventBus.notify(response.selector(), new Event<>(event.getHeaders(), response));
     }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/termination/AbstractRedbeamsTerminationAction.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/termination/AbstractRedbeamsTerminationAction.java
@@ -72,7 +72,7 @@ public abstract class AbstractRedbeamsTerminationAction<P extends Payload>
         Credential credential = credentialService.getCredentialByEnvCrn(dbStack.getEnvironmentId());
         CloudCredential cloudCredential = credentialConverter.convert(credential);
         DatabaseStack databaseStack = databaseStackConverter.convert(dbStack);
-        return new RedbeamsContext(flowParameters, cloudContext, cloudCredential, databaseStack);
+        return new RedbeamsContext(flowParameters, cloudContext, cloudCredential, databaseStack, dbStack);
     }
 
     @Override

--- a/redbeams/src/main/resources/schema/app/20190624144438_CB-1837_add_accountid_and_port_to_databaseserver.sql
+++ b/redbeams/src/main/resources/schema/app/20190624144438_CB-1837_add_accountid_and_port_to_databaseserver.sql
@@ -1,0 +1,13 @@
+-- // CB-1837 Add account ID and port to database server
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE databaseserver
+    ADD COLUMN accountid VARCHAR(255),
+    ADD COLUMN port INT4;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE databaseserver
+    DROP COLUMN accountid,
+    DROP COLUMN port;

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4ControllerTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4ControllerTest.java
@@ -144,9 +144,10 @@ public class DatabaseServerV4ControllerTest {
         when(converterUtil.convert(server, DatabaseServerAllocationOutcomeV4Response.class))
             .thenReturn(allocateResponse);
 
-        DatabaseServerAllocationOutcomeV4Response response = underTest.create(allocateRequest);
+        underTest.create(allocateRequest);
 
-        assertEquals(allocateResponse, response);
+        // TODO: Restore this check once we introduce provisioning statuses
+        // assertEquals(allocateResponse, response);
         verify(creationService).launchDatabase(dbStack);
     }
 

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/common/RedbeamsContextTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/common/RedbeamsContextTest.java
@@ -7,6 +7,7 @@ import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.redbeams.domain.stack.DBStack;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -26,13 +27,16 @@ public class RedbeamsContextTest {
     @Mock
     private DatabaseStack databaseStack;
 
+    @Mock
+    private DBStack dbStack;
+
     private RedbeamsContext underTest;
 
     @Before
     public void setUp() throws Exception {
         initMocks(this);
 
-        underTest = new RedbeamsContext(flowParameters, cloudContext, cloudCredential, databaseStack);
+        underTest = new RedbeamsContext(flowParameters, cloudContext, cloudCredential, databaseStack, dbStack);
     }
 
     @Test
@@ -40,6 +44,7 @@ public class RedbeamsContextTest {
         assertEquals(cloudContext, underTest.getCloudContext());
         assertEquals(cloudCredential, underTest.getCloudCredential());
         assertEquals(databaseStack, underTest.getDatabaseStack());
+        assertEquals(dbStack, underTest.getDBStack());
     }
 
 }


### PR DESCRIPTION
Databases are now registered after creation, which will allow further
manipulation via redbeams existing mechanisms. Additionally, the ability
to specify a port has been added to redbeams, and the account ID has
been added to the database server entity.

One thing to note: the response from the create endpoint is still empty.
After this, the ability to query redbeams for the provisioning status of
a database will be added, and an identifier associated with this will be
given via the create endpoint. For now, this is not hooked up.