### PR TITLE
CB-2684. Improve Swagger docs for redbeams API

### DIFF
--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/RedbeamsApi.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/RedbeamsApi.java
@@ -1,8 +1,18 @@
 package com.sequenceiq.redbeams.api;
 
+import io.swagger.annotations.ApiKeyAuthDefinition;
+import io.swagger.annotations.SecurityDefinition;
+import io.swagger.annotations.SwaggerDefinition;
+
+@SwaggerDefinition(securityDefinition = @SecurityDefinition(
+    apiKeyAuthDefinitions = {
+        @ApiKeyAuthDefinition(key = "crnHeader", in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER, name = "x-cdp-actor-crn")
+    }))
 public class RedbeamsApi {
 
     public static final String API_ROOT_CONTEXT = "/api";
+
+    public static final String CRN_HEADER_API_KEY = "crnHeader";
 
     private RedbeamsApi() {
     }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/database/DatabaseV4Endpoint.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/database/DatabaseV4Endpoint.java
@@ -16,6 +16,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import com.sequenceiq.redbeams.api.RedbeamsApi;
 import com.sequenceiq.redbeams.api.endpoint.v4.database.request.DatabaseTestV4Request;
 import com.sequenceiq.redbeams.api.endpoint.v4.database.request.DatabaseV4Request;
 import com.sequenceiq.redbeams.api.endpoint.v4.database.responses.DatabaseTestV4Response;
@@ -26,10 +27,14 @@ import com.sequenceiq.redbeams.doc.Notes;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.Authorization;
 
 @Path("/v4/databases")
 @Consumes(MediaType.APPLICATION_JSON)
-@Api(value = "/v4/databases", description = ControllerDescriptions.DATABASE_V4_DESCRIPTION, protocols = "http,https")
+@Api(value = "/v4/databases",
+    description = ControllerDescriptions.DATABASE_V4_DESCRIPTION,
+    protocols = "http,https",
+    authorizations = { @Authorization(value = RedbeamsApi.CRN_HEADER_API_KEY) })
 public interface DatabaseV4Endpoint {
 
     @GET

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/DatabaseServerV4Endpoint.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/DatabaseServerV4Endpoint.java
@@ -14,6 +14,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import com.sequenceiq.redbeams.api.RedbeamsApi;
 import com.sequenceiq.redbeams.api.endpoint.v4.database.request.CreateDatabaseV4Request;
 import com.sequenceiq.redbeams.api.endpoint.v4.database.responses.CreateDatabaseV4Response;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.AllocateDatabaseServerV4Request;
@@ -30,12 +31,16 @@ import com.sequenceiq.redbeams.doc.OperationDescriptions.DatabaseServerOpDescrip
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.Authorization;
 
 //import java.util.Set;
 
 @Path("/v4/databaseservers")
 @Consumes(MediaType.APPLICATION_JSON)
-@Api(value = "/v4/databaseservers", description = ControllerDescriptions.DATABASE_SERVER_V4_DESCRIPTION, protocols = "http,https")
+@Api(value = "/v4/databaseservers",
+    description = ControllerDescriptions.DATABASE_SERVER_V4_DESCRIPTION,
+    protocols = "http,https",
+    authorizations = { @Authorization(value = RedbeamsApi.CRN_HEADER_API_KEY) })
 public interface DatabaseServerV4Endpoint {
 
     @GET

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/RedbeamsApplication.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/RedbeamsApplication.java
@@ -5,9 +5,6 @@ import org.springframework.boot.actuate.autoconfigure.metrics.web.servlet.WebMvc
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
-
-@EnableSwagger2
 @EnableJpaRepositories(basePackages = { "com.sequenceiq.redbeams", "com.sequenceiq.flow", "com.sequenceiq.cloudbreak.ha.repository" })
 @SpringBootApplication(scanBasePackages = {"com.sequenceiq.redbeams",
         "com.sequenceiq.cloudbreak.auth",

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/EndpointConfig.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/EndpointConfig.java
@@ -8,19 +8,14 @@ import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.ext.ExceptionMapper;
 
 import org.glassfish.jersey.server.ResourceConfig;
-import org.springframework.beans.factory.annotation.Value;
+// import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.util.StringUtils;
 
 import com.sequenceiq.redbeams.api.RedbeamsApi;
 import com.sequenceiq.redbeams.controller.mapper.DefaultExceptionMapper;
 import com.sequenceiq.redbeams.controller.mapper.WebApplicationExceptionMapper;
 import com.sequenceiq.redbeams.controller.v4.database.DatabaseV4Controller;
 import com.sequenceiq.redbeams.controller.v4.databaseserver.DatabaseServerV4Controller;
-
-import io.swagger.jaxrs.config.BeanConfig;
-import io.swagger.jaxrs.config.SwaggerConfigLocator;
-import io.swagger.jaxrs.config.SwaggerContextService;
 
 @ApplicationPath(RedbeamsApi.API_ROOT_CONTEXT)
 @Configuration
@@ -31,13 +26,8 @@ public class EndpointConfig extends ResourceConfig {
         DatabaseServerV4Controller.class
     );
 
-    private static final String VERSION_UNAVAILABLE = "unspecified";
-
-    @Value("${info.app.version:}")
-    private String applicationVersion;
-
-    @Value("${redbeams.structuredevent.rest.enabled:false}")
-    private Boolean auditEnabled;
+    // @Value("${redbeams.structuredevent.rest.enabled:false}")
+    // private Boolean auditEnabled;
 
     @Inject
     private List<ExceptionMapper<?>> exceptionMappers;
@@ -51,26 +41,6 @@ public class EndpointConfig extends ResourceConfig {
          */
         registerEndpoints();
         registerExceptionMappers();
-    }
-
-    @PostConstruct
-    private void registerSwagger() {
-        BeanConfig swaggerConfig = new BeanConfig();
-        swaggerConfig.setTitle("Redbeams API");
-        swaggerConfig.setDescription("");
-        if (StringUtils.isEmpty(applicationVersion)) {
-            swaggerConfig.setVersion(VERSION_UNAVAILABLE);
-        } else {
-            swaggerConfig.setVersion(applicationVersion);
-        }
-        swaggerConfig.setSchemes(new String[]{"http", "https"});
-        swaggerConfig.setBasePath(RedbeamsApi.API_ROOT_CONTEXT);
-        swaggerConfig.setLicenseUrl("https://github.com/sequenceiq/cloudbreak/blob/master/LICENSE");
-        swaggerConfig.setResourcePackage("com.sequenceiq.redbeams.api");
-        swaggerConfig.setScan(true);
-        swaggerConfig.setContact("https://hortonworks.com/contact-sales/");
-        swaggerConfig.setPrettyPrint(true);
-        SwaggerConfigLocator.getInstance().putConfig(SwaggerContextService.CONFIG_ID_DEFAULT, swaggerConfig);
     }
 
     private void registerExceptionMappers() {

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/SecurityConfig.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/SecurityConfig.java
@@ -101,7 +101,7 @@ public class SecurityConfig {
                     .antMatchers(V4_API)
                     .authenticated()
                     .antMatchers(API_ROOT_CONTEXT + "/swagger.json").permitAll()
-                    .antMatchers(API_ROOT_CONTEXT + "/api-docs/**").permitAll()
+                    // .antMatchers(API_ROOT_CONTEXT + "/api-docs/**").permitAll()
                     .antMatchers(API_ROOT_CONTEXT + "/**").denyAll();
 
             http.csrf().disable();

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/SwaggerConfig.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/SwaggerConfig.java
@@ -1,0 +1,59 @@
+package com.sequenceiq.redbeams.configuration;
+
+import com.sequenceiq.redbeams.api.RedbeamsApi;
+
+import io.swagger.jaxrs.config.BeanConfig;
+import io.swagger.jaxrs.config.SwaggerConfigLocator;
+import io.swagger.jaxrs.config.SwaggerContextService;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@EnableSwagger2
+@Configuration
+public class SwaggerConfig {
+
+    @Value("${info.app.version:unspecified}")
+    private String applicationVersion;
+
+    @Value("${server.servlet.context-path:}")
+    private String contextPath;
+
+    @PostConstruct
+    private void registerSwagger() {
+        BeanConfig swaggerConfig = new BeanConfig();
+        swaggerConfig.setTitle("Redbeams API");
+        swaggerConfig.setDescription("API for working with databases and database servers");
+        swaggerConfig.setVersion(applicationVersion);
+        swaggerConfig.setSchemes(new String[]{"http", "https"});
+        swaggerConfig.setBasePath(contextPath + RedbeamsApi.API_ROOT_CONTEXT);
+        swaggerConfig.setLicenseUrl("https://github.com/sequenceiq/cloudbreak/blob/master/LICENSE");
+        swaggerConfig.setResourcePackage("com.sequenceiq.redbeams.api");
+        swaggerConfig.setScan(true);
+        swaggerConfig.setContact("https://hortonworks.com/contact-sales/");
+        swaggerConfig.setPrettyPrint(true);
+        SwaggerConfigLocator.getInstance().putConfig(SwaggerContextService.CONFIG_ID_DEFAULT, swaggerConfig);
+    }
+
+    // FIXME: This configures documentation at /v2/api-docs, but it currently
+    // doesn't work, probably because the controllers use JAX-RS and not
+    // Spring MVC
+    @Bean
+    public Docket apiDocket() {
+        return new Docket(DocumentationType.SWAGGER_2)
+            .select()
+            .apis(RequestHandlerSelectors.basePackage("com.sequenceiq.redbeams"))
+            .paths(PathSelectors.any())
+            .build();
+    }
+
+}


### PR DESCRIPTION
Swagger configuration in redbeams is split out from general endpoint
configuration. The base path for the configuration is fixed so that it
includes the "/redbeams" context path for the service as a whole.

The API now documents the need for the x-cdp-actor-crn header for
authorization. Not only is this simply more accurate, but it causes the
Swagger UI to offer the option to set the header. Along with the
corrected base path, this makes the UI usable for performing redbeams
calls from a browser.

Unfortunately, the Swagger API documentation available at /v2/api-docs
is not working. My guess is that it's because the API controllers use
JAX-RS, and not Spring, for their annotations. This issue is already
overcome for other Swagger artifacts.