### PR TITLE
CB-3003 Add NoSQL tables listing to environment platform service

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/PlatformResources.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/PlatformResources.java
@@ -14,6 +14,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudSecurityGroups;
 import com.sequenceiq.cloudbreak.cloud.model.CloudSshKeys;
 import com.sequenceiq.cloudbreak.cloud.model.CloudVmTypes;
 import com.sequenceiq.cloudbreak.cloud.model.Region;
+import com.sequenceiq.cloudbreak.cloud.model.nosql.CloudNoSqlTables;
 
 /**
  * Platform resources.
@@ -91,6 +92,15 @@ public interface PlatformResources {
      * @return the {@link CloudEncryptionKeys} contains every encryption key
      */
     CloudEncryptionKeys encryptionKeys(CloudCredential cloudCredential, Region region, Map<String, String> filters);
+
+    /**
+     * Return the No SQL table list in the requested region
+     * @param cloudCredential credentials to connect to the cloud provider
+     * @param region region of the resources
+     * @param filters not used (reserved)
+     * @return the {@link CloudNoSqlTables} contains every No SQL table metadata per region
+     */
+    CloudNoSqlTables noSqlTables(CloudCredential cloudCredential, Region region, Map<String, String> filters);
 
     default boolean regionMatch(Region actualRegion, Region expectedRegion) {
         return expectedRegion == null || Strings.isNullOrEmpty(expectedRegion.value()) || actualRegion.value().equals(expectedRegion.value());

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/nosql/CloudNoSqlTable.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/nosql/CloudNoSqlTable.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.cloudbreak.cloud.model.nosql;
+
+import java.util.Objects;
+
+public class CloudNoSqlTable {
+
+    private String name;
+
+    public CloudNoSqlTable(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !getClass().equals(o.getClass())) {
+            return false;
+        }
+        CloudNoSqlTable that = (CloudNoSqlTable) o;
+        return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    @Override
+    public String toString() {
+        return "CloudNoSqlTable{" +
+                "name='" + name + '\'' +
+                '}';
+    }
+}

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/nosql/CloudNoSqlTables.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/nosql/CloudNoSqlTables.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.cloudbreak.cloud.model.nosql;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import javax.validation.constraints.NotNull;
+
+public class CloudNoSqlTables {
+
+    private List<CloudNoSqlTable> cloudNoSqlTables = new ArrayList<>();
+
+    public CloudNoSqlTables() {
+    }
+
+    public CloudNoSqlTables(@NotNull List<CloudNoSqlTable> cloudNoSqlTables) {
+        this.cloudNoSqlTables = cloudNoSqlTables;
+    }
+
+    public List<CloudNoSqlTable> getCloudNoSqlTables() {
+        return cloudNoSqlTables;
+    }
+
+    public void setCloudNoSqlTables(@NotNull List<CloudNoSqlTable> cloudNoSqlTables) {
+        this.cloudNoSqlTables = cloudNoSqlTables;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !getClass().equals(o.getClass())) {
+            return false;
+        }
+        CloudNoSqlTables that = (CloudNoSqlTables) o;
+        return Objects.equals(cloudNoSqlTables, that.cloudNoSqlTables);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(cloudNoSqlTables);
+    }
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePlatformResources.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePlatformResources.java
@@ -53,6 +53,7 @@ import com.sequenceiq.cloudbreak.cloud.model.RegionCoordinateSpecifications;
 import com.sequenceiq.cloudbreak.cloud.model.VmType;
 import com.sequenceiq.cloudbreak.cloud.model.VmTypeMeta.VmTypeMetaBuilder;
 import com.sequenceiq.cloudbreak.cloud.model.VolumeParameterType;
+import com.sequenceiq.cloudbreak.cloud.model.nosql.CloudNoSqlTables;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 import com.sequenceiq.cloudbreak.service.CloudbreakResourceReaderService;
 
@@ -238,6 +239,12 @@ public class AzurePlatformResources implements PlatformResources {
     @Override
     public CloudEncryptionKeys encryptionKeys(CloudCredential cloudCredential, Region region, Map<String, String> filters) {
         return new CloudEncryptionKeys(new HashSet<>());
+    }
+
+    @Override
+    public CloudNoSqlTables noSqlTables(CloudCredential cloudCredential, Region region, Map<String, String> filters) {
+        LOGGER.warn("NoSQL table list is not supported on 'AZURE'");
+        return new CloudNoSqlTables(new ArrayList<>());
     }
 
 }

--- a/cloud-cumulus-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/cumulus/yarn/CumulusYarnPlatformResources.java
+++ b/cloud-cumulus-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/cumulus/yarn/CumulusYarnPlatformResources.java
@@ -4,6 +4,7 @@ import static com.sequenceiq.cloudbreak.cloud.model.Coordinate.coordinate;
 import static com.sequenceiq.cloudbreak.cloud.model.Region.region;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -31,8 +32,9 @@ import com.sequenceiq.cloudbreak.cloud.model.Coordinate;
 import com.sequenceiq.cloudbreak.cloud.model.Region;
 import com.sequenceiq.cloudbreak.cloud.model.RegionCoordinateSpecification;
 import com.sequenceiq.cloudbreak.cloud.model.RegionCoordinateSpecifications;
-import com.sequenceiq.cloudbreak.service.CloudbreakResourceReaderService;
+import com.sequenceiq.cloudbreak.cloud.model.nosql.CloudNoSqlTables;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
+import com.sequenceiq.cloudbreak.service.CloudbreakResourceReaderService;
 
 @Service
 public class CumulusYarnPlatformResources implements PlatformResources {
@@ -111,5 +113,11 @@ public class CumulusYarnPlatformResources implements PlatformResources {
     @Override
     public CloudEncryptionKeys encryptionKeys(CloudCredential cloudCredential, Region region, Map<String, String> filters) {
         return new CloudEncryptionKeys(new HashSet<>());
+    }
+
+    @Override
+    public CloudNoSqlTables noSqlTables(CloudCredential cloudCredential, Region region, Map<String, String> filters) {
+        LOGGER.warn("NoSQL table list is not supported on 'CUMULUS-YARN'");
+        return new CloudNoSqlTables(new ArrayList<>());
     }
 }

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpPlatformResources.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpPlatformResources.java
@@ -67,6 +67,7 @@ import com.sequenceiq.cloudbreak.cloud.model.RegionCoordinateSpecifications;
 import com.sequenceiq.cloudbreak.cloud.model.VmType;
 import com.sequenceiq.cloudbreak.cloud.model.VmTypeMeta;
 import com.sequenceiq.cloudbreak.cloud.model.VmTypeMeta.VmTypeMetaBuilder;
+import com.sequenceiq.cloudbreak.cloud.model.nosql.CloudNoSqlTables;
 import com.sequenceiq.cloudbreak.service.CloudbreakResourceReaderService;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 
@@ -313,6 +314,12 @@ public class GcpPlatformResources implements PlatformResources {
                 .collect(Collectors.toSet());
 
         return new CloudEncryptionKeys(cloudEncryptionKeys);
+    }
+
+    @Override
+    public CloudNoSqlTables noSqlTables(CloudCredential cloudCredential, Region region, Map<String, String> filters) {
+        LOGGER.warn("NoSQL table list is not supported on 'GCP'");
+        return new CloudNoSqlTables(new ArrayList<>());
     }
 
     private List<KeyRing> getKeyRingList(CloudKMS cloudKMS, String projectId, String regionName) {

--- a/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockPlatformResources.java
+++ b/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockPlatformResources.java
@@ -44,6 +44,7 @@ import com.sequenceiq.cloudbreak.cloud.model.VmType;
 import com.sequenceiq.cloudbreak.cloud.model.VmTypeMeta;
 import com.sequenceiq.cloudbreak.cloud.model.VolumeParameterConfig;
 import com.sequenceiq.cloudbreak.cloud.model.VolumeParameterType;
+import com.sequenceiq.cloudbreak.cloud.model.nosql.CloudNoSqlTables;
 import com.sequenceiq.cloudbreak.service.CloudbreakResourceReaderService;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 
@@ -217,6 +218,11 @@ public class MockPlatformResources implements PlatformResources {
     @Override
     public CloudEncryptionKeys encryptionKeys(CloudCredential cloudCredential, Region region, Map<String, String> filters) {
         return new CloudEncryptionKeys(new HashSet<>());
+    }
+
+    @Override
+    public CloudNoSqlTables noSqlTables(CloudCredential cloudCredential, Region region, Map<String, String> filters) {
+        return new CloudNoSqlTables(new ArrayList<>());
     }
 
     private Region getRegionByName(String name) {

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/common/OpenStackPlatformResources.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/common/OpenStackPlatformResources.java
@@ -6,6 +6,7 @@ import static com.sequenceiq.cloudbreak.cloud.model.VolumeParameterType.MAGNETIC
 import static com.sequenceiq.cloudbreak.cloud.model.VolumeParameterType.values;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -59,6 +60,7 @@ import com.sequenceiq.cloudbreak.cloud.model.VmTypeMeta.VmTypeMetaBuilder;
 import com.sequenceiq.cloudbreak.cloud.model.VolumeParameterConfig;
 import com.sequenceiq.cloudbreak.cloud.model.VolumeParameterType;
 import com.sequenceiq.cloudbreak.cloud.model.generic.StringType;
+import com.sequenceiq.cloudbreak.cloud.model.nosql.CloudNoSqlTables;
 import com.sequenceiq.cloudbreak.cloud.openstack.auth.OpenStackClient;
 import com.sequenceiq.cloudbreak.cloud.openstack.view.KeystoneCredentialView;
 import com.sequenceiq.cloudbreak.service.CloudbreakResourceReaderService;
@@ -340,6 +342,12 @@ public class OpenStackPlatformResources implements PlatformResources {
     @Override
     public CloudEncryptionKeys encryptionKeys(CloudCredential cloudCredential, Region region, Map<String, String> filters) {
         return new CloudEncryptionKeys(new HashSet<>());
+    }
+
+    @Override
+    public CloudNoSqlTables noSqlTables(CloudCredential cloudCredential, Region region, Map<String, String> filters) {
+        LOGGER.warn("NoSQL table list is not supported on 'OPENSTACK'");
+        return new CloudNoSqlTables(new ArrayList<>());
     }
 
     private VolumeParameterConfig volumeParameterConfig(VolumeParameterType volumeParameterType) {

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/platform/GetPlatformNoSqlTablesRequest.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/platform/GetPlatformNoSqlTablesRequest.java
@@ -1,0 +1,50 @@
+package com.sequenceiq.cloudbreak.cloud.event.platform;
+
+import java.util.Map;
+
+import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformRequest;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.ExtendedCloudCredential;
+
+public class GetPlatformNoSqlTablesRequest extends CloudPlatformRequest<GetPlatformNoSqlTablesResult> {
+
+    private final String region;
+
+    private final String variant;
+
+    private final ExtendedCloudCredential extendedCloudCredential;
+
+    private final Map<String, String> filters;
+
+    public GetPlatformNoSqlTablesRequest(CloudCredential cloudCredential, ExtendedCloudCredential extendedCloudCredential, String variant, String region,
+            Map<String, String> filters) {
+        super(null, cloudCredential);
+        this.extendedCloudCredential = extendedCloudCredential;
+        this.variant = variant;
+        this.region = region;
+        this.filters = filters;
+    }
+
+    public String getVariant() {
+        return variant;
+    }
+
+    public ExtendedCloudCredential getExtendedCloudCredential() {
+        return extendedCloudCredential;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public Map<String, String> getFilters() {
+        return filters;
+    }
+
+    //BEGIN GENERATED CODE
+    @Override
+    public String toString() {
+        return "GetPlatformNoSqlTablesRequest{}";
+    }
+    //END GENERATED CODE
+}

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/platform/GetPlatformNoSqlTablesResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/platform/GetPlatformNoSqlTablesResult.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.cloudbreak.cloud.event.platform;
+
+import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
+import com.sequenceiq.cloudbreak.cloud.model.nosql.CloudNoSqlTables;
+
+public class GetPlatformNoSqlTablesResult extends CloudPlatformResult {
+    private CloudNoSqlTables noSqlTables;
+
+    public GetPlatformNoSqlTablesResult(Long resourceId, CloudNoSqlTables noSqlTables) {
+        super(resourceId);
+        this.noSqlTables = noSqlTables;
+    }
+
+    public GetPlatformNoSqlTablesResult(String statusReason, Exception errorDetails, Long resourceId) {
+        super(statusReason, errorDetails, resourceId);
+    }
+
+    public CloudNoSqlTables getNoSqlTables() {
+        return noSqlTables;
+    }
+}

--- a/cloud-reactor/build.gradle
+++ b/cloud-reactor/build.gradle
@@ -25,8 +25,17 @@ dependencies {
     compile group: 'org.freemarker',                name: 'freemarker',                     version: freemarkerVersion
     compile group: 'com.google.code.findbugs',      name: 'jsr305',                         version: '3.0.1'
 
+    testCompile group: 'org.mockito',               name: 'mockito-junit-jupiter',          version: mockitoVersion
     testCompile group: 'org.mockito',               name: 'mockito-core',                   version: mockitoVersion
-    testCompile group: 'junit',                     name: 'junit',                          version: junitVersion
+    testCompile group: 'org.junit.vintage',         name: 'junit-vintage-engine',           version: junitJupiterVersion
+    testCompile group: 'org.junit.jupiter',         name: 'junit-jupiter-api',              version: junitJupiterVersion
+    testRuntime group: 'org.junit.jupiter',         name: 'junit-jupiter-engine',           version: junitJupiterVersion
     testCompile group: 'org.springframework.boot',  name: 'spring-boot-starter',            version: springBootVersion
     testCompile group: 'org.springframework.boot',  name: 'spring-boot-starter-test',       version: springBootVersion
+}
+
+test{
+    useJUnitPlatform {
+        includeEngines 'junit-jupiter', 'junit-vintage'
+    }
 }

--- a/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/handler/GetPlatformNoSqlTablesHandler.java
+++ b/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/handler/GetPlatformNoSqlTablesHandler.java
@@ -1,0 +1,50 @@
+package com.sequenceiq.cloudbreak.cloud.handler;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.event.platform.GetPlatformNoSqlTablesRequest;
+import com.sequenceiq.cloudbreak.cloud.event.platform.GetPlatformNoSqlTablesResult;
+import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
+import com.sequenceiq.cloudbreak.cloud.model.CloudPlatformVariant;
+import com.sequenceiq.cloudbreak.cloud.model.Platform;
+import com.sequenceiq.cloudbreak.cloud.model.Region;
+import com.sequenceiq.cloudbreak.cloud.model.Variant;
+import com.sequenceiq.cloudbreak.cloud.model.nosql.CloudNoSqlTables;
+
+import reactor.bus.Event;
+
+@Component
+public class GetPlatformNoSqlTablesHandler implements CloudPlatformEventHandler<GetPlatformNoSqlTablesRequest> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(GetPlatformNoSqlTablesHandler.class);
+
+    @Inject
+    private CloudPlatformConnectors cloudPlatformConnectors;
+
+    @Override
+    public Class<GetPlatformNoSqlTablesRequest> type() {
+        return GetPlatformNoSqlTablesRequest.class;
+    }
+
+    @Override
+    public void accept(Event<GetPlatformNoSqlTablesRequest> event) {
+        LOGGER.debug("Received event: {}", event);
+        GetPlatformNoSqlTablesRequest request = event.getData();
+
+        try {
+            CloudPlatformVariant cloudPlatformVariant = new CloudPlatformVariant(
+                    Platform.platform(request.getExtendedCloudCredential().getCloudPlatform()),
+                    Variant.variant(request.getVariant()));
+            CloudNoSqlTables cloudNoSqlTables = cloudPlatformConnectors.get(cloudPlatformVariant)
+                    .platformResources().noSqlTables(request.getCloudCredential(), Region.region(request.getRegion()), request.getFilters());
+            GetPlatformNoSqlTablesResult result = new GetPlatformNoSqlTablesResult(request.getResourceId(), cloudNoSqlTables);
+            request.getResult().onNext(result);
+            LOGGER.debug("Query platform NoSQL tables finished.");
+        } catch (RuntimeException e) {
+            request.getResult().onNext(new GetPlatformNoSqlTablesResult(e.getMessage(), e, request.getResourceId()));
+        }
+    }
+}

--- a/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/GetPlatformNoSqlTablesHandlerTest.java
+++ b/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/GetPlatformNoSqlTablesHandlerTest.java
@@ -1,0 +1,66 @@
+package com.sequenceiq.cloudbreak.cloud.handler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cloud.CloudConnector;
+import com.sequenceiq.cloudbreak.cloud.PlatformResources;
+import com.sequenceiq.cloudbreak.cloud.event.platform.GetPlatformNoSqlTablesRequest;
+import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.CloudPlatformVariant;
+import com.sequenceiq.cloudbreak.cloud.model.ExtendedCloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.Region;
+
+import reactor.bus.Event;
+
+@ExtendWith(MockitoExtension.class)
+class GetPlatformNoSqlTablesHandlerTest {
+
+    @Mock
+    private CloudPlatformConnectors cloudPlatformConnectors;
+
+    @Mock
+    private PlatformResources platformResources;
+
+    @Mock
+    private CloudConnector<Object> cloudConnector;
+
+    @InjectMocks
+    private GetPlatformNoSqlTablesHandler underTest;
+
+    @Test
+    void type() {
+        assertEquals(GetPlatformNoSqlTablesRequest.class, underTest.type());
+    }
+
+    @Test
+    void accept() {
+        when(cloudPlatformConnectors.get(any(CloudPlatformVariant.class))).thenReturn(cloudConnector);
+        when(cloudConnector.platformResources()).thenReturn(platformResources);
+
+        CloudCredential cloudCredential = new CloudCredential("id", "name");
+        GetPlatformNoSqlTablesRequest request = spy(new GetPlatformNoSqlTablesRequest(cloudCredential,
+                new ExtendedCloudCredential(
+                        cloudCredential, "aws", "desc", "crn", "account"),
+                "aws",
+                "region",
+                null));
+
+        underTest.accept(new Event<>(request));
+
+        verify(platformResources).noSqlTables(eq(cloudCredential), eq(Region.region("region")), isNull());
+        verify(request).getResult();
+    }
+}

--- a/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/service/CloudParameterServiceTest.java
+++ b/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/service/CloudParameterServiceTest.java
@@ -1,0 +1,56 @@
+package com.sequenceiq.cloudbreak.cloud.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cloud.event.platform.GetPlatformNoSqlTablesRequest;
+import com.sequenceiq.cloudbreak.cloud.event.platform.GetPlatformNoSqlTablesResult;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.ExtendedCloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.nosql.CloudNoSqlTable;
+import com.sequenceiq.cloudbreak.cloud.model.nosql.CloudNoSqlTables;
+import com.sequenceiq.flow.reactor.ErrorHandlerAwareReactorEventFactory;
+
+import reactor.bus.Event;
+import reactor.bus.EventBus;
+
+@ExtendWith(MockitoExtension.class)
+class CloudParameterServiceTest {
+
+    @Mock
+    private EventBus eventBus;
+
+    @Mock
+    private ErrorHandlerAwareReactorEventFactory eventFactory;
+
+    @InjectMocks
+    private CloudParameterService underTest;
+
+    @Test
+    void getNoSqlTables() {
+        CloudNoSqlTables expected = new CloudNoSqlTables(List.of(new CloudNoSqlTable("a"), new CloudNoSqlTable("b")));
+        GetPlatformNoSqlTablesResult response = new GetPlatformNoSqlTablesResult(1L, expected);
+        doAnswer(invocation -> {
+            Event<GetPlatformNoSqlTablesRequest> ev = invocation.getArgument(1);
+            ev.getData().getResult().onNext(response);
+            return null;
+        }).when(eventBus).notify(anyString(), any(Event.class));
+        CloudNoSqlTables noSqlTables = underTest.getNoSqlTables(
+                new ExtendedCloudCredential(
+                        new CloudCredential("id", "name"), "aws", "desc", "crn", "account"),
+                "region",
+                "aws",
+                null);
+        assertEquals(expected, noSqlTables);
+    }
+}

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnPlatformResources.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnPlatformResources.java
@@ -4,6 +4,7 @@ import static com.sequenceiq.cloudbreak.cloud.model.Coordinate.coordinate;
 import static com.sequenceiq.cloudbreak.cloud.model.Region.region;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -31,8 +32,9 @@ import com.sequenceiq.cloudbreak.cloud.model.Coordinate;
 import com.sequenceiq.cloudbreak.cloud.model.Region;
 import com.sequenceiq.cloudbreak.cloud.model.RegionCoordinateSpecification;
 import com.sequenceiq.cloudbreak.cloud.model.RegionCoordinateSpecifications;
-import com.sequenceiq.cloudbreak.service.CloudbreakResourceReaderService;
+import com.sequenceiq.cloudbreak.cloud.model.nosql.CloudNoSqlTables;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
+import com.sequenceiq.cloudbreak.service.CloudbreakResourceReaderService;
 
 @Service
 public class YarnPlatformResources implements PlatformResources {
@@ -111,5 +113,11 @@ public class YarnPlatformResources implements PlatformResources {
     @Override
     public CloudEncryptionKeys encryptionKeys(CloudCredential cloudCredential, Region region, Map<String, String> filters) {
         return new CloudEncryptionKeys(new HashSet<>());
+    }
+
+    @Override
+    public CloudNoSqlTables noSqlTables(CloudCredential cloudCredential, Region region, Map<String, String> filters) {
+        LOGGER.warn("NoSQL table list is not supported on 'YARN'");
+        return new CloudNoSqlTables(new ArrayList<>());
     }
 }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/platformresource/PlatformResourceEndpoint.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/platformresource/PlatformResourceEndpoint.java
@@ -2,6 +2,7 @@ package com.sequenceiq.environment.api.v1.platformresource;
 
 import static com.sequenceiq.environment.api.doc.ModelDescriptions.CONNECTOR_NOTES;
 
+import javax.validation.constraints.NotEmpty;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -16,6 +17,7 @@ import com.sequenceiq.environment.api.v1.platformresource.model.PlatformEncrypti
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformGatewaysResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformIpPoolsResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformNetworksResponse;
+import com.sequenceiq.environment.api.v1.platformresource.model.PlatformNoSqlTablesResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformSecurityGroupsResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformSshKeysResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformVmtypesResponse;
@@ -151,4 +153,16 @@ public interface PlatformResourceEndpoint {
     @ApiOperation(value = OpDescription.GET_TAG_SPECIFICATIONS, produces = PlatformResourceModelDescription.JSON_CONTENT_TYPE, notes = CONNECTOR_NOTES,
             nickname = "getTagSpecifications")
     TagSpecificationsResponse getTagSpecifications();
+
+    @GET
+    @Path("nosql_tables")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = OpDescription.GET_NOSQL_TABLES, produces = PlatformResourceModelDescription.JSON_CONTENT_TYPE, notes = CONNECTOR_NOTES,
+            nickname = "getNoSqlTables")
+    PlatformNoSqlTablesResponse getNoSqlTables(
+            @QueryParam("credentialName") String credentialName,
+            @QueryParam("credentialCrn") String credentialCrn,
+            @QueryParam("region") @NotEmpty String region,
+            @QueryParam("platformVariant") String platformVariant,
+            @QueryParam("availabilityZone") String availabilityZone);
 }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/platformresource/PlatformResourceModelDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/platformresource/PlatformResourceModelDescription.java
@@ -29,6 +29,7 @@ public class PlatformResourceModelDescription {
         public static final String GET_IPPOOLS = "retrive ip pools with properties";
         public static final String GET_ACCESSCONFIGS = "retrive access configs with properties";
         public static final String GET_ENCRYPTIONKEYS = "retrive encryption keys with properties";
+        public static final String GET_NOSQL_TABLES = "retrive nosql tables";
     }
 
     private PlatformResourceModelDescription() {

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/platformresource/model/PlatformNoSqlTableResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/platformresource/model/PlatformNoSqlTableResponse.java
@@ -1,0 +1,24 @@
+package com.sequenceiq.environment.api.v1.platformresource.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import io.swagger.annotations.ApiModel;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PlatformNoSqlTableResponse {
+
+    private String name;
+
+    public PlatformNoSqlTableResponse(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/platformresource/model/PlatformNoSqlTablesResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/platformresource/model/PlatformNoSqlTablesResponse.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.environment.api.v1.platformresource.model;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@SuppressFBWarnings("SE_BAD_FIELD")
+public class PlatformNoSqlTablesResponse implements Serializable {
+
+    private List<PlatformNoSqlTableResponse> noSqlTables = new ArrayList<>();
+
+    public PlatformNoSqlTablesResponse() {
+    }
+
+    public PlatformNoSqlTablesResponse(@NotNull List<PlatformNoSqlTableResponse> noSqlTables) {
+        this.noSqlTables = noSqlTables;
+    }
+
+    public List<PlatformNoSqlTableResponse> getNoSqlTables() {
+        return noSqlTables;
+    }
+
+    public void setNoSqlTables(List<PlatformNoSqlTableResponse> noSqlTables) {
+        this.noSqlTables = noSqlTables;
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/platformresource/PlatformParameterService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/platformresource/PlatformParameterService.java
@@ -21,6 +21,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudSshKeys;
 import com.sequenceiq.cloudbreak.cloud.model.CloudVmTypes;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
 import com.sequenceiq.cloudbreak.cloud.model.PlatformDisks;
+import com.sequenceiq.cloudbreak.cloud.model.nosql.CloudNoSqlTables;
 import com.sequenceiq.cloudbreak.cloud.service.CloudParameterService;
 import com.sequenceiq.environment.credential.service.CredentialService;
 import com.sequenceiq.environment.credential.v1.converter.CredentialToExtendedCloudCredentialConverter;
@@ -116,6 +117,11 @@ public class PlatformParameterService {
 
     public CloudAccessConfigs getAccessConfigs(PlatformResourceRequest request) {
         return cloudParameterService.getCloudAccessConfigs(extendedCloudCredentialConverter.convert(request.getCredential()), request.getRegion(),
+                request.getPlatformVariant(), request.getFilters());
+    }
+
+    public CloudNoSqlTables getNoSqlTables(PlatformResourceRequest request) {
+        return cloudParameterService.getNoSqlTables(extendedCloudCredentialConverter.convert(request.getCredential()), request.getRegion(),
                 request.getPlatformVariant(), request.getFilters());
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/platformresource/v1/PlatformResourceController.java
+++ b/environment/src/main/java/com/sequenceiq/environment/platformresource/v1/PlatformResourceController.java
@@ -23,6 +23,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudSshKeys;
 import com.sequenceiq.cloudbreak.cloud.model.CloudVmTypes;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
 import com.sequenceiq.cloudbreak.cloud.model.PlatformDisks;
+import com.sequenceiq.cloudbreak.cloud.model.nosql.CloudNoSqlTables;
 import com.sequenceiq.environment.api.v1.platformresource.PlatformResourceEndpoint;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformAccessConfigsResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformDisksResponse;
@@ -30,6 +31,7 @@ import com.sequenceiq.environment.api.v1.platformresource.model.PlatformEncrypti
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformGatewaysResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformIpPoolsResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformNetworksResponse;
+import com.sequenceiq.environment.api.v1.platformresource.model.PlatformNoSqlTablesResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformSecurityGroupsResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformSshKeysResponse;
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformVmtypesResponse;
@@ -233,6 +235,26 @@ public class PlatformResourceController implements PlatformResourceEndpoint {
     public TagSpecificationsResponse getTagSpecifications() {
         Map<Platform, PlatformParameters> platformParameters = platformParameterService.getPlatformParameters();
         return convertersionService.convert(platformParameters, TagSpecificationsResponse.class);
+    }
+
+    @Override
+    public PlatformNoSqlTablesResponse getNoSqlTables(
+            String credentialName,
+            String credentialCrn,
+            String region,
+            String platformVariant,
+            String availabilityZone) {
+
+        String accountId = getAccountId();
+        PlatformResourceRequest request = platformParameterService.getPlatformResourceRequest(
+                accountId,
+                credentialName,
+                credentialCrn,
+                region,
+                platformVariant,
+                availabilityZone);
+        CloudNoSqlTables noSqlTables = platformParameterService.getNoSqlTables(request);
+        return convertersionService.convert(noSqlTables, PlatformNoSqlTablesResponse.class);
     }
 
     private String getAccountId() {

--- a/environment/src/main/java/com/sequenceiq/environment/platformresource/v1/converter/CloudNoSqlTablesToPlatformNoSqlTablesV1ResponseConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/platformresource/v1/converter/CloudNoSqlTablesToPlatformNoSqlTablesV1ResponseConverter.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.environment.platformresource.v1.converter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.model.nosql.CloudNoSqlTables;
+import com.sequenceiq.cloudbreak.converter.AbstractConversionServiceAwareConverter;
+import com.sequenceiq.environment.api.v1.platformresource.model.PlatformNoSqlTableResponse;
+import com.sequenceiq.environment.api.v1.platformresource.model.PlatformNoSqlTablesResponse;
+
+@Component
+public class CloudNoSqlTablesToPlatformNoSqlTablesV1ResponseConverter
+        extends AbstractConversionServiceAwareConverter<CloudNoSqlTables, PlatformNoSqlTablesResponse> {
+
+    @Override
+    public PlatformNoSqlTablesResponse convert(CloudNoSqlTables source) {
+        List<PlatformNoSqlTableResponse> result = source.getCloudNoSqlTables()
+                .stream()
+                .map(t -> new PlatformNoSqlTableResponse(t.getName()))
+                .collect(Collectors.toList());
+        return new PlatformNoSqlTablesResponse(result);
+    }
+}

--- a/environment/src/test/java/com/sequenceiq/environment/platformresource/PlatformParameterServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/platformresource/PlatformParameterServiceTest.java
@@ -188,6 +188,12 @@ class PlatformParameterServiceTest {
         verify(cloudParameterService).getPlatformParameters();
     }
 
+    @Test
+    void getNoSqlTables() {
+        platformParameterServiceUnderTest.getNoSqlTables(request);
+        verify(cloudParameterService).getNoSqlTables(any(), eq(REGION), eq(PLATFORM_VARIANT), any());
+    }
+
     @Configuration
     @Import(PlatformParameterService.class)
     static class Config {

--- a/environment/src/test/java/com/sequenceiq/environment/platformresource/v1/PlatformResourceControllerTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/platformresource/v1/PlatformResourceControllerTest.java
@@ -1,0 +1,52 @@
+package com.sequenceiq.environment.platformresource.v1;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.convert.ConversionService;
+
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.cloud.model.nosql.CloudNoSqlTables;
+import com.sequenceiq.environment.api.v1.platformresource.model.PlatformNoSqlTablesResponse;
+import com.sequenceiq.environment.platformresource.PlatformParameterService;
+import com.sequenceiq.environment.platformresource.PlatformResourceRequest;
+
+@ExtendWith(MockitoExtension.class)
+class PlatformResourceControllerTest {
+
+    @Mock
+    private ConversionService convertersionService;
+
+    @Mock
+    private PlatformParameterService platformParameterService;
+
+    @Mock
+    private ThreadBasedUserCrnProvider threadBasedUserCrnProvider;
+
+    @InjectMocks
+    private PlatformResourceController underTest;
+
+    @Test
+    void getNoSqlTables() {
+        CloudNoSqlTables noSqlTables = new CloudNoSqlTables();
+        PlatformResourceRequest platformResourceRequest = new PlatformResourceRequest();
+        PlatformNoSqlTablesResponse response = new PlatformNoSqlTablesResponse();
+        when(platformParameterService.getPlatformResourceRequest(any(), any(), any(), any(), any(), any())).thenReturn(platformResourceRequest);
+        when(platformParameterService.getNoSqlTables(any(PlatformResourceRequest.class))).thenReturn(noSqlTables);
+        when(convertersionService.convert(noSqlTables, PlatformNoSqlTablesResponse.class)).thenReturn(response);
+
+        PlatformNoSqlTablesResponse result = underTest.getNoSqlTables("cred",
+                "crn", "region", "aws", "az");
+
+        verify(platformParameterService).getNoSqlTables(platformResourceRequest);
+        verify(convertersionService).convert(noSqlTables, PlatformNoSqlTablesResponse.class);
+        assertEquals(response, result);
+    }
+}

--- a/environment/src/test/java/com/sequenceiq/environment/platformresource/v1/converter/CloudNoSqlTablesToPlatformNoSqlTablesV1ResponseConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/platformresource/v1/converter/CloudNoSqlTablesToPlatformNoSqlTablesV1ResponseConverterTest.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.environment.platformresource.v1.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.cloud.model.nosql.CloudNoSqlTable;
+import com.sequenceiq.cloudbreak.cloud.model.nosql.CloudNoSqlTables;
+import com.sequenceiq.environment.api.v1.platformresource.model.PlatformNoSqlTableResponse;
+import com.sequenceiq.environment.api.v1.platformresource.model.PlatformNoSqlTablesResponse;
+
+class CloudNoSqlTablesToPlatformNoSqlTablesV1ResponseConverterTest {
+
+    private CloudNoSqlTablesToPlatformNoSqlTablesV1ResponseConverter underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new CloudNoSqlTablesToPlatformNoSqlTablesV1ResponseConverter();
+    }
+
+    @Test
+    void convert() {
+        List<CloudNoSqlTable> tables = List.of(new CloudNoSqlTable("a"), new CloudNoSqlTable("b"));
+        CloudNoSqlTables source = new CloudNoSqlTables(tables);
+        PlatformNoSqlTablesResponse result = underTest.convert(source);
+        List<PlatformNoSqlTableResponse> noSqlTables = result.getNoSqlTables();
+        assertNotNull(noSqlTables);
+        assertEquals(tables.size(), noSqlTables.size());
+        tables.forEach(t -> {
+            assertTrue(noSqlTables.stream().anyMatch(s -> t.getName().equals(s.getName())));
+        });
+    }
+}


### PR DESCRIPTION
Remove DynamoDB table after environment cleanup.
Only do so if the table did not exist before AND if no other environments are referencing it.