### PR TITLE
CB-3306. Add HDFS user to Yarn admin ACL

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering.bp
@@ -47,7 +47,7 @@
         "serviceConfigs": [
           {
             "name": "yarn_admin_acl",
-            "value": "yarn,hive"
+            "value": "yarn,hive,hdfs"
           }
         ],
         "roleConfigGroups": [


### PR DESCRIPTION
The Telemetry Publisher component in Cloudera Manager runs as the HDFS user in this context and needs to have permission to view all jobs in order to collect the YARN logs from S3 when cloud storage is enabled.