### PR TITLE
CB-4026 Added logging about event bus thread statistics before and af…

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/exception/FlowNotAcceptedException.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/exception/FlowNotAcceptedException.java
@@ -1,0 +1,12 @@
+package com.sequenceiq.cloudbreak.exception;
+
+public class FlowNotAcceptedException extends CloudbreakApiException {
+
+    public FlowNotAcceptedException(String message) {
+        super(message);
+    }
+
+    public FlowNotAcceptedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
@@ -291,19 +291,19 @@ public class ReactorFlowManager {
 
         Stack stack = getStackFn.apply(event.getData().getResourceId());
         Optional.ofNullable(stack).map(Stack::getCluster).map(Cluster::getStatus).ifPresent(isTriggerAllowedInMaintenance(selector));
-        reactorReporter.logInfoReport(reactor);
+        reactorReporter.logInfoReport();
         reactor.notify(selector, event);
         try {
             Boolean accepted = true;
             if (event.getData().accepted() != null) {
                 accepted = event.getData().accepted().await(WAIT_FOR_ACCEPT, TimeUnit.SECONDS);
             }
-            if( accepted == null) {
-                reactorReporter.logErrorReport(reactor);
+            if (accepted == null) {
+                reactorReporter.logErrorReport();
                 throw new FlowNotAcceptedException(String.format("Timeout happened when trying to start the flow for stack %s.", stack.getName()));
             }
             if (!accepted) {
-                reactorReporter.logErrorReport(reactor);
+                reactorReporter.logErrorReport();
                 throw new FlowsAlreadyRunningException(String.format("Stack %s has flows under operation, request not allowed.", stack.getName()));
             }
         } catch (InterruptedException e) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/init/CloudbreakCleanupService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/init/CloudbreakCleanupService.java
@@ -30,6 +30,7 @@ import com.sequenceiq.cloudbreak.domain.projection.StackStatusView;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.exception.FlowNotAcceptedException;
 import com.sequenceiq.cloudbreak.exception.FlowsAlreadyRunningException;
 import com.sequenceiq.cloudbreak.service.StackUpdater;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
@@ -146,7 +147,7 @@ public class CloudbreakCleanupService implements ApplicationListener<ContextRefr
                 fireEvent(stack.getId());
                 flowManager.triggerClusterSyncWithoutCheck(stack.getId());
             }
-        } catch (OptimisticLockingFailureException | FlowsAlreadyRunningException e) {
+        } catch (OptimisticLockingFailureException | FlowsAlreadyRunningException | FlowNotAcceptedException e) {
             LOGGER.error("Cannot trigger sync on stacks. Maybe another node is already syncing them?", e);
         }
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/repair/StackRepairService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/repair/StackRepairService.java
@@ -16,6 +16,7 @@ import com.sequenceiq.cloudbreak.core.flow2.stack.CloudbreakFlowMessageService;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostMetadata;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.exception.FlowNotAcceptedException;
 import com.sequenceiq.cloudbreak.exception.FlowsAlreadyRunningException;
 import com.sequenceiq.cloudbreak.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.message.Msg;
@@ -99,7 +100,7 @@ public class StackRepairService {
                     reactorFlowManager.triggerStackRepairFlow(stackId, unhealthyInstances);
                     flowMessageService.fireEventAndLog(stackId, Msg.STACK_REPAIR_TRIGGERED, Status.UPDATE_IN_PROGRESS.name());
                     submitted = true;
-                } catch (FlowsAlreadyRunningException ignored) {
+                } catch (FlowsAlreadyRunningException | FlowNotAcceptedException ignored) {
                     trials++;
                     if (trials == RETRIES) {
                         LOGGER.info("Could not submit because other flows are running for stack " + stackId);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
@@ -38,6 +38,7 @@ import com.sequenceiq.cloudbreak.kerberos.KerberosConfigService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.service.stack.repair.UnhealthyInstances;
 import com.sequenceiq.flow.reactor.ErrorHandlerAwareReactorEventFactory;
+import com.sequenceiq.flow.reactor.config.EventBusStatisticReporter;
 
 import reactor.bus.Event;
 import reactor.bus.EventBus;
@@ -51,6 +52,9 @@ public class ReactorFlowManagerTest {
 
     @Mock
     private EventBus reactor;
+
+    @Mock
+    private EventBusStatisticReporter reactorReporter;
 
     @Mock
     private ErrorHandlerAwareReactorEventFactory eventFactory;

--- a/flow/src/main/java/com/sequenceiq/flow/reactor/config/EventBusStatisticReporter.java
+++ b/flow/src/main/java/com/sequenceiq/flow/reactor/config/EventBusStatisticReporter.java
@@ -1,40 +1,100 @@
 package com.sequenceiq.flow.reactor.config;
 
+import javax.inject.Inject;
+import javax.inject.Named;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.logger.concurrent.MDCCleanerThreadPoolExecutor;
+
 import reactor.bus.EventBus;
+import reactor.core.Dispatcher;
 
 @Component
 public class EventBusStatisticReporter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EventBusStatisticReporter.class);
 
-    public void logInfoReport(EventBus eventbus) {
-        LOGGER.info("Reactor event bus statistics: {}", create(eventbus));
+    @Inject
+    private EventBusConfig eventBusConfig;
+
+    @Inject
+    private EventBus eventBus;
+
+    @Inject
+    @Named("eventBusThreadPoolExecutor")
+    private MDCCleanerThreadPoolExecutor executor;
+
+    public void logInfoReport() {
+        LOGGER.info("Reactor event bus statistics: {}", create());
     }
 
-    public void logErrorReport(EventBus eventbus) {
-        LOGGER.error("Reactor state is critical, statistics: {}", create(eventbus));
+    public void logErrorReport() {
+        LOGGER.error("Reactor state is critical, statistics: {}", create());
     }
 
-    private EventBusStatistics create(EventBus eventBus) {
+    private EventBusStatistics create() {
         EventBusStatistics stats = new EventBusStatistics();
-        stats.setBackLogSize(eventBus.getDispatcher().backlogSize());
-        stats.setRemainingSlots(eventBus.getDispatcher().remainingSlots());
-        stats.setInContext(eventBus.getDispatcher().inContext());
+        Dispatcher dispatcher = eventBus.getDispatcher();
+        stats.setBackLogSize(dispatcher.backlogSize());
+        stats.setRemainingSlots(dispatcher.remainingSlots());
+        stats.setInContext(dispatcher.inContext());
+
+        stats.setPoolSize(executor.getPoolSize());
+        stats.setCorePoolSize(executor.getCorePoolSize());
+        stats.setActiveCount(executor.getActiveCount());
+        stats.setTaskCount(executor.getTaskCount());
+        stats.setActiveCount(executor.getActiveCount());
+        stats.setCompletedTaskCount(executor.getCompletedTaskCount());
+
         return stats;
     }
 
-
-    public class EventBusStatistics {
+    public static class EventBusStatistics {
 
         private long backLogSize;
 
         private long remainingSlots;
 
+        private long getActiveCount;
+
+        private long taskCount;
+
+        private long completedTaskCount;
+
+        private int corePoolSize;
+
+        private int poolSize;
+
+        private int activeCount;
+
         private boolean inContext;
+
+        public void setGetActiveCount(long getActiveCount) {
+            this.getActiveCount = getActiveCount;
+        }
+
+        public void setTaskCount(long taskCount) {
+            this.taskCount = taskCount;
+        }
+
+        public void setCompletedTaskCount(long completedTaskCount) {
+            this.completedTaskCount = completedTaskCount;
+        }
+
+        public void setCorePoolSize(int corePoolSize) {
+            this.corePoolSize = corePoolSize;
+        }
+
+        public void setPoolSize(int poolSize) {
+            this.poolSize = poolSize;
+        }
+
+        public void setActiveCount(int activeCount) {
+            this.activeCount = activeCount;
+        }
 
         public void setBackLogSize(long backLogSize) {
             this.backLogSize = backLogSize;
@@ -53,9 +113,14 @@ public class EventBusStatisticReporter {
             return "EventBusStatistics{" +
                     "backLogSize=" + backLogSize +
                     ", remainingSlots=" + remainingSlots +
+                    ", getActiveCount=" + getActiveCount +
+                    ", taskCount=" + taskCount +
+                    ", completedTaskCount=" + completedTaskCount +
+                    ", corePoolSize=" + corePoolSize +
+                    ", poolSize=" + poolSize +
+                    ", activeCount=" + activeCount +
                     ", inContext=" + inContext +
                     '}';
         }
     }
-
 }

--- a/flow/src/main/java/com/sequenceiq/flow/reactor/config/EventBusStatisticReporter.java
+++ b/flow/src/main/java/com/sequenceiq/flow/reactor/config/EventBusStatisticReporter.java
@@ -1,0 +1,61 @@
+package com.sequenceiq.flow.reactor.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import reactor.bus.EventBus;
+
+@Component
+public class EventBusStatisticReporter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EventBusStatisticReporter.class);
+
+    public void logInfoReport(EventBus eventbus) {
+        LOGGER.info("Reactor event bus statistics: {}", create(eventbus));
+    }
+
+    public void logErrorReport(EventBus eventbus) {
+        LOGGER.error("Reactor state is critical, statistics: {}", create(eventbus));
+    }
+
+    private EventBusStatistics create(EventBus eventBus) {
+        EventBusStatistics stats = new EventBusStatistics();
+        stats.setBackLogSize(eventBus.getDispatcher().backlogSize());
+        stats.setRemainingSlots(eventBus.getDispatcher().remainingSlots());
+        stats.setInContext(eventBus.getDispatcher().inContext());
+        return stats;
+    }
+
+
+    public class EventBusStatistics {
+
+        private long backLogSize;
+
+        private long remainingSlots;
+
+        private boolean inContext;
+
+        public void setBackLogSize(long backLogSize) {
+            this.backLogSize = backLogSize;
+        }
+
+        public void setRemainingSlots(long remainingSlots) {
+            this.remainingSlots = remainingSlots;
+        }
+
+        public void setInContext(boolean inContext) {
+            this.inContext = inContext;
+        }
+
+        @Override
+        public String toString() {
+            return "EventBusStatistics{" +
+                    "backLogSize=" + backLogSize +
+                    ", remainingSlots=" + remainingSlots +
+                    ", inContext=" + inContext +
+                    '}';
+        }
+    }
+
+}


### PR DESCRIPTION
- handling differently if a flow is not accepted because eventbus is busy vs. there is a running flow, because the message was misleading
- need more data on the eventbus thread internals.
- need to do some additional testing

Example:
```
`Reactor event bus statistics: EventBusStatistics{
backLogSize=1000, remainingSlots=9223372036854775807, 
getActiveCount=0, 
taskCount=20, 
completedTaskCount=20, 
corePoolSize=100, 
poolSize=20, 
activeCount=0, 
inContext=false}`
```