### PR TITLE
Make small improvements to integration testing

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/ImageCatalogValidator.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/ImageCatalogValidator.java
@@ -22,7 +22,7 @@ public class ImageCatalogValidator implements ConstraintValidator<ValidImageCata
 
     public static final String FAILED_TO_GET_BY_FAMILY_TYPE = "Failed to get response by the specified URL '%s' due to: '%s'!";
 
-    public static final String FAILED_TO_GET_WITH_EXCEPTION = "Failed to get response by the specified URL!";
+    public static final String FAILED_TO_GET_WITH_EXCEPTION = "Failed to get response by the specified URL '%s'!";
 
     public static final String INVALID_JSON_IN_RESPONSE = "The file on the specified URL couldn't be parsed as JSON!";
 
@@ -53,7 +53,7 @@ public class ImageCatalogValidator implements ConstraintValidator<ValidImageCata
             String msg = String.format(FAILED_TO_GET_BY_FAMILY_TYPE, value, content.getKey().getReasonPhrase());
             context.buildConstraintViolationWithTemplate(msg).addConstraintViolation();
         } catch (Throwable throwable) {
-            context.buildConstraintViolationWithTemplate(FAILED_TO_GET_WITH_EXCEPTION).addConstraintViolation();
+            context.buildConstraintViolationWithTemplate(String.format(FAILED_TO_GET_WITH_EXCEPTION, value)).addConstraintViolation();
             LOGGER.debug("Failed to validate the specified image catalog URL: " + value, throwable);
         }
         return false;

--- a/core-api/src/test/java/com/sequenceiq/cloudbreak/api/model/imagecatalog/ImageCatalogV4BaseTest.java
+++ b/core-api/src/test/java/com/sequenceiq/cloudbreak/api/model/imagecatalog/ImageCatalogV4BaseTest.java
@@ -123,7 +123,7 @@ public class ImageCatalogV4BaseTest {
     }
 
     @Test
-    public void testWhenWebTargetFailesWithException() {
+    public void testWhenWebTargetFailsWithException() {
         when(httpHelper.getContent(anyString())).thenThrow(ProcessingException.class);
 
         ImageCatalogV4Base i = new ImageCatalogV4Base();
@@ -133,7 +133,8 @@ public class ImageCatalogV4BaseTest {
         Set<ConstraintViolation<ImageCatalogV4Base>> violations = validator.validate(i);
 
         assertEquals(2L, violations.size());
-        assertTrue(violations.stream().allMatch(cv -> cv.getMessage().equals(INVALID_MESSAGE) || cv.getMessage().equals(FAILED_TO_GET_WITH_EXCEPTION)));
+        String failsWithExceptionMessage = String.format(FAILED_TO_GET_WITH_EXCEPTION, i.getUrl());
+        assertTrue(violations.stream().allMatch(cv -> cv.getMessage().equals(INVALID_MESSAGE) || cv.getMessage().equals(failsWithExceptionMessage)));
     }
 
     @Test

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/credential/model/request/CredentialRequest.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/credential/model/request/CredentialRequest.java
@@ -29,4 +29,12 @@ public class CredentialRequest extends CredentialBase {
     public void setAzure(AzureCredentialRequestParameters azure) {
         this.azure = azure;
     }
+
+    @Override
+    public String toString() {
+        return "CredentialRequest{"
+            + "name='" + getName()
+            + "',cloudPlatform='" + getCloudPlatform()
+            + "'}";
+    }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/TestParameter.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/TestParameter.java
@@ -29,8 +29,8 @@ public class TestParameter {
             valueAsProperty = Optional.ofNullable(parameters.get(key.toUpperCase().replaceAll("\\.", "_")));
         }
         LOGGER.info(valueAsProperty.isPresent()
-                ? String.format("Aquiring key %s resulting: %s", key, valueAsProperty.get())
-                : String.format("Aquiring key %s, but no result has found.", key));
+                ? String.format("Acquiring key %s resulting: %s", key, valueAsProperty.get())
+                : String.format("Acquiring key %s, but no result has found.", key));
 
         if (key.startsWith(REQUIRED_KEY_PREFIX) && !valueAsProperty.isPresent()) {
             throw new MissingExpectedParameterException(key);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/PurgeGarbageService.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/PurgeGarbageService.java
@@ -38,7 +38,7 @@ public class PurgeGarbageService {
             purge(testContext);
             MDC.put("testlabel", null);
         } catch (Exception e) {
-            LOGGER.error("Error happended during purging the test data. Some entities might have been left over", e);
+            LOGGER.error("Error happened while purging the test data. Some entities might have been left over", e);
         } finally {
             testContext.shutdown();
         }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxInternalTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxInternalTestDto.java
@@ -70,8 +70,8 @@ public class SdxInternalTestDto extends AbstractSdxTestDto<SdxInternalClusterReq
     @Inject
     private CommonCloudProperties commonCloudProperties;
 
-    public SdxInternalTestDto(TestContext testContex) {
-        super(new SdxInternalClusterRequest(), testContex);
+    public SdxInternalTestDto(TestContext testContext) {
+        super(new SdxInternalClusterRequest(), testContext);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/ImageCatalogMockServerSetup.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/ImageCatalogMockServerSetup.java
@@ -77,6 +77,7 @@ public class ImageCatalogMockServerSetup implements AutoCloseable {
             response.header("Content-Length", String.valueOf(patchCbVersion(jsonCatalogResponse, testParameter).length()));
             return "";
         });
+        LOGGER.info("Prewarmed ImageCatalog has started at: {}", sparkServer.getEndpoint() + IMAGE_CATALOG_PREWARMED);
         return String.join("", sparkServer.getEndpoint(), IMAGE_CATALOG_PREWARMED);
     }
 


### PR DESCRIPTION
This changeset contains the following minor improvements to integration
testing.

* CredentialRequest now has a toString method.
* ImageCatalogValidator now includes the URL that failed validation in
its constraint violation message.
* ImageCatalogMockServerSetup now logs when it has started the
"prewarmed" URL, as it does for other URLs.
* Spelling is fixed in various log lines and variables.