### PR TITLE
CB-2971 Increase DB max_connections from 100 to 500

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -233,7 +233,6 @@ dependencies {
   compile project(':usage-collection')
 
   runtime project(':orchestrator-salt')
-  runtime project(':orchestrator-salt')
   runtime project(':orchestrator-yarn')
   runtime project(':cloud-reactor')
   runtime project(':cloud-openstack')

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/conf_pgsql_max_connections.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/conf_pgsql_max_connections.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+CONFIG_FILE=$(psql -c "show config_file;" -t | xargs)
+echo "Config file: $CONFIG_FILE"
+
+set -e
+if grep -qR "^max_connections =" $CONFIG_FILE; then
+    echo "Updating max_connections config in the postgresql.conf"
+    sed -i.orig "/^max_connections =/c\max_connections = 500" $CONFIG_FILE
+else
+    echo "Adding max_connections config to the postgresql.conf"
+    echo "max_connections = 500" >> $CONFIG_FILE
+fi
+set +e


### PR DESCRIPTION
Configure embedded postgres via Salt to allow 500 connections.
@akanto please review.