### PR TITLE
CDPCP-721. Trigger user sync through polling event generation ids

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/UserSyncStatus.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/UserSyncStatus.java
@@ -1,0 +1,59 @@
+package com.sequenceiq.freeipa.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+import javax.persistence.SequenceGenerator;
+
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.common.json.JsonToString;
+import com.sequenceiq.cloudbreak.service.secret.domain.AccountIdAwareResource;
+
+@Entity
+public class UserSyncStatus implements AccountIdAwareResource {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "usersyncstatus_generator")
+    @SequenceGenerator(name = "usersyncstatus_generator", sequenceName = "usersyncstatus_id_seq", allocationSize = 1)
+    private Long id;
+
+    @OneToOne
+    private Stack stack;
+
+    @Convert(converter = JsonToString.class)
+    @Column(columnDefinition = "TEXT")
+    private Json umsEventGenerationIds;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Stack getStack() {
+        return stack;
+    }
+
+    public void setStack(Stack stack) {
+        this.stack = stack;
+    }
+
+    public Json getUmsEventGenerationIds() {
+        return umsEventGenerationIds;
+    }
+
+    public void setUmsEventGenerationIds(Json umsEventGenerationIds) {
+        this.umsEventGenerationIds = umsEventGenerationIds;
+    }
+
+    @Override
+    public String getAccountId() {
+        return stack.getAccountId();
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/repository/StackRepository.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/repository/StackRepository.java
@@ -23,6 +23,10 @@ import com.sequenceiq.freeipa.entity.Stack;
 public interface StackRepository extends BaseJpaRepository<Stack, Long> {
 
     @CheckPermission(action = ResourceAction.READ)
+    @Query("SELECT s FROM Stack s WHERE s.terminated = -1")
+    List<Stack> findAllRunning();
+
+    @CheckPermission(action = ResourceAction.READ)
     @Query("SELECT s FROM Stack s LEFT JOIN FETCH s.instanceGroups ig LEFT JOIN FETCH ig.instanceMetaData WHERE s.id= :id ")
     Optional<Stack> findOneWithLists(@Param("id") Long id);
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/repository/UserSyncStatusRepository.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/repository/UserSyncStatusRepository.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.freeipa.repository;
+
+import java.util.Optional;
+
+import javax.transaction.Transactional;
+
+import com.sequenceiq.authorization.repository.BaseCrudRepository;
+import com.sequenceiq.authorization.repository.CheckPermission;
+import com.sequenceiq.authorization.resource.AuthorizationResource;
+import com.sequenceiq.authorization.resource.AuthorizationResourceType;
+import com.sequenceiq.authorization.resource.ResourceAction;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.entity.UserSyncStatus;
+
+@Transactional(Transactional.TxType.REQUIRED)
+@AuthorizationResourceType(resource = AuthorizationResource.ENVIRONMENT)
+public interface UserSyncStatusRepository extends BaseCrudRepository<UserSyncStatus, Long> {
+
+    @CheckPermission(action = ResourceAction.READ)
+    Optional<UserSyncStatus> getByStack(Stack stack);
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UmsEventGenerationIdsProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UmsEventGenerationIdsProvider.java
@@ -1,0 +1,66 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsResponse;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
+import com.sequenceiq.freeipa.service.freeipa.user.model.UmsEventGenerationIds;
+
+@Component
+public class UmsEventGenerationIdsProvider {
+
+    @VisibleForTesting
+    enum EventMapping {
+        LAST_ROLE_ASSIGNMENT_EVENT_ID("lastRoleAssignmentEventId", GetEventGenerationIdsResponse::getLastRoleAssignmentEventId),
+        LAST_RESOURCE_ROLE_ASSIGNMENT_EVENT_ID("lastResourceRoleAssignmentEventId", GetEventGenerationIdsResponse::getLastResourceRoleAssignmentEventId),
+        LAST_GROUP_MEMBERHSIP_CHANGED_EVENT_ID("lastGroupMembershipChangedEventId", GetEventGenerationIdsResponse::getLastGroupMembershipChangedEventId),
+        LAST_ACTOR_DELETED_EVENT_ID("lastActorDeletedEventId", GetEventGenerationIdsResponse::getLastActorDeletedEventId),
+        LAST_ACTOR_WORKLOAD_CREDENTIALS_CHANGED_EVENT_ID("lastActorWorkloadCredentialsChangedEventId",
+                GetEventGenerationIdsResponse::getLastActorWorkloadCredentialsChangedEventId);
+
+        private String eventName;
+
+        private Function<GetEventGenerationIdsResponse, String> converter;
+
+        EventMapping(String eventName, Function<GetEventGenerationIdsResponse, String> converter) {
+            this.eventName = eventName;
+            this.converter = converter;
+        }
+
+        public String getEventName() {
+            return eventName;
+        }
+
+        public Function<GetEventGenerationIdsResponse, String> getConverter() {
+            return converter;
+        }
+    }
+
+    @Inject
+    private GrpcUmsClient grpcUmsClient;
+
+    public UmsEventGenerationIds getEventGenerationIds(String actor, String accountId, Optional<String> requestId) {
+        GetEventGenerationIdsResponse response = grpcUmsClient.getEventGenerationIds(actor, accountId, requestId);
+
+        UmsEventGenerationIds umsEventGenerationIds = new UmsEventGenerationIds();
+        Map<String, String> eventGenerationIdsMap = new HashMap<>();
+        for (EventMapping eventMapping : EventMapping.values()) {
+            String eventId = eventMapping.converter.apply(response);
+            if (!Strings.isNullOrEmpty(eventId)) {
+                eventGenerationIdsMap.put(eventMapping.getEventName(), eventMapping.getConverter().apply(response));
+            }
+        }
+        umsEventGenerationIds.setEventGenerationIds(eventGenerationIdsMap);
+
+        return umsEventGenerationIds;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncStatusService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncStatusService.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.entity.UserSyncStatus;
+import com.sequenceiq.freeipa.repository.UserSyncStatusRepository;
+import com.sequenceiq.freeipa.service.freeipa.user.model.UmsEventGenerationIds;
+
+@Service
+public class UserSyncStatusService {
+
+    @Inject
+    private UserSyncStatusRepository userSyncStatusRepository;
+
+    public UserSyncStatus save(UserSyncStatus userSyncStatus) {
+        return userSyncStatusRepository.save(userSyncStatus);
+    }
+
+    public UserSyncStatus getOrCreateForStack(Stack stack) {
+        return userSyncStatusRepository.getByStack(stack).orElseGet(() -> {
+            UserSyncStatus userSyncStatus = new UserSyncStatus();
+            userSyncStatus.setStack(stack);
+            userSyncStatus.setUmsEventGenerationIds(new Json(new UmsEventGenerationIds()));
+            return userSyncStatusRepository.save(userSyncStatus);
+        });
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UsersyncPoller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UsersyncPoller.java
@@ -1,0 +1,110 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.cloudbreak.auth.security.InternalCrnBuilder;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SyncOperationStatus;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.entity.UserSyncStatus;
+import com.sequenceiq.freeipa.service.freeipa.user.model.UmsEventGenerationIds;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+@Service
+public class UsersyncPoller {
+    @VisibleForTesting
+    static final String INTERNAL_ACTOR_CRN = new InternalCrnBuilder(Crn.Service.IAM).getInternalCrnForServiceAsString();
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UsersyncPoller.class);
+
+    @Inject
+    private ThreadBasedUserCrnProvider threadBasedUserCrnProvider;
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private UserSyncStatusService userSyncStatusService;
+
+    @Inject
+    private UserService userService;
+
+    @Inject
+    private UmsEventGenerationIdsProvider umsEventGenerationIdsProvider;
+
+    @Value("${freeipa.syncoperation.poller.enabled:true}")
+    private boolean enabled;
+
+    @Scheduled(fixedDelayString = "${freeipa.syncoperation.poller.fixed-delay-millis:60000}",
+            initialDelayString = "${freeipa.syncoperation.poller.initial-delay-millis:300000}")
+    public void pollUms() {
+        try {
+            if (enabled) {
+                syncFreeIpaStacks();
+            }
+        } catch (Exception e) {
+            LOGGER.error("Failed to automatically sync users to FreeIPA stacks", e);
+        }
+    }
+
+    @VisibleForTesting
+    void syncFreeIpaStacks() {
+        threadBasedUserCrnProvider.setUserCrn(INTERNAL_ACTOR_CRN);
+        Optional<String> requestId = Optional.of(UUID.randomUUID().toString());
+        LOGGER.debug("Setting request id = {} for this poll", requestId);
+        MDCBuilder.addRequestId(requestId.get());
+        try {
+            LOGGER.debug("Attempting to sync users to FreeIPA stacks");
+            List<Stack> stackList = stackService.findAllRunning();
+            LOGGER.debug("Found {} active stacks", stackList.size());
+
+            stackList.stream()
+                    .collect(Collectors.groupingBy(Stack::getAccountId))
+                    .entrySet().stream()
+                    .forEach(stringListEntry -> {
+                        UmsEventGenerationIds currentGeneration =
+                                umsEventGenerationIdsProvider.getEventGenerationIds(INTERNAL_ACTOR_CRN, stringListEntry.getKey(), requestId);
+                        stringListEntry.getValue().stream()
+                                .forEach(stack -> {
+                                    if (isStale(stack, currentGeneration)) {
+                                        LOGGER.debug("Environment {} in Account {} is stale.", stack.getEnvironmentCrn(), stack.getAccountId());
+                                        SyncOperationStatus status = userService.synchronizeUsers(stack.getAccountId(), INTERNAL_ACTOR_CRN,
+                                                Set.of(stack.getEnvironmentCrn()), Set.of(), Set.of());
+                                        LOGGER.debug("Sync request resulted in operation {}", status);
+                                    } else {
+                                        LOGGER.debug("Environment {} in Account {} is up-to-date.", stack.getEnvironmentCrn(), stack.getAccountId());
+                                    }
+                                });
+                    });
+        } finally {
+            threadBasedUserCrnProvider.removeUserCrn();
+            MDCBuilder.cleanupMdc();
+        }
+    }
+
+    @VisibleForTesting
+    boolean isStale(Stack stack, UmsEventGenerationIds currentGeneration) {
+        try {
+            UserSyncStatus userSyncStatus = userSyncStatusService.getOrCreateForStack(stack);
+            return !currentGeneration.equals(userSyncStatus.getUmsEventGenerationIds().get(UmsEventGenerationIds.class));
+        } catch (Exception e) {
+            LOGGER.warn("Unable to calculate staleness due to exception.", e);
+            return false;
+        }
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UmsEventGenerationIds.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UmsEventGenerationIds.java
@@ -1,0 +1,45 @@
+package com.sequenceiq.freeipa.service.freeipa.user.model;
+
+import java.util.Map;
+import java.util.Objects;
+
+import com.google.common.collect.ImmutableMap;
+
+public class UmsEventGenerationIds {
+
+    private Map<String, String> eventGenerationIds = ImmutableMap.of();
+
+    public Map<String, String> getEventGenerationIds() {
+        return eventGenerationIds;
+    }
+
+    public void setEventGenerationIds(Map<String, String> eventGenerationIds) {
+        this.eventGenerationIds = ImmutableMap.copyOf(eventGenerationIds);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        UmsEventGenerationIds that = (UmsEventGenerationIds) o;
+
+        return Objects.equals(eventGenerationIds, that.eventGenerationIds);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(eventGenerationIds);
+    }
+
+    @Override
+    public String toString() {
+        return "UmsEventGenerationIds{"
+                + "eventGenerationIds=" + eventGenerationIds
+                + '}';
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
@@ -20,6 +20,10 @@ public class StackService {
     @Inject
     private StackRepository stackRepository;
 
+    public List<Stack> findAllRunning() {
+        return stackRepository.findAllRunning();
+    }
+
     public Stack getByIdWithListsInTransaction(Long id) {
         return stackRepository.findOneWithLists(id).orElseThrow(() -> new NotFoundException(String.format("Stack [%s] not found", id)));
     }

--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -65,6 +65,10 @@ freeipa:
       timeout-millis: 1800000
       initial-delay-millis: 60000
       fixed-delay-millis: 60000
+    poller:
+      enabled: true
+      initial-delay-millis: 60000
+      fixed-delay-millis: 300000
 
 info:
   app:

--- a/freeipa/src/main/resources/schema/app/20191015100823_CDPCP-721_create_usersync_status.sql
+++ b/freeipa/src/main/resources/schema/app/20191015100823_CDPCP-721_create_usersync_status.sql
@@ -1,0 +1,32 @@
+-- // CDPCP-721 Track usersync status
+
+CREATE SEQUENCE IF NOT EXISTS usersyncstatus_id_seq START WITH 1
+  INCREMENT BY 1
+  NO MINVALUE
+  NO MAXVALUE
+  CACHE 1;
+
+CREATE TABLE IF NOT EXISTS usersyncstatus
+(
+  id bigint default nextval('usersyncstatus_id_seq'::regclass) not null
+    constraint usersyncstatus_pkey
+      primary key,
+  stack_id bigint not null
+    constraint fk_usersyncstatus_id
+      references stack,
+  umseventgenerationids text
+);
+
+UPDATE usersyncstatus SET umseventgenerationids='{}';
+
+CREATE UNIQUE INDEX IF NOT EXISTS usersyncstatus_id_idx
+  on usersyncstatus (id);
+
+CREATE INDEX IF NOT EXISTS usersyncstatus_freeipaid_idx
+  on usersyncstatus (stack_id);
+
+-- //@UNDO
+
+DROP TABLE usersyncstatus;
+
+DROP SEQUENCE usersyncstatus_id_seq;

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UmsEventGenerationIdsProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UmsEventGenerationIdsProviderTest.java
@@ -1,0 +1,67 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsResponse;
+import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
+import com.sequenceiq.freeipa.service.freeipa.user.model.UmsEventGenerationIds;
+
+@ExtendWith(MockitoExtension.class)
+class UmsEventGenerationIdsProviderTest {
+
+    private static final String ACCOUNT_ID = UUID.randomUUID().toString();
+
+    private static final String ACTOR_CRN = "crn:cdp:iam:us-west-1:" + ACCOUNT_ID + ":user:" + UUID.randomUUID().toString();
+
+    @Mock
+    GrpcUmsClient grpcUmsClient;
+
+    @InjectMocks
+    UmsEventGenerationIdsProvider underTest;
+
+    @Test
+    void testGetEventGenerationIds() {
+        GetEventGenerationIdsResponse response = createGetEventGenerationIdsResponse();
+        when(grpcUmsClient.getEventGenerationIds(any(), any(), any())).thenReturn(response);
+
+        UmsEventGenerationIds umsEventGenerationIds = underTest.getEventGenerationIds(ACTOR_CRN, ACCOUNT_ID, Optional.of(UUID.randomUUID().toString()));
+
+        for (UmsEventGenerationIdsProvider.EventMapping eventMapping : UmsEventGenerationIdsProvider.EventMapping.values()) {
+            assertEquals(eventMapping.getConverter().apply(response), umsEventGenerationIds.getEventGenerationIds().get(eventMapping.getEventName()));
+        }
+    }
+
+    GetEventGenerationIdsResponse createGetEventGenerationIdsResponse() {
+
+        GetEventGenerationIdsResponse.Builder builder = GetEventGenerationIdsResponse.newBuilder();
+
+        Arrays.stream(GetEventGenerationIdsResponse.Builder.class.getMethods())
+                .filter(m -> m.getName().startsWith("set"))
+                .filter(m -> !m.getName().endsWith("Bytes"))
+                .filter(m -> !m.getName().endsWith("Field"))
+                .filter(m -> !m.getName().endsWith("Fields"))
+                .forEach(m -> {
+                    try {
+                        m.invoke(builder, UUID.randomUUID().toString());
+                    } catch (IllegalAccessException | InvocationTargetException e) {
+                        fail("Could not build GetEventGenerationIdsResponse.", e);
+                    }
+                });
+
+        return builder.build();
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UsersyncPollerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UsersyncPollerTest.java
@@ -1,0 +1,108 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.entity.UserSyncStatus;
+import com.sequenceiq.freeipa.service.freeipa.user.model.UmsEventGenerationIds;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+@ExtendWith(MockitoExtension.class)
+class UsersyncPollerTest {
+
+    private static final String ACCOUNT_ID = UUID.randomUUID().toString();
+
+    private static final String ENVIRONMENT_CRN = "crn:cdp:environments:us-west-1:" + ACCOUNT_ID + ":environment:" + UUID.randomUUID().toString();
+
+    @Mock
+    ThreadBasedUserCrnProvider threadBasedUserCrnProvider;
+
+    @Mock
+    StackService stackService;
+
+    @Mock
+    UserSyncStatusService userSyncStatusService;
+
+    @Mock
+    UserService userService;
+
+    @Mock
+    UmsEventGenerationIdsProvider umsEventGenerationIdsProvider;
+
+    @InjectMocks
+    UsersyncPoller underTest;
+
+    @Test
+    void testIsStale() throws Exception {
+        UmsEventGenerationIds currentEventGenerationIds = mock(UmsEventGenerationIds.class);
+        Stack stack = mock(Stack.class);
+        setupUserSyncStatus(stack, mock(UmsEventGenerationIds.class));
+
+        assertTrue(underTest.isStale(stack, currentEventGenerationIds));
+    }
+
+    @Test
+    void testIsNotStale() throws Exception {
+        UmsEventGenerationIds currentEventGenerationIds = mock(UmsEventGenerationIds.class);
+        Stack stack = mock(Stack.class);
+        setupUserSyncStatus(stack, currentEventGenerationIds);
+
+        assertFalse(underTest.isStale(stack, currentEventGenerationIds));
+    }
+
+    @Test
+    void testSyncStackWhenStale() throws Exception {
+        UmsEventGenerationIds currentEventGenerationIds = mock(UmsEventGenerationIds.class);
+        when(umsEventGenerationIdsProvider.getEventGenerationIds(any(), any(), any())).thenReturn(currentEventGenerationIds);
+        Stack stack = mock(Stack.class);
+        when(stack.getAccountId()).thenReturn(ACCOUNT_ID);
+        when(stack.getEnvironmentCrn()).thenReturn(ENVIRONMENT_CRN);
+        setupUserSyncStatus(stack, mock(UmsEventGenerationIds.class));
+        when(stackService.findAllRunning()).thenReturn(List.of(stack));
+
+        underTest.syncFreeIpaStacks();
+
+        verify(userService).synchronizeUsers(stack.getAccountId(), UsersyncPoller.INTERNAL_ACTOR_CRN,
+                Set.of(stack.getEnvironmentCrn()), Set.of(), Set.of());
+    }
+
+    @Test
+    void testDontSyncStackWhenNotStale() throws Exception {
+        UmsEventGenerationIds currentEventGenerationIds = mock(UmsEventGenerationIds.class);
+        when(umsEventGenerationIdsProvider.getEventGenerationIds(any(), any(), any())).thenReturn(currentEventGenerationIds);
+        Stack stack = mock(Stack.class);
+        when(stack.getAccountId()).thenReturn(ACCOUNT_ID);
+        when(stack.getEnvironmentCrn()).thenReturn(ENVIRONMENT_CRN);
+        setupUserSyncStatus(stack, currentEventGenerationIds);
+        when(stackService.findAllRunning()).thenReturn(List.of(stack));
+
+        underTest.syncFreeIpaStacks();
+
+        verify(userService, times(0))
+                .synchronizeUsers(any(), any(), any(), any(), any());
+    }
+
+    private void setupUserSyncStatus(Stack stack, UmsEventGenerationIds umsEventGenerationIds) throws Exception {
+        UserSyncStatus userSyncStatus = mock(UserSyncStatus.class, RETURNS_DEEP_STUBS);
+        when(userSyncStatus.getUmsEventGenerationIds().get(UmsEventGenerationIds.class)).thenReturn(umsEventGenerationIds);
+        when(userSyncStatusService.getOrCreateForStack(stack)).thenReturn(userSyncStatus);
+    }
+}


### PR DESCRIPTION
This commit supports the automatic user sync feature by polling the UMS
for changes in each account. The UMS now provides an API for retrieving
event generation ids.

A UserSyncStatus model is added to the database to hold the event generation
ids for the last successful full user sync for each environment. A poller
class is added that runs on a configurable interval. The poller retrieves
the event generation ids from the UMS, compares them to the stored event
generation ids, and triggers the user sync if the ids do not match.
