### PR TITLE
CB-3628 test framework validates parameters with wrong parameter name

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/config/CloudbreakServer.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/config/CloudbreakServer.java
@@ -54,7 +54,7 @@ public class CloudbreakServer {
         checkNonEmpty("integrationtest.cloudbreak.server", server);
         checkNonEmpty("server.contextPath", cbRootContextPath);
         checkNonEmpty("integrationtest.user.accesskey", accessKey);
-        checkNonEmpty("integrationtest.user.privatekey", secretKey);
+        checkNonEmpty("integrationtest.user.secretkey", secretKey);
 
         testParameter.put(CloudbreakTest.CLOUDBREAK_SERVER_ROOT, server + cbRootContextPath);
         testParameter.put(CloudbreakTest.ACCESS_KEY, accessKey);


### PR DESCRIPTION
test framework validates parameters with wrong parameter name
Closes CB-3628