### PR TITLE
CDPCP-721 part1

### DIFF
--- a/auth-connector/src/generated/main/grpc/com/cloudera/thunderhead/service/usermanagement/UserManagementGrpc.java
+++ b/auth-connector/src/generated/main/grpc/com/cloudera/thunderhead/service/usermanagement/UserManagementGrpc.java
@@ -2881,6 +2881,80 @@ public final class UserManagementGrpc {
      return getDeleteWorkloadAdministrationGroupNameMethod;
   }
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getListWorkloadAdministrationGroupsMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListWorkloadAdministrationGroupsRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListWorkloadAdministrationGroupsResponse> METHOD_LIST_WORKLOAD_ADMINISTRATION_GROUPS = getListWorkloadAdministrationGroupsMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListWorkloadAdministrationGroupsRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListWorkloadAdministrationGroupsResponse> getListWorkloadAdministrationGroupsMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListWorkloadAdministrationGroupsRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListWorkloadAdministrationGroupsResponse> getListWorkloadAdministrationGroupsMethod() {
+    return getListWorkloadAdministrationGroupsMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListWorkloadAdministrationGroupsRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListWorkloadAdministrationGroupsResponse> getListWorkloadAdministrationGroupsMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListWorkloadAdministrationGroupsRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListWorkloadAdministrationGroupsResponse> getListWorkloadAdministrationGroupsMethod;
+    if ((getListWorkloadAdministrationGroupsMethod = UserManagementGrpc.getListWorkloadAdministrationGroupsMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getListWorkloadAdministrationGroupsMethod = UserManagementGrpc.getListWorkloadAdministrationGroupsMethod) == null) {
+          UserManagementGrpc.getListWorkloadAdministrationGroupsMethod = getListWorkloadAdministrationGroupsMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListWorkloadAdministrationGroupsRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListWorkloadAdministrationGroupsResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "usermanagement.UserManagement", "ListWorkloadAdministrationGroups"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListWorkloadAdministrationGroupsRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListWorkloadAdministrationGroupsResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("ListWorkloadAdministrationGroups"))
+                  .build();
+          }
+        }
+     }
+     return getListWorkloadAdministrationGroupsMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getSetActorWorkloadCredentialsMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetActorWorkloadCredentialsRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetActorWorkloadCredentialsResponse> METHOD_SET_ACTOR_WORKLOAD_CREDENTIALS = getSetActorWorkloadCredentialsMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetActorWorkloadCredentialsRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetActorWorkloadCredentialsResponse> getSetActorWorkloadCredentialsMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetActorWorkloadCredentialsRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetActorWorkloadCredentialsResponse> getSetActorWorkloadCredentialsMethod() {
+    return getSetActorWorkloadCredentialsMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetActorWorkloadCredentialsRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetActorWorkloadCredentialsResponse> getSetActorWorkloadCredentialsMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetActorWorkloadCredentialsRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetActorWorkloadCredentialsResponse> getSetActorWorkloadCredentialsMethod;
+    if ((getSetActorWorkloadCredentialsMethod = UserManagementGrpc.getSetActorWorkloadCredentialsMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getSetActorWorkloadCredentialsMethod = UserManagementGrpc.getSetActorWorkloadCredentialsMethod) == null) {
+          UserManagementGrpc.getSetActorWorkloadCredentialsMethod = getSetActorWorkloadCredentialsMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetActorWorkloadCredentialsRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetActorWorkloadCredentialsResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "usermanagement.UserManagement", "SetActorWorkloadCredentials"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetActorWorkloadCredentialsRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetActorWorkloadCredentialsResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("SetActorWorkloadCredentials"))
+                  .build();
+          }
+        }
+     }
+     return getSetActorWorkloadCredentialsMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getGetActorWorkloadCredentialsMethod()} instead. 
   public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetActorWorkloadCredentialsRequest,
       com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetActorWorkloadCredentialsResponse> METHOD_GET_ACTOR_WORKLOAD_CREDENTIALS = getGetActorWorkloadCredentialsMethodHelper();
