### PR TITLE
CB-3172 | Failing cluster provisioning flow when cluster proxy regist…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/ClusterCreationEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/ClusterCreationEvent.java
@@ -10,6 +10,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.ldap.LdapSSOConfigurationFail
 import com.sequenceiq.cloudbreak.reactor.api.event.ldap.LdapSSOConfigurationSuccess;
 import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.BootstrapMachinesFailed;
 import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.BootstrapMachinesSuccess;
+import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.ClusterProxyGatewayRegistrationFailed;
 import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.ClusterProxyGatewayRegistrationSuccess;
 import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.ClusterProxyRegistrationFailed;
 import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.ClusterProxyRegistrationSuccess;
@@ -32,6 +33,7 @@ public enum ClusterCreationEvent implements FlowEvent {
     CLUSTER_PROXY_REGISTRATION_SUCCEEDED_EVENT(EventSelectorUtil.selector(ClusterProxyRegistrationSuccess.class)),
     CLUSTER_PROXY_GATEWAY_REGISTRATION_SUCCEEDED_EVENT(EventSelectorUtil.selector(ClusterProxyGatewayRegistrationSuccess.class)),
     CLUSTER_PROXY_REGISTRATION_FAILED_EVENT(EventSelectorUtil.selector(ClusterProxyRegistrationFailed.class)),
+    CLUSTER_PROXY_GATEWAY_REGISTRATION_FAILED_EVENT(EventSelectorUtil.selector(ClusterProxyGatewayRegistrationFailed.class)),
     HOST_METADATASETUP_FINISHED_EVENT(EventSelectorUtil.selector(HostMetadataSetupSuccess.class)),
     HOST_METADATASETUP_FAILED_EVENT(EventSelectorUtil.selector(HostMetadataSetupFailed.class)),
     MOUNT_DISKS_FINISHED_EVENT(EventSelectorUtil.selector(MountDisksSuccess.class)),

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/ClusterCreationFlowConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/ClusterCreationFlowConfig.java
@@ -7,7 +7,9 @@ import static com.sequenceiq.cloudbreak.core.flow2.cluster.provision.ClusterCrea
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.provision.ClusterCreationEvent.CLUSTER_CREATION_FAILURE_HANDLED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.provision.ClusterCreationEvent.CLUSTER_CREATION_FINISHED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.provision.ClusterCreationEvent.CLUSTER_INSTALL_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.provision.ClusterCreationEvent.CLUSTER_PROXY_GATEWAY_REGISTRATION_FAILED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.provision.ClusterCreationEvent.CLUSTER_PROXY_GATEWAY_REGISTRATION_SUCCEEDED_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.provision.ClusterCreationEvent.CLUSTER_PROXY_REGISTRATION_FAILED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.provision.ClusterCreationEvent.CLUSTER_PROXY_REGISTRATION_SUCCEEDED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.provision.ClusterCreationEvent.HOST_METADATASETUP_FAILED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.provision.ClusterCreationEvent.HOST_METADATASETUP_FINISHED_EVENT;
@@ -55,7 +57,8 @@ public class ClusterCreationFlowConfig extends AbstractFlowConfiguration<Cluster
     private static final List<Transition<ClusterCreationState, ClusterCreationEvent>> TRANSITIONS =
             new Builder<ClusterCreationState, ClusterCreationEvent>().defaultFailureEvent(CLUSTER_CREATION_FAILED_EVENT)
             .from(INIT_STATE).to(CLUSTER_PROXY_REGISTRATION_STATE).event(CLUSTER_CREATION_EVENT).noFailureEvent()
-            .from(CLUSTER_PROXY_REGISTRATION_STATE).to(BOOTSTRAPPING_MACHINES_STATE).event(CLUSTER_PROXY_REGISTRATION_SUCCEEDED_EVENT).noFailureEvent()
+            .from(CLUSTER_PROXY_REGISTRATION_STATE).to(BOOTSTRAPPING_MACHINES_STATE).event(CLUSTER_PROXY_REGISTRATION_SUCCEEDED_EVENT)
+                    .failureEvent(CLUSTER_PROXY_REGISTRATION_FAILED_EVENT)
             .from(INIT_STATE).to(INSTALLING_CLUSTER_STATE).event(CLUSTER_INSTALL_EVENT).noFailureEvent()
             .from(BOOTSTRAPPING_MACHINES_STATE).to(COLLECTING_HOST_METADATA_STATE).event(BOOTSTRAP_MACHINES_FINISHED_EVENT)
                     .failureEvent(BOOTSTRAP_MACHINES_FAILED_EVENT)
@@ -76,7 +79,7 @@ public class ClusterCreationFlowConfig extends AbstractFlowConfiguration<Cluster
             .from(INSTALLING_CLUSTER_STATE).to(CLUSTER_PROXY_GATEWAY_REGISTRATION_STATE).event(INSTALL_CLUSTER_FINISHED_EVENT)
                     .failureEvent(INSTALL_CLUSTER_FAILED_EVENT)
             .from(CLUSTER_PROXY_GATEWAY_REGISTRATION_STATE).to(CLUSTER_CREATION_FINISHED_STATE).event(CLUSTER_PROXY_GATEWAY_REGISTRATION_SUCCEEDED_EVENT)
-                    .defaultFailureEvent()
+                    .failureEvent(CLUSTER_PROXY_GATEWAY_REGISTRATION_FAILED_EVENT)
             .from(CLUSTER_CREATION_FINISHED_STATE).to(FINAL_STATE).event(CLUSTER_CREATION_FINISHED_EVENT).defaultFailureEvent()
             .build();
 


### PR DESCRIPTION
This is to fail cluster provisioning when calls to cluster proxy fail. Currently when such failure happens, provisioning appears stuck at these states.