### PR TITLE
DISTX-327 - Get all users from FreeIPA those are requested.

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UmsUsersStateProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UmsUsersStateProvider.java
@@ -80,11 +80,18 @@ public class UmsUsersStateProvider {
 
                 users.stream().forEach(u -> {
                     FmsUser fmsUser = umsUserToUser(u);
+                    // add workload username for each user. This will be helpful in getting users from IPA.
+                    userStateBuilder.addRequestedWorkloadUsers(fmsUser);
+
                     handleUser(userStateBuilder, crnToFmsGroup, actorCrn, u.getCrn(), fmsUser, environmentCrn, requestIdOptional);
+
                 });
 
                 machineUsers.stream().forEach(mu -> {
                     FmsUser fmsUser = umsMachineUserToUser(mu);
+                    userStateBuilder.addRequestedWorkloadUsers(fmsUser);
+                    // add workload username for each user. This will be helpful in getting users from IPA.
+
                     handleUser(userStateBuilder, crnToFmsGroup, actorCrn, mu.getCrn(), fmsUser, environmentCrn, requestIdOptional);
                 });
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserService.java
@@ -167,7 +167,11 @@ public class UserService {
             }
 
             FreeIpaClient freeIpaClient = freeIpaClientFactory.getFreeIpaClientForStack(stack);
-            UsersState ipaUsersState = freeIpaUsersStateProvider.getFilteredFreeIPAState(freeIpaClient, umsUsersState.getUsers());
+
+            // Get all users from FreeIPA those are requested.
+            // If we use only UMS provided users for this environment and if user's access is being changed (removed user from env),
+            // then handleUser method will not filter that user and the user will not be updated in IPA.
+            UsersState ipaUsersState = freeIpaUsersStateProvider.getFilteredFreeIPAState(freeIpaClient, umsUsersState.getRequestedWorkloadUsers());
             LOGGER.debug("IPA UsersState, found {} users and {} groups", ipaUsersState.getUsers().size(), ipaUsersState.getGroups().size());
 
             UsersStateDifference stateDifference = UsersStateDifference.fromUmsAndIpaUsersStates(umsUsersState, ipaUsersState);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UsersState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UsersState.java
@@ -19,12 +19,16 @@ public class UsersState {
 
     private Map<String, WorkloadCredential> usersWorkloadCredentialMap;
 
+    private Set<FmsUser> requestedWorkloadUsers = new HashSet<>();
+
     public UsersState(
-        Set<FmsGroup> groups, Set<FmsUser> users, Multimap<String, String> groupMembership, Map<String, WorkloadCredential> usersWorkloadCredentialMap) {
+        Set<FmsGroup> groups, Set<FmsUser> users, Multimap<String, String> groupMembership,
+        Map<String, WorkloadCredential> usersWorkloadCredentialMap, Set<FmsUser> requestedWorkloadUsers) {
         this.groups = requireNonNull(groups);
         this.users = requireNonNull(users);
         this.groupMembership = requireNonNull(groupMembership);
         this.usersWorkloadCredentialMap = usersWorkloadCredentialMap;
+        this.requestedWorkloadUsers = requestedWorkloadUsers;
     }
 
     public Set<FmsGroup> getGroups() {
@@ -41,6 +45,10 @@ public class UsersState {
 
     public Map<String, WorkloadCredential> getUsersWorkloadCredentialMap() {
         return usersWorkloadCredentialMap;
+    }
+
+    public Set<FmsUser> getRequestedWorkloadUsers() {
+        return requestedWorkloadUsers;
     }
 
     @Override
@@ -61,6 +69,8 @@ public class UsersState {
 
         private Map<String, WorkloadCredential> workloadCredentialMap = new HashMap<>();
 
+        private Set<FmsUser> requestedWorkloadUsers = new HashSet<>();
+
         public void addGroup(FmsGroup fmsGroup) {
             fmsGroups.add(fmsGroup);
         }
@@ -78,7 +88,12 @@ public class UsersState {
         }
 
         public UsersState build() {
-            return new UsersState(fmsGroups, fmsUsers, groupMembership, workloadCredentialMap);
+            return new UsersState(fmsGroups, fmsUsers, groupMembership, workloadCredentialMap, requestedWorkloadUsers);
+        }
+
+        public void addRequestedWorkloadUsers(FmsUser user) {
+            requestedWorkloadUsers.add(user);
+
         }
     }
 }


### PR DESCRIPTION
This change is for left out users. In case, if the set of users are passed and the call is not for "user sync all" then, if one of the pre-existing user's access is being changed in CDP, (removed user from env), then handleUser method will filter-out that user and the user will not be removed in IPA.

Currently, we are adding a new map in UserState but later we should have something like "UserSyncRequestContext" and all needed state should be composite in that including user state, ipa state, and additional information. 

Closes DISTX-327

@handavid @keyki @lacikaaa 