### PR TITLE
CB-1898 remove stack crn uq constraint from periscope history table

### DIFF
--- a/autoscale/src/main/resources/schema/app/20190709065638_CB-1859_set_crn_to_stack.sql
+++ b/autoscale/src/main/resources/schema/app/20190709065638_CB-1859_set_crn_to_stack.sql
@@ -24,8 +24,6 @@ FROM (SELECT *
 
 ALTER TABLE "history" ALTER COLUMN cb_stack_crn SET NOT NULL;
 
-ALTER TABLE "history" ADD CONSTRAINT history_cb_stack_crn_uq UNIQUE (cb_stack_crn);
-
 -- //@UNDO
 -- SQL to undo the change goes here.
 ALTER TABLE "cluster" DROP COLUMN IF EXISTS cb_stack_crn;


### PR DESCRIPTION
CB-1898 remove stack crn uq constraint from periscope history table