### PR TITLE
CB-2088 changing FreeIPA domain from cdp.site to cloudera.site

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeipaCreationHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeipaCreationHandler.java
@@ -42,7 +42,7 @@ public class FreeipaCreationHandler extends EventSenderAwareHandler<EnvironmentD
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FreeipaCreationHandler.class);
 
-    private static final String FREEIPA_DOMAIN = "cdp.site";
+    private static final String FREEIPA_DOMAIN = "cloudera.site";
 
     private static final String FREEIPA_HOSTNAME = "ipaserver";
 

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_install.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_install.sh
@@ -13,6 +13,7 @@ ipa-server-install \
           -p $FPW \
           --setup-dns \
           --auto-reverse \
+          --allow-zone-overlap \
           --ssh-trust-dns \
           --mkhomedir \
           --ip-address $IPADDR \


### PR DESCRIPTION
- enable overlapping DNS zone for FreeIPA installation
- change `cdp.site` domain name to `cloudera.site`