### PR TITLE
CB-4037 Remove explicit setting of fs.s3a.block.size in Datamart template

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-mart-702.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-mart-702.bp
@@ -67,7 +67,7 @@
               "value" : "COORDINATOR_ONLY"
             }, {
               "name" : "impala_hdfs_site_conf_safety_valve",
-              "value" : "<property><name>fs.s3a.block.size</name><value>268435456</value></property><property><name>fs.s3a.experimental.input.fadvise</name><value>RANDOM</value></property><property><name>fs.s3a.fast.upload</name><value>true</value></property>"
+              "value" : "<property><name>fs.s3a.experimental.input.fadvise</name><value>RANDOM</value></property><property><name>fs.s3a.fast.upload</name><value>true</value></property>"
             } ],
             "base": false
           },
@@ -79,7 +79,7 @@
               "value" : "EXECUTOR_ONLY"
             }, {
               "name" : "impala_hdfs_site_conf_safety_valve",
-              "value" : "<property><name>fs.s3a.block.size</name><value>268435456</value></property><property><name>fs.s3a.experimental.input.fadvise</name><value>RANDOM</value></property><property><name>fs.s3a.fast.upload</name><value>true</value></property>"
+              "value" : "<property><name>fs.s3a.experimental.input.fadvise</name><value>RANDOM</value></property><property><name>fs.s3a.fast.upload</name><value>true</value></property>"
             } ],
             "base": false
           },

--- a/core/src/main/resources/defaults/blueprints/cdp-op-data-mart-702.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-op-data-mart-702.bp
@@ -104,7 +104,7 @@
               "value" : "COORDINATOR_ONLY"
             }, {
               "name" : "impala_hdfs_site_conf_safety_valve",
-              "value" : "<property><name>fs.s3a.block.size</name><value>268435456</value></property><property><name>fs.s3a.experimental.input.fadvise</name><value>RANDOM</value></property><property><name>fs.s3a.fast.upload</name><value>true</value></property>"
+              "value" : "<property><name>fs.s3a.experimental.input.fadvise</name><value>RANDOM</value></property><property><name>fs.s3a.fast.upload</name><value>true</value></property>"
             } ],
             "base": false
           },
@@ -116,7 +116,7 @@
               "value" : "EXECUTOR_ONLY"
             }, {
               "name" : "impala_hdfs_site_conf_safety_valve",
-              "value" : "<property><name>fs.s3a.block.size</name><value>268435456</value></property><property><name>fs.s3a.experimental.input.fadvise</name><value>RANDOM</value></property><property><name>fs.s3a.fast.upload</name><value>true</value></property>"
+              "value" : "<property><name>fs.s3a.experimental.input.fadvise</name><value>RANDOM</value></property><property><name>fs.s3a.fast.upload</name><value>true</value></property>"
             } ],
             "base": false
           },


### PR DESCRIPTION

Impala was enhanced in CDH-79188 to set a more optimal default block size for Parquet files on object stores.
Now that the Impala default has been fixed we no longer need the explicit fs.s3a.block.size config setting in the Datamart template.
