### PR TITLE
CB-3291 Periscope should restore the instance state automatically

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/domain/FailedNode.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/domain/FailedNode.java
@@ -1,0 +1,78 @@
+package com.sequenceiq.periscope.domain;
+
+import java.util.Date;
+import java.util.Objects;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+
+@Entity(name = "failed_node")
+public class FailedNode {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "failed_node_generator")
+    @SequenceGenerator(name = "failed_node_generator", sequenceName = "failed_node_id_seq", allocationSize = 1)
+    private long id;
+
+    private Long created = new Date().getTime();
+
+    @Column(name = "cluster_id")
+    private long clusterId;
+
+    private String name;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public Long getCreated() {
+        return created;
+    }
+
+    public void setCreated(Long created) {
+        this.created = created;
+    }
+
+    public long getClusterId() {
+        return clusterId;
+    }
+
+    public void setClusterId(long clusterId) {
+        this.clusterId = clusterId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !getClass().equals(o.getClass())) {
+            return false;
+        }
+        FailedNode that = (FailedNode) o;
+        return id == that.id &&
+                clusterId == that.clusterId &&
+                Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, clusterId, name);
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ClusterManagerHostHealthEvaluator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ClusterManagerHostHealthEvaluator.java
@@ -1,27 +1,37 @@
 package com.sequenceiq.periscope.monitor.evaluator;
 
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
-import org.springframework.util.CollectionUtils;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.FailureReportV4Request;
-import com.sequenceiq.cloudbreak.client.CloudbreakInternalCrnClient;
+import com.google.common.collect.Sets;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.ChangedNodesReportV4Request;
 import com.sequenceiq.periscope.domain.Cluster;
 import com.sequenceiq.periscope.domain.ClusterManagerVariant;
+import com.sequenceiq.periscope.domain.FailedNode;
 import com.sequenceiq.periscope.monitor.context.ClusterIdEvaluatorContext;
 import com.sequenceiq.periscope.monitor.context.EvaluatorContext;
+import com.sequenceiq.periscope.repository.FailedNodeRepository;
 import com.sequenceiq.periscope.service.ClusterService;
 import com.sequenceiq.periscope.service.configuration.CloudbreakClientConfiguration;
 
 @Component("ClusterManagerHostHealthEvaluator")
 @Scope("prototype")
 public class ClusterManagerHostHealthEvaluator extends EvaluatorExecutor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterManagerHostHealthEvaluator.class);
 
     private static final String EVALUATOR_NAME = ClusterManagerHostHealthEvaluator.class.getName();
 
