### PR TITLE
CB-3379 Rename dbserver virtual network parameters to subnets

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilder.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilder.java
@@ -128,10 +128,10 @@ public class AzureTemplateBuilder {
             model.put("skuSizeMB", azureDatabaseServerView.getAllocatedStorageInMb().toString());
             model.put("skuTier", azureDatabaseServerView.getSkuTier());
             model.put("storageAutoGrow", azureDatabaseServerView.getStorageAutoGrow());
-            model.put("vnets", databaseStack.getNetwork().getStringParameter("virtualNetwork"));
+            model.put("subnets", databaseStack.getNetwork().getStringParameter("subnets"));
             model.putAll(defaultCostTaggingService.prepareAllTagsForTemplate());
             String generatedTemplate = freeMarkerTemplateUtils.processTemplateIntoString(getTemplate(databaseStack), model);
-            LOGGER.debug("Generated Arm database template: {}", generatedTemplate);
+            LOGGER.debug("Generated ARM database template: {}", generatedTemplate);
             return generatedTemplate;
         } catch (IOException | TemplateException e) {
             throw new CloudConnectorException("Failed to process the ARM TemplateBuilder", e);

--- a/cloud-azure/src/main/resources/templates/arm-dbstack.ftl
+++ b/cloud-azure/src/main/resources/templates/arm-dbstack.ftl
@@ -122,11 +122,11 @@
                 "description": "The location in which the database should be deployed."
             }
         },
-        "vnets": {
+        "subnets": {
             "type": "string",
-            "defaultValue": "${vnets}",
+            "defaultValue": "${subnets}",
             "metadata": {
-                "description": "The virtual networks to connect through service endpoints."
+                "description": "The subnets to connect through virtual network rules. It is expected that each subnet has a service endpoint defined."
             }
         },
         "serverTags": {
@@ -145,7 +145,7 @@
         }
     },
     "variables": {
-        "subnets": "[split(parameters('vnets'),',')]",
+        "subnetList": "[split(parameters('subnets'),',')]",
         "apiVersionMSSql":"2015-05-01-preview",
         "apiVersion":"2017-12-01",
         "sslEnforcementString":"[if(parameters('sslEnforcement'), 'Enabled', 'Disabled')]",
@@ -190,12 +190,12 @@
                 "[concat('Microsoft.DBforPostgreSQL/servers/',parameters('dbServerName'))]"
             ],
             "properties": {
-                "virtualNetworkSubnetId": "[variables('subnets')[copyIndex()]]",
+                "virtualNetworkSubnetId": "[variables('subnetList')[copyIndex()]]",
                 "ignoreMissingVnetServiceEndpoint": false
             },
             "copy": {
                 "name": "vnetcopy",
-                "count": "[length(variables('subnets'))]"
+                "count": "[length(variables('subnetList'))]"
             }
         }
     ],

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/azure/AzureNetworkV4Parameters.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/azure/AzureNetworkV4Parameters.java
@@ -18,23 +18,23 @@ import java.util.Map;
 @JsonInclude(Include.NON_NULL)
 public class AzureNetworkV4Parameters extends MappableBase {
 
-    private static final String VIRTUAL_NETWORK = "virtualNetwork";
+    private static final String SUBNETS = "subnets";
 
-    @ApiModelProperty(AzureNetworkModelDescription.VIRTUAL_NETWORK)
-    private String virtualNetwork;
+    @ApiModelProperty(AzureNetworkModelDescription.SUBNETS)
+    private String subnets;
 
-    public String getVirtualNetwork() {
-        return virtualNetwork;
+    public String getSubnets() {
+        return subnets;
     }
 
-    public void setVirtualNetwork(String virtualNetwork) {
-        this.virtualNetwork = virtualNetwork;
+    public void setSubnets(String subnets) {
+        this.subnets = subnets;
     }
 
     @Override
     public Map<String, Object> asMap() {
         Map<String, Object> map = super.asMap();
-        putIfValueNotNull(map, VIRTUAL_NETWORK, virtualNetwork);
+        putIfValueNotNull(map, SUBNETS, subnets);
         return map;
     }
 
@@ -47,6 +47,6 @@ public class AzureNetworkV4Parameters extends MappableBase {
 
     @Override
     public void parse(Map<String, Object> parameters) {
-        virtualNetwork = getParameterOrNull(parameters, VIRTUAL_NETWORK);
+        subnets = getParameterOrNull(parameters, SUBNETS);
     }
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/ModelDescriptions.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/ModelDescriptions.java
@@ -102,7 +102,7 @@ public final class ModelDescriptions {
     }
 
     public static class AzureNetworkModelDescription {
-        public static final String VIRTUAL_NETWORK = "Fully qualified IDs for an Azure network and subnet";
+        public static final String SUBNETS = "Comma-separated list of fully-qualified subnets with connectivity to the database server";
     }
 
     public static class AwsDatabaseServerModelDescriptions {

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/azure/AzureNetworkV4ParametersTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/azure/AzureNetworkV4ParametersTest.java
@@ -20,15 +20,15 @@ public class AzureNetworkV4ParametersTest {
 
     @Test
     public void testGettersAndSetters() {
-        underTest.setVirtualNetwork("someVirtualNetwork");
-        assertThat(underTest.getVirtualNetwork()).isEqualTo("someVirtualNetwork");
+        underTest.setSubnets("someSubnets");
+        assertThat(underTest.getSubnets()).isEqualTo("someSubnets");
     }
 
     @Test
     public void testAsMap() {
-        underTest.setVirtualNetwork("someVirtualNetwork");
+        underTest.setSubnets("someSubnets");
 
-        assertThat(underTest.asMap()).containsOnly(Map.entry("virtualNetwork", "someVirtualNetwork"),
+        assertThat(underTest.asMap()).containsOnly(Map.entry("subnets", "someSubnets"),
                 Map.entry("cloudPlatform", "AZURE"));
     }
 
@@ -39,11 +39,11 @@ public class AzureNetworkV4ParametersTest {
 
     @Test
     public void testParse() {
-        Map<String, Object> parameters = Map.of("virtualNetwork", "someVirtualNetwork");
+        Map<String, Object> parameters = Map.of("subnets", "someSubnets");
 
         underTest.parse(parameters);
 
-        assertThat(underTest.getVirtualNetwork()).isEqualTo("someVirtualNetwork");
+        assertThat(underTest.getSubnets()).isEqualTo("someSubnets");
     }
 
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/network/NetworkParameterAdder.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/network/NetworkParameterAdder.java
@@ -33,6 +33,8 @@ public class NetworkParameterAdder {
         switch (cloudPlatform) {
             case AWS:
                 return environmentResponse.getNetwork().getAws().getVpcId();
+            case AZURE:
+                return environmentResponse.getNetwork().getAzure().getNetworkId();
             default:
                 throw new RedbeamsException(String.format("Support for cloud platform %s not yet added", cloudPlatform.name()));
         }


### PR DESCRIPTION
The "virtualNetwork" parameter in the redbeams AzureNetworkV4Parameters
class and the "vnets" parameter in the Azure connector's database stack
ARM template are renamed to "subnets", to reflect precisely what their
values need to be.

Bonus changes:

* Azure database server termination now continues without a failure if
  the expected resource group to delete is missing.
* A missing implementation of NetworkParameterAdder::getVpcId for Azure
  is filled in. Without this, database creation fails to start.