### PR TITLE
CDPCP-944. Force sync on environment creation.

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaPostInstallService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaPostInstallService.java
@@ -73,7 +73,7 @@ public class FreeIpaPostInstallService {
             freeIpaClient.setUsernameLength(MAX_USERNAME_LENGTH);
         }
         passwordPolicyService.updatePasswordPolicy(freeIpaClient);
-        userService.synchronizeUsers(
+        userService.forceSynchronizeUsers(
             threadBasedUserCrnProvider.getAccountId(), threadBasedUserCrnProvider.getUserCrn(), Set.of(stack.getEnvironmentCrn()), Set.of(), Set.of());
 
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/AvailableStackProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/AvailableStackProvider.java
@@ -1,0 +1,45 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+@Component
+public class AvailableStackProvider {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AvailableStackProvider.class);
+
+    @Inject
+    private StackService stackService;
+
+    public List<Stack> getAvailableStacks() {
+        LOGGER.debug("Retrieving all stacks");
+        return filterAvailableStacks(stackService.findAllRunning());
+    }
+
+    public List<Stack> getAvailableStacksByAccountId(String accountId) {
+        LOGGER.debug("Retrieving stacks for account {}", accountId);
+        return filterAvailableStacks(stackService.getAllByAccountId(accountId));
+    }
+
+    public List<Stack> getAvailableStacksByAccountIdAndEnvironmentCrns(String accountId, Collection<String> environmentCrnFilter) {
+        if (environmentCrnFilter.isEmpty()) {
+            return getAvailableStacksByAccountId(accountId);
+        } else {
+            LOGGER.debug("Retrieving stacks for account {} that match environment crns {}", accountId, environmentCrnFilter);
+            return filterAvailableStacks(stackService.getMultipleByEnvironmentCrnAndAccountId(environmentCrnFilter, accountId));
+        }
+    }
+
+    private List<Stack> filterAvailableStacks(List<Stack> stacks) {
+        return stacks.stream().filter(Stack::isAvailable).collect(Collectors.toList());
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UsersyncPoller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UsersyncPoller.java
@@ -23,7 +23,6 @@ import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SyncOperationStatus;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.entity.UserSyncStatus;
 import com.sequenceiq.freeipa.service.freeipa.user.model.UmsEventGenerationIds;
-import com.sequenceiq.freeipa.service.stack.StackService;
 
 @Service
 public class UsersyncPoller {
@@ -36,7 +35,7 @@ public class UsersyncPoller {
     private ThreadBasedUserCrnProvider threadBasedUserCrnProvider;
 
     @Inject
-    private StackService stackService;
+    private AvailableStackProvider availableStackProvider;
 
     @Inject
     private UserSyncStatusService userSyncStatusService;
@@ -70,7 +69,7 @@ public class UsersyncPoller {
         MDCBuilder.addRequestId(requestId.get());
         try {
             LOGGER.debug("Attempting to sync users to FreeIPA stacks");
-            List<Stack> stackList = stackService.findAllRunning();
+            List<Stack> stackList = availableStackProvider.getAvailableStacks();
             LOGGER.debug("Found {} active stacks", stackList.size());
 
             stackList.stream()

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UsersyncPollerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UsersyncPollerTest.java
@@ -23,7 +23,6 @@ import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.entity.UserSyncStatus;
 import com.sequenceiq.freeipa.service.freeipa.user.model.UmsEventGenerationIds;
-import com.sequenceiq.freeipa.service.stack.StackService;
 
 @ExtendWith(MockitoExtension.class)
 class UsersyncPollerTest {
@@ -36,7 +35,7 @@ class UsersyncPollerTest {
     ThreadBasedUserCrnProvider threadBasedUserCrnProvider;
 
     @Mock
-    StackService stackService;
+    AvailableStackProvider availableStackProvider;
 
     @Mock
     UserSyncStatusService userSyncStatusService;
@@ -76,7 +75,7 @@ class UsersyncPollerTest {
         when(stack.getAccountId()).thenReturn(ACCOUNT_ID);
         when(stack.getEnvironmentCrn()).thenReturn(ENVIRONMENT_CRN);
         setupUserSyncStatus(stack, mock(UmsEventGenerationIds.class));
-        when(stackService.findAllRunning()).thenReturn(List.of(stack));
+        when(availableStackProvider.getAvailableStacks()).thenReturn(List.of(stack));
 
         underTest.syncFreeIpaStacks();
 
@@ -92,7 +91,7 @@ class UsersyncPollerTest {
         when(stack.getAccountId()).thenReturn(ACCOUNT_ID);
         when(stack.getEnvironmentCrn()).thenReturn(ENVIRONMENT_CRN);
         setupUserSyncStatus(stack, currentEventGenerationIds);
-        when(stackService.findAllRunning()).thenReturn(List.of(stack));
+        when(availableStackProvider.getAvailableStacks()).thenReturn(List.of(stack));
 
         underTest.syncFreeIpaStacks();
 


### PR DESCRIPTION
This commit ensures that a user sync happens for newly created environments by
1. adding a 'force' flag to skip the acceptor when starting operations
2. track actual environments syncing rather than using the empty list to represent all
3. only get available stacks rather than all non-terminated stacks
