### PR TITLE
CB-2695, CB-2766 : Initialize Impala Volume Configurations

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/impala/ImpalaVolumeConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/impala/ImpalaVolumeConfigProvider.java
@@ -1,0 +1,71 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.impala;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static com.sequenceiq.cloudbreak.template.VolumeUtils.buildVolumePathStringZeroVolumeHandled;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.stereotype.Component;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.cmtemplate.CmHostGroupRoleConfigProvider;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.cloudbreak.template.VolumeUtils;
+import com.sequenceiq.cloudbreak.template.views.HostgroupView;
+
+@Component
+public class ImpalaVolumeConfigProvider implements CmHostGroupRoleConfigProvider {
+
+    private static final String IMPALA_DATACACHE_ENABLED_PARAM = "datacache_enabled";
+
+    private static final String IMPALA_DATACACHE_DIRS_PARAM = "datacache_dirs";
+
+    private static final String IMPALA_DATACACHE_CAPACITY_PARAM = "datacache_capacity";
+
+    private static final String IMPALA_SCRATCH_DIRS_PARAM = "scratch_dirs";
+
+    private static final int MAX_IMPALA_DATA_CACHE_SIZE_IN_GB = 130;
+
+    private static final int MIN_ATTACHED_VOLUME_SIZE_TO_ENABLE_CACHE_IN_GB = 0;
+
+    @Override
+    public List<ApiClusterTemplateConfig> getRoleConfigs(String roleType, HostgroupView hostGroupView, TemplatePreparationObject source) {
+        switch (roleType) {
+            case ImpalaRoles.ROLE_IMPALAD:
+                Integer minAttachedVolumeSize = hostGroupView.getVolumeTemplates().stream()
+                        .mapToInt(volume -> volume.getVolumeSize())
+                        .min()
+                        .orElse(0);
+
+                List<ApiClusterTemplateConfig> configs = new ArrayList<>();
+                configs.add(config(IMPALA_SCRATCH_DIRS_PARAM,
+                        buildVolumePathStringZeroVolumeHandled(hostGroupView.getVolumeCount(), "impala/scratch")));
+
+                if (minAttachedVolumeSize > MIN_ATTACHED_VOLUME_SIZE_TO_ENABLE_CACHE_IN_GB) {
+                    long dataCacheCapacityInBytes = VolumeUtils
+                            .convertGBToBytes(Math.min(minAttachedVolumeSize / 2, MAX_IMPALA_DATA_CACHE_SIZE_IN_GB / hostGroupView.getVolumeCount()));
+
+                    configs.add(config(IMPALA_DATACACHE_ENABLED_PARAM, "true"));
+                    configs.add(config(IMPALA_DATACACHE_CAPACITY_PARAM, Long.toString(dataCacheCapacityInBytes)));
+                    configs.add(config(IMPALA_DATACACHE_DIRS_PARAM,
+                            buildVolumePathStringZeroVolumeHandled(hostGroupView.getVolumeCount(), "impala/datacache")));
+                }
+                return configs;
+
+            default:
+                return List.of();
+        }
+    }
+
+    @Override
+    public String getServiceType() {
+        return ImpalaRoles.SERVICE_IMPALA;
+    }
+
+    @Override
+    public Set<String> getRoleTypes() {
+        return Set.of(ImpalaRoles.ROLE_IMPALAD);
+    }
+}

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/VolumeConfigProviderTestHelper.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/VolumeConfigProviderTestHelper.java
@@ -1,10 +1,12 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders;
 
+import java.util.Collections;
 import java.util.Set;
 
