### PR TITLE
CDPSDX-995 Require the role request to be empty for keytab retrieval

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/KerberosMgmtV1Service.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/KerberosMgmtV1Service.java
@@ -56,6 +56,8 @@ public class KerberosMgmtV1Service {
 
     private static final String EMPTY_REALM = "Failed to create service as realm was empty.";
 
+    private static final String ROLE_NOT_ALLOWED = "The role request is not allowed when retrieving a keytab";
+
     private static final String IPA_STACK_NOT_FOUND = "Stack for IPA server not found.";
 
     private static final int NOT_FOUND_ERROR_CODE = 4001;
@@ -98,6 +100,9 @@ public class KerberosMgmtV1Service {
 
     public ServiceKeytabResponse getExistingServiceKeytab(ServiceKeytabRequest request, String accountId) throws FreeIpaClientException {
         LOGGER.debug("Request to get service keytab for account {}: {}", accountId, request);
+        if (request.getRoleRequest() != null) {
+            throw new KeytabCreationException(ROLE_NOT_ALLOWED);
+        }
         ServiceKeytabResponse response = new ServiceKeytabResponse();
         Stack freeIpaStack = getFreeIpaStack(request.getEnvironmentCrn(), accountId);
         String realm = getRealm(freeIpaStack);
@@ -129,6 +134,9 @@ public class KerberosMgmtV1Service {
 
     public HostKeytabResponse getExistingHostKeytab(HostKeytabRequest request, String accountId) throws FreeIpaClientException {
         LOGGER.debug("Request to get host keytab for account {}: {}", accountId, request);
+        if (request.getRoleRequest() != null) {
+            throw new KeytabCreationException(ROLE_NOT_ALLOWED);
+        }
         HostKeytabResponse response = new HostKeytabResponse();
         Stack freeIpaStack = getFreeIpaStack(request.getEnvironmentCrn(), accountId);
         FreeIpaClient ipaClient = freeIpaClientFactory.getFreeIpaClientForStack(freeIpaStack);

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/kerberosmgmt/KerberosMgmtV1ServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/kerberosmgmt/KerberosMgmtV1ServiceTest.java
@@ -376,4 +376,35 @@ public class KerberosMgmtV1ServiceTest {
         Mockito.verify(vaultComponent).cleanupSecrets(ENVIRONMENT_ID, null, ACCOUNT_ID);
     }
 
+    @Test
+    public void testGetExistingServiceKeytabRequiesNoRoleInformation() throws Exception {
+        Set<String> privileges = new HashSet<>();
+        privileges.add(PRIVILEGE);
+        RoleRequest roleRequest = new RoleRequest();
+        roleRequest.setRoleName(ROLE);
+        roleRequest.setPrivileges(privileges);
+        ServiceKeytabRequest request = new ServiceKeytabRequest();
+        request.setServiceName(SERVICE);
+        request.setEnvironmentCrn(ENVIRONMENT_ID);
+        request.setServerHostName(HOST);
+        request.setRoleRequest(roleRequest);
+        Assertions.assertThrows(KeytabCreationException.class,
+            () -> underTest.getExistingServiceKeytab(request, ACCOUNT_ID));
+    }
+
+    @Test
+    public void testGetExistingHostKeytabRequiesNoRoleInformation() throws Exception {
+        Set<String> privileges = new HashSet<>();
+        privileges.add(PRIVILEGE);
+        RoleRequest roleRequest = new RoleRequest();
+        roleRequest.setRoleName(ROLE);
+        roleRequest.setPrivileges(privileges);
+        HostKeytabRequest request = new HostKeytabRequest();
+        request.setEnvironmentCrn(ENVIRONMENT_ID);
+        request.setServerHostName(HOST);
+        request.setRoleRequest(roleRequest);
+        Assertions.assertThrows(KeytabCreationException.class,
+            () -> underTest.getExistingHostKeytab(request, ACCOUNT_ID));
+    }
+
 }


### PR DESCRIPTION
The APIs to get service principal and host principal keytabs have a
role request in them because they reuse the same request type as the
post operation which sets the roles. The get operations no longer
allow the role request to be provided (it used to just silently
ignore it).

This was tested in a stand alone deployment of cloudbreak and by
using unit tests.

Closes #CDPSDX-995