### PR TITLE
CDPSDX-994 Add validation that permissions exist when creating roles

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/KerberosMgmtRoleComponent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/KerberosMgmtRoleComponent.java
@@ -24,6 +24,23 @@ public class KerberosMgmtRoleComponent {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KerberosMgmtV1Service.class);
 
+    public boolean privilegesExist(RoleRequest roleRequest, FreeIpaClient ipaClient) {
+        return roleRequest == null ||
+            roleRequest.getPrivileges().stream().allMatch(privilegeName -> {
+                try {
+                    ipaClient.showPrivilege(privilegeName);
+                    return true;
+                } catch (FreeIpaClientException e) {
+                    if (!KerberosMgmtUtil.isNotFoundException(e)) {
+                        LOGGER.debug("Privilege [{}] does not exist", privilegeName);
+                    } else {
+                        LOGGER.error("Privilege [{}] show error", privilegeName, e);
+                    }
+                    return false;
+                }
+            });
+    }
+
     public void addRoleAndPrivileges(Optional<Service> service, Optional<Host> host, RoleRequest roleRequest,
             FreeIpaClient ipaClient)
             throws FreeIpaClientException {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/KerberosMgmtV1Service.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/KerberosMgmtV1Service.java
@@ -58,6 +58,8 @@ public class KerberosMgmtV1Service {
 
     private static final String ROLE_NOT_ALLOWED = "The role request is not allowed when retrieving a keytab";
 
+    private static final String PRIVILEGE_DOES_NOT_EXIST = "At least one privilege in the role request does not exist.";
+
     private static final String IPA_STACK_NOT_FOUND = "Stack for IPA server not found.";
 
     private static final int NOT_FOUND_ERROR_CODE = 4001;
@@ -85,6 +87,9 @@ public class KerberosMgmtV1Service {
         Stack freeIpaStack = getFreeIpaStack(request.getEnvironmentCrn(), accountId);
         String realm = getRealm(freeIpaStack);
         FreeIpaClient ipaClient = freeIpaClientFactory.getFreeIpaClientForStack(freeIpaStack);
+        if (!roleComponent.privilegesExist(request.getRoleRequest(), ipaClient)) {
+            throw new KeytabCreationException(PRIVILEGE_DOES_NOT_EXIST);
+        }
         addHost(request.getServerHostName(), null, ipaClient);
         com.sequenceiq.freeipa.client.model.Service service = serviceAdd(request, realm, ipaClient);
         String serviceKeytab;
@@ -120,6 +125,9 @@ public class KerberosMgmtV1Service {
         HostKeytabResponse response = new HostKeytabResponse();
         Stack freeIpaStack = getFreeIpaStack(request.getEnvironmentCrn(), accountId);
         FreeIpaClient ipaClient = freeIpaClientFactory.getFreeIpaClientForStack(freeIpaStack);
+        if (!roleComponent.privilegesExist(request.getRoleRequest(), ipaClient)) {
+            throw new KeytabCreationException(PRIVILEGE_DOES_NOT_EXIST);
+        }
         Host host = addHost(request.getServerHostName(), request.getRoleRequest(), ipaClient);
         String hostKeytab;
         if (host.getHasKeytab() && request.getDoNotRecreateKeytab()) {

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/kerberosmgmt/KerberosMgmtRoleComponentV1Test.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/kerberosmgmt/KerberosMgmtRoleComponentV1Test.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
@@ -166,5 +167,31 @@ public class KerberosMgmtRoleComponentV1Test {
         Mockito.when(mockIpaClient.showRole(anyString())).thenReturn(role);
         new KerberosMgmtRoleComponent().deleteRoleIfItIsNoLongerUsed(ROLE, mockIpaClient);
         Mockito.verify(mockIpaClient).deleteRole(ROLE);
+    }
+
+    @Test
+    public void testPrivilegeExistReturnTrue() throws Exception {
+        RoleRequest roleRequest = new RoleRequest();
+        roleRequest.setRoleName(ROLE);
+        Set<String> privileges = new HashSet<>();
+        privileges.add(PRIVILEGE1);
+        privileges.add(PRIVILEGE2);
+        roleRequest.setPrivileges(privileges);
+        Privilege privilege = new Privilege();
+        Mockito.when(mockIpaClient.showPrivilege(any())).thenReturn(privilege);
+        Assertions.assertTrue(new KerberosMgmtRoleComponent().privilegesExist(roleRequest, mockIpaClient));
+    }
+
+    @Test
+    public void testPrivilegeExistReturnFalse() throws Exception {
+        RoleRequest roleRequest = new RoleRequest();
+        roleRequest.setRoleName(ROLE);
+        Set<String> privileges = new HashSet<>();
+        privileges.add(PRIVILEGE1);
+        privileges.add(PRIVILEGE2);
+        roleRequest.setPrivileges(privileges);
+        Mockito.when(mockIpaClient.showPrivilege(any())).thenThrow(new FreeIpaClientException(ERROR_MESSAGE,
+                new JsonRpcClientException(NOT_FOUND, ERROR_MESSAGE, null)));
+        Assertions.assertFalse(new KerberosMgmtRoleComponent().privilegesExist(roleRequest, mockIpaClient));
     }
 }


### PR DESCRIPTION
When adding a role for creating host keytabs and service principal
keytabs. The permissions were not checked to ensure they exist. This
check has been added and the roles are only created if the
permissions already exist.

Although there is a slight race condition, if a permission is removed
concurrently while creating one of the roles, it is possible that the
role is created and the permission does not exist. It is better to
have the check even if it is not perfect.

This was tested using a local deployment of cloudbreak.

Closes #CDPSDX-994