### PR TITLE
CB-3347 Kudu Volume Config Initialization

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kudu/KuduRoles.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kudu/KuduRoles.java
@@ -1,0 +1,13 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.kudu;
+
+public class KuduRoles {
+
+    public static final String KUDU_SERVICE = "KUDU";
+
+    public static final String KUDU_MASTER = "KUDU_MASTER";
+
+    public static final String KUDU_TSERVER = "KUDU_TSERVER";
+
+    private KuduRoles() { }
+
+}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kudu/KuduVolumeConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kudu/KuduVolumeConfigProvider.java
@@ -1,0 +1,53 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.kudu;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static com.sequenceiq.cloudbreak.template.VolumeUtils.buildVolumePathFromVolumeIndexZeroVolumeHandled;
+import static com.sequenceiq.cloudbreak.template.VolumeUtils.buildVolumePathStringZeroVolumeHandled;
+
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.stereotype.Component;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.cmtemplate.CmHostGroupRoleConfigProvider;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.cloudbreak.template.views.HostgroupView;
+
+@Component
+public class KuduVolumeConfigProvider implements CmHostGroupRoleConfigProvider {
+
+    private static final String KUDU_FS_WAL_DIRS = "fs_wal_dir";
+
+    private static final String KUDU_FS_DATA_DIRS = "fs_data_dirs";
+
+    @Override
+    public List<ApiClusterTemplateConfig> getRoleConfigs(String roleType, HostgroupView hostGroupView, TemplatePreparationObject source) {
+
+        switch (roleType) {
+            case KuduRoles.KUDU_MASTER :
+            case KuduRoles.KUDU_TSERVER:
+                String directorySuffix = KuduRoles.KUDU_MASTER.equals(roleType)  ? "kudu/master" : "kudu/tserver";
+                //Only one volume needs to be configured for KUDU_FS_WAL_DIRS
+                Integer walVolumeCount = hostGroupView.getVolumeCount() > 0 ? 1 : 0;
+                Integer dataDirVolumeIndex = hostGroupView.getVolumeCount() <= 1 ? 1 : 2;
+                return List.of(
+                        config(KUDU_FS_WAL_DIRS, buildVolumePathStringZeroVolumeHandled(walVolumeCount, directorySuffix)),
+                        config(KUDU_FS_DATA_DIRS,
+                                buildVolumePathFromVolumeIndexZeroVolumeHandled(dataDirVolumeIndex, hostGroupView.getVolumeCount(), directorySuffix))
+                        );
+            default:
+                return List.of();
+        }
+    }
+
+    @Override
+    public String getServiceType() {
+        return KuduRoles.KUDU_SERVICE;
+    }
+
+    @Override
+    public Set<String> getRoleTypes() {
+        return Set.of(KuduRoles.KUDU_MASTER, KuduRoles.KUDU_TSERVER);
+    }
+}

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kudu/KuduVolumeConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kudu/KuduVolumeConfigProviderTest.java
@@ -1,0 +1,81 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.kudu;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.VolumeConfigProviderTestHelper.hostGroupWithVolumeCount;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.cloudbreak.template.views.BlueprintView;
+import com.sequenceiq.cloudbreak.template.views.HostgroupView;
+import com.sequenceiq.cloudbreak.util.FileReaderUtils;
+
+class KuduVolumeConfigProviderTest {
+
+    private final KuduVolumeConfigProvider subject = new KuduVolumeConfigProvider();
+
+    @Test
+    void testRoleConfigsWithMultipleVolumes() {
+        HostgroupView hostGroup = hostGroupWithVolumeCount(3);
+
+        assertEquals(List.of(
+                config("fs_wal_dir", "/hadoopfs/fs1/kudu/master"),
+                config("fs_data_dirs", "/hadoopfs/fs2/kudu/master,/hadoopfs/fs3/kudu/master")),
+                subject.getRoleConfigs(KuduRoles.KUDU_MASTER, hostGroup, getTemplatePreparationObject(hostGroup))
+        );
+
+        assertEquals(List.of(
+                config("fs_wal_dir", "/hadoopfs/fs1/kudu/tserver"),
+                config("fs_data_dirs", "/hadoopfs/fs2/kudu/tserver,/hadoopfs/fs3/kudu/tserver")),
+                subject.getRoleConfigs(KuduRoles.KUDU_TSERVER, hostGroup, getTemplatePreparationObject(hostGroup))
+        );
+    }
+
+    @Test
+    void testRoleConfigsWithSingleVolume() {
+        HostgroupView hostGroup = hostGroupWithVolumeCount(1);
+
+        assertEquals(List.of(
+                config("fs_wal_dir", "/hadoopfs/fs1/kudu/master"),
+                config("fs_data_dirs", "/hadoopfs/fs1/kudu/master")),
+                subject.getRoleConfigs(KuduRoles.KUDU_MASTER, hostGroup, getTemplatePreparationObject(hostGroup))
+        );
+
+        assertEquals(List.of(
+                config("fs_wal_dir", "/hadoopfs/fs1/kudu/tserver"),
+                config("fs_data_dirs", "/hadoopfs/fs1/kudu/tserver")),
+                subject.getRoleConfigs(KuduRoles.KUDU_TSERVER, hostGroup, getTemplatePreparationObject(hostGroup))
+        );
+    }
+
+    @Test
+    void testRoleConfigsWithoutVolumes() {
+        HostgroupView hostGroup = hostGroupWithVolumeCount(0);
+
+        assertEquals(List.of(
+                config("fs_wal_dir", "/hadoopfs/root1/kudu/master"),
+                config("fs_data_dirs", "/hadoopfs/root1/kudu/master")),
+                subject.getRoleConfigs(KuduRoles.KUDU_MASTER, hostGroup, getTemplatePreparationObject(hostGroup))
+        );
+
+        assertEquals(List.of(
+                config("fs_wal_dir", "/hadoopfs/root1/kudu/tserver"),
+                config("fs_data_dirs", "/hadoopfs/root1/kudu/tserver")),
+                subject.getRoleConfigs(KuduRoles.KUDU_TSERVER, hostGroup, getTemplatePreparationObject(hostGroup))
+        );
+    }
+
+    private TemplatePreparationObject getTemplatePreparationObject(HostgroupView hostGroup) {
+        String inputJson = FileReaderUtils.readFileFromClasspathQuietly("input/cdp-data-mart.bp");
+        TemplatePreparationObject preparationObject = TemplatePreparationObject.Builder.builder()
+                .withHostgroupViews(Set.of(hostGroup))
+                .withBlueprintView(new BlueprintView(inputJson, "CDP", "1.0", new CmTemplateProcessor(inputJson)))
+                .build();
+        return preparationObject;
+    }
+}

