### PR TITLE
CB-2921 Root disk and attached disk size increased

### DIFF
--- a/datalake/src/main/resources/sdx/aws/cluster-light-duty-template.json
+++ b/datalake/src/main/resources/sdx/aws/cluster-light-duty-template.json
@@ -46,12 +46,12 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 100,
+            "size": 250,
             "type": "standard"
           }
         ],
         "rootVolume": {
-          "size": 50
+          "size": 100
         }
       },
       "nodeCount": 1,

--- a/datalake/src/main/resources/sdx/aws/cluster-medium-duty-ha-template.json
+++ b/datalake/src/main/resources/sdx/aws/cluster-medium-duty-ha-template.json
@@ -15,12 +15,12 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 100,
+            "size": 250,
             "type": "standard"
           }
         ],
         "rootVolume": {
-          "size": 50
+          "size": 100
         }
       },
       "nodeCount": 2,
@@ -46,12 +46,12 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 100,
+            "size": 250,
             "type": "standard"
           }
         ],
         "rootVolume": {
-          "size": 50
+          "size": 100
         }
       },
       "nodeCount": 2,
@@ -77,12 +77,12 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 100,
+            "size": 250,
             "type": "standard"
           }
         ],
         "rootVolume": {
-          "size": 50
+          "size": 100
         }
       },
       "nodeCount": 1,

--- a/datalake/src/main/resources/sdx/azure/cluster-light-duty-template.json
+++ b/datalake/src/main/resources/sdx/azure/cluster-light-duty-template.json
@@ -31,7 +31,7 @@
           }
         ],
         "rootVolume": {
-          "size": 50
+          "size": 30
         }
       },
       "nodeCount": 1,
@@ -57,12 +57,12 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 100,
+            "size": 250,
             "type": "Standard_LRS"
           }
         ],
         "rootVolume": {
-          "size": 50
+          "size": 30
         }
       },
       "nodeCount": 1,

--- a/datalake/src/main/resources/sdx/azure/cluster-medium-duty-ha-template.json
+++ b/datalake/src/main/resources/sdx/azure/cluster-medium-duty-ha-template.json
@@ -15,12 +15,12 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 100,
+            "size": 250,
             "type": "StandardSSD_LRS"
           }
         ],
         "rootVolume": {
-          "size": 50
+          "size": 30
         }
       },
       "nodeCount": 2,
@@ -46,12 +46,12 @@
         "attachedVolumes": [
           {
             "count": 1,
-            "size": 100,
+            "size": 250,
             "type": "StandardSSD_LRS"
           }
         ],
         "rootVolume": {
-          "size": 50
+          "size": 30
         }
       },
       "nodeCount": 2,
@@ -82,7 +82,7 @@
           }
         ],
         "rootVolume": {
-          "size": 50
+          "size": 30
         }
       },
       "nodeCount": 1,
@@ -134,7 +134,7 @@
           }
         ],
         "rootVolume": {
-          "size": 50
+          "size": 30
         }
       },
       "nodeCount": 2,


### PR DESCRIPTION
- increased disk sizes according to tickets
- corrected root disk size for Azure templates as it was defaulting to 30gb