### PR TITLE
CB-3375: Added DataCatalog Profiler Services to expose services in Knox

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/ExposedService.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/ExposedService.java
@@ -38,8 +38,9 @@ public enum ExposedService {
     IMPALA("Impala", "IMPALAD", "IMPALA", "/impala/", true, 28000, 28000, true, true),
     NAMENODE_HDFS("NameNode HDFS", "NAMENODE", "NAMENODE", "/", true, 8020, 8020, true, true),
     JOBTRACKER("Job Tracker", "RESOURCEMANAGER", "JOBTRACKER", "/", true, 8032, 8032, true, true),
-    PROFILER_ADMIN("Profiler Admin", "PROFILER_ADMIN_AGENT", "PROFILER_ADMIN", "/profiler-admin/", false, 21700, 21700, true, true),
-    PROFILER_METRICS("Profiler Metrics", "PROFILER_METRICS_AGENT", "PROFILER_METRICS", "/profiler-metrics/", false, 21800, 21800, true, true);
+    PROFILER_ADMIN("Profiler Admin", "PROFILER_ADMIN_AGENT", "PROFILER-ADMIN-API", "/profiler-admin/", false, 21700, 21700, true, true),
+    PROFILER_METRICS("Profiler Metrics", "PROFILER_METRICS_AGENT", "PROFILER-METRICS-API", "/profiler-metrics/", false, 21800, 21800, true, true),
+    PROFILER_SCHEDULER("Profiler Scheduler", "PROFILER_SCHEDULER_AGENT", "PROFILER-SCHEDULER-API", "/profiler-scheduler/", false, 21900, 21900, true, true);
 
     private final String displayName;
     private final String serviceName;

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/ExposedService.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/ExposedService.java
@@ -37,7 +37,9 @@ public enum ExposedService {
     NIFI_REGISTRY("Nifi Registry", "NIFI_REGISTRY_SERVER", "NIFI-REGISTRY", "/nifi-registry-app/nifi-registry/", true, 18080, 18433, false, false),
     IMPALA("Impala", "IMPALAD", "IMPALA", "/impala/", true, 28000, 28000, true, true),
     NAMENODE_HDFS("NameNode HDFS", "NAMENODE", "NAMENODE", "/", true, 8020, 8020, true, true),
-    JOBTRACKER("Job Tracker", "RESOURCEMANAGER", "JOBTRACKER", "/", true, 8032, 8032, true, true);
+    JOBTRACKER("Job Tracker", "RESOURCEMANAGER", "JOBTRACKER", "/", true, 8032, 8032, true, true),
+    PROFILER_ADMIN("Profiler Admin", "PROFILER_ADMIN_AGENT", "PROFILER_ADMIN", "/profiler-admin/", false, 21700, 21700, true, true),
+    PROFILER_METRICS("Profiler Metrics", "PROFILER_METRICS_AGENT", "PROFILER_METRICS", "/profiler-metrics/", false, 21800, 21800, true, true);
 
     private final String displayName;
     private final String serviceName;

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -173,6 +173,18 @@
                  <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000;maxRetryAttempts=300;retrySleep=1000</value>
              </param>
              {%- endif %}
+             {% if 'PROFILER_ADMIN' in exposed and 'PROFILER_ADMIN_AGENT' in salt['pillar.get']('gateway:location') -%}
+             <param>
+                 <name>PROFILER_ADMIN</name>
+                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000;maxRetryAttempts=300;retrySleep=1000</value>
+             </param>
+             {%- endif %}
+             {% if 'PROFILER_METRICS' in exposed and 'PROFILER_METRICS_AGENT' in salt['pillar.get']('gateway:location') -%}
+             <param>
+                 <name>PROFILER_METRICS</name>
+                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000;maxRetryAttempts=300;retrySleep=1000</value>
+             </param>
+             {%- endif %}
          </provider>
 
     </gateway>
@@ -415,6 +427,28 @@
         <role>NIFI</role>
         {% for hostloc in salt['pillar.get']('gateway:location')['NIFI_NODE'] -%}
         <url>{{ protocol }}://{{ hostloc }}:{{ ports['NIFI'] }}</url>
+        {%- endfor %}
+    </service>
+    {%- endif %}
+    {%- endif %}
+
+    {% if 'PROFILER_ADMIN_AGENT' in salt['pillar.get']('gateway:location') -%}
+    {% if 'PROFILER_ADMIN' in exposed -%}
+    <service>
+        <role>PROFILER_ADMIN</role>
+        {% for hostloc in salt['pillar.get']('gateway:location')['PROFILER_ADMIN_AGENT'] -%}
+        <url>{{ protocol }}://{{ hostloc }}:{{ ports['PROFILER_ADMIN'] }}</url>
+        {%- endfor %}
+    </service>
+    {%- endif %}
+    {%- endif %}
+
+    {% if 'PROFILER_METRICS_AGENT' in salt['pillar.get']('gateway:location') -%}
+    {% if 'PROFILER_METRICS' in exposed -%}
+    <service>
+        <role>PROFILER_METRICS</role>
+        {% for hostloc in salt['pillar.get']('gateway:location')['PROFILER_METRICS_AGENT'] -%}
+        <url>{{ protocol }}://{{ hostloc }}:{{ ports['PROFILER_METRICS'] }}</url>
         {%- endfor %}
     </service>
     {%- endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -173,15 +173,21 @@
                  <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000;maxRetryAttempts=300;retrySleep=1000</value>
              </param>
              {%- endif %}
-             {% if 'PROFILER_ADMIN' in exposed and 'PROFILER_ADMIN_AGENT' in salt['pillar.get']('gateway:location') -%}
+             {% if 'PROFILER-ADMIN-API' in exposed and 'PROFILER_ADMIN_AGENT' in salt['pillar.get']('gateway:location') -%}
              <param>
-                 <name>PROFILER_ADMIN</name>
+                 <name>PROFILER-ADMIN-API</name>
                  <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000;maxRetryAttempts=300;retrySleep=1000</value>
              </param>
              {%- endif %}
-             {% if 'PROFILER_METRICS' in exposed and 'PROFILER_METRICS_AGENT' in salt['pillar.get']('gateway:location') -%}
+             {% if 'PROFILER-METRICS-API' in exposed and 'PROFILER_METRICS_AGENT' in salt['pillar.get']('gateway:location') -%}
              <param>
-                 <name>PROFILER_METRICS</name>
+                 <name>PROFILER-METRICS-API</name>
+                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000;maxRetryAttempts=300;retrySleep=1000</value>
+             </param>
+             {%- endif %}
+             {% if 'PROFILER-SCHEDULER-API' in exposed and 'PROFILER_SCHEDULER_AGENT' in salt['pillar.get']('gateway:location') -%}
+             <param>
+                 <name>PROFILER-SCHEDULER-API</name>
                  <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000;maxRetryAttempts=300;retrySleep=1000</value>
              </param>
              {%- endif %}
@@ -433,22 +439,33 @@
     {%- endif %}
 
     {% if 'PROFILER_ADMIN_AGENT' in salt['pillar.get']('gateway:location') -%}
-    {% if 'PROFILER_ADMIN' in exposed -%}
+    {% if 'PROFILER-ADMIN-API' in exposed -%}
     <service>
-        <role>PROFILER_ADMIN</role>
+        <role>PROFILER-ADMIN-API</role>
         {% for hostloc in salt['pillar.get']('gateway:location')['PROFILER_ADMIN_AGENT'] -%}
-        <url>{{ protocol }}://{{ hostloc }}:{{ ports['PROFILER_ADMIN'] }}</url>
+        <url>{{ protocol }}://{{ hostloc }}:{{ ports['PROFILER-ADMIN-API'] }}</url>
         {%- endfor %}
     </service>
     {%- endif %}
     {%- endif %}
 
     {% if 'PROFILER_METRICS_AGENT' in salt['pillar.get']('gateway:location') -%}
-    {% if 'PROFILER_METRICS' in exposed -%}
+    {% if 'PROFILER-METRICS-API' in exposed -%}
     <service>
-        <role>PROFILER_METRICS</role>
+        <role>PROFILER-METRICS-API</role>
         {% for hostloc in salt['pillar.get']('gateway:location')['PROFILER_METRICS_AGENT'] -%}
-        <url>{{ protocol }}://{{ hostloc }}:{{ ports['PROFILER_METRICS'] }}</url>
+        <url>{{ protocol }}://{{ hostloc }}:{{ ports['PROFILER-METRICS-API'] }}</url>
+        {%- endfor %}
+    </service>
+    {%- endif %}
+    {%- endif %}
+
+    {% if 'PROFILER_SCHEDULER_AGENT' in salt['pillar.get']('gateway:location') -%}
+    {% if 'PROFILER-SCHEDULER-API' in exposed -%}
+    <service>
+        <role>PROFILER-SCHEDULER-API</role>
+        {% for hostloc in salt['pillar.get']('gateway:location')['PROFILER_SCHEDULER_AGENT'] -%}
+        <url>{{ protocol }}://{{ hostloc }}:{{ ports['PROFILER-SCHEDULER-API'] }}</url>
         {%- endfor %}
     </service>
     {%- endif %}


### PR DESCRIPTION
Profiler admin and Profiler Metrics services need to expose API in Knox.

E.g
> https://10.97.81.21:8443/sumishra-env3/cdp-proxy/profiler-metrics/asset/metrics/repo?eventType=audit
>https://10.97.81.21:8443/sumishra-env3/cdp-proxy/profiler-admin/profilers/

SSO is not supported. No UI for these services. Currently, API is supported. Above API's would be used by DSS-APP

I could test this by launching an SDX cluster from local cloudbreak code and checked the file 
"/var/lib/knox/gateway/conf/topologies/cdp-proxy.xml" which contained the PROFILER_ADMIN and    PROFILER_METRICS service entries. 