### PR TITLE
CB-3023. Machine user could be not found by the UMS client, right after creation

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
@@ -179,7 +179,7 @@ public class GrpcUmsClient {
             String generatedRequestId = requestId.orElse(UUID.randomUUID().toString());
             LOGGER.debug("Creating machine user {} for {} using request ID {}", machineUserName, userCrn, generatedRequestId);
             client.createMachineUser(requestId.orElse(UUID.randomUUID().toString()), userCrn, machineUserName);
-            MachineUser machineUser = client.getMachineUserForUser(requestId.orElse(UUID.randomUUID().toString()), userCrn, machineUserName);
+            MachineUser machineUser = client.getMachineUserWithRetry(requestId.orElse(UUID.randomUUID().toString()), userCrn, machineUserName);
             LOGGER.debug("Machine User information retrieved for userCrn: {}", machineUser.getCrn());
             return machineUser;
         }

--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/UmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/UmsClient.java
@@ -8,6 +8,8 @@ import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 
 import com.cloudera.thunderhead.service.usermanagement.UserManagementGrpc;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementGrpc.UserManagementBlockingStub;
@@ -32,6 +34,7 @@ import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.Machi
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.User;
 import com.sequenceiq.cloudbreak.auth.altus.config.UmsClientConfig;
 import com.sequenceiq.cloudbreak.auth.altus.exception.UmsAuthenticationException;
+import com.sequenceiq.cloudbreak.auth.altus.exception.UmsOperationException;
 import com.sequenceiq.cloudbreak.grpc.altus.AltusMetadataInterceptor;
 
 import io.grpc.ManagedChannel;
@@ -165,6 +168,20 @@ public class UmsClient {
             requestBuilder.setPageToken(response.getNextPageToken());
         } while (response.hasNextPageToken());
         return users;
+    }
+
+    @Retryable(value = UmsOperationException.class, maxAttempts = 5, backoff = @Backoff(delay = 5000))
+    public MachineUser getMachineUserWithRetry(String requestId, String userCrn, String machineUserName) {
+        try {
+            return getMachineUserForUser(requestId, userCrn, userCrn);
+        } catch (StatusRuntimeException ex) {
+            if (Status.NOT_FOUND.getCode().equals(ex.getStatus().getCode())) {
+                LOGGER.error("Machine user not found.", ex);
+                throw new UmsOperationException(String.format("Machine user with name %s is not found yet", machineUserName), ex);
+            } else {
+                throw ex;
+            }
+        }
     }
 
     public MachineUser getMachineUser(String requestId, String userCrn) {


### PR DESCRIPTION
Less likely, but it is possible after user creation, UMS could answer with not found status (for an already existing user) - as we cannot use the crn from create machine user response (as if the user already exists, it throws an exception, possible on cluster install retries), we need to query it after the creation