### PR TITLE
CB-4290 Enable auto restart for Hive on Tez

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ProcessAutoRestartInjector.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ProcessAutoRestartInjector.java
@@ -26,6 +26,7 @@ public class ProcessAutoRestartInjector implements CmTemplateConfigInjector {
             "HBASE",
             HdfsRoles.HDFS,
             HiveRoles.HIVE,
+            HiveRoles.HIVE_ON_TEZ,
             "KAFKA",
             KnoxRoles.KNOX,
             "LIVY",


### PR DESCRIPTION
Auto restart should be on for Hive on Tez by default.
