### PR TITLE
CB-4040 KnoxSSO - Improve knoxsso.redirect.whitelist.regex

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
@@ -16,6 +16,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
@@ -559,8 +560,13 @@ public class ClusterHostServiceRunner {
             gateway.put("userfacingkey", cluster.getStack().getSecurityConfig().getUserFacingKey());
             gateway.put("userfacingcert", cluster.getStack().getSecurityConfig().getUserFacingCert());
         }
-        if (StringUtils.isNotEmpty(cluster.getFqdn())) {
-            gateway.put("userfacingfqdn", cluster.getFqdn());
+        String fqdn = cluster.getFqdn();
+        if (StringUtils.isNotEmpty(fqdn)) {
+            gateway.put("userfacingfqdn", fqdn);
+            String[] fqdnParts = fqdn.split("\\.", 2);
+            if (fqdnParts.length == 2) {
+                gateway.put("userfacingdomain", Pattern.quote(fqdnParts[1]));
+            }
         }
     }
 

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/knoxsso.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/knoxsso.xml.j2
@@ -123,13 +123,17 @@
             <value>true</value>
         </param>
         <param>
-	    <!-- 24 hours in milliseconds = 86400000 -->
+            <!-- 24 hours in milliseconds = 86400000 -->
             <name>knoxsso.token.ttl</name>
             <value>86400000</value>
         </param>
         <param>
            <name>knoxsso.redirect.whitelist.regex</name>
-           <value>.*</value>
+           {% if salt['pillar.get']('gateway:userfacingdomain') is defined and salt['pillar.get']('gateway:userfacingdomain')|length > 1 %}
+           <value>^\/.*$;^https?:\/\/(.+\.{{ salt['pillar.get']('gateway:userfacingdomain') }}):[0-9]+\/?.*$</value>
+           {% else %}
+           <value>^.*$</value>
+           {% endif %}
         </param>
     </service>
 


### PR DESCRIPTION
If a user facing fqdn is defined, Knox will use that to set the domain for the redirect whitelist regex.