### PR TITLE
CDPCP-606. Metering consumer failed to convert payload to MeteringEvent entity

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/fluent/template/databus_metering.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/fluent/template/databus_metering.conf.j2
@@ -19,6 +19,7 @@
     credential_file_reload_interval  60
     debug                            false
     endpoint                         "{{ databus.endpoint }}"
+    event_message_field              message
     headers                          app:{{ fluent.dbusAppName }}
     stream_name                      Metering
     partition_key                    "#{Socket.gethostname}"


### PR DESCRIPTION
applying fix to rc-2.12 (in order to test metering on mow dev on this week)

also will apply https://github.com/hortonworks/cloudbreak/pull/6082 as well but only after CDPCP-628 is fixed