### PR TITLE
CB-3477 Make NiFi REST API accessible through cdp-proxy-api topology

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/ExposedService.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/ExposedService.java
@@ -33,6 +33,7 @@ public enum ExposedService {
     HBASE_UI("HBase UI", "MASTER", "HBASEUI", "/hbase/webui/master/", true, 16010, 16010, false, false),
     HBASE_REST("HBase Rest", "HBASERESTSERVER", "WEBHBASE", "/hbase/", true, 20550, 20550, true, true),
     NIFI("Nifi", "NIFI_NODE", "NIFI", "/nifi-app/nifi/", true, 8080, 8443, false, false),
+    NIFI_REST("NiFi Rest", "NIFI_NODE", "NIFI_REST", "/nifi-app/nifi-api/", true, 8080, 8443, true, true),
     IMPALA("Impala", "IMPALAD", "IMPALA", "/impala/", true, 28000, 28000, true, true),
     NAMENODE_HDFS("NameNode HDFS", "NAMENODE", "NAMENODE", "/", true, 8020, 8020, true, true),
     JOBTRACKER("Job Tracker", "RESOURCEMANAGER", "JOBTRACKER", "/", true, 8050, 8032, true, true);

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
@@ -101,6 +101,12 @@
                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000;maxRetryAttempts=300;retrySleep=1000</value>
             </param>
             {%- endif %}
+            {% if 'NIFI_REST' in exposed and 'NIFI_NODE' in salt['pillar.get']('gateway:location') -%}
+             <param>
+                 <name>NIFI_REST</name>
+                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000;maxRetryAttempts=300;retrySleep=1000</value>
+             </param>
+             {%- endif %}
         </provider>
     </gateway>
 
@@ -250,6 +256,17 @@
         <role>IMPALA</role>
         {% for hostloc in salt['pillar.get']('gateway:location')['IMPALAD'] -%}
         <url>{{ protocol }}://{{ hostloc }}:{{ ports['IMPALA'] }}</url>
+        {%- endfor %}
+    </service>
+    {%- endif %}
+    {%- endif %}
+
+    {% if 'NIFI_NODE' in salt['pillar.get']('gateway:location') -%}
+    {% if 'NIFI_REST' in exposed -%}
+    <service>
+        <role>NIFI_REST</role>
+        {% for hostloc in salt['pillar.get']('gateway:location')['NIFI_NODE'] -%}
+        <url>{{ protocol }}://{{ hostloc }}:{{ ports['NIFI_REST'] }}</url>
         {%- endfor %}
     </service>
     {%- endif %}


### PR DESCRIPTION
Generate NiFi REST API service and provider param into cdp-proxy-api.xml

Closes #CB-3477