### PR TITLE
Increase default metering log size to 10 MB

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/metering/template/generate_heartbeats.ini.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/metering/template/generate_heartbeats.ini.j2
@@ -13,5 +13,5 @@ WorkloadCRN = {{ metering.clusterCrn }}
 [Output]
 Path = /var/log/metering/heartbeats.json
 Period = 60
-MaxBytes = 5120
+MaxBytes = 10485760
 BackupCount = 10


### PR DESCRIPTION
metering log size is too small, so rotation happens really often, like in every 2 minutes. so increase the size setting to 10 MB