@@ -35,6 +45,9 @@ public class ClusterManagerHostHealthEvaluator extends EvaluatorExecutor {
     private CloudbreakClientConfiguration cloudbreakClientConfiguration;
 
     private long clusterId;
+
+    @Inject
+    private FailedNodeRepository failedNodeRepository;
 
     @Override
     public void setContext(EvaluatorContext context) {
@@ -56,13 +69,59 @@ public class ClusterManagerHostHealthEvaluator extends EvaluatorExecutor {
     public void execute() {
         Cluster cluster = clusterService.findById(clusterId);
         ClusterManagerVariant variant = cluster.getClusterManager().getVariant();
-        ClusterManagerSpecificHostHealthEvaluator clusterManagerSpecificHostHealthEvaluator = hostHealthEvaluatorMap.get(variant);
-        List<String> hostNamesToRecover = clusterManagerSpecificHostHealthEvaluator.determineHostnamesToRecover(cluster);
-        if (!CollectionUtils.isEmpty(hostNamesToRecover)) {
-            CloudbreakInternalCrnClient cbClient = cloudbreakClientConfiguration.cloudbreakInternalCrnClientClient();
-            FailureReportV4Request failureReport = new FailureReportV4Request();
-            failureReport.setFailedNodes(hostNamesToRecover);
-            cbClient.withInternalCrn().autoscaleEndpoint().failureReport(cluster.getStackCrn(), failureReport);
+        List<String> hostNamesToRecover = hostHealthEvaluatorMap.get(variant).determineHostnamesToRecover(cluster);
+        List<FailedNode> failedNodes = failedNodeRepository.findByClusterId(clusterId);
+        Optional<ChangedNodesReportV4Request> changedNodesRequest = getChangedNodes(Set.copyOf(hostNamesToRecover), failedNodes);
+        if (changedNodesRequest.isPresent()) {
+            LOGGER.info("Nodes state changed for cluster {}. New failed nodes {}, new healthy nodes {}.",
+                    clusterId,
+                    changedNodesRequest.get().getNewFailedNodes(),
+                    changedNodesRequest.get().getNewHealthyNodes());
+            cloudbreakClientConfiguration.cloudbreakInternalCrnClientClient()
+                    .withInternalCrn()
+                    .autoscaleEndpoint().changedNodesReport(cluster.getStackCrn(), changedNodesRequest.get());
+            updateFailedNodes(failedNodes, changedNodesRequest.get());
+        } else {
+            LOGGER.debug("Nodes state not changed for cluster {}", clusterId);
+        }
+    }
+
+    private Optional<ChangedNodesReportV4Request> getChangedNodes(Set<String> unhealthyNodes, List<FailedNode> registeredFailedNodes) {
+        Set<String> registeredFailedNodeNames = registeredFailedNodes
+                .stream()
+                .map(FailedNode::getName)
+                .collect(toSet());
+        Set<String> newFailedNodes = Sets.difference(unhealthyNodes, registeredFailedNodeNames);
+        Set<String> newHealthyNodes = Sets.difference(registeredFailedNodeNames, unhealthyNodes);
+        if (newFailedNodes.isEmpty() && newHealthyNodes.isEmpty()) {
+            return Optional.empty();
+        } else {
+            ChangedNodesReportV4Request request = new ChangedNodesReportV4Request();
+            request.setNewFailedNodes(List.copyOf(newFailedNodes));
+            request.setNewHealthyNodes(List.copyOf(newHealthyNodes));
+            return Optional.of(request);
+        }
+    }
+
+    private void updateFailedNodes(List<FailedNode> failedNodes, ChangedNodesReportV4Request changedNodes) {
+        if (!changedNodes.getNewFailedNodes().isEmpty()) {
+            failedNodeRepository.saveAll(changedNodes.getNewFailedNodes()
+                    .stream()
+                    .map(name -> {
+                        FailedNode node = new FailedNode();
+                        node.setClusterId(clusterId);
+                        node.setName(name);
+                        return node;
+                    })
+                    .collect(toList()));
+        }
+        if (!changedNodes.getNewHealthyNodes().isEmpty()) {
+            Set<String> healthyNodeNames = Set.copyOf(changedNodes.getNewHealthyNodes());
+            List<FailedNode> recoveredNodes = failedNodes
+                    .stream()
+                    .filter(node -> healthyNodeNames.contains(node.getName()))
+                    .collect(toList());
+            failedNodeRepository.deleteAll(recoveredNodes);
         }
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/cm/ClouderaManagerHostHealthEvaluator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/cm/ClouderaManagerHostHealthEvaluator.java
@@ -79,12 +79,12 @@ public class ClouderaManagerHostHealthEvaluator implements ClusterManagerSpecifi
                     .peek(hn -> LOGGER.debug("Host to recover: {}", hn))
                     .collect(Collectors.toList());
         } catch (Exception e) {
-            LOGGER.info(String.format("Failed to retrieve '%s' alerts. Original message: %s", CM_HOST_HEARTBEAT, e.getMessage()));
+            LOGGER.info("Failed to retrieve '{}' alerts. Original message: {}", CM_HOST_HEARTBEAT, e.getMessage());
             eventPublisher.publishEvent(new UpdateFailedEvent(clusterId));
+            throw new RuntimeException(e);
         } finally {
             LOGGER.debug("Finished {} for cluster {} in {} ms", CM_HOST_HEARTBEAT, clusterId, System.currentTimeMillis() - start);
         }
-        return List.of();
     }
 
     private Predicate<ApiHost> isAlertStateMet() {

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/UpdateFailedHandler.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/UpdateFailedHandler.java
@@ -13,12 +13,15 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.FailureReportV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.periscope.api.model.ClusterState;
 import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.FailedNode;
 import com.sequenceiq.periscope.monitor.event.UpdateFailedEvent;
+import com.sequenceiq.periscope.repository.FailedNodeRepository;
 import com.sequenceiq.periscope.service.ClusterService;
 import com.sequenceiq.periscope.utils.StackResponseUtils;
 
@@ -42,6 +45,9 @@ public class UpdateFailedHandler implements ApplicationListener<UpdateFailedEven
     @Inject
     private CloudbreakCommunicator cloudbreakCommunicator;
 
+    @Inject
+    private FailedNodeRepository failedNodeRepository;
+
     private final Map<Long, Integer> updateFailures = new ConcurrentHashMap<>();
 
     @Override
@@ -62,7 +68,10 @@ public class UpdateFailedHandler implements ApplicationListener<UpdateFailedEven
         String stackStatus = getStackStatus(stackResponse);
         if (stackStatus.startsWith(DELETE_STATUSES_PREFIX)) {
             clusterService.removeById(autoscaleClusterId);
-            LOGGER.debug("Delete cluster {} due to failing update attempts and Cloudbreak stack status", autoscaleClusterId);
+            long deletedFailedNodeRecords = failedNodeRepository.deleteByClusterId(autoscaleClusterId);
+            LOGGER.debug("Delete cluster {} due to failing update attempts and Cloudbreak stack status. {} deleted failed node records.",
+                    autoscaleClusterId,
+                    deletedFailedNodeRecords);
             return;
         }
         Integer failed = updateFailures.get(autoscaleClusterId);
@@ -70,23 +79,16 @@ public class UpdateFailedHandler implements ApplicationListener<UpdateFailedEven
             LOGGER.debug("New failed cluster id: [{}]", autoscaleClusterId);
             updateFailures.put(autoscaleClusterId, 1);
         } else if (RETRY_THRESHOLD - 1 == failed) {
-            try {
-                String clusterStatus = stackResponse.getCluster().getStatus().name();
-                if (stackStatus.equals(AVAILABLE) && clusterStatus.equals(AVAILABLE)) {
-                    // Cluster manager server is unreacheable but the stack and cluster statuses are "AVAILABLE"
-                    reportClusterManagerServerFailure(cluster, stackResponse);
-                    suspendCluster(cluster);
-                    LOGGER.debug("Suspend cluster monitoring for cluster {} due to failing update attempts and Cloudbreak stack status {}",
-                            autoscaleClusterId, stackStatus);
-                } else {
-                    suspendCluster(cluster);
-                    LOGGER.debug("Suspend cluster monitoring for cluster {}", autoscaleClusterId);
-                }
-            } catch (Exception ex) {
-                LOGGER.warn("Problem when verifying cluster status. Original message: {}",
-                        ex.getMessage());
-                suspendCluster(cluster);
+            Status clusterStatus = stackResponse.getCluster().getStatus();
+            if (stackStatus.equals(AVAILABLE) && clusterStatus != null && clusterStatus.name().equals(AVAILABLE)) {
+                // Cluster manager server is unreacheable but the stack and cluster statuses are "AVAILABLE"
+                reportClusterManagerServerFailure(cluster, stackResponse);
+                LOGGER.debug("Suspend cluster monitoring for cluster {} due to failing update attempts and Cloudbreak stack status {}",
+                        autoscaleClusterId, stackStatus);
+            } else {
+                LOGGER.debug("Suspend cluster monitoring for cluster {}", autoscaleClusterId);
             }
+            suspendCluster(cluster);
             updateFailures.remove(autoscaleClusterId);
         } else {
             int value = failed + 1;
@@ -120,8 +122,13 @@ public class UpdateFailedHandler implements ApplicationListener<UpdateFailedEven
             failureReport.setFailedNodes(Collections.singletonList(pgw.get().getDiscoveryFQDN()));
             try {
                 cloudbreakCommunicator.failureReport(cluster.getStackCrn(), failureReport);
+                FailedNode failedNode = new FailedNode();
+                failedNode.setClusterId(cluster.getId());
+                failedNode.setName(pgw.get().getDiscoveryFQDN());
+                failedNodeRepository.save(failedNode);
             } catch (Exception e) {
                 LOGGER.warn("Exception during failure report. Original message: {}", e.getMessage());
+                throw new RuntimeException(e);
             }
         }
     }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/repository/FailedNodeRepository.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/repository/FailedNodeRepository.java
@@ -1,0 +1,18 @@
+package com.sequenceiq.periscope.repository;
+
+import java.util.List;
+
+import javax.transaction.Transactional;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.sequenceiq.periscope.domain.FailedNode;
+
+@Transactional(Transactional.TxType.REQUIRED)
+public interface FailedNodeRepository extends CrudRepository<FailedNode, Long> {
+
+    List<FailedNode> findByClusterId(long clusterId);
+
+    long deleteByClusterId(long clusterId);
+
+}

--- a/autoscale/src/main/resources/schema/app/20190910083831_CB-3291_periscope_should_restore_instance_state_automatically.sql
+++ b/autoscale/src/main/resources/schema/app/20190910083831_CB-3291_periscope_should_restore_instance_state_automatically.sql
@@ -1,0 +1,33 @@
+-- // CB-3291 periscope should restore instance state automatically
+-- Migration SQL that makes the change goes here.
+
+CREATE TABLE failed_node (
+    id bigint NOT NULL,
+    created BIGINT NOT NULL DEFAULT (date_part('epoch'::text, now()) * (1000)::double precision),
+    cluster_id bigint NOT NULL,
+    name character varying(255),
+    PRIMARY KEY (id)
+);
+
+ALTER TABLE ONLY failed_node ADD CONSTRAINT fk_failed_node_cluster_id FOREIGN KEY (cluster_id) REFERENCES cluster(id);
+
+CREATE INDEX idx_failed_node_cluster_id ON failed_node (cluster_id);
+
+CREATE SEQUENCE failed_node_id_seq START WITH 1
+                                          INCREMENT BY 1
+                                          NO MINVALUE
+                                          NO MAXVALUE
+                                          CACHE 1;
+
+ALTER TABLE failed_node ALTER COLUMN id SET DEFAULT nextval ('failed_node_id_seq');
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE ONLY failed_node DROP CONSTRAINT fk_failed_node_cluster_id:
+
+DROP INDEX idx_failed_node_cluster_id;
+
+DROP SEQUENCE failed_node_id_seq;
+
+DROP TABLE failed_node;

--- a/autoscale/src/test/java/com/sequenceiq/periscope/modul/rejected/ClusterManagerHostHealthMonitorModuleTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/modul/rejected/ClusterManagerHostHealthMonitorModuleTest.java
@@ -40,7 +40,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import com.sequenceiq.ambari.client.AmbariClient;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.AutoscaleV4Endpoint;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.FailureReportV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.ChangedNodesReportV4Request;
 import com.sequenceiq.cloudbreak.client.CloudbreakInternalCrnClient;
 import com.sequenceiq.cloudbreak.client.CloudbreakServiceCrnEndpoints;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
@@ -136,7 +136,7 @@ public class ClusterManagerHostHealthMonitorModuleTest extends RejectedThreadCon
 
         waitForTasksToFinish();
 
-        verify(autoscaleEndpoint, times(1)).failureReport(eq(stackCrn), any(FailureReportV4Request.class));
+        verify(autoscaleEndpoint, times(1)).changedNodesReport(eq(stackCrn), any(ChangedNodesReportV4Request.class));
     }
 
     @Test

--- a/autoscale/src/test/java/com/sequenceiq/periscope/modul/rejected/RejectedThreadContext.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/modul/rejected/RejectedThreadContext.java
@@ -33,6 +33,7 @@ import com.sequenceiq.periscope.monitor.evaluator.ambari.AmbariAgentHealthEvalua
 import com.sequenceiq.periscope.monitor.executor.EvaluatorExecutorRegistry;
 import com.sequenceiq.periscope.monitor.executor.ExecutorServiceWithRegistry;
 import com.sequenceiq.periscope.monitor.handler.PersistRejectedThreadExecutionHandler;
+import com.sequenceiq.periscope.repository.FailedNodeRepository;
 import com.sequenceiq.periscope.service.AmbariClientProvider;
 import com.sequenceiq.periscope.service.ClusterService;
 import com.sequenceiq.periscope.service.RejectedThreadService;
@@ -62,7 +63,7 @@ public class RejectedThreadContext {
                     })
     )
     @MockBean({Clock.class, ClusterService.class, AmbariClientProvider.class, CloudbreakClientConfiguration.class,
-            MetricUtils.class, InternalCrnBuilder.class})
+            MetricUtils.class, InternalCrnBuilder.class, FailedNodeRepository.class})
     @EnableAsync
     public static class SpringConfig implements AsyncConfigurer {
 

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/ClusterManagerHostHealthEvaluatorTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/ClusterManagerHostHealthEvaluatorTest.java
@@ -1,0 +1,173 @@
+package com.sequenceiq.periscope.monitor.evaluator;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.AutoscaleV4Endpoint;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.ChangedNodesReportV4Request;
+import com.sequenceiq.cloudbreak.client.CloudbreakInternalCrnClient;
+import com.sequenceiq.cloudbreak.client.CloudbreakServiceCrnEndpoints;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.ClusterManager;
+import com.sequenceiq.periscope.domain.ClusterManagerVariant;
+import com.sequenceiq.periscope.domain.FailedNode;
+import com.sequenceiq.periscope.monitor.context.EvaluatorContext;
+import com.sequenceiq.periscope.repository.FailedNodeRepository;
+import com.sequenceiq.periscope.service.ClusterService;
+import com.sequenceiq.periscope.service.configuration.CloudbreakClientConfiguration;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClusterManagerHostHealthEvaluatorTest {
+
+    private static final long CLUSTER_ID = 1;
+
+    private static final String STACK_CRN = "STACK_CRN";
+
+    private static final String NEW_HEALTHY = "NEW_HEALTHY";
+
+    private static final String NEW_FAILED = "NEW_FAILED";
+
+    private static final String OLD_FAILED = "OLD_FAILED";
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Mock
+    private ClusterService clusterService;
+
+    @Mock
+    private Map<ClusterManagerVariant, ClusterManagerSpecificHostHealthEvaluator> hostHealthEvaluatorMap;
+
+    @Mock
+    private ClusterManagerSpecificHostHealthEvaluator clusterManagerSpecificHostHealthEvaluator;
+
+    @Mock
+    private CloudbreakClientConfiguration cloudbreakClientConfiguration;
+
+    @Mock
+    private FailedNodeRepository failedNodeRepository;
+
+    @InjectMocks
+    private ClusterManagerHostHealthEvaluator underTest;
+
+    @Mock
+    private EvaluatorContext evaluatorContext;
+
+    @Mock
+    private CloudbreakInternalCrnClient cloudbreakInternalCrnClient;
+
+    @Mock
+    private CloudbreakServiceCrnEndpoints cloudbreakServiceCrnEndpoints;
+
+    @Mock
+    private AutoscaleV4Endpoint autoscaleV4Endpoint;
+
+    @Captor
+    private ArgumentCaptor<ChangedNodesReportV4Request> captor;
+
+    @Before
+    public void setUp() {
+        when(evaluatorContext.getData()).thenReturn(CLUSTER_ID);
+        when(hostHealthEvaluatorMap.get(ClusterManagerVariant.CLOUDERA_MANAGER)).thenReturn(clusterManagerSpecificHostHealthEvaluator);
+
+        underTest.setContext(evaluatorContext);
+
+        when(cloudbreakClientConfiguration.cloudbreakInternalCrnClientClient()).thenReturn(cloudbreakInternalCrnClient);
+        when(cloudbreakInternalCrnClient.withInternalCrn()).thenReturn(cloudbreakServiceCrnEndpoints);
+        when(cloudbreakServiceCrnEndpoints.autoscaleEndpoint()).thenReturn(autoscaleV4Endpoint);
+    }
+
+    @Test
+    public void shouldReportNewFailedAndHealthyNodes() {
+        Cluster cluster = getCluster();
+        when(clusterService.findById(CLUSTER_ID)).thenReturn(cluster);
+        FailedNode oldFailedNode = getFailedNode(OLD_FAILED);
+        FailedNode newHealthyNode = getFailedNode(NEW_HEALTHY);
+        when(failedNodeRepository.findByClusterId(CLUSTER_ID)).thenReturn(List.of(oldFailedNode, newHealthyNode));
+        when(clusterManagerSpecificHostHealthEvaluator.determineHostnamesToRecover(cluster)).thenReturn(List.of(OLD_FAILED, NEW_FAILED));
+
+        underTest.execute();
+
+        verify(autoscaleV4Endpoint).changedNodesReport(eq(STACK_CRN), captor.capture());
+        FailedNode newFailedNode = new FailedNode();
+        newFailedNode.setClusterId(CLUSTER_ID);
+        newFailedNode.setName(NEW_FAILED);
+        verify(failedNodeRepository).findByClusterId(CLUSTER_ID);
+        verify(failedNodeRepository).saveAll(List.of(newFailedNode));
+        verify(failedNodeRepository).deleteAll(List.of(newHealthyNode));
+        verifyNoMoreInteractions(failedNodeRepository);
+
+        ChangedNodesReportV4Request request = captor.getValue();
+        assertThat(request.getNewFailedNodes(), is(List.of(NEW_FAILED)));
+        assertThat(request.getNewHealthyNodes(), is(List.of(NEW_HEALTHY)));
+    }
+
+    @Test
+    public void shouldNotUpdateFailedNodesIfErrorHappens() {
+        Cluster cluster = getCluster();
+        when(clusterService.findById(CLUSTER_ID)).thenReturn(cluster);
+        when(clusterManagerSpecificHostHealthEvaluator.determineHostnamesToRecover(cluster)).thenReturn(List.of(NEW_FAILED));
+        doThrow(new RuntimeException("API exception")).when(autoscaleV4Endpoint).changedNodesReport(anyString(), ArgumentMatchers.any());
+
+        expectedException.expect(RuntimeException.class);
+        expectedException.expectMessage("API exception");
+
+        underTest.execute();
+
+        verify(failedNodeRepository).findByClusterId(CLUSTER_ID);
+        verifyNoMoreInteractions(failedNodeRepository);
+    }
+
+    @Test
+    public void shouldNotUpdateWhenFailedNodesNotChanged() {
+        Cluster cluster = getCluster();
+        when(clusterService.findById(CLUSTER_ID)).thenReturn(cluster);
+        FailedNode failedNode = getFailedNode(OLD_FAILED);
+        when(failedNodeRepository.findByClusterId(CLUSTER_ID)).thenReturn(List.of(failedNode));
+        when(clusterManagerSpecificHostHealthEvaluator.determineHostnamesToRecover(cluster)).thenReturn(List.of(OLD_FAILED));
+
+        underTest.execute();
+
+        verifyZeroInteractions(cloudbreakInternalCrnClient);
+        verify(failedNodeRepository).findByClusterId(CLUSTER_ID);
+        verifyNoMoreInteractions(failedNodeRepository);
+    }
+
+    private Cluster getCluster() {
+        Cluster cluster = new Cluster();
+        cluster.setStackCrn(STACK_CRN);
+        ClusterManager cm = new ClusterManager();
+        cm.setVariant(ClusterManagerVariant.CLOUDERA_MANAGER);
+        cluster.setClusterManager(cm);
+        return cluster;
+    }
+
+    private FailedNode getFailedNode(String name) {
+        FailedNode failedNode = new FailedNode();
+        failedNode.setClusterId(CLUSTER_ID);
+        failedNode.setName(name);
+        return failedNode;
+    }
+}

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/cm/ClouderaManagerClusterCreationEvaluatorTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/cm/ClouderaManagerClusterCreationEvaluatorTest.java
@@ -1,0 +1,217 @@
+package com.sequenceiq.periscope.monitor.evaluator.cm;
+
+import static com.sequenceiq.periscope.api.model.ClusterState.PENDING;
+import static com.sequenceiq.periscope.api.model.ClusterState.RUNNING;
+import static com.sequenceiq.periscope.api.model.ClusterState.SUSPENDED;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.AutoscaleStackV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
+import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerClientFactory;
+import com.sequenceiq.cloudbreak.service.secret.service.SecretService;
+import com.sequenceiq.periscope.api.model.ClusterState;
+import com.sequenceiq.periscope.api.model.ScalingStatus;
+import com.sequenceiq.periscope.aspects.RequestLogging;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.ClusterPertain;
+import com.sequenceiq.periscope.domain.History;
+import com.sequenceiq.periscope.domain.SecurityConfig;
+import com.sequenceiq.periscope.model.MonitoredStack;
+import com.sequenceiq.periscope.monitor.context.EvaluatorContext;
+import com.sequenceiq.periscope.notification.HttpNotificationSender;
+import com.sequenceiq.periscope.service.ClusterService;
+import com.sequenceiq.periscope.service.HistoryService;
+import com.sequenceiq.periscope.service.security.TlsSecurityService;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClouderaManagerClusterCreationEvaluatorTest {
+
+    private static final long STACK_ID = 1;
+
+    private static final String STACK_CRN = "STACK_CRN";
+
+    @Captor
+    public ArgumentCaptor<ClusterPertain> captor;
+
+    @Mock
+    private ClusterService clusterService;
+
+    @Mock
+    private ClouderaManagerClientFactory clouderaManagerClientFactory;
+
+    @Mock
+    private TlsSecurityService tlsSecurityService;
+
+    @Mock
+    private HistoryService historyService;
+
+    @Mock
+    private HttpNotificationSender notificationSender;
+
+    @Mock
+    private RequestLogging requestLogging;
+
+    @Mock
+    private SecretService secretService;
+
+    @InjectMocks
+    private ClouderaManagerClusterCreationEvaluator underTest;
+
+    @Mock
+    private EvaluatorContext evaluatorContext;
+
+    @Before
+    public void setUp() {
+        underTest.setContext(evaluatorContext);
+    }
+
+    @Test
+    public void shouldUpdateSuspendedHelthyCluster() {
+        Cluster cluster = getCluster(SUSPENDED);
+        History history = new History();
+        StackV4Response stack = new StackV4Response();
+
+        setUpMocks(cluster, true, stack, history);
+
+        underTest.execute();
+
+        verify(clusterService).findOneByStackId(STACK_ID);
+        verify(clusterService).update(eq(cluster.getId()), any(), eq(RUNNING), eq(true));
+        verify(historyService).createEntry(ScalingStatus.ENABLED, "Autoscaling has been enabled for the cluster.", 0, cluster);
+        verify(notificationSender).send(cluster, history);
+    }
+
+    @Test
+    public void shouldUpdatePendingHelthyCluster() {
+        Cluster cluster = getCluster(PENDING);
+        History history = new History();
+        StackV4Response stack = new StackV4Response();
+
+        setUpMocks(cluster, true, stack, history);
+
+        underTest.execute();
+
+        verify(clusterService).findOneByStackId(STACK_ID);
+        verify(clusterService).update(eq(cluster.getId()), any(), eq(RUNNING), eq(true));
+        verify(historyService).createEntry(ScalingStatus.ENABLED, "Autoscaling has been enabled for the cluster.", 0, cluster);
+        verify(notificationSender).send(cluster, history);
+    }
+
+    @Test
+    public void shouldNotUpdateRunningHelthyCluster() {
+        Cluster cluster = getCluster(RUNNING);
+        History history = new History();
+        StackV4Response stack = new StackV4Response();
+
+        setUpMocks(cluster, true, stack, history);
+
+        underTest.execute();
+
+        verify(clusterService).findOneByStackId(STACK_ID);
+        verifyNoMoreInteractions(clusterService);
+        verifyZeroInteractions(historyService);
+        verifyZeroInteractions(notificationSender);
+    }
+
+    @Test
+    public void shouldNotUpdateSuspendedUnHelthyCluster() {
+        Cluster cluster = getCluster(SUSPENDED);
+        History history = new History();
+        StackV4Response stack = new StackV4Response();
+
+        setUpMocks(cluster, false, stack, history);
+
+        underTest.execute();
+
+        verify(clusterService).findOneByStackId(STACK_ID);
+        verifyNoMoreInteractions(clusterService);
+        verifyZeroInteractions(historyService);
+        verifyZeroInteractions(notificationSender);
+    }
+
+    @Test
+    public void shouldValidateAndCreateNewCluster() {
+        History history = new History();
+        StackV4Response stack = new StackV4Response();
+
+        setUpMocks(null, false, stack, history);
+
+        Cluster cluster = getCluster(null);
+        when(clusterService.create(any(), any(), any())).thenReturn(cluster);
+        when(historyService.createEntry(any(), anyString(), anyInt(), eq(cluster))).thenReturn(history);
+
+        underTest.execute();
+
+        verify(clusterService).findOneByStackId(STACK_ID);
+        verify(clusterService).validateClusterUniqueness(any());
+        verify(clusterService).create(any(MonitoredStack.class), eq(null), captor.capture());
+        ClusterPertain clusterPertain = captor.getValue();
+        assertThat(clusterPertain.getTenant(), is("TENANT"));
+        assertThat(clusterPertain.getWorkspaceId(), is(10L));
+        assertThat(clusterPertain.getUserId(), is("USER_ID"));
+    }
+
+    private void setUpMocks(Cluster cluster, boolean healthy, StackV4Response stackV4Response, History history) {
+        InstanceMetaDataV4Response instanceMetaData = new InstanceMetaDataV4Response();
+        instanceMetaData.setDiscoveryFQDN("master");
+        setUpMocks(cluster, healthy, stackV4Response, Optional.of(instanceMetaData), history);
+    }
+
+    private void setUpMocks(Cluster cluster, boolean healthy, StackV4Response stackV4Response, Optional<InstanceMetaDataV4Response> primaryGateways,
+            History history) {
+        AutoscaleStackV4Response stack = getStackResponse();
+        when(evaluatorContext.getData()).thenReturn(stack);
+        when(tlsSecurityService.prepareSecurityConfig(STACK_CRN)).thenReturn(new SecurityConfig());
+        when(clusterService.findOneByStackId(anyLong())).thenReturn(cluster);
+        when(requestLogging.logging(any(), any())).thenReturn(healthy);
+        if (cluster != null) {
+            when(historyService.createEntry(any(), anyString(), anyInt(), any(Cluster.class))).thenReturn(history);
+        }
+        when(clusterService.update(anyLong(), any(), any(), anyBoolean())).thenReturn(cluster);
+    }
+
+    private AutoscaleStackV4Response getStackResponse() {
+        AutoscaleStackV4Response stack = new AutoscaleStackV4Response();
+        stack.setStackId(STACK_ID);
+        stack.setStackCrn(STACK_CRN);
+        stack.setAmbariServerIp("0.0.0.0");
+        stack.setGatewayPort(8080);
+        stack.setTenant("TENANT");
+        stack.setWorkspaceId(10L);
+        stack.setUserId("USER_ID");
+        return stack;
+    }
+
+    private Cluster getCluster(ClusterState clusterState) {
+        Cluster cluster = new Cluster();
+        cluster.setId(10);
+        cluster.setStackCrn(STACK_CRN);
+        cluster.setAutoscalingEnabled(true);
+        cluster.setState(clusterState);
+        return cluster;
+    }
+
+}

--- a/autoscale/src/test/java/com/sequenceiq/periscope/utils/ModelTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/utils/ModelTest.java
@@ -19,7 +19,7 @@ import com.openpojo.validation.test.impl.SetterTester;
 
 public class ModelTest {
 
-    private static final int EXPECTED_CLASS_COUNT = 15;
+    private static final int EXPECTED_CLASS_COUNT = 16;
 
     private static final String DOMAIN_PACKAGE = "com.sequenceiq.periscope.domain";
 

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -108,6 +108,7 @@ ambari.cluster.services.stopped=Cloudera Manager services have been stopped.
 cluster.autorecovery.requested=Cluster autorecovery requested, failed nodes: {0}
 cluster.manualrecovery.requested=Cluster manual recovery requested on entities: {0}
 cluster.failednodes.reported=Manual recovery is needed for the following failed nodes: {0}
+cluster.recoverednodes.reported=Recovered nodes detected: {0}
 cluster.gateway.change=Starting primary gateway change
 cluster.gateway.changed.successfully=Primary gateway successfully changed to {0}
 cluster.gateway.change.failed=Primary gateway change failed. Reason: {0}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/autoscales/AutoscaleV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/autoscales/AutoscaleV4Endpoint.java
@@ -12,6 +12,7 @@ import javax.ws.rs.core.MediaType;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.AmbariAddressV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.FailureReportV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.ChangedNodesReportV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.UpdateStackV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.response.AuthorizeForAutoscaleV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.response.AutoscaleStackV4Responses;
@@ -63,6 +64,13 @@ public interface AutoscaleV4Endpoint {
     @ApiOperation(value = ClusterOpDescription.FAILURE_REPORT, produces = ContentType.JSON, notes = Notes.FAILURE_REPORT_NOTES,
             nickname = "failureReportClusterForAutoscale")
     void failureReport(@PathParam("crn") String crn, FailureReportV4Request failureReport);
+
+    @POST
+    @Path("/stack/crn/{crn}/cluster/changed_nodes_report")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = ClusterOpDescription.CHANGED_NODES_REPORT, produces = ContentType.JSON, notes = Notes.CHANGED_NODES_REPORT_NOTES,
+            nickname = "nodeStatusChangeReportClusterForAutoscale")
+    void changedNodesReport(@PathParam("crn") String crn, ChangedNodesReportV4Request changedNodesReport);
 
     @GET
     @Path("/stack/crn/{crn}")

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/autoscales/request/ChangedNodesReportV4Request.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/autoscales/request/ChangedNodesReportV4Request.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request;
+
+import java.util.List;
+
+import javax.validation.constraints.NotNull;
+
+import com.sequenceiq.cloudbreak.doc.ModelDescriptions;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+public class ChangedNodesReportV4Request {
+
+    @NotNull
+    @ApiModelProperty(value = ModelDescriptions.NodeStatusChangeReport.NEW_FAILED_NODES, required = true)
+    private List<String> newFailedNodes;
+
+    @NotNull
+    @ApiModelProperty(value = ModelDescriptions.NodeStatusChangeReport.NEW_FAILED_NODES, required = true)
+    private List<String> newHealthyNodes;
+
+    public List<String> getNewFailedNodes() {
+        return newFailedNodes;
+    }
+
+    public void setNewFailedNodes(List<String> newFailedNodes) {
+        this.newFailedNodes = newFailedNodes;
+    }
+
+    public List<String> getNewHealthyNodes() {
+        return newHealthyNodes;
+    }
+
+    public void setNewHealthyNodes(List<String> newHealthyNodes) {
+        this.newHealthyNodes = newHealthyNodes;
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
@@ -606,6 +606,11 @@ public class ModelDescriptions {
         public static final String FAILED_NODES = "List of failed nodes";
     }
 
+    public static class NodeStatusChangeReport {
+        public static final String NEW_FAILED_NODES = "List of the new failed nodes";
+        public static final String NEW_HEALTHY_NODES = "List of the new healthy nodes";
+    }
+
     public static class RepairClusterRequest {
         public static final String HOSTGROUPS = "List of hostgroups where the failed nodes will be repaired";
         public static final String REMOVE_ONLY = "If true, the failed nodes will only be removed, otherwise the failed nodes will be removed and "

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/Notes.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/Notes.java
@@ -66,6 +66,9 @@ public class Notes {
     public static final String SETTINGS_NOTES = "Collecting Cloudbreak specific resource settings.";
     public static final String FAILURE_REPORT_NOTES = "Endpoint to report the failed nodes in the given cluster. If recovery mode for the node's hostgroup "
             + "is AUTO then autorecovery would be started. If recovery mode for the node's hostgroup is MANUAL, the nodes will be marked as unhealthy.";
+    public static final String CHANGED_NODES_REPORT_NOTES = "Endpoint to report the new failed and healthy nodes in the given cluster. If recovery mode "
+            + "for the node's hostgroup is AUTO then autorecovery would be started. If recovery mode for the node's hostgroup is MANUAL, the nodes will be "
+            + "marked as unhealthy.";
     public static final String CLUSTER_REPAIR_NOTES = "Removing the failed nodes and starting new nodes to substitute them.";
     public static final String SMARTSENSE_SUBSCRIPTION_NOTES = "SmartSense subscriptions could be configured.";
     public static final String FLEX_SUBSCRIPTION_NOTES = "Flex subscriptions could be configured.";

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
@@ -65,6 +65,7 @@ public class OperationDescriptions {
         public static final String SET_MAINTENANCE_MODE_BY_CRN = "set maintenance mode for the cluster by crn";
         public static final String GET_CLUSTER_PROPERTIES = "get cluster properties with blueprint outputs";
         public static final String FAILURE_REPORT = "failure report";
+        public static final String CHANGED_NODES_REPORT = "changed nodes report";
         public static final String REPAIR_CLUSTER = "repair the cluster";
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/AutoscaleV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/AutoscaleV4Controller.java
@@ -14,8 +14,10 @@ import javax.validation.Valid;
 
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.authorization.resource.ResourceAction;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.AutoscaleV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.AmbariAddressV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.ChangedNodesReportV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.FailureReportV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.UpdateStackV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.response.AuthorizeForAutoscaleV4Response;
@@ -24,12 +26,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.response.Certificate
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.UpdateClusterV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.AutoscaleStackV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
-import com.sequenceiq.cloudbreak.workspace.authorization.PermissionCheckingUtils;
-import com.sequenceiq.authorization.resource.ResourceAction;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
-import com.sequenceiq.cloudbreak.workspace.model.Tenant;
-import com.sequenceiq.cloudbreak.workspace.model.User;
-import com.sequenceiq.cloudbreak.workspace.model.Workspace;
 import com.sequenceiq.cloudbreak.service.CloudbreakRestRequestThreadLocalService;
 import com.sequenceiq.cloudbreak.service.ClusterCommonService;
 import com.sequenceiq.cloudbreak.service.StackCommonService;
@@ -37,6 +34,10 @@ import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.service.user.UserService;
 import com.sequenceiq.cloudbreak.service.workspace.WorkspaceService;
+import com.sequenceiq.cloudbreak.workspace.authorization.PermissionCheckingUtils;
+import com.sequenceiq.cloudbreak.workspace.model.Tenant;
+import com.sequenceiq.cloudbreak.workspace.model.User;
+import com.sequenceiq.cloudbreak.workspace.model.Workspace;
 
 @Component
 @Transactional(TxType.NEVER)
@@ -93,7 +94,12 @@ public class AutoscaleV4Controller implements AutoscaleV4Endpoint {
 
     @Override
     public void failureReport(String crn, FailureReportV4Request failureReport) {
-        clusterService.failureReport(crn, failureReport.getFailedNodes());
+        clusterService.reportHealthChange(crn, Set.copyOf(failureReport.getFailedNodes()), Set.of());
+    }
+
+    @Override
+    public void changedNodesReport(String crn, ChangedNodesReportV4Request changedNodesReport) {
+        clusterService.reportHealthChange(crn, Set.copyOf(changedNodesReport.getNewFailedNodes()), Set.copyOf(changedNodesReport.getNewHealthyNodes()));
     }
 
     @Override

--- a/core/src/main/resources/messages/messages.properties
+++ b/core/src/main/resources/messages/messages.properties
@@ -108,6 +108,7 @@ ambari.cluster.services.stopped=Cloudera Manager services have been stopped.
 cluster.autorecovery.requested=Cluster autorecovery requested, failed nodes: {0}
 cluster.manualrecovery.requested=Cluster manual recovery requested on entities: {0}
 cluster.failednodes.reported=Manual recovery is needed for the following failed nodes: {0}
+cluster.recoverednodes.reported=Recovered nodes detected: {0}
 cluster.gateway.change=Starting primary gateway change
 cluster.gateway.changed.successfully=Primary gateway successfully changed to {0}
 cluster.gateway.change.failed=Primary gateway change failed. Reason: {0}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ClusterServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ClusterServiceTest.java
@@ -4,11 +4,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
@@ -16,6 +23,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -28,16 +36,22 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.RecoveryMode;
 import com.sequenceiq.cloudbreak.cloud.model.VolumeSetAttributes;
+import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
+import com.sequenceiq.cloudbreak.cluster.api.ClusterModificationService;
 import com.sequenceiq.cloudbreak.cluster.util.ResourceAttributeUtil;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
 import com.sequenceiq.cloudbreak.common.service.TransactionService.TransactionExecutionException;
 import com.sequenceiq.cloudbreak.common.type.HostMetadataState;
 import com.sequenceiq.cloudbreak.core.flow2.service.ReactorFlowManager;
+import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.domain.Constraint;
+import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.domain.Resource;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
@@ -46,10 +60,13 @@ import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostMetadata;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.exception.FlowsAlreadyRunningException;
 import com.sequenceiq.cloudbreak.message.CloudbreakMessagesService;
 import com.sequenceiq.cloudbreak.service.StackUpdater;
 import com.sequenceiq.cloudbreak.service.blueprint.BlueprintService;
 import com.sequenceiq.cloudbreak.service.hostgroup.HostGroupService;
+import com.sequenceiq.cloudbreak.service.hostmetadata.HostMetadataService;
+import com.sequenceiq.cloudbreak.service.rdsconfig.RdsConfigService;
 import com.sequenceiq.cloudbreak.service.resource.ResourceService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
@@ -62,8 +79,20 @@ import com.sequenceiq.flow.domain.StateStatus;
 @ExtendWith(MockitoExtension.class)
 public class ClusterServiceTest {
 
+    private static final long STACK_ID = 1;
+
+    private static final String STACK_CRN = "STACK_CRN";
+
+    private static final long CLUSTER_ID = 1;
+
     @Mock
     private StackService stackService;
+
+    @Mock
+    private HostMetadataService hostMetadataService;
+
+    @Mock
+    private RdsConfigService rdsConfigService;
 
     @Mock
     private HostGroupService hostGroupService;
@@ -92,8 +121,17 @@ public class ClusterServiceTest {
     @Mock
     private StackUpdater stackUpdater;
 
+    @Mock
+    private ClusterApiConnectors clusterApiConnectors;
+
     @InjectMocks
-    private ClusterService clusterService;
+    private ClusterService underTest;
+
+    @Mock
+    private ClusterApi clusterApi;
+
+    @Mock
+    private ClusterModificationService clusterModificationService;
 
     private Cluster cluster;
 
@@ -105,14 +143,16 @@ public class ClusterServiceTest {
     @BeforeEach
     public void setUp() throws TransactionExecutionException {
         cluster = new Cluster();
-        cluster.setId(1L);
+        cluster.setId(CLUSTER_ID);
         cluster.setRdsConfigs(Set.of());
         stack = spy(new Stack());
-        stack.setId(1L);
+        stack.setId(STACK_ID);
+        stack.setResourceCrn(STACK_CRN);
         stack.setCluster(cluster);
         stack.setPlatformVariant("AWS");
+        cluster.setStack(stack);
 
-        doAnswer(invocation -> ((Supplier<?>) invocation.getArgument(0)).get()).when(transactionService).required(any());
+        lenient().doAnswer(invocation -> ((Supplier<?>) invocation.getArgument(0)).get()).when(transactionService).required(any());
     }
 
     @Test
@@ -146,7 +186,7 @@ public class ClusterServiceTest {
         when(stackUpdater.updateStackStatus(1L, DetailedStackStatus.REPAIR_IN_PROGRESS)).thenReturn(stack);
         when(blueprintService.isAmbariBlueprint(any())).thenReturn(Boolean.TRUE);
 
-        clusterService.repairCluster(1L, List.of("hostGroup1"), false);
+        underTest.repairCluster(1L, List.of("hostGroup1"), false);
 
         verify(stack, never()).getInstanceMetaDataAsList();
         verify(flowManager).triggerClusterRepairFlow(eq(1L), eq(Map.of("hostGroup1", List.of("host1Name"))), eq(false));
@@ -196,7 +236,7 @@ public class ClusterServiceTest {
         when(stackUpdater.updateStackStatus(1L, DetailedStackStatus.REPAIR_IN_PROGRESS)).thenReturn(stack);
         when(blueprintService.isAmbariBlueprint(any())).thenReturn(Boolean.TRUE);
 
-        clusterService.repairCluster(1L, List.of("instanceId1"), false, false);
+        underTest.repairCluster(1L, List.of("instanceId1"), false, false);
         verify(stack).getInstanceMetaDataAsList();
         verify(stack).getDiskResources();
         @SuppressWarnings("unchecked")
@@ -213,10 +253,136 @@ public class ClusterServiceTest {
         when(flowLogService.findAllByResourceIdOrderByCreatedDesc(1L)).thenReturn(List.of(flowLog));
 
         BadRequestException exception = assertThrows(BadRequestException.class, () -> {
-            clusterService.repairCluster(1L, List.of("instanceId1"), false, false);
+            underTest.repairCluster(1L, List.of("instanceId1"), false, false);
         });
         assertEquals("Repair cannot be performed, because there is already an active flow.", exception.getMessage());
 
         verifyZeroInteractions(stackUpdater);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenNewHealthyAndFailedNodeAreTheSame() {
+        BadRequestException exception = assertThrows(BadRequestException.class, () -> {
+            underTest.reportHealthChange(STACK_CRN, Set.of("host"), Set.of("host"));
+        });
+
+        assertEquals("Failed nodes [host] and healthy nodes [host] should not have common items.", exception.getMessage());
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenNoMetaDataFoundDuringFailureReport() {
+        when(stackService.findByCrn(STACK_CRN)).thenReturn(stack);
+
+        BadRequestException exception = assertThrows(BadRequestException.class, () -> {
+            underTest.reportHealthChange(STACK_CRN, Set.of("host1"), Set.of());
+        });
+
+        assertEquals("No metadata information for the node: host1", exception.getMessage());
+    }
+
+    @Test
+    public void shouldTriggerRecoveryInAutoRecoveryHostsAndUpdateHostMetaData() {
+        Blueprint blueprint = new Blueprint();
+        blueprint.setBlueprintText("{ \"Blueprints\": { \"blueprint_name\": \"MyBlueprint\" } }");
+        cluster.setBlueprint(blueprint);
+
+        when(stackService.findByCrn(STACK_CRN)).thenReturn(stack);
+
+        HostMetadata hostMetadata1 = givenHost("host1", "hg1", RecoveryMode.AUTO, HostMetadataState.HEALTHY);
+        HostMetadata hostMetadata2 = givenHost("host2", "hg2", RecoveryMode.MANUAL, HostMetadataState.HEALTHY);
+
+        RDSConfig rdsConfig = new RDSConfig();
+        rdsConfig.setDatabaseEngine(DatabaseVendor.POSTGRES);
+        when(rdsConfigService.findByClusterIdAndType(CLUSTER_ID, DatabaseType.CLOUDERA_MANAGER)).thenReturn(rdsConfig);
+        when(clusterApiConnectors.getConnector(stack)).thenReturn(clusterApi);
+        when(clusterApi.clusterModificationService()).thenReturn(clusterModificationService);
+        when(hostMetadataService.findHostsInCluster(CLUSTER_ID)).thenReturn(Set.of(hostMetadata1, hostMetadata2));
+        when(cloudbreakMessagesService.getMessage(any(), anyCollection())).thenReturn("auto recovery").thenReturn("failed node");
+
+        underTest.reportHealthChange(STACK_CRN, Set.of("host1", "host2"), Set.of());
+
+        Map<String, List<String>> autoRecoveredNodes = Map.of("hg1", List.of("host1"));
+        verify(flowManager).triggerClusterRepairFlow(STACK_ID, autoRecoveredNodes, false);
+        verify(cloudbreakMessagesService, times(1)).getMessage("cluster.autorecovery.requested", Collections.singletonList(autoRecoveredNodes));
+        verify(cloudbreakEventService, times(1)).fireCloudbreakEvent(STACK_ID, "RECOVERY", "auto recovery");
+        verify(hostMetadataService, times(1)).saveAll(Set.of(hostMetadata1));
+        assertEquals(HostMetadataState.WAITING_FOR_REPAIR, hostMetadata1.getHostMetadataState());
+
+        verify(cloudbreakMessagesService, times(1)).getMessage("cluster.failednodes.reported", Collections.singletonList(Set.of("host2")));
+        verify(cloudbreakEventService, times(1)).fireCloudbreakEvent(STACK_ID, "RECOVERY", "failed node");
+        verify(hostMetadataService, times(1)).saveAll(Set.of(hostMetadata2));
+        assertEquals(HostMetadataState.UNHEALTHY, hostMetadata2.getHostMetadataState());
+    }
+
+    @Test
+    public void shouldNotUpdateHostMetaDataWhenRecoveryTriggerFails() {
+        Blueprint blueprint = new Blueprint();
+        blueprint.setBlueprintText("{ \"Blueprints\": { \"blueprint_name\": \"MyBlueprint\" } }");
+        cluster.setBlueprint(blueprint);
+
+        when(stackService.findByCrn(STACK_CRN)).thenReturn(stack);
+
+        HostMetadata hostMetadata = givenHost("host", "hg", RecoveryMode.AUTO, HostMetadataState.HEALTHY);
+
+        RDSConfig rdsConfig = new RDSConfig();
+        rdsConfig.setDatabaseEngine(DatabaseVendor.POSTGRES);
+        when(rdsConfigService.findByClusterIdAndType(CLUSTER_ID, DatabaseType.CLOUDERA_MANAGER)).thenReturn(rdsConfig);
+        when(clusterApiConnectors.getConnector(stack)).thenReturn(clusterApi);
+        when(clusterApi.clusterModificationService()).thenReturn(clusterModificationService);
+        doThrow(new FlowsAlreadyRunningException("Flow in action")).when(flowManager).triggerClusterRepairFlow(anyLong(), anyMap(), anyBoolean());
+
+        assertThrows(FlowsAlreadyRunningException.class, () -> {
+            underTest.reportHealthChange(STACK_CRN, Set.of(hostMetadata.getHostName()), Set.of());
+        });
+
+        verifyNoMoreInteractions(cloudbreakMessagesService);
+        verifyNoMoreInteractions(cloudbreakEventService);
+        verifyNoMoreInteractions(hostMetadataService);
+    }
+
+    @Test
+    public void shouldRegisterNewHealthyHosts() {
+        when(stackService.findByCrn(STACK_CRN)).thenReturn(stack);
+
+        HostMetadata hostMetadata = getHost("host", "hg", RecoveryMode.AUTO, HostMetadataState.UNHEALTHY);
+
+        when(hostMetadataService.findHostsInCluster(CLUSTER_ID)).thenReturn(Set.of(hostMetadata));
+        when(cloudbreakMessagesService.getMessage(any(), anyCollection())).thenReturn("recovery detected");
+
+        underTest.reportHealthChange(STACK_CRN, Set.of(), Set.of("host"));
+
+        verify(cloudbreakMessagesService).getMessage("cluster.recoverednodes.reported", Collections.singletonList(Set.of("host")));
+        verify(cloudbreakEventService).fireCloudbreakEvent(STACK_ID, "AVAILABLE", "recovery detected");
+        verify(hostMetadataService).saveAll(Set.of(hostMetadata));
+        assertEquals(HostMetadataState.HEALTHY, hostMetadata.getHostMetadataState());
+    }
+
+    private HostMetadata givenHost(String hostName, String hostGroupName, RecoveryMode recoveryMode, HostMetadataState hostMetadataState) {
+        HostMetadata hostMetadata = getHost(hostName, hostGroupName, recoveryMode, hostMetadataState);
+
+        when(hostMetadataService.findHostInClusterByName(CLUSTER_ID, hostName)).thenReturn(Optional.of(hostMetadata));
+
+        return hostMetadata;
+    }
+
+    private HostMetadata getHost(String hostName, String hostGroupName, RecoveryMode recoveryMode, HostMetadataState hostMetadataState) {
+        InstanceGroup instanceGroup = new InstanceGroup();
+        instanceGroup.setInstanceGroupType(InstanceGroupType.GATEWAY);
+
+        Constraint constraint = new Constraint();
+        constraint.setInstanceGroup(instanceGroup);
+
+        HostGroup hostGroup = new HostGroup();
+        hostGroup.setName(hostGroupName);
+        hostGroup.setRecoveryMode(recoveryMode);
+        hostGroup.setConstraint(constraint);
+
+        HostMetadata hostMetadata = new HostMetadata();
+        hostMetadata.setHostName(hostName);
+        hostMetadata.setHostGroup(hostGroup);
+        hostMetadata.setHostMetadataState(hostMetadataState);
+        hostGroup.setHostMetadata(Set.of(hostMetadata));
+
+        return hostMetadata;
     }
 }


### PR DESCRIPTION
The issue was that, when no failed nodes detected then periscope didn't notify cloudbreak about that, so previous failed nodes didn't go into healthy state.

In the current solution periscope stores records about failed nodes and notifies cloudbreak when change happens in that. I also add more unit tests.

