### PR TITLE
CB-3145 Null check on cloud storage identity conversion

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/FileSystemConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/FileSystemConverter.java
@@ -23,6 +23,7 @@ import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudWasbView;
 import com.sequenceiq.cloudbreak.domain.FileSystem;
 import com.sequenceiq.cloudbreak.domain.cloudstorage.CloudIdentity;
 import com.sequenceiq.cloudbreak.domain.cloudstorage.CloudStorage;
+import com.sequenceiq.cloudbreak.domain.cloudstorage.S3Identity;
 import com.sequenceiq.common.api.filesystem.AdlsFileSystem;
 import com.sequenceiq.common.api.filesystem.AdlsGen2FileSystem;
 import com.sequenceiq.common.api.filesystem.GcsFileSystem;
@@ -68,7 +69,12 @@ public class FileSystemConverter {
 
     private CloudS3View cloudIdentityToS3View(CloudIdentity cloudIdentity) {
         CloudS3View cloudS3View = new CloudS3View(cloudIdentity.getIdentityType());
-        cloudS3View.setInstanceProfile(cloudIdentity.getS3Identity().getInstanceProfile());
+        S3Identity s3Identity = cloudIdentity.getS3Identity();
+        if (Objects.isNull(s3Identity)) {
+            LOGGER.warn("S3 identity is null. Identity type is {}", cloudIdentity.getIdentityType());
+            return null;
+        }
+        cloudS3View.setInstanceProfile(s3Identity.getInstanceProfile());
         return cloudS3View;
     }
 


### PR DESCRIPTION
Validation is now in place to prevent posting incomplete cloud storage identities, however those clusters, which were deployed before the validation are failing, because of null values. This change should enable the termination of those clusters.