### PR TITLE
CDPCP-751. Metering for DataHub clusters is not working if S3 td-agent output is misconfigured.

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/fluent/template/output.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/fluent/template/output.conf.j2
@@ -8,6 +8,7 @@
     path "{{fluent.logFolderName}}/{{fluent.serviceLogPathSuffix}}"
     s3_object_key_format %{path}-%{index}.%{file_extension}
     auto_create_bucket false
+    check_apikey_on_start false
 
     <buffer tag,time>
       @type file
@@ -29,6 +30,7 @@
     path "{{fluent.logFolderName}}/{{fluent.cmCommandLogPathSuffix}}"
     s3_object_key_format %{path}-%{index}.%{file_extension}
     auto_create_bucket false
+    check_apikey_on_start false
 
     <buffer tag,time>
       @type file


### PR DESCRIPTION
s3 plugin has a pre-check against credentials (api key or instance profile), and if it fails it re-runs the input configuration setup.
basically, this mechanism stop any other plugins to work properly, so if the instance profile is wrong for s3, databus plugin won't work (for metering)