### PR TITLE
CB-3491 Allow more defaults for Azure database server allocation

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilder.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilder.java
@@ -123,11 +123,14 @@ public class AzureTemplateBuilder {
             model.put("dbVersion", azureDatabaseServerView.getDbVersion());
             model.put("geoRedundantBackup", azureDatabaseServerView.getGeoRedundantBackup());
             model.put("location", location);
+            if (azureDatabaseServerView.getPort() != null) {
+                LOGGER.warn("Found port {} in database stack, but Azure ignores it", azureDatabaseServerView.getPort());
+            }
             model.put("serverTags", databaseStack.getTags());
-            model.put("skuCapacity", azureDatabaseServerView.getSkuCapacity().toString());
+            model.put("skuCapacity", azureDatabaseServerView.getSkuCapacity());
             model.put("skuFamily", azureDatabaseServerView.getSkuFamily());
             model.put("skuName", azureDatabaseServerView.getSkuName());
-            model.put("skuSizeMB", azureDatabaseServerView.getAllocatedStorageInMb().toString());
+            model.put("skuSizeMB", azureDatabaseServerView.getAllocatedStorageInMb());
             model.put("skuTier", azureDatabaseServerView.getSkuTier());
             model.put("storageAutoGrow", azureDatabaseServerView.getStorageAutoGrow());
             model.put("subnets", azureNetworkView.getSubnets());

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureDatabaseServerView.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureDatabaseServerView.java
@@ -35,7 +35,7 @@ public class AzureDatabaseServerView {
     }
 
     public Long getAllocatedStorageInMb() {
-        return databaseServer.getStorageSize() * NUM_MB_IN_GB;
+        return databaseServer.getStorageSize() != null ? databaseServer.getStorageSize() * NUM_MB_IN_GB : null;
     }
 
     public Integer getBackupRetentionDays() {
@@ -92,5 +92,9 @@ public class AzureDatabaseServerView {
 
     public String getAdminPassword() {
         return databaseServer.getRootPassword();
+    }
+
+    public Integer getPort() {
+        return databaseServer.getPort();
     }
 }

--- a/cloud-azure/src/main/resources/templates/arm-dbstack.ftl
+++ b/cloud-azure/src/main/resources/templates/arm-dbstack.ftl
@@ -11,7 +11,7 @@
         },
         "skuTier": {
             "type": "string",
-            "defaultValue" : "${skuTier}",
+            "defaultValue" : "${skuTier!"GeneralPurpose"}",
             "allowedValues": [
                 "Basic",
                 "GeneralPurpose",
@@ -23,28 +23,30 @@
         },
         "skuFamily": {
             "type": "string",
-            "defaultValue" : "${skuFamily}",
+            "defaultValue" : "${skuFamily!"Gen5"}",
             "metadata": {
                 "description": "The family of hardware."
             }
         },
+        <#if skuCapacity??>
         "skuCapacity": {
             "type": "int",
-            "defaultValue" : ${skuCapacity},
+            "defaultValue" : ${skuCapacity?c},
             "metadata": {
                 "description": "The scale up/out capacity, representing server's compute units."
             }
         },
+        </#if>
         "skuSizeMB": {
             "type": "int",
-            "defaultValue" : ${skuSizeMB},
+            "defaultValue" : ${(skuSizeMB!10240)?c},
             "metadata": {
                 "description": "The size code, to be interpreted by resource as appropriate."
             }
         },
         "skuName": {
             "type": "string",
-            "defaultValue": "${skuName!GP_Gen5_2}",
+            "defaultValue": "${skuName!"GP_Gen5_2"}",
             "allowedValues": [
                 "GP_Gen5_2",
                 "GP_Gen5_4",
@@ -63,9 +65,9 @@
         },
         "dbVersion": {
             "type": "string",
-            "defaultValue": "${dbVersion}",
+            "defaultValue": "${dbVersion!10}",
             "metadata": {
-                "description": "Server version."
+                "description": "PostgreSQL version."
             }
         },
         "adminLoginName": {
@@ -94,7 +96,7 @@
         },
         "backupRetentionDays": {
             "type": "int",
-            "defaultValue": ${backupRetentionDays!7},
+            "defaultValue": ${(backupRetentionDays!7)?c},
             "minValue": 7,
             "maxValue": 35,
             "metadata": {
@@ -103,7 +105,7 @@
         },
         "geoRedundantBackup": {
             "type": "bool",
-            "defaultValue": ${(geoRedundantBackup!false)?c},
+            "defaultValue": ${(geoRedundantBackup!true)?c},
             "metadata": {
                 "description": "Enable Geo-redundant or not for server backup."
             }
@@ -161,7 +163,9 @@
             "sku": {
                 "name": "[parameters('skuName')]",
                 "tier": "[parameters('skuTier')]",
+                <#if skuCapacity??>
                 "capacity": "[parameters('skuCapacity')]",
+                </#if>
                 "size": "[parameters('skuSizeMB')]",
                 "family": "[parameters('skuFamily')]"
             },


### PR DESCRIPTION
The following parameters for Azure PostgreSQL database server creation
are now optional.

* skuCapacity - no default
* storageSize - defaults to 10 GB
* dbVersion - defaults to 10
* skuFamily - defaults to Gen5
* skuTier - defaults to GeneralPurpose

Azure PostgreSQL does not allow selecting a non-default port. Therefore,
the Azure connector now warns when the port is present, but otherwise
ignores what it is set to, if anything.

The default for geoRedundantBackup is changed from false to true, for
availability in case of a region-wide failure.