### PR TITLE
CB-3148 Remove redbeams database server status API endpoints

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/DatabaseService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/DatabaseService.java
@@ -27,6 +27,7 @@ import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.AllocateDatabaseServerV4Request;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerStatusV4Response;
+import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerV4Response;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerTerminationOutcomeV4Response;
 import com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4StackRequest;
 import com.sequenceiq.redbeams.api.endpoint.v4.stacks.aws.AwsDatabaseServerV4Parameters;
@@ -176,7 +177,14 @@ public class DatabaseService {
     }
 
     private DatabaseServerStatusV4Response getDatabaseStatus(String databaseCrn) {
-        return redbeamsClient.withCrn(threadBasedUserCrnProvider.getUserCrn())
-                .databaseServerV4Endpoint().getStatusOfManagedDatabaseServerByCrn(databaseCrn);
+        DatabaseServerV4Response response = redbeamsClient.withCrn(threadBasedUserCrnProvider.getUserCrn())
+                .databaseServerV4Endpoint().getByCrn(databaseCrn);
+        DatabaseServerStatusV4Response statusResponse = new DatabaseServerStatusV4Response();
+        statusResponse.setEnvironmentCrn(response.getEnvironmentCrn());
+        statusResponse.setName(response.getName());
+        statusResponse.setResourceCrn(response.getCrn());
+        statusResponse.setStatus(response.getStatus());
+        statusResponse.setStatusReason(response.getStatusReason());
+        return statusResponse;
     }
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/DatabaseServerV4Endpoint.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/DatabaseServerV4Endpoint.java
@@ -81,24 +81,6 @@ public interface DatabaseServerV4Endpoint {
             @Valid @ApiParam(DatabaseServerParamDescriptions.ALLOCATE_DATABASE_SERVER_REQUEST) AllocateDatabaseServerV4Request request
     );
 
-    @GET
-    @Path("managed/status/{crn}")
-    @ApiOperation(value = DatabaseServerOpDescription.GET_STATUS_BY_CRN, notes = DatabaseServerNotes.GET_STATUS_BY_CRN,
-            nickname = "getDatabaseServerStatusByCrn")
-    DatabaseServerStatusV4Response getStatusOfManagedDatabaseServerByCrn(
-            @ValidCrn @NotNull @ApiParam(DatabaseServerParamDescriptions.CRN) @PathParam("crn") String crn
-    );
-
-    @GET
-    @Path("managed/status/name/{name}")
-    @ApiOperation(value = DatabaseServerOpDescription.GET_STATUS_BY_NAME, notes = DatabaseServerNotes.GET_STATUS_BY_NAME,
-            nickname = "getDatabaseServerStatusByName")
-    DatabaseServerStatusV4Response getStatusOfManagedDatabaseServerByName(
-            @ValidCrn @NotNull @ApiParam(value = DatabaseServerParamDescriptions.ENVIRONMENT_CRN, required = true)
-            @QueryParam("environmentCrn") String environmentCrn,
-            @NotNull @ApiParam(DatabaseServerParamDescriptions.NAME) @PathParam("name") String name
-    );
-
     @DELETE
     @Path("managed/{crn}")
     @ApiOperation(value = DatabaseServerOpDescription.TERMINATE, notes = DatabaseServerNotes.TERMINATE,

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/Notes.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/Notes.java
@@ -40,10 +40,6 @@ public final class Notes {
             "Gets information on a database server by its name.";
         public static final String GET_BY_CRN =
             "Gets information on a database server by its CRN.";
-        public static final String GET_STATUS_BY_CRN =
-            "get the status of an allocated database server by crn";
-        public static final String GET_STATUS_BY_NAME =
-            "get the status of an allocated database server by name";
         public static final String CREATE =
             "Creates a new database server. The database server starts out with only default databases.";
         public static final String TERMINATE =

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/OperationDescriptions.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/OperationDescriptions.java
@@ -19,8 +19,6 @@ public final class OperationDescriptions {
         public static final String LIST = "list database servers";
         public static final String GET_BY_NAME = "get a database server by name";
         public static final String GET_BY_CRN = "get a database server by CRN";
-        public static final String GET_STATUS_BY_CRN = "get the status of an allocated database server by CRN";
-        public static final String GET_STATUS_BY_NAME = "get the status of an allocated database server by name";
         public static final String CREATE = "creates and registers a database server in a cloud provider";
         public static final String TERMINATE = "terminates a database server in a cloud provider and deregisters it";
         public static final String REGISTER = "register a database server";

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4Controller.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4Controller.java
@@ -25,7 +25,6 @@ import com.sequenceiq.redbeams.converter.stack.AllocateDatabaseServerV4RequestTo
 import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
 import com.sequenceiq.redbeams.service.dbserverconfig.DatabaseServerConfigService;
-import com.sequenceiq.redbeams.service.stack.DBStackService;
 import com.sequenceiq.redbeams.service.stack.RedbeamsCreationService;
 import com.sequenceiq.redbeams.service.stack.RedbeamsTerminationService;
 
@@ -49,9 +48,6 @@ public class DatabaseServerV4Controller implements DatabaseServerV4Endpoint {
 
     @Inject
     private ThreadBasedUserCrnProvider threadBasedUserCrnProvider;
-
-    @Inject
-    private DBStackService dbStackService;
 
     @Inject
     private ConverterUtil converterUtil;
@@ -79,18 +75,6 @@ public class DatabaseServerV4Controller implements DatabaseServerV4Endpoint {
         DBStack dbStack = dbStackConverter.convert(request, threadBasedUserCrnProvider.getUserCrn());
         DBStack savedDBStack = redbeamsCreationService.launchDatabaseServer(dbStack);
         return converterUtil.convert(savedDBStack, DatabaseServerStatusV4Response.class);
-    }
-
-    @Override
-    public DatabaseServerStatusV4Response getStatusOfManagedDatabaseServerByCrn(String crn) {
-        DBStack dbStack = dbStackService.getByCrn(crn);
-        return converterUtil.convert(dbStack, DatabaseServerStatusV4Response.class);
-    }
-
-    @Override
-    public DatabaseServerStatusV4Response getStatusOfManagedDatabaseServerByName(String environmentCrn, String name) {
-        DBStack dbStack = dbStackService.getByNameAndEnvironmentCrn(name, environmentCrn);
-        return converterUtil.convert(dbStack, DatabaseServerStatusV4Response.class);
     }
 
     @Override


### PR DESCRIPTION
The redbeams API endpoints for getting the status of service-managed
database servers are eliminated, because the status information is now
available through the ordinary database server description endpoints.

DatabaseService in the datalake service is updated to use the general
database server description endpoint, with some glue code to translate
the description into a status response as before. It would be better for
the datalake service to transition completely to the general response,
but that is too extensive a change for me to be comfortable doing right
now.