### PR TITLE
CB-3477 Fix NiFi Knox role name in cdp-proxy-api topology

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
@@ -103,7 +103,7 @@
             {%- endif %}
             {% if 'NIFI_REST' in exposed and 'NIFI_NODE' in salt['pillar.get']('gateway:location') -%}
              <param>
-                 <name>NIFI_REST</name>
+                 <name>NIFI</name>
                  <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000;maxRetryAttempts=300;retrySleep=1000</value>
              </param>
              {%- endif %}
@@ -264,7 +264,7 @@
     {% if 'NIFI_NODE' in salt['pillar.get']('gateway:location') -%}
     {% if 'NIFI_REST' in exposed -%}
     <service>
-        <role>NIFI_REST</role>
+        <role>NIFI</role>
         {% for hostloc in salt['pillar.get']('gateway:location')['NIFI_NODE'] -%}
         <url>{{ protocol }}://{{ hostloc }}:{{ ports['NIFI_REST'] }}</url>
         {%- endfor %}


### PR DESCRIPTION
Fix NiFi Knox role name in cdp-proxy-api topology jinja template.

Closes #CB-3477