### PR TITLE
CB-3095. NOT_FOUND: Role 'crn:cdp:iam:us-west-1:altus:role:DbusUpload…

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
@@ -482,6 +482,7 @@ public class GrpcUmsClient {
      */
     public String getBuiltInDatabusRoleCrn() {
         Crn databusCrn = Crn.builder()
+                .setPartition(Crn.Partition.ALTUS)
                 .setAccountId("altus")
                 .setService(Crn.Service.IAM)
                 .setResourceType(Crn.ResourceType.ROLE)

--- a/common/src/main/java/com/sequenceiq/cloudbreak/auth/altus/Crn.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/auth/altus/Crn.java
@@ -504,10 +504,9 @@ public class Crn {
     }
 
     public static class Builder {
-        // We hardcode the following for now as we have neither the partitions nor
-        // regions yet.
-        private final Partition partition = Partition.CDP;
+        private Partition partition = Partition.CDP;
 
+        // We hardcode the following for now
         private final Region region = Region.US_WEST_1;
 
         private Service service;
@@ -517,6 +516,11 @@ public class Crn {
         private ResourceType resourceType;
 
         private String resource;
+
+        public Builder setPartition(Partition partition) {
+            this.partition = checkNotNull(partition);
+            return this;
+        }
 
         public Builder setService(Service service) {
             this.service = checkNotNull(service);


### PR DESCRIPTION
…er' does not exist in the account 'altus

- change is related with https://github.com/hortonworks/cloudbreak/pull/5956

- there is a hidden built-in role in UMS, which we need to use for machine users, hopefully for the new cdp partition, there is a cdp account as well, then this change should be enough.

testing is in progress agains real UMS, i have just opening the PR to let Ut and It finish in time