### PR TITLE
DISTX-212. Cleanup inconsistencies in FMS user sync

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/doc/UserModelDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/doc/UserModelDescriptions.java
@@ -3,21 +3,16 @@ package com.sequenceiq.freeipa.api.v1.freeipa.user.doc;
 public class UserModelDescriptions {
 
     public static final String SYNC_OPERATION = "Operation type";
-    public static final String USERSYNC_ENVIRONMENTS = "Optional environments to sync";
-    public static final String USERSYNC_USERS = "Optional users to sync";
+    public static final String USERSYNC_ENVIRONMENT_CRNS = "Optional environment crns to sync";
+    public static final String USERSYNC_USER_CRNS = "Optional user crns to sync";
+    public static final String USERSYNC_MACHINEUSER_CRNS = "Optional machine user crns to sync";
     public static final String USERSYNC_ID = "User synchronization operation id";
     public static final String USERSYNC_STATUS = "User synchronization operation status";
     public static final String USERSYNC_STARTTIME = "User synchronization operation start time";
     public static final String USERSYNC_ENDTIME = "User synchronization operation end time";
     public static final String USERSYNC_ERROR = "error information about operation failure";
-    public static final String USER_NAME = "name of the user";
-    public static final String SUCCESS_ENVIRONMENTNAME = "environment names where operation succeeded";
-    public static final String FAILURE_ENVIRONMENTNAME = "environment names where operation failed";
-    public static final String USERCREATE_GROUPS = "groups to create";
-    public static final String USERCREATE_USERS = "users to create";
-    public static final String GROUP_NAME = "name of the group";
-    public static final String USER_FIRSTNAME = "first name of the user";
-    public static final String USER_LASTNAME = "last name of the user";
+    public static final String SUCCESS_ENVIRONMENTS = "details about environments where operation succeeded";
+    public static final String FAILURE_ENVIRONMENTS = "details about environments where operation failed";
     public static final String USER_PASSWORD = "the user's password";
 
     private UserModelDescriptions() {

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/FailureDetails.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/FailureDetails.java
@@ -56,4 +56,12 @@ public class FailureDetails {
     public int hashCode() {
         return Objects.hash(environment, message);
     }
+
+    @Override
+    public String toString() {
+        return "FailureDetails{"
+                + "environment='" + environment + '\''
+                + ", message='" + message + '\''
+                + '}';
+    }
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SetPasswordRequest.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SetPasswordRequest.java
@@ -1,29 +1,39 @@
 package com.sequenceiq.freeipa.api.v1.freeipa.user.model;
 
+import java.util.Set;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.doc.UserModelDescriptions;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
-import java.util.HashSet;
-import java.util.Set;
-
 @ApiModel("SetPasswordV1Request")
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class SetPasswordRequest {
-
-    @ApiModelProperty(value = UserModelDescriptions.USERSYNC_ENVIRONMENTS)
-    private Set<String> environments = new HashSet<>();
-
+public class SetPasswordRequest extends SynchronizeOperationRequestBase {
     @ApiModelProperty(value = UserModelDescriptions.USER_PASSWORD)
     private String password;
 
-    public Set<String> getEnvironments() {
-        return environments;
+    public SetPasswordRequest() {
+    }
+
+    public SetPasswordRequest(Set<String> environments, String password) {
+        super(environments);
+        this.password = password;
     }
 
     public String getPassword() {
         return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    @Override
+    public String toString() {
+        return "SetPasswordRequest{"
+                + super.fieldsToString()
+                + '}';
     }
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SuccessDetails.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SuccessDetails.java
@@ -45,4 +45,11 @@ public class SuccessDetails {
     public int hashCode() {
         return Objects.hash(environment);
     }
+
+    @Override
+    public String toString() {
+        return "SuccessDetails{"
+                + "environment='" + environment + '\''
+                + '}';
+    }
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SyncOperationStatus.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SyncOperationStatus.java
@@ -21,10 +21,10 @@ public class SyncOperationStatus {
     @ApiModelProperty(value = UserModelDescriptions.USERSYNC_STATUS)
     private SynchronizationStatus status;
 
-    @ApiModelProperty(value = UserModelDescriptions.SUCCESS_ENVIRONMENTNAME)
+    @ApiModelProperty(value = UserModelDescriptions.SUCCESS_ENVIRONMENTS)
     private List<SuccessDetails> success;
 
-    @ApiModelProperty(value = UserModelDescriptions.FAILURE_ENVIRONMENTNAME)
+    @ApiModelProperty(value = UserModelDescriptions.FAILURE_ENVIRONMENTS)
     private List<FailureDetails> failure;
 
     @ApiModelProperty(value = UserModelDescriptions.USERSYNC_ERROR)
@@ -100,5 +100,19 @@ public class SyncOperationStatus {
 
     public void setEndTime(Long endTime) {
         this.endTime = endTime;
+    }
+
+    @Override
+    public String toString() {
+        return "SyncOperationStatus{"
+                + "operationId='" + operationId + '\''
+                + ", syncOperationType=" + syncOperationType
+                + ", status=" + status
+                + ", success=" + success
+                + ", failure=" + failure
+                + ", error='" + error + '\''
+                + ", startTime=" + startTime
+                + ", endTime=" + endTime
+                + '}';
     }
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SynchronizeAllUsersRequest.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SynchronizeAllUsersRequest.java
@@ -11,22 +11,27 @@ import io.swagger.annotations.ApiModelProperty;
 
 @ApiModel("SynchronizeAllUsersV1Request")
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class SynchronizeAllUsersRequest {
-    @ApiModelProperty(value = UserModelDescriptions.USERSYNC_ENVIRONMENTS)
-    private Set<String> environments = new HashSet<>();
+public class SynchronizeAllUsersRequest extends SynchronizeOperationRequestBase {
+    @ApiModelProperty(value = UserModelDescriptions.USERSYNC_USER_CRNS)
+    private Set<String> machineUsers = new HashSet<>();
 
-    @ApiModelProperty(value = UserModelDescriptions.USERSYNC_USERS)
+    @ApiModelProperty(value = UserModelDescriptions.USERSYNC_USER_CRNS)
     private Set<String> users = new HashSet<>();
 
     public SynchronizeAllUsersRequest() {
     }
 
-    public Set<String> getEnvironments() {
-        return environments;
+    public SynchronizeAllUsersRequest(Set<String> environments, Set<String> users) {
+        super(environments);
+        this.users = users;
     }
 
-    public void setEnvironments(Set<String> environments) {
-        this.environments = environments;
+    public Set<String> getMachineUsers() {
+        return machineUsers;
+    }
+
+    public void setMachineUsers(Set<String> machineUsers) {
+        this.machineUsers = machineUsers;
     }
 
     public Set<String> getUsers() {
@@ -35,5 +40,14 @@ public class SynchronizeAllUsersRequest {
 
     public void setUsers(Set<String> users) {
         this.users = users;
+    }
+
+    @Override
+    public String toString() {
+        return "SynchronizeAllUsersRequest{"
+                + "machineUsers=" + machineUsers
+                + ", users=" + users
+                + ", " + super.fieldsToString()
+                + '}';
     }
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SynchronizeOperationRequestBase.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SynchronizeOperationRequestBase.java
@@ -1,0 +1,39 @@
+package com.sequenceiq.freeipa.api.v1.freeipa.user.model;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.user.doc.UserModelDescriptions;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class SynchronizeOperationRequestBase {
+    @ApiModelProperty(value = UserModelDescriptions.USERSYNC_ENVIRONMENT_CRNS)
+    private Set<String> environments = new HashSet<>();
+
+    public SynchronizeOperationRequestBase() {
+    }
+
+    public SynchronizeOperationRequestBase(Set<String> environments) {
+        this.environments = environments;
+    }
+
+    public Set<String> getEnvironments() {
+        return environments;
+    }
+
+    public void setEnvironments(Set<String> environments) {
+        this.environments = environments;
+    }
+
+    @Override
+    public String toString() {
+        return "SynchronizeOperationRequestBase{"
+                + "environments=" + environments
+                + '}';
+    }
+
+    protected String fieldsToString() {
+        return "environments=" + environments;
+    }
+}

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SynchronizeUserRequest.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SynchronizeUserRequest.java
@@ -1,10 +1,25 @@
 package com.sequenceiq.freeipa.api.v1.freeipa.user.model;
 
+import java.util.Set;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import io.swagger.annotations.ApiModel;
 
 @ApiModel("SynchronizeUserV1Request")
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class SynchronizeUserRequest {
+public class SynchronizeUserRequest  extends SynchronizeOperationRequestBase {
+    public SynchronizeUserRequest() {
+    }
+
+    public SynchronizeUserRequest(Set<String> environments) {
+        super(environments);
+    }
+
+    @Override
+    public String toString() {
+        return "SynchronizeUserRequest{"
+                + super.fieldsToString()
+                + "}";
+    }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/UserV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/UserV1Controller.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
 
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.UserV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SetPasswordRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SyncOperationStatus;
@@ -42,26 +43,44 @@ public class UserV1Controller implements UserV1Endpoint {
     @Override
     public SyncOperationStatus synchronizeUser(SynchronizeUserRequest request) {
         String userCrn = checkUserCrn();
-        LOGGER.debug("synchronizeUser() requested for user {}", userCrn);
         String accountId = threadBaseUserCrnProvider.getAccountId();
-
-        return checkOperationRejected(userService.synchronizeUser(accountId, userCrn, userCrn));
+        LOGGER.debug("synchronizeUser() requested for user {} in account {}", userCrn, accountId);
+        Set<String> environmentCrnFilter = request == null ? Set.of() : nullToEmpty(request.getEnvironments());
+        Set<String> userCrnFilter = Set.of();
+        Set<String> machineUserCrnFilter = Set.of();
+        Crn crn = Crn.safeFromString(userCrn);
+        switch (crn.getResourceType()) {
+            case USER:
+                userCrnFilter = Set.of(userCrn);
+                break;
+            case MACHINE_USER:
+                machineUserCrnFilter = Set.of(userCrn);
+                break;
+            default:
+                throw new BadRequestException(String.format("UserCrn %s is not of resoure type USER or MACHINE_USER", userCrn));
+        }
+        return checkOperationRejected(userService.synchronizeUsers(accountId, userCrn, environmentCrnFilter,
+                userCrnFilter, machineUserCrnFilter));
     }
 
     @Override
     public SyncOperationStatus synchronizeAllUsers(SynchronizeAllUsersRequest request) {
         String userCrn = checkUserCrn();
         String accountId = threadBaseUserCrnProvider.getAccountId();
-        return checkOperationRejected(userService.synchronizeAllUsers(accountId, userCrn, request.getEnvironments(), request.getUsers()));
+        LOGGER.debug("synchronizeAllUsers() requested for account {}", accountId);
+
+        return checkOperationRejected(userService.synchronizeUsers(accountId, userCrn, nullToEmpty(request.getEnvironments()),
+                nullToEmpty(request.getUsers()), nullToEmpty(request.getMachineUsers())));
     }
 
     @Override
     public SyncOperationStatus setPassword(SetPasswordRequest request) {
         String userCrn = checkUserCrn();
-        LOGGER.debug("setPassword() requested for user {}", userCrn);
         String accountId = threadBaseUserCrnProvider.getAccountId();
-        Set<String> envs = request.getEnvironments();
-        return checkOperationRejected(passwordService.setPassword(accountId, userCrn, request.getPassword(), envs));
+        LOGGER.debug("setPassword() requested for user {} in account {}", userCrn, accountId);
+
+        return checkOperationRejected(passwordService.setPassword(accountId, userCrn, userCrn, request.getPassword(),
+                nullToEmpty(request.getEnvironments())));
     }
 
     @Override
@@ -83,5 +102,9 @@ public class UserV1Controller implements UserV1Endpoint {
             throw new BadRequestException("User CRN must be provided");
         }
         return userCrn;
+    }
+
+    private Set<String> nullToEmpty(Set<String> set) {
+        return set == null ? Set.of() : set;
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/repository/StackRepository.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/repository/StackRepository.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.freeipa.repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -39,6 +40,10 @@ public interface StackRepository extends BaseJpaRepository<Stack, Long> {
     @CheckPermission(action = ResourceAction.READ)
     @Query("SELECT s FROM Stack s WHERE s.accountId = :accountId AND s.environmentCrn = :environmentCrn AND s.terminated = -1")
     Optional<Stack> findByEnvironmentCrnAndAccountId(@Param("environmentCrn") String environmentCrn, @Param("accountId") String accountId);
+
+    @CheckPermission(action = ResourceAction.READ)
+    @Query("SELECT s FROM Stack s WHERE s.accountId = :accountId AND s.environmentCrn IN :environmentCrns AND s.terminated = -1")
+    List<Stack> findMultipleByEnvironmentCrnAndAccountId(@Param("environmentCrns") Collection<String> environmentCrns, @Param("accountId") String accountId);
 
     @CheckPermission(action = ResourceAction.READ)
     @Query("SELECT s FROM Stack s WHERE s.accountId = :accountId AND s.environmentCrn = :environmentCrn AND s.terminated = -1")

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactory.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactory.java
@@ -50,7 +50,7 @@ public class FreeIpaClientFactory {
     }
 
     public FreeIpaClient getFreeIpaClientForStack(Stack stack) throws FreeIpaClientException {
-        LOGGER.debug("Creating FreeIpaClient for stack {}", stack.getId());
+        LOGGER.debug("Creating FreeIpaClient for stack {}", stack.getResourceCrn());
 
         GatewayConfig primaryGatewayConfig = gatewayConfigService.getPrimaryGatewayConfig(stack);
         HttpClientConfig httpClientConfig = tlsSecurityService.buildTLSClientConfigForPrimaryGateway(

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/SyncOperationStatusService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/SyncOperationStatusService.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.freeipa.service.freeipa.user;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -51,8 +52,9 @@ public class SyncOperationStatusService {
         }
     }
 
-    public SyncOperation startOperation(String accountId, SyncOperationType syncOperationType, List<String> environments, List<String> users) {
-        SyncOperation syncOperation = requestOperation(accountId, syncOperationType, environments, users);
+    public SyncOperation startOperation(String accountId, SyncOperationType syncOperationType,
+            Collection<String> environmentCrns, Collection<String> userCrns) {
+        SyncOperation syncOperation = requestOperation(accountId, syncOperationType, environmentCrns, userCrns);
         SyncOperationAcceptor acceptor = syncOperationAcceptorMap.get(syncOperationType);
 
         AcceptResult acceptResult = acceptor.accept(syncOperation);
@@ -86,14 +88,15 @@ public class SyncOperationStatusService {
         return syncOperationToSyncOperationStatus.convert(getSyncOperationForOperationId(operationId));
     }
 
-    private SyncOperation requestOperation(String accountId, SyncOperationType syncOperationType, List<String> environments, List<String> users) {
+    private SyncOperation requestOperation(String accountId, SyncOperationType syncOperationType,
+            Collection<String> environmentCrns, Collection<String> userCrns) {
         SyncOperation syncOperation = new SyncOperation();
         syncOperation.setOperationId(UUID.randomUUID().toString());
         syncOperation.setStatus(SynchronizationStatus.REQUESTED);
         syncOperation.setAccountId(accountId);
         syncOperation.setSyncOperationType(syncOperationType);
-        syncOperation.setEnvironmentList(environments);
-        syncOperation.setUserList(users);
+        syncOperation.setEnvironmentList(List.copyOf(environmentCrns));
+        syncOperation.setUserList(List.copyOf(userCrns));
         return syncOperationRepository.save(syncOperation);
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/FmsGroup.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/FmsGroup.java
@@ -1,21 +1,9 @@
-package com.sequenceiq.freeipa.api.v1.freeipa.user.model;
+package com.sequenceiq.freeipa.service.freeipa.user.model;
 
 import java.util.Objects;
 
-import javax.validation.constraints.NotNull;
+public class FmsGroup {
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.sequenceiq.freeipa.api.v1.freeipa.user.doc.UserModelDescriptions;
-
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
-
-@ApiModel("GroupV1")
-@JsonIgnoreProperties(ignoreUnknown = true)
-public class Group {
-
-    @NotNull
-    @ApiModelProperty(value = UserModelDescriptions.GROUP_NAME, required = true)
     private String name;
 
     public void setName(String name) {
@@ -35,7 +23,7 @@ public class Group {
             return false;
         }
 
-        Group other = (Group) o;
+        FmsGroup other = (FmsGroup) o;
 
         return Objects.equals(this.name, other.name);
 
@@ -48,7 +36,7 @@ public class Group {
 
     @Override
     public String toString() {
-        return "Group{"
+        return "FmsGroup{"
                 + "name='" + name + '\''
                 + '}';
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/FmsUser.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/FmsUser.java
@@ -1,29 +1,13 @@
-package com.sequenceiq.freeipa.api.v1.freeipa.user.model;
+package com.sequenceiq.freeipa.service.freeipa.user.model;
 
 import java.util.Objects;
 
-import javax.validation.constraints.NotNull;
+public class FmsUser {
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.sequenceiq.freeipa.api.v1.freeipa.user.doc.UserModelDescriptions;
-
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
-
-@ApiModel("UserV1")
-@JsonIgnoreProperties(ignoreUnknown = true)
-public class User {
-
-    @NotNull
-    @ApiModelProperty(value = UserModelDescriptions.USER_NAME, required = true)
     private String name;
 
-    @NotNull
-    @ApiModelProperty(value = UserModelDescriptions.USER_FIRSTNAME, required = true)
     private String firstName;
 
-    @NotNull
-    @ApiModelProperty(value = UserModelDescriptions.USER_LASTNAME, required = true)
     private String lastName;
 
     public String getName() {
@@ -59,7 +43,7 @@ public class User {
             return false;
         }
 
-        User other = (User) o;
+        FmsUser other = (FmsUser) o;
         return Objects.equals(this.name, other.name)
                 && Objects.equals(this.firstName, other.firstName)
                 && Objects.equals(this.lastName, other.lastName);
@@ -72,7 +56,7 @@ public class User {
 
     @Override
     public String toString() {
-        return "User{"
+        return "FmsUser{"
                 + "name='" + name + '\''
                 + ", firstName='" + firstName + '\''
                 + ", lastName='" + lastName + '\''

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UsersState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UsersState.java
@@ -7,27 +7,25 @@ import java.util.Set;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
-import com.sequenceiq.freeipa.api.v1.freeipa.user.model.Group;
-import com.sequenceiq.freeipa.api.v1.freeipa.user.model.User;
 
 public class UsersState {
-    private Set<Group> groups;
+    private Set<FmsGroup> groups;
 
-    private Set<User> users;
+    private Set<FmsUser> users;
 
     private Multimap<String, String> groupMembership;
 
-    public UsersState(Set<Group> groups, Set<User> users, Multimap<String, String> groupMembership) {
+    public UsersState(Set<FmsGroup> groups, Set<FmsUser> users, Multimap<String, String> groupMembership) {
         this.groups = requireNonNull(groups);
         this.users = requireNonNull(users);
         this.groupMembership = requireNonNull(groupMembership);
     }
 
-    public Set<Group> getGroups() {
+    public Set<FmsGroup> getGroups() {
         return groups;
     }
 
-    public Set<User> getUsers() {
+    public Set<FmsUser> getUsers() {
         return users;
     }
 
@@ -45,18 +43,18 @@ public class UsersState {
     }
 
     public static class Builder {
-        private Set<Group> groups = new HashSet<>();
+        private Set<FmsGroup> fmsGroups = new HashSet<>();
 
-        private Set<User> users = new HashSet<>();
+        private Set<FmsUser> fmsUsers = new HashSet<>();
 
         private Multimap<String, String> groupMembership = HashMultimap.create();
 
-        public void addGroup(Group group) {
-            groups.add(group);
+        public void addGroup(FmsGroup fmsGroup) {
+            fmsGroups.add(fmsGroup);
         }
 
-        public void addUser(User user) {
-            users.add(user);
+        public void addUser(FmsUser fmsUser) {
+            fmsUsers.add(fmsUser);
         }
 
         public void addMemberToGroup(String group, String user) {
@@ -64,7 +62,7 @@ public class UsersState {
         }
 
         public UsersState build() {
-            return new UsersState(groups, users, groupMembership);
+            return new UsersState(fmsGroups, fmsUsers, groupMembership);
         }
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UsersStateDifference.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UsersStateDifference.java
@@ -10,25 +10,23 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
-import com.sequenceiq.freeipa.api.v1.freeipa.user.model.Group;
-import com.sequenceiq.freeipa.api.v1.freeipa.user.model.User;
 
 public class UsersStateDifference {
     private static final Logger LOGGER = LoggerFactory.getLogger(UsersStateDifference.class);
 
-    private Set<Group> groupsToAdd;
+    private Set<FmsGroup> groupsToAdd;
 
-    private Set<User> usersToAdd;
+    private Set<FmsUser> usersToAdd;
 
-    private Set<Group> groupsToRemove;
+    private Set<FmsGroup> groupsToRemove;
 
-    private Set<User> usersToRemove;
+    private Set<FmsUser> usersToRemove;
 
     private Multimap<String, String> groupMembershipToAdd;
 
     private Multimap<String, String> groupMembershipToRemove;
 
-    public UsersStateDifference(Set<Group> groupsToAdd, Set<User> usersToAdd, Set<Group> groupsToRemove, Set<User> usersToRemove,
+    public UsersStateDifference(Set<FmsGroup> groupsToAdd, Set<FmsUser> usersToAdd, Set<FmsGroup> groupsToRemove, Set<FmsUser> usersToRemove,
             Multimap<String, String> groupMembershipToAdd, Multimap<String, String> groupMembershipToRemove) {
         this.groupsToAdd = requireNonNull(groupsToAdd);
         this.usersToAdd = requireNonNull(usersToAdd);
@@ -38,19 +36,19 @@ public class UsersStateDifference {
         this.groupMembershipToRemove = requireNonNull(groupMembershipToRemove);
     }
 
-    public Set<Group> getGroupsToAdd() {
+    public Set<FmsGroup> getGroupsToAdd() {
         return groupsToAdd;
     }
 
-    public Set<User> getUsersToAdd() {
+    public Set<FmsUser> getUsersToAdd() {
         return usersToAdd;
     }
 
-    public Set<Group> getGroupsToRemove() {
+    public Set<FmsGroup> getGroupsToRemove() {
         return groupsToRemove;
     }
 
-    public Set<User> getUsersToRemove() {
+    public Set<FmsUser> getUsersToRemove() {
         return usersToRemove;
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.freeipa.service.stack;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -39,6 +40,10 @@ public class StackService {
     public Stack getByEnvironmentCrnAndAccountId(String environmentCrn, String accountId) {
         return stackRepository.findByEnvironmentCrnAndAccountId(environmentCrn, accountId)
                 .orElseThrow(() -> new NotFoundException(String.format("Stack by environment [%s] not found", environmentCrn)));
+    }
+
+    public List<Stack> getMultipleByEnvironmentCrnAndAccountId(Collection<String> environmentCrns, String accountId) {
+        return stackRepository.findMultipleByEnvironmentCrnAndAccountId(environmentCrns, accountId);
     }
 
     public Optional<Stack> findByEnvironmentCrnAndAccountId(String environmentCrn, String accountId) {

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/FreeIpaUsersStateProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/FreeIpaUsersStateProviderTest.java
@@ -17,11 +17,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.sequenceiq.freeipa.api.v1.freeipa.user.model.Group;
-import com.sequenceiq.freeipa.api.v1.freeipa.user.model.User;
 import com.sequenceiq.freeipa.client.FreeIpaClient;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
+import com.sequenceiq.freeipa.service.freeipa.user.model.FmsGroup;
+import com.sequenceiq.freeipa.service.freeipa.user.model.FmsUser;
 import com.sequenceiq.freeipa.service.freeipa.user.model.UsersState;
 
 @ExtendWith(MockitoExtension.class)
@@ -74,15 +74,15 @@ class FreeIpaUsersStateProviderTest {
                 .filter(group -> !FreeIpaUsersStateProvider.IPA_ONLY_GROUPS.contains(group))
                 .collect(Collectors.toSet());
 
-        for (User user : ipaState.getUsers()) {
-            assertTrue(expectedUsers.contains(user.getName()));
-            expectedUsers.remove(user.getName());
+        for (FmsUser fmsUser : ipaState.getUsers()) {
+            assertTrue(expectedUsers.contains(fmsUser.getName()));
+            expectedUsers.remove(fmsUser.getName());
         }
         assertTrue(expectedUsers.isEmpty());
 
-        for (Group group : ipaState.getGroups()) {
-            assertTrue(expectedGroups.contains(group.getName()));
-            expectedGroups.remove(group.getName());
+        for (FmsGroup fmsGroup : ipaState.getGroups()) {
+            assertTrue(expectedGroups.contains(fmsGroup.getName()));
+            expectedGroups.remove(fmsGroup.getName());
         }
         assertTrue(expectedGroups.isEmpty());
     }
@@ -91,20 +91,20 @@ class FreeIpaUsersStateProviderTest {
     void testFromIpaUser() {
         com.sequenceiq.freeipa.client.model.User ipaUser = createIpaUser("uid", List.of("group1", "group2"));
 
-        User user = underTest.fromIpaUser(ipaUser);
+        FmsUser fmsUser = underTest.fromIpaUser(ipaUser);
 
-        assertEquals(user.getName(), ipaUser.getUid());
-        assertEquals(user.getLastName(), ipaUser.getSn());
-        assertEquals(user.getFirstName(), ipaUser.getGivenname());
+        assertEquals(fmsUser.getName(), ipaUser.getUid());
+        assertEquals(fmsUser.getLastName(), ipaUser.getSn());
+        assertEquals(fmsUser.getFirstName(), ipaUser.getGivenname());
     }
 
     @Test
     void testFromIpaGroup() {
         com.sequenceiq.freeipa.client.model.Group ipaGroup = createIpaGroup("cn");
 
-        Group group = underTest.fromIpaGroup(ipaGroup);
+        FmsGroup fmsGroup = underTest.fromIpaGroup(ipaGroup);
 
-        assertEquals(group.getName(), ipaGroup.getCn());
+        assertEquals(fmsGroup.getName(), ipaGroup.getCn());
     }
 
     private com.sequenceiq.freeipa.client.model.User createIpaUser(String uid, List<String> memberOfGroup) {

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserServiceTest.java
@@ -1,0 +1,80 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.freeipa.controller.exception.BadRequestException;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+    private static final String ACCOUNT_ID = UUID.randomUUID().toString();
+
+    private static final String NOT_CRN = "not:a:crn:";
+
+    private static final String OTHER_CRN = "crn:altus:environments:us-west-1:"
+            + ACCOUNT_ID + ":database:" + UUID.randomUUID().toString();
+
+    private static final String ENV_CRN = "crn:altus:environments:us-west-1:"
+            + ACCOUNT_ID + ":environment:" + UUID.randomUUID().toString();
+
+    private static final String USER_CRN = "crn:altus:iam:us-west-1:"
+            + ACCOUNT_ID + ":user:" + UUID.randomUUID().toString();
+
+    private static final String MACHINE_USER_CRN = "crn:altus:iam:us-west-1:"
+            + ACCOUNT_ID + ":machineUser:" + UUID.randomUUID().toString();
+
+    @InjectMocks
+    UserService underTest;
+
+    @Test
+    void testValidateParameters() {
+        underTest.validateParameters(ACCOUNT_ID, USER_CRN, Set.of(ENV_CRN), Set.of(USER_CRN), Set.of(MACHINE_USER_CRN));
+    }
+
+    @Test
+    void testValidateParametersBadEnv() {
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            underTest.validateParameters(ACCOUNT_ID, USER_CRN, Set.of(OTHER_CRN), Set.of(), Set.of());
+        });
+    }
+
+    @Test
+    void testValidateParametersBadUser() {
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            underTest.validateParameters(ACCOUNT_ID, USER_CRN, Set.of(), Set.of(OTHER_CRN), Set.of());
+        });
+    }
+
+    @Test
+    void testValidateParametersBadMachineUser() {
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            underTest.validateParameters(ACCOUNT_ID, USER_CRN, Set.of(), Set.of(), Set.of(OTHER_CRN));
+        });
+    }
+
+    @Test
+    void testValidateCrnFilter() {
+        underTest.validateCrnFilter(Set.of(ENV_CRN), Crn.ResourceType.ENVIRONMENT);
+    }
+
+    @Test
+    void testValidateCrnFilterNotCrn() {
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            underTest.validateCrnFilter(Set.of(NOT_CRN), Crn.ResourceType.ENVIRONMENT);
+        });
+    }
+
+    @Test
+    void testValidateCrnFilterWrongResourceType() {
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            underTest.validateCrnFilter(Set.of(ENV_CRN), Crn.ResourceType.USER);
+        });
+    }
+}


### PR DESCRIPTION
This commit makes the various user sync apis behave more similarly.

The environment crn filter was pulled out into a base class for all
the requests (set password, sync all, single user sync). The User
and Group models were removed from freeipa-api since they are now
only used internally to the FMS. They have also been renamed to
FmsUser and FmsGroup to make it easier to distinguish from UMS
users/groups and IPA users/groups.

All APIs can handle machine users as well as users. Sync code paths
were consolidated internally to use a single method for entry to the
UserService. Parameters are assumed (and validated) to be non-null
to simplify the code and the user controller was updated to adhere
to this change.

Retrieving stacks matching an environment crn filter has been moved
into the StackRepository instead of filtering a list of all stacks.

Logging is improved by adding toString to API models and MDC is
set.
