### PR TITLE
OPSAPS-51980 - enable delegation tokens in Kafka

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-sdx-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx-ha.bp
@@ -235,6 +235,10 @@
                     {
                         "name": "zookeeper_service",
                         "ref": "zookeeper"
+                    },
+	            {
+                        "name": "delegation.token.enable",
+                        "value": "true"
                     }
                 ],
                 "serviceType": "KAFKA"

--- a/core/src/main/resources/defaults/blueprints/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx-medium-ha.bp
@@ -245,6 +245,10 @@
           {
             "name": "offsets.topic.replication.factor",
             "value": "1"
+          },
+	  {
+            "name": "delegation.token.enable",
+            "value": "true"
           }
         ],
         "serviceType": "KAFKA"

--- a/core/src/main/resources/defaults/blueprints/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx.bp
@@ -258,6 +258,10 @@
           {
             "name": "transaction.state.log.min.isr",
             "value": "1"
+          },
+	  {
+            "name": "delegation.token.enable",
+            "value": "true"
           }
         ],
         "serviceType": "KAFKA"


### PR DESCRIPTION
Notes:
Please take a moment to review this code change.  The change is a single property to enable delegation tokens in kafka.  (for all 3 blueprints)

Testing:
1. set value in CM ui, then exported blueprint to verify that the location and value for the config in the blueprint.
2. provisioned a datalake with the cdp-sdx.bp + this 1 change.
3. logged into provisioned cluster and verified key was configured with the expected value.

Closes #OPSAPS-51980