### PR TITLE
CB-2719 Create IDBMMS gRPC client for fetching mappings

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/AuthorizationClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/AuthorizationClient.java
@@ -6,6 +6,7 @@ import org.springframework.util.StringUtils;
 
 import com.cloudera.thunderhead.service.authorization.AuthorizationGrpc;
 import com.cloudera.thunderhead.service.authorization.AuthorizationProto;
+import com.sequenceiq.cloudbreak.grpc.altus.AltusMetadataInterceptor;
 
 import io.grpc.ManagedChannel;
 

--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/UmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/UmsClient.java
@@ -32,6 +32,7 @@ import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.Machi
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.User;
 import com.sequenceiq.cloudbreak.auth.altus.config.UmsClientConfig;
 import com.sequenceiq.cloudbreak.auth.altus.exception.UmsAuthenticationException;
+import com.sequenceiq.cloudbreak.grpc.altus.AltusMetadataInterceptor;
 
 import io.grpc.ManagedChannel;
 import io.grpc.Status;
@@ -560,7 +561,7 @@ public class UmsClient {
     /**
      * Queries the metadata file used to configure SSO authentication on clusters.
      * @param requestId the Request ID
-     * @param accountId the user CRN
+     * @param accountId the account ID
      * @return metadata as string
      */
     public String getIdentityProviderMetadataXml(String requestId, String accountId) {
@@ -573,4 +574,5 @@ public class UmsClient {
         GetIdPMetadataForWorkloadSSOResponse response = newStub(requestId).getIdPMetadataForWorkloadSSO(request);
         return response.getMetadata();
     }
+
 }

--- a/grpc-common/src/main/java/com/sequenceiq/cloudbreak/grpc/altus/AltusMetadataInterceptor.java
+++ b/grpc-common/src/main/java/com/sequenceiq/cloudbreak/grpc/altus/AltusMetadataInterceptor.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.cloudbreak.auth.altus;
+package com.sequenceiq.cloudbreak.grpc.altus;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -58,7 +58,7 @@ public class AltusMetadataInterceptor implements ClientInterceptor {
      * @param requestId the request ID
      * @param actorCrn  the actor CRN
      */
-    AltusMetadataInterceptor(String requestId, String actorCrn) {
+    public AltusMetadataInterceptor(String requestId, String actorCrn) {
         this.requestId = checkNotNull(requestId);
         this.actorCrn = checkNotNull(actorCrn);
     }
@@ -82,4 +82,5 @@ public class AltusMetadataInterceptor implements ClientInterceptor {
             }
         };
     }
+
 }

--- a/idbmms-connector/build.gradle
+++ b/idbmms-connector/build.gradle
@@ -5,10 +5,22 @@ buildscript {
     mavenLocal()
     mavenCentral()
     maven { url = "$repoUrl" }
+    maven { url 'http://repo.spring.io/libs-release' }
     jcenter()
   }
   dependencies {
+    classpath "org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}"
     classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.8'
+  }
+}
+
+apply plugin: 'io.spring.dependency-management'
+
+dependencyManagement {
+  dependencies {
+    dependencySet(group: 'org.springframework.boot', version: springBootVersion) {
+      entry 'spring-boot-starter-test'
+    }
   }
 }
 
@@ -21,10 +33,8 @@ dependencies {
   }
 
   testCompile group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