--- a/template-manager-cmtemplate/src/test/resources/input/cdp-data-mart.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/cdp-data-mart.bp
@@ -109,6 +109,28 @@
       ]
     },
     {
+      "refName": "kudu",
+      "serviceType": "KUDU",
+      "serviceConfigs": [
+        {
+          "name": "gflagfile_service_safety_valve",
+          "value": "--use_hybrid_clock=false"
+        }
+      ],
+      "roleConfigGroups": [
+        {
+          "refName": "kudu-MASTER-BASE",
+          "roleType": "KUDU_MASTER",
+          "base": true
+        },
+        {
+          "refName": "kudu-TSERVER-BASE",
+          "roleType": "KUDU_TSERVER",
+          "base": true
+        }
+      ]
+    },
+    {
       "refName": "impala",
       "serviceType": "IMPALA",
       "roleConfigGroups": [
@@ -147,7 +169,8 @@
         "impala-STATESTORE-BASE",
         "oozie-OOZIE_SERVER-BASE",
         "yarn-JOBHISTORY-BASE",
-        "yarn-RESOURCEMANAGER-BASE"
+        "yarn-RESOURCEMANAGER-BASE",
+        "kudu-MASTER-BASE"
       ]
     },
     {
@@ -157,7 +180,8 @@
         "hdfs-DATANODE-BASE",
         "hive-GATEWAY-BASE",
         "impala-IMPALAD-BASE",
-        "yarn-NODEMANAGER-WORKER"
+        "yarn-NODEMANAGER-WORKER",
+        "kudu-TSERVER-BASE"
       ]
     },
     {

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/VolumeUtils.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/VolumeUtils.java
@@ -60,14 +60,24 @@ public final class VolumeUtils {
     }
 
     private static String buildVolumePathString(int volumeCount, String directory, String dirPrefix) {
+        return buildVolumePathString(1, volumeCount, directory, dirPrefix);
+    }
+
+    private static String buildVolumePathString(int startIndex, int volumeCount, String directory, String dirPrefix) {
         StringBuilder localDirs = new StringBuilder();
-        for (int i = 1; i <= volumeCount; i++) {
+        for (int i = startIndex; i <= volumeCount; i++) {
             localDirs.append(getVolumeDir(i, dirPrefix, directory));
             if (i != volumeCount) {
                 localDirs.append(',');
             }
         }
         return localDirs.toString();
+    }
+
+    public static String buildVolumePathFromVolumeIndexZeroVolumeHandled(int startIndex, int volumeCount, String directory) {
+        String prefix = volumeCount > 0 ? VOLUME_PREFIX : ROOT_VOLUME_PREFIX;
+        int calculatedVolumeCount = volumeCount == 0 ? 1 : volumeCount;
+        return buildVolumePathString(startIndex, calculatedVolumeCount, directory, prefix);
     }
 
     private static String getVolumeDir(int volumeIndex, String dirPrefix, String directory) {


### PR DESCRIPTION
Initialize Kudu Volume Configs.
Based on discussions with @akanto  since CB does not provide Mount Paths associated with specific type of attched volumes like SSD, Magnetic Disk  to ConfigProviders,  the kudu volume configs are initialized based on default mount paths similar to all other Volume Initializations.

Closes #CB-3347