### PR TITLE
Initial commit of data mart blueprint with support for Kudu

### DIFF
--- a/cloud-common/src/main/resources/application.yml
+++ b/cloud-common/src/main/resources/application.yml
@@ -169,6 +169,7 @@ cb:
                 CDP 1.1 - Data Engineering: Apache Spark, Apache Hive, Apache Oozie=cdp-data-engineering-710;
                 CDP 1.1 - Data Engineering HA: Apache Spark, Apache Livy, Apache Zeppelin=cdp-data-engineering-ha-710;
                 CDP 1.1 - Data Mart: Apache Impala, Hue=cdp-data-mart-710;
+                CDP 1.1 - Operations Data Mart: Apache Impala, Hue, Apache Kudu, Apache Spark=cdp-op-data-mart-710;
                 CDP 1.1 - Operational Database: Apache HBase=cdp-opdb-710;
                 CDP 1.1 - Operational Database: Apache HBase (Custom)=cdp-opdb-custom-710;
                 CDP 1.1 - SDX Light Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas=cdp-sdx-710;

--- a/core/src/main/resources/defaults/blueprints/cdp-op-data-mart-710.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-op-data-mart-710.bp
@@ -1,0 +1,208 @@
+{
+  "description": "CDP 1.1 Operations Data Mart template with Apache Impala, Hue, Apache Kudu, and Apache Spark",
+  "blueprint": {
+    "cdhVersion": "7.1.0",
+    "displayName": "op-datamart-710",
+    "services": [
+      {
+        "refName": "hdfs",
+        "serviceType": "HDFS",
+        "roleConfigGroups": [
+          {
+            "refName": "hdfs-NAMENODE-BASE",
+            "roleType": "NAMENODE",
+            "base": true
+          },
+          {
+            "refName": "hdfs-SECONDARYNAMENODE-BASE",
+            "roleType": "SECONDARYNAMENODE",
+            "base": true
+          },
+          {
+            "refName": "hdfs-DATANODE-BASE",
+            "roleType": "DATANODE",
+            "configs" : [ {
+              "name" : "dfs_datanode_max_locked_memory",
+              "value" : "0",
+              "autoConfig" : false
+            } ],
+            "base": true
+          },
+          {
+            "refName": "hdfs-BALANCER-BASE",
+            "roleType": "BALANCER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "kudu",
+        "serviceType": "KUDU",
+        "roleConfigGroups": [
+          {
+            "refName": "kudu-MASTER-BASE",
+            "roleType": "KUDU_MASTER",
+            "base": true
+          },
+          {
+            "refName": "kudu-TSERVER-BASE",
+            "roleType": "KUDU_TSERVER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "yarn",
+        "serviceType": "YARN",
+        "roleConfigGroups": [
+          {
+            "refName": "yarn-RESOURCEMANAGER-BASE",
+            "roleType": "RESOURCEMANAGER",
+            "base": true
+          },
+          {
+            "refName": "yarn-NODEMANAGER-BASE",
+            "roleType": "NODEMANAGER",
+            "base": true
+          },
+          {
+            "refName": "yarn-JOBHISTORY-BASE",
+            "roleType": "JOBHISTORY",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "spark_on_yarn",
+        "serviceType": "SPARK_ON_YARN",
+        "roleConfigGroups": [
+          {
+            "refName": "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+            "roleType": "SPARK_YARN_HISTORY_SERVER",
+            "base": true
+          },
+          {
+            "refName": "spark_on_yarn-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "impala",
+        "serviceType": "IMPALA",
+        "serviceConfigs" : [ {
+          "name" : "impala_cmd_args_safety_valve",
+          "value" : "--cache_s3_file_handles=true"
+        } ],
+        "roleConfigGroups": [
+          {
+            "refName": "impala-IMPALAD-COORDINATOR",
+            "roleType": "IMPALAD",
+            "configs" : [ {
+              "name" : "impalad_specialization",
+              "value" : "COORDINATOR_ONLY"
+            }, {
+              "name" : "impala_hdfs_site_conf_safety_valve",
+              "value" : "<property><name>fs.s3a.block.size</name><value>268435456</value></property><property><name>fs.s3a.experimental.input.fadvise</name><value>RANDOM</value></property><property><name>fs.s3a.fast.upload</name><value>true</value></property>"
+            } ],
+            "base": false
+          },
+          {
+            "refName": "impala-IMPALAD-EXECUTOR",
+            "roleType": "IMPALAD",
+            "configs" : [ {
+              "name" : "impalad_specialization",
+              "value" : "EXECUTOR_ONLY"
+            }, {
+              "name" : "impala_hdfs_site_conf_safety_valve",
+              "value" : "<property><name>fs.s3a.block.size</name><value>268435456</value></property><property><name>fs.s3a.experimental.input.fadvise</name><value>RANDOM</value></property><property><name>fs.s3a.fast.upload</name><value>true</value></property>"
+            } ],
+            "base": false
+          },
+          {
+            "refName": "impala-STATESTORE-BASE",
+            "roleType": "STATESTORE",
+            "base": true
+          },
+          {
+            "refName": "impala-CATALOGSERVER-BASE",
+            "roleType": "CATALOGSERVER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "hue",
+        "serviceType": "HUE",
+        "roleConfigGroups": [
+          {
+            "refName": "hue-HUE_SERVER-BASE",
+            "roleType": "HUE_SERVER",
+            "base": true
+          },
+          {
+            "refName": "hue-HUE_LOAD_BALANCER-BASE",
+            "roleType": "HUE_LOAD_BALANCER",
+            "base": true
+          }
+        ]
+      }
+    ],
+    "hostTemplates": [
+      {
+        "refName": "master1",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "hdfs-BALANCER-BASE",
+          "hdfs-NAMENODE-BASE",
+          "hdfs-SECONDARYNAMENODE-BASE",
+          "kudu-MASTER-BASE"
+        ]
+      },
+      {
+        "refName": "master2",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "hue-HUE_LOAD_BALANCER-BASE",
+          "hue-HUE_SERVER-BASE",
+          "impala-CATALOGSERVER-BASE",
+          "impala-STATESTORE-BASE",
+          "kudu-MASTER-BASE"
+        ]
+      },
+      {
+        "refName": "master3",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+          "yarn-JOBHISTORY-BASE",
+          "yarn-RESOURCEMANAGER-BASE",
+          "kudu-MASTER-BASE"
+        ]
+      },
+      {
+        "refName": "coordinator",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "hdfs-DATANODE-BASE",
+          "spark_on_yarn-GATEWAY-BASE",
+          "yarn-NODEMANAGER-BASE",
+          "impala-IMPALAD-COORDINATOR",
+          "kudu-TSERVER-BASE"
+        ]
+      },
+      {
+        "refName": "executor",
+        "cardinality": 3,
+        "roleConfigGroupsRefNames": [
+          "hdfs-DATANODE-BASE",
+          "spark_on_yarn-GATEWAY-BASE",
+          "yarn-NODEMANAGER-BASE",
+          "impala-IMPALAD-EXECUTOR",
+          "kudu-TSERVER-BASE"
+        ]
+      }
+    ]
+  }
+}

--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/ipa.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/ipa.sls
@@ -20,11 +20,48 @@ join_ipa:
         runuser -l root -c 'ipa-client-install --server={{salt['pillar.get']('sssd-ipa:server')}} --realm={{salt['pillar.get']('sssd-ipa:realm')}} \
           --domain={{salt['pillar.get']('sssd-ipa:domain')}} --mkhomedir --principal={{salt['pillar.get']('sssd-ipa:principal')}} \
           --password {{salt['pillar.get']('sssd-ipa:password')}} --unattended --force-join --ssh-trust-dns --force-ntpd --unattended'
-{% endif%}
+{% endif %}
     - unless: ipa env
     - runas: root
     - env:
         - PW: {{salt['pillar.get']('sssd-ipa:password')}}
+
+replace_ntp_conf:
+  file.managed:
+    - source: salt://sssd/template/ntp_conf.j2
+    - name: /etc/ntp.conf
+    - template: jinja
+    - require:
+      - cmd: join_ipa
+
+replace_sysconfig_ntpd:
+  file.managed:
+    - source: salt://sssd/ntp/sysconfig_ntpd
+    - name: /etc/sysconfig/ntpd
+    - require:
+      - cmd: join_ipa
+
+{% if salt['file.directory_exists']('/yarn-private') %}
+
+force_restart_ntpd:
+  cmd.run:
+    - name: runuser -l root -c 'systemctl restart ntpd'
+    - runas: root
+    - require:
+      - file: replace_ntp_conf
+      - file: replace_sysconfig_ntpd
+
+{% else %}
+
+restart_ntpd_if_reconfigured:
+  service.running:
+    - enable: True
+    - name: ntpd
+    - watch:
+      - file: /etc/ntp.conf
+      - file: /etc/sysconfig/ntpd
+
+{% endif %}
 
 {% if salt['file.directory_exists']('/yarn-private') %}
 dns_remove_script:
@@ -40,7 +77,7 @@ removing_dns_entries:
   cmd.run:
     - name: runuser -l root -c '/opt/salt/scripts/dns_cleanup.sh 2>&1 | tee -a /var/log/dns_cleanup.log'
     - unless: test -f /var/log/dns_cleanup.log
-{% endif%}
+{% endif %}
 
 add_dns_record:
   cmd.run:
@@ -51,7 +88,7 @@ add_dns_record:
 
 {% if not salt['file.directory_exists']('/yarn-private') %}
 
-restart-sssd-if-reconfigured:
+restart_sssd_if_reconfigured:
   service.running:
     - enable: True
     - name: sssd
@@ -70,7 +107,7 @@ restart-sssd-if-reconfigured:
 
 {% if salt['file.directory_exists']('/yarn-private') %}
 
-backup-systemctl:
+backup_systemctl:
   file.copy:
     - name: /usr/bin/systemctl.bak
     - source: /usr/bin/systemctl.orig

--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/ntp/sysconfig_ntpd
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/ntp/sysconfig_ntpd
@@ -1,0 +1,11 @@
+# /etc/sysconfig/ntpd as configured by ipa-client-install from ipa-client 4.6.4
+# with some changes to make time synchronization more robust for Kudu.
+
+# Cloudera: removed -x to allow time to be stepped if the offset is very high.
+OPTIONS="-p /var/run/ntpd.pid"
+
+# Set to 'yes' to sync hw clock after successful ntpdate
+SYNC_HWCLOCK=yes
+
+# Additional options for ntpdate
+NTPDATE_OPTIONS=""

--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/template/ntp_conf.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/template/ntp_conf.j2
@@ -1,0 +1,55 @@
+# /etc/ntp.conf as configured by ipa-client-install from ipa-client 4.6.4
+# with some changes to make time synchronization more robust for Kudu.
+
+# Permit time synchronization with our time source, but do not
+# permit the source to query or modify the service on this system.
+restrict default kod nomodify notrap nopeer noquery
+restrict -6 default kod nomodify notrap nopeer noquery
+
+# Permit all access over the loopback interface.  This could
+# be tightened as well, but to do so would effect some of
+# the administrative functions.
+restrict 127.0.0.1
+restrict -6 ::1
+
+# Hosts on local network are less restricted.
+#restrict 192.168.1.0 mask 255.255.255.0 nomodify notrap
+
+# Use public servers from the pool.ntp.org project.
+# Please consider joining the pool (http://www.pool.ntp.org/join.html).
+#
+# Cloudera: added 'iburst' for faster synchronization at startup.
+server {{salt['pillar.get']('sssd-ipa:server')}} iburst
+
+#broadcast 192.168.1.255 key 42		# broadcast server
+#broadcastclient			# broadcast client
+#broadcast 224.0.1.1 key 42		# multicast server
+#multicastclient 224.0.1.1		# multicast client
+#manycastserver 239.255.254.254		# manycast server
+#manycastclient 239.255.254.254 key 42	# manycast client
+
+# Undisciplined Local Clock. This is a fake driver intended for backup
+# and when no outside source of synchronized time is available.
+#
+# Cloudera: ULC disabled because it interferes with Kudu.
+#server	127.127.1.0	# local clock
+#fudge	127.127.1.0 stratum 10
+
+# Drift file.  Put this in a directory which the daemon can write to.
+# No symbolic links allowed, either, since the daemon updates the file
+# by creating a temporary in the same directory and then rename()'ing
+# it to the file.
+driftfile /var/lib/ntp/drift
+
+# Key file containing the keys and key identifiers used when operating
+# with symmetric key cryptography.
+keys /etc/ntp/keys
+
+# Specify the key identifiers which are trusted.
+#trustedkey 4 8 42
+
+# Specify the key identifier to use with the ntpdc utility.
+#requestkey 8
+
+# Specify the key identifier to use with the ntpq utility.
+#controlkey 8


### PR DESCRIPTION
This commit introduces a new blueprint which I've called the "active data
mart". The name is a reference to Active Data Warehouse, a term we often use
to describe a data warehouse that leverages Kudu for additional real-time
storage and query capabilities. The blueprint is based on the existing data
mart template, complete with custom Impala performance tuning. Besides the
obvious inclusion of Kudu, I've also added Spark (and a dependent YARN) for
eventual Kudu BDR support.

The topology itself consists of three masters (for HA) and four tablet
servers (for 3-4-3 replication). To minimize the effect of a failure, each
master and tablet server runs on its own node, which makes the minimal
cluster size seven nodes. The worker nodes are partitioned into a singleton
"coordinator" group running an Impala coordinator and an "executor" group
running the remaining workers; users who need larger clusters should scale
up the size of the executor group. The non-Kudu master roles are spread out
across the three master nodes to make more efficient use of those resources.

Effective use of this blueprint requires a few things:
1. Configuration of Impala and Kudu for hierarchical storage management
   (i.e. aging out of cold data to object storage). This isn't something we
   can automate due to its domain-specific nature.
2. Connectivity with another cluster responsible for ingest. In theory we
   could automate this if we had a better sense for other "cluster shapes"
   that handled ingest (via NiFi, Spark Streaming, etc).

To get all of this to work, I had to add a few temporary workarounds:
- Kudu's hybrid clock is disabled. The NTP configuration found on VMs
  deployed by Cloudbreak is really bad inasfar as fast synchronization. I'm
  working on an alternative configuration, but for the time being we need to
  sidestep the NTP dependency altogether. This also means that Kudu BDR
  doesn't work, because its snapshot scans require the hybrid clock.
- Kudu's on-disk directories are hardcoded to the first EBS volume attached
  to each VM by Cloudbreak. This should be removed when CB-3347 is fixed.

What has been tested?
- Deploying the template. OPSAPS-52447 is a blocking bug, but when deploying
  with a custom CM including the fix, it works.
- `kudu perf loadgen` initiated from a cluster host.
- Kudu backup initiated from a cluster host. This fails due to the
  aforementioned hybrid clock issues.
