### PR TITLE
CB-2966: remove hue hive service from blacklist

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hue/HueConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hue/HueConfigProvider.java
@@ -30,7 +30,7 @@ public class HueConfigProvider extends AbstractRdsRoleConfigProvider {
 
     private static final String HUE_SAFETY_VALVE = "hue-hue_service_safety_valve";
 
-    private static final String SAFETY_VALVE_VALUE = "[desktop]\napp_blacklist=hive, metastore, pig";
+    private static final String SAFETY_VALVE_VALUE = "[desktop]\napp_blacklist=pig";
 
     @Override
     public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject source) {


### PR DESCRIPTION
In CB-2966 Hue team requested to add Hive to the blacklist. This was due to lack of resource for testing Hive in Hue in DE cluster. We managed to pull it off and can confirm it's working so we'd like to remove Hive from blacklist. Sorry of the back and forth.
Pig still needs to be there as Pig will not be supported by DE in 7.0