### PR TITLE
CDPSDX-519 Add keytab retrieval for host principals to support CML

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/KerberosMgmtV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/KerberosMgmtV1Endpoint.java
@@ -13,9 +13,11 @@ import javax.ws.rs.core.MediaType;
 
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.doc.KeytabModelNotes;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.doc.KeytabOperationsDescription;
+import com.sequenceiq.freeipa.api.v1.kerberosmgmt.model.HostKeytabRequest;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.model.ServiceKeytabRequest;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.model.VaultCleanupRequest;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.model.HostRequest;
+import com.sequenceiq.freeipa.api.v1.kerberosmgmt.model.HostKeytabResponse;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.model.ServiceKeytabResponse;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.model.ServicePrincipalRequest;
 import com.sequenceiq.service.api.doc.ContentType;
@@ -32,16 +34,31 @@ public interface KerberosMgmtV1Endpoint {
     @Path("servicekeytab")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = KeytabOperationsDescription.DESCRIBE_GENERATE_SERVICE_KEYTAB, produces = ContentType.JSON,
-            notes = KeytabModelNotes.GENERATE_KEYTAB_NOTES,
+            notes = KeytabModelNotes.GENERATE_SERVICE_KEYTAB_NOTES,
             nickname = "generateServiceKeytabV1")
     ServiceKeytabResponse generateServiceKeytab(@Valid ServiceKeytabRequest request) throws Exception;
 
     @GET
     @Path("servicekeytab")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = KeytabOperationsDescription.DESCRIBE_SERVICE_KEYTAB, produces = ContentType.JSON, notes = KeytabModelNotes.GET_KEYTAB_NOTES,
+    @ApiOperation(value = KeytabOperationsDescription.DESCRIBE_SERVICE_KEYTAB, produces = ContentType.JSON, notes = KeytabModelNotes.GET_SERVICE_KEYTAB_NOTES,
             nickname = "getServiceKeytabV1")
     ServiceKeytabResponse getServiceKeytab(@Valid ServiceKeytabRequest request) throws Exception;
