### PR TITLE
CB-3842. Add get DistroX api endpoint for internal CB user

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/security/InternalCrnBuilder.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/security/InternalCrnBuilder.java
@@ -54,13 +54,15 @@ public class InternalCrnBuilder {
         return getInternalCrnForService().toString();
     }
 
-    public static CrnUser createInternalCrnUser(Crn crn) {
+    public static CrnUser createInternalCrnUser(Crn crn)  {
+        String service = crn.getService().toString().toUpperCase();
+        String role = "AUTOSCALE".equals(service) ? "ROLE_AUTOSCALE" : "ROLE_INTERNAL";
         return new CrnUser(crn.getResource(),
                 crn.toString(),
                 crn.getResourceType().toString(),
                 crn.getResourceType().toString(),
                 crn.getAccountId(),
-                "ROLE_" + crn.getService().toString().toUpperCase());
+                role);
     }
 
 }

--- a/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/security/CrnUserDetailsServiceTest.java
+++ b/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/security/CrnUserDetailsServiceTest.java
@@ -35,7 +35,14 @@ public class CrnUserDetailsServiceTest {
     public void loadUserByInternalCrn() {
         InternalCrnBuilder crnBuilder = new InternalCrnBuilder(Crn.Service.ENVIRONMENTS);
         UserDetails userDetails = underTest.loadUserByUsername(crnBuilder.getInternalCrnForServiceAsString());
-        assertTrue(userDetails.getAuthorities().iterator().next().getAuthority().equals("ROLE_ENVIRONMENTS"));
+        assertTrue(userDetails.getAuthorities().iterator().next().getAuthority().equals("ROLE_INTERNAL"));
+    }
+
+    @Test
+    public void loadUserByInternalCrnWithAutoscale() {
+        InternalCrnBuilder crnBuilder = new InternalCrnBuilder(Crn.Service.AUTOSCALE);
+        UserDetails userDetails = underTest.loadUserByUsername(crnBuilder.getInternalCrnForServiceAsString());
+        assertTrue(userDetails.getAuthorities().iterator().next().getAuthority().equals("ROLE_AUTOSCALE"));
     }
 
     @Test

--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/doc/DistroXOpDescription.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/doc/DistroXOpDescription.java
@@ -12,6 +12,7 @@ public class DistroXOpDescription {
     public static final String LIST = "list stacks by environment crn";
     public static final String GET_BY_NAME = "get stack by name";
     public static final String GET_BY_CRN = "get stack by crn";
+    public static final String GET_BY_CRN_INTERNAL = "get stack by crn (for internal user)";
     public static final String CREATE = "create stack";
     public static final String DELETE_BY_NAME = "delete stack by name";
     public static final String DELETE_BY_CRN = "delete stack by crn";

--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/endpoint/DistroXInternalV1Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/endpoint/DistroXInternalV1Endpoint.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.distrox.api.v1.distrox.endpoint;
+
+import static com.sequenceiq.distrox.api.v1.distrox.doc.DistroXOpDescription.GET_BY_CRN_INTERNAL;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Response;
+import com.sequenceiq.cloudbreak.doc.Notes;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
+@Path("/v1/internal/distrox")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+@Api(value = "/v1/internal/distrox", protocols = "http,https")
+public interface DistroXInternalV1Endpoint {
+
+    @GET
+    @Path("crn/{crn}")
+    @ApiOperation(value = GET_BY_CRN_INTERNAL, produces = MediaType.APPLICATION_JSON, notes = Notes.STACK_NOTES,
+            nickname = "getDistroXInternalV1ByCrn")
+    StackViewV4Response getByCrn(@PathParam("crn") String crn);
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/conf/SecurityConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/conf/SecurityConfig.java
@@ -55,6 +55,8 @@ public class SecurityConfig {
 
         private static final String DISTROX_API = API_ROOT_CONTEXT + "/v1/distrox/**";
 
+        private static final String INTERNAL_DISTROX_API = API_ROOT_CONTEXT + "/v1/internal/distrox/**";
+
         private static final String AUTOSCALE_API = API_ROOT_CONTEXT + "/autoscale/**";
 
         private static final String FLOW_API = API_ROOT_CONTEXT + "/flow_logs/**";
@@ -106,6 +108,8 @@ public class SecurityConfig {
                     .antMatchers(V4_API)
                     .authenticated()
                     .antMatchers(DISTROX_API)
+                    .authenticated()
+                    .antMatchers(INTERNAL_DISTROX_API)
                     .authenticated()
                     .antMatchers(AUTOSCALE_API)
                     .authenticated()

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/EndpointConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/EndpointConfig.java
@@ -40,6 +40,7 @@ import com.sequenceiq.cloudbreak.controller.v4.WorkspaceAwareUtilV4Controller;
 import com.sequenceiq.cloudbreak.controller.v4.WorkspaceV4Controller;
 import com.sequenceiq.cloudbreak.structuredevent.rest.StructuredEventFilter;
 import com.sequenceiq.cloudbreak.util.FileReaderUtils;
+import com.sequenceiq.distrox.v1.distrox.controller.DistroXInternalV1Controller;
 import com.sequenceiq.distrox.v1.distrox.controller.DistroXV1Controller;
 import com.sequenceiq.flow.controller.FlowController;
 
@@ -75,6 +76,7 @@ public class EndpointConfig extends ResourceConfig {
             StackV4Controller.class,
             CloudbreakInfoV4Controller.class,
             DistroXV1Controller.class,
+            DistroXInternalV1Controller.class,
             DatalakeV4Controller.class,
             CloudProviderServicesV4Controller.class,
             FlowController.class

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackApiViewRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackApiViewRepository.java
@@ -12,6 +12,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.sequenceiq.authorization.resource.AuthorizationResource;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.workspace.repository.DisableHasPermission;
 import com.sequenceiq.cloudbreak.workspace.repository.check.CheckPermissionsByReturnValue;
 import com.sequenceiq.cloudbreak.workspace.repository.check.CheckPermissionsByWorkspaceId;
@@ -32,6 +33,13 @@ public interface StackApiViewRepository extends WorkspaceResourceRepository<Stac
             + "LEFT JOIN FETCH s.stackStatus LEFT JOIN FETCH s.instanceGroups ig LEFT JOIN FETCH ig.instanceMetaData "
             + "LEFT JOIN FETCH s.userView LEFT JOIN FETCH s.workspace w LEFT JOIN FETCH w.tenant WHERE s.id= :id")
     Optional<StackApiView> findById(@Param("id") Long id);
+
+    @CheckPermissionsByReturnValue
+    @Query("SELECT s FROM StackApiView s LEFT JOIN FETCH s.cluster c LEFT JOIN FETCH c.blueprint "
+            + "LEFT JOIN FETCH c.hostGroups hg LEFT JOIN FETCH hg.hostMetadata "
+            + "LEFT JOIN FETCH s.stackStatus LEFT JOIN FETCH s.instanceGroups ig LEFT JOIN FETCH ig.instanceMetaData "
+            + "LEFT JOIN FETCH s.userView LEFT JOIN FETCH s.workspace w LEFT JOIN FETCH w.tenant WHERE s.resourceCrn= :crn AND s.type = :type")
+    Optional<StackApiView> findByResourceCrnAndStackType(@Param("crn") String crn, @Param("type") StackType type);
 
     @CheckPermissionsByWorkspaceId
     @Query("SELECT s FROM StackApiView s LEFT JOIN FETCH s.cluster c LEFT JOIN FETCH c.blueprint "

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackApiViewService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackApiViewService.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.service.stack;
 
+import static com.sequenceiq.cloudbreak.exception.NotFoundException.notFound;
+
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -9,6 +11,7 @@ import javax.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
@@ -88,6 +91,11 @@ public class StackApiViewService {
             stackViewResponses = filterByStackType(stackType, stackViewResponses);
         }
         return stackViewResponses;
+    }
+
+    @PreAuthorize("hasRole('INTERNAL')")
+    public StackApiView retrieveStackByCrnAndType(String crn, StackType stackType) {
+        return stackApiViewRepository.findByResourceCrnAndStackType(crn, stackType).orElseThrow(notFound("Stack", crn));
     }
 
     private Set<StackApiView> filterByStackType(StackType stackType, Set<StackApiView> stackViewResponses) {

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperation.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperation.java
@@ -31,6 +31,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Resp
 import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
 import com.sequenceiq.cloudbreak.common.user.CloudbreakUser;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.view.StackApiView;
 import com.sequenceiq.cloudbreak.service.CloudbreakRestRequestThreadLocalService;
 import com.sequenceiq.cloudbreak.service.ClusterCommonService;
 import com.sequenceiq.cloudbreak.service.DefaultClouderaManagerRepoService;
@@ -141,6 +142,17 @@ public class StackOperation {
         sdxServiceDecorator.prepareSdxAttributes(stackResponse);
         LOGGER.info("Query Stack successfully decorated.");
         return stackResponse;
+    }
+
+    public StackViewV4Response getForInternalCrn(@NotNull StackAccessDto stackAccessDto, StackType stackType) {
+        LOGGER.info("Validate stack against internal user.");
+        validateAccessDto(stackAccessDto);
+        StackApiView stackApiView = stackApiViewService.retrieveStackByCrnAndType(stackAccessDto.getCrn(), stackType);
+        LOGGER.info("Query Stack (view) successfully finished with crn {}", stackAccessDto.getCrn());
+        StackViewV4Response stackViewV4Response = converterUtil.convert(stackApiView, StackViewV4Response.class);
+        LOGGER.info("Adding environment name to the response.");
+        environmentServiceDecorator.prepareEnvironment(stackViewV4Response);
+        return stackViewV4Response;
     }
 
     public void delete(StackAccessDto stackAccessDto, Long workspaceId, Boolean forced) {

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXInternalV1Controller.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXInternalV1Controller.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.distrox.v1.distrox.controller;
+
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.dto.StackAccessDto.StackAccessDtoBuilder.aStackAccessDtoBuilder;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Controller;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Response;
+import com.sequenceiq.distrox.api.v1.distrox.endpoint.DistroXInternalV1Endpoint;
+import com.sequenceiq.distrox.v1.distrox.StackOperation;
+
+@Controller
+public class DistroXInternalV1Controller implements DistroXInternalV1Endpoint {
+
+    @Inject
+    private StackOperation stackOperation;
+
+    @Override
+    public StackViewV4Response getByCrn(String crn) {
+        return stackOperation.getForInternalCrn(
+                aStackAccessDtoBuilder().withCrn(crn).build(),
+                StackType.WORKLOAD);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/service/EnvironmentServiceDecorator.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/service/EnvironmentServiceDecorator.java
@@ -71,4 +71,13 @@ public class EnvironmentServiceDecorator {
         }
     }
 
+    public void prepareEnvironment(StackViewV4Response stackViewResponse) {
+        try {
+            DetailedEnvironmentResponse byCrn = environmentClientService.getByCrn(stackViewResponse.getEnvironmentCrn());
+            stackViewResponse.setEnvironmentName(byCrn.getName());
+        } catch (Exception e) {
+            LOGGER.warn("Environment deleted which had crn: {}.", stackViewResponse.getEnvironmentCrn());
+        }
+    }
+
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/structuredevent/rest/urlparsers/RestUrlParserTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/structuredevent/rest/urlparsers/RestUrlParserTest.java
@@ -83,7 +83,7 @@ public class RestUrlParserTest {
     @Autowired
     private List<RestUrlParser> restUrlParsers;
 
-    private String[] excludes = {"/v1/distrox", "/autoscale"};
+    private String[] excludes = {"/v1/distrox", "/v1/internal/distrox", "/autoscale"};
 
     @Test
     public void testEventUrlParser() {


### PR DESCRIPTION
Requirement:
- have an ability to get some stack details (env crn/name, stack crn/name, stack create/terminate timestamp) based on a crn for an internal user 

Solution:
- added **internal** distrox endpoint (similar as sdx internal) - that is for internal usage inside Control Plane, so that is the name right now, that can be changed in another commit if that needs to be changed (like support by a query param like tenantUnawere or something . else)
- use INTERNAL role for the operation (that can be re-used) - map to AUTOSCALE role only for autoscale (as that is internal from CB perspective)

edit: use only default iam internal actor

testing is in progress ...
manual tests looked ok