### PR TITLE
CB-2903. Do not use booleans for Telemetry objects

### DIFF
--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/base/TelemetryBase.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/base/TelemetryBase.java
@@ -2,6 +2,7 @@ package com.sequenceiq.common.api.telemetry.base;
 
 import java.io.Serializable;
 
+import com.sequenceiq.common.api.telemetry.common.TelemetrySetting;
 import com.sequenceiq.common.api.telemetry.doc.TelemetryModelDescription;
 
 import io.swagger.annotations.ApiModelProperty;
@@ -9,13 +10,13 @@ import io.swagger.annotations.ApiModelProperty;
 public abstract class TelemetryBase implements Serializable {
 
     @ApiModelProperty(TelemetryModelDescription.TELEMETRY_REPORT_DEPLOYMENT_LOGS_ENABLED)
-    private Boolean reportDeploymentLogs = Boolean.TRUE;
+    private TelemetrySetting reportDeploymentLogs = TelemetrySetting.ENABLED;
 
-    public Boolean getReportDeploymentLogs() {
+    public TelemetrySetting getReportDeploymentLogs() {
         return reportDeploymentLogs;
     }
 
-    public void setReportDeploymentLogs(Boolean reportDeploymentLogs) {
+    public void setReportDeploymentLogs(TelemetrySetting reportDeploymentLogs) {
         this.reportDeploymentLogs = reportDeploymentLogs;
     }
 }

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/common/TelemetrySetting.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/common/TelemetrySetting.java
@@ -1,0 +1,6 @@
+package com.sequenceiq.common.api.telemetry.common;
+
+public enum TelemetrySetting {
+    ENABLED,
+    DISABLED;
+}

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/Telemetry.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/Telemetry.java
@@ -8,6 +8,7 @@ import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.common.api.telemetry.common.TelemetrySetting;
 
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -22,11 +23,11 @@ public class Telemetry implements Serializable {
     @JsonProperty("databusEndpoint")
     private String databusEndpoint;
 
-    @JsonProperty("meteringEnabled")
-    private boolean meteringEnabled;
+    @JsonProperty("metering")
+    private TelemetrySetting metering;
 
     @JsonProperty("reportDeploymentLogs")
-    private boolean reportDeploymentLogs;
+    private TelemetrySetting reportDeploymentLogs;
 
     public Logging getLogging() {
         return logging;
@@ -52,19 +53,19 @@ public class Telemetry implements Serializable {
         this.databusEndpoint = databusEndpoint;
     }
 
-    public boolean isMeteringEnabled() {
-        return meteringEnabled;
+    public TelemetrySetting getMetering() {
+        return metering;
     }
 
-    public void setMeteringEnabled(boolean meteringEnabled) {
-        this.meteringEnabled = meteringEnabled;
+    public void setMetering(TelemetrySetting metering) {
+        this.metering = metering;
     }
 
-    public boolean isReportDeploymentLogs() {
+    public TelemetrySetting getReportDeploymentLogs() {
         return reportDeploymentLogs;
     }
 
-    public void setReportDeploymentLogs(boolean reportDeploymentLogs) {
+    public void setReportDeploymentLogs(TelemetrySetting reportDeploymentLogs) {
         this.reportDeploymentLogs = reportDeploymentLogs;
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigService.java
@@ -12,6 +12,7 @@ import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.S3ConfigGenerator;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.WasbConfig;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.WasbConfigGenerator;
 import com.sequenceiq.common.api.cloudstorage.old.WasbCloudStorageV1Parameters;
+import com.sequenceiq.common.api.telemetry.common.TelemetrySetting;
 import com.sequenceiq.common.api.telemetry.model.Logging;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
 
@@ -76,13 +77,13 @@ public class FluentConfigService {
     private boolean fillMeteringAndDeploymentReportConfigs(Telemetry telemetry, boolean databusEnabled,
             boolean meteringEnabled, FluentConfigView.Builder builder) {
         boolean validDatabusLogging = false;
-        if (meteringEnabled || telemetry.isReportDeploymentLogs()) {
+        if (meteringEnabled || TelemetrySetting.ENABLED.equals(telemetry.getReportDeploymentLogs())) {
             if (databusEnabled && meteringEnabled) {
                 builder.withMeteringEnabled(true);
                 LOGGER.debug("Fluent will be configured to send metering events.");
                 validDatabusLogging = true;
             }
-            if (databusEnabled && telemetry.isReportDeploymentLogs()) {
+            if (databusEnabled && TelemetrySetting.ENABLED.equals(telemetry.getReportDeploymentLogs())) {
                 builder.withReportClusterDeploymentLogs(true);
                 LOGGER.debug("Fluent based metering is enabled.");
                 validDatabusLogging = true;

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigServiceTest.java
@@ -12,6 +12,7 @@ import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.S3ConfigGenerator;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.WasbConfigGenerator;
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
 import com.sequenceiq.common.api.cloudstorage.old.WasbCloudStorageV1Parameters;
+import com.sequenceiq.common.api.telemetry.common.TelemetrySetting;
 import com.sequenceiq.common.api.telemetry.model.Logging;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
 
@@ -187,7 +188,7 @@ public class FluentConfigServiceTest {
     public void testCreateFluentConfigMetering() {
         // GIVEN
         Telemetry telemetry = new Telemetry();
-        telemetry.setMeteringEnabled(true);
+        telemetry.setMetering(TelemetrySetting.ENABLED);
         telemetry.setDatabusEndpoint("myEndpoint");
         // WHEN
         FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
@@ -201,7 +202,7 @@ public class FluentConfigServiceTest {
     public void testCreateFluentConfigMeteringWithoutDatabusEndpoint() {
         // GIVEN
         Telemetry telemetry = new Telemetry();
-        telemetry.setMeteringEnabled(true);
+        telemetry.setMetering(TelemetrySetting.ENABLED);
         // WHEN
         FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
                 false, false, telemetry);
@@ -214,7 +215,7 @@ public class FluentConfigServiceTest {
     public void testCreateFluentConfigMeteringWithoutDatabusSecret() {
         // GIVEN
         Telemetry telemetry = new Telemetry();
-        telemetry.setMeteringEnabled(true);
+        telemetry.setMetering(TelemetrySetting.ENABLED);
         // WHEN
         FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
                 false, false, telemetry);
@@ -227,7 +228,7 @@ public class FluentConfigServiceTest {
     public void testCreateFluentConfigReportDeploymentLogs() {
         // GIVEN
         Telemetry telemetry = new Telemetry();
-        telemetry.setReportDeploymentLogs(true);
+        telemetry.setReportDeploymentLogs(TelemetrySetting.ENABLED);
         // WHEN
         FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
                 true, false, telemetry);
@@ -240,7 +241,7 @@ public class FluentConfigServiceTest {
     public void testCreateFluentConfigReportDeploymentLogsWithoutDatabus() {
         // GIVEN
         Telemetry telemetry = new Telemetry();
-        telemetry.setReportDeploymentLogs(true);
+        telemetry.setReportDeploymentLogs(TelemetrySetting.ENABLED);
         // WHEN
         FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
                 false, true, telemetry);

--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/model/DistroXV1Base.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/model/DistroXV1Base.java
@@ -7,6 +7,7 @@ import javax.validation.constraints.NotNull;
 import com.sequenceiq.cloudbreak.doc.ModelDescriptions.StackModelDescription;
 import com.sequenceiq.cloudbreak.validation.ValidStackNameFormat;
 import com.sequenceiq.cloudbreak.validation.ValidStackNameLength;
+import com.sequenceiq.common.api.telemetry.common.TelemetrySetting;
 
 import io.swagger.annotations.ApiModelProperty;
 
@@ -28,7 +29,7 @@ public abstract class DistroXV1Base implements Serializable, CloudPlatformProvid
     private YarnDistroXV1Parameters yarn;
 
     @ApiModelProperty(StackModelDescription.WORKLOAD_ANALYTICS)
-    private Boolean workloadAnalytics = Boolean.TRUE;
+    private TelemetrySetting workloadAnalytics = TelemetrySetting.ENABLED;
 
     @ApiModelProperty
     private Long timeToLive;
@@ -76,11 +77,11 @@ public abstract class DistroXV1Base implements Serializable, CloudPlatformProvid
         this.yarn = yarn;
     }
 
-    public Boolean getWorkloadAnalytics() {
+    public TelemetrySetting getWorkloadAnalytics() {
         return workloadAnalytics;
     }
 
-    public void setWorkloadAnalytics(Boolean workloadAnalytics) {
+    public void setWorkloadAnalytics(TelemetrySetting workloadAnalytics) {
         this.workloadAnalytics = workloadAnalytics;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecorator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecorator.java
@@ -20,6 +20,7 @@ import com.sequenceiq.cloudbreak.telemetry.fluent.FluentConfigService;
 import com.sequenceiq.cloudbreak.telemetry.fluent.FluentConfigView;
 import com.sequenceiq.cloudbreak.telemetry.metering.MeteringConfigService;
 import com.sequenceiq.cloudbreak.telemetry.metering.MeteringConfigView;
+import com.sequenceiq.common.api.telemetry.common.TelemetrySetting;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
 
 /**
@@ -89,7 +90,8 @@ public class TelemetryDecorator {
         }
 
         // for datalake - metering is not enabled yet
-        boolean meteringEnabled = telemetry.isMeteringEnabled() && !StackType.DATALAKE.equals(stack.getType());
+        boolean meteringEnabled = TelemetrySetting.ENABLED.equals(telemetry.getMetering())
+                && !StackType.DATALAKE.equals(stack.getType());
 
         FluentConfigView fluentConfigView = fluentConfigService.createFluentConfigs(clusterType,
                 stack.getCloudPlatform(), databusConfigView.isEnabled(), meteringEnabled, telemetry);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/altus/AltusIAMService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/altus/AltusIAMService.java
@@ -12,6 +12,7 @@ import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
 import com.sequenceiq.cloudbreak.auth.altus.model.AltusCredential;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.common.api.telemetry.common.TelemetrySetting;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
 
 @Service
@@ -59,7 +60,9 @@ public class AltusIAMService {
 
     // for datalake metering is not supported/required right now
     private boolean isMeteringOrDeploymentReportingSupported(Stack stack, Telemetry telemetry) {
-        return telemetry != null && (telemetry.isReportDeploymentLogs() || (telemetry.isMeteringEnabled() && !StackType.DATALAKE.equals(stack.getType())));
+        return TelemetrySetting.ENABLED.equals(telemetry.getReportDeploymentLogs())
+                || (TelemetrySetting.ENABLED.equals(telemetry.getMetering())
+                && !StackType.DATALAKE.equals(stack.getType()));
     }
 
     private String getFluentDatabusMachineUserName(Stack stack) {

--- a/core/src/main/resources/schema/app/20190815235323_CB-2903_use_telemetry_enums.sql
+++ b/core/src/main/resources/schema/app/20190815235323_CB-2903_use_telemetry_enums.sql
@@ -1,0 +1,33 @@
+-- // CB-2903 Use enums instead of booleans
+-- Migration SQL that makes the change goes here.
+
+UPDATE
+   component SET attributes = jsonb_set(attributes::jsonb,
+                 '{reportDeploymentLogs}' , '"DISABLED"' )::text
+WHERE attributes is not null AND componenttype = 'TELEMETRY';
+
+UPDATE
+   component SET attributes = (attributes::jsonb - 'meteringEnabled' )::text
+WHERE attributes is not null AND componenttype = 'TELEMETRY';
+
+UPDATE
+   component SET attributes = jsonb_set(attributes::jsonb,
+                 '{metering}' , '"DISABLED"' )::text
+WHERE attributes is not null AND componenttype = 'TELEMETRY';
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+UPDATE
+   component SET attributes = jsonb_set(attributes::jsonb,
+                 '{reportDeploymentLogs}' , 'false' )::text
+WHERE attributes is not null AND componenttype = 'TELEMETRY';
+
+UPDATE
+   component SET attributes = (attributes::jsonb - 'metering' )::text
+WHERE attributes is not null AND componenttype = 'TELEMETRY';
+
+UPDATE
+   component SET attributes = jsonb_set(attributes::jsonb,
+                 '{meteringEnabled}' , 'false' )::text
+WHERE attributes is not null AND componenttype = 'TELEMETRY';

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
@@ -8,6 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
+import com.sequenceiq.common.api.telemetry.common.TelemetrySetting;
 import com.sequenceiq.common.api.telemetry.model.Logging;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
 import com.sequenceiq.common.api.telemetry.request.TelemetryRequest;
@@ -74,7 +75,7 @@ public class TelemetryConverterTest {
         sdxClusterResponse.setCrn("crn:cdp:cloudbreak:us-west-1:someone:sdxcluster:sdxId");
         sdxClusterResponse.setName("sdxName");
         // WHEN
-        TelemetryRequest result = underTest.convert(response, sdxClusterResponse, true);
+        TelemetryRequest result = underTest.convert(response, sdxClusterResponse, TelemetrySetting.ENABLED);
         // THEN
         assertEquals(INSTANCE_PROFILE_VALUE, result.getLogging().getS3().getInstanceProfile());
         assertEquals(DATABUS_ENDPOINT, result.getWorkloadAnalytics().getDatabusEndpoint());
@@ -91,6 +92,7 @@ public class TelemetryConverterTest {
         s3Params.setInstanceProfile(INSTANCE_PROFILE_VALUE);
         loggingResponse.setS3(s3Params);
         response.setLogging(loggingResponse);
+        response.setReportDeploymentLogs(TelemetrySetting.ENABLED);
         WorkloadAnalyticsResponse waResponse = new WorkloadAnalyticsResponse();
         waResponse.setDatabusEndpoint("myOtherEndpoint");
         response.setWorkloadAnalytics(waResponse);
@@ -98,8 +100,9 @@ public class TelemetryConverterTest {
         sdxClusterResponse.setCrn("crn:cdp:cloudbreak:us-west-1:someone:sdxcluster:sdxId");
         sdxClusterResponse.setName("sdxName");
         // WHEN
-        TelemetryRequest result = underTest.convert(response, sdxClusterResponse, false);
+        TelemetryRequest result = underTest.convert(response, sdxClusterResponse, TelemetrySetting.DISABLED);
         // THEN
+        assertEquals(TelemetrySetting.ENABLED, result.getReportDeploymentLogs());
         assertEquals(INSTANCE_PROFILE_VALUE, result.getLogging().getS3().getInstanceProfile());
         assertEquals("myOtherEndpoint", result.getWorkloadAnalytics().getDatabusEndpoint());
         assertEquals("sdxId", result.getWorkloadAnalytics().getAttributes().get("databus.header.sdx.id").toString());
@@ -118,7 +121,7 @@ public class TelemetryConverterTest {
         WorkloadAnalyticsResponse waResponse = new WorkloadAnalyticsResponse();
         response.setWorkloadAnalytics(waResponse);
         // WHEN
-        TelemetryRequest result = underTest.convert(response, null, false);
+        TelemetryRequest result = underTest.convert(response, null, TelemetrySetting.DISABLED);
         // THEN
         assertEquals(INSTANCE_PROFILE_VALUE, result.getLogging().getS3().getInstanceProfile());
         assertTrue(result.getWorkloadAnalytics().getAttributes().isEmpty());

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/altus/AltusIAMServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/altus/AltusIAMServiceTest.java
@@ -18,6 +18,7 @@ import com.sequenceiq.cloudbreak.auth.altus.model.AltusCredential;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.workspace.model.User;
+import com.sequenceiq.common.api.telemetry.common.TelemetrySetting;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
 
 public class AltusIAMServiceTest {
@@ -46,7 +47,7 @@ public class AltusIAMServiceTest {
         cluster.setId(1L);
         stack.setCluster(cluster);
         telemetry = new Telemetry();
-        telemetry.setReportDeploymentLogs(true);
+        telemetry.setReportDeploymentLogs(TelemetrySetting.ENABLED);
         underTest = new AltusIAMService(umsClient);
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/telemetry/EnvironmentTelemetry.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/telemetry/EnvironmentTelemetry.java
@@ -8,6 +8,7 @@ import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.common.api.telemetry.common.TelemetrySetting;
 
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -17,11 +18,11 @@ public class EnvironmentTelemetry implements Serializable {
 
     private final EnvironmentWorkloadAnalytics workloadAnalytics;
 
-    private final boolean reportDeploymentLogs;
+    private final TelemetrySetting reportDeploymentLogs;
 
     public EnvironmentTelemetry(@JsonProperty("logging") EnvironmentLogging logging,
             @JsonProperty("workloadAnalytics") EnvironmentWorkloadAnalytics workloadAnalytics,
-            @JsonProperty("reportDeploymentLogs") boolean reportDeploymentLogs) {
+            @JsonProperty("reportDeploymentLogs") TelemetrySetting reportDeploymentLogs) {
         this.logging = logging;
         this.workloadAnalytics = workloadAnalytics;
         this.reportDeploymentLogs = reportDeploymentLogs;
@@ -35,7 +36,7 @@ public class EnvironmentTelemetry implements Serializable {
         return workloadAnalytics;
     }
 
-    public boolean isReportDeploymentLogs() {
+    public TelemetrySetting getReportDeploymentLogs() {
         return reportDeploymentLogs;
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/TelemetryApiConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/TelemetryApiConverter.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
 import com.sequenceiq.common.api.cloudstorage.old.WasbCloudStorageV1Parameters;
+import com.sequenceiq.common.api.telemetry.common.TelemetrySetting;
 import com.sequenceiq.common.api.telemetry.request.LoggingRequest;
 import com.sequenceiq.common.api.telemetry.request.TelemetryRequest;
 import com.sequenceiq.common.api.telemetry.request.WorkloadAnalyticsRequest;
@@ -51,8 +52,9 @@ public class TelemetryApiConverter {
                         StringUtils.isNotEmpty(waRequest.getDatabusEndpoint()) ? waRequest.getDatabusEndpoint() : databusEndpoint
                 );
             }
-            boolean reportDeploymentLogsEnabled = reportDeploymentLogs ? request.getReportDeploymentLogs() : false;
-            telemetry = new EnvironmentTelemetry(logging, workloadAnalytics, reportDeploymentLogsEnabled);
+            TelemetrySetting telemetrySetting = reportDeploymentLogs
+                    ? request.getReportDeploymentLogs() : TelemetrySetting.DISABLED;
+            telemetry = new EnvironmentTelemetry(logging, workloadAnalytics, telemetrySetting);
         }
         return telemetry;
     }
@@ -99,7 +101,7 @@ public class TelemetryApiConverter {
             response = new TelemetryResponse();
             response.setLogging(loggingResponse);
             response.setWorkloadAnalytics(waResponse);
-            response.setReportDeploymentLogs(telemetry.isReportDeploymentLogs());
+            response.setReportDeploymentLogs(telemetry.getReportDeploymentLogs());
         }
         return response;
     }

--- a/environment/src/main/resources/schema/app/20190815085321_CB-2903_use_telemetry_enums.sql
+++ b/environment/src/main/resources/schema/app/20190815085321_CB-2903_use_telemetry_enums.sql
@@ -1,0 +1,15 @@
+-- // CB-2903 Use enums instead of booleans
+-- Migration SQL that makes the change goes here.
+
+UPDATE
+   environment SET telemetry = jsonb_set(telemetry::jsonb,
+                 '{reportDeploymentLogs}' , '"DISABLED"' )::text
+WHERE telemetry is not null;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+UPDATE
+   environment SET telemetry = jsonb_set(telemetry::jsonb,
+                 '{reportDeploymentLogs}' , 'false' )::text
+WHERE telemetry is not null;

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/TelemetryApiConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/TelemetryApiConverterTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import org.mockito.MockitoAnnotations;
 
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
+import com.sequenceiq.common.api.telemetry.common.TelemetrySetting;
 import com.sequenceiq.common.api.telemetry.request.LoggingRequest;
 import com.sequenceiq.common.api.telemetry.request.TelemetryRequest;
 import com.sequenceiq.common.api.telemetry.request.WorkloadAnalyticsRequest;
@@ -54,7 +55,7 @@ public class TelemetryApiConverterTest {
         S3CloudStorageParameters s3Params = new S3CloudStorageParameters();
         s3Params.setInstanceProfile(INSTANCE_PROFILE_VALUE);
         logging.setS3(s3Params);
-        EnvironmentTelemetry telemetry = new EnvironmentTelemetry(logging, null, false);
+        EnvironmentTelemetry telemetry = new EnvironmentTelemetry(logging, null, TelemetrySetting.DISABLED);
         // WHEN
         TelemetryResponse result = underTest.convert(telemetry);
         // THEN


### PR DESCRIPTION
use enum instead of true/false boolean input for setting workload Telemetry objects (both api and db as it was asked)

only `ENABLED` and `DISABLED` fields are acceptable in that case (no json aliases)

added db update scripts as well