### PR TITLE
CB-3699. Add cdp binary usage event to mdc context

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/logger/MDCBuilder.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/logger/MDCBuilder.java
@@ -26,6 +26,14 @@ public class MDCBuilder {
         buildMdcContext(null);
     }
 
+    public static void addMdcField(String field, String value) {
+        MDC.put(field, value);
+    }
+
+    public static void removeMdcField(String field) {
+        MDC.remove(field);
+    }
+
     public static void addFlowId(String flowId) {
         MDC.put(LoggerContextKey.FLOW_ID.toString(), flowId);
     }

--- a/usage-collection/src/main/java/com/sequenceiq/cloudbreak/usage/LoggingUsageReporter.java
+++ b/usage-collection/src/main/java/com/sequenceiq/cloudbreak/usage/LoggingUsageReporter.java
@@ -1,20 +1,24 @@
 package com.sequenceiq.cloudbreak.usage;
 
-import com.cloudera.thunderhead.service.common.usage.UsageProto;
-import com.google.common.io.BaseEncoding;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.time.Instant;
 import java.util.UUID;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.cloudera.thunderhead.service.common.usage.UsageProto;
+import com.google.common.io.BaseEncoding;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 
 /**
  * A usage reporter that logs usage events.
  */
 public class LoggingUsageReporter implements UsageReporter {
     private static final Logger BINARY_EVENT_LOGGER = LoggerFactory.getLogger("CDP_BINARY_USAGE_EVENT");
+
+    private static final String USAGE_EVENT_MDC_NAME = "binaryUsageEvent";
 
     @Override
     public void cdpDatahubClusterRequested(long timestamp, UsageProto.CDPDatahubClusterRequested details) {
@@ -58,6 +62,9 @@ public class LoggingUsageReporter implements UsageReporter {
     }
 
     void log(UsageProto.Event event) {
-        BINARY_EVENT_LOGGER.info(BaseEncoding.base64().encode(event.toByteArray()));
+        String binaryUsageEvent = BaseEncoding.base64().encode(event.toByteArray());
+        MDCBuilder.addMdcField(USAGE_EVENT_MDC_NAME, binaryUsageEvent);
+        BINARY_EVENT_LOGGER.info(binaryUsageEvent);
+        MDCBuilder.removeMdcField(USAGE_EVENT_MDC_NAME);
     }
 }


### PR DESCRIPTION
cloudbreak_log_message is not used anymore for fluentd, we are producing json output on manowar, message field is used only for the full message.

usage collection requires only the message part of the log message in binary format, so im putting this to mdc context in a dynamic way (that is processed as a context field in EK index), so the new output would be like this for usage events:

logger: CDP_BINARY_USAGE_EVENT
context.requestId: \<request id\>
context.binaryUsageEvent: \<binary event\>