### PR TITLE
Fix metering settings with lowercase service type

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/metering/MeteringConfigService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/metering/MeteringConfigService.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.telemetry.metering;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -11,7 +12,7 @@ public class MeteringConfigService {
         if (enabled) {
             builder.withPlatform(platform)
                     .withClusterCrn(clusterCrn)
-                    .withServiceType(serviceType)
+                    .withServiceType(StringUtils.upperCase(serviceType))
                     .withServiceVersion(serviceVersion);
         }
         return builder

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/metering/MeteringConfigServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/metering/MeteringConfigServiceTest.java
@@ -28,6 +28,17 @@ public class MeteringConfigServiceTest {
     }
 
     @Test
+    public void testCreateMeteringConfigsWithLowercaseServiceType() {
+        // GIVEN
+        // WHEN
+        MeteringConfigView result = underTest.createMeteringConfigs(true, "AWS", "myCrn",
+                "datahub", "1.0.0");
+        // THEN
+        assertTrue(result.isEnabled());
+        assertEquals("DATAHUB", result.getServiceType());
+    }
+
+    @Test
     public void testCreateMeteringConfigsIfDisabled() {
         // GIVEN
         // WHEN


### PR DESCRIPTION
seems like during a refactor, making uppercase value from metering service type  (that is used as a value in salt config) was removed at some point, adding uppercase stuff to metering config generator level

without uppercase DATAHUB value, metering application fails on it cannot use datahub as an enum on python level