### PR TITLE
CB-1692 Fix some spelling / grammar in integration tests

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
@@ -636,7 +636,7 @@ public abstract class TestContext implements ApplicationContextAware {
                 || Pattern.compile(runningParameter.getExpectedMessage()).matcher(ResponseUtil.getErrorMessage(exception)).find();
     }
 
-    public void handleExecptionsDuringTest(boolean silently) {
+    public void handleExceptionsDuringTest(boolean silently) {
         validated = true;
         checkShutdown();
         Map<String, Exception> exceptionsDuringTest = getErrors();
@@ -708,10 +708,10 @@ public abstract class TestContext implements ApplicationContextAware {
     public void cleanupTestContext() {
         if (!validated && initialized) {
             throw new IllegalStateException(
-                    "Test context should be validated! Maybe do you forgot to call .validate() end of the test? See other tests as an example.");
+                    "Test context should be validated! Maybe you forgot to call .validate() at the end of the test? See other tests as an example.");
         }
         checkShutdown();
-        handleExecptionsDuringTest(true);
+        handleExceptionsDuringTest(true);
         if (!cleanUpOnFailure && !getExceptionMap().isEmpty()) {
             LOGGER.info("Cleanup skipped beacuse cleanupOnFail is false");
             return;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractTestDto.java
@@ -212,10 +212,10 @@ public abstract class AbstractTestDto<R, S, T extends CloudbreakTestDto, U exten
     }
 
     public void validate() {
-        testContext.handleExecptionsDuringTest(false);
+        testContext.handleExceptionsDuringTest(false);
     }
 
-    public ResourcePropertyProvider getResourceProperyProvider() {
+    public ResourcePropertyProvider getResourcePropertyProvider() {
         return resourcePropertyProvider;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/DeletableEnvironmentTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/DeletableEnvironmentTestDto.java
@@ -17,7 +17,7 @@ public abstract class DeletableEnvironmentTestDto<R, S, T extends CloudbreakTest
 
     @Override
     public boolean deletable(Z entity) {
-        return name(entity).startsWith(getResourceProperyProvider().prefix());
+        return name(entity).startsWith(getResourcePropertyProvider().prefix());
     }
 
     protected abstract String name(Z entity);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/DeletableTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/DeletableTestDto.java
@@ -17,7 +17,7 @@ public abstract class DeletableTestDto<R, S, T extends CloudbreakTestDto, Z> ext
 
     @Override
     public boolean deletable(Z entity) {
-        return name(entity).startsWith(getResourceProperyProvider().prefix());
+        return name(entity).startsWith(getResourcePropertyProvider().prefix());
     }
 
     protected abstract String name(Z entity);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/EnvironmentSettingsV4TestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/EnvironmentSettingsV4TestDto.java
@@ -30,7 +30,7 @@ public class EnvironmentSettingsV4TestDto extends AbstractCloudbreakTestDto<Envi
 
     @Override
     public EnvironmentSettingsV4TestDto valid() {
-        return withName(getResourceProperyProvider().getName());
+        return withName(getResourcePropertyProvider().getName());
     }
 
     public EnvironmentSettingsV4TestDto withName(String name) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/blueprint/BlueprintTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/blueprint/BlueprintTestDto.java
@@ -35,7 +35,7 @@ public class BlueprintTestDto extends AbstractCloudbreakTestDto<BlueprintV4Reque
     }
 
     public BlueprintTestDto valid() {
-        return withName(getResourceProperyProvider().getName())
+        return withName(getResourcePropertyProvider().getName())
                 .withBlueprint("someBlueprint");
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/clustertemplate/ClusterTemplateTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/clustertemplate/ClusterTemplateTestDto.java
@@ -26,7 +26,7 @@ public class ClusterTemplateTestDto extends DeletableTestDto<ClusterTemplateV4Re
     }
 
     public ClusterTemplateTestDto valid() {
-        return withName(getResourceProperyProvider().getName())
+        return withName(getResourcePropertyProvider().getName())
                 .withDistroXTemplate(getTestContext().init(DistroXTemplateTestDto.class).getRequest());
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/clustertemplate/DistroXTemplateTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/clustertemplate/DistroXTemplateTestDto.java
@@ -35,7 +35,7 @@ public class DistroXTemplateTestDto extends DeletableTestDto<DistroXV1Request, C
     }
 
     public DistroXTemplateTestDto valid() {
-        return withName(getResourceProperyProvider().getName())
+        return withName(getResourcePropertyProvider().getName())
                 .withEnvironmentName(getTestContext().get(EnvironmentTestDto.class).getName())
                 .withCluster(getTestContext().init(ClusterTestDto.class).getRequest())
                 .withInstanceGroups(getTestContext().init(InstanceGroupTestDto.class).getRequest());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/credential/CredentialTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/credential/CredentialTestDto.java
@@ -40,8 +40,8 @@ public class CredentialTestDto extends DeletableEnvironmentTestDto<CredentialReq
     }
 
     public CredentialTestDto valid() {
-        withName(getResourceProperyProvider().getName());
-        withDescription(getResourceProperyProvider().getDescription("credential"));
+        withName(getResourcePropertyProvider().getName());
+        withDescription(getResourcePropertyProvider().getDescription("credential"));
         return getCloudProvider().credential(this);
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/database/DatabaseTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/database/DatabaseTestDto.java
@@ -48,8 +48,8 @@ public class DatabaseTestDto extends DeletableTestDto<DatabaseV4Request, Databas
     }
 
     public DatabaseTestDto valid() {
-        return withName(getResourceProperyProvider().getName())
-                .withDescription(getResourceProperyProvider().getDescription("database"))
+        return withName(getResourcePropertyProvider().getName())
+                .withDescription(getResourcePropertyProvider().getDescription("database"))
                 .withConnectionUserName("user")
                 .withConnectionPassword("password")
                 .withConnectionURL("jdbc:postgresql://somedb.com:5432/mydb")

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/database/DatabaseTestTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/database/DatabaseTestTestDto.java
@@ -30,7 +30,7 @@ public class DatabaseTestTestDto extends AbstractCloudbreakTestDto<DatabaseTestV
 
     public DatabaseTestTestDto valid() {
         return withRequest(new DatabaseV4Request())
-                .withName(getResourceProperyProvider().getName())
+                .withName(getResourcePropertyProvider().getName())
                 .withConnectionUserName("user")
                 .withConnectionPassword("password")
                 .withConnectionURL("jdbc:postgresql://somedb.com:5432/mydb")

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDto.java
@@ -73,7 +73,7 @@ public class DistroXTestDto extends DistroXTestDtoBase<DistroXTestDto> implement
 
     @Override
     public boolean deletable(StackV4Response entity) {
-        return entity.getName().startsWith(getResourceProperyProvider().prefix());
+        return entity.getName().startsWith(getResourcePropertyProvider().prefix());
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDtoBase.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDtoBase.java
@@ -30,7 +30,7 @@ public class DistroXTestDtoBase<T extends DistroXTestDtoBase> extends AbstractCl
     }
 
     public DistroXTestDtoBase<T> valid() {
-        String name = getResourceProperyProvider().getName();
+        String name = getResourcePropertyProvider().getName();
         withName(name)
                 .withInstanceGroupsEntity(DistroXInstanceGroupTestDto.defaultHostGroup(getTestContext()))
                 .withCluster(getTestContext().given(DistroXClusterTestDto.class));

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
@@ -83,8 +83,8 @@ public class EnvironmentTestDto
     @Override
     public EnvironmentTestDto valid() {
         return getCloudProvider()
-                .environment(withName(getResourceProperyProvider().getEnvironmentName())
-                        .withDescription(getResourceProperyProvider().getDescription("environment")))
+                .environment(withName(getResourcePropertyProvider().getEnvironmentName())
+                        .withDescription(getResourcePropertyProvider().getDescription("environment")))
                         .withCredentialName(getTestContext().get(CredentialTestDto.class).getName())
                         .withAuthentication(DUMMY_SSH_KEY)
                         .withIdBrokerMappingSource(IdBrokerMappingSource.MOCK);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIPATestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIPATestDto.java
@@ -56,7 +56,7 @@ public class FreeIPATestDto extends AbstractFreeIPATestDto<CreateFreeIpaRequest,
 
     @Override
     public FreeIPATestDto valid() {
-        return withName(getResourceProperyProvider().getName())
+        return withName(getResourcePropertyProvider().getName())
                 .withEnvironment(getTestContext().given(EnvironmentTestDto.class))
                 .withPlacement(getTestContext().given(PlacementSettingsTestDto.class))
                 .withInstanceGroupsEntity(InstanceGroupTestDto.defaultHostGroup(getTestContext()))
@@ -206,7 +206,7 @@ public class FreeIPATestDto extends AbstractFreeIPATestDto<CreateFreeIpaRequest,
 
     @Override
     public boolean deletable(ListFreeIpaResponse entity) {
-        return entity.getName().startsWith(getResourceProperyProvider().prefix());
+        return entity.getName().startsWith(getResourcePropertyProvider().prefix());
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/imagecatalog/ImageCatalogTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/imagecatalog/ImageCatalogTestDto.java
@@ -47,7 +47,7 @@ public class ImageCatalogTestDto extends AbstractCloudbreakTestDto<ImageCatalogV
     }
 
     public ImageCatalogTestDto valid() {
-        return getCloudProvider().imageCatalog(withName(getResourceProperyProvider().getName()));
+        return getCloudProvider().imageCatalog(withName(getResourcePropertyProvider().getName()));
     }
 
     public ImagesV4Response getResponseByProvider() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/kerberos/KerberosTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/kerberos/KerberosTestDto.java
@@ -50,7 +50,7 @@ public class KerberosTestDto extends AbstractFreeIPATestDto<CreateKerberosConfig
 
     @Override
     public KerberosTestDto valid() {
-        String name = getResourceProperyProvider().getName();
+        String name = getResourcePropertyProvider().getName();
         return withName(name).withEnvironment(EnvironmentTestDto.class);
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/kubernetes/KubernetesTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/kubernetes/KubernetesTestDto.java
@@ -51,7 +51,7 @@ public class KubernetesTestDto extends DeletableTestDto<KubernetesV4Request, Kub
     }
 
     public KubernetesTestDto valid() {
-        return withName(getResourceProperyProvider().getName())
+        return withName(getResourcePropertyProvider().getName())
                 .withContent("content")
                 .withDesription("great kubernetes config");
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/ldap/LdapTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/ldap/LdapTestDto.java
@@ -38,9 +38,9 @@ public class LdapTestDto extends AbstractFreeIPATestDto<CreateLdapConfigRequest,
     }
 
     public LdapTestDto valid() {
-        return withName(getResourceProperyProvider().getName())
+        return withName(getResourcePropertyProvider().getName())
                 .withEnvironment(EnvironmentTestDto.class)
-                .withDescription(getResourceProperyProvider().getDescription("LDAP"))
+                .withDescription(getResourcePropertyProvider().getDescription("LDAP"))
                 .withBindPassword("bindPassword")
                 .withAdminGroup("group")
                 .withBindDn("bindDn")

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/mpack/MPackTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/mpack/MPackTestDto.java
@@ -18,9 +18,9 @@ public class MPackTestDto extends DeletableTestDto<ManagementPackV4Request, Mana
     }
 
     public MPackTestDto valid() {
-        return withName(getResourceProperyProvider().getName())
+        return withName(getResourcePropertyProvider().getName())
                 .witMpackUrl("http://public-repo-1.hortonworks.com/HDF/centos7/3.x/updates/3.2.0.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.2.0.0-520.tar.gz")
-                .withDescription(getResourceProperyProvider().getDescription("management pack"));
+                .withDescription(getResourcePropertyProvider().getDescription("management pack"));
     }
 
     public MPackTestDto withName(String name) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/proxy/ProxyTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/proxy/ProxyTestDto.java
@@ -29,8 +29,8 @@ public class ProxyTestDto extends AbstractEnvironmentTestDto<ProxyRequest, Proxy
 
     @Override
     public ProxyTestDto valid() {
-        return withName(getResourceProperyProvider().getName())
-                .withDescription(getResourceProperyProvider().getDescription("proxy"))
+        return withName(getResourcePropertyProvider().getName())
+                .withDescription(getResourcePropertyProvider().getDescription("proxy"))
                 .withServerHost("1.2.3.4")
                 .withServerUser("mock")
                 .withPassword("akarmi")

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/recipe/RecipeTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/recipe/RecipeTestDto.java
@@ -43,8 +43,8 @@ public class RecipeTestDto extends DeletableTestDto<RecipeV4Request, RecipeV4Res
     }
 
     public RecipeTestDto valid() {
-        return withName(getResourceProperyProvider().getName())
-                .withDescription(getResourceProperyProvider().getDescription("recipe"))
+        return withName(getResourcePropertyProvider().getName())
+                .withDescription(getResourcePropertyProvider().getDescription("recipe"))
                 .withRecipeType(RecipeV4Type.PRE_CLOUDERA_MANAGER_START)
                 .withContent(new String(Base64.getEncoder().encode("#!/bin/bash%necho ALMAA".getBytes())));
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxInternalTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxInternalTestDto.java
@@ -76,7 +76,7 @@ public class SdxInternalTestDto extends AbstractSdxTestDto<SdxInternalClusterReq
 
     @Override
     public SdxInternalTestDto valid() {
-        withName(getResourceProperyProvider().getName())
+        withName(getResourcePropertyProvider().getName())
                 .withStackRequest()
                 .withEnvironmentName(getTestContext().get(EnvironmentTestDto.class).getName())
                 .withClusterShape(getCloudProvider().getInternalClusterShape())
@@ -225,7 +225,7 @@ public class SdxInternalTestDto extends AbstractSdxTestDto<SdxInternalClusterReq
 
     @Override
     public boolean deletable(SdxClusterResponse entity) {
-        return getName().startsWith(getResourceProperyProvider().prefix());
+        return getName().startsWith(getResourcePropertyProvider().prefix());
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxRepairTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxRepairTestDto.java
@@ -29,7 +29,7 @@ public class SdxRepairTestDto extends AbstractSdxTestDto<SdxRepairRequest, SdxCl
     }
 
     public SdxRepairTestDto valid() {
-        withSdxName(getResourceProperyProvider().getName())
+        withSdxName(getResourcePropertyProvider().getName())
                 .withHostGroupName(HOSTGROUP_NAME);
         return getCloudProvider().sdxRepair(this);
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
@@ -50,7 +50,7 @@ public class SdxTestDto extends AbstractSdxTestDto<SdxClusterRequest, SdxCluster
 
     @Override
     public SdxTestDto valid() {
-        withName(getResourceProperyProvider().getName())
+        withName(getResourcePropertyProvider().getName())
                 .withEnvironment(getTestContext().get(EnvironmentTestDto.class).getName())
                 .withClusterShape(getCloudProvider().getClusterShape())
                 .withTags(getCloudProvider().getTags());
@@ -74,7 +74,7 @@ public class SdxTestDto extends AbstractSdxTestDto<SdxClusterRequest, SdxCluster
 
     @Override
     public boolean deletable(SdxClusterResponse entity) {
-        return entity.getName().startsWith(getResourceProperyProvider().prefix());
+        return entity.getName().startsWith(getResourcePropertyProvider().prefix());
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/stack/StackTemplateTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/stack/StackTemplateTestDto.java
@@ -13,7 +13,7 @@ public class StackTemplateTestDto extends StackTestDtoBase<StackTemplateTestDto>
     }
 
     public StackTemplateTestDto valid() {
-        return withName(getResourceProperyProvider().getName())
+        return withName(getResourcePropertyProvider().getName())
                 .withCluster(getTestContext().init(ClusterTestDto.class))
                 .withAuthentication(getTestContext().init(StackTestDto.class).getRequest().getAuthentication());
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/stack/StackTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/stack/StackTestDto.java
@@ -84,7 +84,7 @@ public class StackTestDto extends StackTestDtoBase<StackTestDto> implements Purg
 
     @Override
     public boolean deletable(StackV4Response entity) {
-        return entity.getName().startsWith(getResourceProperyProvider().prefix());
+        return entity.getName().startsWith(getResourcePropertyProvider().prefix());
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/stack/StackTestDtoBase.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/stack/StackTestDtoBase.java
@@ -88,7 +88,7 @@ public abstract class StackTestDtoBase<T extends StackTestDtoBase<T>> extends Ab
     }
 
     public StackTestDtoBase<T> valid() {
-        String name = getResourceProperyProvider().getName();
+        String name = getResourcePropertyProvider().getName();
         withName(name)
                 .withImageSettings(getCloudProvider().imageSettings(getTestContext().given(ImageSettingsTestDto.class)))
                 .withPlacement(getTestContext().given(PlacementSettingsTestDto.class))


### PR DESCRIPTION
* In TestContext, the spelling of the "handleExceptionsDuringTest"
  method is fixed.
* In AbstractTestDto, the spelling of the method
  "resourcePropertyProvider" is fixed.
