### PR TITLE
Dynamic configuration of delegation token for Kafka

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-sdx-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx-ha.bp
@@ -251,10 +251,6 @@
                     {
                       "name": "service_config_suppression_kafka_broker_count_validator",
                       "value": "true"
-                    },
-	                  {
-                        "name": "delegation.token.enable",
-                        "value": "true"
                     }
                 ],
                 "serviceType": "KAFKA"

--- a/core/src/main/resources/defaults/blueprints/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx-medium-ha.bp
@@ -261,10 +261,6 @@
           {
             "name": "service_config_suppression_kafka_broker_count_validator",
             "value": "true"
-          },
-	        {
-            "name": "delegation.token.enable",
-            "value": "true"
           }
         ],
         "serviceType": "KAFKA"

--- a/core/src/main/resources/defaults/blueprints/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx.bp
@@ -280,10 +280,6 @@
           {
             "name": "service_config_suppression_kafka_broker_count_validator",
             "value": "true"
-          },
-	        {
-            "name": "delegation.token.enable",
-            "value": "true"
           }
         ],
         "serviceType": "KAFKA"

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/config/ServerUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/config/ServerUtil.java
@@ -32,13 +32,14 @@ class ServerUtil {
     }
 
     private String enforceHttpsForServerAddress(String serverRaw) {
+        //Hack to avoid SSLException in local mock/e2e tests due to CBD modification that allows traffic to services without https
+        if ("localhost".equals(serverRaw) || "http://localhost".equals(serverRaw)) {
+            return "http://" + serverRaw;
+        }
         return "https://" + getDomainFromUrl(serverRaw);
     }
 
     private String getDomainFromUrl(String url) {
-        if ("localhost".equals(url)) {
-            return url;
-        }
         try {
             return new URL(url).getHost();
         } catch (MalformedURLException e) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/BasicSdxTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/BasicSdxTests.java
@@ -27,7 +27,7 @@ public class BasicSdxTests extends AbstractE2ETest {
     protected void setupTest(TestContext testContext) {
         createDefaultUser(testContext);
         createDefaultCredential(testContext);
-        createEnvironmentWithNetworkAndFreeIPA(testContext);
+        createEnvironmentWithNetwork(testContext);
         initializeDefaultBlueprints(testContext);
     }
 

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaDelegationTokenConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaDelegationTokenConfigProvider.java
@@ -1,0 +1,45 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateComponentConfigProvider;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+
+@Component
+public class KafkaDelegationTokenConfigProvider implements CmTemplateComponentConfigProvider {
+
+    private static final String CONFIG_NAME = "delegation.token.enable";
+
+    private static final String CONFIG_VALUE = "true";
+
+    @Override
+    public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject source) {
+        return List.of(config(CONFIG_NAME, CONFIG_VALUE));
+    }
+
+    @Override
+    public String getServiceType() {
+        return KafkaRoles.KAFKA_SERVICE;
+    }
+
+    @Override
+    public List<String> getRoleTypes() {
+        return List.of(KafkaRoles.KAFKA_BROKER);
+    }
+
+    @Override
+    public boolean isConfigurationNeeded(CmTemplateProcessor cmTemplateProcessor, TemplatePreparationObject source) {
+        return isKerberosEnabled(source)
+                && cmTemplateProcessor.isRoleTypePresentInService(getServiceType(), getRoleTypes());
+    }
+
+    private boolean isKerberosEnabled(TemplatePreparationObject source) {
+        return source.getKerberosConfig().isPresent();
+    }
+}

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaDelegationTokenConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaDelegationTokenConfigProviderTest.java
@@ -1,0 +1,67 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka;
+
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.dto.KerberosConfig;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+
+@ExtendWith(MockitoExtension.class)
+class KafkaDelegationTokenConfigProviderTest {
+
+    @Mock
+    private CmTemplateProcessor cmTemplateProcessor;
+
+    @InjectMocks
+    private KafkaDelegationTokenConfigProvider underTest;
+
+    @Test
+    void testIsConfigurationNeededWhenNoKafkaBrokerRoleType() {
+        KerberosConfig kerberosConfig = KerberosConfig
+                .KerberosConfigBuilder
+                .aKerberosConfig()
+                .build();
+        TemplatePreparationObject templatePreparationObject = TemplatePreparationObject.Builder
+                .builder()
+                .withKerberosConfig(kerberosConfig)
+                .build();
+        when(cmTemplateProcessor.isRoleTypePresentInService(underTest.getServiceType(), underTest.getRoleTypes())).thenReturn(Boolean.FALSE);
+
+        boolean result = underTest.isConfigurationNeeded(cmTemplateProcessor, templatePreparationObject);
+
+        Assertions.assertFalse(result);
+    }
+
+    @Test
+    void testIsConfigurationNeededWhenKerberosIsNotEnabled() {
+        TemplatePreparationObject templatePreparationObject = TemplatePreparationObject.Builder.builder().build();
+
+        boolean result = underTest.isConfigurationNeeded(null, templatePreparationObject);
+
+        Assertions.assertFalse(result);
+    }
+
+    @Test
+    void testIsConfigurationNeededShouldReturnTrueWhenKafkaBrokerRoleTypeAndKafkaServiceAreAvailableAndKerberosIsEnabled() {
+        KerberosConfig kerberosConfig = KerberosConfig
+                .KerberosConfigBuilder
+                .aKerberosConfig()
+                .build();
+        TemplatePreparationObject templatePreparationObject = TemplatePreparationObject.Builder
+                .builder()
+                .withKerberosConfig(kerberosConfig)
+                .build();
+        when(cmTemplateProcessor.isRoleTypePresentInService(underTest.getServiceType(), underTest.getRoleTypes())).thenReturn(Boolean.TRUE);
+
+        boolean result = underTest.isConfigurationNeeded(cmTemplateProcessor, templatePreparationObject);
+
+        Assertions.assertTrue(result);
+    }
+}


### PR DESCRIPTION
**Changes**:
 - Dynamic configuration of delegation token for Kafka. Some of our tests tries to create clusters with env without freeipa/kerberos, but the mentioned `delegation.token.enable` property with `true` value works only with kerberos enabled clusters.
 - Make the mock/e2e tests runnable on localhost, avoid enhancing the usage of HTTPS on local deployments.