### PR TITLE
CDPSDX-693 - added display name for HMS in hive section.

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-sdx-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx-ha.bp
@@ -207,6 +207,7 @@
             },
             {
                 "refName": "hive",
+                "displayName": "Hive Metastore",
                 "roleConfigGroups": [
                     {
                         "base": true,

--- a/core/src/main/resources/defaults/blueprints/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx-medium-ha.bp
@@ -213,6 +213,7 @@
       },
       {
         "refName": "hive",
+        "displayName": "Hive Metastore",
         "roleConfigGroups": [
           {
             "base": true,

--- a/core/src/main/resources/defaults/blueprints/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx.bp
@@ -286,6 +286,7 @@
       },
       {
         "refName": "hive",
+        "displayName": "Hive Metastore",
         "roleConfigGroups": [
           {
             "base": true,


### PR DESCRIPTION
This pull requests addresses CDPSDX-693 - we wanted to chang the GUI label from "Hive" to "Hive Metastore".  i have deployed a cluster to verify the change.

Closes #CDPSDX-693
Closes #xxx