### PR TITLE
CB-4286 Add "ml" as a valid service CRN

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/auth/altus/Crn.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/auth/altus/Crn.java
@@ -158,7 +158,8 @@ public class Crn {
         WORKSPACES("workspaces", NON_ADMIN_SERVICE),
         FREEIPA("freeipa", NON_ADMIN_SERVICE),
         DATAHUB("datahub", NON_ADMIN_SERVICE),
-        DATALAKE("datalake", NON_ADMIN_SERVICE);
+        DATALAKE("datalake", NON_ADMIN_SERVICE),
+        ML("ml", NON_ADMIN_SERVICE);
 
         private static final ImmutableMap<String, Service> FROM_STRING;
 


### PR DESCRIPTION
This allows the "ml" service to use its CRN as the cluster CRN for the
kerberos management APIs.

This was manully tested with the following CRN:
crn:cdp:ml:us-west-1:9d74eee4-1cad-45d7-b645-7ccf9edbb73d:workspace:
e4ef2cc9-904f-4d5a-80cb-929e76f9d288

Closes #CB-4286