### PR TITLE
CB-1818 Update redbeams logging

### DIFF
--- a/redbeams/src/main/java/com/sequenceiq/redbeams/RedbeamsApplication.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/RedbeamsApplication.java
@@ -37,6 +37,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
         "com.sequenceiq.cloudbreak.validation",
         "com.sequenceiq.cloudbreak.common.converter",
         "com.sequenceiq.cloudbreak.json",
+        "com.sequenceiq.cloudbreak.logger",
         "com.sequenceiq.cloudbreak.util",
         "com.sequenceiq.flow",
         "com.sequenceiq.environment.client",

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/aspect/ControllerLogContextAspects.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/aspect/ControllerLogContextAspects.java
@@ -1,0 +1,55 @@
+package com.sequenceiq.redbeams.aspect;
+
+import java.util.Arrays;
+
+import javax.inject.Inject;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.CodeSignature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.logger.LogContextService;
+
+@Component
+@Aspect
+public class ControllerLogContextAspects {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ControllerLogContextAspects.class);
+
+    @Inject
+    private LogContextService logContextService;
+
+    @Pointcut("execution(public * com.sequenceiq.redbeams.controller..*(..))")
+    public void interceptControllerMethodCalls() {
+    }
+
+    @Before("com.sequenceiq.redbeams.aspect.ControllerLogContextAspects.interceptControllerMethodCalls()")
+    public void buildLogContextForControllerCalls(JoinPoint joinPoint) {
+
+        LOGGER.debug("Intercepted controller method {}", joinPoint.toShortString());
+
+        try {
+            Object[] args = joinPoint.getArgs();
+            CodeSignature sig = (CodeSignature) joinPoint.getSignature();
+            String[] paramNames = sig.getParameterNames();
+
+            // FIXME Once CB-1923 is done, this param name patching can be removed
+            // This does not help getting the environment CRN from a request object anyway
+            for (int i = 0; i < paramNames.length; i++) {
+                if (paramNames[i].equalsIgnoreCase("environmentid")) {
+                    paramNames[i] = "environmentCrn";
+                }
+            }
+            logContextService.buildMDCParams(joinPoint.getTarget(), paramNames, args);
+
+            LOGGER.debug("Added selected controller method parameters to MDC; param names {}", Arrays.toString(paramNames));
+        } catch (Exception e) {
+            LOGGER.warn("Failed to add controller method parameters to MDC, continuing with call", e);
+        }
+    }
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/AppConfig.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/AppConfig.java
@@ -18,7 +18,9 @@ import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.concurrent.MDCCleanerTaskDecorator;
+import com.sequenceiq.redbeams.filter.MDCFilter;
 import com.sequenceiq.redbeams.filter.RequestIdFilter;
 import com.sequenceiq.redbeams.filter.RequestIdGeneratingFilter;
 import com.sequenceiq.redbeams.service.ThreadBasedRequestIdProvider;
