### PR TITLE
DISTX-327 changes for set of user sync:

### DIFF
--- a/mock-caas/src/main/java/com/sequenceiq/caas/grpc/service/MockUserManagementService.java
+++ b/mock-caas/src/main/java/com/sequenceiq/caas/grpc/service/MockUserManagementService.java
@@ -537,7 +537,7 @@ public class MockUserManagementService extends UserManagementGrpc.UserManagement
             .build();
 
         // sha256 hashed value of "Password123!"
-        respBuilder.setPasswordHash("e512ca494a454a47ad102dd3f05d48e0e647c8619e734621a760da360c198f32");
+        respBuilder.setPasswordHash("008c70392e3abfbd0fa47bbc2ed96aa99bd49e159727fcba0f2e6abeb3a9d601");
         responseObserver.onNext(respBuilder.build());
         responseObserver.onCompleted();
     }


### PR DESCRIPTION
- Since we get all groups from UMS, therefore we should get all groups from FreeIPA. This way, diff for groups is always based on all groups.
- Getting only those users those are passed in as an argument. Sync will be performed only for those users.
- If none of the users is provided, we still go and fetch all users and sync all eligible users for the given environment.


Closes DISTX-327

@handavid @keyki @lacikaaa 
