### PR TITLE
CDPCP-743. Usersync adds workload administration groups

### DIFF
--- a/auth-connector/src/generated/main/grpc/com/cloudera/thunderhead/service/usermanagement/UserManagementGrpc.java
+++ b/auth-connector/src/generated/main/grpc/com/cloudera/thunderhead/service/usermanagement/UserManagementGrpc.java
@@ -2695,6 +2695,191 @@ public final class UserManagementGrpc {
      }
      return getSetWorkloadSubdomainMethod;
   }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getCreateWorkloadMachineUserMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateWorkloadMachineUserRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateWorkloadMachineUserResponse> METHOD_CREATE_WORKLOAD_MACHINE_USER = getCreateWorkloadMachineUserMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateWorkloadMachineUserRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateWorkloadMachineUserResponse> getCreateWorkloadMachineUserMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateWorkloadMachineUserRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateWorkloadMachineUserResponse> getCreateWorkloadMachineUserMethod() {
+    return getCreateWorkloadMachineUserMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateWorkloadMachineUserRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateWorkloadMachineUserResponse> getCreateWorkloadMachineUserMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateWorkloadMachineUserRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateWorkloadMachineUserResponse> getCreateWorkloadMachineUserMethod;
+    if ((getCreateWorkloadMachineUserMethod = UserManagementGrpc.getCreateWorkloadMachineUserMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getCreateWorkloadMachineUserMethod = UserManagementGrpc.getCreateWorkloadMachineUserMethod) == null) {
+          UserManagementGrpc.getCreateWorkloadMachineUserMethod = getCreateWorkloadMachineUserMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateWorkloadMachineUserRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateWorkloadMachineUserResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "usermanagement.UserManagement", "CreateWorkloadMachineUser"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateWorkloadMachineUserRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateWorkloadMachineUserResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("CreateWorkloadMachineUser"))
+                  .build();
+          }
+        }
+     }
+     return getCreateWorkloadMachineUserMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getDeleteWorkloadMachineUserMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadMachineUserRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadMachineUserResponse> METHOD_DELETE_WORKLOAD_MACHINE_USER = getDeleteWorkloadMachineUserMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadMachineUserRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadMachineUserResponse> getDeleteWorkloadMachineUserMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadMachineUserRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadMachineUserResponse> getDeleteWorkloadMachineUserMethod() {
+    return getDeleteWorkloadMachineUserMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadMachineUserRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadMachineUserResponse> getDeleteWorkloadMachineUserMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadMachineUserRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadMachineUserResponse> getDeleteWorkloadMachineUserMethod;
+    if ((getDeleteWorkloadMachineUserMethod = UserManagementGrpc.getDeleteWorkloadMachineUserMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getDeleteWorkloadMachineUserMethod = UserManagementGrpc.getDeleteWorkloadMachineUserMethod) == null) {
+          UserManagementGrpc.getDeleteWorkloadMachineUserMethod = getDeleteWorkloadMachineUserMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadMachineUserRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadMachineUserResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "usermanagement.UserManagement", "DeleteWorkloadMachineUser"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadMachineUserRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadMachineUserResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("DeleteWorkloadMachineUser"))
+                  .build();
+          }
+        }
+     }
+     return getDeleteWorkloadMachineUserMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getGetWorkloadAdministrationGroupNameMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAdministrationGroupNameRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAdministrationGroupNameResponse> METHOD_GET_WORKLOAD_ADMINISTRATION_GROUP_NAME = getGetWorkloadAdministrationGroupNameMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAdministrationGroupNameRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAdministrationGroupNameResponse> getGetWorkloadAdministrationGroupNameMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAdministrationGroupNameRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAdministrationGroupNameResponse> getGetWorkloadAdministrationGroupNameMethod() {
+    return getGetWorkloadAdministrationGroupNameMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAdministrationGroupNameRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAdministrationGroupNameResponse> getGetWorkloadAdministrationGroupNameMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAdministrationGroupNameRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAdministrationGroupNameResponse> getGetWorkloadAdministrationGroupNameMethod;
+    if ((getGetWorkloadAdministrationGroupNameMethod = UserManagementGrpc.getGetWorkloadAdministrationGroupNameMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getGetWorkloadAdministrationGroupNameMethod = UserManagementGrpc.getGetWorkloadAdministrationGroupNameMethod) == null) {
+          UserManagementGrpc.getGetWorkloadAdministrationGroupNameMethod = getGetWorkloadAdministrationGroupNameMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAdministrationGroupNameRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAdministrationGroupNameResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "usermanagement.UserManagement", "GetWorkloadAdministrationGroupName"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAdministrationGroupNameRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAdministrationGroupNameResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("GetWorkloadAdministrationGroupName"))
+                  .build();
+          }
+        }
+     }
+     return getGetWorkloadAdministrationGroupNameMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getSetWorkloadAdministrationGroupNameMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadAdministrationGroupNameRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadAdministrationGroupNameResponse> METHOD_SET_WORKLOAD_ADMINISTRATION_GROUP_NAME = getSetWorkloadAdministrationGroupNameMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadAdministrationGroupNameRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadAdministrationGroupNameResponse> getSetWorkloadAdministrationGroupNameMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadAdministrationGroupNameRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadAdministrationGroupNameResponse> getSetWorkloadAdministrationGroupNameMethod() {
+    return getSetWorkloadAdministrationGroupNameMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadAdministrationGroupNameRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadAdministrationGroupNameResponse> getSetWorkloadAdministrationGroupNameMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadAdministrationGroupNameRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadAdministrationGroupNameResponse> getSetWorkloadAdministrationGroupNameMethod;
+    if ((getSetWorkloadAdministrationGroupNameMethod = UserManagementGrpc.getSetWorkloadAdministrationGroupNameMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getSetWorkloadAdministrationGroupNameMethod = UserManagementGrpc.getSetWorkloadAdministrationGroupNameMethod) == null) {
+          UserManagementGrpc.getSetWorkloadAdministrationGroupNameMethod = getSetWorkloadAdministrationGroupNameMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadAdministrationGroupNameRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadAdministrationGroupNameResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "usermanagement.UserManagement", "SetWorkloadAdministrationGroupName"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadAdministrationGroupNameRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadAdministrationGroupNameResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("SetWorkloadAdministrationGroupName"))
+                  .build();
+          }
+        }
+     }
+     return getSetWorkloadAdministrationGroupNameMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getDeleteWorkloadAdministrationGroupNameMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadAdministrationGroupNameRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadAdministrationGroupNameResponse> METHOD_DELETE_WORKLOAD_ADMINISTRATION_GROUP_NAME = getDeleteWorkloadAdministrationGroupNameMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadAdministrationGroupNameRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadAdministrationGroupNameResponse> getDeleteWorkloadAdministrationGroupNameMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadAdministrationGroupNameRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadAdministrationGroupNameResponse> getDeleteWorkloadAdministrationGroupNameMethod() {
+    return getDeleteWorkloadAdministrationGroupNameMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadAdministrationGroupNameRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadAdministrationGroupNameResponse> getDeleteWorkloadAdministrationGroupNameMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadAdministrationGroupNameRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadAdministrationGroupNameResponse> getDeleteWorkloadAdministrationGroupNameMethod;
+    if ((getDeleteWorkloadAdministrationGroupNameMethod = UserManagementGrpc.getDeleteWorkloadAdministrationGroupNameMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getDeleteWorkloadAdministrationGroupNameMethod = UserManagementGrpc.getDeleteWorkloadAdministrationGroupNameMethod) == null) {
+          UserManagementGrpc.getDeleteWorkloadAdministrationGroupNameMethod = getDeleteWorkloadAdministrationGroupNameMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadAdministrationGroupNameRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadAdministrationGroupNameResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "usermanagement.UserManagement", "DeleteWorkloadAdministrationGroupName"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadAdministrationGroupNameRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadAdministrationGroupNameResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("DeleteWorkloadAdministrationGroupName"))
+                  .build();
+          }
+        }
+     }
+     return getDeleteWorkloadAdministrationGroupNameMethod;
+  }
 
   /**
    * Creates a new async stub that supports all call types for the service
@@ -3462,6 +3647,69 @@ public final class UserManagementGrpc {
       asyncUnimplementedUnaryCall(getSetWorkloadSubdomainMethodHelper(), responseObserver);
     }
 
+    /**
+     * <pre>
+     * Create a machine-user, assign the resource roles and roles to it, create
+     * an access key for it, and return it. This is exposed as a convenience method
+     * for applications. Callers must be internal actors. The call is idempotent
+     * and safe to be called multiple times. Machine users created through this
+     * interface should be deleted by called DeleteWorkloadMachineUser.
+     * </pre>
+     */
+    public void createWorkloadMachineUser(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateWorkloadMachineUserRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateWorkloadMachineUserResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getCreateWorkloadMachineUserMethodHelper(), responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Delete the workload machine user, all the role and resource role assignments,
+     * as well as any access keys. This is a convenience method for application who
+     * created a machine user using CreateWorkloadMachineUser.
+     * </pre>
+     */
+    public void deleteWorkloadMachineUser(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadMachineUserRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadMachineUserResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getDeleteWorkloadMachineUserMethodHelper(), responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Returns the the workload administration group name for the
+     * (account, right, resource) tuple. Will throw NOT_FOUND exception if no name
+     * for the workload administration group has been set yet.
+     * </pre>
+     */
+    public void getWorkloadAdministrationGroupName(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAdministrationGroupNameRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAdministrationGroupNameResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getGetWorkloadAdministrationGroupNameMethodHelper(), responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Sets the workload administration group name for the (account, right, resource)
+     * tuple. If the name was already set for the workload administration group
+     * this is a no-op and the name generated for the workload administration group
+     * will be returned.
+     * </pre>
+     */
+    public void setWorkloadAdministrationGroupName(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadAdministrationGroupNameRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadAdministrationGroupNameResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getSetWorkloadAdministrationGroupNameMethodHelper(), responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Deletes the workload administration group name for the (account, right, resource)
+     * tuple. Throws a NOT_FOUND exception if no such workload administration group
+     * can be found.
+     * </pre>
+     */
+    public void deleteWorkloadAdministrationGroupName(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadAdministrationGroupNameRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadAdministrationGroupNameResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getDeleteWorkloadAdministrationGroupNameMethodHelper(), responseObserver);
+    }
+
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
@@ -3968,6 +4216,41 @@ public final class UserManagementGrpc {
                 com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadSubdomainRequest,
                 com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadSubdomainResponse>(
                   this, METHODID_SET_WORKLOAD_SUBDOMAIN)))
+          .addMethod(
+            getCreateWorkloadMachineUserMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateWorkloadMachineUserRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateWorkloadMachineUserResponse>(
+                  this, METHODID_CREATE_WORKLOAD_MACHINE_USER)))
+          .addMethod(
+            getDeleteWorkloadMachineUserMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadMachineUserRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadMachineUserResponse>(
+                  this, METHODID_DELETE_WORKLOAD_MACHINE_USER)))
+          .addMethod(
+            getGetWorkloadAdministrationGroupNameMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAdministrationGroupNameRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAdministrationGroupNameResponse>(
+                  this, METHODID_GET_WORKLOAD_ADMINISTRATION_GROUP_NAME)))
+          .addMethod(
+            getSetWorkloadAdministrationGroupNameMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadAdministrationGroupNameRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadAdministrationGroupNameResponse>(
+                  this, METHODID_SET_WORKLOAD_ADMINISTRATION_GROUP_NAME)))
+          .addMethod(
+            getDeleteWorkloadAdministrationGroupNameMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadAdministrationGroupNameRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadAdministrationGroupNameResponse>(
+                  this, METHODID_DELETE_WORKLOAD_ADMINISTRATION_GROUP_NAME)))
           .build();
     }
   }
