### PR TITLE
CB-3039. Set user shell to bash

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
@@ -145,6 +145,7 @@ public class FreeIpaClient {
         Map<String, Object> params = Map.of(
                 "givenname", firstName,
                 "sn", lastName,
+                "loginshell", "/bin/bash",
                 "random", true,
                 "setattr", "krbPasswordExpiration=20380101000000Z"
         );


### PR DESCRIPTION
User sync sets the login shell for ipa users to /bin/bash when adding
new users to IPA. This does not affect existing users.
