### PR TITLE
CB-2366 Normalize redbeams treatment of connection information

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/DatabaseServer.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/DatabaseServer.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.cloud.model;
 
 import com.sequenceiq.cloudbreak.cloud.model.generic.DynamicModel;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class DatabaseServer extends DynamicModel {
@@ -12,37 +13,31 @@ public class DatabaseServer extends DynamicModel {
 
     private final DatabaseEngine engine;
 
+    private final String connectionDriver;
+
+    private final String connectorJarUrl;
+
     private final String rootUserName;
 
     private final String rootPassword;
 
     private final Integer port;
 
-    private final long storageSize;
+    private final Long storageSize;
 
     private final Security security;
 
     private final InstanceStatus status;
 
-    public DatabaseServer(String serverId, String flavor, DatabaseEngine engine, String rootUserName, String rootPassword,
-            Integer port, long storageSize, Security security, InstanceStatus status) {
-        this.serverId = serverId;
-        this.flavor = flavor;
-        this.engine = engine;
-        this.rootUserName = rootUserName;
-        this.rootPassword = rootPassword;
-        this.port = port;
-        this.storageSize = storageSize;
-        this.security = security;
-        this.status = status;
-    }
-
-    public DatabaseServer(String serverId, String flavor, DatabaseEngine engine, String rootUserName, String rootPassword,
-            Integer port, long storageSize, Security security, InstanceStatus status, Map<String, Object> parameters) {
+    private DatabaseServer(String serverId, String flavor, DatabaseEngine engine, String connectionDriver,
+            String connectorJarUrl, String rootUserName, String rootPassword,
+            Integer port, Long storageSize, Security security, InstanceStatus status, Map<String, Object> parameters) {
         super(parameters);
         this.serverId = serverId;
         this.flavor = flavor;
         this.engine = engine;
+        this.connectionDriver = connectionDriver;
+        this.connectorJarUrl = connectorJarUrl;
         this.rootUserName = rootUserName;
         this.rootPassword = rootPassword;
         this.port = port;
@@ -63,6 +58,14 @@ public class DatabaseServer extends DynamicModel {
         return engine;
     }
 
+    public String getConnectionDriver() {
+        return connectionDriver;
+    }
+
+    public String getConnectorJarUrl() {
+        return connectorJarUrl;
+    }
+
     public String getRootUserName() {
         return rootUserName;
     }
@@ -75,7 +78,7 @@ public class DatabaseServer extends DynamicModel {
         return port;
     }
 
-    public long getStorageSize() {
+    public Long getStorageSize() {
         return storageSize;
     }
 
@@ -93,11 +96,110 @@ public class DatabaseServer extends DynamicModel {
                 + "serverId='" + serverId + '\''
                 + ", flavor='" + flavor + '\''
                 + ", engine='" + engine + '\''
+                + ", connectionDriver='" + connectionDriver + '\''
+                + ", connectorJarUrl='" + connectorJarUrl + '\''
                 + ", rootUserName='" + rootUserName + '\''
                 + ", port='" + port + '\''
                 + ", storageSize=" + storageSize
                 + ", security=" + security
                 + ", status=" + status
                 + '}';
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String serverId;
+
+        private String flavor;
+
+        private DatabaseEngine engine;
+
+        private String connectionDriver;
+
+        private String connectorJarUrl;
+
+        private String rootUserName;
+
+        private String rootPassword;
+
+        private Integer port;
+
+        private long storageSize;
+
+        private Security security;
+
+        private InstanceStatus status;
+
+        private Map<String, Object> params = new HashMap<>();
+
+        public Builder serverId(String serverId) {
+            this.serverId = serverId;
+            return this;
+        }
+
+        public Builder flavor(String flavor) {
+            this.flavor = flavor;
+            return this;
+        }
+
+        public Builder engine(DatabaseEngine engine) {
+            this.engine = engine;
+            return this;
+        }
+
+        public Builder connectionDriver(String connectionDriver) {
+            this.connectionDriver = connectionDriver;
+            return this;
+        }
+
+        public Builder connectorJarUrl(String connectorJarUrl) {
+            this.connectorJarUrl = connectorJarUrl;
+            return this;
+        }
+
+        public Builder rootUserName(String rootUserName) {
+            this.rootUserName = rootUserName;
+            return this;
+        }
+
+        public Builder rootPassword(String rootPassword) {
+            this.rootPassword = rootPassword;
+            return this;
+        }
+
+        public Builder port(Integer port) {
+            this.port = port;
+            return this;
+        }
+
+        public Builder storageSize(Long storageSize) {
+            this.storageSize = storageSize;
+            return this;
+        }
+
+        public Builder security(Security security) {
+            this.security = security;
+            return this;
+        }
+
+        public Builder status(InstanceStatus status) {
+            this.status = status;
+            return this;
+        }
+
+        public Builder params(Map<String, Object> params) {
+            this.params = params;
+            return this;
+        }
+
+        public DatabaseServer build() {
+            return new DatabaseServer(serverId, flavor, engine, connectionDriver, connectorJarUrl, rootUserName, rootPassword,
+                port, storageSize, security, status, params);
+        }
+
     }
 }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsStackRequestHelper.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsStackRequestHelper.java
@@ -122,6 +122,7 @@ public class AwsStackRequestHelper {
         AwsRdsInstanceView awsRdsInstanceView = new AwsRdsInstanceView(stack.getDatabaseServer());
         AwsRdsDbSubnetGroupView awsRdsDbSubnetGroupView = new AwsRdsDbSubnetGroupView(stack.getDatabaseServer());
         List<Parameter> parameters = new ArrayList<>(asList(
+                // FIXME allocated storage might be null
                 new Parameter().withParameterKey("AllocatedStorageParameter").withParameterValue(Objects.toString(awsRdsInstanceView.getAllocatedStorage())),
                 new Parameter().withParameterKey("BackupRetentionPeriodParameter")
                     .withParameterValue(Objects.toString(awsRdsInstanceView.getBackupRetentionPeriod())),

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilderDBTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilderDBTest.java
@@ -160,9 +160,18 @@ public class CloudFormationTemplateBuilderDBTest {
     }
 
     private DatabaseServer createDefaultDatabaseServer() {
-        return new DatabaseServer("myserver", "db.m3.medium", DatabaseEngine.POSTGRESQL,
-            "root", "cloudera", 5432, 50L, createDefaultSecurity(),
-            InstanceStatus.CREATE_REQUESTED, Map.of("engineVersion", "1.2.3"));
+        return DatabaseServer.builder()
+            .serverId("myserver")
+            .flavor("db.m3.medium")
+            .engine(DatabaseEngine.POSTGRESQL)
+            .rootUserName("root")
+            .rootPassword("cloudera")
+            .port(5432)
+            .storageSize(50L)
+            .security(createDefaultSecurity())
+            .status(InstanceStatus.CREATE_REQUESTED)
+            .params(Map.of("engineVersion", "1.2.3"))
+            .build();
     }
 
     private Map<String, String> getDefaultDatabaseStackTags() {

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/database/base/DatabaseV4Base.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/database/base/DatabaseV4Base.java
@@ -43,6 +43,9 @@ public abstract class DatabaseV4Base implements Serializable {
     @ApiModelProperty(value = Database.TYPE, required = true)
     private String type;
 
+    @ApiModelProperty(value = Database.CONNECTION_DRIVER)
+    private String connectionDriver;
+
     @Size(max = 150)
     @ValidUrl
     @ApiModelProperty(Database.CONNECTOR_JAR_URL)
@@ -81,6 +84,14 @@ public abstract class DatabaseV4Base implements Serializable {
 
     public void setType(String type) {
         this.type = type;
+    }
+
+    public String getConnectionDriver() {
+        return connectionDriver;
+    }
+
+    public void setConnectionDriver(String connectionDriver) {
+        this.connectionDriver = connectionDriver;
     }
 
     public String getConnectorJarUrl() {

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/base/DatabaseServerV4Base.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/base/DatabaseServerV4Base.java
@@ -43,6 +43,9 @@ public abstract class DatabaseServerV4Base implements Serializable {
     @ApiModelProperty(value = DatabaseServer.DATABASE_VENDOR, required = true)
     private String databaseVendor;
 
+    @ApiModelProperty(value = DatabaseServer.CONNECTION_DRIVER)
+    private String connectionDriver;
+
     @Size(max = 150)
     @ValidUrl
     @ApiModelProperty(DatabaseServer.CONNECTOR_JAR_URL)
@@ -90,6 +93,14 @@ public abstract class DatabaseServerV4Base implements Serializable {
 
     public void setDatabaseVendor(String databaseVendor) {
         this.databaseVendor = databaseVendor;
+    }
+
+    public String getConnectionDriver() {
+        return connectionDriver;
+    }
+
+    public void setConnectionDriver(String connectionDriver) {
+        this.connectionDriver = connectionDriver;
     }
 
     public String getConnectorJarUrl() {

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/DatabaseServerV4Base.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/DatabaseServerV4Base.java
@@ -3,6 +3,7 @@ package com.sequenceiq.redbeams.api.endpoint.v4.stacks;
 import com.sequenceiq.cloudbreak.common.mappable.Mappable;
 import com.sequenceiq.cloudbreak.common.mappable.ProviderParametersBase;
 import com.sequenceiq.cloudbreak.validation.ValidDatabaseVendor;
+import com.sequenceiq.cloudbreak.validation.ValidUrl;
 import com.sequenceiq.redbeams.doc.ModelDescriptions.DatabaseServerModelDescription;
 
 import io.swagger.annotations.ApiModelProperty;
@@ -15,6 +16,13 @@ public class DatabaseServerV4Base extends ProviderParametersBase {
     @ValidDatabaseVendor
     @ApiModelProperty(DatabaseServerModelDescription.DATABASE_VENDOR)
     private String databaseVendor;
+
+    @ApiModelProperty(DatabaseServerModelDescription.CONNECTION_DRIVER)
+    private String connectionDriver;
+
+    @ValidUrl
+    @ApiModelProperty(DatabaseServerModelDescription.CONNECTOR_JAR_URL)
+    private String connectorJarUrl;
 
     @ApiModelProperty(DatabaseServerModelDescription.STORAGE_SIZE)
     private Long storageSize;
@@ -60,6 +68,22 @@ public class DatabaseServerV4Base extends ProviderParametersBase {
 
     public void setDatabaseVendor(String databaseVendor) {
         this.databaseVendor = databaseVendor;
+    }
+
+    public String getConnectionDriver() {
+        return connectionDriver;
+    }
+
+    public void setConnectionDriver(String connectionDriver) {
+        this.connectionDriver = connectionDriver;
+    }
+
+    public String getConnectorJarUrl() {
+        return connectorJarUrl;
+    }
+
+    public void setConnectorJarUrl(String connectorJarUrl) {
+        this.connectorJarUrl = connectorJarUrl;
     }
 
     public Long getStorageSize() {

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/ModelDescriptions.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/ModelDescriptions.java
@@ -69,6 +69,8 @@ public final class ModelDescriptions {
     public static class DatabaseServerModelDescription {
         public static final String INSTANCE_TYPE = "Instance type of the database server";
         public static final String DATABASE_VENDOR = "Database vendor of the database server";
+        public static final String CONNECTION_DRIVER = "Name of the JDBC connection driver (for example: 'org.postgresql.Driver')";
+        public static final String CONNECTOR_JAR_URL = "URL that points to the JAR of the connection driver (JDBC connector)";
         public static final String STORAGE_SIZE = "Storage size of the database server, in GB";
         public static final String ROOT_USER_NAME = "Root user name of the database server";
         public static final String ROOT_USER_PASSWORD = "Root user password of the database server";

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/database/base/DatabaseV4BaseTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/database/base/DatabaseV4BaseTest.java
@@ -28,6 +28,9 @@ public class DatabaseV4BaseTest {
         base.setType("hive");
         assertEquals("hive", base.getType());
 
+        base.setConnectionDriver("org.postgresql.Driver");
+        assertEquals("org.postgresql.Driver", base.getConnectionDriver());
+
         base.setConnectorJarUrl("http://drivers.example.com/postgresql.jar");
         assertEquals("http://drivers.example.com/postgresql.jar", base.getConnectorJarUrl());
 

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/base/DatabaseServerV4BaseTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/base/DatabaseServerV4BaseTest.java
@@ -31,6 +31,9 @@ public class DatabaseServerV4BaseTest {
         base.setDatabaseVendor("postgres");
         assertEquals("postgres", base.getDatabaseVendor());
 
+        base.setConnectionDriver("org.postgresql.Driver");
+        assertEquals("org.postgresql.Driver", base.getConnectionDriver());
+
         base.setConnectorJarUrl("http://drivers.example.com/postgresql.jar");
         assertEquals("http://drivers.example.com/postgresql.jar", base.getConnectorJarUrl());
 

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/DatabaseServerV4BaseTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/DatabaseServerV4BaseTest.java
@@ -24,6 +24,12 @@ public class DatabaseServerV4BaseTest {
         underTest.setDatabaseVendor("postgresql");
         assertEquals("postgresql", underTest.getDatabaseVendor());
 
+        underTest.setConnectionDriver("org.postgresql.Driver");
+        assertEquals("org.postgresql.Driver", underTest.getConnectionDriver());
+
+        underTest.setConnectorJarUrl("http://drivers.example.com/postgresql.jar");
+        assertEquals("http://drivers.example.com/postgresql.jar", underTest.getConnectorJarUrl());
+
         underTest.setStorageSize(50L);
         assertEquals(50L, underTest.getStorageSize().longValue());
 

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/converter/database/DatabaseV4RequestToDatabaseConfigConverter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/converter/database/DatabaseV4RequestToDatabaseConfigConverter.java
@@ -3,7 +3,6 @@ package com.sequenceiq.redbeams.converter.database;
 
 import javax.inject.Inject;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -36,7 +35,7 @@ public class DatabaseV4RequestToDatabaseConfigConverter  extends AbstractConvers
 
         DatabaseVendor databaseVendor = databaseVendorUtil.getVendorByJdbcUrl(source).get();
         databaseConfig.setDatabaseVendor(databaseVendor);
-        databaseConfig.setConnectionDriver(databaseVendor.connectionDriver());
+        databaseConfig.setConnectionDriver(source.getConnectionDriver());
         databaseConfig.setConnectionUserName(source.getConnectionUserName());
         databaseConfig.setConnectionPassword(source.getConnectionPassword());
         databaseConfig.setCreationDate(clock.getCurrentTimeMillis());
@@ -44,11 +43,6 @@ public class DatabaseV4RequestToDatabaseConfigConverter  extends AbstractConvers
         databaseConfig.setType(source.getType());
         databaseConfig.setEnvironmentId(source.getEnvironmentCrn());
 
-        // TODO this should be part of a validator, and delete it from here.
-        if (databaseConfig.getDatabaseVendor() != DatabaseVendor.POSTGRES && StringUtils.isEmpty(source.getConnectorJarUrl())) {
-            String msg = String.format("The 'connectorJarUrl' field needs to be specified for database engine: '%s'.", databaseConfig.getDatabaseVendor());
-            LOGGER.info(msg);
-        }
         databaseConfig.setConnectorJarUrl(source.getConnectorJarUrl());
         return databaseConfig;
     }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverter.java
@@ -173,6 +173,8 @@ public class AllocateDatabaseServerV4RequestToDBStackConverter {
         server.setInstanceType(source.getInstanceType());
         DatabaseVendor databaseVendor = DatabaseVendor.fromValue(source.getDatabaseVendor());
         server.setDatabaseVendor(databaseVendor);
+        server.setConnectionDriver(source.getConnectionDriver());
+        server.setConnectorJarUrl(source.getConnectorJarUrl());
         server.setStorageSize(source.getStorageSize());
         server.setRootUserName(source.getRootUserName() != null ? source.getRootUserName() : userGeneratorService.generateUserName());
         server.setRootPassword(source.getRootUserPassword() != null ? source.getRootUserPassword() : userGeneratorService.generatePassword());

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/converter/v4/databaseserver/DatabaseServerV4RequestToDatabaseServerConfigConverter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/converter/v4/databaseserver/DatabaseServerV4RequestToDatabaseServerConfigConverter.java
@@ -33,17 +33,12 @@ public class DatabaseServerV4RequestToDatabaseServerConfigConverter
 
         DatabaseVendor databaseVendor = DatabaseVendor.fromValue(source.getDatabaseVendor());
         server.setDatabaseVendor(databaseVendor);
-        server.setConnectionDriver(databaseVendor.connectionDriver());
+        server.setConnectionDriver(source.getConnectionDriver());
         server.setConnectionUserName(source.getConnectionUserName());
         server.setConnectionPassword(source.getConnectionPassword());
 
         server.setResourceStatus(ResourceStatus.USER_MANAGED);
 
-        if (server.getDatabaseVendor() != DatabaseVendor.POSTGRES && Strings.isNullOrEmpty(source.getConnectorJarUrl())) {
-            String msg = String.format("The 'connectorJarUrl' field needs to be specified for database vendor '%s'.", server.getDatabaseVendor());
-            LOGGER.info(msg);
-            // FIXME: should this fail?
-        }
         server.setConnectorJarUrl(source.getConnectorJarUrl());
 
         server.setArchived(false);

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/domain/stack/DatabaseServer.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/domain/stack/DatabaseServer.java
@@ -45,6 +45,12 @@ public class DatabaseServer implements AccountIdAwareResource {
     @Enumerated(EnumType.STRING)
     private DatabaseVendor databaseVendor;
 
+    @Column
+    private String connectionDriver;
+
+    @Column
+    private String connectorJarUrl;
+
     private Long storageSize;
 
     @Convert(converter = SecretToString.class)
@@ -114,6 +120,22 @@ public class DatabaseServer implements AccountIdAwareResource {
 
     public void setDatabaseVendor(DatabaseVendor databaseVendor) {
         this.databaseVendor = databaseVendor;
+    }
+
+    public String getConnectionDriver() {
+        return connectionDriver;
+    }
+
+    public void setConnectionDriver(String connectionDriver) {
+        this.connectionDriver = connectionDriver;
+    }
+
+    public String getConnectorJarUrl() {
+        return connectorJarUrl;
+    }
+
+    public void setConnectorJarUrl(String connectorJarUrl) {
+        this.connectorJarUrl = connectorJarUrl;
     }
 
     public Long getStorageSize() {

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/handler/RegisterDatabaseServerHandler.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/handler/RegisterDatabaseServerHandler.java
@@ -60,10 +60,8 @@ public class RegisterDatabaseServerHandler implements EventHandler<RegisterDatab
         dbServerConfig.setAccountId(databaseServer.getAccountId());
         dbServerConfig.setName(dbStack.getName());
         dbServerConfig.setEnvironmentId(dbStack.getEnvironmentId());
-        // TODO: Since the postgres driver is built in, we don't have to worry about setting the driver info.
-        //       However, we'll need to address this when adding in new types of database servers.
-        //dbServerConfig.setConnectionDriver("POSTGRESQL");
-        //dbServerConfig.setConnectorJarUrl("");
+        dbServerConfig.setConnectionDriver(dbStack.getDatabaseServer().getConnectionDriver());
+        dbServerConfig.setConnectorJarUrl(dbStack.getDatabaseServer().getConnectorJarUrl());
         dbServerConfig.setConnectionUserName(dbStack.getDatabaseServer().getRootUserName());
         dbServerConfig.setConnectionPassword(dbStack.getDatabaseServer().getRootPassword());
         dbServerConfig.setDatabaseVendor(dbStack.getDatabaseServer().getDatabaseVendor());

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbconfig/DatabaseConfigService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbconfig/DatabaseConfigService.java
@@ -72,6 +72,13 @@ public class DatabaseConfigService extends AbstractArchivistService<DatabaseConf
     }
 
     public DatabaseConfig register(DatabaseConfig configToSave) {
+
+        if (configToSave.getConnectionDriver() == null) {
+            configToSave.setConnectionDriver(configToSave.getDatabaseVendor().connectionDriver());
+            LOGGER.info("Database configuration lacked a connection driver; defaulting to {}",
+                configToSave.getConnectionDriver());
+        }
+
         String testResults = testConnection(configToSave);
 
         if (!testResults.equals(DATABASE_TEST_RESULT_SUCCESS)) {

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigService.java
@@ -85,6 +85,13 @@ public class DatabaseServerConfigService extends AbstractArchivistService<Databa
     }
 
     public DatabaseServerConfig create(DatabaseServerConfig resource, Long workspaceId) {
+
+        if (resource.getConnectionDriver() == null) {
+            resource.setConnectionDriver(resource.getDatabaseVendor().connectionDriver());
+            LOGGER.info("Database server configuration lacked a connection driver; defaulting to {}",
+                resource.getConnectionDriver());
+        }
+
         // FIXME? Currently no checks if logged-in user has access to workspace
         // Compare with AbstractWorkspaceAwareResourceService
         String testResults = testConnection(resource);

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/RedbeamsCreationService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/RedbeamsCreationService.java
@@ -60,6 +60,12 @@ public class RedbeamsCreationService {
             throw new RedbeamsException("Failed to retrieve database stack template for cloud platform", e);
         }
 
+        if (dbStack.getDatabaseServer().getConnectionDriver() == null) {
+            String connectionDriver = dbStack.getDatabaseServer().getDatabaseVendor().connectionDriver();
+            dbStack.getDatabaseServer().setConnectionDriver(connectionDriver);
+            LOGGER.info("Database server allocation request lacked a connection driver; defaulting to {}", connectionDriver);
+        }
+
         DBStack savedStack = dbStackService.save(dbStack);
 
         flowManager.notify(RedbeamsProvisionEvent.REDBEAMS_PROVISION_EVENT.selector(),

--- a/redbeams/src/main/resources/schema/app/20190712171448_CB-2366_Add_connection_driver_and_jar_to_stack_db_server.sql
+++ b/redbeams/src/main/resources/schema/app/20190712171448_CB-2366_Add_connection_driver_and_jar_to_stack_db_server.sql
@@ -1,0 +1,13 @@
+-- // CB-2366 Add connection driver and jar to stack db server
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE databaseserver
+    ADD COLUMN connectiondriver VARCHAR(255) DEFAULT 'org.postgresql.Driver',
+    ADD COLUMN connectorjarurl VARCHAR(255);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE databaseserver
+    DROP COLUMN connectiondriver,
+    DROP COLUMN connectorjarurl;

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/converter/database/DatabaseV4RequestToDatabaseConfigConverterTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/converter/database/DatabaseV4RequestToDatabaseConfigConverterTest.java
@@ -38,6 +38,8 @@ public class DatabaseV4RequestToDatabaseConfigConverterTest {
 
     private static final String CONNECTION_USERNAME = "connectionUsername";
 
+    private static final String CONNECTION_DRIVER = "connectionDriver";
+
     private static final String CONNECTOR_JAR_URL = "connectorJarUrl";
 
     @Mock
@@ -67,6 +69,7 @@ public class DatabaseV4RequestToDatabaseConfigConverterTest {
         request.setConnectionURL(CONNECTION_URL);
         request.setConnectionPassword(CONNECTION_PASSWORD);
         request.setConnectionUserName(CONNECTION_USERNAME);
+        request.setConnectionDriver(CONNECTION_DRIVER);
         request.setConnectorJarUrl(CONNECTOR_JAR_URL);
         when(databaseVendorUtil.getVendorByJdbcUrl(request)).thenReturn(Optional.of(DatabaseVendor.POSTGRES));
 
@@ -79,6 +82,7 @@ public class DatabaseV4RequestToDatabaseConfigConverterTest {
         assertEquals(CONNECTION_URL, databaseConfig.getConnectionURL());
         assertEquals(CONNECTION_PASSWORD, databaseConfig.getConnectionPassword().getRaw());
         assertEquals(CONNECTION_USERNAME, databaseConfig.getConnectionUserName().getRaw());
+        assertEquals(CONNECTION_DRIVER, databaseConfig.getConnectionDriver());
         assertEquals(CONNECTOR_JAR_URL, databaseConfig.getConnectorJarUrl());
         assertEquals(DatabaseVendor.POSTGRES, databaseConfig.getDatabaseVendor());
         assertEquals(ResourceStatus.USER_MANAGED, databaseConfig.getStatus());

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/converter/spi/DBStackToDatabaseStackConverterTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/converter/spi/DBStackToDatabaseStackConverterTest.java
@@ -59,6 +59,8 @@ public class DBStackToDatabaseStackConverterTest {
         server.setName("myserver");
         server.setInstanceType("db.m3.medium");
         server.setDatabaseVendor(DatabaseVendor.POSTGRES);
+        server.setConnectionDriver("org.postgresql.Driver");
+        server.setConnectorJarUrl("http://drivers.example.com/postgresql.jar");
         server.setRootUserName("root");
         server.setRootPassword("cloudera");
         server.setStorageSize(50L);
@@ -81,9 +83,11 @@ public class DBStackToDatabaseStackConverterTest {
         assertEquals("myserver", convertedStack.getDatabaseServer().getServerId());
         assertEquals("db.m3.medium", convertedStack.getDatabaseServer().getFlavor());
         assertEquals(DatabaseEngine.POSTGRESQL, convertedStack.getDatabaseServer().getEngine());
+        assertEquals("org.postgresql.Driver", convertedStack.getDatabaseServer().getConnectionDriver());
+        assertEquals("http://drivers.example.com/postgresql.jar", convertedStack.getDatabaseServer().getConnectorJarUrl());
         assertEquals("root", convertedStack.getDatabaseServer().getRootUserName());
         assertEquals("cloudera", convertedStack.getDatabaseServer().getRootPassword());
-        assertEquals(50L, convertedStack.getDatabaseServer().getStorageSize());
+        assertEquals(50L, convertedStack.getDatabaseServer().getStorageSize().longValue());
         assertEquals(List.of("sg-1234"), convertedStack.getDatabaseServer().getSecurity().getCloudSecurityIds());
         // FIXME test instanceStatus
         assertEquals(1, convertedStack.getDatabaseServer().getParameters().size());

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverterTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverterTest.java
@@ -160,6 +160,8 @@ public class AllocateDatabaseServerV4RequestToDBStackConverterTest {
         assertNotNull(dbStack.getDatabaseServer().getName());
         assertEquals(databaseServerRequest.getInstanceType(), dbStack.getDatabaseServer().getInstanceType());
         assertEquals(DatabaseVendor.fromValue(databaseServerRequest.getDatabaseVendor()), dbStack.getDatabaseServer().getDatabaseVendor());
+        assertEquals("org.postgresql.Driver", dbStack.getDatabaseServer().getConnectionDriver());
+        assertEquals("http://drivers.example.com/postgresql.jar", dbStack.getDatabaseServer().getConnectorJarUrl());
         assertEquals(databaseServerRequest.getStorageSize(), dbStack.getDatabaseServer().getStorageSize());
         assertEquals(databaseServerRequest.getRootUserName(), dbStack.getDatabaseServer().getRootUserName());
         assertEquals(databaseServerRequest.getRootUserPassword(), dbStack.getDatabaseServer().getRootPassword());
@@ -234,6 +236,8 @@ public class AllocateDatabaseServerV4RequestToDBStackConverterTest {
 
         databaseServerRequest.setInstanceType("db.m3.medium");
         databaseServerRequest.setDatabaseVendor("postgres");
+        databaseServerRequest.setConnectionDriver("org.postgresql.Driver");
+        databaseServerRequest.setConnectorJarUrl("http://drivers.example.com/postgresql.jar");
         databaseServerRequest.setStorageSize(50L);
         if (provideOptionalFields) {
             databaseServerRequest.setRootUserName("root");
@@ -252,3 +256,5 @@ public class AllocateDatabaseServerV4RequestToDBStackConverterTest {
     }
 
 }
+
+

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/converter/v4/databaseserver/DatabaseServerV4RequestToDatabaseServerConfigConverterTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/converter/v4/databaseserver/DatabaseServerV4RequestToDatabaseServerConfigConverterTest.java
@@ -28,6 +28,7 @@ public class DatabaseServerV4RequestToDatabaseServerConfigConverterTest {
         request.setDatabaseVendor("postgres");
         request.setConnectionUserName("root");
         request.setConnectionPassword("cloudera");
+        request.setConnectionDriver("org.postgresql.Driver");
         request.setConnectorJarUrl("http://drivers.example.com/postgresql.jar");
         request.setEnvironmentCrn("myenvironment");
 
@@ -40,6 +41,7 @@ public class DatabaseServerV4RequestToDatabaseServerConfigConverterTest {
         assertEquals(request.getDatabaseVendor(), server.getDatabaseVendor().databaseType());
         assertEquals(request.getConnectionUserName(), server.getConnectionUserName());
         assertEquals(request.getConnectionPassword(), server.getConnectionPassword());
+        assertEquals(request.getConnectionDriver(), server.getConnectionDriver());
         assertEquals(request.getConnectorJarUrl(), server.getConnectorJarUrl());
         assertEquals(request.getEnvironmentCrn(), server.getEnvironmentId());
         assertEquals(ResourceStatus.USER_MANAGED, server.getResourceStatus());

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/domain/DatabaseServerConfigTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/domain/DatabaseServerConfigTest.java
@@ -56,8 +56,8 @@ public class DatabaseServerConfigTest {
         config.setDatabaseVendor(DatabaseVendor.POSTGRES);
         assertEquals(DatabaseVendor.POSTGRES, config.getDatabaseVendor());
 
-        config.setConnectionDriver("postgresql.jar");
-        assertEquals("postgresql.jar", config.getConnectionDriver());
+        config.setConnectionDriver("org.postgresql.Driver");
+        assertEquals("org.postgresql.Driver", config.getConnectionDriver());
 
         config.setConnectionUserName("root");
         assertEquals("root", config.getConnectionUserName());
@@ -110,7 +110,7 @@ public class DatabaseServerConfigTest {
         config.setHost("myserver.db.example.com");
         config.setPort(5432);
         config.setDatabaseVendor(DatabaseVendor.POSTGRES);
-        config.setConnectionDriver("postgresql.jar");
+        config.setConnectionDriver("org.postgresql.Driver");
         config.setConnectionUserName("root");
         config.setConnectionPassword("cloudera");
         long now = System.currentTimeMillis();

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/domain/stack/DatabaseServerTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/domain/stack/DatabaseServerTest.java
@@ -38,6 +38,12 @@ public class DatabaseServerTest {
         server.setDatabaseVendor(DatabaseVendor.POSTGRES);
         assertEquals(DatabaseVendor.POSTGRES, server.getDatabaseVendor());
 
+        server.setConnectionDriver("org.postgresql.Driver");
+        assertEquals("org.postgresql.Driver", server.getConnectionDriver());
+
+        server.setConnectorJarUrl("http://drivers.example.com/postgresql.jar");
+        assertEquals("http://drivers.example.com/postgresql.jar", server.getConnectorJarUrl());
+
         server.setStorageSize(50L);
         assertEquals(50L, server.getStorageSize().longValue());
 


### PR DESCRIPTION
The following kinds of redbeams API requests now fully support the
caller specifying the class name of the required JDBC driver and a
URL for a JAR from which the driver can be loaded.

* existing database (driver class name added)
* existing database server (driver class name added)
* new database server allocation (both added)

The various object converters used in these API calls are updated so
that they pass these values along. Notably, the database stack's
database server object lacked space for them, so columns were added.
RegisterDatabaseServerHandler, which registers newly created database
servers, now gets the values from the stack instead of just skipping
them.

Business logic is now responsible for explicitly filling in the class
name of the connection driver when it is missing from an API request.
The class name is found from the definition of the database vendor.
(This was being done in some converters, as the field wasn't present in
the requests until now.) Redbeams logs when it defaults this field. If
the default value wouldn't work, then the caller is responsible for
specifying the right value. A result of this change is that databases
and database servers always have a connection driver class name.

Other changes:

* The DatabaseServer object in the database stack is now built using
  a builder instead of a constructor with too many arguments.
* The storage size in that object is now stored as a Long object, not
  a long primitive. This accurately represents when the user does not
  provide a value. A lingering problem, though, is that
  AwsStackRequestHelper does not cope with this condition.

Some converters would log when a connector JAR URL was absent from a
request. This is valid for PostgreSQL, but not other vendors. This
logging is removed, but full validation will be added in a subsequent
change.