### PR TITLE
CDPCP-578. Loosen rights check on the syncoperation table

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/repository/SyncOperationRepository.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/repository/SyncOperationRepository.java
@@ -20,10 +20,12 @@ import com.sequenceiq.freeipa.entity.SyncOperation;
 @AuthorizationResourceType(resource = AuthorizationResource.ENVIRONMENT)
 public interface SyncOperationRepository extends BaseJpaRepository<SyncOperation, Long> {
 
+    // TODO restrict this permission. Set Password and User sync should have more
+    // restrictive permissions than READ but more permissive than WRITE
+    // TODO override other BaseJpaRepository methods for consistent behavior
     @CheckPermission(action = ResourceAction.READ)
     @Override
-    @Query("SELECT s FROM SyncOperation s WHERE s.id = :id")
-    Optional<SyncOperation> findById(@Param("id") Long id);
+    SyncOperation save(SyncOperation entity);
 
     @CheckPermission(action = ResourceAction.READ)
     @Query("SELECT s FROM SyncOperation s WHERE s.operationId = :operationId")


### PR DESCRIPTION
The syncoperation table is used to track the set password and user sync
operations. environments/write permissions should not be required for
writing to this table. We should be able to check other rights instead,
e.g., environments/setPassword.

This commit loosens the rights check on saving to the syncoperation table
to environments/read to enable non-admin users to set their passwords.
DISTX-317 will follow up this change with a more meaningful treatment of
rights for sync operations.
