### PR TITLE
CB-3203 remove CM 6.2 version from distrox UI

### DIFF
--- a/cloud-common/src/main/resources/application.yml
+++ b/cloud-common/src/main/resources/application.yml
@@ -153,8 +153,6 @@ cb:
   blueprint:
     cm:
       defaults: >
-                CDH 6.2 - Data Science: Apache Spark, Apache Hive=cdh6-data-science;
-                CDH 6.2 - Data Lake: Hive Metastore=cdh6-shared-services;
                 CDP 1.0 - Data Science: Apache Spark, Apache Hive=cdp-data-science;
                 CDP 1.0 - Data Engineering: Apache Spark, Apache Hive, Apache Oozie=cdp-data-engineering;
                 CDP 1.0 - Data Engineering HA: Apache Spark, Apache Livy, Apache Zeppelin=cdp-data-engineering-ha;

--- a/core/src/main/resources/schema/app/20190822084041_CB-3203_remove_CM_6_2_version_from_distrox.sql
+++ b/core/src/main/resources/schema/app/20190822084041_CB-3203_remove_CM_6_2_version_from_distrox.sql
@@ -1,0 +1,11 @@
+-- // CB-3203 remove CM 6.2 version from distrox
+-- Migration SQL that makes the change goes here.
+
+UPDATE blueprint SET status = 'DEFAULT_DELETED' WHERE status = 'DEFAULT'  AND name = 'CDH 6.2 - Data Science: Apache Spark, Apache Hive';
+UPDATE blueprint SET status = 'DEFAULT_DELETED' WHERE status = 'DEFAULT'  AND name = 'CDH 6.2 - Data Lake: Hive Metastore';
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+UPDATE blueprint SET status = 'DEFAULT' WHERE status = 'DEFAULT_DELETED'  AND name = 'CDH 6.2 - Data Science: Apache Spark, Apache Hive';
+UPDATE blueprint SET status = 'DEFAULT' WHERE status = 'DEFAULT_DELETED'  AND name = 'CDH 6.2 - Data Lake: Hive Metastore';


### PR DESCRIPTION
Removed CM 6.2 templates and set it to default_deleted in database. @horadla23 @akanto please review.