-}
-
-dependencies {
   testCompile group: 'junit', name: 'junit', version: '4.12'
+  testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'
 }
 
 checkstyle {

--- a/idbmms-connector/src/main/java/com/sequenceiq/cloudbreak/idbmms/GrpcIdbmmsClient.java
+++ b/idbmms-connector/src/main/java/com/sequenceiq/cloudbreak/idbmms/GrpcIdbmmsClient.java
@@ -1,0 +1,65 @@
+package com.sequenceiq.cloudbreak.idbmms;
+
+import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.grpc.ManagedChannelWrapper;
+import com.sequenceiq.cloudbreak.idbmms.config.IdbmmsConfig;
+import com.sequenceiq.cloudbreak.idbmms.exception.IdbmmsOperationException;
+import com.sequenceiq.cloudbreak.idbmms.model.MappingsConfig;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+
+/**
+ * A GRPC-based client for the IDBroker Mapping Management Service.
+ */
+@Component
+public class GrpcIdbmmsClient {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GrpcIdbmmsClient.class);
+
+    @Inject
+    private IdbmmsConfig idbmmsConfig;
+
+    /**
+     * Retrieves mappings from IDBMMS.
+     *
+     * @param actorCrn the actor CRN
+     * @param environmentCrn the environment CRN to get mappings for
+     * @param requestId an optional request ID
+     * @return the mappings config associated with environment {@code environmentCrn}; never {@code null}
+     */
+    public MappingsConfig getMappingsConfig(String actorCrn, String environmentCrn, Optional<String> requestId) {
+        try (ManagedChannelWrapper channelWrapper = makeWrapper()) {
+            IdbmmsClient client = makeClient(channelWrapper.getChannel(), actorCrn);
+            LOGGER.debug("Fetching mappings for environment {} using request ID {}", environmentCrn, requestId);
+            MappingsConfig mappingsConfig = client.getMappingsConfig(requestId.orElse(UUID.randomUUID().toString()), environmentCrn);
+            LOGGER.debug("Retrieved mappings of version {} for environment {}", mappingsConfig.getMappingsVersion(), environmentCrn);
+            return mappingsConfig;
+        } catch (RuntimeException e) {
+            throw new IdbmmsOperationException(String.format("Error during IDBMMS operation: %s", e.getMessage()), e);
+        }
+    }
+
+    private ManagedChannelWrapper makeWrapper() {
+        return new ManagedChannelWrapper(
+                ManagedChannelBuilder.forAddress(idbmmsConfig.getEndpoint(), idbmmsConfig.getPort())
+                        .usePlaintext()
+                        .maxInboundMessageSize(DEFAULT_MAX_MESSAGE_SIZE)
+                        .build());
+    }
+
+    private IdbmmsClient makeClient(ManagedChannel channel, String actorCrn) {
+        return new IdbmmsClient(channel, actorCrn);
+    }
+
+}

--- a/idbmms-connector/src/main/java/com/sequenceiq/cloudbreak/idbmms/IdbmmsClient.java
+++ b/idbmms-connector/src/main/java/com/sequenceiq/cloudbreak/idbmms/IdbmmsClient.java
@@ -1,0 +1,68 @@
+package com.sequenceiq.cloudbreak.idbmms;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Map;
+
+import com.cloudera.thunderhead.service.idbrokermappingmanagement.IdBrokerMappingManagementGrpc;
+import com.cloudera.thunderhead.service.idbrokermappingmanagement.IdBrokerMappingManagementProto;
+import com.sequenceiq.cloudbreak.grpc.altus.AltusMetadataInterceptor;
+import com.sequenceiq.cloudbreak.idbmms.model.MappingsConfig;
+
+import io.grpc.ManagedChannel;
+
+/**
+ * A simple wrapper to the GRPC IDBroker Mapping Management Service. This handles setting up
+ * the appropriate context-propagating interceptors and hides some boilerplate.
+ */
+class IdbmmsClient {
+
+    private final ManagedChannel channel;
+
+    private final String actorCrn;
+
+    /**
+     * Constructor.
+     *
+     * @param channel  the managed channel.
+     * @param actorCrn the actor CRN.
+     */
+    IdbmmsClient(ManagedChannel channel, String actorCrn) {
+        this.channel = checkNotNull(channel);
+        this.actorCrn = checkNotNull(actorCrn);
+    }
+
+    /**
+     * Wraps a call to getMappingsConfig.
+     *
+     * @param requestId the request ID for the request
+     * @param environmentCrn the environment CRN
+     * @return the mappings config; never {@code null}
+     */
+    MappingsConfig getMappingsConfig(String requestId, String environmentCrn) {
+        checkNotNull(requestId);
+        checkNotNull(environmentCrn);
+        IdBrokerMappingManagementProto.GetMappingsConfigResponse mappingsConfig = newStub(requestId).getMappingsConfig(
+                IdBrokerMappingManagementProto.GetMappingsConfigRequest.newBuilder()
+                        .setEnvironmentCrn(environmentCrn)
+                        .build()
+        );
+        long mappingsVersion = mappingsConfig.getMappingsVersion();
+        Map<String, String> actorMappings = mappingsConfig.getActorMappingsMap();
+        Map<String, String> groupMappings = mappingsConfig.getGroupMappingsMap();
+        return new MappingsConfig(mappingsVersion, actorMappings, groupMappings);
+    }
+
+    /**
+     * Creates a new stub with the appropriate metadata injecting interceptors.
+     *
+     * @param requestId the request ID
+     * @return the stub
+     */
+    private IdBrokerMappingManagementGrpc.IdBrokerMappingManagementBlockingStub newStub(String requestId) {
+        checkNotNull(requestId);
+        return IdBrokerMappingManagementGrpc.newBlockingStub(channel)
+                .withInterceptors(new AltusMetadataInterceptor(requestId, actorCrn));
+    }
+
+}

