### PR TITLE
Fix missing endif from topology.xml.j2

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -172,6 +172,7 @@
                  <name>NIFI</name>
                  <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000;maxRetryAttempts=300;retrySleep=1000</value>
              </param>
+             {%- endif %}
              {% if 'NIFI-REGISTRY' in exposed and 'NIFI_REGISTRY_SERVER' in salt['pillar.get']('gateway:location') -%}
              <param>
                  <name>NIFI-REGISTRY</name>


### PR DESCRIPTION
I think this was broken in commit fbbf20e9a5. Deployments now fail with:

Name: /var/lib/knox/cloudbreak_resources//topologies/cdp-proxy.xml
Comment: Unable to manage file: Jinja syntax error: Unexpected end of template. Jinja was looking for the following tags: 'elif' or 'else' or 'endif'. The innermost block that needs to be closed is 'if'.; line 488

---
[...]
        {% for hostloc in salt['pillar.get']('gateway:location')['PROFILER_SCHEDULER_AGENT'] -%}
        <url>{{ protocol }}://{{ hostloc }}:{{ ports['PROFILER-SCHEDULER-API'] }}</url>
        {%- endfor %}
    </service>
    {%- endif %}
    {%- endif %}    <======================

</topology>