### PR TITLE
CB-3856 Knox - NiFi service needs useTwoWaySsl parameter

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -437,6 +437,7 @@
     {% if 'NIFI' in exposed -%}
     <service>
         <role>NIFI</role>
+        <param name="useTwoWaySsl" value="true" />
         {% for hostloc in salt['pillar.get']('gateway:location')['NIFI_NODE'] -%}
         <url>{{ protocol }}://{{ hostloc }}:{{ ports['NIFI'] }}</url>
         {%- endfor %}
@@ -448,6 +449,7 @@
     {% if 'NIFI-REGISTRY' in exposed -%}
         <service>
             <role>NIFI-REGISTRY</role>
+            <param name="useTwoWaySsl" value="true" />
             {% for hostloc in salt['pillar.get']('gateway:location')['NIFI_REGISTRY_SERVER'] -%}
             <url>{{ protocol }}://{{ hostloc }}:{{ ports['NIFI-REGISTRY'] }}</url>
             {%- endfor %}

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
@@ -265,6 +265,7 @@
     {% if 'NIFI_REST' in exposed -%}
     <service>
         <role>NIFI</role>
+        <param name="useTwoWaySsl" value="true" />
         {% for hostloc in salt['pillar.get']('gateway:location')['NIFI_NODE'] -%}
         <url>{{ protocol }}://{{ hostloc }}:{{ ports['NIFI_REST'] }}</url>
         {%- endfor %}


### PR DESCRIPTION
NiFi needs to have the useTwoWalSsl parameter in order to authenticate Knox to NiFi. Added to NiFi Registry as well since they use a similar authentication mechanism. If NiFi is not configured for TLS, then this should have no affect since HTTP client won't send the client certificate.