### PR TITLE
CB-3639 Correct service-managed database server deletion

### DIFF
--- a/redbeams/src/main/java/com/sequenceiq/redbeams/domain/DatabaseServerConfig.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/domain/DatabaseServerConfig.java
@@ -243,6 +243,7 @@ public class DatabaseServerConfig implements ArchivableResource, AccountIdAwareR
 
     @Override
     public void unsetRelationsToEntitiesToBeDeleted() {
+        dbStack = null;
     }
 
     public String getEnvironmentId() {

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/termination/handler/DeregisterDatabaseServerHandler.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/termination/handler/DeregisterDatabaseServerHandler.java
@@ -45,7 +45,7 @@ public class DeregisterDatabaseServerHandler implements EventHandler<DeregisterD
 
         try {
             databaseServerConfigService.getByCrn(dbStack.getResourceCrn())
-                    .ifPresent(dsc -> databaseServerConfigService.archive(dsc));
+                    .ifPresent(dsc -> databaseServerConfigService.delete(dsc));
             eventBus.notify(response.selector(), new Event<>(event.getHeaders(), response));
         } catch (Exception e) {
             DeregisterDatabaseServerFailed failure = new DeregisterDatabaseServerFailed(request.getResourceId(), e);

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigService.java
@@ -170,15 +170,6 @@ public class DatabaseServerConfigService extends AbstractArchivistService<Databa
         }
     }
 
-    public void archive(DatabaseServerConfig resource) {
-        for (DatabaseConfig dbConfig : resource.getDatabases()) {
-            databaseConfigService.archive(dbConfig);
-        }
-        resource.setArchived(true);
-        resource.setDbStack(null);
-        repository.save(resource);
-    }
-
     public DatabaseServerConfig getByName(Long workspaceId, String environmentCrn, String name) {
         Optional<DatabaseServerConfig> resourceOpt = repository.findByNameAndWorkspaceIdAndEnvironmentId(name, workspaceId, environmentCrn);
         if (resourceOpt.isEmpty()) {

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/domain/DatabaseServerConfigTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/domain/DatabaseServerConfigTest.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.redbeams.domain;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -133,5 +134,14 @@ public class DatabaseServerConfigTest {
         assertEquals("hive", db.getType());
         assertEquals(config.getEnvironmentId(), db.getEnvironmentId());
         assertEquals(config, db.getServer());
+    }
+
+    @Test
+    public void testUnsetRelationsToEntitiesToBeDeleted() {
+        config.setDbStack(new DBStack());
+
+        config.unsetRelationsToEntitiesToBeDeleted();
+
+        assertFalse(config.getDbStack().isPresent());
     }
 }


### PR DESCRIPTION
Deletion (actually archival) of service-managed database servers by
redbeams now includes setting a correct deletion timestamp. This allows
database server names in an environment to be reused as expected.

This change temporarily removes one useful feature: archival of
databases in a database server when that server is deleted. However,
this will be restored by work in CB-3638.