### PR TITLE
CB-1812. Use /redbeams/shared vault path.

### DIFF
--- a/redbeams/src/main/resources/application.yml
+++ b/redbeams/src/main/resources/application.yml
@@ -68,7 +68,7 @@ cert:
   ignorePreValidation: false
 
 secret:
-  application: cb/shared
+  application: redbeams/shared
   engine: "com.sequenceiq.cloudbreak.service.secret.vault.VaultKvV2Engine"
 
 vault:


### PR DESCRIPTION
redbeams now uses /redbeams/shared as its vault path instead of
/cb/shared.

Note: Verified that secret fields in the database show up as the new vault path.

```
 15 | dbsvr-3a376221-2320-4e08-9944-6861dcd3577c |             | db.m3.medium | POSTGRES       |          40 | {"enginePath":"secret","engineClass":"com.sequenceiq.cloudbreak.service.secret.vault.VaultKvV2Engine","path":"redbeams/shared/databaseserver/rootusername/a502f36b-f639-41be-a6ec-dfaf2b7fa1a3-16bbaa1e62c"} | {"enginePath":"secret","engineClass":"com.sequenceiq.cloudbreak.service.secret.vault.VaultKvV2Engine","path":"redbeams/shared/databaseserver/rootpassword/c6d44782-1a34-4232-b2e1-b790cc838473-16bbaa1e6a2"} |               15 | {"engineVersion":"10.6","cloudPlatform":"AWS","backupRetentionPeriod":1} | cloudera  | 55432
```