### PR TITLE
Cloud storage logging: use "_ " instead of "-" between cluster name and UUID

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecorator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecorator.java
@@ -94,7 +94,7 @@ public class TelemetryDecorator {
         // for datalake - metering is not enabled yet
         boolean meteringEnabled = telemetry.isMeteringEnabled() && !StackType.DATALAKE.equals(stack.getType());
 
-        String clusterNameWithUUID = String.format("%s-%s",
+        String clusterNameWithUUID = String.format("%s_%s",
                 stack.getCluster().getName(), Crn.fromString(stack.getResourceCrn()).getResource());
 
         FluentConfigView fluentConfigView = fluentConfigService.createFluentConfigs(clusterNameWithUUID,


### PR DESCRIPTION
for cloud storage logging, cluster folder generated as <cluster name>-<uuid from crn>, but as uuid contains "-", it's not clear where cluster name ends and uuid starts. So use "_" instead