### PR TITLE
CB-1692 Create first redbeams integration test

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/CrnValidator.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/CrnValidator.java
@@ -9,6 +9,8 @@ public class CrnValidator implements ConstraintValidator<ValidCrn, String> {
 
     @Override
     public boolean isValid(String req, ConstraintValidatorContext constraintValidatorContext) {
+        constraintValidatorContext.disableDefaultConstraintViolation();
+
         if (req == null) {
             return true;
         }

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -75,6 +75,9 @@ dependencies {
   compile (project(':datalake-api')) {
     transitive = false;
   }
+  compile (project(':redbeams-api')) {
+    transitive = false;
+  }
   compile("com.sequenceiq:${ambariClientName}:${ambariClientVersion}") {
     exclude group: 'org.slf4j'
     exclude group: 'xerces.xercesImpl'

--- a/integration-test/docker-compose_template.yml
+++ b/integration-test/docker-compose_template.yml
@@ -30,6 +30,7 @@ services:
       - INTEGRATIONTEST_FREEIPA_SERVER=http://dev-gateway
       - INTEGRATIONTEST_ENVIRONMENT_SERVER=http://dev-gateway
       - INTEGRATIONTEST_SDX_SERVER=http://dev-gateway
+      - INTEGRATIONTEST_REDBEAMS_SERVER=http://dev-gateway
       - CLOUDBREAK_URL=cloudbreak:8080
       - SPRING_CONFIG_LOCATION=classpath:/application.yml,/it/it-application.yml
       - INTEGRATIONTEST_SUITEFILES

--- a/integration-test/integcb/Profile_template
+++ b/integration-test/integcb/Profile_template
@@ -4,6 +4,7 @@ export DOCKER_TAG_FREEIPA=dev
 export DOCKER_TAG_REDBEAMS=dev
 export DOCKER_TAG_ENVIRONMENT=dev
 export DOCKER_TAG_DATALAKE=dev
+export DOCKER_TAG_REDBEAMS=dev
 export DOCKER_TAG_PERISCOPE=dev
 export CB_JAVA_OPTS="-Dcaas.url=caas-mock:8080 -Xmx4G -Drest.debug=true -Dmock.spi.endpoint=https://test:9443"
 export UAA_DEFAULT_SECRET=cbsecret2015

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/RedBeamsTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/RedBeamsTest.java
@@ -3,5 +3,9 @@ package com.sequenceiq.it.cloudbreak;
 public class RedBeamsTest extends GherkinTest {
 
     public static final String REDBEAMS_SERVER_ROOT = "REDBEAMS_SERVER_ROOT";
+
+    public static final String ACCESS_KEY = "ACCESS_KEY";
+
+    public static final String SECRET_KEY = "SECRET_KEY";
 }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/RedbeamsClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/RedbeamsClient.java
@@ -1,0 +1,39 @@
+package com.sequenceiq.it.cloudbreak;
+
+import com.sequenceiq.cloudbreak.client.ConfigKey;
+import com.sequenceiq.it.TestParameter;
+import com.sequenceiq.it.cloudbreak.actor.CloudbreakUser;
+import com.sequenceiq.redbeams.client.RedbeamsApiKeyClient;
+
+public class RedbeamsClient extends MicroserviceClient {
+    public static final String REDBEAMS_CLIENT = "REDBEAMS_CLIENT";
+
+    private com.sequenceiq.redbeams.client.RedbeamsClient endpoints;
+
+    private String environmentCrn;
+
+    private RedbeamsClient() {
+        super(REDBEAMS_CLIENT);
+    }
+
+    public static synchronized RedbeamsClient createProxyRedbeamsClient(TestParameter testParameter, CloudbreakUser cloudbreakUser) {
+        RedbeamsClient clientEntity = new RedbeamsClient();
+        clientEntity.endpoints = new RedbeamsApiKeyClient(
+                testParameter.get(RedBeamsTest.REDBEAMS_SERVER_ROOT),
+                new ConfigKey(false, true, true))
+                .withKeys(cloudbreakUser.getAccessKey(), cloudbreakUser.getSecretKey());
+        return clientEntity;
+    }
+
+    public com.sequenceiq.redbeams.client.RedbeamsClient getEndpoints() {
+        return endpoints;
+    }
+
+    public String getEnvironmentCrn() {
+        return environmentCrn;
+    }
+
+    public void setEnvironmentCrn(String environmentCrn) {
+        this.environmentCrn = environmentCrn;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/database/RedbeamsDatabaseCreateAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/database/RedbeamsDatabaseCreateAction.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.it.cloudbreak.action.v4.database;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.RedbeamsClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.database.RedbeamsDatabaseTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+
+public class RedbeamsDatabaseCreateAction implements Action<RedbeamsDatabaseTestDto, RedbeamsClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RedbeamsDatabaseCreateAction.class);
+
+    @Override
+    public RedbeamsDatabaseTestDto action(TestContext testContext, RedbeamsDatabaseTestDto testDto, RedbeamsClient client) throws Exception {
+        Log.logJSON(LOGGER, " Database register request:\n", testDto.getRequest());
+        testDto.setResponse(
+                client.getEndpoints()
+                        .databaseV4Endpoint()
+                        .register(testDto.getRequest()));
+        Log.logJSON(LOGGER, " Database registered successfully:\n", testDto.getResponse());
+        Log.log(LOGGER, String.format(" CRN: %s", testDto.getResponse().getCrn()));
+
+        return testDto;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/database/RedbeamsDatabaseCreateIfNotExistsAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/database/RedbeamsDatabaseCreateIfNotExistsAction.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.it.cloudbreak.action.v4.database;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.RedbeamsClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.database.RedbeamsDatabaseTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+
+public class RedbeamsDatabaseCreateIfNotExistsAction implements Action<RedbeamsDatabaseTestDto, RedbeamsClient> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RedbeamsDatabaseCreateIfNotExistsAction.class);
+
+    @Override
+    public RedbeamsDatabaseTestDto action(TestContext testContext, RedbeamsDatabaseTestDto testDto, RedbeamsClient client) throws Exception {
+        LOGGER.info("Register Database with name: {}", testDto.getRequest().getName());
+        try {
+            testDto.setResponse(
+                    client.getEndpoints().databaseV4Endpoint().register(testDto.getRequest())
+            );
+            Log.logJSON(LOGGER, "Database registered successfully: ", testDto.getRequest());
+        } catch (Exception e) {
+            LOGGER.info("Cannot register Database, fetch existing one: {}", testDto.getRequest().getName());
+            testDto.setResponse(
+                    client.getEndpoints().databaseV4Endpoint()
+                            .getByName(client.getEnvironmentCrn(), testDto.getRequest().getName()));
+        }
+        if (testDto.getResponse() == null) {
+            throw new IllegalStateException("Database could not be registered.");
+        }
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/database/RedbeamsDatabaseDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/database/RedbeamsDatabaseDeleteAction.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.it.cloudbreak.action.v4.database;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.RedbeamsClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.database.RedbeamsDatabaseTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+
+public class RedbeamsDatabaseDeleteAction implements Action<RedbeamsDatabaseTestDto, RedbeamsClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RedbeamsDatabaseDeleteAction.class);
+
+    @Override
+    public RedbeamsDatabaseTestDto action(TestContext testContext, RedbeamsDatabaseTestDto testDto, RedbeamsClient client) throws Exception {
+        Log.log(LOGGER, String.format(" Name: %s", testDto.getRequest().getName()));
+        Log.logJSON(LOGGER, " Database delete request:\n", testDto.getRequest());
+        testDto.setResponse(
+                client.getEndpoints()
+                        .databaseV4Endpoint()
+                        .deleteByName(client.getEnvironmentCrn(), testDto.getName()));
+        Log.logJSON(LOGGER, " Database deleted successfully:\n", testDto.getResponse());
+        return testDto;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/database/RedbeamsDatabaseListAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/database/RedbeamsDatabaseListAction.java
@@ -1,0 +1,30 @@
+package com.sequenceiq.it.cloudbreak.action.v4.database;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.RedbeamsClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.database.RedbeamsDatabaseTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+import com.sequenceiq.redbeams.api.endpoint.v4.database.responses.DatabaseV4Response;
+
+public class RedbeamsDatabaseListAction implements Action<RedbeamsDatabaseTestDto, RedbeamsClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RedbeamsDatabaseListAction.class);
+
+    @Override
+    public RedbeamsDatabaseTestDto action(TestContext testContext, RedbeamsDatabaseTestDto testDto, RedbeamsClient client) throws Exception {
+        Collection<DatabaseV4Response> responses = client.getEndpoints()
+                .databaseV4Endpoint()
+                .list(client.getEnvironmentCrn())
+                .getResponses();
+        testDto.setResponses(responses.stream().collect(Collectors.toSet()));
+        Log.logJSON(LOGGER, " Databases listed successfully:\n", testDto.getResponses());
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/database/RedbeamsDatabaseTestAssertion.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/database/RedbeamsDatabaseTestAssertion.java
@@ -1,0 +1,24 @@
+package com.sequenceiq.it.cloudbreak.assertion.database;
+
+import com.sequenceiq.it.cloudbreak.RedbeamsClient;
+import com.sequenceiq.it.cloudbreak.dto.database.RedbeamsDatabaseTestDto;
+import com.sequenceiq.it.cloudbreak.assertion.Assertion;
+
+public class RedbeamsDatabaseTestAssertion {
+
+    private RedbeamsDatabaseTestAssertion() {
+    }
+
+    public static Assertion<RedbeamsDatabaseTestDto, RedbeamsClient> containsDatabaseName(String databaseName, Integer expectedCount) {
+        return (testContext, entity, redbeamsClient) -> {
+            boolean countCorrect = entity.getResponses()
+                    .stream()
+                    .filter(databaseV4Response -> databaseV4Response.getName().contentEquals(databaseName))
+                    .count() == expectedCount;
+            if (!countCorrect) {
+                throw new IllegalArgumentException("Database count for " + databaseName + " is not as expected!");
+            }
+            return entity;
+        };
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/RedbeamsDatabaseTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/RedbeamsDatabaseTestClient.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.it.cloudbreak.client;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.it.cloudbreak.RedbeamsClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.action.v4.database.RedbeamsDatabaseCreateAction;
+import com.sequenceiq.it.cloudbreak.action.v4.database.RedbeamsDatabaseCreateIfNotExistsAction;
+import com.sequenceiq.it.cloudbreak.action.v4.database.RedbeamsDatabaseDeleteAction;
+import com.sequenceiq.it.cloudbreak.action.v4.database.RedbeamsDatabaseListAction;
+import com.sequenceiq.it.cloudbreak.dto.database.RedbeamsDatabaseTestDto;
+
+@Service
+public class RedbeamsDatabaseTestClient {
+
+    public Action<RedbeamsDatabaseTestDto, RedbeamsClient> createV4() {
+        return new RedbeamsDatabaseCreateAction();
+    }
+
+    public Action<RedbeamsDatabaseTestDto, RedbeamsClient> deleteV4() {
+        return new RedbeamsDatabaseDeleteAction();
+    }
+
+    public Action<RedbeamsDatabaseTestDto, RedbeamsClient> listV4() {
+        return new RedbeamsDatabaseListAction();
+    }
+
+    public Action<RedbeamsDatabaseTestDto, RedbeamsClient> createIfNotExistV4() {
+        return new RedbeamsDatabaseCreateIfNotExistsAction();
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/config/CliProfileReaderService.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/config/CliProfileReaderService.java
@@ -11,7 +11,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
 import org.yaml.snakeyaml.Yaml;
 
 @Service
@@ -19,7 +18,7 @@ class CliProfileReaderService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CliProfileReaderService.class);
 
-    @Value("${integrationtest.dp.profile:}")
+    @Value("${integrationtest.dp.profile:localhost}")
     private String profile;
 
     Map<String, String> read() throws IOException {
@@ -36,12 +35,6 @@ class CliProfileReaderService {
         Yaml yaml = new Yaml();
         Map<String, Object> profiles = yaml.load(profileString);
 
-        String usedProfile = "localhost";
-
-        if (!StringUtils.isEmpty(profile)) {
-            usedProfile = profile;
-        }
-
-        return (Map<String, String>) profiles.get(usedProfile);
+        return (Map<String, String>) profiles.get(profile);
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/config/RedbeamsServer.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/config/RedbeamsServer.java
@@ -1,0 +1,79 @@
+package com.sequenceiq.it.cloudbreak.config;
+
+import java.io.IOException;
+import java.util.Map;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.it.TestParameter;
+import com.sequenceiq.it.cloudbreak.RedBeamsTest;
+
+@Component
+public class RedbeamsServer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RedbeamsServer.class);
+
+    private static final String WARNING_TEXT_FORMAT = "Following variable(s) must be set as environment variables or in (test) application.yaml: %s";
+
+    @Value("${integrationtest.redbeams.server}")
+    private String server;
+
+    @Value("${redbeams.server.contextPath:/redbeams}")
+    private String rootContextPath;
+
+    @Value("${integrationtest.user.accesskey:}")
+    private String accessKey;
+
+    @Value("${integrationtest.user.secretkey:}")
+    private String secretKey;
+
+    @Inject
+    private TestParameter testParameter;
+
+    @Inject
+    private CliProfileReaderService cliProfileReaderService;
+
+    @Inject
+    private ServerUtil serverUtil;
+
+    @PostConstruct
+    private void init() throws IOException {
+        configureFromCliProfile();
+
+        checkNonEmpty("integrationtest.redbeams.server", server);
+        checkNonEmpty("redbeams.server.contextPath", rootContextPath);
+        checkNonEmpty("integrationtest.user.accesskey", accessKey);
+        checkNonEmpty("integrationtest.user.privatekey", secretKey);
+
+        testParameter.put(RedBeamsTest.REDBEAMS_SERVER_ROOT, server + rootContextPath);
+        testParameter.put(RedBeamsTest.ACCESS_KEY, accessKey);
+        testParameter.put(RedBeamsTest.SECRET_KEY, secretKey);
+    }
+
+    private void configureFromCliProfile() throws IOException {
+        Map<String, String> profile = cliProfileReaderService.read();
+        if (profile == null) {
+            LOGGER.warn("Failed to find specified profile (default \"localhost\") in ~/.dp/config. Set the profile "
+                    + "name using integrationtest.dp.profile Spring Boot configuration property (application.yml), or "
+                    + "-Dintegrationtest.dp.profile system property.");
+            return;
+        }
+
+        server = serverUtil.calculateServerAddressFromProfile(server, profile);
+        accessKey = serverUtil.calculateApiKeyFromProfile(accessKey, profile);
+        secretKey = serverUtil.calculatePrivateKeyFromProfile(secretKey, profile);
+    }
+
+    private void checkNonEmpty(String name, String value) {
+        if (StringUtils.isEmpty(value)) {
+            throw new NullPointerException(String.format(WARNING_TEXT_FORMAT, name.replaceAll("\\.", "_").toUpperCase()));
+        }
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/config/ServerUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/config/ServerUtil.java
@@ -31,10 +31,10 @@ class ServerUtil {
                 : enforceHttpsForServerAddress(serverRaw);
     }
 
-    private String enforceHttpsForServerAddress(String serverRaw) {
+    String enforceHttpsForServerAddress(String serverRaw) {
         //Hack to avoid SSLException in local mock/e2e tests due to CBD modification that allows traffic to services without https
         if ("localhost".equals(serverRaw) || "http://localhost".equals(serverRaw)) {
-            return "http://" + serverRaw;
+            return "http://localhost";
         }
         return "https://" + getDomainFromUrl(serverRaw);
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractRedbeamsTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractRedbeamsTestDto.java
@@ -1,0 +1,79 @@
+package com.sequenceiq.it.cloudbreak.dto;
+
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.emptyRunningParameter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.ws.rs.BadRequestException;
+
+import com.sequenceiq.it.cloudbreak.RedbeamsClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.assertion.Assertion;
+import com.sequenceiq.it.cloudbreak.context.RunningParameter;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+
+public abstract class AbstractRedbeamsTestDto<R, S, T extends CloudbreakTestDto> extends AbstractTestDto<R, S, T, RedbeamsClient> {
+
+    protected AbstractRedbeamsTestDto(String newId) {
+        super(newId);
+    }
+
+    protected AbstractRedbeamsTestDto(R request, TestContext testContext) {
+        super(request, testContext);
+    }
+
+    @Override
+    public T when(Class<T> entityClass, Action<T, RedbeamsClient> action) {
+        return getTestContext().when(entityClass, RedbeamsClient.class, action, emptyRunningParameter());
+    }
+
+    @Override
+    public T when(Action<T, RedbeamsClient> action) {
+        return getTestContext().when((T) this, RedbeamsClient.class, action, emptyRunningParameter());
+    }
+
+    @Override
+    public T when(Class<T> entityClass, Action<T, RedbeamsClient> action, RunningParameter runningParameter) {
+        return getTestContext().when(entityClass, RedbeamsClient.class, action, runningParameter);
+    }
+
+    @Override
+    public T when(Action<T, RedbeamsClient> action, RunningParameter runningParameter) {
+        return getTestContext().when((T) this, RedbeamsClient.class, action, runningParameter);
+    }
+
+    @Override
+    public <T extends CloudbreakTestDto> T deleteGiven(Class<T> clazz, Action<T, RedbeamsClient> action, RunningParameter runningParameter) {
+        getTestContext().when((T) getTestContext().given(clazz), RedbeamsClient.class, action, runningParameter);
+        return getTestContext().expect((T) getTestContext().given(clazz), BadRequestException.class, runningParameter);
+    }
+
+    @Override
+    public T then(Assertion<T, RedbeamsClient> assertion) {
+        return then(assertion, emptyRunningParameter());
+    }
+
+    @Override
+    public T then(Assertion<T, RedbeamsClient> assertion, RunningParameter runningParameter) {
+        return getTestContext().then((T) this, RedbeamsClient.class, assertion, runningParameter);
+    }
+
+    @Override
+    public T then(List<Assertion<T, RedbeamsClient>> assertions) {
+        List<RunningParameter> runningParameters = new ArrayList<>(assertions.size());
+        for (int i = 0; i < assertions.size(); i++) {
+            runningParameters.add(emptyRunningParameter());
+        }
+        return then(assertions, runningParameters);
+    }
+
+    @Override
+    public T then(List<Assertion<T, RedbeamsClient>> assertions, List<RunningParameter> runningParameters) {
+        for (int i = 0; i < assertions.size() - 1; i++) {
+            getTestContext().then((T) this, RedbeamsClient.class, assertions.get(i), runningParameters.get(i));
+        }
+        return getTestContext()
+                .then((T) this, RedbeamsClient.class, assertions.get(assertions.size() - 1), runningParameters.get(runningParameters.size() - 1));
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/DeletableRedbeamsTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/DeletableRedbeamsTestDto.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.it.cloudbreak.dto;
+
+import com.sequenceiq.it.cloudbreak.RedbeamsClient;
+import com.sequenceiq.it.cloudbreak.context.Purgable;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+
+public abstract class DeletableRedbeamsTestDto<R, S, T extends CloudbreakTestDto, Z> extends AbstractRedbeamsTestDto<R, S, T>
+        implements Purgable<Z, RedbeamsClient> {
+
+    protected DeletableRedbeamsTestDto(String newId) {
+        super(newId);
+    }
+
+    protected DeletableRedbeamsTestDto(R request, TestContext testContext) {
+        super(request, testContext);
+    }
+
+    @Override
+    public boolean deletable(Z entity) {
+        return name(entity).startsWith(getResourcePropertyProvider().prefix());
+    }
+
+    protected abstract String name(Z entity);
+
+    @Override
+    public Class<RedbeamsClient> client() {
+        return RedbeamsClient.class;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/database/RedbeamsDatabaseTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/database/RedbeamsDatabaseTestDto.java
@@ -1,0 +1,137 @@
+package com.sequenceiq.it.cloudbreak.dto.database;
+
+import java.util.List;
+// import java.util.function.BiConsumer;
+// import java.util.function.Function;
+import java.util.stream.Collectors;
+
+// import javax.ws.rs.WebApplicationException;
+
+// import com.sequenceiq.it.IntegrationTestContext;
+import com.sequenceiq.it.cloudbreak.dto.DeletableRedbeamsTestDto;
+// import com.sequenceiq.it.cloudbreak.Assertion;
+// import com.sequenceiq.it.cloudbreak.GherkinTest;
+import com.sequenceiq.it.cloudbreak.Prototype;
+import com.sequenceiq.it.cloudbreak.RedbeamsClient;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.util.ResponseUtil;
+import com.sequenceiq.redbeams.api.endpoint.v4.database.DatabaseV4Endpoint;
+import com.sequenceiq.redbeams.api.endpoint.v4.database.request.DatabaseV4Request;
+import com.sequenceiq.redbeams.api.endpoint.v4.database.responses.DatabaseV4Response;
+
+@Prototype
+public class RedbeamsDatabaseTestDto extends DeletableRedbeamsTestDto<DatabaseV4Request, DatabaseV4Response, RedbeamsDatabaseTestDto, DatabaseV4Response> {
+
+    public static final String DATABASE = "DATABASE";
+
+    RedbeamsDatabaseTestDto(String newId) {
+        super(newId);
+        setRequest(new DatabaseV4Request());
+    }
+
+    RedbeamsDatabaseTestDto() {
+        this(DATABASE);
+    }
+
+    public RedbeamsDatabaseTestDto(TestContext testContext) {
+        super(new DatabaseV4Request(), testContext);
+    }
+
+    public RedbeamsDatabaseTestDto(DatabaseV4Request request, TestContext testContext) {
+        super(request, testContext);
+    }
+
+    // @Override
+    // public void cleanUp(TestContext context, RedbeamsClient redbeamsClient) {
+    //     LOGGER.info("Cleaning up resource with name: {}", getName());
+    //     try {
+    //         redbeamsClient.getEndpoints().databaseV4Endpoint().deleteByName(cloudbreakClient.getWorkspaceId(), getName());
+    //     } catch (WebApplicationException ignore) {
+    //         LOGGER.warn("Cleaning up resource failed", ignore);
+    //     }
+    // }
+
+    @Override
+    public RedbeamsDatabaseTestDto valid() {
+        TestContext testContext = getTestContext();
+        if (testContext == null) {
+            throw new IllegalStateException("Cannot create valid instance, test context is not available");
+        }
+        String environmentCrn = ((RedbeamsClient) testContext.getMicroserviceClient(RedbeamsClient.class)).getEnvironmentCrn();
+        return withName(getResourcePropertyProvider().getName())
+                .withDescription(getResourcePropertyProvider().getDescription("database"))
+                .withConnectionUserName("user")
+                .withConnectionPassword("password")
+                .withConnectionURL("jdbc:postgresql://somedb.com:5432/mydb")
+                .withType("HIVE")
+                .withEnvironmentCrn(environmentCrn);
+    }
+
+    public RedbeamsDatabaseTestDto withRequest(DatabaseV4Request request) {
+        setRequest(request);
+        return this;
+    }
+
+    public RedbeamsDatabaseTestDto withName(String name) {
+        getRequest().setName(name);
+        setName(name);
+        return this;
+    }
+
+    public RedbeamsDatabaseTestDto withDescription(String description) {
+        getRequest().setDescription(description);
+        return this;
+    }
+
+    public RedbeamsDatabaseTestDto withConnectionPassword(String password) {
+        getRequest().setConnectionPassword(password);
+        return this;
+    }
+
+    public RedbeamsDatabaseTestDto withConnectionUserName(String username) {
+        getRequest().setConnectionUserName(username);
+        return this;
+    }
+
+    public RedbeamsDatabaseTestDto withConnectionURL(String connectionURL) {
+        getRequest().setConnectionURL(connectionURL);
+        return this;
+    }
+
+    public RedbeamsDatabaseTestDto withType(String type) {
+        getRequest().setType(type);
+        return this;
+    }
+
+    public RedbeamsDatabaseTestDto withEnvironmentCrn(String environmentCrn) {
+        getRequest().setEnvironmentCrn(environmentCrn);
+        return this;
+    }
+
+    @Override
+    public List<DatabaseV4Response> getAll(RedbeamsClient client) {
+        DatabaseV4Endpoint databaseV4Endpoint = client.getEndpoints().databaseV4Endpoint();
+        return databaseV4Endpoint.list(client.getEnvironmentCrn()).getResponses().stream()
+                .filter(s -> s.getName() != null)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    protected String name(DatabaseV4Response entity) {
+        return entity.getName();
+    }
+
+    @Override
+    public void delete(TestContext testContext, DatabaseV4Response entity, RedbeamsClient client) {
+        try {
+            client.getEndpoints().databaseV4Endpoint().deleteByName(client.getEnvironmentCrn(), entity.getName());
+        } catch (Exception e) {
+            LOGGER.warn("Something went wrong on {} purge. {}", entity.getName(), ResponseUtil.getErrorMessage(e), e);
+        }
+    }
+
+    @Override
+    public int order() {
+        return 500;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/RedbeamsDatabaseTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/RedbeamsDatabaseTest.java
@@ -1,0 +1,67 @@
+package com.sequenceiq.it.cloudbreak.testcase.mock;
+
+import javax.inject.Inject;
+import javax.ws.rs.BadRequestException;
+
+import org.testng.annotations.Test;
+
+import com.sequenceiq.it.cloudbreak.assertion.database.RedbeamsDatabaseTestAssertion;
+import com.sequenceiq.it.cloudbreak.client.RedbeamsDatabaseTestClient;
+import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.RunningParameter;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.database.RedbeamsDatabaseTestDto;
+import com.sequenceiq.it.cloudbreak.testcase.AbstractIntegrationTest;
+
+public class RedbeamsDatabaseTest extends AbstractIntegrationTest {
+
+    @Inject
+    private RedbeamsDatabaseTestClient databaseTestClient;
+
+    @Override
+    protected void setupTest(TestContext testContext) {
+        createDefaultUser(testContext);
+        createDefaultCredential(testContext);
+        createDefaultEnvironment(testContext);
+    }
+
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
+    @Description(
+            given = "there is a prepared database",
+            when = "the database is deleted and then a create request is sent with the same database name",
+            then = "the database should be created again")
+    public void createAndDeleteAndCreateWithSameNameThenShouldRecreatedDatabase(TestContext testContext) {
+        String databaseName = resourcePropertyProvider().getName();
+        testContext
+                .given(RedbeamsDatabaseTestDto.class)
+                .withName(databaseName)
+                .when(databaseTestClient.createV4(), RunningParameter.key(databaseName))
+                .when(databaseTestClient.listV4(), RunningParameter.key(databaseName))
+                .then(RedbeamsDatabaseTestAssertion.containsDatabaseName(databaseName, 1), RunningParameter.key(databaseName))
+                .when(databaseTestClient.deleteV4(), RunningParameter.key(databaseName))
+                .when(databaseTestClient.listV4(), RunningParameter.key(databaseName))
+                .then(RedbeamsDatabaseTestAssertion.containsDatabaseName(databaseName, 0), RunningParameter.key(databaseName))
+                .when(databaseTestClient.createV4(), RunningParameter.key(databaseName))
+                .when(databaseTestClient.listV4(), RunningParameter.key(databaseName))
+                .then(RedbeamsDatabaseTestAssertion.containsDatabaseName(databaseName, 1), RunningParameter.key(databaseName))
+                .validate();
+    }
+
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
+    @Description(
+            given = "there is a prepared database",
+            when = "when a database create request is sent with the same database name",
+            then = "the create should return a BadRequestException")
+    public void createAndCreateWithSameNameThenShouldThrowBadRequestException(TestContext testContext) {
+        String databaseName = resourcePropertyProvider().getName();
+        testContext
+                .given(RedbeamsDatabaseTestDto.class)
+                .withName(databaseName)
+                .when(databaseTestClient.createV4(), RunningParameter.key(databaseName))
+                .when(databaseTestClient.listV4(), RunningParameter.key(databaseName))
+                .then(RedbeamsDatabaseTestAssertion.containsDatabaseName(databaseName, 1), RunningParameter.key(databaseName))
+                .when(databaseTestClient.createV4(), RunningParameter.key(databaseName))
+                .expect(BadRequestException.class, RunningParameter.key(databaseName))
+                .validate();
+    }
+}

--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -281,6 +281,10 @@ integrationtest:
   sdx:
       server: http://localhost
 
+  # redbeams properties
+  redbeams:
+      server: http://localhost
+
   # gcp credential details
   gcpcredential:
      name:

--- a/redbeams-api/build.gradle
+++ b/redbeams-api/build.gradle
@@ -34,6 +34,7 @@ dependencies {
   testCompile group: 'org.springframework.boot',  name: 'spring-boot-starter',            version: springBootVersion
   testCompile group: 'org.springframework.boot',  name: 'spring-boot-starter-test',       version: springBootVersion
   testCompile group: 'junit',                     name: 'junit',                          version: junitVersion
+  testCompile group: 'javax.validation',          name: 'validation-api',                 version: javaxValidationVersion
   testImplementation group: 'org.junit.jupiter',  name: 'junit-jupiter-api'
   testImplementation group: 'org.junit.jupiter',  name: 'junit-jupiter-params',           version: junitJupiterVersion
 

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/client/RedbeamsApiKeyClient.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/client/RedbeamsApiKeyClient.java
@@ -1,0 +1,17 @@
+package com.sequenceiq.redbeams.client;
+
+import com.sequenceiq.cloudbreak.client.AbstractKeyBasedServiceClient;
+import com.sequenceiq.cloudbreak.client.ConfigKey;
+import com.sequenceiq.redbeams.api.RedbeamsApi;
+
+public class RedbeamsApiKeyClient extends AbstractKeyBasedServiceClient<RedbeamsApiKeyEndpoints> {
+
+    public RedbeamsApiKeyClient(String serviceAddress, ConfigKey configKey) {
+        super(serviceAddress, configKey, RedbeamsApi.API_ROOT_CONTEXT);
+    }
+
+    @Override
+    public RedbeamsApiKeyEndpoints withKeys(String accessKey, String secretKey) {
+        return new RedbeamsApiKeyEndpoints(getWebTarget(), accessKey, secretKey);
+    }
+}

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/client/RedbeamsApiKeyEndpoints.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/client/RedbeamsApiKeyEndpoints.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.redbeams.client;
+
+import javax.ws.rs.client.WebTarget;
+
+import com.sequenceiq.cloudbreak.client.AbstractKeyBasedServiceEndpoint;
+import com.sequenceiq.redbeams.api.endpoint.v4.database.DatabaseV4Endpoint;
+import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.DatabaseServerV4Endpoint;
+
+public class RedbeamsApiKeyEndpoints extends AbstractKeyBasedServiceEndpoint implements RedbeamsClient {
+
+    protected RedbeamsApiKeyEndpoints(WebTarget webTarget, String accessKey, String secretKey) {
+        super(webTarget, accessKey, secretKey);
+    }
+
+    @Override
+    public DatabaseV4Endpoint databaseV4Endpoint() {
+        return getEndpoint(DatabaseV4Endpoint.class);
+    }
+
+    @Override
+    public DatabaseServerV4Endpoint databaseServerV4Endpoint() {
+        return getEndpoint(DatabaseServerV4Endpoint.class);
+    }
+}
+

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/validation/DatabaseVendorAndServiceValidator.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/validation/DatabaseVendorAndServiceValidator.java
@@ -21,6 +21,8 @@ public class DatabaseVendorAndServiceValidator implements ConstraintValidator<Va
 
     @Override
     public boolean isValid(DatabaseV4Request request, ConstraintValidatorContext context) {
+        context.disableDefaultConstraintViolation();
+
         Optional<DatabaseVendor> vendorByJdbcUrl = databaseVendorUtil.getVendorByJdbcUrl(request.getConnectionURL());
         if (!vendorByJdbcUrl.isPresent()) {
             ValidatorUtil.addConstraintViolation(context, "Could not determine database vendor from JDBC URL "

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/database/request/DatabaseV4RequestValidationTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/database/request/DatabaseV4RequestValidationTest.java
@@ -1,0 +1,210 @@
+package com.sequenceiq.redbeams.api.endpoint.v4.database.request;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.base.Strings;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class DatabaseV4RequestValidationTest {
+
+    private static final String DATABASE_NAME = "mydb1";
+
+    private static final String DATABASE_PROTOCOL = "jdbc:postgresql://";
+
+    private static final String DATABASE_HOST_PORT_DB = "somedb.com:5432/mydb";
+
+    private static final String DATABASE_USERNAME = "username";
+
+    private static final String DATABASE_PASSWORD = "password";
+
+    private static final String DATABASE_TYPE = "hive";
+
+    private static final String ENVIRONMENT_CRN = "crn:cdp:environments:us-west-1:cloudera:environment:myenv";
+
+    private static ValidatorFactory validatorFactory;
+
+    private static Validator validator;
+
+    private final DatabaseV4Request underTest;
+
+    private final Set<String> expectedErrorMessages;
+
+    public DatabaseV4RequestValidationTest(
+        String databaseName,
+        String username,
+        String password,
+        String connectionUrl,
+        String type,
+        String environmentCrn,
+        Set<String> expectedErrorMessages) {
+        underTest = new DatabaseV4Request();
+
+        underTest.setName(databaseName);
+        underTest.setConnectionUserName(username);
+        underTest.setConnectionPassword(password);
+        underTest.setConnectionURL(connectionUrl);
+        underTest.setType(type);
+        underTest.setEnvironmentCrn(environmentCrn);
+
+        this.expectedErrorMessages = expectedErrorMessages;
+    }
+
+    @Parameters
+    public static Iterable<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+            {
+                DATABASE_NAME,
+                DATABASE_USERNAME,
+                DATABASE_PASSWORD,
+                DATABASE_PROTOCOL + DATABASE_HOST_PORT_DB,
+                DATABASE_TYPE,
+                ENVIRONMENT_CRN,
+                Set.<String>of()
+            },
+            {
+                Strings.repeat("a", 101),
+                DATABASE_USERNAME,
+                DATABASE_PASSWORD,
+                DATABASE_PROTOCOL + DATABASE_HOST_PORT_DB,
+                DATABASE_TYPE,
+                ENVIRONMENT_CRN,
+                Set.<String>of("The length of the database's name must be between 5 to 100")
+            },
+            {
+                "abc",
+                DATABASE_USERNAME,
+                DATABASE_PASSWORD,
+                DATABASE_PROTOCOL + DATABASE_HOST_PORT_DB,
+                DATABASE_TYPE,
+                ENVIRONMENT_CRN,
+                Set.<String>of("The length of the database's name must be between 5 to 100")
+            },
+            {
+                "a-@#$%|:&*;",
+                DATABASE_USERNAME,
+                DATABASE_PASSWORD,
+                DATABASE_PROTOCOL + DATABASE_HOST_PORT_DB,
+                DATABASE_TYPE,
+                ENVIRONMENT_CRN,
+                Set.<String>of("The database's name may only contain lowercase characters")
+            },
+            {
+                DATABASE_NAME,
+                null,
+                DATABASE_PASSWORD,
+                DATABASE_PROTOCOL + DATABASE_HOST_PORT_DB,
+                DATABASE_TYPE,
+                ENVIRONMENT_CRN,
+                Set.<String>of("must not be null")
+            },
+            {
+                DATABASE_NAME,
+                DATABASE_USERNAME,
+                null,
+                DATABASE_PROTOCOL + DATABASE_HOST_PORT_DB,
+                DATABASE_TYPE,
+                ENVIRONMENT_CRN,
+                Set.<String>of("must not be null")
+            },
+            {
+                DATABASE_NAME,
+                DATABASE_USERNAME,
+                DATABASE_PASSWORD,
+                DATABASE_HOST_PORT_DB,
+                DATABASE_TYPE,
+                ENVIRONMENT_CRN,
+                Set.<String>of("JDBC connection URL is not valid", "Could not determine database vendor from JDBC URL")
+            },
+            {
+                DATABASE_NAME,
+                DATABASE_USERNAME,
+                DATABASE_PASSWORD,
+                DATABASE_PROTOCOL + DATABASE_HOST_PORT_DB,
+                Strings.repeat("a", 57),
+                ENVIRONMENT_CRN,
+                Set.<String>of("The length of the database's type must be between 3 and 56")
+            },
+            {
+                DATABASE_NAME,
+                DATABASE_USERNAME,
+                DATABASE_PASSWORD,
+                DATABASE_PROTOCOL + DATABASE_HOST_PORT_DB,
+                "ab",
+                ENVIRONMENT_CRN,
+                Set.<String>of("The length of the database's type must be between 3 and 56")
+            },
+            {
+                DATABASE_NAME,
+                DATABASE_USERNAME,
+                DATABASE_PASSWORD,
+                DATABASE_PROTOCOL + DATABASE_HOST_PORT_DB,
+                "a-@#$%|:&*;",
+                ENVIRONMENT_CRN,
+                Set.<String>of("The database's type may only contain alphanumeric characters")
+            },
+            {
+                DATABASE_NAME,
+                DATABASE_USERNAME,
+                DATABASE_PASSWORD,
+                DATABASE_PROTOCOL + DATABASE_HOST_PORT_DB,
+                DATABASE_TYPE,
+                null,
+                Set.<String>of("must not be null")
+            },
+            {
+                DATABASE_NAME,
+                DATABASE_USERNAME,
+                DATABASE_PASSWORD,
+                DATABASE_PROTOCOL + DATABASE_HOST_PORT_DB,
+                DATABASE_TYPE,
+                "abc",
+                Set.<String>of("Invalid crn provided")
+            }
+        });
+    }
+
+    @BeforeClass
+    public static void setUpClass() {
+        validatorFactory = Validation.buildDefaultValidatorFactory();
+        validator = validatorFactory.getValidator();
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        validatorFactory.close();
+    }
+
+    @Test
+    public void testValidation() {
+        Set<ConstraintViolation<DatabaseV4Request>> violations = validator.validate(underTest);
+
+        if (expectedErrorMessages.isEmpty()) {
+            assertTrue(violations.isEmpty());
+        } else {
+            assertEquals(expectedErrorMessages.size(), violations.size());
+
+            for (ConstraintViolation<DatabaseV4Request> violation : violations) {
+                String violationMessage = violation.getMessage();
+                assertTrue("Unexpected message: " + violationMessage,
+                    expectedErrorMessages.stream().anyMatch(m -> violationMessage.contains(m)));
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
RedbeamsDatabaseTest is the first integration test for the redbeams
service. It tests database registration, like the older DatabaseTest
does for the core cloudbreak service.

There are many ancillary classes introduced in order to make the
integration test possible.

* RedbeamsApiKeyEndpoints and RedbeamsApiKeyClient: These objects make
  it feasible for integration tests, or other code, to call redbeams
  passing in the necessary Altus API key headers for redbeams calls.
* RedbeamsDatabaseTestDto: This holds the request and response for
  database registration tests.
* DeletableRedbeamsTestDto and AbstractRedbeamsTestDto: These are common
  base classes for all redbeams integration test DTOs, including
  RedbeamsDatabaseTestDto.
* RedbeamsDatabaseTestAssertion: This class is a factory for functions
  that perform assertions on the outcomes of test actions for redbeams
  calls. RedbeamsDatabaseTest uses it.
* RedbeamsDatabaseCreateAction, RedbeamsDatabaseCreateIfNotExistsAction,
  RedbeamsDatabaseDeleteAction, and RedbeamsDatabaseListAction: These
  are action classes that manage database-related API calls to the
  redbeams service. Each one submits a request from a DTO and stores the
  response back into it.
* RedbeamsDatabaseTestClient: This is the wrapper for performing
  database-related API calls to redbeams. Each call is implemented by an
  action class.
* RedbeamsServer: This sets the test parameters necessary to locate the
  redbeams service to test.
* RedbeamsClient - This is the client object integration tests can use
  to call redbeams. Under the hood, it uses RedbeamsApiKeyClient. It
  stores a fake environment CRN to use for all test calls. TestContext
  creates the client along with those for other services, and stores it
  into the set of clients available for tests to use. This class is
  vastly simpler than similar client objects for other services.

The classes above are based on existing classes for other services'
integration tests.

Other changes:

* The logic for the default profile used by CliProfileReaderService is
  simplified.
* A bug in ServerUtil is fixed.
* A new getMicroserviceClient method in TestContext is added to make it
  easier for integration tests to retrieve a service client. For
  redbeams tests, this is used in order to find the test environment
  CRN.