### PR TITLE
CB-3975 Azure - Don't override topology name and SSO type

### DIFF
--- a/datalake/src/main/resources/sdx/azure/cluster-light-duty-template.json
+++ b/datalake/src/main/resources/sdx/azure/cluster-light-duty-template.json
@@ -1,17 +1,7 @@
 {
   "cluster": {
     "blueprintName": "CDP 1.2 - SDX Light Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas",
-    "validateBlueprint": false,
-    "gateway": {
-      "topologies": [
-        {
-          "topologyName": "dp-proxy",
-          "exposedServices": [
-            "ALL"
-          ]
-        }
-      ],
-      "ssoType": "SSO_PROVIDER"
+    "validateBlueprint": false
     }
   },
   "customDomain": {


### PR DESCRIPTION
Removed override of topology name and SSO type. 

I don't know how to test this currently, but wanted to open a PR to get some reviews. 