### PR TITLE
CB-2434 Add settings for AWS mappings

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/StackToTemplatePreparationObjectConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/StackToTemplatePreparationObjectConverter.java
@@ -122,6 +122,7 @@ public class StackToTemplatePreparationObjectConverter extends AbstractConversio
                 gatewaySignKey = gateway.getSignKey();
             }
             Builder builder = Builder.builder()
+                    .withCloudPlatform(CloudPlatform.valueOf(source.getCloudPlatform()))
                     .withRdsConfigs(postgresConfigService.createRdsConfigIfNeeded(source, cluster))
                     .withHostgroups(hostGroupService.getByCluster(cluster.getId()))
                     .withGateway(gateway, gatewaySignKey)

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToTemplatePreparationObjectConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToTemplatePreparationObjectConverter.java
@@ -152,6 +152,7 @@ public class StackV4RequestToTemplatePreparationObjectConverter extends Abstract
                 gatewaySignKey = gateway.getSignKey();
             }
             Builder builder = Builder.builder()
+                    .withCloudPlatform(source.getCloudPlatform())
                     .withRdsConfigs(rdsConfigs)
                     .withHostgroupViews(hostgroupViews)
                     .withGateway(gateway, gatewaySignKey)

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v2/StackToTemplatePreparationObjectConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v2/StackToTemplatePreparationObjectConverterTest.java
@@ -35,12 +35,12 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.blueprint.GeneralClusterConfigsProvider;
 import com.sequenceiq.cloudbreak.blueprint.nifi.HdfConfigProvider;
 import com.sequenceiq.cloudbreak.blueprint.sharedservice.SharedServiceConfigsViewProvider;
-import com.sequenceiq.cloudbreak.blueprint.utils.StackInfoService;
 import com.sequenceiq.cloudbreak.cloud.model.StackInputs;
 import com.sequenceiq.cloudbreak.cloud.model.component.StackRepoDetails;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.common.user.CloudbreakUser;
 import com.sequenceiq.cloudbreak.converter.StackToTemplatePreparationObjectConverter;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.container.postgres.PostgresConfigService;
@@ -64,11 +64,9 @@ import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
 import com.sequenceiq.cloudbreak.service.environment.credential.CredentialConverter;
 import com.sequenceiq.cloudbreak.service.hostgroup.HostGroupService;
 import com.sequenceiq.cloudbreak.service.identitymapping.AwsMockIdentityMappingService;
-import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.filesystem.BaseFileSystemConfigurationsView;
 import com.sequenceiq.cloudbreak.template.filesystem.FileSystemConfigurationProvider;
-import com.sequenceiq.cloudbreak.template.model.BlueprintStackInfo;
 import com.sequenceiq.cloudbreak.template.model.GeneralClusterConfigs;
 import com.sequenceiq.cloudbreak.template.model.HdfConfigs;
 import com.sequenceiq.cloudbreak.template.views.BlueprintView;
