### PR TITLE
CB-2723 Derive tez.history.logging.proto-base-dir and hive.hook.proto.base-directory property values from hive.metastore.warehouse.external.dir

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveOnTezServiceConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveOnTezServiceConfigProvider.java
@@ -1,0 +1,46 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive.HiveMetastoreCloudStorageServiceConfigProvider.HMS_METASTORE_EXTERNAL_DIR;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateComponentConfigProvider;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+
+@Component
+public class HiveOnTezServiceConfigProvider implements CmTemplateComponentConfigProvider {
+
+    private static final String HIVE_HOOK_PROTO_BASE_DIR_PARAM = "hive_hook_proto_base_directory";
+
+    private static final String HIVE_HOOK_PROTO_BASE_DIR_SUFFIX = "/sys.db/query_data";
+
+    @Override
+    public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject source) {
+        return ConfigUtils.getStorageLocationForServiceProperty(source, HMS_METASTORE_EXTERNAL_DIR)
+                .map(location -> location.getValue().replaceAll("/?$", "") + HIVE_HOOK_PROTO_BASE_DIR_SUFFIX)
+                .map(logDir -> List.of(config(HIVE_HOOK_PROTO_BASE_DIR_PARAM, logDir)))
+                .orElseGet(List::of);
+    }
+
+    @Override
+    public String getServiceType() {
+        return HiveRoles.HIVE_ON_TEZ;
+    }
+
+    @Override
+    public List<String> getRoleTypes() {
+        return List.of(HiveRoles.GATEWAY);
+    }
+
+    @Override
+    public boolean isConfigurationNeeded(CmTemplateProcessor cmTemplateProcessor, TemplatePreparationObject source) {
+        return source.getFileSystemConfigurationView().isPresent()
+                && cmTemplateProcessor.isRoleTypePresentInService(getServiceType(), getRoleTypes());
+    }
+}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveRoles.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveRoles.java
@@ -10,6 +10,8 @@ public class HiveRoles {
 
     public static final String HIVESERVER2 = "HIVESERVER2";
 
+    public static final String HIVE_ON_TEZ = "HIVE_ON_TEZ";
+
     public static final String WEBHCAT = "WEBHCAT";
 
     public static final String GATEWAY = "GATEWAY";

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/tez/TezRoleConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/tez/TezRoleConfigProvider.java
@@ -1,0 +1,55 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.tez;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive.HiveMetastoreCloudStorageServiceConfigProvider.HMS_METASTORE_EXTERNAL_DIR;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRoleConfigProvider;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+
+@Component
+public class TezRoleConfigProvider extends AbstractRoleConfigProvider {
+
+    private static final String TEZ_CONF_CLIENT_SAFETY_VALVE = "tez-conf/tez-site.xml_client_config_safety_valve";
+
+    private static final String TEZ_LOGGING_PROTO_BASE_DIR_PARAM = "tez.history.logging.proto-base-dir";
+
+    private static final String TEZ_LOGGING_PROTO_BASE_DIR_SUFFIX = "/sys.db";
+
+    @Override
+    protected List<ApiClusterTemplateConfig> getRoleConfigs(String roleType, TemplatePreparationObject source) {
+        switch (roleType) {
+            case TezRoles.GATEWAY:
+                return ConfigUtils.getStorageLocationForServiceProperty(source, HMS_METASTORE_EXTERNAL_DIR)
+                        .map(location ->
+                                location.getValue().replaceAll("/?$", "") + TEZ_LOGGING_PROTO_BASE_DIR_SUFFIX)
+                        .map(logDir -> List.of(config(TEZ_CONF_CLIENT_SAFETY_VALVE,
+                                ConfigUtils.getSafetyValveProperty(TEZ_LOGGING_PROTO_BASE_DIR_PARAM, logDir))))
+                        .orElseGet(List::of);
+            default:
+                return List.of();
+        }
+    }
+
+    @Override
+    public String getServiceType() {
+        return TezRoles.TEZ;
+    }
+
+    @Override
+    public List<String> getRoleTypes() {
+        return List.of(TezRoles.GATEWAY);
+    }
+
+    @Override
+    public boolean isConfigurationNeeded(CmTemplateProcessor cmTemplateProcessor, TemplatePreparationObject source) {
+        return source.getFileSystemConfigurationView().isPresent()
+                && cmTemplateProcessor.isRoleTypePresentInService(getServiceType(), getRoleTypes());
+    }
+}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/tez/TezRoles.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/tez/TezRoles.java
@@ -1,0 +1,10 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.tez;
+
+public class TezRoles {
+
+    public static final String TEZ = "TEZ";
+
+    public static final String GATEWAY = "GATEWAY";
+
+    private TezRoles() { }
+}

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveOnTezServiceConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveOnTezServiceConfigProviderTest.java
@@ -1,0 +1,74 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.domain.StorageLocation;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject.Builder;
+import com.sequenceiq.cloudbreak.template.filesystem.StorageLocationView;
+import com.sequenceiq.cloudbreak.template.filesystem.s3.S3FileSystemConfigurationsView;
+import com.sequenceiq.cloudbreak.template.views.HostgroupView;
+import com.sequenceiq.cloudbreak.util.FileReaderUtils;
+import com.sequenceiq.common.api.filesystem.S3FileSystem;
+import com.sequenceiq.common.api.type.InstanceGroupType;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HiveOnTezServiceConfigProviderTest {
+
+    private final HiveOnTezServiceConfigProvider underTest = new HiveOnTezServiceConfigProvider();
+
+    @Test
+    public void testGetHiveOnTezServiceConfigs() {
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject(true);
+        String inputJson = getBlueprintText("input/clouderamanager-ds.bp");
+        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(cmTemplateProcessor, preparationObject);
+
+        assertEquals(1, serviceConfigs.size());
+        assertEquals("hive_hook_proto_base_directory", serviceConfigs.get(0).getName());
+        assertEquals("s3a://bucket/hive/warehouse/external/sys.db/query_data", serviceConfigs.get(0).getValue());
+    }
+
+    @Test
+    public void testGetHiveOnTezServiceConfigsWhenNoStorageConfigured() {
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject(false);
+        String inputJson = getBlueprintText("input/clouderamanager-ds.bp");
+        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(cmTemplateProcessor, preparationObject);
+        assertEquals(0, serviceConfigs.size());
+    }
+
+    private TemplatePreparationObject getTemplatePreparationObject(boolean includeLocations) {
+        HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, 1);
+        HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, 2);
+
+        List<StorageLocationView> locations = new ArrayList<>();
+        if (includeLocations) {
+            StorageLocation hmsExternalWarehouseDir = new StorageLocation();
+            hmsExternalWarehouseDir.setProperty("hive.metastore.warehouse.external.dir");
+            hmsExternalWarehouseDir.setValue("s3a://bucket/hive/warehouse/external");
+            locations.add(new StorageLocationView(hmsExternalWarehouseDir));
+        }
+        S3FileSystemConfigurationsView fileSystemConfigurationsView =
+                new S3FileSystemConfigurationsView(new S3FileSystem(), locations, false);
+
+        return Builder.builder().withFileSystemConfigurationView(fileSystemConfigurationsView)
+                .withHostgroupViews(Set.of(master, worker)).build();
+    }
+
+    private String getBlueprintText(String path) {
+        return FileReaderUtils.readFileFromClasspathQuietly(path);
+    }
+}

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/tez/TezRoleConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/tez/TezRoleConfigProviderTest.java
@@ -1,0 +1,83 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.tez;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.domain.StorageLocation;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject.Builder;
+import com.sequenceiq.cloudbreak.template.filesystem.StorageLocationView;
+import com.sequenceiq.cloudbreak.template.filesystem.s3.S3FileSystemConfigurationsView;
+import com.sequenceiq.cloudbreak.template.views.HostgroupView;
+import com.sequenceiq.cloudbreak.util.FileReaderUtils;
+import com.sequenceiq.common.api.filesystem.S3FileSystem;
+import com.sequenceiq.common.api.type.InstanceGroupType;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TezRoleConfigProviderTest {
+
+    private final TezRoleConfigProvider underTest = new TezRoleConfigProvider();
+
+    @Test
+    public void testGetTezClientRoleConfigs() {
+        validateClientConfig("s3a://hive/warehouse/external", "s3a://hive/warehouse/external/sys.db");
+        validateClientConfig("s3a://hive/warehouse/external/", "s3a://hive/warehouse/external/sys.db");
+    }
+
+    @Test
+    public void testGetTezClientRoleConfigsWhenNoStorageConfigured() {
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject();
+        String inputJson = getBlueprintText("input/clouderamanager-ds.bp");
+        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+
+        Map<String, List<ApiClusterTemplateConfig>> roleConfigs = underTest.getRoleConfigs(cmTemplateProcessor, preparationObject);
+        List<ApiClusterTemplateConfig> tezConfigs = roleConfigs.get("tez-GATEWAY-BASE");
+        assertEquals(0, tezConfigs.size());
+    }
+
+    protected void validateClientConfig(String hmsExternalDirLocation, String protoDirLocation) {
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject(hmsExternalDirLocation);
+        String inputJson = getBlueprintText("input/clouderamanager-ds.bp");
+        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+
+        Map<String, List<ApiClusterTemplateConfig>> roleConfigs = underTest.getRoleConfigs(cmTemplateProcessor, preparationObject);
+        List<ApiClusterTemplateConfig> tezConfigs = roleConfigs.get("tez-GATEWAY-BASE");
+
+        assertEquals(1, tezConfigs.size());
+        assertEquals("tez-conf/tez-site.xml_client_config_safety_valve", tezConfigs.get(0).getName());
+        assertEquals("<property><name>tez.history.logging.proto-base-dir</name><value>"
+                + protoDirLocation + "</value></property>", tezConfigs.get(0).getValue());
+    }
+
+    private TemplatePreparationObject getTemplatePreparationObject(String... locations) {
+        HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, 1);
+        HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, 2);
+
+        List<StorageLocationView> storageLocations = new ArrayList<>();
+        if (locations.length >= 1) {
+            StorageLocation hmsExternalWarehouseDir = new StorageLocation();
+            hmsExternalWarehouseDir.setProperty("hive.metastore.warehouse.external.dir");
+            hmsExternalWarehouseDir.setValue(locations[0]);
+            storageLocations.add(new StorageLocationView(hmsExternalWarehouseDir));
+        }
+        S3FileSystemConfigurationsView fileSystemConfigurationsView =
+                new S3FileSystemConfigurationsView(new S3FileSystem(), storageLocations, false);
+
+        return Builder.builder().withFileSystemConfigurationView(fileSystemConfigurationsView)
+                .withHostgroupViews(Set.of(master, worker)).build();
+    }
+
+    private String getBlueprintText(String path) {
+        return FileReaderUtils.readFileFromClasspathQuietly(path);
+    }
+}

--- a/template-manager-cmtemplate/src/test/resources/input/clouderamanager-ds.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/clouderamanager-ds.bp
@@ -168,6 +168,23 @@
       ]
     },
     {
+      "refName": "tez",
+      "serviceType": "TEZ",
+      "serviceConfigs": [
+        {
+          "name": "yarn_service",
+          "ref": "yarn"
+        }
+      ],
+      "roleConfigGroups": [
+        {
+          "refName": "tez-GATEWAY-BASE",
+          "roleType": "GATEWAY",
+          "base": true
+        }
+      ]
+    },
+    {
       "refName": "impala",
       "serviceType": "IMPALA",
       "roleConfigGroups": [
@@ -205,6 +222,7 @@
         "kafka-KAFKA_BROKER-BASE",
         "spark_on_yarn-GATEWAY-BASE",
         "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+        "tez-GATEWAY-BASE",
         "yarn-JOBHISTORY-BASE",
         "yarn-RESOURCEMANAGER-BASE",
         "zookeeper-SERVER-BASE",


### PR DESCRIPTION
Derive tez.history.logging.proto-base-dir and hive.hook.proto.base-directory property values from hive.metastore.warehouse.external.dir for Hive/HMS Inserts to work with cloud storage

Closes #CB-2723