### PR TITLE
CDPSDX-839 Allow a role to be deleted when deleting a host or service

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/doc/KeytabModelNotes.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/doc/KeytabModelNotes.java
@@ -13,9 +13,10 @@ public class KeytabModelNotes {
     public static final String GET_HOST_KEYTAB_NOTES = "Retrieves the existing keytab for the host provided. Gets the existing keytab without modification "
             + "and not effecting the prior keytab. The keytab in the response is base64 encoded.";
     public static final String DELETE_SERVICE_PRINCIPAL_NOTES = "Deletes the principal from the FreeIPA. It also deletes vault secrets associated with the "
-            + "principal";
+            + "principal. If a role is specified, it will also be deleted. However, if the role is still in use, it will not be deleted in a normal scenerio.";
     public static final String DELETE_HOST_NOTES = "Deletes the host and all the principals associated with the host in the FreeIPA. It also deletes vault "
-            + "secrets associated with the host.";
+            + "secrets associated with the host. If a role is specified, it will also be deleted. However, if the role is still in use, it will not be deleted "
+            + "in a normal scenerio.";
     public static final String CLEANUP_NOTES = "Deletes all the secrets that are associated for the given cluster.";
 
     private KeytabModelNotes() {

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/model/HostRequest.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/model/HostRequest.java
@@ -24,6 +24,9 @@ public class HostRequest {
     @ApiModelProperty(value = ModelDescriptions.CLUSTER_CRN)
     private String clusterCrn;
 
+    @ApiModelProperty(value = KeytabModelDescription.ROLE_NAME)
+    private String roleName;
+
     public String getEnvironmentCrn() {
         return environmentCrn;
     }
@@ -48,12 +51,21 @@ public class HostRequest {
         this.clusterCrn = clusterCrn;
     }
 
+    public String getRoleName() {
+        return roleName;
+    }
+
+    public void setRoleName(String roleName) {
+        this.roleName = roleName;
+    }
+
     @Override
     public String toString() {
         return "HostRequest{"
                 + "environmentCrn='" + environmentCrn + '\''
                 + ", serverHostName='" + serverHostName + '\''
                 + ", clusterCrn='" + clusterCrn + '\''
+                + ", roleName='" + roleName + '\''
                 + '}';
     }
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/model/ServicePrincipalRequest.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberosmgmt/model/ServicePrincipalRequest.java
@@ -28,6 +28,9 @@ public class ServicePrincipalRequest {
     @ApiModelProperty(value = ModelDescriptions.CLUSTER_CRN)
     private String clusterCrn;
 
+    @ApiModelProperty(value = KeytabModelDescription.ROLE_NAME)
+    private String roleName;
+
     public String getEnvironmentCrn() {
         return environmentCrn;
     }
@@ -60,6 +63,14 @@ public class ServicePrincipalRequest {
         this.clusterCrn = clusterCrn;
     }
 
+    public String getRoleName() {
+        return roleName;
+    }
+
+    public void setRoleName(String roleName) {
+        this.roleName = roleName;
+    }
+
     @Override
     public String toString() {
         return "ServicePrincipalRequest{"
@@ -67,6 +78,7 @@ public class ServicePrincipalRequest {
                 + ", serviceName='" + serviceName + '\''
                 + ", serverHostName='" + serverHostName + '\''
                 + ", clusterCrn='" + clusterCrn + '\''
+                + ", roleName='" + roleName + '\''
                 + '}';
     }
 }

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/model/Role.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/model/Role.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.sequenceiq.freeipa.client.deserializer.ListFlatteningDeserializer;
 
@@ -12,7 +13,20 @@ public class Role {
     @JsonDeserialize(using = ListFlatteningDeserializer.class)
     private String cn;
 
-    private List<String> member = new ArrayList<>();
+    @JsonProperty("member_user")
+    private List<String> memberUser = new ArrayList<>();
+
+    @JsonProperty("member_group")
+    private List<String> memberGroup = new ArrayList<>();
+
+    @JsonProperty("member_host")
+    private List<String> memberHost = new ArrayList<>();
+
+    @JsonProperty("member_hostgroup")
+    private List<String> memberHostGroup = new ArrayList<>();
+
+    @JsonProperty("member_service")
+    private List<String> memberService = new ArrayList<>();
 
     public String getCn() {
         return cn;
@@ -22,11 +36,43 @@ public class Role {
         this.cn = cn;
     }
 
-    public List<String> getMember() {
-        return member;
+    public List<String> getMemberUser() {
+        return memberUser;
     }
 
-    public void setMember(List<String> member) {
-        this.member = member;
+    public void setMemberUser(List<String> memberUser) {
+        this.memberUser = memberUser;
+    }
+
+    public List<String> getMemberGroup() {
+        return memberGroup;
+    }
+
+    public void setMemberGroup(List<String> memberGroup) {
+        this.memberGroup = memberGroup;
+    }
+
+    public List<String> getMemberHost() {
+        return memberHost;
+    }
+
+    public void setMemberHost(List<String> memberHost) {
+        this.memberHost = memberHost;
+    }
+
+    public List<String> getMemberHostGroup() {
+        return memberHostGroup;
+    }
+
+    public void setMemberHostGroup(List<String> memberHostGroup) {
+        this.memberHostGroup = memberHostGroup;
+    }
+
+    public List<String> getMemberService() {
+        return memberService;
+    }
+
+    public void setMemberService(List<String> memberService) {
+        this.memberService = memberService;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/freeipa/RoleAddResponse.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/freeipa/RoleAddResponse.java
@@ -20,7 +20,11 @@ public class RoleAddResponse extends AbstractFreeIpaResponse<Role> {
     protected Role handleInternal(Request request, Response response) {
         Role role = new Role();
         role.setCn("roleName");
-        role.setMember(List.of());
+        role.setMemberUser(List.of());
+        role.setMemberGroup(List.of());
+        role.setMemberHost(List.of());
+        role.setMemberHostGroup(List.of());
+        role.setMemberService(List.of());
         return role;
     }
 }


### PR DESCRIPTION
An optional way to delete roles was added to the kerberos management
delete host and delete service principal APIs. An attempt is made to
ensure the role is not in use, although the verification has a race
condition, the check will handle most common use cases and it is
better than nothing.

This was tested manually using a local deployment of cloudbreak.

Closes #CDPSDX-839