### PR TITLE
DISTX-296. Hue Load Balancer missing from DE blueprint

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering.bp
@@ -160,6 +160,11 @@
             "refName": "hue-HUE_SERVER-BASE",
             "roleType": "HUE_SERVER",
             "base": true
+          },
+          {
+            "refName": "hue-HUE_LOAD_BALANCER-BASE",
+            "roleType": "HUE_LOAD_BALANCER",
+            "base": true
           }
         ]
       },
@@ -228,6 +233,7 @@
           "hms-HIVEMETASTORE-BASE",
           "hive_on_tez-HIVESERVER2-BASE",
           "hive_on_tez-GATEWAY-BASE",
+          "hue-HUE_LOAD_BALANCER-BASE",
           "hue-HUE_SERVER-BASE",
           "tez-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",

--- a/core/src/main/resources/defaults/blueprints/cdp-de-llap.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-de-llap.bp
@@ -200,6 +200,11 @@
             "refName": "hue-HUE_SERVER-BASE",
             "roleType": "HUE_SERVER",
             "base": true
+          },
+          {
+            "refName": "hue-HUE_LOAD_BALANCER-BASE",
+            "roleType": "HUE_LOAD_BALANCER",
+            "base": true
           }
         ]
       },
@@ -271,6 +276,7 @@
           "llap-HIVESERVER2-BASE",
           "llap-GATEWAY-BASE",
           "llap-LLAPPROXY-BASE",
+          "hue-HUE_LOAD_BALANCER-BASE",
           "hue-HUE_SERVER-BASE",
           "tez-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add Hue Load Balancer to the non-HA Data Engineering blueprint (and its LLAP version).  While there is only one Hue Server, Load Balancer is still required because Knox topology generator does not handle standalone Server (adb229cd86e8cad05bece04cf3ee36398df3703c).

## How was this patch tested?

Deployed data hub cluster with this blueprint.