### PR TITLE
CB-3734 - Instantiating CM tasks instead of using them as services

### DIFF
--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/polling/PollingService.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/polling/PollingService.java
@@ -25,7 +25,7 @@ public class PollingService<T> {
         return pollWithTimeout(statusCheckerTask, t, interval, new AttemptBasedTimeoutChecker(maxAttempts), maxFailure);
     }
 
-    public Pair<PollingResult, Exception> pollWithAbsolutTimeout(StatusCheckerTask<T> statusCheckerTask, T t, long interval, long waitSec, int maxFailure) {
+    public Pair<PollingResult, Exception> pollWithAbsoluteTimeout(StatusCheckerTask<T> statusCheckerTask, T t, long interval, long waitSec, int maxFailure) {
         return pollWithTimeout(statusCheckerTask, t, interval, new AbsolutTimeBasedTimeoutChecker(waitSec), maxFailure);
     }
 
@@ -69,7 +69,7 @@ public class PollingService<T> {
     }
 
     public PollingResult pollWithTimeoutSingleFailure(StatusCheckerTask<T> statusCheckerTask, T t, int interval, int maxAttempts) {
-        return pollWithTimeout(statusCheckerTask, t, interval, maxAttempts, 1).getLeft();
+        return pollWithAbsoluteTimeout(statusCheckerTask, t, interval, maxAttempts, 1).getLeft();
     }
 
     private void sleep(long duration) {

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerDecomissioner.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerDecomissioner.java
@@ -177,7 +177,7 @@ public class ClouderaManagerDecomissioner {
             ClouderaManagerResourceApi apiInstance = new ClouderaManagerResourceApi(client);
             ApiHostNameList body = new ApiHostNameList().items(stillAvailableRemovableHosts);
             ApiCommand apiCommand = apiInstance.hostsDecommissionCommand(body);
-            PollingResult pollingResult = clouderaManagerPollingServiceProvider.decommissionHostPollingService(stack, client, apiCommand.getId());
+            PollingResult pollingResult = clouderaManagerPollingServiceProvider.startPollingCmHostDecommissioning(stack, client, apiCommand.getId());
             if (isExited(pollingResult)) {
                 throw new CancellationException("Cluster was terminated while waiting for host decommission");
             } else if (isTimeout(pollingResult)) {
@@ -250,7 +250,7 @@ public class ClouderaManagerDecomissioner {
             ApiHostNameList body = new ApiHostNameList().addItemsItem(hostMetadata.getHostName());
             try {
                 ApiCommand apiCommand = apiInstance.hostsDecommissionCommand(body);
-                PollingResult pollingResult = clouderaManagerPollingServiceProvider.decommissionHostPollingService(stack, client, apiCommand.getId());
+                PollingResult pollingResult = clouderaManagerPollingServiceProvider.startPollingCmHostDecommissioning(stack, client, apiCommand.getId());
                 if (isExited(pollingResult)) {
                     throw new CancellationException("Cluster was terminated while waiting for host decommission");
                 } else if (isTimeout(pollingResult)) {
@@ -288,7 +288,7 @@ public class ClouderaManagerDecomissioner {
         ClouderaManagerResourceApi clouderaManagerResourceApi = new ClouderaManagerResourceApi(client);
         try {
             ApiCommand command = clouderaManagerResourceApi.deleteCredentialsCommand("unused");
-            clouderaManagerPollingServiceProvider.kerberosConfigurePollingService(stack, client, command.getId());
+            clouderaManagerPollingServiceProvider.startPollingCmKerberosJob(stack, client, command.getId());
         } catch (ApiException e) {
             LOGGER.error("Failed to delete credentials of host: {}", data.getHostName(), e);
             throw new CloudbreakServiceException(e.getMessage(), e);
@@ -339,7 +339,7 @@ public class ClouderaManagerDecomissioner {
     public void stopAndRemoveMgmtService(Stack stack, ApiClient client) {
         MgmtServiceResourceApi mgmtServiceResourceApi = new MgmtServiceResourceApi(client);
         try {
-            clouderaManagerPollingServiceProvider.stopManagementServicePollingService(stack,
+            clouderaManagerPollingServiceProvider.startPollingCmManagementServiceShutdown(stack,
                     client, mgmtServiceResourceApi.stopCommand().getId());
             mgmtServiceResourceApi.deleteCMS();
         } catch (ApiException e) {

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerKerberosService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerKerberosService.java
@@ -56,11 +56,11 @@ public class ClouderaManagerKerberosService {
             modificationService.stopCluster();
             ClustersResourceApi clustersResourceApi = clouderaManagerClientFactory.getClustersResourceApi(client);
             ApiCommand configureForKerberos = clustersResourceApi.configureForKerberos(cluster.getName(), new ApiConfigureForKerberosArguments());
-            clouderaManagerPollingServiceProvider.kerberosConfigurePollingService(stack, client, configureForKerberos.getId());
+            clouderaManagerPollingServiceProvider.startPollingCmKerberosJob(stack, client, configureForKerberos.getId());
             ApiCommand generateCredentials = clouderaManagerResourceApi.generateCredentialsCommand();
-            clouderaManagerPollingServiceProvider.kerberosConfigurePollingService(stack, client, generateCredentials.getId());
+            clouderaManagerPollingServiceProvider.startPollingCmKerberosJob(stack, client, generateCredentials.getId());
             ApiCommand deployClusterConfig = clustersResourceApi.deployClientConfig(cluster.getName());
-            clouderaManagerPollingServiceProvider.kerberosConfigurePollingService(stack, client, deployClusterConfig.getId());
+            clouderaManagerPollingServiceProvider.startPollingCmKerberosJob(stack, client, deployClusterConfig.getId());
             modificationService.startCluster(Collections.emptySet());
         }
     }
@@ -76,7 +76,7 @@ public class ClouderaManagerKerberosService {
             decomissionService.removeManagementServices();
 
             ApiCommand command = apiInstance.deleteCredentialsCommand("all");
-            clouderaManagerPollingServiceProvider.kerberosConfigurePollingService(stack, client, command.getId());
+            clouderaManagerPollingServiceProvider.startPollingCmKerberosJob(stack, client, command.getId());
         } catch (ApiException | CloudbreakException e) {
             LOGGER.info("Failed to remove Kerberos credentials", e);
             throw new ClouderaManagerOperationFailedException("Failed to remove Kerberos credentials", e);

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerMgmtSetupService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerMgmtSetupService.java
@@ -141,7 +141,7 @@ public class ClouderaManagerMgmtSetupService {
     private Consumer<BigDecimal> pollCredentialGeneration(Stack stack, ApiClient client) {
         return id -> {
             LOGGER.debug("Generate Credentials command is still active.");
-            clouderaManagerPollingServiceProvider.generateCredentialsPollingService(stack, client, id);
+            clouderaManagerPollingServiceProvider.startPollingCmGenerateCredentials(stack, client, id);
         };
     }
 
@@ -169,7 +169,7 @@ public class ClouderaManagerMgmtSetupService {
         } else if (mgmtService.getServiceState() != ApiServiceState.STARTED) {
             startCommand = Optional.of(mgmtServiceResourceApi.startCommand());
         }
-        startCommand.ifPresent(sc -> clouderaManagerPollingServiceProvider.startManagementServicePollingService(stack, client, sc.getId()));
+        startCommand.ifPresent(sc -> clouderaManagerPollingServiceProvider.startPollingCmManagementServiceStartup(stack, client, sc.getId()));
     }
 
     private void setupCMS(MgmtServiceResourceApi mgmtServiceResourceApi, ApiService mgmtService) throws ApiException {

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerRoleRefreshService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerRoleRefreshService.java
@@ -50,7 +50,7 @@ class ClouderaManagerRoleRefreshService {
     }
 
     private void pollingRefresh(ApiCommand command, ApiClient client, Stack stack) throws CloudbreakException {
-        PollingResult pollingResult = clouderaManagerPollingServiceProvider.refreshClusterPollingService(stack, client, command.getId());
+        PollingResult pollingResult = clouderaManagerPollingServiceProvider.startPollingCmConfigurationRefresh(stack, client, command.getId());
         if (isExited(pollingResult)) {
             throw new CancellationException("Cluster was terminated while waiting for cluster refresh");
         } else if (isTimeout(pollingResult)) {
@@ -74,7 +74,7 @@ class ClouderaManagerRoleRefreshService {
     private Consumer<BigDecimal> pollCredentialGeneration(Stack stack, ApiClient client) {
         return id -> {
             LOGGER.debug("Generate Credentials command is still active.");
-            clouderaManagerPollingServiceProvider.generateCredentialsPollingService(stack, client, id);
+            clouderaManagerPollingServiceProvider.startPollingCmGenerateCredentials(stack, client, id);
         };
     }
 }

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerSetupService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerSetupService.java
@@ -122,7 +122,7 @@ public class ClouderaManagerSetupService implements ClusterSetupService {
         } catch (ClouderaManagerClientInitException e) {
             throw new ClusterClientInitException(e);
         }
-        PollingResult pollingResult = clouderaManagerPollingServiceProvider.clouderaManagerStartupPollerObjectPollingService(stack, client);
+        PollingResult pollingResult = clouderaManagerPollingServiceProvider.startPollingCmStartup(stack, client);
         if (isSuccess(pollingResult)) {
             LOGGER.debug("Cloudera Manager server has successfully started! Polling result: {}", pollingResult);
         } else if (isExited(pollingResult)) {
@@ -231,7 +231,7 @@ public class ClouderaManagerSetupService implements ClusterSetupService {
                 throw new ClouderaManagerOperationFailedException(msg, e);
             }
         }
-        clusterInstallCommand.ifPresent(cmd -> clouderaManagerPollingServiceProvider.templateInstallCheckerService(stack, client, cmd.getId()));
+        clusterInstallCommand.ifPresent(cmd -> clouderaManagerPollingServiceProvider.startPollingCmTemplateInstallation(stack, client, cmd.getId()));
     }
 
     private void removeRemoteParcelRepos(ClouderaManagerResourceApi clouderaManagerResourceApi) {
@@ -248,7 +248,7 @@ public class ClouderaManagerSetupService implements ClusterSetupService {
     private void refreshParcelRepos(ClouderaManagerResourceApi clouderaManagerResourceApi) {
         try {
             ApiCommand apiCommand = clouderaManagerResourceApi.refreshParcelRepos();
-            clouderaManagerPollingServiceProvider.parcelRepoRefreshCheckerService(stack, client, apiCommand.getId());
+            clouderaManagerPollingServiceProvider.startPollingCmParcelRepositoryRefresh(stack, client, apiCommand.getId());
         } catch (ApiException e) {
             LOGGER.info("Unable to refresh parcel repo", e);
             throw new CloudbreakServiceException(e);
@@ -279,7 +279,7 @@ public class ClouderaManagerSetupService implements ClusterSetupService {
         } catch (ClouderaManagerClientInitException e) {
             throw new ClusterClientInitException(e);
         }
-        clouderaManagerPollingServiceProvider.hostsPollingService(stack, client);
+        clouderaManagerPollingServiceProvider.startPollingCmHostStatus(stack, client);
     }
 
     @Override

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerApplyHostTemplateListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerApplyHostTemplateListenerTask.java
@@ -1,11 +1,8 @@
 package com.sequenceiq.cloudbreak.cm.polling.task;
 
-import org.springframework.stereotype.Service;
-
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 
-@Service
 public class ClouderaManagerApplyHostTemplateListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     @Override

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerDecommissionHostListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerDecommissionHostListenerTask.java
@@ -1,11 +1,8 @@
 package com.sequenceiq.cloudbreak.cm.polling.task;
 
-import org.springframework.stereotype.Service;
-
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 
-@Service
 public class ClouderaManagerDecommissionHostListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     @Override

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerDeployClientConfigListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerDeployClientConfigListenerTask.java
@@ -1,11 +1,8 @@
 package com.sequenceiq.cloudbreak.cm.polling.task;
 
-import org.springframework.stereotype.Service;
-
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 
-@Service
 public class ClouderaManagerDeployClientConfigListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     @Override

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerGenerateCredentialsListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerGenerateCredentialsListenerTask.java
@@ -1,11 +1,8 @@
 package com.sequenceiq.cloudbreak.cm.polling.task;
 
-import org.springframework.stereotype.Service;
-
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 
-@Service
 public class ClouderaManagerGenerateCredentialsListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     @Override

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerHostStatusChecker.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerHostStatusChecker.java
@@ -5,7 +5,6 @@ import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Service;
 
 import com.cloudera.api.swagger.HostsResourceApi;
 import com.cloudera.api.swagger.client.ApiClient;
@@ -17,7 +16,6 @@ import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 
-@Service
 public class ClouderaManagerHostStatusChecker extends ClusterBasedStatusCheckerTask<ClouderaManagerPollerObject> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerHostStatusChecker.class);

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerKerberosConfigureListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerKerberosConfigureListenerTask.java
@@ -1,11 +1,8 @@
 package com.sequenceiq.cloudbreak.cm.polling.task;
 
-import org.springframework.stereotype.Service;
-
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 
-@Service
 public class ClouderaManagerKerberosConfigureListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     @Override

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerParcelActivationListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerParcelActivationListenerTask.java
@@ -8,11 +8,8 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import javax.inject.Inject;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Service;
 
 import com.cloudera.api.swagger.ParcelsResourceApi;
 import com.cloudera.api.swagger.client.ApiClient;
@@ -30,15 +27,17 @@ import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterComponent;
 
-@Service
 public class ClouderaManagerParcelActivationListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerParcelActivationListenerTask.class);
 
     private static final String PARCEL_ACTIVATED_STAGE = "ACTIVATED";
 
-    @Inject
-    private ClouderaManagerClientFactory clouderaManagerClientFactory;
+    private final ClouderaManagerClientFactory clouderaManagerClientFactory;
+
+    public ClouderaManagerParcelActivationListenerTask(ClouderaManagerClientFactory clouderaManagerClientFactory) {
+        this.clouderaManagerClientFactory = clouderaManagerClientFactory;
+    }
 
     @Override
     public boolean checkStatus(ClouderaManagerCommandPollerObject clouderaManagerPollerObject) {

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerParcelRepositoryRefreshChecker.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerParcelRepositoryRefreshChecker.java
@@ -2,15 +2,13 @@ package com.sequenceiq.cloudbreak.cm.polling.task;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 
-@Service
-public class ClouderaManagerParcelRepoChecker extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
+public class ClouderaManagerParcelRepositoryRefreshChecker extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerParcelRepoChecker.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerParcelRepositoryRefreshChecker.class);
 
     @Override
     public void handleTimeout(ClouderaManagerCommandPollerObject clouderaManagerPollerObject) {

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerRefreshServiceConfigsListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerRefreshServiceConfigsListenerTask.java
@@ -1,11 +1,8 @@
 package com.sequenceiq.cloudbreak.cm.polling.task;
 
-import org.springframework.stereotype.Service;
-
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 
-@Service
 public class ClouderaManagerRefreshServiceConfigsListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     @Override

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerRestartServicesListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerRestartServicesListenerTask.java
@@ -1,11 +1,8 @@
 package com.sequenceiq.cloudbreak.cm.polling.task;
 
-import org.springframework.stereotype.Service;
-
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 
-@Service
 public class ClouderaManagerRestartServicesListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     @Override

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerServiceStartListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerServiceStartListenerTask.java
@@ -1,11 +1,8 @@
 package com.sequenceiq.cloudbreak.cm.polling.task;
 
-import org.springframework.stereotype.Service;
-
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 
-@Service
 public class ClouderaManagerServiceStartListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     @Override

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerStartManagementServiceListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerStartManagementServiceListenerTask.java
@@ -3,9 +3,6 @@ package com.sequenceiq.cloudbreak.cm.polling.task;
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 
-import org.springframework.stereotype.Service;
-
-@Service
 public class ClouderaManagerStartManagementServiceListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     @Override

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerStartupListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerStartupListenerTask.java
@@ -5,7 +5,6 @@ import static org.apache.commons.lang3.StringUtils.containsIgnoreCase;
 import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Service;
 
 import com.cloudera.api.swagger.ToolsResourceApi;
 import com.cloudera.api.swagger.client.ApiClient;
@@ -15,7 +14,6 @@ import com.sequenceiq.cloudbreak.cluster.service.ClusterBasedStatusCheckerTask;
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
 
-@Service
 public class ClouderaManagerStartupListenerTask extends ClusterBasedStatusCheckerTask<ClouderaManagerPollerObject> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerStartupListenerTask.class);

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerStopListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerStopListenerTask.java
@@ -1,11 +1,8 @@
 package com.sequenceiq.cloudbreak.cm.polling.task;
 
-import org.springframework.stereotype.Service;
-
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 
-@Service
 public class ClouderaManagerStopListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     @Override

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerStopManagementServiceListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerStopManagementServiceListenerTask.java
@@ -1,11 +1,8 @@
 package com.sequenceiq.cloudbreak.cm.polling.task;
 
-import org.springframework.stereotype.Service;
-
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 
-@Service
 public class ClouderaManagerStopManagementServiceListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     @Override

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerTemplateInstallationChecker.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerTemplateInstallationChecker.java
@@ -7,12 +7,9 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import javax.inject.Inject;
-
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Service;
 
 import com.cloudera.api.swagger.CommandsResourceApi;
 import com.cloudera.api.swagger.client.ApiClient;
@@ -23,13 +20,15 @@ import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerClientFactory;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 
-@Service
-public class ClouderaManagerTemplateInstallChecker extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
+public class ClouderaManagerTemplateInstallationChecker extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerTemplateInstallChecker.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerTemplateInstallationChecker.class);
 
-    @Inject
-    private ClouderaManagerClientFactory clouderaManagerClientFactory;
+    private final ClouderaManagerClientFactory clouderaManagerClientFactory;
+
+    public ClouderaManagerTemplateInstallationChecker(ClouderaManagerClientFactory clouderaManagerClientFactory) {
+        this.clouderaManagerClientFactory = clouderaManagerClientFactory;
+    }
 
     @Override
     public boolean checkStatus(ClouderaManagerCommandPollerObject pollerObject) {

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerKerberosServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerKerberosServiceTest.java
@@ -104,8 +104,8 @@ public class ClouderaManagerKerberosServiceTest {
         underTest.configureKerberosViaApi(client, clientConfig, stack, kerberosConfig);
 
         verify(modificationService).stopCluster();
-        verify(clouderaManagerPollingServiceProvider).kerberosConfigurePollingService(stack, client, BigDecimal.TEN);
-        verify(clouderaManagerPollingServiceProvider).kerberosConfigurePollingService(stack, client, BigDecimal.ZERO);
+        verify(clouderaManagerPollingServiceProvider).startPollingCmKerberosJob(stack, client, BigDecimal.TEN);
+        verify(clouderaManagerPollingServiceProvider).startPollingCmKerberosJob(stack, client, BigDecimal.ZERO);
         verify(clustersResourceApi).deployClientConfig(cluster.getName());
         verify(modificationService).startCluster(anySet());
     }
@@ -117,6 +117,6 @@ public class ClouderaManagerKerberosServiceTest {
         underTest.deleteCredentials(client, clientConfig, stack);
 
         verify(modificationService).stopCluster();
-        clouderaManagerPollingServiceProvider.kerberosConfigurePollingService(stack, client, BigDecimal.ZERO);
+        clouderaManagerPollingServiceProvider.startPollingCmKerberosJob(stack, client, BigDecimal.ZERO);
     }
 }

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationServiceTest.java
@@ -161,7 +161,7 @@ class ClouderaManagerModificationServiceTest {
 
         when(clouderaManagerClientFactory.getClouderaManagerResourceApi(any())).thenReturn(clouderaManagerResourceApi);
         when(clouderaManagerResourceApi.refreshParcelRepos()).thenReturn(new ApiCommand().id(REFRESH_PARCEL_REPOS_ID));
-        when(clouderaManagerPollingServiceProvider.deployClientConfigPollingService(stack, apiClientMock, REFRESH_PARCEL_REPOS_ID))
+        when(clouderaManagerPollingServiceProvider.startPollingCmClientConfigDeployment(stack, apiClientMock, REFRESH_PARCEL_REPOS_ID))
                 .thenReturn(PollingResult.SUCCESS);
         when(clusterComponentProvider.getClouderaManagerRepoDetails(CLUSTER_ID)).thenReturn(null);
         setUpListClusterHosts();
@@ -232,7 +232,7 @@ class ClouderaManagerModificationServiceTest {
         when(clouderaManagerClientFactory.getHostTemplatesResourceApi(eq(apiClientMock))).thenReturn(hostTemplatesResourceApi);
 
         PollingResult applyTemplatePollingResult = PollingResult.SUCCESS;
-        when(clouderaManagerPollingServiceProvider.applyHostTemplatePollingService(eq(stack), eq(apiClientMock), eq(applyHostTemplateCommandId)))
+        when(clouderaManagerPollingServiceProvider.startPollingCmApplyHostTemplate(eq(stack), eq(apiClientMock), eq(applyHostTemplateCommandId)))
                 .thenReturn(applyTemplatePollingResult);
 
         underTest.upscaleCluster(hostGroup, hostMetadataList, instaneMetadata);
@@ -256,14 +256,14 @@ class ClouderaManagerModificationServiceTest {
         BigDecimal restartMgmtCommandId = new BigDecimal(300);
         when(mgmtServiceResourceApi.restartCommand()).thenReturn(new ApiCommand().id(restartMgmtCommandId));
         PollingResult restartMgmtCommandResult = PollingResult.SUCCESS;
-        when(clouderaManagerPollingServiceProvider.restartServicesPollingService(eq(stack), eq(apiClientMock), eq(restartMgmtCommandId)))
+        when(clouderaManagerPollingServiceProvider.startPollingCmServicesRestart(eq(stack), eq(apiClientMock), eq(restartMgmtCommandId)))
                 .thenReturn(restartMgmtCommandResult);
 
         ArgumentCaptor<ApiRestartClusterArgs> apiRestartClusterArgs = ArgumentCaptor.forClass(ApiRestartClusterArgs.class);
         BigDecimal restartClusterCommandId = new BigDecimal(400);
         when(clustersResourceApi.restartCommand(eq(STACK_NAME), apiRestartClusterArgs.capture())).thenReturn(new ApiCommand().id(restartClusterCommandId));
         PollingResult restartClusterCommandResult = PollingResult.SUCCESS;
-        when(clouderaManagerPollingServiceProvider.restartServicesPollingService(eq(stack), eq(apiClientMock), eq(restartClusterCommandId)))
+        when(clouderaManagerPollingServiceProvider.startPollingCmServicesRestart(eq(stack), eq(apiClientMock), eq(restartClusterCommandId)))
                 .thenReturn(restartClusterCommandResult);
         return apiRestartClusterArgs;
     }
@@ -279,7 +279,7 @@ class ClouderaManagerModificationServiceTest {
         BigDecimal deployClientCommandId = new BigDecimal(100);
         when(clustersResourceApi.deployClientConfig(eq(STACK_NAME))).thenReturn(new ApiCommand().id(deployClientCommandId));
 
-        when(clouderaManagerPollingServiceProvider.deployClientConfigPollingService(eq(stack), eq(apiClientMock), eq(deployClientCommandId)))
+        when(clouderaManagerPollingServiceProvider.startPollingCmClientConfigDeployment(eq(stack), eq(apiClientMock), eq(deployClientCommandId)))
                 .thenReturn(success);
     }
 }

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerRoleRefreshServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerRoleRefreshServiceTest.java
@@ -55,13 +55,13 @@ public class ClouderaManagerRoleRefreshServiceTest {
         when(clouderaManagerResourceApi.listActiveCommands(DataView.SUMMARY.name())).thenReturn(apiCommandList);
         when(clouderaManagerClientFactory.getClustersResourceApi(apiClient)).thenReturn(clustersResourceApi);
         when(clustersResourceApi.refresh(CLUSTER_NAME)).thenReturn(apiCommand);
-        when(clouderaManagerPollingServiceProvider.refreshClusterPollingService(stack, apiClient, COMMAND_ID)).thenReturn(PollingResult.SUCCESS);
+        when(clouderaManagerPollingServiceProvider.startPollingCmConfigurationRefresh(stack, apiClient, COMMAND_ID)).thenReturn(PollingResult.SUCCESS);
 
         underTest.refreshClusterRoles(apiClient, stack);
 
-        verify(clouderaManagerPollingServiceProvider).refreshClusterPollingService(stack, apiClient, COMMAND_ID);
+        verify(clouderaManagerPollingServiceProvider).startPollingCmConfigurationRefresh(stack, apiClient, COMMAND_ID);
         verify(clustersResourceApi).refresh(CLUSTER_NAME);
-        verify(clouderaManagerPollingServiceProvider).refreshClusterPollingService(stack, apiClient, COMMAND_ID);
+        verify(clouderaManagerPollingServiceProvider).startPollingCmConfigurationRefresh(stack, apiClient, COMMAND_ID);
     }
 
     private ApiCommand createApiCommand() {

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerTemplateInstallationCheckerTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerTemplateInstallationCheckerTest.java
@@ -16,11 +16,7 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.Mockito;
 
 import com.cloudera.api.swagger.CommandsResourceApi;
 import com.cloudera.api.swagger.client.ApiClient;
@@ -32,8 +28,7 @@ import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerClientFactory;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 
-@ExtendWith(MockitoExtension.class)
-class ClouderaManagerTemplateInstallCheckerTest {
+class ClouderaManagerTemplateInstallationCheckerTest {
 
     private static final BigDecimal TEMPLATE_INSTALL_ID = new BigDecimal(1);
 
@@ -51,23 +46,18 @@ class ClouderaManagerTemplateInstallCheckerTest {
 
     private static final String FIRST_RUN_NAME = "First Run";
 
-    @InjectMocks
-    private ClouderaManagerTemplateInstallChecker underTest;
+    private ApiClient apiClient = Mockito.mock(ApiClient.class);
 
-    @Mock
-    private ApiClient apiClient;
+    private ClouderaManagerClientFactory clouderaManagerClientFactory = Mockito.mock(ClouderaManagerClientFactory.class);
 
-    @Mock
-    private ClouderaManagerClientFactory clouderaManagerClientFactory;
+    private CommandsResourceApi commandsResourceApi = Mockito.mock(CommandsResourceApi.class);
 
-    @Mock
-    private CommandsResourceApi commandsResourceApi;
+    private ClouderaManagerTemplateInstallationChecker underTest = new ClouderaManagerTemplateInstallationChecker(clouderaManagerClientFactory);
 
     private ClouderaManagerCommandPollerObject pollerObject;
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.initMocks(this);
         when(clouderaManagerClientFactory.getCommandsResourceApi(eq(apiClient))).thenReturn(commandsResourceApi);
         pollerObject = new ClouderaManagerCommandPollerObject(new Stack(), apiClient, TEMPLATE_INSTALL_ID);
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/TlsSetupService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/TlsSetupService.java
@@ -62,7 +62,7 @@ public class TlsSetupService {
             Integer gatewayPort = stack.getGatewayPort();
             String ip = gatewayConfigService.getGatewayIp(stack, gwInstance);
             LOGGER.debug("Trying to fetch the server's certificate: {}:{}", ip, gatewayPort);
-            nginxPollerService.pollWithAbsolutTimeout(
+            nginxPollerService.pollWithAbsoluteTimeout(
                     nginxCertListenerTask, new NginxPollerObject(client, ip, gatewayPort, x509TrustManager),
                     POLLING_INTERVAL, FIVE_MIN, MAX_FAILURE);
             WebTarget nginxTarget = client.target(String.format("https://%s:%d", ip, gatewayPort));

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/TlsSetupService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/TlsSetupService.java
@@ -65,7 +65,7 @@ public class TlsSetupService {
             Stack stack = stackRepository.findById(stackId).get();
             Integer gatewayPort = stack.getGatewayport();
             LOGGER.debug("Trying to fetch the server's certificate: {}:{}", ip, gatewayPort);
-            nginxPollerService.pollWithAbsolutTimeout(
+            nginxPollerService.pollWithAbsoluteTimeout(
                 nginxCertListenerTask, new NginxPollerObject(client, ip, gatewayPort, x509TrustManager),
                 POLLING_INTERVAL, FIVE_MIN, MAX_FAILURE);
             WebTarget nginxTarget = client.target(String.format("https://%s:%d", ip, gatewayPort));


### PR DESCRIPTION
This change is necessary for two reasons:
- Task is a unit of work that can be passed to an executor to execute it. Therefore a task must be instantiable and should be able to store state. The executor in our case is the PollingService.
- For this task: https://jira.cloudera.com/browse/CB-3749