### PR TITLE
CB-3849 – upon env creation with new VPC an alert comes

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/validators/EnvironmentCreationValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/validators/EnvironmentCreationValidator.java
@@ -6,6 +6,8 @@ import static com.sequenceiq.environment.CloudPlatform.AZURE;
 import static com.sequenceiq.environment.CloudPlatform.MOCK;
 import static com.sequenceiq.environment.CloudPlatform.YARN;
 import static com.sequenceiq.environment.CloudPlatform.valueOf;
+import static java.util.Objects.nonNull;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 import java.util.Map;
 import java.util.Optional;
@@ -63,7 +65,7 @@ public class EnvironmentCreationValidator {
     private void validateNetworkHasTheSamePropertyFilledAsTheDesiredCloudPlatform(NetworkDto networkDto, String cloudPlatform,
             ValidationResultBuilder resultBuilder) {
 
-        if (networkDto != null) {
+        if (nonNull(networkDto) && isEmpty(networkDto.getNetworkCidr())) {
             Map<CloudPlatform, Optional<Object>> providerNetworkParamPair = Map.of(
                     AWS,   optional(networkDto.getAws()),
                     AZURE, optional(networkDto.getAzure()),


### PR DESCRIPTION
CB-3849 – upon env creation with new VPC an alert comes

brief expl.: based on how the ui sends the new env. request, if the network CIDR has not set, we take it as a new network creation request on our side