### PR TITLE
CB-3757 Honor Spring Boot property loading in IT config

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/config/IntegrationTestConfiguration.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/config/IntegrationTestConfiguration.java
@@ -75,7 +75,8 @@ public class IntegrationTestConfiguration {
                     LOGGER.info("processing property source ::: " + propertySource.getName());
                     for (String key : ((EnumerablePropertySource) propertySource).getPropertyNames()) {
                         String value = propertySource.getProperty(key).toString();
-                        if (!StringUtils.isEmpty(value)) {
+                        LOGGER.debug("{} = {}", key, value);
+                        if (!StringUtils.isEmpty(value) && !rtn.containsKey(key)) {
                             rtn.put(key, propertySource.getProperty(key).toString());
                         }
                     }


### PR DESCRIPTION
When loading Spring configuration properties,
IntegrationTestConfiguration now conforms to the defined Spring Boot
priority order for property sources. If a lower-priority source has a
value for a property, it no longer replaces one from a higher-priority
source.