### PR TITLE
CDPCP-1017. Entitle automatic usersync poller

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
@@ -16,27 +16,31 @@ public class EntitlementService {
     @Inject
     private GrpcUmsClient umsClient;
 
-    public boolean ccmEnabled(String userCrn) {
-        return isEntitlementRegistered(userCrn, "CDP_REVERSE_SSH_TUNNEL");
+    public boolean ccmEnabled(String actorCrn, String accountId) {
+        return isEntitlementRegistered(actorCrn, accountId, "CDP_REVERSE_SSH_TUNNEL");
     }
 
-    public boolean azureEnabled(String userCrn) {
-        return isEntitlementRegistered(userCrn, "CDP_AZURE");
+    public boolean azureEnabled(String actorCrn, String accountId) {
+        return isEntitlementRegistered(actorCrn, accountId, "CDP_AZURE");
     }
 
-    public List<String> getEntitlements(String userCrn) {
-        return getAccount(userCrn).getEntitlementsList()
+    public boolean automaticUsersyncPollerEnabled(String actorCrn, String accountId) {
+        return isEntitlementRegistered(actorCrn, accountId, "CDP_AUTOMATIC_USERSYNC_POLLER");
+    }
+
+    public List<String> getEntitlements(String actorCrn, String accountId) {
+        return getAccount(actorCrn, accountId).getEntitlementsList()
                 .stream()
                 .map(e -> e.getEntitlementName().toUpperCase())
                 .collect(Collectors.toList());
     }
 
-    private UserManagementProto.Account getAccount(String userCrn) {
-        return umsClient.getAccountDetails(userCrn, userCrn, Optional.empty());
+    private UserManagementProto.Account getAccount(String actorCrn, String accountId) {
+        return umsClient.getAccountDetails(actorCrn, accountId, Optional.empty());
     }
 
-    private boolean isEntitlementRegistered(String userCrn, String entitlement) {
-        return getEntitlements(userCrn)
+    private boolean isEntitlementRegistered(String actorCrn, String accountId, String entitlement) {
+        return getEntitlements(actorCrn, accountId)
                 .stream()
                 .filter(e -> e.equalsIgnoreCase(entitlement))
                 .findFirst()

--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
@@ -278,16 +278,16 @@ public class GrpcUmsClient {
      * Retrieves account details from UMS, which includes the CM license.
      *
      * @param actorCrn  the CRN of the actor
-     * @param userCrn   the CRN of the user
+     * @param accountId the account ID
      * @param requestId an optional request Id
      * @return the account associated with this user CRN
      */
     @Cacheable(cacheNames = "umsAccountCache", key = "{ #actorCrn, #userCrn }")
-    public Account getAccountDetails(String actorCrn, String userCrn, Optional<String> requestId) {
+    public Account getAccountDetails(String actorCrn, String accountId, Optional<String> requestId) {
         try (ManagedChannelWrapper channelWrapper = makeWrapper()) {
             UmsClient client = makeClient(channelWrapper.getChannel(), actorCrn);
-            LOGGER.debug("Getting account information for {} using request ID {}", userCrn, requestId);
-            return client.getAccount(requestId.orElse(UUID.randomUUID().toString()), userCrn);
+            LOGGER.debug("Getting information for account ID {} using request ID {}", accountId, requestId);
+            return client.getAccount(requestId.orElse(UUID.randomUUID().toString()), accountId);
         }
     }
 

--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/UmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/UmsClient.java
@@ -440,15 +440,15 @@ public class UmsClient {
      * Wraps a call to getAccount.
      *
      * @param requestId the request ID for the request
-     * @param userCrn   the user CRN
+     * @param accountId the account ID
      * @return the account
      */
-    public Account getAccount(String requestId, String userCrn) {
+    public Account getAccount(String requestId, String accountId) {
         checkNotNull(requestId);
-        checkNotNull(userCrn);
+        checkNotNull(accountId);
         return newStub(requestId).getAccount(
                 GetAccountRequest.newBuilder()
-                        .setAccountId(Crn.fromString(userCrn).getAccountId())
+                        .setAccountId(accountId)
                         .build()
         ).getAccount();
     }

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerLicenseService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerLicenseService.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
 import com.sequenceiq.cloudbreak.workspace.model.User;
 
@@ -28,7 +29,8 @@ class ClouderaManagerLicenseService {
     }
 
     private boolean hasNoLicense(String userCrn) {
-        return StringUtils.isEmpty(umsClient.getAccountDetails(userCrn, userCrn, Optional.empty()).getClouderaManagerLicenseKey());
+        return StringUtils.isEmpty(umsClient.getAccountDetails(userCrn, Crn.safeFromString(userCrn).getAccountId(), Optional.empty())
+                .getClouderaManagerLicenseKey());
     }
 
 }

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerLicenseServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerLicenseServiceTest.java
@@ -4,6 +4,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -20,7 +21,9 @@ import com.sequenceiq.cloudbreak.workspace.model.User;
 @RunWith(MockitoJUnitRunner.class)
 public class ClouderaManagerLicenseServiceTest {
 
-    private static final String USER_CRN = "userCrn";
+    private static final String ACCOUNT_ID = UUID.randomUUID().toString();
+
+    private static final String USER_CRN = "crn:altus:iam:us-west-1:" + ACCOUNT_ID + ":user:" + UUID.randomUUID().toString();
 
     private static final String LICENSE = "license";
 
@@ -37,25 +40,25 @@ public class ClouderaManagerLicenseServiceTest {
     public void validWhenLicenseIsNotEmpty() {
         User user = createUser();
         UserManagementProto.Account account = UserManagementProto.Account.newBuilder().setClouderaManagerLicenseKey(LICENSE).build();
-        when(umsClient.getAccountDetails(USER_CRN, USER_CRN, Optional.empty())).thenReturn(account);
+        when(umsClient.getAccountDetails(USER_CRN, ACCOUNT_ID, Optional.empty())).thenReturn(account);
 
         underTest.validateClouderaManagerLicense(user);
 
-        verify(umsClient).getAccountDetails(USER_CRN, USER_CRN, Optional.empty());
+        verify(umsClient).getAccountDetails(USER_CRN, ACCOUNT_ID, Optional.empty());
     }
 
     @Test
     public void invalidWhenLicenseIsEmpty() {
         User user = createUser();
         UserManagementProto.Account account = UserManagementProto.Account.newBuilder().setClouderaManagerLicenseKey("").build();
-        when(umsClient.getAccountDetails(USER_CRN, USER_CRN, Optional.empty())).thenReturn(account);
+        when(umsClient.getAccountDetails(USER_CRN, ACCOUNT_ID, Optional.empty())).thenReturn(account);
 
         expectedException.expect(RuntimeException.class);
         expectedException.expectMessage("User doesn't have a valid cloudera manager license.");
 
         underTest.validateClouderaManagerLicense(user);
 
-        verify(umsClient).getAccountDetails(USER_CRN, USER_CRN, Optional.empty());
+        verify(umsClient).getAccountDetails(USER_CRN, ACCOUNT_ID, Optional.empty());
     }
 
     private User createUser() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
@@ -34,6 +34,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ExecutorType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.SSOType;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
 import com.sequenceiq.cloudbreak.cloud.PlatformParameters;
 import com.sequenceiq.cloudbreak.cloud.model.AmbariRepo;
@@ -414,7 +415,7 @@ public class ClusterHostServiceRunner {
             throws CloudbreakOrchestratorFailedException {
         String userCrn = stackService.get(stackId).getCreator().getUserCrn();
 
-        UserManagementProto.Account account = umsClient.getAccountDetails(userCrn, userCrn, Optional.empty());
+        UserManagementProto.Account account = umsClient.getAccountDetails(userCrn, Crn.safeFromString(userCrn).getAccountId(), Optional.empty());
 
         if (StringUtils.isNotEmpty(account.getClouderaManagerLicenseKey())) {
             LOGGER.debug("Got license key from UMS: {}", account.getClouderaManagerLicenseKey());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/gateway/GatewayPublicEndpointManagementService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/gateway/GatewayPublicEndpointManagementService.java
@@ -15,6 +15,7 @@ import org.springframework.util.StringUtils;
 
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
 import com.sequenceiq.cloudbreak.certificate.PkiUtil;
 import com.sequenceiq.cloudbreak.certificate.service.CertificateCreationService;
@@ -189,7 +190,7 @@ public class GatewayPublicEndpointManagementService {
 
     private String getWorkloadSubdomain(String actorCrn) {
         Optional<String> requestIdOptional = Optional.ofNullable(MDCBuilder.getMdcContextMap().get(LoggerContextKey.REQUEST_ID.toString()));
-        UserManagementProto.Account account = grpcUmsClient.getAccountDetails(actorCrn, actorCrn, requestIdOptional);
+        UserManagementProto.Account account = grpcUmsClient.getAccountDetails(actorCrn, Crn.safeFromString(actorCrn).getAccountId(), requestIdOptional);
         return account.getWorkloadSubdomain();
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/user/UserProfileDecorator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/user/UserProfileDecorator.java
@@ -5,6 +5,7 @@ import javax.inject.Inject;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.userprofile.responses.UserProfileV4Response;
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 
 @Service
@@ -14,7 +15,7 @@ public class UserProfileDecorator {
     private EntitlementService entitlementService;
 
     public UserProfileV4Response decorate(UserProfileV4Response userProfileV4Response, String userCrn) {
-        userProfileV4Response.setEntitlements(entitlementService.getEntitlements(userCrn));
+        userProfileV4Response.setEntitlements(entitlementService.getEntitlements(userCrn, Crn.safeFromString(userCrn).getAccountId()));
         return userProfileV4Response;
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/credential/validation/CredentialValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/validation/CredentialValidator.java
@@ -13,6 +13,7 @@ import javax.ws.rs.BadRequestException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
 import com.sequenceiq.cloudbreak.common.json.Json;
@@ -50,7 +51,7 @@ public class CredentialValidator {
         if (!enabledPlatforms.contains(cloudPlatform)) {
             throw new BadRequestException(String.format("There is no such cloud platform as '%s'", cloudPlatform));
         }
-        if (AZURE.name().equalsIgnoreCase(cloudPlatform) && !entitlementService.azureEnabled(userCrn)) {
+        if (AZURE.name().equalsIgnoreCase(cloudPlatform) && !entitlementService.azureEnabled(userCrn, Crn.safeFromString(userCrn).getAccountId())) {
             throw new BadRequestException("Provisioning in Microsoft Azure is not enabled for this account.");
         }
     }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeIpaServerRequestProvider.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeIpaServerRequestProvider.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
 import com.sequenceiq.cloudbreak.dns.EnvironmentBasedDomainNameProvider;
 import com.sequenceiq.cloudbreak.logger.LoggerContextKey;
@@ -56,7 +57,7 @@ class FreeIpaServerRequestProvider {
         String userCrn = threadBasedUserCrnProvider.getUserCrn();
         Optional<String> requestIdOptional = Optional.ofNullable(MDCBuilder.getMdcContextMap().get(LoggerContextKey.REQUEST_ID.toString()));
         // I think this should be better/safer if we could use the account id of environment,
-        UserManagementProto.Account account = grpcUmsClient.getAccountDetails(userCrn, userCrn, requestIdOptional);
+        UserManagementProto.Account account = grpcUmsClient.getAccountDetails(userCrn, Crn.safeFromString(userCrn).getAccountId(), requestIdOptional);
         String accountSubdomain = account.getWorkloadSubdomain();
         if (accountSubdomain == null || accountSubdomain.isEmpty()) {
             accountSubdomain = FREEIPA_DEFAULT_ACCOUNT_DOMAIN;

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentCreationService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentCreationService.java
@@ -114,13 +114,13 @@ public class EnvironmentCreationService {
     }
 
     private void validateTunnel(String userCrn, Tunnel tunnel) {
-        if (!entitlementService.ccmEnabled(userCrn) && Tunnel.CCM.equals(tunnel)) {
+        if (!entitlementService.ccmEnabled(userCrn, Crn.safeFromString(userCrn).getAccountId()) && Tunnel.CCM.equals(tunnel)) {
             throw new BadRequestException("Reverse SSH tunnel is not enabled for this account.");
         }
     }
 
     private void validateCloudPlatform(String userCrn, String cloudPlatform) {
-        if (AZURE.name().equalsIgnoreCase(cloudPlatform) && !entitlementService.azureEnabled(userCrn)) {
+        if (AZURE.name().equalsIgnoreCase(cloudPlatform) && !entitlementService.azureEnabled(userCrn, Crn.safeFromString(userCrn).getAccountId())) {
             throw new BadRequestException("Provisioning in Microsoft Azure is not enabled for this account.");
         }
     }

--- a/environment/src/test/java/com/sequenceiq/environment/credential/validation/CredentialValidatorTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/credential/validation/CredentialValidatorTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.Set;
+import java.util.UUID;
 
 import javax.ws.rs.BadRequestException;
 
@@ -27,7 +28,9 @@ import com.sequenceiq.environment.credential.validation.definition.CredentialDef
 @ExtendWith(MockitoExtension.class)
 class CredentialValidatorTest {
 
-    private static final String USER_CRN = "USER_CRN";
+    private static final String ACCOUNT_ID = UUID.randomUUID().toString();
+
+    private static final String USER_CRN = "crn:altus:iam:us-west-1:" + ACCOUNT_ID + ":user:" + UUID.randomUUID().toString();
 
     @Mock
     private CredentialDefinitionService credentialDefinitionService;
@@ -49,13 +52,13 @@ class CredentialValidatorTest {
 
     @Test
     void testValidateCredentialCloudPlatformWhenAzureDisabled() {
-        when(entitlementService.azureEnabled(USER_CRN)).thenReturn(false);
+        when(entitlementService.azureEnabled(USER_CRN, ACCOUNT_ID)).thenReturn(false);
         assertThrows(BadRequestException.class, () -> underTest.validateCredentialCloudPlatform("AZURE", USER_CRN));
     }
 
     @Test
     void testValidateCredentialCloudPlatformWhenAzureSuccess() {
-        when(entitlementService.azureEnabled(USER_CRN)).thenReturn(true);
+        when(entitlementService.azureEnabled(USER_CRN, ACCOUNT_ID)).thenReturn(true);
         underTest.validateCredentialCloudPlatform("AZURE", USER_CRN);
     }
 

--- a/environment/src/test/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeIpaServerRequestProviderTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeIpaServerRequestProviderTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,9 +24,11 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.FreeIpaServerRequest;
 @ExtendWith(MockitoExtension.class)
 class FreeIpaServerRequestProviderTest {
 
-    private static final String ENV_NAME = "userCrn";
+    private static final String ENV_NAME = "envName";
 
-    private static final String USER_CRN = "userCrn";
+    private static final String ACCOUNT_ID = UUID.randomUUID().toString();
+
+    private static final String USER_CRN = "crn:altus:iam:us-west-1:" + ACCOUNT_ID + ":user:" + UUID.randomUUID().toString();
 
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private GrpcUmsClient grpcUmsClient;
@@ -43,7 +46,7 @@ class FreeIpaServerRequestProviderTest {
     void testCreateWithLegacyDomain() {
         UserManagementProto.Account account = UserManagementProto.Account.newBuilder().build();
         when(threadBasedUserCrnProvider.getUserCrn()).thenReturn(USER_CRN);
-        when(grpcUmsClient.getAccountDetails(USER_CRN, USER_CRN, Optional.empty())).thenReturn(account);
+        when(grpcUmsClient.getAccountDetails(USER_CRN, ACCOUNT_ID, Optional.empty())).thenReturn(account);
         when(environmentBasedDomainNameProvider.getDomainName(ENV_NAME, "internal")).thenReturn("mydomain");
 
         EnvironmentDto environmentDto = new EnvironmentDto();
@@ -57,7 +60,7 @@ class FreeIpaServerRequestProviderTest {
     void testCreateWithDomainReturnedFromUms() {
         UserManagementProto.Account account = UserManagementProto.Account.newBuilder().setWorkloadSubdomain("checkme").build();
         when(threadBasedUserCrnProvider.getUserCrn()).thenReturn(USER_CRN);
-        when(grpcUmsClient.getAccountDetails(USER_CRN, USER_CRN, Optional.empty())).thenReturn(account);
+        when(grpcUmsClient.getAccountDetails(USER_CRN, ACCOUNT_ID, Optional.empty())).thenReturn(account);
         when(environmentBasedDomainNameProvider.getDomainName(ENV_NAME, "checkme")).thenReturn("checkme.mydomain");
 
         EnvironmentDto environmentDto = new EnvironmentDto();

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentCreationServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentCreationServiceTest.java
@@ -102,7 +102,7 @@ class EnvironmentCreationServiceTest {
                 .withCloudPlatform("AZURE")
                 .build();
 
-        when(entitlementService.azureEnabled(eq(CRN))).thenReturn(false);
+        when(entitlementService.azureEnabled(eq(CRN), eq(ACCOUNT_ID))).thenReturn(false);
         assertThrows(BadRequestException.class, () -> environmentCreationServiceUnderTest.create(environmentCreationDto));
         verify(environmentService, never()).save(any());
         verify(environmentResourceService, never()).createAndSetNetwork(any(), any(), any(), any());
@@ -114,7 +114,7 @@ class EnvironmentCreationServiceTest {
         ParametersDto parametersDto = ParametersDto.builder().withAwsParameters(AwsParametersDto.builder().withDynamoDbTableName("dynamo").build()).build();
         final EnvironmentCreationDto environmentCreationDto = new EnvironmentCreationDto.Builder()
                 .withName(ENVIRONMENT_NAME)
-                .withCreator(USER)
+                .withCreator(CRN)
                 .withAccountId(ACCOUNT_ID)
                 .withAuthentication(AuthenticationDto.builder().build())
                 .withParameters(parametersDto)
@@ -128,7 +128,7 @@ class EnvironmentCreationServiceTest {
 
         when(environmentService.isNameOccupied(eq(ENVIRONMENT_NAME), eq(ACCOUNT_ID))).thenReturn(false);
         when(environmentDtoConverter.creationDtoToEnvironment(eq(environmentCreationDto))).thenReturn(environment);
-        when(environmentResourceService.getCredentialFromRequest(any(), eq(ACCOUNT_ID), eq(EnvironmentTestData.USER)))
+        when(environmentResourceService.getCredentialFromRequest(any(), eq(ACCOUNT_ID), eq(CRN)))
                 .thenReturn(credential);
         when(authenticationDtoConverter.dtoToAuthentication(any())).thenReturn(new EnvironmentAuthentication());
         when(environmentService.getRegionsByEnvironment(eq(environment))).thenReturn(getCloudRegions());
@@ -140,7 +140,7 @@ class EnvironmentCreationServiceTest {
         verify(environmentService, times(2)).save(any());
         verify(parametersService).saveParameters(eq(environment), eq(parametersDto));
         verify(environmentResourceService).createAndSetNetwork(any(), any(), any(), any());
-        verify(reactorFlowManager).triggerCreationFlow(anyLong(), eq(ENVIRONMENT_NAME), eq(USER), anyString());
+        verify(reactorFlowManager).triggerCreationFlow(anyLong(), eq(ENVIRONMENT_NAME), eq(CRN), anyString());
     }
 
     @Test
@@ -150,7 +150,7 @@ class EnvironmentCreationServiceTest {
                 .withName(ENVIRONMENT_NAME)
                 .withAccountId(ACCOUNT_ID)
                 .withAuthentication(AuthenticationDto.builder().build())
-                .withCreator(USER)
+                .withCreator(CRN)
                 .withAccountId(ACCOUNT_ID)
                 .withParameters(parametersDto)
                 .build();
@@ -163,7 +163,7 @@ class EnvironmentCreationServiceTest {
 
         when(environmentService.isNameOccupied(eq(ENVIRONMENT_NAME), eq(ACCOUNT_ID))).thenReturn(false);
         when(environmentDtoConverter.creationDtoToEnvironment(eq(environmentCreationDto))).thenReturn(environment);
-        when(environmentResourceService.getCredentialFromRequest(any(), eq(ACCOUNT_ID), eq(EnvironmentTestData.USER)))
+        when(environmentResourceService.getCredentialFromRequest(any(), eq(ACCOUNT_ID), eq(CRN)))
                 .thenReturn(credential);
         when(authenticationDtoConverter.dtoToAuthentication(any())).thenReturn(new EnvironmentAuthentication());
         when(environmentService.getRegionsByEnvironment(eq(environment))).thenReturn(getCloudRegions());
@@ -184,7 +184,7 @@ class EnvironmentCreationServiceTest {
                 .withName(ENVIRONMENT_NAME)
                 .withAccountId(ACCOUNT_ID)
                 .withAuthentication(AuthenticationDto.builder().build())
-                .withCreator(USER)
+                .withCreator(CRN)
                 .withAccountId(ACCOUNT_ID)
                 .withParameters(parametersDto)
                 .build();
@@ -197,7 +197,7 @@ class EnvironmentCreationServiceTest {
 
         when(environmentService.isNameOccupied(eq(ENVIRONMENT_NAME), eq(ACCOUNT_ID))).thenReturn(false);
         when(environmentDtoConverter.creationDtoToEnvironment(eq(environmentCreationDto))).thenReturn(environment);
-        when(environmentResourceService.getCredentialFromRequest(any(), eq(ACCOUNT_ID), eq(EnvironmentTestData.USER)))
+        when(environmentResourceService.getCredentialFromRequest(any(), eq(ACCOUNT_ID), eq(CRN)))
                 .thenReturn(credential);
         when(authenticationDtoConverter.dtoToAuthentication(any())).thenReturn(new EnvironmentAuthentication());
         when(environmentService.getRegionsByEnvironment(eq(environment))).thenReturn(getCloudRegions());

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentTestData.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentTestData.java
@@ -2,6 +2,7 @@ package com.sequenceiq.environment.environment.service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -23,9 +24,9 @@ import com.sequenceiq.environment.parameters.dao.domain.S3GuardTableCreation;
 public class EnvironmentTestData {
     public static final String ACCOUNT_ID = "accid";
 
-    public static final String USER = "userid";
+    public static final String USER = UUID.randomUUID().toString();
 
-    public static final String CRN = "crnid";
+    public static final String CRN = "crn:altus:iam:us-west-1:" + ACCOUNT_ID + ":user:" + USER;
 
     public static final String ENVIRONMENT_NAME = "envname";
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UsersyncPoller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UsersyncPoller.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.auth.security.InternalCrnBuilder;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SyncOperationStatus;
@@ -50,6 +51,9 @@ public class UsersyncPoller {
     @Value("${freeipa.syncoperation.poller.enabled:true}")
     private boolean enabled;
 
+    @Inject
+    private EntitlementService entitlementService;
+
     @Scheduled(fixedDelayString = "${freeipa.syncoperation.poller.fixed-delay-millis:60000}",
             initialDelayString = "${freeipa.syncoperation.poller.initial-delay-millis:300000}")
     public void pollUms() {
@@ -77,19 +81,25 @@ public class UsersyncPoller {
                     .collect(Collectors.groupingBy(Stack::getAccountId))
                     .entrySet().stream()
                     .forEach(stringListEntry -> {
-                        UmsEventGenerationIds currentGeneration =
-                                umsEventGenerationIdsProvider.getEventGenerationIds(stringListEntry.getKey(), requestId);
-                        stringListEntry.getValue().stream()
-                                .forEach(stack -> {
-                                    if (isStale(stack, currentGeneration)) {
-                                        LOGGER.debug("Environment {} in Account {} is stale.", stack.getEnvironmentCrn(), stack.getAccountId());
-                                        SyncOperationStatus status = userService.synchronizeUsers(stack.getAccountId(), INTERNAL_ACTOR_CRN,
-                                                Set.of(stack.getEnvironmentCrn()), Set.of(), Set.of());
-                                        LOGGER.debug("Sync request resulted in operation {}", status);
-                                    } else {
-                                        LOGGER.debug("Environment {} in Account {} is up-to-date.", stack.getEnvironmentCrn(), stack.getAccountId());
-                                    }
-                                });
+                        String accountId = stringListEntry.getKey();
+                        if (entitlementService.automaticUsersyncPollerEnabled(INTERNAL_ACTOR_CRN, accountId)) {
+                            LOGGER.debug("Usersync polling entitled in account {}", accountId);
+                            UmsEventGenerationIds currentGeneration =
+                                    umsEventGenerationIdsProvider.getEventGenerationIds(accountId, requestId);
+                            stringListEntry.getValue().stream()
+                                    .forEach(stack -> {
+                                        if (isStale(stack, currentGeneration)) {
+                                            LOGGER.debug("Environment {} in Account {} is stale.", stack.getEnvironmentCrn(), stack.getAccountId());
+                                            SyncOperationStatus status = userService.synchronizeUsers(stack.getAccountId(), INTERNAL_ACTOR_CRN,
+                                                    Set.of(stack.getEnvironmentCrn()), Set.of(), Set.of());
+                                            LOGGER.debug("Sync request resulted in operation {}", status);
+                                        } else {
+                                            LOGGER.debug("Environment {} in Account {} is up-to-date.", stack.getEnvironmentCrn(), stack.getAccountId());
+                                        }
+                                    });
+                        } else {
+                            LOGGER.debug("Usersync polling not entitled in account {}. skipping", accountId);
+                        }
                     });
         } finally {
             threadBasedUserCrnProvider.removeUserCrn();

--- a/mock-caas/src/main/java/com/sequenceiq/caas/grpc/service/MockUserManagementService.java
+++ b/mock-caas/src/main/java/com/sequenceiq/caas/grpc/service/MockUserManagementService.java
@@ -109,6 +109,8 @@ public class MockUserManagementService extends UserManagementGrpc.UserManagement
 
     private static final String CDP_AZURE = "CDP_AZURE";
 
+    private static final String CDP_AUTOMATIC_USERSYNC_POLLER = "CDP_AUTOMATIC_USERSYNC_POLLER";
+
     @Inject
     private JsonUtil jsonUtil;
 
@@ -318,6 +320,7 @@ public class MockUserManagementService extends UserManagementGrpc.UserManagement
                                 .setWorkloadSubdomain(ACCOUNT_SUBDOMAIN)
                                 .addEntitlements(createEntitlement(NO_TUNNEL_PROVISIONING))
                                 .addEntitlements(createEntitlement(CDP_AZURE))
+                                .addEntitlements(createEntitlement(CDP_AUTOMATIC_USERSYNC_POLLER))
                                 .build())
                         .build());
         responseObserver.onCompleted();
@@ -520,6 +523,7 @@ public class MockUserManagementService extends UserManagementGrpc.UserManagement
 
     @Override
     public void getEventGenerationIds(GetEventGenerationIdsRequest request, StreamObserver<GetEventGenerationIdsResponse> responseObserver) {
+        mockCrnService.ensureInternalActor();
         try {
             responseObserver.onNext(eventGenerationIdsCache.get(request.getAccountId()));
             responseObserver.onCompleted();


### PR DESCRIPTION
The UmsClient and EntitlementService were modified to accept an accountId
in addition to an actorCrn. This change is needed to support calling
with an internal actor crn.

The UsersyncPoller was modified to check the CDP_AUTOMATIC_USERSYNC_POLLER
entitlement for each account.
