### PR TITLE
CDPSDX-986 - remove atlas_kafka_bootstrap_servers, rename for cdp-1.2…

### DIFF
--- a/cloud-common/src/main/resources/application.yml
+++ b/cloud-common/src/main/resources/application.yml
@@ -163,8 +163,8 @@ cb:
                 CDP 1.1 - Data Mart: Apache Impala, Hue=cdp-data-mart-701;
                 CDP 1.1 - Operations Data Mart: Apache Impala, Hue, Apache Kudu, Apache Spark=cdp-op-data-mart-701;
                 CDP 1.1 - Operational Database: Apache HBase=cdp-opdb-701;
-                CDP 1.1 - SDX Light Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas=cdp-sdx-701;
-                CDP 1.1 - SDX Medium Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas=cdp-sdx-medium-ha-701;
+                CDP 1.2 - SDX Light Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas=cdp-sdx-702;
+                CDP 1.2 - SDX Medium Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas=cdp-sdx-medium-ha-702;
 
     ambari:
       defaults:

--- a/core/src/main/resources/defaults/blueprints/cdp-sdx-702.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx-702.bp
@@ -112,10 +112,6 @@
             "base": true,
             "configs": [
               {
-                "name": "atlas_kafka_bootstrap_servers",
-                "value": "{{{format-join host_groups.master format='%s:9092' }}}"
-              },
-              {
                 "name": "atlas_authentication_method_file",
                 "value": "false"
               }

--- a/core/src/main/resources/defaults/blueprints/cdp-sdx-ha-702.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx-ha-702.bp
@@ -55,10 +55,6 @@
                         "base": true,
                         "configs": [
                             {
-                                "name": "atlas_kafka_bootstrap_servers",
-                                "value": "{{{format-join host_groups.master format='%s:9092' }}}"
-                            },
-                            {
                               "name": "atlas_authentication_method_file",
                               "value": "false"
                             }

--- a/core/src/main/resources/defaults/blueprints/cdp-sdx-medium-ha-702.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx-medium-ha-702.bp
@@ -61,10 +61,6 @@
             "base": true,
             "configs": [
               {
-                "name": "atlas_kafka_bootstrap_servers",
-                "value": "{{{format-join host_groups.master format='%s:9092' }}}"
-              },
-              {
                 "name": "atlas_authentication_method_file",
                 "value": "false"
               }


### PR DESCRIPTION
Changes:
1) remove atlas_kafka_bootstrap_servers from all 3 datalake blueprints
2) rename for cdp-1.2 . (1.1 to 1.2) in application.yml
3) rename blueprints from 701 to 702

…, and updated application.yml with new versions

https://jira.cloudera.com/browse/CDPSDX-986 - (Data lake update to remove error.)
Are caused by:
https://jira.cloudera.com/browse/CDPSDX-961 . (QE error encountered b/c of CM change)
which are caused by 
https://jira.cloudera.com/browse/OPSAPS-52445 . (CM removed the config in 1.2)

Closes # CDPSDX-986