### PR TITLE
CDPSDX-595: Replacing the sensitive strings on the response to Secret…

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/model/ServiceKeytabResponse.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/model/ServiceKeytabResponse.java
@@ -2,6 +2,7 @@ package com.sequenceiq.freeipa.api.v1.kerberosmgmt.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.doc.KeytabModelDescription;
+import com.sequenceiq.cloudbreak.service.secret.model.SecretResponse;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -11,24 +12,24 @@ import io.swagger.annotations.ApiModelProperty;
 public class ServiceKeytabResponse {
 
     @ApiModelProperty (KeytabModelDescription.PRINCIPAL)
-    private String servicePrincial;
+    private SecretResponse servicePrincial;
 
     @ApiModelProperty (KeytabModelDescription.KEYTAB)
-    private String keytab;
+    private SecretResponse keytab;
 
-    public String getServicePrincial() {
+    public SecretResponse getServicePrincial() {
         return servicePrincial;
     }
 
-    public void setServicePrincial(String servicePrincial) {
+    public void setServicePrincial(SecretResponse servicePrincial) {
         this.servicePrincial = servicePrincial;
     }
 
-    public String getKeytab() {
+    public SecretResponse getKeytab() {
         return keytab;
     }
 
-    public void setKeytab(String keytab) {
+    public void setKeytab(SecretResponse keytab) {
         this.keytab = keytab;
     }
 }


### PR DESCRIPTION
The intent of this change is to store sensitive information like principal and keytab in the vault and send the SecureResponses for them with the path and secret.

Testing performed
1. Invoked the API and made sure that vault is updated with the corresponding entries and the path and secret match the value that is returned by the API. I have used vault web UI for it.
2. Added test code to retrieve the value from the vault using the path and secret and made sure that they match with the values that are inserted into the vault. This test code is not committed.
