### PR TITLE
CB-2148 invalid api path variable

### DIFF
--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/DatabaseServerV4Endpoint.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/DatabaseServerV4Endpoint.java
@@ -79,7 +79,7 @@ public interface DatabaseServerV4Endpoint {
     @ApiOperation(value = DatabaseServerOpDescription.GET_STATUS_BY_NAME, produces = MediaType.APPLICATION_JSON, notes = Notes.DATABASE_SERVER_NOTES,
             nickname = "getDatabaseServerStatusByName")
     DatabaseServerStatusV4Response getStatusOfManagedDatabaseServerByName(
-            @NotNull @PathParam("environmentCrn") String environmentCrn,
+            @NotNull @QueryParam("environmentCrn") String environmentCrn,
             @NotNull @PathParam("name") String name
     );
 


### PR DESCRIPTION
swagger generate client -f http://localhost:8087/redbeams/api/swagger.json -c client -m model -t dataplane/api-redbeams
2019/07/23 14:45:51 validating spec http://localhost:8087/redbeams/api/swagger.json
The swagger spec at "http://localhost:8087/redbeams/api/swagger.json" is invalid against swagger specification 2.0. see errors :
- path param "environmentCrn" is not present in path "/v4/databaseservers/managed/status/name/{name}"

make: *** [generate-swagger-redbeams] Error 1