### PR TITLE
CB-3388 | Re-registering with cluster proxy on cluster repair

### DIFF
--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/message/Msg.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/message/Msg.java
@@ -73,6 +73,7 @@ public enum Msg {
     CLUSTER_BUILT("cluster.built"),
     CLUSTER_CREATE_FAILED("cluster.create.failed"),
     CLUSTER_SCALING_UP("cluster.scaling.up"),
+    RE_REGISTER_WITH_CLUSTER_PROXY("re.register.with.cluster.proxy"),
     CLUSTER_SCALED_UP("cluster.scaled.up"),
     CLUSTER_SCALING_DOWN("cluster.scaling.down"),
     CLUSTER_SCALED_DOWN("cluster.scaled.down"),

--- a/common/src/main/java/com/sequenceiq/cloudbreak/message/Msg.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/message/Msg.java
@@ -73,6 +73,7 @@ public enum Msg {
     CLUSTER_BUILT("cluster.built"),
     CLUSTER_CREATE_FAILED("cluster.create.failed"),
     CLUSTER_SCALING_UP("cluster.scaling.up"),
+    RE_REGISTER_WITH_CLUSTER_PROXY("re.register.with.cluster.proxy"),
     CLUSTER_SCALED_UP("cluster.scaled.up"),
     CLUSTER_SCALING_DOWN("cluster.scaling.down"),
     CLUSTER_SCALED_DOWN("cluster.scaled.down"),

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -71,6 +71,7 @@ cluster.start.components.started=Starting components
 cluster.stop.components.started=Stopping all cluster components
 
 cluster.scaling.up=Scaling up the cluster
+re.register.with.cluster.proxy=Re-registering with Cluster Proxy service
 cluster.scaled.up=Cluster scaled up
 cluster.scaling.down=Scaling down the cluster
 cluster.scaled.down=Cluster scaled down

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/FlowChainTriggers.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/FlowChainTriggers.java
@@ -33,6 +33,8 @@ public class FlowChainTriggers {
 
     public static final String CLUSTER_MAINTENANCE_MODE_VALIDATION_TRIGGER_EVENT = "CLUSTER_MAINTENANCE_MODE_VALIDATION_TRIGGER_EVENT";
 
+    public static final String CLUSTER_PROXY_RE_REGISTER_EVENT = "CLUSTER_PROXY_RE_REGISTER_EVENT";
+
     private FlowChainTriggers() {
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/clusterproxy/ConfigRegistrationRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/clusterproxy/ConfigRegistrationRequest.java
@@ -12,14 +12,27 @@ class ConfigRegistrationRequest {
     @JsonProperty
     private List<ClusterServiceConfig> services;
 
+    @JsonProperty
+    private String uriOfKnox;
+
     @JsonCreator
     ConfigRegistrationRequest(String clusterCrn, List<ClusterServiceConfig> services) {
         this.clusterCrn = clusterCrn;
         this.services = services;
     }
 
+    @JsonCreator
+    ConfigRegistrationRequest(String clusterCrn, String knoxUrl, List<ClusterServiceConfig> services) {
+        this(clusterCrn, services);
+        this.uriOfKnox = knoxUrl;
+    }
+
     @Override
     public String toString() {
-        return "ConfigRegistrationRequest{clusterCrn='" + clusterCrn + '\'' + ", services=" + services + '}';
+        return "ConfigRegistrationRequest{" +
+                "clusterCrn='" + clusterCrn + '\'' +
+                ", services=" + services +
+                ", uriOfKnox='" + uriOfKnox + '\'' +
+                '}';
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/upscale/ClusterUpscaleEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/upscale/ClusterUpscaleEvent.java
@@ -1,31 +1,33 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.upscale;
 
-import com.sequenceiq.cloudbreak.reactor.api.event.kerberos.KeytabConfigurationFailed;
-import com.sequenceiq.cloudbreak.reactor.api.event.kerberos.KeytabConfigurationSuccess;
-import com.sequenceiq.flow.core.FlowEvent;
-import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.AmbariEnsureComponentsAreStoppedResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.AmbariGatherInstalledComponentsResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.AmbariInitComponentsResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.AmbariInstallComponentsResult;
-import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RegenerateKerberosKeytabsResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.AmbariRepairSingleMasterStartResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.AmbariRestartAllResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.AmbariStartComponentsResult;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.AmbariStopServerAndAgentResult;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.RegenerateKerberosKeytabsResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.StartServerAndAgentResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.StopClusterComponentsResult;
-import com.sequenceiq.cloudbreak.reactor.api.event.cluster.AmbariStopServerAndAgentResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.UpscaleClusterResult;
+import com.sequenceiq.cloudbreak.reactor.api.event.kerberos.KeytabConfigurationFailed;
+import com.sequenceiq.cloudbreak.reactor.api.event.kerberos.KeytabConfigurationSuccess;
+import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.ClusterProxyReRegistrationResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.UpscaleClusterManagerResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.recipe.UploadUpscaleRecipesResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.recipe.UpscalePostRecipesResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.UpscaleCheckHostMetadataResult;
+import com.sequenceiq.flow.core.FlowEvent;
+import com.sequenceiq.flow.event.EventSelectorUtil;
 
 public enum ClusterUpscaleEvent implements FlowEvent {
     CLUSTER_UPSCALE_TRIGGER_EVENT("CLUSTER_UPSCALE_TRIGGER_EVENT"),
     UPSCALE_AMBARI_FINISHED_EVENT(EventSelectorUtil.selector(UpscaleClusterManagerResult.class)),
     UPSCALE_AMBARI_FAILED_EVENT(EventSelectorUtil.failureSelector(UpscaleClusterManagerResult.class)),
     CLUSTER_REPAIR_SINGLE_MASTER_START_EVENT(EventSelectorUtil.selector(AmbariRepairSingleMasterStartResult.class)),
+    CLUSTER_PROXY_RE_REGISTRATION_FINISHED_EVENT(EventSelectorUtil.selector(ClusterProxyReRegistrationResult.class)),
     UPLOAD_UPSCALE_RECIPES_FINISHED_EVENT(EventSelectorUtil.selector(UploadUpscaleRecipesResult.class)),
     UPLOAD_UPSCALE_RECIPES_FAILED_EVENT(EventSelectorUtil.failureSelector(UploadUpscaleRecipesResult.class)),
     RECONFIGURE_KEYTABS_FINISHED_EVENT(EventSelectorUtil.selector(KeytabConfigurationSuccess.class)),
@@ -57,6 +59,7 @@ public enum ClusterUpscaleEvent implements FlowEvent {
 
     CLUSTER_UPSCALE_FINISHED_EVENT(EventSelectorUtil.selector(UpscaleClusterResult.class)),
     CLUSTER_UPSCALE_FAILED_EVENT(EventSelectorUtil.failureSelector(UpscaleClusterResult.class)),
+    CLUSTER_PROXY_RE_REGISTRATION_FAILED_EVENT(EventSelectorUtil.failureSelector(ClusterProxyReRegistrationResult.class)),
     EXECUTE_POSTRECIPES_FINISHED_EVENT(EventSelectorUtil.selector(UpscalePostRecipesResult.class)),
     EXECUTE_POSTRECIPES_FAILED_EVENT(EventSelectorUtil.failureSelector(UpscalePostRecipesResult.class)),
     FINALIZED_EVENT("CLUSTERUPSCALEFINALIZEDEVENT"),

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/upscale/ClusterUpscaleFlowConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/upscale/ClusterUpscaleFlowConfig.java
@@ -21,6 +21,8 @@ import static com.sequenceiq.cloudbreak.core.flow2.cluster.upscale.ClusterUpscal
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.upscale.ClusterUpscaleEvent.AMBARI_STOP_SERVER_AGENT_FINISHED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.upscale.ClusterUpscaleEvent.CHECK_HOST_METADATA_FAILED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.upscale.ClusterUpscaleEvent.CHECK_HOST_METADATA_FINISHED_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.upscale.ClusterUpscaleEvent.CLUSTER_PROXY_RE_REGISTRATION_FAILED_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.upscale.ClusterUpscaleEvent.CLUSTER_PROXY_RE_REGISTRATION_FINISHED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.upscale.ClusterUpscaleEvent.CLUSTER_REPAIR_SINGLE_MASTER_START_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.upscale.ClusterUpscaleEvent.CLUSTER_UPSCALE_FAILED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.upscale.ClusterUpscaleEvent.CLUSTER_UPSCALE_FINISHED_EVENT;
@@ -55,6 +57,7 @@ import static com.sequenceiq.cloudbreak.core.flow2.cluster.upscale.ClusterUpscal
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.upscale.ClusterUpscaleState.FINAL_STATE;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.upscale.ClusterUpscaleState.INIT_STATE;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.upscale.ClusterUpscaleState.RECONFIGURE_KEYTABS_STATE;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.upscale.ClusterUpscaleState.RE_REGISTER_WITH_CLUSTER_PROXY_STATE;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.upscale.ClusterUpscaleState.UPLOAD_UPSCALE_RECIPES_STATE;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.upscale.ClusterUpscaleState.UPSCALING_AMBARI_FINISHED_STATE;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.upscale.ClusterUpscaleState.UPSCALING_CLUSTER_MANAGER_STATE;
@@ -71,7 +74,9 @@ public class ClusterUpscaleFlowConfig extends AbstractFlowConfiguration<ClusterU
     private static final List<Transition<ClusterUpscaleState, ClusterUpscaleEvent>> TRANSITIONS =
             new Builder<ClusterUpscaleState, ClusterUpscaleEvent>()
                     .defaultFailureEvent(FAILURE_EVENT)
-                    .from(INIT_STATE).to(UPLOAD_UPSCALE_RECIPES_STATE).event(CLUSTER_UPSCALE_TRIGGER_EVENT).noFailureEvent()
+                    .from(INIT_STATE).to(RE_REGISTER_WITH_CLUSTER_PROXY_STATE).event(CLUSTER_UPSCALE_TRIGGER_EVENT).noFailureEvent()
+                    .from(RE_REGISTER_WITH_CLUSTER_PROXY_STATE).to(UPLOAD_UPSCALE_RECIPES_STATE).event(CLUSTER_PROXY_RE_REGISTRATION_FINISHED_EVENT)
+                    .failureEvent(CLUSTER_PROXY_RE_REGISTRATION_FAILED_EVENT)
                     .from(UPLOAD_UPSCALE_RECIPES_STATE).to(RECONFIGURE_KEYTABS_STATE).event(UPLOAD_UPSCALE_RECIPES_FINISHED_EVENT)
                         .failureEvent(UPLOAD_UPSCALE_RECIPES_FAILED_EVENT)
                     .from(RECONFIGURE_KEYTABS_STATE).to(CHECK_HOST_METADATA_STATE).event(RECONFIGURE_KEYTABS_FINISHED_EVENT)

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/upscale/ClusterUpscaleFlowService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/upscale/ClusterUpscaleFlowService.java
@@ -75,6 +75,11 @@ class ClusterUpscaleFlowService {
         flowMessageService.fireEventAndLog(stackId, Msg.CLUSTER_SCALING_UP, UPDATE_IN_PROGRESS.name());
     }
 
+    void reRegisterWithClusterProxy(long stackId) {
+        clusterService.updateClusterStatusByStackId(stackId, UPDATE_IN_PROGRESS, "Re-registering with Cluster Proxy service.");
+        flowMessageService.fireEventAndLog(stackId, Msg.RE_REGISTER_WITH_CLUSTER_PROXY, UPDATE_IN_PROGRESS.name());
+    }
+
     void stopClusterManagementServer(long stackId) {
         sendMessage(stackId, Msg.CLUSTER_STOP_MANAGEMENT_SERVER_STARTED, "Stopping cluster management server.");
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/upscale/ClusterUpscaleState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/upscale/ClusterUpscaleState.java
@@ -6,6 +6,7 @@ import com.sequenceiq.cloudbreak.core.flow2.restart.FillInMemoryStateStoreRestar
 
 enum ClusterUpscaleState implements FlowState {
     INIT_STATE,
+    RE_REGISTER_WITH_CLUSTER_PROXY_STATE,
     UPLOAD_UPSCALE_RECIPES_STATE,
     CHECK_HOST_METADATA_STATE,
     RECONFIGURE_KEYTABS_STATE,

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/ClusterProxyReRegistrationFailed.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/ClusterProxyReRegistrationFailed.java
@@ -1,0 +1,9 @@
+package com.sequenceiq.cloudbreak.reactor.api.event.orchestration;
+
+import com.sequenceiq.cloudbreak.reactor.api.event.StackFailureEvent;
+
+public class ClusterProxyReRegistrationFailed extends StackFailureEvent {
+    public ClusterProxyReRegistrationFailed(Long stackId, Exception ex) {
+        super(stackId, ex);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/ClusterProxyReRegistrationRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/ClusterProxyReRegistrationRequest.java
@@ -1,0 +1,9 @@
+package com.sequenceiq.cloudbreak.reactor.api.event.orchestration;
+
+import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleRequest;
+
+public class ClusterProxyReRegistrationRequest extends AbstractClusterScaleRequest {
+    public ClusterProxyReRegistrationRequest(Long stackId, String hostGroupName) {
+        super(stackId, hostGroupName);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/ClusterProxyReRegistrationResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/ClusterProxyReRegistrationResult.java
@@ -1,0 +1,13 @@
+package com.sequenceiq.cloudbreak.reactor.api.event.orchestration;
+
+import com.sequenceiq.cloudbreak.reactor.api.event.resource.AbstractClusterScaleResult;
+
+public class ClusterProxyReRegistrationResult extends AbstractClusterScaleResult<ClusterProxyReRegistrationRequest> {
+    public ClusterProxyReRegistrationResult(ClusterProxyReRegistrationRequest request) {
+        super(request);
+    }
+
+    public ClusterProxyReRegistrationResult(String statusReason, Exception errorDetails, ClusterProxyReRegistrationRequest request) {
+        super(statusReason, errorDetails, request);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/orchestration/ClusterProxyReRegistrationHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/orchestration/ClusterProxyReRegistrationHandler.java
@@ -1,0 +1,87 @@
+package com.sequenceiq.cloudbreak.reactor.handler.orchestration;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.provision.clusterproxy.ClusterProxyService;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.exception.NotFoundException;
+import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.ClusterProxyReRegistrationRequest;
+import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.ClusterProxyReRegistrationResult;
+import com.sequenceiq.cloudbreak.service.gateway.GatewayService;
+import com.sequenceiq.cloudbreak.service.hostgroup.HostGroupService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.common.api.type.InstanceGroupType;
+import com.sequenceiq.flow.event.EventSelectorUtil;
+import com.sequenceiq.flow.reactor.api.handler.EventHandler;
+
+import reactor.bus.Event;
+import reactor.bus.EventBus;
+
+@Component
+public class ClusterProxyReRegistrationHandler implements EventHandler<ClusterProxyReRegistrationRequest> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterProxyReRegistrationHandler.class);
+
+    @Value("${clusterProxy.enabled:false}")
+    private boolean clusterProxyIntegrationEnabled;
+
+    @Inject
+    private EventBus eventBus;
+
+    @Inject
+    private ClusterProxyService clusterProxyService;
+
+    @Inject
+    private HostGroupService hostGroupService;
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private GatewayService gatewayService;
+
+    @Override
+    public String selector() {
+        return EventSelectorUtil.selector(ClusterProxyReRegistrationRequest.class);
+    }
+
+    @Override
+    public void accept(Event<ClusterProxyReRegistrationRequest> event) {
+        ClusterProxyReRegistrationRequest request = event.getData();
+        Selectable response = registerCluster(request);
+        eventBus.notify(response.selector(), new Event<>(event.getHeaders(), response));
+    }
+
+    private Selectable registerCluster(ClusterProxyReRegistrationRequest request) {
+        if (!clusterProxyIntegrationEnabled) {
+            return new ClusterProxyReRegistrationResult(request);
+        }
+
+        Stack stack = stackService.getByIdWithListsInTransaction(request.getResourceId());
+        try {
+            String hostGroupName = request.getHostGroupName();
+            HostGroup hostGroup = hostGroupService.findHostGroupInClusterByName(stack.getCluster().getId(), hostGroupName)
+                    .orElseThrow(NotFoundException.notFound("hostgroup", hostGroupName));
+            InstanceGroup instanceGroup = hostGroup.getConstraint().getInstanceGroup();
+            boolean gatewayInstanceGroup = InstanceGroupType.GATEWAY.equals(instanceGroup.getInstanceGroupType());
+
+            if (!gatewayInstanceGroup) {
+                LOGGER.info("Not re-registering with Cluster Proxy as this is not a gateway host group. stack crn: {}", stack.getResourceCrn());
+                return new ClusterProxyReRegistrationResult(request);
+            }
+            clusterProxyService.reRegisterCluster(stack);
+            return new ClusterProxyReRegistrationResult(request);
+        } catch (Exception e) {
+            LOGGER.error("Error occurred re-registering cluster {} in environment {} to cluster proxy",
+                    stack.getCluster().getId(), stack.getEnvironmentCrn(), e);
+            return new ClusterProxyReRegistrationResult(e.getMessage(), e, request);
+        }
+    }
+}

--- a/core/src/main/resources/messages/messages.properties
+++ b/core/src/main/resources/messages/messages.properties
@@ -71,6 +71,7 @@ cluster.start.components.started=Starting components
 cluster.stop.components.started=Stopping all cluster components
 
 cluster.scaling.up=Scaling up the cluster
+re.register.with.cluster.proxy=Re-registering with Cluster Proxy service
 cluster.scaled.up=Cluster scaled up
 cluster.scaling.down=Scaling down the cluster
 cluster.scaled.down=Cluster scaled down


### PR DESCRIPTION
Introduced a new state in ClusterUpscaleFlowConfig that re-registers proxy configuration with cluster proxy service - only if the host groups is of type gateway. This is done because the private ip may change on repair.

On re-registration with cluster proxy, the existing public key certificate that knox token topology was configured with is returned. The assumption here is that we don't need to re-configure knox topology as part of repair flow. 

Have done some local testing on my machine. Needs to be tested on mow-dev.