### PR TITLE
CB-1926: Update blueprint for SDX-HA lite using cardinality.

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-sdx-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx-ha.bp
@@ -1,404 +1,338 @@
 {
-  "tags": {
-    "shared_services_ready": true
-  },
-  "description": "CDP 1.0 SDX-HA template with Atlas, HMS, Ranger and other services they are dependent on. Services like HDFS, HBASE have HA",
-  "blueprint": {
-    "cdhVersion": "7.0.0",
-    "displayName": "ha-datalake",
-    "hostTemplates": [
-      {
-        "refName": "master",
-        "roleConfigGroupsRefNames": [
-          "atlas-ATLAS_SERVER-BASE",
-          "hbase-MASTER-BASE",
-          "hbase-REGIONSERVER-BASE",
-          "hdfs-DATANODE-BASE",
-          "hdfs-FAILOVERCONTROLLER-BASE",
-          "hdfs-JOURNALNODE-BASE",
-          "hdfs-NAMENODE-1",
-          "hive-HIVEMETASTORE-BASE",
-          "kafka-GATEWAY-BASE",
-          "kafka-KAFKA_BROKER-BASE",
-          "ranger-RANGER_ADMIN-BASE",
-          "ranger-RANGER_USERSYNC-BASE",
-          "solr-SOLR_SERVER-BASE",
-          "zookeeper-SERVER-BASE"
-        ]
-      },
-      {
-        "refName": "alpha",
-        "roleConfigGroupsRefNames": [
-          "atlas-ATLAS_SERVER-1",
-          "hbase-MASTER-BASE",
-          "hbase-REGIONSERVER-BASE",
-          "hdfs-DATANODE-BASE",
-          "hdfs-JOURNALNODE-BASE",
-          "knox-KNOX_GATEWAY-BASE",
-          "ranger-RANGER_TAGSYNC-BASE",
-          "zookeeper-SERVER-BASE"
-        ]
-      },
-      {
-        "refName": "beta",
-        "roleConfigGroupsRefNames": [
-          "hbase-MASTER-BASE",
-          "hbase-REGIONSERVER-BASE",
-          "hdfs-BALANCER-BASE",
-          "hdfs-DATANODE-BASE",
-          "hdfs-FAILOVERCONTROLLER-BASE",
-          "hdfs-JOURNALNODE-BASE",
-          "hdfs-NAMENODE-2",
-          "zookeeper-SERVER-BASE"
-        ]
-      },
-      {
-        "cardinality": 1,
-        "refName": "idbroker",
-        "roleConfigGroupsRefNames": [
-          "knox-IDBROKER-BASE"
-        ]
-      }
-    ],
-    "services": [
-      {
-        "refName": "atlas",
-        "serviceType": "ATLAS",
-        "roleConfigGroups": [
-          {
-            "refName": "atlas-ATLAS_SERVER-BASE",
-            "roleType": "ATLAS_SERVER",
-            "base": true,
-            "configs": [
-              {
-                "name": "atlas_kafka_bootstrap_servers",
-                "value": "{{{format-join host_groups.master format='%s:9092' }}}"
-              }
-            ]
-          },
-          {
-            "refName": "atlas-ATLAS_SERVER-1",
-            "roleType": "ATLAS_SERVER",
-            "base": false,
-            "configs": [
-              {
-                "name": "atlas_kafka_bootstrap_servers",
-                "value": "{{{format-join host_groups.master format='%s:9092' }}}"
-              }
-            ]
-          }
+    "tags": {
+        "shared_services_ready": true
+    },
+    "description": "CDP 1.0 SDX-HA template with Atlas, HMS, Ranger and other services they are dependent on. Services like HDFS, HBASE have HA",
+    "blueprint": {
+        "cdhVersion": "7.0.0",
+        "displayName": "ha-datalake",
+        "hostTemplates": [
+            {
+                "cardinality": 2,
+                "refName": "master",
+                "roleConfigGroupsRefNames": [
+                    "hdfs-DATANODE-BASE",
+                    "hdfs-FAILOVERCONTROLLER-BASE",
+                    "hdfs-JOURNALNODE-BASE",
+                    "hdfs-NAMENODE-BASE",
+                    "hive-HIVEMETASTORE-BASE",
+                    "zookeeper-SERVER-BASE",
+                    "kafka-GATEWAY-BASE",
+                    "kafka-KAFKA_BROKER-BASE",
+                    "solr-SOLR_SERVER-BASE",
+                    "ranger-RANGER_ADMIN-BASE",
+                    "knox-KNOX_GATEWAY-BASE",
+                    "hbase-REGIONSERVER-BASE",
+                    "hbase-MASTER-BASE",
+                    "atlas-ATLAS_SERVER-BASE"
+                ]
+            },
+            {
+                "cardinality": 1,
+                "refName": "gateway",
+                "roleConfigGroupsRefNames": [
+                    "hdfs-DATANODE-BASE",
+                    "hdfs-BALANCER-BASE",
+                    "hdfs-JOURNALNODE-BASE",
+                    "ranger-RANGER_USERSYNC-BASE",
+                    "ranger-RANGER_TAGSYNC-BASE",
+                    "zookeeper-SERVER-BASE"
+                ]
+            },
+            {
+                "cardinality": 2,
+                "refName": "idbroker",
+                "roleConfigGroupsRefNames": [
+                    "knox-IDBROKER-BASE"
+                ]
+            }
         ],
-        "serviceConfigs": [
-          {
-            "name": "solr_service",
-            "ref": "solr"
-          },
-          {
-            "name": "kafka_service",
-            "ref": "kafka"
-          },
-          {
-            "name": "hbase_service",
-            "ref": "hbase"
-          },
-          {
-            "name": "hdfs_service",
-            "ref": "hdfs"
-          }
+        "services": [
+            {
+                "refName": "atlas",
+                "roleConfigGroups": [
+                    {
+                        "base": true,
+                        "configs": [
+                            {
+                                "name": "atlas_kafka_bootstrap_servers",
+                                "value": "{{{format-join host_groups.master format='%s:9092' }}}"
+                            }
+                        ],
+                        "refName": "atlas-ATLAS_SERVER-BASE",
+                        "roleType": "ATLAS_SERVER"
+                    }
+                ],
+                "serviceConfigs": [
+                    {
+                        "name": "solr_service",
+                        "ref": "solr"
+                    },
+                    {
+                        "name": "kafka_service",
+                        "ref": "kafka"
+                    },
+                    {
+                        "name": "hbase_service",
+                        "ref": "hbase"
+                    },
+                    {
+                        "name": "hdfs_service",
+                        "ref": "hdfs"
+                    }
+                ],
+                "serviceType": "ATLAS"
+            },
+            {
+                "refName": "hbase",
+                "roleConfigGroups": [
+                    {
+                        "base": true,
+                        "configs": [
+                            {
+                                "name": "hbase_master_info_port",
+                                "value": "22002"
+                            },
+                            {
+                                "name": "hbase_master_port",
+                                "value": "22001"
+                            }
+                        ],
+                        "refName": "hbase-MASTER-BASE",
+                        "roleType": "MASTER"
+                    },
+                    {
+                        "base": true,
+                        "configs": [
+                            {
+                                "name": "hbase_regionserver_java_opts",
+                                "value": "-XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=70 -XX:+CMSParallelRemarkEnabled -XX:ReservedCodeCacheSize=256m -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps"
+                            },
+                            {
+                                "name": "hbase_regionserver_info_port",
+                                "value": "22102"
+                            },
+                            {
+                                "name": "hbase_regionserver_port",
+                                "value": "22101"
+                            }
+                        ],
+                        "refName": "hbase-REGIONSERVER-BASE",
+                        "roleType": "REGIONSERVER"
+                    }
+                ],
+                "serviceConfigs": [
+                    {
+                        "name": "hbase_enable_indexing",
+                        "value": "true"
+                    },
+                    {
+                        "name": "hbase_enable_replication",
+                        "value": "true"
+                    },
+                    {
+                        "name": "zookeeper_session_timeout",
+                        "value": "30000"
+                    }
+                ],
+                "serviceType": "HBASE"
+            },
+            {
+                "refName": "hdfs",
+                "roleConfigGroups": [
+                    {
+                        "base": true,
+                        "refName": "hdfs-NAMENODE-BASE",
+                        "roleType": "NAMENODE"
+                    },
+                    {
+                        "base": true,
+                        "refName": "hdfs-FAILOVERCONTROLLER-BASE",
+                        "roleType": "FAILOVERCONTROLLER"
+                    },
+                    {
+                        "base": true,
+                        "configs": [
+                            {
+                                "name": "dfs_journalnode_edits_dir",
+                                "value": "/dfs/jn"
+                            }
+                        ],
+                        "refName": "hdfs-JOURNALNODE-BASE",
+                        "roleType": "JOURNALNODE"
+                    },
+                    {
+                        "base": true,
+                        "configs": [
+                            {
+                                "name": "dfs_datanode_failed_volumes_tolerated",
+                                "value": "0"
+                            },
+                            {
+                                "name": "dfs_data_dir_list",
+                                "value": "/dfs/dn"
+                            }
+                        ],
+                        "refName": "hdfs-DATANODE-BASE",
+                        "roleType": "DATANODE"
+                    },
+                    {
+                        "base": true,
+                        "configs": [
+                            {
+                                "name": "fs_checkpoint_dir_list",
+                                "value": "/should_not_be_required_in_HA_setup"
+                            }
+                        ],
+                        "refName": "hdfs-SECONDARYNAMENODE-BASE",
+                        "roleType": "SECONDARYNAMENODE"
+                    },
+                    {
+                        "base": true,
+                        "refName": "hdfs-BALANCER-BASE",
+                        "roleType": "BALANCER"
+                    }
+                ],
+                "serviceConfigs": [
+                    {
+                        "name": "redaction_policy_enabled",
+                        "value": "false"
+                    }
+                ],
+                "serviceType": "HDFS"
+            },
+            {
+                "refName": "hive",
+                "roleConfigGroups": [
+                    {
+                        "base": true,
+                        "refName": "hive-HIVEMETASTORE-BASE",
+                        "roleType": "HIVEMETASTORE"
+                    }
+                ],
+                "serviceType": "HIVE"
+            },
+            {
+                "refName": "kafka",
+                "roleConfigGroups": [
+                    {
+                        "base": true,
+                        "refName": "kafka-GATEWAY-BASE",
+                        "roleType": "GATEWAY"
+                    },
+                    {
+                        "base": true,
+                        "refName": "kafka-KAFKA_BROKER-BASE",
+                        "roleType": "KAFKA_BROKER"
+                    }
+                ],
+                "serviceConfigs": [
+                    {
+                        "name": "zookeeper_service",
+                        "ref": "zookeeper"
+                    },
+                    {
+                        "name": "offsets.topic.replication.factor",
+                        "value": "1"
+                    }
+                ],
+                "serviceType": "KAFKA"
+            },
+            {
+                "refName": "ranger",
+                "roleConfigGroups": [
+                    {
+                        "base": true,
+                        "refName": "ranger-RANGER_USERSYNC-BASE",
+                        "roleType": "RANGER_USERSYNC"
+                    },
+                    {
+                        "base": true,
+                        "refName": "ranger-RANGER_TAGSYNC-BASE",
+                        "roleType": "RANGER_TAGSYNC"
+                    },
+                    {
+                        "base": true,
+                        "refName": "ranger-RANGER_ADMIN-BASE",
+                        "roleType": "RANGER_ADMIN"
+                    }
+                ],
+                "serviceConfigs": [
+                    {
+                        "name": "hdfs_service",
+                        "ref": "hdfs"
+                    },
+                    {
+                        "name": "rangeradmin_user_password",
+                        "value": "{{{ general.password }}}"
+                    },
+                    {
+                        "name": "rangertagsync_user_password",
+                        "value": "{{{ general.password }}}"
+                    },
+                    {
+                        "name": "solr_service",
+                        "ref": "solr"
+                    },
+                    {
+                        "name": "rangerusersync_user_password",
+                        "value": "{{{ general.password }}}"
+                    },
+                    {
+                        "name": "keyadmin_user_password",
+                        "value": "{{{ general.password }}}"
+                    }
+                ],
+                "serviceType": "RANGER"
+            },
+            {
+                "refName": "solr",
+                "roleConfigGroups": [
+                    {
+                        "base": true,
+                        "refName": "solr-SOLR_SERVER-BASE",
+                        "roleType": "SOLR_SERVER"
+                    }
+                ],
+                "serviceConfigs": [
+                    {
+                        "name": "hdfs_service",
+                        "ref": "hdfs"
+                    },
+                    {
+                        "name": "zookeeper_service",
+                        "ref": "zookeeper"
+                    }
+                ],
+                "serviceType": "SOLR"
+            },
+            {
+                "refName": "zookeeper",
+                "roleConfigGroups": [
+                    {
+                        "base": true,
+                        "refName": "zookeeper-SERVER-BASE",
+                        "roleType": "SERVER"
+                    }
+                ],
+                "serviceType": "ZOOKEEPER"
+            },
+            {
+                "refName": "knox",
+                "roleConfigGroups": [
+                    {
+                        "base": true,
+                        "refName": "knox-KNOX_GATEWAY-BASE",
+                        "roleType": "KNOX_GATEWAY"
+                    },
+                    {
+                        "base": true,
+                        "refName": "knox-IDBROKER-BASE",
+                        "roleType": "IDBROKER"
+                    }
+                ],
+                "serviceType": "KNOX"
+            }
         ]
-      },
-      {
-        "refName": "hbase",
-        "serviceType": "HBASE",
-        "serviceConfigs": [
-          {
-            "name": "hbase_enable_indexing",
-            "value": "true"
-          },
-          {
-            "name": "hbase_enable_replication",
-            "value": "true"
-          },
-          {
-            "name": "zookeeper_session_timeout",
-            "value": "30000"
-          }
-        ],
-        "roleConfigGroups": [
-          {
-            "refName": "hbase-MASTER-BASE",
-            "roleType": "MASTER",
-            "base": true,
-            "configs": [
-              {
-                "name": "hbase_master_info_port",
-                "value": "22002"
-              },
-              {
-                "name": "hbase_master_port",
-                "value": "22001"
-              }
-            ]
-          },
-          {
-            "refName": "hbase-REGIONSERVER-BASE",
-            "roleType": "REGIONSERVER",
-            "base": true,
-            "configs": [
-              {
-                "name": "hbase_regionserver_java_opts",
-                "value": "-XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=70 -XX:+CMSParallelRemarkEnabled -XX:ReservedCodeCacheSize=256m -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps"
-              },
-              {
-                "name": "hbase_regionserver_info_port",
-                "value": "22102"
-              },
-              {
-                "name": "hbase_regionserver_port",
-                "value": "22101"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "refName": "hdfs",
-        "serviceType": "HDFS",
-        "serviceConfigs": [
-          {
-            "name": "dfs_replication",
-            "value": "3"
-          },
-          {
-            "name": "redaction_policy_enabled",
-            "value": "false"
-          }
-        ],
-        "roleConfigGroups": [
-          {
-            "refName": "hdfs-NAMENODE-1",
-            "roleType": "NAMENODE",
-            "base": false,
-            "configs": [
-              {
-                "name": "dfs_federation_namenode_nameservice",
-                "value": "nameservice1"
-              },
-              {
-                "name": "dfs_namenode_quorum_journal_name",
-                "value": "nameservice1"
-              },
-              {
-                "name": "dfs_http_port",
-                "value": "20101"
-              },
-              {
-                "name": "namenode_config_safety_valve",
-                "value": "\n        <property>\n          <name>dfs.namenode.redundancy.considerLoad</name>\n          <value>false</value>\n        </property>"
-              },
-              {
-                "name": "dfs_https_port",
-                "value": "20102"
-              }
-            ]
-          },
-          {
-            "refName": "hdfs-NAMENODE-2",
-            "roleType": "NAMENODE",
-            "base": false,
-            "configs": [
-              {
-                "name": "dfs_federation_namenode_nameservice",
-                "value": "nameservice1"
-              },
-              {
-                "name": "dfs_namenode_quorum_journal_name",
-                "value": "nameservice1"
-              },
-              {
-                "name": "autofailover_enabled",
-                "value": "true"
-              },
-              {
-                "name": "dfs_http_port",
-                "value": "20101"
-              },
-              {
-                "name": "dfs_https_port",
-                "value": "20102"
-              }
-            ]
-          },
-          {
-            "refName": "hdfs-DATANODE-BASE",
-            "roleType": "DATANODE",
-            "base": true,
-            "configs": [
-              {
-                "name": "dfs_datanode_failed_volumes_tolerated",
-                "value": "0"
-              },
-              {
-                "name": "dfs_data_dir_list",
-                "value": "/dfs/dn"
-              }
-            ]
-          },
-          {
-            "refName": "hdfs-BALANCER-BASE",
-            "roleType": "BALANCER",
-            "base": true
-          },
-          {
-            "refName": "hdfs-FAILOVERCONTROLLER-BASE",
-            "roleType": "FAILOVERCONTROLLER",
-            "base": true
-          },
-          {
-            "refName": "hdfs-JOURNALNODE-BASE",
-            "roleType": "JOURNALNODE",
-            "base": true,
-            "configs": [
-              {
-                "name": "dfs_journalnode_edits_dir",
-                "value": "/dfs/jn"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "refName": "hive",
-        "serviceType": "HIVE",
-        "roleConfigGroups": [
-          {
-            "refName": "hive-HIVEMETASTORE-BASE",
-            "roleType": "HIVEMETASTORE",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "kafka",
-        "roleConfigGroups": [
-          {
-            "base": true,
-            "refName": "kafka-GATEWAY-BASE",
-            "roleType": "GATEWAY"
-          },
-          {
-            "base": true,
-            "refName": "kafka-KAFKA_BROKER-BASE",
-            "roleType": "KAFKA_BROKER"
-          }
-        ],
-        "serviceConfigs": [
-          {
-            "name": "zookeeper_service",
-            "ref": "zookeeper"
-          },
-          {
-            "name": "offsets.topic.replication.factor",
-            "value": "1"
-          }
-        ],
-        "serviceType": "KAFKA"
-      },
-      {
-        "refName": "ranger",
-        "roleConfigGroups": [
-          {
-            "base": true,
-            "refName": "ranger-RANGER_USERSYNC-BASE",
-            "roleType": "RANGER_USERSYNC"
-          },
-          {
-            "base": true,
-            "refName": "ranger-RANGER_TAGSYNC-BASE",
-            "roleType": "RANGER_TAGSYNC"
-          },
-          {
-            "base": true,
-            "refName": "ranger-RANGER_ADMIN-BASE",
-            "roleType": "RANGER_ADMIN"
-          }
-        ],
-        "serviceConfigs": [
-          {
-            "name": "hdfs_service",
-            "ref": "hdfs"
-          },
-          {
-            "name": "rangeradmin_user_password",
-            "value": "{{{ general.password }}}"
-          },
-          {
-            "name": "rangertagsync_user_password",
-            "value": "{{{ general.password }}}"
-          },
-          {
-            "name": "solr_service",
-            "ref": "solr"
-          },
-          {
-            "name": "rangerusersync_user_password",
-            "value": "{{{ general.password }}}"
-          },
-          {
-            "name": "keyadmin_user_password",
-            "value": "{{{ general.password }}}"
-          }
-        ],
-        "serviceType": "RANGER"
-      },
-      {
-        "refName": "solr",
-        "roleConfigGroups": [
-          {
-            "refName": "solr-SOLR_SERVER-BASE",
-            "roleType": "SOLR_SERVER",
-            "base": true
-          }
-        ],
-        "serviceConfigs": [
-          {
-            "name": "hdfs_service",
-            "ref": "hdfs"
-          },
-          {
-            "name": "zookeeper_service",
-            "ref": "zookeeper"
-          }
-        ],
-        "serviceType": "SOLR"
-      },
-      {
-        "refName": "zookeeper",
-        "serviceType": "ZOOKEEPER",
-        "roleConfigGroups": [
-          {
-            "refName": "zookeeper-SERVER-BASE",
-            "roleType": "SERVER",
-            "base": true
-          }
-        ]
-      },
-      {
-        "serviceType": "KNOX",
-        "refName": "knox",
-        "roleConfigGroups": [
-          {
-            "base": true,
-            "refName": "knox-KNOX_GATEWAY-BASE",
-            "roleType": "KNOX_GATEWAY"
-          },
-          {
-            "refName": "knox-IDBROKER-BASE",
-            "roleType": "IDBROKER",
-            "base": true
-          }
-        ]
-      }
-    ]
-  }
+    }
 }


### PR DESCRIPTION
Used cardinality to create lite SDX HA cluster following the lines of blueprint for medium SDX HA.

Verified the changed by creating an SDX cluster in Manowar-int using it.

This is a continuation of https://github.com/hortonworks/cloudbreak/pull/5354. It took a while to get back to it. This pull request address the comment you had there.
