### PR TITLE
CB-3380 Add more validation to Azure PostgreSQL allocation requests

### DIFF
--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/DatabaseServerV4StackBase.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/DatabaseServerV4StackBase.java
@@ -9,6 +9,10 @@ import com.sequenceiq.redbeams.doc.ModelDescriptions.DatabaseServerModelDescript
 
 import io.swagger.annotations.ApiModelProperty;
 
+import javax.validation.Valid;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Max;
+
 public class DatabaseServerV4StackBase extends ProviderParametersBase {
 
     @ApiModelProperty(DatabaseServerModelDescriptions.INSTANCE_TYPE)
@@ -30,12 +34,15 @@ public class DatabaseServerV4StackBase extends ProviderParametersBase {
     @ApiModelProperty(DatabaseServerModelDescriptions.ROOT_USER_PASSWORD)
     private String rootUserPassword;
 
+    @Min(value = 1, message = "Port must be between 1 and 65535")
+    @Max(value = 65535, message = "Port must be between 1 and 65535")
     @ApiModelProperty(DatabaseServerModelDescriptions.PORT)
     private Integer port;
 
     @ApiModelProperty(DatabaseServerModelDescriptions.AWS_PARAMETERS)
     private AwsDatabaseServerV4Parameters aws;
 
+    @Valid
     @ApiModelProperty(DatabaseServerModelDescriptions.AZURE_PARAMETERS)
     private AzureDatabaseServerV4Parameters azure;
 

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/azure/AzureDatabaseServerV4Parameters.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/azure/AzureDatabaseServerV4Parameters.java
@@ -13,6 +13,9 @@ import io.swagger.annotations.ApiModelProperty;
 
 import java.util.Map;
 
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Pattern;
+
 @ApiModel
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(Include.NON_NULL)
@@ -32,26 +35,30 @@ public class AzureDatabaseServerV4Parameters extends MappableBase {
 
     private static final String STORAGE_AUTO_GROW = "storageAutoGrow";
 
+    @Min(value = 7, message = "backupRetentionDays must be 7 or higher")
     @ApiModelProperty(AzureDatabaseServerModelDescriptions.BACKUP_RETENTION_DAYS)
     private Integer backupRetentionDays;
 
+    @Pattern(regexp = "\\d+(?:\\.\\d)?")
     @ApiModelProperty(AzureDatabaseServerModelDescriptions.DB_VERSION)
     private String dbVersion;
 
     @ApiModelProperty(AzureDatabaseServerModelDescriptions.GEO_REDUNDANT_BACKUPS)
-    private boolean geoRedundantBackup;
+    private Boolean geoRedundantBackup;
 
+    @Min(value = 2, message = "skuCapacity must be 2 or higher")
     @ApiModelProperty(AzureDatabaseServerModelDescriptions.SKU_CAPACITY)
     private Integer skuCapacity;
 
     @ApiModelProperty(AzureDatabaseServerModelDescriptions.SKU_FAMILY)
     private String skuFamily;
 
+    @Pattern(regexp = "Basic|GeneralPurpose|MemoryOptimized")
     @ApiModelProperty(AzureDatabaseServerModelDescriptions.SKU_TIER)
     private String skuTier;
 
     @ApiModelProperty(AzureDatabaseServerModelDescriptions.STORAGE_AUTO_GROW)
-    private boolean storageAutoGrow;
+    private Boolean storageAutoGrow;
 
     public Integer getBackupRetentionDays() {
         return backupRetentionDays;
@@ -69,11 +76,11 @@ public class AzureDatabaseServerV4Parameters extends MappableBase {
         this.dbVersion = dbVersion;
     }
 
-    public boolean isGeoRedundantBackup() {
+    public Boolean getGeoRedundantBackup() {
         return geoRedundantBackup;
     }
 
-    public void setGeoRedundantBackup(boolean geoRedundantBackup) {
+    public void setGeoRedundantBackup(Boolean geoRedundantBackup) {
         this.geoRedundantBackup = geoRedundantBackup;
     }
 
@@ -101,11 +108,11 @@ public class AzureDatabaseServerV4Parameters extends MappableBase {
         this.skuTier = skuTier;
     }
 
-    public boolean isStorageAutoGrow() {
+    public Boolean getStorageAutoGrow() {
         return storageAutoGrow;
     }
 
-    public void setStorageAutoGrow(boolean storageAutoGrow) {
+    public void setStorageAutoGrow(Boolean storageAutoGrow) {
         this.storageAutoGrow = storageAutoGrow;
     }
 
@@ -133,10 +140,10 @@ public class AzureDatabaseServerV4Parameters extends MappableBase {
     public void parse(Map<String, Object> parameters) {
         backupRetentionDays = getInt(parameters, BACKUP_RETENTION_DAYS);
         dbVersion = getParameterOrNull(parameters, DB_VERSION);
-        geoRedundantBackup = Boolean.parseBoolean(getParameterOrNull(parameters, GEO_REDUNDANT_BACKUP));
+        geoRedundantBackup = Boolean.valueOf(getParameterOrNull(parameters, GEO_REDUNDANT_BACKUP));
         skuCapacity = getInt(parameters, SKU_CAPACITY);
         skuFamily = getParameterOrNull(parameters, SKU_FAMILY);
         skuTier = getParameterOrNull(parameters, SKU_TIER);
-        storageAutoGrow = Boolean.parseBoolean(getParameterOrNull(parameters, STORAGE_AUTO_GROW));
+        storageAutoGrow = Boolean.valueOf(getParameterOrNull(parameters, STORAGE_AUTO_GROW));
     }
 }

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/azure/AzureDatabaseServerV4ParametersTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/azure/AzureDatabaseServerV4ParametersTest.java
@@ -25,7 +25,7 @@ public class AzureDatabaseServerV4ParametersTest {
         assertThat(underTest.getBackupRetentionDays().intValue()).isEqualTo(3);
 
         underTest.setGeoRedundantBackup(true);
-        assertThat(underTest.isGeoRedundantBackup()).isTrue();
+        assertThat(underTest.getGeoRedundantBackup()).isTrue();
 
         underTest.setSkuCapacity(5);
         assertThat(underTest.getSkuCapacity().intValue()).isEqualTo(5);
@@ -37,7 +37,7 @@ public class AzureDatabaseServerV4ParametersTest {
         assertThat(underTest.getSkuTier()).isEqualTo("some-tier");
 
         underTest.setStorageAutoGrow(true);
-        assertThat(underTest.isStorageAutoGrow()).isTrue();
+        assertThat(underTest.getStorageAutoGrow()).isTrue();
 
         underTest.setDbVersion("1.2.3");
         assertThat(underTest.getDbVersion()).isEqualTo("1.2.3");
@@ -50,9 +50,7 @@ public class AzureDatabaseServerV4ParametersTest {
 
         assertThat(underTest.asMap()).containsOnly(Map.entry("backupRetentionDays", 3),
                 Map.entry("dbVersion", "1.2.3"),
-                Map.entry("cloudPlatform", "AZURE"),
-                Map.entry("geoRedundantBackup", false),
-                Map.entry("storageAutoGrow", false));
+                Map.entry("cloudPlatform", "AZURE"));
 
         underTest.setSkuCapacity(5);
         underTest.setSkuFamily("some-family");
@@ -89,13 +87,13 @@ public class AzureDatabaseServerV4ParametersTest {
 
         underTest.parse(parameters);
 
-        underTest.setBackupRetentionDays(3);
-        underTest.setGeoRedundantBackup(true);
-        underTest.setSkuCapacity(5);
-        underTest.setSkuFamily("some-family");
-        underTest.setSkuTier("some-tier");
-        underTest.setStorageAutoGrow(true);
-        underTest.setDbVersion("1.2.3");
+        assertThat(underTest.getBackupRetentionDays().intValue()).isEqualTo(3);
+        assertThat(underTest.getDbVersion()).isEqualTo("1.2.3");
+        assertThat(underTest.getSkuCapacity().intValue()).isEqualTo(5);
+        assertThat(underTest.getSkuFamily()).isEqualTo("some-family");
+        assertThat(underTest.getSkuTier()).isEqualTo("some-tier");
+        assertThat(underTest.getGeoRedundantBackup()).isTrue();
+        assertThat(underTest.getStorageAutoGrow()).isTrue();
     }
 
 }


### PR DESCRIPTION
Redbeams now validates the following for Azure PostgreSQL allocation
requests:

* port number (true for AWS as well)
* backup retention days
* database version, pattern match only
* SKU capacity minimum
* SKU tier

In addition:

* The boolean parameters in AzureDatabaseServerV4Parameters are now
  Boolean object types, so that omitted values can be represented
  accurately.
* Error logging for ARM template deployment failure is much improved,
  so that it's less necessary to go look in the Azure Portal for
  details.