### PR TITLE
CB-3453 Preserve subnets in environment creation API request

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/EnvironmentApiConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/EnvironmentApiConverter.java
@@ -155,7 +155,10 @@ public class EnvironmentApiConverter {
             yarnParams.setQueue(network.getYarn().getQueue());
             builder.withYarn(yarnParams);
         }
-        Optional.ofNullable(network.getSubnetIds()).ifPresent(ids -> ids.stream().collect(Collectors.toMap(id -> id, id -> new CloudSubnet(id, id))));
+        if (network.getSubnetIds() != null) {
+            builder.withSubnetMetas(network.getSubnetIds().stream()
+                .collect(Collectors.toMap(id -> id, id -> new CloudSubnet(id, id))));
+        }
         builder.withPrivateSubnetCreation(getPrivateSubnetCreation(network));
         return builder
                 .withNetworkCidr(network.getNetworkCidr())


### PR DESCRIPTION
Subnet IDs passed in the network portion of an environment creation API
request are once again carried forward into the converted network DTO by
EnvironmentApiConverter.