+
+    @POST
+    @Path("hostkeytab")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = KeytabOperationsDescription.DESCRIBE_GENERATE_HOST_KEYTAB, produces = ContentType.JSON,
+            notes = KeytabModelNotes.GENERATE_HOST_KEYTAB_NOTES,
+            nickname = "generateHostKeytabV1")
+    HostKeytabResponse generateHostKeytab(@Valid HostKeytabRequest request) throws Exception;
+
+    @GET
+    @Path("hostkeytab")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = KeytabOperationsDescription.DESCRIBE_HOST_KEYTAB, produces = ContentType.JSON, notes = KeytabModelNotes.GET_HOST_KEYTAB_NOTES,
+            nickname = "getHostKeytabV1")
+    HostKeytabResponse getHostKeytab(@Valid HostKeytabRequest request) throws Exception;
 
     @DELETE
     @Path("serviceprincipal")

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/doc/KeytabModelDescription.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/doc/KeytabModelDescription.java
@@ -4,7 +4,7 @@ public class KeytabModelDescription {
     public static final String SERVICE_NAME = "Service requesting keytab";
     public static final String SERVICE_HOST = "Hostname where the service is running";
     public static final String ID = "Unique Request Id";
-    public static final String PRINCIPAL = "Kerberos Service Principal Name";
+    public static final String PRINCIPAL = "Kerberos Principal Name";
     public static final String KEYTAB = "Keytab that was requested";
     public static final String DO_NOT_RECREATE_KEYTAB = "If true existing keytab won't be overriden for service in normal scenario. "
             + "Preserving the keytab is best effort, it may invalidate prior keytabs.";

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/doc/KeytabModelNotes.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/doc/KeytabModelNotes.java
@@ -1,12 +1,17 @@
 package com.sequenceiq.freeipa.api.v1.kerberosmgmt.doc;
 
 public class KeytabModelNotes {
-    public static final String GENERATE_KEYTAB_NOTES = "Creates the host if it doesn't exist and also creates the service principal for the given "
+    public static final String GENERATE_SERVICE_KEYTAB_NOTES = "Creates the host if it doesn't exist and also creates the service principal for the given "
             + "service before generating keytab for the principal. Resets the secret for the Kerberos principal redering all other keytabs for that principal"
             + " invalid. Calling the API multiple times for the same principal renders the keytab already generated for that principal invalid. The keytab in "
             + "the response is base64 encoded.";
-    public static final String GET_KEYTAB_NOTES = "Retrieves the existing keytab for the service principal derived from the host and service provided. "
+    public static final String GET_SERVICE_KEYTAB_NOTES = "Retrieves the existing keytab for the service principal derived from the host and service provided. "
             + "Gets the existing keytab without modification and not effecting the prior keytab. The keytab in the response is base64 encoded.";
+    public static final String GENERATE_HOST_KEYTAB_NOTES = "Creates the host if it doesn't exist and also generates keytab for the host. Resets the secret "
+            + "for the Kerberos principal redering all other keytabs for that principal invalid. Calling the API multiple times for the same principal renders "
+            + "the keytab already generated for that principal invalid. The keytab in the response is base64 encoded.";
+    public static final String GET_HOST_KEYTAB_NOTES = "Retrieves the existing keytab for the host provided. Gets the existing keytab without modification "
+            + "and not effecting the prior keytab. The keytab in the response is base64 encoded.";
     public static final String DELETE_SERVICE_PRINCIPAL_NOTES = "Deletes the principal from the FreeIPA. It also deletes vault secrets associated with the "
             + "principal";
     public static final String DELETE_HOST_NOTES = "Deletes the host and all the principals associated with the host in the FreeIPA. It also deletes vault "

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/doc/KeytabOperationsDescription.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/doc/KeytabOperationsDescription.java
@@ -4,6 +4,8 @@ public class KeytabOperationsDescription {
     public static final String DESCRIBE_GENERATE_SERVICE_KEYTAB = "Create the host and the service principal and then get the keytab for the provided "
             + "service on a specific host";
     public static final String DESCRIBE_SERVICE_KEYTAB = "Get the keytab for the provided service on a specific host";
+    public static final String DESCRIBE_GENERATE_HOST_KEYTAB = "Create the host and then get the keytab for the provided host";
+    public static final String DESCRIBE_HOST_KEYTAB = "Get the keytab for the provided host";
     public static final String DESCRIBE_DELETE_SERVICE_PRINCIPAL = "Delete the service principal";
     public static final String DESCRIBE_DELETE_HOST = "Delete the host";
     public static final String DESCRIBE_CLUSTER_CLEANUP = "Cleanup the secrets associated with the cluster";

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/model/HostKeytabRequest.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/model/HostKeytabRequest.java
@@ -1,0 +1,82 @@
+package com.sequenceiq.freeipa.api.v1.kerberosmgmt.model;
+
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.sequenceiq.freeipa.api.v1.kerberosmgmt.doc.KeytabModelDescription;
+import com.sequenceiq.service.api.doc.ModelDescriptions;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel("HostKeytabV1Request")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class HostKeytabRequest {
+
+    @ApiModelProperty(value = ModelDescriptions.ENVIRONMENT_CRN, required = true)
+    @NotNull
+    private String environmentCrn;
+
+    @NotNull
+    private String serverHostName;
+
+    @ApiModelProperty(value = ModelDescriptions.CLUSTER_CRN)
+    private String clusterCrn;
+
+    @ApiModelProperty(value = KeytabModelDescription.DO_NOT_RECREATE_KEYTAB)
+    private Boolean doNotRecreateKeytab = Boolean.FALSE;
+
+    @ApiModelProperty(value = KeytabModelDescription.ROLE)
+    private RoleRequest roleRequest;
+
+    public String getEnvironmentCrn() {
+        return environmentCrn;
+    }
+
+    public void setEnvironmentCrn(String environmentCrn) {
+        this.environmentCrn = environmentCrn;
+    }
+
+    public String getServerHostName() {
+        return serverHostName;
+    }
+
+    public void setServerHostName(String serverHostName) {
+        this.serverHostName = serverHostName;
+    }
+
+    public Boolean getDoNotRecreateKeytab() {
+        return doNotRecreateKeytab;
+    }
+
+    public void setDoNotRecreateKeytab(Boolean doNotRecreateKeytab) {
+        this.doNotRecreateKeytab = doNotRecreateKeytab;
+    }
+
+    public RoleRequest getRoleRequest() {
+        return roleRequest;
+    }
+
+    public void setRoleRequest(RoleRequest roleRequest) {
+        this.roleRequest = roleRequest;
+    }
+
+    public String getClusterCrn() {
+        return clusterCrn;
+    }
+
+    public void setClusterCrn(String clusterCrn) {
+        this.clusterCrn = clusterCrn;
+    }
+
+    @Override
+    public String toString() {
+        return "HostKeytabRequest{"
+                + "environmentCrn='" + environmentCrn + '\''
+                + ", serverHostName='" + serverHostName + '\''
+                + ", clusterCrn='" + clusterCrn + '\''
+                + ", doNotRecreateKeytab=" + doNotRecreateKeytab
+                + ", roleRequest=" + roleRequest
+                + '}';
+    }
+}

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/model/HostKeytabResponse.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/model/HostKeytabResponse.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.freeipa.api.v1.kerberosmgmt.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.sequenceiq.freeipa.api.v1.kerberosmgmt.doc.KeytabModelDescription;
+import com.sequenceiq.cloudbreak.service.secret.model.SecretResponse;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel("HostKeytabV1Response")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class HostKeytabResponse {
+
+    @ApiModelProperty (KeytabModelDescription.PRINCIPAL)
+    private SecretResponse hostPrincipal;
+
+    @ApiModelProperty (KeytabModelDescription.KEYTAB)
+    private SecretResponse keytab;
+
+    public SecretResponse getHostPrincipal() {
+        return hostPrincipal;
+    }
+
+    public void setHostPrincipal(SecretResponse hostPrincipal) {
+        this.hostPrincipal = hostPrincipal;
+    }
+
+    public SecretResponse getKeytab() {
+        return keytab;
+    }
+
+    public void setKeytab(SecretResponse keytab) {
+        this.keytab = keytab;
+    }
+}

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
@@ -423,6 +423,12 @@ public class FreeIpaClient {
         invoke("service_allow_retrieve_keytab", flags, params, Service.class);
     }
 
+    public void allowHostKeytabRetrieval(String fqdn, String user) throws FreeIpaClientException {
+        List<String> flags = List.of(fqdn);
+        Map<String, Object> params = Map.of("user", user);
+        invoke("host_allow_retrieve_keytab", flags, params, Host.class);
+    }
+
     public Keytab getExistingKeytab(String canonicalPrincipal) throws FreeIpaClientException {
         List<String> flags = List.of(canonicalPrincipal);
         Map<String, Object> params = Map.of("retrieve", true);
@@ -433,6 +439,12 @@ public class FreeIpaClient {
         List<String> flags = List.of(canonicalPrincipal);
         Map<String, Object> params = Map.of();
         return (Keytab) invoke("get_keytab", flags, params, Keytab.class).getResult();
+    }
+
+    public Host showHost(String fqdn) throws FreeIpaClientException {
+        List<String> flags = List.of(fqdn);
+        Map<String, Object> params = Map.of();
+        return (Host) invoke("host_show", flags, params, Host.class).getResult();
     }
 
     public <T> RPCResponse<T> invoke(String method, List<String> flags, Map<String, Object> params, Type resultType) throws FreeIpaClientException {

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/model/Host.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/model/Host.java
@@ -1,8 +1,10 @@
 package com.sequenceiq.freeipa.client.model;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.sequenceiq.freeipa.client.deserializer.ListFlatteningDeserializer;
 
@@ -21,6 +23,12 @@ public class Host {
 
     @JsonDeserialize(using = ListFlatteningDeserializer.class)
     private String krbcanonicalname;
+
+    @JsonProperty("has_keytab")
+    private Boolean hasKeytab = Boolean.FALSE;
+
+    @JsonProperty("memberof_role")
+    private List<String> memberOfRole = new ArrayList<>();
 
     public String getDn() {
         return dn;
@@ -58,7 +66,19 @@ public class Host {
         return krbcanonicalname;
     }
 
-    public void setKrbcanonicalname(String krbcanonicalname) {
-        this.krbcanonicalname = krbcanonicalname;
+    public void setHasKeytab(Boolean hasKeytab) {
+        this.hasKeytab = hasKeytab;
+    }
+
+    public Boolean getHasKeytab() {
+        return hasKeytab;
+    }
+
+    public List<String> getMemberOfRole() {
+        return memberOfRole;
+    }
+
+    public void setMemberOfRole(List<String> memberOfRole) {
+        this.memberOfRole = memberOfRole;
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/KerberosMgmtV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/KerberosMgmtV1Controller.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Controller;
 
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.KerberosMgmtV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.model.VaultCleanupRequest;
+import com.sequenceiq.freeipa.api.v1.kerberosmgmt.model.HostKeytabRequest;
+import com.sequenceiq.freeipa.api.v1.kerberosmgmt.model.HostKeytabResponse;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.model.HostRequest;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.model.ServiceKeytabRequest;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.model.ServiceKeytabResponse;
@@ -33,6 +35,16 @@ public class KerberosMgmtV1Controller implements KerberosMgmtV1Endpoint {
     public ServiceKeytabResponse getServiceKeytab(@Valid ServiceKeytabRequest request) throws FreeIpaClientException {
         String accountId = crnService.getCurrentAccountId();
         return kerberosMgmtV1Service.getExistingServiceKeytab(request, accountId);
+    }
+
+    public HostKeytabResponse generateHostKeytab(@Valid HostKeytabRequest request) throws FreeIpaClientException {
+        String accountId = crnService.getCurrentAccountId();
+        return kerberosMgmtV1Service.generateHostKeytab(request, accountId);
+    }
+
+    public HostKeytabResponse getHostKeytab(@Valid HostKeytabRequest request) throws FreeIpaClientException {
+        String accountId = crnService.getCurrentAccountId();
+        return kerberosMgmtV1Service.getExistingHostKeytab(request, accountId);
     }
 
     public void deleteServicePrincipal(@Valid ServicePrincipalRequest request) throws FreeIpaClientException, DeleteException {

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/kerberosmgmt/VaultPathBuilderV1Test.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/kerberosmgmt/VaultPathBuilderV1Test.java
@@ -22,6 +22,7 @@ public class VaultPathBuilderV1Test {
     public void testVaultServicePrincipalPath() throws Exception {
         Assertions.assertEquals("accountId/ServiceKeytab/keytab/12345-6789/54321-9876/host1/service1",
                 new VaultPathBuilder()
+                        .withSecretType(VaultPathBuilder.SecretType.SERVICE_KEYTAB)
                         .withAccountId(ACCOUNT_ID)
                         .withSubType(SUBTYPE)
                         .withEnvironmentCrn(ENVIRONMENT_ID)
@@ -36,6 +37,7 @@ public class VaultPathBuilderV1Test {
         Assertions.assertEquals("accountId/ServiceKeytab/keytab/12345-6789/accountId-12345-6789/host1/service1",
                 new VaultPathBuilder()
                         .enableGeneratingClusterIdIfNotPresent()
+                        .withSecretType(VaultPathBuilder.SecretType.SERVICE_KEYTAB)
                         .withAccountId(ACCOUNT_ID)
                         .withSubType(SUBTYPE)
                         .withEnvironmentCrn(ENVIRONMENT_ID)
@@ -45,9 +47,36 @@ public class VaultPathBuilderV1Test {
     }
 
     @Test
+    public void testVaultHostPrincipalPath() throws Exception {
+        Assertions.assertEquals("accountId/HostKeytab/keytab/12345-6789/54321-9876/host1",
+                new VaultPathBuilder()
+                        .withSecretType(VaultPathBuilder.SecretType.HOST_KEYTAB)
+                        .withAccountId(ACCOUNT_ID)
+                        .withSubType(SUBTYPE)
+                        .withEnvironmentCrn(ENVIRONMENT_ID)
+                        .withClusterCrn(CLUSTER_ID)
+                        .withServerHostName(HOST)
+                        .build());
+    }
+
+    @Test
+    public void testVaultHostPrincipalPathGenerateClusterId() throws Exception {
+        Assertions.assertEquals("accountId/HostKeytab/keytab/12345-6789/accountId-12345-6789/host1",
+                new VaultPathBuilder()
+                        .enableGeneratingClusterIdIfNotPresent()
+                        .withSecretType(VaultPathBuilder.SecretType.HOST_KEYTAB)
+                        .withAccountId(ACCOUNT_ID)
+                        .withSubType(SUBTYPE)
+                        .withEnvironmentCrn(ENVIRONMENT_ID)
+                        .withServerHostName(HOST)
+                        .build());
+    }
+
+    @Test
     public void testVaultHostPath() throws Exception {
         Assertions.assertEquals("accountId/ServiceKeytab/keytab/12345-6789/54321-9876/host1/",
                 new VaultPathBuilder()
+                        .withSecretType(VaultPathBuilder.SecretType.SERVICE_KEYTAB)
                         .withAccountId(ACCOUNT_ID)
                         .withSubType(SUBTYPE)
                         .withEnvironmentCrn(ENVIRONMENT_ID)
@@ -61,6 +90,7 @@ public class VaultPathBuilderV1Test {
         Assertions.assertEquals("accountId/ServiceKeytab/keytab/12345-6789/accountId-12345-6789/host1/",
                 new VaultPathBuilder()
                         .enableGeneratingClusterIdIfNotPresent()
+                        .withSecretType(VaultPathBuilder.SecretType.SERVICE_KEYTAB)
                         .withAccountId(ACCOUNT_ID)
                         .withSubType(SUBTYPE)
                         .withEnvironmentCrn(ENVIRONMENT_ID)
@@ -72,6 +102,7 @@ public class VaultPathBuilderV1Test {
     public void testVaultClusterCrnPath() throws Exception {
         Assertions.assertEquals("accountId/ServiceKeytab/keytab/12345-6789/54321-9876/",
                 new VaultPathBuilder()
+                        .withSecretType(VaultPathBuilder.SecretType.SERVICE_KEYTAB)
                         .withAccountId(ACCOUNT_ID)
                         .withSubType(SUBTYPE)
                         .withEnvironmentCrn(ENVIRONMENT_ID)
@@ -84,6 +115,7 @@ public class VaultPathBuilderV1Test {
         Assertions.assertEquals("accountId/ServiceKeytab/keytab/12345-6789/accountId-12345-6789/",
                 new VaultPathBuilder()
                         .enableGeneratingClusterIdIfNotPresent()
+                        .withSecretType(VaultPathBuilder.SecretType.SERVICE_KEYTAB)
                         .withAccountId(ACCOUNT_ID)
                         .withSubType(SUBTYPE)
                         .withEnvironmentCrn(ENVIRONMENT_ID)
@@ -94,6 +126,7 @@ public class VaultPathBuilderV1Test {
     public void testVaultEnvironmentCrnPath() throws Exception {
         Assertions.assertEquals("accountId/ServiceKeytab/keytab/12345-6789/",
                 new VaultPathBuilder()
+                        .withSecretType(VaultPathBuilder.SecretType.SERVICE_KEYTAB)
                         .withAccountId(ACCOUNT_ID)
                         .withSubType(SUBTYPE)
                         .withEnvironmentCrn(ENVIRONMENT_ID)
@@ -105,6 +138,7 @@ public class VaultPathBuilderV1Test {
         Assertions.assertEquals("accountId/ServiceKeytab/keytab/12345-6789/accountId-12345-6789/",
                 new VaultPathBuilder()
                         .enableGeneratingClusterIdIfNotPresent()
+                        .withSecretType(VaultPathBuilder.SecretType.SERVICE_KEYTAB)
                         .withAccountId(ACCOUNT_ID)
                         .withSubType(SUBTYPE)
                         .withEnvironmentCrn(ENVIRONMENT_ID)
@@ -116,16 +150,25 @@ public class VaultPathBuilderV1Test {
     public void testMissingRequiredConfiguration() throws Exception {
         Assertions.assertThrows(IllegalStateException.class,
                 () -> new VaultPathBuilder()
+                        .withAccountId(ACCOUNT_ID)
                         .withSubType(SUBTYPE)
                         .withEnvironmentCrn(ENVIRONMENT_ID)
                         .build());
         Assertions.assertThrows(IllegalStateException.class,
                 () -> new VaultPathBuilder()
+                        .withSecretType(VaultPathBuilder.SecretType.SERVICE_KEYTAB)
+                        .withSubType(SUBTYPE)
+                        .withEnvironmentCrn(ENVIRONMENT_ID)
+                        .build());
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> new VaultPathBuilder()
+                        .withSecretType(VaultPathBuilder.SecretType.SERVICE_KEYTAB)
                         .withAccountId(ACCOUNT_ID)
                         .withEnvironmentCrn(ENVIRONMENT_ID)
                         .build());
         Assertions.assertThrows(IllegalStateException.class,
                 () -> new VaultPathBuilder()
+                        .withSecretType(VaultPathBuilder.SecretType.SERVICE_KEYTAB)
                         .withAccountId(ACCOUNT_ID)
                         .withSubType(SUBTYPE)
                         .build());


### PR DESCRIPTION
Adds keytab creation and retrieval for host principals to support CML
which needs to use the host principals to manage service principals.
The host principals have the ability to be created with privileges
such as service principal management by using a role.

The deletion operations for host, cleanupClusterSecrets, and
cleanupEnvironmentSecrets were updated to also delete the host
principal secrets.

Unit tests were added and it was also tested on a local cloudbreak
build.

Closes #CDPSDX-519