### PR TITLE
CB-1097 – modifying environmnet service check due to different type(s) of dep.inj. usages

### DIFF
--- a/core/src/test/java/com/sequenceiq/general/RepositoryRestrictionTest.java
+++ b/core/src/test/java/com/sequenceiq/general/RepositoryRestrictionTest.java
@@ -13,6 +13,7 @@ import java.util.stream.Stream;
 import javax.inject.Inject;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -31,8 +32,9 @@ class RepositoryRestrictionTest {
     private static final String DISTROX_BASE_PACKAGE = BASE_PATH + ".distrox";
 
     @ParameterizedTest
-    @MethodSource("testDataProvider")
     @SuppressWarnings("unchecked")
+    @MethodSource("testDataProvider")
+    @DisplayName("Testing if core module's components are using the repositories trough delegated method(s) from the related service")
     void testForSingleRepositoryUsage(String basePath) {
         Set<Class<? extends Repository>> repos = getRepos(basePath);
         Set<Class<?>> compos = getServicesAndComponents(basePath);

--- a/environment/src/main/java/com/sequenceiq/environment/credential/service/CredentialService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/service/CredentialService.java
@@ -4,6 +4,7 @@ package com.sequenceiq.environment.credential.service;
 import static com.sequenceiq.cloudbreak.common.exception.NotFoundException.notFound;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -192,6 +193,18 @@ public class CredentialService extends AbstractCredentialService {
         Credential updated = repository.save(credentialAdapter.verify(original, accountId).getCredential());
         secretService.delete(attributesSecret);
         return updated;
+    }
+
+    Optional<Credential> findByNameAndAccountId(String name, String accountId, Collection<String> cloudPlatforms) {
+        return repository.findByNameAndAccountId(name, accountId, cloudPlatforms);
+    }
+
+    Optional<Credential> findByCrnAndAccountId(String crn, String accountId, Collection<String> cloudPlatforms) {
+        return repository.findByCrnAndAccountId(crn, accountId, cloudPlatforms);
+    }
+
+    Credential save(Credential credential) {
+        return repository.save(credential);
     }
 
     private void validateDeploymentAddress(Credential credential) {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentModificationService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentModificationService.java
@@ -47,8 +47,6 @@ public class EnvironmentModificationService {
 
     private final EnvironmentDtoConverter environmentDtoConverter;
 
-    private final EnvironmentRepository environmentRepository;
-
     private final EnvironmentService environmentService;
 
     private final CredentialService credentialService;
@@ -66,7 +64,6 @@ public class EnvironmentModificationService {
             AuthenticationDtoConverter authenticationDtoConverter, ParametersService parametersService,
             EnvironmentFlowValidatorService environmentFlowValidatorService) {
         this.environmentDtoConverter = environmentDtoConverter;
-        this.environmentRepository = environmentRepository;
         this.environmentService = environmentService;
         this.credentialService = credentialService;
         this.networkService = networkService;
@@ -76,28 +73,28 @@ public class EnvironmentModificationService {
     }
 
     public EnvironmentDto editByName(String environmentName, EnvironmentEditDto editDto) {
-        Environment env = environmentRepository
+        Environment env = environmentService
                 .findByNameAndAccountIdAndArchivedIsFalse(environmentName, editDto.getAccountId())
                 .orElseThrow(() -> new NotFoundException(String.format("No environment found with name '%s'", environmentName)));
         return edit(editDto, env);
     }
 
     public EnvironmentDto editByCrn(String crn, EnvironmentEditDto editDto) {
-        Environment env = environmentRepository
+        Environment env = environmentService
                 .findByResourceCrnAndAccountIdAndArchivedIsFalse(crn, editDto.getAccountId())
                 .orElseThrow(() -> new NotFoundException(String.format("No environment found with crn '%s'", crn)));
         return edit(editDto, env);
     }
 
     public EnvironmentDto changeCredentialByEnvironmentName(String accountId, String environmentName, EnvironmentChangeCredentialDto dto) {
-        Environment environment = environmentRepository
+        Environment environment = environmentService
                 .findByNameAndAccountIdAndArchivedIsFalse(environmentName, accountId)
                 .orElseThrow(() -> new NotFoundException(String.format("No environment found with name '%s'", environmentName)));
         return changeCredential(accountId, environmentName, dto, environment);
     }
 
     public EnvironmentDto changeCredentialByEnvironmentCrn(String accountId, String crn, EnvironmentChangeCredentialDto dto) {
-        Environment environment = environmentRepository
+        Environment environment = environmentService
                 .findByResourceCrnAndAccountIdAndArchivedIsFalse(crn, accountId)
                 .orElseThrow(() -> new NotFoundException(String.format("No environment found with CRN '%s'", crn)));
         return changeCredential(accountId, crn, dto, environment);
@@ -113,7 +110,7 @@ public class EnvironmentModificationService {
         editSecurityAccessIfChanged(editDto, env);
         editIdBrokerMappingSource(editDto, env);
         editEnvironmentParameters(editDto, env);
-        Environment saved = environmentRepository.save(env);
+        Environment saved = environmentService.save(env);
         return environmentDtoConverter.environmentToDto(saved);
     }
 
@@ -124,7 +121,7 @@ public class EnvironmentModificationService {
         Credential credential = credentialService.getByNameForAccountId(dto.getCredentialName(), accountId);
         environment.setCredential(credential);
         LOGGER.debug("About to change credential on environment \"{}\"", environmentName);
-        Environment saved = environmentRepository.save(environment);
+        Environment saved = environmentService.save(environment);
         return environmentDtoConverter.environmentToDto(saved);
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentService.java
@@ -250,6 +250,14 @@ public class EnvironmentService implements ResourceIdProvider {
         return environments.stream().map(environmentDtoConverter::environmentToDto).collect(Collectors.toList());
     }
 
+    Optional<Environment> findByNameAndAccountIdAndArchivedIsFalse(String name, String accountId) {
+        return environmentRepository.findByNameAndAccountIdAndArchivedIsFalse(name, accountId);
+    }
+
+    Optional<Environment> findByResourceCrnAndAccountIdAndArchivedIsFalse(String resourceCrn, String accountId) {
+        return environmentRepository.findByResourceCrnAndAccountIdAndArchivedIsFalse(resourceCrn, accountId);
+    }
+
     void setSecurityAccess(Environment environment, SecurityAccessDto securityAccess) {
         if (securityAccess != null) {
             environment.setCidr(securityAccess.getCidr());

--- a/environment/src/test/java/com/sequenceiq/environment/RepositoryRestrictionTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/RepositoryRestrictionTest.java
@@ -4,14 +4,12 @@ import static java.util.stream.Collectors.toSet;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
-import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
-import javax.inject.Inject;
-
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.reflections.ReflectionUtils;
 import org.reflections.Reflections;
@@ -27,6 +25,7 @@ class RepositoryRestrictionTest {
 
     @Test
     @SuppressWarnings("unchecked")
+    @DisplayName("Testing if environment module's components are using the repositories trough delegated method(s) from the related service")
     void testForSingleRepositoryUsage() {
         Set<Class<? extends Repository>> repos = getRepos();
         Set<Class<?>> compos = getServicesAndComponents();
@@ -36,7 +35,6 @@ class RepositoryRestrictionTest {
             compos.forEach(service -> {
                 Set<? extends Class<?>> injectedFields = ReflectionUtils.getFields(service)
                         .stream()
-                        .filter(this::isFieldInjected)
                         .map(Field::getType)
                         .collect(toSet());
                 if (injectedFields.stream().anyMatch(fieldClass -> fieldClass.equals(repo))) {
@@ -65,10 +63,6 @@ class RepositoryRestrictionTest {
             servicesAndComponents.addAll(reflections.getTypesAnnotatedWith(annotationClass));
         }
         return servicesAndComponents;
-    }
-
-    private boolean isFieldInjected(Field field) {
-        return Arrays.stream(field.getAnnotations()).anyMatch(annotation -> Inject.class.equals(annotation.annotationType()));
     }
 
     private String getExceptionMessage(String repoName, Set<String> affectedClasses) {

--- a/environment/src/test/java/com/sequenceiq/environment/credential/service/CredentialDeleteServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/credential/service/CredentialDeleteServiceTest.java
@@ -28,7 +28,6 @@ import org.mockito.MockitoAnnotations;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.message.CloudbreakMessagesService;
 import com.sequenceiq.environment.credential.domain.Credential;
-import com.sequenceiq.environment.credential.repository.CredentialRepository;
 import com.sequenceiq.environment.environment.domain.EnvironmentView;
 import com.sequenceiq.environment.environment.service.EnvironmentViewService;
 import com.sequenceiq.notification.Notification;
@@ -41,7 +40,7 @@ class CredentialDeleteServiceTest {
     private CredentialDeleteService underTest;
 
     @Mock
-    private CredentialRepository repository;
+    private CredentialService credentialService;
 
     @Mock
     private NotificationSender notificationSender;
@@ -55,7 +54,7 @@ class CredentialDeleteServiceTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.initMocks(this);
-        underTest = new CredentialDeleteService(repository, notificationSender, messagesService, environmentViewService, Set.of("AWS", "AZURE", "YARN"));
+        underTest = new CredentialDeleteService(credentialService, notificationSender, messagesService, environmentViewService, Set.of("AWS", "AZURE", "YARN"));
     }
 
     @Test
@@ -65,10 +64,10 @@ class CredentialDeleteServiceTest {
         Credential firstCred = createCredentialWithName(firstCredentialName);
         Credential secondCred = createCredentialWithName(secondCredentialName);
         Set<String> names = Set.of(firstCredentialName, secondCredentialName);
-        when(repository.findByNameAndAccountId(eq(firstCredentialName), eq(ACCOUNT_ID), any(Set.class))).thenReturn(Optional.of(firstCred));
-        when(repository.findByNameAndAccountId(eq(secondCredentialName), eq(ACCOUNT_ID), any(Set.class))).thenReturn(Optional.of(secondCred));
-        when(repository.save(firstCred)).thenReturn(firstCred);
-        when(repository.save(secondCred)).thenReturn(secondCred);
+        when(credentialService.findByNameAndAccountId(eq(firstCredentialName), eq(ACCOUNT_ID), any(Set.class))).thenReturn(Optional.of(firstCred));
+        when(credentialService.findByNameAndAccountId(eq(secondCredentialName), eq(ACCOUNT_ID), any(Set.class))).thenReturn(Optional.of(secondCred));
+        when(credentialService.save(firstCred)).thenReturn(firstCred);
+        when(credentialService.save(secondCred)).thenReturn(secondCred);
 
         Set<Credential> result = underTest.deleteMultiple(names, ACCOUNT_ID);
 
@@ -78,21 +77,21 @@ class CredentialDeleteServiceTest {
         assertTrue(result.stream().anyMatch(credential -> credential.getName().startsWith(secondCredentialName)));
         assertTrue(result.stream().allMatch(Credential::isArchived));
 
-        verify(repository, times(2)).findByNameAndAccountId(anyString(), anyString(), anyCollection());
+        verify(credentialService, times(2)).findByNameAndAccountId(anyString(), anyString(), anyCollection());
         verify(environmentViewService, times(2)).findAllByCredentialId(any());
-        verify(repository, times(2)).save(any());
-        verify(repository, times(1)).save(firstCred);
-        verify(repository, times(1)).save(secondCred);
+        verify(credentialService, times(2)).save(any());
+        verify(credentialService, times(1)).save(firstCred);
+        verify(credentialService, times(1)).save(secondCred);
     }
 
     @Test
     void testMultipleIfOneOfTheCredentialsIsNotExistsThenNotFoundExceptionComes() {
-        when(repository.findByNameAndAccountId(anyString(), anyString(), any(Set.class))).thenReturn(Optional.empty());
+        when(credentialService.findByNameAndAccountId(anyString(), anyString(), any(Set.class))).thenReturn(Optional.empty());
         assertThrows(NotFoundException.class, () -> underTest.deleteMultiple(Set.of("someCredNameWhichDoesNotExists"), ACCOUNT_ID));
 
-        verify(repository, times(1)).findByNameAndAccountId(anyString(), anyString(), anyCollection());
+        verify(credentialService, times(1)).findByNameAndAccountId(anyString(), anyString(), anyCollection());
         verify(environmentViewService, times(0)).findAllByCredentialId(anyLong());
-        verify(repository, times(0)).save(any());
+        verify(credentialService, times(0)).save(any());
     }
 
     @Test
@@ -100,22 +99,22 @@ class CredentialDeleteServiceTest {
         String name = "something";
         Credential cred = createCredentialWithName(name);
         cred.setId(1L);
-        when(repository.findByNameAndAccountId(eq(name), eq(ACCOUNT_ID), any(Set.class))).thenReturn(Optional.of(cred));
+        when(credentialService.findByNameAndAccountId(eq(name), eq(ACCOUNT_ID), any(Set.class))).thenReturn(Optional.of(cred));
         when(environmentViewService.findAllByCredentialId(cred.getId())).thenReturn(Set.of(new EnvironmentView()));
 
         assertThrows(BadRequestException.class, () -> underTest.deleteMultiple(Set.of(name), ACCOUNT_ID));
 
-        verify(repository, times(1)).findByNameAndAccountId(anyString(), anyString(), anyCollection());
+        verify(credentialService, times(1)).findByNameAndAccountId(anyString(), anyString(), anyCollection());
         verify(environmentViewService, times(1)).findAllByCredentialId(anyLong());
         verify(environmentViewService, times(1)).findAllByCredentialId(cred.getId());
-        verify(repository, times(0)).save(any());
+        verify(credentialService, times(0)).save(any());
     }
 
     @Test
     void testWhenCredentialDeleteIsSuccessfulThenNotificationShouldBeSent() {
         Credential cred = createCredentialWithName("first");
-        when(repository.findByNameAndAccountId(eq(cred.getName()), eq(ACCOUNT_ID), any(Set.class))).thenReturn(Optional.of(cred));
-        when(repository.save(cred)).thenReturn(cred);
+        when(credentialService.findByNameAndAccountId(eq(cred.getName()), eq(ACCOUNT_ID), any(Set.class))).thenReturn(Optional.of(cred));
+        when(credentialService.save(cred)).thenReturn(cred);
 
         underTest.deleteMultiple(Set.of(cred.getName()), ACCOUNT_ID);
 

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentModificationServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentModificationServiceTest.java
@@ -92,40 +92,40 @@ class EnvironmentModificationServiceTest {
     private ValidationResult validationResult;
 
     @Test
-    public void editByName() {
+    void editByName() {
         EnvironmentEditDto environmentDto = EnvironmentEditDto.builder()
                 .withAccountId(ACCOUNT_ID)
                 .build();
-        when(environmentRepository
+        when(environmentService
                 .findByNameAndAccountIdAndArchivedIsFalse(eq(ENVIRONMENT_NAME), eq(ACCOUNT_ID))).thenReturn(Optional.of(new Environment()));
         environmentModificationServiceUnderTest.editByName(ENVIRONMENT_NAME, environmentDto);
-        verify(environmentRepository).save(any());
+        verify(environmentService).save(any());
     }
 
     @Test
-    public void editByNameDescriptionChange() {
+    void editByNameDescriptionChange() {
         final String description = "test";
         EnvironmentEditDto environmentDto = EnvironmentEditDto.builder()
                 .withAccountId(ACCOUNT_ID)
                 .withDescription(description)
                 .build();
-        when(environmentRepository
+        when(environmentService
                 .findByNameAndAccountIdAndArchivedIsFalse(eq(ENVIRONMENT_NAME), eq(ACCOUNT_ID))).thenReturn(Optional.of(new Environment()));
         environmentModificationServiceUnderTest.editByName(ENVIRONMENT_NAME, environmentDto);
 
         ArgumentCaptor<Environment> environmentArgumentCaptor = ArgumentCaptor.forClass(Environment.class);
-        verify(environmentRepository).save(environmentArgumentCaptor.capture());
+        verify(environmentService).save(environmentArgumentCaptor.capture());
         assertEquals(description, environmentArgumentCaptor.getValue().getDescription());
     }
 
     @Test
-    public void editByNameRegionChange() {
+    void editByNameRegionChange() {
         EnvironmentEditDto environmentDto = EnvironmentEditDto.builder()
                 .withAccountId(ACCOUNT_ID)
                 .withRegions(Set.of("r1"))
                 .build();
         when(environmentDtoConverter.environmentToLocationDto(any())).thenReturn(LocationDto.builder().withName("loc").build());
-        when(environmentRepository
+        when(environmentService
                 .findByNameAndAccountIdAndArchivedIsFalse(eq(ENVIRONMENT_NAME), eq(ACCOUNT_ID))).thenReturn(Optional.of(new Environment()));
         when(environmentService.getValidatorService()).thenReturn(validatorService);
         when(validatorService.validateRegionsAndLocation(any(), any(), any(), any())).thenReturn(validationResultBuilder);
@@ -134,13 +134,13 @@ class EnvironmentModificationServiceTest {
         environmentModificationServiceUnderTest.editByName(ENVIRONMENT_NAME, environmentDto);
 
         ArgumentCaptor<Environment> environmentArgumentCaptor = ArgumentCaptor.forClass(Environment.class);
-        verify(environmentRepository).save(environmentArgumentCaptor.capture());
+        verify(environmentService).save(environmentArgumentCaptor.capture());
         verify(environmentService).setRegions(any(), any(), any());
         verify(environmentService, never()).setLocation(any(), any(), any());
     }
 
     @Test
-    public void editByNameRegionAndLocationChange() {
+    void editByNameRegionAndLocationChange() {
         EnvironmentEditDto environmentDto = EnvironmentEditDto.builder()
                 .withAccountId(ACCOUNT_ID)
                 .withRegions(Set.of("r1"))
@@ -151,7 +151,7 @@ class EnvironmentModificationServiceTest {
                         .withLongitude(0.1)
                         .build())
                 .build();
-        when(environmentRepository
+        when(environmentService
                 .findByNameAndAccountIdAndArchivedIsFalse(eq(ENVIRONMENT_NAME), eq(ACCOUNT_ID))).thenReturn(Optional.of(new Environment()));
         when(environmentService.getValidatorService()).thenReturn(validatorService);
         when(validatorService.validateRegionsAndLocation(any(), any(), any(), any())).thenReturn(validationResultBuilder);
@@ -160,13 +160,13 @@ class EnvironmentModificationServiceTest {
         environmentModificationServiceUnderTest.editByName(ENVIRONMENT_NAME, environmentDto);
 
         ArgumentCaptor<Environment> environmentArgumentCaptor = ArgumentCaptor.forClass(Environment.class);
-        verify(environmentRepository).save(environmentArgumentCaptor.capture());
+        verify(environmentService).save(environmentArgumentCaptor.capture());
         verify(environmentService).setRegions(any(), any(), any());
         verify(environmentService).setLocation(any(), any(), any());
     }
 
     @Test
-    public void editByNameRegionAndLocationChangeValidationError() {
+    void editByNameRegionAndLocationChangeValidationError() {
         final String description = "test";
         EnvironmentEditDto environmentDto = EnvironmentEditDto.builder()
                 .withAccountId(ACCOUNT_ID)
@@ -178,7 +178,7 @@ class EnvironmentModificationServiceTest {
                         .withLongitude(0.1)
                         .build())
                 .build();
-        when(environmentRepository
+        when(environmentService
                 .findByNameAndAccountIdAndArchivedIsFalse(eq(ENVIRONMENT_NAME), eq(ACCOUNT_ID))).thenReturn(Optional.of(new Environment()));
         when(environmentService.getValidatorService()).thenReturn(validatorService);
         when(validatorService.validateRegionsAndLocation(any(), any(), any(), any())).thenReturn(validationResultBuilder);
@@ -188,13 +188,13 @@ class EnvironmentModificationServiceTest {
         assertThrows(BadRequestException.class,
                 () -> environmentModificationServiceUnderTest.editByName(ENVIRONMENT_NAME, environmentDto));
 
-        verify(environmentRepository, never()).save(any());
+        verify(environmentService, never()).save(any());
         verify(environmentService, never()).setRegions(any(), any(), any());
         verify(environmentService, never()).setLocation(any(), any(), any());
     }
 
     @Test
-    public void editByNameLocationChange() {
+    void editByNameLocationChange() {
         EnvironmentEditDto environmentDto = EnvironmentEditDto.builder()
                 .withAccountId(ACCOUNT_ID)
                 .withLocation(LocationDto.builder()
@@ -208,7 +208,7 @@ class EnvironmentModificationServiceTest {
         Region region = new Region();
         region.setName("r3");
         value.setRegions(Set.of(region));
-        when(environmentRepository
+        when(environmentService
                 .findByNameAndAccountIdAndArchivedIsFalse(eq(ENVIRONMENT_NAME), eq(ACCOUNT_ID))).thenReturn(Optional.of(value));
         when(environmentService.getValidatorService()).thenReturn(validatorService);
         when(validatorService.validateRegionsAndLocation(any(), any(), any(), any())).thenReturn(validationResultBuilder);
@@ -217,20 +217,20 @@ class EnvironmentModificationServiceTest {
         environmentModificationServiceUnderTest.editByName(ENVIRONMENT_NAME, environmentDto);
 
         ArgumentCaptor<Environment> environmentArgumentCaptor = ArgumentCaptor.forClass(Environment.class);
-        verify(environmentRepository).save(environmentArgumentCaptor.capture());
+        verify(environmentService).save(environmentArgumentCaptor.capture());
         verify(environmentService, never()).setRegions(any(), any(), any());
         verify(environmentService).setLocation(any(), any(), any());
     }
 
     @Test
-    public void editByNameNetworkChange() {
+    void editByNameNetworkChange() {
         NetworkDto network = NetworkDto.builder().build();
         EnvironmentEditDto environmentDto = EnvironmentEditDto.builder()
                 .withAccountId(ACCOUNT_ID)
                 .withNetwork(network)
                 .build();
         Environment value = new Environment();
-        when(environmentRepository
+        when(environmentService
                 .findByNameAndAccountIdAndArchivedIsFalse(eq(ENVIRONMENT_NAME), eq(ACCOUNT_ID))).thenReturn(Optional.of(value));
         when(networkService.findByEnvironment(any())).thenReturn(Optional.empty());
         when(networkService.saveNetwork(any(), any(), anyString(), any())).thenReturn(new AwsNetwork());
@@ -238,12 +238,13 @@ class EnvironmentModificationServiceTest {
         environmentModificationServiceUnderTest.editByName(ENVIRONMENT_NAME, environmentDto);
 
         ArgumentCaptor<Environment> environmentArgumentCaptor = ArgumentCaptor.forClass(Environment.class);
-        verify(environmentRepository).save(environmentArgumentCaptor.capture());
+        verify(environmentService).save(environmentArgumentCaptor.capture());
         verify(networkService).saveNetwork(any(), any(), any(), any());
     }
 
     @Test
-    public void editByNameAuthenticationChange() {
+    void editByNameAuthenticationChange() {
+        final String description = "test";
         final EnvironmentAuthentication envAuthResult = new EnvironmentAuthentication();
         AuthenticationDto authentication = AuthenticationDto.builder().build();
         EnvironmentEditDto environmentDto = EnvironmentEditDto.builder()
@@ -251,50 +252,49 @@ class EnvironmentModificationServiceTest {
                 .withAuthentication(authentication)
                 .build();
         Environment value = new Environment();
-        when(environmentRepository
+        when(environmentService
                 .findByNameAndAccountIdAndArchivedIsFalse(eq(ENVIRONMENT_NAME), eq(ACCOUNT_ID))).thenReturn(Optional.of(value));
         when(authenticationDtoConverter.dtoToAuthentication(any())).thenReturn(envAuthResult);
 
         environmentModificationServiceUnderTest.editByName(ENVIRONMENT_NAME, environmentDto);
 
         ArgumentCaptor<Environment> environmentArgumentCaptor = ArgumentCaptor.forClass(Environment.class);
-        verify(environmentRepository).save(environmentArgumentCaptor.capture());
+        verify(environmentService).save(environmentArgumentCaptor.capture());
         assertEquals(envAuthResult, environmentArgumentCaptor.getValue().getAuthentication());
     }
 
     @Test
-    public void editByNameSecurityAccessChange() {
+    void editByNameSecurityAccessChange() {
         SecurityAccessDto securityAccessDto = SecurityAccessDto.builder().withCidr("test").build();
         EnvironmentEditDto environmentDto = EnvironmentEditDto.builder()
                 .withAccountId(ACCOUNT_ID)
                 .withSecurityAccess(securityAccessDto)
                 .build();
         Environment value = new Environment();
-        when(environmentRepository
+        when(environmentService
                 .findByNameAndAccountIdAndArchivedIsFalse(eq(ENVIRONMENT_NAME), eq(ACCOUNT_ID))).thenReturn(Optional.of(value));
 
         environmentModificationServiceUnderTest.editByName(ENVIRONMENT_NAME, environmentDto);
 
         ArgumentCaptor<Environment> environmentArgumentCaptor = ArgumentCaptor.forClass(Environment.class);
-        verify(environmentRepository).save(environmentArgumentCaptor.capture());
+        verify(environmentService).save(environmentArgumentCaptor.capture());
         verify(environmentService).setSecurityAccess(eq(value), eq(securityAccessDto));
     }
 
     @Test
-    public void editByCrn() {
+    void editByCrn() {
         EnvironmentEditDto environmentDto = EnvironmentEditDto.builder()
                 .withAccountId(ACCOUNT_ID)
                 .build();
-        when(environmentRepository
+        when(environmentService
                 .findByResourceCrnAndAccountIdAndArchivedIsFalse(eq(CRN), eq(ACCOUNT_ID))).thenReturn(Optional.of(new Environment()));
 
         environmentModificationServiceUnderTest.editByCrn(CRN, environmentDto);
-
-        verify(environmentRepository).save(any());
+        verify(environmentService).save(any());
     }
 
     @Test
-    public void editByNameParametersNotExisted() {
+    void editByNameParametersNotExisted() {
         String dynamotable = "dynamotable";
         ParametersDto parameters = ParametersDto.builder()
                 .withAccountId(ACCOUNT_ID)
@@ -309,7 +309,8 @@ class EnvironmentModificationServiceTest {
         Environment environment = new Environment();
         environment.setAccountId(ACCOUNT_ID);
         BaseParameters baseParameters = new AwsParameters();
-        when(environmentRepository
+
+        when(environmentService
                 .findByNameAndAccountIdAndArchivedIsFalse(eq(ENVIRONMENT_NAME), eq(ACCOUNT_ID))).thenReturn(Optional.of(environment));
         when(parametersService.saveParameters(environment, parameters)).thenReturn(baseParameters);
 
@@ -320,7 +321,7 @@ class EnvironmentModificationServiceTest {
     }
 
     @Test
-    public void editByNameParametersExistedAndValid() {
+    void editByNameParametersExistedAndValid() {
         String dynamotable = "dynamotable";
         ParametersDto parameters = ParametersDto.builder()
                 .withAccountId(ACCOUNT_ID)
@@ -341,7 +342,7 @@ class EnvironmentModificationServiceTest {
         when(environmentFlowValidatorService.validateAndDetermineAwsParameters(any(), any())).thenReturn(validationResult);
         when(validationResult.hasError()).thenReturn(false);
         when(parametersService.findByEnvironment(any())).thenReturn(Optional.of(baseParameters));
-        when(environmentRepository
+        when(environmentService
                 .findByNameAndAccountIdAndArchivedIsFalse(eq(ENVIRONMENT_NAME), eq(ACCOUNT_ID))).thenReturn(Optional.of(environment));
         when(parametersService.saveParameters(environment, parameters)).thenReturn(baseParameters);
 
@@ -352,7 +353,7 @@ class EnvironmentModificationServiceTest {
     }
 
     @Test
-    public void editByNameParametersExistedAndNotValid() {
+    void editByNameParametersExistedAndNotValid() {
         String dynamotable = "dynamotable";
         ParametersDto parameters = ParametersDto.builder()
                 .withAccountId(ACCOUNT_ID)
@@ -373,7 +374,7 @@ class EnvironmentModificationServiceTest {
         when(environmentFlowValidatorService.validateAndDetermineAwsParameters(any(), any())).thenReturn(validationResult);
         when(validationResult.hasError()).thenReturn(true);
         when(parametersService.findByEnvironment(any())).thenReturn(Optional.of(baseParameters));
-        when(environmentRepository
+        when(environmentService
                 .findByNameAndAccountIdAndArchivedIsFalse(eq(ENVIRONMENT_NAME), eq(ACCOUNT_ID))).thenReturn(Optional.of(environment));
         when(parametersService.saveParameters(environment, parameters)).thenReturn(baseParameters);
 
@@ -383,40 +384,40 @@ class EnvironmentModificationServiceTest {
     }
 
     @Test
-    public void changeCredentialByEnvironmentName() {
+    void changeCredentialByEnvironmentName() {
         String credentialName = "credentialName";
         final Credential value = new Credential();
         EnvironmentChangeCredentialDto environmentChangeDto = EnvironmentChangeCredentialDto.EnvironmentChangeCredentialDtoBuilder
                 .anEnvironmentChangeCredentialDto()
                 .withCredentialName(credentialName)
                 .build();
-        when(environmentRepository
+        when(environmentService
                 .findByNameAndAccountIdAndArchivedIsFalse(eq(ENVIRONMENT_NAME), eq(ACCOUNT_ID))).thenReturn(Optional.of(new Environment()));
         when(credentialService.getByNameForAccountId(eq(credentialName), eq(ACCOUNT_ID))).thenReturn(value);
 
         environmentModificationServiceUnderTest.changeCredentialByEnvironmentName(ACCOUNT_ID, ENVIRONMENT_NAME, environmentChangeDto);
 
         ArgumentCaptor<Environment> environmentArgumentCaptor = ArgumentCaptor.forClass(Environment.class);
-        verify(environmentRepository).save(environmentArgumentCaptor.capture());
+        verify(environmentService).save(environmentArgumentCaptor.capture());
         assertEquals(value, environmentArgumentCaptor.getValue().getCredential());
     }
 
     @Test
-    public void changeCredentialByEnvironmentCrn() {
+    void changeCredentialByEnvironmentCrn() {
         String credentialName = "credentialName";
         final Credential value = new Credential();
         EnvironmentChangeCredentialDto environmentChangeDto = EnvironmentChangeCredentialDto.EnvironmentChangeCredentialDtoBuilder
                 .anEnvironmentChangeCredentialDto()
                 .withCredentialName(credentialName)
                 .build();
-        when(environmentRepository
+        when(environmentService
                 .findByResourceCrnAndAccountIdAndArchivedIsFalse(eq(CRN), eq(ACCOUNT_ID))).thenReturn(Optional.of(new Environment()));
         when(credentialService.getByNameForAccountId(eq(credentialName), eq(ACCOUNT_ID))).thenReturn(value);
 
         environmentModificationServiceUnderTest.changeCredentialByEnvironmentCrn(ACCOUNT_ID, CRN, environmentChangeDto);
 
         ArgumentCaptor<Environment> environmentArgumentCaptor = ArgumentCaptor.forClass(Environment.class);
-        verify(environmentRepository).save(environmentArgumentCaptor.capture());
+        verify(environmentService).save(environmentArgumentCaptor.capture());
         assertEquals(value, environmentArgumentCaptor.getValue().getCredential());
     }
 


### PR DESCRIPTION
Since environment service uses both annotation and constructor dependency injection, the related unit test had to be changed