### PR TITLE
Make cloud storage validator nullsafe (telemetry)

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/service/validation/cloudstorage/CloudStorageLocationValidator.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/validation/cloudstorage/CloudStorageLocationValidator.java
@@ -48,14 +48,17 @@ public class CloudStorageLocationValidator {
     }
 
     private Optional<FileSystemType> getFileSystemType(DetailedEnvironmentResponse environment) {
-        LoggingResponse logging = environment.getTelemetry().getLogging();
-        if (logging.getS3() != null) {
-            return Optional.of(logging.getS3().getType());
+        Optional<FileSystemType> response = Optional.empty();
+        if (environment.getTelemetry() != null && environment.getTelemetry().getLogging() != null) {
+            LoggingResponse logging = environment.getTelemetry().getLogging();
+            if (logging.getS3() != null) {
+                return Optional.of(logging.getS3().getType());
+            }
+            if (logging.getWasb() != null) {
+                return Optional.of(logging.getWasb().getType());
+            }
         }
-        if (logging.getWasb() != null) {
-            return Optional.of(logging.getWasb().getType());
-        }
-        return Optional.empty();
+        return response;
     }
 
     private String getBucketName(Optional<FileSystemType> fileSystemType, String storageLocation) {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/cloudstorage/CloudStorageLocationValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/cloudstorage/CloudStorageLocationValidator.java
@@ -42,14 +42,17 @@ public class CloudStorageLocationValidator {
     }
 
     private Optional<FileSystemType> getFileSystemType(Environment environment) {
-        EnvironmentLogging logging = environment.getTelemetry().getLogging();
-        if (logging.getS3() != null) {
-            return Optional.of(logging.getS3().getType());
+        Optional<FileSystemType> response = Optional.empty();
+        if (environment.getTelemetry() != null && environment.getTelemetry().getLogging() != null) {
+            EnvironmentLogging logging = environment.getTelemetry().getLogging();
+            if (logging.getS3() != null) {
+                return Optional.of(logging.getS3().getType());
+            }
+            if (logging.getWasb() != null) {
+                return Optional.of(logging.getWasb().getType());
+            }
         }
-        if (logging.getWasb() != null) {
-            return Optional.of(logging.getWasb().getType());
-        }
-        return Optional.empty();
+        return response;
     }
 
     private String getBucketName(Optional<FileSystemType> fileSystemType, String storageLocation) {


### PR DESCRIPTION
there is a fluent call against logging in cloud storage validator, so it assumes logging could not be null, but on object level it could be as that fields (telemetry or logging) is optional.