### PR TITLE
OPSAPS-51269 Hive Needs to be in HTTP Mode for Knox to Proxy J/ODBC Access

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering.bp
@@ -148,7 +148,13 @@
           {
             "refName": "hive_on_tez-HIVESERVER2-BASE",
             "roleType": "HIVESERVER2",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                "name": "hive_hs2_config_safety_valve",
+                "value": "<property><name>hive.server2.thrift.http.port</name><value>10001</value></property><property><name>hive.server2.thrift.http.path</name><value>cliservice</value></property><property><name>hive.server2.transport.mode</name><value>http</value></property><property><name>hive.server2.allow.user.substitution</name><value>true</value></property><property><name>hive.server2.authentication.spnego.keytab</name><value>hive.keytab</value></property><property><name>hive.server2.authentication.spnego.principal</name><value>HTTP/_HOST@GCE.CLOUDERA.COM</value></property>"
+              }
+            ]
           }
         ]
       },


### PR DESCRIPTION
Added some parameters to the cdp-data-engineering.bp blueprint in order to integrate with knox.

Tested by using this modified blueprint in MOW, the parameters were present.