### PR TITLE
CB-2566. Enable process auto-restart for all SDX services

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ProcessAutoRestartInjector.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ProcessAutoRestartInjector.java
@@ -13,6 +13,7 @@ import com.cloudera.api.swagger.model.ApiClusterTemplateService;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateConfigInjector;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.hdfs.HdfsRoles;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive.HiveRoles;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.knox.KnoxRoles;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.ranger.RangerRoles;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.yarn.YarnRoles;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
@@ -25,6 +26,8 @@ public class ProcessAutoRestartInjector implements CmTemplateConfigInjector {
             "HBASE",
             HdfsRoles.HDFS,
             HiveRoles.HIVE,
+            "KAFKA",
+            KnoxRoles.KNOX,
             "LIVY",
             RangerRoles.RANGER,
             "SOLR",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Set `process_auto_restart: true` for Kafka and Knox, too.

## How was this patch tested?

Deployed SDX cluster, verified config sent to CM.