### PR TITLE
CB-3230 Fix deleting vault kv version 2 secrets

### DIFF
--- a/secret-engine/src/main/java/com/sequenceiq/cloudbreak/service/secret/vault/VaultKvV2Engine.java
+++ b/secret-engine/src/main/java/com/sequenceiq/cloudbreak/service/secret/vault/VaultKvV2Engine.java
@@ -61,7 +61,7 @@ public class VaultKvV2Engine extends AbstractVaultEngine<VaultKvV2Engine> {
     @Override
     @CacheEvict(cacheNames = "vaultCache", allEntries = true)
     public void delete(String secret) {
-        Optional.ofNullable(convertToVaultSecret(secret)).ifPresent(s -> template.opsForVersionedKeyValue(s.getEnginePath()).delete(s.getPath()));
+        Optional.ofNullable(convertToVaultSecret(secret)).ifPresent(s -> deleteAllVersionsOfSecret(s.getEnginePath(), s.getPath()));
     }
 
     @Override
@@ -83,6 +83,13 @@ public class VaultKvV2Engine extends AbstractVaultEngine<VaultKvV2Engine> {
     @Override
     @CacheEvict(cacheNames = "vaultCache", allEntries = true)
     public void cleanup(String path) {
-        template.opsForVersionedKeyValue(enginePath).delete(appPath + path);
+        deleteAllVersionsOfSecret(enginePath, appPath + path);
+    }
+
+    private void deleteAllVersionsOfSecret(String engingPath, String path) {
+        template.doWithSession(restOperations -> {
+            restOperations.delete("/" + enginePath + "/metadata/" + path);
+            return null;
+        });
     }
 }


### PR DESCRIPTION
Deleting the vault kv version 2 secrets was fixed so that the key and
all values are fully deleted. Version 2 allows the secrets to be
versioned and keys can be undeleted. Version 2 also supports a
destroy which cleans up the data for a specific version so undelete
is not possible for that version. But if all versions are destroyed,
the key still remains stored without any versions of the value. The
key and all versions can be fully destroyed by deleting the metadata
for the secret. The delete operation was updated to delete the
metadata.

This was tested manually on a local build of cloudbreak. The vault
UI was checked to ensure the secret was actually deleted.

Closes #CB-3230
