### PR TITLE
CB-3243 Cleanup CRN handling from CB-2907

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/KerberosMgmtV1Service.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/KerberosMgmtV1Service.java
@@ -127,7 +127,7 @@ public class KerberosMgmtV1Service {
         FreeIpaClient ipaClient = freeIpaClientFactory.getFreeIpaClientForStack(freeIpaStack);
         delService(canonicalPrincipal, ipaClient);
         VaultPathBuilder vaultPathBuilder = new VaultPathBuilder()
-                .enableGeneratingClusterCrnIfNotPresent()
+                .enableGeneratingClusterIdIfNotPresent()
                 .withAccountId(accountId)
                 .withEnvironmentCrn(request.getEnvironmentCrn())
                 .withClusterCrn(request.getClusterCrn())
@@ -151,7 +151,7 @@ public class KerberosMgmtV1Service {
         }
         delHost(request.getServerHostName(), ipaClient);
         VaultPathBuilder vaultPathBuilder = new VaultPathBuilder()
-                .enableGeneratingClusterCrnIfNotPresent()
+                .enableGeneratingClusterIdIfNotPresent()
                 .withAccountId(accountId)
                 .withEnvironmentCrn(request.getEnvironmentCrn())
                 .withClusterCrn(request.getClusterCrn())
@@ -369,7 +369,7 @@ public class KerberosMgmtV1Service {
     private SecretResponse getSecretResponseForPrincipal(ServiceKeytabRequest request, String accountId, String principal) {
         try {
             String path = new VaultPathBuilder()
-                    .enableGeneratingClusterCrnIfNotPresent()
+                    .enableGeneratingClusterIdIfNotPresent()
                     .withAccountId(accountId)
                     .withSubType(PRINCIPAL_SUB_TYPE)
                     .withEnvironmentCrn(request.getEnvironmentCrn())
@@ -388,7 +388,7 @@ public class KerberosMgmtV1Service {
     private SecretResponse getSecretResponseForKeytab(ServiceKeytabRequest request, String accountId, String keytab) {
         try {
             String path = new VaultPathBuilder()
-                    .enableGeneratingClusterCrnIfNotPresent()
+                    .enableGeneratingClusterIdIfNotPresent()
                     .withAccountId(accountId)
                     .withSubType(KEYTAB_SUB_TYPE)
                     .withEnvironmentCrn(request.getEnvironmentCrn())

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/kerberosmgmt/VaultPathBuilderV1Test.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/kerberosmgmt/VaultPathBuilderV1Test.java
@@ -10,9 +10,9 @@ public class VaultPathBuilderV1Test {
 
     private static final String SUBTYPE = "keytab";
 
-    private static final String ENVIRONMENT_ID = "environmentId:12345-6789";
+    private static final String ENVIRONMENT_ID = "crn:cdp:environments:us-west-1:f39af961-e0ce-4f79-826c-45502efb9ca3:environment:12345-6789";
 
-    private static final String CLUSTER_ID = "clusterId:54321-9876";
+    private static final String CLUSTER_ID = "crn:cdp:datalake:us-west-1:f39af961-e0ce-4f79-826c-45502efb9ca3:datalake:54321-9876";
 
     private static final String HOST = "host1";
 
@@ -35,7 +35,7 @@ public class VaultPathBuilderV1Test {
     public void testVaultServicePrincipalPathGenerateClusterId() throws Exception {
         Assertions.assertEquals("accountId/ServiceKeytab/keytab/12345-6789/accountId-12345-6789/host1/service1",
                 new VaultPathBuilder()
-                        .enableGeneratingClusterCrnIfNotPresent()
+                        .enableGeneratingClusterIdIfNotPresent()
                         .withAccountId(ACCOUNT_ID)
                         .withSubType(SUBTYPE)
                         .withEnvironmentCrn(ENVIRONMENT_ID)
@@ -60,7 +60,7 @@ public class VaultPathBuilderV1Test {
     public void testVaultHostPathGenerateClusterId() throws Exception {
         Assertions.assertEquals("accountId/ServiceKeytab/keytab/12345-6789/accountId-12345-6789/host1/",
                 new VaultPathBuilder()
-                        .enableGeneratingClusterCrnIfNotPresent()
+                        .enableGeneratingClusterIdIfNotPresent()
                         .withAccountId(ACCOUNT_ID)
                         .withSubType(SUBTYPE)
                         .withEnvironmentCrn(ENVIRONMENT_ID)
@@ -83,7 +83,7 @@ public class VaultPathBuilderV1Test {
     public void testVaultClusterCrnPathGenerateClusterId() throws Exception {
         Assertions.assertEquals("accountId/ServiceKeytab/keytab/12345-6789/accountId-12345-6789/",
                 new VaultPathBuilder()
-                        .enableGeneratingClusterCrnIfNotPresent()
+                        .enableGeneratingClusterIdIfNotPresent()
                         .withAccountId(ACCOUNT_ID)
                         .withSubType(SUBTYPE)
                         .withEnvironmentCrn(ENVIRONMENT_ID)
@@ -97,6 +97,18 @@ public class VaultPathBuilderV1Test {
                         .withAccountId(ACCOUNT_ID)
                         .withSubType(SUBTYPE)
                         .withEnvironmentCrn(ENVIRONMENT_ID)
+                        .build());
+    }
+
+    @Test
+    public void testVaultClusterCrnPathNullClusterId() throws Exception {
+        Assertions.assertEquals("accountId/ServiceKeytab/keytab/12345-6789/accountId-12345-6789/",
+                new VaultPathBuilder()
+                        .enableGeneratingClusterIdIfNotPresent()
+                        .withAccountId(ACCOUNT_ID)
+                        .withSubType(SUBTYPE)
+                        .withEnvironmentCrn(ENVIRONMENT_ID)
+                        .withClusterCrn(null)
                         .build());
     }
 

--- a/secret-engine/src/main/java/com/sequenceiq/cloudbreak/service/secret/service/SecretService.java
+++ b/secret-engine/src/main/java/com/sequenceiq/cloudbreak/service/secret/service/SecretService.java
@@ -31,7 +31,7 @@ import com.sequenceiq.cloudbreak.service.secret.vault.VaultSecret;
 @ConditionalOnBean({VaultKvV2Engine.class, VaultKvV1Engine.class, VaultConfig.class})
 public class SecretService {
 
-    public static final int MAX_VAUL_PATH_LENGTH = 256;
+    public static final int MAX_VAULT_PATH_LENGTH = 256;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SecretService.class);
 
@@ -65,7 +65,7 @@ public class SecretService {
      * @throws Exception is thrown in case the key-value key is already contains a secret
      */
     public String put(String key, String value) throws Exception {
-        if (key.length() > MAX_VAUL_PATH_LENGTH) {
+        if (key.length() > MAX_VAULT_PATH_LENGTH) {
             throw new SecretOperationException(String.format("Key size [%s] is greater than 256", key.length()));
         }
         long start = System.currentTimeMillis();


### PR DESCRIPTION
CRN handling is cleaned up to use the Crn class to get the resource
rather than just using everything after the last ":".

NOTE: cluster-ambari/src/main/java/com/sequenceiq/cloudbreak/ambari/AmbariBlueprintPortConfigCollector.java still uses the last ":" rather than the using the CRN class. I didn't update this because I don't know how to test it and I think it may be deprecated. If this assumption is wrong, please let me know and I will change it there too.

Closes #CB-3243