### PR TITLE
CDPD-2339 - Disable ability to create local users in Atlas

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-sdx-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx-ha.bp
@@ -57,6 +57,10 @@
                             {
                                 "name": "atlas_kafka_bootstrap_servers",
                                 "value": "{{{format-join host_groups.master format='%s:9092' }}}"
+                            },
+                            {
+                              "name": "atlas_authentication_method_file",
+                              "value": "false"
                             }
                         ],
                         "refName": "atlas-ATLAS_SERVER-BASE",

--- a/core/src/main/resources/defaults/blueprints/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx-medium-ha.bp
@@ -63,6 +63,10 @@
               {
                 "name": "atlas_kafka_bootstrap_servers",
                 "value": "{{{format-join host_groups.master format='%s:9092' }}}"
+              },
+              {
+                "name": "atlas_authentication_method_file",
+                "value": "false"
               }
             ],
             "refName": "atlas-ATLAS_SERVER-BASE",

--- a/core/src/main/resources/defaults/blueprints/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx.bp
@@ -114,6 +114,10 @@
               {
                 "name": "atlas_kafka_bootstrap_servers",
                 "value": "{{{format-join host_groups.master format='%s:9092' }}}"
+              },
+              {
+                "name": "atlas_authentication_method_file",
+                "value": "false"
               }
             ],
             "refName": "atlas-ATLAS_SERVER-BASE",


### PR DESCRIPTION
CDPD-2339 - Disable ability to create local users in Atlas

simple config addition to atlas to disable local users.  

{
    "name": "atlas_authentication_method_file",
    "value": "false"
},

Closes #CDPD-2339