### PR TITLE
POC - redbeams databaseservers api suggestion (never merge)

### DIFF
--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/DatabaseServerV4Endpoint.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/DatabaseServerV4Endpoint.java
@@ -56,42 +56,42 @@ public interface DatabaseServerV4Endpoint {
     DatabaseServerV4Response get(@NotNull @QueryParam("environmentId") String environmentId, @PathParam("name") String name);
 
     @POST
-    @Path("external")
+    @Path("/managed")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = DatabaseServerOpDescription.CREATE, produces = MediaType.APPLICATION_JSON, notes = Notes.DATABASE_SERVER_NOTES,
             nickname = "createDatabaseServer")
     DatabaseServerStatusV4Response create(@Valid AllocateDatabaseServerV4Request request);
 
     @GET
-    @Path("external/status/{name}")
+    @Path("/managed/status/{name}")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = DatabaseServerOpDescription.GET_STATUS_BY_NAME, produces = MediaType.APPLICATION_JSON, notes = Notes.DATABASE_SERVER_NOTES,
             nickname = "getDatabaseServerStatus")
     DatabaseServerStatusV4Response getExternalStatus(@NotNull @QueryParam("environmentId") String environmentId, @PathParam("name") String name);
 
     @DELETE
-    @Path("external")
+    @Path("/managed")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = DatabaseServerOpDescription.TERMINATE, produces = MediaType.APPLICATION_JSON, notes = Notes.DATABASE_SERVER_NOTES,
             nickname = "terminateDatabaseServer")
     DatabaseServerTerminationOutcomeV4Response terminate(@Valid TerminateDatabaseServerV4Request request);
 
     @POST
-    @Path("register")
+    @Path("/register")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = DatabaseServerOpDescription.REGISTER, produces = MediaType.APPLICATION_JSON, notes = Notes.DATABASE_SERVER_NOTES,
         nickname = "registerDatabaseServer")
     DatabaseServerV4Response register(@Valid DatabaseServerV4Request request);
 
     @DELETE
-    @Path("{name}")
+    @Path("/registered/{name}")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = DatabaseServerOpDescription.DELETE_BY_NAME, produces = MediaType.APPLICATION_JSON, notes = Notes.DATABASE_SERVER_NOTES,
         nickname = "deleteDatabaseServer")
     DatabaseServerV4Response delete(@NotNull @QueryParam("environmentId") String environmentId, @PathParam("name") String name);
 
     @DELETE
-    @Path("")
+    @Path("/registered")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = DatabaseServerOpDescription.DELETE_MULTIPLE_BY_NAME, produces = MediaType.APPLICATION_JSON, notes = Notes.DATABASE_SERVER_NOTES,
             nickname = "deleteMultipleDatabaseServers")


### PR DESCRIPTION
Please have a look at just DatabaseServerV4Endpoint, and within that tothe api paths. Return types are not always updated.

I basically suggest a better distinction between allocated and registered databases as their representations (entities and dtos) are I think different enough.

Another option would be to merge RegisteredDatabaseServer and AllocatedDatabaseServer as much as possible where either the registered or the allocated part of the request / response is filled in.

What is your opinion? What other options do we have?

This is a POC, never merge it.