### PR TITLE
CB-3382 Support Azure environment subnets for redbeams

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudSubnet.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudSubnet.java
@@ -104,6 +104,10 @@ public class CloudSubnet implements Serializable {
         this.igwAvailable = igwAvailable;
     }
 
+    public CloudSubnet withId(String newId) {
+        return new CloudSubnet(newId, name, availabilityZone, cidr, privateSubnet, mapPublicIpOnLaunch, igwAvailable);
+    }
+
     @Override
     public String toString() {
         return "CloudSubnet{"

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsNetworkView.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsNetworkView.java
@@ -10,7 +10,7 @@ import com.sequenceiq.cloudbreak.cloud.model.Network;
 public class AwsNetworkView {
 
     @VisibleForTesting
-    static final String VPC = "vpcId";
+    static final String VPC_ID = "vpcId";
 
     @VisibleForTesting
     static final String VPC_CIDR = "vpcCidr";
@@ -19,7 +19,7 @@ public class AwsNetworkView {
     static final String IGW = "internetGatewayId";
 
     @VisibleForTesting
-    static final String SUBNET = "subnetId";
+    static final String SUBNET_ID = "subnetId";
 
     private final Network network;
 
@@ -28,11 +28,11 @@ public class AwsNetworkView {
     }
 
     public boolean isExistingVPC() {
-        return isNotEmpty(network.getStringParameter(VPC));
+        return isNotEmpty(network.getStringParameter(VPC_ID));
     }
 
     public boolean isExistingSubnet() {
-        return isNotEmpty(network.getStringParameter(SUBNET));
+        return isNotEmpty(network.getStringParameter(SUBNET_ID));
     }
 
     public boolean isExistingIGW() {
@@ -40,7 +40,7 @@ public class AwsNetworkView {
     }
 
     public String getExistingSubnet() {
-        return network.getStringParameter(SUBNET);
+        return network.getStringParameter(SUBNET_ID);
     }
 
     public boolean isSubnetList() {
@@ -56,7 +56,7 @@ public class AwsNetworkView {
     }
 
     public String getExistingVpc() {
-        return network.getStringParameter(VPC);
+        return network.getStringParameter(VPC_ID);
     }
 
     public String getExistingVpcCidr() {

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsNetworkViewTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsNetworkViewTest.java
@@ -1,9 +1,9 @@
 package com.sequenceiq.cloudbreak.cloud.aws.view;
 
 import static com.sequenceiq.cloudbreak.cloud.aws.view.AwsNetworkView.IGW;
-import static com.sequenceiq.cloudbreak.cloud.aws.view.AwsNetworkView.SUBNET;
-import static com.sequenceiq.cloudbreak.cloud.aws.view.AwsNetworkView.VPC;
+import static com.sequenceiq.cloudbreak.cloud.aws.view.AwsNetworkView.SUBNET_ID;
 import static com.sequenceiq.cloudbreak.cloud.aws.view.AwsNetworkView.VPC_CIDR;
+import static com.sequenceiq.cloudbreak.cloud.aws.view.AwsNetworkView.VPC_ID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -35,14 +35,14 @@ public class AwsNetworkViewTest {
 
     @Test
     public void testVpc() {
-        when(network.getStringParameter(VPC)).thenReturn("vpc-123");
+        when(network.getStringParameter(VPC_ID)).thenReturn("vpc-123");
         assertTrue(underTest.isExistingVPC());
         assertEquals("vpc-123", underTest.getExistingVpc());
     }
 
     @Test
     public void testNoVpc() {
-        when(network.getStringParameter(VPC)).thenReturn(null);
+        when(network.getStringParameter(VPC_ID)).thenReturn(null);
         assertFalse(underTest.isExistingVPC());
         assertNull(underTest.getExistingVpc());
     }
@@ -55,7 +55,7 @@ public class AwsNetworkViewTest {
 
     @Test
     public void testNoVpcCidr() {
-        when(network.getStringParameter(VPC)).thenReturn(null);
+        when(network.getStringParameter(VPC_ID)).thenReturn(null);
         assertNull(underTest.getExistingVpcCidr());
     }
 
@@ -75,7 +75,7 @@ public class AwsNetworkViewTest {
 
     @Test
     public void testSingleSubnet() {
-        when(network.getStringParameter(SUBNET)).thenReturn("subnet-123");
+        when(network.getStringParameter(SUBNET_ID)).thenReturn("subnet-123");
         assertTrue(underTest.isExistingSubnet());
         assertEquals("subnet-123", underTest.getExistingSubnet());
         assertFalse(underTest.isSubnetList());
@@ -84,7 +84,7 @@ public class AwsNetworkViewTest {
 
     @Test
     public void testMultipleSubnet() {
-        when(network.getStringParameter(SUBNET)).thenReturn("subnet-123,subnet-456,subnet-789");
+        when(network.getStringParameter(SUBNET_ID)).thenReturn("subnet-123,subnet-456,subnet-789");
         assertTrue(underTest.isExistingSubnet());
         assertEquals("subnet-123,subnet-456,subnet-789", underTest.getExistingSubnet());
         assertTrue(underTest.isSubnetList());
@@ -93,7 +93,7 @@ public class AwsNetworkViewTest {
 
     @Test
     public void testNoSubnet() {
-        when(network.getStringParameter(SUBNET)).thenReturn(null);
+        when(network.getStringParameter(SUBNET_ID)).thenReturn(null);
         assertFalse(underTest.isExistingSubnet());
         assertNull(underTest.getExistingSubnet());
         assertFalse(underTest.isSubnetList());

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilder.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilder.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.sequenceiq.cloudbreak.cloud.azure.view.AzureCredentialView;
 import com.sequenceiq.cloudbreak.cloud.azure.view.AzureDatabaseServerView;
 import com.sequenceiq.cloudbreak.cloud.azure.view.AzureInstanceCredentialView;
+import com.sequenceiq.cloudbreak.cloud.azure.view.AzureNetworkView;
 import com.sequenceiq.cloudbreak.cloud.azure.view.AzureSecurityView;
 import com.sequenceiq.cloudbreak.cloud.azure.view.AzureStackView;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
@@ -111,6 +112,7 @@ public class AzureTemplateBuilder {
     public String build(String stackName, CloudContext cloudContext, DatabaseStack databaseStack) {
         try {
             String location = cloudContext.getLocation().getRegion().getRegionName();
+            AzureNetworkView azureNetworkView = new AzureNetworkView(databaseStack.getNetwork());
             AzureDatabaseServerView azureDatabaseServerView = new AzureDatabaseServerView(databaseStack.getDatabaseServer());
             Map<String, Object> model = new HashMap<>();
 
@@ -128,7 +130,7 @@ public class AzureTemplateBuilder {
             model.put("skuSizeMB", azureDatabaseServerView.getAllocatedStorageInMb().toString());
             model.put("skuTier", azureDatabaseServerView.getSkuTier());
             model.put("storageAutoGrow", azureDatabaseServerView.getStorageAutoGrow());
-            model.put("subnets", databaseStack.getNetwork().getStringParameter("subnets"));
+            model.put("subnets", azureNetworkView.getSubnets());
             model.putAll(defaultCostTaggingService.prepareAllTagsForTemplate());
             String generatedTemplate = freeMarkerTemplateUtils.processTemplateIntoString(getTemplate(databaseStack), model);
             LOGGER.debug("Generated ARM database template: {}", generatedTemplate);

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureNetworkView.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureNetworkView.java
@@ -1,0 +1,20 @@
+package com.sequenceiq.cloudbreak.cloud.azure.view;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.sequenceiq.cloudbreak.cloud.model.Network;
+
+public class AzureNetworkView {
+
+    @VisibleForTesting
+    static final String SUBNETS = "subnets";
+
+    private final Network network;
+
+    public AzureNetworkView(Network network) {
+        this.network = network;
+    }
+
+    public String getSubnets() {
+        return network.getStringParameter(SUBNETS);
+    }
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureNetworkViewTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureNetworkViewTest.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.cloudbreak.cloud.azure.view;
+
+import static com.sequenceiq.cloudbreak.cloud.azure.view.AzureNetworkView.SUBNETS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import com.sequenceiq.cloudbreak.cloud.model.Network;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+public class AzureNetworkViewTest {
+
+    @Mock
+    private Network network;
+
+    private AzureNetworkView underTest;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+
+        underTest = new AzureNetworkView(network);
+    }
+
+    @Test
+    public void testSubnets() {
+        when(network.getStringParameter(SUBNETS)).thenReturn("subnet-a,subnet-b");
+        assertThat(underTest.getSubnets()).isEqualTo("subnet-a,subnet-b");
+    }
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/dto/Credential.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/dto/Credential.java
@@ -1,28 +1,106 @@
 package com.sequenceiq.redbeams.dto;
 
+import java.util.Optional;
+
+/**
+ * Credential information extracted from a credential service response.
+ */
 public class Credential {
+
+    private final String crn;
 
     private final String name;
 
     private final String attributes;
 
-    private final String crn;
+    private final Optional<AzureParameters> azure;
 
-    public Credential(String name, String attributes, String crn) {
-        this.name = name;
-        this.attributes = attributes;
-        this.crn = crn;
+    /**
+     * Creates a new credential.
+     *
+     * @param  crn        credential CRN
+     * @param  name       credential name
+     * @param  attributes credential attributes
+     */
+    public Credential(String crn, String name, String attributes) {
+        this(crn, name, attributes, null);
     }
 
+    /**
+     * Creates a new Azure credential.
+     *
+     * @param  crn        credential CRN
+     * @param  name       credential name
+     * @param  attributes credential attributes
+     * @param  Azure      Azure-specific credential information (null if a non-Azure credential)
+     */
+    public Credential(String crn, String name, String attributes, AzureParameters azure) {
+        this.crn = crn;
+        this.name = name;
+        this.attributes = attributes;
+        this.azure = Optional.ofNullable(azure);
+    }
+
+    /**
+     * Gets the credential CRN.
+     *
+     * @return credential CRN
+     */
+    public String getCrn() {
+        return crn;
+    }
+
+    /**
+     * Gets the credential name.
+     *
+     * @return credential name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Gets the credential attributes.
+     *
+     * @return credential attributes
+     */
     public String getAttributes() {
         return attributes;
     }
 
-    public String getCrn() {
-        return crn;
+    /**
+     * Gets the Azure parameters of the credential.
+     *
+     * @return Azure parameters of the credential
+     */
+    public Optional<AzureParameters> getAzure() {
+        return azure;
     }
+
+    /**
+     * Azure-specific credential parameters.
+     */
+    public static class AzureParameters {
+
+        private final String subscriptionId;
+
+        /**
+         * Creates new Azure parameters.
+         *
+         * @param  subscriptionId Azure subscription ID
+         */
+        public AzureParameters(String subscriptionId) {
+            this.subscriptionId = subscriptionId;
+        }
+
+        /**
+         * Gets the subscription ID.
+         *
+         * @return subscription ID
+         */
+        public String getSubscriptionId() {
+            return subscriptionId;
+        }
+    }
+
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/CredentialService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/CredentialService.java
@@ -19,10 +19,23 @@ public class CredentialService {
     @Inject
     private SecretService secretService;
 
+    /**
+     * Gets the credential for an environment.
+     *
+     * @param  envCrn environment CRN
+     * @return        environment credential
+     */
     public Credential getCredentialByEnvCrn(String envCrn) {
         CredentialResponse credentialResponse = credentialEndpoint.getByEnvironmentCrn(envCrn);
+
         SecretResponse secretResponse = credentialResponse.getAttributes();
         String attributes = secretService.getByResponse(secretResponse);
-        return new Credential(credentialResponse.getName(), attributes, credentialResponse.getCrn());
+
+        if (credentialResponse.getAzure() != null) {
+            return new Credential(credentialResponse.getCrn(), credentialResponse.getName(), attributes,
+                new Credential.AzureParameters(credentialResponse.getAzure().getSubscriptionId()));
+        } else {
+            return new Credential(credentialResponse.getCrn(), credentialResponse.getName(), attributes);
+        }
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/network/SubnetChooserService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/network/SubnetChooserService.java
@@ -10,12 +10,25 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.redbeams.exception.BadRequestException;
+import com.sequenceiq.redbeams.exception.RedbeamsException;
 
 @Service
 public class SubnetChooserService {
 
-    public List<CloudSubnet> chooseSubnetsFromDifferentAzs(List<CloudSubnet> subnetMetas) {
+    public List<CloudSubnet> chooseSubnets(List<CloudSubnet> subnetMetas, CloudPlatform cloudPlatform) {
+        switch (cloudPlatform) {
+            case AWS:
+                return chooseSubnetsAws(subnetMetas);
+            case AZURE:
+                return chooseSubnetsAzure(subnetMetas);
+            default:
+                throw new RedbeamsException(String.format("Support for cloud platform %s not yet added", cloudPlatform.name()));
+        }
+    }
+
+    private List<CloudSubnet> chooseSubnetsAws(List<CloudSubnet> subnetMetas) {
         if (subnetMetas.size() < 2) {
             throw new BadRequestException("Insufficient number of subnets: at least two subnets in two different availability zones needed");
         }
@@ -32,5 +45,9 @@ public class SubnetChooserService {
     private static <T> Predicate<T> distinctByKey(Function<? super T, ?> keyExtractor) {
         Set<Object> seen = ConcurrentHashMap.newKeySet();
         return t -> seen.add(keyExtractor.apply(t));
+    }
+
+    private List<CloudSubnet> chooseSubnetsAzure(List<CloudSubnet> subnetMetas) {
+        return subnetMetas;
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/network/SubnetListerService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/network/SubnetListerService.java
@@ -1,0 +1,74 @@
+package com.sequenceiq.redbeams.service.network;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
+import com.sequenceiq.redbeams.dto.Credential;
+import com.sequenceiq.redbeams.exception.RedbeamsException;
+import com.sequenceiq.redbeams.service.CredentialService;
+
+@Service
+public class SubnetListerService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SubnetListerService.class);
+
+    @Inject
+    private CredentialService credentialService;
+
+    public List<CloudSubnet> listSubnets(DetailedEnvironmentResponse environmentResponse, CloudPlatform cloudPlatform) {
+        EnvironmentNetworkResponse environmentNetworkResponse = environmentResponse.getNetwork();
+        if (environmentNetworkResponse == null || environmentNetworkResponse.getSubnetMetas() == null) {
+            throw new RedbeamsException("Environment does not contain metadata for subnets");
+        }
+
+        switch (cloudPlatform) {
+            case AWS:
+                // IDs in metas are fine as is
+                return new ArrayList<>(environmentNetworkResponse.getSubnetMetas().values());
+            case AZURE:
+                // IDs in metas must be expanded to full resource IDs
+                String subscriptionId = getAzureSubscriptionId(environmentResponse.getCrn());
+                return new ArrayList<>(environmentNetworkResponse.getSubnetMetas().values().stream()
+                        .map(meta -> expandAzureResourceId(meta, environmentResponse, subscriptionId))
+                        .collect(Collectors.toList()));
+            default:
+                throw new RedbeamsException(String.format("Support for cloud platform %s not yet added", cloudPlatform.name()));
+        }
+    }
+
+    @VisibleForTesting
+    String getAzureSubscriptionId(String environmentCrn) {
+        Credential credential = credentialService.getCredentialByEnvCrn(environmentCrn);
+        LOGGER.info("Found credential {} for environment {}", credential.getName(), environmentCrn);
+        if (credential.getAzure().isPresent()) {
+            return credential.getAzure().get().getSubscriptionId();
+        } else {
+            throw new RedbeamsException(String.format("Retrieved credential {} for Azure environment {} which lacks subscription ID",
+                credential.getName(), environmentCrn));
+        }
+    }
+
+    @VisibleForTesting
+    static CloudSubnet expandAzureResourceId(CloudSubnet meta, DetailedEnvironmentResponse environmentResponse, String subscriptionId) {
+
+        StringBuilder expandedId = new StringBuilder("/subscriptions/");
+        expandedId.append(subscriptionId);
+        expandedId.append("/resourceGroups/").append(environmentResponse.getNetwork().getAzure().getResourceGroupName());
+        expandedId.append("/providers/Microsoft.Network/virtualNetworks/").append(environmentResponse.getNetwork().getAzure().getNetworkId());
+        expandedId.append("/subnets/").append(meta.getId());
+
+        return meta.withId(expandedId.toString());
+    }
+}

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/converter/cloud/CredentialToCloudCredentialConverterTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/converter/cloud/CredentialToCloudCredentialConverterTest.java
@@ -25,7 +25,7 @@ public class CredentialToCloudCredentialConverterTest {
 
     @Test
     public void testConvert() {
-        credential = new Credential("userId", "{ \"foo\": \"bar\" }", "userCrn");
+        credential = new Credential("userCrn", "userId", "{ \"foo\": \"bar\" }");
 
         CloudCredential cloudCredential = underTest.convert(credential);
 
@@ -37,7 +37,7 @@ public class CredentialToCloudCredentialConverterTest {
 
     @Test
     public void testConvertNoAttributes() {
-        credential = new Credential("userId", null, "userCrn");
+        credential = new Credential("userCrn", "userId", null);
 
         CloudCredential cloudCredential = underTest.convert(credential);
 

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/dto/CredentialTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/dto/CredentialTest.java
@@ -1,24 +1,42 @@
 package com.sequenceiq.redbeams.dto;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
 import org.junit.Test;
 
 public class CredentialTest {
 
+    private static final String CRN = "crn";
+
+    private static final String NAME = "name";
+
+    private static final String ATTRIBUTES = "attributes";
+
+    private static final String SUBSCRIPTION_ID = "subscriptionId";
+
     private Credential underTest;
 
     @Before
     public void setUp() {
-        underTest = new Credential("name", "attributes", "crn");
+        underTest = new Credential(CRN, NAME, ATTRIBUTES);
     }
 
     @Test
     public void testGetters() {
-        assertEquals("name", underTest.getName());
-        assertEquals("attributes", underTest.getAttributes());
-        assertEquals("crn", underTest.getCrn());
+        assertEquals(CRN, underTest.getCrn());
+        assertEquals(NAME, underTest.getName());
+        assertEquals(ATTRIBUTES, underTest.getAttributes());
+
+        assertTrue(underTest.getAzure().isEmpty());
     }
 
+    @Test
+    public void testAzureParameters() {
+        Credential.AzureParameters azure = new Credential.AzureParameters(SUBSCRIPTION_ID);
+        underTest = new Credential(CRN, NAME, ATTRIBUTES, azure);
+
+        assertEquals(SUBSCRIPTION_ID, underTest.getAzure().get().getSubscriptionId());
+    }
 }

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/service/CredentialServiceTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/service/CredentialServiceTest.java
@@ -1,0 +1,87 @@
+package com.sequenceiq.redbeams.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import com.sequenceiq.cloudbreak.service.secret.model.SecretResponse;
+import com.sequenceiq.cloudbreak.service.secret.service.SecretService;
+import com.sequenceiq.environment.api.v1.credential.endpoint.CredentialEndpoint;
+import com.sequenceiq.environment.api.v1.credential.model.response.CredentialResponse;
+import com.sequenceiq.environment.api.v1.credential.model.parameters.azure.AzureCredentialResponseParameters;
+import com.sequenceiq.redbeams.dto.Credential;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+public class CredentialServiceTest {
+
+    private static final String ENVIRONMENT_CRN = "envCrn";
+
+    private static final String CRN = "crn";
+
+    private static final String NAME = "name";
+
+    private static final String ATTRIBUTES = "attributes";
+
+    private static final String SUBSCRIPTION_ID = "subscriptionId";
+
+    @Mock
+    private CredentialEndpoint credentialEndpoint;
+
+    @Mock
+    private SecretService secretService;
+
+    @Mock
+    private SecretResponse secretResponse;
+
+    @InjectMocks
+    private CredentialService underTest;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+
+        when(secretService.getByResponse(secretResponse)).thenReturn(ATTRIBUTES);
+    }
+
+    @Test
+    public void testNonAzureCredential() {
+        CredentialResponse credentialResponse = new CredentialResponse();
+        credentialResponse.setCrn(CRN);
+        credentialResponse.setName(NAME);
+        credentialResponse.setAttributes(secretResponse);
+        when(credentialEndpoint.getByEnvironmentCrn(ENVIRONMENT_CRN)).thenReturn(credentialResponse);
+
+        Credential credential = underTest.getCredentialByEnvCrn(ENVIRONMENT_CRN);
+
+        assertEquals(CRN, credential.getCrn());
+        assertEquals(NAME, credential.getName());
+        assertEquals(ATTRIBUTES, credential.getAttributes());
+        assertFalse(credential.getAzure().isPresent());
+    }
+
+    @Test
+    public void testAzureCredential() {
+        CredentialResponse credentialResponse = new CredentialResponse();
+        credentialResponse.setCrn(CRN);
+        credentialResponse.setName(NAME);
+        credentialResponse.setAttributes(secretResponse);
+        AzureCredentialResponseParameters azureResponse = new AzureCredentialResponseParameters();
+        azureResponse.setSubscriptionId(SUBSCRIPTION_ID);
+        credentialResponse.setAzure(azureResponse);
+        when(credentialEndpoint.getByEnvironmentCrn(ENVIRONMENT_CRN)).thenReturn(credentialResponse);
+
+        Credential credential = underTest.getCredentialByEnvCrn(ENVIRONMENT_CRN);
+
+        assertEquals(CRN, credential.getCrn());
+        assertEquals(NAME, credential.getName());
+        assertEquals(ATTRIBUTES, credential.getAttributes());
+        assertTrue(credential.getAzure().isPresent());
+        assertEquals(SUBSCRIPTION_ID, credential.getAzure().get().getSubscriptionId());
+    }
+}

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/service/network/NetworkParameterAdderTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/service/network/NetworkParameterAdderTest.java
@@ -17,37 +17,37 @@ import com.sequenceiq.environment.api.v1.environment.model.response.SecurityAcce
 
 public class NetworkParameterAdderTest {
 
-    private static final String VPC_SECURITY_CIDR = "1.2.3.4/16";
+    private static final String TEST_VPC_CIDR = "1.2.3.4/16";
 
-    private static final String VPC_ID = "vpcId";
+    private static final String TEST_VPC_ID = "vpcId";
 
     private final NetworkParameterAdder underTest = new NetworkParameterAdder();
 
     @Test
-    public void testAddNetworkParameters() {
+    public void testAddNetworkParametersWhenAws() {
         Map<String, Object> parameters = new HashMap<>();
         List<String> subnetIds = List.of("subnet1", "subnet2");
 
-        parameters = underTest.addNetworkParameters(parameters, subnetIds);
+        parameters = underTest.addSubnetIds(parameters, subnetIds, CloudPlatform.AWS);
 
-        assertThat(parameters, IsMapContaining.hasEntry("subnetId", String.join(",", subnetIds)));
+        assertThat(parameters, IsMapContaining.hasEntry(NetworkParameterAdder.SUBNET_ID, String.join(",", subnetIds)));
     }
 
     @Test
-    public void testAddVpcParametersWhenAws() {
+    public void testAddParametersWhenAws() {
         Map<String, Object> parameters = new HashMap<>();
         DetailedEnvironmentResponse environment = DetailedEnvironmentResponse.Builder.builder()
                 .withCloudPlatform(CloudPlatform.AWS.name())
                 .withSecurityAccess(SecurityAccessResponse.builder()
-                        .withCidr(VPC_SECURITY_CIDR).build())
+                        .withCidr(TEST_VPC_CIDR).build())
                 .withNetwork(EnvironmentNetworkResponseBuilder.anEnvironmentNetworkResponse()
-                        .withAws(EnvironmentNetworkAwsParamsBuilder.anEnvironmentNetworkAwsParams().withVpcId(VPC_ID).build())
+                        .withAws(EnvironmentNetworkAwsParamsBuilder.anEnvironmentNetworkAwsParams().withVpcId(TEST_VPC_ID).build())
                         .build())
                 .build();
 
-        parameters = underTest.addVpcParameters(parameters, environment, CloudPlatform.AWS);
+        parameters = underTest.addParameters(parameters, environment, CloudPlatform.AWS);
 
-        assertThat(parameters, IsMapContaining.hasEntry("vpcId", VPC_ID));
-        assertThat(parameters, IsMapContaining.hasEntry("vpcCidr", VPC_SECURITY_CIDR));
+        assertThat(parameters, IsMapContaining.hasEntry(NetworkParameterAdder.VPC_ID, TEST_VPC_ID));
+        assertThat(parameters, IsMapContaining.hasEntry(NetworkParameterAdder.VPC_CIDR, TEST_VPC_CIDR));
     }
 }

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/service/network/SubnetListerServiceTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/service/network/SubnetListerServiceTest.java
@@ -1,0 +1,119 @@
+package com.sequenceiq.redbeams.service.network;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
+import com.sequenceiq.redbeams.dto.Credential;
+import com.sequenceiq.redbeams.service.CredentialService;
+
+public class SubnetListerServiceTest {
+
+    private static final String ENVIRONMENT_CRN = "envCrn";
+
+    private static final String SUBNET_ID_1 = "subnet-1";
+
+    private static final String SUBNET_ID_2 = "subnet-2";
+
+    private static final String RESOURCE_GROUP = "rg";
+
+    private static final String NETWORK_ID = "vnet";
+
+    private static final String CREDENTIAL_CRN = "mycredsCrn";
+
+    private static final String CREDENTIAL_NAME = "mycreds";
+
+    private static final String CREDENTIAL_ATTRIBUTES = "mycredsAttributes";
+
+    private static final String SUBSCRIPTION_ID = "subscriptionId";
+
+    @Mock
+    private CredentialService credentialService;
+
+    @Mock
+    private DetailedEnvironmentResponse detailedEnvironmentResponse;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private EnvironmentNetworkResponse environmentNetworkResponse;
+
+    private CloudSubnet subnet1;
+
+    private CloudSubnet subnet2;
+
+    private Map<String, CloudSubnet> subnets;
+
+    private Credential credential;
+
+    @InjectMocks
+    private SubnetListerService underTest;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+
+        when(detailedEnvironmentResponse.getCrn()).thenReturn(ENVIRONMENT_CRN);
+        when(detailedEnvironmentResponse.getNetwork()).thenReturn(environmentNetworkResponse);
+
+        subnet1 = new CloudSubnet(SUBNET_ID_1, "name1");
+        subnet2 = new CloudSubnet(SUBNET_ID_2, "name2");
+        subnets = Map.of(SUBNET_ID_1, subnet1, SUBNET_ID_2, subnet2);
+    }
+
+    @Test
+    public void testListSubnetsAws() {
+        when(environmentNetworkResponse.getSubnetMetas()).thenReturn(subnets);
+        credential = new Credential(CREDENTIAL_CRN, CREDENTIAL_NAME, CREDENTIAL_ATTRIBUTES);
+        when(credentialService.getCredentialByEnvCrn(ENVIRONMENT_CRN)).thenReturn(credential);
+
+        List<CloudSubnet> subnets = underTest.listSubnets(detailedEnvironmentResponse, CloudPlatform.AWS);
+
+        assertEquals(2, subnets.size());
+        assertTrue(subnets.contains(subnet1));
+        assertTrue(subnets.contains(subnet2));
+    }
+
+    @Test
+    public void testListSubnetsAzure() {
+        when(environmentNetworkResponse.getSubnetMetas()).thenReturn(subnets);
+        when(environmentNetworkResponse.getAzure().getResourceGroupName()).thenReturn(RESOURCE_GROUP);
+        when(environmentNetworkResponse.getAzure().getNetworkId()).thenReturn(NETWORK_ID);
+        Credential.AzureParameters azure = new Credential.AzureParameters(SUBSCRIPTION_ID);
+        credential = new Credential(CREDENTIAL_CRN, CREDENTIAL_NAME, CREDENTIAL_ATTRIBUTES, azure);
+        when(credentialService.getCredentialByEnvCrn(ENVIRONMENT_CRN)).thenReturn(credential);
+
+        List<CloudSubnet> subnets = underTest.listSubnets(detailedEnvironmentResponse, CloudPlatform.AZURE);
+
+        assertEquals(2, subnets.size());
+        Set<String> ids = subnets.stream().map(CloudSubnet::getId).collect(Collectors.toSet());
+        assertTrue(ids.contains(SubnetListerService.expandAzureResourceId(subnet1, detailedEnvironmentResponse, SUBSCRIPTION_ID).getId()));
+        assertTrue(ids.contains(SubnetListerService.expandAzureResourceId(subnet2, detailedEnvironmentResponse, SUBSCRIPTION_ID).getId()));
+    }
+
+    @Test
+    public void testExpandAzureResourceId() {
+        when(environmentNetworkResponse.getAzure().getResourceGroupName()).thenReturn(RESOURCE_GROUP);
+        when(environmentNetworkResponse.getAzure().getNetworkId()).thenReturn(NETWORK_ID);
+
+        CloudSubnet expandedSubnet = SubnetListerService.expandAzureResourceId(subnet1, detailedEnvironmentResponse, SUBSCRIPTION_ID);
+
+        String expectedId = String.format("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/%s/subnets/%s",
+            SUBSCRIPTION_ID, RESOURCE_GROUP, NETWORK_ID, subnet1.getId());
+        assertEquals(expectedId, expandedSubnet.getId());
+    }
+}


### PR DESCRIPTION
The task of listing subnets in an environment is refactored out of
AllocateDatabaseServerV4RequestToDBStackConverter into the new
SubnetListerService class. For AWS, the class behaves as the previous
code, simply listing all the subnets by their IDs. For Azure, the class
modifies each subnet, expanding out its ID into the complete Azure
resource ID. Some of the necessary information is already available in
the environment response, but the subscription ID must be retrieved from
the credential associated with the environment.

SubnetChooserService is still in use, but it is now aware of the cloud
platform and supports Azure. Since there are no AZ restrictons in Azure,
it just chooses all of the subnets.

Other changes:

* The new CloudSubnet::withId method makes it easy to create a new
  subnet definition with an updated ID. SubnetListerService uses this.
* A new AzureNetworkView helper class formalizes how to retrieve subnets
  from an Azure network cloud model (done in AzureTemplateBuilder).
* Constants in AwsNetworkView are renamed to line up better with their
  use across the code base.
* Methods in the redbeams classes
  AllocateDatabaseServerV4RequestToDBStackConverter,
  SubnetChooserService, NetworkParameterAdder are renamed to be clearer
  on what they do, and less specific to AWS.
* The Credential DTO in redbeams now carries along the Azure
  subscription ID, placed there by CredentialService. Its constructors
  are updated for a more natural ordering of arguments.
* NetworkParameterAdder::addParameters (formerly addVpcParameters) no
  longer sets the "vpcId" parameter for Azure, as it turns out it was
  unused. Although the case for Azure is now a no-op, it must remain for
  Azure processing to work.