### PR TITLE
CB-3176 Retry calls from redbeams to other services

### DIFF
--- a/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/RetryConfig.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/RetryConfig.java
@@ -1,0 +1,47 @@
+package com.sequenceiq.redbeams.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.backoff.FixedBackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
+
+/**
+ * Configures retry logic for redbeams.
+ */
+@Configuration
+public class RetryConfig {
+
+    /**
+     * The maximum number of attempts to make when calling another Cloudbreak
+     * service.
+     */
+    @Value("${redbeams.retry.cb.maxAttempts:3}")
+    private int cbMaxAttempts;
+
+    /**
+     * The fixed backoff period, in milliseconds, for retries of calls to other
+     * Cloudbreak services.
+     */
+    @Value("${redbeams.retry.cb.backOffPeriodInMs:5000}")
+    private long cbBackOffPeriodInMs;
+
+    /**
+     * Defines the retry template to use for calls to other Cloudbreak services.
+     *
+     * @return retry template
+     */
+    @Bean
+    public RetryTemplate cbRetryTemplate() {
+        RetryTemplate t = new RetryTemplate();
+
+        t.setRetryPolicy(new SimpleRetryPolicy(cbMaxAttempts));
+        FixedBackOffPolicy backOffPolicy = new FixedBackOffPolicy();
+        backOffPolicy.setBackOffPeriod(cbBackOffPeriodInMs);
+        t.setBackOffPolicy(backOffPolicy);
+
+        return t;
+    }
+
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/CredentialService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/CredentialService.java
@@ -2,6 +2,7 @@ package com.sequenceiq.redbeams.service;
 
 import javax.inject.Inject;
 
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.service.secret.model.SecretResponse;
@@ -12,6 +13,9 @@ import com.sequenceiq.redbeams.dto.Credential;
 
 @Service
 public class CredentialService {
+
+    @Inject
+    private RetryTemplate cbRetryTemplate;
 
     @Inject
     private CredentialEndpoint credentialEndpoint;
@@ -26,7 +30,7 @@ public class CredentialService {
      * @return        environment credential
      */
     public Credential getCredentialByEnvCrn(String envCrn) {
-        CredentialResponse credentialResponse = credentialEndpoint.getByEnvironmentCrn(envCrn);
+        CredentialResponse credentialResponse = cbRetryTemplate.execute(rctx -> credentialEndpoint.getByEnvironmentCrn(envCrn));
 
         SecretResponse secretResponse = credentialResponse.getAttributes();
         String attributes = secretService.getByResponse(secretResponse);

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/EnvironmentService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/EnvironmentService.java
@@ -2,6 +2,7 @@ package com.sequenceiq.redbeams.service;
 
 import javax.inject.Inject;
 
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.environment.api.v1.environment.endpoint.EnvironmentEndpoint;
@@ -11,9 +12,12 @@ import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvi
 public class EnvironmentService {
 
     @Inject
+    private RetryTemplate cbRetryTemplate;
+
+    @Inject
     private EnvironmentEndpoint environmentEndpoint;
 
     public DetailedEnvironmentResponse getByCrn(String envCrn) {
-        return environmentEndpoint.getByCrn(envCrn);
+        return cbRetryTemplate.execute(rctx -> environmentEndpoint.getByCrn(envCrn));
     }
 }

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/service/CredentialServiceTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/service/CredentialServiceTest.java
@@ -13,10 +13,14 @@ import com.sequenceiq.environment.api.v1.credential.model.response.CredentialRes
 import com.sequenceiq.environment.api.v1.credential.model.parameters.azure.AzureCredentialResponseParameters;
 import com.sequenceiq.redbeams.dto.Credential;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
+import org.springframework.retry.support.RetryTemplate;
 
 public class CredentialServiceTest {
 
@@ -29,6 +33,10 @@ public class CredentialServiceTest {
     private static final String ATTRIBUTES = "attributes";
 
     private static final String SUBSCRIPTION_ID = "subscriptionId";
+
+    @SuppressFBWarnings(value = "UrF", justification = "Gets injected into CredentialService")
+    @Spy
+    private RetryTemplate cbRetryTemplate = new RetryTemplate();
 
     @Mock
     private CredentialEndpoint credentialEndpoint;


### PR DESCRIPTION
Redbeams now uses a retry template for calls to other services,
specifically the environment and credential services. The number of
attempts and retry interval may be configured.