--- a/idbmms-connector/src/main/java/com/sequenceiq/cloudbreak/idbmms/config/IdbmmsConfig.java
+++ b/idbmms-connector/src/main/java/com/sequenceiq/cloudbreak/idbmms/config/IdbmmsConfig.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.cloudbreak.idbmms.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+import io.netty.util.internal.StringUtil;
+
+/**
+ * Configuration settings for the IDBroker Mapping Management Service endpoint.
+ */
+@Configuration
+public class IdbmmsConfig {
+
+    @Value("${altus.idbmms.host:}")
+    private String endpoint;
+
+    @Value("${altus.idbmms.port:8990}")
+    private int port;
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public boolean isConfigured() {
+        return !StringUtil.isNullOrEmpty(endpoint);
+    }
+
+}

--- a/idbmms-connector/src/main/java/com/sequenceiq/cloudbreak/idbmms/exception/IdbmmsOperationException.java
+++ b/idbmms-connector/src/main/java/com/sequenceiq/cloudbreak/idbmms/exception/IdbmmsOperationException.java
@@ -1,0 +1,16 @@
+package com.sequenceiq.cloudbreak.idbmms.exception;
+
+/**
+ * A {@link RuntimeException} representing a problem encountered during an IDBroker Mapping Management Service operation.
+ */
+public class IdbmmsOperationException extends RuntimeException {
+
+    public IdbmmsOperationException(String message) {
+        super(message);
+    }
+
+    public IdbmmsOperationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/idbmms-connector/src/main/java/com/sequenceiq/cloudbreak/idbmms/model/MappingsConfig.java
+++ b/idbmms-connector/src/main/java/com/sequenceiq/cloudbreak/idbmms/model/MappingsConfig.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.cloudbreak.idbmms.model;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * A POJO representing an immutable IDBroker Mapping Management Service mappings config.
+ */
+public class MappingsConfig {
+
+    /**
+     * The version of the mappings.
+     */
+    private final long mappingsVersion;
+
+    /**
+     * A map of actor workloadUsernames to cloud provider roles. Includes mappings for data access services.
+     */
+    private final Map<String, String> actorMappings;
+
+    /**
+     * A map of group names to cloud provider roles.
+     */
+    private final Map<String, String> groupMappings;
+
+    public MappingsConfig(long mappingsVersion, Map<String, String> actorMappings, Map<String, String> groupMappings) {
+        this.mappingsVersion = mappingsVersion;
+        this.actorMappings = actorMappings == null ? Collections.emptyMap() : Collections.unmodifiableMap(actorMappings);
+        this.groupMappings = groupMappings == null ? Collections.emptyMap() : Collections.unmodifiableMap(groupMappings);
+    }
+
+    public long getMappingsVersion() {
+        return mappingsVersion;
+    }
+
+    public Map<String, String> getActorMappings() {
+        return actorMappings;
+    }
+
+    public Map<String, String> getGroupMappings() {
+        return groupMappings;
+    }
+
+}

--- a/idbmms-connector/src/test/java/com/sequenceiq/cloudbreak/idbmms/config/IdbmmsConfigTest.java
+++ b/idbmms-connector/src/test/java/com/sequenceiq/cloudbreak/idbmms/config/IdbmmsConfigTest.java
@@ -1,0 +1,40 @@
+package com.sequenceiq.cloudbreak.idbmms.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class IdbmmsConfigTest {
+
+    @InjectMocks
+    private IdbmmsConfig underTest;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testIsConfiguredNullEndpoint() {
+        assertThat(underTest.isConfigured()).isFalse();
+    }
+
+    @Test
+    public void testIsConfiguredEmptyEndpoint() {
+        ReflectionTestUtils.setField(underTest, "endpoint", "");
+
+        assertThat(underTest.isConfigured()).isFalse();
+    }
+
+    @Test
+    public void testIsConfiguredGoodEndpoint() {
+        ReflectionTestUtils.setField(underTest, "endpoint", "myhost.com");
+
+        assertThat(underTest.isConfigured()).isTrue();
+    }
+
+}


### PR DESCRIPTION
Follow-up to  #5818. Wiring into Datalake service will come in a later PR.

Notes:
* `IdbmmsClient` cannot be unit tested because `IdBrokerMappingManagementGrpc.IdBrokerMappingManagementBlockingStub` is a `final` class (hence cannot be mocked easily).
* While `GrpcIdbmmsClient` could theoretically be unit tested, that would need the mocking of `makeWrapper()` and `makeClient()` via some nested factory classes. Even then `getMappingsConfig()` has a pretty trivial logic that is deemed not worth testing in its current form.
* `MappingsConfig` is an immutable POJO so it does not need to be unit tested.