### PR TITLE
CDPSDX-699 - removed hdfs-nfs-gateway from datalake blueprint.

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx.bp
@@ -20,7 +20,6 @@
           "hdfs-BALANCER-BASE",
           "hdfs-GATEWAY-BASE",
           "hdfs-NAMENODE-BASE",
-          "hdfs-NFSGATEWAY-BASE",
           "hdfs-SECONDARYNAMENODE-BASE",
           "hive-HIVEMETASTORE-BASE",
           "kafka-GATEWAY-BASE",
@@ -219,11 +218,6 @@
             "base": true,
             "refName": "hdfs-GATEWAY-BASE",
             "roleType": "GATEWAY"
-          },
-          {
-            "base": true,
-            "refName": "hdfs-NFSGATEWAY-BASE",
-            "roleType": "NFSGATEWAY"
           }
         ],
         "serviceConfigs": [


### PR DESCRIPTION
CDPSDX-699 - remove HDFS NFS Gateway from DataLake blueprints

tested via deployment of blueprint into datalake via cli.

Closes #CDPSDX-699