### PR TITLE
Disable Scheduler Config Mutation in YARN RM

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-702.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-702.bp
@@ -57,6 +57,10 @@
             "base": true,
             "configs": [
               {
+                "name":"yarn.scheduler.configuration.store.class",
+                "value":"file"
+              },
+              {
                 "name": "yarn_resourcemanager_scheduler_class",
                 "value": "org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler"
               },


### PR DESCRIPTION
1. This disables YARN Scheduler Config Mutation so that the default refresh YARN queue refresh option works.