### PR TITLE
CB-3166 Add multiAZ and storageType RDS options

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsStackRequestHelper.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsStackRequestHelper.java
@@ -139,6 +139,8 @@ public class AwsStackRequestHelper {
         addParameterIfNotNull(parameters, "AllocatedStorageParameter", awsRdsInstanceView.getAllocatedStorage());
         addParameterIfNotNull(parameters, "BackupRetentionPeriodParameter", awsRdsInstanceView.getBackupRetentionPeriod());
         addParameterIfNotNull(parameters, "EngineVersionParameter", awsRdsInstanceView.getEngineVersion());
+        addParameterIfNotNull(parameters, "MultiAZParameter", awsRdsInstanceView.getMultiAZ());
+        addParameterIfNotNull(parameters, "StorageTypeParameter", awsRdsInstanceView.getStorageType());
         addParameterIfNotNull(parameters, "PortParameter", stack.getDatabaseServer().getPort());
 
         if (awsRdsInstanceView.getVPCSecurityGroups().isEmpty()) {

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsRdsInstanceView.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsRdsInstanceView.java
@@ -13,6 +13,12 @@ public class AwsRdsInstanceView {
     @VisibleForTesting
     static final String ENGINE_VERSION = "engineVersion";
 
+    @VisibleForTesting
+    static final String MULTI_AZ = "multiAZ";
+
+    @VisibleForTesting
+    static final String STORAGE_TYPE = "storageType";
+
     private final DatabaseServer databaseServer;
 
     public AwsRdsInstanceView(DatabaseServer databaseServer) {
@@ -57,6 +63,14 @@ public class AwsRdsInstanceView {
 
     public String getMasterUserPassword() {
         return databaseServer.getRootPassword();
+    }
+
+    public String getMultiAZ() {
+        return databaseServer.getStringParameter(MULTI_AZ);
+    }
+
+    public String getStorageType() {
+        return databaseServer.getStringParameter(STORAGE_TYPE);
     }
 
     public List<String> getVPCSecurityGroups() {

--- a/cloud-aws/src/main/resources/templates/aws-cf-dbstack.ftl
+++ b/cloud-aws/src/main/resources/templates/aws-cf-dbstack.ftl
@@ -65,6 +65,18 @@
         "MinLength": 8,
         "MaxLength": 30
     },
+    "MultiAZParameter": {
+        "Type": "String",
+        "Default": "true",
+        "Description": "Whether to use a multi-AZ deployment",
+        "AllowedValues": [ "true", "false" ]
+    },
+    "StorageTypeParameter": {
+        "Type": "String",
+        "Default": "gp2",
+        "Description": "Storage type",
+        "AllowedValues": [ "standard", "gp2", "io1" ]
+    },
     <#if hasPort>
     "PortParameter": {
         "Type": "Number",
@@ -98,6 +110,10 @@
       "MinLength": "1",
       "MaxLength": "50"
     }
+  },
+
+  "Conditions" : {
+    "UseMultiAZ" : { "Fn::Equals" : [{ "Ref": "MultiAZParameter" }, "true"] }
   },
 
   "Resources" : {
@@ -160,11 +176,12 @@
                 "EngineVersion": { "Ref": "EngineVersionParameter" },
                 "MasterUserPassword": { "Ref": "MasterUserPasswordParameter" },
                 "MasterUsername": { "Ref": "MasterUsernameParameter" },
-                "MultiAZ": true,
+                "MultiAZ": { "Fn::If" : [ "UseMultiAZ", true, false ] },
                 <#if hasPort>
                 "Port": { "Ref": "PortParameter" },
                 </#if>
                 "StorageEncrypted": true,
+                "StorageType": { "Ref": "StorageTypeParameter" },
                 "Tags": [
                     { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
                     { "Key" : "cb-resource-type", "Value" : "${database_resource}" },

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsStackRequestHelperTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsStackRequestHelperTest.java
@@ -140,6 +140,8 @@ public class AwsStackRequestHelperTest {
         when(databaseServer.getServerId()).thenReturn("myserver");
         when(databaseServer.getEngine()).thenReturn(DatabaseEngine.POSTGRESQL);
         when(databaseServer.getStringParameter("engineVersion")).thenReturn("10.6");
+        when(databaseServer.getStringParameter("multiAZ")).thenReturn("true");
+        when(databaseServer.getStringParameter("storageType")).thenReturn("gp2");
         when(databaseServer.getPort()).thenReturn(Integer.valueOf(5432));
         when(databaseServer.getRootUserName()).thenReturn("root");
         when(databaseServer.getRootPassword()).thenReturn("cloudera");
@@ -159,7 +161,9 @@ public class AwsStackRequestHelperTest {
         assertContainsParameter(parameters, "EngineVersionParameter", "10.6");
         assertContainsParameter(parameters, "MasterUsernameParameter", "root");
         assertContainsParameter(parameters, "MasterUserPasswordParameter", "cloudera");
+        assertContainsParameter(parameters, "MultiAZParameter", "true");
         assertContainsParameter(parameters, "PortParameter", "5432");
+        assertContainsParameter(parameters, "StorageTypeParameter", "gp2");
         assertContainsParameter(parameters, "VPCSecurityGroupsParameter", "sg-1234,sg-5678");
         assertContainsParameter(parameters, "StackOwner", "bob@cloudera.com");
     }
@@ -174,6 +178,8 @@ public class AwsStackRequestHelperTest {
         when(databaseServer.getServerId()).thenReturn("myserver");
         when(databaseServer.getEngine()).thenReturn(DatabaseEngine.POSTGRESQL);
         when(databaseServer.getStringParameter("engineVersion")).thenReturn(null);
+        when(databaseServer.getStringParameter("multiAZ")).thenReturn(null);
+        when(databaseServer.getStringParameter("storageType")).thenReturn(null);
         when(databaseServer.getPort()).thenReturn(null);
         when(databaseServer.getRootUserName()).thenReturn("root");
         when(databaseServer.getRootPassword()).thenReturn("cloudera");
@@ -186,6 +192,8 @@ public class AwsStackRequestHelperTest {
         assertDoesNotContainParameter(parameters, "AllocatedStorageParameter");
         assertDoesNotContainParameter(parameters, "BackupRetentionPeriodParameter");
         assertDoesNotContainParameter(parameters, "EngineVersionParameter");
+        assertDoesNotContainParameter(parameters, "MultiAZParameter");
+        assertDoesNotContainParameter(parameters, "StorageTypeParameter");
         assertDoesNotContainParameter(parameters, "PortParameter");
     }
 

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsRdsInstanceViewTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsRdsInstanceViewTest.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.cloud.aws.view;
 
 import static com.sequenceiq.cloudbreak.cloud.aws.view.AwsRdsInstanceView.BACKUP_RETENTION_PERIOD;
 import static com.sequenceiq.cloudbreak.cloud.aws.view.AwsRdsInstanceView.ENGINE_VERSION;
+import static com.sequenceiq.cloudbreak.cloud.aws.view.AwsRdsInstanceView.MULTI_AZ;
+import static com.sequenceiq.cloudbreak.cloud.aws.view.AwsRdsInstanceView.STORAGE_TYPE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
@@ -119,6 +121,30 @@ public class AwsRdsInstanceViewTest {
     public void testNoMasterUserPassword() {
         when(server.getRootPassword()).thenReturn(null);
         assertNull(underTest.getMasterUserPassword());
+    }
+
+    @Test
+    public void testMultiAZ() {
+        when(server.getStringParameter(MULTI_AZ)).thenReturn("true");
+        assertEquals("true", underTest.getMultiAZ());
+    }
+
+    @Test
+    public void testNoMultiAZ() {
+        when(server.getStringParameter(MULTI_AZ)).thenReturn(null);
+        assertNull(underTest.getMultiAZ());
+    }
+
+    @Test
+    public void testStorageType() {
+        when(server.getStringParameter(STORAGE_TYPE)).thenReturn("gp2");
+        assertEquals("gp2", underTest.getStorageType());
+    }
+
+    @Test
+    public void testNoStorageType() {
+        when(server.getStringParameter(STORAGE_TYPE)).thenReturn(null);
+        assertNull(underTest.getStorageType());
     }
 
     @Test

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/aws/AwsDatabaseServerV4Parameters.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/aws/AwsDatabaseServerV4Parameters.java
@@ -24,6 +24,13 @@ public class AwsDatabaseServerV4Parameters extends MappableBase {
     @ApiModelProperty(AwsDatabaseServerModelDescriptions.ENGINE_VERSION)
     private String engineVersion;
 
+    // This is a String because of https://github.com/swagger-api/swagger-codegen/issues/7391
+    @ApiModelProperty(AwsDatabaseServerModelDescriptions.MULTI_AZ)
+    private String multiAZ;
+
+    @ApiModelProperty(AwsDatabaseServerModelDescriptions.STORAGE_TYPE)
+    private String storageType;
+
     public Integer getBackupRetentionPeriod() {
         return backupRetentionPeriod;
     }
@@ -40,11 +47,29 @@ public class AwsDatabaseServerV4Parameters extends MappableBase {
         this.engineVersion = engineVersion;
     }
 
+    public String getMultiAZ() {
+        return multiAZ;
+    }
+
+    public void setMultiAZ(String multiAZ) {
+        this.multiAZ = multiAZ;
+    }
+
+    public String getStorageType() {
+        return storageType;
+    }
+
+    public void setStorageType(String storageType) {
+        this.storageType = storageType;
+    }
+
     @Override
     public Map<String, Object> asMap() {
         Map<String, Object> map = super.asMap();
         putIfValueNotNull(map, "backupRetentionPeriod", backupRetentionPeriod);
         putIfValueNotNull(map, "engineVersion", engineVersion);
+        putIfValueNotNull(map, "multiAZ", multiAZ);
+        putIfValueNotNull(map, "storageType", storageType);
         return map;
     }
 
@@ -59,5 +84,7 @@ public class AwsDatabaseServerV4Parameters extends MappableBase {
     public void parse(Map<String, Object> parameters) {
         backupRetentionPeriod = getInt(parameters, "backupRetentionPeriod");
         engineVersion = getParameterOrNull(parameters, "engineVersion");
+        multiAZ = getParameterOrNull(parameters, "multiAZ");
+        storageType = getParameterOrNull(parameters, "storageType");
     }
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/ModelDescriptions.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/ModelDescriptions.java
@@ -108,6 +108,8 @@ public final class ModelDescriptions {
     public static class AwsDatabaseServerModelDescriptions {
         public static final String BACKUP_RETENTION_PERIOD = "Time to retain backups, in days";
         public static final String ENGINE_VERSION = "Version of the database engine (vendor)";
+        public static final String MULTI_AZ = "Whether to use a multi-AZ deployment";
+        public static final String STORAGE_TYPE = "Storage type";
     }
 
     public static class AzureDatabaseServerModelDescriptions {

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/aws/AwsDatabaseServerV4ParametersTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/aws/AwsDatabaseServerV4ParametersTest.java
@@ -25,17 +25,27 @@ public class AwsDatabaseServerV4ParametersTest {
 
         underTest.setEngineVersion("1.2.3");
         assertEquals("1.2.3", underTest.getEngineVersion());
+
+        underTest.setMultiAZ("true");
+        assertEquals("true", underTest.getMultiAZ());
+
+        underTest.setStorageType("gp2");
+        assertEquals("gp2", underTest.getStorageType());
     }
 
     @Test
     public void testAsMap() {
         underTest.setBackupRetentionPeriod(3);
         underTest.setEngineVersion("1.2.3");
+        underTest.setMultiAZ("true");
+        underTest.setStorageType("gp2");
 
         Map<String, Object> map = underTest.asMap();
 
         assertEquals(3, ((Integer) map.get("backupRetentionPeriod")).intValue());
         assertEquals("1.2.3", map.get("engineVersion"));
+        assertEquals("true", map.get("multiAZ"));
+        assertEquals("gp2", map.get("storageType"));
     }
 
     @Test
@@ -45,12 +55,15 @@ public class AwsDatabaseServerV4ParametersTest {
 
     @Test
     public void testParse() {
-        Map<String, Object> parameters = Map.of("backupRetentionPeriod", 3, "engineVersion", "1.2.3");
+        Map<String, Object> parameters = Map.of("backupRetentionPeriod", 3, "engineVersion", "1.2.3",
+            "multiAZ", "true", "storageType", "gp2");
 
         underTest.parse(parameters);
 
         assertEquals(3, underTest.getBackupRetentionPeriod().intValue());
         assertEquals("1.2.3", underTest.getEngineVersion());
+        assertEquals("true", underTest.getMultiAZ());
+        assertEquals("gp2", underTest.getStorageType());
     }
 
 }


### PR DESCRIPTION
Redbeams now supports parameterized choices for whether to deploy a
multi-AZ RDS instance (default is true) and for the storage type of the
instance. Because of a bug in the Go implementation of Swagger, the
multiAZ property must be a string instead of a Boolean, or else Go
clients will never sent a false value for the property.