### PR TITLE
CB-3758 do not generate cluster id into Vault path in FreeIpa

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/kerberos/CmServiceKeytabRequestFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/kerberos/CmServiceKeytabRequestFactory.java
@@ -16,6 +16,7 @@ public class CmServiceKeytabRequestFactory {
     public ServiceKeytabRequest create(Stack stack, GatewayConfig primaryGatewayConfig) {
         ServiceKeytabRequest request = new ServiceKeytabRequest();
         request.setEnvironmentCrn(stack.getEnvironmentCrn());
+        request.setClusterCrn(stack.getResourceCrn());
         String fqdn = primaryGatewayConfig.getHostname();
         request.setServerHostName(fqdn);
         String hostname = StringUtils.substringBefore(fqdn, ".");

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/KerberosMgmtV1Service.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/KerberosMgmtV1Service.java
@@ -164,7 +164,6 @@ public class KerberosMgmtV1Service {
         FreeIpaClient ipaClient = freeIpaClientFactory.getFreeIpaClientForStack(freeIpaStack);
         delService(canonicalPrincipal, ipaClient);
         VaultPathBuilder vaultPathBuilder = new VaultPathBuilder()
-                .enableGeneratingClusterIdIfNotPresent()
                 .withSecretType(VaultPathBuilder.SecretType.SERVICE_KEYTAB)
                 .withAccountId(accountId)
                 .withEnvironmentCrn(request.getEnvironmentCrn())
@@ -190,7 +189,6 @@ public class KerberosMgmtV1Service {
         }
         delHost(request.getServerHostName(), ipaClient);
         VaultPathBuilder vaultPathBuilder = new VaultPathBuilder()
-                .enableGeneratingClusterIdIfNotPresent()
                 .withAccountId(accountId)
                 .withEnvironmentCrn(request.getEnvironmentCrn())
                 .withClusterCrn(request.getClusterCrn())

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/KerberosMgmtVaultComponent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/KerberosMgmtVaultComponent.java
@@ -57,7 +57,6 @@ public class KerberosMgmtVaultComponent {
     public SecretResponse getSecretResponseForPrincipal(ServiceKeytabRequest request, String accountId, String principal) {
         try {
             String path = new VaultPathBuilder()
-                    .enableGeneratingClusterIdIfNotPresent()
                     .withSecretType(VaultPathBuilder.SecretType.SERVICE_KEYTAB)
                     .withAccountId(accountId)
                     .withSubType(VaultPathBuilder.SecretSubType.SERVICE_PRINCIPAL)
@@ -77,7 +76,6 @@ public class KerberosMgmtVaultComponent {
     public SecretResponse getSecretResponseForKeytab(ServiceKeytabRequest request, String accountId, String keytab) {
         try {
             String path = new VaultPathBuilder()
-                    .enableGeneratingClusterIdIfNotPresent()
                     .withSecretType(VaultPathBuilder.SecretType.SERVICE_KEYTAB)
                     .withAccountId(accountId)
                     .withSubType(VaultPathBuilder.SecretSubType.KEYTAB)
@@ -97,7 +95,6 @@ public class KerberosMgmtVaultComponent {
     public SecretResponse getSecretResponseForPrincipal(HostKeytabRequest request, String accountId, String principal) {
         try {
             String path = new VaultPathBuilder()
-                    .enableGeneratingClusterIdIfNotPresent()
                     .withSecretType(VaultPathBuilder.SecretType.HOST_KEYTAB)
                     .withAccountId(accountId)
                     .withSubType(VaultPathBuilder.SecretSubType.SERVICE_PRINCIPAL)
@@ -116,7 +113,6 @@ public class KerberosMgmtVaultComponent {
     public SecretResponse getSecretResponseForKeytab(HostKeytabRequest request, String accountId, String keytab) {
         try {
             String path = new VaultPathBuilder()
-                    .enableGeneratingClusterIdIfNotPresent()
                     .withSecretType(VaultPathBuilder.SecretType.HOST_KEYTAB)
                     .withAccountId(accountId)
                     .withSubType(VaultPathBuilder.SecretSubType.KEYTAB)

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/kerberosmgmt/VaultPathBuilderV1Test.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/kerberosmgmt/VaultPathBuilderV1Test.java
@@ -34,10 +34,9 @@ public class VaultPathBuilderV1Test {
     }
 
     @Test
-    public void testVaultServicePrincipalKeytabPathGenerateClusterId() throws Exception {
-        Assertions.assertEquals("accountId/ServiceKeytab/keytab/12345-6789/accountId-12345-6789/host1/service1",
+    public void testVaultServicePrincipalKeytabPathWithoutClusterId() throws Exception {
+        Assertions.assertEquals("accountId/ServiceKeytab/keytab/12345-6789/host1/service1",
                 new VaultPathBuilder()
-                        .enableGeneratingClusterIdIfNotPresent()
                         .withSecretType(VaultPathBuilder.SecretType.SERVICE_KEYTAB)
                         .withAccountId(ACCOUNT_ID)
                         .withSubType(VaultPathBuilder.SecretSubType.KEYTAB)
@@ -48,10 +47,9 @@ public class VaultPathBuilderV1Test {
     }
 
     @Test
-    public void testVaultServicePrincipalPathGenerateClusterId() throws Exception {
-        Assertions.assertEquals("accountId/ServiceKeytab/serviceprincipal/12345-6789/accountId-12345-6789/host1/service1",
+    public void testVaultServicePrincipalPathWithoutClusterId() throws Exception {
+        Assertions.assertEquals("accountId/ServiceKeytab/serviceprincipal/12345-6789/host1/service1",
                 new VaultPathBuilder()
-                        .enableGeneratingClusterIdIfNotPresent()
                         .withSecretType(VaultPathBuilder.SecretType.SERVICE_KEYTAB)
                         .withAccountId(ACCOUNT_ID)
                         .withSubType(VaultPathBuilder.SecretSubType.SERVICE_PRINCIPAL)
@@ -75,10 +73,9 @@ public class VaultPathBuilderV1Test {
     }
 
     @Test
-    public void testVaultHostPrincipalPathGenerateClusterId() throws Exception {
-        Assertions.assertEquals("accountId/HostKeytab/keytab/12345-6789/accountId-12345-6789/host1",
+    public void testVaultHostPrincipalPathWithoutClusterId() throws Exception {
+        Assertions.assertEquals("accountId/HostKeytab/keytab/12345-6789/host1",
                 new VaultPathBuilder()
-                        .enableGeneratingClusterIdIfNotPresent()
                         .withSecretType(VaultPathBuilder.SecretType.HOST_KEYTAB)
                         .withAccountId(ACCOUNT_ID)
                         .withSubType(VaultPathBuilder.SecretSubType.KEYTAB)
@@ -101,10 +98,9 @@ public class VaultPathBuilderV1Test {
     }
 
     @Test
-    public void testVaultHostPathGenerateClusterId() throws Exception {
-        Assertions.assertEquals("accountId/ServiceKeytab/keytab/12345-6789/accountId-12345-6789/host1/",
+    public void testVaultHostPathWithoutClusterId() throws Exception {
+        Assertions.assertEquals("accountId/ServiceKeytab/keytab/12345-6789/host1/",
                 new VaultPathBuilder()
-                        .enableGeneratingClusterIdIfNotPresent()
                         .withSecretType(VaultPathBuilder.SecretType.SERVICE_KEYTAB)
                         .withAccountId(ACCOUNT_ID)
                         .withSubType(VaultPathBuilder.SecretSubType.KEYTAB)
@@ -126,18 +122,6 @@ public class VaultPathBuilderV1Test {
     }
 
     @Test
-    public void testVaultClusterCrnPathGenerateClusterId() throws Exception {
-        Assertions.assertEquals("accountId/ServiceKeytab/keytab/12345-6789/accountId-12345-6789/",
-                new VaultPathBuilder()
-                        .enableGeneratingClusterIdIfNotPresent()
-                        .withSecretType(VaultPathBuilder.SecretType.SERVICE_KEYTAB)
-                        .withAccountId(ACCOUNT_ID)
-                        .withSubType(VaultPathBuilder.SecretSubType.KEYTAB)
-                        .withEnvironmentCrn(ENVIRONMENT_ID)
-                        .build());
-    }
-
-    @Test
     public void testVaultEnvironmentCrnPath() throws Exception {
         Assertions.assertEquals("accountId/ServiceKeytab/keytab/12345-6789/",
                 new VaultPathBuilder()
@@ -150,9 +134,8 @@ public class VaultPathBuilderV1Test {
 
     @Test
     public void testVaultClusterCrnPathNullClusterId() throws Exception {
-        Assertions.assertEquals("accountId/ServiceKeytab/keytab/12345-6789/accountId-12345-6789/",
+        Assertions.assertEquals("accountId/ServiceKeytab/keytab/12345-6789/",
                 new VaultPathBuilder()
-                        .enableGeneratingClusterIdIfNotPresent()
                         .withSecretType(VaultPathBuilder.SecretType.SERVICE_KEYTAB)
                         .withAccountId(ACCOUNT_ID)
                         .withSubType(VaultPathBuilder.SecretSubType.KEYTAB)


### PR DESCRIPTION
Due to [this issue](https://jira.cloudera.com/browse/CB-3758) we tried to find a way to reduce the size of the paths in Vault. The original Vault path builder generated the cluster id if it hasn't been provided previously as concatenating the account and environment ids, but they are already part of the path, so with @keyki we think it is better not to have such a long part in the paths. I think the cleanup of Vault should not be affected by this change.

Also the cluster id is set from CB side to decrease the cases where cluster id is not specified for service keytab generation.

@jamisonbennett Could you please take a look and validate our approach?