### PR TITLE
CB-1691. Test connection as part of database registration.

### DIFF
--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbconfig/DatabaseConfigService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbconfig/DatabaseConfigService.java
@@ -78,6 +78,12 @@ public class DatabaseConfigService extends AbstractArchivistService<DatabaseConf
     }
 
     public DatabaseConfig register(DatabaseConfig configToSave) {
+        String testResults = testConnection(configToSave);
+
+        if (!testResults.equals(DATABASE_TEST_RESULT_SUCCESS)) {
+            throw new IllegalArgumentException(testResults);
+        }
+
         try {
             MDCBuilder.buildMdcContext(configToSave);
             // prepareCreation(configToSave);

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigService.java
@@ -95,6 +95,12 @@ public class DatabaseServerConfigService extends AbstractArchivistService<Databa
     public DatabaseServerConfig create(DatabaseServerConfig resource, Long workspaceId) {
         // FIXME? Currently no checks if logged-in user has access to workspace
         // Compare with AbstractWorkspaceAwareResourceService
+        String testResults = testConnection(resource);
+
+        if (!testResults.equals(DATABASE_TEST_RESULT_SUCCESS)) {
+            throw new IllegalArgumentException(testResults);
+        }
+
         try {
             MDCBuilder.buildMdcContext(resource);
             // prepareCreation(resource);

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/service/dbconfig/DatabaseConfigServiceTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/service/dbconfig/DatabaseConfigServiceTest.java
@@ -133,6 +133,20 @@ public class DatabaseConfigServiceTest {
     }
 
     @Test
+    public void testRegisterConnectionFailure() {
+        thrown.expect(IllegalArgumentException.class);
+        DatabaseConfig configToRegister = new DatabaseConfig();
+        doAnswer((Answer) invocation -> {
+            MapBindingResult errors = invocation.getArgument(1, MapBindingResult.class);
+            errors.addError(new ObjectError("failed", ERROR_MESSAGE));
+            return null;
+        }).when(connectionValidator).validate(any(), any());
+
+        underTest.register(configToRegister);
+
+    }
+
+    @Test
     public void testDeleteRegisteredDatabase() throws TransactionService.TransactionExecutionException {
         DatabaseConfig databaseConfig = getDatabaseConfig(ResourceStatus.USER_MANAGED, DATABASE_NAME);
         when(repository.findByEnvironmentIdAndName(ENVIRONMENT_CRN, DATABASE_NAME)).thenReturn(Optional.of(databaseConfig));

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigServiceTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigServiceTest.java
@@ -159,6 +159,22 @@ public class DatabaseServerConfigServiceTest {
     }
 
     @Test
+    public void testCreateConnectionFailure() {
+        thrown.expect(IllegalArgumentException.class);
+
+        doAnswer(new Answer() {
+            public Object answer(InvocationOnMock invocation) {
+                Errors errors = invocation.getArgument(1);
+                errors.rejectValue("connectorJarUrl", "", "bad jar");
+                errors.reject("", "epic fail");
+                return null;
+            }
+        }).when(connectionValidator).validate(eq(server), any(Errors.class));
+
+        underTest.create(server, 0L);
+    }
+
+    @Test
     public void testGetByNameFound() {
         when(repository.findByNameAndWorkspaceIdAndEnvironmentId(server.getName(), 0L, "myenv")).thenReturn(Optional.of(server));
 


### PR DESCRIPTION
Database and database server registration now test the connection as
part of the registration.

Note: My initial thought was that I was able to register databases with bad credentials because bad credentials passed the test connection. However, on further inspection, it looks like database registration didn't test the credentials at all, so this has been added.

Unit tests and manual tests have been run.