### PR TITLE
CB-2878 - Hive Needs to be in HTTP Mode for Knox to Proxy J/ODBC Access

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha.bp
@@ -97,7 +97,13 @@
           {
             "refName": "hive-HIVESERVER2-BASE",
             "roleType": "HIVESERVER2",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                 "name": "hive_server2_transport_mode",
+                 "value": "http"
+              }
+            ]
           }
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering.bp
@@ -148,7 +148,13 @@
           {
             "refName": "hive_on_tez-HIVESERVER2-BASE",
             "roleType": "HIVESERVER2",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                 "name": "hive_server2_transport_mode",
+                 "value": "http"
+              }
+            ]
           }
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/cdp-data-science.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-science.bp
@@ -105,6 +105,10 @@
               {
                 "name": "hs2_execution_engine",
                 "value": "spark"
+              },
+              {
+                 "name": "hive_server2_transport_mode",
+                 "value": "http"
               }
             ],
             "base": true

--- a/core/src/main/resources/defaults/blueprints/cdp-de-llap.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-de-llap.bp
@@ -148,7 +148,13 @@
           {
             "refName": "hive_on_tez-HIVESERVER2-BASE",
             "roleType": "HIVESERVER2",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                 "name": "hive_server2_transport_mode",
+                 "value": "http"
+              }
+            ]
           }
         ]
       },
@@ -183,7 +189,13 @@
           {
             "refName": "llap-HIVESERVER2-BASE",
             "roleType": "HIVESERVER2",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                 "name": "hive_server2_transport_mode",
+                 "value": "http"
+              }
+            ]
           },
           {
             "refName": "llap-LLAPPROXY-BASE",


### PR DESCRIPTION
Adding HTTP mode to the default blueprints