@@ -108,9 +106,6 @@ public class StackToTemplatePreparationObjectConverterTest {
     private InstanceGroupMetadataCollector instanceGroupMetadataCollector;
 
     @Mock
-    private StackInfoService stackInfoService;
-
-    @Mock
     private HdfConfigProvider hdfConfigProvider;
 
     @Mock
@@ -118,9 +113,6 @@ public class StackToTemplatePreparationObjectConverterTest {
 
     @Mock
     private FileSystemConfigurationProvider fileSystemConfigurationProvider;
-
-    @Mock
-    private StackService stackService;
 
     @Mock
     private ClusterService clusterService;
@@ -154,9 +146,6 @@ public class StackToTemplatePreparationObjectConverterTest {
 
     @Mock
     private Json stackInputs;
-
-    @Mock
-    private BlueprintStackInfo blueprintStackInfo;
 
     @Mock
     private BlueprintViewProvider blueprintViewProvider;
@@ -197,7 +186,6 @@ public class StackToTemplatePreparationObjectConverterTest {
         when(blueprint.getBlueprintText()).thenReturn(TEST_BLUEPRINT_TEXT);
         when(stackMock.getInputs()).thenReturn(stackInputs);
         when(stackInputs.get(StackInputs.class)).thenReturn(null);
-        when(stackInfoService.blueprintStackInfo(TEST_BLUEPRINT_TEXT)).thenReturn(blueprintStackInfo);
         Credential credential = Credential.builder()
                 .crn("aCredentialCRN")
                 .attributes(new Json(""))
@@ -341,12 +329,8 @@ public class StackToTemplatePreparationObjectConverterTest {
     }
 
     @Test
-    public void testConvertWhenProvidingStackAndBlueprintStackInfoThenExpectedBlueprintViewShouldBeStored() {
-        String type = "HDF";
-        String version = "2.6";
+    public void testConvertBlueprintViewShouldMatch() {
         BlueprintView expected = mock(BlueprintView.class);
-        when(blueprintStackInfo.getType()).thenReturn(type);
-        when(blueprintStackInfo.getVersion()).thenReturn(version);
         when(blueprintViewProvider.getBlueprintView(blueprint)).thenReturn(expected);
 
         TemplatePreparationObject result = underTest.convert(stackMock);
@@ -413,6 +397,12 @@ public class StackToTemplatePreparationObjectConverterTest {
         expectedException.expectCause(is(invokedException));
 
         underTest.convert(stackMock);
+    }
+
+    @Test
+    public void testConvertCloudPlatformMatches() {
+        TemplatePreparationObject result = underTest.convert(stackMock);
+        assertEquals(CloudPlatform.AWS, result.getCloudPlatform());
     }
 
     @Test

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxIdBrokerConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxIdBrokerConfigProvider.java
@@ -1,0 +1,91 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.knox;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.knox.KnoxRoles.IDBROKER;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.knox.KnoxRoles.KNOX;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRoleConfigProvider;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.common.api.filesystem.FileSystemType;
+
+@Component
+public class KnoxIdBrokerConfigProvider extends AbstractRoleConfigProvider {
+
+    private static final Map<String, CloudPlatform> FILE_SYSTEM_TYPE_TO_CLOUD_PLATFORM_MAP = Map.ofEntries(
+            Map.entry(FileSystemType.S3.name(), CloudPlatform.AWS),
+            Map.entry(FileSystemType.ADLS.name(), CloudPlatform.AZURE),
+            Map.entry(FileSystemType.ADLS_GEN_2.name(), CloudPlatform.AZURE),
+            Map.entry(FileSystemType.WASB.name(), CloudPlatform.AZURE),
+            Map.entry(FileSystemType.WASB_INTEGRATED.name(), CloudPlatform.AZURE),
+            Map.entry(FileSystemType.GCS.name(), CloudPlatform.GCP)
+    );
+
+    @Override
+    protected List<ApiClusterTemplateConfig> getRoleConfigs(String roleType, TemplatePreparationObject source) {
+        switch (roleType) {
+            case IDBROKER:
+                List<ApiClusterTemplateConfig> config;
+                String userMapping = getIdentityMapping(source.getIdentityUserMapping());
+                String groupMapping = getIdentityMapping(source.getIdentityGroupMapping());
+                switch (getCloudPlatform(source)) {
+                    case AWS:
+                        config = List.of(config("idbroker_aws_user_mapping", userMapping),
+                                config("idbroker_aws_group_mapping", groupMapping));
+                        break;
+                    case AZURE:
+                        config = List.of(config("idbroker_azure_user_mapping", userMapping),
+                                config("idbroker_azure_group_mapping", groupMapping));
+                        break;
+                    case GCP:
+                        config = List.of(config("idbroker_gcp_user_mapping", userMapping),
+                                config("idbroker_gcp_group_mapping", groupMapping));
+                        break;
+                    default:
+                        config = List.of();
+                        break;
+                }
+                return config;
+            default:
+                return List.of();
+        }
+    }
+
+    private String getIdentityMapping(Map<String, String> identityMapping) {
+        return identityMapping.entrySet().stream()
+                .map(e -> String.format("%s=%s", e.getKey(), e.getValue()))
+                .collect(Collectors.joining(";"));
+    }
+
+    private CloudPlatform getCloudPlatform(TemplatePreparationObject source) {
+        CloudPlatform cloudPlatform;
+        if (source.getFileSystemConfigurationView().isPresent()) {
+            String fileSystemType = source.getFileSystemConfigurationView().get().getType();
+            cloudPlatform = FILE_SYSTEM_TYPE_TO_CLOUD_PLATFORM_MAP.get(fileSystemType);
+            if (cloudPlatform == null) {
+                throw new IllegalStateException("Unknown file system type: " + fileSystemType);
+            }
+        } else {
+            cloudPlatform = source.getCloudPlatform();
+        }
+        return cloudPlatform;
+    }
+
+    @Override
+    public String getServiceType() {
+        return KNOX;
+    }
+
+    @Override
+    public List<String> getRoleTypes() {
+        return List.of(IDBROKER);
+    }
+
+}

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxIdBrokerConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxIdBrokerConfigProviderTest.java
@@ -1,0 +1,343 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.knox;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigTestUtil.getConfigNameToValueMap;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigTestUtil.getConfigNameToVariableNameMap;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.knox.KnoxRoles.IDBROKER;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.knox.KnoxRoles.KNOX;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject.Builder;
+import com.sequenceiq.cloudbreak.template.filesystem.BaseFileSystemConfigurationsView;
+
+public class KnoxIdBrokerConfigProviderTest {
+
+    // Note: We need a predictable iteration order, so cannot rely on Map.ofEntries()
+    private static final Map<String, String> IDENTITY_USER_MAPPING = fixedIterationMapOfEntries(
+            Map.entry("user1", "role1"),
+            Map.entry("user2", "role2"),
+            Map.entry("user3", "role3")
+    );
+
+    private static final Map<String, String> IDENTITY_GROUP_MAPPING = fixedIterationMapOfEntries(
+            Map.entry("group4", "role4"),
+            Map.entry("group5", "role5")
+    );
+
+    private static final String IDENTITY_USER_MAPPING_STR = "user1=role1;user2=role2;user3=role3";
+
+    private static final String IDENTITY_GROUP_MAPPING_STR = "group4=role4;group5=role5";
+
+    private static final String IDBROKER_AWS_USER_MAPPING = "idbroker_aws_user_mapping";
+
+    private static final String IDBROKER_AWS_GROUP_MAPPING = "idbroker_aws_group_mapping";
+
+    private static final String IDBROKER_AZURE_USER_MAPPING = "idbroker_azure_user_mapping";
+
+    private static final String IDBROKER_AZURE_GROUP_MAPPING = "idbroker_azure_group_mapping";
+
+    private static final String IDBROKER_GCP_USER_MAPPING = "idbroker_gcp_user_mapping";
+
+    private static final String IDBROKER_GCP_GROUP_MAPPING = "idbroker_gcp_group_mapping";
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @InjectMocks
+    private KnoxIdBrokerConfigProvider underTest;
+
+    private static <K, V> Map<K, V> fixedIterationMapOfEntries(Map.Entry<K, V>... entries) {
+        Map<K, V> result = new LinkedHashMap<>();
+        Arrays.stream(entries).forEach(e -> result.put(e.getKey(), e.getValue()));
+        return result;
+    }
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void getRoleConfigWhenBadRole() {
+        TemplatePreparationObject tpo = new Builder()
+                .build();
+
+        List<ApiClusterTemplateConfig> result = underTest.getRoleConfigs("DUMMY", tpo);
+
+        Map<String, String> configNameToValueMap = getConfigNameToValueMap(result);
+        assertThat(configNameToValueMap).isEmpty();
+        Map<String, String> configNameToVariableNameMap = getConfigNameToVariableNameMap(result);
+        assertThat(configNameToVariableNameMap).isEmpty();
+    }
+
+    @Test
+    public void getRoleConfigWhenIdBrokerAndNoFileSystemAndAwsAndNoMappings() {
+        TemplatePreparationObject tpo = new Builder()
+                .withCloudPlatform(CloudPlatform.AWS)
+                .build();
+
+        List<ApiClusterTemplateConfig> result = underTest.getRoleConfigs(IDBROKER, tpo);
+
+        Map<String, String> configNameToValueMap = getConfigNameToValueMap(result);
+        assertThat(configNameToValueMap).containsOnly(
+                Map.entry(IDBROKER_AWS_USER_MAPPING, ""),
+                Map.entry(IDBROKER_AWS_GROUP_MAPPING, "")
+        );
+        Map<String, String> configNameToVariableNameMap = getConfigNameToVariableNameMap(result);
+        assertThat(configNameToVariableNameMap).isEmpty();
+    }
+
+    @Test
+    public void getRoleConfigWhenIdBrokerAndNoFileSystemAndAws() {
+        TemplatePreparationObject tpo = new Builder()
+                .withCloudPlatform(CloudPlatform.AWS)
+                .withIdentityUserMapping(IDENTITY_USER_MAPPING)
+                .withIdentityGroupMapping(IDENTITY_GROUP_MAPPING)
+                .build();
+
+        List<ApiClusterTemplateConfig> result = underTest.getRoleConfigs(IDBROKER, tpo);
+
+        Map<String, String> configNameToValueMap = getConfigNameToValueMap(result);
+        assertThat(configNameToValueMap).containsOnly(
+                Map.entry(IDBROKER_AWS_USER_MAPPING, IDENTITY_USER_MAPPING_STR),
+                Map.entry(IDBROKER_AWS_GROUP_MAPPING, IDENTITY_GROUP_MAPPING_STR)
+        );
+        Map<String, String> configNameToVariableNameMap = getConfigNameToVariableNameMap(result);
+        assertThat(configNameToVariableNameMap).isEmpty();
+    }
+
+    @Test
+    public void getRoleConfigWhenIdBrokerAndNoFileSystemAndAzure() {
+        TemplatePreparationObject tpo = new Builder()
+                .withCloudPlatform(CloudPlatform.AZURE)
+                .withIdentityUserMapping(IDENTITY_USER_MAPPING)
+                .withIdentityGroupMapping(IDENTITY_GROUP_MAPPING)
+                .build();
+
+        List<ApiClusterTemplateConfig> result = underTest.getRoleConfigs(IDBROKER, tpo);
+
+        Map<String, String> configNameToValueMap = getConfigNameToValueMap(result);
+        assertThat(configNameToValueMap).containsOnly(
+                Map.entry(IDBROKER_AZURE_USER_MAPPING, IDENTITY_USER_MAPPING_STR),
+                Map.entry(IDBROKER_AZURE_GROUP_MAPPING, IDENTITY_GROUP_MAPPING_STR)
+        );
+        Map<String, String> configNameToVariableNameMap = getConfigNameToVariableNameMap(result);
+        assertThat(configNameToVariableNameMap).isEmpty();
+    }
+
+    @Test
+    public void getRoleConfigWhenIdBrokerAndNoFileSystemAndGcp() {
+        TemplatePreparationObject tpo = new Builder()
+                .withCloudPlatform(CloudPlatform.GCP)
+                .withIdentityUserMapping(IDENTITY_USER_MAPPING)
+                .withIdentityGroupMapping(IDENTITY_GROUP_MAPPING)
+                .build();
+
+        List<ApiClusterTemplateConfig> result = underTest.getRoleConfigs(IDBROKER, tpo);
+
+        Map<String, String> configNameToValueMap = getConfigNameToValueMap(result);
+        assertThat(configNameToValueMap).containsOnly(
+                Map.entry(IDBROKER_GCP_USER_MAPPING, IDENTITY_USER_MAPPING_STR),
+                Map.entry(IDBROKER_GCP_GROUP_MAPPING, IDENTITY_GROUP_MAPPING_STR)
+        );
+        Map<String, String> configNameToVariableNameMap = getConfigNameToVariableNameMap(result);
+        assertThat(configNameToVariableNameMap).isEmpty();
+    }
+
+    @Test
+    public void getRoleConfigWhenIdBrokerAndNoFileSystemAndYarn() {
+        TemplatePreparationObject tpo = new Builder()
+                .withCloudPlatform(CloudPlatform.YARN)
+                .withIdentityUserMapping(IDENTITY_USER_MAPPING)
+                .withIdentityGroupMapping(IDENTITY_GROUP_MAPPING)
+                .build();
+
+        List<ApiClusterTemplateConfig> result = underTest.getRoleConfigs(IDBROKER, tpo);
+
+        Map<String, String> configNameToValueMap = getConfigNameToValueMap(result);
+        assertThat(configNameToValueMap).isEmpty();
+        Map<String, String> configNameToVariableNameMap = getConfigNameToVariableNameMap(result);
+        assertThat(configNameToVariableNameMap).isEmpty();
+    }
+
+    @Test
+    public void getRoleConfigWhenIdBrokerAndInvalidFileSystem() {
+        BaseFileSystemConfigurationsView fileSystemConfigurationsView = mock(BaseFileSystemConfigurationsView.class);
+        when(fileSystemConfigurationsView.getType()).thenReturn("DOS");
+
+        TemplatePreparationObject tpo = new Builder()
+                .withCloudPlatform(CloudPlatform.AWS)
+                .withFileSystemConfigurationView(fileSystemConfigurationsView)
+                .build();
+
+        thrown.expect(IllegalStateException.class);
+        thrown.expectMessage("Unknown file system type:");
+
+        underTest.getRoleConfigs(IDBROKER, tpo);
+    }
+
+    @Test
+    public void getRoleConfigWhenIdBrokerAndS3FileSystem() {
+        BaseFileSystemConfigurationsView fileSystemConfigurationsView = mock(BaseFileSystemConfigurationsView.class);
+        when(fileSystemConfigurationsView.getType()).thenReturn("S3");
+
+        TemplatePreparationObject tpo = new Builder()
+                .withCloudPlatform(CloudPlatform.AWS)
+                .withFileSystemConfigurationView(fileSystemConfigurationsView)
+                .withIdentityUserMapping(IDENTITY_USER_MAPPING)
+                .withIdentityGroupMapping(IDENTITY_GROUP_MAPPING)
+                .build();
+
+        List<ApiClusterTemplateConfig> result = underTest.getRoleConfigs(IDBROKER, tpo);
+
+        Map<String, String> configNameToValueMap = getConfigNameToValueMap(result);
+        assertThat(configNameToValueMap).containsOnly(
+                Map.entry(IDBROKER_AWS_USER_MAPPING, IDENTITY_USER_MAPPING_STR),
+                Map.entry(IDBROKER_AWS_GROUP_MAPPING, IDENTITY_GROUP_MAPPING_STR)
+        );
+        Map<String, String> configNameToVariableNameMap = getConfigNameToVariableNameMap(result);
+        assertThat(configNameToVariableNameMap).isEmpty();
+    }
+
+    @Test
+    public void getRoleConfigWhenIdBrokerAndAdlsFileSystem() {
+        BaseFileSystemConfigurationsView fileSystemConfigurationsView = mock(BaseFileSystemConfigurationsView.class);
+        when(fileSystemConfigurationsView.getType()).thenReturn("ADLS");
+
+        TemplatePreparationObject tpo = new Builder()
+                .withCloudPlatform(CloudPlatform.AZURE)
+                .withFileSystemConfigurationView(fileSystemConfigurationsView)
+                .withIdentityUserMapping(IDENTITY_USER_MAPPING)
+                .withIdentityGroupMapping(IDENTITY_GROUP_MAPPING)
+                .build();
+
+        List<ApiClusterTemplateConfig> result = underTest.getRoleConfigs(IDBROKER, tpo);
+
+        Map<String, String> configNameToValueMap = getConfigNameToValueMap(result);
+        assertThat(configNameToValueMap).containsOnly(
+                Map.entry(IDBROKER_AZURE_USER_MAPPING, IDENTITY_USER_MAPPING_STR),
+                Map.entry(IDBROKER_AZURE_GROUP_MAPPING, IDENTITY_GROUP_MAPPING_STR)
+        );
+        Map<String, String> configNameToVariableNameMap = getConfigNameToVariableNameMap(result);
+        assertThat(configNameToVariableNameMap).isEmpty();
+    }
+
+    @Test
+    public void getRoleConfigWhenIdBrokerAndAdlsGen2FileSystem() {
+        BaseFileSystemConfigurationsView fileSystemConfigurationsView = mock(BaseFileSystemConfigurationsView.class);
+        when(fileSystemConfigurationsView.getType()).thenReturn("ADLS_GEN_2");
+
+        TemplatePreparationObject tpo = new Builder()
+                .withCloudPlatform(CloudPlatform.AZURE)
+                .withFileSystemConfigurationView(fileSystemConfigurationsView)
+                .withIdentityUserMapping(IDENTITY_USER_MAPPING)
+                .withIdentityGroupMapping(IDENTITY_GROUP_MAPPING)
+                .build();
+
+        List<ApiClusterTemplateConfig> result = underTest.getRoleConfigs(IDBROKER, tpo);
+
+        Map<String, String> configNameToValueMap = getConfigNameToValueMap(result);
+        assertThat(configNameToValueMap).containsOnly(
+                Map.entry(IDBROKER_AZURE_USER_MAPPING, IDENTITY_USER_MAPPING_STR),
+                Map.entry(IDBROKER_AZURE_GROUP_MAPPING, IDENTITY_GROUP_MAPPING_STR)
+        );
+        Map<String, String> configNameToVariableNameMap = getConfigNameToVariableNameMap(result);
+        assertThat(configNameToVariableNameMap).isEmpty();
+    }
+
+    @Test
+    public void getRoleConfigWhenIdBrokerAndWasbFileSystem() {
+        BaseFileSystemConfigurationsView fileSystemConfigurationsView = mock(BaseFileSystemConfigurationsView.class);
+        when(fileSystemConfigurationsView.getType()).thenReturn("WASB");
+
+        TemplatePreparationObject tpo = new Builder()
+                .withCloudPlatform(CloudPlatform.AZURE)
+                .withFileSystemConfigurationView(fileSystemConfigurationsView)
+                .withIdentityUserMapping(IDENTITY_USER_MAPPING)
+                .withIdentityGroupMapping(IDENTITY_GROUP_MAPPING)
+                .build();
+
+        List<ApiClusterTemplateConfig> result = underTest.getRoleConfigs(IDBROKER, tpo);
+
+        Map<String, String> configNameToValueMap = getConfigNameToValueMap(result);
+        assertThat(configNameToValueMap).containsOnly(
+                Map.entry(IDBROKER_AZURE_USER_MAPPING, IDENTITY_USER_MAPPING_STR),
+                Map.entry(IDBROKER_AZURE_GROUP_MAPPING, IDENTITY_GROUP_MAPPING_STR)
+        );
+        Map<String, String> configNameToVariableNameMap = getConfigNameToVariableNameMap(result);
+        assertThat(configNameToVariableNameMap).isEmpty();
+    }
+
+    @Test
+    public void getRoleConfigWhenIdBrokerAndWasbIntegratedFileSystem() {
+        BaseFileSystemConfigurationsView fileSystemConfigurationsView = mock(BaseFileSystemConfigurationsView.class);
+        when(fileSystemConfigurationsView.getType()).thenReturn("WASB_INTEGRATED");
+
+        TemplatePreparationObject tpo = new Builder()
+                .withCloudPlatform(CloudPlatform.AZURE)
+                .withFileSystemConfigurationView(fileSystemConfigurationsView)
+                .withIdentityUserMapping(IDENTITY_USER_MAPPING)
+                .withIdentityGroupMapping(IDENTITY_GROUP_MAPPING)
+                .build();
+
+        List<ApiClusterTemplateConfig> result = underTest.getRoleConfigs(IDBROKER, tpo);
+
+        Map<String, String> configNameToValueMap = getConfigNameToValueMap(result);
+        assertThat(configNameToValueMap).containsOnly(
+                Map.entry(IDBROKER_AZURE_USER_MAPPING, IDENTITY_USER_MAPPING_STR),
+                Map.entry(IDBROKER_AZURE_GROUP_MAPPING, IDENTITY_GROUP_MAPPING_STR)
+        );
+        Map<String, String> configNameToVariableNameMap = getConfigNameToVariableNameMap(result);
+        assertThat(configNameToVariableNameMap).isEmpty();
+    }
+
+    @Test
+    public void getRoleConfigWhenIdBrokerAndGcsFileSystem() {
+        BaseFileSystemConfigurationsView fileSystemConfigurationsView = mock(BaseFileSystemConfigurationsView.class);
+        when(fileSystemConfigurationsView.getType()).thenReturn("GCS");
+
+        TemplatePreparationObject tpo = new Builder()
+                .withCloudPlatform(CloudPlatform.GCP)
+                .withFileSystemConfigurationView(fileSystemConfigurationsView)
+                .withIdentityUserMapping(IDENTITY_USER_MAPPING)
+                .withIdentityGroupMapping(IDENTITY_GROUP_MAPPING)
+                .build();
+
+        List<ApiClusterTemplateConfig> result = underTest.getRoleConfigs(IDBROKER, tpo);
+
+        Map<String, String> configNameToValueMap = getConfigNameToValueMap(result);
+        assertThat(configNameToValueMap).containsOnly(
+                Map.entry(IDBROKER_GCP_USER_MAPPING, IDENTITY_USER_MAPPING_STR),
+                Map.entry(IDBROKER_GCP_GROUP_MAPPING, IDENTITY_GROUP_MAPPING_STR)
+        );
+        Map<String, String> configNameToVariableNameMap = getConfigNameToVariableNameMap(result);
+        assertThat(configNameToVariableNameMap).isEmpty();
+    }
+
+    @Test
+    public void getServiceType() {
+        assertThat(underTest.getServiceType()).isEqualTo(KNOX);
+    }
+
+    @Test
+    public void getRoleTypes() {
+        assertThat(underTest.getRoleTypes()).containsOnly(IDBROKER);
+    }
+
+}

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/TemplatePreparationObject.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/TemplatePreparationObject.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.domain.Template;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.gateway.Gateway;
@@ -27,6 +28,8 @@ import com.sequenceiq.cloudbreak.template.views.HostgroupView;
 import com.sequenceiq.cloudbreak.template.views.SharedServiceConfigsView;
 
 public class TemplatePreparationObject {
+
+    private final CloudPlatform cloudPlatform;
 
     private final GatewayView gatewayView;
 
@@ -59,6 +62,7 @@ public class TemplatePreparationObject {
     private final Map<String, String> identityUserMapping;
 
     private TemplatePreparationObject(Builder builder) {
+        cloudPlatform = builder.cloudPlatform;
         rdsConfigs = builder.rdsConfigs.stream().collect(Collectors.toMap(
                 rdsConfig -> rdsConfig.getType().toLowerCase(),
                 Function.identity()
@@ -84,6 +88,10 @@ public class TemplatePreparationObject {
                 .getHostGroupsWithComponent(component);
         return getHostgroupViews().stream()
                 .filter(hostGroup -> groups.contains(hostGroup.getName()));
+    }
+
+    public CloudPlatform getCloudPlatform() {
+        return cloudPlatform;
     }
 
     public Set<RDSConfig> getRdsConfigs() {
@@ -152,6 +160,8 @@ public class TemplatePreparationObject {
 
     public static class Builder {
 
+        private CloudPlatform cloudPlatform;
+
         private Set<RDSConfig> rdsConfigs = new HashSet<>();
 
         private Set<HostgroupView> hostgroupViews = new HashSet<>();
@@ -184,6 +194,11 @@ public class TemplatePreparationObject {
 
         public static Builder builder() {
             return new Builder();
+        }
+
+        public Builder withCloudPlatform(CloudPlatform cloudPlatform) {
+            this.cloudPlatform = cloudPlatform;
+            return this;
         }
 
         public Builder withRdsConfigs(Set<RDSConfig> rdsConfigs) {
@@ -286,4 +301,5 @@ public class TemplatePreparationObject {
             return new TemplatePreparationObject(this);
         }
     }
+
 }


### PR DESCRIPTION
This change injects mock user/group-to-role IDB mappings from `TemplatePreparationObject` (provided by #5664 as mock settings) in a new `KnoxIdBrokerConfigProvider`. Limitations:

* Could not be tested E2E with scenario "datalake & cloud storage locations" due to some blocker issues, but IDB mappings were correctly reflected in both CM and `/var/run/cloudera-scm-agent/process/14-knox-IDBROKER/conf/gateway-reloadable.xml`.