### PR TITLE
CDPCP-854. Retrieve full ipa user state for full user sync

### DIFF
--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserServiceTest.java
@@ -1,5 +1,11 @@
 package com.sequenceiq.freeipa.service.freeipa.user;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import java.util.Set;
 import java.util.UUID;
 
@@ -7,10 +13,14 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.freeipa.client.FreeIpaClient;
 import com.sequenceiq.freeipa.controller.exception.BadRequestException;
+import com.sequenceiq.freeipa.service.freeipa.user.model.FmsUser;
+import com.sequenceiq.freeipa.service.freeipa.user.model.UsersState;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -29,6 +39,9 @@ class UserServiceTest {
 
     private static final String MACHINE_USER_CRN = "crn:cdp:iam:us-west-1:"
             + ACCOUNT_ID + ":machineUser:" + UUID.randomUUID().toString();
+
+    @Mock
+    FreeIpaUsersStateProvider freeIpaUsersStateProvider;
 
     @InjectMocks
     UserService underTest;
@@ -76,5 +89,23 @@ class UserServiceTest {
         Assertions.assertThrows(BadRequestException.class, () -> {
             underTest.validateCrnFilter(Set.of(ENV_CRN), Crn.ResourceType.USER);
         });
+    }
+
+    @Test
+    void testFullSyncRetrievesFullIpaState() throws Exception {
+        FreeIpaClient freeIpaClient = mock(FreeIpaClient.class);
+        UsersState umsUsersState = mock(UsersState.class);
+        underTest.getIpaUserState(freeIpaClient, umsUsersState, Set.of(), Set.of());
+        verify(freeIpaUsersStateProvider).getUsersState(any());
+    }
+
+    @Test
+    void testFilteredSyncRetrievesFilteredIpaState() throws Exception {
+        FreeIpaClient freeIpaClient = mock(FreeIpaClient.class);
+        UsersState umsUsersState = mock(UsersState.class);
+        Set<FmsUser> workloadUsers = mock(Set.class);
+        when(umsUsersState.getRequestedWorkloadUsers()).thenReturn(workloadUsers);
+        underTest.getIpaUserState(freeIpaClient, umsUsersState, Set.of(USER_CRN), Set.of(MACHINE_USER_CRN));
+        verify(freeIpaUsersStateProvider).getFilteredFreeIPAState(any(), eq(workloadUsers));
     }
 }


### PR DESCRIPTION
This is a minor fix to retrieve the full user state from ipa instead of the filtered user state when performing a full user sync.