### PR TITLE
CB-2187. Add CCM tunnel registration to cloud-init.

### DIFF
--- a/cloud-aws/src/main/resources/templates/aws-cf-stack.ftl
+++ b/cloud-aws/src/main/resources/templates/aws-cf-stack.ftl
@@ -71,14 +71,56 @@
       "Description" : "User data to be executed",
       "Type" : "String",
       "MinLength": "9",
-      "MaxLength": "50000"
+      "MaxLength": "4096"
+    },
+
+    "CBUserData1" : {
+      "Description" : "User data to be executed (continued)",
+      "Type" : "String",
+      "MinLength": "0",
+      "MaxLength": "4096"
+    },
+
+    "CBUserData2" : {
+      "Description" : "User data to be executed (continued)",
+      "Type" : "String",
+      "MinLength": "0",
+      "MaxLength": "4096"
+    },
+
+    "CBUserData3" : {
+      "Description" : "User data to be executed (continued)",
+      "Type" : "String",
+      "MinLength": "0",
+      "MaxLength": "4096"
     },
 
     "CBGateWayUserData" : {
       "Description" : "Gateway user data to be executed",
       "Type" : "String",
       "MinLength": "9",
-      "MaxLength": "50000"
+      "MaxLength": "4096"
+    },
+
+    "CBGateWayUserData1" : {
+      "Description" : "Gateway user data to be executed (continued)",
+      "Type" : "String",
+      "MinLength": "0",
+      "MaxLength": "4096"
+    },
+
+    "CBGateWayUserData2" : {
+      "Description" : "Gateway user data to be executed (continued)",
+      "Type" : "String",
+      "MinLength": "0",
+      "MaxLength": "4096"
+    },
+
+    "CBGateWayUserData3" : {
+      "Description" : "Gateway user data to be executed (continued)",
+      "Type" : "String",
+      "MinLength": "0",
+      "MaxLength": "4096"
     },
 
     "KeyName": {
@@ -318,10 +360,16 @@
         "SpotPrice"      : "${group.spotPrice}",
         </#if>
         <#if group.type == "CORE">
-        "UserData"       : { "Fn::Base64" : { "Ref" : "CBUserData"}}
+        "UserData"       : { "Fn::Base64" : { "Fn::Join" : ["", [ { "Ref" : "CBUserData"},
+                                                                  { "Ref" : "CBUserData1"},
+                                                                  { "Ref" : "CBUserData2"},
+                                                                  { "Ref" : "CBUserData3"}]] }}
         </#if>
         <#if group.type == "GATEWAY">
-        "UserData"       : { "Fn::Base64" : { "Ref" : "CBGateWayUserData"}}
+        "UserData"       : { "Fn::Base64" : { "Fn::Join" : ["", [ { "Ref" : "CBGateWayUserData"},
+                                                                  { "Ref" : "CBGateWayUserData1"},
+                                                                  { "Ref" : "CBGateWayUserData2"},
+                                                                  { "Ref" : "CBGateWayUserData3"}]] }}
         </#if>
       }
     }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/CcmParameterConstants.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/CcmParameterConstants.java
