### PR TITLE
CB-3041. Consider SDX internal request for cloud storage request manifester

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -239,9 +239,8 @@ public class SdxService {
     private StackV4Request prepareStackRequest(SdxClusterRequest sdxClusterRequest, StackV4Request stackV4Request,
             SdxCluster sdxCluster, DetailedEnvironmentResponse environment) {
         stackV4Request = getStackRequest(stackV4Request, sdxClusterRequest.getClusterShape(), environment.getCloudPlatform());
-        CloudStorageRequest cloudStorageRequest =
-                cloudStorageManifester.initCloudStorageRequest(environment,
-                        stackV4Request.getCluster().getBlueprintName(), sdxCluster, sdxClusterRequest);
+        CloudStorageRequest cloudStorageRequest = cloudStorageManifester.initCloudStorageRequest(environment,
+                stackV4Request.getCluster(), sdxCluster, sdxClusterRequest);
         stackV4Request.getCluster().setCloudStorage(cloudStorageRequest);
         prepareTelemetryForStack(stackV4Request, environment);
         return stackV4Request;


### PR DESCRIPTION
creating cloud storage request behavior for SDX with internal SDX stack request:
- if cloud storage data is filled in sdx request use that
- if cloud storage data is not filled in sdx request but sdx internal request has, use that
- if logging is enabled, enrich cloud request with that, if none of the above 2 is enabled, create a new cloud request with logging
- if any from the above 3 is enabled, enrich with s3 guard dynamo table (if it has not set already in sdx internal request and it is enabled)

added a lot of logging as well
added new UTs