### PR TITLE
Fix telemetry cleanup

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecorator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecorator.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.core.bootstrap.service.host.decorator;
 import static java.util.Collections.singletonMap;
 
 import java.util.Map;
+import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -76,11 +77,11 @@ public class TelemetryDecorator {
 
     public Map<String, SaltPillarProperties> decoratePillar(Map<String, SaltPillarProperties> servicePillar,
             Stack stack, Telemetry telemetry) {
-        AltusCredential altusCredential = altusIAMService.generateDatabusMachineUserForFluent(stack, telemetry);
+        Optional<AltusCredential> altusCredential = altusIAMService.generateDatabusMachineUserForFluent(stack, telemetry);
         String clusterType = StackType.DATALAKE.equals(stack.getType()) ? CLUSTER_TYPE_SDX : CLUSTER_TYPE_DISTROX;
         String serviceType = StackType.WORKLOAD.equals(stack.getType()) ? CLUSTER_TYPE_DISTROX.toUpperCase() : "";
-        String accessKey = altusCredential != null ? altusCredential.getAccessKey() : null;
-        char[] privateKey = altusCredential != null ? altusCredential.getPrivateKey() : null;
+        String accessKey = altusCredential.map(AltusCredential::getAccessKey).orElse(null);
+        char[] privateKey = altusCredential.map(AltusCredential::getPrivateKey).orElse(null);
 
         DatabusConfigView databusConfigView = databusConfigService.createDatabusConfigs(accessKey, privateKey,
                 null, telemetry.getDatabusEndpoint());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/altus/AltusIAMService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/altus/AltusIAMService.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.service.altus;
 
+import java.util.Optional;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -28,22 +30,22 @@ public class AltusIAMService {
     /**
      * Generate machine user for fluentd - databus communication
      */
-    public AltusCredential generateDatabusMachineUserForFluent(Stack stack, Telemetry telemetry) {
-        if (isMeteringOrDeploymentReportingSupported(stack, telemetry)) {
-            return umsClient.createMachineUserAndGenerateKeys(
+    public Optional<AltusCredential> generateDatabusMachineUserForFluent(Stack stack, Telemetry telemetry) {
+        if (telemetry != null && isMeteringOrDeploymentReportingSupported(stack, telemetry)) {
+            return Optional.of(umsClient.createMachineUserAndGenerateKeys(
                     getFluentDatabusMachineUserName(stack),
                     stack.getCreator().getUserCrn(),
                     umsClient.getBuiltInDatabusRoleCrn(),
-                    UserManagementProto.AccessKeyType.Value.ED25519);
+                    UserManagementProto.AccessKeyType.Value.ED25519));
         }
-        return null;
+        return Optional.empty();
     }
 
     /**
      * Delete machine user with its access keys (and unassign databus role if required)
      */
     public void clearFluentMachineUser(Stack stack, Telemetry telemetry) {
-        if (isMeteringOrDeploymentReportingSupported(stack, telemetry)) {
+        if (telemetry != null && isMeteringOrDeploymentReportingSupported(stack, telemetry)) {
             try {
                 String machineUserName = getFluentDatabusMachineUserName(stack);
                 String userCrn = stack.getCreator().getUserCrn();

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecoratorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecoratorTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.verify;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -54,7 +55,7 @@ public class TelemetryDecoratorTest {
         MockitoAnnotations.initMocks(this);
         AltusCredential altusCredential = new AltusCredential("myAccessKey", "mySecretKey".toCharArray());
         given(altusIAMService.generateDatabusMachineUserForFluent(any(Stack.class), any(Telemetry.class)))
-                .willReturn(altusCredential);
+                .willReturn(Optional.of(altusCredential));
         underTest = new TelemetryDecorator(databusConfigService, fluentConfigService,
                 meteringConfigService, altusIAMService, "1.0.0");
     }


### PR DESCRIPTION
Nullpointer can happen as during cluster cleanup, machine user deletion happens outside of telemetry context (as it was moved out in a more common module)