### PR TITLE
Disable Scheduler Configuration Mutation Api

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-702.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-702.bp
@@ -57,6 +57,10 @@
             "base": true,
             "configs": [
               {
+			          "name": "resourcemanager_config_safety_valve",
+			          "value": "<property><name>yarn.scheduler.configuration.store.class</name><value>file</value></property>"
+			        },
+              {
                 "name": "yarn_resourcemanager_scheduler_class",
                 "value": "org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler"
               },


### PR DESCRIPTION
Disable Scheduler Configuration Mutation Api. YARN Queue Manager is Technical Preview in CDP-7.0.2. This config is by default disabled and will be enabled when Queue Manager is installed by CM.
Have tested with launching a CM cluster using CloudBreak and the config is added properly in Safety Valve.