@@ -2916,6 +2990,43 @@ public final class UserManagementGrpc {
         }
      }
      return getGetActorWorkloadCredentialsMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getGetEventGenerationIdsMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsResponse> METHOD_GET_EVENT_GENERATION_IDS = getGetEventGenerationIdsMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsResponse> getGetEventGenerationIdsMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsResponse> getGetEventGenerationIdsMethod() {
+    return getGetEventGenerationIdsMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsResponse> getGetEventGenerationIdsMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsResponse> getGetEventGenerationIdsMethod;
+    if ((getGetEventGenerationIdsMethod = UserManagementGrpc.getGetEventGenerationIdsMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getGetEventGenerationIdsMethod = UserManagementGrpc.getGetEventGenerationIdsMethod) == null) {
+          UserManagementGrpc.getGetEventGenerationIdsMethod = getGetEventGenerationIdsMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "usermanagement.UserManagement", "GetEventGenerationIds"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("GetEventGenerationIds"))
+                  .build();
+          }
+        }
+     }
+     return getGetEventGenerationIdsMethod;
   }
 
   /**
@@ -3749,12 +3860,51 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
+     * Lists the workload administration groups in an account.
+     * </pre>
+     */
+    public void listWorkloadAdministrationGroups(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListWorkloadAdministrationGroupsRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListWorkloadAdministrationGroupsResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getListWorkloadAdministrationGroupsMethodHelper(), responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Sets the actor workloads credentials. This will replace and overwrite any
+     * existing actor credentials.
+     * </pre>
+     */
+    public void setActorWorkloadCredentials(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetActorWorkloadCredentialsRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetActorWorkloadCredentialsResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getSetActorWorkloadCredentialsMethodHelper(), responseObserver);
+    }
+
+    /**
+     * <pre>
      * Retrieves the actor workload credentials.
      * </pre>
      */
     public void getActorWorkloadCredentials(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetActorWorkloadCredentialsRequest request,
         io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetActorWorkloadCredentialsResponse> responseObserver) {
       asyncUnimplementedUnaryCall(getGetActorWorkloadCredentialsMethodHelper(), responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Returns a unique ID for the following events:
+     * * Role assignment events.
+     * * Resource role assignment events.
+     * * Group membership changes events.
+     * * Actor deletion events.
+     * * Actore workload credentials change events.
+     * The IDs are guaranteed to be unique and can be used to track the above
+     * changes in a specific account. If no such event has happened in the account
+     * since tracking started an empty string will be returned instead of an ID.
+     * </pre>
+     */
+    public void getEventGenerationIds(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getGetEventGenerationIdsMethodHelper(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
@@ -4299,12 +4449,33 @@ public final class UserManagementGrpc {
                 com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadAdministrationGroupNameResponse>(
                   this, METHODID_DELETE_WORKLOAD_ADMINISTRATION_GROUP_NAME)))
           .addMethod(
+            getListWorkloadAdministrationGroupsMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListWorkloadAdministrationGroupsRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListWorkloadAdministrationGroupsResponse>(
+                  this, METHODID_LIST_WORKLOAD_ADMINISTRATION_GROUPS)))
+          .addMethod(
+            getSetActorWorkloadCredentialsMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetActorWorkloadCredentialsRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetActorWorkloadCredentialsResponse>(
+                  this, METHODID_SET_ACTOR_WORKLOAD_CREDENTIALS)))
+          .addMethod(
             getGetActorWorkloadCredentialsMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
                 com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetActorWorkloadCredentialsRequest,
                 com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetActorWorkloadCredentialsResponse>(
                   this, METHODID_GET_ACTOR_WORKLOAD_CREDENTIALS)))
+          .addMethod(
+            getGetEventGenerationIdsMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsResponse>(
+                  this, METHODID_GET_EVENT_GENERATION_IDS)))
           .build();
     }
   }
