### PR TITLE
CB-4167 Enable Nginx websockets proxying for Knox/Zeppelin

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/clouderamanager-ssl-user-facing.conf
+++ b/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/clouderamanager-ssl-user-facing.conf
@@ -45,5 +45,9 @@ server {
         proxy_set_header   Referer https://$host/;
         proxy_set_header   X-Forwarded-Host $server_name;
         proxy_set_header   X-Forwarded-Proto $scheme;
+        # Ensure that websockets work
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
     }
 }


### PR DESCRIPTION
Add config for Nginx to enable websockets when proxying Knox/Zeppelin