@@ -1,0 +1,63 @@
+package com.sequenceiq.cloudbreak.ccm.cloudinit;
+
+/**
+ * Provides constants used when passing CCM parameters to cloud-init scripts.
+ */
+@SuppressWarnings("WeakerAccess")
+public class CcmParameterConstants {
+
+    /**
+     * The template model key for whether CCM is enabled.
+     */
+    public static final String CCM_ENABLED_KEY = "ccmEnabled";
+
+    /**
+     * The template model key for the hostname used for connecting to CCM via SSH.
+     */
+    public static final String CCM_HOST_KEY = "ccmHost";
+
+    /**
+     * The template model key for the port used for connecting to CCM via SSH.
+     */
+    public static final String CCM_SSH_PORT_KEY = "ccmSshPort";
+
+    /**
+     * The default CCM SSH port.
+     */
+    public static final int DEFAULT_CCM_SSH_PORT = 8990;
+
+    /**
+     * The template model key for the public key for CCM, which allows the client to verify that it is talking to a valid CCM.
+     */
+    public static final String CCM_PUBLIC_KEY_KEY = "ccmPublicKey";
+
+    /**
+     * The (known hosts file) format for the public key for CCM. The first placeholder is the host address,
+     * the second placeholder is for the SSH port, and the third placeholder is for the public key itself.
+     */
+    public static final String CCM_PUBLIC_KEY_FORMAT = "[%s]:%d %s";
+
+    /**
+     * The template model key for the optional tunnel initiator ID.
+     */
+    public static final String TUNNEL_INITIATOR_ID_KEY = "ccmTunnelInitiatorId";
+
+    /**
+     * The template model key for the enciphered private key, which CCM uses to authenticate the instance.
+     */
+    public static final String ENCIPHERED_PRIVATE_KEY = "ccmEncipheredPrivateKey";
+
+    /**
+     * The template model key for specifying the port for which a tunnel is being registered.
+     * The first placeholder is for the first character of the well-known service identifier, which will
+     * be uppercased, and the second placeholder is for the remainder of the well-known service identifier,
+     * which will remain in its current case.
+     */
+    public static final String SERVICE_PORT_KEY_FORMAT = "ccm%C%sPort";
+
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private CcmParameterConstants() {
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/CcmParameters.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/CcmParameters.java
@@ -1,0 +1,61 @@
+package com.sequenceiq.cloudbreak.ccm.cloudinit;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Holds CCM cloud-init parameters, which encapsulate the user data required to configure an instance to
+ * connect to CCM, identify itself to CCM, and register tunnels with CCM.
+ */
+public interface CcmParameters {
+
+    /**
+     * Adds keys and values corresponding to the CCM parameters to the specified template model.
+     *
+     * @param model the template model map
+     */
+    static void addToTemplateModel(CcmParameters ccmParameters, Map<String, Object> model) {
+        if (ccmParameters == null) {
+            model.put(CcmParameterConstants.CCM_ENABLED_KEY, Boolean.FALSE);
+        } else {
+            model.put(CcmParameterConstants.CCM_ENABLED_KEY, Boolean.TRUE);
+            ccmParameters.addToTemplateModel(model);
+        }
+    }
+
+    /**
+     * Returns the CCM server parameters, which specify how to connect to CCM.
+     *
+     * @return the CCM server parameters, which specify how to connect to CCM
+     */
+    ServerParameters getServerParameters();
+
+    /**
+     * Returns the instance parameters, which specify how the instance identifies itself to CCM.
+     *
+     * @return the instance parameters, which specify how the instance identifies itself to CCM
+     */
+    InstanceParameters getInstanceParameters();
+
+    /**
+     * Returns the list of CCM tunnel parameters, each of which specifies how to register a tunnel
+     * for a single service with CCM.
+     *
+     * @return the list of CCM tunnel parameters, each of which specifies how to register a tunnel
+     * for a single service with CCM
+     */
+    List<TunnelParameters> getTunnelParameters();
+
+    /**
+     * Adds keys and values corresponding to the CCM parameters to the specified template model.
+     *
+     * @param model the template model map
+     */
+    default void addToTemplateModel(Map<String, Object> model) {
+        getServerParameters().addToTemplateModel(model);
+        getInstanceParameters().addToTemplateModel(model);
+        for (TunnelParameters tunnelParameters : getTunnelParameters()) {
+            tunnelParameters.addToTemplateModel(model);
+        }
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/DefaultCcmParameters.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/DefaultCcmParameters.java
@@ -1,0 +1,58 @@
+package com.sequenceiq.cloudbreak.ccm.cloudinit;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Objects;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Default {@link CcmParameters} implementation.
+ */
+public class DefaultCcmParameters implements CcmParameters, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The CCM server parameters, which specify how to connect to CCM.
+     */
+    private final ServerParameters serverParameters;
+
+    /**
+     * The instance parameters, which specify how the instance identifies itself to CCM.
+     */
+    private final InstanceParameters instanceParameters;
+
+    /**
+     * The list of CCM tunnel parameters, each of which specifies how to register a tunnel for a single service with CCM.
+     */
+    private final List<TunnelParameters> tunnelParameters;
+
+    /**
+     * Creates default CCM parameters with the specified parameters.
+     *
+     * @param serverParameters   the CCM server parameters, which specify how to connect to CCM
+     * @param instanceParameters the instance parameters, which specify how the instance identifies itself to CCM
+     * @param tunnelParameters   the list of CCM tunnel parameters, each of which specifies how to register a tunnel for a single service with CCM
+     */
+    public DefaultCcmParameters(ServerParameters serverParameters, InstanceParameters instanceParameters, List<TunnelParameters> tunnelParameters) {
+        this.serverParameters = Objects.requireNonNull(serverParameters, "serverParameters is null");
+        this.instanceParameters = Objects.requireNonNull(instanceParameters, "instanceParameters is null");
+        this.tunnelParameters = ImmutableList.copyOf(Objects.requireNonNull(tunnelParameters, "tunnelParameters is null"));
+    }
+
+    @Override
+    public ServerParameters getServerParameters() {
+        return serverParameters;
+    }
+
+    @Override
+    public InstanceParameters getInstanceParameters() {
+        return instanceParameters;
+    }
+
+    @Override
+    public List<TunnelParameters> getTunnelParameters() {
+        return tunnelParameters;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/DefaultInstanceParameters.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/DefaultInstanceParameters.java
@@ -1,0 +1,49 @@
+package com.sequenceiq.cloudbreak.ccm.cloudinit;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Default {@link InstanceParameters} implementation.
+ */
+public class DefaultInstanceParameters implements InstanceParameters, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The optional tunnel initiator ID, which uniquely identifies the instance to CCM.
+     */
+    private final String tunnelInitiatorId;
+
+    /**
+     * The enciphered private key, which CCM uses to authenticate the instance.
+     */
+    private final String encipheredPrivateKey;
+
+    /**
+     * Creates default CCM instance parameters with the specified parameters.
+     *
+     * @param tunnelInitiatorId    the optional tunnel initiator ID, which uniquely identifies the instance to CCM
+     * @param encipheredPrivateKey the enciphered private key, which CCM uses to authenticate the instance
+     */
+    public DefaultInstanceParameters(@Nullable String tunnelInitiatorId, @Nonnull String encipheredPrivateKey) {
+        this.tunnelInitiatorId = tunnelInitiatorId;
+        this.encipheredPrivateKey = Objects.requireNonNull(encipheredPrivateKey, "encipheredPrivateKey is null");
+    }
+
+    @Nonnull
+    @Override
+    public Optional<String> getTunnelInitiatorId() {
+        return Optional.ofNullable(tunnelInitiatorId);
+    }
+
+    @Nonnull
+    @Override
+    public String getEncipheredPrivateKey() {
+        return encipheredPrivateKey;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/DefaultServerParameters.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/DefaultServerParameters.java
@@ -1,0 +1,49 @@
+package com.sequenceiq.cloudbreak.ccm.cloudinit;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import javax.annotation.Nonnull;
+
+import com.sequenceiq.cloudbreak.ccm.endpoint.ServiceEndpoint;
+
+/**
+ * Default {@link ServerParameters} implementation.
+ */
+public class DefaultServerParameters implements ServerParameters, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The SSH service endpoint for connecting to CCM.
+     */
+    private final ServiceEndpoint ccmSshServiceEndpoint;
+
+    /**
+     * Tthe public key for CCM, which allows the client to verify that it is talking to a valid CCM.
+     */
+    private final String ccmPublicKey;
+
+    /**
+     * Creates default server parameters with the specified parameters.
+     *
+     * @param ccmSshServiceEndpoint the SSH service endpoint for connecting to CCM
+     * @param ccmPublicKey          tthe public key for CCM, which allows the client to verify that it is talking to a valid CCM
+     */
+    public DefaultServerParameters(ServiceEndpoint ccmSshServiceEndpoint, String ccmPublicKey) {
+        this.ccmSshServiceEndpoint = Objects.requireNonNull(ccmSshServiceEndpoint, "ccmSshServiceEndpoint is null");
+        this.ccmPublicKey = Objects.requireNonNull(ccmPublicKey, "ccmPublicKey is null");
+    }
+
+    @Nonnull
+    @Override
+    public ServiceEndpoint getCcmSshServiceEndpoint() {
+        return ccmSshServiceEndpoint;
+    }
+
+    @Nonnull
+    @Override
+    public String getCcmPublicKey() {
+        return ccmPublicKey;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/DefaultTunnelParameters.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/DefaultTunnelParameters.java
@@ -1,0 +1,48 @@
+package com.sequenceiq.cloudbreak.ccm.cloudinit;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import javax.annotation.Nonnull;
+
+import com.sequenceiq.cloudbreak.ccm.endpoint.KnownServiceIdentifier;
+
+/**
+ * Default {@link TunnelParameters} implementation.
+ */
+public class DefaultTunnelParameters implements TunnelParameters, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * The known service identifier for the service.
+     */
+    private final KnownServiceIdentifier knownServiceIdentifier;
+
+    /**
+     * The port for which the tunnel is being registered.
+     */
+    private final int port;
+
+    /**
+     * Creates default tunnel parameters with the specified parameters.
+     *
+     * @param knownServiceIdentifier the known service identifier for the service
+     * @param port                   the port for which the tunnel is being registered
+     */
+    public DefaultTunnelParameters(@Nonnull KnownServiceIdentifier knownServiceIdentifier, int port) {
+        this.knownServiceIdentifier = Objects.requireNonNull(knownServiceIdentifier, "knownServiceIdentifier is null");
+        this.port = port;
+    }
+
+    @Nonnull
+    @Override
+    public KnownServiceIdentifier getKnownServiceIdentifier() {
+        return knownServiceIdentifier;
+    }
+
+    @Override
+    public int getPort() {
+        return port;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/InstanceParameters.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/InstanceParameters.java
@@ -1,0 +1,43 @@
+package com.sequenceiq.cloudbreak.ccm.cloudinit;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+
+import com.google.common.io.BaseEncoding;
+
+/**
+ * Holds instance parameters, which specify how an instance identifies itself to CCM.
+ */
+public interface InstanceParameters {
+
+    /**
+     * Returns the optional tunnel initiator ID, which uniquely identifies the instance to CCM.
+     * If absent, the provider-specific instance ID will be used instead.
+     *
+     * @return the optional tunnel initiator ID, which uniquely identifies the instance to CCM
+     */
+    @Nonnull
+    Optional<String> getTunnelInitiatorId();
+
+    /**
+     * Returns the enciphered private key, which CCM uses to authenticate the instance.
+     *
+     * @return the enciphered private key, which CCM uses to authenticate the instance
+     */
+    @Nonnull
+    String getEncipheredPrivateKey();
+
+    /**
+     * Adds keys and values corresponding to the CCM parameters to the specified template model.
+     *
+     * @param model the template model map
+     */
+    default void addToTemplateModel(Map<String, Object> model) {
+        getTunnelInitiatorId().ifPresent(s -> model.put(CcmParameterConstants.TUNNEL_INITIATOR_ID_KEY, s));
+        model.put(CcmParameterConstants.ENCIPHERED_PRIVATE_KEY,
+                BaseEncoding.base64().encode(getEncipheredPrivateKey().getBytes(StandardCharsets.UTF_8)));
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/ServerParameters.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/ServerParameters.java
@@ -1,0 +1,52 @@
+package com.sequenceiq.cloudbreak.ccm.cloudinit;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+
+import com.google.common.io.BaseEncoding;
+import com.sequenceiq.cloudbreak.ccm.endpoint.ServiceEndpoint;
+
+/**
+ * Holds CCM server parameters, which specify how to connect to CCM.
+ */
+public interface ServerParameters {
+
+    /**
+     * Returns the SSH service endpoint for connecting to CCM.
+     *
+     * @return the SSH service endpoint for connecting to CCM
+     */
+    @Nonnull
+    ServiceEndpoint getCcmSshServiceEndpoint();
+
+    /**
+     * Returns the public key for CCM, which allows the client to verify that it is
+     * talking to a valid CCM.
+     *
+     * @return the public key for CCM, which allows the client to verify that it is
+     * talking to a valid CCM
+     */
+    @Nonnull
+    String getCcmPublicKey();
+
+    /**
+     * Adds keys and values corresponding to the CCM parameters to the specified template model.
+     *
+     * @param model the template model map
+     */
+    default void addToTemplateModel(Map<String, Object> model) {
+        ServiceEndpoint ccmSshServiceEndpoint = getCcmSshServiceEndpoint();
+        String ccmHostAddressString = ccmSshServiceEndpoint.getHostEndpoint().getHostAddressString();
+        model.put(CcmParameterConstants.CCM_HOST_KEY, ccmHostAddressString);
+        int ccmSshPort = ccmSshServiceEndpoint.getPort().orElse(CcmParameterConstants.DEFAULT_CCM_SSH_PORT);
+        model.put(CcmParameterConstants.CCM_SSH_PORT_KEY, ccmSshPort);
+        // Put public key into known_hosts format
+        String formattedPublicKey = String.format(
+                CcmParameterConstants.CCM_PUBLIC_KEY_FORMAT,
+                ccmHostAddressString, ccmSshPort, getCcmPublicKey());
+        model.put(CcmParameterConstants.CCM_PUBLIC_KEY_KEY,
+                BaseEncoding.base64().encode(formattedPublicKey.getBytes(StandardCharsets.UTF_8)));
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/TunnelParameters.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/TunnelParameters.java
@@ -1,0 +1,39 @@
+package com.sequenceiq.cloudbreak.ccm.cloudinit;
+
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+
+import com.sequenceiq.cloudbreak.ccm.endpoint.KnownServiceIdentifier;
+
+/**
+ * Holds tunnel parameters, each of which specifies how to register a tunnel
+ * for a single service with CCM.
+ */
+public interface TunnelParameters {
+
+    /**
+     * Returns the known service identifier for the service. Only known services can be registered,
+     * because CCM only recognizes a fixed set of known services.
+     *
+     * @return the known service identifier for the service
+     */
+    @Nonnull
+    KnownServiceIdentifier getKnownServiceIdentifier();
+
+    /**
+     * Returns the port for which the tunnel is being registered.
+     */
+    int getPort();
+
+    /**
+     * Adds keys and values corresponding to the CCM parameters to the specified template model.
+     *
+     * @param model the template model map
+     */
+    default void addToTemplateModel(Map<String, Object> model) {
+        String knownServiceName = getKnownServiceIdentifier().name().toLowerCase();
+        String portKey = String.format(CcmParameterConstants.SERVICE_PORT_KEY_FORMAT, knownServiceName.charAt(0), knownServiceName.substring(1));
+        model.put(portKey, getPort());
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageService.java
@@ -24,6 +24,7 @@ import org.springframework.util.StringUtils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.sequenceiq.cloudbreak.ccm.cloudinit.CcmParameters;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.image.ImageSettingsV4Request;
 import com.sequenceiq.cloudbreak.aspect.Measure;
@@ -85,7 +86,7 @@ public class ImageService {
     }
 
     @Measure(ImageService.class)
-    public void create(Stack stack, String platformString, PlatformParameters params, StatedImage imgFromCatalog)
+    public void create(Stack stack, String platformString, PlatformParameters params, StatedImage imgFromCatalog, CcmParameters ccmParameters)
             throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
         try {
             Platform platform = platform(stack.cloudPlatform());
@@ -97,7 +98,8 @@ public class ImageService {
             String sshUser = stack.getStackAuthentication().getLoginUserName();
             String cbCert = securityConfig.getClientCert();
             String saltBootPassword = saltSecurityConfig.getSaltBootPassword();
-            Map<InstanceGroupType, String> userData = userDataBuilder.buildUserData(platform, cbSshKeyDer, sshUser, params, saltBootPassword, cbCert);
+            Map<InstanceGroupType, String> userData =
+                    userDataBuilder.buildUserData(platform, cbSshKeyDer, sshUser, params, saltBootPassword, cbCert, ccmParameters);
 
             LOGGER.debug("Determined image from catalog: {}", imgFromCatalog);
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/UserDataBuilder.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/UserDataBuilder.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.BaseEncoding;
+import com.sequenceiq.cloudbreak.ccm.cloudinit.CcmParameters;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.cloudbreak.cloud.PlatformParameters;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
@@ -37,10 +38,10 @@ public class UserDataBuilder {
     private FreeMarkerTemplateUtils freeMarkerTemplateUtils;
 
     Map<InstanceGroupType, String> buildUserData(Platform cloudPlatform, byte[] cbSshKeyDer, String sshUser,
-        PlatformParameters parameters, String saltBootPassword, String cbCert) {
+            PlatformParameters parameters, String saltBootPassword, String cbCert, CcmParameters ccmParameters) {
         Map<InstanceGroupType, String> result = new EnumMap<>(InstanceGroupType.class);
         for (InstanceGroupType type : InstanceGroupType.values()) {
-            String userData = build(type, cloudPlatform, cbSshKeyDer, sshUser, parameters, saltBootPassword, cbCert);
+            String userData = build(type, cloudPlatform, cbSshKeyDer, sshUser, parameters, saltBootPassword, cbCert, ccmParameters);
             result.put(type, userData);
             LOGGER.debug("User data for {}, content; {}", type, userData);
         }
@@ -48,7 +49,7 @@ public class UserDataBuilder {
     }
 
     private String build(InstanceGroupType type, Platform cloudPlatform, byte[] cbSshKeyDer, String sshUser,
-        PlatformParameters params, String saltBootPassword, String cbCert) {
+            PlatformParameters params, String saltBootPassword, String cbCert, CcmParameters ccmParameters) {
         Map<String, Object> model = new HashMap<>();
         model.put("cloudPlatform", cloudPlatform.value());
         model.put("platformDiskPrefix", params.scriptParams().getDiskPrefix());
@@ -60,6 +61,7 @@ public class UserDataBuilder {
         model.put("customUserData", userDataBuilderParams.getCustomData());
         model.put("saltBootPassword", saltBootPassword);
         model.put("cbCert", cbCert);
+        CcmParameters.addToTemplateModel(ccmParameters, model);
         return build(model);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
@@ -46,6 +46,7 @@ import com.sequenceiq.cloudbreak.telemetry.fluent.FluentClusterType;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.CloudStorageFolderResolverService;
 import com.sequenceiq.cloudbreak.workspace.authorization.PermissionCheckingUtils;
 import com.sequenceiq.cloudbreak.blueprint.validation.AmbariBlueprintValidator;
+import com.sequenceiq.cloudbreak.ccm.cloudinit.CcmParameters;
 import com.sequenceiq.cloudbreak.cloud.event.platform.GetPlatformTemplateRequest;
 import com.sequenceiq.cloudbreak.cloud.model.CloudbreakDetails;
 import com.sequenceiq.cloudbreak.cloud.model.StackTemplate;
@@ -521,8 +522,11 @@ public class StackService {
         }, LOGGER, "Security config save took {} ms for stack {}", stackName);
         savedStack.setSecurityConfig(securityConfig);
 
+        // JSA todo populate CCM parameters
+        CcmParameters ccmParameters = null;
+
         try {
-            imageService.create(savedStack, platformString, connector.getPlatformParameters(savedStack), imgFromCatalog);
+            imageService.create(savedStack, platformString, connector.getPlatformParameters(savedStack), imgFromCatalog, ccmParameters);
         } catch (CloudbreakImageNotFoundException e) {
             LOGGER.info("Cloudbreak Image not found", e);
             throw new CloudbreakApiException(e.getMessage(), e);

--- a/core/src/main/resources/init/init.ftl
+++ b/core/src/main/resources/init/init.ftl
@@ -15,6 +15,24 @@ export SSH_USER=${sshUser}
 export SALT_BOOT_PASSWORD=${saltBootPassword}
 export SALT_BOOT_SIGN_KEY=${signaturePublicKey}
 export CB_CERT=${cbCert}
+<#if ccmEnabled!false>
+export IS_CCM_ENABLED=true
+export CCM_HOST=${ccmHost}
+export CCM_SSH_PORT=${ccmSshPort?c}
+export CCM_PUBLIC_KEY="${ccmPublicKey}"
+<#if ccmTunnelInitiatorId??>
+export CCM_TUNNEL_INITIATOR_ID="${ccmTunnelInitiatorId}"
+</#if>
+export CCM_ENCIPHERED_PRIVATE_KEY="${ccmEncipheredPrivateKey}"
+<#if ccmGatewayPort??>
+export CCM_GATEWAY_PORT=${ccmGatewayPort?c}
+</#if>
+<#if ccmKnoxPort??>
+export CCM_KNOX_PORT=${ccmKnoxPort?c}
+</#if>
+<#else>
+export IS_CCM_ENABLED=false
+</#if>
 
 ${customUserData}
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/UserDataBuilderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/UserDataBuilderTest.java
@@ -64,8 +64,9 @@ public class UserDataBuilderTest {
     public void testBuildUserDataAzure() throws IOException {
         String expectedGwScript = FileReaderUtils.readFileFromClasspath("azure-gateway-init.sh");
         String expectedCoreScript = FileReaderUtils.readFileFromClasspath("azure-core-init.sh");
+        // JSA todo add test for CCM parameters
         Map<InstanceGroupType, String> userdata = underTest.buildUserData(Platform.platform("AZURE"), "priv-key".getBytes(),
-            "cloudbreak", getPlatformParameters(), "pass", "cert");
+            "cloudbreak", getPlatformParameters(), "pass", "cert", null);
         Assert.assertEquals(expectedGwScript, userdata.get(InstanceGroupType.GATEWAY));
         Assert.assertEquals(expectedCoreScript, userdata.get(InstanceGroupType.CORE));
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/StackServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/StackServiceTest.java
@@ -40,6 +40,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.AutoscaleStackV4Response;
 import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.ccm.cloudinit.CcmParameters;
 import com.sequenceiq.cloudbreak.cloud.PlatformParameters;
 import com.sequenceiq.cloudbreak.cloud.model.Variant;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
@@ -649,7 +650,7 @@ public class StackServiceTest {
         String platformString = "AWS";
         doThrow(new CloudbreakImageNotFoundException("Image not found"))
                 .when(imageService)
-                .create(eq(stack), eq(platformString), eq(parameters), nullable(StatedImage.class));
+                .create(eq(stack), eq(platformString), eq(parameters), nullable(StatedImage.class), nullable(CcmParameters.class));
 
         try {
             stack = underTest.create(stack, platformString, mock(StatedImage.class), user, workspace);

--- a/core/src/test/resources/azure-core-init.sh
+++ b/core/src/test/resources/azure-core-init.sh
@@ -15,6 +15,7 @@ export SSH_USER=cloudbreak
 export SALT_BOOT_PASSWORD=pass
 export SALT_BOOT_SIGN_KEY=cHJpdi1rZXk=
 export CB_CERT=cert
+export IS_CCM_ENABLED=false
 
 date >> /tmp/time.txt
 

--- a/core/src/test/resources/azure-gateway-init.sh
+++ b/core/src/test/resources/azure-gateway-init.sh
@@ -15,6 +15,7 @@ export SSH_USER=cloudbreak
 export SALT_BOOT_PASSWORD=pass
 export SALT_BOOT_SIGN_KEY=cHJpdi1rZXk=
 export CB_CERT=cert
+export IS_CCM_ENABLED=false
 
 date >> /tmp/time.txt
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/ImageService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/ImageService.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.ccm.cloudinit.CcmParameters;
 import com.sequenceiq.cloudbreak.certificate.PkiUtil;
 import com.sequenceiq.cloudbreak.cloud.PlatformParameters;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
@@ -65,10 +66,10 @@ public class ImageService {
     @Value("${freeipa.image.catalog.default.os}")
     private String defaultOs;
 
-    public Image create(Stack stack, ImageSettingsRequest imageRequest, Credential credential) {
+    public Image create(Stack stack, ImageSettingsRequest imageRequest, Credential credential, CcmParameters ccmParameters) {
         Future<PlatformParameters> platformParametersFuture =
                 intermediateBuilderExecutor.submit(() -> platformParameterService.getPlatformParameters(stack, credential));
-        String userData = createUserData(stack, platformParametersFuture);
+        String userData = createUserData(stack, platformParametersFuture, ccmParameters);
         String region = stack.getRegion();
         String platformString = stack.getCloudPlatform().toLowerCase();
         com.sequenceiq.freeipa.api.model.image.Image imageCatalogImage = getImage(imageRequest, region, platformString);
@@ -172,7 +173,7 @@ public class ImageService {
                 .findFirst();
     }
 
-    private String createUserData(Stack stack, Future<PlatformParameters> platformParametersFuture) {
+    private String createUserData(Stack stack, Future<PlatformParameters> platformParametersFuture, CcmParameters ccmParameters) {
         SecurityConfig securityConfig = stack.getSecurityConfig();
         SaltSecurityConfig saltSecurityConfig = securityConfig.getSaltSecurityConfig();
         String cbPrivKey = saltSecurityConfig.getSaltBootSignPrivateKey();
@@ -184,7 +185,7 @@ public class ImageService {
         try {
             platformParameters = platformParametersFuture.get();
             return userDataBuilder.buildUserData(Platform.platform(stack.getCloudPlatform()), cbSshKeyDer, sshUser, platformParameters, saltBootPassword,
-                    cbCert);
+                    cbCert, ccmParameters);
         } catch (InterruptedException | ExecutionException e) {
             LOGGER.error("Failed to get Platform parmaters", e);
             throw new GetCloudParameterException("Failed to get Platform parmaters", e);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/UserDataBuilder.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/UserDataBuilder.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.BaseEncoding;
+import com.sequenceiq.cloudbreak.ccm.cloudinit.CcmParameters;
 import com.sequenceiq.cloudbreak.cloud.PlatformParameters;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
@@ -35,14 +36,14 @@ public class UserDataBuilder {
     private FreeMarkerTemplateUtils freeMarkerTemplateUtils;
 
     public String buildUserData(Platform cloudPlatform, byte[] cbSshKeyDer, String sshUser,
-            PlatformParameters parameters, String saltBootPassword, String cbCert) {
-        String userData = build(cloudPlatform, cbSshKeyDer, sshUser, parameters, saltBootPassword, cbCert);
+            PlatformParameters parameters, String saltBootPassword, String cbCert, CcmParameters ccmParameters) {
+        String userData = build(cloudPlatform, cbSshKeyDer, sshUser, parameters, saltBootPassword, cbCert, ccmParameters);
         LOGGER.debug("User data  content; {}", userData);
         return userData;
     }
 
     private String build(Platform cloudPlatform, byte[] cbSshKeyDer, String sshUser,
-            PlatformParameters params, String saltBootPassword, String cbCert) {
+            PlatformParameters params, String saltBootPassword, String cbCert, CcmParameters ccmParameters) {
         Map<String, Object> model = new HashMap<>();
         model.put("cloudPlatform", cloudPlatform.value());
         model.put("platformDiskPrefix", params.scriptParams().getDiskPrefix());
@@ -53,6 +54,7 @@ public class UserDataBuilder {
         model.put("customUserData", userDataBuilderParams.getCustomData());
         model.put("saltBootPassword", saltBootPassword);
         model.put("cbCert", cbCert);
+        CcmParameters.addToTemplateModel(ccmParameters, model);
         return build(model);
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaCreationService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaCreationService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.User;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
+import com.sequenceiq.cloudbreak.ccm.cloudinit.CcmParameters;
 import com.sequenceiq.cloudbreak.cloud.event.platform.GetPlatformTemplateRequest;
 import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
 import com.sequenceiq.cloudbreak.cloud.store.InMemoryStateStore;
@@ -114,8 +115,12 @@ public class FreeIpaCreationService {
             Triple<Stack, Image, FreeIpa> stackImageFreeIpaTuple = transactionService.required(() -> {
                 Stack savedStack = stackService.save(stack);
                 ImageSettingsRequest imageSettingsRequest = request.getImage();
+
+                // JSA todo populate CCM parameters
+                CcmParameters ccmParameters = null;
+
                 Image image = imageService.create(savedStack, Objects.nonNull(imageSettingsRequest) ? imageSettingsRequest
-                        : new ImageSettingsRequest(), credential);
+                        : new ImageSettingsRequest(), credential, ccmParameters);
                 FreeIpa freeIpa = freeIpaService.create(savedStack, request.getFreeIpa());
                 return Triple.of(savedStack, image, freeIpa);
             });

--- a/freeipa/src/main/resources/init/init.ftl
+++ b/freeipa/src/main/resources/init/init.ftl
@@ -15,6 +15,24 @@ export SSH_USER=${sshUser}
 export SALT_BOOT_PASSWORD=${saltBootPassword}
 export SALT_BOOT_SIGN_KEY=${signaturePublicKey}
 export CB_CERT=${cbCert}
+<#if ccmEnabled!false>
+export IS_CCM_ENABLED=true
+export CCM_HOST=${ccmHost}
+export CCM_SSH_PORT=${ccmSshPort?c}
+export CCM_PUBLIC_KEY="${ccmPublicKey}"
+<#if ccmTunnelInitiatorId??>
+export CCM_TUNNEL_INITIATOR_ID="${ccmTunnelInitiatorId}"
+</#if>
+export CCM_ENCIPHERED_PRIVATE_KEY="${ccmEncipheredPrivateKey}"
+<#if ccmGatewayPort??>
+export CCM_GATEWAY_PORT=${ccmGatewayPort?c}
+</#if>
+<#if ccmKnoxPort??>
+export CCM_KNOX_PORT=${ccmKnoxPort?c}
+</#if>
+<#else>
+export IS_CCM_ENABLED=false
+</#if>
 
 ${customUserData}
 


### PR DESCRIPTION
With these changes, all the plumbing has been done for communicating
CCM parameters down through the freemarker templates to the cloud-init
user data script.

Specific changes include:
1. New model objects for CCM parameters, including server parameters
   that represent information required to contact CCM, instance
   parameters required to identify the instance to CCM, and tunnel
   parameters which represent the tunnels to be registered with CCM.
2. The ability to pass the CCM parameters from the stack service
   through the image service to the user data builder. Note that
   with this commit, the CCM parameters are always absent. They
   will be populated from communication with the mina management
   service in a subsequent commit.
3. Updates to the freemarker templates for the cloud-init user data
   script for both CB and FreeIPA, to do all the work required to
   configure and invoke the CCM client scripts.
3. Logic to add the CCM parameters to the template models for
   freemarker template processing. Note that with this commit,
   the absent CCM parameters means the ccmEnabled template model
   parameter will be absent, and none of the CCM part will be
   included in the generated user data. I have tested locally with
   populated template model parameters based on hard-coded CCM
   parameters, and observed not only correct user data generation,
   but actual successful tunneling.
4. Updates to the freemarker template for the Cloud Formation stack,
   and corresponding template model updates in the AWS stack request
   helper, to support user data up to the fully allowed 16k, passed
   in up to four chunks, each of size up to 4k. The previous mechanism
   used only a single parameter, which was limited to 4k in size.
   Although the current commit does not increase the user data size,
   manual testing revealed that the new keys for CCM pushed us past
   the 4k limit, but nowhere near the 16k limit.
