### PR TITLE
Backport the kerberos keytab functionality to 2.10.

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/model/ServiceKeytabResponse.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/model/ServiceKeytabResponse.java
@@ -2,6 +2,7 @@ package com.sequenceiq.freeipa.api.v1.kerberosmgmt.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.doc.KeytabModelDescription;
+import com.sequenceiq.cloudbreak.service.secret.model.SecretResponse;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -11,24 +12,24 @@ import io.swagger.annotations.ApiModelProperty;
 public class ServiceKeytabResponse {
 
     @ApiModelProperty (KeytabModelDescription.PRINCIPAL)
-    private String servicePrincial;
+    private SecretResponse servicePrincial;
 
     @ApiModelProperty (KeytabModelDescription.KEYTAB)
-    private String keytab;
+    private SecretResponse keytab;
 
-    public String getServicePrincial() {
+    public SecretResponse getServicePrincial() {
         return servicePrincial;
     }
 
-    public void setServicePrincial(String servicePrincial) {
+    public void setServicePrincial(SecretResponse servicePrincial) {
         this.servicePrincial = servicePrincial;
     }
 
-    public String getKeytab() {
+    public SecretResponse getKeytab() {
         return keytab;
     }
 
-    public void setKeytab(String keytab) {
+    public void setKeytab(SecretResponse keytab) {
         this.keytab = keytab;
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
@@ -110,10 +110,10 @@ public class FreeIpaClient {
         return (Host) invoke("host_del", List.of(fqdn), params, Host.class).getResult();
     }
 
-    public RPCResponse<Host> addHost(String fqdn) throws FreeIpaClientException {
+    public Host addHost(String fqdn) throws FreeIpaClientException {
         RPCResponse<Host> response = null;
-        //TODO Implement as part of CDPSDX-584
-        return response;
+        Map<String, Object> params = Map.of("force", true);
+        return (Host) invoke("host_add", List.of(fqdn), params, Host.class).getResult();
     }
 
     public User deleteUser(String userUid) throws FreeIpaClientException {
@@ -308,10 +308,16 @@ public class FreeIpaClient {
         return (Service) invoke("service_del", flags, params, Service.class).getResult();
     }
 
-    public RPCResponse<Service> addService(String canonicalPrincipal) throws FreeIpaClientException {
-        RPCResponse<Service> response = null;
-        //TODO Implement as part of CDPSDX-584
-        return response;
+    public Service addService(String canonicalPrincipal) throws FreeIpaClientException {
+        List<String> flags = List.of(canonicalPrincipal);
+        Map<String, Object> params = Map.of("force", true);
+        return (Service) invoke("service_add", flags, params, Service.class).getResult();
+    }
+
+    public Service showService(String canonicalPrincipal) throws FreeIpaClientException {
+        List<String> flags = List.of(canonicalPrincipal);
+        Map<String, Object> params = Map.of();
+        return (Service) invoke("service_show", flags, params, Service.class).getResult();
     }
 
     /**
@@ -348,22 +354,22 @@ public class FreeIpaClient {
         return invoke("dnsrecord_del", flags, params, Object.class);
     }
 
-    public RPCResponse<Service> serviceAllowRetrieveKeytab(String canonicalPrincipal, String user) throws FreeIpaClientException {
-        RPCResponse<Service> response = null;
-        //TODO Implement as part of CDPSDX-584
-        return response;
+    public void allowServiceKeytabRetrieval(String canonicalPrincipal, String user) throws FreeIpaClientException {
+        List<String> flags = List.of(canonicalPrincipal);
+        Map<String, Object> params = Map.of("user", user);
+        invoke("service_allow_retrieve_keytab", flags, params, Service.class);
     }
 
-    public RPCResponse<Keytab> getExistingKeytab(String canonicalPrincipal) throws FreeIpaClientException {
-        RPCResponse<Keytab> response = null;
-        //TODO Implement as part of CDPSDX-584
-        return response;
+    public Keytab getExistingKeytab(String canonicalPrincipal) throws FreeIpaClientException {
+        List<String> flags = List.of(canonicalPrincipal);
+        Map<String, Object> params = Map.of("retrieve", true);
+        return (Keytab) invoke("get_keytab", flags, params, Keytab.class).getResult();
     }
 
-    public RPCResponse<Keytab> getKeytab(String canonicalPrincipal) throws FreeIpaClientException {
-        RPCResponse<Keytab> response = null;
-        //TODO Implement as part of CDPSDX-584
-        return response;
+    public Keytab getKeytab(String canonicalPrincipal) throws FreeIpaClientException {
+        List<String> flags = List.of(canonicalPrincipal);
+        Map<String, Object> params = Map.of();
+        return (Keytab) invoke("get_keytab", flags, params, Keytab.class).getResult();
     }
 
     public <T> RPCResponse<T> invoke(String method, List<String> flags, Map<String, Object> params, Type resultType) throws FreeIpaClientException {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/client/model/Keytab.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/client/model/Keytab.java
@@ -1,13 +1,10 @@
 package com.sequenceiq.freeipa.client.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.sequenceiq.freeipa.client.deserializer.ListFlatteningDeserializer;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Keytab {
 
-    @JsonDeserialize(using = ListFlatteningDeserializer.class)
     private String keytab;
 
     public String getKeytab() {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactory.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactory.java
@@ -22,6 +22,8 @@ public class FreeIpaClientFactory {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FreeIpaClientFactory.class);
 
+    private static final String ADMIN_USER = "admin";
+
     @Inject
     private GatewayConfigService gatewayConfigService;
 
@@ -56,10 +58,14 @@ public class FreeIpaClientFactory {
         FreeIpa freeIpa = freeIpaService.findByStack(stack);
 
         try {
-            return new FreeIpaClientBuilder("admin", freeIpa.getAdminPassword(), freeIpa.getDomain().toUpperCase(),
+            return new FreeIpaClientBuilder(ADMIN_USER, freeIpa.getAdminPassword(), freeIpa.getDomain().toUpperCase(),
                     httpClientConfig, stack.getGatewayport().toString()).build();
         } catch (Exception e) {
             throw new FreeIpaClientException("Couldn't build FreeIPA client: " + e.getLocalizedMessage(), e);
         }
+    }
+
+    public String getAdminUser() {
+        return ADMIN_USER;
     }
 }

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/getkeytab.py
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/getkeytab.py
@@ -84,7 +84,11 @@ class GetKeytab(Command):
 
     has_output = (
         output.summary,
-        output.Output('keytab', unicode, _('The keytab encoded as base64')),
+        output.Output(
+            'result',
+            dict,
+            _('The keytab response which has a base64 encoded keytab element.')
+        ),
     )
 
     # See https://web.mit.edu/kerberos/krb5-devel/doc/formats/keytab_file_format.html
@@ -122,7 +126,7 @@ class GetKeytab(Command):
 
         return dict(
             summary=summary,
-            keytab=base64_keytab
+            result=dict(keytab=base64_keytab)
         )
 
     def get_keytab(self, principal, retrieve):

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/kerberosmgmt/KerberosMgmtV1ServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/kerberosmgmt/KerberosMgmtV1ServiceTest.java
@@ -18,7 +18,6 @@ import com.sequenceiq.freeipa.api.v1.kerberosmgmt.model.ServiceKeytabResponse;
 import com.sequenceiq.freeipa.client.FreeIpaClient;
 import com.sequenceiq.freeipa.client.model.Host;
 import com.sequenceiq.freeipa.client.model.Keytab;
-import com.sequenceiq.freeipa.client.model.RPCResponse;
 import com.sequenceiq.freeipa.client.model.Service;
 import com.sequenceiq.freeipa.controller.exception.NotFoundException;
 import com.sequenceiq.freeipa.entity.FreeIpa;
@@ -28,7 +27,6 @@ import com.sequenceiq.freeipa.kerberosmgmt.v1.KerberosMgmtV1Service;
 import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
 import com.sequenceiq.freeipa.service.freeipa.FreeIpaService;
 import com.sequenceiq.freeipa.service.stack.StackService;
-import com.sequenceiq.freeipa.util.CrnService;
 
 @RunWith(MockitoJUnitRunner.class)
 public class KerberosMgmtV1ServiceTest {
@@ -57,9 +55,6 @@ public class KerberosMgmtV1ServiceTest {
     private static Keytab keytab;
 
     @Mock
-    private CrnService crnService;
-
-    @Mock
     private StackService stackService;
 
     @Mock
@@ -70,15 +65,6 @@ public class KerberosMgmtV1ServiceTest {
 
     @Mock
     private ThreadBasedUserCrnProvider threadBaseUserCrnProvider;
-
-    @Mock
-    private RPCResponse<Host> hostMock;
-
-    @Mock
-    private RPCResponse<Service> serviceMock;
-
-    @Mock
-    private RPCResponse<Keytab> keytabMock;
 
     @InjectMocks
     private KerberosMgmtV1Service underTest;
@@ -157,17 +143,13 @@ public class KerberosMgmtV1ServiceTest {
         } catch (RuntimeException exp) {
             Assert.assertEquals("Failed to create host.", exp.getMessage());
         }
-        Mockito.when(hostMock.getResult()).thenReturn(host);
-        Mockito.when(mockIpaClient.addHost(anyString())).thenReturn(hostMock);
+        Mockito.when(mockIpaClient.addHost(anyString())).thenReturn(host);
         try {
             underTest.generateServiceKeytab(request, ACCOUNT_ID);
         } catch (RuntimeException exp) {
             Assert.assertEquals("Failed to create service principal.", exp.getMessage());
         }
-        Mockito.when(serviceMock.getResult()).thenReturn(service);
-        Mockito.when(mockIpaClient.addService(anyString())).thenReturn(serviceMock);
-        Mockito.when(mockIpaClient.serviceAllowRetrieveKeytab(anyString(), anyString())).thenReturn(serviceMock);
-        Mockito.when(crnService.getCurrentUserId()).thenReturn(USERCRN);
+        Mockito.when(mockIpaClient.addService(anyString())).thenReturn(service);
         try {
             underTest.generateServiceKeytab(request, ACCOUNT_ID);
         } catch (RuntimeException exp) {
@@ -178,17 +160,12 @@ public class KerberosMgmtV1ServiceTest {
     @Test
     public void testGenerateServiceKeytab() throws Exception {
         FreeIpaClient mockIpaClient = Mockito.mock(FreeIpaClient.class);
-        Mockito.when(crnService.getCurrentUserId()).thenReturn(USERCRN);
         Mockito.when(stackService.getByEnvironmentCrnAndAccountId(anyString(), anyString())).thenReturn(stack);
         Mockito.when(freeIpaService.findByStack(any())).thenReturn(freeIpa);
         Mockito.when(freeIpaClientFactory.getFreeIpaClientForStack(any())).thenReturn(mockIpaClient);
-        Mockito.when(hostMock.getResult()).thenReturn(host);
-        Mockito.when(mockIpaClient.addHost(anyString())).thenReturn(hostMock);
-        Mockito.when(serviceMock.getResult()).thenReturn(service);
-        Mockito.when(mockIpaClient.addService(anyString())).thenReturn(serviceMock);
-        Mockito.when(mockIpaClient.serviceAllowRetrieveKeytab(anyString(), anyString())).thenReturn(serviceMock);
-        Mockito.when(keytabMock.getResult()).thenReturn(keytab);
-        Mockito.when(mockIpaClient.getKeytab(anyString())).thenReturn(keytabMock);
+        Mockito.when(mockIpaClient.addHost(anyString())).thenReturn(host);
+        Mockito.when(mockIpaClient.addService(anyString())).thenReturn(service);
+        Mockito.when(mockIpaClient.getKeytab(anyString())).thenReturn(keytab);
         ServiceKeytabRequest request = new ServiceKeytabRequest();
         request.setServiceName(USERCRN);
         request.setEnvironmentCrn(ENVIRONMENT_ID);
@@ -204,8 +181,7 @@ public class KerberosMgmtV1ServiceTest {
         Mockito.when(stackService.getByEnvironmentCrnAndAccountId(anyString(), anyString())).thenReturn(stack);
         Mockito.when(freeIpaService.findByStack(any())).thenReturn(freeIpa);
         Mockito.when(freeIpaClientFactory.getFreeIpaClientForStack(any())).thenReturn(mockIpaClient);
-        Mockito.when(keytabMock.getResult()).thenReturn(keytab);
-        Mockito.when(mockIpaClient.getExistingKeytab(anyString())).thenReturn(keytabMock);
+        Mockito.when(mockIpaClient.getExistingKeytab(anyString())).thenReturn(keytab);
         ServiceKeytabRequest request = new ServiceKeytabRequest();
         request.setServiceName(USERCRN);
         request.setEnvironmentCrn(ENVIRONMENT_ID);


### PR DESCRIPTION
This backports the keytab changes into the 2.10 branch so that the DWX team can use them before the 2.11 sprint is complete.

Since this is a new feature being added to the RC branch, I want to call out that I have a deployment locally. The FreeIPA server was created successfully but the SDX cluster failed to provision with the reason "RuntimeException: Can not start provisioning, client error happened on Cloudbreak side: HTTP 400 Bad Request". The same error message is present when I locally deploy without this change.