### PR TITLE
CB-3021. SDX: cloud storage logging should only depend on telemetry o…

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -239,24 +239,26 @@ public class SdxService {
     private StackV4Request prepareStackRequest(SdxClusterRequest sdxClusterRequest, StackV4Request stackV4Request,
             SdxCluster sdxCluster, DetailedEnvironmentResponse environment) {
         stackV4Request = getStackRequest(stackV4Request, sdxClusterRequest.getClusterShape(), environment.getCloudPlatform());
-        if (isCloudStorageConfigured(sdxClusterRequest)) {
-            CloudStorageRequest cloudStorageRequest =
-                    cloudStorageManifester.initCloudStorageRequest(environment,
-                            stackV4Request.getCluster().getBlueprintName(), sdxCluster, sdxClusterRequest);
-            stackV4Request.getCluster().setCloudStorage(cloudStorageRequest);
-            if (environment.getTelemetry() != null && environment.getTelemetry().getLogging() != null) {
-                TelemetryRequest telemetryRequest = new TelemetryRequest();
-                LoggingRequest loggingRequest = new LoggingRequest();
-                loggingRequest.setS3(environment.getTelemetry().getLogging().getS3());
-                loggingRequest.setWasb(environment.getTelemetry().getLogging().getWasb());
-                loggingRequest.setStorageLocation(environment.getTelemetry().getLogging().getStorageLocation());
-                telemetryRequest.setLogging(loggingRequest);
-                telemetryRequest.setReportDeploymentLogs(
-                        environment.getTelemetry().getReportDeploymentLogs());
-                stackV4Request.setTelemetry(telemetryRequest);
-            }
-        }
+        CloudStorageRequest cloudStorageRequest =
+                cloudStorageManifester.initCloudStorageRequest(environment,
+                        stackV4Request.getCluster().getBlueprintName(), sdxCluster, sdxClusterRequest);
+        stackV4Request.getCluster().setCloudStorage(cloudStorageRequest);
+        prepareTelemetryForStack(stackV4Request, environment);
         return stackV4Request;
+    }
+
+    private void prepareTelemetryForStack(StackV4Request stackV4Request, DetailedEnvironmentResponse environment) {
+        if (environment.getTelemetry() != null && environment.getTelemetry().getLogging() != null) {
+            TelemetryRequest telemetryRequest = new TelemetryRequest();
+            LoggingRequest loggingRequest = new LoggingRequest();
+            loggingRequest.setS3(environment.getTelemetry().getLogging().getS3());
+            loggingRequest.setWasb(environment.getTelemetry().getLogging().getWasb());
+            loggingRequest.setStorageLocation(environment.getTelemetry().getLogging().getStorageLocation());
+            telemetryRequest.setLogging(loggingRequest);
+            telemetryRequest.setReportDeploymentLogs(
+                    environment.getTelemetry().getReportDeploymentLogs());
+            stackV4Request.setTelemetry(telemetryRequest);
+        }
     }
 
     private boolean isCloudStorageConfigured(SdxClusterRequest clusterRequest) {

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxServiceTest.java
@@ -76,6 +76,9 @@ public class SdxServiceTest {
     @Mock
     private Clock clock;
 
+    @Mock
+    private CloudStorageManifester cloudStorageManifester;
+
     @InjectMocks
     private SdxService sdxService;
 


### PR DESCRIPTION
…bject (not on cloud storage data access)

If logging is set, but cloud storage (data access) is not, then logging is not set as well.

Expected behavior would be to setup log identity for SDX if it is enabled on environment side (that's how it is working for DistroX)

UI flows looked ok. I have tested with this cli change as well: https://github.com/hortonworks/cb-cli/pull/612