### PR TITLE
CB-2581 Fix typo in HBaseUI gateway proxy URL

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/ServiceEndpointCollector.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/ServiceEndpointCollector.java
@@ -297,7 +297,7 @@ public class ServiceEndpointCollector {
 
     private String getHBaseUIUrlWithHostParameterFromGatewayTopology(String managerIp, GatewayTopology gt, String nameNodePrivateIp) {
         Gateway gateway = gt.getGateway();
-        String url = String.format("https://%s:%s/%s/%s%s?host=%s?port=%s", managerIp, knoxPort, gateway.getPath(), gt.getTopologyName(),
+        String url = String.format("https://%s:%s/%s/%s%s?host=%s&port=%s", managerIp, knoxPort, gateway.getPath(), gt.getTopologyName(),
                 ExposedService.HBASE_UI.getKnoxUrl(), nameNodePrivateIp, ExposedService.HBASE_UI.getCmPort());
         return url;
     }


### PR DESCRIPTION
Simple change to change the generated url from `?host=<host>?port=<port>` to `?host=<host>&port=<port>`. The initial page will load from this URL, but subsequent traversals on the proxied UI will break.