### PR TITLE
CB-3441 Select all subnets for RDS DB subnet group

### DIFF
--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/network/SubnetChooserService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/network/SubnetChooserService.java
@@ -1,11 +1,6 @@
 package com.sequenceiq.redbeams.service.network;
 
 import java.util.List;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
@@ -35,18 +30,12 @@ public class SubnetChooserService {
             throw new BadRequestException("Insufficient number of subnets: at least two subnets in two different availability zones needed");
         }
 
-        List<CloudSubnet> subnetsDistinctedByAZ = subnetMetas.stream().filter(distinctByKey(CloudSubnet::getAvailabilityZone)).collect(Collectors.toList());
-
-        if (subnetsDistinctedByAZ.size() < 2) {
-            throw new BadRequestException("All subnets in the same availability zone: at least two subnets in two different availability zones needed");
+        long numAZs = subnetMetas.stream().map(CloudSubnet::getAvailabilityZone).distinct().count();
+        if (numAZs < 2L) {
+            throw new BadRequestException("All subnets are in the same availability zone: at least two subnets in two different availability zones needed");
         } else {
-            return List.of(subnetsDistinctedByAZ.get(0), subnetsDistinctedByAZ.get(1));
+            return subnetMetas;
         }
-    }
-
-    private static <T> Predicate<T> distinctByKey(Function<? super T, ?> keyExtractor) {
-        Set<Object> seen = ConcurrentHashMap.newKeySet();
-        return t -> seen.add(keyExtractor.apply(t));
     }
 
     private List<CloudSubnet> chooseSubnetsAzure(List<CloudSubnet> subnetMetas) {

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/service/network/SubnetChooserServiceTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/service/network/SubnetChooserServiceTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 
 import java.util.List;
@@ -28,21 +27,24 @@ public class SubnetChooserServiceTest {
 
     private static final String SUBNET_2 = "subnet-2";
 
+    private static final String SUBNET_3 = "subnet-3";
+
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
     private final SubnetChooserService underTest = new SubnetChooserService();
 
     @Test
-    public void testChooseSubnetsAwsFromDifferentAzs() {
+    public void testChooseSubnetsAwsSuccess() {
         List<CloudSubnet> subnets = List.of(
                 new CloudSubnet(SUBNET_1, "", AVAILABILITY_ZONE_A, ""),
-                new CloudSubnet(SUBNET_2, "", AVAILABILITY_ZONE_B, "")
+                new CloudSubnet(SUBNET_2, "", AVAILABILITY_ZONE_B, ""),
+                new CloudSubnet(SUBNET_3, "", AVAILABILITY_ZONE_B, "")
         );
 
         List<CloudSubnet> chosenSubnets = underTest.chooseSubnets(subnets, CloudPlatform.AWS);
 
-        assertThat(chosenSubnets, hasSize(2));
+        assertThat(chosenSubnets, hasSize(3));
         assertThat(chosenSubnets, hasItem(hasProperty("availabilityZone", is(AVAILABILITY_ZONE_A))));
         assertThat(chosenSubnets, hasItem(hasProperty("availabilityZone", is(AVAILABILITY_ZONE_B))));
     }
@@ -72,7 +74,7 @@ public class SubnetChooserServiceTest {
                 new CloudSubnet(SUBNET_2, "", AVAILABILITY_ZONE_A, "")
         );
         thrown.expect(BadRequestException.class);
-        thrown.expectMessage("All subnets in the same availability zone");
+        thrown.expectMessage("All subnets are in the same availability zone");
 
         underTest.chooseSubnets(subnets, CloudPlatform.AWS);
     }
@@ -90,10 +92,7 @@ public class SubnetChooserServiceTest {
 
         List<CloudSubnet> chosenSubnets = underTest.chooseSubnets(subnets, CloudPlatform.AWS);
 
-        assertThat(chosenSubnets, hasSize(2));
-        String az1 = chosenSubnets.get(0).getAvailabilityZone();
-        String az2 = chosenSubnets.get(1).getAvailabilityZone();
-        assertNotEquals(az1, az2);
+        assertThat(chosenSubnets, hasSize(6));
     }
 
     // ---


### PR DESCRIPTION
Rather than selecting exactly two subnets from different AZs for an RDS
instance's DB subnet group, redbeams now selects all available subnets,
while still verifying that the subnets are spread across at least two
AZs.