### PR TITLE
CB-3298. Query machine user for crn only if user already exist during user creation.

### DIFF
--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerDatabusServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerDatabusServiceTest.java
@@ -5,6 +5,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -50,7 +52,7 @@ public class ClouderaManagerDatabusServiceTest {
                 .setMachineUserName("machineUser")
                 .setCrn(USER_CRN)
                 .build();
-        when(umsClient.createMachineUser(any(), any(), any())).thenReturn(machineUser);
+        when(umsClient.createMachineUser(any(), any(), any())).thenReturn(Optional.of(machineUser.getCrn()));
         doNothing().when(umsClient).assignMachineUserRole(any(), any(), any(), any());
         when(umsClient.createMachineUserAndGenerateKeys(any(), any(), any())).thenReturn(credential);
         // WHEN


### PR DESCRIPTION
query against machine user only if it exists or the response does not contain the machine user crn. if user already exists that means that is in the UMS index so we can safely send a get query. therefore we can avoid eventual consistency issues for machine user creation

edit: validated