### PR TITLE
CB-3390 Implement forced termination for Azure database servers

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
@@ -252,7 +252,7 @@ public class AzureResourceConnector implements ResourceConnector<Map<String, Map
 
     @Override
     public List<CloudResourceStatus> terminateDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack, boolean force) {
-        return azureDatabaseResourceService.terminateDatabaseServer(authenticatedContext, stack);
+        return azureDatabaseResourceService.terminateDatabaseServer(authenticatedContext, stack, force);
     }
 
     @Override


### PR DESCRIPTION
AzureDatabaseResourceService now supports forcing termination of
database servers. Essentially, failure to delete the server's resource
group does not cause termination failure if the force flag is set.
