### PR TITLE
CB-4524. Enable cluster proxy for FMS through entitlements

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
@@ -28,6 +28,10 @@ public class EntitlementService {
         return isEntitlementRegistered(actorCrn, accountId, "CDP_AUTOMATIC_USERSYNC_POLLER");
     }
 
+    public boolean fmsClusterProxyEnabled(String actorCrn, String accountId) {
+        return isEntitlementRegistered(actorCrn, accountId, "CDP_FMS_CLUSTER_PROXY");
+    }
+
     public List<String> getEntitlements(String actorCrn, String accountId) {
         return getAccount(actorCrn, accountId).getEntitlementsList()
                 .stream()

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/provision/handler/ClusterProxyRegistrationHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/provision/handler/ClusterProxyRegistrationHandler.java
@@ -6,7 +6,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.clusterproxy.ClusterProxyConfiguration;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.EventHandler;
@@ -24,9 +23,6 @@ public class ClusterProxyRegistrationHandler implements EventHandler<ClusterProx
     private static final Logger LOGGER = LoggerFactory.getLogger(ClusterProxyRegistrationHandler.class);
 
     @Inject
-    private ClusterProxyConfiguration clusterProxyConfiguration;
-
-    @Inject
     private EventBus eventBus;
 
     @Inject
@@ -42,12 +38,7 @@ public class ClusterProxyRegistrationHandler implements EventHandler<ClusterProx
         ClusterProxyRegistrationRequest request = event.getData();
         Selectable response;
         try {
-            if (clusterProxyConfiguration.isClusterProxyIntegrationEnabled()) {
-                LOGGER.debug("Cluster Proxy integration enabled. Registering FreeIpa [{}]", request.getResourceId());
-                clusterProxyService.registerFreeIpa(request.getResourceId());
-            } else {
-                LOGGER.debug("Cluster Proxy integration disabled. Skipping registering FreeIpa [{}]", request.getResourceId());
-            }
+            clusterProxyService.registerFreeIpa(request.getResourceId());
             response = new ClusterProxyRegistrationSuccess(request.getResourceId());
         } catch (Exception e) {
             LOGGER.error("Cluster Proxy registration has failed", e);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/handler/ClusterProxyDeregistrationHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/handler/ClusterProxyDeregistrationHandler.java
@@ -35,14 +35,10 @@ public class ClusterProxyDeregistrationHandler implements EventHandler<ClusterPr
     public void accept(Event<ClusterProxyDeregistrationRequest> requestEvent) {
         ClusterProxyDeregistrationRequest request = requestEvent.getData();
         LOGGER.debug("De-registering freeipa stack {} from cluster proxy", request.getResourceId());
-        if (clusterProxyConfiguration.isClusterProxyIntegrationEnabled()) {
-            try {
-                clusterProxyService.deregisterFreeIpa(request.getResourceId());
-            } catch (Exception ex) {
-                LOGGER.error("Cluster proxy de-registration failed", ex);
-            }
-        } else {
-            LOGGER.debug("Cluster proxy integration not enabled. Skipping de-registration");
+        try {
+            clusterProxyService.deregisterFreeIpa(request.getResourceId());
+        } catch (Exception ex) {
+            LOGGER.error("Cluster proxy de-registration failed", ex);
         }
         Selectable result = new ClusterProxyDeregistrationFinished(request.getResourceId(), request.getForced());
         eventBus.notify(result.selector(), new Event<>(requestEvent.getHeaders(), result));

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/config/FmsClusterProxyEnablement.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/config/FmsClusterProxyEnablement.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.freeipa.service.config;
+
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.auth.security.InternalCrnBuilder;
+import com.sequenceiq.cloudbreak.clusterproxy.ClusterProxyConfiguration;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.stack.StackService;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+
+@Component
+public class FmsClusterProxyEnablement {
+
+    private static final String INTERNAL_ACTOR_CRN = new InternalCrnBuilder(Crn.Service.IAM).getInternalCrnForServiceAsString();
+
+    @Inject
+    private ClusterProxyConfiguration clusterProxyConfiguration;
+
+    @Inject
+    private EntitlementService entitlementService;
+
+    @Inject
+    private StackService stackService;
+
+    public boolean isEnabled(Stack stack) {
+        return clusterProxyConfiguration.isClusterProxyIntegrationEnabled() && hasEntitlement(stack.getAccountId());
+    }
+
+    private boolean hasEntitlement(String accountId) {
+        return entitlementService.fmsClusterProxyEnabled(INTERNAL_ACTOR_CRN, accountId);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactory.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactory.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import com.sequenceiq.freeipa.service.config.FmsClusterProxyEnablement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -31,6 +32,9 @@ public class FreeIpaClientFactory {
 
     @Inject
     private ClusterProxyConfiguration clusterProxyConfiguration;
+
+    @Inject
+    private FmsClusterProxyEnablement fmsClusterProxyEnablement;
 
     @Inject
     private GatewayConfigService gatewayConfigService;
@@ -65,7 +69,7 @@ public class FreeIpaClientFactory {
         LOGGER.debug("Creating FreeIpaClient for stack {}", stack.getResourceCrn());
 
         try {
-            if (clusterProxyConfiguration.isClusterProxyIntegrationEnabled() && Boolean.TRUE.equals(stack.getClusterProxyRegistered())) {
+            if (fmsClusterProxyEnablement.isEnabled(stack) && Boolean.TRUE.equals(stack.getClusterProxyRegistered())) {
                 HttpClientConfig httpClientConfig = new HttpClientConfig(clusterProxyConfiguration.getClusterProxyHost());
                 FreeIpa freeIpa = freeIpaService.findByStack(stack);
                 String clusterProxyPath = toClusterProxyBasepath(stack.getResourceCrn());


### PR DESCRIPTION
Cluster proxy integration for FMS now also requires an
entitlement. This will allow us to continue testing in
mow-dev while keeping it disabled for other users. Note
that since we've moved the check into ClusterProxyService,
this will also affect the register/deregister api.