### PR TITLE
CB-3169 Fix redbeams handling of user ID in CRN

### DIFF
--- a/cloud-aws/src/main/resources/templates/aws-cf-dbstack.ftl
+++ b/cloud-aws/src/main/resources/templates/aws-cf-dbstack.ftl
@@ -96,7 +96,7 @@
       "Description" : "The instances will have this parameter as an Owner tag.",
       "Type" : "String",
       "MinLength": "1",
-      "MaxLength": "50"
+      "MaxLength": "200"
     }
   },
 

--- a/common/src/main/java/com/sequenceiq/cloudbreak/auth/altus/Crn.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/auth/altus/Crn.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.auth.altus;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 
 import java.util.Arrays;
 import java.util.regex.Matcher;
@@ -444,6 +445,21 @@ public class Crn {
      */
     public String getResource() {
         return resource;
+    }
+
+    /**
+     * Returns the user ID for this CRN. A type 0 user CRN is composed of an
+     * external ID and the user ID separated by a slash; a type 1 user CRN has
+     * only the user ID.
+     *
+     * @return the user ID
+     * @throws IllegalStateException if this is not a user CRN
+     */
+    public String getUserId() {
+        checkState(resourceType == ResourceType.USER,
+            String.format("CRN %s has no user ID because it is of type %s", toString(), resourceType));
+        int idx = resource.indexOf('/');
+        return idx == -1 ? resource : resource.substring(idx + 1);
     }
 
     @Override

--- a/common/src/test/java/com/sequenceiq/cloudbreak/auth/altus/CrnTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/auth/altus/CrnTest.java
@@ -99,4 +99,23 @@ public class CrnTest {
         thrown.expect(CrnParseException.class);
         Crn.fromString(invalidCrnResourceType);
     }
+
+    @Test
+    public void testGetUserId() {
+        Crn crn = Crn.builder()
+            .setService(Crn.Service.IAM)
+            .setAccountId("accountId")
+            .setResourceType(Crn.ResourceType.USER)
+            .setResource("userId")
+            .build();
+        assertEquals("userId", crn.getUserId());
+
+        crn = Crn.builder()
+            .setService(Crn.Service.IAM)
+            .setAccountId("accountId")
+            .setResourceType(Crn.ResourceType.USER)
+            .setResource("externalId/userId")
+            .build();
+        assertEquals("userId", crn.getUserId());
+    }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverter.java
@@ -239,7 +239,7 @@ public class AllocateDatabaseServerV4RequestToDBStackConverter {
 
     private Json getTags(Crn ownerCrn, CloudPlatform cloudPlatform, long now) {
         // freeipa currently uses account ID for username / owner
-        String user = ownerCrn.getResource().toString();
+        String user = ownerCrn.getUserId();
 
         Map<String, String> defaultTags = new HashMap<>();
         defaultTags.put(safeTagString(CB_USER_NAME.key(), cloudPlatform), safeTagString(user, cloudPlatform));

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/AbstractRedbeamsProvisionAction.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/AbstractRedbeamsProvisionAction.java
@@ -64,7 +64,7 @@ public abstract class AbstractRedbeamsProvisionAction<P extends Payload>
         DBStack dbStack = dbStackService.getById(payload.getResourceId());
         MDCBuilder.buildMdcContext(dbStack);
         Location location = location(region(dbStack.getRegion()), availabilityZone(dbStack.getAvailabilityZone()));
-        String userName = dbStack.getOwnerCrn().getResource();
+        String userName = dbStack.getOwnerCrn().getUserId();
         String accountId = dbStack.getOwnerCrn().getAccountId();
         CloudContext cloudContext = new CloudContext(dbStack.getId(), dbStack.getName(), dbStack.getCloudPlatform(), dbStack.getPlatformVariant(),
                 location, userName, userName, accountId);

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/termination/AbstractRedbeamsTerminationAction.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/termination/AbstractRedbeamsTerminationAction.java
@@ -72,7 +72,7 @@ public abstract class AbstractRedbeamsTerminationAction<P extends Payload>
             dbStack = optionalDBStack.get();
             MDCBuilder.buildMdcContext(dbStack);
             Location location = location(region(dbStack.getRegion()), availabilityZone(dbStack.getAvailabilityZone()));
-            String userName = dbStack.getOwnerCrn().getResource();
+            String userName = dbStack.getOwnerCrn().getUserId();
             String accountId = dbStack.getOwnerCrn().getAccountId();
             cloudContext = new CloudContext(dbStack.getId(), dbStack.getName(), dbStack.getCloudPlatform(), dbStack.getPlatformVariant(),
                     location, userName, accountId);

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/crn/CrnService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/crn/CrnService.java
@@ -34,7 +34,7 @@ public class CrnService {
             throw new CrnParseException("Current user CRN is not set");
         }
         Crn crn = Crn.safeFromString(userCrn);
-        return crn.getResource();
+        return crn.getUserId();
     }
 
     public Crn createCrn(DatabaseConfig resource) {

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverterTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverterTest.java
@@ -62,7 +62,7 @@ import com.sequenceiq.redbeams.service.network.SubnetChooserService;
 
 public class AllocateDatabaseServerV4RequestToDBStackConverterTest {
 
-    private static final String OWNER_CRN = "crn:cdp:iam:us-west-1:cloudera:user:bob@cloudera.com";
+    private static final String OWNER_CRN = "crn:cdp:iam:us-west-1:cloudera:user:external/bob@cloudera.com";
 
     private static final String ENVIRONMENT_CRN = "myenv";
 

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/provision/AbstractRedbeamsProvisionActionTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/provision/AbstractRedbeamsProvisionActionTest.java
@@ -94,7 +94,7 @@ public class AbstractRedbeamsProvisionActionTest {
         assertEquals(Variant.variant(dbStack.getPlatformVariant()), ctx.getCloudContext().getVariant());
         assertEquals(Location.location(Region.region(dbStack.getRegion()), AvailabilityZone.availabilityZone(dbStack.getAvailabilityZone())),
             ctx.getCloudContext().getLocation());
-        assertEquals(dbStack.getOwnerCrn().getResource(), ctx.getCloudContext().getUserId());
+        assertEquals(dbStack.getOwnerCrn().getUserId(), ctx.getCloudContext().getUserId());
         assertEquals(dbStack.getOwnerCrn().getAccountId(), ctx.getCloudContext().getAccountId());
 
         assertEquals(cloudCredential, ctx.getCloudCredential());

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/termination/AbstractRedbeamsTerminationActionTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/termination/AbstractRedbeamsTerminationActionTest.java
@@ -96,7 +96,7 @@ public class AbstractRedbeamsTerminationActionTest {
         assertEquals(Variant.variant(dbStack.getPlatformVariant()), ctx.getCloudContext().getVariant());
         assertEquals(Location.location(Region.region(dbStack.getRegion()), AvailabilityZone.availabilityZone(dbStack.getAvailabilityZone())),
             ctx.getCloudContext().getLocation());
-        assertEquals(dbStack.getOwnerCrn().getResource(), ctx.getCloudContext().getUserId());
+        assertEquals(dbStack.getOwnerCrn().getUserId(), ctx.getCloudContext().getUserId());
         assertEquals(dbStack.getOwnerCrn().getAccountId(), ctx.getCloudContext().getAccountId());
 
         assertEquals(cloudCredential, ctx.getCloudCredential());


### PR DESCRIPTION
The new Crn::getUserId method retrieves the correct value of the user ID
in a user CRN. For "type 0" CRNs, the user ID is the value after the
first slash character in the resource ID. Otherwise ("type 1"), the user
ID is the entire resource ID.

Redbeams now uses this interpretation of user ID. Specifically, user
names and IDs attached to stacks and used as the value fo resource tags
are now derived from the proper user ID of the owner CRN.

In addition, the maximum length of the "StackOwner" parameter in the
AWS database stack CloudFormation template is changed from 50 to a more
generous 200.