### PR TITLE
CB-2366 Restore validation of connector JAR URL

### DIFF
--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/database/request/DatabaseV4Request.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/database/request/DatabaseV4Request.java
@@ -6,6 +6,7 @@ import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.sequenceiq.redbeams.api.endpoint.v4.database.base.DatabaseV4Base;
+import com.sequenceiq.redbeams.validation.ValidConnectorJarUrlForDatabaseVendor;
 import com.sequenceiq.redbeams.validation.ValidDatabaseVendorAndService;
 
 import io.swagger.annotations.ApiModel;
@@ -13,6 +14,7 @@ import io.swagger.annotations.ApiModelProperty;
 
 @ApiModel
 @ValidDatabaseVendorAndService
+@ValidConnectorJarUrlForDatabaseVendor
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DatabaseV4Request extends DatabaseV4Base {
 

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/DatabaseServerV4Request.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/DatabaseServerV4Request.java
@@ -5,11 +5,13 @@ import javax.validation.constraints.NotNull;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.base.DatabaseServerV4Base;
 import com.sequenceiq.redbeams.doc.ModelDescriptions.DatabaseServer;
+import com.sequenceiq.redbeams.validation.ValidConnectorJarUrlForDatabaseVendor;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
 @ApiModel
+@ValidConnectorJarUrlForDatabaseVendor
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DatabaseServerV4Request extends DatabaseServerV4Base {
 

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/DatabaseServerV4Request.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/DatabaseServerV4Request.java
@@ -4,11 +4,13 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.sequenceiq.redbeams.doc.ModelDescriptions.DatabaseServerModelDescription;
+import com.sequenceiq.redbeams.validation.ValidConnectorJarUrlForDatabaseVendor;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
 @ApiModel
+@ValidConnectorJarUrlForDatabaseVendor
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(Include.NON_NULL)
 public class DatabaseServerV4Request extends DatabaseServerV4Base {

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/util/DatabaseVendorUtil.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/util/DatabaseVendorUtil.java
@@ -5,14 +5,23 @@ import java.util.Optional;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
-import com.sequenceiq.redbeams.api.endpoint.v4.database.request.DatabaseV4Request;
 
 @Component
 public class DatabaseVendorUtil {
 
-    public Optional<DatabaseVendor> getVendorByJdbcUrl(DatabaseV4Request configRequest) {
+    /**
+     * Identifies an appropriate database vendor based on a JDBC connection URL.
+     * The behavior of the method depends on the ordering of DatabaseVendor
+     * enum definitions; a value later in the list that shares the same JDBC URL
+     * driver ID with one earlier in the list will <em>never</em> be returned by
+     * this method.
+     *
+     * @param  jdbcUrl JDBC connection URL
+     * @return         appropriate database vendor
+     */
+    public Optional<DatabaseVendor> getVendorByJdbcUrl(String jdbcUrl) {
         for (DatabaseVendor databaseVendor : DatabaseVendor.values()) {
-            if (configRequest.getConnectionURL().startsWith(String.format("jdbc:%s:", databaseVendor.jdbcUrlDriverId()))) {
+            if (jdbcUrl.startsWith(String.format("jdbc:%s:", databaseVendor.jdbcUrlDriverId()))) {
                 return Optional.of(databaseVendor);
             }
         }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/validation/ConnectorJarUrlForDatabaseVendorValidator.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/validation/ConnectorJarUrlForDatabaseVendorValidator.java
@@ -1,0 +1,61 @@
+package com.sequenceiq.redbeams.validation;
+
+import java.util.EnumSet;
+import java.util.Optional;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
+import com.sequenceiq.cloudbreak.validation.ValidatorUtil;
+import com.sequenceiq.redbeams.api.endpoint.v4.database.request.DatabaseV4Request;
+import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.DatabaseServerV4Request;
+import com.sequenceiq.redbeams.api.util.DatabaseVendorUtil;
+
+/**
+ * Validates whether the connector JAR URL for a request is valid based on its
+ * database vendor.
+ */
+public class ConnectorJarUrlForDatabaseVendorValidator implements ConstraintValidator<ValidConnectorJarUrlForDatabaseVendor, Object> {
+
+    // Connector JAR URL is optional for PostgreSQL only.
+    private static final EnumSet<DatabaseVendor> DATABASE_VENDORS_ALLOWING_NULL_CONNECTOR_JAR_URL =
+        EnumSet.of(DatabaseVendor.POSTGRES);
+
+    private DatabaseVendorUtil databaseVendorUtil = new DatabaseVendorUtil();
+
+    @Override
+    public boolean isValid(Object request, ConstraintValidatorContext context) {
+        String connectorJarUrl;
+        DatabaseVendor databaseVendor;
+
+        if (request instanceof DatabaseV4Request) {
+            DatabaseV4Request req = (DatabaseV4Request) request;
+            connectorJarUrl = req.getConnectorJarUrl();
+            Optional<DatabaseVendor> vendorByJdbcUrl = databaseVendorUtil.getVendorByJdbcUrl(req.getConnectionURL());
+            if (!vendorByJdbcUrl.isPresent()) {
+                ValidatorUtil.addConstraintViolation(context, "Could not determine database vendor from JDBC URL "
+                    + req.getConnectionURL(), "connectionURL");
+                return false;
+            }
+            databaseVendor = vendorByJdbcUrl.get();
+        } else if (request instanceof DatabaseServerV4Request) {
+            connectorJarUrl = ((DatabaseServerV4Request) request).getConnectorJarUrl();
+            databaseVendor = DatabaseVendor.fromValue(((DatabaseServerV4Request) request).getDatabaseVendor());
+        } else if (request instanceof com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4Request) {
+            connectorJarUrl = ((com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4Request) request).getConnectorJarUrl();
+            databaseVendor = DatabaseVendor.fromValue(((com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4Request) request).getDatabaseVendor());
+        } else {
+            throw new IllegalStateException("@ValidConnectorJarUrlForDatabaseVendor is applied to request of type "
+                + request.getClass().toString() + " which isn't supported");
+        }
+
+        if (connectorJarUrl == null && !DATABASE_VENDORS_ALLOWING_NULL_CONNECTOR_JAR_URL.contains(databaseVendor)) {
+            ValidatorUtil.addConstraintViolation(context, "Database vendor " + databaseVendor + " requires a connector JAR URL", "connectorJarUrl");
+            return false;
+        }
+
+        return true;
+    }
+
+}

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/validation/DatabaseVendorAndServiceValidator.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/validation/DatabaseVendorAndServiceValidator.java
@@ -21,7 +21,7 @@ public class DatabaseVendorAndServiceValidator implements ConstraintValidator<Va
 
     @Override
     public boolean isValid(DatabaseV4Request request, ConstraintValidatorContext context) {
-        Optional<DatabaseVendor> vendorByJdbcUrl = databaseVendorUtil.getVendorByJdbcUrl(request);
+        Optional<DatabaseVendor> vendorByJdbcUrl = databaseVendorUtil.getVendorByJdbcUrl(request.getConnectionURL());
         if (!vendorByJdbcUrl.isPresent()) {
             ValidatorUtil.addConstraintViolation(context, "Could not determine database vendor from JDBC URL "
                 + request.getConnectionURL(), "connectionURL");

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/validation/ValidConnectorJarUrlForDatabaseVendor.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/validation/ValidConnectorJarUrlForDatabaseVendor.java
@@ -1,0 +1,24 @@
+package com.sequenceiq.redbeams.validation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ConnectorJarUrlForDatabaseVendorValidator.class)
+public @interface ValidConnectorJarUrlForDatabaseVendor {
+
+    String message() default "";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/util/DatabaseVendorUtilTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/util/DatabaseVendorUtilTest.java
@@ -1,0 +1,49 @@
+package com.sequenceiq.redbeams.api.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
+
+import java.util.EnumSet;
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class DatabaseVendorUtilTest {
+
+    /*
+     * This set takes into account the fact that some database vendors will
+     * never be returned by getVendorByJdbcUrl, due to DatabaseVendor enum
+     * definition ordering. When that ordering changes, this set must be
+     * updated.
+     */
+    private static final EnumSet<DatabaseVendor> TO_TEST =
+        EnumSet.of(DatabaseVendor.POSTGRES, DatabaseVendor.MYSQL, DatabaseVendor.MSSQL, DatabaseVendor.ORACLE11,
+            DatabaseVendor.SQLANYWHERE, DatabaseVendor.EMBEDDED);
+
+    private DatabaseVendorUtil underTest;
+
+    @Before
+    public void setUp() throws Exception {
+        underTest = new DatabaseVendorUtil();
+    }
+
+    @Test
+    public void testValidUrls() {
+        for (DatabaseVendor databaseVendor : TO_TEST) {
+            String jdbcUrl = "jdbc:" + databaseVendor.jdbcUrlDriverId() + ":etc";
+            Optional<DatabaseVendor> foundVendor = underTest.getVendorByJdbcUrl(jdbcUrl);
+            assertFalse(foundVendor.isEmpty());
+            assertEquals("Expected " + databaseVendor + " but got " + foundVendor.get(), databaseVendor, foundVendor.get());
+        }
+    }
+
+    @Test
+    public void testUnrecognizedUrl() {
+        assertTrue(underTest.getVendorByJdbcUrl("unrecognized").isEmpty());
+    }
+
+}

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/validation/ConnectorJarUrlForDatabaseVendorValidatorTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/validation/ConnectorJarUrlForDatabaseVendorValidatorTest.java
@@ -1,0 +1,105 @@
+package com.sequenceiq.redbeams.validation;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
+import com.sequenceiq.redbeams.api.endpoint.v4.database.request.DatabaseV4Request;
+import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.DatabaseServerV4Request;
+
+import java.util.Arrays;
+
+import javax.validation.ConstraintValidatorContext;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.mockito.Mock;
+
+@RunWith(Parameterized.class)
+public class ConnectorJarUrlForDatabaseVendorValidatorTest {
+
+    private static final String CONNECTOR_JAR_URL = "http://drivers.example.com/mydriver.jar";
+
+    @Mock(answer = RETURNS_DEEP_STUBS)
+    private ConstraintValidatorContext context;
+
+    private final Class requestClass;
+
+    private final DatabaseVendor databaseVendor;
+
+    private final boolean connectorJarUrlProvided;
+
+    private final boolean expectedResult;
+
+    private ConnectorJarUrlForDatabaseVendorValidator underTest;
+
+    public ConnectorJarUrlForDatabaseVendorValidatorTest(Class requestClass, DatabaseVendor databaseVendor,
+        boolean connectorJarUrlProvided, boolean expectedResult) {
+        this.requestClass = requestClass;
+        this.databaseVendor = databaseVendor;
+        this.connectorJarUrlProvided = connectorJarUrlProvided;
+        this.expectedResult = expectedResult;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+        when(context.buildConstraintViolationWithTemplate(any(String.class)).addConstraintViolation()).thenReturn(context);
+
+        underTest = new ConnectorJarUrlForDatabaseVendorValidator();
+    }
+
+    @Parameters(name = "{index}: request type: {0} database vendor: {1} connector JAR URL provided: {2} should return: {3}")
+    public static Iterable<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+            { DatabaseV4Request.class, DatabaseVendor.POSTGRES, true, true },
+            { DatabaseV4Request.class, DatabaseVendor.POSTGRES, false, true },
+            { DatabaseV4Request.class, DatabaseVendor.MYSQL, true, true },
+            { DatabaseV4Request.class, DatabaseVendor.MYSQL, false, false },
+            { DatabaseServerV4Request.class, DatabaseVendor.POSTGRES, true, true },
+            { DatabaseServerV4Request.class, DatabaseVendor.POSTGRES, false, true },
+            { DatabaseServerV4Request.class, DatabaseVendor.MYSQL, true, true },
+            { DatabaseServerV4Request.class, DatabaseVendor.MYSQL, false, false },
+            { com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4Request.class, DatabaseVendor.POSTGRES, true, true },
+            { com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4Request.class, DatabaseVendor.POSTGRES, false, true },
+            { com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4Request.class, DatabaseVendor.MYSQL, true, true },
+            { com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4Request.class, DatabaseVendor.MYSQL, false, false }
+        });
+    }
+
+    @Test
+    public void testValidation() {
+        Object request;
+        if (requestClass.equals(DatabaseV4Request.class)) {
+            DatabaseV4Request req = new DatabaseV4Request();
+            req.setConnectorJarUrl(connectorJarUrlProvided ? CONNECTOR_JAR_URL : null);
+            req.setConnectionURL("jdbc:" + databaseVendor.jdbcUrlDriverId() + ":etc");
+            request = req;
+        } else if (requestClass.equals(DatabaseServerV4Request.class)) {
+            DatabaseServerV4Request req = new DatabaseServerV4Request();
+            req.setConnectorJarUrl(connectorJarUrlProvided ? CONNECTOR_JAR_URL : null);
+            req.setDatabaseVendor(databaseVendor.databaseType());
+            request = req;
+        } else {
+            com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4Request req =
+                new com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4Request();
+            req.setConnectorJarUrl(connectorJarUrlProvided ? CONNECTOR_JAR_URL : null);
+            req.setDatabaseVendor(databaseVendor.databaseType());
+            request = req;
+        }
+
+        assertEquals(expectedResult, underTest.isValid(request, context));
+
+        int expectedTimes = expectedResult ? 0 : 1;
+        verify(context, times(expectedTimes)).buildConstraintViolationWithTemplate(any(String.class));
+    }
+
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/converter/database/DatabaseV4RequestToDatabaseConfigConverter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/converter/database/DatabaseV4RequestToDatabaseConfigConverter.java
@@ -33,7 +33,7 @@ public class DatabaseV4RequestToDatabaseConfigConverter  extends AbstractConvers
         databaseConfig.setDescription(source.getDescription());
         databaseConfig.setConnectionURL(source.getConnectionURL());
 
-        DatabaseVendor databaseVendor = databaseVendorUtil.getVendorByJdbcUrl(source).get();
+        DatabaseVendor databaseVendor = databaseVendorUtil.getVendorByJdbcUrl(source.getConnectionURL()).get();
         databaseConfig.setDatabaseVendor(databaseVendor);
         databaseConfig.setConnectionDriver(source.getConnectionDriver());
         databaseConfig.setConnectionUserName(source.getConnectionUserName());

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/drivers/DriverFunctions.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/drivers/DriverFunctions.java
@@ -33,7 +33,7 @@ public class DriverFunctions {
      * @throws DriverLoadingException if there was a problem loading the driver
      */
     public void execWithDatabaseDriver(DatabaseConfig databaseConfig, Consumer<DriverWithConnectivity> consumer) {
-        execWithDatabaseDriver(databaseConfig.getConnectorJarUrl(), databaseConfig.getDatabaseVendor(), consumer);
+        execWithDatabaseDriver(databaseConfig.getName(), databaseConfig.getConnectorJarUrl(), databaseConfig.getDatabaseVendor(), consumer);
     }
 
     /**
@@ -44,26 +44,29 @@ public class DriverFunctions {
      */
     public void execWithDatabaseDriver(DatabaseServerConfig databaseServerConfig,
         Consumer<DriverWithConnectivity> consumer) {
-        execWithDatabaseDriver(databaseServerConfig.getConnectorJarUrl(), databaseServerConfig.getDatabaseVendor(),
+        execWithDatabaseDriver(databaseServerConfig.getName(), databaseServerConfig.getConnectorJarUrl(), databaseServerConfig.getDatabaseVendor(),
                 consumer);
     }
 
     /**
      * Executes the given function with the associated driver.
      *
+     * @param resourceName    name of database / database server
      * @param connectorJarUrl the URL to the connector jar
      * @param databaseVendor  the database vendor
      * @param consumer        the function to execute
      * @throws DriverLoadingException if there was a problem loading the driver
      */
-    public void execWithDatabaseDriver(String connectorJarUrl, DatabaseVendor databaseVendor,
+    private void execWithDatabaseDriver(String resourceName, String connectorJarUrl, DatabaseVendor databaseVendor,
         Consumer<DriverWithConnectivity> consumer) {
         if (StringUtils.isEmpty(connectorJarUrl)) {
             if (databaseVendor == DatabaseVendor.POSTGRES) {
+                LOGGER.warn("There is no connector JAR URL associated with {}, using internal PostgreSQL driver",
+                            resourceName);
                 consumer.accept(new DriverWithConnectivity(new org.postgresql.Driver()));
             } else {
                 throw new DriverLoadingException("connectorJarUrl", "missingjarurl",
-                        "Only PostgreSQL can be validated without a connector JAR URL");
+                        "Only PostgreSQL database access is supported without a connector JAR URL");
             }
         } else {
             try {

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/converter/database/DatabaseV4RequestToDatabaseConfigConverterTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/converter/database/DatabaseV4RequestToDatabaseConfigConverterTest.java
@@ -71,7 +71,7 @@ public class DatabaseV4RequestToDatabaseConfigConverterTest {
         request.setConnectionUserName(CONNECTION_USERNAME);
         request.setConnectionDriver(CONNECTION_DRIVER);
         request.setConnectorJarUrl(CONNECTOR_JAR_URL);
-        when(databaseVendorUtil.getVendorByJdbcUrl(request)).thenReturn(Optional.of(DatabaseVendor.POSTGRES));
+        when(databaseVendorUtil.getVendorByJdbcUrl(CONNECTION_URL)).thenReturn(Optional.of(DatabaseVendor.POSTGRES));
 
         DatabaseConfig databaseConfig = underTest.convert(request);
 
@@ -86,7 +86,7 @@ public class DatabaseV4RequestToDatabaseConfigConverterTest {
         assertEquals(CONNECTOR_JAR_URL, databaseConfig.getConnectorJarUrl());
         assertEquals(DatabaseVendor.POSTGRES, databaseConfig.getDatabaseVendor());
         assertEquals(ResourceStatus.USER_MANAGED, databaseConfig.getStatus());
-        verify(databaseVendorUtil).getVendorByJdbcUrl(request);
+        verify(databaseVendorUtil).getVendorByJdbcUrl(CONNECTION_URL);
         verify(missingResourceNameGenerator, never()).generateName(any());
     }
 }

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/service/drivers/DriverFunctionsTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/service/drivers/DriverFunctionsTest.java
@@ -3,6 +3,8 @@ package com.sequenceiq.redbeams.service.drivers;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
+import com.sequenceiq.redbeams.domain.DatabaseConfig;
+import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -14,23 +16,33 @@ public class DriverFunctionsTest {
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
 
-    private DriverFunctions driverFunctions;
+    private DriverFunctions underTest;
 
     @Before
     public void setup() {
-        driverFunctions = new DriverFunctions();
+        underTest = new DriverFunctions();
     }
 
     @Test
     public void testDriverFunctions() {
-        driverFunctions.execWithDatabaseDriver("", DatabaseVendor.POSTGRES,
+        DatabaseConfig databaseConfig = new DatabaseConfig();
+        databaseConfig.setName("name");
+        databaseConfig.setDatabaseVendor(DatabaseVendor.POSTGRES);
+        databaseConfig.setConnectorJarUrl("");
+
+        underTest.execWithDatabaseDriver(databaseConfig,
                 d -> assertThat(d.getDelegate() instanceof org.postgresql.Driver).isTrue());
     }
 
     @Test
     public void testDriverFunctionsLoadFailure() {
+        DatabaseServerConfig databaseServerConfig = new DatabaseServerConfig();
+        databaseServerConfig.setName("name");
+        databaseServerConfig.setDatabaseVendor(DatabaseVendor.MYSQL);
+        databaseServerConfig.setConnectorJarUrl("");
+
         thrown.expect(DriverLoadingException.class);
-        driverFunctions.execWithDatabaseDriver("", DatabaseVendor.MYSQL, d -> {
+        underTest.execWithDatabaseDriver(databaseServerConfig, d -> {
             // Do nothing
         });
     }


### PR DESCRIPTION
Redbeams once again validates the connector JAR URL passed in requests
to register databases and database servers and to allocate new database
servers. The URL is required in a request unless PostgreSQL is being
used.