### PR TITLE
CB-3210. Update telemetry model (v2) - less strict JSON as first step

### DIFF
--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/base/FeaturesBase.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/base/FeaturesBase.java
@@ -1,0 +1,36 @@
+package com.sequenceiq.common.api.telemetry.base;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.common.api.telemetry.doc.TelemetryModelDescription;
+import com.sequenceiq.common.api.type.FeatureSetting;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public abstract class FeaturesBase implements Serializable {
+
+    @JsonProperty("workloadAnalytics")
+    @ApiModelProperty(TelemetryModelDescription.TELEMETRY_WORKLOAD_ANALYTICS)
+    private FeatureSetting workloadAnalytics;
+
+    @JsonProperty("reportDeploymentLogs")
+    @ApiModelProperty(TelemetryModelDescription.TELEMETRY_REPORT_DEPLOYMENT_LOGS_ENABLED)
+    private FeatureSetting reportDeploymentLogs;
+
+    public FeatureSetting getWorkloadAnalytics() {
+        return workloadAnalytics;
+    }
+
+    public void setWorkloadAnalytics(FeatureSetting workloadAnalytics) {
+        this.workloadAnalytics = workloadAnalytics;
+    }
+
+    public FeatureSetting getReportDeploymentLogs() {
+        return reportDeploymentLogs;
+    }
+
+    public void setReportDeploymentLogs(FeatureSetting reportDeploymentLogs) {
+        this.reportDeploymentLogs = reportDeploymentLogs;
+    }
+}

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/base/TelemetryBase.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/base/TelemetryBase.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.common.api.telemetry.base;
 
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
 
 import com.sequenceiq.common.api.telemetry.doc.TelemetryModelDescription;
 
