### PR TITLE
CDPSDX-606 Cleanup the CM keytabs secrets

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/KerberosMgmtV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/KerberosMgmtV1Controller.java
@@ -35,12 +35,12 @@ public class KerberosMgmtV1Controller implements KerberosMgmtV1Endpoint {
         return kerberosMgmtV1Service.getExistingServiceKeytab(request, accountId);
     }
 
-    public void deleteServicePrincipal(@Valid ServicePrincipalRequest request) throws FreeIpaClientException {
+    public void deleteServicePrincipal(@Valid ServicePrincipalRequest request) throws FreeIpaClientException, DeleteException {
         String accountId = crnService.getCurrentAccountId();
         kerberosMgmtV1Service.deleteServicePrincipal(request, accountId);
     }
 
-    public void deleteHost(@Valid HostRequest request) throws FreeIpaClientException {
+    public void deleteHost(@Valid HostRequest request) throws FreeIpaClientException, DeleteException {
         String accountId = crnService.getCurrentAccountId();
         kerberosMgmtV1Service.deleteHost(request, accountId);
     }


### PR DESCRIPTION
    CDPSDX-606 Cleanup the CM keytabs secrets
    
    Delete the CM keytab secrets when deleting a cluster with CM. Add
    kerberosmgmt delete APIs that use query parameters rather than the
    entity body so that Jersey can validate the args. This fixes the
    error "Entity must be null for http method DELETE" when using Jersey
    clients.
    
    Tested manually using a local cloudbreak deployment.


This pull request is for master so that it makes it into 2.13 rather than 2.12.

Closes #CDPSDX-606