### PR TITLE
CDPSDX-935 Fix invalid cluster CRNs from deleting wrong vault secrets

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/VaultPathBuilder.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/VaultPathBuilder.java
@@ -89,13 +89,8 @@ public class VaultPathBuilder {
     }
 
     public VaultPathBuilder withClusterCrn(String clusterCrn) {
-        this.clusterId = Optional.ofNullable(clusterCrn).map((String crnString) -> {
-            Crn crn = Crn.fromString(crnString);
-            if (crn == null) {
-                LOGGER.debug("An invalid cluster CRN was provided, it will be ignored.");
-                return null;
-            }
-            return crn.getResource();
+        this.clusterId = Optional.ofNullable(clusterCrn).map((String crn) -> {
+            return Crn.safeFromString(crn).getResource();
         });
         return this;
     }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/kerberosmgmt/VaultPathBuilderV1Test.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/kerberosmgmt/VaultPathBuilderV1Test.java
@@ -3,6 +3,7 @@ package com.sequenceiq.freeipa.kerberosmgmt;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import com.sequenceiq.cloudbreak.auth.altus.CrnParseException;
 import com.sequenceiq.freeipa.kerberosmgmt.v1.VaultPathBuilder;
 
 public class VaultPathBuilderV1Test {
@@ -11,6 +12,8 @@ public class VaultPathBuilderV1Test {
     private static final String ENVIRONMENT_ID = "crn:cdp:environments:us-west-1:f39af961-e0ce-4f79-826c-45502efb9ca3:environment:12345-6789";
 
     private static final String CLUSTER_ID = "crn:cdp:datalake:us-west-1:f39af961-e0ce-4f79-826c-45502efb9ca3:datalake:54321-9876";
+
+    private static final String INVALID_CRN = "Invalid Crn";
 
     private static final String HOST = "host1";
 
@@ -184,5 +187,15 @@ public class VaultPathBuilderV1Test {
                         .withAccountId(ACCOUNT_ID)
                         .withSubType(VaultPathBuilder.SecretSubType.KEYTAB)
                         .build());
+    }
+
+    @Test
+    public void testInvalidCrn() throws Exception {
+        Assertions.assertThrows(CrnParseException.class,
+                () -> new VaultPathBuilder()
+                        .withEnvironmentCrn(INVALID_CRN));
+        Assertions.assertThrows(CrnParseException.class,
+                () -> new VaultPathBuilder()
+                        .withEnvironmentCrn(INVALID_CRN));
     }
 }


### PR DESCRIPTION
If a cluster CRN which was formatted in an invalid way was provided
to the cleanup cluster secrets API, previously all secrets for the
entire environment would be deleted. This fix throws exceptions when
and invalid CRN is provided.

Testing was performed manually using a local deployment of cloudbreak
and unit tests were added.

In https://github.com/hortonworks/cloudbreak/pull/6093, there was a discussion about whether or not we should throw exceptions for invalid CRNs. At the time, the thought was to require a valid CRN for the environment since it must match and to ignore invalid cluster CRNs since it was optional. The problem with ignoring the invalid CRN is that recursive deletes will now delete a vault path which does not have the CRN so it will delete the secrets from all CRNs. Additionally, I looked at the logs since we added the logging about a month ago, and the only times invalid CRNs were actually being used was by the test team. So this should not affect anyone that is using the API in the MOW-dev environment.

Closes #CDPSDX-935