### PR TITLE
CB-1677. Add in Azure database allocation.

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
@@ -37,6 +37,7 @@ import com.microsoft.azure.management.resources.fluentcore.arm.models.HasId;
 import com.sequenceiq.cloudbreak.cloud.ResourceConnector;
 import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
 import com.sequenceiq.cloudbreak.cloud.azure.connector.resource.AzureComputeResourceService;
+import com.sequenceiq.cloudbreak.cloud.azure.connector.resource.AzureDatabaseResourceService;
 import com.sequenceiq.cloudbreak.cloud.azure.subnetstrategy.AzureSubnetStrategy;
 import com.sequenceiq.cloudbreak.cloud.azure.view.AzureCredentialView;
 import com.sequenceiq.cloudbreak.cloud.azure.view.AzureStackView;
@@ -44,7 +45,6 @@ import com.sequenceiq.cloudbreak.cloud.azure.view.AzureStorageView;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
-import com.sequenceiq.cloudbreak.cloud.exception.TemplatingDoesNotSupportedException;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource.Builder;
@@ -105,6 +105,9 @@ public class AzureResourceConnector implements ResourceConnector<Map<String, Map
     @Inject
     private AzureComputeResourceService azureComputeResourceService;
 
+    @Inject
+    private AzureDatabaseResourceService azureDatabaseResourceService;
+
     @Override
     public List<CloudResourceStatus> launch(AuthenticatedContext ac, CloudStack stack, PersistenceNotifier notifier,
             AdjustmentType adjustmentType, Long threshold) {
@@ -162,7 +165,7 @@ public class AzureResourceConnector implements ResourceConnector<Map<String, Map
     @Override
     public List<CloudResourceStatus> launchDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
         PersistenceNotifier persistenceNotifier) {
-        throw new UnsupportedOperationException("Database server launch is not supported for " + getClass().getName());
+        return azureDatabaseResourceService.buildDatabaseResourcesForLaunch(authenticatedContext, stack);
     }
 
     @Override
@@ -454,8 +457,8 @@ public class AzureResourceConnector implements ResourceConnector<Map<String, Map
     }
 
     @Override
