### PR TITLE
CB-2970. Telemetry publisher install fails with: account already exists error message

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerExternalAccountService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerExternalAccountService.java
@@ -11,6 +11,7 @@ import com.cloudera.api.swagger.client.ApiClient;
 import com.cloudera.api.swagger.client.ApiException;
 import com.cloudera.api.swagger.model.ApiConfigList;
 import com.cloudera.api.swagger.model.ApiExternalAccount;
+import com.cloudera.api.swagger.model.ApiExternalAccountList;
 
 @Service
 public class ClouderaManagerExternalAccountService {
@@ -18,13 +19,24 @@ public class ClouderaManagerExternalAccountService {
     public ApiExternalAccount createExternalAccount(String accountName, String displayName, String typeName,
             Map<String, String> configs, ApiClient client) throws ApiException {
         ExternalAccountsResourceApi externalAccountsResourceApi = new ExternalAccountsResourceApi(client);
+        ApiExternalAccountList externalAccountList = externalAccountsResourceApi.readAccounts(typeName, "FULL");
+        boolean accountFound = false;
+        if (externalAccountList.getItems() != null && !externalAccountList.getItems().isEmpty()) {
+            for (ApiExternalAccount externalAccount : externalAccountList.getItems()) {
+                if (accountName.equals(externalAccount.getName())) {
+                    accountFound = true;
+                }
+            }
+        }
         ApiExternalAccount apiExternalAccount = new ApiExternalAccount();
         apiExternalAccount.setName(accountName);
         apiExternalAccount.setDisplayName(displayName);
         apiExternalAccount.setTypeName(typeName);
         ApiConfigList accountConfigList = makeApiConfigList(configs);
         apiExternalAccount.setAccountConfigs(accountConfigList);
-        externalAccountsResourceApi.createAccount(apiExternalAccount);
+        if (!accountFound) {
+            externalAccountsResourceApi.createAccount(apiExternalAccount);
+        }
         return apiExternalAccount;
     }
 

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerExternalAccountServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerExternalAccountServiceTest.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.cm;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -17,6 +18,7 @@ import com.cloudera.api.swagger.client.ApiClient;
 import com.cloudera.api.swagger.client.ApiException;
 import com.cloudera.api.swagger.client.ApiResponse;
 import com.cloudera.api.swagger.model.ApiExternalAccount;
+import com.cloudera.api.swagger.model.ApiExternalAccountList;
 
 public class ClouderaManagerExternalAccountServiceTest {
 
@@ -35,11 +37,16 @@ public class ClouderaManagerExternalAccountServiceTest {
     public void testCreateExternalAccount() throws ApiException {
         // GIVEN
         ApiExternalAccount apiExternalAccount = new ApiExternalAccount();
+        ApiExternalAccountList apiExternalAccountList = new ApiExternalAccountList();
+        ApiResponse readAccountsResponse = new ApiResponse<>(0, null, apiExternalAccountList);
         ApiResponse response = new ApiResponse<>(0, null, apiExternalAccount);
-        when(apiClient.execute(any(), any())).thenReturn(response);
+        when(apiClient.execute(any(), any()))
+                .thenReturn(readAccountsResponse)
+                .thenReturn(response);
+        when(apiClient.escapeString(anyString())).thenReturn(anyString());
         // WHEN
-        underTest.createExternalAccount(null, null, null, new HashMap<>(), apiClient);
+        underTest.createExternalAccount("cb-altus-access", null, "ALTUS_ACCESS_KEY", new HashMap<>(), apiClient);
         // THEN
-        verify(apiClient, times(1)).execute(any(), any());
+        verify(apiClient, times(2)).execute(any(), any());
     }
 }


### PR DESCRIPTION
if cm cluster install flow step re-runs for some reason, it will try to re-create altus external account with the same name as it was created, so that api call can fail

can be solved easily just create an account with an additional uuid string