### PR TITLE
CB-2480 Improve redbeams database API

### DIFF
--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/database/DatabaseV4Endpoint.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/database/DatabaseV4Endpoint.java
@@ -59,20 +59,36 @@ public interface DatabaseV4Endpoint {
     );
 
     @GET
-    @Path("/{name}")
+    @Path("/{crn}")
+    @ApiOperation(value = DatabaseOpDescription.GET_BY_CRN, notes = DatabaseNotes.GET_BY_CRN,
+            nickname = "getDatabaseByCrn")
+    DatabaseV4Response getByCrn(
+        @ValidCrn @NotNull @ApiParam(DatabaseParamDescriptions.CRN) @PathParam("crn") String crn
+    );
+
+    @GET
+    @Path("/name/{name}")
     @ApiOperation(value = DatabaseOpDescription.GET_BY_NAME, notes = DatabaseNotes.GET_BY_NAME,
-            nickname = "getDatabase")
-    DatabaseV4Response get(
+            nickname = "getDatabaseByName")
+    DatabaseV4Response getByName(
         @ValidCrn @NotNull @ApiParam(value = DatabaseParamDescriptions.ENVIRONMENT_CRN, required = true)
         @QueryParam("environmentCrn") String environmentCrn,
         @ApiParam(DatabaseParamDescriptions.NAME) @PathParam("name") String name
     );
 
     @DELETE
