### PR TITLE
CDPD-3127 Update OpDB blueprints and add first cluster template

### DIFF
--- a/cloud-common/src/main/resources/application.yml
+++ b/cloud-common/src/main/resources/application.yml
@@ -160,6 +160,7 @@ cb:
                 CDP 1.0 - Data Engineering HA: Apache Spark, Apache Livy, Apache Zeppelin=cdp-data-engineering-ha;
                 CDP 1.0 - Data Mart: Apache Impala, Hue=cdp-data-mart;
                 CDP 1.0 - Operational Database: Apache HBase=cdp-opdb;
+                CDP 1.0 - Operational Database: Apache HBase (Custom)=cdp-opdb-custom;
                 CDP 1.0 - SDX Light Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas=cdp-sdx;
                 CDP 1.0 - SDX Medium Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas=cdp-sdx-medium-ha;
 

--- a/core/src/main/resources/defaults/blueprints/cdp-opdb-custom.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-opdb-custom.bp
@@ -1,8 +1,8 @@
 {
-  "description": "CDP 1.0 Operational Database with Apache HBase",
+  "description": "CDP 1.0 Operational Database with Apache HBase (custom)",
   "blueprint": {
     "cdhVersion": "7.0.0",
-    "displayName": "opdb",
+    "displayName": "opdb-custom",
     "services": [
       {
         "refName": "zookeeper",
@@ -11,16 +11,6 @@
           {
             "refName": "zookeeper-SERVER-BASE",
             "roleType": "SERVER",
-            "configs": [
-              {
-                "name": "zookeeper_server_java_heapsize",
-                "value": "8589934592"
-              },
-              {
-                "name": "maxClientCnxns",
-                "value": "200"
-              }
-            ],
             "base": true
           }
         ]
@@ -80,12 +70,6 @@
           {
             "refName": "hbase-MASTER-BASE",
             "roleType": "MASTER",
-            "configs": [
-              {
-                "name": "hbase_master_java_heapsize",
-                "value": "4294967296"
-              }
-            ],
             "base": true
           },
           {
@@ -98,36 +82,8 @@
             "roleType": "REGIONSERVER",
             "configs": [
               {
-                "name": "hbase_regionserver_java_heapsize",
-                "value": "17179869184"
-              },
-              {
-                "name": "hbase_bucketcache_ioengine",
-                "value": "offheap"
-              },
-              {
-                "name": "hbase_regionserver_global_memstore_upperLimit",
-                "value": "0.25"
-              },
-              {
-                "name": "hfile_block_cache_size",
-                "value": "0.12"
-              },
-              {
-                "name": "hbase_bucketcache_size",
-                "value": "12288"
-              },
-              {
-                "name": "hbase_regionserver_handler_count",
-                "value": "60"
-              },
-              {
                 "name": "hbase_regionserver_maxlogs",
                 "value": "100"
-              },
-              {
-                "name": "hbase_hregion_memstore_block_multiplier",
-                "value": "4"
               }
             ],
             "base": true

--- a/core/src/main/resources/defaults/clustertemplates/aws/aws-opdb-700.json
+++ b/core/src/main/resources/defaults/clustertemplates/aws/aws-opdb-700.json
@@ -1,0 +1,109 @@
+{
+  "workloadAnalytics": true,
+  "instanceGroups": [
+    {
+      "nodeCount": 2,
+      "name": "master",
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "template": {
+        "aws": {},
+        "instanceType": "m5.2xlarge",
+        "rootVolume": {
+          "size": 50
+        },
+        "attachedVolumes": [
+          {
+            "size": 100,
+            "count": 1,
+            "type": "standard"
+          }
+        ],
+        "cloudPlatform": "AWS"
+      },
+      "recipeNames": []
+    },
+    {
+      "nodeCount": 1,
+      "name": "gateway",
+      "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "template": {
+        "aws": {},
+        "instanceType": "m5.2xlarge",
+        "rootVolume": {
+          "size": 50
+        },
+        "attachedVolumes": [
+          {
+            "size": 100,
+            "count": 1,
+            "type": "standard"
+          }
+        ],
+        "cloudPlatform": "AWS"
+      },
+      "recipeNames": []
+    },
+    {
+      "nodeCount": 1,
+      "name": "leader",
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "template": {
+        "aws": {},
+        "instanceType": "m5.2xlarge",
+        "rootVolume": {
+          "size": 50
+        },
+        "attachedVolumes": [
+          {
+            "size": 100,
+            "count": 1,
+            "type": "standard"
+          }
+        ],
+        "cloudPlatform": "AWS"
+      },
+      "recipeNames": []
+    },
+    {
+      "nodeCount": 3,
+      "name": "worker",
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "template": {
+        "aws": {},
+        "instanceType": "m5.2xlarge",
+        "rootVolume": {
+          "size": 50
+        },
+        "attachedVolumes": [
+          {
+            "size": 100,
+            "count": 1,
+            "type": "standard"
+          }
+        ],
+        "cloudPlatform": "AWS"
+      },
+      "recipeNames": []
+    }
+  ],
+  "cluster": {
+    "userName": "",
+    "password": "",
+    "databases": [],
+    "exposedServices": [
+      "ALL"
+    ],
+    "blueprintName": "CDP 1.0 - Operational Database: Apache HBase",
+    "validateBlueprint": false
+  },
+  "tags": {
+    "application": null,
+    "userDefined": {},
+    "defaults": null
+  },
+  "inputs": {}
+}


### PR DESCRIPTION
Two blueprints now: one for the cluster template, optimized for
the instance types in that template. A second with no configuration
optimizations.