### PR TITLE
CB-3463. Log identity is not filled if identity is set to null manually for distrox template

### DIFF
--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/CloudStorageDecorator.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/CloudStorageDecorator.java
@@ -64,6 +64,7 @@ public class CloudStorageDecorator {
                 if (!logConfiguredInRequest) {
                     identities.add(identity);
                 }
+                request.setIdentities(identities);
             }
             List<SdxClusterResponse> datalakes = sdxClientService.getByEnvironmentCrn(environment.getCrn());
             updateCloudStorageLocations(blueprintName, clusterName, request, datalakes);

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/CloudStorageDecoratorTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/CloudStorageDecoratorTest.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.distrox.v1.distrox.converter;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -65,6 +66,22 @@ class CloudStorageDecoratorTest {
 
         assertNotNull(result);
         assertTrue(result.getIdentities().stream().anyMatch(id -> CloudIdentityType.LOG.equals(id.getType())));
+    }
+
+    @Test
+    void testConvertWhenIdentityIsSetToNull() {
+        CloudStorageRequest request = new CloudStorageRequest();
+        request.setIdentities(null);
+
+        DetailedEnvironmentResponse environment = new DetailedEnvironmentResponse();
+        TelemetryResponse telemetry = new TelemetryResponse();
+        telemetry.setLogging(new LoggingResponse());
+        environment.setTelemetry(telemetry);
+
+        CloudStorageRequest result = underTest.decorate(BLUEPRINT_NAME, CLUSTER_NAME, request, environment);
+
+        assertNotNull(result);
+        assertEquals(1, result.getIdentities().size());
     }
 
     @Test


### PR DESCRIPTION
if you are setting `identities` field in cloud storage request (in distrox cluster template) to `null`, then log identity is not added to the identity list (not causing any issues with the UI or default flows with cb cli) -> main problem with this is if identities field is missing , generated go client will fill that as null (workaround is to set identities as empty [])
