### PR TITLE
CB-3804 Allow multiple host repair.

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceMetaDataRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceMetaDataRepository.java
@@ -61,8 +61,8 @@ public interface InstanceMetaDataRepository extends DisabledBaseRepository<Insta
             + "AND i.instanceGroup.stack.id= :stackId")
     Optional<InstanceMetaData> getPrimaryGatewayInstanceMetadata(@Param("stackId") Long stackId);
 
-    @Query("SELECT i FROM InstanceMetaData i WHERE i.instanceGroup.id = :instanceGroupId AND i.instanceMetadataType = 'GATEWAY_PRIMARY' AND"
+    @Query("SELECT i.discoveryFQDN FROM InstanceMetaData i WHERE i.instanceGroup.id = :instanceGroupId AND i.instanceMetadataType = 'GATEWAY_PRIMARY' AND"
             + " i.instanceStatus <> 'TERMINATED' AND i.instanceGroup.stack.id= :stackId")
-    List<InstanceMetaData> getPrimaryGatewayByInstanceGroup(@Param("stackId") Long stackId, @Param("instanceGroupId") Long instanceGroupId);
+    Optional<String> getPrimaryGatewayDiscoveryFQDNByInstanceGroup(@Param("stackId") Long stackId, @Param("instanceGroupId") Long instanceGroupId);
 
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterService.java
@@ -449,11 +449,20 @@ public class ClusterService {
                         hostGroupEntry.getValue().stream()
                                 .filter(hostName -> !existingHosts.contains(hostName))
                                 .forEach(hostName -> {
-                                    HostMetadata hostMetadataEntry = new HostMetadata();
-                                    hostMetadataEntry.setHostName(hostName);
-                                    hostMetadataEntry.setHostGroup(hostGroup.get());
-                                    hostMetadataEntry.setHostMetadataState(hostMetadataState);
-                                    hostGroup.get().getHostMetadata().add(hostMetadataEntry);
+                                    hostGroup.get().getHostMetadata()
+                                            .stream()
+                                            .filter(hm -> hostName.equals(hm.getHostName()))
+                                            .findFirst()
+                                            .ifPresentOrElse(hostMetadata -> {
+                                                hostMetadata.setHostMetadataState(hostMetadataState);
+                                                hostMetadata.setStatusReason(null);
+                                            }, () -> {
+                                                HostMetadata hostMetadata = new HostMetadata();
+                                                hostMetadata.setHostName(hostName);
+                                                hostMetadata.setHostGroup(hostGroup.get());
+                                                hostMetadata.setHostMetadataState(hostMetadataState);
+                                                hostGroup.get().getHostMetadata().add(hostMetadata);
+                                            });
                                 });
                         hostGroupService.save(hostGroup.get());
                     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/InstanceMetaDataService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/InstanceMetaDataService.java
@@ -171,8 +171,8 @@ public class InstanceMetaDataService {
         return repository.saveAll(instanceMetaData);
     }
 
-    public List<InstanceMetaData> getPrimaryGatewayByInstanceGroup(Long stackId, Long instanceGroupId) {
-        return repository.getPrimaryGatewayByInstanceGroup(stackId, instanceGroupId);
+    public Optional<String> getPrimaryGatewayDiscoveryFQDNByInstanceGroup(Long stackId, Long instanceGroupId) {
+        return repository.getPrimaryGatewayDiscoveryFQDNByInstanceGroup(stackId, instanceGroupId);
     }
 
     public Optional<String> getServerCertByStackId(Long stackId) {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxRepairRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxRepairRequest.java
@@ -1,11 +1,12 @@
 package com.sequenceiq.sdx.api.model;
 
-import javax.validation.constraints.NotNull;
+import java.util.List;
 
 public class SdxRepairRequest {
 
-    @NotNull
     private String hostGroupName;
+
+    private List<String> hostGroupNames;
 
     public String getHostGroupName() {
         return hostGroupName;
@@ -13,5 +14,13 @@ public class SdxRepairRequest {
 
     public void setHostGroupName(String hostGroupName) {
         this.hostGroupName = hostGroupName;
+    }
+
+    public List<String> getHostGroupNames() {
+        return hostGroupNames;
+    }
+
+    public void setHostGroupNames(List<String> hostGroupNames) {
+        this.hostGroupNames = hostGroupNames;
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxReactorFlowManager.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxReactorFlowManager.java
@@ -9,10 +9,13 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.common.event.Acceptable;
+import com.sequenceiq.cloudbreak.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.exception.CloudbreakApiException;
 import com.sequenceiq.cloudbreak.exception.FlowsAlreadyRunningException;
 import com.sequenceiq.datalake.entity.SdxCluster;
@@ -63,6 +66,10 @@ public class SdxReactorFlowManager {
     }
 
     public void triggerSdxRepairFlow(Long sdxId, SdxRepairRequest repairRequest) {
+        if (StringUtils.isNotBlank(repairRequest.getHostGroupName()) && CollectionUtils.isNotEmpty(repairRequest.getHostGroupNames())) {
+            throw new BadRequestException("Please send only one hostGroupName in the 'hostGroupName' field " +
+                    "or multiple hostGroups in the 'hostGroupNames' fields");
+        }
         String selector = SDX_REPAIR_EVENT.event();
         String userId = threadBasedUserCrnProvider.getUserCrn();
         String requestId = threadBasedRequestIdProvider.getRequestId();

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxRepairService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxRepairService.java
@@ -109,7 +109,13 @@ public class SdxRepairService {
 
     private ClusterRepairV4Request createRepairRequest(SdxRepairRequest sdxRepairRequest) {
         ClusterRepairV4Request repairRequest = new ClusterRepairV4Request();
-        repairRequest.setHostGroups(List.of(sdxRepairRequest.getHostGroupName()));
+        List<String> hostGroupNames;
+        if (StringUtils.isNotBlank(sdxRepairRequest.getHostGroupName())) {
+            hostGroupNames = List.of(sdxRepairRequest.getHostGroupName());
+        } else {
+            hostGroupNames = sdxRepairRequest.getHostGroupNames();
+        }
+        repairRequest.setHostGroups(hostGroupNames);
         return repairRequest;
     }
 


### PR DESCRIPTION
- Previously datalake only allowed one host to repair now, it can handle multiple hosts as well.
- Previously during multi host repair when a gateway and a core node were unhealthy the core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterRepairFlowEventChainFactory.java would have generate an incorrect flow where it adds a cluster downscale event to the flow for thee idbroker host. This is problematic because during this process the master might not be available so that the salt's tearDown wont work.