### PR TITLE
Refactor of Public Endpoint Management service related logic

### DIFF
--- a/cluster-dns-connector/src/main/java/com/sequenceiq/cloudbreak/certificate/service/CertificateCreationService.java
+++ b/cluster-dns-connector/src/main/java/com/sequenceiq/cloudbreak/certificate/service/CertificateCreationService.java
@@ -44,14 +44,14 @@ public class CertificateCreationService {
     @Inject
     private EnvironmentBasedDomainNameProvider environmentBasedDomainNameProvider;
 
-    public List<String> create(String actorCrn, String accountId, String endpoint, String environment, boolean wildcard, KeyPair identity, String internalFQDN)
+    public List<String> create(String actorCrn, String accountId, String endpoint, String environment, boolean wildcard, KeyPair identity)
             throws IOException {
         LOGGER.info("Start cert creation");
         Optional<String> requestIdOptional = Optional.ofNullable(MDCBuilder.getMdcContextMap().get(LoggerContextKey.REQUEST_ID.toString()));
         UserManagementProto.Account account = grpcUmsClient.getAccountDetails(actorCrn, actorCrn, requestIdOptional);
         String externalFQDN = environmentBasedDomainNameProvider.getDomainName(endpoint, environment, account.getWorkloadSubdomain());
         LOGGER.info("Create cert for {}", externalFQDN);
-        PKCS10CertificationRequest csr = PkiUtil.csr(identity, externalFQDN, internalFQDN);
+        PKCS10CertificationRequest csr = PkiUtil.csr(identity, externalFQDN);
         String pollingRequestId = grpcClusterDnsClient
                 .createCertificate(actorCrn, accountId, endpoint, environment, wildcard, csr.getEncoded(), requestIdOptional);
         return polling(actorCrn, pollingRequestId);

--- a/cluster-dns-connector/src/main/java/com/sequenceiq/cloudbreak/certificate/service/CertificateCreationService.java
+++ b/cluster-dns-connector/src/main/java/com/sequenceiq/cloudbreak/certificate/service/CertificateCreationService.java
@@ -1,7 +1,5 @@
 package com.sequenceiq.cloudbreak.certificate.service;
 
-import static com.sequenceiq.cloudbreak.certificate.PkiUtil.csr;
-
 import java.io.IOException;
 import java.security.KeyPair;
 import java.util.List;
@@ -19,6 +17,7 @@ import org.springframework.stereotype.Service;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
 import com.dyngr.Polling;
 import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
+import com.sequenceiq.cloudbreak.certificate.PkiUtil;
 import com.sequenceiq.cloudbreak.certificate.poller.CreateCertificationPoller;
 import com.sequenceiq.cloudbreak.client.GrpcClusterDnsClient;
 import com.sequenceiq.cloudbreak.dns.EnvironmentBasedDomainNameProvider;
@@ -45,13 +44,14 @@ public class CertificateCreationService {
     @Inject
     private EnvironmentBasedDomainNameProvider environmentBasedDomainNameProvider;
 
-    public List<String> create(String actorCrn, String accountId, String endpoint, String environment, boolean wildcard, KeyPair identity) throws IOException {
+    public List<String> create(String actorCrn, String accountId, String endpoint, String environment, boolean wildcard, KeyPair identity, String internalFQDN)
+            throws IOException {
         LOGGER.info("Start cert creation");
         Optional<String> requestIdOptional = Optional.ofNullable(MDCBuilder.getMdcContextMap().get(LoggerContextKey.REQUEST_ID.toString()));
         UserManagementProto.Account account = grpcUmsClient.getAccountDetails(actorCrn, actorCrn, requestIdOptional);
-        String fullQualifiedDomainName = environmentBasedDomainNameProvider.getDomainName(endpoint, environment, account.getWorkloadSubdomain());
-        LOGGER.info("Create cert for {}", fullQualifiedDomainName);
-        PKCS10CertificationRequest csr = csr(identity, fullQualifiedDomainName);
+        String externalFQDN = environmentBasedDomainNameProvider.getDomainName(endpoint, environment, account.getWorkloadSubdomain());
+        LOGGER.info("Create cert for {}", externalFQDN);
+        PKCS10CertificationRequest csr = PkiUtil.csr(identity, externalFQDN, internalFQDN);
         String pollingRequestId = grpcClusterDnsClient
                 .createCertificate(actorCrn, accountId, endpoint, environment, wildcard, csr.getEncoded(), requestIdOptional);
         return polling(actorCrn, pollingRequestId);

--- a/cluster-dns-connector/src/test/java/com/sequenceiq/cloudbreak/component/CreateCertificationTest.java
+++ b/cluster-dns-connector/src/test/java/com/sequenceiq/cloudbreak/component/CreateCertificationTest.java
@@ -57,8 +57,7 @@ public class CreateCertificationTest {
                 "cluster-tb",
                 "env-tb",
                 false,
-                keyPair,
-                internalFQDN);
+                keyPair);
         LOGGER.info("CERT: \n" + String.join("\n", strings));
     }
 

--- a/cluster-dns-connector/src/test/java/com/sequenceiq/cloudbreak/component/CreateCertificationTest.java
+++ b/cluster-dns-connector/src/test/java/com/sequenceiq/cloudbreak/component/CreateCertificationTest.java
@@ -51,12 +51,14 @@ public class CreateCertificationTest {
         KeyPair keyPair = PkiUtil.generateKeypair();
         LOGGER.info("Key: \n{}", PkiUtil.convert(keyPair.getPrivate()));
         LOGGER.info("Pub: \n{}", PkiUtil.convert(keyPair.getPublic()));
+        String internalFQDN = "ip-10-97-110-78.cloudera.site";
         List<String> strings = certificateCreationService.create(actorCrn,
                 accountId,
                 "cluster-tb",
                 "env-tb",
                 false,
-                keyPair);
+                keyPair,
+                internalFQDN);
         LOGGER.info("CERT: \n" + String.join("\n", strings));
     }
 

--- a/common/src/main/java/com/sequenceiq/cloudbreak/certificate/PkiUtil.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/certificate/PkiUtil.java
@@ -28,13 +28,20 @@ import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.security.auth.x500.X500Principal;
 
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.StringUtils;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.ExtensionsGenerator;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.crypto.CryptoException;
@@ -60,6 +67,7 @@ import org.bouncycastle.pkcs.PKCS10CertificationRequestBuilder;
 import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.util.CollectionUtils;
 
 import com.google.common.io.BaseEncoding;
 
@@ -149,11 +157,15 @@ public class PkiUtil {
         }
     }
 
-    public static PKCS10CertificationRequest csr(KeyPair identity, String publicAddress) {
+    public static PKCS10CertificationRequest csr(KeyPair identity, String externalAddress, String internalFQDN) {
         try {
-            String name = String.format("C=US, CN=%s, O=Cloudera", publicAddress);
-            LOGGER.info("Generate CSR with X.500 distinguished name: '{}'", name);
-            return generateCsrWithName(identity, name);
+            String name = String.format("C=US, CN=%s, O=Cloudera", externalAddress);
+            List<String> sanList = List.of("localhost");
+            if (StringUtils.isNotEmpty(internalFQDN)) {
+                sanList = List.of(internalFQDN, "localhost");
+            }
+            LOGGER.info("Generate CSR with X.500 distinguished name: '{}' and list of SAN: '{}'", name, String.join(",", sanList));
+            return generateCsrWithName(identity, name, sanList);
         } catch (Exception e) {
             throw new PkiException("Failed to generate csr for the cluster!", e);
         }
@@ -249,15 +261,33 @@ public class PkiUtil {
 
     private static PKCS10CertificationRequest generateCsr(KeyPair identity, String publicAddress) throws Exception {
         String name = String.format("cn=%s", publicAddress);
-        return generateCsrWithName(identity, name);
+        return generateCsrWithName(identity, name, null);
     }
 
-    private static PKCS10CertificationRequest generateCsrWithName(KeyPair identity, String name) throws Exception {
+    private static PKCS10CertificationRequest generateCsrWithName(KeyPair identity, String name, List<String> sanList) throws Exception {
         X500Principal principal = new X500Principal(name);
         PKCS10CertificationRequestBuilder p10Builder = new JcaPKCS10CertificationRequestBuilder(principal, identity.getPublic());
+
+        if (!CollectionUtils.isEmpty(sanList)) {
+            p10Builder = addSubjectAlternativeNames(p10Builder, sanList);
+        }
+
         JcaContentSignerBuilder csBuilder = new JcaContentSignerBuilder("SHA256withRSA");
         ContentSigner signer = csBuilder.build(identity.getPrivate());
         return p10Builder.build(signer);
+    }
+
+    private static PKCS10CertificationRequestBuilder addSubjectAlternativeNames(PKCS10CertificationRequestBuilder p10Builder, List<String> sanList)
+            throws IOException {
+        GeneralName[] generalNames = sanList
+                .stream()
+                .map(address -> new GeneralName(GeneralName.dNSName, address))
+                .toArray(GeneralName[]::new);
+
+        GeneralNames subjectAltNames = new GeneralNames(generalNames);
+        ExtensionsGenerator extGen = new ExtensionsGenerator();
+        extGen.addExtension(Extension.subjectAlternativeName, false, subjectAltNames);
+        return p10Builder.addAttribute(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest, extGen.generate());
     }
 
     private static String convertToString(Object o) throws IOException {

--- a/common/src/main/java/com/sequenceiq/cloudbreak/certificate/PkiUtil.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/certificate/PkiUtil.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import javax.security.auth.x500.X500Principal;
 
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.lang3.StringUtils;
 import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
@@ -157,13 +156,13 @@ public class PkiUtil {
         }
     }
 
-    public static PKCS10CertificationRequest csr(KeyPair identity, String externalAddress, String internalFQDN) {
+    public static PKCS10CertificationRequest csr(KeyPair identity, String externalAddress) {
+        if (identity == null) {
+            throw new PkiException("Failed to generate CSR because KeyPair hasn't been specified for the method!");
+        }
         try {
             String name = String.format("C=US, CN=%s, O=Cloudera", externalAddress);
-            List<String> sanList = List.of("localhost");
-            if (StringUtils.isNotEmpty(internalFQDN)) {
-                sanList = List.of(internalFQDN, "localhost");
-            }
+            List<String> sanList = List.of();
             LOGGER.info("Generate CSR with X.500 distinguished name: '{}' and list of SAN: '{}'", name, String.join(",", sanList));
             return generateCsrWithName(identity, name, sanList);
         } catch (Exception e) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/ClusterCreationActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/ClusterCreationActions.java
@@ -99,6 +99,7 @@ public class ClusterCreationActions {
         return new AbstractStackCreationAction<>(HostMetadataSetupSuccess.class) {
             @Override
             protected void doExecute(StackContext context, HostMetadataSetupSuccess payload, Map<Object, Object> variables) {
+                clusterCreationService.generateCertAndDnsEntryForGateway(context.getStack());
                 clusterCreationService.mountDisks(context.getStack());
                 sendEvent(context);
             }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/ClusterCreationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/ClusterCreationService.java
@@ -75,7 +75,7 @@ public class ClusterCreationService {
 
     public void generateCertAndDnsEntryForGateway(Stack stack) {
         boolean success = gatewayPublicEndpointManagementService.generateCertAndSaveForStackAndUpdateDnsEntry(stack);
-        if (success) {
+        if (!success) {
             flowMessageService.fireEventAndLog(stack.getId(), Msg.STACK_GATEWAY_CERTIFICATE_CREATE_FAILED, UPDATE_IN_PROGRESS.name());
         }
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/ClusterCreationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/ClusterCreationService.java
@@ -24,6 +24,7 @@ import com.sequenceiq.cloudbreak.service.StackUpdater;
 import com.sequenceiq.cloudbreak.common.service.TransactionService.TransactionRuntimeExecutionException;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
 import com.sequenceiq.cloudbreak.service.cluster.flow.ClusterTerminationService;
+import com.sequenceiq.cloudbreak.service.gateway.GatewayPublicEndpointManagementService;
 import com.sequenceiq.cloudbreak.service.stack.flow.TerminationFailedException;
 import com.sequenceiq.cloudbreak.util.StackUtil;
 
@@ -49,6 +50,9 @@ public class ClusterCreationService {
     @Inject
     private StackUtil stackUtil;
 
+    @Inject
+    private GatewayPublicEndpointManagementService gatewayPublicEndpointManagementService;
+
     public void bootstrappingMachines(Stack stack) {
         stackUpdater.updateStackStatus(stack.getId(), DetailedStackStatus.BOOTSTRAPPING_MACHINES);
         flowMessageService.fireEventAndLog(stack.getId(), Msg.STACK_INFRASTRUCTURE_BOOTSTRAP, UPDATE_IN_PROGRESS.name());
@@ -67,6 +71,13 @@ public class ClusterCreationService {
     public void collectingHostMetadata(Stack stack) {
         stackUpdater.updateStackStatus(stack.getId(), DetailedStackStatus.COLLECTING_HOST_METADATA);
         flowMessageService.fireEventAndLog(stack.getId(), Msg.STACK_INFRASTRUCTURE_METADATA_SETUP, UPDATE_IN_PROGRESS.name());
+    }
+
+    public void generateCertAndDnsEntryForGateway(Stack stack) {
+        boolean success = gatewayPublicEndpointManagementService.generateCertAndSaveForStackAndUpdateDnsEntry(stack);
+        if (success) {
+            flowMessageService.fireEventAndLog(stack.getId(), Msg.STACK_GATEWAY_CERTIFICATE_CREATE_FAILED, UPDATE_IN_PROGRESS.name());
+        }
     }
 
     public void startingClusterServices(StackView stack) throws CloudbreakException {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/repair/master/ha/ChangePrimaryGatewayService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/repair/master/ha/ChangePrimaryGatewayService.java
@@ -27,9 +27,9 @@ import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.cloudbreak.service.GatewayConfigService;
 import com.sequenceiq.cloudbreak.service.StackUpdater;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
+import com.sequenceiq.cloudbreak.service.gateway.GatewayPublicEndpointManagementService;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
-import com.sequenceiq.cloudbreak.service.stack.flow.TlsSetupService;
 import com.sequenceiq.cloudbreak.util.StackUtil;
 
 @Component
@@ -62,7 +62,7 @@ public class ChangePrimaryGatewayService {
     private TransactionService transactionService;
 
     @Inject
-    private TlsSetupService tlsSetupService;
+    private GatewayPublicEndpointManagementService gatewayPublicEndpointManagementService;
 
     public void changePrimaryGatewayStarted(long stackId) {
         clusterService.updateClusterStatusByStackId(stackId, UPDATE_IN_PROGRESS);
@@ -93,8 +93,8 @@ public class ChangePrimaryGatewayService {
                 Cluster cluster = updatedStack.getCluster();
                 cluster.setClusterManagerIp(gatewayIp);
                 clusterService.save(cluster);
-                if (tlsSetupService.isCertGenerationEnabled()) {
-                    tlsSetupService.updateDnsEntry(updatedStack);
+                if (gatewayPublicEndpointManagementService.isCertGenerationEnabled()) {
+                    gatewayPublicEndpointManagementService.updateDnsEntry(updatedStack);
                 }
                 return null;
             });

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/action/StackCreationActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/action/StackCreationActions.java
@@ -230,7 +230,6 @@ public class StackCreationActions {
         return new AbstractStackCreationAction<>(GetSSHFingerprintsResult.class) {
             @Override
             protected void doExecute(StackContext context, GetSSHFingerprintsResult payload, Map<Object, Object> variables) throws Exception {
-                stackCreationService.generateCertAndSaveForStackAndUpdateDnsEntry(context.getStack());
                 stackCreationService.setupTls(context);
                 StackWithFingerprintsEvent fingerprintsEvent = new StackWithFingerprintsEvent(payload.getResourceId(), payload.getSshFingerprints());
                 sendEvent(context, StackCreationEvent.TLS_SETUP_FINISHED_EVENT.event(), fingerprintsEvent);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/termination/StackTerminationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/termination/StackTerminationService.java
@@ -2,8 +2,6 @@ package com.sequenceiq.cloudbreak.core.flow2.stack.termination;
 
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.DELETE_COMPLETED;
 
-import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 
 import javax.inject.Inject;
@@ -16,12 +14,10 @@ import org.springframework.stereotype.Service;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
-import com.sequenceiq.cloudbreak.certificate.service.DnsManagementService;
 import com.sequenceiq.cloudbreak.cloud.event.resource.TerminateStackResult;
 import com.sequenceiq.cloudbreak.common.type.BillingStatus;
 import com.sequenceiq.cloudbreak.core.flow2.stack.CloudbreakFlowMessageService;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
-import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.domain.view.StackView;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.cloudbreak.message.Msg;
@@ -29,11 +25,10 @@ import com.sequenceiq.cloudbreak.reactor.api.event.StackFailureEvent;
 import com.sequenceiq.cloudbreak.service.StackUpdater;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
 import com.sequenceiq.cloudbreak.service.datalake.DatalakeResourcesService;
-import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
+import com.sequenceiq.cloudbreak.service.gateway.GatewayPublicEndpointManagementService;
 import com.sequenceiq.cloudbreak.service.metrics.CloudbreakMetricService;
 import com.sequenceiq.cloudbreak.service.metrics.MetricType;
 import com.sequenceiq.cloudbreak.service.stack.flow.TerminationService;
-import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.FreeIpaV1Endpoint;
 
 @Service
@@ -69,10 +64,7 @@ public class StackTerminationService {
     private ThreadBasedUserCrnProvider threadBasedUserCrnProvider;
 
     @Inject
-    private DnsManagementService dnsManagementService;
-
-    @Inject
-    private EnvironmentClientService environmentClientService;
+    private GatewayPublicEndpointManagementService gatewayPublicEndpointManagementService;
 
     public void finishStackTermination(StackTerminationContext context, TerminateStackResult payload) {
         LOGGER.debug("Terminate stack result: {}", payload);
@@ -111,25 +103,7 @@ public class StackTerminationService {
         flowMessageService.fireEventAndLog(stackView.getId(), eventMessage, status.name(), stackUpdateMessage);
     }
 
-    public String deleteDnsEntry(Stack stack, String environmentName) {
-        String actorCrn = threadBasedUserCrnProvider.getUserCrn();
-        String accountId = threadBasedUserCrnProvider.getAccountId();
-        if (environmentName == null) {
-            DetailedEnvironmentResponse environment = environmentClientService.getByCrn(stack.getEnvironmentCrn());
-            environmentName = environment.getName();
-        }
-        Optional<InstanceMetaData> gateway = stack.getGatewayInstanceMetadata().stream()
-                .filter(it -> !it.isTerminated())
-                .findFirst();
-        if (!gateway.isPresent()) {
-            LOGGER.info("No running gateway or all node is terminated, we skip the dns entry deletion.");
-            return null;
-        }
-        String ip = gateway.get().getPublicIpWrapper();
-        if (ip == null) {
-            return null;
-        }
-        dnsManagementService.deleteDnsEntryWithIp(actorCrn, accountId, stack.getName(), environmentName, false, List.of(ip));
-        return ip;
+    public void deleteDnsEntry(Stack stack) {
+        gatewayPublicEndpointManagementService.deleteDnsEntry(stack, null);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/recipe/ClusterProxyDeregisterHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/recipe/ClusterProxyDeregisterHandler.java
@@ -54,7 +54,7 @@ public class ClusterProxyDeregisterHandler implements EventHandler<ClusterProxyD
                     LOGGER.warn("Cluster proxy deregister failed", ex);
                 }
             }
-            stackTerminationService.deleteDnsEntry(stack, null);
+            stackTerminationService.deleteDnsEntry(stack);
             result = new ClusterProxyDeregisterSuccess(stack.getId());
         } catch (Exception ex) {
             LOGGER.warn("Cluster proxy deregister failed", ex);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/gateway/GatewayPublicEndpointManagementService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/gateway/GatewayPublicEndpointManagementService.java
@@ -68,7 +68,10 @@ public class GatewayPublicEndpointManagementService {
 
     public boolean generateCertAndSaveForStackAndUpdateDnsEntry(Stack stack) {
         boolean certGeneratedAndSaved = false;
-        if (isCertGenerationEnabled() && stack.getCluster().getGateway() != null) {
+        if (isCertGenerationEnabled()
+                && stack != null
+                && stack.getCluster() != null
+                && stack.getCluster().getGateway() != null) {
             if (StringUtils.isEmpty(stack.getSecurityConfig().getUserFacingCert())) {
                 certGeneratedAndSaved = generateCertAndSaveForStack(stack);
                 if (certGeneratedAndSaved) {
@@ -150,10 +153,8 @@ public class GatewayPublicEndpointManagementService {
             }
         }
         try {
-            String internalFQDN = stack.getPrimaryGatewayInstance().getDiscoveryFQDN();
             DetailedEnvironmentResponse environment = environmentClientService.getByCrn(stack.getEnvironmentCrn());
-            List<String> certs = certificateCreationService.create(userCrn, accountId, stack.getName(), environment.getName(), false, keyPair,
-                    internalFQDN);
+            List<String> certs = certificateCreationService.create(userCrn, accountId, stack.getName(), environment.getName(), false, keyPair);
             securityConfig.setUserFacingCert(String.join("", certs));
             securityConfigService.save(securityConfig);
             success = true;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/gateway/GatewayPublicEndpointManagementService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/gateway/GatewayPublicEndpointManagementService.java
@@ -1,0 +1,181 @@
+package com.sequenceiq.cloudbreak.service.gateway;
+
+import java.security.KeyPair;
+import java.util.List;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
+import com.sequenceiq.cloudbreak.certificate.PkiUtil;
+import com.sequenceiq.cloudbreak.certificate.service.CertificateCreationService;
+import com.sequenceiq.cloudbreak.certificate.service.DnsManagementService;
+import com.sequenceiq.cloudbreak.dns.EnvironmentBasedDomainNameProvider;
+import com.sequenceiq.cloudbreak.domain.SecurityConfig;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.logger.LoggerContextKey;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
+import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
+import com.sequenceiq.cloudbreak.service.securityconfig.SecurityConfigService;
+import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
+
+@Service
+public class GatewayPublicEndpointManagementService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GatewayPublicEndpointManagementService.class);
+
+    @Value("${gateway.cert.generation.enabled:false}")
+    private boolean certGenerationEnabled;
+
+    @Inject
+    private EnvironmentClientService environmentClientService;
+
+    @Inject
+    private DnsManagementService dnsManagementService;
+
+    @Inject
+    private EnvironmentBasedDomainNameProvider environmentBasedDomainNameProvider;
+
+    @Inject
+    private GrpcUmsClient grpcUmsClient;
+
+    @Inject
+    private ThreadBasedUserCrnProvider threadBasedUserCrnProvider;
+
+    @Inject
+    private SecurityConfigService securityConfigService;
+
+    @Inject
+    private CertificateCreationService certificateCreationService;
+
+    @Inject
+    private ClusterService clusterService;
+
+    public boolean isCertGenerationEnabled() {
+        return certGenerationEnabled;
+    }
+
+    public boolean generateCertAndSaveForStackAndUpdateDnsEntry(Stack stack) {
+        boolean certGeneratedAndSaved = false;
+        if (isCertGenerationEnabled() && stack.getCluster().getGateway() != null) {
+            if (StringUtils.isEmpty(stack.getSecurityConfig().getUserFacingCert())) {
+                certGeneratedAndSaved = generateCertAndSaveForStack(stack);
+                if (certGeneratedAndSaved) {
+                    updateDnsEntryForCluster(stack);
+                }
+            } else {
+                LOGGER.info("CERT is already generated for stack, we don't generate a new one");
+                updateDnsEntryForCluster(stack);
+            }
+        } else {
+            LOGGER.info("Cert generation is disabled.");
+        }
+        return certGeneratedAndSaved;
+    }
+
+    public String updateDnsEntry(Stack stack) {
+        LOGGER.info("Update dns entry");
+        String userCrn = threadBasedUserCrnProvider.getUserCrn();
+        String accountId = threadBasedUserCrnProvider.getAccountId();
+        DetailedEnvironmentResponse environment = environmentClientService.getByCrn(stack.getEnvironmentCrn());
+
+        String ip = deleteDnsEntry(stack, environment.getName());
+        if (ip == null) {
+            return null;
+        }
+        boolean success = dnsManagementService.createDnsEntryWithIp(userCrn, accountId, stack.getName(), environment.getName(), false, List.of(ip));
+        if (success) {
+            try {
+                String fullQualifiedDomainName = environmentBasedDomainNameProvider
+                        .getDomainName(stack.getName(), environment.getName(), getWorkloadSubdomain(userCrn));
+                if (fullQualifiedDomainName != null) {
+                    LOGGER.info("Dns entry updated: ip: {}, FQDN: {}", ip, fullQualifiedDomainName);
+                    return fullQualifiedDomainName;
+                }
+            } catch (Exception e) {
+                LOGGER.info("Cannot generate fqdn: {}", e.getMessage(), e);
+            }
+        }
+        return null;
+    }
+
+    public String deleteDnsEntry(Stack stack, String environmentName) {
+        String actorCrn = threadBasedUserCrnProvider.getUserCrn();
+        String accountId = threadBasedUserCrnProvider.getAccountId();
+        if (StringUtils.isEmpty(environmentName)) {
+            DetailedEnvironmentResponse environment = environmentClientService.getByCrn(stack.getEnvironmentCrn());
+            environmentName = environment.getName();
+        }
+        Optional<InstanceMetaData> gateway = stack.getGatewayInstanceMetadata().stream()
+                .filter(it -> !it.isTerminated())
+                .findFirst();
+        if (gateway.isEmpty()) {
+            LOGGER.info("No running gateway or all node is terminated, we skip the dns entry deletion.");
+            return null;
+        }
+        String ip = gateway.get().getPublicIpWrapper();
+        if (ip == null) {
+            return null;
+        }
+        dnsManagementService.deleteDnsEntryWithIp(actorCrn, accountId, stack.getName(), environmentName, false, List.of(ip));
+        return ip;
+    }
+
+    private boolean generateCertAndSaveForStack(Stack stack) {
+        boolean success = false;
+        LOGGER.info("Generate cert and save for stack");
+        String userCrn = threadBasedUserCrnProvider.getUserCrn();
+        String accountId = threadBasedUserCrnProvider.getAccountId();
+        KeyPair keyPair;
+        SecurityConfig securityConfig = stack.getSecurityConfig();
+        if (StringUtils.isEmpty(securityConfig.getUserFacingKey())) {
+            keyPair = PkiUtil.generateKeypair();
+            securityConfig.setUserFacingKey(PkiUtil.convert(keyPair.getPrivate()));
+            securityConfig = securityConfigService.save(securityConfig);
+        } else {
+            keyPair = PkiUtil.fromPrivateKeyPem(securityConfig.getUserFacingKey());
+            if (keyPair == null) {
+                keyPair = PkiUtil.generateKeypair();
+            }
+        }
+        try {
+            String internalFQDN = stack.getPrimaryGatewayInstance().getDiscoveryFQDN();
+            DetailedEnvironmentResponse environment = environmentClientService.getByCrn(stack.getEnvironmentCrn());
+            List<String> certs = certificateCreationService.create(userCrn, accountId, stack.getName(), environment.getName(), false, keyPair,
+                    internalFQDN);
+            securityConfig.setUserFacingCert(String.join("", certs));
+            securityConfigService.save(securityConfig);
+            success = true;
+        } catch (Exception e) {
+            LOGGER.info("The cert could not be generated by Public Endpoint Management service: " + e.getMessage(), e);
+        }
+        return success;
+    }
+
+    private void updateDnsEntryForCluster(Stack stack) {
+        String fqdn = updateDnsEntry(stack);
+        if (fqdn != null) {
+            Cluster cluster = stack.getCluster();
+            cluster.setFqdn(fqdn);
+            clusterService.save(cluster);
+            LOGGER.info("The '{}' domain name has been generated, registered through PEM service and saved for the cluster.", fqdn);
+        }
+    }
+
+    private String getWorkloadSubdomain(String actorCrn) {
+        Optional<String> requestIdOptional = Optional.ofNullable(MDCBuilder.getMdcContextMap().get(LoggerContextKey.REQUEST_ID.toString()));
+        UserManagementProto.Account account = grpcUmsClient.getAccountDetails(actorCrn, actorCrn, requestIdOptional);
+        return account.getWorkloadSubdomain();
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/TlsSetupService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/TlsSetupService.java
@@ -2,11 +2,8 @@ package com.sequenceiq.cloudbreak.service.stack.flow;
 
 import static com.sequenceiq.cloudbreak.exception.NotFoundException.notFound;
 
-import java.security.KeyPair;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
-import java.util.List;
-import java.util.Optional;
 
 import javax.inject.Inject;
 import javax.net.ssl.SSLContext;
@@ -17,35 +14,20 @@ import javax.ws.rs.client.WebTarget;
 import org.glassfish.jersey.SslConfigurator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
-import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
 import com.google.common.io.BaseEncoding;
-import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
-import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
 import com.sequenceiq.cloudbreak.certificate.PkiUtil;
-import com.sequenceiq.cloudbreak.certificate.service.CertificateCreationService;
-import com.sequenceiq.cloudbreak.certificate.service.DnsManagementService;
 import com.sequenceiq.cloudbreak.client.CertificateTrustManager.SavingX509TrustManager;
 import com.sequenceiq.cloudbreak.client.RestClientUtil;
-import com.sequenceiq.cloudbreak.core.flow2.stack.termination.StackTerminationService;
-import com.sequenceiq.cloudbreak.dns.EnvironmentBasedDomainNameProvider;
-import com.sequenceiq.cloudbreak.domain.SecurityConfig;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
-import com.sequenceiq.cloudbreak.logger.LoggerContextKey;
-import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.cloudbreak.polling.PollingService;
 import com.sequenceiq.cloudbreak.polling.nginx.NginxCertListenerTask;
 import com.sequenceiq.cloudbreak.polling.nginx.NginxPollerObject;
 import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.cloudbreak.service.GatewayConfigService;
-import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
-import com.sequenceiq.cloudbreak.service.securityconfig.SecurityConfigService;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
-import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 
 @Component
 public class TlsSetupService {
@@ -58,9 +40,6 @@ public class TlsSetupService {
 
     private static final int MAX_FAILURE = 1;
 
-    @Value("${gateway.cert.generation.enabled:false}")
-    private boolean certGenerationEnabled;
-
     @Inject
     private PollingService<NginxPollerObject> nginxPollerService;
 
@@ -72,61 +51,6 @@ public class TlsSetupService {
 
     @Inject
     private InstanceMetaDataService instanceMetaDataService;
-
-    @Inject
-    private CertificateCreationService certificateCreationService;
-
-    @Inject
-    private ThreadBasedUserCrnProvider threadBasedUserCrnProvider;
-
-    @Inject
-    private SecurityConfigService securityConfigService;
-
-    @Inject
-    private EnvironmentClientService environmentClientService;
-
-    @Inject
-    private DnsManagementService dnsManagementService;
-
-    @Inject
-    private StackTerminationService stackTerminationService;
-
-    @Inject
-    private EnvironmentBasedDomainNameProvider environmentBasedDomainNameProvider;
-
-    @Inject
-    private GrpcUmsClient grpcUmsClient;
-
-    public boolean generateCertAndSaveForStack(Stack stack) {
-        boolean success = false;
-        LOGGER.info("Generate cert and save for stack");
-        String userCrn = threadBasedUserCrnProvider.getUserCrn();
-        String accountId = threadBasedUserCrnProvider.getAccountId();
-        KeyPair keyPair;
-        SecurityConfig securityConfig = stack.getSecurityConfig();
-        if (StringUtils.isEmpty(securityConfig.getUserFacingKey())) {
-            keyPair = PkiUtil.generateKeypair();
-            securityConfig.setUserFacingKey(PkiUtil.convert(keyPair.getPrivate()));
-            securityConfig = securityConfigService.save(securityConfig);
-        } else {
-            keyPair = PkiUtil.fromPrivateKeyPem(securityConfig.getUserFacingKey());
-            if (keyPair == null) {
-                keyPair = PkiUtil.generateKeypair();
-            }
-        }
-        try {
-            String internalFQDN = stack.getPrimaryGatewayInstance().getDiscoveryFQDN();
-            DetailedEnvironmentResponse environment = environmentClientService.getByCrn(stack.getEnvironmentCrn());
-            List<String> certs = certificateCreationService.create(userCrn, accountId, stack.getName(), environment.getName(), false, keyPair,
-                    internalFQDN);
-            securityConfig.setUserFacingCert(String.join("", certs));
-            securityConfigService.save(securityConfig);
-            success = true;
-        } catch (Exception e) {
-            LOGGER.info("The cert could not be generated by Public Endpoint Management service: " + e.getMessage(), e);
-        }
-        return success;
-    }
 
     public void setupTls(Stack stack, InstanceMetaData gwInstance) throws CloudbreakException {
         try {
@@ -157,41 +81,5 @@ public class TlsSetupService {
     private InstanceMetaData getInstanceMetaData(InstanceMetaData gwInstance) {
         return instanceMetaDataService.findById(gwInstance.getId())
                 .orElseThrow(notFound("Instance metadata", gwInstance.getId()));
-    }
-
-    public boolean isCertGenerationEnabled() {
-        return certGenerationEnabled;
-    }
-
-    public String updateDnsEntry(Stack stack) {
-        LOGGER.info("Update dns entry");
-        String userCrn = threadBasedUserCrnProvider.getUserCrn();
-        String accountId = threadBasedUserCrnProvider.getAccountId();
-        DetailedEnvironmentResponse environment = environmentClientService.getByCrn(stack.getEnvironmentCrn());
-
-        String ip = stackTerminationService.deleteDnsEntry(stack, environment.getName());
-        if (ip == null) {
-            return null;
-        }
-        boolean success = dnsManagementService.createDnsEntryWithIp(userCrn, accountId, stack.getName(), environment.getName(), false, List.of(ip));
-        if (success) {
-            try {
-                String fullQualifiedDomainName = environmentBasedDomainNameProvider
-                        .getDomainName(stack.getName(), environment.getName(), getWorkloadSubdomain(userCrn));
-                if (fullQualifiedDomainName != null) {
-                    LOGGER.info("Dns entry updated: ip: {}, FQDN: {}", ip, fullQualifiedDomainName);
-                    return fullQualifiedDomainName;
-                }
-            } catch (Exception e) {
-                LOGGER.info("Cannot generate fqdn: {}", e.getMessage(), e);
-            }
-        }
-        return null;
-    }
-
-    private String getWorkloadSubdomain(String actorCrn) {
-        Optional<String> requestIdOptional = Optional.ofNullable(MDCBuilder.getMdcContextMap().get(LoggerContextKey.REQUEST_ID.toString()));
-        UserManagementProto.Account account = grpcUmsClient.getAccountDetails(actorCrn, actorCrn, requestIdOptional);
-        return account.getWorkloadSubdomain();
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/TlsSetupService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/TlsSetupService.java
@@ -115,8 +115,10 @@ public class TlsSetupService {
             }
         }
         try {
+            String internalFQDN = stack.getPrimaryGatewayInstance().getDiscoveryFQDN();
             DetailedEnvironmentResponse environment = environmentClientService.getByCrn(stack.getEnvironmentCrn());
-            List<String> certs = certificateCreationService.create(userCrn, accountId, stack.getName(), environment.getName(), false, keyPair);
+            List<String> certs = certificateCreationService.create(userCrn, accountId, stack.getName(), environment.getName(), false, keyPair,
+                    internalFQDN);
             securityConfig.setUserFacingCert(String.join("", certs));
             securityConfigService.save(securityConfig);
             success = true;


### PR DESCRIPTION
Changes:
 - SAN support in CSR generation, which is now disabled as PEM doesn't support SANs
 - Separate the PEM service related logic into an individual service in core and call the `cluster-dns-connector` module from there
 - Move the new service to be wired after host metadata setup to internal FQDNs be available

The only refactor that needs to be done is to create a new flow step for this logic.