### PR TITLE
DISTX-305. Telemetry publisher: update cluster type to DATALAKE instead of DISTROX

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerMgmtTelemetryService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerMgmtTelemetryService.java
@@ -69,7 +69,7 @@ public class ClouderaManagerMgmtTelemetryService {
 
     private static final String TELEMETRY_UPLOAD_LOGS = "telemetry.upload.job.logs";
 
-    private static final String TELEMETRY_WA_DEFAULT_CLUSTER_TYPE = "DISTROX";
+    private static final String TELEMETRY_WA_DEFAULT_CLUSTER_TYPE = "DATALAKE";
 
     @Inject
     private ClouderaManagerExternalAccountService externalAccountService;

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerMgmtTelemetryServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerMgmtTelemetryServiceTest.java
@@ -134,6 +134,7 @@ public class ClouderaManagerMgmtTelemetryServiceTest {
         ApiConfigList result = underTest.buildTelemetryConfigList(stack, wa, null, null);
         // THEN
         assertEquals(1, result.getItems().size());
+        assertTrue(result.getItems().get(0).getValue().contains("cluster.type=DATALAKE"));
     }
 
     @Test


### PR DESCRIPTION
- need to use sdx type for WXM which is now datalake
- also add UT