### PR TITLE
CDPSDX-596: Set "Enable Knox Trusted Proxy Support" to true for Range…

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-sdx-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx-ha.bp
@@ -252,9 +252,15 @@
                         "roleType": "RANGER_TAGSYNC"
                     },
                     {
-                        "base": true,
-                        "refName": "ranger-RANGER_ADMIN-BASE",
-                        "roleType": "RANGER_ADMIN"
+                      "base": true,
+                      "refName": "ranger-RANGER_ADMIN-BASE",
+                      "roleType": "RANGER_ADMIN",
+                      "configs": [
+                          {
+                              "name": "ranger.authentication.allow.trustedproxy",
+                              "value": "true"
+                          }
+                      ]
                     }
                 ],
                 "serviceConfigs": [

--- a/core/src/main/resources/defaults/blueprints/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx-medium-ha.bp
@@ -48,7 +48,8 @@
         "cardinality": 2,
         "refName": "idbroker",
         "roleConfigGroupsRefNames": [
-          "knox-IDBROKER-BASE"
+          "knox-IDBROKER-BASE",
+          "knox-KNOX_GATEWAY-BASE"
         ]
       }
     ],
@@ -259,7 +260,13 @@
           {
             "base": true,
             "refName": "ranger-RANGER_ADMIN-BASE",
-            "roleType": "RANGER_ADMIN"
+            "roleType": "RANGER_ADMIN",
+            "configs": [
+                {
+                    "name": "ranger.authentication.allow.trustedproxy",
+                    "value": "true"
+                }
+            ]
           }
         ],
         "serviceConfigs": [
@@ -325,6 +332,11 @@
       {
         "refName": "knox",
         "roleConfigGroups": [
+          {
+            "base": true,
+            "refName": "knox-KNOX_GATEWAY-BASE",
+            "roleType": "KNOX_GATEWAY"
+          },
           {
             "base": true,
             "refName": "knox-IDBROKER-BASE",

--- a/core/src/main/resources/defaults/blueprints/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx.bp
@@ -69,7 +69,13 @@
           {
             "base": true,
             "refName": "ranger-RANGER_ADMIN-BASE",
-            "roleType": "RANGER_ADMIN"
+            "roleType": "RANGER_ADMIN",
+            "configs": [
+                {
+                    "name": "ranger.authentication.allow.trustedproxy",
+                    "value": "true"
+                }
+            ]
           }
         ],
         "serviceConfigs": [


### PR DESCRIPTION
added configuration "ranger.authentication.allow.trustedproxy" with default value "true" to ranger admin service. This change is done in sdx, sdx-lite and sdx-medium blueprints.