### PR TITLE
DISTX-195. Replace Hive-on-Spark with Hive-on-Tez in Data Mart

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-mart-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-mart-ha.bp
@@ -53,8 +53,26 @@
         ]
       },
       {
-        "refName": "hive",
+        "refName": "hms",
         "serviceType": "HIVE",
+        "displayName": "Hive Metastore",
+        "roleConfigGroups": [
+          {
+            "refName": "hms-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          },
+          {
+            "refName": "hms-HIVEMETASTORE-BASE",
+            "roleType": "HIVEMETASTORE",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "hive",
+        "serviceType": "HIVE_ON_TEZ",
+        "displayName": "Hive",
         "roleConfigGroups": [
           {
             "refName": "hive-GATEWAY-BASE",
@@ -64,17 +82,6 @@
           {
             "refName": "hive-HIVESERVER2-BASE",
             "roleType": "HIVESERVER2",
-            "configs": [
-              {
-                "name": "hs2_execution_engine",
-                "value": "spark"
-              }
-            ],
-            "base": true
-          },
-          {
-            "refName": "hive-HIVEMETASTORE-BASE",
-            "roleType": "HIVEMETASTORE",
             "base": true
           }
         ]
@@ -128,16 +135,11 @@
         ]
       },
       {
-        "refName": "spark_on_yarn",
-        "serviceType": "SPARK_ON_YARN",
+        "refName": "tez",
+        "serviceType": "TEZ",
         "roleConfigGroups": [
           {
-            "refName": "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
-            "roleType": "SPARK_YARN_HISTORY_SERVER",
-            "base": true
-          },
-          {
-            "refName": "spark_on_yarn-GATEWAY-BASE",
+            "refName": "tez-GATEWAY-BASE",
             "roleType": "GATEWAY",
             "base": true
           }
@@ -188,11 +190,12 @@
         "roleConfigGroupsRefNames": [
           "hdfs-BALANCER-BASE",
           "hive-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
           "hue-HUE_LOAD_BALANCER-BASE",
           "impala-STATESTORE-BASE",
           "impala-CATALOGSERVER-BASE",
           "oozie-OOZIE_SERVER-BASE",
-          "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+          "tez-GATEWAY-BASE",
           "yarn-JOBHISTORY-BASE"
         ]
       },
@@ -203,10 +206,11 @@
           "hdfs-FAILOVERCONTROLLER-BASE",
           "hdfs-NAMENODE-BASE",
           "hive-GATEWAY-BASE",
-          "hive-HIVEMETASTORE-BASE",
           "hive-HIVESERVER2-BASE",
+          "hms-GATEWAY-BASE",
+          "hms-HIVEMETASTORE-BASE",
           "hue-HUE_SERVER-BASE",
-          "spark_on_yarn-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
           "yarn-RESOURCEMANAGER-BASE"
         ]
       },
@@ -216,8 +220,9 @@
         "roleConfigGroupsRefNames": [
           "hdfs-DATANODE-BASE",
           "hive-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
           "impala-IMPALAD-BASE",
-          "spark_on_yarn-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
           "yarn-NODEMANAGER-WORKER"
         ]
       },
@@ -226,7 +231,8 @@
         "cardinality": 0,
         "roleConfigGroupsRefNames": [
           "hive-GATEWAY-BASE",
-          "spark_on_yarn-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
           "yarn-NODEMANAGER-COMPUTE"
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/cdp-data-mart.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-mart.bp
@@ -57,8 +57,37 @@
         ]
       },
       {
-        "refName": "hive",
+        "refName": "tez",
+        "serviceType": "TEZ",
+        "roleConfigGroups": [
+          {
+            "refName": "tez-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "hms",
         "serviceType": "HIVE",
+        "displayName": "Hive Metastore",
+        "roleConfigGroups": [
+          {
+            "refName": "hms-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          },
+          {
+            "refName": "hms-HIVEMETASTORE-BASE",
+            "roleType": "HIVEMETASTORE",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "hive",
+        "serviceType": "HIVE_ON_TEZ",
+        "displayName": "Hive",
         "roleConfigGroups": [
           {
             "refName": "hive-GATEWAY-BASE",
@@ -68,17 +97,6 @@
           {
             "refName": "hive-HIVESERVER2-BASE",
             "roleType": "HIVESERVER2",
-            "configs": [
-              {
-                "name": "hs2_execution_engine",
-                "value": "spark"
-              }
-            ],
-            "base": true
-          },
-          {
-            "refName": "hive-HIVEMETASTORE-BASE",
-            "roleType": "HIVEMETASTORE",
             "base": true
           }
         ]
@@ -106,22 +124,6 @@
           {
             "refName": "oozie-OOZIE_SERVER-BASE",
             "roleType": "OOZIE_SERVER",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "spark_on_yarn",
-        "serviceType": "SPARK_ON_YARN",
-        "roleConfigGroups": [
-          {
-            "refName": "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
-            "roleType": "SPARK_YARN_HISTORY_SERVER",
-            "base": true
-          },
-          {
-            "refName": "spark_on_yarn-GATEWAY-BASE",
-            "roleType": "GATEWAY",
             "base": true
           }
         ]
@@ -156,15 +158,16 @@
           "hdfs-BALANCER-BASE",
           "hdfs-NAMENODE-BASE",
           "hdfs-SECONDARYNAMENODE-BASE",
-          "hive-GATEWAY-BASE",
-          "hive-HIVEMETASTORE-BASE",
           "hive-HIVESERVER2-BASE",
+          "hive-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
+          "hms-HIVEMETASTORE-BASE",
           "hue-HUE_LOAD_BALANCER-BASE",
           "hue-HUE_SERVER-BASE",
           "impala-CATALOGSERVER-BASE",
           "impala-STATESTORE-BASE",
           "oozie-OOZIE_SERVER-BASE",
-          "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+          "tez-GATEWAY-BASE",
           "yarn-JOBHISTORY-BASE",
           "yarn-RESOURCEMANAGER-BASE"
         ]
@@ -175,8 +178,9 @@
         "roleConfigGroupsRefNames": [
           "hdfs-DATANODE-BASE",
           "hive-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
           "impala-IMPALAD-BASE",
-          "spark_on_yarn-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
           "yarn-NODEMANAGER-WORKER"
         ]
       },
@@ -185,7 +189,8 @@
         "cardinality": 0,
         "roleConfigGroupsRefNames": [
           "hive-GATEWAY-BASE",
-          "spark_on_yarn-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
           "yarn-NODEMANAGER-COMPUTE"
         ]
       }


### PR DESCRIPTION
Hive is still required for Hue, but at least we can remove Spark.