### PR TITLE
CB-3211 Skip RDS termination if CF template is missing

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsTerminateService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsTerminateService.java
@@ -64,7 +64,9 @@ public class AwsRdsTerminateService {
             if (!e.getErrorMessage().contains(cFStackName + " does not exist")) {
                 throw e;
             }
-            throw new CloudConnectorException(cFStackName + " does not exist", e);
+            LOGGER.warn("Stack " + cFStackName + " does not exist, assuming that it has already been deleted");
+            // FIXME
+            return List.of();
         }
 
         cfRetryClient.deleteStack(awsStackRequestHelper.createDeleteStackRequest(cFStackName));


### PR DESCRIPTION
When AwsRdsTerminateService fails to locate the CF template for a
database server to terminate, rather than fail, it now assumes that the
template has been properly deleted, and returns successfully (without
itself issuing a termination request). This prevents this likely common
occurrence from causing termination failures.

If a redbeams server is already in a DELETE_FAILED status because of
some earlier termination failure, it turns out you can issue another
termination and redbeams will try again. This provides an escape hatch
for failed terminations, by manually getting rid of the CF template and
then rerunning termination.

---

This is currently targeted at rc-2.12, but won't be merged without approval.