### PR TITLE
CDPSDX-602: HDFS ranger plugin is not auto enabled - Handle via bluep…

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-sdx-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx-ha.bp
@@ -197,6 +197,10 @@
                     {
                         "name": "redaction_policy_enabled",
                         "value": "false"
+                    },
+                    {
+                        "name": "enable_ranger_authorization",
+                        "value": "true"
                     }
                 ],
                 "serviceType": "HDFS"

--- a/core/src/main/resources/defaults/blueprints/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx-medium-ha.bp
@@ -202,6 +202,10 @@
           {
             "name": "redaction_policy_enabled",
             "value": "false"
+          },
+          {
+              "name": "enable_ranger_authorization",
+              "value": "true"
           }
         ],
         "serviceType": "HDFS"

--- a/core/src/main/resources/defaults/blueprints/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx.bp
@@ -216,6 +216,12 @@
             "roleType": "NFSGATEWAY"
           }
         ],
+        "serviceConfigs": [
+            {
+                "name": "enable_ranger_authorization",
+                "value": "true"
+            }
+        ],
         "serviceType": "HDFS"
       },
       {


### PR DESCRIPTION
added configuration "enable_ranger_authorization" with default value "true" as service configuration for HDFS. This change is done in sdx, sdx-lite and sdx-medium blueprints.