### PR TITLE
DISTX-234. Improve exception handling for set password

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientBuilder.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientBuilder.java
@@ -103,7 +103,7 @@ public class FreeIpaClientBuilder {
             throws IOException, URISyntaxException, FreeIpaClientException {
 
         URI target = getIpaUrl(apiAddress, port, basePath, "/session/login_password").toURI();
-        LOGGER.debug("Connecting for user: $user at target: $target");
+        LOGGER.debug("Connecting for user: {} at target: {}", user, target);
 
         HttpPost post = getPost(target);
         post.setEntity(new UrlEncodedFormEntity(List.of(new BasicNameValuePair("user", user), new BasicNameValuePair("password", pass))));

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/user/handler/SetPasswordHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/user/handler/SetPasswordHandler.java
@@ -6,7 +6,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.service.OperationException;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.EventHandler;
 import com.sequenceiq.freeipa.client.FreeIpaClient;
@@ -39,7 +38,7 @@ public class SetPasswordHandler implements EventHandler<SetPasswordRequest> {
             SetPasswordResult result = new SetPasswordResult(request);
             request.getResult().onNext(result);
         } catch (Exception e) {
-            request.getResult().onError(new OperationException(e));
+            request.getResult().onError(e);
         }
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactory.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactory.java
@@ -59,8 +59,7 @@ public class FreeIpaClientFactory {
             return new FreeIpaClientBuilder("admin", freeIpa.getAdminPassword(), freeIpa.getDomain().toUpperCase(),
                     httpClientConfig, stack.getGatewayport().toString()).build();
         } catch (Exception e) {
-            LOGGER.error("Couldn't build FreeIPA client", e);
-            throw new FreeIpaClientException("Couldn't build FreeIPA client", e);
+            throw new FreeIpaClientException("Couldn't build FreeIPA client: " + e.getLocalizedMessage(), e);
         }
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/PasswordService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/PasswordService.java
@@ -63,12 +63,12 @@ public class PasswordService {
             try {
                 waitSetPassword(request);
                 success.add(request.getEnvironment());
-            } catch (OperationException e) {
-                LOGGER.debug("Failed to set password for user {} in environment {}", userCrn, request.getEnvironment());
-                failure.put(request.getEnvironment(), e.getCause().getLocalizedMessage());
             } catch (InterruptedException e) {
                 LOGGER.error("Interrupted while setting passwords for user {} in account {}", userCrn, accountId);
                 throw new OperationException(e);
+            } catch (Exception e) {
+                LOGGER.debug("Failed to set password for user {} in environment {}", userCrn, request.getEnvironment(), e);
+                failure.put(request.getEnvironment(), e.getLocalizedMessage());
             }
         }
 


### PR DESCRIPTION
This changes the exception handling and logging for the set password
api. The FreeIpaClientBuilder throws an exception on failure to
connect instead of logging then throwing. The PasswordService logs
the exceptions when it swallows it and collates failure messages
for the response object. Exceptions are not wrapped in OperationException
in waitSetPassword() since they are just unwrapped again in setPassword().
