### PR TITLE
CDPD-4781 Increase HBase max blocking store files

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-opdb-702.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-opdb-702.bp
@@ -128,6 +128,10 @@
               {
                 "name": "hbase_hregion_memstore_block_multiplier",
                 "value": "4"
+              },
+              {
+                "name": "hbase_hstore_blockingStoreFiles",
+                "value": "50"
               }
             ],
             "base": true


### PR DESCRIPTION
Increase `hbase.hstore.blockingStoreFiles` configuration value to 50 for HBase RegionServers.