### PR TITLE
DISTX-201. Use 'random' option when adding users to ipa

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
@@ -136,12 +136,12 @@ public class FreeIpaClient {
         return (Role) invoke("role_del", flags, params, Role.class).getResult();
     }
 
-    public User userAdd(String user, String firstName, String lastName, String password) throws FreeIpaClientException {
+    public User userAdd(String user, String firstName, String lastName) throws FreeIpaClientException {
         List<String> flags = List.of(user);
         Map<String, Object> params = Map.of(
                 "givenname", firstName,
                 "sn", lastName,
-                "userpassword", password,
+                "random", true,
                 "setattr", "krbPasswordExpiration=20380101000000Z"
         );
         return (User) invoke("user_add", flags, params, User.class).getResult();

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserService.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
@@ -182,7 +181,7 @@ public class UserService {
 
             try {
                 com.sequenceiq.freeipa.client.model.User userAdd = freeIpaClient.userAdd(
-                        username, user.getFirstName(), user.getLastName(), generateRandomPassword());
+                        username, user.getFirstName(), user.getLastName());
                 LOGGER.debug("Success: {}", userAdd);
             } catch (FreeIpaClientException e) {
                 // TODO propagate this information out to API
@@ -222,9 +221,5 @@ public class UserService {
                 LOGGER.error("Failed to add {} to group", users, group, e);
             }
         }
-    }
-
-    private String generateRandomPassword() {
-        return UUID.randomUUID().toString();
     }
 }


### PR DESCRIPTION
User the 'random' option to allow the ipa server to set a random password
for new users instead of generating a random password in the FMS.
