### PR TITLE
Support formatted JSON log output for cb components

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -20,6 +20,7 @@ dependencies {
   compile project(':common-model')
   
   compile group: 'org.slf4j',                             name: 'slf4j-api',                      version: slf4jApiVersion
+  compile group: 'ch.qos.logback.contrib',                name: 'logback-json-classic',           version: logbackJsonClassicVersion
   compile group: 'io.micrometer',                         name: 'micrometer-core',                version: micrometerVersion
   compile group: 'org.apache.commons',                    name: 'commons-lang3',                  version: apacheCommonsLangVersion
   compile group: 'commons-io',                            name: 'commons-io',                     version: apacheCommonsIoVersion

--- a/common/src/main/java/com/sequenceiq/cloudbreak/logger/MaskingPatternLayout.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/logger/MaskingPatternLayout.java
@@ -1,7 +1,8 @@
 package com.sequenceiq.cloudbreak.logger;
 
 
-import static com.sequenceiq.cloudbreak.common.anonymizer.AnonymizerUtil.anonymize;
+import com.sequenceiq.cloudbreak.logger.format.LayoutFormat;
+import com.sequenceiq.cloudbreak.logger.format.LayoutFormatFactory;
 
 import ch.qos.logback.classic.PatternLayout;
 import ch.qos.logback.classic.spi.ILoggingEvent;
@@ -9,6 +10,8 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 public class MaskingPatternLayout extends PatternLayout {
 
     private String loggerNameFilter;
+
+    private final LayoutFormat layoutFormat = LayoutFormatFactory.getLayoutFormat();
 
     public String getLoggerNameFilter() {
         return loggerNameFilter;
@@ -22,10 +25,6 @@ public class MaskingPatternLayout extends PatternLayout {
 
     @Override
     public String doLayout(ILoggingEvent event) {
-        String message = super.doLayout(event);
-        if (loggerNameFilter != null && event.getLoggerName().startsWith(loggerNameFilter)) {
-            message = anonymize(message);
-        }
-        return message;
+        return layoutFormat.format(event, super.doLayout(event), loggerNameFilter);
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/logger/format/CustomJsonLayout.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/logger/format/CustomJsonLayout.java
@@ -1,0 +1,66 @@
+package com.sequenceiq.cloudbreak.logger.format;
+
+import static com.sequenceiq.cloudbreak.common.anonymizer.AnonymizerUtil.anonymize;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.contrib.json.classic.JsonLayout;
+import ch.qos.logback.core.CoreConstants;
+
+public class CustomJsonLayout extends JsonLayout {
+
+    private final String prefix;
+
+    CustomJsonLayout(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public String doLayout(ILoggingEvent event, String fullLogMessage, String loggerNameFilter) {
+        Map map = toJsonMap(event, fullLogMessage, loggerNameFilter);
+        if (map == null || map.isEmpty()) {
+            return null;
+        }
+        return toJsonString(map) + CoreConstants.LINE_SEPARATOR;
+    }
+
+    private Map toJsonMap(ILoggingEvent event, String fullLogMessage, String loggerNameFilter) {
+        Map<String, Object> map = new LinkedHashMap<>();
+        addTimestamp("@" + TIMESTAMP_ATTR_NAME, this.includeTimestamp, event.getTimeStamp(), map);
+        add(LEVEL_ATTR_NAME, this.includeLevel, String.valueOf(event.getLevel()), map);
+        add(THREAD_ATTR_NAME, this.includeThreadName, event.getThreadName(), map);
+        add(LOGGER_ATTR_NAME, this.includeLoggerName, event.getLoggerName(), map);
+        addMdcMapWithPrefix(event.getMDCPropertyMap(), map, this.prefix);
+        String exceptionKey = this.prefix + EXCEPTION_ATTR_NAME;
+        addThrowableInfo(exceptionKey, this.includeException, event, map);
+        String message = event.getFormattedMessage();
+        if (map.containsKey(exceptionKey)) {
+            message = String.format("%s%n%s", message, map.get(exceptionKey));
+            map.remove(exceptionKey);
+        }
+        if (loggerNameFilter != null && event.getLoggerName().startsWith(loggerNameFilter)) {
+            message = anonymize(message);
+        }
+        add(this.prefix + "log_message", true, message, map);
+        add("@" + FORMATTED_MESSAGE_ATTR_NAME, this.includeFormattedMessage, fullLogMessage, map);
+        return map;
+    }
+
+    private String toJsonString(Map map) {
+        try {
+            return getJsonFormatter().toJsonString(map);
+        } catch (Exception e) {
+            addError("JsonFormatter failed.  Defaulting to map.toString().  Message: " + e.getMessage(), e);
+            return map.toString();
+        }
+    }
+
+    private void addMdcMapWithPrefix(Map<String, ?> mdcPropertMap, Map<String, Object> map, String prefix) {
+        if (!mdcPropertMap.isEmpty()) {
+            for (Map.Entry<String, ?> mdcEntry : mdcPropertMap.entrySet()) {
+                map.put(prefix + mdcEntry.getKey(), mdcEntry.getValue());
+            }
+        }
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/logger/format/JsonLayoutFormat.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/logger/format/JsonLayoutFormat.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.cloudbreak.logger.format;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+public class JsonLayoutFormat extends SimpleLayoutFormat {
+
+    private final CustomJsonLayout jsonLayout;
+
+    JsonLayoutFormat(String prefix) {
+        this.jsonLayout = new CustomJsonLayout(prefix);
+        jsonLayout.setIncludeMessage(true);
+        jsonLayout.setAppendLineSeparator(true);
+        jsonLayout.setJsonFormatter(m -> new ObjectMapper().writeValueAsString(m));
+    }
+
+    @Override
+    public String format(ILoggingEvent event, String message, String loggerNameFilter) {
+        String filteredLogMessage = super.format(event, message, loggerNameFilter);
+        return jsonLayout.doLayout(event, filteredLogMessage, loggerNameFilter);
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/logger/format/LayoutFormat.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/logger/format/LayoutFormat.java
@@ -1,0 +1,7 @@
+package com.sequenceiq.cloudbreak.logger.format;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+public interface LayoutFormat {
+    String format(ILoggingEvent event, String message, String loggerNameFilter);
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/logger/format/LayoutFormatFactory.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/logger/format/LayoutFormatFactory.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.cloudbreak.logger.format;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class LayoutFormatFactory {
+
+    private LayoutFormatFactory() {
+    }
+
+    public static LayoutFormat getLayoutFormat() {
+        final String property = getProperty("logger.format.json.enabled", null);
+        if (Boolean.parseBoolean(property)) {
+            final String cbPrefix = getProperty("logger.format.json.prefix", "cloudbreak.");
+            return new JsonLayoutFormat(cbPrefix);
+        }
+        return new SimpleLayoutFormat();
+    }
+
+    private static String getProperty(String property, String defaultValue) {
+        String env = System.getenv(property.toUpperCase().replace(".", "_"));
+        if (StringUtils.isNotEmpty(env)) {
+            return System.getenv(env);
+        } else if (StringUtils.isNotEmpty(System.getProperty(property))) {
+            return System.getProperty(property);
+        }
+        return defaultValue;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/logger/format/SimpleLayoutFormat.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/logger/format/SimpleLayoutFormat.java
@@ -1,0 +1,16 @@
+package com.sequenceiq.cloudbreak.logger.format;
+
+import static com.sequenceiq.cloudbreak.common.anonymizer.AnonymizerUtil.anonymize;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+public class SimpleLayoutFormat implements LayoutFormat {
+
+    @Override
+    public String format(ILoggingEvent event, String message, String loggerNameFilter) {
+        if (loggerNameFilter != null && event.getLoggerName().startsWith(loggerNameFilter)) {
+            message = anonymize(message);
+        }
+        return message;
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/logger/MaskingPatternLayout.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/logger/MaskingPatternLayout.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.logger;
 
-import static com.sequenceiq.cloudbreak.common.anonymizer.AnonymizerUtil.anonymize;
+import com.sequenceiq.cloudbreak.logger.format.LayoutFormat;
+import com.sequenceiq.cloudbreak.logger.format.LayoutFormatFactory;
 
 import ch.qos.logback.classic.PatternLayout;
 import ch.qos.logback.classic.spi.ILoggingEvent;
@@ -8,6 +9,8 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 public class MaskingPatternLayout extends PatternLayout {
 
     private String loggerNameFilter;
+
+    private final LayoutFormat layoutFormat = LayoutFormatFactory.getLayoutFormat();
 
     public String getLoggerNameFilter() {
         return loggerNameFilter;
@@ -21,10 +24,6 @@ public class MaskingPatternLayout extends PatternLayout {
 
     @Override
     public String doLayout(ILoggingEvent event) {
-        String message = super.doLayout(event);
-        if (loggerNameFilter != null && event.getLoggerName().startsWith(loggerNameFilter)) {
-            message = anonymize(message);
-        }
-        return message;
+        return layoutFormat.format(event, super.doLayout(event), loggerNameFilter);
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,7 @@ awsSdkVersion=1.11.273
 azureSdkVersion=1.20.1
 eventBusVersion=2.0.7.RELEASE
 slf4jApiVersion=1.7.12
+logbackJsonClassicVersion=0.1.5
 guavaVersion=27.1-jre
 freemarkerVersion=2.3.26-incubating
 jacksonVersion=2.9.9


### PR DESCRIPTION
support JSON log output (based on property logger.format.json.enabled , or LOGGER_FORMAT_JSON_ENABLED env variable)

Can be considered as a POC. Idea is the propagate the log formatting into an interface which is created at startup (before spring bootstrap so im using System. calls to get env or properrty)

By default without enabling JSON output, it works as it worked before.

also added prefix options, so you can define how the fields from MDC map should look like (e.g.: userCrn -> cloudbreal.userCrn ...note, now we can use "." in prefix instead of "_" as i was problematic for fluend regex filter)