### PR TITLE
CB-2418 Make more redbeams db server parameters optional

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/DatabaseServer.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/DatabaseServer.java
@@ -128,7 +128,7 @@ public class DatabaseServer extends DynamicModel {
 
         private Integer port;
 
-        private long storageSize;
+        private Long storageSize;
 
         private Security security;
 

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsStackRequestHelperTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsStackRequestHelperTest.java
@@ -1,6 +1,9 @@
 package com.sequenceiq.cloudbreak.cloud.aws;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
@@ -8,6 +11,8 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -15,6 +20,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
 import com.amazonaws.services.cloudformation.model.CreateStackRequest;
+import com.amazonaws.services.cloudformation.model.Parameter;
 import com.amazonaws.services.cloudformation.model.Tag;
 import com.amazonaws.services.ec2.AmazonEC2Client;
 import com.amazonaws.services.ec2.model.DescribeImagesRequest;
@@ -25,6 +31,7 @@ import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.AvailabilityZone;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseEngine;
 import com.sequenceiq.cloudbreak.cloud.model.DatabaseServer;
 import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
@@ -59,7 +66,7 @@ public class AwsStackRequestHelperTest {
     @Mock
     private Network network;
 
-    @Mock
+    @Mock(answer = RETURNS_DEEP_STUBS)
     private DatabaseServer databaseServer;
 
     @Mock
@@ -123,5 +130,79 @@ public class AwsStackRequestHelperTest {
         assertEquals(tags, createStackRequest.getTags());
     }
 
-    // TODO: test getStackParameters
+    @Test
+    public void testGetStackParameters() {
+        when(network.getStringParameter("subnetId")).thenReturn("subnet-1234");
+
+        when(databaseServer.getStorageSize()).thenReturn(Long.valueOf(50L));
+        when(databaseServer.getParameter("backupRetentionPeriod", Integer.class)).thenReturn(Integer.valueOf(1));
+        when(databaseServer.getFlavor()).thenReturn("db.m3.medium");
+        when(databaseServer.getServerId()).thenReturn("myserver");
+        when(databaseServer.getEngine()).thenReturn(DatabaseEngine.POSTGRESQL);
+        when(databaseServer.getStringParameter("engineVersion")).thenReturn("10.6");
+        when(databaseServer.getPort()).thenReturn(Integer.valueOf(5432));
+        when(databaseServer.getRootUserName()).thenReturn("root");
+        when(databaseServer.getRootPassword()).thenReturn("cloudera");
+        when(databaseServer.getSecurity().getCloudSecurityIds()).thenReturn(List.of("sg-1234", "sg-5678"));
+
+        when(cloudContext.getUserName()).thenReturn("bob@cloudera.com");
+
+        Collection<Parameter> parameters = underTest.getStackParameters(authenticatedContext, databaseStack);
+
+        assertContainsParameter(parameters, "AllocatedStorageParameter", "50");
+        assertContainsParameter(parameters, "BackupRetentionPeriodParameter", "1");
+        assertContainsParameter(parameters, "DBInstanceClassParameter", "db.m3.medium");
+        assertContainsParameter(parameters, "DBInstanceIdentifierParameter", "myserver");
+        assertContainsParameter(parameters, "DBSubnetGroupNameParameter", "dsg-myserver");
+        assertContainsParameter(parameters, "DBSubnetGroupSubnetIdsParameter", "subnet-1234");
+        assertContainsParameter(parameters, "EngineParameter", "postgres");
+        assertContainsParameter(parameters, "EngineVersionParameter", "10.6");
+        assertContainsParameter(parameters, "MasterUsernameParameter", "root");
+        assertContainsParameter(parameters, "MasterUserPasswordParameter", "cloudera");
+        assertContainsParameter(parameters, "PortParameter", "5432");
+        assertContainsParameter(parameters, "VPCSecurityGroupsParameter", "sg-1234,sg-5678");
+        assertContainsParameter(parameters, "StackOwner", "bob@cloudera.com");
+    }
+
+    @Test
+    public void testGetMinimalStackParameters() {
+        when(network.getStringParameter("subnetId")).thenReturn("subnet-1234");
+
+        when(databaseServer.getStorageSize()).thenReturn(null);
+        when(databaseServer.getParameter("backupRetentionPeriod", Integer.class)).thenReturn(null);
+        when(databaseServer.getFlavor()).thenReturn("db.m3.medium");
+        when(databaseServer.getServerId()).thenReturn("myserver");
+        when(databaseServer.getEngine()).thenReturn(DatabaseEngine.POSTGRESQL);
+        when(databaseServer.getStringParameter("engineVersion")).thenReturn(null);
+        when(databaseServer.getPort()).thenReturn(null);
+        when(databaseServer.getRootUserName()).thenReturn("root");
+        when(databaseServer.getRootPassword()).thenReturn("cloudera");
+        when(databaseServer.getSecurity().getCloudSecurityIds()).thenReturn(List.of("sg-1234", "sg-5678"));
+
+        when(cloudContext.getUserName()).thenReturn("bob@cloudera.com");
+
+        Collection<Parameter> parameters = underTest.getStackParameters(authenticatedContext, databaseStack);
+
+        assertDoesNotContainParameter(parameters, "AllocatedStorageParameter");
+        assertDoesNotContainParameter(parameters, "BackupRetentionPeriodParameter");
+        assertDoesNotContainParameter(parameters, "EngineVersionParameter");
+        assertDoesNotContainParameter(parameters, "PortParameter");
+    }
+
+    private void assertContainsParameter(Collection<Parameter> parameters, String key, String value) {
+        Optional<Parameter> foundParameterOpt = parameters.stream()
+            .filter(p -> p.getParameterKey().equals(key))
+            .findFirst();
+        assertTrue("Parameters are missing " + key, foundParameterOpt.isPresent());
+        String foundValue = foundParameterOpt.get().getParameterValue();
+        assertEquals("Parameter " + key + " should have value " + value + " but has value " + foundValue,
+            value, foundValue);
+    }
+
+    private void assertDoesNotContainParameter(Collection<Parameter> parameters, String key) {
+        Optional<Parameter> foundParameterOpt = parameters.stream()
+            .filter(p -> p.getParameterKey().equals(key))
+            .findFirst();
+        assertFalse("Parameters include " + key, foundParameterOpt.isPresent());
+    }
 }


### PR DESCRIPTION
The following parameters for redbeams database server allocation are
now fully optional: allocated storage, backup retention period, engine
version. The server port also remains optional, as before.

Additionally, a type error in the cloud model's DatabaseServer object
is fixed, so that null allocated storage sizes may pass fully through
the necessary data conversions.