### PR TITLE
CDPSDX-715 - suppress kafka warnings

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-sdx-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx-ha.bp
@@ -240,7 +240,19 @@
                         "name": "zookeeper_service",
                         "ref": "zookeeper"
                     },
-	            {
+                    {
+                      "name": "service_config_suppression_offsets.topic.replication.factor",
+                      "value": "true"
+                    },
+                    {
+                      "name": "service_config_suppression_transaction.state.log.replication.factor",
+                      "value": "true"
+                    },
+                    {
+                      "name": "service_config_suppression_kafka_broker_count_validator",
+                      "value": "true"
+                    },
+	                  {
                         "name": "delegation.token.enable",
                         "value": "true"
                     }

--- a/core/src/main/resources/defaults/blueprints/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx-medium-ha.bp
@@ -250,7 +250,19 @@
             "name": "offsets.topic.replication.factor",
             "value": "1"
           },
-	  {
+          {
+            "name": "service_config_suppression_offsets.topic.replication.factor",
+            "value": "true"
+          },
+          {
+            "name": "service_config_suppression_transaction.state.log.replication.factor",
+            "value": "true"
+          },
+          {
+            "name": "service_config_suppression_kafka_broker_count_validator",
+            "value": "true"
+          },
+	        {
             "name": "delegation.token.enable",
             "value": "true"
           }

--- a/core/src/main/resources/defaults/blueprints/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx.bp
@@ -269,7 +269,19 @@
             "name": "transaction.state.log.min.isr",
             "value": "1"
           },
-	  {
+          {
+            "name": "service_config_suppression_offsets.topic.replication.factor",
+            "value": "true"
+          },
+          {
+            "name": "service_config_suppression_transaction.state.log.replication.factor",
+            "value": "true"
+          },
+          {
+            "name": "service_config_suppression_kafka_broker_count_validator",
+            "value": "true"
+          },
+	        {
             "name": "delegation.token.enable",
             "value": "true"
           }


### PR DESCRIPTION
This change will suppress the 3 kafka warnings that were showing up in the datalake, based on the light duty blueprint.

Notes:

including all 3 blueprint changes, but only tested the lite-duty version. (HA is not supported in GA, but adding the configs now to avoid technical debt that must be done after GA for 1.1.
Tests performed: (only "cdp-sdx.bp")

deployed cluster in mow-dev, verified via CM API that these 3 configuration values are available in the current supported CM version.
deploy via CLI with configuration changes to verify that there were no provision errors when including the 3 values in the blueprint.
Closes #CDPSDX-715