### PR TITLE
Revert CDPSDX-595 and do not use vault to store keytabs

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/kerberos/KeytabConfigurationHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/kerberos/KeytabConfigurationHandler.java
@@ -25,7 +25,6 @@ import com.sequenceiq.cloudbreak.reactor.api.event.kerberos.KeytabConfigurationF
 import com.sequenceiq.cloudbreak.reactor.api.event.kerberos.KeytabConfigurationRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.kerberos.KeytabConfigurationSuccess;
 import com.sequenceiq.cloudbreak.service.GatewayConfigService;
-import com.sequenceiq.cloudbreak.service.secret.service.SecretService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.template.kerberos.KerberosDetailService;
 import com.sequenceiq.flow.event.EventSelectorUtil;
@@ -64,9 +63,6 @@ public class KeytabConfigurationHandler implements EventHandler<KeytabConfigurat
     @Inject
     private HostOrchestrator hostOrchestrator;
 
-    @Inject
-    private SecretService secretService;
-
     @Override
     public String selector() {
         return EventSelectorUtil.selector(KeytabConfigurationRequest.class);
@@ -97,9 +93,9 @@ public class KeytabConfigurationHandler implements EventHandler<KeytabConfigurat
     }
 
     private KeytabModel buildKeytabModel(ServiceKeytabResponse serviceKeytabResponse) {
-        String keytabInBase64 = secretService.getByResponse(serviceKeytabResponse.getKeytab());
+        String keytabInBase64 = serviceKeytabResponse.getKeytab();
         byte[] keytab = Base64.getDecoder().decode(keytabInBase64.getBytes(StandardCharsets.UTF_8));
-        String principal = secretService.getByResponse(serviceKeytabResponse.getServicePrincial());
+        String principal = serviceKeytabResponse.getServicePrincipal();
         return new KeytabModel("CM", "/etc/cloudera-scm-server", "cmf.keytab", principal, keytab);
     }
 

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/doc/KeytabModelDescription.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/doc/KeytabModelDescription.java
@@ -5,7 +5,7 @@ public class KeytabModelDescription {
     public static final String SERVICE_HOST = "Hostname where the service is running";
     public static final String ID = "Unique Request Id";
     public static final String PRINCIPAL = "Kerberos Service Principal Name";
-    public static final String KEYTAB = "Keytab that was requested";
+    public static final String KEYTAB = "Keytab that was requested base64 encoded";
     public static final String DO_NOT_RECREATE_KEYTAB = "If true existing keytab won't be overriden for service in normal scenario. "
             + "Preserving the keytab is best effort, it may invalidate prior keytabs.";
     public static final String ROLE = "Role request for adding roles and privileges to service";

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/model/ServiceKeytabResponse.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/model/ServiceKeytabResponse.java
@@ -2,7 +2,6 @@ package com.sequenceiq.freeipa.api.v1.kerberosmgmt.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.doc.KeytabModelDescription;
-import com.sequenceiq.cloudbreak.service.secret.model.SecretResponse;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -12,24 +11,24 @@ import io.swagger.annotations.ApiModelProperty;
 public class ServiceKeytabResponse {
 
     @ApiModelProperty (KeytabModelDescription.PRINCIPAL)
-    private SecretResponse servicePrincial;
+    private String servicePrincipal;
 
     @ApiModelProperty (KeytabModelDescription.KEYTAB)
-    private SecretResponse keytab;
+    private String keytab;
 
-    public SecretResponse getServicePrincial() {
-        return servicePrincial;
+    public String getServicePrincipal() {
+        return servicePrincipal;
     }
 
-    public void setServicePrincial(SecretResponse servicePrincial) {
-        this.servicePrincial = servicePrincial;
+    public void setServicePrincipal(String servicePrincipal) {
+        this.servicePrincipal = servicePrincipal;
     }
 
-    public SecretResponse getKeytab() {
+    public String getKeytab() {
         return keytab;
     }
 
-    public void setKeytab(SecretResponse keytab) {
+    public void setKeytab(String keytab) {
         this.keytab = keytab;
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/KerberosMgmtV1Service.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/KerberosMgmtV1Service.java
@@ -2,7 +2,6 @@ package com.sequenceiq.freeipa.kerberosmgmt.v1;
 
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -14,9 +13,6 @@ import org.springframework.stereotype.Service;
 
 import com.google.common.base.Strings;
 import com.googlecode.jsonrpc4j.JsonRpcClientException;
-import com.sequenceiq.cloudbreak.service.secret.model.SecretResponse;
-import com.sequenceiq.cloudbreak.service.secret.model.StringToSecretResponseConverter;
-import com.sequenceiq.cloudbreak.service.secret.service.SecretService;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.model.HostRequest;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.model.RoleRequest;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.model.ServiceKeytabRequest;
@@ -50,8 +46,6 @@ public class KerberosMgmtV1Service {
 
     private static final String KEYTAB_FETCH_FAILED = "Failed to fetch keytab.";
 
-    private static final String VAULT_UPDATE_FAILED = "Failed to update Vault.";
-
     private static final String EMPTY_REALM = "Failed to create service as realm was empty.";
 
     private static final String IPA_STACK_NOT_FOUND = "Stack for IPA server not found.";
@@ -66,12 +60,6 @@ public class KerberosMgmtV1Service {
 
     @Inject
     private FreeIpaClientFactory freeIpaClientFactory;
-
-    @Inject
-    private SecretService secretService;
-
-    @Inject
-    private StringToSecretResponseConverter stringToSecretResponseConverter;
 
     public ServiceKeytabResponse generateServiceKeytab(ServiceKeytabRequest request, String accountId) throws FreeIpaClientException {
         LOGGER.debug("Request to generate keytab for Service:{} Host:{} in Environment:{}", request.getServiceName(), request.getServerHostName(),
@@ -89,8 +77,8 @@ public class KerberosMgmtV1Service {
         } else {
             serviceKeytab = getServiceKeytab(service.getKrbprincipalname(), ipaClient);
         }
-        response.setKeytab(getSecretResponseForKeytab(accountId, serviceKeytab));
-        response.setServicePrincial(getSecretResponseForPrincipal(accountId, service.getKrbprincipalname()));
+        response.setKeytab(serviceKeytab);
+        response.setServicePrincipal(service.getKrbprincipalname());
         return response;
     }
 
@@ -103,8 +91,8 @@ public class KerberosMgmtV1Service {
 
         String servicePrincipal = request.getServiceName() + "/" + request.getServerHostName() + "@" + realm;
         String serviceKeytab = getExistingServiceKeytab(servicePrincipal, ipaClient);
-        response.setKeytab(getSecretResponseForKeytab(accountId, serviceKeytab));
-        response.setServicePrincial(getSecretResponseForPrincipal(accountId, servicePrincipal));
+        response.setKeytab(serviceKeytab);
+        response.setServicePrincipal(servicePrincipal);
         return response;
     }
 
@@ -237,32 +225,5 @@ public class KerberosMgmtV1Service {
                 .map(JsonRpcClientException::getCode)
                 .filter(c -> c == DUPLICATE_ENTRY_ERROR_CODE)
                 .isPresent();
-    }
-
-    private SecretResponse getSecretResponseForPrincipal(String accountId, String principal) {
-        try {
-            String path = constructVaultPath(accountId, "ServiceKeytab", "serviceprincipal");
-            String secret = secretService.put(path, principal);
-            return stringToSecretResponseConverter.convert(secret);
-        } catch (Exception exception) {
-            LOGGER.warn("Failure while updating vault.", exception);
-            throw new KeytabCreationException(VAULT_UPDATE_FAILED);
-        }
-    }
-
-    private SecretResponse getSecretResponseForKeytab(String accountId, String keytab) {
-        try {
-            String path = constructVaultPath(accountId, "ServiceKeytab", "keytab");
-            String secret = secretService.put(path, keytab);
-            return stringToSecretResponseConverter.convert(secret);
-        } catch (Exception exception) {
-            LOGGER.warn("Failure while updating vault.", exception);
-            throw new KeytabCreationException(VAULT_UPDATE_FAILED);
-        }
-    }
-
-    private String constructVaultPath(String accountId, String type, String subtype) {
-        return String.format("%s/%s/%s/%s-%s", accountId, type, subtype,
-                UUID.randomUUID().toString(), Long.toHexString(System.currentTimeMillis()));
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/kerberosmgmt/KerberosMgmtV1ServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/kerberosmgmt/KerberosMgmtV1ServiceTest.java
@@ -13,13 +13,9 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
-import com.sequenceiq.cloudbreak.service.secret.model.SecretResponse;
-import com.sequenceiq.cloudbreak.service.secret.model.StringToSecretResponseConverter;
-import com.sequenceiq.cloudbreak.service.secret.service.SecretService;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.model.ServiceKeytabRequest;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.model.ServiceKeytabResponse;
 import com.sequenceiq.freeipa.client.FreeIpaClient;
-import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.client.model.Host;
 import com.sequenceiq.freeipa.client.model.Keytab;
 import com.sequenceiq.freeipa.client.model.Service;
@@ -48,8 +44,6 @@ public class KerberosMgmtV1ServiceTest {
 
     private static final String SERVICE_PRINCIPAL = "principal";
 
-    private static final String SECRET = "secret";
-
     private static FreeIpa freeIpa;
 
     private static Stack stack;
@@ -59,8 +53,6 @@ public class KerberosMgmtV1ServiceTest {
     private static Service service;
 
     private static Keytab keytab;
-
-    private static FreeIpaClientException ipaClientException;
 
     @Mock
     private StackService stackService;
@@ -73,12 +65,6 @@ public class KerberosMgmtV1ServiceTest {
 
     @Mock
     private ThreadBasedUserCrnProvider threadBaseUserCrnProvider;
-
-    @Mock
-    private StringToSecretResponseConverter stringToSecretResponseConverter;
-
-    @Mock
-    private SecretService secretService;
 
     @InjectMocks
     private KerberosMgmtV1Service underTest;
@@ -95,7 +81,6 @@ public class KerberosMgmtV1ServiceTest {
         service.setKrbprincipalname(SERVICE_PRINCIPAL);
         keytab = new Keytab();
         keytab.setKeytab(KEYTAB);
-        ipaClientException = new FreeIpaClientException("failure");
     }
 
     @Test
@@ -122,7 +107,6 @@ public class KerberosMgmtV1ServiceTest {
         Mockito.reset(freeIpaService);
         Mockito.when(freeIpaService.findByStack(any())).thenReturn(freeIpa);
         Mockito.when(freeIpaClientFactory.getFreeIpaClientForStack(any())).thenReturn(mockIpaClient);
-        Mockito.when(mockIpaClient.getExistingKeytab(anyString())).thenReturn(new Keytab());
         try {
             underTest.getExistingServiceKeytab(request, ACCOUNT_ID);
         } catch (RuntimeException exp) {
@@ -154,24 +138,18 @@ public class KerberosMgmtV1ServiceTest {
         Mockito.reset(freeIpaService);
         Mockito.when(freeIpaService.findByStack(any())).thenReturn(freeIpa);
         Mockito.when(freeIpaClientFactory.getFreeIpaClientForStack(any())).thenReturn(mockIpaClient);
-        Mockito.when(mockIpaClient.addHost(anyString())).thenThrow(ipaClientException);
         try {
-
             underTest.generateServiceKeytab(request, ACCOUNT_ID);
         } catch (RuntimeException exp) {
             Assert.assertEquals("Failed to create host.", exp.getMessage());
         }
-        Mockito.reset(mockIpaClient);
         Mockito.when(mockIpaClient.addHost(anyString())).thenReturn(host);
-        Mockito.when(mockIpaClient.addService(anyString())).thenThrow(ipaClientException);
         try {
             underTest.generateServiceKeytab(request, ACCOUNT_ID);
         } catch (RuntimeException exp) {
             Assert.assertEquals("Failed to create service principal.", exp.getMessage());
         }
-        Mockito.reset(mockIpaClient);
         Mockito.when(mockIpaClient.addService(anyString())).thenReturn(service);
-        Mockito.when(mockIpaClient.getKeytab(anyString())).thenThrow(ipaClientException);
         try {
             underTest.generateServiceKeytab(request, ACCOUNT_ID);
         } catch (RuntimeException exp) {
@@ -188,15 +166,13 @@ public class KerberosMgmtV1ServiceTest {
         Mockito.when(mockIpaClient.addHost(anyString())).thenReturn(host);
         Mockito.when(mockIpaClient.addService(anyString())).thenReturn(service);
         Mockito.when(mockIpaClient.getKeytab(anyString())).thenReturn(keytab);
-        Mockito.when(secretService.put(anyString(), anyString())).thenReturn(SECRET);
-        Mockito.when(stringToSecretResponseConverter.convert(SECRET)).thenReturn(new SecretResponse());
         ServiceKeytabRequest request = new ServiceKeytabRequest();
         request.setServiceName(USERCRN);
         request.setEnvironmentCrn(ENVIRONMENT_ID);
         request.setServerHostName(HOST);
         ServiceKeytabResponse resp = underTest.generateServiceKeytab(request, ACCOUNT_ID);
-        Assert.assertNotNull(resp.getKeytab());
-        Assert.assertNotNull(resp.getServicePrincial());
+        Assert.assertEquals(resp.getKeytab(), "keytab");
+        Assert.assertEquals(resp.getServicePrincipal(), SERVICE_PRINCIPAL);
     }
 
     @Test
@@ -206,13 +182,11 @@ public class KerberosMgmtV1ServiceTest {
         Mockito.when(freeIpaService.findByStack(any())).thenReturn(freeIpa);
         Mockito.when(freeIpaClientFactory.getFreeIpaClientForStack(any())).thenReturn(mockIpaClient);
         Mockito.when(mockIpaClient.getExistingKeytab(anyString())).thenReturn(keytab);
-        Mockito.when(secretService.put(anyString(), anyString())).thenReturn(SECRET);
-        Mockito.when(stringToSecretResponseConverter.convert(SECRET)).thenReturn(new SecretResponse());
         ServiceKeytabRequest request = new ServiceKeytabRequest();
         request.setServiceName(USERCRN);
         request.setEnvironmentCrn(ENVIRONMENT_ID);
         request.setServerHostName(HOST);
         ServiceKeytabResponse resp = underTest.getExistingServiceKeytab(request, ACCOUNT_ID);
-        Assert.assertNotNull(resp.getKeytab());
+        Assert.assertEquals(resp.getKeytab(), KEYTAB);
     }
 }


### PR DESCRIPTION
Previously, keytabs were stored in the control plane's vault and this
was used to distribute the keytabs between control plane services. It
is not necessary to store keytabs anywhere in the control plane. The
fewer places they are stored, the better. If a new keytab is needed
the client can make another request. All API calls to these keytab
retrieval APIs originate from the control plane which is assumed to
be trusted.

As a result, the keytabs and kerberos service principals are directly
returned to the client in the response.

This was manually tested to validate that vault is no longer used for
the service principal and keytab in the response.