### PR TITLE
CB-3314 Allow null AZ in EnvironmentBaseNetworkConverter

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/EnvironmentBaseNetworkConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/EnvironmentBaseNetworkConverter.java
@@ -30,7 +30,7 @@ public abstract class EnvironmentBaseNetworkConverter implements EnvironmentNetw
         result.setSubnetCIDR(null);
         Map<String, Object> attributes = new HashMap<>();
         Optional<CloudSubnet> cloudSubnet = source.getSubnetMetas().values().stream()
-                .filter(s -> s.getAvailabilityZone().equals(availabilityZone))
+                .filter(s -> s.getAvailabilityZone() == null ? availabilityZone == null : s.getAvailabilityZone().equals(availabilityZone))
                 .findFirst();
         if (!cloudSubnet.isPresent()) {
             throw new BadRequestException("No subnet for the given availability zone: " + availabilityZone);


### PR DESCRIPTION
The convertToLegacyNetwork method in EnvironmentBaseNetworkConverter
filters subnets in a network response based on their availability
zones. However, Azure subnets have no availability zones. Therefore,
this method now checks for that condition, and allows matching those
subnets against a null AZ passed to the method, which occurs during
validation in Azure stack creation.