-    @Path("/{name}")
+    @Path("/{crn}")
+    @ApiOperation(value = DatabaseOpDescription.DELETE_BY_CRN, notes = DatabaseNotes.DELETE_BY_CRN,
+            nickname = "deleteDatabaseByCrn")
+    DatabaseV4Response deleteByCrn(
+        @ValidCrn @NotNull @ApiParam(DatabaseParamDescriptions.CRN) @PathParam("crn") String crn
+    );
+
+    @DELETE
+    @Path("/name/{name}")
     @ApiOperation(value = DatabaseOpDescription.DELETE_BY_NAME, notes = DatabaseNotes.DELETE_BY_NAME,
-            nickname = "deleteDatabase")
-    DatabaseV4Response delete(
+            nickname = "deleteDatabaseByName")
+    DatabaseV4Response deleteByName(
         @ValidCrn @NotNull @ApiParam(value = DatabaseParamDescriptions.ENVIRONMENT_CRN, required = true)
         @QueryParam("environmentCrn") String environmentCrn,
         @ApiParam(DatabaseParamDescriptions.NAME) @PathParam("name") String name
@@ -81,12 +97,10 @@ public interface DatabaseV4Endpoint {
     @DELETE
     @Path("")
     @Consumes(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = DatabaseOpDescription.DELETE_MULTIPLE_BY_NAME, notes = DatabaseNotes.DELETE_MULTIPLE_BY_NAME,
-            nickname = "deleteMultipleDatabases")
+    @ApiOperation(value = DatabaseOpDescription.DELETE_MULTIPLE_BY_CRN, notes = DatabaseNotes.DELETE_MULTIPLE_BY_CRN,
+            nickname = "deleteMultipleDatabasesByCrn")
     DatabaseV4Responses deleteMultiple(
-        @ValidCrn @NotNull @ApiParam(value = DatabaseParamDescriptions.ENVIRONMENT_CRN, required = true)
-        @QueryParam("environmentCrn") String environmentCrn,
-        @ApiParam(DatabaseParamDescriptions.NAMES) Set<String> names
+        @ApiParam(DatabaseParamDescriptions.CRNS) Set<@ValidCrn String> crns
     );
 
     @POST

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/database/request/CreateDatabaseV4Request.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/database/request/CreateDatabaseV4Request.java
@@ -3,6 +3,7 @@ package com.sequenceiq.redbeams.api.endpoint.v4.database.request;
 import java.io.Serializable;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.sequenceiq.cloudbreak.validation.ValidCrn;
@@ -32,6 +33,10 @@ public class CreateDatabaseV4Request implements Serializable {
     @NotNull
     @ApiModelProperty(Database.TYPE)
     private String type;
+
+    @Size(max = 1000000)
+    @ApiModelProperty(Database.DESCRIPTION)
+    private String databaseDescription;
 
     /**
      * Gets the crn of the existing database on which to create the schema.
@@ -85,5 +90,23 @@ public class CreateDatabaseV4Request implements Serializable {
      */
     public void setType(String type) {
         this.type = type;
+    }
+
+    /**
+     * Gets the database description.
+     *
+     * @return the database description
+     */
+    public String getDatabaseDescription() {
+        return databaseDescription;
+    }
+
+    /**
+     * Sets the database description.
+     *
+     * @param databaseDescription the database description
+     */
+    public void setDatabaseDescription(String databaseDescription) {
+        this.databaseDescription = databaseDescription;
     }
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/Notes.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/Notes.java
@@ -10,6 +10,8 @@ public final class Notes {
         public static final String LIST =
             "Lists all databases that are known, either because they were registered or because this service created "
             + "them.";
+        public static final String GET_BY_CRN =
+            "Gets information on a database by its CRN.";
         public static final String GET_BY_NAME =
             "Gets information on a database by its name.";
         public static final String CREATE =
@@ -17,12 +19,16 @@ public final class Notes {
             + "separate from the database server's administrative user is also created, with full rights to the new database.";
         public static final String REGISTER =
             "Registers an existing database, residing on some database server.";
+        public static final String DELETE_BY_CRN =
+            "Deletes a database by its CRN. If the database was registered with this service, then this operation "
+            + "merely deregisters it. Otherwise, this operation deletes the database from the database server, along "
+            + "with its corresponding user.";
         public static final String DELETE_BY_NAME =
             "Deletes a database by its name. If the database was registered with this service, then this operation "
             + "merely deregisters it. Otherwise, this operation deletes the database from the database server, along "
             + "with its corresponding user.";
-        public static final String DELETE_MULTIPLE_BY_NAME =
-            "Deletes multiple databases, each by name. See the notes on the single delete operation for details.";
+        public static final String DELETE_MULTIPLE_BY_CRN =
+            "Deletes multiple databases, each by CRN. See the notes on the single delete operation for details.";
 
         private DatabaseNotes() {
         }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/OperationDescriptions.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/OperationDescriptions.java
@@ -5,10 +5,12 @@ public final class OperationDescriptions {
     public static final class DatabaseOpDescription {
         public static final String TEST_CONNECTION = "test database connectivity";
         public static final String LIST = "list database configs";
-        public static final String GET_BY_NAME = "get database config by name";
-        public static final String REGISTER = "register database config of existing database";
-        public static final String DELETE_BY_NAME = "delete database config by name";
-        public static final String DELETE_MULTIPLE_BY_NAME = "delete multiple database configs by name";
+        public static final String GET_BY_NAME = "get a database config by name";
+        public static final String GET_BY_CRN = "get a database config by CRN";
+        public static final String REGISTER = "register a database config of existing database";
+        public static final String DELETE_BY_CRN = "delete a database config by CRN";
+        public static final String DELETE_BY_NAME = "delete a database config by name";
+        public static final String DELETE_MULTIPLE_BY_CRN = "delete multiple database configs by CRN";
 
         private DatabaseOpDescription() {
         }
@@ -19,8 +21,8 @@ public final class OperationDescriptions {
         public static final String LIST = "list database servers";
         public static final String GET_BY_NAME = "get a database server by name";
         public static final String GET_BY_CRN = "get a database server by CRN";
-        public static final String CREATE = "creates and registers a database server in a cloud provider";
-        public static final String TERMINATE = "terminates a database server in a cloud provider and deregisters it";
+        public static final String CREATE = "create and register a database server in a cloud provider";
+        public static final String TERMINATE = "terminate a database server in a cloud provider and deregister it";
         public static final String REGISTER = "register a database server";
         public static final String DELETE_BY_CRN = "deregister a database server by CRN";
         public static final String DELETE_BY_NAME = "deregister a database server by name";

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/ParamDescriptions.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/ParamDescriptions.java
@@ -4,8 +4,9 @@ public final class ParamDescriptions {
 
     public static final class DatabaseParamDescriptions {
 
+        public static final String CRN = "CRN of the database";
+        public static final String CRNS = "CRNs of the databases";
         public static final String NAME = "Name of the database";
-        public static final String NAMES = "Names of the databases";
         public static final String ENVIRONMENT_CRN = "CRN of the environment of the database(s)";
 
         public static final String DATABASE_REQUEST = ModelDescriptions.DATABASE_REQUEST;

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/database/DatabaseV4Controller.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/database/DatabaseV4Controller.java
@@ -25,37 +25,48 @@ import com.sequenceiq.redbeams.service.dbconfig.DatabaseConfigService;
 public class DatabaseV4Controller implements DatabaseV4Endpoint {
 
     @Inject
-    private ConverterUtil redbeamsConverterUtil;
+    private ConverterUtil converterUtil;
 
     @Inject
     private DatabaseConfigService databaseConfigService;
 
     @Override
     public DatabaseV4Responses list(String environmentCrn) {
-        return new DatabaseV4Responses(redbeamsConverterUtil.convertAllAsSet(databaseConfigService.findAll(environmentCrn),
+        return new DatabaseV4Responses(converterUtil.convertAllAsSet(databaseConfigService.findAll(environmentCrn),
                 DatabaseV4Response.class));
     }
 
     @Override
     public DatabaseV4Response register(@Valid DatabaseV4Request request) {
-        DatabaseConfig databaseConfig = redbeamsConverterUtil.convert(request, DatabaseConfig.class);
-        return redbeamsConverterUtil.convert(databaseConfigService.register(databaseConfig, false), DatabaseV4Response.class);
+        DatabaseConfig databaseConfig = converterUtil.convert(request, DatabaseConfig.class);
+        return converterUtil.convert(databaseConfigService.register(databaseConfig, false), DatabaseV4Response.class);
     }
 
     @Override
-    public DatabaseV4Response get(String environmentCrn, String name) {
-        DatabaseConfig databaseConfig = databaseConfigService.get(name, environmentCrn);
-        return redbeamsConverterUtil.convert(databaseConfig, DatabaseV4Response.class);
+    public DatabaseV4Response getByCrn(String crn) {
+        DatabaseConfig databaseConfig = databaseConfigService.getByCrn(crn);
+        return converterUtil.convert(databaseConfig, DatabaseV4Response.class);
     }
 
     @Override
-    public DatabaseV4Response delete(String environmentCrn, String name) {
-        return redbeamsConverterUtil.convert(databaseConfigService.delete(name, environmentCrn), DatabaseV4Response.class);
+    public DatabaseV4Response getByName(String environmentCrn, String name) {
+        DatabaseConfig databaseConfig = databaseConfigService.getByName(name, environmentCrn);
+        return converterUtil.convert(databaseConfig, DatabaseV4Response.class);
     }
 
     @Override
-    public DatabaseV4Responses deleteMultiple(String environmentCrn, Set<String> names) {
-        return new DatabaseV4Responses(redbeamsConverterUtil.convertAllAsSet(databaseConfigService.delete(names, environmentCrn), DatabaseV4Response.class));
+    public DatabaseV4Response deleteByCrn(String crn) {
+        return converterUtil.convert(databaseConfigService.deleteByCrn(crn), DatabaseV4Response.class);
+    }
+
+    @Override
+    public DatabaseV4Response deleteByName(String environmentCrn, String name) {
+        return converterUtil.convert(databaseConfigService.deleteByName(name, environmentCrn), DatabaseV4Response.class);
+    }
+
+    @Override
+    public DatabaseV4Responses deleteMultiple(Set<String> crns) {
+        return new DatabaseV4Responses(converterUtil.convertAllAsSet(databaseConfigService.deleteMultipleByCrn(crns), DatabaseV4Response.class));
     }
 
     @Override
@@ -68,7 +79,7 @@ public class DatabaseV4Controller implements DatabaseV4Endpoint {
         //             databaseTestV4Request.getExistingDatabase().getEnvironmentCrn()
         //     );
         // } else {
-        //     DatabaseConfig databaseConfig = redbeamsConverterUtil.convert(databaseTestV4Request.getDatabase(), DatabaseConfig.class);
+        //     DatabaseConfig databaseConfig = converterUtil.convert(databaseTestV4Request.getDatabase(), DatabaseConfig.class);
         //     result = databaseConfigService.testConnection(databaseConfig);
         // }
         // return new DatabaseTestV4Response(result);

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4Controller.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4Controller.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.redbeams.controller.v4.databaseserver;
 
+import java.util.Optional;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -128,7 +129,8 @@ public class DatabaseServerV4Controller implements DatabaseServerV4Endpoint {
         String result = databaseServerConfigService.createDatabaseOnServer(
                 request.getExistingDatabaseServerCrn(),
                 request.getDatabaseName(),
-                request.getType());
+                request.getType(),
+                Optional.ofNullable(request.getDatabaseDescription()));
         return new CreateDatabaseV4Response(result);
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/domain/DatabaseServerConfig.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/domain/DatabaseServerConfig.java
@@ -268,15 +268,16 @@ public class DatabaseServerConfig implements ArchivableResource, AccountIdAwareR
     /**
      * Creates a database based on this database server config.
      *
-     * @param databaseName the name of the database
-     * @param type         the type of the database
-     * @param status       the resource status of the database
-     * @param userName     the username for the user associated with the database
-     * @param password     the password for the user associated with the database
+     * @param databaseName         the name of the database
+     * @param type                 the type of the database
+     * @param databaseDescription  the description of the database
+     * @param status               the resource status of the database
+     * @param userName             the username for the user associated with the database
+     * @param password             the password for the user associated with the database
      * @return a DatabaseConfig
      * @throws IllegalStateException if this database server config lacks a host or port
      */
-    public DatabaseConfig createDatabaseConfig(String databaseName, String type, ResourceStatus status,
+    public DatabaseConfig createDatabaseConfig(String databaseName, String type, Optional<String> databaseDescription, ResourceStatus status,
         String userName, String password) {
         if (host == null) {
             throw new IllegalStateException("Database server config has no host");
@@ -289,7 +290,7 @@ public class DatabaseServerConfig implements ArchivableResource, AccountIdAwareR
 
         databaseConfig.setDatabaseVendor(databaseVendor);
         databaseConfig.setName(databaseName);
-        databaseConfig.setDescription(description);
+        databaseConfig.setDescription(databaseDescription.orElse(description));
         databaseConfig.setConnectionURL(new DatabaseCommon().getJdbcConnectionUrl(databaseVendor.jdbcUrlDriverId(),
             host, port, Optional.of(databaseName)));
         databaseConfig.setConnectionDriver(connectionDriver);

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/termination/handler/DeregisterDatabaseServerHandler.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/termination/handler/DeregisterDatabaseServerHandler.java
@@ -13,7 +13,6 @@ import com.sequenceiq.redbeams.domain.stack.DBStack;
 import com.sequenceiq.redbeams.flow.redbeams.termination.event.deregister.DeregisterDatabaseServerFailed;
 import com.sequenceiq.redbeams.flow.redbeams.termination.event.deregister.DeregisterDatabaseServerRequest;
 import com.sequenceiq.redbeams.flow.redbeams.termination.event.deregister.DeregisterDatabaseServerSuccess;
-import com.sequenceiq.redbeams.repository.DatabaseConfigRepository;
 import com.sequenceiq.redbeams.service.dbserverconfig.DatabaseServerConfigService;
 
 import reactor.bus.Event;
@@ -28,9 +27,6 @@ public class DeregisterDatabaseServerHandler implements EventHandler<DeregisterD
 
     @Inject
     private EventBus eventBus;
-
-    @Inject
-    private DatabaseConfigRepository databaseConfigRepository;
 
     @Inject
     private DatabaseServerConfigService databaseServerConfigService;

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/repository/DatabaseConfigRepository.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/repository/DatabaseConfigRepository.java
@@ -5,14 +5,12 @@ import java.util.Set;
 
 import javax.transaction.Transactional;
 
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
 import com.sequenceiq.authorization.repository.BaseJpaRepository;
 import com.sequenceiq.authorization.repository.CheckPermission;
 import com.sequenceiq.authorization.resource.AuthorizationResource;
 import com.sequenceiq.authorization.resource.AuthorizationResourceType;
 import com.sequenceiq.authorization.resource.ResourceAction;
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
 import com.sequenceiq.redbeams.domain.DatabaseConfig;
 
@@ -22,15 +20,16 @@ import com.sequenceiq.redbeams.domain.DatabaseConfig;
 public interface DatabaseConfigRepository extends BaseJpaRepository<DatabaseConfig, Long> {
 
     @CheckPermission(action = ResourceAction.READ)
-    @Query("SELECT d FROM DatabaseConfig d WHERE d.environmentId = :environmentId "
-            + "AND (d.name = :name OR d.resourceCrn = :name)")
-    Optional<DatabaseConfig> findByEnvironmentIdAndName(@Param("environmentId") String environmentId, @Param("name") String name);
+    Optional<DatabaseConfig> findByEnvironmentIdAndName(String environmentId, String name);
+
+    @CheckPermission(action = ResourceAction.READ)
+    Optional<DatabaseConfig> findByResourceCrn(Crn crn);
 
     @CheckPermission(action = ResourceAction.READ)
     Set<DatabaseConfig> findByEnvironmentId(String environmentId);
 
     @CheckPermission(action = ResourceAction.READ)
-    @Query("SELECT d FROM DatabaseConfig d WHERE d.environmentId = :environmentId "
-            + "AND (d.name IN :names OR d.resourceCrn IN :names)")
-    Set<DatabaseConfig> findAllByEnvironmentIdAndNameIn(@Param("environmentId") String environmentId, @Param("names") Set<String> names);
+    Set<DatabaseConfig> findByResourceCrnIn(Set<Crn> resourceCrns);
+
+    // save does not require a permission check
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigService.java
@@ -248,7 +248,7 @@ public class DatabaseServerConfigService extends AbstractArchivistService<Databa
                 .collect(Collectors.joining("; "));
     }
 
-    public String createDatabaseOnServer(String serverCrn, String databaseName, String databaseType) {
+    public String createDatabaseOnServer(String serverCrn, String databaseName, String databaseType, Optional<String> databaseDescription) {
         // Prepared statements cannot be used for DDL statements, so we have to scrub the databaseName ourselves.
         // This is a subset of valid SQL identifiers, but I believe it's a sane constraint to put on database name
         // identifiers that protects us from SQL injections
@@ -281,7 +281,7 @@ public class DatabaseServerConfigService extends AbstractArchivistService<Databa
 
         // Only record database on server if successfully created on server
         DatabaseConfig newDatabaseConfig =
-                databaseServerConfig.createDatabaseConfig(databaseName, databaseType, ResourceStatus.SERVICE_MANAGED,
+                databaseServerConfig.createDatabaseConfig(databaseName, databaseType, databaseDescription, ResourceStatus.SERVICE_MANAGED,
                         databaseUserName, databasePassword);
         databaseConfigService.register(newDatabaseConfig, false);
 

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4ControllerTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4ControllerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 import org.junit.Before;
@@ -17,6 +18,8 @@ import org.mockito.Mock;
 import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.redbeams.api.endpoint.v4.database.request.CreateDatabaseV4Request;
+import com.sequenceiq.redbeams.api.endpoint.v4.database.responses.CreateDatabaseV4Response;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.AllocateDatabaseServerV4Request;
 // import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.DatabaseServerTestV4Request;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.DatabaseServerV4Request;
@@ -41,7 +44,9 @@ public class DatabaseServerV4ControllerTest {
             .setResource("resource")
             .build();
 
-    private static final String SERVER_CRN = "myserver";
+    private static final String SERVER_CRN = CRN.toString();
+
+    private static final String SERVER_NAME = "myserver";
 
     private static final String ENVIRONMENT_CRN = "myenv";
 
@@ -92,7 +97,7 @@ public class DatabaseServerV4ControllerTest {
 
         server = new DatabaseServerConfig();
         server.setId(1L);
-        server.setName(SERVER_CRN);
+        server.setName(SERVER_NAME);
         server.setEnvironmentId(ENVIRONMENT_CRN);
         server.setResourceCrn(CRN);
 
@@ -102,11 +107,11 @@ public class DatabaseServerV4ControllerTest {
         server2.setEnvironmentId(ENVIRONMENT_CRN);
 
         request = new DatabaseServerV4Request();
-        request.setName(SERVER_CRN);
+        request.setName(SERVER_NAME);
 
         response = new DatabaseServerV4Response();
         response.setId(1L);
-        response.setName(SERVER_CRN);
+        response.setName(SERVER_NAME);
 
         response2 = new DatabaseServerV4Response();
         response2.setId(2L);
@@ -136,10 +141,10 @@ public class DatabaseServerV4ControllerTest {
 
     @Test
     public void testGetByName() {
-        when(service.getByName(DatabaseServerV4Controller.DEFAULT_WORKSPACE, ENVIRONMENT_CRN, SERVER_CRN)).thenReturn(server);
+        when(service.getByName(DatabaseServerV4Controller.DEFAULT_WORKSPACE, ENVIRONMENT_CRN, SERVER_NAME)).thenReturn(server);
         when(converterUtil.convert(server, DatabaseServerV4Response.class)).thenReturn(response);
 
-        DatabaseServerV4Response response = underTest.getByName(ENVIRONMENT_CRN, SERVER_CRN);
+        DatabaseServerV4Response response = underTest.getByName(ENVIRONMENT_CRN, SERVER_NAME);
 
         assertEquals(1L, response.getId().longValue());
     }
@@ -244,4 +249,18 @@ public class DatabaseServerV4ControllerTest {
 
     //     assertEquals("okayyy", response.getResult());
     // }
+
+    @Test
+    public void testCreateDatabase() {
+        CreateDatabaseV4Request createRequest = new CreateDatabaseV4Request();
+        createRequest.setExistingDatabaseServerCrn(SERVER_CRN);
+        createRequest.setDatabaseName("mydb");
+        createRequest.setType("hive");
+        createRequest.setDatabaseDescription("mine not yours");
+        when(service.createDatabaseOnServer(SERVER_CRN, "mydb", "hive", Optional.of("mine not yours"))).thenReturn("ok");
+
+        CreateDatabaseV4Response createResponse = underTest.createDatabase(createRequest);
+
+        assertEquals("ok", createResponse.getResult());
+    }
 }

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/domain/DatabaseServerConfigTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/domain/DatabaseServerConfigTest.java
@@ -118,7 +118,7 @@ public class DatabaseServerConfigTest {
         config.setArchived(true);
         config.setEnvironmentId("myenvironment");
 
-        DatabaseConfig db = config.createDatabaseConfig("mydb", "hive", ResourceStatus.USER_MANAGED, "dbuser", "dbpass");
+        DatabaseConfig db = config.createDatabaseConfig("mydb", "hive", Optional.empty(), ResourceStatus.USER_MANAGED, "dbuser", "dbpass");
 
         assertEquals(config.getDatabaseVendor(), db.getDatabaseVendor());
         assertEquals("mydb", db.getName());

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigServiceTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigServiceTest.java
@@ -418,8 +418,9 @@ public class DatabaseServerConfigServiceTest {
         server.setConnectionPassword("rootpassword");
         String databaseName = "mydb";
         String databaseType = "hive";
+        Optional<String> databaseDescription = Optional.of("mine not yours");
 
-        String result = underTest.createDatabaseOnServer(SERVER_CRN.toString(), databaseName, databaseType);
+        String result = underTest.createDatabaseOnServer(SERVER_CRN.toString(), databaseName, databaseType, databaseDescription);
 
         assertEquals("created", result);
         verify(driverFunctions).execWithDatabaseDriver(eq(server), any());
@@ -428,6 +429,7 @@ public class DatabaseServerConfigServiceTest {
         DatabaseConfig db = captor.getValue();
         assertEquals(databaseName, db.getName());
         assertEquals(databaseType, db.getType());
+        assertEquals(databaseDescription.get(), db.getDescription());
         String databaseUserName = db.getConnectionUserName().getRaw();
         assertEquals(USERNAME, databaseUserName);
         assertNotEquals(server.getConnectionUserName(), databaseUserName);


### PR DESCRIPTION
The following improvements are in place for the redbeams database API:

* Redbeams now supports API endpoints for getting and deleting databases
  by CRN. The paths of the existing corresponding endpoints that work by
  environment CRN and name have been altered to include "name/", so that
  the CRN-based endpoints are now primary.
* A database description may now be supplied in a database creation
  request. If one is not present, then the description of the hosting
  database server is used, as before.
* The multi-delete API operation now uses CRNs instead of names.
* Additional unit tests are uncommented / created.
* Some unnecessary code injections are removed.