### PR TITLE
CB-3211 Add redbeams db server release function

### DIFF
--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/ResourceStatus.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/ResourceStatus.java
@@ -1,5 +1,9 @@
 package com.sequenceiq.redbeams.api.endpoint.v4;
 
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
 public enum ResourceStatus {
     UNKNOWN,
     /**
@@ -9,5 +13,15 @@ public enum ResourceStatus {
     /**
      * The user is managing / owns the resource.
      */
-    USER_MANAGED
+    USER_MANAGED;
+
+    private static final Set<ResourceStatus> RELEASABLE = Collections.unmodifiableSet(EnumSet.of(SERVICE_MANAGED));
+
+    public static Set<ResourceStatus> getReleasableValues() {
+        return RELEASABLE;
+    }
+
+    public boolean isReleasable() {
+        return RELEASABLE.contains(this);
+    }
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/DatabaseServerV4Endpoint.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/DatabaseServerV4Endpoint.java
@@ -9,6 +9,7 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -80,6 +81,14 @@ public interface DatabaseServerV4Endpoint {
             nickname = "createDatabaseServer")
     DatabaseServerStatusV4Response create(
             @Valid @ApiParam(DatabaseServerParamDescriptions.ALLOCATE_DATABASE_SERVER_REQUEST) AllocateDatabaseServerV4Request request
+    );
+
+    @PUT
+    @Path("{crn}/release")
+    @ApiOperation(value = DatabaseServerOpDescription.RELEASE, notes = DatabaseServerNotes.RELEASE,
+            nickname = "releaseManagedDatabaseServer")
+    DatabaseServerV4Response release(
+            @ValidCrn @NotNull @ApiParam(DatabaseServerParamDescriptions.CRN) @PathParam("crn") String crn
     );
 
     @DELETE

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/Notes.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/Notes.java
@@ -48,8 +48,11 @@ public final class Notes {
             "Gets information on a database server by its CRN.";
         public static final String CREATE =
             "Creates a new database server. The database server starts out with only default databases.";
+        public static final String RELEASE =
+            "Releases management of a service-managed database server. Resource tracking information is discarded, "
+            + " but the server remains registered as user-managed.";
         public static final String TERMINATE =
-            "terminates a database server in a cloud provider and deregisters it";
+            "Terminates a database server in a cloud provider and deregisters it.";
         public static final String REGISTER =
             "Registers an existing database server.";
         public static final String DELETE_BY_CRN =

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/OperationDescriptions.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/OperationDescriptions.java
@@ -22,6 +22,7 @@ public final class OperationDescriptions {
         public static final String GET_BY_NAME = "get a database server by name";
         public static final String GET_BY_CRN = "get a database server by CRN";
         public static final String CREATE = "create and register a database server in a cloud provider";
+        public static final String RELEASE = "release management of a service-managed database server";
         public static final String TERMINATE = "terminate a database server in a cloud provider and deregister it";
         public static final String REGISTER = "register a database server";
         public static final String DELETE_BY_CRN = "deregister a database server by CRN";

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/ResourceStatusTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/ResourceStatusTest.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.redbeams.api.endpoint.v4;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Set;
+
+import org.junit.Test;
+
+public class ResourceStatusTest {
+
+    @Test
+    public void testReleasability() {
+        Set<ResourceStatus> releasableValues = ResourceStatus.getReleasableValues();
+        assertEquals(1, releasableValues.size());
+        assertTrue(releasableValues.contains(ResourceStatus.SERVICE_MANAGED));
+
+        assertTrue(ResourceStatus.SERVICE_MANAGED.isReleasable());
+        assertFalse(ResourceStatus.USER_MANAGED.isReleasable());
+    }
+
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/controller/mapper/ConflictExceptionMapper.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/controller/mapper/ConflictExceptionMapper.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.redbeams.controller.mapper;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.redbeams.exception.ConflictException;
+
+@Component
+public class ConflictExceptionMapper extends BaseExceptionMapper<ConflictException> {
+
+    @Override
+    Status getResponseStatus() {
+        return Status.CONFLICT;
+    }
+
+    @Override
+    Class<ConflictException> getExceptionType() {
+        return ConflictException.class;
+    }
+
+    @Override
+    public Response toResponse(ConflictException exception) {
+        return Response.status(getResponseStatus()).entity(getEntity(exception)).build();
+    }
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4Controller.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4Controller.java
@@ -79,6 +79,12 @@ public class DatabaseServerV4Controller implements DatabaseServerV4Endpoint {
     }
 
     @Override
+    public DatabaseServerV4Response release(String crn) {
+        DatabaseServerConfig server = databaseServerConfigService.release(crn);
+        return converterUtil.convert(server, DatabaseServerV4Response.class);
+    }
+
+    @Override
     public DatabaseServerTerminationOutcomeV4Response terminate(String crn, boolean force) {
         DBStack dbStack = redbeamsTerminationService.terminateDatabaseServer(crn, force);
         return converterUtil.convert(dbStack, DatabaseServerTerminationOutcomeV4Response.class);

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/exception/ConflictException.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/exception/ConflictException.java
@@ -1,0 +1,12 @@
+package com.sequenceiq.redbeams.exception;
+
+public class ConflictException extends RuntimeException {
+
+    public ConflictException(String message) {
+        super(message);
+    }
+
+    public ConflictException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4ControllerTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4ControllerTest.java
@@ -176,6 +176,16 @@ public class DatabaseServerV4ControllerTest {
     }
 
     @Test
+    public void testRelease() {
+        when(service.release(SERVER_CRN)).thenReturn(server);
+        when(converterUtil.convert(server, DatabaseServerV4Response.class)).thenReturn(response);
+
+        DatabaseServerV4Response response = underTest.release(SERVER_CRN);
+
+        assertEquals(1L, response.getId().longValue());
+    }
+
+    @Test
     public void testTerminate() {
         when(terminationService.terminateDatabaseServer(server.getResourceCrn().toString(), true)).thenReturn(dbStack);
         when(converterUtil.convert(dbStack, DatabaseServerTerminationOutcomeV4Response.class))


### PR DESCRIPTION
It is now possible to have redbeams "release" a service-managed database
server, i.e., a server that it initially created. When a server is
released, then the following things happen:

* the database stack associated with the server is deleted
* the server's resource status is changed from SERIVCE_MANAGED to
  USER_MANAGED

Only service-managed servers may be released; an attempt on an already
user-managed server results in a 409 error.