### PR TITLE
CB-3791 Revert to passing full db usernames to CM

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/start.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/start.sls
@@ -5,7 +5,7 @@ init-cloudera-manager-db:
     - name: /opt/cloudera/cm/schema/scm_prepare_database.sh -h {{ cloudera_manager.cloudera_manager_database.host }} {{ cloudera_manager.cloudera_manager_database.subprotocol }} {{ cloudera_manager.cloudera_manager_database.databaseName }} $user $pass && echo $(date +%Y-%m-%d:%H:%M:%S) >> /var/log/init-cloudera-manager-db-executed
     - unless: test -f /var/log/init-cloudera-manager-db-executed
     - env:
-        - user: {{ cloudera_manager.cloudera_manager_database.fullConnectionUserName }}
+        - user: {{ cloudera_manager.cloudera_manager_database.connectionUserName }}
         - pass: {{ cloudera_manager.cloudera_manager_database.connectionPassword }}
 
 start_server:

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/views/RdsView.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/views/RdsView.java
@@ -21,8 +21,6 @@ public class RdsView {
 
     private final String connectionDriver;
 
-    private final String fullConnectionUserName;
-
     private final String connectionUserName;
 
     private final String connectionPassword;
@@ -47,9 +45,7 @@ public class RdsView {
 
     public RdsView(RDSConfig rdsConfig) {
         connectionURL = rdsConfig.getConnectionURL();
-        fullConnectionUserName = rdsConfig.getConnectionUserName();
-        int atidx = fullConnectionUserName.indexOf('@');
-        connectionUserName = atidx != -1 ? fullConnectionUserName.substring(0, atidx) : fullConnectionUserName;
+        connectionUserName = rdsConfig.getConnectionUserName();
         connectionPassword = rdsConfig.getConnectionPassword();
         rdsViewDialect = createDialect(rdsConfig);
         String[] split = connectionURL.split(rdsViewDialect.jdbcPrefixSplitter());
@@ -95,10 +91,6 @@ public class RdsView {
 
     public String getConnectionURL() {
         return connectionURL;
-    }
-
-    public String getFullConnectionUserName() {
-        return fullConnectionUserName;
     }
 
     public String getConnectionUserName() {

--- a/template-manager-core/src/test/java/com/sequenceiq/cloudbreak/template/views/RdsViewTest.java
+++ b/template-manager-core/src/test/java/com/sequenceiq/cloudbreak/template/views/RdsViewTest.java
@@ -40,6 +40,7 @@ public class RdsViewTest {
         Assert.assertEquals("adminpassword", underTest.getConnectionPassword());
     }
 
+    // Do pass the Azure-specific hostname suffix to CM. See CB-3791.
     @Test
     public void testCreateRdsViewWhenConnectionUserNameHasSuffix() {
         String connectionUrl = "jdbc:postgresql://some-rds.1d3nt1f13r.eu-west-1.rds.amazonaws.com:5432/ranger";
@@ -48,7 +49,7 @@ public class RdsViewTest {
 
         RdsView underTest = new RdsView(rdsConfig);
 
-        Assert.assertEquals("admin", underTest.getConnectionUserName());
+        Assert.assertEquals("admin@some-rds", underTest.getConnectionUserName());
     }
 
     @Test


### PR DESCRIPTION
One change in the prior commit for CB-3791 was having Cloudbreak
configure Cloudera Manager with only the bare usernames for database
connections, instead of the "full" username@short-hostname format needed
for connections to Azure-managed databases. This change undoes that
work, so that once again the entire username is configured in Cloudera
Manager.

This still does not allow Cloudera Manager to support clusters backed
by Azure databases, because of OPSAPS-53099. However, once that CM work
is done, Hive metastore table creation should succeed, and perhaps
overall cluster creation will as well.

Other previous changes in CB-3791 to username handling are preserved.
This change only affects how Cloudera Manager is configured.