### PR TITLE
Env delete with workload cluster

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/endpoint/DistroXV1Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/endpoint/DistroXV1Endpoint.java
@@ -56,7 +56,7 @@ public interface DistroXV1Endpoint {
     @Path("")
     @ApiOperation(value = LIST, produces = MediaType.APPLICATION_JSON, notes = Notes.STACK_NOTES,
             nickname = "listDistroXV1")
-    StackViewV4Responses list(@QueryParam("environment") String environment);
+    StackViewV4Responses list(@QueryParam("environment") String environmentName);
 
     @POST
     @Path("")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackApiViewService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackApiViewService.java
@@ -21,6 +21,7 @@ import com.sequenceiq.cloudbreak.domain.view.StackApiView;
 import com.sequenceiq.cloudbreak.repository.StackApiViewRepository;
 import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
 import com.sequenceiq.cloudbreak.service.stack.ShowTerminatedClusterConfigService.ShowTerminatedClustersAfterConfig;
+import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.flow.core.FlowLogService;
 
 @Service
@@ -57,11 +58,17 @@ public class StackApiViewService {
         return stackApiViewRepository.save(stackApiView);
     }
 
-    public Set<StackApiView> retrieveStackViewsByWorkspaceId(Long workspaceId, String environmentCrn, @Nullable StackType stackType) {
+    public Set<StackApiView> retrieveStackViewsByWorkspaceId(Long workspaceId, String environmentName, @Nullable StackType stackType) {
         ShowTerminatedClustersAfterConfig showTerminatedClustersAfterConfig = showTerminatedClusterConfigService.get();
-        Set<StackApiView> stackViewResponses = StringUtils.isEmpty(environmentCrn)
-                ? getAllByWorkspace(workspaceId, showTerminatedClustersAfterConfig)
-                : getAllByWorkspaceAndEnvironment(workspaceId, environmentCrn, showTerminatedClustersAfterConfig);
+
+        Set<StackApiView> stackViewResponses;
+        if (StringUtils.isEmpty(environmentName)) {
+            stackViewResponses = getAllByWorkspace(workspaceId, showTerminatedClustersAfterConfig);
+        } else {
+            DetailedEnvironmentResponse environmentResponse = environmentClientService.getByName(environmentName);
+            stackViewResponses = getAllByWorkspaceAndEnvironment(workspaceId, environmentResponse.getCrn(), showTerminatedClustersAfterConfig);
+        }
+
         if (stackType != null) {
             stackViewResponses = filterByStackType(stackType, stackViewResponses);
         }

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperation.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperation.java
@@ -71,10 +71,10 @@ public class StackOperation {
     @Inject
     private EnvironmentServiceDecorator environmentServiceDecorator;
 
-    public StackViewV4Responses list(Long workspaceId, String environmentCrn, StackType stackType) {
+    public StackViewV4Responses list(Long workspaceId, String environmentName, StackType stackType) {
         Set<StackViewV4Response> stackViewResponses;
         stackViewResponses = converterUtil.convertAllAsSet(
-                stackApiViewService.retrieveStackViewsByWorkspaceId(workspaceId, environmentCrn, stackType),
+                stackApiViewService.retrieveStackViewsByWorkspaceId(workspaceId, environmentName, stackType),
                 StackViewV4Response.class);
         environmentServiceDecorator.prepareEnvironmentsAndCredentialName(stackViewResponses);
 

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXV1Controller.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXV1Controller.java
@@ -53,8 +53,8 @@ public class DistroXV1Controller implements DistroXV1Endpoint {
     private DistroXMaintenanceModeV1ToMainenanceModeV4Converter maintenanceModeConverter;
 
     @Override
-    public StackViewV4Responses list(String environment) {
-        return stackOperation.list(workspaceService.getForCurrentUser().getId(), environment, StackType.WORKLOAD);
+    public StackViewV4Responses list(String environmentName) {
+        return stackOperation.list(workspaceService.getForCurrentUser().getId(), environmentName, StackType.WORKLOAD);
     }
 
     @Override

--- a/environment/build.gradle
+++ b/environment/build.gradle
@@ -54,6 +54,7 @@ dependencies {
   compile project (":cloud-gcp")
   compile project (":cloud-openstack")
   compile project (":cloud-cumulus-yarn")
+  compile project(":core-api")
   implementation (project (":redbeams-api")) {
 //    exclude module: 'core-api'
   }

--- a/environment/src/main/java/com/sequenceiq/environment/configuration/CloudbreakApiClientConfig.java
+++ b/environment/src/main/java/com/sequenceiq/environment/configuration/CloudbreakApiClientConfig.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.environment.configuration;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.sequenceiq.cloudbreak.client.CloudbreakUserCrnClient;
+import com.sequenceiq.cloudbreak.client.CloudbreakUserCrnClientBuilder;
+
+@Configuration
+public class CloudbreakApiClientConfig {
+
+    @Inject
+    @Named("cloudbreakUrl")
+    private String cloudbreakUrl;
+
+    @Value("${rest.debug:false}")
+    private boolean restDebug;
+
+    @Value("${cert.validation:true}")
+    private boolean certificateValidation;
+
+    @Value("${cert.ignorePreValidation:false}")
+    private boolean ignorePreValidation;
+
+    @Bean
+    public CloudbreakUserCrnClient cloudbreakClient() {
+        return new CloudbreakUserCrnClientBuilder(cloudbreakUrl)
+                .withCertificateValidation(certificateValidation)
+                .withIgnorePreValidation(ignorePreValidation)
+                .withDebug(restDebug)
+                .build();
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/delete/handler/NetworkDeleteHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/delete/handler/NetworkDeleteHandler.java
@@ -45,11 +45,14 @@ public class NetworkDeleteHandler extends EventSenderAwareHandler<EnvironmentDto
         EnvironmentDto environmentDto = environmentDtoEvent.getData();
         try {
             environmentService.findEnvironmentById(environmentDto.getId()).ifPresent(environment -> {
-                environmentService.save(environment);
-                if (environment.getNetwork().getRegistrationType().equals(RegistrationType.CREATE_NEW)) {
-                    environmentNetworkManagementService.deleteNetwork(environmentDtoConverter.environmentToDto(environment));
+                if (environment.getNetwork() != null) {
+                    RegistrationType registrationType = environment.getNetwork().getRegistrationType();
+                    if (registrationType != null && registrationType.equals(RegistrationType.CREATE_NEW)) {
+                        environmentNetworkManagementService.deleteNetwork(environmentDtoConverter.environmentToDto(environment));
+                    }
+                    environment.setNetwork(null);
+                    environmentService.save(environment);
                 }
-                environment.setNetwork(null);
             });
 
             environmentService.findEnvironmentById(environmentDto.getId()).ifPresent(environment -> deleteNetworkIfExists(environment.getId()));

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentService.java
@@ -193,11 +193,18 @@ public class EnvironmentService {
     }
 
     private void checkForDeletePermit(Environment env) {
-        LOGGER.debug("Checking if environment [name: {}] is deletable", env.getName());
+        LOGGER.info("Checking if environment [name: {}] is deletable", env.getName());
+
         Set<String> sdxNames = environmentResourceDeletionService.getAttachedSdxClusterNames(env);
         if (!sdxNames.isEmpty()) {
-            throw new BadRequestException(String.format("The following cluster(s) must be terminated before Environment deletion [%s]",
+            throw new BadRequestException(String.format("The following Data Lake cluster(s) must be terminated before Environment deletion [%s]",
                     String.join(", ", sdxNames)));
+        }
+
+        Set<String> distroXClusterNames = environmentResourceDeletionService.getAttachedDistroXClusterNames(env);
+        if (!distroXClusterNames.isEmpty()) {
+            throw new BadRequestException(String.format("The following Data Hub cluster(s) must be terminated before Environment deletion [%s]",
+                    String.join(", ", distroXClusterNames)));
         }
     }
 


### PR DESCRIPTION
**Changes:**
 - validate the existence of workload cluster at environment deletion

**Two additional changes to the desired test could be validated:**
 - modify DistroX API to list by environment name instead of CRN
 - handle null network in environment deletion handler