### PR TITLE
Enable WA by default until CB-2903 is not merged and wired on the UI

### DIFF
--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXV1RequestToStackV4RequestConverter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXV1RequestToStackV4RequestConverter.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 
 import javax.inject.Inject;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.stereotype.Component;
 
@@ -129,7 +128,7 @@ public class DistroXV1RequestToStackV4RequestConverter {
 
     private TelemetryRequest getTelemetryRequest(DistroXV1Request source, DetailedEnvironmentResponse environment) {
         TelemetryResponse envTelemetryResp = environment != null ? environment.getTelemetry() : null;
-        boolean workloadAnalytics = ObjectUtils.defaultIfNull(source.getWorkloadAnalytics(), true);
+        boolean workloadAnalytics = true;
         return telemetryConverter.convert(envTelemetryResp, workloadAnalytics);
     }
 


### PR DESCRIPTION
make sure until we are not using enums for telemetry + generate new UI objects, WA enabled by default (if enabled globally), so would not run issues, until those changes are done