### PR TITLE
CB-2844. HA deployment fails due to invalid node counts

### DIFF
--- a/core/src/main/resources/defaults/clustertemplates/aws/aws-dataengineering-ha-700.json
+++ b/core/src/main/resources/defaults/clustertemplates/aws/aws-dataengineering-ha-700.json
@@ -29,13 +29,15 @@
           }
         },
         "nodeCount": 1,
-        "type": "CORE",
+        "type": "GATEWAY",
         "recoveryMode": "MANUAL",
         "securityGroup": {
           "securityRules": [
             {
               "subnet": "0.0.0.0/0",
               "ports": [
+                "9443",
+                "443",
                 "22"
               ],
               "protocol": "tcp"
@@ -98,16 +100,14 @@
             "size": 50
           }
         },
-        "nodeCount": 1,
-        "type": "GATEWAY",
+        "nodeCount": 2,
+        "type": "CORE",
         "recoveryMode": "MANUAL",
         "securityGroup": {
           "securityRules": [
             {
               "subnet": "0.0.0.0/0",
               "ports": [
-                "9443",
-                "443",
                 "22"
               ],
               "protocol": "tcp"
@@ -170,7 +170,7 @@
             "size": 50
           }
         },
-        "nodeCount": 1,
+        "nodeCount": 3,
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "securityGroup": {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix problems with HA cluster definitions:

 * correct instance count for `master` and `quorum`
 * make `gateway` the `GATEWAY` (the one with CM) instead of `master`, and change exposed ports accordingly