@@ -11,11 +13,22 @@ public abstract class TelemetryBase implements Serializable {
     @ApiModelProperty(TelemetryModelDescription.TELEMETRY_REPORT_DEPLOYMENT_LOGS_ENABLED)
     private Boolean reportDeploymentLogs = Boolean.TRUE;
 
+    @ApiModelProperty(TelemetryModelDescription.TELEMETRY_FLUENT_ATTRIBUTES)
+    private Map<String, Object> fluentAttributes = new HashMap<>();
+
     public Boolean getReportDeploymentLogs() {
         return reportDeploymentLogs;
     }
 
     public void setReportDeploymentLogs(Boolean reportDeploymentLogs) {
         this.reportDeploymentLogs = reportDeploymentLogs;
+    }
+
+    public Map<String, Object> getFluentAttributes() {
+        return fluentAttributes;
+    }
+
+    public void setFluentAttributes(Map<String, Object> fluentAttributes) {
+        this.fluentAttributes = fluentAttributes;
     }
 }

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/doc/TelemetryModelDescription.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/doc/TelemetryModelDescription.java
@@ -5,9 +5,14 @@ public class TelemetryModelDescription {
     public static final String TELEMETRY_LOGGING = "Cloud Logging (telemetry) settings.";
     public static final String TELEMETRY_WORKLOAD_ANALYTICS = "Workload analytics (telemetry) settings.";
     public static final String TELEMETRY_COMPONENT_ATTRIBUTES = "telemetry component custom attributes";
+    public static final String TELEMETRY_WORKLOAD_ANALYTICS_ATTRIBUTES = "Workload analytics (telemetry) attributes.";
+    public static final String TELEMETRY_FLUENT_ATTRIBUTES = "Telemetry fluent settings (overrides).";
+    public static final String TELEMETRY_FEATURES = "Telemetry features settings";
+    public static final String TELEMETRY_METERING = "Telemetry metering feature setting";
     public static final String TELEMETRY_LOGGING_S3_ATTRIBUTES = "telemetry - logging s3 attributes";
     public static final String TELEMETRY_LOGGING_WASB_ATTRIBUTES = "telemetry - logging wasb attributes";
     public static final String TELEMETRY_LOGGING_STORAGE_LOCATION = "telemetry - logging storage location / container";
+    public static final String TELEMETRY_DATABUS_ENDPOINT = "telemetry - altus service (databus) endpoint url";
     public static final String TELEMETRY_WA_DATABUS_ENDPOINT = "telemetry - workload altus service (databus) endpoint url";
     public static final String TELEMETRY_REPORT_DEPLOYMENT_LOGS_ENABLED = "enable cluster deployment log reporting.";
 

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/Features.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/Features.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.common.api.telemetry.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.common.api.telemetry.base.FeaturesBase;
+import com.sequenceiq.common.api.type.FeatureSetting;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Features extends FeaturesBase {
+
+    @JsonProperty("metering")
+    private FeatureSetting metering;
+
+    public FeatureSetting getMetering() {
+        return metering;
+    }
+
+    public void setMetering(FeatureSetting metering) {
+        this.metering = metering;
+    }
+}

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/Telemetry.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/Telemetry.java
@@ -4,6 +4,8 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -27,6 +29,12 @@ public class Telemetry implements Serializable {
 
     @JsonProperty("reportDeploymentLogs")
     private boolean reportDeploymentLogs;
+
+    @JsonProperty("features")
+    private Features features;
+
+    @JsonProperty("fluentAttributes")
+    private Map<String, Object> fluentAttributes = new HashMap<>();
 
     public Logging getLogging() {
         return logging;
@@ -66,5 +74,21 @@ public class Telemetry implements Serializable {
 
     public void setReportDeploymentLogs(boolean reportDeploymentLogs) {
         this.reportDeploymentLogs = reportDeploymentLogs;
+    }
+
+    public Features getFeatures() {
+        return features;
+    }
+
+    public void setFeatures(Features features) {
+        this.features = features;
+    }
+
+    public Map<String, Object> getFluentAttributes() {
+        return fluentAttributes;
+    }
+
+    public void setFluentAttributes(Map<String, Object> fluentAttributes) {
+        this.fluentAttributes = fluentAttributes;
     }
 }

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/request/FeaturesRequest.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/request/FeaturesRequest.java
@@ -1,0 +1,9 @@
+package com.sequenceiq.common.api.telemetry.request;
+
+import com.sequenceiq.common.api.telemetry.base.FeaturesBase;
+
+import io.swagger.annotations.ApiModel;
+
+@ApiModel(value = "FeaturesRequest")
+public class FeaturesRequest extends FeaturesBase {
+}

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/request/TelemetryRequest.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/request/TelemetryRequest.java
@@ -17,6 +17,9 @@ public class TelemetryRequest extends TelemetryBase {
     @ApiModelProperty(TelemetryModelDescription.TELEMETRY_WORKLOAD_ANALYTICS)
     private WorkloadAnalyticsRequest workloadAnalytics;
 
+    @ApiModelProperty(TelemetryModelDescription.TELEMETRY_FEATURES)
+    private FeaturesRequest features;
+
     public LoggingRequest getLogging() {
         return logging;
     }
@@ -31,5 +34,13 @@ public class TelemetryRequest extends TelemetryBase {
 
     public void setWorkloadAnalytics(WorkloadAnalyticsRequest workloadAnalytics) {
         this.workloadAnalytics = workloadAnalytics;
+    }
+
+    public FeaturesRequest getFeatures() {
+        return features;
+    }
+
+    public void setFeatures(FeaturesRequest features) {
+        this.features = features;
     }
 }

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/response/FeaturesResponse.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/response/FeaturesResponse.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.common.api.telemetry.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.common.api.telemetry.base.FeaturesBase;
+import com.sequenceiq.common.api.telemetry.doc.TelemetryModelDescription;
+import com.sequenceiq.common.api.type.FeatureSetting;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel(value = "FeaturesResponse")
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FeaturesResponse extends FeaturesBase {
+
+    @JsonProperty("metering")
+    @ApiModelProperty(TelemetryModelDescription.TELEMETRY_METERING)
+    private FeatureSetting metering;
+
+    public FeatureSetting getMetering() {
+        return metering;
+    }
+
+    public void setMetering(FeatureSetting metering) {
+        this.metering = metering;
+    }
+}

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/response/TelemetryResponse.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/response/TelemetryResponse.java
@@ -17,6 +17,9 @@ public class TelemetryResponse extends TelemetryBase {
     @ApiModelProperty(TelemetryModelDescription.TELEMETRY_WORKLOAD_ANALYTICS)
     private WorkloadAnalyticsResponse workloadAnalytics;
 
+    @ApiModelProperty(TelemetryModelDescription.TELEMETRY_FEATURES)
+    private FeaturesResponse features;
+
     public LoggingResponse getLogging() {
         return logging;
     }
@@ -31,5 +34,13 @@ public class TelemetryResponse extends TelemetryBase {
 
     public void setWorkloadAnalytics(WorkloadAnalyticsResponse workloadAnalytics) {
         this.workloadAnalytics = workloadAnalytics;
+    }
+
+    public FeaturesResponse getFeatures() {
+        return features;
+    }
+
+    public void setFeatures(FeaturesResponse features) {
+        this.features = features;
     }
 }

--- a/common-model/src/main/java/com/sequenceiq/common/api/type/FeatureSetting.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/type/FeatureSetting.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.common.api.type;
+
+import java.io.Serializable;
+
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FeatureSetting implements Serializable {
+
+    @NotNull
+    @ApiModelProperty(value = "enabled", required = true)
+    private Boolean enabled;
+
+    public Boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.common.api.telemetry.model.Features;
 import com.sequenceiq.common.api.telemetry.model.Logging;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
 import com.sequenceiq.common.api.telemetry.model.WorkloadAnalytics;
@@ -17,6 +18,7 @@ import com.sequenceiq.common.api.telemetry.request.WorkloadAnalyticsRequest;
 import com.sequenceiq.common.api.telemetry.response.LoggingResponse;
 import com.sequenceiq.common.api.telemetry.response.TelemetryResponse;
 import com.sequenceiq.common.api.telemetry.response.WorkloadAnalyticsResponse;
+import com.sequenceiq.common.api.type.FeatureSetting;
 import com.sequenceiq.sdx.api.model.SdxClusterResponse;
 
 @Component
@@ -98,6 +100,11 @@ public class TelemetryConverter {
         }
         if (meteringEnabled) {
             telemetry.setMeteringEnabled(true);
+            FeatureSetting meteringFeature = new FeatureSetting();
+            meteringFeature.setEnabled(true);
+            Features features = new Features();
+            features.setMetering(meteringFeature);
+            telemetry.setFeatures(features);
         }
         if (StringUtils.isNotEmpty(databusEndpoint)) {
             telemetry.setDatabusEndpoint(databusEndpoint);

--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/telemetry/EnvironmentFeatures.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/telemetry/EnvironmentFeatures.java
@@ -1,0 +1,30 @@
+package com.sequenceiq.environment.environment.dto.telemetry;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.sequenceiq.common.api.type.FeatureSetting;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EnvironmentFeatures implements Serializable {
+
+    private FeatureSetting workloadAnalytics;
+
+    private FeatureSetting reportDeploymentLogs;
+
+    public FeatureSetting getReportDeploymentLogs() {
+        return reportDeploymentLogs;
+    }
+
+    public void setReportDeploymentLogs(FeatureSetting reportDeploymentLogs) {
+        this.reportDeploymentLogs = reportDeploymentLogs;
+    }
+
+    public FeatureSetting getWorkloadAnalytics() {
+        return workloadAnalytics;
+    }
+
+    public void setWorkloadAnalytics(FeatureSetting workloadAnalytics) {
+        this.workloadAnalytics = workloadAnalytics;
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/telemetry/EnvironmentLogging.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/telemetry/EnvironmentLogging.java
@@ -1,5 +1,8 @@
 package com.sequenceiq.environment.environment.dto.telemetry;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class EnvironmentLogging extends CommonTelemetryParams {
 
     private String storageLocation;

--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/telemetry/EnvironmentTelemetry.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/telemetry/EnvironmentTelemetry.java
@@ -1,41 +1,61 @@
 package com.sequenceiq.environment.environment.dto.telemetry;
 
-import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
-import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
-
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
-@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class EnvironmentTelemetry implements Serializable {
 
-    private final EnvironmentLogging logging;
+    private EnvironmentLogging logging;
 
-    private final EnvironmentWorkloadAnalytics workloadAnalytics;
+    private EnvironmentWorkloadAnalytics workloadAnalytics;
 
-    private final boolean reportDeploymentLogs;
+    private boolean reportDeploymentLogs;
 
-    public EnvironmentTelemetry(@JsonProperty("logging") EnvironmentLogging logging,
-            @JsonProperty("workloadAnalytics") EnvironmentWorkloadAnalytics workloadAnalytics,
-            @JsonProperty("reportDeploymentLogs") boolean reportDeploymentLogs) {
-        this.logging = logging;
-        this.workloadAnalytics = workloadAnalytics;
-        this.reportDeploymentLogs = reportDeploymentLogs;
-    }
+    private EnvironmentFeatures features;
+
+    private Map<String, Object> fluentAttributes = new HashMap<>();
 
     public EnvironmentLogging getLogging() {
         return logging;
+    }
+
+    public void setLogging(EnvironmentLogging logging) {
+        this.logging = logging;
     }
 
     public EnvironmentWorkloadAnalytics getWorkloadAnalytics() {
         return workloadAnalytics;
     }
 
+    public void setWorkloadAnalytics(EnvironmentWorkloadAnalytics workloadAnalytics) {
+        this.workloadAnalytics = workloadAnalytics;
+    }
+
     public boolean isReportDeploymentLogs() {
         return reportDeploymentLogs;
+    }
+
+    public void setReportDeploymentLogs(boolean reportDeploymentLogs) {
+        this.reportDeploymentLogs = reportDeploymentLogs;
+    }
+
+    public EnvironmentFeatures getFeatures() {
+        return features;
+    }
+
+    public void setFeatures(EnvironmentFeatures features) {
+        this.features = features;
+    }
+
+    public Map<String, Object> getFluentAttributes() {
+        return fluentAttributes;
+    }
+
+    public void setFluentAttributes(Map<String, Object> fluentAttributes) {
+        this.fluentAttributes = fluentAttributes;
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/telemetry/EnvironmentWorkloadAnalytics.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/telemetry/EnvironmentWorkloadAnalytics.java
@@ -1,5 +1,8 @@
 package com.sequenceiq.environment.environment.dto.telemetry;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class EnvironmentWorkloadAnalytics extends CommonTelemetryParams {
 
     private String databusEndpoint;

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/TelemetryApiConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/TelemetryApiConverter.java
@@ -52,7 +52,11 @@ public class TelemetryApiConverter {
                 );
             }
             boolean reportDeploymentLogsEnabled = reportDeploymentLogs ? request.getReportDeploymentLogs() : false;
-            telemetry = new EnvironmentTelemetry(logging, workloadAnalytics, reportDeploymentLogsEnabled);
+            telemetry = new EnvironmentTelemetry();
+            telemetry.setLogging(logging);
+            telemetry.setWorkloadAnalytics(workloadAnalytics);
+            telemetry.setReportDeploymentLogs(reportDeploymentLogsEnabled);
+            telemetry.setFluentAttributes(request.getFluentAttributes());
         }
         return telemetry;
     }
@@ -100,6 +104,7 @@ public class TelemetryApiConverter {
             response.setLogging(loggingResponse);
             response.setWorkloadAnalytics(waResponse);
             response.setReportDeploymentLogs(telemetry.isReportDeploymentLogs());
+            response.setFluentAttributes(telemetry.getFluentAttributes());
         }
         return response;
     }

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/TelemetryApiConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/TelemetryApiConverterTest.java
@@ -54,7 +54,8 @@ public class TelemetryApiConverterTest {
         S3CloudStorageParameters s3Params = new S3CloudStorageParameters();
         s3Params.setInstanceProfile(INSTANCE_PROFILE_VALUE);
         logging.setS3(s3Params);
-        EnvironmentTelemetry telemetry = new EnvironmentTelemetry(logging, null, false);
+        EnvironmentTelemetry telemetry = new EnvironmentTelemetry();
+        telemetry.setLogging(logging);
         // WHEN
         TelemetryResponse result = underTest.convert(telemetry);
         // THEN


### PR DESCRIPTION
that is for 2.13

idea:
- support new fields in saved json and in objects
-> on the follow up  change (after that is deployed already) , if an older request will be persisted, it will persist things like metering in the new features object, so that can be processed by that actual or new cb/env pod as well

cluster deployment testing is done - i have tried out to use an old model for telemetry json + create a new one, which persisting features object as well - deployment did not stack on telemetry parsing + s3 logs where generated (+ contained metering data)