### PR TITLE
CDPD-4978 - updated blueprints with new configuration

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-sdx-702.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx-702.bp
@@ -197,7 +197,13 @@
           {
             "base": true,
             "refName": "hdfs-NAMENODE-BASE",
-            "roleType": "NAMENODE"
+            "roleType": "NAMENODE",
+            "configs": [
+              {
+                "name": "namenode_config_safety_valve",
+                "value": "<property><name>dfs.namenode.fs-limits.max-component-length</name><value>2048</value></property>"
+              }
+            ]
           },
           {
             "base": true,

--- a/core/src/main/resources/defaults/blueprints/cdp-sdx-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx-ha.bp
@@ -147,7 +147,13 @@
                     {
                         "base": true,
                         "refName": "hdfs-NAMENODE-BASE",
-                        "roleType": "NAMENODE"
+                        "roleType": "NAMENODE",
+                        "configs": [
+                            {
+                                "name": "namenode_config_safety_valve",
+                                "value": "<property><name>dfs.namenode.fs-limits.max-component-length</name><value>2048</value></property>"
+                            }
+                        ]
                     },
                     {
                         "base": true,

--- a/core/src/main/resources/defaults/blueprints/cdp-sdx-medium-ha-702.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx-medium-ha-702.bp
@@ -149,7 +149,13 @@
           {
             "base": true,
             "refName": "hdfs-NAMENODE-BASE",
-            "roleType": "NAMENODE"
+            "roleType": "NAMENODE",
+            "configs": [
+              {
+                "name": "namenode_config_safety_valve",
+                "value": "<property><name>dfs.namenode.fs-limits.max-component-length</name><value>2048</value></property>"
+              }
+            ]
           },
           {
             "base": true,


### PR DESCRIPTION
add new config to hdfs name node to support long hostnames.

`
{
"name": "namenode_config_safety_valve",
"value": "<property><name>dfs.namenode.fs-limits.max-component-length</name><value>2048</value></property>"
}
`


- Testing
in order to validate, i did a dp sdx-internal create with this blueprint.
verified provision correctly.
verified no errors in CM.
verified config change in CM > HDFS > configurations > "dfs.namenode.fs-limits.max-component-length"

- https://github.com/hortonworks/cloudbreak/commit/888b2e2a8887def28a24e26efcd6d9ca5863733a

If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:

Closes # CDPD-4978