### PR TITLE
Use string return type (plan/text) for inventory generation

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
@@ -36,7 +36,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.ClusterRepairV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.MaintenanceModeV4Request;
@@ -190,8 +189,8 @@ public interface StackV4Endpoint {
 
     @GET
     @Path("{name}/inventory")
-    @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    @ApiOperation(value = GENERATE_HOSTS_INVENTORY, produces = ContentType.FILE_STREAM, nickname = "getClusterHostsInventory")
-    Response getClusterHostsInventory(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name);
+    @Produces(MediaType.TEXT_PLAIN)
+    @ApiOperation(value = GENERATE_HOSTS_INVENTORY, produces = MediaType.TEXT_PLAIN, nickname = "getClusterHostsInventory")
+    String getClusterHostsInventory(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name);
 
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
@@ -7,7 +7,6 @@ import java.util.Set;
 import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import javax.ws.rs.core.Response;
 
 import org.springframework.stereotype.Controller;
 
@@ -135,7 +134,7 @@ public class StackV4Controller extends NotificationController implements StackV4
     }
 
     @Override
-    public Response getClusterHostsInventory(Long workspaceId, String name) {
+    public String getClusterHostsInventory(Long workspaceId, String name) {
         return stackOperation.getClusterHostsInventory(workspaceId, name);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/ClusterCommonService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/ClusterCommonService.java
@@ -219,12 +219,14 @@ public class ClusterCommonService {
     /**
      * Get cluster host details (ips + cluster name) - ini format
      * @param cluster cluster object that is used to fill the cluster details ini
+     * @param loginUser ssh username that will be used as a default user in the inventory
      * @return Ini file content in string
      */
-    public String getHostNamesAsIniString(Cluster cluster) {
+    public String getHostNamesAsIniString(Cluster cluster, String loginUser) {
         Long clusterId = cluster.getId();
         String clusterName = cluster.getName();
         String serverHost = cluster.getAmbariIp();
+
         Set<HostMetadata> agentHostsSet = hostMetadataService.findHostsInCluster(clusterId);
         if (agentHostsSet.isEmpty()) {
             throw new NotFoundException(String.format("Not found any agent hosts (yet) for cluster '%s'", cluster.getId()));
@@ -246,7 +248,8 @@ public class ClusterCommonService {
                 addSectionWithBody("cluster", "name=" + clusterName),
                 addSectionWithBody("server", serverHost),
                 String.join("\n", hostGroupHostsStrings),
-                addSectionWithBody("agent", agentHosts)
+                addSectionWithBody("agent", agentHosts),
+                addSectionWithBody("all:vars", String.format("ansible_ssh_user=%s", loginUser))
         );
     }
 

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperation.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperation.java
@@ -9,8 +9,6 @@ import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.BadRequestException;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -227,13 +225,10 @@ public class StackOperation {
         clusterCommonService.put(stack.getResourceCrn(), updateJson, user, workspace);
     }
 
-    public Response getClusterHostsInventory(Long workspaceId, String name) {
+    public String getClusterHostsInventory(Long workspaceId, String name) {
         Stack stack = stackService.getByNameInWorkspace(name, workspaceId);
-        String iniStr = clusterCommonService.getHostNamesAsIniString(stack.getCluster());
-        return Response
-                .ok(iniStr, MediaType.APPLICATION_OCTET_STREAM)
-                .header("content-disposition", String.format("attachment; filename = %s-hosts.ini", stack.getName()))
-                .build();
+        String loginUser = stack.getStackAuthentication().getLoginUserName();
+        return clusterCommonService.getHostNamesAsIniString(stack.getCluster(), loginUser);
     }
 
     public Stack getStackByName(String name) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ClusterCommonServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ClusterCommonServiceTest.java
@@ -45,13 +45,14 @@ public class ClusterCommonServiceTest {
         when(hostMetadataService.findHostsInCluster(1L)).thenReturn(generateHostMetadata());
 
         // WHEN
-        String result = underTest.getHostNamesAsIniString(cluster);
+        String result = underTest.getHostNamesAsIniString(cluster, "cloudbreak");
         // THEN
         verify(hostMetadataService).findHostsInCluster(1L);
         assertTrue(result.contains("[server]\ngatewayIP\n\n"));
         assertTrue(result.contains("[cluster]\nname=cl1\n\n"));
         assertTrue(result.contains("[master]\nh1\n"));
         assertTrue(result.contains("[agent]\n"));
+        assertTrue(result.contains("[all:vars]\nansible_ssh_user=cloudbreak\n"));
     }
 
     @Test(expected = NotFoundException.class)
@@ -63,7 +64,7 @@ public class ClusterCommonServiceTest {
 
         when(hostMetadataService.findHostsInCluster(1L)).thenReturn(new HashSet<>());
         // WHEN
-        underTest.getHostNamesAsIniString(cluster);
+        underTest.getHostNamesAsIniString(cluster, "cloudbreak");
     }
 
     private Set<HostMetadata> generateHostMetadata() {


### PR DESCRIPTION
use plain text response for generate inventory hosts.
this way that can be used in cb-cli (swagger has problems with attachment response types for go)