### PR TITLE
CB-4039 KnoxSSO - JWT Tokens Are Valid for Extremely Long Duration

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/knoxsso.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/knoxsso.xml.j2
@@ -123,8 +123,9 @@
             <value>true</value>
         </param>
         <param>
+	    <!-- 24 hours in milliseconds = 86400000 -->
             <name>knoxsso.token.ttl</name>
-            <value>-1</value>
+            <value>86400000</value>
         </param>
         <param>
            <name>knoxsso.redirect.whitelist.regex</name>

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/knoxsso.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/knoxsso.xml.j2
@@ -123,8 +123,9 @@
             <value>true</value>
         </param>
         <param>
+	    <!-- 24hrs in milliseconds = 86400000 -->
             <name>knoxsso.token.ttl</name>
-            <value>-1</value>
+            <value>86400000</value>
         </param>
         <param>
            <name>knoxsso.redirect.whitelist.regex</name>


### PR DESCRIPTION
The KnoxSSO topology TTL should be limited to a duration instead of -1. This sets the duration to 24hrs in milliseconds. After this ttl expires, the user will need to login again.