### PR TITLE
CDPCP-606. Metering consumer failed to convert payload to MeteringEve…

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/fluent/template/databus_metering.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/fluent/template/databus_metering.conf.j2
@@ -19,6 +19,7 @@
     credential_file_reload_interval  60
     debug                            false
     endpoint                         "{{ databus.endpoint }}"
+    event_message_field              message
     headers                          app:{{ fluent.dbusAppName }}
     stream_name                      Metering
     partition_key                    "#{Socket.gethostname}"


### PR DESCRIPTION
…nt entity

for processing payload, message field is required for databus as none format is used on fluentd side