### PR TITLE
CB-2687 Disable db and db server verification upon registration

### DIFF
--- a/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/database/DatabaseV4Controller.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/database/DatabaseV4Controller.java
@@ -39,7 +39,7 @@ public class DatabaseV4Controller implements DatabaseV4Endpoint {
     @Override
     public DatabaseV4Response register(@Valid DatabaseV4Request request) {
         DatabaseConfig databaseConfig = redbeamsConverterUtil.convert(request, DatabaseConfig.class);
-        return redbeamsConverterUtil.convert(databaseConfigService.register(databaseConfig), DatabaseV4Response.class);
+        return redbeamsConverterUtil.convert(databaseConfigService.register(databaseConfig, false), DatabaseV4Response.class);
     }
 
     @Override

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4Controller.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4Controller.java
@@ -106,7 +106,7 @@ public class DatabaseServerV4Controller implements DatabaseServerV4Endpoint {
 
     @Override
     public DatabaseServerV4Response register(DatabaseServerV4Request request) {
-        DatabaseServerConfig server = databaseServerConfigService.create(converterUtil.convert(request, DatabaseServerConfig.class), DEFAULT_WORKSPACE);
+        DatabaseServerConfig server = databaseServerConfigService.create(converterUtil.convert(request, DatabaseServerConfig.class), DEFAULT_WORKSPACE, false);
         //notify(ResourceEvent.DATABASE_SERVER_CONFIG_CREATED);
         return converterUtil.convert(server, DatabaseServerV4Response.class);
     }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbconfig/DatabaseConfigService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbconfig/DatabaseConfigService.java
@@ -71,7 +71,7 @@ public class DatabaseConfigService extends AbstractArchivistService<DatabaseConf
         return repository.findByEnvironmentId(environmentCrn);
     }
 
-    public DatabaseConfig register(DatabaseConfig configToSave) {
+    public DatabaseConfig register(DatabaseConfig configToSave, boolean test) {
 
         if (configToSave.getConnectionDriver() == null) {
             configToSave.setConnectionDriver(configToSave.getDatabaseVendor().connectionDriver());
@@ -79,10 +79,12 @@ public class DatabaseConfigService extends AbstractArchivistService<DatabaseConf
                 configToSave.getConnectionDriver());
         }
 
-        String testResults = testConnection(configToSave);
+        if (test) {
+            String testResults = testConnection(configToSave);
 
-        if (!testResults.equals(DATABASE_TEST_RESULT_SUCCESS)) {
-            throw new IllegalArgumentException(testResults);
+            if (!testResults.equals(DATABASE_TEST_RESULT_SUCCESS)) {
+                throw new IllegalArgumentException(testResults);
+            }
         }
 
         try {

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigService.java
@@ -85,7 +85,7 @@ public class DatabaseServerConfigService extends AbstractArchivistService<Databa
         return repository.findByWorkspaceIdAndEnvironmentId(workspaceId, environmentCrn);
     }
 
-    public DatabaseServerConfig create(DatabaseServerConfig resource, Long workspaceId) {
+    public DatabaseServerConfig create(DatabaseServerConfig resource, Long workspaceId, boolean test) {
 
         if (resource.getConnectionDriver() == null) {
             resource.setConnectionDriver(resource.getDatabaseVendor().connectionDriver());
@@ -93,12 +93,14 @@ public class DatabaseServerConfigService extends AbstractArchivistService<Databa
                     resource.getConnectionDriver());
         }
 
-        // FIXME? Currently no checks if logged-in user has access to workspace
-        // Compare with AbstractWorkspaceAwareResourceService
-        String testResults = testConnection(resource);
+        if (test) {
+            // FIXME? Currently no checks if logged-in user has access to workspace
+            // Compare with AbstractWorkspaceAwareResourceService
+            String testResults = testConnection(resource);
 
-        if (!testResults.equals(DATABASE_TEST_RESULT_SUCCESS)) {
-            throw new IllegalArgumentException(testResults);
+            if (!testResults.equals(DATABASE_TEST_RESULT_SUCCESS)) {
+                throw new IllegalArgumentException(testResults);
+            }
         }
 
         try {
@@ -274,7 +276,7 @@ public class DatabaseServerConfigService extends AbstractArchivistService<Databa
         DatabaseConfig newDatabaseConfig =
                 databaseServerConfig.createDatabaseConfig(databaseName, databaseType, ResourceStatus.SERVICE_MANAGED,
                         databaseUserName, databasePassword);
-        databaseConfigService.register(newDatabaseConfig);
+        databaseConfigService.register(newDatabaseConfig, false);
 
         return "created";
     }

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/controller/v4/database/DatabaseV4ControllerTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/controller/v4/database/DatabaseV4ControllerTest.java
@@ -92,7 +92,7 @@ public class DatabaseV4ControllerTest {
     @Test
     public void testRegister() {
         when(converterUtil.convert(request, DatabaseConfig.class)).thenReturn(db);
-        when(service.register(db)).thenReturn(db);
+        when(service.register(db, false)).thenReturn(db);
         when(converterUtil.convert(db, DatabaseV4Response.class)).thenReturn(response);
 
         DatabaseV4Response response = underTest.register(request);

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4ControllerTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4ControllerTest.java
@@ -189,7 +189,7 @@ public class DatabaseServerV4ControllerTest {
     @Test
     public void testRegister() {
         when(converterUtil.convert(request, DatabaseServerConfig.class)).thenReturn(server);
-        when(service.create(server, DatabaseServerV4Controller.DEFAULT_WORKSPACE)).thenReturn(server);
+        when(service.create(server, DatabaseServerV4Controller.DEFAULT_WORKSPACE, false)).thenReturn(server);
         when(converterUtil.convert(server, DatabaseServerV4Response.class)).thenReturn(response);
 
         DatabaseServerV4Response response = underTest.register(request);

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/service/dbconfig/DatabaseConfigServiceTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/service/dbconfig/DatabaseConfigServiceTest.java
@@ -120,7 +120,7 @@ public class DatabaseConfigServiceTest {
         when(crnService.createCrn(configToRegister)).thenReturn(dbCrn);
         when(repository.save(configToRegister)).thenReturn(configToRegister);
 
-        DatabaseConfig createdConfig = underTest.register(configToRegister);
+        DatabaseConfig createdConfig = underTest.register(configToRegister, false);
 
         assertEquals(configToRegister, createdConfig);
         verify(repository).save(configToRegister);
@@ -140,7 +140,7 @@ public class DatabaseConfigServiceTest {
         when(crnService.createCrn(configToRegister)).thenReturn(dbCrn);
         when(repository.save(configToRegister)).thenReturn(configToRegister);
 
-        DatabaseConfig createdConfig = underTest.register(configToRegister);
+        DatabaseConfig createdConfig = underTest.register(configToRegister, false);
 
         assertEquals(DatabaseVendor.POSTGRES.connectionDriver(), createdConfig.getConnectionDriver());
     }
@@ -156,7 +156,7 @@ public class DatabaseConfigServiceTest {
             return null;
         }).when(connectionValidator).validate(any(), any());
 
-        underTest.register(configToRegister);
+        underTest.register(configToRegister, true);
 
     }
 
@@ -233,7 +233,7 @@ public class DatabaseConfigServiceTest {
         when(crnService.createCrn(configToRegister)).thenReturn(TestData.getTestCrn("database", "name"));
         when(repository.save(configToRegister)).thenThrow(getDataIntegrityException());
 
-        underTest.register(configToRegister);
+        underTest.register(configToRegister, false);
     }
 
     private DatabaseConfig getDatabaseConfig(ResourceStatus resourceStatus, String name) {
@@ -257,7 +257,7 @@ public class DatabaseConfigServiceTest {
         when(crnService.createCrn(configToRegister)).thenReturn(TestData.getTestCrn("database", "name"));
         when(repository.save(configToRegister)).thenThrow(new AccessDeniedException("User has no right to access resource"));
 
-        underTest.register(configToRegister);
+        underTest.register(configToRegister, false);
     }
 
     @Test

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigServiceTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigServiceTest.java
@@ -150,7 +150,7 @@ public class DatabaseServerConfigServiceTest {
         when(crnService.createCrn(server)).thenReturn(serverCrn);
         when(repository.save(server)).thenReturn(server);
 
-        DatabaseServerConfig createdServer = underTest.create(server, 0L);
+        DatabaseServerConfig createdServer = underTest.create(server, 0L, false);
 
         assertEquals(server, createdServer);
         assertEquals(0L, createdServer.getWorkspaceId().longValue());
@@ -170,7 +170,7 @@ public class DatabaseServerConfigServiceTest {
         when(crnService.createCrn(server)).thenReturn(serverCrn);
         when(repository.save(server)).thenReturn(server);
 
-        DatabaseServerConfig createdServer = underTest.create(server, 0L);
+        DatabaseServerConfig createdServer = underTest.create(server, 0L, false);
 
         assertEquals(DatabaseVendor.POSTGRES.connectionDriver(), createdServer.getConnectionDriver());
     }
@@ -185,7 +185,7 @@ public class DatabaseServerConfigServiceTest {
         AccessDeniedException e = new AccessDeniedException("no way", mock(ConstraintViolationException.class));
         when(repository.save(server)).thenThrow(e);
 
-        underTest.create(server, 0L);
+        underTest.create(server, 0L, false);
     }
 
     @Test
@@ -198,7 +198,7 @@ public class DatabaseServerConfigServiceTest {
         AccessDeniedException e = new AccessDeniedException("no way");
         when(repository.save(server)).thenThrow(e);
 
-        underTest.create(server, 0L);
+        underTest.create(server, 0L, false);
     }
 
     @Test
@@ -215,7 +215,7 @@ public class DatabaseServerConfigServiceTest {
             }
         }).when(connectionValidator).validate(eq(server), any(Errors.class));
 
-        underTest.create(server, 0L);
+        underTest.create(server, 0L, true);
     }
 
     @Test
@@ -406,7 +406,7 @@ public class DatabaseServerConfigServiceTest {
     @Test
     public void testCreateDatabaseOnServer() {
         when(repository.findByResourceCrn(SERVER_CRN)).thenReturn(Optional.of(server));
-        when(databaseConfigService.register(any(DatabaseConfig.class)))
+        when(databaseConfigService.register(any(DatabaseConfig.class), eq(false)))
                 .thenAnswer((Answer<DatabaseConfig>) invocation -> {
                     return invocation.getArgument(0, DatabaseConfig.class);
                 });
@@ -424,7 +424,7 @@ public class DatabaseServerConfigServiceTest {
         assertEquals("created", result);
         verify(driverFunctions).execWithDatabaseDriver(eq(server), any());
         ArgumentCaptor<DatabaseConfig> captor = ArgumentCaptor.forClass(DatabaseConfig.class);
-        verify(databaseConfigService).register(captor.capture());
+        verify(databaseConfigService).register(captor.capture(), eq(false));
         DatabaseConfig db = captor.getValue();
         assertEquals(databaseName, db.getName());
         assertEquals(databaseType, db.getType());


### PR DESCRIPTION
Redbeams no longer verifies connectivity for databases and database
servers before registration, because it relies on open JDBC access to
do so. Verification should be restored once redbeams uses salt / remote
access for database operations.