### PR TITLE
CB-3638 Delete service-managed dbs when server deleted

### DIFF
--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/database/responses/DatabaseV4Response.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/database/responses/DatabaseV4Response.java
@@ -3,6 +3,7 @@ package com.sequenceiq.redbeams.api.endpoint.v4.database.responses;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.sequenceiq.cloudbreak.service.secret.model.SecretResponse;
+import com.sequenceiq.redbeams.api.endpoint.v4.ResourceStatus;
 import com.sequenceiq.redbeams.api.endpoint.v4.database.base.DatabaseV4Base;
 import com.sequenceiq.redbeams.doc.ModelDescriptions;
 import com.sequenceiq.redbeams.doc.ModelDescriptions.Database;
@@ -34,6 +35,9 @@ public class DatabaseV4Response extends DatabaseV4Base {
 
     @ApiModelProperty(Database.PASSWORD)
     private SecretResponse connectionPassword;
+
+    @ApiModelProperty(Database.RESOURCE_STATUS)
+    private ResourceStatus resourceStatus;
 
     public Long getCreationDate() {
         return creationDate;
@@ -89,5 +93,13 @@ public class DatabaseV4Response extends DatabaseV4Base {
 
     public void setConnectionPassword(SecretResponse connectionPassword) {
         this.connectionPassword = connectionPassword;
+    }
+
+    public ResourceStatus getResourceStatus() {
+        return resourceStatus;
+    }
+
+    public void setResourceStatus(ResourceStatus resourceStatus) {
+        this.resourceStatus = resourceStatus;
     }
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/ModelDescriptions.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/ModelDescriptions.java
@@ -34,6 +34,7 @@ public final class ModelDescriptions {
         public static final String CREATE_RESULT = "Result of database creation";
         public static final String ENVIRONMENT_CRN = "CRN of the environment of the database";
         public static final String CREATION_DATE = "Creation date / time of the database, in epoch milliseconds";
+        public static final String RESOURCE_STATUS = "Ownership status of the database";
     }
 
     public static class DatabaseTest {

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/database/responses/DatabaseV4ResponseTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/database/responses/DatabaseV4ResponseTest.java
@@ -1,36 +1,42 @@
-package com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses;
+package com.sequenceiq.redbeams.api.endpoint.v4.database.responses;
 
 import static org.junit.Assert.assertEquals;
 
 import com.sequenceiq.cloudbreak.service.secret.model.SecretResponse;
 import com.sequenceiq.redbeams.api.endpoint.v4.ResourceStatus;
-import com.sequenceiq.redbeams.api.model.common.Status;
 
 import org.junit.Before;
 import org.junit.Test;
 
-public class DatabaseServerV4ResponseTest {
+public class DatabaseV4ResponseTest {
 
-    private DatabaseServerV4Response response;
+    private DatabaseV4Response response;
 
     @Before
     public void setUp() {
-        response = new DatabaseServerV4Response();
+        response = new DatabaseV4Response();
     }
 
     @Test
     public void testGettersAndSetters() {
-        response.setId(1L);
-        assertEquals(1L, response.getId().longValue());
+        response.setCrn("crn:mydb");
+        assertEquals("crn:mydb", response.getCrn());
 
-        response.setCrn("crn:myserver");
-        assertEquals("crn:myserver", response.getCrn());
+        response.setType("hive");
+        assertEquals("hive", response.getType());
 
-        response.setDatabaseVendorDisplayName("PostgreSQL");
-        assertEquals("PostgreSQL", response.getDatabaseVendorDisplayName());
+        long now = System.currentTimeMillis();
+        response.setCreationDate(now);
+        assertEquals(now, response.getCreationDate().longValue());
+
+        response.setDatabaseEngine("postgres");
+        assertEquals("postgres", response.getDatabaseEngine());
 
         response.setConnectionDriver("postgresql.jar");
         assertEquals("postgresql.jar", response.getConnectionDriver());
+
+        response.setDatabaseEngineDisplayName("PostgreSQL");
+        assertEquals("PostgreSQL", response.getDatabaseEngineDisplayName());
 
         SecretResponse username = new SecretResponse("engine", "username");
         response.setConnectionUserName(username);
@@ -40,18 +46,8 @@ public class DatabaseServerV4ResponseTest {
         response.setConnectionPassword(password);
         verifyEqualSecretResponses(password, response.getConnectionPassword());
 
-        long now = System.currentTimeMillis();
-        response.setCreationDate(now);
-        assertEquals(now, response.getCreationDate().longValue());
-
         response.setResourceStatus(ResourceStatus.USER_MANAGED);
         assertEquals(ResourceStatus.USER_MANAGED, response.getResourceStatus());
-
-        response.setStatus(Status.AVAILABLE);
-        assertEquals(Status.AVAILABLE, response.getStatus());
-
-        response.setStatusReason("because");
-        assertEquals("because", response.getStatusReason());
     }
 
     private static void verifyEqualSecretResponses(SecretResponse expected, SecretResponse actual) {

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/converter/database/DatabaseConfigToDatabaseV4ResponseConverter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/converter/database/DatabaseConfigToDatabaseV4ResponseConverter.java
@@ -25,6 +25,7 @@ public class DatabaseConfigToDatabaseV4ResponseConverter extends AbstractConvers
         json.setCreationDate(source.getCreationDate());
         json.setEnvironmentCrn(source.getEnvironmentId());
         json.setType(source.getType());
+        json.setResourceStatus(source.getStatus());
         return json;
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/domain/DatabaseConfig.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/domain/DatabaseConfig.java
@@ -216,6 +216,7 @@ public class DatabaseConfig implements ArchivableResource, AccountIdAwareResourc
 
     @Override
     public void unsetRelationsToEntitiesToBeDeleted() {
+        server = null;
     }
 
     public void setDeletionTimestamp(Long deletionTimestamp) {

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/domain/DatabaseServerConfig.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/domain/DatabaseServerConfig.java
@@ -20,6 +20,7 @@ import javax.persistence.UniqueConstraint;
 
 import org.hibernate.annotations.Where;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.common.archive.ArchivableResource;
@@ -244,6 +245,9 @@ public class DatabaseServerConfig implements ArchivableResource, AccountIdAwareR
     @Override
     public void unsetRelationsToEntitiesToBeDeleted() {
         dbStack = null;
+        if (databases != null) {
+            databases.clear();
+        }
     }
 
     public String getEnvironmentId() {
@@ -256,6 +260,11 @@ public class DatabaseServerConfig implements ArchivableResource, AccountIdAwareR
 
     public Set<DatabaseConfig> getDatabases() {
         return databases;
+    }
+
+    @VisibleForTesting
+    public void setDatabases(Set<DatabaseConfig> databases) {
+        this.databases = databases;
     }
 
     public Optional<DBStack> getDbStack() {

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigService.java
@@ -170,6 +170,20 @@ public class DatabaseServerConfigService extends AbstractArchivistService<Databa
         }
     }
 
+    @Override
+    public DatabaseServerConfig delete(DatabaseServerConfig resource) {
+        if (resource.getDatabases() != null) {
+            for (DatabaseConfig db : resource.getDatabases()) {
+                databaseConfigService.delete(db, true, true);
+            }
+        }
+
+        // Reload the entity so that we start without any referenced databases in it
+        // Otherwise, JPA/Hibernate pitches a fit
+        DatabaseServerConfig resourceToDelete = getByCrn(resource.getResourceCrn()).get();
+        return super.delete(resourceToDelete);
+    }
+
     public DatabaseServerConfig getByName(Long workspaceId, String environmentCrn, String name) {
         Optional<DatabaseServerConfig> resourceOpt = repository.findByNameAndWorkspaceIdAndEnvironmentId(name, workspaceId, environmentCrn);
         if (resourceOpt.isEmpty()) {

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/converter/database/DatabaseConfigToDatabaseV4ResponseConverterTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/converter/database/DatabaseConfigToDatabaseV4ResponseConverterTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import org.springframework.core.convert.ConversionService;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
+import com.sequenceiq.redbeams.api.endpoint.v4.ResourceStatus;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.redbeams.TestData;
 import com.sequenceiq.redbeams.api.endpoint.v4.database.responses.DatabaseV4Response;
@@ -62,6 +63,7 @@ public class DatabaseConfigToDatabaseV4ResponseConverterTest {
         databaseConfig.setDatabaseVendor(DatabaseVendor.MYSQL);
         databaseConfig.setType(TYPE);
         databaseConfig.setEnvironmentId(ENVIRONMENT_CRN);
+        databaseConfig.setStatus(ResourceStatus.SERVICE_MANAGED);
 
         DatabaseV4Response response = underTest.convert(databaseConfig);
 
@@ -76,5 +78,6 @@ public class DatabaseConfigToDatabaseV4ResponseConverterTest {
         assertEquals(DatabaseVendor.MYSQL.name(), response.getDatabaseEngine());
         assertEquals(TYPE, response.getType());
         assertEquals(ENVIRONMENT_CRN, response.getEnvironmentCrn());
+        assertEquals(ResourceStatus.SERVICE_MANAGED, response.getResourceStatus());
     }
 }

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/domain/DatabaseConfigTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/domain/DatabaseConfigTest.java
@@ -1,0 +1,89 @@
+package com.sequenceiq.redbeams.domain;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.redbeams.TestData;
+import com.sequenceiq.redbeams.api.endpoint.v4.ResourceStatus;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class DatabaseConfigTest {
+
+    private DatabaseConfig config;
+
+    @Before
+    public void setUp() {
+        config = new DatabaseConfig();
+    }
+
+    @Test
+    public void testGettersAndSetters() {
+        config.setId(1L);
+        assertEquals(1L, config.getId().longValue());
+
+        config.setAccountId("myaccount");
+        assertEquals("myaccount", config.getAccountId());
+
+        Crn crn = TestData.getTestCrn("database", "mydb");
+        config.setResourceCrn(crn);
+        assertEquals(crn, config.getResourceCrn());
+
+        config.setName("mydb");
+        assertEquals("mydb", config.getName());
+
+        config.setDescription("mine not yours");
+        assertEquals("mine not yours", config.getDescription());
+
+        config.setConnectionURL("jdbc:postgresql://myserver.db.example.com:5432");
+        assertEquals("jdbc:postgresql://myserver.db.example.com:5432", config.getConnectionURL());
+
+        config.setDatabaseVendor(DatabaseVendor.POSTGRES);
+        assertEquals(DatabaseVendor.POSTGRES, config.getDatabaseVendor());
+
+        config.setConnectionDriver("org.postgresql.Driver");
+        assertEquals("org.postgresql.Driver", config.getConnectionDriver());
+
+        config.setConnectionUserName("root");
+        assertEquals("root", config.getConnectionUserName().getRaw());
+
+        config.setConnectionPassword("cloudera");
+        assertEquals("cloudera", config.getConnectionPassword().getRaw());
+
+        long now = System.currentTimeMillis();
+        config.setCreationDate(now);
+        assertEquals(now, config.getCreationDate().longValue());
+
+        config.setStatus(ResourceStatus.SERVICE_MANAGED);
+        assertEquals(ResourceStatus.SERVICE_MANAGED, config.getStatus());
+
+        config.setType("hive");
+        assertEquals("hive", config.getType());
+
+        config.setArchived(true);
+        assertTrue(config.isArchived());
+
+        config.setDeletionTimestamp(2L);
+        assertEquals(2L, config.getDeletionTimestamp().longValue());
+
+        config.setEnvironmentId("myenvironment");
+        assertEquals("myenvironment", config.getEnvironmentId());
+
+        config.setServer(new DatabaseServerConfig());
+        assertNotNull(config.getServer());
+    }
+
+    @Test
+    public void testUnsetRelationsToEntitiesToBeDeleted() {
+        config.setServer(new DatabaseServerConfig());
+
+        config.unsetRelationsToEntitiesToBeDeleted();
+
+        assertNull(config.getServer());
+    }
+}

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/domain/DatabaseServerConfigTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/domain/DatabaseServerConfigTest.java
@@ -5,7 +5,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 
 import org.hibernate.annotations.Where;
 import org.junit.Before;
@@ -82,9 +84,6 @@ public class DatabaseServerConfigTest {
         config.setEnvironmentId("myenvironment");
         assertEquals("myenvironment", config.getEnvironmentId());
 
-        config.setResourceStatus(ResourceStatus.SERVICE_MANAGED);
-        assertEquals(ResourceStatus.SERVICE_MANAGED, config.getResourceStatus());
-
         config.setDbStack(new DBStack());
         assertTrue(config.getDbStack().isPresent());
     }
@@ -139,9 +138,13 @@ public class DatabaseServerConfigTest {
     @Test
     public void testUnsetRelationsToEntitiesToBeDeleted() {
         config.setDbStack(new DBStack());
+        Set<DatabaseConfig> databases = new HashSet<>();
+        databases.add(new DatabaseConfig());
+        config.setDatabases(databases);
 
         config.unsetRelationsToEntitiesToBeDeleted();
 
         assertFalse(config.getDbStack().isPresent());
+        assertTrue(config.getDatabases().isEmpty());
     }
 }

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigServiceTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigServiceTest.java
@@ -18,6 +18,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -307,6 +308,27 @@ public class DatabaseServerConfigServiceTest {
         when(repository.findByResourceCrn(SERVER_CRN)).thenReturn(Optional.empty());
 
         underTest.deleteByCrn(server.getResourceCrn().toString());
+    }
+
+    @Test
+    public void testDeleteCreatedServerWithDatabases() {
+        when(repository.findByResourceCrn(SERVER_CRN)).thenReturn(Optional.of(server));
+
+        server.setResourceStatus(ResourceStatus.SERVICE_MANAGED);
+
+        DatabaseConfig databaseConfig1 = new DatabaseConfig();
+        databaseConfig1.setId(1L);
+        DatabaseConfig databaseConfig2 = new DatabaseConfig();
+        databaseConfig2.setId(2L);
+        Set<DatabaseConfig> databases = new HashSet<>();
+        databases.add(databaseConfig1);
+        databases.add(databaseConfig2);
+        server.setDatabases(databases);
+
+        underTest.delete(server);
+
+        verify(databaseConfigService).delete(databaseConfig1, true, true);
+        verify(databaseConfigService).delete(databaseConfig2, true, true);
     }
 
     @Test


### PR DESCRIPTION
When a service-managed database server is deleted (as part of
deregistration after termination), the databases that were created by
redbeams on it are deleted first. Otherwise, deletion, which is actually
archival, happens as before.

Both DatabaseConfig and DatabaseServerConfig now have implementations of
the unsetRelationsToEntitiesToBeDeleted which clear out relations from
those entities to each other as part of the deletion (archival) process.

For simplicity, the DatabaseConfigService::deleteOne method is renamed
to simply delete, overriding but calling to its superclass
implementation. The full implementation of the method accepts a
skipDeletionOnServer flag, so that database deletion due to a database
server deletion does not try to contact the deleted server; at that
point, the database is already gone. The method also accepts a force
flag so that failure to delete a database on a server does not have to
fail the deletion attempt overall. (This mechanism isn't directly used
yet.)

Other changes:

* DatabaseV4Response gains a new resourceStatus field, for more
  information in the API.
* DatabaseConfigTest and DatabaseV4ResponseTest are added.
* DatabaseServerV4ResponseTest is slightly expanded.
* The unused method DatabaseConfigService::archive is removed.