### PR TITLE
CB-1898 remove stack crn uq constraint from periscope history table

### DIFF
--- a/autoscale/src/main/resources/schema/app/20190712170608_CB-1859_remove_stack_crn_uq_constraint_from_history_table.sql
+++ b/autoscale/src/main/resources/schema/app/20190712170608_CB-1859_remove_stack_crn_uq_constraint_from_history_table.sql
@@ -1,0 +1,8 @@
+-- // CB-1859 remove stack crn uq constraint from history table
+-- Migration SQL that makes the change goes here.
+ALTER TABLE "history" DROP CONSTRAINT "history_cb_stack_crn_uq";
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+


### PR DESCRIPTION
not a reversible change. re-creating the constraint could lead the migration script to failure