### PR TITLE
CB-2959. Telemetry: Store full cloud storage log path in DB (do not only set/generate for Salt pillars).

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentClusterType.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentClusterType.java
@@ -1,0 +1,15 @@
+package com.sequenceiq.cloudbreak.telemetry.fluent;
+
+public enum FluentClusterType {
+    DATAHUB("datahub"), DATALAKE("datalake");
+
+    private String value;
+
+    FluentClusterType(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return this.value;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigService.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.cloudbreak.telemetry.fluent;
 
-import java.nio.file.Paths;
 import java.util.HashMap;
 
 import org.apache.commons.lang3.StringUtils;
@@ -21,8 +20,6 @@ public class FluentConfigService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FluentConfigService.class);
 
-    private static final String CLUSTER_LOG_PREFIX = "cluster-logs";
-
     private static final String S3_PROVIDER_PREFIX = "s3";
 
     private static final String WASB_PROVIDER_PREFIX = "wasb";
@@ -38,7 +35,7 @@ public class FluentConfigService {
         this.wasbConfigGenerator = wasbConfigGenerator;
     }
 
-    public FluentConfigView createFluentConfigs(String clusterName, String clusterType, String platform,
+    public FluentConfigView createFluentConfigs(String clusterType, String platform,
             boolean databusEnabled, boolean meteringEnabled, Telemetry telemetry) {
         final FluentConfigView.Builder builder = new FluentConfigView.Builder();
         boolean enabled = false;
@@ -46,9 +43,6 @@ public class FluentConfigService {
         if (telemetry != null) {
             if (telemetry.getLogging() != null) {
                 Logging logging = telemetry.getLogging();
-                String storageLocation = logging.getStorageLocation();
-                String logFolderName = Paths.get(CLUSTER_LOG_PREFIX, clusterType, clusterName).toString();
-
                 builder.withPlatform(platform)
                         .withOverrideAttributes(
                                 logging.getAttributes() != null ? new HashMap<>(logging.getAttributes()) : new HashMap<>()
@@ -56,11 +50,11 @@ public class FluentConfigService {
                         .withProviderPrefix(DEFAULT_PROVIDER_PREFIX);
 
                 if (logging.getS3() != null) {
-                    fillS3Configs(builder, storageLocation, clusterType, clusterName, logFolderName);
+                    fillS3Configs(builder, logging.getStorageLocation());
                     LOGGER.debug("Fluent will be configured to use S3 output.");
                     cloudStorageLoggingEnabled = true;
                 } else if (logging.getWasb() != null) {
-                    fillWasbConfigs(builder, storageLocation, logging.getWasb(), clusterType, clusterName, logFolderName);
+                    fillWasbConfigs(builder, logging.getStorageLocation(), logging.getWasb());
                     LOGGER.debug("Fluent will be configured to use WASB output.");
                     cloudStorageLoggingEnabled = true;
                 }
@@ -97,21 +91,18 @@ public class FluentConfigService {
         return validDatabusLogging;
     }
 
-    private void fillS3Configs(FluentConfigView.Builder builder, String storageLocation,
-            String clusterType, String clusterName, String logFolderName) {
+    private void fillS3Configs(FluentConfigView.Builder builder, String storageLocation) {
         S3Config s3Config = s3ConfigGenerator.generateStorageConfig(storageLocation);
-        logFolderName = resolveLogFolder(logFolderName, s3Config.getFolderPrefix(), clusterType, clusterName);
 
         builder.withProviderPrefix(S3_PROVIDER_PREFIX)
                 .withS3LogArchiveBucketName(s3Config.getBucket())
-                .withLogFolderName(logFolderName);
+                .withLogFolderName(s3Config.getFolderPrefix());
     }
 
     // TODO: add support for Azure MSI
     private void fillWasbConfigs(FluentConfigView.Builder builder, String storageLocation,
-            WasbCloudStorageV1Parameters wasbParams, String clusterType, String clusterName, String logFolderName) {
+            WasbCloudStorageV1Parameters wasbParams) {
         WasbConfig wasbConfig = wasbConfigGenerator.generateStorageConfig(storageLocation);
-        logFolderName = resolveLogFolder(logFolderName, wasbConfig.getFolderPrefix(), clusterType, clusterName);
         String storageAccount = StringUtils.isNotEmpty(wasbConfig.getAccount())
                 ? wasbConfig.getAccount() : wasbParams.getAccountName();
 
@@ -119,13 +110,6 @@ public class FluentConfigService {
                 .withAzureStorageAccessKey(wasbParams.getAccountKey())
                 .withAzureContainer(wasbConfig.getStorageContainer())
                 .withAzureStorageAccount(storageAccount)
-                .withLogFolderName(logFolderName);
-    }
-
-    private String resolveLogFolder(String logFolderName, String folderPrefix, String clusterType, String clusterName) {
-        if (StringUtils.isNotEmpty(folderPrefix)) {
-            logFolderName = Paths.get(folderPrefix, clusterType, clusterName).toString();
-        }
-        return logFolderName;
+                .withLogFolderName(wasbConfig.getFolderPrefix());
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/cloud/CloudStorageConfigGenerator.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/cloud/CloudStorageConfigGenerator.java
@@ -1,6 +1,15 @@
 package com.sequenceiq.cloudbreak.telemetry.fluent.cloud;
 
+import java.nio.file.Paths;
+
+import org.apache.commons.lang3.StringUtils;
+
 public abstract class CloudStorageConfigGenerator<T extends CloudStorageConfig> {
+
+    private static final String CLUSTER_LOG_PREFIX = "cluster-logs";
+
+    public abstract String generateStoredLocation(String location, String clusterType,
+            String clusterName, String clusterId);
 
     public abstract T generateStorageConfig(String location);
 
@@ -14,5 +23,12 @@ public abstract class CloudStorageConfigGenerator<T extends CloudStorageConfig> 
             }
         }
         return input;
+    }
+
+    String resolveLogFolder(CloudStorageConfig cloudStorageConfig, String clusterType,
+            String clusterName, String clusterId) {
+        String folderPrefix = StringUtils.isNotEmpty(cloudStorageConfig.getFolderPrefix())
+                ? cloudStorageConfig.getFolderPrefix() : CLUSTER_LOG_PREFIX;
+        return Paths.get(folderPrefix, clusterType, String.format("%s_%s", clusterName, clusterId)).toString();
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/cloud/CloudStorageFolderResolverService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/cloud/CloudStorageFolderResolverService.java
@@ -1,0 +1,64 @@
+package com.sequenceiq.cloudbreak.telemetry.fluent.cloud;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.common.api.telemetry.model.Logging;
+import com.sequenceiq.common.api.telemetry.model.Telemetry;
+
+@Service
+public class CloudStorageFolderResolverService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CloudStorageFolderResolverService.class);
+
+    private final S3ConfigGenerator s3ConfigGenerator;
+
+    private final WasbConfigGenerator wasbConfigGenerator;
+
+    public CloudStorageFolderResolverService(S3ConfigGenerator s3ConfigGenerator,
+            WasbConfigGenerator wasbConfigGenerator) {
+        this.s3ConfigGenerator = s3ConfigGenerator;
+        this.wasbConfigGenerator = wasbConfigGenerator;
+    }
+
+    public void updateStorageLocation(Telemetry telemetry, String clusterType,
+            String clusterName, String clusterCrn) {
+        LOGGER.debug("Updating/enriching telemetry storage locations with cluster data.");
+        if (telemetry != null && telemetry.getLogging() != null
+                && StringUtils.isNotEmpty(telemetry.getLogging().getStorageLocation())) {
+            Logging logging = telemetry.getLogging();
+            String storageLocation = logging.getStorageLocation();
+            if (logging.getS3() != null) {
+                storageLocation = resolveS3Location(storageLocation,
+                        clusterType, clusterName, clusterCrn);
+            } else if (logging.getWasb() != null) {
+                storageLocation = resolveWasbLocation(storageLocation,
+                        clusterType, clusterName, clusterCrn);
+            } else {
+                LOGGER.warn("None of the telemetry logging storage location was resolved, "
+                        + "make sure storage type is set properly (currently supported: s3, wasb)");
+            }
+            logging.setStorageLocation(storageLocation);
+        } else {
+            LOGGER.debug("Telemetry is not set, skipping cloud storage location updates.");
+        }
+    }
+
+    public String resolveS3Location(String location, String clusterType,
+            String clusterName, String clusterCrn) {
+        LOGGER.debug("Start to resolve S3 storage location for telemetry (logging).");
+        return s3ConfigGenerator.generateStoredLocation(location,
+                clusterType, clusterName, Crn.fromString(clusterCrn).getResource());
+    }
+
+    public String resolveWasbLocation(String location, String clusterType,
+            String clusterName, String clusterCrn) {
+        LOGGER.debug("Start to resolve WASB storage location for telemetry (logging).");
+        return wasbConfigGenerator.generateStoredLocation(location,
+                clusterType, clusterName, Crn.fromString(clusterCrn).getResource());
+    }
+
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/cloud/S3ConfigGenerator.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/cloud/S3ConfigGenerator.java
@@ -1,6 +1,10 @@
 package com.sequenceiq.cloudbreak.telemetry.fluent.cloud;
 
+import java.nio.file.Paths;
+
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
@@ -8,7 +12,19 @@ import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 @Component
 public class S3ConfigGenerator extends CloudStorageConfigGenerator<S3Config> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(S3ConfigGenerator.class);
+
     private static final String[] S3_SCHEME_PREFIXES = {"s3://", "s3a://", "s3n://"};
+
+    @Override
+    public String generateStoredLocation(String location, String clusterType, String clusterName, String clusterId) {
+        S3Config s3Config = generateStorageConfig(location);
+        String generatedS3Location = S3_SCHEME_PREFIXES[0] + Paths.get(s3Config.getBucket(),
+                resolveLogFolder(s3Config, clusterType, clusterName, clusterId));
+        LOGGER.debug("The following S3 base folder location is generated: {} (from {})",
+                generatedS3Location, location);
+        return generatedS3Location;
+    }
 
     @Override
     public S3Config generateStorageConfig(String location) {

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/cloud/WasbConfig.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/cloud/WasbConfig.java
@@ -6,10 +6,13 @@ public class WasbConfig extends CloudStorageConfig {
 
     private final String account;
 
-    public WasbConfig(String folderPrefix, String storageContainer, String account) {
+    private final boolean secure;
+
+    public WasbConfig(String folderPrefix, String storageContainer, String account, boolean secure) {
         super(folderPrefix);
         this.storageContainer = storageContainer;
         this.account = account;
+        this.secure = secure;
     }
 
     public String getStorageContainer() {
@@ -18,5 +21,9 @@ public class WasbConfig extends CloudStorageConfig {
 
     public String getAccount() {
         return account;
+    }
+
+    public boolean isSecure() {
+        return secure;
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/cloud/WasbConfigGenerator.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/cloud/WasbConfigGenerator.java
@@ -1,6 +1,10 @@
 package com.sequenceiq.cloudbreak.telemetry.fluent.cloud;
 
+import java.nio.file.Paths;
+
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
@@ -8,19 +12,35 @@ import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 @Component
 public class WasbConfigGenerator extends CloudStorageConfigGenerator<WasbConfig> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(WasbConfigGenerator.class);
+
     private static final String[] WASB_SCHEME_PREFIXES = {"wasb://", "wasbs://"};
 
     private static final String AZURE_BLOB_DOMAIN_SUFFIX = ".blob.core.windows.net";
 
     @Override
+    public String generateStoredLocation(String location, String clusterType,
+            String clusterName, String clusterId) {
+        WasbConfig wasbConfig = generateStorageConfig(location);
+        String scheme = wasbConfig.isSecure() ? WASB_SCHEME_PREFIXES[1] : WASB_SCHEME_PREFIXES[0];
+        String logFolder = resolveLogFolder(wasbConfig, clusterType, clusterName, clusterId);
+        String generatedS3Location = String.format("%s%s@%s", scheme, wasbConfig.getStorageContainer(),
+                Paths.get(String.format("%s%s", wasbConfig.getAccount(), AZURE_BLOB_DOMAIN_SUFFIX), logFolder));
+        LOGGER.debug("The following WASB base folder location is generated: {} (from {})",
+                generatedS3Location, location);
+        return generatedS3Location;
+    }
+
+    @Override
     public WasbConfig generateStorageConfig(String location) {
         if (StringUtils.isNotEmpty(location)) {
+            boolean secure = location.startsWith(WASB_SCHEME_PREFIXES[1]);
             String locationWithoutScheme = getLocationWithoutSchemePrefixes(location, WASB_SCHEME_PREFIXES);
             String[] splitted = locationWithoutScheme.split("@");
             String[] storageWithSuffix = splitted[0].split("/", 2);
             String folderPrefix = storageWithSuffix.length < 2 ? "" :  "/" + storageWithSuffix[1];
             if (splitted.length < 2) {
-                return new WasbConfig(folderPrefix, storageWithSuffix[0], null);
+                return new WasbConfig(folderPrefix, storageWithSuffix[0], null, secure);
             } else {
                 String[] splittedByDomain = splitted[1].split(AZURE_BLOB_DOMAIN_SUFFIX);
                 String account = splittedByDomain[0];
@@ -31,7 +51,7 @@ public class WasbConfigGenerator extends CloudStorageConfigGenerator<WasbConfig>
                     }
                     folderPrefix = StringUtils.isNotEmpty(folderPrefixAfterDomain) ? folderPrefixAfterDomain : folderPrefix;
                 }
-                return new WasbConfig(folderPrefix, storageWithSuffix[0], account);
+                return new WasbConfig(folderPrefix, storageWithSuffix[0], account, secure);
             }
         }
         throw new CloudbreakServiceException("Storage location parameter is missing for WASB");

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigServiceTest.java
@@ -21,8 +21,6 @@ public class FluentConfigServiceTest {
 
     private static final String PLATFORM_DEFAULT = "AWS";
 
-    private static final String CLUSTER_NAME_DEFAULT = "cl1";
-
     private FluentConfigService underTest;
 
     @Before
@@ -34,12 +32,12 @@ public class FluentConfigServiceTest {
     public void testCreateFluentConfig() {
         // GIVEN
         Logging logging = new Logging();
-        logging.setStorageLocation("mybucket");
+        logging.setStorageLocation("mybucket/cluster-logs/datahub/cl1");
         logging.setS3(new S3CloudStorageV1Parameters());
         Telemetry telemetry = new Telemetry();
         telemetry.setLogging(logging);
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_NAME_DEFAULT, CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
+        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
                 false, false, telemetry);
         // THEN
         assertTrue(result.isEnabled());
@@ -49,38 +47,20 @@ public class FluentConfigServiceTest {
     }
 
     @Test
-    public void testCreateFluentConfigWithDatalake() {
-        // GIVEN
-        Logging logging = new Logging();
-        logging.setStorageLocation("mybucket");
-        logging.setS3(new S3CloudStorageV1Parameters());
-        Telemetry telemetry = new Telemetry();
-        telemetry.setLogging(logging);
-        // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_NAME_DEFAULT, "datalake", PLATFORM_DEFAULT,
-                false, false, telemetry);
-        // THEN
-        assertTrue(result.isEnabled());
-        assertTrue(result.isCloudStorageLoggingEnabled());
-        assertEquals("cluster-logs/datalake/cl1", result.getLogFolderName());
-        assertEquals("mybucket", result.getS3LogArchiveBucketName());
-    }
-
-    @Test
     public void testCreateFluentConfigWithCustomPath() {
         // GIVEN
         Logging logging = new Logging();
-        logging.setStorageLocation("mybucket/cluster-logs/custom");
+        logging.setStorageLocation("mybucket/custom");
         logging.setS3(new S3CloudStorageV1Parameters());
         Telemetry telemetry = new Telemetry();
         telemetry.setLogging(logging);
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_NAME_DEFAULT, CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
+        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
                 false, false, telemetry);
         // THEN
         assertTrue(result.isEnabled());
         assertTrue(result.isCloudStorageLoggingEnabled());
-        assertEquals("cluster-logs/custom/datahub/cl1", result.getLogFolderName());
+        assertEquals("custom", result.getLogFolderName());
         assertEquals("mybucket", result.getS3LogArchiveBucketName());
     }
 
@@ -88,12 +68,12 @@ public class FluentConfigServiceTest {
     public void testCreateFluentConfigWithS3Path() {
         // GIVEN
         Logging logging = new Logging();
-        logging.setStorageLocation("s3://mybucket");
+        logging.setStorageLocation("s3://mybucket/cluster-logs/datahub/cl1");
         logging.setS3(new S3CloudStorageV1Parameters());
         Telemetry telemetry = new Telemetry();
         telemetry.setLogging(logging);
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_NAME_DEFAULT, CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
+        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
                 false, false, telemetry);
         // THEN
         assertTrue(result.isEnabled());
@@ -106,12 +86,12 @@ public class FluentConfigServiceTest {
     public void testCreateFluentConfigWithS3APath() {
         // GIVEN
         Logging logging = new Logging();
-        logging.setStorageLocation("s3a://mybucket");
+        logging.setStorageLocation("s3a://mybucket/cluster-logs/datahub/cl1");
         logging.setS3(new S3CloudStorageV1Parameters());
         Telemetry telemetry = new Telemetry();
         telemetry.setLogging(logging);
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_NAME_DEFAULT, CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
+        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
                 false, false, telemetry);
         // THEN
         assertTrue(result.isEnabled());
@@ -131,13 +111,13 @@ public class FluentConfigServiceTest {
         Telemetry telemetry = new Telemetry();
         telemetry.setLogging(logging);
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_NAME_DEFAULT, CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
+        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
                 false, false, telemetry);
         // THEN
         assertTrue(result.isEnabled());
         assertTrue(result.isCloudStorageLoggingEnabled());
         assertEquals("myAccountKey", result.getAzureStorageAccessKey());
-        assertEquals("cluster-logs/datahub/cl1", result.getLogFolderName());
+        assertTrue(result.getLogFolderName().isBlank());
         assertEquals("mycontainer", result.getAzureContainer());
     }
 
@@ -153,13 +133,13 @@ public class FluentConfigServiceTest {
         Telemetry telemetry = new Telemetry();
         telemetry.setLogging(logging);
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_NAME_DEFAULT, CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
+        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
                 false, false, telemetry);
         // THEN
         assertTrue(result.isEnabled());
         assertEquals("myAccountKey", result.getAzureStorageAccessKey());
         assertEquals("myaccount", result.getAzureStorageAccount());
-        assertEquals("/my/custom/path/datahub/cl1", result.getLogFolderName());
+        assertEquals("/my/custom/path", result.getLogFolderName());
         assertEquals("mycontainer", result.getAzureContainer());
     }
 
@@ -174,12 +154,12 @@ public class FluentConfigServiceTest {
         Telemetry telemetry = new Telemetry();
         telemetry.setLogging(logging);
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_NAME_DEFAULT, CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
+        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
                 false, false, telemetry);
         // THEN
         assertTrue(result.isEnabled());
         assertEquals("myAccountKey", result.getAzureStorageAccessKey());
-        assertEquals("/my/custom/path/datahub/cl1", result.getLogFolderName());
+        assertEquals("/my/custom/path", result.getLogFolderName());
         assertEquals("mycontainer", result.getAzureContainer());
     }
 
@@ -187,42 +167,19 @@ public class FluentConfigServiceTest {
     public void testCreateFluentConfigWithoutScheme() {
         // GIVEN
         Logging logging = new Logging();
-        logging.setStorageLocation("mycontainer@myaccount.blob.core.windows.net");
+        logging.setStorageLocation("mycontainer/cluster-logs/datahub/cl1@myaccount.blob.core.windows.net");
         WasbCloudStorageV1Parameters wasbParams = new WasbCloudStorageV1Parameters();
         wasbParams.setAccountKey("myAccountKey");
         logging.setWasb(wasbParams);
         Telemetry telemetry = new Telemetry();
         telemetry.setLogging(logging);
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_NAME_DEFAULT, CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
+        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
                 false, false, telemetry);
         // THEN
         assertTrue(result.isEnabled());
         assertEquals("myAccountKey", result.getAzureStorageAccessKey());
-        assertEquals("cluster-logs/datahub/cl1", result.getLogFolderName());
-        assertEquals("mycontainer", result.getAzureContainer());
-    }
-
-    @Test
-    public void testCreateFluentConfigWithOnlyContainer() {
-        // GIVEN
-        Logging logging = new Logging();
-        logging.setStorageLocation("mycontainer");
-        WasbCloudStorageV1Parameters wasbParams = new WasbCloudStorageV1Parameters();
-        wasbParams.setAccountKey("myAccountKey");
-        wasbParams.setAccountName("myAccount");
-        logging.setWasb(wasbParams);
-        Telemetry telemetry = new Telemetry();
-        telemetry.setLogging(logging);
-        // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_NAME_DEFAULT, CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
-                false, false, telemetry);
-        // THEN
-        assertTrue(result.isEnabled());
-        assertTrue(result.isCloudStorageLoggingEnabled());
-        assertEquals("myAccountKey", result.getAzureStorageAccessKey());
-        assertEquals("myAccount", result.getAzureStorageAccount());
-        assertEquals("cluster-logs/datahub/cl1", result.getLogFolderName());
+        assertEquals("/cluster-logs/datahub/cl1", result.getLogFolderName());
         assertEquals("mycontainer", result.getAzureContainer());
     }
 
@@ -233,7 +190,7 @@ public class FluentConfigServiceTest {
         telemetry.setMeteringEnabled(true);
         telemetry.setDatabusEndpoint("myEndpoint");
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_NAME_DEFAULT, CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
+        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
                 true, true, telemetry);
         // THEN
         assertTrue(result.isEnabled());
@@ -246,7 +203,7 @@ public class FluentConfigServiceTest {
         Telemetry telemetry = new Telemetry();
         telemetry.setMeteringEnabled(true);
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_NAME_DEFAULT, CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
+        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
                 false, false, telemetry);
         // THEN
         assertFalse(result.isEnabled());
@@ -259,7 +216,7 @@ public class FluentConfigServiceTest {
         Telemetry telemetry = new Telemetry();
         telemetry.setMeteringEnabled(true);
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_NAME_DEFAULT, CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
+        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
                 false, false, telemetry);
         // THEN
         assertFalse(result.isEnabled());
@@ -272,7 +229,7 @@ public class FluentConfigServiceTest {
         Telemetry telemetry = new Telemetry();
         telemetry.setReportDeploymentLogs(true);
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_NAME_DEFAULT, CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
+        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
                 true, false, telemetry);
         // THEN
         assertTrue(result.isEnabled());
@@ -285,7 +242,7 @@ public class FluentConfigServiceTest {
         Telemetry telemetry = new Telemetry();
         telemetry.setReportDeploymentLogs(true);
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_NAME_DEFAULT, CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
+        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
                 false, true, telemetry);
         // THEN
         assertFalse(result.isEnabled());
@@ -301,7 +258,7 @@ public class FluentConfigServiceTest {
         Telemetry telemetry = new Telemetry();
         telemetry.setLogging(logging);
         // WHEN
-        underTest.createFluentConfigs(CLUSTER_NAME_DEFAULT, CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
+        underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
                 false, false, telemetry);
     }
 
@@ -316,7 +273,7 @@ public class FluentConfigServiceTest {
         Telemetry telemetry = new Telemetry();
         telemetry.setLogging(logging);
         // WHEN
-        underTest.createFluentConfigs(CLUSTER_NAME_DEFAULT, CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
+        underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
                 false, false, telemetry);
     }
 }

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/cloud/CloudStorageFolderResolverServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/cloud/CloudStorageFolderResolverServiceTest.java
@@ -1,0 +1,105 @@
+package com.sequenceiq.cloudbreak.telemetry.fluent.cloud;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.sequenceiq.cloudbreak.auth.altus.CrnParseException;
+import com.sequenceiq.cloudbreak.telemetry.fluent.FluentClusterType;
+import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
+import com.sequenceiq.common.api.cloudstorage.old.WasbCloudStorageV1Parameters;
+import com.sequenceiq.common.api.telemetry.model.Logging;
+import com.sequenceiq.common.api.telemetry.model.Telemetry;
+
+public class CloudStorageFolderResolverServiceTest {
+
+    private CloudStorageFolderResolverService underTest;
+
+    @Before
+    public void setUp() {
+        underTest = new CloudStorageFolderResolverService(new S3ConfigGenerator(),
+                new WasbConfigGenerator());
+    }
+
+    @Test
+    public void testUpdateStorageLocationS3() {
+        // GIVEN
+        Telemetry telemetry = createTelemetry();
+        // WHEN
+        underTest.updateStorageLocation(telemetry, FluentClusterType.DATAHUB.value(), "mycluster",
+                "crn:altus:cloudbreak:us-west-1:someone:stack:12345");
+        // THEN
+        assertEquals("s3://mybucket/cluster-logs/datahub/mycluster_12345", telemetry.getLogging().getStorageLocation());
+    }
+
+    @Test
+    public void testUpdateStorageLocationWasb() {
+        // GIVEN
+        Telemetry telemetry = createTelemetry();
+        telemetry.getLogging().setS3(null);
+        telemetry.getLogging().setWasb(new WasbCloudStorageV1Parameters());
+        telemetry.getLogging().setStorageLocation("wasb://mycontainer");
+        // WHEN
+        underTest.updateStorageLocation(telemetry, FluentClusterType.DATAHUB.value(), "mycluster",
+                "crn:altus:cloudbreak:us-west-1:someone:stack:12345");
+        // THEN
+        assertEquals("wasb://mycontainer@null.blob.core.windows.net/cluster-logs/datahub/mycluster_12345", telemetry.getLogging().getStorageLocation());
+    }
+
+    @Test
+    public void testUpdateStorageLocationWasbWithoutScheme() {
+        // GIVEN
+        Telemetry telemetry = createTelemetry();
+        telemetry.getLogging().setS3(null);
+        telemetry.getLogging().setWasb(new WasbCloudStorageV1Parameters());
+        telemetry.getLogging().setStorageLocation("wasb://mycontainer");
+        // WHEN
+        underTest.updateStorageLocation(telemetry, FluentClusterType.DATAHUB.value(), "mycluster",
+                "crn:altus:cloudbreak:us-west-1:someone:stack:12345");
+        // THEN
+        assertEquals("wasb://mycontainer@null.blob.core.windows.net/cluster-logs/datahub/mycluster_12345", telemetry.getLogging().getStorageLocation());
+    }
+
+    @Test
+    public void testUpdateStorageLocationWithoutScheme() {
+        // GIVEN
+        Telemetry telemetry = createTelemetry();
+        telemetry.getLogging().setStorageLocation("mybucket");
+        // WHEN
+        underTest.updateStorageLocation(telemetry, FluentClusterType.DATAHUB.value(), "mycluster",
+                "crn:altus:cloudbreak:us-west-1:someone:stack:12345");
+        // THEN
+        assertEquals("s3://mybucket/cluster-logs/datahub/mycluster_12345", telemetry.getLogging().getStorageLocation());
+    }
+
+    @Test
+    public void testUpdateStorageLocationWithoutTelemetry() {
+        // GIVEN
+        Telemetry telemetry = null;
+        // WHEN
+        underTest.updateStorageLocation(telemetry, null, null, null);
+        // THEN
+        assertNull(telemetry);
+    }
+
+    @Test(expected = CrnParseException.class)
+    public void testUpdateStorageLocationWithInvalidCrn() {
+        // GIVEN
+        Telemetry telemetry = createTelemetry();
+        // WHEN
+        underTest.updateStorageLocation(telemetry, FluentClusterType.DATAHUB.value(), "mycluster",
+                "crn:altus:cloudbreak:us-west:someone:stack:12345");
+    }
+
+    private Telemetry createTelemetry() {
+        Telemetry telemetry = new Telemetry();
+        Logging logging = new Logging();
+        logging.setStorageLocation("s3://mybucket");
+        logging.setS3(new S3CloudStorageV1Parameters());
+        telemetry.setLogging(logging);
+        return telemetry;
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecoratorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecoratorTest.java
@@ -86,7 +86,7 @@ public class TelemetryDecoratorTest {
         assertEquals(results.get("enabled"), true);
         assertEquals(results.get("platform"), CloudPlatform.AWS.name());
         assertEquals(results.get("user"), "root");
-        verify(fluentConfigService, times(1)).createFluentConfigs(anyString(), anyString(), anyString(),
+        verify(fluentConfigService, times(1)).createFluentConfigs(anyString(), anyString(),
                 anyBoolean(), anyBoolean(), any(Telemetry.class));
         verify(meteringConfigService, times(1)).createMeteringConfigs(anyBoolean(), anyString(), anyString(), anyString(),
                 anyString());
@@ -203,7 +203,7 @@ public class TelemetryDecoratorTest {
             MeteringConfigView meteringConfigView) {
         given(databusConfigService.createDatabusConfigs(anyString(), any(), isNull(), isNull()))
                 .willReturn(databusConfigView);
-        given(fluentConfigService.createFluentConfigs(anyString(), anyString(), anyString(),
+        given(fluentConfigService.createFluentConfigs(anyString(), anyString(),
                 anyBoolean(), anyBoolean(), any(Telemetry.class)))
                 .willReturn(fluentConfigView);
         given(meteringConfigService.createMeteringConfigs(anyBoolean(), anyString(), anyString(), anyString(),


### PR DESCRIPTION
as it was requested, we are storing the full path of the log locations on the stack side (so that can be gathered by the api, detailed responses will contain the generated full path), enrich the env based telemetry location with cluster details,
so for example, env response:
```
"telemetry": {
      "logging": {
        "s3": {
          "instanceProfile": "arn:aws:iam::980678866538:instance-profile/oszabo-s3-access"
        },
        "storageLocation": "s3://oszabo"
      }
    }
```
stack response:
```
"telemetry": {
      "logging": {
        "s3": {
          "instanceProfile": "arn:aws:iam::980678866538:instance-profile/oszabo-s3-access"
        },
        "storageLocation": "s3://oszabo/cluster-logs/datahub/oszabo-distrox-1_0fc69cab-c421-4948-bbdd-b86b6ba178b3"
      }
    }
```
also make enum from some built-in constants