### PR TITLE
CB-3080 Set CapacityScheduler as default scheduler for YARN in the Data Engineering blueprint

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering.bp
@@ -44,11 +44,23 @@
       {
         "refName": "yarn",
         "serviceType": "YARN",
+        "serviceConfigs": [
+          {
+            "name": "yarn_admin_acl",
+            "value": "hive"
+          }
+        ],
         "roleConfigGroups": [
           {
             "refName": "yarn-RESOURCEMANAGER-BASE",
             "roleType": "RESOURCEMANAGER",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                "name": "yarn_resourcemanager_scheduler_class",
+                "value": "org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler"
+              }
+            ]
           },
           {
             "refName": "yarn-NODEMANAGER-WORKER",


### PR DESCRIPTION
Describe the change you are making here!

In the Data engineering blueprint CapacityScheduler should be the default, and hive the default acl for yarn.

Please include tests. Check out these examples:

Tested on Manowar.
- https://github.com/hortonworks/cloudbreak/blob/master/core/src/test/java/com/sequenceiq/cloudbreak/service/blueprint/BlueprintLoaderServiceTest.java#L62-L76

Please include a short description. Check out these examples:

- https://github.com/hortonworks/cloudbreak/commit/888b2e2a8887def28a24e26efcd6d9ca5863733a

If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:

Closes #xxx
Closes #xxx