### PR TITLE
DISTX-258. Workload analytics installation improvements.

### DIFF
--- a/cluster-ambari/src/main/java/com/sequenceiq/cloudbreak/ambari/AmbariClusterSetupService.java
+++ b/cluster-ambari/src/main/java/com/sequenceiq/cloudbreak/ambari/AmbariClusterSetupService.java
@@ -127,7 +127,7 @@ public class AmbariClusterSetupService implements ClusterSetupService {
 
     @Override
     public Cluster buildCluster(Map<HostGroup, List<InstanceMetaData>> instanceMetaDataByHostGroup, TemplatePreparationObject templatePreparationObject,
-            Set<HostMetadata> hostsInCluster, String sdxContext, Telemetry telemetry, KerberosConfig kerberosConfig) {
+            Set<HostMetadata> hostsInCluster, String sdxContext, String sdxStackCrn, Telemetry telemetry, KerberosConfig kerberosConfig) {
         Cluster cluster = stack.getCluster();
         try {
             ambariRepositoryVersionService.setBaseRepoURL(stack.getName(), cluster.getId(), ambariClient);

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
@@ -32,8 +32,8 @@ public interface ClusterApi {
     }
 
     default Cluster buildCluster(Map<HostGroup, List<InstanceMetaData>> instanceMetaDataByHostGroup, TemplatePreparationObject templatePreparationObject,
-            Set<HostMetadata> hostsInCluster, String sdxContext, Telemetry telemetry, KerberosConfig kerberosConfig) {
-        return clusterSetupService().buildCluster(instanceMetaDataByHostGroup, templatePreparationObject, hostsInCluster, sdxContext, telemetry,
+            Set<HostMetadata> hostsInCluster, String sdxContext, String sdxCrn, Telemetry telemetry, KerberosConfig kerberosConfig) {
+        return clusterSetupService().buildCluster(instanceMetaDataByHostGroup, templatePreparationObject, hostsInCluster, sdxContext, sdxCrn, telemetry,
                 kerberosConfig);
     }
 

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterSetupService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterSetupService.java
@@ -20,7 +20,7 @@ public interface ClusterSetupService {
     void waitForServer() throws CloudbreakException;
 
     Cluster buildCluster(Map<HostGroup, List<InstanceMetaData>> instanceMetaDataByHostGroup, TemplatePreparationObject templatePreparationObject,
-            Set<HostMetadata> hostsInCluster, String sdxContext, Telemetry telemetry, KerberosConfig kerberosConfig);
+            Set<HostMetadata> hostsInCluster, String sdxContext, String sdxStackCrn, Telemetry telemetry, KerberosConfig kerberosConfig);
 
     void waitForHosts(Set<HostMetadata> hostsInCluster);
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerMgmtSetupService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerMgmtSetupService.java
@@ -76,11 +76,12 @@ public class ClouderaManagerMgmtSetupService {
      * @param cmHostRef  reference to the CM host
      * @param rdsConfigs the set of all database configs
      * @param telemetry  telemetry (logging/workload/billing etc.) details
-     * @param sdxContext sdx data holder
+     * @param sdxContextName sdx name holder
+     * @param sdxStackCrn sdx stack crn holder
      * @throws ApiException if there's a problem setting up management services
      */
     public void setupMgmtServices(Stack stack, ApiClient client, ApiHostRef cmHostRef,
-            Set<RDSConfig> rdsConfigs, Telemetry telemetry, String sdxContext)
+            Set<RDSConfig> rdsConfigs, Telemetry telemetry, String sdxContextName, String sdxStackCrn)
             throws ApiException {
         licenseService.beginTrialIfNeeded(stack.getCreator(), client);
         MgmtServiceResourceApi mgmtServiceResourceApi = new MgmtServiceResourceApi(client);
@@ -105,7 +106,7 @@ public class ClouderaManagerMgmtSetupService {
         }
         telemetryService.setupTelemetryRole(stack, client, cmHostRef, mgmtRoles, telemetry);
         createMgmtRoles(mgmtRolesResourceApi, mgmtRoles);
-        telemetryService.updateTelemetryConfigs(stack, client, telemetry, sdxContext);
+        telemetryService.updateTelemetryConfigs(stack, client, telemetry, sdxContextName, sdxStackCrn);
         createMgmtDatabases(client, rdsConfigs);
         startMgmtServices(stack, client, mgmtServiceResourceApi);
     }

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerSetupService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerSetupService.java
@@ -123,7 +123,7 @@ public class ClouderaManagerSetupService implements ClusterSetupService {
 
     @Override
     public Cluster buildCluster(Map<HostGroup, List<InstanceMetaData>> instanceMetaDataByHostGroup, TemplatePreparationObject templatePreparationObject,
-            Set<HostMetadata> hostsInCluster, String sdxContext, Telemetry telemetry, KerberosConfig kerberosConfig) {
+            Set<HostMetadata> hostsInCluster, String sdxContext, String sdxCrn, Telemetry telemetry, KerberosConfig kerberosConfig) {
         Cluster cluster = stack.getCluster();
         Long clusterId = cluster.getId();
         try {
@@ -133,18 +133,17 @@ public class ClouderaManagerSetupService implements ClusterSetupService {
                     .findFirst();
 
             clouderaManagerLicenseService.beginTrialIfNeeded(stack.getCreator(), client);
+            String sdxContextName = Optional.ofNullable(sdxContext).map(this::createDataContext).orElse(null);
 
             if (optionalCmHost.isPresent()) {
                 ApiHost cmHost = optionalCmHost.get();
                 ApiHostRef cmHostRef = new ApiHostRef();
                 cmHostRef.setHostId(cmHost.getHostId());
                 cmHostRef.setHostname(cmHost.getHostname());
-                mgmtSetupService.setupMgmtServices(stack, client, cmHostRef, templatePreparationObject.getRdsConfigs(), telemetry, sdxContext);
+                mgmtSetupService.setupMgmtServices(stack, client, cmHostRef, templatePreparationObject.getRdsConfigs(), telemetry, sdxContextName, sdxCrn);
             } else {
                 LOGGER.warn("Unable to determine Cloudera Manager host. Skipping management services installation.");
             }
-
-            String sdxContextName = Optional.ofNullable(sdxContext).map(this::createDataContext).orElse(null);
             Map<String, List<Map<String, String>>> hostGroupMappings = hostGroupAssociationBuilder.buildHostGroupAssociations(instanceMetaDataByHostGroup);
             ClouderaManagerRepo clouderaManagerRepoDetails = clusterComponentProvider.getClouderaManagerRepoDetails(clusterId);
             List<ClouderaManagerProduct> clouderaManagerProductDetails = clusterComponentProvider.getClouderaManagerProductDetails(clusterId);

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerDatabusServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerDatabusServiceTest.java
@@ -1,17 +1,11 @@
 package com.sequenceiq.cloudbreak.cm;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import java.io.IOException;
-import java.io.StringReader;
-import java.util.Map;
-import java.util.Properties;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -122,17 +116,5 @@ public class ClouderaManagerDatabusServiceTest {
         String result = underTest.getBuiltInDatabusCrn();
         // THEN
         assertEquals("crn:altus:iam:us-west-1:altus:role:DbusUploader", result);
-    }
-
-    @Test
-    public void testParseINI() throws IOException {
-        // GIVEN
-        StringReader srData = new StringReader("[default]\naltus_access_key_id=accesKey\naltus_private_key=privateKey");
-        // WHEN
-        Map<String, Properties> result = underTest.parseINI(srData);
-        // THEN
-        assertTrue(result.containsKey("default"));
-        assertEquals(result.get("default").getProperty("altus_access_key_id"), "accesKey");
-        assertEquals(result.get("default").getProperty("altus_private_key"), "privateKey");
     }
 }

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerMgmtTelemetryServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerMgmtTelemetryServiceTest.java
@@ -129,7 +129,7 @@ public class ClouderaManagerMgmtTelemetryServiceTest {
         stack.setCluster(cluster);
         WorkloadAnalytics wa = new WorkloadAnalytics();
         // WHEN
-        ApiConfigList result = underTest.buildTelemetryConfigList(stack, wa, null);
+        ApiConfigList result = underTest.buildTelemetryConfigList(stack, wa, null, null);
         // THEN
         assertEquals(1, result.getItems().size());
     }
@@ -146,11 +146,26 @@ public class ClouderaManagerMgmtTelemetryServiceTest {
         WorkloadAnalytics workloadAnalytics = new WorkloadAnalytics();
         workloadAnalytics.setDatabusEndpoint("customEndpoint");
         // WHEN
-        underTest.enrichWithSdxData(null, stack, workloadAnalytics, safetyValveMap);
+        underTest.enrichWithSdxData(null, null, stack, workloadAnalytics, safetyValveMap);
         // THEN
         assertTrue(safetyValveMap.containsKey("databus.header.sdx.id"));
         assertTrue(safetyValveMap.containsKey("databus.header.sdx.name"));
         assertEquals(safetyValveMap.get("databus.header.sdx.name"), "cl1-1");
+    }
+
+    @Test
+    public void testEnrichWithSdxDataWithExistingSdxData() {
+        // GIVEN
+        Map<String, String> safetyValveMap = new HashMap<>();
+        WorkloadAnalytics workloadAnalytics = new WorkloadAnalytics();
+        workloadAnalytics.setDatabusEndpoint("customEndpoint");
+        // WHEN
+        underTest.enrichWithSdxData("mySdxName", "crn:altus:iam:us-west-1:accountId:user:mySdxId", null, workloadAnalytics, safetyValveMap);
+        // THEN
+        assertTrue(safetyValveMap.containsKey("databus.header.sdx.id"));
+        assertTrue(safetyValveMap.containsKey("databus.header.sdx.name"));
+        assertEquals(safetyValveMap.get("databus.header.sdx.id"), "mySdxId");
+        assertEquals(safetyValveMap.get("databus.header.sdx.name"), "mySdxName");
     }
 
     @Test
@@ -169,7 +184,7 @@ public class ClouderaManagerMgmtTelemetryServiceTest {
         workloadAnalytics.setDatabusEndpoint("customEndpoint");
         workloadAnalytics.setAttributes(attributes);
         // WHEN
-        underTest.enrichWithSdxData(null, stack, workloadAnalytics, safetyValveMap);
+        underTest.enrichWithSdxData(null, null, stack, workloadAnalytics, safetyValveMap);
         // THEN
         assertEquals(safetyValveMap.get("databus.header.sdx.id"), "mySdxId");
         assertEquals(safetyValveMap.get("databus.header.sdx.name"), "mySdxName");

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.converter.v4.stacks;
 
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.common.api.telemetry.model.Logging;
@@ -11,6 +13,17 @@ import com.sequenceiq.common.api.telemetry.response.WorkloadAnalyticsResponse;
 
 @Component
 public class TelemetryConverter {
+
+    private final boolean telemetryPublisherEnabled;
+
+    private final String databusEndpoint;
+
+    public TelemetryConverter(
+            @Value("${cb.cm.telemetrypublisher.enabled:false}") boolean telemetryPublisherEnabled,
+            @Value("${altus.databus.endpoint:}") String databusEndpoint) {
+        this.telemetryPublisherEnabled = telemetryPublisherEnabled;
+        this.databusEndpoint = databusEndpoint;
+    }
 
     public TelemetryResponse convert(Telemetry telemetry) {
         TelemetryResponse response = null;
@@ -54,6 +67,11 @@ public class TelemetryConverter {
                 workloadAnalytics = new WorkloadAnalytics();
                 workloadAnalytics.setAttributes(waResponse.getAttributes());
                 workloadAnalytics.setDatabusEndpoint(waResponse.getDatabusEndpoint());
+            } else if (telemetryPublisherEnabled) {
+                workloadAnalytics = new WorkloadAnalytics();
+                if (StringUtils.isNotEmpty(databusEndpoint)) {
+                    workloadAnalytics.setDatabusEndpoint(databusEndpoint);
+                }
             }
             telemetry = new Telemetry(logging, workloadAnalytics);
         }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.converter.v4.stacks;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import com.sequenceiq.common.api.cloudstorage.S3CloudStorageV1Parameters;
@@ -10,12 +11,20 @@ import com.sequenceiq.common.api.telemetry.model.Logging;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
 import com.sequenceiq.common.api.telemetry.response.LoggingResponse;
 import com.sequenceiq.common.api.telemetry.response.TelemetryResponse;
+import com.sequenceiq.common.api.telemetry.response.WorkloadAnalyticsResponse;
 
 public class TelemetryConverterTest {
 
     private static final String INSTANCE_PROFILE_VALUE = "myInstanceProfile";
 
-    private final TelemetryConverter underTest = new TelemetryConverter();
+    private static final String DATABUS_ENDPOINT = "myCustomEndpoint";
+
+    private TelemetryConverter underTest;
+
+    @Before
+    public void setUp() {
+        underTest = new TelemetryConverter(true, DATABUS_ENDPOINT);
+    }
 
     @Test
     public void testConvertToResponse() {
@@ -27,6 +36,20 @@ public class TelemetryConverterTest {
         Telemetry telemetry = new Telemetry(logging, null);
         // WHEN
         TelemetryResponse result = underTest.convert(telemetry);
+        // THEN
+        assertEquals(INSTANCE_PROFILE_VALUE, result.getLogging().getS3().getInstanceProfile());
+    }
+
+    @Test
+    public void testConvertToResponseWithoutWA() {
+        // GIVEN
+        Logging logging = new Logging();
+        S3CloudStorageV1Parameters s3Params = new S3CloudStorageV1Parameters();
+        s3Params.setInstanceProfile(INSTANCE_PROFILE_VALUE);
+        logging.setS3(s3Params);
+        Telemetry telemetry = new Telemetry(logging, null);
+        // WHEN
+        TelemetryResponse result = new TelemetryConverter(false, DATABUS_ENDPOINT).convert(telemetry);
         // THEN
         assertEquals(INSTANCE_PROFILE_VALUE, result.getLogging().getS3().getInstanceProfile());
         assertNull(result.getWorkloadAnalytics());
@@ -45,6 +68,25 @@ public class TelemetryConverterTest {
         Telemetry result = underTest.convert(response);
         // THEN
         assertEquals(INSTANCE_PROFILE_VALUE, result.getLogging().getS3().getInstanceProfile());
-        assertNull(result.getWorkloadAnalytics());
+        assertEquals(DATABUS_ENDPOINT, result.getWorkloadAnalytics().getDatabusEndpoint());
+    }
+
+    @Test
+    public void testConvertFromResponseWithWARequest() {
+        // GIVEN
+        TelemetryResponse response = new TelemetryResponse();
+        LoggingResponse loggingResponse = new LoggingResponse();
+        S3CloudStorageV1Parameters s3Params = new S3CloudStorageV1Parameters();
+        s3Params.setInstanceProfile(INSTANCE_PROFILE_VALUE);
+        loggingResponse.setS3(s3Params);
+        response.setLogging(loggingResponse);
+        WorkloadAnalyticsResponse waResponse = new WorkloadAnalyticsResponse();
+        waResponse.setDatabusEndpoint("myOtherEndpoint");
+        response.setWorkloadAnalytics(waResponse);
+        // WHEN
+        Telemetry result = underTest.convert(response);
+        // THEN
+        assertEquals(INSTANCE_PROFILE_VALUE, result.getLogging().getS3().getInstanceProfile());
+        assertEquals("myOtherEndpoint", result.getWorkloadAnalytics().getDatabusEndpoint());
     }
 }

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterDetailResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterDetailResponse.java
@@ -12,7 +12,8 @@ public class SdxClusterDetailResponse extends SdxClusterResponse {
     public SdxClusterDetailResponse(SdxClusterResponse sdxClusterResponse, StackV4Response stackV4Response) {
         super(sdxClusterResponse.getCrn(), sdxClusterResponse.getName(), sdxClusterResponse.getStatus(),
                 sdxClusterResponse.getStatusReason(), sdxClusterResponse.getEnvironmentName(),
-                sdxClusterResponse.getEnvironmentCrn(), sdxClusterResponse.getClusterShape());
+                sdxClusterResponse.getEnvironmentCrn(), sdxClusterResponse.getStackCrn(),
+                sdxClusterResponse.getClusterShape());
         this.stackV4Response = stackV4Response;
     }
 

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterResponse.java
@@ -16,17 +16,21 @@ public class SdxClusterResponse {
 
     private String environmentCrn;
 
+    private String stackCrn;
+
     public SdxClusterResponse() {
     }
 
     public SdxClusterResponse(String crn, String name, SdxClusterStatusResponse status,
-            String statusReason, String environmentName, String environmentCrn, SdxClusterShape clusterShape) {
+            String statusReason, String environmentName, String environmentCrn, String stackCrn,
+            SdxClusterShape clusterShape) {
         this.crn = crn;
         this.name = name;
         this.status = status;
         this.statusReason = statusReason;
         this.environmentName = environmentName;
         this.environmentCrn = environmentCrn;
+        this.stackCrn = stackCrn;
         this.clusterShape = clusterShape;
     }
 
@@ -84,5 +88,13 @@ public class SdxClusterResponse {
 
     public void setStatusReason(String statusReason) {
         this.statusReason = statusReason;
+    }
+
+    public String getStackCrn() {
+        return stackCrn;
+    }
+
+    public void setStackCrn(String stackCrn) {
+        this.stackCrn = stackCrn;
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxClusterConverter.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxClusterConverter.java
@@ -20,6 +20,7 @@ public class SdxClusterConverter {
         sdxClusterResponse.setClusterShape(sdxCluster.getClusterShape());
         sdxClusterResponse.setEnvironmentName(sdxCluster.getEnvName());
         sdxClusterResponse.setEnvironmentCrn(sdxCluster.getEnvCrn());
+        sdxClusterResponse.setStackCrn(sdxCluster.getStackCrn());
         return sdxClusterResponse;
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/entity/SdxCluster.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/entity/SdxCluster.java
@@ -47,6 +47,8 @@ public class SdxCluster implements AccountIdAwareResource {
     @NotNull
     private String envCrn;
 
+    private String stackCrn;
+
     @NotNull
     @Enumerated(EnumType.STRING)
     private SdxClusterShape clusterShape;
@@ -192,5 +194,13 @@ public class SdxCluster implements AccountIdAwareResource {
 
     public void setStatusReason(String statusReason) {
         this.statusReason = statusReason;
+    }
+
+    public String getStackCrn() {
+        return stackCrn;
+    }
+
+    public void setStackCrn(String stackCrn) {
+        this.stackCrn = stackCrn;
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/ProvisionerService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/ProvisionerService.java
@@ -106,6 +106,7 @@ public class ProvisionerService {
                         .stackV4Endpoint()
                         .post(0L, JsonUtil.readValue(sdxCluster.getStackRequestToCloudbreak(), StackV4Request.class));
                 sdxCluster.setStackId(stackV4Response.getId());
+                sdxCluster.setStackCrn(stackV4Response.getCrn());
                 sdxCluster.setStatus(SdxClusterStatus.REQUESTED_FROM_CLOUDBREAK);
                 sdxClusterRepository.save(sdxCluster);
                 LOGGER.info("Sdx cluster updated");

--- a/datalake/src/main/resources/schema/mybatis/20190718101135_add_sdx_crn.sql
+++ b/datalake/src/main/resources/schema/mybatis/20190718101135_add_sdx_crn.sql
@@ -1,0 +1,9 @@
+-- // DISTX-258 Store sdx crn on stack side
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE sdxcluster ADD COLUMN IF NOT EXISTS stackCrn TEXT;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE sdxcluster DROP COLUMN IF EXISTS stackCrn;

--- a/mock-caas/src/main/java/com/sequenceiq/caas/util/IniUtil.java
+++ b/mock-caas/src/main/java/com/sequenceiq/caas/util/IniUtil.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.caas.util;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class IniUtil {
+
+    public Map<String, Properties> parseIni(Reader reader) throws IOException {
+        Map<String, Properties> result = new HashMap<>();
+        new Properties() {
+
+            private Properties section;
+
+            @Override
+            public Object put(Object key, Object value) {
+                String header = String.format("%s %s", key, value).trim();
+                if (header.startsWith("[") && header.endsWith("]")) {
+                    section = new Properties();
+                    return result.put(header.substring(1, header.length() - 1), section);
+                } else {
+                    return section.put(key, value);
+                }
+            }
+
+            @Override
+            public synchronized boolean equals(Object o) {
+                return super.equals(o);
+            }
+
+            @Override
+            public synchronized int hashCode() {
+                return super.hashCode();
+            }
+        }.load(reader);
+        return result;
+    }
+
+}

--- a/mock-caas/src/main/resources/application.yml
+++ b/mock-caas/src/main/resources/application.yml
@@ -3,3 +3,6 @@ auth:
     file: license.txt
   config:
     dir: /etc/auth
+  altus:
+    credential:
+      file: altus_credentials

--- a/mock-caas/src/test/java/com/sequenceiq/caas/grpc/service/MockUserManagementServiceTest.java
+++ b/mock-caas/src/test/java/com/sequenceiq/caas/grpc/service/MockUserManagementServiceTest.java
@@ -1,6 +1,9 @@
 package com.sequenceiq.caas.grpc.service;
 
-import com.sequenceiq.caas.util.JsonUtil;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -9,9 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import com.sequenceiq.caas.util.JsonUtil;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MockUserManagementServiceTest {
@@ -31,7 +32,7 @@ public class MockUserManagementServiceTest {
         Path licenseFilePath = Files.createTempFile("license", "txt");
         Files.writeString(licenseFilePath, VALID_LICENSE);
         ReflectionTestUtils.setField(underTest, "cbLicenseFilePath", licenseFilePath.toString());
-        underTest.setLicense();
+        underTest.init();
 
         String actual = ReflectionTestUtils.getField(underTest, "cbLicense").toString();
 
@@ -42,7 +43,7 @@ public class MockUserManagementServiceTest {
     @Test
     public void testSetLicenseShouldEmptyStringWhenTheFileIsNotExists() {
         ReflectionTestUtils.setField(underTest, "cbLicenseFilePath", "/etc/license");
-        underTest.setLicense();
+        underTest.init();
 
         String actual = ReflectionTestUtils.getField(underTest, "cbLicense").toString();
 

--- a/mock-caas/src/test/java/com/sequenceiq/caas/util/IniUtilTest.java
+++ b/mock-caas/src/test/java/com/sequenceiq/caas/util/IniUtilTest.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.caas.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.Test;
+
+public class IniUtilTest {
+
+    private final IniUtil underTest = new IniUtil();
+
+    @Test
+    public void testParseIniFromReader() throws IOException {
+        // GIVEN
+        StringReader srData = new StringReader("[default]\naltus_access_key_id=accesKey\naltus_private_key=privateKey");
+        // WHEN
+        Map<String, Properties> result = underTest.parseIni(srData);
+        // THEN
+        assertTrue(result.containsKey("default"));
+        assertEquals(result.get("default").getProperty("altus_access_key_id"), "accesKey");
+        assertEquals(result.get("default").getProperty("altus_private_key"), "privateKey");
+    }
+}


### PR DESCRIPTION
Contains a few changes:
- move altus credential reading to auth mock side (so from that point you will be able to provide your altus secret / access keypair for auth app - so the mock will send that back if you will try to create a keypair )
- use sdx STACK crn tp gather sdx id for telemetry publisher (also store sdx crn on stack side - nullable)
- installing telemetry publisher feature can be enabled by default without providing in the request (of course using in the request can install it even if it is disabled...it makes sense as this way as you can install TP manually anyway if you go to CM UI)