### PR TITLE
CDPAM-129 | Cluster proxy registration with Stack CRN and Cluster Id

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/recipe/ClusterProxyDeregisterHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/recipe/ClusterProxyDeregisterHandler.java
@@ -42,7 +42,7 @@ public class ClusterProxyDeregisterHandler implements EventHandler<ClusterProxyD
         Stack stack = stackService.getByIdWithListsInTransaction(request.getResourceId());
         if (clusterProxyIntegrationEnabled) {
             try {
-                clusterProxyService.deregisterCluster(stack.getCluster());
+                clusterProxyService.deregisterCluster(stack);
             } catch (Exception ex) {
                 LOGGER.error("Cluster proxy deregister failed", ex);
             }


### PR DESCRIPTION
This change is to start using the Stack CRN as identifier when registering a cluster with Cluster Proxy service. We were using Cluster Id as the identifier previously, and there are consumers of Cluster Proxy service that depend on Cluster Id. Therefore to maintain backwards compatibility, we are registering with both the Cluster Id as well as the Stack CRN. We will remove the Cluster Id once all consumers switch to using Stack CRN.