### PR TITLE
Fix operation id duplication (swagger) - verify credential by name/crn

### DIFF
--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/credential/endpoint/CredentialEndpoint.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/credential/endpoint/CredentialEndpoint.java
@@ -151,6 +151,6 @@ public interface CredentialEndpoint {
     @Path("/crn/{crn}/verify")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = CredentialOpDescription.VERIFY_BR_CRN, notes = CredentialDescriptor.CREDENTIAL_NOTES,
-            nickname = "verifyCredentialByName", httpMethod = "GET")
+            nickname = "verifyCredentialByCrn", httpMethod = "GET")
     CredentialResponse verifyByCrn(@PathParam("crn") String crn);
 }


### PR DESCRIPTION
verifyCredentialByName is duplicated - because of that swagger cannot generate the go client model from the swagger definition