### PR TITLE
CB-2682 Initialize SMM Config With CM FQDN

### DIFF
--- a/template-manager-blueprint/src/main/java/com/sequenceiq/cloudbreak/blueprint/GeneralClusterConfigsProvider.java
+++ b/template-manager-blueprint/src/main/java/com/sequenceiq/cloudbreak/blueprint/GeneralClusterConfigsProvider.java
@@ -62,6 +62,7 @@ public class GeneralClusterConfigsProvider {
         boolean userFacingCertHasBeenGenerated = StringUtils.isNotEmpty(stack.getSecurityConfig().getUserFacingKey())
                 && StringUtils.isNotEmpty(stack.getSecurityConfig().getUserFacingCert());
         generalClusterConfigs.setKnoxUserFacingCertConfigured(userFacingCertHasBeenGenerated);
+        generalClusterConfigs.setExternalFQDN(cluster.getFqdn());
         return generalClusterConfigs;
     }
 

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/smm/StreamsMessagingManagerServiceConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/smm/StreamsMessagingManagerServiceConfigProvider.java
@@ -4,6 +4,7 @@ import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.c
 
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
@@ -19,8 +20,12 @@ public class StreamsMessagingManagerServiceConfigProvider extends AbstractRdsRol
 
     @Override
     public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject source) {
+        String cmHost = StringUtils.isNotEmpty(source.getGeneralClusterConfigs().getExternalFQDN()) ?
+                source.getGeneralClusterConfigs().getExternalFQDN() :
+                source.getGeneralClusterConfigs().getClusterManagerIp();
+
         List<ApiClusterTemplateConfig> configs = Lists.newArrayList(
-                config("cm.metrics.host", source.getGeneralClusterConfigs().getClusterManagerIp()),
+                config("cm.metrics.host", cmHost),
                 config("cm.metrics.username", source.getGeneralClusterConfigs().getCloudbreakAmbariUser()),
                 config("cm.metrics.password", source.getGeneralClusterConfigs().getCloudbreakAmbariPassword())
         );

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/smm/StreamsMessagingManagerServiceConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/smm/StreamsMessagingManagerServiceConfigProviderTest.java
@@ -26,8 +26,8 @@ public class StreamsMessagingManagerServiceConfigProviderTest {
     private final StreamsMessagingManagerServiceConfigProvider underTest = new StreamsMessagingManagerServiceConfigProvider();
 
     @Test
-    public void testGetStreamsMessagingManagerServiceConfigs() {
-        TemplatePreparationObject preparationObject = getTemplatePreparationObject();
+    public void testGetStreamsMessagingManagerServiceConfigsWhenExternalFqdn() {
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject("cm.fqdn.host");
         String inputJson = getBlueprintText("input/cdp-streaming.bp");
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
 
@@ -35,7 +35,7 @@ public class StreamsMessagingManagerServiceConfigProviderTest {
 
         assertEquals(3, streamsMessagingManagerServiceConfigs.size());
         assertEquals("cm.metrics.host", streamsMessagingManagerServiceConfigs.get(0).getName());
-        assertEquals("128.128.4.1", streamsMessagingManagerServiceConfigs.get(0).getValue());
+        assertEquals("cm.fqdn.host", streamsMessagingManagerServiceConfigs.get(0).getValue());
 
         assertEquals("cm.metrics.username", streamsMessagingManagerServiceConfigs.get(1).getName());
         assertEquals("cbambariuser", streamsMessagingManagerServiceConfigs.get(1).getValue());
@@ -45,8 +45,21 @@ public class StreamsMessagingManagerServiceConfigProviderTest {
     }
 
     @Test
+    public void testGetStreamsMessagingManagerServiceConfigsWhenNoExternalFqdn() {
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject(null);
+        String inputJson = getBlueprintText("input/cdp-streaming.bp");
+        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+
+        List<ApiClusterTemplateConfig> streamsMessagingManagerServiceConfigs = underTest.getServiceConfigs(cmTemplateProcessor, preparationObject);
+
+        assertEquals(3, streamsMessagingManagerServiceConfigs.size());
+        assertEquals("cm.metrics.host", streamsMessagingManagerServiceConfigs.get(0).getName());
+        assertEquals("122.0.0.1", streamsMessagingManagerServiceConfigs.get(0).getValue());
+    }
+
+    @Test
     public void testGetStreamsMessagingManagerServerRoleConfigs() {
-        TemplatePreparationObject preparationObject = getTemplatePreparationObject();
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject(null);
         String inputJson = getBlueprintText("input/cdp-streaming.bp");
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
 
@@ -64,7 +77,7 @@ public class StreamsMessagingManagerServiceConfigProviderTest {
         assertEquals("smm_server_db_password", streamsMessagingManager.get(2).getValue());
     }
 
-    private TemplatePreparationObject getTemplatePreparationObject() {
+    private TemplatePreparationObject getTemplatePreparationObject(String externalFqdn) {
         HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, 1);
         HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, 3);
 
@@ -75,7 +88,8 @@ public class StreamsMessagingManagerServiceConfigProviderTest {
         rdsConfig.setConnectionURL("jdbc:postgresql://testhost:5432/smm");
 
         GeneralClusterConfigs gcc = new GeneralClusterConfigs();
-        gcc.setClusterManagerIp("128.128.4.1");
+        gcc.setExternalFQDN(externalFqdn);
+        gcc.setClusterManagerIp("122.0.0.1");
         gcc.setCloudbreakAmbariUser("cbambariuser");
         gcc.setCloudbreakAmbariPassword("cbambaripassword");
 

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/model/GeneralClusterConfigs.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/model/GeneralClusterConfigs.java
@@ -31,6 +31,8 @@ public class GeneralClusterConfigs {
 
     private String clusterManagerIp;
 
+    private String externalFQDN;
+
     private OrchestratorType orchestratorType = OrchestratorType.HOST;
 
     private int nodeCount;
@@ -195,5 +197,13 @@ public class GeneralClusterConfigs {
 
     public void setKnoxUserFacingCertConfigured(boolean knoxUserFacingCertConfigured) {
         this.knoxUserFacingCertConfigured = knoxUserFacingCertConfigured;
+    }
+
+    public String getExternalFQDN() {
+        return externalFQDN;
+    }
+
+    public void setExternalFQDN(String externalFQDN) {
+        this.externalFQDN = externalFQDN;
     }
 }


### PR DESCRIPTION
Initialize SMM Config With CM FQDN instead of CM IP Address.

Closes #CB-2682