-    public String getDBStackTemplate() throws TemplatingDoesNotSupportedException {
-        throw new TemplatingDoesNotSupportedException();
+    public String getDBStackTemplate() {
+        return azureTemplateBuilder.getDBTemplateString();
     }
 
     private AzureStackView getAzureStack(AzureCredentialView azureCredentialView, CloudStack cloudStack,

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtils.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtils.java
@@ -36,6 +36,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
@@ -138,6 +139,11 @@ public class AzureUtils {
 
     public String getResourceGroupName(CloudContext cloudContext, CloudStack cloudStack) {
         return cloudStack.getParameters().getOrDefault(RESOURCE_GROUP_NAME, getDefaultResourceGroupName(cloudContext));
+    }
+
+    public String getResourceGroupName(CloudContext cloudContext, DatabaseStack databaseStack) {
+        return databaseStack.getDatabaseServer().getParameters()
+                .getOrDefault(RESOURCE_GROUP_NAME, getDefaultResourceGroupName(cloudContext)).toString();
     }
 
     public String getResourceGroupName(CloudContext cloudContext, DynamicModel dynamicModel) {

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/AzureDatabaseResourceService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/AzureDatabaseResourceService.java
@@ -1,0 +1,90 @@
+package com.sequenceiq.cloudbreak.cloud.azure.connector.resource;
+
+import com.google.common.collect.Lists;
+import com.microsoft.azure.management.resources.Deployment;
+import com.sequenceiq.cloudbreak.cloud.azure.AzureContextService;
+import com.sequenceiq.cloudbreak.cloud.azure.AzureTemplateBuilder;
+import com.sequenceiq.cloudbreak.cloud.azure.AzureUtils;
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.azure.context.AzureContextBuilder;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
+import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
+import com.sequenceiq.cloudbreak.common.service.DefaultCostTaggingService;
+import com.sequenceiq.common.api.type.ResourceType;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class AzureDatabaseResourceService {
+
+    // PostgreSQL server port is fixed for now
+    private static final int POSTGRESQL_SERVER_PORT = 5432;
+
+    private static final String DATABASE_SERVER_FQDN = "databaseServerFQDN";
+
+    @Inject
+    private AzureContextBuilder contextBuilder;
+
+    @Inject
+    private AzureContextService azureContextService;
+
+    @Inject
+    private AzureTemplateBuilder azureTemplateBuilder;
+
+    @Inject
+    private AzureUtils azureUtils;
+
+    @Inject
+    private DefaultCostTaggingService defaultCostTaggingService;
+
+    public List<CloudResourceStatus> buildDatabaseResourcesForLaunch(AuthenticatedContext ac, DatabaseStack stack) {
+        CloudContext cloudContext = ac.getCloudContext();
+        AzureClient client = ac.getParameter(AzureClient.class);
+
+        String stackName = azureUtils.getStackName(cloudContext);
+        String resourceGroupName = azureUtils.getResourceGroupName(cloudContext, stack);
+        String template = azureTemplateBuilder.build(stackName, cloudContext, stack);
+        String region = ac.getCloudContext().getLocation().getRegion().value();
+
+        try {
+            if (!client.resourceGroupExists(resourceGroupName)) {
+                client.createResourceGroup(resourceGroupName, region, stack.getTags(), defaultCostTaggingService.prepareTemplateTagging());
+            }
+        } catch (Exception ex) {
+            throw new CloudConnectorException(ex);
+        }
+
+        client.createTemplateDeployment(resourceGroupName, stackName, template, "");
+
+        Deployment deployment = client.getTemplateDeployment(resourceGroupName, stackName);
+
+        String fqdn = (String) ((Map) ((Map) deployment.outputs()).get(DATABASE_SERVER_FQDN)).get("value");
+
+        List<CloudResource> databaseResources = Lists.newArrayList();
+
+        databaseResources.add(CloudResource.builder()
+                .type(ResourceType.RDS_HOSTNAME)
+                .name(fqdn)
+                .build());
+        databaseResources.add(CloudResource.builder()
+                .type(ResourceType.RDS_PORT)
+                .name(Integer.toString(POSTGRESQL_SERVER_PORT))
+                .build());
+
+        return databaseResources.stream()
+                .map(resource -> new CloudResourceStatus(resource, ResourceStatus.CREATED))
+                .collect(Collectors.toList());
+    }
+}
+

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureDatabaseServerView.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureDatabaseServerView.java
@@ -1,0 +1,96 @@
+package com.sequenceiq.cloudbreak.cloud.azure.view;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseServer;
+
+public class AzureDatabaseServerView {
+
+    @VisibleForTesting
+    static final String DB_VERSION = "dbVersion";
+
+    @VisibleForTesting
+    static final String BACKUP_RETENTION_DAYS = "backupRetentionDays";
+
+    @VisibleForTesting
+    static final String GEO_REDUNDANT_BACKUP = "geoRedundantBackup";
+
+    @VisibleForTesting
+    static final String SKU_CAPACITY = "skuCapacity";
+
+    @VisibleForTesting
+    static final String SKU_FAMILY = "skuFamily";
+
+    @VisibleForTesting
+    static final String SKU_TIER = "skuTier";
+
+    @VisibleForTesting
+    static final String STORAGE_AUTO_GROW = "storageAutoGrow";
+
+    private static final int NUM_MB_IN_GB = 1024;
+
+    private final DatabaseServer databaseServer;
+
+    public AzureDatabaseServerView(DatabaseServer databaseServer) {
+        this.databaseServer = databaseServer;
+    }
+
+    public Long getAllocatedStorageInMb() {
+        return databaseServer.getStorageSize() * NUM_MB_IN_GB;
+    }
+
+    public Integer getBackupRetentionDays() {
+        return databaseServer.getParameter(BACKUP_RETENTION_DAYS, Integer.class);
+    }
+
+    public Integer getSkuCapacity() {
+        return databaseServer.getParameter(SKU_CAPACITY, Integer.class);
+    }
+
+    public String getSkuFamily() {
+        return databaseServer.getStringParameter(SKU_FAMILY);
+    }
+
+    public String getSkuName() {
+        return databaseServer.getFlavor();
+    }
+
+    public String getSkuTier() {
+        return databaseServer.getStringParameter(SKU_TIER);
+    }
+
+    public String getDbServerName() {
+        return databaseServer.getServerId();
+    }
+
+    public String getDatabaseType() {
+        if (databaseServer.getEngine() == null) {
+            return null;
+        }
+        switch (databaseServer.getEngine()) {
+            case POSTGRESQL:
+                return "postgres";
+            default:
+                throw new IllegalStateException("Unsupported Azure Database Server engine " + databaseServer.getEngine());
+        }
+    }
+
+    public String getDbVersion() {
+        return databaseServer.getStringParameter(DB_VERSION);
+    }
+
+    public Boolean getGeoRedundantBackup() {
+        return Boolean.parseBoolean(databaseServer.getStringParameter(GEO_REDUNDANT_BACKUP));
+    }
+
+    public Boolean getStorageAutoGrow() {
+        return Boolean.parseBoolean(databaseServer.getStringParameter(STORAGE_AUTO_GROW));
+    }
+
+    public String getAdminLoginName() {
+        return databaseServer.getRootUserName();
+    }
+
+    public String getAdminPassword() {
+        return databaseServer.getRootPassword();
+    }
+}

--- a/cloud-azure/src/main/resources/templates/arm-dbstack.ftl
+++ b/cloud-azure/src/main/resources/templates/arm-dbstack.ftl
@@ -4,12 +4,14 @@
     "parameters": {
         "dbServerName": {
             "type": "string",
+            "defaultValue" : "${dbServerName}",
             "metadata": {
                 "description": "Name of the database server resource."
             }
         },
         "skuTier": {
             "type": "string",
+            "defaultValue" : "${skuTier}",
             "allowedValues": [
                 "Basic",
                 "GeneralPurpose",
@@ -21,25 +23,28 @@
         },
         "skuFamily": {
             "type": "string",
+            "defaultValue" : "${skuFamily}",
             "metadata": {
                 "description": "The family of hardware."
             }
         },
         "skuCapacity": {
             "type": "int",
+            "defaultValue" : ${skuCapacity},
             "metadata": {
                 "description": "The scale up/out capacity, representing server's compute units."
             }
         },
         "skuSizeMB": {
             "type": "int",
+            "defaultValue" : ${skuSizeMB},
             "metadata": {
                 "description": "The size code, to be interpreted by resource as appropriate."
             }
         },
         "skuName": {
             "type": "string",
-            "defaultValue": "GP_Gen5_2",
+            "defaultValue": "${skuName!GP_Gen5_2}",
             "allowedValues": [
                 "GP_Gen5_2",
                 "GP_Gen5_4",
@@ -58,12 +63,14 @@
         },
         "dbVersion": {
             "type": "string",
+            "defaultValue": "${dbVersion}",
             "metadata": {
                 "description": "Server version."
             }
         },
         "adminLoginName": {
             "type": "securestring",
+            "defaultValue" : "${adminLoginName}",
             "minLength": 1,
             "metadata": {
                 "description": "The administrator login name for the database server."
@@ -71,6 +78,7 @@
         },
         "adminPassword": {
             "type": "securestring",
+            "defaultValue" : "${adminPassword}",
             "minLength": 8,
             "maxLength": 128,
             "metadata": {
@@ -79,14 +87,14 @@
         },
         "sslEnforcement": {
             "type": "bool",
-            "defaultValue": true,
+            "defaultValue": ${(sslEnforcement!true)?c},
             "metadata": {
                 "description": "Enable ssl enforcement or not when connect to server."
             }
         },
         "backupRetentionDays": {
             "type": "int",
-            "defaultValue": 7,
+            "defaultValue": ${backupRetentionDays!7},
             "minValue": 7,
             "maxValue": 35,
             "metadata": {
@@ -95,23 +103,14 @@
         },
         "geoRedundantBackup": {
             "type": "bool",
-            "defaultValue": false,
+            "defaultValue": ${(geoRedundantBackup!false)?c},
             "metadata": {
                 "description": "Enable Geo-redundant or not for server backup."
             }
         },
-        "storageMb": {
-            "type": "int",
-            "defaultValue": 5120,
-            "minValue": 5120,
-            "maxValue": 4194304,
-            "metadata": {
-                "description": "Max storage allowed for a server."
-            }
-        },
-        "storageAutogrow": {
+        "storageAutoGrow": {
             "type": "bool",
-            "defaultValue": false,
+            "defaultValue": ${(storageAutoGrow!false)?c},
             "metadata": {
                 "description": "Enable Storage Auto Grow."
             }
@@ -125,12 +124,21 @@
         },
         "vnets": {
             "type": "string",
+            "defaultValue": "${vnets}",
             "metadata": {
                 "description": "The virtual networks to connect through service endpoints."
             }
         },
         "serverTags": {
             "type":"object",
+            "defaultValue": {
+                <#if serverTags?? && serverTags?has_content>
+                    <#list serverTags?keys as key>
+                      "${key}": "${serverTags[key]}",
+                      </#list>
+                </#if>
+                    "cb-resource-type": "database"
+            },
             "metadata": {
                 "description": "User defined tags to be attached to the resource."
             }
@@ -142,7 +150,7 @@
         "apiVersion":"2017-12-01",
         "sslEnforcementString":"[if(parameters('sslEnforcement'), 'Enabled', 'Disabled')]",
         "geoRedundantBackupString":"[if(parameters('geoRedundantBackup'), 'Enabled', 'Disabled')]",
-        "storageAutogrowString":"[if(parameters('storageAutogrow'), 'Enabled', 'Disabled')]"
+        "storageAutoGrowString":"[if(parameters('storageAutoGrow'), 'Enabled', 'Disabled')]"
 
     },
     "resources": [
@@ -167,7 +175,7 @@
                     "backupRetentionDays": "[parameters('backupRetentionDays')]",
                     "geoRedundantBackup": "[variables('geoRedundantBackupString')]",
                     "storageMB": "[parameters('skuSizeMB')]",
-                    "storageAutogrow": "[variables('storageAutogrowString')]"
+                    "storageAutoGrow": "[variables('storageAutoGrowString')]"
                 },
                 "createMode": "Default"
             },
@@ -190,5 +198,11 @@
                 "count": "[length(variables('subnets'))]"
             }
         }
-    ]
+    ],
+    "outputs": {
+        "databaseServerFQDN": {
+            "type": "string",
+            "value": "[reference(parameters('dbServerName')).fullyQualifiedDomainName]"
+        }
+    }
 }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureDatabaseServerViewTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureDatabaseServerViewTest.java
@@ -1,0 +1,107 @@
+package com.sequenceiq.cloudbreak.cloud.azure.view;
+
+import static com.sequenceiq.cloudbreak.cloud.azure.view.AzureDatabaseServerView.DB_VERSION;
+import static com.sequenceiq.cloudbreak.cloud.azure.view.AzureDatabaseServerView.BACKUP_RETENTION_DAYS;
+import static com.sequenceiq.cloudbreak.cloud.azure.view.AzureDatabaseServerView.GEO_REDUNDANT_BACKUP;
+import static com.sequenceiq.cloudbreak.cloud.azure.view.AzureDatabaseServerView.SKU_CAPACITY;
+import static com.sequenceiq.cloudbreak.cloud.azure.view.AzureDatabaseServerView.SKU_FAMILY;
+import static com.sequenceiq.cloudbreak.cloud.azure.view.AzureDatabaseServerView.SKU_TIER;
+import static com.sequenceiq.cloudbreak.cloud.azure.view.AzureDatabaseServerView.STORAGE_AUTO_GROW;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseEngine;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseServer;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.Mock;
+
+public class AzureDatabaseServerViewTest {
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private DatabaseServer server;
+
+    private AzureDatabaseServerView underTest;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+
+        underTest = new AzureDatabaseServerView(server);
+    }
+
+    @Test
+    public void testDbVersion() {
+        when(server.getStringParameter(DB_VERSION)).thenReturn("1234");
+        assertThat(underTest.getDbVersion()).isEqualTo("1234");
+    }
+
+    @Test
+    public void testBackupRetentionDays() {
+        when(server.getParameter(BACKUP_RETENTION_DAYS, Integer.class)).thenReturn(5);
+        assertThat(underTest.getBackupRetentionDays()).isEqualTo(5);
+    }
+
+    @Test
+    public void testGeoRedundantBackup() {
+        when(server.getStringParameter(GEO_REDUNDANT_BACKUP)).thenReturn("true");
+        assertThat(underTest.getGeoRedundantBackup()).isEqualTo(true);
+    }
+
+    @Test
+    public void testSkuCapacity() {
+        when(server.getParameter(SKU_CAPACITY, Integer.class)).thenReturn(4);
+        assertThat(underTest.getSkuCapacity()).isEqualTo(4);
+    }
+
+    @Test
+    public void testSkuFamily() {
+        when(server.getStringParameter(SKU_FAMILY)).thenReturn("some-family");
+        assertThat(underTest.getSkuFamily()).isEqualTo("some-family");
+    }
+
+    @Test
+    public void testSkuTier() {
+        when(server.getStringParameter(SKU_TIER)).thenReturn("some-tier");
+        assertThat(underTest.getSkuTier()).isEqualTo("some-tier");
+    }
+
+    @Test
+    public void testStorageAutoGrow() {
+        when(server.getStringParameter(STORAGE_AUTO_GROW)).thenReturn("true");
+        assertThat(underTest.getStorageAutoGrow()).isEqualTo(true);
+    }
+
+    @Test
+    public void testAllocatedStorageInMB() {
+        when(server.getStorageSize()).thenReturn(5L);
+        assertThat(underTest.getAllocatedStorageInMb()).isEqualTo(5L * 1024);
+    }
+
+    @Test
+    public void testDbServerName() {
+        when(server.getServerId()).thenReturn("some-name");
+        assertThat(underTest.getDbServerName()).isEqualTo("some-name");
+    }
+
+    @Test
+    public void testDatabaseType() {
+        when(server.getEngine()).thenReturn(DatabaseEngine.POSTGRESQL);
+        assertThat(underTest.getDatabaseType()).isEqualTo("postgres");
+    }
+
+    @Test
+    public void testAdminLoginName() {
+        when(server.getRootUserName()).thenReturn("some-user");
+        assertThat(underTest.getAdminLoginName()).isEqualTo("some-user");
+    }
+
+    @Test
+    public void testAdminPassword() {
+        when(server.getRootPassword()).thenReturn("some-password");
+        assertThat(underTest.getAdminPassword()).isEqualTo("some-password");
+    }
+}

--- a/cloud-common/src/main/resources/application.yml
+++ b/cloud-common/src/main/resources/application.yml
@@ -189,6 +189,7 @@ cb:
     template.path: templates/arm-v2.ftl
     network.template.path: templates/arm-network.ftl
     parameter.path: templates/parameters.ftl
+    database.template.path: templates/arm-database.ftl
     app.creation.template:
       command.path: templates/app-creation-command.ftl
       json.path: templates/app-creation.json

--- a/common-model/src/main/java/com/sequenceiq/common/api/type/ResourceType.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/type/ResourceType.java
@@ -49,6 +49,7 @@ public enum ResourceType {
     AZURE_VOLUMESET,
     AZURE_DISK,
     AZURE_RESOURCE_GROUP,
+    AZURE_DATABASE,
 
     // ARM
     ARM_TEMPLATE(CommonResourceType.TEMPLATE),

--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -23,7 +23,7 @@
     <suppress checks="ParameterNumber" files="UserDataBuilder.java|ServiceEndpointCollector.java"/>
     <suppress checks="EmptyLineSeparator" files=".*Description.java|.*Descriptions.java|Notes.java"/>
     <suppress checks=".*" files="PrometheusResponse.java"/>
-    <suppress checks="CyclomaticComplexity" files="PrometheusEvaluator.java|MetadataSetupService.java|AzureRoleManager.java"/>
+    <suppress checks="CyclomaticComplexity" files="PrometheusEvaluator.java|MetadataSetupService.java|AzureRoleManager.java|DBStackToDatabaseStackConverter.java"/>
     <suppress checks="ModifierOrderCheck" files="EncryptedJsonToString.java"/>
     <suppress checks="TrailingComment" files="HeartbeatServiceTest.java"/>
     <suppress checks="VisibilityModifier" files="AbstractAction.java"/>

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/DatabaseService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/DatabaseService.java
@@ -24,7 +24,7 @@ import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.DatabaseServerV4En
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.AllocateDatabaseServerV4Request;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerStatusV4Response;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerTerminationOutcomeV4Response;
-import com.sequenceiq.redbeams.api.endpoint.v4.stacks.AwsDatabaseServerV4Parameters;
+import com.sequenceiq.redbeams.api.endpoint.v4.stacks.aws.AwsDatabaseServerV4Parameters;
 import com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4Request;
 import com.sequenceiq.redbeams.api.model.common.Status;
 

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/AllocateDatabaseServerV4Request.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/AllocateDatabaseServerV4Request.java
@@ -8,9 +8,10 @@ import javax.validation.constraints.Size;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.sequenceiq.cloudbreak.common.mappable.Mappable;
 import com.sequenceiq.cloudbreak.common.mappable.ProviderParametersBase;
-import com.sequenceiq.redbeams.api.endpoint.v4.stacks.AwsDBStackV4Parameters;
+import com.sequenceiq.redbeams.api.endpoint.v4.stacks.aws.AwsDBStackV4Parameters;
 import com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4Request;
 import com.sequenceiq.redbeams.api.endpoint.v4.stacks.NetworkV4Request;
+import com.sequenceiq.redbeams.api.endpoint.v4.stacks.azure.AzureDBStackV4Parameters;
 import com.sequenceiq.redbeams.doc.ModelDescriptions;
 import com.sequenceiq.redbeams.doc.ModelDescriptions.DatabaseServer;
 import com.sequenceiq.redbeams.doc.ModelDescriptions.DBStack;
@@ -42,6 +43,9 @@ public class AllocateDatabaseServerV4Request extends ProviderParametersBase {
 
     @ApiModelProperty(DBStack.AWS_PARAMETERS)
     private AwsDBStackV4Parameters aws;
+
+    @ApiModelProperty(DBStack.AZURE_PARAMETERS)
+    private AzureDBStackV4Parameters azure;
 
     public String getName() {
         return name;
@@ -94,7 +98,14 @@ public class AllocateDatabaseServerV4Request extends ProviderParametersBase {
 
     @Override
     public Mappable createAzure() {
-        return null;
+        if (azure == null) {
+            azure = new AzureDBStackV4Parameters();
+        }
+        return azure;
+    }
+
+    public void setAzure(AzureDBStackV4Parameters azure) {
+        this.azure = azure;
     }
 
     @Override

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/DatabaseServerV4Base.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/DatabaseServerV4Base.java
@@ -3,6 +3,8 @@ package com.sequenceiq.redbeams.api.endpoint.v4.stacks;
 import com.sequenceiq.cloudbreak.common.mappable.Mappable;
 import com.sequenceiq.cloudbreak.common.mappable.ProviderParametersBase;
 import com.sequenceiq.cloudbreak.validation.ValidDatabaseVendor;
+import com.sequenceiq.redbeams.api.endpoint.v4.stacks.aws.AwsDatabaseServerV4Parameters;
+import com.sequenceiq.redbeams.api.endpoint.v4.stacks.azure.AzureDatabaseServerV4Parameters;
 import com.sequenceiq.redbeams.doc.ModelDescriptions.DatabaseServerModelDescriptions;
 
 import io.swagger.annotations.ApiModelProperty;
@@ -33,6 +35,9 @@ public class DatabaseServerV4Base extends ProviderParametersBase {
 
     @ApiModelProperty(DatabaseServerModelDescriptions.AWS_PARAMETERS)
     private AwsDatabaseServerV4Parameters aws;
+
+    @ApiModelProperty(DatabaseServerModelDescriptions.AZURE_PARAMETERS)
+    private AzureDatabaseServerV4Parameters azure;
 
     // @ApiModelProperty(DatabaseServerModelDescriptions.GCP_PARAMETERS)
     // private GcpDatabaseServerV4Parameters gcp;
@@ -124,7 +129,14 @@ public class DatabaseServerV4Base extends ProviderParametersBase {
 
     @Override
     public Mappable createAzure() {
-        return null;
+        if (azure == null) {
+            azure = new AzureDatabaseServerV4Parameters();
+        }
+        return azure;
+    }
+
+    public void setAzure(AzureDatabaseServerV4Parameters azure) {
+        this.azure = azure;
     }
 
     @Override
@@ -146,4 +158,7 @@ public class DatabaseServerV4Base extends ProviderParametersBase {
         return aws;
     }
 
+    public AzureDatabaseServerV4Parameters getAzure() {
+        return azure;
+    }
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/NetworkV4Base.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/NetworkV4Base.java
@@ -2,6 +2,8 @@ package com.sequenceiq.redbeams.api.endpoint.v4.stacks;
 
 import com.sequenceiq.cloudbreak.common.mappable.Mappable;
 import com.sequenceiq.cloudbreak.common.mappable.ProviderParametersBase;
+import com.sequenceiq.redbeams.api.endpoint.v4.stacks.aws.AwsNetworkV4Parameters;
+import com.sequenceiq.redbeams.api.endpoint.v4.stacks.azure.AzureNetworkV4Parameters;
 import com.sequenceiq.redbeams.doc.ModelDescriptions.NetworkModelDescriptions;
 
 import io.swagger.annotations.ApiModelProperty;
@@ -10,6 +12,9 @@ public class NetworkV4Base extends ProviderParametersBase {
 
     @ApiModelProperty(NetworkModelDescriptions.AWS_PARAMETERS)
     private AwsNetworkV4Parameters aws;
+
+    @ApiModelProperty(NetworkModelDescriptions.AZURE_PARAMETERS)
+    private AzureNetworkV4Parameters azure;
 
     // @ApiModelProperty(NetworkModelDescriptions.GCP_PARAMETERS)
     // private GcpNetworkV4Parameters gcp;
@@ -45,7 +50,15 @@ public class NetworkV4Base extends ProviderParametersBase {
 
     @Override
     public Mappable createAzure() {
-        return null;
+        if (azure == null) {
+            azure = new AzureNetworkV4Parameters();
+        }
+
+        return azure;
+    }
+
+    public void setAzure(AzureNetworkV4Parameters azure) {
+        this.azure = azure;
     }
 
     @Override
@@ -67,4 +80,7 @@ public class NetworkV4Base extends ProviderParametersBase {
         return aws;
     }
 
+    public AzureNetworkV4Parameters getAzure() {
+        return azure;
+    }
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/aws/AwsDBStackV4Parameters.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/aws/AwsDBStackV4Parameters.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.redbeams.api.endpoint.v4.stacks;
+package com.sequenceiq.redbeams.api.endpoint.v4.stacks.aws;
 
 import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AWS;
 

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/aws/AwsDatabaseServerV4Parameters.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/aws/AwsDatabaseServerV4Parameters.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.redbeams.api.endpoint.v4.stacks;
+package com.sequenceiq.redbeams.api.endpoint.v4.stacks.aws;
 
 import java.util.Map;
 

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/aws/AwsNetworkV4Parameters.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/aws/AwsNetworkV4Parameters.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.redbeams.api.endpoint.v4.stacks;
+package com.sequenceiq.redbeams.api.endpoint.v4.stacks.aws;
 
 import java.util.Map;
 

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/azure/AzureDBStackV4Parameters.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/azure/AzureDBStackV4Parameters.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.redbeams.api.endpoint.v4.stacks.azure;
+
+import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AZURE;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.common.mappable.MappableBase;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(Include.NON_NULL)
+public class AzureDBStackV4Parameters extends MappableBase {
+
+    @Override
+    @JsonIgnore
+    @ApiModelProperty(hidden = true)
+    public CloudPlatform getCloudPlatform() {
+        return AZURE;
+    }
+}

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/azure/AzureDatabaseServerV4Parameters.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/azure/AzureDatabaseServerV4Parameters.java
@@ -1,0 +1,142 @@
+package com.sequenceiq.redbeams.api.endpoint.v4.stacks.azure;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.common.mappable.MappableBase;
+import com.sequenceiq.redbeams.doc.ModelDescriptions.AzureDatabaseServerModelDescriptions;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.Map;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(Include.NON_NULL)
+public class AzureDatabaseServerV4Parameters extends MappableBase {
+
+    private static final String BACKUP_RETENTION_DAYS = "backupRetentionDays";
+
+    private static final String DB_VERSION = "dbVersion";
+
+    private static final String GEO_REDUNDANT_BACKUP = "geoRedundantBackup";
+
+    private static final String SKU_CAPACITY = "skuCapacity";
+
+    private static final String SKU_FAMILY = "skuFamily";
+
+    private static final String SKU_TIER = "skuTier";
+
+    private static final String STORAGE_AUTO_GROW = "storageAutoGrow";
+
+    @ApiModelProperty(AzureDatabaseServerModelDescriptions.BACKUP_RETENTION_DAYS)
+    private Integer backupRetentionDays;
+
+    @ApiModelProperty(AzureDatabaseServerModelDescriptions.DB_VERSION)
+    private String dbVersion;
+
+    @ApiModelProperty(AzureDatabaseServerModelDescriptions.GEO_REDUNDANT_BACKUPS)
+    private boolean geoRedundantBackup;
+
+    @ApiModelProperty(AzureDatabaseServerModelDescriptions.SKU_CAPACITY)
+    private Integer skuCapacity;
+
+    @ApiModelProperty(AzureDatabaseServerModelDescriptions.SKU_FAMILY)
+    private String skuFamily;
+
+    @ApiModelProperty(AzureDatabaseServerModelDescriptions.SKU_TIER)
+    private String skuTier;
+
+    @ApiModelProperty(AzureDatabaseServerModelDescriptions.STORAGE_AUTO_GROW)
+    private boolean storageAutoGrow;
+
+    public Integer getBackupRetentionDays() {
+        return backupRetentionDays;
+    }
+
+    public void setBackupRetentionDays(Integer backupRetentionDays) {
+        this.backupRetentionDays = backupRetentionDays;
+    }
+
+    public String getDbVersion() {
+        return dbVersion;
+    }
+
+    public void setDbVersion(String dbVersion) {
+        this.dbVersion = dbVersion;
+    }
+
+    public boolean isGeoRedundantBackup() {
+        return geoRedundantBackup;
+    }
+
+    public void setGeoRedundantBackup(boolean geoRedundantBackup) {
+        this.geoRedundantBackup = geoRedundantBackup;
+    }
+
+    public Integer getSkuCapacity() {
+        return skuCapacity;
+    }
+
+    public void setSkuCapacity(Integer skuCapacity) {
+        this.skuCapacity = skuCapacity;
+    }
+
+    public String getSkuFamily() {
+        return skuFamily;
+    }
+
+    public void setSkuFamily(String skuFamily) {
+        this.skuFamily = skuFamily;
+    }
+
+    public String getSkuTier() {
+        return skuTier;
+    }
+
+    public void setSkuTier(String skuTier) {
+        this.skuTier = skuTier;
+    }
+
+    public boolean isStorageAutoGrow() {
+        return storageAutoGrow;
+    }
+
+    public void setStorageAutoGrow(boolean storageAutoGrow) {
+        this.storageAutoGrow = storageAutoGrow;
+    }
+
+    @Override
+    public Map<String, Object> asMap() {
+        Map<String, Object> map = super.asMap();
+        putIfValueNotNull(map, BACKUP_RETENTION_DAYS, backupRetentionDays);
+        putIfValueNotNull(map, DB_VERSION, dbVersion);
+        putIfValueNotNull(map, GEO_REDUNDANT_BACKUP, geoRedundantBackup);
+        putIfValueNotNull(map, SKU_CAPACITY, skuCapacity);
+        putIfValueNotNull(map, SKU_FAMILY, skuFamily);
+        putIfValueNotNull(map, SKU_TIER, skuTier);
+        putIfValueNotNull(map, STORAGE_AUTO_GROW, storageAutoGrow);
+        return map;
+    }
+
+    @Override
+    @JsonIgnore
+    @ApiModelProperty(hidden = true)
+    public CloudPlatform getCloudPlatform() {
+        return CloudPlatform.AZURE;
+    }
+
+    @Override
+    public void parse(Map<String, Object> parameters) {
+        backupRetentionDays = getInt(parameters, BACKUP_RETENTION_DAYS);
+        dbVersion = getParameterOrNull(parameters, DB_VERSION);
+        geoRedundantBackup = Boolean.parseBoolean(getParameterOrNull(parameters, GEO_REDUNDANT_BACKUP));
+        skuCapacity = getInt(parameters, SKU_CAPACITY);
+        skuFamily = getParameterOrNull(parameters, SKU_FAMILY);
+        skuTier = getParameterOrNull(parameters, SKU_TIER);
+        storageAutoGrow = Boolean.parseBoolean(getParameterOrNull(parameters, STORAGE_AUTO_GROW));
+    }
+}

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/azure/AzureNetworkV4Parameters.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/azure/AzureNetworkV4Parameters.java
@@ -1,0 +1,52 @@
+package com.sequenceiq.redbeams.api.endpoint.v4.stacks.azure;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.common.mappable.MappableBase;
+import com.sequenceiq.redbeams.doc.ModelDescriptions.AzureNetworkModelDescription;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.Map;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(Include.NON_NULL)
+public class AzureNetworkV4Parameters extends MappableBase {
+
+    private static final String VIRTUAL_NETWORK = "virtualNetwork";
+
+    @ApiModelProperty(AzureNetworkModelDescription.VIRTUAL_NETWORK)
+    private String virtualNetwork;
+
+    public String getVirtualNetwork() {
+        return virtualNetwork;
+    }
+
+    public void setVirtualNetwork(String virtualNetwork) {
+        this.virtualNetwork = virtualNetwork;
+    }
+
+    @Override
+    public Map<String, Object> asMap() {
+        Map<String, Object> map = super.asMap();
+        putIfValueNotNull(map, VIRTUAL_NETWORK, virtualNetwork);
+        return map;
+    }
+
+    @Override
+    @JsonIgnore
+    @ApiModelProperty(hidden = true)
+    public CloudPlatform getCloudPlatform() {
+        return CloudPlatform.AZURE;
+    }
+
+    @Override
+    public void parse(Map<String, Object> parameters) {
+        virtualNetwork = getParameterOrNull(parameters, VIRTUAL_NETWORK);
+    }
+}

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/ModelDescriptions.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/ModelDescriptions.java
@@ -72,6 +72,7 @@ public final class ModelDescriptions {
         public static final String NETWORK = "Network information for the database stack";
         public static final String DATABASE_SERVER = "Database server information for the database stack";
         public static final String AWS_PARAMETERS = "AWS-specific parameters for the database stack";
+        public static final String AZURE_PARAMETERS = "Azure-specific parameters for the database stack";
     }
 
     public static class NetworkModelDescriptions {
@@ -100,9 +101,23 @@ public final class ModelDescriptions {
         public static final String SECURITY_GROUP = "Security group of the database server";
     }
 
+    public static class AzureNetworkModelDescription {
+        public static final String VIRTUAL_NETWORK = "Fully qualified IDs for an Azure network and subnet";
+    }
+
     public static class AwsDatabaseServerModelDescriptions {
         public static final String BACKUP_RETENTION_PERIOD = "Time to retain backups, in days";
         public static final String ENGINE_VERSION = "Version of the database engine (vendor)";
+    }
+
+    public static class AzureDatabaseServerModelDescriptions {
+        public static final String BACKUP_RETENTION_DAYS = "Time to retain backups, in days";
+        public static final String GEO_REDUNDANT_BACKUPS = "Whether backups are geographically redundant";
+        public static final String SKU_CAPACITY = "The number of vCPUs assigned to the database server";
+        public static final String SKU_FAMILY = "The family of hardware used for the database server";
+        public static final String SKU_TIER = "The tier of SKU for the database server";
+        public static final String STORAGE_AUTO_GROW = "Whether the database server will automatically grow storage when necessary";
+        public static final String DB_VERSION = "The version of the database software to use";
     }
 
     public static class SecurityGroupModelDescriptions {

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/AllocateDatabaseServerV4RequestTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/AllocateDatabaseServerV4RequestTest.java
@@ -7,7 +7,7 @@ import static org.junit.Assert.assertNull;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.sequenceiq.redbeams.api.endpoint.v4.stacks.AwsDBStackV4Parameters;
+import com.sequenceiq.redbeams.api.endpoint.v4.stacks.aws.AwsDBStackV4Parameters;
 import com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4Request;
 import com.sequenceiq.redbeams.api.endpoint.v4.stacks.NetworkV4Request;
 

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/DatabaseServerV4BaseTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/DatabaseServerV4BaseTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
+import com.sequenceiq.redbeams.api.endpoint.v4.stacks.aws.AwsDatabaseServerV4Parameters;
+
 import org.junit.Before;
 import org.junit.Test;
 

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/NetworkV4BaseTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/NetworkV4BaseTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
+import com.sequenceiq.redbeams.api.endpoint.v4.stacks.aws.AwsNetworkV4Parameters;
+
 import org.junit.Before;
 import org.junit.Test;
 

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/aws/AwsDBStackV4ParametersTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/aws/AwsDBStackV4ParametersTest.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.redbeams.api.endpoint.v4.stacks;
+package com.sequenceiq.redbeams.api.endpoint.v4.stacks.aws;
 
 import static org.junit.Assert.assertEquals;
 

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/aws/AwsDatabaseServerV4ParametersTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/aws/AwsDatabaseServerV4ParametersTest.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.redbeams.api.endpoint.v4.stacks;
+package com.sequenceiq.redbeams.api.endpoint.v4.stacks.aws;
 
 import static org.junit.Assert.assertEquals;
 

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/aws/AwsNetworkV4ParametersTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/aws/AwsNetworkV4ParametersTest.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.redbeams.api.endpoint.v4.stacks;
+package com.sequenceiq.redbeams.api.endpoint.v4.stacks.aws;
 
 import static org.junit.Assert.assertEquals;
 

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/azure/AzureDBStackV4ParametersTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/azure/AzureDBStackV4ParametersTest.java
@@ -1,0 +1,24 @@
+package com.sequenceiq.redbeams.api.endpoint.v4.stacks.azure;
+
+import static org.junit.Assert.assertEquals;
+
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class AzureDBStackV4ParametersTest {
+
+    private AzureDBStackV4Parameters underTest;
+
+    @Before
+    public void setUp() {
+        underTest = new AzureDBStackV4Parameters();
+    }
+
+    @Test
+    public void testGetCloudPlatform() {
+        assertEquals(CloudPlatform.AZURE, underTest.getCloudPlatform());
+    }
+
+}

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/azure/AzureDatabaseServerV4ParametersTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/azure/AzureDatabaseServerV4ParametersTest.java
@@ -1,0 +1,101 @@
+package com.sequenceiq.redbeams.api.endpoint.v4.stacks.azure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class AzureDatabaseServerV4ParametersTest {
+
+    private AzureDatabaseServerV4Parameters underTest;
+
+    @Before
+    public void setUp() {
+        underTest = new AzureDatabaseServerV4Parameters();
+    }
+
+    @Test
+    public void testGettersAndSetters() {
+        underTest.setBackupRetentionDays(3);
+        assertThat(underTest.getBackupRetentionDays().intValue()).isEqualTo(3);
+
+        underTest.setGeoRedundantBackup(true);
+        assertThat(underTest.isGeoRedundantBackup()).isTrue();
+
+        underTest.setSkuCapacity(5);
+        assertThat(underTest.getSkuCapacity().intValue()).isEqualTo(5);
+
+        underTest.setSkuFamily("some-family");
+        assertThat(underTest.getSkuFamily()).isEqualTo("some-family");
+
+        underTest.setSkuTier("some-tier");
+        assertThat(underTest.getSkuTier()).isEqualTo("some-tier");
+
+        underTest.setStorageAutoGrow(true);
+        assertThat(underTest.isStorageAutoGrow()).isTrue();
+
+        underTest.setDbVersion("1.2.3");
+        assertThat(underTest.getDbVersion()).isEqualTo("1.2.3");
+    }
+
+    @Test
+    public void testAsMap() {
+        underTest.setBackupRetentionDays(3);
+        underTest.setDbVersion("1.2.3");
+
+        assertThat(underTest.asMap()).containsOnly(Map.entry("backupRetentionDays", 3),
+                Map.entry("dbVersion", "1.2.3"),
+                Map.entry("cloudPlatform", "AZURE"),
+                Map.entry("geoRedundantBackup", false),
+                Map.entry("storageAutoGrow", false));
+
+        underTest.setSkuCapacity(5);
+        underTest.setSkuFamily("some-family");
+        underTest.setSkuTier("some-tier");
+        underTest.setGeoRedundantBackup(true);
+        underTest.setStorageAutoGrow(true);
+
+        assertThat(underTest.asMap()).containsOnly(Map.entry("backupRetentionDays", 3),
+                Map.entry("dbVersion", "1.2.3"),
+                Map.entry("cloudPlatform", "AZURE"),
+                Map.entry("skuCapacity", 5),
+                Map.entry("skuFamily", "some-family"),
+                Map.entry("skuTier", "some-tier"),
+                Map.entry("geoRedundantBackup", true),
+                Map.entry("storageAutoGrow", true));
+    }
+
+    @Test
+    public void testGetCloudPlatform() {
+        assertThat(underTest.getCloudPlatform()).isEqualTo(CloudPlatform.AZURE);
+    }
+
+    @Test
+    public void testParse() {
+        Map<String, Object> parameters = ImmutableMap.<String, Object>builder()
+                .put("backupRetentionDays", 3)
+                .put("dbVersion", "1.2.3")
+                .put("skuCapacity", 5)
+                .put("skuFamily", "some-family")
+                .put("skuTier", "some-tier")
+                .put("geoRedundantBackup", true)
+                .put("storageAutoGrow", true)
+                .build();
+
+        underTest.parse(parameters);
+
+        underTest.setBackupRetentionDays(3);
+        underTest.setGeoRedundantBackup(true);
+        underTest.setSkuCapacity(5);
+        underTest.setSkuFamily("some-family");
+        underTest.setSkuTier("some-tier");
+        underTest.setStorageAutoGrow(true);
+        underTest.setDbVersion("1.2.3");
+    }
+
+}

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/azure/AzureNetworkV4ParametersTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/azure/AzureNetworkV4ParametersTest.java
@@ -1,0 +1,49 @@
+package com.sequenceiq.redbeams.api.endpoint.v4.stacks.azure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class AzureNetworkV4ParametersTest {
+
+    private AzureNetworkV4Parameters underTest;
+
+    @Before
+    public void setUp() {
+        underTest = new AzureNetworkV4Parameters();
+    }
+
+    @Test
+    public void testGettersAndSetters() {
+        underTest.setVirtualNetwork("someVirtualNetwork");
+        assertThat(underTest.getVirtualNetwork()).isEqualTo("someVirtualNetwork");
+    }
+
+    @Test
+    public void testAsMap() {
+        underTest.setVirtualNetwork("someVirtualNetwork");
+
+        assertThat(underTest.asMap()).containsOnly(Map.entry("virtualNetwork", "someVirtualNetwork"),
+                Map.entry("cloudPlatform", "AZURE"));
+    }
+
+    @Test
+    public void testGetCloudPlatform() {
+        assertThat(underTest.getCloudPlatform()).isEqualTo(CloudPlatform.AZURE);
+    }
+
+    @Test
+    public void testParse() {
+        Map<String, Object> parameters = Map.of("virtualNetwork", "someVirtualNetwork");
+
+        underTest.parse(parameters);
+
+        assertThat(underTest.getVirtualNetwork()).isEqualTo("someVirtualNetwork");
+    }
+
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/RedbeamsApplication.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/RedbeamsApplication.java
@@ -15,6 +15,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
         "com.sequenceiq.cloudbreak.security",
         "com.sequenceiq.cloudbreak.api.util",
         "com.sequenceiq.cloudbreak.cloud.aws",
+        "com.sequenceiq.cloudbreak.cloud.azure",
         "com.sequenceiq.cloudbreak.cloud.configuration",
         "com.sequenceiq.cloudbreak.cloud.credential",
         "com.sequenceiq.cloudbreak.cloud.handler",

--- a/redbeams/src/main/resources/application.yml
+++ b/redbeams/src/main/resources/application.yml
@@ -186,6 +186,7 @@ cb:
   arm:
     template.path: templates/arm-v2.ftl
     parameter.path: templates/parameters.ftl
+    database.template.path: templates/arm-dbstack.ftl
     app.creation.template:
       command.path: templates/app-creation-command.ftl
       json.path: templates/app-creation.json

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverterTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverterTest.java
@@ -45,7 +45,7 @@ import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentN
 import com.sequenceiq.environment.api.v1.environment.model.response.LocationResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.SecurityAccessResponse;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.AllocateDatabaseServerV4Request;
-import com.sequenceiq.redbeams.api.endpoint.v4.stacks.AwsNetworkV4Parameters;
+import com.sequenceiq.redbeams.api.endpoint.v4.stacks.aws.AwsNetworkV4Parameters;
 import com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4Request;
 import com.sequenceiq.redbeams.api.endpoint.v4.stacks.NetworkV4Request;
 import com.sequenceiq.redbeams.api.endpoint.v4.stacks.SecurityGroupV4Request;


### PR DESCRIPTION
Azure database allocation has been added to Redbeams. This includes some
slight reworking of the allocation request from the Redbeams API, as
well as adding in Azure specific API requests.

Note: I ended up keeping with the Azure pattern of using defaultValues/interpolation to push values into the freemarker template. Feel free to push back if you'd rather I did this a different way, but I have a feeling it's done this way for a reason. Happy to be wrong about that, though.