### PR TITLE
CB-3054. Invalid Machine user Crn during Machine user creation.

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/UmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/UmsClient.java
@@ -173,7 +173,7 @@ public class UmsClient {
     @Retryable(value = UmsOperationException.class, maxAttempts = 5, backoff = @Backoff(delay = 5000))
     public MachineUser getMachineUserWithRetry(String requestId, String userCrn, String machineUserName) {
         try {
-            return getMachineUserForUser(requestId, userCrn, userCrn);
+            return getMachineUserForUser(requestId, userCrn, machineUserName);
         } catch (StatusRuntimeException ex) {
             if (Status.NOT_FOUND.getCode().equals(ex.getStatus().getCode())) {
                 LOGGER.error("Machine user not found.", ex);


### PR DESCRIPTION
actor is not a machine user so CRN, so it cannot get machine user details by itself. (copied that from a few lines below, but that is invalid for dbus user)