### PR TITLE
CB-2937. Storage location parameter is missing for S3 for SDX

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -181,6 +181,7 @@ public class SdxService {
                 LoggingRequest loggingRequest = new LoggingRequest();
                 loggingRequest.setS3(environment.getTelemetry().getLogging().getS3());
                 loggingRequest.setWasb(environment.getTelemetry().getLogging().getWasb());
+                loggingRequest.setStorageLocation(environment.getTelemetry().getLogging().getStorageLocation());
                 telemetryRequest.setLogging(loggingRequest);
                 telemetryRequest.setReportDeploymentLogs(
                         environment.getTelemetry().getReportDeploymentLogs());


### PR DESCRIPTION
Storage location missing from SDX telemetry request