### PR TITLE
DISTX-266. Reject concurrent user sync requests

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SynchronizationStatus.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SynchronizationStatus.java
@@ -1,5 +1,5 @@
 package com.sequenceiq.freeipa.api.v1.freeipa.user.model;
 
 public enum SynchronizationStatus {
-    RUNNING, COMPLETED, FAILED
+    REQUESTED, RUNNING, COMPLETED, FAILED, REJECTED, TIMEDOUT
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/exception/SyncOperationAlreadyRunningException.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/exception/SyncOperationAlreadyRunningException.java
@@ -1,0 +1,30 @@
+package com.sequenceiq.freeipa.controller.exception;
+
+import java.util.Objects;
+
+public class SyncOperationAlreadyRunningException extends RuntimeException {
+
+    public SyncOperationAlreadyRunningException(String message) {
+        super(message);
+    }
+
+    public SyncOperationAlreadyRunningException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o instanceof SyncOperationAlreadyRunningException) {
+            return getMessage().equals(((Throwable) o).getMessage());
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getMessage());
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/mapper/SyncOperationAlreadyRunningExceptionMapper.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/mapper/SyncOperationAlreadyRunningExceptionMapper.java
@@ -1,0 +1,22 @@
+package com.sequenceiq.freeipa.controller.mapper;
+
+import javax.ws.rs.core.Response.Status;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.freeipa.controller.exception.SyncOperationAlreadyRunningException;
+
+@Component
+public class SyncOperationAlreadyRunningExceptionMapper extends BaseExceptionMapper<SyncOperationAlreadyRunningException> {
+
+    @Override
+    Status getResponseStatus() {
+        return Status.CONFLICT;
+    }
+
+    @Override
+    Class<SyncOperationAlreadyRunningException> getExceptionType() {
+        return SyncOperationAlreadyRunningException.class;
+    }
+
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/freeipa/user/SyncOperationToSyncOperationStatus.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/freeipa/user/SyncOperationToSyncOperationStatus.java
@@ -1,44 +1,25 @@
 package com.sequenceiq.freeipa.converter.freeipa.user;
 
-import java.io.IOException;
-import java.util.List;
-
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.sequenceiq.cloudbreak.common.json.Json;
-import com.sequenceiq.freeipa.api.v1.freeipa.user.model.FailureDetails;
-import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SuccessDetails;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SyncOperationStatus;
 import com.sequenceiq.freeipa.entity.SyncOperation;
 
 @Component
 public class SyncOperationToSyncOperationStatus  implements Converter<SyncOperation, SyncOperationStatus> {
 
-    private final TypeReference<List<SuccessDetails>> successListTypeReference = new TypeReference<>() { };
-
-    private final TypeReference<List<FailureDetails>> failureListTypeReference = new TypeReference<>() { };
-
     @Override
     public SyncOperationStatus convert(SyncOperation source) {
-        try {
-            Json successListJson = source.getSuccessList();
-            List<SuccessDetails> successList = successListJson == null ? List.of() : successListJson.get(successListTypeReference);
-            Json failureListJson = source.getFailureList();
-            List<FailureDetails> failureList = failureListJson == null ? List.of() : failureListJson.get(failureListTypeReference);
-            return new SyncOperationStatus(
-                    source.getOperationId(),
-                    source.getSyncOperationType(),
-                    source.getStatus(),
-                    successList,
-                    failureList,
-                    source.getError(),
-                    source.getStartTime(),
-                    source.getEndTime()
-            );
-        } catch (IOException e) {
-            throw new IllegalArgumentException("Unable to convert SyncOperation to SyncOperationStatus", e);
-        }
+        return new SyncOperationStatus(
+                source.getOperationId(),
+                source.getSyncOperationType(),
+                source.getStatus(),
+                source.getSuccessList(),
+                source.getFailureList(),
+                source.getError(),
+                source.getStartTime(),
+                source.getEndTime()
+        );
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/util/ListFailureDetailsToString.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/util/ListFailureDetailsToString.java
@@ -1,0 +1,14 @@
+package com.sequenceiq.freeipa.entity.util;
+
+import java.util.List;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.FailureDetails;
+
+public class ListFailureDetailsToString extends ListToString<FailureDetails> {
+    private static final TypeReference<List<FailureDetails>> TYPE_REFERENCE = new TypeReference<>() { };
+
+    public TypeReference<List<FailureDetails>> getTypeReference() {
+        return TYPE_REFERENCE;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/util/ListStringToString.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/util/ListStringToString.java
@@ -1,0 +1,13 @@
+package com.sequenceiq.freeipa.entity.util;
+
+import java.util.List;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+public class ListStringToString extends ListToString<String> {
+    private static final TypeReference<List<String>> TYPE_REFERENCE = new TypeReference<>() { };
+
+    public TypeReference<List<String>> getTypeReference() {
+        return TYPE_REFERENCE;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/util/ListSuccessDetailsToString.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/util/ListSuccessDetailsToString.java
@@ -1,0 +1,14 @@
+package com.sequenceiq.freeipa.entity.util;
+
+import java.util.List;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SuccessDetails;
+
+public class ListSuccessDetailsToString extends ListToString<SuccessDetails> {
+    private static final TypeReference<List<SuccessDetails>> TYPE_REFERENCE = new TypeReference<>() { };
+
+    public TypeReference<List<SuccessDetails>> getTypeReference() {
+        return TYPE_REFERENCE;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/util/ListToString.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/util/ListToString.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.freeipa.entity.util;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.persistence.AttributeConverter;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.sequenceiq.cloudbreak.common.json.Json;
+
+public abstract class ListToString<U> implements AttributeConverter<List<U>, String> {
+
+    public abstract <U> TypeReference<List<U>> getTypeReference();
+
+    @Override
+    public String convertToDatabaseColumn(List<U> entityData) {
+        if (entityData != null) {
+            return new Json(entityData).getValue();
+        }
+        return null;
+    }
+
+    @Override
+    public List<U> convertToEntityAttribute(String dbData) {
+        try {
+            return new Json(dbData).get(getTypeReference());
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed to parse list from Json.", e);
+        }
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/repository/SyncOperationRepository.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/repository/SyncOperationRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SyncOperationType;
 import com.sequenceiq.freeipa.entity.SyncOperation;
 
 @Transactional(Transactional.TxType.REQUIRED)
@@ -20,6 +21,12 @@ public interface SyncOperationRepository extends JpaRepository<SyncOperation, Lo
     @Query("SELECT s FROM SyncOperation s WHERE s.operationId = :operationId")
     Optional<SyncOperation> findByOperationId(@Param("operationId") String operationId);
 
-    @Query("SELECT s FROM SyncOperation s WHERE s.accountId = :accountId AND s.endTime = -1")
+    @Query("SELECT s FROM SyncOperation s WHERE s.accountId = :accountId AND s.endTime IS NULL")
     List<SyncOperation> findRunningByAccountId(@Param("accountId") String accountId);
+
+    @Query("SELECT s FROM SyncOperation s WHERE s.accountId = :accountId AND s.syncOperationType = :syncOperationType AND s.endTime IS NULL")
+    List<SyncOperation> findRunningByAccountIdAndType(@Param("accountId") String accountId, @Param("syncOperationType")SyncOperationType syncOperationType);
+
+    @Query("SELECT s FROM SyncOperation s WHERE s.startTime < :startBeforeTime AND s.endTime IS NULL")
+    List<SyncOperation> findStaleRunning(@Param("startBeforeTime") Long startBeforeTime);
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/AcceptResult.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/AcceptResult.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import java.util.Optional;
+
+public class AcceptResult {
+    private static final AcceptResult ACCEPTED = new AcceptResult(true, Optional.empty());
+
+    private final boolean accepted;
+
+    private final Optional<String> rejectionMessage;
+
+    public AcceptResult(boolean accepted, Optional<String> rejectionMessage) {
+        this.accepted = accepted;
+        this.rejectionMessage = rejectionMessage;
+    }
+
+    public boolean isAccepted() {
+        return accepted;
+    }
+
+    public Optional<String> getRejectionMessage() {
+        return rejectionMessage;
+    }
+
+    public static AcceptResult accept() {
+        return ACCEPTED;
+    }
+
+    public static AcceptResult reject(String reason) {
+        return new AcceptResult(false, Optional.ofNullable(reason));
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/CleanupSyncOperation.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/CleanupSyncOperation.java
@@ -1,0 +1,47 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizationStatus;
+import com.sequenceiq.freeipa.entity.SyncOperation;
+import com.sequenceiq.freeipa.repository.SyncOperationRepository;
+
+@Service
+public class CleanupSyncOperation {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CleanupSyncOperation.class);
+
+    private static final Long SYNC_OPERATION_TIMEOUT = 30L * 60L * 1000L;
+
+    @Inject
+    private SyncOperationRepository syncOperationRepository;
+
+    @Scheduled(fixedDelay = 60 * 1000, initialDelay = 60 * 1000)
+    public void triggerCleanup() {
+        try {
+            cleanupStaleSyncOperation(System.currentTimeMillis() - SYNC_OPERATION_TIMEOUT);
+        } catch (Exception e) {
+            LOGGER.error("Failed to clean up SyncOperation table", e);
+        }
+    }
+
+    public void cleanupStaleSyncOperation(Long startedBeforeTime) {
+        List<SyncOperation> staleOperations = syncOperationRepository.findStaleRunning(startedBeforeTime);
+
+        LOGGER.debug("{} operations have TIMEDOUT.", staleOperations.size());
+        Long endTime = System.currentTimeMillis();
+
+        staleOperations.stream().forEach(o -> {
+            LOGGER.debug("Recording that operation {} TIMEDOUT", o.getOperationId());
+            o.setStatus(SynchronizationStatus.TIMEDOUT);
+            o.setEndTime(endTime);
+            syncOperationRepository.save(o);
+        });
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/SetPasswordAcceptor.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/SetPasswordAcceptor.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SyncOperationType;
+import com.sequenceiq.freeipa.repository.SyncOperationRepository;
+
+@Component
+public class SetPasswordAcceptor extends SyncOperationAcceptor {
+    @Inject
+    public SetPasswordAcceptor(SyncOperationRepository syncOperationRepository) {
+        super(syncOperationRepository);
+    }
+
+    @Override
+    SyncOperationType selector() {
+        return SyncOperationType.SET_PASSWORD;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/SyncOperationAcceptor.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/SyncOperationAcceptor.java
@@ -1,0 +1,66 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import com.google.common.collect.Sets;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SyncOperationType;
+import com.sequenceiq.freeipa.entity.SyncOperation;
+import com.sequenceiq.freeipa.repository.SyncOperationRepository;
+
+public abstract class SyncOperationAcceptor {
+    private static final String REJECTION_MESSAGE = "%s operation %s rejected due to conflicts: %s";
+
+    private static final String CONFLICT_REASON = "operation %s running for users %s in environments %s";
+
+    private final SyncOperationRepository syncOperationRepository;
+
+    protected SyncOperationAcceptor(SyncOperationRepository syncOperationRepository) {
+        this.syncOperationRepository = syncOperationRepository;
+    }
+
+    abstract SyncOperationType selector();
+
+    public AcceptResult accept(SyncOperation syncOperation) {
+        List<SyncOperation> runningOperations = syncOperationRepository
+                .findRunningByAccountIdAndType(syncOperation.getAccountId(), selector());
+        List<String> rejectionReasons = new ArrayList<>(runningOperations.size());
+
+        for (SyncOperation o : runningOperations) {
+            if (o.getId() < syncOperation.getId() && doOperationsConflict(syncOperation, o)) {
+                rejectionReasons.add(String.format(CONFLICT_REASON, o.getOperationId(), o.getUserList(), o.getEnvironmentList()));
+            }
+        }
+
+        if (rejectionReasons.isEmpty()) {
+            return AcceptResult.accept();
+        } else {
+            return AcceptResult.reject(String.format(REJECTION_MESSAGE, selector(), syncOperation.getOperationId(), rejectionReasons));
+        }
+    }
+
+    /**
+     * Returns whether two sync operations conflict. Operations are considered to conflict if they overlap
+     * in both environment and user.
+     *
+     * @param syncOperation the sync operation
+     * @param other another sync operation
+     * @return true if the sync operations conflict
+     */
+    protected boolean doOperationsConflict(SyncOperation syncOperation, SyncOperation other) {
+        return doUsersConflict(syncOperation, other) && doEnvironmentsConflict(syncOperation, other);
+    }
+
+    protected boolean doEnvironmentsConflict(SyncOperation syncOperation, SyncOperation other) {
+        return doListsConflict(syncOperation.getEnvironmentList(), other.getEnvironmentList());
+    }
+
+    protected boolean doUsersConflict(SyncOperation syncOperation, SyncOperation other) {
+        return doListsConflict(syncOperation.getUserList(), other.getUserList());
+    }
+
+    protected boolean doListsConflict(List<String> list1, List<String> list2) {
+        return list1.isEmpty() || list2.isEmpty() || !Sets.intersection(Set.copyOf(list1), Set.copyOf(list2)).isEmpty();
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UmsUsersStateProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UmsUsersStateProvider.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service;
 
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetRightsResponse;
 import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
-import com.sequenceiq.freeipa.service.user.model.UmsState;
+import com.sequenceiq.freeipa.service.freeipa.user.model.UmsState;
 
 @Service
 public class UmsUsersStateProvider {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncAcceptor.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncAcceptor.java
@@ -1,0 +1,40 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SyncOperationType;
+import com.sequenceiq.freeipa.entity.SyncOperation;
+import com.sequenceiq.freeipa.repository.SyncOperationRepository;
+
+@Component
+public class UserSyncAcceptor extends SyncOperationAcceptor {
+    @Inject
+    public UserSyncAcceptor(SyncOperationRepository syncOperationRepository) {
+        super(syncOperationRepository);
+    }
+
+    @Override
+    SyncOperationType selector() {
+        return SyncOperationType.USER_SYNC;
+    }
+
+    /**
+     * Returns whether two user sync operations conflict. User sync conflicts are asymmetrical. User-
+     * filtered operations should be rejected if there is a full sync running for that environment because
+     * it is redundant. Full sync is not rejected due to a user-filtered sync, but only for other full syncs.
+     *
+     * @param syncOperation this sync operation
+     * @param other another running sync operation
+     * @return true if the operations conflict
+     */
+    @Override
+    protected boolean doOperationsConflict(SyncOperation syncOperation, SyncOperation other) {
+        if (!syncOperation.getUserList().isEmpty()) {
+            return super.doOperationsConflict(syncOperation, other);
+        } else {
+            return other.getUserList().isEmpty() && doEnvironmentsConflict(syncOperation, other);
+        }
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/SyncStatusDetail.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/SyncStatusDetail.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.freeipa.service.user.model;
+package com.sequenceiq.freeipa.service.freeipa.user.model;
 
 import static java.util.Objects.requireNonNull;
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UmsState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UmsState.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.freeipa.service.user.model;
+package com.sequenceiq.freeipa.service.freeipa.user.model;
 
 import static java.util.Objects.requireNonNull;
 
@@ -11,7 +11,6 @@ import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetRi
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.Group;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.MachineUser;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.User;
-import com.sequenceiq.freeipa.service.freeipa.user.model.UsersState;
 
 public class UmsState {
     private Map<String, Group> groupMap;

--- a/freeipa/src/main/resources/schema/app/20190715135810_add_version_and_filters_to_syncoperation.sql
+++ b/freeipa/src/main/resources/schema/app/20190715135810_add_version_and_filters_to_syncoperation.sql
@@ -1,0 +1,22 @@
+-- // Adds version, environmentlist, and userlist columns to syncoperation table
+
+ALTER TABLE syncoperation
+  ADD COLUMN IF NOT EXISTS version bigint,
+  ADD COLUMN IF NOT EXISTS environmentlist text,
+  ADD COLUMN IF NOT EXISTS userlist text;
+
+UPDATE syncoperation SET version = 1 WHERE version IS NULL;
+UPDATE syncoperation SET environmentlist = '[]' WHERE environmentlist IS NULL;
+UPDATE syncoperation SET userlist = '[]' WHERE userlist IS NULL;
+
+CREATE INDEX IF NOT EXISTS syncoperation_accountid_syncoperationtype_endtime_idx
+  on syncoperation (accountid, syncoperationtype, endtime)
+
+-- //@UNDO
+
+DROP INDEX IF EXISTS syncoperation_accountid_syncoperationtype_endtime_idx;
+
+ALTER TABLE syncoperation
+  DROP COLUMN IF EXISTS version,
+  DROP COLUMN IF EXISTS environmentlist,
+  DROP COLUMN IF EXISTS userlist;

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/controller/UserV1ControllerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/controller/UserV1ControllerTest.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.freeipa.controller;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -17,8 +19,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SetPasswordRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SyncOperationStatus;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizationStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeAllUsersRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeUserRequest;
+import com.sequenceiq.freeipa.controller.exception.SyncOperationAlreadyRunningException;
 import com.sequenceiq.freeipa.service.freeipa.user.PasswordService;
 import com.sequenceiq.freeipa.service.freeipa.user.SyncOperationStatusService;
 import com.sequenceiq.freeipa.service.freeipa.user.UserService;
@@ -52,11 +57,28 @@ public class UserV1ControllerTest {
         when(threadBaseUserCrnProvider.getUserCrn()).thenReturn(USER_CRN);
         when(threadBaseUserCrnProvider.getAccountId()).thenReturn(ACCOUNT_ID);
 
+        SyncOperationStatus status = mock(SyncOperationStatus.class);
+        when(userService.synchronizeUser(ACCOUNT_ID, USER_CRN, USER_CRN)).thenReturn(status);
+
         SynchronizeUserRequest request = mock(SynchronizeUserRequest.class);
 
         underTest.synchronizeUser(request);
 
         verify(userService, times(1)).synchronizeUser(ACCOUNT_ID, USER_CRN, USER_CRN);
+    }
+
+    @Test
+    void synchronizeUserRejected() {
+        when(threadBaseUserCrnProvider.getUserCrn()).thenReturn(USER_CRN);
+        when(threadBaseUserCrnProvider.getAccountId()).thenReturn(ACCOUNT_ID);
+
+        SyncOperationStatus status = mock(SyncOperationStatus.class);
+        when(status.getStatus()).thenReturn(SynchronizationStatus.REJECTED);
+        when(userService.synchronizeUser(ACCOUNT_ID, USER_CRN, USER_CRN)).thenReturn(status);
+
+        SynchronizeUserRequest request = mock(SynchronizeUserRequest.class);
+
+        assertThrows(SyncOperationAlreadyRunningException.class, () -> underTest.synchronizeUser(request));
     }
 
     @Test
@@ -70,9 +92,30 @@ public class UserV1ControllerTest {
         request.setEnvironments(environments);
         request.setUsers(users);
 
+        SyncOperationStatus status = mock(SyncOperationStatus.class);
+        when(userService.synchronizeAllUsers(ACCOUNT_ID, USER_CRN, environments, users)).thenReturn(status);
+
         underTest.synchronizeAllUsers(request);
 
         verify(userService, times(1)).synchronizeAllUsers(ACCOUNT_ID, USER_CRN, environments, users);
+    }
+
+    @Test
+    void synchronizeAllUsersRejected() {
+        when(threadBaseUserCrnProvider.getUserCrn()).thenReturn(USER_CRN);
+        when(threadBaseUserCrnProvider.getAccountId()).thenReturn(ACCOUNT_ID);
+
+        Set<String> environments = Set.of(ENV_CRN);
+        Set<String> users = Set.of(USER_CRN);
+        SynchronizeAllUsersRequest request = new SynchronizeAllUsersRequest();
+        request.setEnvironments(environments);
+        request.setUsers(users);
+
+        SyncOperationStatus status = mock(SyncOperationStatus.class);
+        when(status.getStatus()).thenReturn(SynchronizationStatus.REJECTED);
+        when(userService.synchronizeAllUsers(ACCOUNT_ID, USER_CRN, environments, users)).thenReturn(status);
+
+        assertThrows(SyncOperationAlreadyRunningException.class, () -> underTest.synchronizeAllUsers(request));
     }
 
     @Test
@@ -85,6 +128,19 @@ public class UserV1ControllerTest {
     }
 
     @Test
+    void getStatusRejected() {
+        String operationId = "testId";
+
+        SyncOperationStatus status = mock(SyncOperationStatus.class);
+        when(syncOperationStatusService.getStatus(operationId)).thenReturn(status);
+
+        underTest.getSyncOperationStatus(operationId);
+
+        verify(syncOperationStatusService, times(1)).getStatus(operationId);
+        verify(status, never()).getStatus();
+    }
+
+    @Test
     void setPassword() {
         when(threadBaseUserCrnProvider.getUserCrn()).thenReturn(USER_CRN);
         when(threadBaseUserCrnProvider.getAccountId()).thenReturn(ACCOUNT_ID);
@@ -93,8 +149,27 @@ public class UserV1ControllerTest {
         SetPasswordRequest request = mock(SetPasswordRequest.class);
         when(request.getPassword()).thenReturn(password);
 
+        SyncOperationStatus status = mock(SyncOperationStatus.class);
+        when(passwordService.setPassword(ACCOUNT_ID, USER_CRN, password, new HashSet<>())).thenReturn(status);
+
         underTest.setPassword(request);
 
         verify(passwordService, times(1)).setPassword(ACCOUNT_ID, USER_CRN, password, new HashSet<>());
+    }
+
+    @Test
+    void setPasswordRejected() {
+        when(threadBaseUserCrnProvider.getUserCrn()).thenReturn(USER_CRN);
+        when(threadBaseUserCrnProvider.getAccountId()).thenReturn(ACCOUNT_ID);
+
+        String password = "password";
+        SetPasswordRequest request = mock(SetPasswordRequest.class);
+        when(request.getPassword()).thenReturn(password);
+
+        SyncOperationStatus status = mock(SyncOperationStatus.class);
+        when(status.getStatus()).thenReturn(SynchronizationStatus.REJECTED);
+        when(passwordService.setPassword(ACCOUNT_ID, USER_CRN, password, new HashSet<>())).thenReturn(status);
+
+        assertThrows(SyncOperationAlreadyRunningException.class, () -> underTest.setPassword(request));
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/freeipa/user/SyncOperationToSyncOperationStatusTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/freeipa/user/SyncOperationToSyncOperationStatusTest.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.FailureDetails;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SuccessDetails;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SyncOperationStatus;
@@ -51,16 +50,14 @@ class SyncOperationToSyncOperationStatusTest {
                 new SuccessDetails("environment1"),
                 new SuccessDetails("environment2")
         );
-        Json successDetailsJson = new Json(successDetails);
         List<FailureDetails> failureDetails = List.of(
                 new FailureDetails("environment3", "failure message1"),
                 new FailureDetails("environment4", "failure message2")
         );
-        Json failureDetailsJson = new Json(failureDetails);
 
         SyncOperation syncOperation = createSyncOperation(synchronizationStatus);
-        syncOperation.setSuccessList(successDetailsJson);
-        syncOperation.setFailureList(failureDetailsJson);
+        syncOperation.setSuccessList(successDetails);
+        syncOperation.setFailureList(failureDetails);
 
         SyncOperationStatus actual = underTest.convert(syncOperation);
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/entity/util/ListToStringTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/entity/util/ListToStringTest.java
@@ -1,0 +1,102 @@
+package com.sequenceiq.freeipa.entity.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+public class ListToStringTest {
+
+    private static final List<TestPojo> TESTPOJO_LIST = List.of(
+            new TestPojo("string1", 1L, List.of("internal1.1", "internal.2")),
+            new TestPojo("string2", 2L, List.of("internal2.1", "internal2.2"))
+    );
+
+    private ListPojoToString converter = new ListPojoToString();
+
+    @Test
+    void convertRoundTrip() {
+        String convertedString = converter.convertToDatabaseColumn(TESTPOJO_LIST);
+        List<TestPojo> convertedList = converter.convertToEntityAttribute(convertedString);
+        assertEquals(TESTPOJO_LIST, convertedList);
+    }
+
+    @Test
+    void convertToEntityAttribute() {
+    }
+
+    public static class TestPojo {
+        private String strField;
+
+        private Long longField;
+
+        private List<String> listField;
+
+        public TestPojo() {
+        }
+
+        public TestPojo(String strField, Long longField, List<String> listField) {
+            this.strField = strField;
+            this.longField = longField;
+            this.listField = listField;
+        }
+
+        public String getStrField() {
+            return strField;
+        }
+
+        public void setStrField(String strField) {
+            this.strField = strField;
+        }
+
+        public Long getLongField() {
+            return longField;
+        }
+
+        public void setLongField(Long longField) {
+            this.longField = longField;
+        }
+
+        public List<String> getListField() {
+            return listField;
+        }
+
+        public void setListField(List<String> listField) {
+            this.listField = listField;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            TestPojo testPojo = (TestPojo) o;
+
+            return Objects.equals(strField, testPojo.strField)
+                    && Objects.equals(longField, testPojo.longField)
+                    && Objects.equals(listField, testPojo.listField);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(strField, longField, listField);
+        }
+    }
+
+    public static class ListPojoToString extends ListToString<ListToStringTest.TestPojo> {
+        private static final TypeReference<List<ListToStringTest.TestPojo>> TYPE_REFERENCE = new TypeReference<>() { };
+
+        @Override
+        public TypeReference<List<ListToStringTest.TestPojo>> getTypeReference() {
+            return TYPE_REFERENCE;
+        }
+    }
+}


### PR DESCRIPTION
The FMS was enhanced to better track SyncOperations and reject
concurrent requests.

The syncoperation table was modified
to add the environmentList and userList columns to represent
the scope of the sync operation. The SyncOperation entity was
modified to use new AttributeConverters to hide the conversion
to/from Json.

When requested, the FMS will store the SyncOperation in the db
then check whether to accept the request or not based on other
active requests in the db.

The SyncOperationAlreadyRunningException was created and mapped
to 409 CONFLICT.
