### PR TITLE
Change default MinaSshdManagementConfig.port to 80

### DIFF
--- a/ccm-connector/src/main/java/com/sequenceiq/cloudbreak/ccmimpl/altus/config/MinaSshdManagementConfig.java
+++ b/ccm-connector/src/main/java/com/sequenceiq/cloudbreak/ccmimpl/altus/config/MinaSshdManagementConfig.java
@@ -12,7 +12,7 @@ public class MinaSshdManagementConfig {
     @Value("${altus.minasshdmgmt.host:thunderhead-clusterconnectivitymanagement.thunderhead-clusterconnectivitymanagement.svc.cluster.local}")
     private String endpoint;
 
-    @Value("${altus.minasshdmgmt.port:8982}")
+    @Value("${altus.minasshdmgmt.port:80}")
     private int port;
 
     public String getEndpoint() {


### PR DESCRIPTION
In k8 the ccm service is exposed in port 80, this updates the default
port to be the same.