### PR TITLE
CB-4160 Knox - Increase connection and read timeout values for Hive

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
@@ -147,6 +147,14 @@
         {% for hostloc in salt['pillar.get']('gateway:location')['HIVESERVER2'] -%}
         <url>{{ protocol }}://{{ hostloc }}:{{ ports['HIVE'] }}/cliservice</url>
         {%- endfor %}
+        <param>
+            <name>httpclient.connectionTimeout</name>
+            <value>5m</value>
+        </param>
+        <param>
+            <name>httpclient.socketTimeout</name>
+            <value>5m</value>
+        </param>
     </service>
     {%- endif %}
     {%- endif %}


### PR DESCRIPTION
Increases the Hive connection/read timeout from 20s to 5m