### PR TITLE
CB-3780 – wrap ResourceEvent enum on postNotificationTest

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/util/UtilV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/util/UtilV4Endpoint.java
@@ -16,6 +16,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.CheckRightV4Resp
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.CloudStorageSupportedV4Responses;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.DeploymentPreferencesV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.RepoConfigValidationV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.ResourceEventResponse;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.SecurityRulesV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.StackMatrixV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.VersionCheckV4Result;
@@ -26,7 +27,6 @@ import com.sequenceiq.cloudbreak.doc.OperationDescriptions.AccountPreferencesDes
 import com.sequenceiq.cloudbreak.doc.OperationDescriptions.RepositoryConfigsValidationOpDescription;
 import com.sequenceiq.cloudbreak.doc.OperationDescriptions.SecurityRuleOpDescription;
 import com.sequenceiq.cloudbreak.doc.OperationDescriptions.UtilityOpDescription;
-import com.sequenceiq.cloudbreak.event.ResourceEvent;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -82,7 +82,7 @@ public interface UtilV4Endpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = UtilityOpDescription.NOTIFICATION_TEST, produces = ContentType.JSON, notes = Notes.ACCOUNT_PREFERENCES_NOTES,
             nickname = "postNotificationTest")
-    ResourceEvent postNotificationTest();
+    ResourceEventResponse postNotificationTest();
 
     @POST
     @Path("check_right")

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/util/responses/ResourceEventResponse.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/util/responses/ResourceEventResponse.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.sequenceiq.cloudbreak.doc.ModelDescriptions;
+import com.sequenceiq.cloudbreak.event.ResourceEvent;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ResourceEventResponse {
+
+    @ApiModelProperty(ModelDescriptions.StackModelDescription.EVENTS)
+    private ResourceEvent event;
+
+    public ResourceEvent getEvent() {
+        return event;
+    }
+
+    public void setEvent(ResourceEvent event) {
+        this.event = event;
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/UtilV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/UtilV4Controller.java
@@ -16,6 +16,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.CheckRightV4Sing
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.CloudStorageSupportedV4Responses;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.DeploymentPreferencesV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.RepoConfigValidationV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.ResourceEventResponse;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.SecurityRulesV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.StackMatrixV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.SupportedExternalDatabaseServiceEntryV4Response;
@@ -109,10 +110,12 @@ public class UtilV4Controller extends NotificationController implements UtilV4En
     }
 
     @Override
-    public ResourceEvent postNotificationTest() {
+    public ResourceEventResponse postNotificationTest() {
         CloudbreakUser cloudbreakUser = restRequestThreadLocalService.getCloudbreakUser();
         notificationSender.sendTestNotification(cloudbreakUser.getUserId());
-        return ResourceEvent.CREDENTIAL_CREATED;
+        ResourceEventResponse response = new ResourceEventResponse();
+        response.setEvent(ResourceEvent.CREDENTIAL_CREATED);
+        return response;
     }
 
     @Override


### PR DESCRIPTION
CB-3780 – wrap ResourceEvent enum on postNotificationTest