### PR TITLE
CB-3196 allow all read operations

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
@@ -268,6 +268,10 @@ public class GrpcUmsClient {
             LOGGER.info("InternalCrn, allow right {} for user {}!", right, userCrn);
             return true;
         }
+        if (isReadRight(right)) {
+            LOGGER.info("Letting read operation through for right {} for user {}!", right, userCrn);
+            return true;
+        }
         try (ManagedChannelWrapper channelWrapper = makeWrapper()) {
             AuthorizationClient client = new AuthorizationClient(channelWrapper.getChannel(), actorCrn);
             LOGGER.info("Checking right {} for user {}!", right, userCrn);
@@ -489,5 +493,16 @@ public class GrpcUmsClient {
                 .setResource("DbusUploader")
                 .build();
         return databusCrn.toString();
+    }
+
+    protected boolean isReadRight(String action) {
+        if (action == null) {
+            return false;
+        }
+        String[] parts = action.split("/");
+        if (parts.length == 2 && parts[1] != null && parts[1].equals("read")) {
+            return true;
+        }
+        return false;
     }
 }

--- a/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClientTest.java
+++ b/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClientTest.java
@@ -1,17 +1,14 @@
 package com.sequenceiq.cloudbreak.auth.altus;
 
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import java.util.Optional;
-
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
 import com.sequenceiq.cloudbreak.auth.altus.config.UmsConfig;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -24,15 +21,23 @@ public class GrpcUmsClientTest {
     private GrpcUmsClient testedClass = new GrpcUmsClient();
 
     @Test
-    @Ignore
-    public void getUserDetails() {
+    public void checkIfReadRightCorrect() {
+        assertTrue(testedClass.isReadRight("environment/read"));
+    }
 
-        when(umsConfigMock.getEndpoint()).thenReturn("ums.thunderhead-dev.cloudera.com");
-        when(umsConfigMock.getPort()).thenReturn(8982);
+    @Test
+    public void checkIfReadRightInvalid() {
+        assertFalse(testedClass.isReadRight("environmentsinvalidread"));
+    }
 
-        String exampleCrn = "crn:cdp:iam:us-west-1:9d74eee4-1cad-45d7-b645-7ccf9edbb73d:user:f3b8ed82-e712-4f89-bda7-be07183720d3";
+    @Test
+    public void checkIfReadRightRight() {
+        assertFalse(testedClass.isReadRight("datalake/write"));
+        assertFalse(testedClass.isReadRight("datahub/write"));
+    }
 
-        UserManagementProto.User user = testedClass.getUserDetails(exampleCrn, exampleCrn, Optional.of("uuid"));
-        user.getCrn();
+    @Test
+    public void checkIfReadRightNull() {
+        assertFalse(testedClass.isReadRight(null));
     }
 }

--- a/authorization-common/src/main/java/com/sequenceiq/authorization/service/UmsAuthorizationService.java
+++ b/authorization-common/src/main/java/com/sequenceiq/authorization/service/UmsAuthorizationService.java
@@ -50,7 +50,7 @@ public class UmsAuthorizationService {
         String right = RightUtils.getRight(resource, action);
         String unauthorizedMessage = String.format("You have no right to perform %s. This requires one of these roles: %s. "
                         + "You can request access through IAM service from an administrator.",
-                right, getRolesByRights(userCrn).get(right));
+                right, "PowerUser");
         checkRightOfUserForResource(userCrn, resource, action, unauthorizedMessage);
     }
 

--- a/authorization-common/src/test/java/com/sequenceiq/authorization/service/UmsAuthorizationServiceTest.java
+++ b/authorization-common/src/test/java/com/sequenceiq/authorization/service/UmsAuthorizationServiceTest.java
@@ -51,10 +51,9 @@ public class UmsAuthorizationServiceTest {
     @Test
     public void testCheckReadRight() {
         when(umsClient.checkRight(anyString(), anyString(), anyString(), any())).thenReturn(false);
-        when(umsClient.listRoles(anyString(), anyString(), any())).thenReturn(getRoles());
 
         thrown.expect(AccessDeniedException.class);
-        thrown.expectMessage("You have no right to perform datalake/write. This requires one of these roles: EnvironmentAdmin. "
+        thrown.expectMessage("You have no right to perform datalake/write. This requires one of these roles: PowerUser. "
                 + "You can request access through IAM service from an administrator.");
 
         underTest.checkRightOfUserForResource(USER_CRN, AuthorizationResource.DATALAKE, ResourceAction.WRITE);
@@ -63,10 +62,9 @@ public class UmsAuthorizationServiceTest {
     @Test
     public void testCheckWriteRight() {
         when(umsClient.checkRight(anyString(), anyString(), anyString(), any())).thenReturn(false);
-        when(umsClient.listRoles(anyString(), anyString(), any())).thenReturn(getRoles());
 
         thrown.expect(AccessDeniedException.class);
-        thrown.expectMessage("You have no right to perform datalake/read. This requires one of these roles: EnvironmentAdmin, EnvironmentUser. "
+        thrown.expectMessage("You have no right to perform datalake/read. This requires one of these roles: PowerUser. "
                 + "You can request access through IAM service from an administrator.");
 
         underTest.checkRightOfUserForResource(USER_CRN, AuthorizationResource.DATALAKE, ResourceAction.READ);


### PR DESCRIPTION
!Letting all read rights checks through by skipping UMS call if the right ends with /read!