### PR TITLE
CDPSDX-716 - suppress warning for single zookeeper

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx.bp
@@ -50,7 +50,13 @@
             "roleType": "SERVER"
           }
         ],
-        "serviceType": "ZOOKEEPER"
+        "serviceType": "ZOOKEEPER",
+        "serviceConfigs": [
+          {
+            "name": "service_config_suppression_server_count_validator",
+            "value": "true"
+          }
+        ]
       },
       {
         "refName": "ranger",


### PR DESCRIPTION
CDPSDX-716 - suppress warning for single zookeeper

2nd attempt for zookeeper config change to suppress.  previous pull request was denied due to changes in the 2 HA blueprints.  this pull request only includes changes to the NON-HA blueprint.

Closes #CDPSDX-716
