### PR TITLE
CDPCP-1023. 

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
@@ -485,6 +485,11 @@ public class FreeIpaClient {
         try {
             RPCResponse<T> response = (RPCResponse<T>) jsonRpcHttpClient.invoke(method, List.of(flags, parameterMap), type);
             LOGGER.debug("Response object: {}", response);
+            if (response == null) {
+                // TODO CDPCP-1028 investigate why invoke returns null instead of throwing an exception
+                // when the cluster-proxy request times out.
+                throw new NullPointerException("JSON-RPC response is null");
+            }
             return response;
         } catch (Throwable throwable) {
             String message = String.format("Invoke FreeIpa failed: %s", throwable.getLocalizedMessage());

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
@@ -2,6 +2,7 @@ package com.sequenceiq.freeipa.client;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -219,7 +220,7 @@ public class FreeIpaClient {
     //    "version": "4.6.4"
     //}
     // TODO the response to this API call not currently deserializable
-    public RPCResponse<Object> groupAddMembers(String group, Set<String> users) throws FreeIpaClientException {
+    public RPCResponse<Object> groupAddMembers(String group, Collection<String> users) throws FreeIpaClientException {
         List<String> flags = List.of(group);
         Map<String, Object> params = Map.of(
                 "user", users
@@ -227,7 +228,7 @@ public class FreeIpaClient {
         return invoke("group_add_member", flags, params, Object.class);
     }
 
-    public RPCResponse<Object> groupRemoveMembers(String group, Set<String> users) throws FreeIpaClientException {
+    public RPCResponse<Object> groupRemoveMembers(String group, Collection<String> users) throws FreeIpaClientException {
         List<String> flags = List.of(group);
         Map<String, Object> params = Map.of(
                 "user", users

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserService.java
@@ -20,6 +20,7 @@ import javax.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
@@ -27,6 +28,7 @@ import org.springframework.util.CollectionUtils;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.auth.altus.CrnParseException;
@@ -62,6 +64,12 @@ import com.sequenceiq.freeipa.util.KrbKeySetEncoder;
 public class UserService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UserService.class);
+
+    private static final int DEFAULT_MAX_SUBJECTS_PER_REQUEST = 10;
+
+    @VisibleForTesting
+    @Value("${freeipa.syncoperation.max-subjects-per-request:10}")
+    int maxSubjectsPerRequest = DEFAULT_MAX_SUBJECTS_PER_REQUEST;
 
     @Inject
     private StackService stackService;
@@ -316,36 +324,38 @@ public class UserService {
 
     }
 
-    private void addUsersToGroups(FreeIpaClient freeIpaClient, Multimap<String, String> groupMapping) throws FreeIpaClientException {
+    @VisibleForTesting
+    void addUsersToGroups(FreeIpaClient freeIpaClient, Multimap<String, String> groupMapping) throws FreeIpaClientException {
         LOGGER.debug("adding users to groups: [{}]", groupMapping);
         for (String group : groupMapping.keySet()) {
-            Set<String> users = Set.copyOf(groupMapping.get(group));
-            LOGGER.debug("adding users [{}] to group [{}]", users, group);
-
-            try {
-                // TODO specialize response object
-                RPCResponse<Object> groupAddMember = freeIpaClient.groupAddMembers(group, users);
-                LOGGER.debug("Success: {}", groupAddMember.getResult());
-            } catch (FreeIpaClientException e) {
-                // TODO propagate this information out to API
-                LOGGER.error("Failed to add [{}] to group [{}]", users, group, e);
-            }
+            Iterables.partition(groupMapping.get(group), maxSubjectsPerRequest).forEach(users -> {
+                LOGGER.debug("adding users [{}] to group [{}]", users, group);
+                try {
+                    // TODO specialize response object
+                    RPCResponse<Object> groupAddMember = freeIpaClient.groupAddMembers(group, users);
+                    LOGGER.debug("Success: {}", groupAddMember.getResult());
+                } catch (FreeIpaClientException e) {
+                    // TODO propagate this information out to API
+                    LOGGER.error("Failed to add [{}] to group [{}]", users, group, e);
+                }
+            });
         }
     }
 
-    private void removeUsersFromGroups(FreeIpaClient freeIpaClient, Multimap<String, String> groupMapping) throws FreeIpaClientException {
+    @VisibleForTesting
+    void removeUsersFromGroups(FreeIpaClient freeIpaClient, Multimap<String, String> groupMapping) throws FreeIpaClientException {
         for (String group : groupMapping.keySet()) {
-            Set<String> users = Set.copyOf(groupMapping.get(group));
-            LOGGER.debug("removing users {} from group {}", users, group);
-
-            try {
-                // TODO specialize response object
-                RPCResponse<Object> groupRemoveMembers = freeIpaClient.groupRemoveMembers(group, users);
-                LOGGER.debug("Success: {}", groupRemoveMembers.getResult());
-            } catch (FreeIpaClientException e) {
-                // TODO propagate this information out to API
-                LOGGER.error("Failed to add [{}] to group [{}]", users, group, e);
-            }
+            Iterables.partition(groupMapping.get(group), maxSubjectsPerRequest).forEach(users -> {
+                LOGGER.debug("removing users {} from group {}", users, group);
+                try {
+                    // TODO specialize response object
+                    RPCResponse<Object> groupRemoveMembers = freeIpaClient.groupRemoveMembers(group, users);
+                    LOGGER.debug("Success: {}", groupRemoveMembers.getResult());
+                } catch (FreeIpaClientException e) {
+                    // TODO propagate this information out to API
+                    LOGGER.error("Failed to add [{}] to group [{}]", users, group, e);
+                }
+            });
         }
     }
 

--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -61,6 +61,7 @@ freeipa:
     failure-reset-interval: 3
     lockout-duration: 10
   syncoperation:
+    max-subjects-per-request: 10
     cleanup:
       timeout-millis: 1800000
       initial-delay-millis: 60000

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserServiceTest.java
@@ -3,6 +3,7 @@ package com.sequenceiq.freeipa.service.freeipa.user;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -16,8 +17,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.freeipa.client.FreeIpaClient;
+import com.sequenceiq.freeipa.client.FreeIpaClientException;
+import com.sequenceiq.freeipa.client.model.RPCResponse;
 import com.sequenceiq.freeipa.controller.exception.BadRequestException;
 import com.sequenceiq.freeipa.service.freeipa.user.model.FmsUser;
 import com.sequenceiq.freeipa.service.freeipa.user.model.UsersState;
@@ -107,5 +112,52 @@ class UserServiceTest {
         when(umsUsersState.getRequestedWorkloadUsers()).thenReturn(workloadUsers);
         underTest.getIpaUserState(freeIpaClient, umsUsersState, Set.of(USER_CRN), Set.of(MACHINE_USER_CRN));
         verify(freeIpaUsersStateProvider).getFilteredFreeIPAState(any(), eq(workloadUsers));
+    }
+
+    @Test
+    void testAddUsersToGroupsPartitionsReqeusts() throws Exception {
+        FreeIpaClient freeIpaClient = mock(FreeIpaClient.class);
+        RPCResponse<Object> response = mock(RPCResponse.class);
+        when(freeIpaClient.groupAddMembers(any(), any())).thenReturn(response);
+
+        Multimap<String, String> groupMapping = setupGroupMapping(5, underTest.maxSubjectsPerRequest * 2);
+        underTest.addUsersToGroups(freeIpaClient, groupMapping);
+
+        groupMapping.keySet().stream().forEach(group -> {
+            try {
+                verify(freeIpaClient, times(2)).groupAddMembers(eq(group), any());
+            } catch (FreeIpaClientException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @Test
+    void testRemoveUsersFromGroupsPartitionsRequests() throws Exception {
+        FreeIpaClient freeIpaClient = mock(FreeIpaClient.class);
+        RPCResponse<Object> response = mock(RPCResponse.class);
+        when(freeIpaClient.groupRemoveMembers(any(), any())).thenReturn(response);
+
+        Multimap<String, String> groupMapping = setupGroupMapping(5, underTest.maxSubjectsPerRequest * 2);
+        underTest.removeUsersFromGroups(freeIpaClient, groupMapping);
+
+        groupMapping.keySet().stream().forEach(group -> {
+            try {
+                verify(freeIpaClient, times(2)).groupRemoveMembers(eq(group), any());
+            } catch (FreeIpaClientException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    private Multimap<String, String> setupGroupMapping(int numGroups, int numPerGroup) {
+        Multimap<String, String> groupMapping = HashMultimap.create();
+        for (int i = 0; i < numGroups; ++i) {
+            String group = "group" + i;
+            for (int j = 0; j < numPerGroup; ++j) {
+                groupMapping.put(group, "user" + j);
+            }
+        }
+        return groupMapping;
     }
 }


### PR DESCRIPTION
The FreeIpaClient returns a null response object when the cluster-proxy request times out. The first commit null-checks the response and throws an exception. The second commit partitions the known potentially long-running requests into smaller chunks of work.