### PR TITLE
CB-2909 Restore Swagger authorization annotation for redbeams

### DIFF
--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/DatabaseServerV4Endpoint.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/DatabaseServerV4Endpoint.java
@@ -15,6 +15,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import com.sequenceiq.cloudbreak.validation.ValidCrn;
+import com.sequenceiq.redbeams.api.RedbeamsApi;
 import com.sequenceiq.redbeams.api.endpoint.v4.database.request.CreateDatabaseV4Request;
 import com.sequenceiq.redbeams.api.endpoint.v4.database.responses.CreateDatabaseV4Response;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.AllocateDatabaseServerV4Request;
@@ -32,13 +33,15 @@ import com.sequenceiq.redbeams.doc.ParamDescriptions.DatabaseServerParamDescript
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.Authorization;
 
 import org.springframework.validation.annotation.Validated;
 
 @Path("/v4/databaseservers")
 @Produces(MediaType.APPLICATION_JSON)
 @Api(tags = {"database servers"},
-        protocols = "http,https")
+        protocols = "http,https",
+        authorizations = { @Authorization(value = RedbeamsApi.CRN_HEADER_API_KEY) })
 @Validated
 public interface DatabaseServerV4Endpoint {
 


### PR DESCRIPTION
The Swagger @Api annotation for DatabaseServerV4Endpoint once again
describes the use of the user CRN header for authorization. Its presence
was causing problems for implementing the Cloudbreak (dp) CLI commands
for redbeams, but I found that simply passing a null value for the
authorization information to the generated client worked. This means
that both the Cloudbreak CLI and the Swagger UI console function for
redbeams.

---

I tested this by successfully using the CLI, with regenerated client code, on both my local Cloudbreak and on manowar-dev. In the CLI, I just pass `nil` for the authorization information, and there's no problem.

I will put up a separate PR up for the CLI modifications, including the regenerated redbeams client, in the hortonworks/cb-cli repository.