### PR TITLE
CB-2935 Rename redbeams API model classes to avoid name conflicts

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/DatabaseService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/DatabaseService.java
@@ -22,7 +22,7 @@ import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvi
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.AllocateDatabaseServerV4Request;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerStatusV4Response;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerTerminationOutcomeV4Response;
-import com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4Request;
+import com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4StackRequest;
 import com.sequenceiq.redbeams.api.endpoint.v4.stacks.aws.AwsDatabaseServerV4Parameters;
 import com.sequenceiq.redbeams.api.model.common.Status;
 import com.sequenceiq.redbeams.client.RedbeamsServiceCrnClient;
@@ -84,8 +84,8 @@ public class DatabaseService {
         return req;
     }
 
-    private DatabaseServerV4Request getDatabaseServerRequest(DetailedEnvironmentResponse env) {
-        DatabaseServerV4Request req = new DatabaseServerV4Request();
+    private DatabaseServerV4StackRequest getDatabaseServerRequest(DetailedEnvironmentResponse env) {
+        DatabaseServerV4StackRequest req = new DatabaseServerV4StackRequest();
         req.setInstanceType("db.m3.medium");
         req.setDatabaseVendor("postgres");
         req.setStorageSize(STORAGE_SIZE);

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/AllocateDatabaseServerV4Request.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/AllocateDatabaseServerV4Request.java
@@ -9,9 +9,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.sequenceiq.cloudbreak.common.mappable.Mappable;
 import com.sequenceiq.cloudbreak.common.mappable.ProviderParametersBase;
 import com.sequenceiq.cloudbreak.validation.ValidCrn;
+import com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4StackRequest;
+import com.sequenceiq.redbeams.api.endpoint.v4.stacks.NetworkV4StackRequest;
 import com.sequenceiq.redbeams.api.endpoint.v4.stacks.aws.AwsDBStackV4Parameters;
-import com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4Request;
-import com.sequenceiq.redbeams.api.endpoint.v4.stacks.NetworkV4Request;
 import com.sequenceiq.redbeams.api.endpoint.v4.stacks.azure.AzureDBStackV4Parameters;
 import com.sequenceiq.redbeams.doc.ModelDescriptions;
 import com.sequenceiq.redbeams.doc.ModelDescriptions.DatabaseServer;
@@ -37,11 +37,11 @@ public class AllocateDatabaseServerV4Request extends ProviderParametersBase {
 
     @Valid
     @ApiModelProperty(DBStack.NETWORK)
-    private NetworkV4Request network;
+    private NetworkV4StackRequest network;
 
     @Valid
     @ApiModelProperty(value = DBStack.DATABASE_SERVER, required = true)
-    private DatabaseServerV4Request databaseServer;
+    private DatabaseServerV4StackRequest databaseServer;
 
     @ApiModelProperty(DBStack.AWS_PARAMETERS)
     private AwsDBStackV4Parameters aws;
@@ -65,19 +65,19 @@ public class AllocateDatabaseServerV4Request extends ProviderParametersBase {
         this.environmentCrn = environmentCrn;
     }
 
-    public NetworkV4Request getNetwork() {
+    public NetworkV4StackRequest getNetwork() {
         return network;
     }
 
-    public void setNetwork(NetworkV4Request network) {
+    public void setNetwork(NetworkV4StackRequest network) {
         this.network = network;
     }
 
-    public DatabaseServerV4Request getDatabaseServer() {
+    public DatabaseServerV4StackRequest getDatabaseServer() {
         return databaseServer;
     }
 
-    public void setDatabaseServer(DatabaseServerV4Request databaseServer) {
+    public void setDatabaseServer(DatabaseServerV4StackRequest databaseServer) {
         this.databaseServer = databaseServer;
     }
 

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/DatabaseServerV4StackBase.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/DatabaseServerV4StackBase.java
@@ -9,7 +9,7 @@ import com.sequenceiq.redbeams.doc.ModelDescriptions.DatabaseServerModelDescript
 
 import io.swagger.annotations.ApiModelProperty;
 
-public class DatabaseServerV4Base extends ProviderParametersBase {
+public class DatabaseServerV4StackBase extends ProviderParametersBase {
 
     @ApiModelProperty(DatabaseServerModelDescriptions.INSTANCE_TYPE)
     private String instanceType;

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/DatabaseServerV4StackRequest.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/DatabaseServerV4StackRequest.java
@@ -11,16 +11,16 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(Include.NON_NULL)
-public class DatabaseServerV4Request extends DatabaseServerV4Base {
+public class DatabaseServerV4StackRequest extends DatabaseServerV4StackBase {
 
     @ApiModelProperty(DatabaseServerModelDescriptions.SECURITY_GROUP)
-    private SecurityGroupV4Request securityGroup;
+    private SecurityGroupV4StackRequest securityGroup;
 
-    public SecurityGroupV4Request getSecurityGroup() {
+    public SecurityGroupV4StackRequest getSecurityGroup() {
         return securityGroup;
     }
 
-    public void setSecurityGroup(SecurityGroupV4Request securityGroup) {
+    public void setSecurityGroup(SecurityGroupV4StackRequest securityGroup) {
         this.securityGroup = securityGroup;
     }
 

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/NetworkV4StackBase.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/NetworkV4StackBase.java
@@ -8,7 +8,7 @@ import com.sequenceiq.redbeams.doc.ModelDescriptions.NetworkModelDescriptions;
 
 import io.swagger.annotations.ApiModelProperty;
 
-public class NetworkV4Base extends ProviderParametersBase {
+public class NetworkV4StackBase extends ProviderParametersBase {
 
     @ApiModelProperty(NetworkModelDescriptions.AWS_PARAMETERS)
     private AwsNetworkV4Parameters aws;

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/NetworkV4StackRequest.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/NetworkV4StackRequest.java
@@ -9,6 +9,6 @@ import io.swagger.annotations.ApiModel;
 @ApiModel
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(Include.NON_NULL)
-public class NetworkV4Request extends NetworkV4Base {
+public class NetworkV4StackRequest extends NetworkV4StackBase {
 
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/SecurityGroupV4StackRequest.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/SecurityGroupV4StackRequest.java
@@ -13,7 +13,7 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(Include.NON_NULL)
-public class SecurityGroupV4Request {
+public class SecurityGroupV4StackRequest {
 
     @ApiModelProperty(SecurityGroupModelDescriptions.SECURITY_GROUP_IDS)
     private Set<String> securityGroupIds;

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/AllocateDatabaseServerV4RequestTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/AllocateDatabaseServerV4RequestTest.java
@@ -8,8 +8,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.sequenceiq.redbeams.api.endpoint.v4.stacks.aws.AwsDBStackV4Parameters;
-import com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4Request;
-import com.sequenceiq.redbeams.api.endpoint.v4.stacks.NetworkV4Request;
+import com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4StackRequest;
+import com.sequenceiq.redbeams.api.endpoint.v4.stacks.NetworkV4StackRequest;
 
 public class AllocateDatabaseServerV4RequestTest {
 
@@ -28,11 +28,11 @@ public class AllocateDatabaseServerV4RequestTest {
         request.setEnvironmentCrn("myenv");
         assertEquals("myenv", request.getEnvironmentCrn());
 
-        NetworkV4Request network = new NetworkV4Request();
+        NetworkV4StackRequest network = new NetworkV4StackRequest();
         request.setNetwork(network);
         assertEquals(network, request.getNetwork());
 
-        DatabaseServerV4Request server = new DatabaseServerV4Request();
+        DatabaseServerV4StackRequest server = new DatabaseServerV4StackRequest();
         request.setDatabaseServer(server);
         assertEquals(server, request.getDatabaseServer());
     }

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/DatabaseServerV4StackBaseTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/DatabaseServerV4StackBaseTest.java
@@ -9,13 +9,13 @@ import com.sequenceiq.redbeams.api.endpoint.v4.stacks.aws.AwsDatabaseServerV4Par
 import org.junit.Before;
 import org.junit.Test;
 
-public class DatabaseServerV4BaseTest {
+public class DatabaseServerV4StackBaseTest {
 
-    private DatabaseServerV4Base underTest;
+    private DatabaseServerV4StackBase underTest;
 
     @Before
     public void setUp() throws Exception {
-        underTest = new DatabaseServerV4Base();
+        underTest = new DatabaseServerV4StackBase();
     }
 
     @Test

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/NetworkV4StackBaseTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/NetworkV4StackBaseTest.java
@@ -9,13 +9,13 @@ import com.sequenceiq.redbeams.api.endpoint.v4.stacks.aws.AwsNetworkV4Parameters
 import org.junit.Before;
 import org.junit.Test;
 
-public class NetworkV4BaseTest {
+public class NetworkV4StackBaseTest {
 
-    private NetworkV4Base underTest;
+    private NetworkV4StackBase underTest;
 
     @Before
     public void setUp() throws Exception {
-        underTest = new NetworkV4Base();
+        underTest = new NetworkV4StackBase();
     }
 
     @Test

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverter.java
@@ -35,9 +35,9 @@ import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvi
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.SecurityAccessResponse;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.AllocateDatabaseServerV4Request;
-import com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4Request;
-import com.sequenceiq.redbeams.api.endpoint.v4.stacks.NetworkV4Request;
-import com.sequenceiq.redbeams.api.endpoint.v4.stacks.SecurityGroupV4Request;
+import com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4StackRequest;
+import com.sequenceiq.redbeams.api.endpoint.v4.stacks.NetworkV4StackRequest;
+import com.sequenceiq.redbeams.api.endpoint.v4.stacks.SecurityGroupV4StackRequest;
 import com.sequenceiq.redbeams.api.model.common.DetailedDBStackStatus;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
 import com.sequenceiq.redbeams.domain.stack.DBStackStatus;
@@ -169,7 +169,7 @@ public class AllocateDatabaseServerV4RequestToDBStackConverter {
         return networkParameterAdder.addNetworkParameters(new HashMap<>(), chosenSubnetIds);
     }
 
-    private Network buildNetwork(NetworkV4Request source, DetailedEnvironmentResponse environmentResponse, CloudPlatform cloudPlatform) {
+    private Network buildNetwork(NetworkV4StackRequest source, DetailedEnvironmentResponse environmentResponse, CloudPlatform cloudPlatform) {
         Network network = new Network();
         network.setName(generateNetworkName());
 
@@ -189,7 +189,7 @@ public class AllocateDatabaseServerV4RequestToDBStackConverter {
         return network;
     }
 
-    private DatabaseServer buildDatabaseServer(DatabaseServerV4Request source, String name, Crn ownerCrn, SecurityAccessResponse securityAccessResponse) {
+    private DatabaseServer buildDatabaseServer(DatabaseServerV4StackRequest source, String name, Crn ownerCrn, SecurityAccessResponse securityAccessResponse) {
         DatabaseServer server = new DatabaseServer();
         server.setAccountId(ownerCrn.getAccountId());
         server.setName(generateDatabaseServerName());
@@ -224,7 +224,7 @@ public class AllocateDatabaseServerV4RequestToDBStackConverter {
      * @param securityAccessResponse - environment data
      * @return returns the saved security groups. If none is specified, then an empty security gorup is returned.
      */
-    private SecurityGroup buildExistingSecurityGroup(SecurityGroupV4Request source, SecurityAccessResponse securityAccessResponse) {
+    private SecurityGroup buildExistingSecurityGroup(SecurityGroupV4StackRequest source, SecurityAccessResponse securityAccessResponse) {
         SecurityGroup securityGroup = new SecurityGroup();
         if (source != null) {
             securityGroup.setSecurityGroupIds(source.getSecurityGroupIds());

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverterTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverterTest.java
@@ -49,9 +49,9 @@ import com.sequenceiq.environment.api.v1.environment.model.response.LocationResp
 import com.sequenceiq.environment.api.v1.environment.model.response.SecurityAccessResponse;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.AllocateDatabaseServerV4Request;
 import com.sequenceiq.redbeams.api.endpoint.v4.stacks.aws.AwsNetworkV4Parameters;
-import com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4Request;
-import com.sequenceiq.redbeams.api.endpoint.v4.stacks.NetworkV4Request;
-import com.sequenceiq.redbeams.api.endpoint.v4.stacks.SecurityGroupV4Request;
+import com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4StackRequest;
+import com.sequenceiq.redbeams.api.endpoint.v4.stacks.NetworkV4StackRequest;
+import com.sequenceiq.redbeams.api.endpoint.v4.stacks.SecurityGroupV4StackRequest;
 import com.sequenceiq.redbeams.api.model.common.DetailedDBStackStatus;
 import com.sequenceiq.redbeams.api.model.common.Status;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
@@ -110,11 +110,11 @@ public class AllocateDatabaseServerV4RequestToDBStackConverterTest {
 
     private AllocateDatabaseServerV4Request allocateRequest;
 
-    private NetworkV4Request networkRequest;
+    private NetworkV4StackRequest networkRequest;
 
-    private DatabaseServerV4Request databaseServerRequest;
+    private DatabaseServerV4StackRequest databaseServerRequest;
 
-    private SecurityGroupV4Request securityGroupRequest;
+    private SecurityGroupV4StackRequest securityGroupRequest;
 
     @Before
     public void setUp() throws Exception {
@@ -123,13 +123,13 @@ public class AllocateDatabaseServerV4RequestToDBStackConverterTest {
 
         allocateRequest = new AllocateDatabaseServerV4Request();
 
-        networkRequest = new NetworkV4Request();
+        networkRequest = new NetworkV4StackRequest();
         allocateRequest.setNetwork(networkRequest);
 
-        databaseServerRequest = new DatabaseServerV4Request();
+        databaseServerRequest = new DatabaseServerV4StackRequest();
         allocateRequest.setDatabaseServer(databaseServerRequest);
 
-        securityGroupRequest = new SecurityGroupV4Request();
+        securityGroupRequest = new SecurityGroupV4StackRequest();
         databaseServerRequest.setSecurityGroup(securityGroupRequest);
 
         when(clock.getCurrentInstant()).thenReturn(NOW);


### PR DESCRIPTION
Some classes in the redbeams API model are renamed to avoid name
conflicts with other classes in the API model. This ensures that API
client code generated by Swagger is correct and complete.