@@ -4800,6 +5083,74 @@ public final class UserManagementGrpc {
       asyncUnaryCall(
           getChannel().newCall(getSetWorkloadSubdomainMethodHelper(), getCallOptions()), request, responseObserver);
     }
+
+    /**
+     * <pre>
+     * Create a machine-user, assign the resource roles and roles to it, create
+     * an access key for it, and return it. This is exposed as a convenience method
+     * for applications. Callers must be internal actors. The call is idempotent
+     * and safe to be called multiple times. Machine users created through this
+     * interface should be deleted by called DeleteWorkloadMachineUser.
+     * </pre>
+     */
+    public void createWorkloadMachineUser(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateWorkloadMachineUserRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateWorkloadMachineUserResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getCreateWorkloadMachineUserMethodHelper(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Delete the workload machine user, all the role and resource role assignments,
+     * as well as any access keys. This is a convenience method for application who
+     * created a machine user using CreateWorkloadMachineUser.
+     * </pre>
+     */
+    public void deleteWorkloadMachineUser(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadMachineUserRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadMachineUserResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getDeleteWorkloadMachineUserMethodHelper(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Returns the the workload administration group name for the
+     * (account, right, resource) tuple. Will throw NOT_FOUND exception if no name
+     * for the workload administration group has been set yet.
+     * </pre>
+     */
+    public void getWorkloadAdministrationGroupName(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAdministrationGroupNameRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAdministrationGroupNameResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getGetWorkloadAdministrationGroupNameMethodHelper(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Sets the workload administration group name for the (account, right, resource)
+     * tuple. If the name was already set for the workload administration group
+     * this is a no-op and the name generated for the workload administration group
+     * will be returned.
+     * </pre>
+     */
+    public void setWorkloadAdministrationGroupName(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadAdministrationGroupNameRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadAdministrationGroupNameResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getSetWorkloadAdministrationGroupNameMethodHelper(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Deletes the workload administration group name for the (account, right, resource)
+     * tuple. Throws a NOT_FOUND exception if no such workload administration group
+     * can be found.
+     * </pre>
+     */
+    public void deleteWorkloadAdministrationGroupName(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadAdministrationGroupNameRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadAdministrationGroupNameResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getDeleteWorkloadAdministrationGroupNameMethodHelper(), getCallOptions()), request, responseObserver);
+    }
   }
 
   /**
@@ -5557,6 +5908,69 @@ public final class UserManagementGrpc {
     public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadSubdomainResponse setWorkloadSubdomain(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadSubdomainRequest request) {
       return blockingUnaryCall(
           getChannel(), getSetWorkloadSubdomainMethodHelper(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * Create a machine-user, assign the resource roles and roles to it, create
+     * an access key for it, and return it. This is exposed as a convenience method
+     * for applications. Callers must be internal actors. The call is idempotent
+     * and safe to be called multiple times. Machine users created through this
+     * interface should be deleted by called DeleteWorkloadMachineUser.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateWorkloadMachineUserResponse createWorkloadMachineUser(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateWorkloadMachineUserRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getCreateWorkloadMachineUserMethodHelper(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * Delete the workload machine user, all the role and resource role assignments,
+     * as well as any access keys. This is a convenience method for application who
+     * created a machine user using CreateWorkloadMachineUser.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadMachineUserResponse deleteWorkloadMachineUser(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadMachineUserRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getDeleteWorkloadMachineUserMethodHelper(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * Returns the the workload administration group name for the
+     * (account, right, resource) tuple. Will throw NOT_FOUND exception if no name
+     * for the workload administration group has been set yet.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAdministrationGroupNameResponse getWorkloadAdministrationGroupName(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAdministrationGroupNameRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getGetWorkloadAdministrationGroupNameMethodHelper(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * Sets the workload administration group name for the (account, right, resource)
+     * tuple. If the name was already set for the workload administration group
+     * this is a no-op and the name generated for the workload administration group
+     * will be returned.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadAdministrationGroupNameResponse setWorkloadAdministrationGroupName(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadAdministrationGroupNameRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getSetWorkloadAdministrationGroupNameMethodHelper(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * Deletes the workload administration group name for the (account, right, resource)
+     * tuple. Throws a NOT_FOUND exception if no such workload administration group
+     * can be found.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadAdministrationGroupNameResponse deleteWorkloadAdministrationGroupName(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadAdministrationGroupNameRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getDeleteWorkloadAdministrationGroupNameMethodHelper(), getCallOptions(), request);
     }
   }
 
@@ -6388,6 +6802,74 @@ public final class UserManagementGrpc {
       return futureUnaryCall(
           getChannel().newCall(getSetWorkloadSubdomainMethodHelper(), getCallOptions()), request);
     }
+
+    /**
+     * <pre>
+     * Create a machine-user, assign the resource roles and roles to it, create
+     * an access key for it, and return it. This is exposed as a convenience method
+     * for applications. Callers must be internal actors. The call is idempotent
+     * and safe to be called multiple times. Machine users created through this
+     * interface should be deleted by called DeleteWorkloadMachineUser.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateWorkloadMachineUserResponse> createWorkloadMachineUser(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateWorkloadMachineUserRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getCreateWorkloadMachineUserMethodHelper(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
+     * Delete the workload machine user, all the role and resource role assignments,
+     * as well as any access keys. This is a convenience method for application who
+     * created a machine user using CreateWorkloadMachineUser.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadMachineUserResponse> deleteWorkloadMachineUser(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadMachineUserRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getDeleteWorkloadMachineUserMethodHelper(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
+     * Returns the the workload administration group name for the
+     * (account, right, resource) tuple. Will throw NOT_FOUND exception if no name
+     * for the workload administration group has been set yet.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAdministrationGroupNameResponse> getWorkloadAdministrationGroupName(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAdministrationGroupNameRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getGetWorkloadAdministrationGroupNameMethodHelper(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
+     * Sets the workload administration group name for the (account, right, resource)
+     * tuple. If the name was already set for the workload administration group
+     * this is a no-op and the name generated for the workload administration group
+     * will be returned.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadAdministrationGroupNameResponse> setWorkloadAdministrationGroupName(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadAdministrationGroupNameRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getSetWorkloadAdministrationGroupNameMethodHelper(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
+     * Deletes the workload administration group name for the (account, right, resource)
+     * tuple. Throws a NOT_FOUND exception if no such workload administration group
+     * can be found.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadAdministrationGroupNameResponse> deleteWorkloadAdministrationGroupName(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadAdministrationGroupNameRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getDeleteWorkloadAdministrationGroupNameMethodHelper(), getCallOptions()), request);
+    }
   }
 
   private static final int METHODID_INTERACTIVE_LOGIN = 0;
@@ -6462,6 +6944,11 @@ public final class UserManagementGrpc {
   private static final int METHODID_GET_ID_PMETADATA_FOR_WORKLOAD_SSO = 69;
   private static final int METHODID_PROCESS_WORKLOAD_SSOAUTHN_REQ = 70;
   private static final int METHODID_SET_WORKLOAD_SUBDOMAIN = 71;
+  private static final int METHODID_CREATE_WORKLOAD_MACHINE_USER = 72;
+  private static final int METHODID_DELETE_WORKLOAD_MACHINE_USER = 73;
+  private static final int METHODID_GET_WORKLOAD_ADMINISTRATION_GROUP_NAME = 74;
+  private static final int METHODID_SET_WORKLOAD_ADMINISTRATION_GROUP_NAME = 75;
+  private static final int METHODID_DELETE_WORKLOAD_ADMINISTRATION_GROUP_NAME = 76;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -6768,6 +7255,26 @@ public final class UserManagementGrpc {
           serviceImpl.setWorkloadSubdomain((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadSubdomainRequest) request,
               (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadSubdomainResponse>) responseObserver);
           break;
+        case METHODID_CREATE_WORKLOAD_MACHINE_USER:
+          serviceImpl.createWorkloadMachineUser((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateWorkloadMachineUserRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateWorkloadMachineUserResponse>) responseObserver);
+          break;
+        case METHODID_DELETE_WORKLOAD_MACHINE_USER:
+          serviceImpl.deleteWorkloadMachineUser((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadMachineUserRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadMachineUserResponse>) responseObserver);
+          break;
+        case METHODID_GET_WORKLOAD_ADMINISTRATION_GROUP_NAME:
+          serviceImpl.getWorkloadAdministrationGroupName((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAdministrationGroupNameRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAdministrationGroupNameResponse>) responseObserver);
+          break;
+        case METHODID_SET_WORKLOAD_ADMINISTRATION_GROUP_NAME:
+          serviceImpl.setWorkloadAdministrationGroupName((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadAdministrationGroupNameRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadAdministrationGroupNameResponse>) responseObserver);
+          break;
+        case METHODID_DELETE_WORKLOAD_ADMINISTRATION_GROUP_NAME:
+          serviceImpl.deleteWorkloadAdministrationGroupName((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadAdministrationGroupNameRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadAdministrationGroupNameResponse>) responseObserver);
+          break;
         default:
           throw new AssertionError();
       }
@@ -6901,6 +7408,11 @@ public final class UserManagementGrpc {
               .addMethod(getGetIdPMetadataForWorkloadSSOMethodHelper())
               .addMethod(getProcessWorkloadSSOAuthnReqMethodHelper())
               .addMethod(getSetWorkloadSubdomainMethodHelper())
+              .addMethod(getCreateWorkloadMachineUserMethodHelper())
+              .addMethod(getDeleteWorkloadMachineUserMethodHelper())
+              .addMethod(getGetWorkloadAdministrationGroupNameMethodHelper())
+              .addMethod(getSetWorkloadAdministrationGroupNameMethodHelper())
+              .addMethod(getDeleteWorkloadAdministrationGroupNameMethodHelper())
               .build();
         }
       }

--- a/auth-connector/src/generated/main/java/com/cloudera/thunderhead/service/common/options/Options.java
+++ b/auth-connector/src/generated/main/java/com/cloudera/thunderhead/service/common/options/Options.java
@@ -7,8 +7,26 @@ public final class Options {
   private Options() {}
   public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistryLite registry) {
-    registry.add(com.cloudera.thunderhead.service.common.options.Options.sensitive);
-    registry.add(com.cloudera.thunderhead.service.common.options.Options.skipLogging);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.sensitive);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.skipLogging);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.pagingPageSize);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.pagingInputToken);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.pagingResult);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.pagingOutputToken);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.datetime);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.hidden);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.hiddenReason);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.hiddenRetention);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.right);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.entitlement);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.paginates);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.pagingDefaultMaxItems);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.hidden);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.hiddenReason);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.hiddenRetention);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.MessageExtension.hidden);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.MessageExtension.hiddenReason);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.MessageExtension.hiddenRetention);
   }
 
   public static void registerAllExtensions(
@@ -16,38 +34,1599 @@ public final class Options {
     registerAllExtensions(
         (com.google.protobuf.ExtensionRegistryLite) registry);
   }
-  public static final int SENSITIVE_FIELD_NUMBER = 50000;
+  public interface FieldExtensionOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:options.FieldExtension)
+      com.google.protobuf.MessageOrBuilder {
+  }
   /**
-   * <pre>
-   * The field is sensitive. It will not be logged and may receive other special
-   * handling in the future.
-   * </pre>
-   *
-   * <code>extend .google.protobuf.FieldOptions { ... }</code>
+   * Protobuf type {@code options.FieldExtension}
    */
-  public static final
-    com.google.protobuf.GeneratedMessage.GeneratedExtension<
-      com.google.protobuf.DescriptorProtos.FieldOptions,
-      java.lang.Boolean> sensitive = com.google.protobuf.GeneratedMessage
-          .newFileScopedGeneratedExtension(
-        java.lang.Boolean.class,
-        null);
-  public static final int SKIPLOGGING_FIELD_NUMBER = 50001;
+  public  static final class FieldExtension extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:options.FieldExtension)
+      FieldExtensionOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use FieldExtension.newBuilder() to construct.
+    private FieldExtension(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private FieldExtension() {
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private FieldExtension(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownFieldProto3(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_FieldExtension_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_FieldExtension_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.cloudera.thunderhead.service.common.options.Options.FieldExtension.class, com.cloudera.thunderhead.service.common.options.Options.FieldExtension.Builder.class);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.cloudera.thunderhead.service.common.options.Options.FieldExtension)) {
+        return super.equals(obj);
+      }
+      com.cloudera.thunderhead.service.common.options.Options.FieldExtension other = (com.cloudera.thunderhead.service.common.options.Options.FieldExtension) obj;
+
+      boolean result = true;
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.cloudera.thunderhead.service.common.options.Options.FieldExtension parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FieldExtension parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FieldExtension parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FieldExtension parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FieldExtension parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FieldExtension parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FieldExtension parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FieldExtension parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FieldExtension parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FieldExtension parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FieldExtension parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FieldExtension parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.cloudera.thunderhead.service.common.options.Options.FieldExtension prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code options.FieldExtension}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:options.FieldExtension)
+        com.cloudera.thunderhead.service.common.options.Options.FieldExtensionOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_FieldExtension_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_FieldExtension_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.cloudera.thunderhead.service.common.options.Options.FieldExtension.class, com.cloudera.thunderhead.service.common.options.Options.FieldExtension.Builder.class);
+      }
+
+      // Construct using com.cloudera.thunderhead.service.common.options.Options.FieldExtension.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_FieldExtension_descriptor;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.FieldExtension getDefaultInstanceForType() {
+        return com.cloudera.thunderhead.service.common.options.Options.FieldExtension.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.FieldExtension build() {
+        com.cloudera.thunderhead.service.common.options.Options.FieldExtension result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.FieldExtension buildPartial() {
+        com.cloudera.thunderhead.service.common.options.Options.FieldExtension result = new com.cloudera.thunderhead.service.common.options.Options.FieldExtension(this);
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.cloudera.thunderhead.service.common.options.Options.FieldExtension) {
+          return mergeFrom((com.cloudera.thunderhead.service.common.options.Options.FieldExtension)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.cloudera.thunderhead.service.common.options.Options.FieldExtension other) {
+        if (other == com.cloudera.thunderhead.service.common.options.Options.FieldExtension.getDefaultInstance()) return this;
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.cloudera.thunderhead.service.common.options.Options.FieldExtension parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.cloudera.thunderhead.service.common.options.Options.FieldExtension) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFieldsProto3(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:options.FieldExtension)
+    }
+
+    // @@protoc_insertion_point(class_scope:options.FieldExtension)
+    private static final com.cloudera.thunderhead.service.common.options.Options.FieldExtension DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.cloudera.thunderhead.service.common.options.Options.FieldExtension();
+    }
+
+    public static com.cloudera.thunderhead.service.common.options.Options.FieldExtension getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<FieldExtension>
+        PARSER = new com.google.protobuf.AbstractParser<FieldExtension>() {
+      @java.lang.Override
+      public FieldExtension parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new FieldExtension(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<FieldExtension> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<FieldExtension> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.cloudera.thunderhead.service.common.options.Options.FieldExtension getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+    public static final int SENSITIVE_FIELD_NUMBER = 50000;
+    /**
+     * <pre>
+     * The field is sensitive. It will not be logged and may receive other special
+     * handling in the future.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.FieldOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.FieldOptions,
+        java.lang.Boolean> sensitive = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.FieldExtension.getDefaultInstance(),
+          0,
+          java.lang.Boolean.class,
+          null);
+    public static final int SKIPLOGGING_FIELD_NUMBER = 50001;
+    /**
+     * <pre>
+     * The field should not be logged. This may be useful on fields that have very
+     * large values.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.FieldOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.FieldOptions,
+        java.lang.Boolean> skipLogging = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.FieldExtension.getDefaultInstance(),
+          1,
+          java.lang.Boolean.class,
+          null);
+    public static final int PAGINGPAGESIZE_FIELD_NUMBER = 50002;
+    /**
+     * <pre>
+     * This field controls the page size.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.FieldOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.FieldOptions,
+        java.lang.Boolean> pagingPageSize = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.FieldExtension.getDefaultInstance(),
+          2,
+          java.lang.Boolean.class,
+          null);
+    public static final int PAGINGINPUTTOKEN_FIELD_NUMBER = 50003;
+    /**
+     * <pre>
+     * This field is the input paging token.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.FieldOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.FieldOptions,
+        java.lang.Boolean> pagingInputToken = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.FieldExtension.getDefaultInstance(),
+          3,
+          java.lang.Boolean.class,
+          null);
+    public static final int PAGINGRESULT_FIELD_NUMBER = 50004;
+    /**
+     * <pre>
+     * This field contains a page of results.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.FieldOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.FieldOptions,
+        java.lang.Boolean> pagingResult = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.FieldExtension.getDefaultInstance(),
+          4,
+          java.lang.Boolean.class,
+          null);
+    public static final int PAGINGOUTPUTTOKEN_FIELD_NUMBER = 50005;
+    /**
+     * <pre>
+     * This field is the output paging token.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.FieldOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.FieldOptions,
+        java.lang.Boolean> pagingOutputToken = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.FieldExtension.getDefaultInstance(),
+          5,
+          java.lang.Boolean.class,
+          null);
+    public static final int DATETIME_FIELD_NUMBER = 50006;
+    /**
+     * <pre>
+     * This field is a date time.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.FieldOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.FieldOptions,
+        java.lang.Boolean> datetime = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.FieldExtension.getDefaultInstance(),
+          6,
+          java.lang.Boolean.class,
+          null);
+    public static final int HIDDEN_FIELD_NUMBER = 50007;
+    /**
+     * <pre>
+     * This field is hidden.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.FieldOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.FieldOptions,
+        java.lang.Boolean> hidden = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.FieldExtension.getDefaultInstance(),
+          7,
+          java.lang.Boolean.class,
+          null);
+    public static final int HIDDENREASON_FIELD_NUMBER = 50008;
+    /**
+     * <pre>
+     * The reason this field is hidden.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.FieldOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.FieldOptions,
+        java.lang.String> hiddenReason = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.FieldExtension.getDefaultInstance(),
+          8,
+          java.lang.String.class,
+          null);
+    public static final int HIDDENRETENTION_FIELD_NUMBER = 50009;
+    /**
+     * <pre>
+     * This conditions under which this hidden field is made visible.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.FieldOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.FieldOptions,
+        java.lang.String> hiddenRetention = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.FieldExtension.getDefaultInstance(),
+          9,
+          java.lang.String.class,
+          null);
+  }
+
+  public interface MethodExtensionOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:options.MethodExtension)
+      com.google.protobuf.MessageOrBuilder {
+  }
   /**
-   * <pre>
-   * The field should not be logged. This may be useful on fields that have very
-   * large values.
-   * </pre>
-   *
-   * <code>extend .google.protobuf.FieldOptions { ... }</code>
+   * Protobuf type {@code options.MethodExtension}
    */
-  public static final
-    com.google.protobuf.GeneratedMessage.GeneratedExtension<
-      com.google.protobuf.DescriptorProtos.FieldOptions,
-      java.lang.Boolean> skipLogging = com.google.protobuf.GeneratedMessage
-          .newFileScopedGeneratedExtension(
-        java.lang.Boolean.class,
-        null);
+  public  static final class MethodExtension extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:options.MethodExtension)
+      MethodExtensionOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use MethodExtension.newBuilder() to construct.
+    private MethodExtension(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private MethodExtension() {
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private MethodExtension(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownFieldProto3(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_MethodExtension_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_MethodExtension_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.cloudera.thunderhead.service.common.options.Options.MethodExtension.class, com.cloudera.thunderhead.service.common.options.Options.MethodExtension.Builder.class);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.cloudera.thunderhead.service.common.options.Options.MethodExtension)) {
+        return super.equals(obj);
+      }
+      com.cloudera.thunderhead.service.common.options.Options.MethodExtension other = (com.cloudera.thunderhead.service.common.options.Options.MethodExtension) obj;
+
+      boolean result = true;
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.cloudera.thunderhead.service.common.options.Options.MethodExtension parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.MethodExtension parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.MethodExtension parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.MethodExtension parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.MethodExtension parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.MethodExtension parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.MethodExtension parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.MethodExtension parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.MethodExtension parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.MethodExtension parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.MethodExtension parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.MethodExtension parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.cloudera.thunderhead.service.common.options.Options.MethodExtension prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code options.MethodExtension}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:options.MethodExtension)
+        com.cloudera.thunderhead.service.common.options.Options.MethodExtensionOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_MethodExtension_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_MethodExtension_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.cloudera.thunderhead.service.common.options.Options.MethodExtension.class, com.cloudera.thunderhead.service.common.options.Options.MethodExtension.Builder.class);
+      }
+
+      // Construct using com.cloudera.thunderhead.service.common.options.Options.MethodExtension.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_MethodExtension_descriptor;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.MethodExtension getDefaultInstanceForType() {
+        return com.cloudera.thunderhead.service.common.options.Options.MethodExtension.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.MethodExtension build() {
+        com.cloudera.thunderhead.service.common.options.Options.MethodExtension result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.MethodExtension buildPartial() {
+        com.cloudera.thunderhead.service.common.options.Options.MethodExtension result = new com.cloudera.thunderhead.service.common.options.Options.MethodExtension(this);
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.cloudera.thunderhead.service.common.options.Options.MethodExtension) {
+          return mergeFrom((com.cloudera.thunderhead.service.common.options.Options.MethodExtension)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.cloudera.thunderhead.service.common.options.Options.MethodExtension other) {
+        if (other == com.cloudera.thunderhead.service.common.options.Options.MethodExtension.getDefaultInstance()) return this;
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.cloudera.thunderhead.service.common.options.Options.MethodExtension parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.cloudera.thunderhead.service.common.options.Options.MethodExtension) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFieldsProto3(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:options.MethodExtension)
+    }
+
+    // @@protoc_insertion_point(class_scope:options.MethodExtension)
+    private static final com.cloudera.thunderhead.service.common.options.Options.MethodExtension DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.cloudera.thunderhead.service.common.options.Options.MethodExtension();
+    }
+
+    public static com.cloudera.thunderhead.service.common.options.Options.MethodExtension getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<MethodExtension>
+        PARSER = new com.google.protobuf.AbstractParser<MethodExtension>() {
+      @java.lang.Override
+      public MethodExtension parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new MethodExtension(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<MethodExtension> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<MethodExtension> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.cloudera.thunderhead.service.common.options.Options.MethodExtension getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+    public static final int RIGHT_FIELD_NUMBER = 60000;
+    /**
+     * <pre>
+     * This method requires the specified right.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.MethodOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.MethodOptions,
+        java.lang.String> right = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.MethodExtension.getDefaultInstance(),
+          0,
+          java.lang.String.class,
+          null);
+    public static final int ENTITLEMENT_FIELD_NUMBER = 60001;
+    /**
+     * <pre>
+     * This method requires the specified entitlement.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.MethodOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.MethodOptions,
+        java.lang.String> entitlement = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.MethodExtension.getDefaultInstance(),
+          1,
+          java.lang.String.class,
+          null);
+    public static final int PAGINATES_FIELD_NUMBER = 60002;
+    /**
+     * <pre>
+     * This method returnes paginated results.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.MethodOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.MethodOptions,
+        java.lang.Boolean> paginates = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.MethodExtension.getDefaultInstance(),
+          2,
+          java.lang.Boolean.class,
+          null);
+    public static final int PAGINGDEFAULTMAXITEMS_FIELD_NUMBER = 60003;
+    /**
+     * <pre>
+     * This default number of max items for auto-pagination to fetch.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.MethodOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.MethodOptions,
+        java.lang.Integer> pagingDefaultMaxItems = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.MethodExtension.getDefaultInstance(),
+          3,
+          java.lang.Integer.class,
+          null);
+    public static final int HIDDEN_FIELD_NUMBER = 60004;
+    /**
+     * <pre>
+     * This method is hidden.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.MethodOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.MethodOptions,
+        java.lang.Boolean> hidden = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.MethodExtension.getDefaultInstance(),
+          4,
+          java.lang.Boolean.class,
+          null);
+    public static final int HIDDENREASON_FIELD_NUMBER = 60005;
+    /**
+     * <pre>
+     * The reason this method is hidden.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.MethodOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.MethodOptions,
+        java.lang.String> hiddenReason = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.MethodExtension.getDefaultInstance(),
+          5,
+          java.lang.String.class,
+          null);
+    public static final int HIDDENRETENTION_FIELD_NUMBER = 60006;
+    /**
+     * <pre>
+     * This conditions under which this hidden method is made visible.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.MethodOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.MethodOptions,
+        java.lang.String> hiddenRetention = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.MethodExtension.getDefaultInstance(),
+          6,
+          java.lang.String.class,
+          null);
+  }
+
+  public interface MessageExtensionOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:options.MessageExtension)
+      com.google.protobuf.MessageOrBuilder {
+  }
+  /**
+   * Protobuf type {@code options.MessageExtension}
+   */
+  public  static final class MessageExtension extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:options.MessageExtension)
+      MessageExtensionOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use MessageExtension.newBuilder() to construct.
+    private MessageExtension(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private MessageExtension() {
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private MessageExtension(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownFieldProto3(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_MessageExtension_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_MessageExtension_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.cloudera.thunderhead.service.common.options.Options.MessageExtension.class, com.cloudera.thunderhead.service.common.options.Options.MessageExtension.Builder.class);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.cloudera.thunderhead.service.common.options.Options.MessageExtension)) {
+        return super.equals(obj);
+      }
+      com.cloudera.thunderhead.service.common.options.Options.MessageExtension other = (com.cloudera.thunderhead.service.common.options.Options.MessageExtension) obj;
+
+      boolean result = true;
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.cloudera.thunderhead.service.common.options.Options.MessageExtension parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.MessageExtension parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.MessageExtension parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.MessageExtension parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.MessageExtension parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.MessageExtension parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.MessageExtension parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.MessageExtension parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.MessageExtension parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.MessageExtension parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.MessageExtension parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.MessageExtension parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.cloudera.thunderhead.service.common.options.Options.MessageExtension prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code options.MessageExtension}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:options.MessageExtension)
+        com.cloudera.thunderhead.service.common.options.Options.MessageExtensionOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_MessageExtension_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_MessageExtension_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.cloudera.thunderhead.service.common.options.Options.MessageExtension.class, com.cloudera.thunderhead.service.common.options.Options.MessageExtension.Builder.class);
+      }
+
+      // Construct using com.cloudera.thunderhead.service.common.options.Options.MessageExtension.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_MessageExtension_descriptor;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.MessageExtension getDefaultInstanceForType() {
+        return com.cloudera.thunderhead.service.common.options.Options.MessageExtension.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.MessageExtension build() {
+        com.cloudera.thunderhead.service.common.options.Options.MessageExtension result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.MessageExtension buildPartial() {
+        com.cloudera.thunderhead.service.common.options.Options.MessageExtension result = new com.cloudera.thunderhead.service.common.options.Options.MessageExtension(this);
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.cloudera.thunderhead.service.common.options.Options.MessageExtension) {
+          return mergeFrom((com.cloudera.thunderhead.service.common.options.Options.MessageExtension)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.cloudera.thunderhead.service.common.options.Options.MessageExtension other) {
+        if (other == com.cloudera.thunderhead.service.common.options.Options.MessageExtension.getDefaultInstance()) return this;
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.cloudera.thunderhead.service.common.options.Options.MessageExtension parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.cloudera.thunderhead.service.common.options.Options.MessageExtension) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFieldsProto3(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:options.MessageExtension)
+    }
+
+    // @@protoc_insertion_point(class_scope:options.MessageExtension)
+    private static final com.cloudera.thunderhead.service.common.options.Options.MessageExtension DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.cloudera.thunderhead.service.common.options.Options.MessageExtension();
+    }
+
+    public static com.cloudera.thunderhead.service.common.options.Options.MessageExtension getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<MessageExtension>
+        PARSER = new com.google.protobuf.AbstractParser<MessageExtension>() {
+      @java.lang.Override
+      public MessageExtension parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new MessageExtension(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<MessageExtension> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<MessageExtension> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.cloudera.thunderhead.service.common.options.Options.MessageExtension getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+    public static final int HIDDEN_FIELD_NUMBER = 70000;
+    /**
+     * <pre>
+     * This message is hidden.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.MessageOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.MessageOptions,
+        java.lang.Boolean> hidden = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.MessageExtension.getDefaultInstance(),
+          0,
+          java.lang.Boolean.class,
+          null);
+    public static final int HIDDENREASON_FIELD_NUMBER = 70001;
+    /**
+     * <pre>
+     * The reason this message is hidden.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.MessageOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.MessageOptions,
+        java.lang.String> hiddenReason = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.MessageExtension.getDefaultInstance(),
+          1,
+          java.lang.String.class,
+          null);
+    public static final int HIDDENRETENTION_FIELD_NUMBER = 70002;
+    /**
+     * <pre>
+     * This conditions under this hidden message is made visible.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.MessageOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.MessageOptions,
+        java.lang.String> hiddenRetention = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.MessageExtension.getDefaultInstance(),
+          2,
+          java.lang.String.class,
+          null);
+  }
+
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_options_FieldExtension_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_options_FieldExtension_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_options_MethodExtension_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_options_MethodExtension_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_options_MessageExtension_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_options_MessageExtension_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -58,11 +1637,38 @@ public final class Options {
   static {
     java.lang.String[] descriptorData = {
       "\n\roptions.proto\022\007options\032 google/protobu" +
-      "f/descriptor.proto:2\n\tsensitive\022\035.google" +
-      ".protobuf.FieldOptions\030\320\206\003 \001(\010:4\n\013skipLo" +
-      "gging\022\035.google.protobuf.FieldOptions\030\321\206\003" +
-      " \001(\010B:\n/com.cloudera.thunderhead.service" +
-      ".common.optionsB\007Optionsb\006proto3"
+      "f/descriptor.proto\"\266\004\n\016FieldExtension22\n" +
+      "\tsensitive\022\035.google.protobuf.FieldOption" +
+      "s\030\320\206\003 \001(\01024\n\013skipLogging\022\035.google.protob" +
+      "uf.FieldOptions\030\321\206\003 \001(\01027\n\016pagingPageSiz" +
+      "e\022\035.google.protobuf.FieldOptions\030\322\206\003 \001(\010" +
+      "29\n\020pagingInputToken\022\035.google.protobuf.F" +
+      "ieldOptions\030\323\206\003 \001(\01025\n\014pagingResult\022\035.go" +
+      "ogle.protobuf.FieldOptions\030\324\206\003 \001(\0102:\n\021pa" +
+      "gingOutputToken\022\035.google.protobuf.FieldO" +
+      "ptions\030\325\206\003 \001(\01021\n\010datetime\022\035.google.prot" +
+      "obuf.FieldOptions\030\326\206\003 \001(\0102/\n\006hidden\022\035.go" +
+      "ogle.protobuf.FieldOptions\030\327\206\003 \001(\01025\n\014hi" +
+      "ddenReason\022\035.google.protobuf.FieldOption" +
+      "s\030\330\206\003 \001(\t28\n\017hiddenRetention\022\035.google.pr" +
+      "otobuf.FieldOptions\030\331\206\003 \001(\t\"\224\003\n\017MethodEx" +
+      "tension2/\n\005right\022\036.google.protobuf.Metho" +
+      "dOptions\030\340\324\003 \001(\t25\n\013entitlement\022\036.google" +
+      ".protobuf.MethodOptions\030\341\324\003 \001(\t23\n\tpagin" +
+      "ates\022\036.google.protobuf.MethodOptions\030\342\324\003" +
+      " \001(\0102?\n\025pagingDefaultMaxItems\022\036.google.p" +
+      "rotobuf.MethodOptions\030\343\324\003 \001(\00520\n\006hidden\022" +
+      "\036.google.protobuf.MethodOptions\030\344\324\003 \001(\0102" +
+      "6\n\014hiddenReason\022\036.google.protobuf.Method" +
+      "Options\030\345\324\003 \001(\t29\n\017hiddenRetention\022\036.goo" +
+      "gle.protobuf.MethodOptions\030\346\324\003 \001(\t\"\272\001\n\020M" +
+      "essageExtension21\n\006hidden\022\037.google.proto" +
+      "buf.MessageOptions\030\360\242\004 \001(\01027\n\014hiddenReas" +
+      "on\022\037.google.protobuf.MessageOptions\030\361\242\004 " +
+      "\001(\t2:\n\017hiddenRetention\022\037.google.protobuf" +
+      ".MessageOptions\030\362\242\004 \001(\tBU\n/com.cloudera." +
+      "thunderhead.service.common.optionsB\007Opti" +
+      "onsZ\031com/cloudera/cdp/protobufb\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -77,8 +1683,24 @@ public final class Options {
         new com.google.protobuf.Descriptors.FileDescriptor[] {
           com.google.protobuf.DescriptorProtos.getDescriptor(),
         }, assigner);
-    sensitive.internalInit(descriptor.getExtensions().get(0));
-    skipLogging.internalInit(descriptor.getExtensions().get(1));
+    internal_static_options_FieldExtension_descriptor =
+      getDescriptor().getMessageTypes().get(0);
+    internal_static_options_FieldExtension_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_options_FieldExtension_descriptor,
+        new java.lang.String[] { });
+    internal_static_options_MethodExtension_descriptor =
+      getDescriptor().getMessageTypes().get(1);
+    internal_static_options_MethodExtension_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_options_MethodExtension_descriptor,
+        new java.lang.String[] { });
+    internal_static_options_MessageExtension_descriptor =
+      getDescriptor().getMessageTypes().get(2);
+    internal_static_options_MessageExtension_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_options_MessageExtension_descriptor,
+        new java.lang.String[] { });
     com.google.protobuf.DescriptorProtos.getDescriptor();
   }
 

--- a/auth-connector/src/main/proto/options.proto
+++ b/auth-connector/src/main/proto/options.proto
@@ -6,12 +6,61 @@ package options;
 
 option java_package = "com.cloudera.thunderhead.service.common.options";
 option java_outer_classname = "Options";
+option go_package = "com/cloudera/cdp/protobuf";
 
-extend google.protobuf.FieldOptions {
-  // The field is sensitive. It will not be logged and may receive other special
-  // handling in the future.
-  bool sensitive = 50000;
-  // The field should not be logged. This may be useful on fields that have very
-  // large values.
-  bool skipLogging = 50001;
+message FieldExtension {
+  extend google.protobuf.FieldOptions {
+    // The field is sensitive. It will not be logged and may receive other special
+    // handling in the future.
+    bool sensitive = 50000;
+    // The field should not be logged. This may be useful on fields that have very
+    // large values.
+    bool skipLogging = 50001;
+    // This field controls the page size.
+    bool pagingPageSize = 50002;
+    // This field is the input paging token.
+    bool pagingInputToken = 50003;
+    // This field contains a page of results.
+    bool pagingResult = 50004;
+    // This field is the output paging token.
+    bool pagingOutputToken = 50005;
+    // This field is a date time.
+    bool datetime = 50006;
+    // This field is hidden.
+    bool hidden = 50007;
+    // The reason this field is hidden.
+    string hiddenReason = 50008;
+    // This conditions under which this hidden field is made visible.
+    string hiddenRetention = 50009;
+  }
+}
+
+message MethodExtension {
+  extend google.protobuf.MethodOptions {
+    // This method requires the specified right.
+    string right = 60000;
+    // This method requires the specified entitlement.
+    string entitlement = 60001;
+    // This method returnes paginated results.
+    bool paginates = 60002;
+    // This default number of max items for auto-pagination to fetch.
+    int32 pagingDefaultMaxItems = 60003;
+    // This method is hidden.
+    bool hidden = 60004;
+    // The reason this method is hidden.
+    string hiddenReason = 60005;
+    // This conditions under which this hidden method is made visible.
+    string hiddenRetention = 60006;
+  }
+}
+
+message MessageExtension {
+  extend google.protobuf.MessageOptions {
+    // This message is hidden.
+    bool hidden = 70000;
+    // The reason this message is hidden.
+    string hiddenReason = 70001;
+    // This conditions under this hidden message is made visible.
+    string hiddenRetention = 70002;
+  }
 }

--- a/auth-connector/src/main/proto/usermanagement.proto
+++ b/auth-connector/src/main/proto/usermanagement.proto
@@ -319,6 +319,39 @@ service UserManagement {
   // been set for a different account before.
   rpc SetWorkloadSubdomain(SetWorkloadSubdomainRequest)
     returns (SetWorkloadSubdomainResponse) {}
+
+  // Create a machine-user, assign the resource roles and roles to it, create
+  // an access key for it, and return it. This is exposed as a convenience method
+  // for applications. Callers must be internal actors. The call is idempotent
+  // and safe to be called multiple times. Machine users created through this
+  // interface should be deleted by called DeleteWorkloadMachineUser.
+  rpc CreateWorkloadMachineUser(CreateWorkloadMachineUserRequest)
+    returns (CreateWorkloadMachineUserResponse) {}
+
+  // Delete the workload machine user, all the role and resource role assignments,
+  // as well as any access keys. This is a convenience method for application who
+  // created a machine user using CreateWorkloadMachineUser.
+  rpc DeleteWorkloadMachineUser(DeleteWorkloadMachineUserRequest)
+    returns (DeleteWorkloadMachineUserResponse) {}
+
+  // Returns the the workload administration group name for the
+  // (account, right, resource) tuple. Will throw NOT_FOUND exception if no name
+  // for the workload administration group has been set yet.
+  rpc GetWorkloadAdministrationGroupName(GetWorkloadAdministrationGroupNameRequest)
+    returns (GetWorkloadAdministrationGroupNameResponse) {}
+
+  // Sets the workload administration group name for the (account, right, resource)
+  // tuple. If the name was already set for the workload administration group
+  // this is a no-op and the name generated for the workload administration group
+  // will be returned.
+  rpc SetWorkloadAdministrationGroupName(SetWorkloadAdministrationGroupNameRequest)
+    returns (SetWorkloadAdministrationGroupNameResponse) {}
+
+  // Deletes the workload administration group name for the (account, right, resource)
+  // tuple. Throws a NOT_FOUND exception if no such workload administration group
+  // can be found.
+  rpc DeleteWorkloadAdministrationGroupName(DeleteWorkloadAdministrationGroupNameRequest)
+    returns (DeleteWorkloadAdministrationGroupNameResponse) {}
 }
 
 // An User is the Altus identity corresponding to an external SFDC contact. Users
@@ -449,7 +482,7 @@ message ClusterSshPrivateKey {
   string clusterSshPrivateKeyId = 2;
   // This is the contents of a PEM file containing a PKCS#8 private key for SSHing to
   // clusters.
-  string encryptedClusterSshPrivateKey = 3 [(options.sensitive) = true];
+  string encryptedClusterSshPrivateKey = 3 [(options.FieldExtension.sensitive) = true];
   string awsAccountId = 4;
   string awsRegion = 5;
   // The creation date in ms from the Java epoch of 1970-01-01T00:00:00Z.
@@ -483,6 +516,10 @@ message InteractiveLoginRequest {
   string firstName = 5;
   // This may be an empty string.
   string lastName = 6;
+  // Optional. The InResponseTo field, which is included in the AuthnResponse by
+  // the IdP during an SP-initiated login. For an IdP-initiated login this will
+  // be an empty string.
+  string inResponseTo = 10;
 }
 
 // The message to verify if the given account has been verified with
@@ -513,9 +550,18 @@ message InteractiveLoginResponse {
   string accessKeyId = 2;
   // See AccessKeyKeyPairGenerator.AccessKeyPair.
   // Ed25519 private key is 32 bytes encoded in base64
-  string privateKey = 3 [(options.sensitive) = true];
+  string privateKey = 3 [(options.FieldExtension.sensitive) = true];
   // A session token that can be used by consoles to authenticate users.
-  string sessionToken = 7 [(options.sensitive) = true];
+  string sessionToken = 7 [(options.FieldExtension.sensitive) = true];
+  // Optional. A SAML AuthnResponse that should be sent to the to the workload
+  // cluster. Will be empty if we are not forwarding the user to a workload
+  // cluster.
+  WorkloadSamlAuthnResponse workloadResponse = 8;
+  // True if the InteractiveLoginRequest contained an InResponseTo that did not
+  // exist in the cache (i.e. we got the request back after the cache TTL
+  // expired). Will be false if we are not forwarding the user to a workload
+  // cluster
+  bool unknownInResponseTo = 9;
 }
 
 message InteractiveLoginTrialRequest {
@@ -544,9 +590,9 @@ message InteractiveLoginTrialResponse {
   string accessKeyId = 2;
   // See AccessKeyKeyPairGenerator.AccessKeyPair.
   // Ed25519 private key is 32 bytes encoded in base64
-  string privateKey = 3 [(options.sensitive) = true];
+  string privateKey = 3 [(options.FieldExtension.sensitive) = true];
   // A session token that can be used by consoles to authenticate users.
-  string sessionToken = 6 [(options.sensitive) = true];
+  string sessionToken = 6 [(options.FieldExtension.sensitive) = true];
 }
 
 message InteractiveLogin3rdPartyRequest {
@@ -565,6 +611,10 @@ message InteractiveLogin3rdPartyRequest {
   string firstName = 5;
   // This may be an empty string.
   string lastName = 6;
+  // Optional. The InResponseTo field, which is included in the AuthnResponse by
+  // the IdP during an SP-initiated login. For an IdP-initiated login this will
+  // be an empty string.
+  string inResponseTo = 7;
 }
 
 message InteractiveLogin3rdPartyResponse {
@@ -573,9 +623,19 @@ message InteractiveLogin3rdPartyResponse {
   string accessKeyId = 2;
   // See AccessKeyKeyPairGenerator.AccessKeyPair.
   // Ed25519 private key is 32 bytes encoded in base64
-  string privateKey = 3 [(options.sensitive) = true];
+  string privateKey = 3 [(options.FieldExtension.sensitive) = true];
   // A session token that can be used by consoles to authenticate users.
-  string sessionToken = 4 [(options.sensitive) = true];
+  string sessionToken = 4 [(options.FieldExtension.sensitive) = true];
+  // Optional. A SAML AuthnResponse that should be sent to the to the workload
+  // cluster. Will be empty if we are not forwarding the user to a workload
+  // cluster.
+  WorkloadSamlAuthnResponse workloadResponse = 5;
+  // True if the InteractiveLogin3rdPartyRequest contained an InResponseTo that
+  // did not exist in the cache (i.e. we got the request back after the cache
+  // TTL expired). Will be false if we are not forwarding the user to a workload
+  // cluster
+  bool unknownInResponseTo = 6;
+
 }
 
 // Note that this intentionally lacks a request context as this is called during
@@ -598,12 +658,12 @@ message GetAccessKeyVerificationDataResponse {
   string actorCrn = 7;
   AccessKeyType.Value type = 9;
   // See AccessKeyType for key format
-  bytes publicKey = 6 [(options.skipLogging) = true];
+  bytes publicKey = 6 [(options.FieldExtension.skipLogging) = true];
 }
 
 message VerifyInteractiveUserSessionTokenRequest {
   // The interactive user's session token.
-  string sessionToken = 1 [(options.sensitive) = true];
+  string sessionToken = 1 [(options.FieldExtension.sensitive) = true];
 }
 
 message VerifyInteractiveUserSessionTokenResponse {
@@ -622,16 +682,16 @@ message VerifyInteractiveUserSessionTokenResponse {
 message AccessKeyRequestSigningV1AuthRequest {
   // The authentication header as was received from the caller in the
   // x-altus-auth-header HTTP header.
-  string authHeader = 1 [(options.skipLogging) = true];
+  string authHeader = 1 [(options.FieldExtension.skipLogging) = true];
   // The message that was signed. For V1 this includes the HTTP method, content
   // type, date, and path of the request. See V1Authenticator for more details.
-  string msgToVerify = 2 [(options.skipLogging) = true];
+  string msgToVerify = 2 [(options.FieldExtension.skipLogging) = true];
 }
 
 // A request to authenticate a session token.
 message SessionTokenAuthRequest {
   // The session token to authenticate.
-  string sessionToken = 1 [(options.sensitive) = true];
+  string sessionToken = 1 [(options.FieldExtension.sensitive) = true];
 }
 
 message AuthenticateRequest {
@@ -754,7 +814,7 @@ message CreateAccessKeyRequest {
 message CreateAccessKeyResponse {
   AccessKey accessKey = 1;
   // See AccessKeyType for key format
-  string privateKey = 2 [(options.sensitive) = true];
+  string privateKey = 2 [(options.FieldExtension.sensitive) = true];
 }
 
 message UpdateAccessKeyRequest {
@@ -892,7 +952,7 @@ message Account {
   // The creation date in ms from the Java epoch of 1970-01-01T00:00:00Z.
   uint64 creationDateMs = 7;
   // May be empty string
-  string clouderaManagerLicenseKey = 4 [(options.skipLogging) = true];
+  string clouderaManagerLicenseKey = 4 [(options.FieldExtension.skipLogging) = true];
   string externalIdForAWSDelegatedAccess = 5;
   // Contains account-wide user configurable messages
   AccountMessages accountMessages = 10;
@@ -949,7 +1009,7 @@ message DeleteAccountResponse {
 message GetRightsRequest {
   string actorCrn = 1;
   // To collect rights relevant to a specific resource specify the
-  // resource CRN. To collect rights relevent to resource indepedent
+  // resource CRN. To collect rights relevant to resource independent
   // service rights pass '*' (Resource.WILDCARD).
   string resourceCrn = 2;
 }
@@ -1012,10 +1072,17 @@ message ResourceAssignee {
 }
 
 message GetRightsResponse {
+  // A list of resource role assignments.
   repeated ResourceRoleAssignment resourceRolesAssignment = 1;
+  // A list of RoleAssignments.
   repeated RoleAssignment roleAssignment = 2;
+  // Whether the actor is a thunderhead admin or not.
   bool thunderheadAdmin = 3;
+  // A list of group CRNs the actor is a member of.
   repeated string groupCrn = 4;
+  // A list of workload administration group names the actor
+  // is a member of.
+  repeated string workloadAdministrationGroupName = 5;
 }
 
 message RightsCheck {
@@ -1034,7 +1101,7 @@ message CheckRightsResponse {
 
 message CreateAccountRequest {
   string externalAccountId = 1;
-  string clouderaManagerLicenseKey = 2 [(options.skipLogging) = true];
+  string clouderaManagerLicenseKey = 2 [(options.FieldExtension.skipLogging) = true];
   // if none is passed, the default cloudera provider id will be used
   string identityProviderId = 3;
 }
@@ -1280,7 +1347,7 @@ message RedisAccessKeyCacheEntry {
   // The type of altus account.
   AccountType accountType = 10;
   AccessKeyType.Value accessKeyType = 11;
-  bytes publicKey = 3 [(options.skipLogging) = true];
+  bytes publicKey = 3 [(options.FieldExtension.skipLogging) = true];
   int64 lastAccessed = 4;
   int32 inactivityDurationSec = 5;
   // Marks the entry as a "do not use" entry. Used by the UMS to prevent
@@ -1296,6 +1363,37 @@ message RedisActorTombstoneCacheEntry {
   // have to some mbmer that we set to a non default value. Let's use a bool for
   // that. This is always set to 'true' and the actual value is ignored.
   bool created = 1;
+}
+
+// A structure that contains information about SSO session that was initiated
+// by a workload cluster SP.
+message SSOForWorkloadClusterDetails {
+  // The account ID for which this SSO request is for.
+  string accountId = 1;
+  // The workload cluster service provider (SP) AuthnRequest ID.
+  string workloadClusterAuthnRequestId = 2;
+  // The workload cluster assertion consumer service (ACS) URL.
+  string workloadClusterAcs = 3;
+  // The workload cluster assertion consumer service protocol binding to use.
+  string workloadClusterAcsProtocolBinding = 4;
+  // The relay state passed to us as part of the workload cluster service
+  // provider (SP) AuthnRequest.
+  string workloadClusterRelayState = 5;
+}
+
+// This structure is used to serialize the redis cache entry for workload
+// clusters authn requests while waiting for the user to login using the idp
+// for the account. It contains information that is needed to complete the
+// AuthResponse to the workload cluster SP.
+message RedisSSOCacheEntry {
+  // The AuthnRequest ID of the control plane AuthnRequest to the IdP the user
+  // needs to authenticate with. It is used as the key of the cache entry as
+  // this is what we get back from the IdP in the InResponseTo field.
+  string controlPlaneAuthnRequestId = 1;
+  oneof ssoDetails {
+    // Covers SAML provider attributes.
+    SSOForWorkloadClusterDetails forWorkloadClusters = 2;
+  }
 }
 
 message SessionTokenVerificationAlgorithm {
@@ -1320,7 +1418,7 @@ message RedisSessionTokenCacheEntry {
   // The verification algorithm to use.
   SessionTokenVerificationAlgorithm.Value verificationAlgo = 3;
   // The public key to use to verify the session token.
-  bytes publicKey = 4 [(options.skipLogging) = true];
+  bytes publicKey = 4 [(options.FieldExtension.skipLogging) = true];
   int64 lastAccessed = 5;
   int32 inactivityDurationSec = 6;
 }
@@ -1799,14 +1897,14 @@ message SamlCert {
   // The type of the certificate;
   SamlCertType.Value type = 1;
   // The X.509 PEM encoded public key.
-  string cert = 2 [(options.skipLogging) = true];
+  string cert = 2 [(options.FieldExtension.skipLogging) = true];
 }
 
 // The IdP connector details for a SAML typed connector. Used only for
 // dynamo db storage
 message SamlIdpDetails {
   // The original metadata xml provided to us when the IdP connector was defined.
-  string metadataXml = 1 [(options.skipLogging) = true];
+  string metadataXml = 1 [(options.FieldExtension.skipLogging) = true];
   // The certs provided to us in the IdP metadata xml.
   repeated SamlCert certs = 2;
 }
@@ -1879,7 +1977,7 @@ message WorkloadSamlAuthnResponse {
   // 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
   string binding = 2;
   // A SAML 2.0 signed authn response.
-  string authnResponse = 3 [(options.skipLogging) = true];
+  string authnResponse = 3 [(options.FieldExtension.skipLogging) = true];
   // The relay state, if any, that was passed to us in the original authn
   // request.
   string relayState = 4;
@@ -1894,7 +1992,7 @@ message IdpAuthnRequest {
   // 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
   string binding = 2;
   // The authn response - a SAML 2.0 signed authn response.
-  string authnRequest = 3 [(options.skipLogging) = true];
+  string authnRequest = 3 [(options.FieldExtension.skipLogging) = true];
 }
 
 message ProcessWorkloadSSOAuthnReqRequest {
@@ -1902,9 +2000,9 @@ message ProcessWorkloadSSOAuthnReqRequest {
   string accountId = 1;
   // The deflated base64 encoded SAML2.0 payload as was received from the
   // workload cluster.
-  string authnRequest = 2 [(options.skipLogging) = true];
+  string authnRequest = 2 [(options.FieldExtension.skipLogging) = true];
   // The session-token if one was received.
-  string sessionToken = 3 [(options.sensitive) = true];
+  string sessionToken = 3 [(options.FieldExtension.sensitive) = true];
   // The relay state provided by the workload SP. May be empty.
   string relayState = 4;
 }
@@ -1926,4 +2024,101 @@ message SetWorkloadSubdomainRequest {
 }
 
 message SetWorkloadSubdomainResponse {
+}
+
+message CreateWorkloadMachineUserRequest {
+  // The account ID for which the machine user is needed.
+  string accountId = 1;
+  // The machine user name. This must be unique name for the username in the
+  // account. In case a machine-user with this name already exists the UMS will
+  // assume that the machine-user the caller wants to use had already been
+  // created before and no error will be thrown.
+  string machineUserName = 2;
+  // A list of resource assignments to use. May be empty.
+  repeated ResourceAssignment resourceAssignment = 3;
+  // A list of role roles to use. May be empty
+  repeated string roleCrn = 4;
+}
+
+message CreateWorkloadMachineUserResponse {
+  // The CRN for the machine user created.
+  string machineUserCrn = 1;
+  // The access key ID. Since the rpc is idempotent a new key will be generated
+  // for each successful call. Old keys are not removed by this call and will
+  // only be removed by calling DeleteWorkloadMachineUser.
+  string accessKeyId = 2;
+  // The private key for the machine user. This is an Ed25519 private key and is
+  // 32 bytes encoded in base64 that should be used to sign requests.
+  string privateKey = 3 [(options.FieldExtension.sensitive) = true];
+}
+
+message DeleteWorkloadMachineUserRequest {
+  // The account ID from which to delete the machine user.
+  string accountId = 1;
+  // The machine user name or CRN to delete.
+  string machineUserNameOrCrn = 2;
+}
+
+message DeleteWorkloadMachineUserResponse {
+}
+
+message GetWorkloadAdministrationGroupNameRequest {
+  // The account ID for the workload administration group.
+  string accountId = 1;
+  // The name of the right associated with this workload administration group.
+  string rightName = 2;
+  // The resource on which the above right was granted, e.g., the environment CRN.
+  // The resource should be a unique, immutable, and stable over time.
+  string resource = 3;
+}
+
+message GetWorkloadAdministrationGroupNameResponse {
+  // The workload administration group name.
+  string workloadAdministrationGroupName = 1;
+}
+
+message SetWorkloadAdministrationGroupNameRequest {
+  reserved 4;
+  // The account ID for the workload administration group.
+  string accountId = 1;
+  // The name of the right associated with this workload administration group.
+  string rightName = 2;
+  // The resource on which the above right was granted, e.g., the environment CRN.
+  // The resource should be a unique, immutable, and stable over time.
+  string resource = 3;
+}
+
+message SetWorkloadAdministrationGroupNameResponse {
+  // The workload administration group name.
+  string workloadAdministrationGroupName = 1;
+}
+
+message DeleteWorkloadAdministrationGroupNameRequest {
+  // The account ID for the workload administration group.
+  string accountId = 1;
+  // The name of the right associated with this workload administration group.
+  string rightName = 2;
+  // The resource on which the above right was granted, e.g., the environment CRN.
+  // This should be the same resource identifier as the resource identifier used
+  // in the SetWorkloadAdministrationGroupName request.
+  string resource = 3;
+}
+
+message DeleteWorkloadAdministrationGroupNameResponse {
+}
+
+// A representation of a kerberos key. This does not exactly reflect the formal
+// ASN.1 structure; that seemed gratuitous.
+message KerberosKey {
+    int32 keyType = 1;
+    bytes encryptedKeyValue = 2 [(options.FieldExtension.skipLogging) = true];
+    int32 saltType = 3;
+    string saltValue = 4;
+}
+
+// This is used to serialize all the Actor dynamoDB related information that is
+// not indexed.
+message ActorDetails {
+    string encryptedPasswordHash = 1 [(options.FieldExtension.skipLogging) = true];
+    repeated KerberosKey kerberosKeys = 2;
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UmsUsersStateProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UmsUsersStateProvider.java
@@ -148,6 +148,13 @@ public class UmsUsersStateProvider {
             // Since this user is eligible, add this user to internal group
             userStateBuilder.addMemberToGroup(UserServiceConstants.CDP_USERSYNC_INTERNAL_GROUP, fmsUser.getName());
 
+            List<String> workloadAdministrationGroupNames = rightsResponse.getWorkloadAdministrationGroupNameList();
+            LOGGER.debug("workloadAdministrationGroupNameList = {}", workloadAdministrationGroupNames);
+            workloadAdministrationGroupNames.forEach(groupName -> {
+                userStateBuilder.addGroup(nameToGroup(groupName));
+                userStateBuilder.addMemberToGroup(groupName, fmsUser.getName());
+            });
+
             if (isEnvironmentAdmin(environmentCrn, rightsResponse)) {
                 // TODO: introduce a flag for adding admin
                 userStateBuilder.addMemberToGroup("admins", fmsUser.getName());
@@ -161,6 +168,12 @@ public class UmsUsersStateProvider {
         fmsUser.setFirstName(getOrDefault(umsUser.getFirstName(), "None"));
         fmsUser.setLastName(getOrDefault(umsUser.getLastName(), "None"));
         return fmsUser;
+    }
+
+    private FmsGroup nameToGroup(String name) {
+        FmsGroup fmsGroup = new FmsGroup();
+        fmsGroup.setName(name);
+        return fmsGroup;
     }
 
     private String getOrDefault(String value, String other) {

--- a/mock-caas/src/main/java/com/sequenceiq/caas/grpc/service/MockUserManagementService.java
+++ b/mock-caas/src/main/java/com/sequenceiq/caas/grpc/service/MockUserManagementService.java
@@ -198,10 +198,11 @@ public class MockUserManagementService extends UserManagementGrpc.UserManagement
                 .addPolicy(powerUserPolicy)
                 .build();
         RoleAssignment roleAssignment = RoleAssignment.newBuilder().setRole(powerUserRole).build();
-        responseObserver.onNext(
-                GetRightsResponse.newBuilder()
-                        .addGroupCrn(group.getCrn())
-                        .addRoleAssignment(roleAssignment).build());
+        GetRightsResponse.Builder responseBuilder = GetRightsResponse.newBuilder()
+                .addGroupCrn(group.getCrn())
+                .addRoleAssignment(roleAssignment)
+                .addWorkloadAdministrationGroupName("mockworkloadadministrationgroup0");
+        responseObserver.onNext(responseBuilder.build());
         responseObserver.onCompleted();
     }
 


### PR DESCRIPTION
The first commit updates the options and usermanagement proto files from thunderhead and regenerates the code. There are no manual changes in that commit.

The second commit modifies usersync to retrieve the workloadAdministrationGroupNames from the getRights response.

NOTE: I've only tested this with the mock ums so far. I intend to test this with the real ums tomorrow morning. I'll leave a comment here when I'm done with that.