### PR TITLE
Configure VMs with cloud provider NTP servers

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/ntp/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/ntp/init.sls
@@ -1,0 +1,37 @@
+{% if salt['file.file_exists' ]('/etc/chrony.conf') %}
+
+# Restart chronyd if its configuration file changes, but only if it was actually
+# running from the get go.
+chronyd:
+  service.running:
+    - watch:
+      - file: /etc/chrony.conf
+    - onlyif:
+      - service chronyd status
+
+# Add the cloud provider's NTP server to chronyd's configuration. We'll still
+# consider whatever servers chronyd was configured with out of the box; this
+# just gives preference to the cloud native one.
+add_cloud_platform_time_server_to_chrony:
+  file.append:
+    - name: /etc/chrony.conf
+{% if salt['pillar.get']('platform') == 'AWS' %}
+# https://aws.amazon.com/blogs/aws/keeping-time-with-amazon-time-sync-service/
+    - text: |
+
+        server 169.254.169.123 prefer iburst
+
+{% elif salt['pillar.get']('platform') == 'GCP' %}
+# https://cloud.google.com/compute/docs/instances/managing-instances#configure_ntp_for_your_instances
+    - text: |
+
+        server metadata.google.internal prefer iburst
+{% elif salt['pillar.get']('platform') == 'Azure' %}
+# TODO: For Azure, there's no link-local NTP service. Instead, we need to make
+# sure the Linux Integration Services are installed.
+#
+# https://docs.microsoft.com/en-us/azure/virtual-machines/linux/time-sync#host-only
+
+{% endif %}
+
+{% endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/top.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/top.sls
@@ -8,6 +8,7 @@ base:
     - recipes.runner
     - fluent
     - metering
+    - ntp
 
   'G@roles:ad_member and G@os_family:RedHat':
     - match: compound


### PR DESCRIPTION
The time synchronization status quo as of commit 909127e is that
provisioned VMs will use their out-of-the-box time service and
configuration as-is. For CDP CentOS 7 VMs, this means using chronyd to sync
with public NTP pool servers on the Internet.

Not all deployments will have Internet access, however. In fact, we've seen
some sporadic instances[1] where the NTP port appears to be blocked. To fix
this, let's reconfigure the VMs to incorporate whatever time sync service is
prescribed by the relevant cloud provider. Given our exclusive use of
CentOS 7 VMs I only bothered to do so for chronyd.

Note: I've only tested AWS deployments. Azure is especially frustrating
since the recommendation is to forgo NTP-based sync in favor of their Linux
Integration Services, so I've held off on that.