### PR TITLE
CB-3791 Begin enabling Azure datalakes (no external db servers yet)

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilder.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilder.java
@@ -133,6 +133,8 @@ public class AzureTemplateBuilder {
             model.put("skuName", azureDatabaseServerView.getSkuName());
             model.put("skuSizeMB", azureDatabaseServerView.getAllocatedStorageInMb());
             model.put("skuTier", azureDatabaseServerView.getSkuTier());
+            // FUTURE: When CM scm_prepare_database.sh supports it, use TLS
+            model.put("sslEnforcement", false);
             model.put("storageAutoGrow", azureDatabaseServerView.getStorageAutoGrow());
             model.put("subnets", azureNetworkView.getSubnets());
             model.putAll(defaultCostTaggingService.prepareAllTagsForTemplate());

--- a/cloud-azure/src/main/resources/templates/arm-dbstack.ftl
+++ b/cloud-azure/src/main/resources/templates/arm-dbstack.ftl
@@ -91,7 +91,7 @@
             "type": "bool",
             "defaultValue": ${(sslEnforcement!true)?c},
             "metadata": {
-                "description": "Enable ssl enforcement or not when connect to server."
+                "description": "Enable ssl enforcement or not when connecting to the server."
             }
         },
         "backupRetentionDays": {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/AbstractRdsConfigProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/AbstractRdsConfigProvider.java
@@ -5,7 +5,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -20,14 +19,14 @@ import com.google.common.collect.Lists;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ResourceStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
-import com.sequenceiq.cloudbreak.common.database.DatabaseCommon;
-import com.sequenceiq.cloudbreak.common.database.DatabaseCommon.JdbcConnectionUrlFields;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
+import com.sequenceiq.cloudbreak.service.secret.service.SecretService;
 import com.sequenceiq.cloudbreak.util.PasswordUtil;
+import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerV4Response;
 
 public abstract class AbstractRdsConfigProvider {
 
@@ -43,56 +42,78 @@ public abstract class AbstractRdsConfigProvider {
     private RedbeamsDbServerConfigurer dbServerConfigurer;
 
     @Inject
-    private DatabaseCommon dbCommon;
-
-    @Inject
     private RedbeamsClientService redbeamsClientService;
 
+    @Inject
+    private SecretService secretService;
+
+    /**
+     * Creates a map of database information for this provider's database, suitable for inclusion
+     * in a salt pillar. The map usually contains only one key, that being the return value of
+     * {@link #getPillarKey()}. The configuration information is ultimately used to create the
+     * database.
+     *
+     * @param  stack   stack for cluster
+     * @param  cluster cluster to associate database with
+     * @return         salt pillar configuration information for this provider's database
+     */
     public Map<String, Object> createServicePillarConfigMapIfNeeded(Stack stack, Cluster cluster) {
         if (isRdsConfigNeeded(cluster.getBlueprint())) {
             Set<RDSConfig> rdsConfigs = createPostgresRdsConfigIfNeeded(stack, cluster);
             RDSConfig rdsConfig = rdsConfigs.stream().filter(rdsConfig1 -> rdsConfig1.getType().equalsIgnoreCase(getRdsType().name())).findFirst().get();
             if (rdsConfig.getStatus() == ResourceStatus.DEFAULT && rdsConfig.getDatabaseEngine() != DatabaseVendor.EMBEDDED) {
                 Map<String, Object> postgres = new HashMap<>();
-                String db = getDb();
                 if (dbServerConfigurer.isRemoteDatabaseNeeded(cluster)) {
-                    JdbcConnectionUrlFields parsedUrl = dbCommon.parseJdbcConnectionUrl(rdsConfig.getConnectionURL());
-                    postgres.put("remote_db_url", parsedUrl.getHost());
-                    postgres.put("remote_db_port", parsedUrl.getPort());
-                    postgres.put("remote_admin", rdsConfig.getConnectionUserName());
-                    postgres.put("remote_admin_pw", rdsConfig.getConnectionPassword());
+                    DatabaseServerV4Response dbServerResponse = dbServerConfigurer.getDatabaseServer(cluster.getDatabaseServerCrn());
+                    postgres.put("remote_db_host", dbServerResponse.getHost());
+                    postgres.put("remote_db_port", dbServerResponse.getPort());
+                    postgres.put("remote_admin", secretService.getByResponse(dbServerResponse.getConnectionUserName()));
+                    postgres.put("remote_admin_pw", secretService.getByResponse(dbServerResponse.getConnectionPassword()));
                 }
-                postgres.put("database", db);
+                String dbName = getDb();
+                postgres.put("database", dbName);
                 postgres.put("user", getDbUser());
                 postgres.put("password", rdsConfig.getConnectionPassword());
-                LOGGER.debug("Rds config added: {}, databaseEngine: {}", db, rdsConfig.getDatabaseEngine());
+                LOGGER.debug("Rds config added: {}, databaseEngine: {}", dbName, rdsConfig.getDatabaseEngine());
                 return Collections.singletonMap(getPillarKey(), postgres);
             }
         }
         return Collections.emptyMap();
     }
 
+    /**
+     * Creates a new RDSConfig object for this provider's database, if one is not already present in
+     * the cluster and if one is called for by the cluster blueprint. Most of the database
+     * information is based on the database type and this provider, but the database password is
+     * chosen here.
+     *
+     * Note that this does not actually create the database. However, the RDSConfig object is saved
+     * and associated with the cluster.
+     *
+     * @param  stack   stack for cluster
+     * @param  cluster cluster to associate database with
+     * @return         all RDSConfig objects for the cluster, potentially including a new one for
+     *                 this provider's database
+     */
     public Set<RDSConfig> createPostgresRdsConfigIfNeeded(Stack stack, Cluster cluster) {
         Set<RDSConfig> rdsConfigs = rdsConfigService.findByClusterId(cluster.getId());
         rdsConfigs = rdsConfigs.stream().map(c -> rdsConfigService.resolveVaultValues(c)).collect(Collectors.toSet());
         if (isRdsConfigNeeded(cluster.getBlueprint())
                 && rdsConfigs.stream().noneMatch(rdsConfig -> rdsConfig.getType().equalsIgnoreCase(getRdsType().name()))) {
+            RDSConfig newRdsConfig;
             if (dbServerConfigurer.isRemoteDatabaseNeeded(cluster)) {
-                RDSConfig rbRdsConfig = dbServerConfigurer.getRdsConfig(stack, cluster, getDb(), getRdsType());
-                rdsConfigs = populateRdsConfig(rdsConfigs, stack, cluster, rbRdsConfig);
+                newRdsConfig = dbServerConfigurer.createNewRdsConfig(stack, cluster, getDb(), getDbUser(), getRdsType());
             } else {
                 LOGGER.debug("Creating postgres Database for {}", getRdsType().name());
-                rdsConfigs = createPostgresRdsConf(stack, cluster, rdsConfigs, getDbUser(), getDbPort(), getDb());
+                newRdsConfig = createNewRdsConfig(stack, cluster, getDb(), getDbUser(), getDbPort());
             }
+            rdsConfigs = populateNewRdsConfig(rdsConfigs, stack, cluster, newRdsConfig);
         }
         return rdsConfigs;
     }
 
-    private Set<RDSConfig> populateRdsConfig(Set<RDSConfig> rdsConfigs, Stack stack, Cluster cluster, RDSConfig rdsConfig) {
+    private Set<RDSConfig> populateNewRdsConfig(Set<RDSConfig> rdsConfigs, Stack stack, Cluster cluster, RDSConfig rdsConfig) {
         rdsConfig = rdsConfigService.createIfNotExists(stack.getCreator(), rdsConfig, stack.getWorkspace().getId());
-        if (rdsConfigs == null) {
-            rdsConfigs = new HashSet<>();
-        }
         rdsConfigs.add(rdsConfig);
         cluster.setRdsConfigs(rdsConfigs);
         clusterService.save(cluster);
@@ -100,8 +121,17 @@ public abstract class AbstractRdsConfigProvider {
         return rdsConfigs;
     }
 
-    private Set<RDSConfig> createPostgresRdsConf(Stack stack, Cluster cluster,
-            Set<RDSConfig> rdsConfigs, String dbUserName, String dbPort, String dbName) {
+    /**
+     * Creates an RDSConfig object for a specific database.
+     *
+     * @param  stack   stack for naming purposes
+     * @param  cluster cluster to associate database with
+     * @param  dbName  database name
+     * @param  dbUser  database user
+     * @param  dbPort  port for database connections (through gateway)
+     * @return         RDSConfig object for database
+     */
+    private RDSConfig createNewRdsConfig(Stack stack, Cluster cluster, String dbName, String dbUserName, String dbPort) {
         RDSConfig rdsConfig = new RDSConfig();
         rdsConfig.setName(getRdsType().name() + '_' + stack.getName() + stack.getId());
         rdsConfig.setConnectionUserName(dbUserName);
@@ -114,7 +144,7 @@ public abstract class AbstractRdsConfigProvider {
         rdsConfig.setStatus(ResourceStatus.DEFAULT);
         rdsConfig.setCreationDate(new Date().getTime());
         rdsConfig.setClusters(Collections.singleton(cluster));
-        return populateRdsConfig(rdsConfigs, stack, cluster, rdsConfig);
+        return rdsConfig;
     }
 
     protected List<String[]> createPathListFromConfigurations(String[] path, String[] configurations) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/RedbeamsDbServerConfigurer.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/RedbeamsDbServerConfigurer.java
@@ -2,7 +2,9 @@ package com.sequenceiq.cloudbreak.service.rdsconfig;
 
 import java.util.Collections;
 import java.util.Date;
+import java.util.Locale;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 import javax.inject.Inject;
 
@@ -20,6 +22,7 @@ import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.service.secret.service.SecretService;
+import com.sequenceiq.cloudbreak.util.PasswordUtil;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerV4Response;
 
 @Service
@@ -28,6 +31,10 @@ public class RedbeamsDbServerConfigurer {
     private static final Logger LOGGER = LoggerFactory.getLogger(RedbeamsDbServerConfigurer.class);
 
     private static final String JDBC_PATTERN = "\\/\\/(.*?):(\\d*)";
+
+    private static final Pattern AZURE_DATABASE_SERVER_HOST_PATTERN =
+        Pattern.compile(".*\\.(database\\.azure\\.com|database\\.windows\\.net|database\\.usgovcloudapi\\.net|"
+            + "database\\.microsoftazure\\.de|database\\.chinacloudapi\\.cn)");
 
     @Inject
     private RedbeamsClientService redbeamsClientService;
@@ -38,35 +45,55 @@ public class RedbeamsDbServerConfigurer {
     @Inject
     private SecretService secretService;
 
-    public RDSConfig getRdsConfig(Stack stack, Cluster cluster, String db, DatabaseType type) {
-        DatabaseServerV4Response resp = redbeamsClientService.getByCrn(cluster.getDatabaseServerCrn());
-        if (resp == null) {
-            throw new NotFoundException("RDS not found with crn: " + cluster.getDatabaseServerCrn());
-        }
+    /**
+     * Creates an RDSConfig object for a specific database.
+     *
+     * @param  stack   stack for naming purposes
+     * @param  cluster cluster to associate database with
+     * @param  dbName  database name
+     * @param  dbUser  database user
+     * @param  type    database type
+     * @return         RDSConfig object for database
+     */
+    public RDSConfig createNewRdsConfig(Stack stack, Cluster cluster, String dbName, String dbUser, DatabaseType type) {
+        DatabaseServerV4Response resp = getDatabaseServer(cluster.getDatabaseServerCrn());
         LOGGER.info("Using redbeams for remote database configuration");
-        return convertToRds(resp, stack, cluster, db, type);
-    }
 
-    private RDSConfig convertToRds(DatabaseServerV4Response source,
-            Stack stack,
-            Cluster cluster,
-            String db,
-            DatabaseType type) {
         RDSConfig rdsConfig = new RDSConfig();
-        rdsConfig.setConnectionURL(dbCommon.getJdbcConnectionUrl(source.getDatabaseVendor(), source.getHost(), source.getPort(), Optional.of(db)));
-        rdsConfig.setConnectionUserName(secretService.getByResponse(source.getConnectionUserName()));
-        rdsConfig.setConnectionPassword(secretService.getByResponse(source.getConnectionPassword()));
-        rdsConfig.setDatabaseEngine(DatabaseVendor.fromValue(source.getDatabaseVendor()));
+        rdsConfig.setConnectionURL(dbCommon.getJdbcConnectionUrl(resp.getDatabaseVendor(), resp.getHost(), resp.getPort(), Optional.of(dbName)));
+        rdsConfig.setConnectionUserName(formConnectionUserName(resp, dbUser));
+        rdsConfig.setConnectionPassword(PasswordUtil.generatePassword());
+        rdsConfig.setDatabaseEngine(DatabaseVendor.fromValue(resp.getDatabaseVendor()));
         rdsConfig.setStatus(ResourceStatus.DEFAULT);
         rdsConfig.setName(type.name() + '_' + stack.getName() + stack.getId());
         rdsConfig.setType(type.name());
         rdsConfig.setStatus(ResourceStatus.DEFAULT);
         rdsConfig.setCreationDate(new Date().getTime());
         rdsConfig.setClusters(Collections.singleton(cluster));
+        LOGGER.info("Created RDS config {} for database type {} with connection URL {}, connection username {}",
+            rdsConfig.getName(), type, rdsConfig.getConnectionURL(), rdsConfig.getConnectionUserName());
         return rdsConfig;
+    }
+
+    private String formConnectionUserName(DatabaseServerV4Response resp, String dbUser) {
+        String host = resp.getHost();
+        if (AZURE_DATABASE_SERVER_HOST_PATTERN.matcher(host.toLowerCase(Locale.US)).matches()) {
+            LOGGER.debug("Detected Azure database server {}, appending short hostname to connection username", host);
+            return dbUser + "@" + host.substring(0, host.indexOf('.'));
+        }
+
+        return dbUser;
     }
 
     public boolean isRemoteDatabaseNeeded(Cluster cluster) {
         return StringUtils.isNotEmpty(cluster.getDatabaseServerCrn());
+    }
+
+    public DatabaseServerV4Response getDatabaseServer(String serverCrn) {
+        DatabaseServerV4Response resp = redbeamsClientService.getByCrn(serverCrn);
+        if (resp == null) {
+            throw new NotFoundException("Database server not found with crn: " + serverCrn);
+        }
+        return resp;
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/rdsconfig/AbstractRdsConfigProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/rdsconfig/AbstractRdsConfigProviderTest.java
@@ -7,7 +7,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.Map;
-import java.util.Optional;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -20,15 +19,25 @@ import org.powermock.reflect.Whitebox;
 import com.sequenceiq.cloudbreak.TestUtil;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceMetadataType;
-import com.sequenceiq.cloudbreak.common.database.DatabaseCommon;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
+import com.sequenceiq.cloudbreak.service.secret.model.SecretResponse;
+import com.sequenceiq.cloudbreak.service.secret.service.SecretService;
+import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerV4Response;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AbstractRdsConfigProviderTest {
+
+    private static final String DB_HOST = "dbsvr-ed671174-77de-40e5-ad59-37761d8230d9.c8uqzbscgqmb.eu-west-1.rds.amazonaws.com";
+
+    private static final int DB_PORT = 1234;
+
+    private static final String REMOTE_ADMIN = "admin";
+
+    private static final String REMOTE_ADMIN_PASSWORD = "adminPassword";
 
     @Mock
     private RdsConfigService rdsConfigService;
@@ -37,12 +46,10 @@ public class AbstractRdsConfigProviderTest {
     private ClusterService clusterService;
 
     @Mock
-    private DatabaseCommon dbCommon;
+    private SecretService secretService;
 
     @Mock
     private RedbeamsDbServerConfigurer dbServerConfigurer;
-
-    private String dbHost = "dbsvr-ed671174-77de-40e5-ad59-37761d8230d9.c8uqzbscgqmb.eu-west-1.rds.amazonaws.com";
 
     @InjectMocks
     private ClouderaManagerRdsConfigProvider underTest;
@@ -53,39 +60,53 @@ public class AbstractRdsConfigProviderTest {
     }
 
     @Test
-    public void createservicePillarForLocalRdsConfig() {
+    public void createServicePillarForLocalRdsConfig() {
         when(rdsConfigService.createIfNotExists(any(), any(), any())).thenAnswer(i -> i.getArguments()[1]);
         Stack testStack = TestUtil.stack();
         InstanceMetaData metaData = testStack.getGatewayInstanceMetadata().iterator().next();
         metaData.setInstanceMetadataType(InstanceMetadataType.GATEWAY_PRIMARY);
         testStack.getGatewayInstanceMetadata().add(metaData);
         Cluster testCluster = TestUtil.cluster();
+
         Map<String, Object> result = underTest.createServicePillarConfigMapIfNeeded(testStack, testCluster);
+
         Map<String, Object> postgresData = (Map<String, Object>) result.get("clouderamanager");
         assertEquals("clouderamanager", postgresData.get("database"));
-        assertNull(postgresData.get("remote_db_url"));
+        assertNull(postgresData.get("remote_db_host"));
         assertNotNull(postgresData.get("password"));
     }
 
     @Test
-    public void createservicePillarForRemoteRdsConfig() {
+    public void createServicePillarForRemoteRdsConfig() {
         when(rdsConfigService.createIfNotExists(any(), any(), any())).thenAnswer(i -> i.getArguments()[1]);
         RDSConfig config = TestUtil.rdsConfig(DatabaseType.CLOUDERA_MANAGER);
-        when(dbServerConfigurer.getRdsConfig(any(), any(), any(), any())).thenReturn(config);
+        when(dbServerConfigurer.createNewRdsConfig(any(), any(), any(), any(), any())).thenReturn(config);
         when(dbServerConfigurer.isRemoteDatabaseNeeded(any())).thenReturn(true);
-        DatabaseCommon.JdbcConnectionUrlFields fields = new DatabaseCommon.JdbcConnectionUrlFields("postgres", dbHost, 1234, Optional.empty());
-        when(dbCommon.parseJdbcConnectionUrl(any())).thenReturn(fields);
+        DatabaseServerV4Response resp = new DatabaseServerV4Response();
+        resp.setHost(DB_HOST);
+        resp.setPort(DB_PORT);
+        SecretResponse username = new SecretResponse("user", "name");
+        SecretResponse password = new SecretResponse("pass", "word");
+        resp.setConnectionUserName(username);
+        resp.setConnectionPassword(password);
+        when(dbServerConfigurer.getDatabaseServer(any())).thenReturn(resp);
+        when(secretService.getByResponse(username)).thenReturn(REMOTE_ADMIN);
+        when(secretService.getByResponse(password)).thenReturn(REMOTE_ADMIN_PASSWORD);
         Stack testStack = TestUtil.stack();
         InstanceMetaData metaData = testStack.getGatewayInstanceMetadata().iterator().next();
         metaData.setInstanceMetadataType(InstanceMetadataType.GATEWAY_PRIMARY);
         testStack.getGatewayInstanceMetadata().add(metaData);
         Cluster testCluster = TestUtil.cluster();
         testStack.setCluster(testCluster);
+
         Map<String, Object> result = underTest.createServicePillarConfigMapIfNeeded(testStack, testCluster);
+
         Map<String, Object> postgresData = (Map<String, Object>) result.get("clouderamanager");
         assertEquals("clouderamanager", postgresData.get("database"));
-        assertEquals(dbHost, postgresData.get("remote_db_url"));
-        assertEquals(1234, postgresData.get("remote_db_port"));
-        assertNotNull(postgresData.get("database"));
+        assertEquals(REMOTE_ADMIN, postgresData.get("remote_admin"));
+        assertEquals(REMOTE_ADMIN_PASSWORD, postgresData.get("remote_admin_pw"));
+        assertEquals(DB_HOST, postgresData.get("remote_db_host"));
+        assertEquals(DB_PORT, postgresData.get("remote_db_port"));
+        assertNotNull(postgresData.get("password"));
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/rdsconfig/RedbeamsDbServerConfigurerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/rdsconfig/RedbeamsDbServerConfigurerTest.java
@@ -27,11 +27,21 @@ import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.Database
 @RunWith(MockitoJUnitRunner.class)
 public class RedbeamsDbServerConfigurerTest {
 
-    private String exampleJdbcUrl = "jdbc:postgresql://dbsvr-ed671174-77de-40e5-ad59-37761d8230d9.c8uqzbscgqmb.eu-west-1.rds.amazonaws.com:5432/clouderamanager";
+    private static final String EXAMPLE_JDBC_URL =
+        "jdbc:postgresql://dbsvr-ed671174-77de-40e5-ad59-37761d8230d9.c8uqzbscgqmb.eu-west-1.rds.amazonaws.com:5432/clouderamanager";
 
-    private String dbServerCrn = "crn:cdp:redbeams:us-west-1:default:databaseServer:e63520c8-aaf0-4bf3-b872-5613ce496ac3";
+    private static final String DB_SERVER_CRN = "crn:cdp:redbeams:us-west-1:default:databaseServer:e63520c8-aaf0-4bf3-b872-5613ce496ac3";
 
-    private String dbHost = "dbsvr-ed671174-77de-40e5-ad59-37761d8230d9.c8uqzbscgqmb.eu-west-1.rds.amazonaws.com";
+    private static final String DB_HOST = "dbsvr-ed671174-77de-40e5-ad59-37761d8230d9.c8uqzbscgqmb.eu-west-1.rds.amazonaws.com";
+
+    private static final String DB_USER = "cmuser";
+
+    private static final String EXAMPLE_JDBC_URL_AZURE =
+        "jdbc:postgresql://dbsvr-ed671174-77de-40e5-ad59-37761d8230d9.postgres.database.azure.com:5432/clouderamanager";
+
+    private static final String DB_HOST_AZURE = "dbsvr-ed671174-77de-40e5-ad59-37761d8230d9.postgres.database.azure.com";
+
+    private static final String DB_HOST_SHORT_NAME = "dbsvr-ed671174-77de-40e5-ad59-37761d8230d9";
 
     @Mock
     private RedbeamsClientService redbeamsClientService;
@@ -49,27 +59,48 @@ public class RedbeamsDbServerConfigurerTest {
     public void getRdsConfig() {
         DatabaseServerV4Response resp = new DatabaseServerV4Response();
         resp.setPort(1234);
-        resp.setHost(dbHost);
+        resp.setHost(DB_HOST);
         resp.setDatabaseVendor("postgres");
-        when(redbeamsClientService.getByCrn(dbServerCrn)).thenReturn(resp);
-        when(dbCommon.getJdbcConnectionUrl(any(), any(), anyInt(), any())).thenReturn(exampleJdbcUrl);
+        when(redbeamsClientService.getByCrn(DB_SERVER_CRN)).thenReturn(resp);
+        when(dbCommon.getJdbcConnectionUrl(any(), any(), anyInt(), any())).thenReturn(EXAMPLE_JDBC_URL);
         Stack testStack = TestUtil.stack();
         InstanceMetaData metaData = testStack.getGatewayInstanceMetadata().iterator().next();
         metaData.setInstanceMetadataType(InstanceMetadataType.GATEWAY_PRIMARY);
         testStack.getGatewayInstanceMetadata().add(metaData);
         Cluster testCluster = TestUtil.cluster();
-        testCluster.setDatabaseServerCrn(dbServerCrn);
+        testCluster.setDatabaseServerCrn(DB_SERVER_CRN);
         testStack.setCluster(testCluster);
-        RDSConfig config = underTest.getRdsConfig(testStack, testCluster, "clouderamanager", DatabaseType.CLOUDERA_MANAGER);
+        RDSConfig config = underTest.createNewRdsConfig(testStack, testCluster, "clouderamanager", DB_USER, DatabaseType.CLOUDERA_MANAGER);
         assertEquals("CLOUDERA_MANAGER_simplestack1", config.getName());
-        assertEquals(exampleJdbcUrl,
-                config.getConnectionURL());
+        assertEquals(EXAMPLE_JDBC_URL, config.getConnectionURL());
+        assertEquals(DB_USER, config.getConnectionUserName());
+    }
+
+    @Test
+    public void getRdsConfigForAzure() {
+        DatabaseServerV4Response resp = new DatabaseServerV4Response();
+        resp.setPort(1234);
+        resp.setHost(DB_HOST_AZURE);
+        resp.setDatabaseVendor("postgres");
+        when(redbeamsClientService.getByCrn(DB_SERVER_CRN)).thenReturn(resp);
+        when(dbCommon.getJdbcConnectionUrl(any(), any(), anyInt(), any())).thenReturn(EXAMPLE_JDBC_URL_AZURE);
+        Stack testStack = TestUtil.stack();
+        InstanceMetaData metaData = testStack.getGatewayInstanceMetadata().iterator().next();
+        metaData.setInstanceMetadataType(InstanceMetadataType.GATEWAY_PRIMARY);
+        testStack.getGatewayInstanceMetadata().add(metaData);
+        Cluster testCluster = TestUtil.cluster();
+        testCluster.setDatabaseServerCrn(DB_SERVER_CRN);
+        testStack.setCluster(testCluster);
+        RDSConfig config = underTest.createNewRdsConfig(testStack, testCluster, "clouderamanager", DB_USER, DatabaseType.CLOUDERA_MANAGER);
+        assertEquals("CLOUDERA_MANAGER_simplestack1", config.getName());
+        assertEquals(EXAMPLE_JDBC_URL_AZURE, config.getConnectionURL());
+        assertEquals("cmuser@" + DB_HOST_SHORT_NAME, config.getConnectionUserName());
     }
 
     @Test
     public void isRemoteDatabaseNeededWhenDbServerCrnIsPresent() {
         Cluster testCluster = TestUtil.cluster();
-        testCluster.setDatabaseServerCrn(dbServerCrn);
+        testCluster.setDatabaseServerCrn(DB_SERVER_CRN);
         assertTrue(underTest.isRemoteDatabaseNeeded(testCluster));
     }
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/configuration/AppConfig.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/configuration/AppConfig.java
@@ -1,11 +1,15 @@
 package com.sequenceiq.datalake.configuration;
 
 import java.io.IOException;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,9 +21,11 @@ import com.google.common.collect.ImmutableMap;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.client.internal.CloudbreakApiClientParams;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.util.FileReaderUtils;
 import com.sequenceiq.datalake.logger.ThreadBasedRequestIdProvider;
 import com.sequenceiq.datalake.service.sdx.DatabaseConfig;
+import com.sequenceiq.datalake.service.sdx.DatabaseConfigKey;
 import com.sequenceiq.environment.client.internal.EnvironmentApiClientParams;
 import com.sequenceiq.redbeams.client.internal.RedbeamsApiClientParams;
 import com.sequenceiq.sdx.api.model.SdxClusterShape;
@@ -28,6 +34,8 @@ import com.sequenceiq.sdx.api.model.SdxClusterShape;
 @EnableAsync
 @EnableScheduling
 public class AppConfig implements AsyncConfigurer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AppConfig.class);
 
     @Inject
     @Named("cloudbreakUrl")
@@ -72,18 +80,29 @@ public class AppConfig implements AsyncConfigurer {
     }
 
     @Bean
-    public Map<SdxClusterShape, DatabaseConfig> databaseConfigs() throws IOException {
-        return ImmutableMap.<SdxClusterShape, DatabaseConfig>builder()
-                .put(SdxClusterShape.CUSTOM, readDbConfig(SdxClusterShape.CUSTOM))
-                .put(SdxClusterShape.LIGHT_DUTY, readDbConfig(SdxClusterShape.LIGHT_DUTY))
-                .put(SdxClusterShape.MEDIUM_DUTY_HA, readDbConfig(SdxClusterShape.MEDIUM_DUTY_HA))
-                .build();
+    public Map<DatabaseConfigKey, DatabaseConfig> databaseConfigs() throws IOException {
+        ImmutableMap.Builder<DatabaseConfigKey, DatabaseConfig> builder = new ImmutableMap.Builder<>();
+        for (CloudPlatform cloudPlatform : CloudPlatform.values()) {
+            for (SdxClusterShape sdxClusterShape : SdxClusterShape.values()) {
+                Optional<DatabaseConfig> dbConfig = readDbConfig(cloudPlatform, sdxClusterShape);
+                if (dbConfig.isPresent()) {
+                    builder.put(new DatabaseConfigKey(cloudPlatform, sdxClusterShape), dbConfig.get());
+                }
+            }
+        }
+        return builder.build();
     }
 
-    private DatabaseConfig readDbConfig(SdxClusterShape sdxClusterShape) throws IOException {
-        String databaseTemplateJson = FileReaderUtils.readFileFromClasspath("sdx/aws/database-" + sdxClusterShape.toString()
-                .toLowerCase()
-                .replaceAll("_", "-") + "-template.json");
-        return JsonUtil.readValue(databaseTemplateJson, DatabaseConfig.class);
+    private Optional<DatabaseConfig> readDbConfig(CloudPlatform cloudPlatform, SdxClusterShape sdxClusterShape) throws IOException {
+        String resourcePath = String.format("sdx/%s/database-%s-template.json",
+            cloudPlatform.toString().toLowerCase(Locale.US),
+            sdxClusterShape.toString().toLowerCase(Locale.US).replaceAll("_", "-"));
+        String databaseTemplateJson = FileReaderUtils.readFileFromClasspathQuietly(resourcePath);
+        if (databaseTemplateJson == null) {
+            LOGGER.debug("No readable database config found for cloud platform {}, cluster shape {}: skipping",
+                cloudPlatform, sdxClusterShape);
+            return Optional.empty();
+        }
+        return Optional.of(JsonUtil.readValue(databaseTemplateJson, DatabaseConfig.class));
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/create/handler/RdsWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/create/handler/RdsWaitHandler.java
@@ -101,18 +101,20 @@ public class RdsWaitHandler extends ExceptionCatcherEventHandler<RdsWaitRequest>
 
     private void validForDatabaseCreation(Long sdxId, DetailedEnvironmentResponse env) {
         String message;
-        if (env.getNetwork().getSubnetMetas().size() < 2) {
-            message = String.format("Cannot create external database for sdx: %s, not enough subnets in the vpc", sdxId);
-            LOGGER.debug(message);
-            throw new BadRequestException(message);
-        }
-        Map<String, Long> zones = env.getNetwork().getSubnetMetas().values().stream()
-                .collect(Collectors.groupingBy(CloudSubnet::getAvailabilityZone, Collectors.counting()));
-        if (zones.size() < 2) {
-            message = String.format("Cannot create external database for sdx: %s, the subnets in the vpc should be at least in two different availabilityzones",
-                    sdxId);
-            LOGGER.debug(message);
-            throw new BadRequestException(message);
+        if ("aws".equalsIgnoreCase(env.getCloudPlatform())) {
+            if (env.getNetwork().getSubnetMetas().size() < 2) {
+                message = String.format("Cannot create external database for sdx: %s, not enough subnets in the vpc", sdxId);
+                LOGGER.debug(message);
+                throw new BadRequestException(message);
+            }
+            Map<String, Long> zones = env.getNetwork().getSubnetMetas().values().stream()
+                    .collect(Collectors.groupingBy(CloudSubnet::getAvailabilityZone, Collectors.counting()));
+            if (zones.size() < 2) {
+                message = String.format("Cannot create external database for sdx: %s, vpc subnets must cover at least two different availability zones",
+                        sdxId);
+                LOGGER.debug(message);
+                throw new BadRequestException(message);
+            }
         }
     }
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/DatabaseConfigKey.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/DatabaseConfigKey.java
@@ -1,0 +1,45 @@
+package com.sequenceiq.datalake.service.sdx;
+
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.sdx.api.model.SdxClusterShape;
+
+import java.util.Objects;
+
+public class DatabaseConfigKey {
+
+    private final CloudPlatform cloudPlatform;
+
+    private final SdxClusterShape sdxClusterShape;
+
+    public DatabaseConfigKey(CloudPlatform cloudPlatform, SdxClusterShape sdxClusterShape) {
+        this.cloudPlatform = Objects.requireNonNull(cloudPlatform, "cloudPlatform is null");
+        this.sdxClusterShape = Objects.requireNonNull(sdxClusterShape, "sdxClusterShape is null");
+    }
+
+    public CloudPlatform getCloudPlatform() {
+        return cloudPlatform;
+    }
+
+    public SdxClusterShape getSdxClusterShape() {
+        return sdxClusterShape;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DatabaseConfigKey that = (DatabaseConfigKey) o;
+        return cloudPlatform == that.cloudPlatform && sdxClusterShape == that.sdxClusterShape;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(cloudPlatform, sdxClusterShape);
+    }
+
+}

--- a/datalake/src/main/resources/sdx/azure/database-custom-template.json
+++ b/datalake/src/main/resources/sdx/azure/database-custom-template.json
@@ -1,0 +1,5 @@
+{
+  "instanceType": "GP_Gen5_2",
+  "vendor": "postgres",
+  "volumeSize": 100
+}

--- a/datalake/src/main/resources/sdx/azure/database-light-duty-template.json
+++ b/datalake/src/main/resources/sdx/azure/database-light-duty-template.json
@@ -1,0 +1,5 @@
+{
+  "instanceType": "GP_Gen5_2",
+  "vendor": "postgres",
+  "volumeSize": 100
+}

--- a/datalake/src/main/resources/sdx/azure/database-medium-duty-ha-template.json
+++ b/datalake/src/main/resources/sdx/azure/database-medium-duty-ha-template.json
@@ -1,0 +1,5 @@
+{
+  "instanceType": "GP_Gen5_2",
+  "vendor": "postgres",
+  "volumeSize": 100
+}

--- a/datalake/src/main/resources/sdx/mock/database-custom-template.json
+++ b/datalake/src/main/resources/sdx/mock/database-custom-template.json
@@ -1,0 +1,5 @@
+{
+  "instanceType": "db.m5.large",
+  "vendor": "postgres",
+  "volumeSize": 100
+}

--- a/datalake/src/main/resources/sdx/mock/database-light-duty-template.json
+++ b/datalake/src/main/resources/sdx/mock/database-light-duty-template.json
@@ -1,0 +1,5 @@
+{
+  "instanceType": "db.m5.large",
+  "vendor": "postgres",
+  "volumeSize": 100
+}

--- a/datalake/src/main/resources/sdx/mock/database-medium-duty-ha-template.json
+++ b/datalake/src/main/resources/sdx/mock/database-medium-duty-ha-template.json
@@ -1,0 +1,5 @@
+{
+  "instanceType": "db.m5.large",
+  "vendor": "postgres",
+  "volumeSize": 100
+}

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/DatabaseConfigKeyTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/DatabaseConfigKeyTest.java
@@ -1,0 +1,46 @@
+package com.sequenceiq.datalake.service.sdx;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.sdx.api.model.SdxClusterShape;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class DatabaseConfigKeyTest {
+
+    private DatabaseConfigKey underTest;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        underTest = new DatabaseConfigKey(CloudPlatform.AWS, SdxClusterShape.LIGHT_DUTY);
+    }
+
+    @Test
+    public void testGetters() {
+        assertEquals(CloudPlatform.AWS, underTest.getCloudPlatform());
+        assertEquals(SdxClusterShape.LIGHT_DUTY, underTest.getSdxClusterShape());
+    }
+
+    @Test
+    public void testEquals() {
+        assertTrue(underTest.equals(underTest));
+
+        DatabaseConfigKey underTest2 = new DatabaseConfigKey(CloudPlatform.AWS, SdxClusterShape.LIGHT_DUTY);
+        assertTrue(underTest2.equals(underTest));
+        assertTrue(underTest.equals(underTest2));
+
+        underTest2 = new DatabaseConfigKey(CloudPlatform.AZURE, SdxClusterShape.LIGHT_DUTY);
+        assertFalse(underTest.equals(underTest2));
+
+        underTest2 = new DatabaseConfigKey(CloudPlatform.AWS, SdxClusterShape.CUSTOM);
+        assertFalse(underTest.equals(underTest2));
+
+        assertFalse(underTest.equals(null));
+        assertFalse(underTest.equals(1234));
+    }
+
+}

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/DatabaseServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/DatabaseServiceTest.java
@@ -3,7 +3,6 @@ package com.sequenceiq.datalake.service.sdx;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
@@ -20,6 +19,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.exception.BadRequestException;
 import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.repository.SdxClusterRepository;
@@ -52,7 +52,7 @@ public class DatabaseServiceTest {
     private SdxStatusService sdxStatusService;
 
     @Mock
-    private Map<SdxClusterShape, DatabaseConfig> dbConfigs;
+    private Map<DatabaseConfigKey, DatabaseConfig> dbConfigs;
 
     @InjectMocks
     private DatabaseService underTest;
@@ -67,10 +67,12 @@ public class DatabaseServiceTest {
         cluster.setClusterShape(SdxClusterShape.LIGHT_DUTY);
         DetailedEnvironmentResponse env = new DetailedEnvironmentResponse();
         env.setName("ENV");
+        env.setCloudPlatform("aws");
         DatabaseConfig databaseConfig = getDatabaseConfig();
 
         when(databaseServerV4Endpoint.create(any())).thenThrow(BadRequestException.class);
-        when(dbConfigs.get(eq(SdxClusterShape.LIGHT_DUTY))).thenReturn(databaseConfig);
+        DatabaseConfigKey dbConfigKey = new DatabaseConfigKey(CloudPlatform.AWS, SdxClusterShape.LIGHT_DUTY);
+        when(dbConfigs.get(dbConfigKey)).thenReturn(databaseConfig);
 
         Assertions.assertThrows(BadRequestException.class, () -> {
             underTest.create(cluster, env, "ID");

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXClusterCreationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXClusterCreationTest.java
@@ -181,7 +181,7 @@ public class DistroXClusterCreationTest extends AbstractClouderaManagerTest {
                 .withImageSettings(DIX_IMG_KEY)
                 .withNetwork(DIX_NET_KEY)
                 .when(distroXClient.create(), key(DISTRO_X_STACK))
-                .await(STACK_AVAILABLE)
+                .await(STACK_AVAILABLE, key(DISTRO_X_STACK))
                 .then(DistroXClusterCreationTest::distroxInheritedCloudStorage)
                 .then(DistroXClusterCreationTest::distroxCloudStorageLocationNotEmpty)
                 .validate();
@@ -235,7 +235,7 @@ public class DistroXClusterCreationTest extends AbstractClouderaManagerTest {
                 .withImageSettings(DIX_IMG_KEY)
                 .withNetwork(DIX_NET_KEY)
                 .when(distroXClient.create(), key(DISTRO_X_STACK))
-                .await(STACK_AVAILABLE)
+                .await(STACK_AVAILABLE, key(DISTRO_X_STACK))
                 .then(DistroXClusterCreationTest::distroxClusterTemplateContainsMockHostname)
                 .validate();
     }

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/init_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/init_db.sh
@@ -11,7 +11,7 @@ echo "CONFIG_DIR: $CONFIG_DIR"
 echo "Create {{ service }} database"
 echo "CREATE DATABASE {{ values['database'] }};" | psql -U postgres -v "ON_ERROR_STOP=1"
 echo "CREATE USER {{ values['user'] }} WITH PASSWORD '{{ values['password'] }}';" | psql -U postgres -v "ON_ERROR_STOP=1"
-echo "GRANT ALL PRIVILEGES ON DATABASE {{ values['user'] }} TO {{ values['database'] }};" | psql -U postgres -v "ON_ERROR_STOP=1"
+echo "GRANT ALL PRIVILEGES ON DATABASE {{ values['database'] }} TO {{ values['user'] }};" | psql -U postgres -v "ON_ERROR_STOP=1"
 echo "ALTER SCHEMA public OWNER TO {{ values['user'] }};" | psql -U postgres -d {{ values['database'] }} -v "ON_ERROR_STOP=1"
 
 echo "Add access to pg_hba.conf"

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/init_db_remote.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/init_db_remote.sh
@@ -6,18 +6,23 @@
 
 
 echo "Check if database already exists for {{ service }}"
-PGPASSWORD={{ values['remote_admin_pw'] }} psql --host={{ values['remote_db_url'] }} --port={{ values['remote_db_port'] }} --username={{ values['remote_admin'] }} -v "ON_ERROR_STOP=1" -lqt | awk {'print $1'} | grep -qw {{ values['database'] }}
+PGPASSWORD={{ values['remote_admin_pw'] }} psql --host={{ values['remote_db_host'] }} --port={{ values['remote_db_port'] }} --username={{ values['remote_admin'] }} -v "ON_ERROR_STOP=1" -lqt | awk {'print $1'} | grep -qw {{ values['database'] }}
 result=$?
 
 set -e
 if [[ $result -eq 0 ]]; then
     echo "Database already exists for {{ service }}, skipping initialization."
 else
+    username="{{ values['user'] }}"
+    username="${username%%@*}"
+    admin_username="{{ values['remote_admin'] }}"
+    admin_username="${admin_username%%@*}"
     echo "Create remote database and user for service {{ service }}"
-    PGPASSWORD={{ values['remote_admin_pw'] }} createdb --host={{ values['remote_db_url'] }} --port={{ values['remote_db_port'] }} --username={{ values['remote_admin'] }} {{ values['database'] }}
-    echo "CREATE USER {{ values['user'] }} WITH PASSWORD '{{ values['password'] }}';" | PGPASSWORD={{ values['remote_admin_pw'] }} psql --host={{ values['remote_db_url'] }} --port={{ values['remote_db_port'] }} --username={{ values['remote_admin'] }} -v "ON_ERROR_STOP=1" {{ values['database'] }}
-    echo "GRANT ALL PRIVILEGES ON DATABASE {{ values['user'] }} TO {{ values['database'] }};" | PGPASSWORD={{ values['remote_admin_pw'] }} psql --host={{ values['remote_db_url'] }} --port={{ values['remote_db_port'] }} --username={{ values['remote_admin'] }} -v "ON_ERROR_STOP=1" {{ values['database'] }}
-    echo "ALTER SCHEMA public OWNER TO {{ values['user'] }};" | PGPASSWORD={{ values['remote_admin_pw'] }} psql --host={{ values['remote_db_url'] }} --port={{ values['remote_db_port'] }} --username={{ values['remote_admin'] }} -v "ON_ERROR_STOP=1" {{ values['database'] }}
+    PGPASSWORD={{ values['remote_admin_pw'] }} createdb --host={{ values['remote_db_host'] }} --port={{ values['remote_db_port'] }} --username={{ values['remote_admin'] }} {{ values['database'] }}
+    echo "CREATE USER $username WITH PASSWORD '{{ values['password'] }}';" | PGPASSWORD={{ values['remote_admin_pw'] }} psql --host={{ values['remote_db_host'] }} --port={{ values['remote_db_port'] }} --username={{ values['remote_admin'] }} -v "ON_ERROR_STOP=1" {{ values['database'] }}
+    echo "GRANT ALL PRIVILEGES ON DATABASE {{ values['database'] }} TO $username;" | PGPASSWORD={{ values['remote_admin_pw'] }} psql --host={{ values['remote_db_host'] }} --port={{ values['remote_db_port'] }} --username={{ values['remote_admin'] }} -v "ON_ERROR_STOP=1" {{ values['database'] }}
+    echo "GRANT $username TO $admin_username" | PGPASSWORD={{ values['remote_admin_pw'] }} psql --host={{ values['remote_db_host'] }} --port={{ values['remote_db_port'] }} --username={{ values['remote_admin'] }} -v "ON_ERROR_STOP=1" {{ values['database'] }}
+    echo "ALTER SCHEMA public OWNER TO $username" | PGPASSWORD={{ values['remote_admin_pw'] }} psql --host={{ values['remote_db_host'] }} --port={{ values['remote_db_port'] }} --username={{ values['remote_admin'] }} -v "ON_ERROR_STOP=1" {{ values['database'] }}
 fi
 set +e
 


### PR DESCRIPTION
A datalake / SDX cluster may now be created in an Azure environment,
although not with an external database server, yet.

First, the subnet checks in RdsWaitHandler now only apply to AWS. They
are unnecessary for Azure. With this change alone, it is possible to
create an Azure datalake without having redbeams create an external
database server.

SDX templates are introduced for Azure, to go along with the existing
ones for AWS. Currently, the templates are identical, each calling for a
GP_Gen5_2 instance for the database server. The map of templates in
DatabaseService was keyed only by SDX cluster shape, but is now keyed by
both cluster shape and cloud platform.

TLS is disabled for new Azure database servers. This is done because the
Cloudera Manager code which is responsible for creating databases on a
database server does not support connecting over TLS. (RDS instances in
AWS already do not use TLS.)

Usernames for Azure databases are now stored in the format
'username'@'short-hostname', as required to connect to them specifically
by Azure. A pattern in RedbeamsDbServerConfigurer is responsible for
detecting Azure database servers by their domain names.

Accordingly, queries issued by the salt script init_db_remote.sh are
sure to strip the @'short-hostname' suffix from the database username
and admin username before using them in query contents.

Also in init_db_remote.sh, an additional SQL command is inserted which
grants the role of the new database's user to the admin user. This is
necessary for the subsequent ALTER SCHEMA command to succeed, at least
in Azure PostgreSQL.

SdxService does not yet enable Azure database server use by default,
because at this time use of one causes failure during Cloudera Manager's
First Run command, while it attempts to create Hive metastore tables.

The following additional changes are not related to Azure specifically.

* The core cloudbreak service now correctly creates and configures a
  unique username and password for each remote database. Before this, it
  would reuse the administrative username and password for the entire
  database server.
* The GRANT ALL PRIVILEGES SQL command in the salt scripts init_db.sh
  and init_db_remote.sh had the database and username arguments
  reversed. (This wasn't a problem in practice, because the two are
  normally identical.) They have been switched to their correct
  positions.
* The salt pillar key "remote_db_url" has been renamed to
  "remote_db_host", since the value is in fact only a host name.