@@ -36,6 +38,8 @@ public class AppConfig implements ResourceLoaderAware {
     private static final int BEAN_ORDER_REQUEST_ID_GENERATING_FILTER = 100;
 
     private static final int BEAN_ORDER_REQUEST_ID_FILTER = 110;
+
+    private static final int BEAN_ORDER_MDC_FILTER = 200;
 
     @Value("${redbeams.etc.config.dir}")
     private String etcConfigDir;
@@ -85,6 +89,9 @@ public class AppConfig implements ResourceLoaderAware {
     @Inject
     private ThreadBasedRequestIdProvider threadBasedRequestIdProvider;
 
+    @Inject
+    private ThreadBasedUserCrnProvider threadBasedUserCrnProvider;
+
     private ResourceLoader resourceLoader;
 
     @PostConstruct
@@ -107,6 +114,15 @@ public class AppConfig implements ResourceLoaderAware {
         RequestIdFilter filter = new RequestIdFilter(threadBasedRequestIdProvider);
         registrationBean.setFilter(filter);
         registrationBean.setOrder(BEAN_ORDER_REQUEST_ID_FILTER);
+        return registrationBean;
+    }
+
+    @Bean
+    public FilterRegistrationBean<MDCFilter> mdcFilterRegistrationBean() {
+        FilterRegistrationBean<MDCFilter> registrationBean = new FilterRegistrationBean<>();
+        MDCFilter filter = new MDCFilter(threadBasedRequestIdProvider, threadBasedUserCrnProvider);
+        registrationBean.setFilter(filter);
+        registrationBean.setOrder(BEAN_ORDER_MDC_FILTER);
         return registrationBean;
     }
 

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/filter/MDCFilter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/filter/MDCFilter.java
@@ -1,0 +1,56 @@
+package com.sequenceiq.redbeams.filter;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.cloudbreak.auth.altus.CrnParseException;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.redbeams.service.ThreadBasedRequestIdProvider;
+
+/**
+ * A filter that establishes a fresh MDC for each request. The MDC contains the
+ * request ID and user CRN information.
+ */
+public class MDCFilter extends OncePerRequestFilter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MDCFilter.class);
+
+    private final ThreadBasedRequestIdProvider threadBasedRequestIdProvider;
+
+    private final ThreadBasedUserCrnProvider threadBaseUserCrnProvider;
+
+    public MDCFilter(ThreadBasedRequestIdProvider threadBasedRequestIdProvider, ThreadBasedUserCrnProvider threadBaseUserCrnProvider) {
+        this.threadBasedRequestIdProvider = threadBasedRequestIdProvider;
+        this.threadBaseUserCrnProvider = threadBaseUserCrnProvider;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+
+        MDCBuilder.cleanupMdc();
+
+        String requestId = threadBasedRequestIdProvider.getRequestId();
+        MDCBuilder.addRequestIdToMdcContext(requestId);
+        LOGGER.info("Added request ID {} to MDC", requestId);
+
+        String userCrnString = threadBaseUserCrnProvider.getUserCrn();
+        try {
+            MDCBuilder.buildMdcContextFromCrn(Crn.safeFromString(userCrnString));
+            LOGGER.info("Added user CRN information from {} to MDC", userCrnString);
+        } catch (CrnParseException e) {
+            LOGGER.warn("Failed to parse user CRN, not including its information in MDC", e);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/termination/AbstractRedbeamsTerminationAction.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/termination/AbstractRedbeamsTerminationAction.java
@@ -8,7 +8,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.cloudbreak.cloud.model.Location;
 import com.sequenceiq.cloudbreak.common.event.Payload;
-//import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.flow.core.AbstractAction;
 import com.sequenceiq.flow.core.FlowParameters;
 import com.sequenceiq.redbeams.converter.cloud.CredentialToCloudCredentialConverter;
@@ -69,8 +69,7 @@ public abstract class AbstractRedbeamsTerminationAction<P extends Payload>
 
         if (optionalDBStack.isPresent()) {
             dbStack = optionalDBStack.get();
-            // FIXME add MDCBuilder stuff
-            // MDCBuilder.buildMdcContext(dbStack);
+            MDCBuilder.buildMdcContext(dbStack);
             Location location = location(region(dbStack.getRegion()), availabilityZone(dbStack.getAvailabilityZone()));
             String userName = dbStack.getOwnerCrn().getResource();
             String accountId = dbStack.getOwnerCrn().getAccountId();

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/RedbeamsCreationService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/RedbeamsCreationService.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.redbeams.service.stack;
 
-// import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.cloud.CloudConnector;
 import com.sequenceiq.cloudbreak.cloud.exception.TemplatingDoesNotSupportedException;
 import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
@@ -11,7 +10,6 @@ import com.sequenceiq.redbeams.exception.RedbeamsException;
 import com.sequenceiq.redbeams.flow.RedbeamsFlowManager;
 import com.sequenceiq.redbeams.flow.redbeams.common.RedbeamsEvent;
 import com.sequenceiq.redbeams.flow.redbeams.provision.RedbeamsProvisionEvent;
-// import com.sequenceiq.redbeams.service.crn.CrnService;
 
 import javax.inject.Inject;
 
@@ -33,9 +31,6 @@ public class RedbeamsCreationService {
     @Inject
     private RedbeamsFlowManager flowManager;
 
-    // @Inject
-    // private CrnService crnService;
-
     public DBStack launchDatabaseServer(DBStack dbStack) {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Create called with: {}", dbStack);
@@ -45,10 +40,8 @@ public class RedbeamsCreationService {
             throw new BadRequestException("A stack for this database server already exists in the environment");
         }
 
-        // String accountId = crnService.getCurrentAccountId();
-        // String userId = crnService.getCurrentUserId();
-        // crnService doesn't really use dbStack, for now
-        // dbStack.setResourceCrn(crnService.createCrn(dbStack, Crn.ResourceType.DATABASE_SERVER));
+        // The database server does not receive a resource CRN until its stack
+        // is successfully created and it is then registered.
 
         // possible future change is to use a flow here (GetPlatformTemplateRequest, modified for database server)
         // for now, just get it synchronously / within this thread, it ought to be quick

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/RedbeamsTerminationService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/RedbeamsTerminationService.java
@@ -5,7 +5,6 @@ import com.sequenceiq.redbeams.domain.stack.DBStack;
 import com.sequenceiq.redbeams.flow.RedbeamsFlowManager;
 import com.sequenceiq.redbeams.flow.redbeams.common.RedbeamsEvent;
 import com.sequenceiq.redbeams.flow.redbeams.termination.RedbeamsTerminationEvent;
-// import com.sequenceiq.redbeams.service.crn.CrnService;
 
 import java.security.SecureRandom;
 import java.util.Random;
@@ -30,15 +29,14 @@ public class RedbeamsTerminationService {
     @Inject
     private RedbeamsFlowManager flowManager;
 
-    // @Inject
-    // private CrnService crnService;
-
     private final Random random = new SecureRandom();
 
     public DBStack terminateDatabaseServer(String dbStackName, String environmentId) {
-        // FIXME log the stack?
-
         DBStack dbStack = dbStackService.getByNameAndEnvironmentId(dbStackName, environmentId);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Terminate called for: {}", dbStack);
+        }
+
         dbStackStatusUpdater.updateStatus(dbStack.getId(), DetailedDBStackStatus.DELETE_REQUESTED);
         // Get the updated entity with the updated status
         dbStack = dbStackService.getById(dbStack.getId());

--- a/redbeams/src/main/resources/logback.xml
+++ b/redbeams/src/main/resources/logback.xml
@@ -12,8 +12,7 @@
         <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
             <layout class="com.sequenceiq.cloudbreak.logger.MaskingPatternLayout">
                 <loggerNameFilter>com.sequenceiq</loggerNameFilter>
-                <!-- <pattern>%date{ISO8601} [%thread] %method:%line %-5level %logger{5} - [type:%X{resourceType:-springLog}] [id:%X{resourceId:-}] [name:%X{resourceName:-}] [flow:%X{flowId:-}] [requestid:%X{requestId:-}] [tenant:%X{tenant:-}] [workspaceId:%X{workspaceId:-}] [userId:%X{userId:-}] [userName:%X{userName:-}] %msg%n</pattern> -->
-                <pattern>%date{ISO8601} [%thread] %method:%line %-5level %logger{5} - [owner:%X{owner:-spring}] [crn:%X{resourceCrn:-}] [cb-stack-id:%X{cbStack:-}] %msg%n</pattern>
+                <pattern>%date{ISO8601} [%thread] %method:%line %-5level %logger{5} - [type:%X{resourceType:-springLog}] [crn:%X{resourceCrn:-}] [name:%X{resourceName:-}] [flow:%X{flowId:-}] [requestid:%X{requestId:-}] [tenant:%X{tenant:-}] [userCrn:%X{userCrn:-}] [environment:%X{environmentCrn:-}] %msg%n</pattern>
             </layout>
         </encoder>
     </appender>
@@ -27,8 +26,7 @@
                 <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
                     <layout class="com.sequenceiq.cloudbreak.logger.MaskingPatternLayout">
                         <loggerNameFilter>com.sequenceiq</loggerNameFilter>
-                        <!-- <pattern>%date{ISO8601} [%thread] %method:%line %-5level %logger{5} - [instance:${nodeid}] [type:%X{resourceType:-springLog}] [id:%X{resourceId:-}] [name:%X{resourceName:-}] [requestid:%X{requestId:-}] [tenant:%X{tenant:-}] [workspaceId:%X{workspaceId:-}] [userId:%X{userId:-}] [userName:%X{userName:-}] %msg%n</pattern> -->
-                        <pattern>%date{ISO8601} [%thread] %method:%line %-5level %logger{5} - [instance:${nodeid}] [owner:%X{owner:-spring}] [crn:%X{resourceCrn:-}] [flow:%X{flowId:-}] [cb-stack-id:%X{cbStack:-}] %msg%n</pattern>
+                        <pattern>%date{ISO8601} [%thread] %method:%line %-5level %logger{5} - [instance:${nodeid}] [type:%X{resourceType:-springLog}] [crn:%X{resourceCrn:-}] [name:%X{resourceName:-}] [flow:%X{flowId:-}] [requestid:%X{requestId:-}] [tenant:%X{tenant:-}] [userCrn:%X{userCrn:-}] [environment:%X{environmentCrn:-}] %msg%n</pattern>
                     </layout>
                 </encoder>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/aspect/ControllerLogContextAspectsTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/aspect/ControllerLogContextAspectsTest.java
@@ -1,0 +1,52 @@
+package com.sequenceiq.redbeams.aspect;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import com.sequenceiq.cloudbreak.logger.LogContextService;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.reflect.CodeSignature;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+public class ControllerLogContextAspectsTest {
+
+    @Mock
+    private LogContextService logContextService;
+
+    @Mock
+    private JoinPoint joinPoint;
+
+    @Mock
+    private CodeSignature sig;
+
+    @InjectMocks
+    private ControllerLogContextAspects underTest;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+
+        when(joinPoint.getSignature()).thenReturn(sig);
+    }
+
+    @Test
+    public void testMDCUpdates() {
+        String[] paramNames = { "param1", "param2" };
+        when(sig.getParameterNames()).thenReturn(paramNames);
+
+        Object[] args = { "value1", "value2" };
+        when(joinPoint.getArgs()).thenReturn(args);
+
+        Object target = new Object();
+        when(joinPoint.getTarget()).thenReturn(target);
+
+        underTest.buildLogContextForControllerCalls(joinPoint);
+
+        verify(logContextService).buildMDCParams(target, paramNames, args);
+    }
+}

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/filter/MDCFilterTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/filter/MDCFilterTest.java
@@ -1,0 +1,70 @@
+package com.sequenceiq.redbeams.filter;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.logger.LoggerContextKey;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.redbeams.service.ThreadBasedRequestIdProvider;
+
+import java.io.IOException;
+import java.util.Map;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+public class MDCFilterTest {
+
+    private static final String REQUEST_ID = "requestId1";
+
+    private static final String USER_CRN = "crn:altus:iam:us-west-1:cloudera:user:bob@cloudera.com";
+
+    private MDCFilter underTest;
+
+    @Mock
+    private ThreadBasedRequestIdProvider threadBasedRequestIdProvider;
+
+    @Mock
+    private ThreadBasedUserCrnProvider threadBasedUserCrnProvider;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+
+        underTest = new MDCFilter(threadBasedRequestIdProvider, threadBasedUserCrnProvider);
+    }
+
+    @Test
+    public void testDoFilterInternal() throws IOException, ServletException {
+        when(threadBasedRequestIdProvider.getRequestId()).thenReturn(REQUEST_ID);
+        when(threadBasedUserCrnProvider.getUserCrn()).thenReturn(USER_CRN);
+
+        underTest.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+
+        // highly coupled verification :(
+        Map<String, String> mdcMap = MDCBuilder.getMdcContextMap();
+        assertEquals(REQUEST_ID, mdcMap.get(LoggerContextKey.REQUEST_ID.toString()));
+        assertEquals(USER_CRN, mdcMap.get(LoggerContextKey.USER_CRN.toString()));
+    }
+
+}


### PR DESCRIPTION
Redbeams logging is improved in several ways. First, a new MDCFilter
inserts the request ID and user CRN associated with every request into
the MDC. Second, the new ControllerLogContextAspects aspect intercepts
calls to redbeams controllers and updates the MDC based on method
arguments. It is worth noting that the corresponding aspect in other
services also stores the request ID, but that is in fact redundant with
the filter.

The logback.xml file for redbeams is updated to match those of other
services. It pulls out expected values from the MDC, and so makes
log entries much more useful and relevant.

Additional logging has been added to AbstractRedbeamsTerminationAction
and RedbeamsTerminationService, to bring them in line with corresponding
logging during the creation flow.