### PR TITLE
CDPD-3127 Update OpDB blueprints and add first cluster template

### DIFF
--- a/cloud-common/src/main/resources/application.yml
+++ b/cloud-common/src/main/resources/application.yml
@@ -160,6 +160,7 @@ cb:
                 CDP 1.0 - Data Engineering HA: Apache Spark, Apache Livy, Apache Zeppelin=cdp-data-engineering-ha;
                 CDP 1.0 - Data Mart: Apache Impala, Hue=cdp-data-mart;
                 CDP 1.0 - Operational Database: Apache HBase=cdp-opdb;
+                CDP 1.0 - Operational Database: Apache HBase (Custom)=cdp-opdb-custom;
                 CDP 1.0 - SDX Light Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas=cdp-sdx;
                 CDP 1.0 - SDX Medium Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas=cdp-sdx-medium-ha;
 

--- a/core/src/main/resources/defaults/blueprints/cdp-opdb-custom.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-opdb-custom.bp
@@ -1,8 +1,8 @@
 {
-  "description": "CDP 1.0 Operational Database with Apache HBase",
+  "description": "CDP 1.0 Operational Database with Apache HBase (custom)",
   "blueprint": {
     "cdhVersion": "7.0.0",
-    "displayName": "opdb",
+    "displayName": "opdb-custom",
     "services": [
       {
         "refName": "zookeeper",
@@ -11,16 +11,6 @@
           {
             "refName": "zookeeper-SERVER-BASE",
             "roleType": "SERVER",
-            "configs": [
-              {
-                "name": "zookeeper_server_java_heapsize",
-                "value": "8589934592"
-              },
-              {
-                "name": "maxClientCnxns",
-                "value": "200"
-              }
-            ],
             "base": true
           }
         ]
@@ -80,12 +70,6 @@
           {
             "refName": "hbase-MASTER-BASE",
             "roleType": "MASTER",
-            "configs": [
-              {
-                "name": "hbase_master_java_heapsize",
-                "value": "4294967296"
-              }
-            ],
             "base": true
           },
           {
@@ -98,36 +82,8 @@
             "roleType": "REGIONSERVER",
             "configs": [
               {
-                "name": "hbase_regionserver_java_heapsize",
-                "value": "17179869184"
-              },
-              {
-                "name": "hbase_bucketcache_ioengine",
-                "value": "offheap"
-              },
-              {
-                "name": "hbase_regionserver_global_memstore_upperLimit",
-                "value": "0.25"
-              },
-              {
-                "name": "hfile_block_cache_size",
-                "value": "0.12"
-              },
-              {
-                "name": "hbase_bucketcache_size",
-                "value": "12288"
-              },
-              {
-                "name": "hbase_regionserver_handler_count",
-                "value": "60"
-              },
-              {
                 "name": "hbase_regionserver_maxlogs",
                 "value": "100"
-              },
-              {
-                "name": "hbase_hregion_memstore_block_multiplier",
-                "value": "4"
               }
             ],
             "base": true

--- a/core/src/main/resources/defaults/clustertemplates/aws/aws-opdb-700.json
+++ b/core/src/main/resources/defaults/clustertemplates/aws/aws-opdb-700.json
@@ -1,0 +1,159 @@
+{
+  "name": "CDP 1.0 - Operational Database template",
+  "description": "",
+  "type": "OTHER",
+  "cloudPlatform": "AWS",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "CDP 1.0 - Operational Database: Apache HBase"
+    },
+    "instanceGroups": [
+      {
+        "name": "master",
+        "nodeCount": 2,
+        "recoveryMode": "MANUAL",
+        "securityGroup": {
+          "securityRules": [
+            {
+              "subnet": "0.0.0.0/0",
+              "ports": [
+                "22"
+              ],
+              "protocol": "tcp"
+            }
+          ]
+        },
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "standard"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge",
+          "rootVolume": {
+            "size": 50
+          },
+          "cloudPlatform": "AWS"
+        },
+        "type": "CORE"
+      },
+      {
+        "name": "gateway",
+        "nodeCount": 1,
+        "recoveryMode": "MANUAL",
+        "securityGroup": {
+          "securityRules": [
+            {
+              "subnet": "0.0.0.0/0",
+              "ports": [
+                "22",
+                "443",
+                "9443"
+              ],
+              "protocol": "tcp"
+            }
+          ]
+        },
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "standard"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge",
+          "rootVolume": {
+            "size": 50
+          },
+          "cloudPlatform": "AWS"
+        },
+        "type": "GATEWAY"
+      },
+      {
+        "name": "leader",
+        "nodeCount": 1,
+        "recoveryMode": "MANUAL",
+        "securityGroup": {
+          "securityRules": [
+            {
+              "subnet": "0.0.0.0/0",
+              "ports": [
+                "22"
+              ],
+              "protocol": "tcp"
+            }
+          ]
+        },
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "standard"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge",
+          "rootVolume": {
+            "size": 50
+          },
+          "cloudPlatform": "AWS"
+        },
+        "type": "CORE"
+      },
+      {
+        "name": "worker",
+        "nodeCount": 3,
+        "recoveryMode": "MANUAL",
+        "securityGroup": {
+          "securityRules": [
+            {
+              "subnet": "0.0.0.0/0",
+              "ports": [
+                "22"
+              ],
+              "protocol": "tcp"
+            }
+          ]
+        },
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "standard"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge",
+          "rootVolume": {
+            "size": 50
+          },
+          "cloudPlatform": "AWS"
+        },
+        "type": "CORE"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This reverts commit bd8c3685f6bd419bdddcd00435cf3b705cbc93b2.

Revert the first revert (re-apply the original) with some modifications.

@lnardai @daszabo trying a re-apply of the same template from over the weekend which broke things. Best as I can tell, the `distroXTemplate` attribute was the only thing missing, but, for the life of me, I can't seem to figure out a way to validate before asking you all to review it. Sorry :(