### PR TITLE
CDPCP-871 - removing parameter map since it leaks password

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
@@ -479,7 +479,7 @@ public class FreeIpaClient {
         }
         parameterMap.put("version", apiVersion);
 
-        LOGGER.debug("Issuing JSON-RPC request:\n\n method: {}\n flags: {}\n params: {}\n", method, flags, parameterMap);
+        LOGGER.debug("Issuing JSON-RPC request:\n\n method: {}\n flags: {}\n", method, flags);
         ParameterizedType type = TypeUtils
                 .parameterize(RPCResponse.class, resultType);
         try {


### PR DESCRIPTION
Currently in logs password also gets leaked. As a temp fix, we can remove param map from logs. 

Closes CDPCP-871

