### PR TITLE
CB-3578 ephemeral disk list is not parsed correctly

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/bootstrapnodes/mount-disks.sh
+++ b/orchestrator-salt/src/main/resources/salt/bootstrapnodes/mount-disks.sh
@@ -19,7 +19,7 @@ VERSION="V1.0"
 mount_remaining() {
       local hadoop_fs_dir_counter=$1
       local return_value=0
-      not_mounted_volume_names=$(lsblk_command --noheadings --raw -o NAME,MOUNTPOINT | awk '$1~/[[:digit:]]/ && $2 == ""')
+      not_mounted_volume_names=$(lsblk_command | grep -v / | grep ^[a-z] | cut -f1 -d' ')
       log $LOG_FILE remaining not mounted volumes: $not_mounted_volume_names
       root_disk=$(get_root_disk)
       for volume in $not_mounted_volume_names; do


### PR DESCRIPTION
**DELETE THIS TEMPLATE BEFORE SUBMITTING**

Describe the change you are making here!

Please include tests. Check out these examples:

- https://github.com/hortonworks/cloudbreak/blob/master/core/src/test/java/com/sequenceiq/cloudbreak/service/blueprint/BlueprintLoaderServiceTest.java#L62-L76

Please include a short description. Check out these examples:

- https://github.com/hortonworks/cloudbreak/commit/888b2e2a8887def28a24e26efcd6d9ca5863733a

If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:

Closes #xxx
Closes #xxx