### PR TITLE
CB-4192 Hive metastore - hive.server2.authentication.kerberos.* shouldn't be set by CB anymore

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveMetastoreConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveMetastoreConfigProvider.java
@@ -3,7 +3,6 @@ package com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 
@@ -13,7 +12,6 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRdsRoleConfigProvider;
-import com.sequenceiq.cloudbreak.dto.KerberosConfig;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.views.RdsView;
 
@@ -32,14 +30,6 @@ public class HiveMetastoreConfigProvider extends AbstractRdsRoleConfigProvider {
                 config("hive_metastore_database_type", hiveView.getSubprotocol()),
                 config("hive_metastore_database_user", hiveView.getConnectionUserName())
         );
-
-        Optional<KerberosConfig> kerberosConfigOpt = source.getKerberosConfig();
-        if (kerberosConfigOpt.isPresent()) {
-            String realm = Optional.ofNullable(kerberosConfigOpt.get().getRealm()).orElse("").toUpperCase();
-            String safetyValveValue = "<property><name>hive.server2.authentication.kerberos.principal</name><value>hive/_HOST@" + realm
-                    + "</value></property><property><name>hive.server2.authentication.kerberos.keytab</name><value>hive.keytab</value></property>";
-            configs.add(config("hive_service_config_safety_valve", safetyValveValue));
-        }
 
         if (source.getStackType() == StackType.DATALAKE) {
             source.getLdapConfig().ifPresent(ldap -> {


### PR DESCRIPTION
Hive metastore - hive.server2.authentication.kerberos.* shouldn't be set by CB anymore. This should be set by CM automatically.