-import com.sequenceiq.common.api.type.InstanceGroupType;
+import com.sequenceiq.cloudbreak.domain.VolumeTemplate;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.views.HostgroupView;
+import com.sequenceiq.common.api.type.InstanceGroupType;
 
 public class VolumeConfigProviderTestHelper {
 
@@ -12,6 +14,10 @@ public class VolumeConfigProviderTestHelper {
 
     public static HostgroupView hostGroupWithVolumeCount(int volumeCount) {
         return new HostgroupView("some name", volumeCount, InstanceGroupType.CORE, 2);
+    }
+
+    public static HostgroupView hostGroupWithVolumeTemplates(int volumeCount, Set<VolumeTemplate> volumeTemplates) {
+        return new HostgroupView("some name", volumeCount, InstanceGroupType.CORE, Collections.EMPTY_SET, volumeTemplates);
     }
 
     public static TemplatePreparationObject preparatorWithHostGroups(HostgroupView... hostGroups) {

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/impala/ImpalaVolumeConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/impala/ImpalaVolumeConfigProviderTest.java
@@ -1,0 +1,88 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.impala;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.VolumeConfigProviderTestHelper.hostGroupWithVolumeTemplates;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.VolumeConfigProviderTestHelper.preparatorWithHostGroups;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.google.common.collect.Sets;
+import com.sequenceiq.cloudbreak.domain.Template;
+import com.sequenceiq.cloudbreak.domain.VolumeTemplate;
+import com.sequenceiq.cloudbreak.template.views.HostgroupView;
+
+class ImpalaVolumeConfigProviderTest {
+
+    private final ImpalaVolumeConfigProvider subject = new ImpalaVolumeConfigProvider();
+
+    @Test
+    void testRoleConfigsWithAttachedVolumes100GB() {
+        HostgroupView worker = hostGroupWithVolumeTemplates(2, getVolumeTemplates(100));
+        List<ApiClusterTemplateConfig> roleConfigs = subject.getRoleConfigs(ImpalaRoles.ROLE_IMPALAD, worker, preparatorWithHostGroups(worker));
+
+        assertEquals(
+                List.of(
+                        config("scratch_dirs", "/hadoopfs/fs1/impala/scratch,/hadoopfs/fs2/impala/scratch"),
+                        config("datacache_enabled", "true"),
+                        config("datacache_capacity", "53687091200"),
+                        config("datacache_dirs", "/hadoopfs/fs1/impala/datacache,/hadoopfs/fs2/impala/datacache")),
+                roleConfigs
+        );
+    }
+
+    @Test
+    void testRoleConfigsWithAttachedVolumes200GB() {
+        HostgroupView worker = hostGroupWithVolumeTemplates(3, getVolumeTemplates(200));
+        List<ApiClusterTemplateConfig> roleConfigs = subject.getRoleConfigs(ImpalaRoles.ROLE_IMPALAD, worker, preparatorWithHostGroups(worker));
+
+        assertEquals(
+                List.of(
+                        config("scratch_dirs", "/hadoopfs/fs1/impala/scratch,/hadoopfs/fs2/impala/scratch,/hadoopfs/fs3/impala/scratch"),
+                        config("datacache_enabled", "true"),
+                        config("datacache_capacity", "46170898432"),
+                        config("datacache_dirs", "/hadoopfs/fs1/impala/datacache,/hadoopfs/fs2/impala/datacache,/hadoopfs/fs3/impala/datacache")),
+                roleConfigs
+        );
+    }
+
+    @Test
+    void testRoleConfigsWithAttachedVolumesGreaterThanMaxImapalaCacheVolumeSize() {
+        HostgroupView worker = hostGroupWithVolumeTemplates(3, getVolumeTemplates(1000));
+        List<ApiClusterTemplateConfig> roleConfigs = subject.getRoleConfigs(ImpalaRoles.ROLE_IMPALAD, worker, preparatorWithHostGroups(worker));
+
+        assertEquals(
+                List.of(
+                        config("scratch_dirs", "/hadoopfs/fs1/impala/scratch,/hadoopfs/fs2/impala/scratch,/hadoopfs/fs3/impala/scratch"),
+                        config("datacache_enabled", "true"),
+                        config("datacache_capacity", "46170898432"),
+                        config("datacache_dirs", "/hadoopfs/fs1/impala/datacache,/hadoopfs/fs2/impala/datacache,/hadoopfs/fs3/impala/datacache")),
+                roleConfigs
+        );
+    }
+
+    @Test
+    void testRoleConfigsWithAttachedVolumeCountZero() {
+
+        HostgroupView worker = hostGroupWithVolumeTemplates(0, getVolumeTemplates(0));
+        List<ApiClusterTemplateConfig> roleConfigs = subject.getRoleConfigs(ImpalaRoles.ROLE_IMPALAD, worker, preparatorWithHostGroups(worker));
+
+        assertEquals(
+                List.of(
+                        config("scratch_dirs", "/hadoopfs/root1/impala/scratch")),
+                roleConfigs
+        );
+    }
+
+    protected Set<VolumeTemplate> getVolumeTemplates(int attachedVolumeSize) {
+        Template rootStorageTemplate = new Template();
+        VolumeTemplate volumeTemplate = new VolumeTemplate();
+        volumeTemplate.setVolumeSize(attachedVolumeSize);
+        volumeTemplate.setTemplate(rootStorageTemplate);
+        return Sets.newHashSet(volumeTemplate);
+    }
+}

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/TemplatePreparationObject.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/TemplatePreparationObject.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.template;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -13,6 +14,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.domain.Template;
+import com.sequenceiq.cloudbreak.domain.VolumeTemplate;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.gateway.Gateway;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
@@ -213,11 +215,13 @@ public class TemplatePreparationObject {
                     Template template = instanceGroup.getTemplate();
                     int volumeCount = template == null ? 1 : template.getVolumeTemplates().stream()
                             .mapToInt(volume -> volume.getVolumeCount()).sum();
+                    Set<VolumeTemplate> volumeTemplates = template == null ? Collections.EMPTY_SET
+                            : template.getVolumeTemplates();
                     Set<String> fqdns = instanceGroup.getAllInstanceMetaData().stream()
                             .map(InstanceMetaData::getDiscoveryFQDN)
                             .collect(Collectors.toSet());
                     hostgroupViews.add(new HostgroupView(hostGroup.getName(), volumeCount,
-                            instanceGroup.getInstanceGroupType(), fqdns));
+                            instanceGroup.getInstanceGroupType(), fqdns, volumeTemplates));
                 } else {
                     hostgroupViews.add(new HostgroupView(hostGroup.getName()));
                 }

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/VolumeUtils.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/VolumeUtils.java
@@ -8,6 +8,8 @@ public final class VolumeUtils {
 
     private static final int FIRST_VOLUME = 1;
 
+    private static final long GB_TO_BYTES = 1024 * 1024 * 1024;
+
     private VolumeUtils() {
         throw new IllegalStateException();
     }
@@ -70,5 +72,9 @@ public final class VolumeUtils {
 
     private static String getVolumeDir(int volumeIndex, String dirPrefix, String directory) {
         return dirPrefix + volumeIndex + '/' + directory;
+    }
+
+    public static long convertGBToBytes(int sizeInGb) {
+        return sizeInGb * GB_TO_BYTES;
     }
 }

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/views/HostgroupView.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/views/HostgroupView.java
@@ -2,9 +2,11 @@ package com.sequenceiq.cloudbreak.template.views;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import com.sequenceiq.cloudbreak.domain.VolumeTemplate;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 
 public class HostgroupView {
@@ -21,6 +23,8 @@ public class HostgroupView {
 
     private final SortedSet<String> hosts;
 
+    private final Set<VolumeTemplate> volumeTemplates;
+
     public HostgroupView(String name, int volumeCount, InstanceGroupType instanceGroupType, Collection<String> hosts) {
         this.name = name;
         this.volumeCount = volumeCount;
@@ -35,6 +39,25 @@ public class HostgroupView {
                 })
             : Collections.emptySortedSet();
         nodeCount = this.hosts.size();
+        volumeTemplates = Collections.emptySet();
+    }
+
+    public HostgroupView(String name, int volumeCount, InstanceGroupType instanceGroupType,
+            Collection<String> hosts, Set<VolumeTemplate> volumeTemplates) {
+        this.name = name;
+        this.volumeCount = volumeCount;
+        instanceGroupConfigured = true;
+        this.instanceGroupType = instanceGroupType;
+        this.hosts = hosts != null
+                ? Collections.unmodifiableSortedSet(new TreeSet<>(hosts) {
+            @Override
+            public String toString() {
+                return String.join(",", this);
+            }
+        })
+                : Collections.emptySortedSet();
+        nodeCount = this.hosts.size();
+        this.volumeTemplates = Collections.unmodifiableSet(volumeTemplates);
     }
 
     public HostgroupView(String name, int volumeCount, InstanceGroupType instanceGroupType, Integer nodeCount) {
@@ -44,6 +67,7 @@ public class HostgroupView {
         this.instanceGroupType = instanceGroupType;
         this.nodeCount = nodeCount;
         hosts = Collections.emptySortedSet();
+        volumeTemplates = Collections.emptySet();
     }
 
     public HostgroupView(String name) {
@@ -53,6 +77,7 @@ public class HostgroupView {
         instanceGroupType = InstanceGroupType.CORE;
         nodeCount = 0;
         hosts = Collections.emptySortedSet();
+        volumeTemplates = Collections.emptySet();
     }
 
     public String getName() {
@@ -77,5 +102,9 @@ public class HostgroupView {
 
     public SortedSet<String> getHosts() {
         return hosts;
+    }
+
+    public Set<VolumeTemplate> getVolumeTemplates() {
+        return volumeTemplates;
     }
 }


### PR DESCRIPTION
CB-2695 :  Expose volume configuration templates to role config providers.
CB-2766 :  Initialize Impala Volume Configurations.


Closes #CB-2695
Closes #CB-2766