### PR TITLE
CDPSDX-800 Fix cleanup of kerberos secrets when deleting an env

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/KerberosMgmtV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/KerberosMgmtV1Endpoint.java
@@ -1,12 +1,14 @@
 package com.sequenceiq.freeipa.api.v1.kerberosmgmt;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.doc.KeytabModelNotes;
@@ -59,7 +61,14 @@ public interface KerberosMgmtV1Endpoint {
     @DELETE
     @Path("cleanupClusterSecrets")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = KeytabOperationsDescription.DESCRIBE_CLEANUP, produces = ContentType.JSON, notes = KeytabModelNotes.CLEANUP_NOTES,
+    @ApiOperation(value = KeytabOperationsDescription.DESCRIBE_CLUSTER_CLEANUP, produces = ContentType.JSON, notes = KeytabModelNotes.CLEANUP_NOTES,
             nickname = "cleanupClusterSecretsV1")
     void cleanupClusterSecrets(@Valid VaultCleanupRequest request) throws Exception;
+
+    @DELETE
+    @Path("cleanupEnvironmentSecrets")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = KeytabOperationsDescription.DESCRIBE_ENVIRONMENT_CLEANUP, produces = ContentType.JSON, notes = KeytabModelNotes.CLEANUP_NOTES,
+            nickname = "cleanupEnvironmentSecretsV1")
+    void cleanupEnvironmentSecrets(@QueryParam("environmentCrn") @NotEmpty String environmentCrn) throws Exception;
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/doc/KeytabOperationsDescription.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/doc/KeytabOperationsDescription.java
@@ -6,7 +6,8 @@ public class KeytabOperationsDescription {
     public static final String DESCRIBE_SERVICE_KEYTAB = "Get the keytab for the provided service on a specific host";
     public static final String DESCRIBE_DELETE_SERVICE_PRINCIPAL = "Delete the service principal";
     public static final String DESCRIBE_DELETE_HOST = "Delete the host";
-    public static final String DESCRIBE_CLEANUP = "Cleanup the secrets associated with the cluster";
+    public static final String DESCRIBE_CLUSTER_CLEANUP = "Cleanup the secrets associated with the cluster";
+    public static final String DESCRIBE_ENVIRONMENT_CLEANUP = "Cleanup all the secrets associated with the environment";
 
 
     private KeytabOperationsDescription() {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/KerberosMgmtV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/KerberosMgmtV1Controller.java
@@ -49,4 +49,9 @@ public class KerberosMgmtV1Controller implements KerberosMgmtV1Endpoint {
         String accountId = crnService.getCurrentAccountId();
         kerberosMgmtV1Service.cleanupByCluster(request, accountId);
     }
+
+    public void cleanupEnvironmentSecrets(String environmentCrn) throws DeleteException {
+        String accountId = crnService.getCurrentAccountId();
+        kerberosMgmtV1Service.cleanupByEnvironment(environmentCrn, accountId);
+    }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/VaultPathBuilder.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/VaultPathBuilder.java
@@ -1,0 +1,105 @@
+package com.sequenceiq.freeipa.kerberosmgmt.v1;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class VaultPathBuilder {
+
+    private static final String VAULT_SECRET_TYPE = "ServiceKeytab";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KerberosMgmtV1Service.class);
+
+    private boolean generateClusterCrnIfNotPresent;
+
+    private Optional<String> accountId = Optional.empty();
+
+    private Optional<String> subType = Optional.empty();
+
+    private Optional<String> environmentCrn = Optional.empty();
+
+    private Optional<String> clusterCrn = Optional.empty();
+
+    private Optional<String> serverHostName = Optional.empty();
+
+    private Optional<String> serviceName = Optional.empty();
+
+    public VaultPathBuilder enableGeneratingClusterCrnIfNotPresent() {
+        generateClusterCrnIfNotPresent = true;
+        return this;
+    }
+
+    public VaultPathBuilder withAccountId(String accountId) {
+        this.accountId = Optional.ofNullable(accountId);
+        return this;
+    }
+
+    public VaultPathBuilder withSubType(String subType) {
+        this.subType = Optional.ofNullable(subType);
+        return this;
+    }
+
+    public VaultPathBuilder withEnvironmentCrn(String environmentCrn) {
+        String envCrn = StringUtils.substringAfterLast(environmentCrn, ":");
+        this.environmentCrn = Optional.ofNullable(envCrn);
+        return this;
+    }
+
+    public VaultPathBuilder withClusterCrn(String clusterCrn) {
+        String crn = StringUtils.substringAfterLast(clusterCrn, ":");
+        this.clusterCrn = Optional.ofNullable(crn);
+        return this;
+    }
+
+    public VaultPathBuilder withServerHostName(String serverHostName) {
+        this.serverHostName = Optional.ofNullable(serverHostName);
+        return this;
+    }
+
+    public VaultPathBuilder withServiceName(String serviceName) {
+        this.serviceName = Optional.ofNullable(serviceName);
+        return this;
+    }
+
+    public String build() {
+        // Sample Vault Path "/enginePath/appPath/account-id/Type/SubType/envCrn/clusterCrn/hostname/serviceName"
+        StringBuilder ret = new StringBuilder();
+        List<Optional<String>> requiredEntries = Arrays.asList(
+                accountId,
+                Optional.of(VAULT_SECRET_TYPE),
+                subType,
+                environmentCrn
+        );
+
+        requiredEntries.stream().forEachOrdered(entry -> {
+            ret.append(entry.orElseThrow(() -> new IllegalStateException("Missing required vault path entry.")));
+            ret.append("/");
+        });
+
+        if (clusterCrn.isPresent() || generateClusterCrnIfNotPresent) {
+            ret.append(clusterCrn.orElseGet(() -> {
+                LOGGER.debug("Cluster CRN not provided. Auto-generating one");
+                return generateClusterCrn(accountId.get(), environmentCrn.get());
+            }));
+            ret.append("/");
+
+            if (serverHostName.isPresent()) {
+                ret.append(serverHostName.get());
+                ret.append("/");
+                ret.append(serviceName.orElse(""));
+            }
+        }
+
+        LOGGER.debug("Generated vault path: [{}]", ret);
+        return ret.toString();
+    }
+
+    private String generateClusterCrn(String accountId, String envCrn) {
+        return accountId + "-" + envCrn;
+    }
+
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/kerberosmgmt/VaultPathBuilderV1Test.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/kerberosmgmt/VaultPathBuilderV1Test.java
@@ -1,0 +1,121 @@
+package com.sequenceiq.freeipa.kerberosmgmt;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.freeipa.kerberosmgmt.v1.VaultPathBuilder;
+
+public class VaultPathBuilderV1Test {
+    private static final String ACCOUNT_ID = "accountId";
+
+    private static final String SUBTYPE = "keytab";
+
+    private static final String ENVIRONMENT_ID = "environmentId:12345-6789";
+
+    private static final String CLUSTER_ID = "clusterId:54321-9876";
+
+    private static final String HOST = "host1";
+
+    private static final String SERVICE = "service1";
+
+    @Test
+    public void testVaultServicePrincipalPath() throws Exception {
+        Assertions.assertEquals("accountId/ServiceKeytab/keytab/12345-6789/54321-9876/host1/service1",
+                new VaultPathBuilder()
+                        .withAccountId(ACCOUNT_ID)
+                        .withSubType(SUBTYPE)
+                        .withEnvironmentCrn(ENVIRONMENT_ID)
+                        .withClusterCrn(CLUSTER_ID)
+                        .withServerHostName(HOST)
+                        .withServiceName(SERVICE)
+                        .build());
+    }
+
+    @Test
+    public void testVaultServicePrincipalPathGenerateClusterId() throws Exception {
+        Assertions.assertEquals("accountId/ServiceKeytab/keytab/12345-6789/accountId-12345-6789/host1/service1",
+                new VaultPathBuilder()
+                        .enableGeneratingClusterCrnIfNotPresent()
+                        .withAccountId(ACCOUNT_ID)
+                        .withSubType(SUBTYPE)
+                        .withEnvironmentCrn(ENVIRONMENT_ID)
+                        .withServerHostName(HOST)
+                        .withServiceName(SERVICE)
+                        .build());
+    }
+
+    @Test
+    public void testVaultHostPath() throws Exception {
+        Assertions.assertEquals("accountId/ServiceKeytab/keytab/12345-6789/54321-9876/host1/",
+                new VaultPathBuilder()
+                        .withAccountId(ACCOUNT_ID)
+                        .withSubType(SUBTYPE)
+                        .withEnvironmentCrn(ENVIRONMENT_ID)
+                        .withClusterCrn(CLUSTER_ID)
+                        .withServerHostName(HOST)
+                        .build());
+    }
+
+    @Test
+    public void testVaultHostPathGenerateClusterId() throws Exception {
+        Assertions.assertEquals("accountId/ServiceKeytab/keytab/12345-6789/accountId-12345-6789/host1/",
+                new VaultPathBuilder()
+                        .enableGeneratingClusterCrnIfNotPresent()
+                        .withAccountId(ACCOUNT_ID)
+                        .withSubType(SUBTYPE)
+                        .withEnvironmentCrn(ENVIRONMENT_ID)
+                        .withServerHostName(HOST)
+                        .build());
+    }
+
+    @Test
+    public void testVaultClusterCrnPath() throws Exception {
+        Assertions.assertEquals("accountId/ServiceKeytab/keytab/12345-6789/54321-9876/",
+                new VaultPathBuilder()
+                        .withAccountId(ACCOUNT_ID)
+                        .withSubType(SUBTYPE)
+                        .withEnvironmentCrn(ENVIRONMENT_ID)
+                        .withClusterCrn(CLUSTER_ID)
+                        .build());
+    }
+
+    @Test
+    public void testVaultClusterCrnPathGenerateClusterId() throws Exception {
+        Assertions.assertEquals("accountId/ServiceKeytab/keytab/12345-6789/accountId-12345-6789/",
+                new VaultPathBuilder()
+                        .enableGeneratingClusterCrnIfNotPresent()
+                        .withAccountId(ACCOUNT_ID)
+                        .withSubType(SUBTYPE)
+                        .withEnvironmentCrn(ENVIRONMENT_ID)
+                        .build());
+    }
+
+    @Test
+    public void testVaultEnvironmentCrnPath() throws Exception {
+        Assertions.assertEquals("accountId/ServiceKeytab/keytab/12345-6789/",
+                new VaultPathBuilder()
+                        .withAccountId(ACCOUNT_ID)
+                        .withSubType(SUBTYPE)
+                        .withEnvironmentCrn(ENVIRONMENT_ID)
+                        .build());
+    }
+
+    @Test
+    public void testMissingRequiredConfiguration() throws Exception {
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> new VaultPathBuilder()
+                        .withSubType(SUBTYPE)
+                        .withEnvironmentCrn(ENVIRONMENT_ID)
+                        .build());
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> new VaultPathBuilder()
+                        .withAccountId(ACCOUNT_ID)
+                        .withEnvironmentCrn(ENVIRONMENT_ID)
+                        .build());
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> new VaultPathBuilder()
+                        .withAccountId(ACCOUNT_ID)
+                        .withSubType(SUBTYPE)
+                        .build());
+    }
+}


### PR DESCRIPTION
    CDPSDX-800 Fix cleanup of kerberos secrets when deleting an env
    
    Delete all vault secrets that are associated with an environment when
    that environment is deleted. This prevents the secrets from remaining
    in the control plane after the environment has been deleted.
    
    Manually tested using a local development version of cloudbreak.

    
Closes #CDPSDX-800