### PR TITLE
CB-2365. Allocate CRN prior to external database creation.

### DIFF
--- a/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4Controller.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4Controller.java
@@ -26,6 +26,7 @@ import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.Database
 import com.sequenceiq.redbeams.converter.stack.AllocateDatabaseServerV4RequestToDBStackConverter;
 import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
+import com.sequenceiq.redbeams.service.crn.CrnService;
 import com.sequenceiq.redbeams.service.dbserverconfig.DatabaseServerConfigService;
 import com.sequenceiq.redbeams.service.stack.DBStackService;
 import com.sequenceiq.redbeams.service.stack.RedbeamsCreationService;
@@ -58,6 +59,9 @@ public class DatabaseServerV4Controller implements DatabaseServerV4Endpoint {
     @Inject
     private ConverterUtil converterUtil;
 
+    @Inject
+    private CrnService crnService;
+
     @Override
     public DatabaseServerV4Responses list(String environmentId, Boolean attachGlobal) {
         Set<DatabaseServerConfig> all = databaseServerConfigService.findAll(DEFAULT_WORKSPACE, environmentId, attachGlobal);
@@ -79,6 +83,7 @@ public class DatabaseServerV4Controller implements DatabaseServerV4Endpoint {
     @Override
     public DatabaseServerStatusV4Response create(AllocateDatabaseServerV4Request request) {
         DBStack dbStack = dbStackConverter.convert(request, threadBasedUserCrnProvider.getUserCrn());
+        dbStack.setResourceCrn(crnService.createCrn(dbStack));
         DBStack savedDBStack = redbeamsCreationService.launchDatabaseServer(dbStack);
         return converterUtil.convert(savedDBStack, DatabaseServerStatusV4Response.class);
     }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/converter/v4/databaseserver/DBStackToDatabaseServerStatusV4ResponseConverter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/converter/v4/databaseserver/DBStackToDatabaseServerStatusV4ResponseConverter.java
@@ -7,7 +7,7 @@ import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.Database
 import com.sequenceiq.redbeams.domain.stack.DBStack;
 
 @Component
-public class DBStackToDatabaseServerAllocationOutcomeV4ResponseConverter
+public class DBStackToDatabaseServerStatusV4ResponseConverter
     extends AbstractConversionServiceAwareConverter<DBStack, DatabaseServerStatusV4Response> {
 
     @Override
@@ -15,6 +15,7 @@ public class DBStackToDatabaseServerAllocationOutcomeV4ResponseConverter
         DatabaseServerStatusV4Response response = new DatabaseServerStatusV4Response();
         response.setName(source.getName());
         response.setEnvironmentId(source.getEnvironmentId());
+        response.setResourceCrn(source.getResourceCrn().toString());
 
         response.setStatus(source.getStatus());
         response.setStatusReason(source.getStatusReason());

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/converter/v4/databaseserver/DBStackToDatabaseServerTerminationOutcomeV4ResponseConverter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/converter/v4/databaseserver/DBStackToDatabaseServerTerminationOutcomeV4ResponseConverter.java
@@ -15,6 +15,7 @@ public class DBStackToDatabaseServerTerminationOutcomeV4ResponseConverter
         DatabaseServerTerminationOutcomeV4Response response = new DatabaseServerTerminationOutcomeV4Response();
         response.setName(source.getName());
         response.setEnvironmentId(source.getEnvironmentId());
+        response.setResourceCrn(source.getResourceCrn().toString());
 
         response.setStatus(source.getStatus());
         response.setStatusReason(source.getStatusReason());

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/domain/stack/DBStack.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/domain/stack/DBStack.java
@@ -75,6 +75,9 @@ public class DBStack {
     @Convert(converter = CrnConverter.class)
     private Crn ownerCrn;
 
+    @Convert(converter = CrnConverter.class)
+    private Crn resourceCrn;
+
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "dbStack")
     private DBStackStatus dbStackStatus;
 
@@ -198,6 +201,14 @@ public class DBStack {
         this.ownerCrn = ownerCrn;
     }
 
+    public Crn getResourceCrn() {
+        return resourceCrn;
+    }
+
+    public void setResourceCrn(Crn resourceCrn) {
+        this.resourceCrn = resourceCrn;
+    }
+
     public String getAccountId() {
         return ownerCrn != null ? ownerCrn.getAccountId() : null;
     }
@@ -236,6 +247,7 @@ public class DBStack {
             + "',platformVariant='" + platformVariant
             + "',environmentId='" + environmentId
             + "',ownerCrn='" + (ownerCrn != null ? ownerCrn.toString() : "null")
+            + "',resourceCrn='" + (resourceCrn != null ? resourceCrn.toString() : "null")
             + '}';
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/handler/RegisterDatabaseServerHandler.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/handler/RegisterDatabaseServerHandler.java
@@ -13,7 +13,6 @@ import com.sequenceiq.redbeams.flow.redbeams.provision.event.register.RegisterDa
 import com.sequenceiq.redbeams.flow.redbeams.provision.event.register.RegisterDatabaseServerRequest;
 import com.sequenceiq.redbeams.flow.redbeams.provision.event.register.RegisterDatabaseServerSuccess;
 import com.sequenceiq.redbeams.repository.DatabaseServerConfigRepository;
-import com.sequenceiq.redbeams.service.crn.CrnService;
 
 import java.util.List;
 import java.util.Optional;
@@ -36,9 +35,6 @@ public class RegisterDatabaseServerHandler implements EventHandler<RegisterDatab
 
     @Inject
     private EventBus eventBus;
-
-    @Inject
-    private CrnService crnService;
 
     @Inject
     private DatabaseServerConfigRepository databaseServerConfigRepository;
@@ -85,7 +81,7 @@ public class RegisterDatabaseServerHandler implements EventHandler<RegisterDatab
 
         dbServerConfig.setHost(dbHostname.get().getName());
         dbServerConfig.setPort(Integer.parseInt(dbPort.get().getName()));
-        dbServerConfig.setResourceCrn(crnService.createCrn(dbServerConfig));
+        dbServerConfig.setResourceCrn(dbStack.getResourceCrn());
 
         Selectable response;
         try {

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/crn/CrnService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/crn/CrnService.java
@@ -11,6 +11,7 @@ import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.auth.altus.CrnParseException;
 import com.sequenceiq.redbeams.domain.DatabaseConfig;
 import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
+import com.sequenceiq.redbeams.domain.stack.DBStack;
 
 @Service
 public class CrnService {
@@ -41,6 +42,12 @@ public class CrnService {
     }
 
     public Crn createCrn(DatabaseServerConfig resource) {
+        return createCrn(resource, Crn.ResourceType.DATABASE_SERVER);
+    }
+
+    public Crn createCrn(DBStack resource) {
+        // We want this resource to be DATABASE_SERVER as well, since this resource will end up
+        // being attached to a database server.
         return createCrn(resource, Crn.ResourceType.DATABASE_SERVER);
     }
 

--- a/redbeams/src/main/resources/schema/app/20190711232220_CB-2365_add_resource_crn_to_dbstack.sql
+++ b/redbeams/src/main/resources/schema/app/20190711232220_CB-2365_add_resource_crn_to_dbstack.sql
@@ -1,0 +1,12 @@
+-- // CB-2365 Add a resource CRN to the DBStack
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE dbStack
+    ADD COLUMN resourcecrn TEXT;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE dbStack
+    DROP COLUMN resourcecrn TEXT;
+

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4ControllerTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4ControllerTest.java
@@ -29,6 +29,7 @@ import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.Database
 import com.sequenceiq.redbeams.converter.stack.AllocateDatabaseServerV4RequestToDBStackConverter;
 import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
+import com.sequenceiq.redbeams.service.crn.CrnService;
 import com.sequenceiq.redbeams.service.dbserverconfig.DatabaseServerConfigService;
 import com.sequenceiq.redbeams.service.stack.RedbeamsCreationService;
 import com.sequenceiq.redbeams.service.stack.RedbeamsTerminationService;
@@ -55,6 +56,9 @@ public class DatabaseServerV4ControllerTest {
 
     @Mock
     private ConverterUtil converterUtil;
+
+    @Mock
+    private CrnService crnService;
 
     private DatabaseServerConfig server;
 


### PR DESCRIPTION
When creating a redbeams managed database, the CRN is generated up front
and passed to the user as part of the status response. Similarly, the
CRN is now passed to the user as part of the termination response as
well.

Notes:

```
 mike@mikework  ~/src/launchpad/cli   DIR9076  curl -k -H "Content-Type: application/json" -H "x-cdp-actor-crn: crn:altus:iam:us-west-1:cloudera:user:mike.wilson@cloudera.com" -d @/home/mike/createexternaldb.json http://localhost:8087/redbeams/api/v4/databaseservers/managed 
{"environmentId":"crn:altus:environments:us-west-1:cloudera:environment:b6b81d4f-c889-48a0-8168-ded330517a48","name":"mw-cb-alloc15","resourceCrn":"crn:altus:redbeams:us-west-1:cloudera:databaseServer:5047d12e-2ed7-4b08-96a9-bda7ddc87e2d","status":"REQUESTED","statusReason":""}% 
```

Also verified the CRN in the dbstack/databaseserverconfig tables.