@@ -5208,6 +5379,29 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
+     * Lists the workload administration groups in an account.
+     * </pre>
+     */
+    public void listWorkloadAdministrationGroups(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListWorkloadAdministrationGroupsRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListWorkloadAdministrationGroupsResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getListWorkloadAdministrationGroupsMethodHelper(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Sets the actor workloads credentials. This will replace and overwrite any
+     * existing actor credentials.
+     * </pre>
+     */
+    public void setActorWorkloadCredentials(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetActorWorkloadCredentialsRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetActorWorkloadCredentialsResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getSetActorWorkloadCredentialsMethodHelper(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
      * Retrieves the actor workload credentials.
      * </pre>
      */
@@ -5215,6 +5409,25 @@ public final class UserManagementGrpc {
         io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetActorWorkloadCredentialsResponse> responseObserver) {
       asyncUnaryCall(
           getChannel().newCall(getGetActorWorkloadCredentialsMethodHelper(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Returns a unique ID for the following events:
+     * * Role assignment events.
+     * * Resource role assignment events.
+     * * Group membership changes events.
+     * * Actor deletion events.
+     * * Actore workload credentials change events.
+     * The IDs are guaranteed to be unique and can be used to track the above
+     * changes in a specific account. If no such event has happened in the account
+     * since tracking started an empty string will be returned instead of an ID.
+     * </pre>
+     */
+    public void getEventGenerationIds(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getGetEventGenerationIdsMethodHelper(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -6040,12 +6253,51 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
+     * Lists the workload administration groups in an account.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListWorkloadAdministrationGroupsResponse listWorkloadAdministrationGroups(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListWorkloadAdministrationGroupsRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getListWorkloadAdministrationGroupsMethodHelper(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * Sets the actor workloads credentials. This will replace and overwrite any
+     * existing actor credentials.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetActorWorkloadCredentialsResponse setActorWorkloadCredentials(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetActorWorkloadCredentialsRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getSetActorWorkloadCredentialsMethodHelper(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
      * Retrieves the actor workload credentials.
      * </pre>
      */
     public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetActorWorkloadCredentialsResponse getActorWorkloadCredentials(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetActorWorkloadCredentialsRequest request) {
       return blockingUnaryCall(
           getChannel(), getGetActorWorkloadCredentialsMethodHelper(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * Returns a unique ID for the following events:
+     * * Role assignment events.
+     * * Resource role assignment events.
+     * * Group membership changes events.
+     * * Actor deletion events.
+     * * Actore workload credentials change events.
+     * The IDs are guaranteed to be unique and can be used to track the above
+     * changes in a specific account. If no such event has happened in the account
+     * since tracking started an empty string will be returned instead of an ID.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsResponse getEventGenerationIds(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getGetEventGenerationIdsMethodHelper(), getCallOptions(), request);
     }
   }
 
@@ -6948,6 +7200,29 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
+     * Lists the workload administration groups in an account.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListWorkloadAdministrationGroupsResponse> listWorkloadAdministrationGroups(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListWorkloadAdministrationGroupsRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getListWorkloadAdministrationGroupsMethodHelper(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
+     * Sets the actor workloads credentials. This will replace and overwrite any
+     * existing actor credentials.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetActorWorkloadCredentialsResponse> setActorWorkloadCredentials(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetActorWorkloadCredentialsRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getSetActorWorkloadCredentialsMethodHelper(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
      * Retrieves the actor workload credentials.
      * </pre>
      */
@@ -6955,6 +7230,25 @@ public final class UserManagementGrpc {
         com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetActorWorkloadCredentialsRequest request) {
       return futureUnaryCall(
           getChannel().newCall(getGetActorWorkloadCredentialsMethodHelper(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
+     * Returns a unique ID for the following events:
+     * * Role assignment events.
+     * * Resource role assignment events.
+     * * Group membership changes events.
+     * * Actor deletion events.
+     * * Actore workload credentials change events.
+     * The IDs are guaranteed to be unique and can be used to track the above
+     * changes in a specific account. If no such event has happened in the account
+     * since tracking started an empty string will be returned instead of an ID.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsResponse> getEventGenerationIds(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getGetEventGenerationIdsMethodHelper(), getCallOptions()), request);
     }
   }
 
@@ -7035,7 +7329,10 @@ public final class UserManagementGrpc {
   private static final int METHODID_GET_WORKLOAD_ADMINISTRATION_GROUP_NAME = 74;
   private static final int METHODID_SET_WORKLOAD_ADMINISTRATION_GROUP_NAME = 75;
   private static final int METHODID_DELETE_WORKLOAD_ADMINISTRATION_GROUP_NAME = 76;
-  private static final int METHODID_GET_ACTOR_WORKLOAD_CREDENTIALS = 77;
+  private static final int METHODID_LIST_WORKLOAD_ADMINISTRATION_GROUPS = 77;
+  private static final int METHODID_SET_ACTOR_WORKLOAD_CREDENTIALS = 78;
+  private static final int METHODID_GET_ACTOR_WORKLOAD_CREDENTIALS = 79;
+  private static final int METHODID_GET_EVENT_GENERATION_IDS = 80;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -7362,9 +7659,21 @@ public final class UserManagementGrpc {
           serviceImpl.deleteWorkloadAdministrationGroupName((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadAdministrationGroupNameRequest) request,
               (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteWorkloadAdministrationGroupNameResponse>) responseObserver);
           break;
+        case METHODID_LIST_WORKLOAD_ADMINISTRATION_GROUPS:
+          serviceImpl.listWorkloadAdministrationGroups((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListWorkloadAdministrationGroupsRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListWorkloadAdministrationGroupsResponse>) responseObserver);
+          break;
+        case METHODID_SET_ACTOR_WORKLOAD_CREDENTIALS:
+          serviceImpl.setActorWorkloadCredentials((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetActorWorkloadCredentialsRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetActorWorkloadCredentialsResponse>) responseObserver);
+          break;
         case METHODID_GET_ACTOR_WORKLOAD_CREDENTIALS:
           serviceImpl.getActorWorkloadCredentials((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetActorWorkloadCredentialsRequest) request,
               (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetActorWorkloadCredentialsResponse>) responseObserver);
+          break;
+        case METHODID_GET_EVENT_GENERATION_IDS:
+          serviceImpl.getEventGenerationIds((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsResponse>) responseObserver);
           break;
         default:
           throw new AssertionError();
@@ -7504,7 +7813,10 @@ public final class UserManagementGrpc {
               .addMethod(getGetWorkloadAdministrationGroupNameMethodHelper())
               .addMethod(getSetWorkloadAdministrationGroupNameMethodHelper())
               .addMethod(getDeleteWorkloadAdministrationGroupNameMethodHelper())
+              .addMethod(getListWorkloadAdministrationGroupsMethodHelper())
+              .addMethod(getSetActorWorkloadCredentialsMethodHelper())
               .addMethod(getGetActorWorkloadCredentialsMethodHelper())
+              .addMethod(getGetEventGenerationIdsMethodHelper())
               .build();
         }
       }

--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
@@ -20,6 +20,7 @@ import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.Account;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateAccessKeyResponse;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetActorWorkloadCredentialsResponse;
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsResponse;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetRightsResponse;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.Group;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.MachineUser;
@@ -514,6 +515,22 @@ public class GrpcUmsClient {
         try (ManagedChannelWrapper channelWrapper = makeWrapper()) {
             UmsClient client = makeClient(channelWrapper.getChannel(), actorCrn);
             return client.listRoles(requestId.orElse(UUID.randomUUID().toString()), accountId).getRoleList();
+        }
+    }
+
+    /**
+     * Retrieves event generation ids for an account from UMS.
+     *
+     * @param actorCrn  the CRN of the actor
+     * @param accountId the account id
+     * @param requestId an optional request Id
+     * @return the user associated with this user CRN
+     */
+    public GetEventGenerationIdsResponse getEventGenerationIds(String actorCrn, String accountId, Optional<String> requestId) {
+        try (ManagedChannelWrapper channelWrapper = makeWrapper()) {
+            UmsClient client = makeClient(channelWrapper.getChannel(), actorCrn);
+            LOGGER.debug("Getting event generation ids for account {} using request ID {}", accountId, requestId);
+            return client.getEventGenerationIds(requestId.orElse(UUID.randomUUID().toString()), accountId);
         }
     }
 

--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/UmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/UmsClient.java
@@ -604,6 +604,21 @@ public class UmsClient {
     }
 
     /**
+     * Retrieves event generation ids for an account
+     *
+     * @param requestId     id of the request
+     * @param accountId     id of the account
+     */
+    UserManagementProto.GetEventGenerationIdsResponse getEventGenerationIds(String requestId, String accountId) {
+        checkNotNull(requestId);
+        checkNotNull(accountId);
+
+        return newStub(requestId).getEventGenerationIds(UserManagementProto.GetEventGenerationIdsRequest.newBuilder()
+                .setAccountId(accountId)
+                .build());
+    }
+
+    /**
      * Creates a new stub with the appropriate metadata injecting interceptors.
      *
      * @param requestId the request ID

--- a/auth-connector/src/main/proto/usermanagement.proto
+++ b/auth-connector/src/main/proto/usermanagement.proto
@@ -337,25 +337,46 @@ service UserManagement {
   // Returns the the workload administration group name for the
   // (account, right, resource) tuple. Will throw NOT_FOUND exception if no name
   // for the workload administration group has been set yet.
-  rpc GetWorkloadAdministrationGroupName (GetWorkloadAdministrationGroupNameRequest)
-  returns (GetWorkloadAdministrationGroupNameResponse) {}
+  rpc GetWorkloadAdministrationGroupName(GetWorkloadAdministrationGroupNameRequest)
+    returns (GetWorkloadAdministrationGroupNameResponse) {}
 
   // Sets the workload administration group name for the (account, right, resource)
   // tuple. If the name was already set for the workload administration group
   // this is a no-op and the name generated for the workload administration group
   // will be returned.
-  rpc SetWorkloadAdministrationGroupName (SetWorkloadAdministrationGroupNameRequest) returns (SetWorkloadAdministrationGroupNameResponse) {
-  }
+  rpc SetWorkloadAdministrationGroupName(SetWorkloadAdministrationGroupNameRequest)
+    returns (SetWorkloadAdministrationGroupNameResponse) {}
 
   // Deletes the workload administration group name for the (account, right, resource)
   // tuple. Throws a NOT_FOUND exception if no such workload administration group
   // can be found.
-  rpc DeleteWorkloadAdministrationGroupName (DeleteWorkloadAdministrationGroupNameRequest) returns (DeleteWorkloadAdministrationGroupNameResponse) {
-  }
+  rpc DeleteWorkloadAdministrationGroupName(DeleteWorkloadAdministrationGroupNameRequest)
+    returns (DeleteWorkloadAdministrationGroupNameResponse) {}
+
+  // Lists the workload administration groups in an account.
+  rpc ListWorkloadAdministrationGroups(ListWorkloadAdministrationGroupsRequest)
+    returns (ListWorkloadAdministrationGroupsResponse) {}
+
+  // Sets the actor workloads credentials. This will replace and overwrite any
+  // existing actor credentials.
+  rpc SetActorWorkloadCredentials(SetActorWorkloadCredentialsRequest)
+    returns (SetActorWorkloadCredentialsResponse) {}
 
   // Retrieves the actor workload credentials.
-  rpc GetActorWorkloadCredentials (GetActorWorkloadCredentialsRequest) returns (GetActorWorkloadCredentialsResponse) {
-  }
+  rpc GetActorWorkloadCredentials(GetActorWorkloadCredentialsRequest)
+    returns (GetActorWorkloadCredentialsResponse) {}
+
+  // Returns a unique ID for the following events:
+  // * Role assignment events.
+  // * Resource role assignment events.
+  // * Group membership changes events.
+  // * Actor deletion events.
+  // * Actore workload credentials change events.
+  // The IDs are guaranteed to be unique and can be used to track the above
+  // changes in a specific account. If no such event has happened in the account
+  // since tracking started an empty string will be returned instead of an ID.
+  rpc GetEventGenerationIds(GetEventGenerationIdsRequest)
+    returns (GetEventGenerationIdsResponse) {}
 }
 
 // An User is the Altus identity corresponding to an external SFDC contact. Users
@@ -415,6 +436,13 @@ message MachineUser {
   // though that if the machine user is deleted the workload username it used
   // becomes available to new machine users in the account.
   string workloadUsername = 5;
+  // Whether this is an internal machine user. Internal machine users are made
+  // by platform services and not end-users. They are filtered out of account
+  // level listing operations and cannot be modified by end-user operations.
+  // Note that it is possible for end-users to list by name or CRN and otherwise
+  // determine the existence of an internal machine user. We simply prevent them
+  // from shooting themselves in the foot by modifying one.
+  bool internal = 6;
 }
 
 // A Group is a Altus resource that contains a collection of Actors. Groups
@@ -478,6 +506,13 @@ message AccessKey {
   // The creation date in ms from the Java epoch of 1970-01-01T00:00:00Z.
   uint64 creationDateMs = 8;
   AccessKeyUsage lastUsage = 6;
+  // Whether this is an internal machine user. Internal machine users are made
+  // by platform services and not end-users. They are filtered out of default
+  // listing operations and cannot be modified by end-user operations. Note that
+  // it is possible for end-users to list by ID or CRN and otherwise
+  // determine the existence of an internal access key. We simply prevent them
+  // from shooting themselves in the foot by modifying one.
+  bool internal = 11;
 }
 
 
@@ -859,6 +894,10 @@ message ListAccessKeysRequest {
   // This optionally filters the request to the given actor, a user or a
   // machine user.
   Actor keyAssignee = 6;
+  // Whether to include internal access keys. Note that this has no impact when
+  // listing by ID or CRN. For those calls, internal access keys are always
+  // returned.
+  bool includeInternal = 7;
   // See the PageToken comment in paging.proto on paging usage.
   int32 pageSize = 2;
   paging.PageToken pageToken = 3;
@@ -1467,6 +1506,10 @@ message ListMachineUsersRequest {
   // A list of MachineUsers name or CRN to retrieve. The list is optional if
   // not provided all MachineUsers in the account will be returned.
   repeated string machineUserNameOrCrn = 2;
+  // Whether to include internal machine users. Note that this has no impact
+  // when listing by name or CRN. For those calls, internal machine users are
+  // always returned.
+  bool includeInternal = 5;
   // See the PageToken comment in paging.proto on paging usage.
   int32 pageSize = 3;
   paging.PageToken pageToken = 4;
@@ -1563,7 +1606,7 @@ message DescribeTermsResponse {
   // The termsName for these terms
   string termsName = 1;
   // The text of the terms
-  string termsText = 2;
+  string termsText = 2 [(options.FieldExtension.skipLogging) = true];
   // The acceptance state of the terms
   AcceptanceState acceptanceState = 3;
   // The date the terms were accepted, if they have been accepted
@@ -2111,25 +2154,36 @@ message DeleteWorkloadAdministrationGroupNameRequest {
 message DeleteWorkloadAdministrationGroupNameResponse {
 }
 
-// A representation of a kerberos key. This does not exactly reflect the formal
+message ListWorkloadAdministrationGroupsRequest {
+  // The account ID to list the workload administration group names for.
+  string accountId = 1;
+  // See the PageToken comment in paging.proto on paging usage.
+  int32 pageSize = 2;
+  paging.PageToken pageToken = 3;
+}
+
+message WorkloadAdministrationGroup {
+  // The workload administration group name.
+  string workloadAdministrationGroupName = 1;
+  // The name of the right associated with this workload administration group.
+  string rightName = 2;
+  // The resource on which the above right was granted, e.g., the environment CRN.
+  string resource = 3;
+}
+
+message ListWorkloadAdministrationGroupsResponse {
+  repeated WorkloadAdministrationGroup workloadAdministrationGroup = 1;
+  // See the PageToken comment in paging.proto on paging usage.
+  paging.PageToken nextPageToken = 2;
+}
+
+// A representation of a stored kerberos key. This does not exactly reflect the formal
 // ASN.1 structure; that seemed gratuitous.
 message StoredKerberosKey {
   // The key type
   int32 keyType = 1;
   // The encrypted value as was returned from the AWS kms client
   string encryptedKeyValue = 2 [(options.FieldExtension.sensitive) = true];
-  // The salt type
-  int32 saltType = 3;
-  // The salt value
-  string saltValue = 4;
-}
-
-// Definition of a Kerberos Key used in rpc calls (vs storage)
-message ActorKerberosKey {
-  // The key type
-  int32 keyType = 1;
-  // The key value, base64 encoded
-  string keyValue = 2 [(options.FieldExtension.sensitive) = true];
   // The salt type
   int32 saltType = 3;
   // The salt value
@@ -2145,6 +2199,29 @@ message ActorDetails {
   repeated StoredKerberosKey kerberosKeys = 2;
 }
 
+message SetActorWorkloadCredentialsRequest {
+  // The actor's CRN
+  string actorCrn = 1;
+  // The CDP workloads password. This password is going to be hashed and the
+  // hash is the only thing that is going to be saved, encrypted, in our database.
+  string password = 2 [(options.FieldExtension.sensitive) = true];
+}
+
+message SetActorWorkloadCredentialsResponse {
+}
+
+// Definition of a Kerberos Key used in rpc calls (vs storage)
+message ActorKerberosKey {
+  // The key type
+  int32 keyType = 1;
+  // The key value, base64 encoded
+  string keyValue = 2 [(options.FieldExtension.sensitive) = true];
+  // The salt type
+  int32 saltType = 3;
+  // The salt value
+  string saltValue = 4;
+}
+
 message GetActorWorkloadCredentialsRequest {
   // The actor CRN
   string actorCrn = 1;
@@ -2155,4 +2232,31 @@ message GetActorWorkloadCredentialsResponse {
   string passwordHash = 1 [(options.FieldExtension.sensitive) = true];
   // A list of kerberos keys for the actor.
   repeated ActorKerberosKey kerberosKeys = 2;
+}
+
+message GetEventGenerationIdsRequest {
+  // The account ID to retrieve the last event generation IDs for.
+  string accountId = 1;
+}
+
+message GetEventGenerationIdsResponse {
+  // Generated when a role was assigned or unassigned to a user, machine-user, or
+  // a group. Empty string if no such event has been occurred since tracking
+  // started.
+  string lastRoleAssignmentEventId = 1;
+  // Generated when a resource role was assigned or unassigned to a user,
+  // machine-user, or a group. Empty string if no such event has been occurred
+  // since tracking started.
+  string lastResourceRoleAssignmentEventId = 2;
+  // Generated when a member, i.e., a user or a machine-user, was added or
+  // removed from a group. Empty string if no such event has been occurred
+  // since tracking started.
+  string lastGroupMembershipChangedEventId = 3;
+  // Generated when an actor, i.e., a user or a machine-user, was deleted.
+  // Empty string if no such event has been occurred since tracking started.
+  string lastActorDeletedEventId = 4;
+  // Generated when an actor workload credentials change - the actor called
+  // set-workload-password. Empty string if no such event has been occurred since
+  // tracking started.
+  string lastActorWorkloadCredentialsChangedEventId = 5;
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/CleanupSyncOperation.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/CleanupSyncOperation.java
@@ -6,6 +6,7 @@ import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -17,15 +18,17 @@ import com.sequenceiq.freeipa.repository.SyncOperationRepository;
 public class CleanupSyncOperation {
     private static final Logger LOGGER = LoggerFactory.getLogger(CleanupSyncOperation.class);
 
-    private static final Long SYNC_OPERATION_TIMEOUT = 30L * 60L * 1000L;
+    @Value("${freeipa.syncoperation.cleanup.timeout-millis:1800000}")
+    private  Long syncOperationTimeout;
 
     @Inject
     private SyncOperationRepository syncOperationRepository;
 
-    @Scheduled(fixedDelay = 60 * 1000, initialDelay = 60 * 1000)
+    @Scheduled(fixedDelayString = "${freeipa.syncoperation.cleanup.fixed-delay-millis:60000}",
+            initialDelayString = "${freeipa.syncoperation.cleanup.initial-delay-millis:60000}")
     public void triggerCleanup() {
         try {
-            cleanupStaleSyncOperation(System.currentTimeMillis() - SYNC_OPERATION_TIMEOUT);
+            cleanupStaleSyncOperation(System.currentTimeMillis() - syncOperationTimeout);
         } catch (Exception e) {
             LOGGER.error("Failed to clean up SyncOperation table", e);
         }

--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -60,7 +60,11 @@ freeipa:
     max-failures-before-lock: 10
     failure-reset-interval: 3
     lockout-duration: 10
-
+  syncoperation:
+    cleanup:
+      timeout-millis: 1800000
+      initial-delay-millis: 60000
+      fixed-delay-millis: 60000
 
 info:
   app:

--- a/mock-caas/src/main/java/com/sequenceiq/caas/grpc/service/MockUserManagementService.java
+++ b/mock-caas/src/main/java/com/sequenceiq/caas/grpc/service/MockUserManagementService.java
@@ -21,6 +21,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -38,6 +39,8 @@ import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetAccountRequest;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetAccountResponse;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetActorWorkloadCredentialsResponse;
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsRequest;
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsResponse;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetIdPMetadataForWorkloadSSOResponse;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetRightsRequest;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetRightsResponse;
@@ -59,6 +62,9 @@ import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.User;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.google.common.io.Resources;
 import com.sequenceiq.caas.grpc.GrpcActorContext;
 import com.sequenceiq.caas.model.AltusToken;
@@ -131,11 +137,30 @@ public class MockUserManagementService extends UserManagementGrpc.UserManagement
 
     private final Map<String, Map<String, Group>> accountGroups = new ConcurrentHashMap<>();
 
+    @Value("${auth.mock.event-generation.expiration-minutes:10}")
+    private long eventGenerationExirationMinutes;
+
+    private LoadingCache<String, GetEventGenerationIdsResponse> eventGenerationIdsCache;
+
     @PostConstruct
     public void init() {
         this.cbLicense = getLicense();
         this.telemetyPublisherCredential = getAltusCredential(databusTpCredentialFile, databusTpCredentialProfile);
         this.fluentCredential = getAltusCredential(databusFluentCredentialFile, databusFluentCredentialProfile);
+        this.eventGenerationIdsCache = CacheBuilder.newBuilder()
+                .expireAfterWrite(eventGenerationExirationMinutes, TimeUnit.MINUTES)
+                .build(new CacheLoader<String, GetEventGenerationIdsResponse>() {
+                    @Override
+                    public GetEventGenerationIdsResponse load(String key) throws Exception {
+                        GetEventGenerationIdsResponse.Builder respBuilder = GetEventGenerationIdsResponse.newBuilder();
+                        respBuilder.setLastRoleAssignmentEventId(UUID.randomUUID().toString());
+                        respBuilder.setLastResourceRoleAssignmentEventId(UUID.randomUUID().toString());
+                        respBuilder.setLastGroupMembershipChangedEventId(UUID.randomUUID().toString());
+                        respBuilder.setLastActorDeletedEventId(UUID.randomUUID().toString());
+                        respBuilder.setLastActorWorkloadCredentialsChangedEventId(UUID.randomUUID().toString());
+                        return respBuilder.build();
+                    }
+                });
     }
 
     @Override
@@ -540,6 +565,19 @@ public class MockUserManagementService extends UserManagementGrpc.UserManagement
         respBuilder.setPasswordHash("008c70392e3abfbd0fa47bbc2ed96aa99bd49e159727fcba0f2e6abeb3a9d601");
         responseObserver.onNext(respBuilder.build());
         responseObserver.onCompleted();
+    }
+
+    @Override
+    public void getEventGenerationIds(GetEventGenerationIdsRequest request, StreamObserver<GetEventGenerationIdsResponse> responseObserver) {
+        try {
+            responseObserver.onNext(eventGenerationIdsCache.get(request.getAccountId()));
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            throw Status.INTERNAL
+                    .withDescription("Error retrieving/creating event generation ids.")
+                    .withCause(e)
+                    .asRuntimeException();
+        }
     }
 
     private String getLicense() {

--- a/mock-caas/src/main/java/com/sequenceiq/caas/grpc/service/MockUserManagementService.java
+++ b/mock-caas/src/main/java/com/sequenceiq/caas/grpc/service/MockUserManagementService.java
@@ -213,7 +213,7 @@ public class MockUserManagementService extends UserManagementGrpc.UserManagement
         Crn actorCrn = Crn.safeFromString(GrpcActorContext.ACTOR_CONTEXT.get().getActorCrn());
         String userCrn = Crn.builder()
                 .setService(actorCrn.getService())
-                .setAccountId(actorCrn.getAccountId())
+                .setAccountId(accountId)
                 .setResourceType(actorCrn.getResourceType())
                 .setResource(userName)
                 .build().toString();
@@ -299,17 +299,14 @@ public class MockUserManagementService extends UserManagementGrpc.UserManagement
             String machineUserIdOrCrn = request.getMachineUserNameOrCrn(0);
             String[] splittedCrn = machineUserIdOrCrn.split(":");
             String userName;
-            String accountId;
+            String accountId = request.getAccountId();
             String crnString;
             if (splittedCrn.length > 1) {
                 userName = splittedCrn[6];
-                accountId = splittedCrn[4];
                 crnString = machineUserIdOrCrn;
             } else {
                 userName = machineUserIdOrCrn;
-                accountId = UUID.randomUUID().toString();
-                Crn crn = createCrn(GrpcActorContext.ACTOR_CONTEXT.get().getActorCrn(), Crn.ResourceType.MACHINE_USER, userName);
-                accountId = crn.getAccountId();
+                Crn crn = createCrn(accountId, Crn.Service.IAM, Crn.ResourceType.MACHINE_USER, userName);
                 crnString = crn.toString();
             }
             responseObserver.onNext(

--- a/mock-caas/src/main/resources/application.yml
+++ b/mock-caas/src/main/resources/application.yml
@@ -9,3 +9,6 @@ auth:
         file: altus_credentials
       fluent:
         file: databus_credentials
+  mock:
+    event-generation:
+      expiration-minutes: 10


### PR DESCRIPTION
These commits update the usermanagement.proto, regenerate the code, and update the MockUserManagementService. As part of this update, a fix to the MockUserManagementService is included that uses the specified accountId when retrieving users or machine users.

There is a small unrelated change in a separate commit to make the syncoperation cleanup schedule configurable.
