### PR TITLE
CB-2687 Disable redbeams dbserver test endpoint

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/CrnValidator.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/CrnValidator.java
@@ -9,6 +9,9 @@ public class CrnValidator implements ConstraintValidator<ValidCrn, String> {
 
     @Override
     public boolean isValid(String req, ConstraintValidatorContext constraintValidatorContext) {
+        if (req == null) {
+            return true;
+        }
         if (!Crn.isCrn(req)) {
             constraintValidatorContext
                     .buildConstraintViolationWithTemplate("Invalid crn provided")

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/database/base/DatabaseV4Base.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/database/base/DatabaseV4Base.java
@@ -44,6 +44,7 @@ public abstract class DatabaseV4Base implements Serializable {
     private String connectionDriver;
 
     @ValidCrn
+    @NotNull
     @ApiModelProperty(Database.ENVIRONMENT_CRN)
     private String environmentCrn;
 

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/DatabaseServerV4Endpoint.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/DatabaseServerV4Endpoint.java
@@ -56,7 +56,7 @@ public interface DatabaseServerV4Endpoint {
     @ApiOperation(value = DatabaseServerOpDescription.GET_BY_CRN, notes = DatabaseServerNotes.GET_BY_CRN,
             nickname = "getDatabaseServerByCrn")
     DatabaseServerV4Response getByCrn(
-            @ValidCrn @ApiParam(DatabaseServerParamDescriptions.CRN) @PathParam("crn") String crn
+            @ValidCrn @NotNull @ApiParam(DatabaseServerParamDescriptions.CRN) @PathParam("crn") String crn
     );
 
     @GET
@@ -83,7 +83,7 @@ public interface DatabaseServerV4Endpoint {
     @ApiOperation(value = DatabaseServerOpDescription.GET_STATUS_BY_CRN, notes = DatabaseServerNotes.GET_STATUS_BY_CRN,
             nickname = "getDatabaseServerStatusByCrn")
     DatabaseServerStatusV4Response getStatusOfManagedDatabaseServerByCrn(
-            @ValidCrn @ApiParam(DatabaseServerParamDescriptions.CRN) @PathParam("crn") String crn
+            @ValidCrn @NotNull @ApiParam(DatabaseServerParamDescriptions.CRN) @PathParam("crn") String crn
     );
 
     @GET
@@ -101,7 +101,7 @@ public interface DatabaseServerV4Endpoint {
     @ApiOperation(value = DatabaseServerOpDescription.TERMINATE, notes = DatabaseServerNotes.TERMINATE,
             nickname = "terminateManagedDatabaseServer")
     DatabaseServerTerminationOutcomeV4Response terminate(
-            @ValidCrn @ApiParam(DatabaseServerParamDescriptions.CRN) @PathParam("crn") String crn
+            @ValidCrn @NotNull @ApiParam(DatabaseServerParamDescriptions.CRN) @PathParam("crn") String crn
     );
 
     @POST
@@ -118,7 +118,7 @@ public interface DatabaseServerV4Endpoint {
     @ApiOperation(value = DatabaseServerOpDescription.DELETE_BY_CRN, notes = DatabaseServerNotes.DELETE_BY_CRN,
             nickname = "deleteDatabaseServerByCrn")
     DatabaseServerV4Response deleteByCrn(
-            @ValidCrn @ApiParam(DatabaseServerParamDescriptions.CRN) @PathParam("crn") String crn
+            @ValidCrn @NotNull @ApiParam(DatabaseServerParamDescriptions.CRN) @PathParam("crn") String crn
     );
 
     @DELETE

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/database/DatabaseV4Controller.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/database/DatabaseV4Controller.java
@@ -60,16 +60,17 @@ public class DatabaseV4Controller implements DatabaseV4Endpoint {
 
     @Override
     public DatabaseTestV4Response test(@Valid DatabaseTestV4Request databaseTestV4Request) {
-        String result = "";
-        if (databaseTestV4Request.getExistingDatabase() != null) {
-            result = databaseConfigService.testConnection(
-                    databaseTestV4Request.getExistingDatabase().getName(),
-                    databaseTestV4Request.getExistingDatabase().getEnvironmentCrn()
-            );
-        } else {
-            DatabaseConfig databaseConfig = redbeamsConverterUtil.convert(databaseTestV4Request.getDatabase(), DatabaseConfig.class);
-            result = databaseConfigService.testConnection(databaseConfig);
-        }
-        return new DatabaseTestV4Response(result);
+        throw new UnsupportedOperationException("Connection testing is disabled for security reasons until further notice");
+        // String result = "";
+        // if (databaseTestV4Request.getExistingDatabase() != null) {
+        //     result = databaseConfigService.testConnection(
+        //             databaseTestV4Request.getExistingDatabase().getName(),
+        //             databaseTestV4Request.getExistingDatabase().getEnvironmentCrn()
+        //     );
+        // } else {
+        //     DatabaseConfig databaseConfig = redbeamsConverterUtil.convert(databaseTestV4Request.getDatabase(), DatabaseConfig.class);
+        //     result = databaseConfigService.testConnection(databaseConfig);
+        // }
+        // return new DatabaseTestV4Response(result);
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4Controller.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4Controller.java
@@ -133,14 +133,15 @@ public class DatabaseServerV4Controller implements DatabaseServerV4Endpoint {
 
     @Override
     public DatabaseServerTestV4Response test(DatabaseServerTestV4Request request) {
-        String connectionResult;
-        if (request.getExistingDatabaseServerCrn() != null) {
-            connectionResult = databaseServerConfigService.testConnection(request.getExistingDatabaseServerCrn());
-        } else {
-            DatabaseServerConfig server = converterUtil.convert(request.getDatabaseServer(), DatabaseServerConfig.class);
-            connectionResult = databaseServerConfigService.testConnection(server);
-        }
-        return new DatabaseServerTestV4Response(connectionResult);
+        throw new UnsupportedOperationException("Connection testing is disabled for security reasons until further notice");
+        // String connectionResult;
+        // if (request.getExistingDatabaseServerCrn() != null) {
+        //     connectionResult = databaseServerConfigService.testConnection(request.getExistingDatabaseServerCrn());
+        // } else {
+        //     DatabaseServerConfig server = converterUtil.convert(request.getDatabaseServer(), DatabaseServerConfig.class);
+        //     connectionResult = databaseServerConfigService.testConnection(server);
+        // }
+        // return new DatabaseServerTestV4Response(connectionResult);
     }
 
     @Override

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4ControllerTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4ControllerTest.java
@@ -18,11 +18,11 @@ import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.AllocateDatabaseServerV4Request;
-import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.DatabaseServerTestV4Request;
+// import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.DatabaseServerTestV4Request;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.DatabaseServerV4Request;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerStatusV4Response;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerTerminationOutcomeV4Response;
-import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerTestV4Response;
+// import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerTestV4Response;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerV4Response;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerV4Responses;
 import com.sequenceiq.redbeams.converter.stack.AllocateDatabaseServerV4RequestToDBStackConverter;
@@ -226,26 +226,26 @@ public class DatabaseServerV4ControllerTest {
         assertEquals(2, responses.getResponses().size());
     }
 
-    @Test
-    public void testTestWithIdentifiers() {
-        when(service.testConnection(SERVER_CRN)).thenReturn("yeahhh");
-        DatabaseServerTestV4Request testRequest = new DatabaseServerTestV4Request();
-        testRequest.setExistingDatabaseServerCrn(SERVER_CRN);
+    // @Test
+    // public void testTestWithIdentifiers() {
+    //     when(service.testConnection(SERVER_CRN)).thenReturn("yeahhh");
+    //     DatabaseServerTestV4Request testRequest = new DatabaseServerTestV4Request();
+    //     testRequest.setExistingDatabaseServerCrn(SERVER_CRN);
 
-        DatabaseServerTestV4Response response = underTest.test(testRequest);
+    //     DatabaseServerTestV4Response response = underTest.test(testRequest);
 
-        assertEquals("yeahhh", response.getResult());
-    }
+    //     assertEquals("yeahhh", response.getResult());
+    // }
 
-    @Test
-    public void testTestWithServer() {
-        when(converterUtil.convert(request, DatabaseServerConfig.class)).thenReturn(server);
-        when(service.testConnection(server)).thenReturn("okayyy");
-        DatabaseServerTestV4Request testRequest = new DatabaseServerTestV4Request();
-        testRequest.setDatabaseServer(request);
+    // @Test
+    // public void testTestWithServer() {
+    //     when(converterUtil.convert(request, DatabaseServerConfig.class)).thenReturn(server);
+    //     when(service.testConnection(server)).thenReturn("okayyy");
+    //     DatabaseServerTestV4Request testRequest = new DatabaseServerTestV4Request();
+    //     testRequest.setDatabaseServer(request);
 
-        DatabaseServerTestV4Response response = underTest.test(testRequest);
+    //     DatabaseServerTestV4Response response = underTest.test(testRequest);
 
-        assertEquals("okayyy", response.getResult());
-    }
+    //     assertEquals("okayyy", response.getResult());
+    // }
 }


### PR DESCRIPTION
The database and database server test API endpoints for redbeams are
disabled, to eliminate the possibility of an outside, compromised
database server gaining access to redbeams or its hosting compute
resource. The endpoints may come back later once it's certain that they
can be implemented safely.

While testing, I found that CrnValidator was too strict and rejecting
null CRN values, which are valid in some cases. The validator now
permits nulls, and I added the @NotNull validation annotation in places
where the CRN really shouldn't be null.