### PR TITLE
CB-3513 IDBroker Mapping Validation

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/ObjectStorageConnector.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/ObjectStorageConnector.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.cloud;
 
 import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageMetadataRequest;
 import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageMetadataResponse;
+import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageValidateRequest;
+import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageValidateResponse;
 
 /**
  * Object storage connectors.
@@ -10,4 +12,5 @@ public interface ObjectStorageConnector extends CloudPlatformAware {
 
     ObjectStorageMetadataResponse getObjectStorageMetadata(ObjectStorageMetadataRequest request);
 
+    ObjectStorageValidateResponse validateObjectStorage(ObjectStorageValidateRequest request);
 }

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/base/ResponseStatus.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/base/ResponseStatus.java
@@ -3,5 +3,6 @@ package com.sequenceiq.cloudbreak.cloud.model.base;
 public enum ResponseStatus {
     OK,
     ACCESS_DENIED,
+    ERROR,
     RESOURCE_NOT_FOUND
 }

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/filesystem/CloudFileSystemView.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/filesystem/CloudFileSystemView.java
@@ -1,10 +1,18 @@
 package com.sequenceiq.cloudbreak.cloud.model.filesystem;
 
+import com.sequenceiq.common.api.cloudstorage.AccountMappingBase;
+import com.sequenceiq.common.api.cloudstorage.StorageLocationBase;
 import com.sequenceiq.common.model.CloudIdentityType;
+
+import java.util.List;
 
 public abstract class CloudFileSystemView {
 
     private final CloudIdentityType cloudIdentityType;
+
+    private AccountMappingBase accountMapping;
+
+    private List<StorageLocationBase> locations;
 
     protected CloudFileSystemView(CloudIdentityType cloudIdentityType) {
         this.cloudIdentityType = cloudIdentityType;
@@ -12,5 +20,21 @@ public abstract class CloudFileSystemView {
 
     public CloudIdentityType getCloudIdentityType() {
         return cloudIdentityType;
+    }
+
+    public void setAccountMapping(AccountMappingBase accountMapping) {
+        this.accountMapping = accountMapping;
+    }
+
+    public AccountMappingBase getAccountMapping() {
+        return accountMapping;
+    }
+
+    public void setLocations(List<StorageLocationBase> locations) {
+        this.locations = locations;
+    }
+
+    public List<StorageLocationBase> getLocations() {
+        return locations;
     }
 }

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/objectstorage/ObjectStorageValidateRequest.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/objectstorage/ObjectStorageValidateRequest.java
@@ -1,0 +1,142 @@
+package com.sequenceiq.cloudbreak.cloud.model.objectstorage;
+
+import com.sequenceiq.cloudbreak.cloud.CloudPlatformAware;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.Platform;
+import com.sequenceiq.cloudbreak.cloud.model.SpiFileSystem;
+import com.sequenceiq.cloudbreak.cloud.model.Variant;
+import com.sequenceiq.common.api.cloudstorage.CloudStorageRequest;
+
+import javax.validation.constraints.NotNull;
+import java.util.Objects;
+
+public class ObjectStorageValidateRequest implements CloudPlatformAware {
+
+    private @NotNull CloudCredential credential;
+
+    private @NotNull String cloudPlatform;
+
+    private @NotNull CloudStorageRequest cloudStorageRequest;
+
+    private SpiFileSystem spiFileSystem;
+
+    public ObjectStorageValidateRequest() {
+    }
+
+    public ObjectStorageValidateRequest(Builder builder) {
+        this.credential = builder.credential;
+        this.cloudPlatform = builder.cloudPlatform;
+        this.cloudStorageRequest = builder.cloudStorageRequest;
+        this.spiFileSystem = builder.spiFileSystem;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String getCloudPlatform() {
+        return cloudPlatform;
+    }
+
+    public void setCloudPlatform(String cloudPlatform) {
+        this.cloudPlatform = cloudPlatform;
+    }
+
+    public CloudCredential getCredential() {
+        return credential;
+    }
+
+    public void setCredential(CloudCredential credential) {
+        this.credential = credential;
+    }
+
+    public CloudStorageRequest getCloudStorageRequest() {
+        return cloudStorageRequest;
+    }
+
+    public void setCloudStorageRequest(CloudStorageRequest cloudStorageRequest) {
+        this.cloudStorageRequest = cloudStorageRequest;
+    }
+
+    public SpiFileSystem getSpiFileSystem() {
+        return spiFileSystem;
+    }
+
+    public void setSpiFileSystem(SpiFileSystem spiFileSystem) {
+        this.spiFileSystem = spiFileSystem;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !getClass().equals(o.getClass())) {
+            return false;
+        }
+        ObjectStorageValidateRequest request = (ObjectStorageValidateRequest) o;
+        return Objects.equals(credential, request.credential) &&
+                Objects.equals(cloudPlatform, request.cloudPlatform) &&
+                Objects.equals(cloudStorageRequest, request.cloudStorageRequest) &&
+                Objects.equals(spiFileSystem, request.spiFileSystem);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(credential, cloudPlatform, cloudStorageRequest, spiFileSystem);
+    }
+
+    @Override
+    public String toString() {
+        return "ObjectStorageMetadataRequest{" +
+                ", cloudPlatform='" + cloudPlatform + '\'' +
+                ", cloudStorageRequest='" + cloudStorageRequest + '\'' +
+                ", spiFileSystem='" + spiFileSystem + '\'' +
+                '}';
+    }
+
+    @Override
+    public Platform platform() {
+        return Platform.platform(cloudPlatform);
+    }
+
+    @Override
+    public Variant variant() {
+        return Variant.variant(cloudPlatform);
+    }
+
+    public static class Builder {
+
+        private CloudCredential credential;
+
+        private String cloudPlatform;
+
+        private CloudStorageRequest cloudStorageRequest;
+
+        private SpiFileSystem spiFileSystem;
+
+        public Builder withCredential(CloudCredential credential) {
+            this.credential = credential;
+            return this;
+        }
+
+        public Builder withCloudPlatform(String cloudPlatform) {
+            this.cloudPlatform = cloudPlatform;
+            return this;
+        }
+
+        public Builder withCloudStorageRequest(CloudStorageRequest cloudStorageRequest) {
+            this.cloudStorageRequest = cloudStorageRequest;
+            return this;
+        }
+
+        public Builder withSpiFileSystem(SpiFileSystem spiFileSystem) {
+            this.spiFileSystem = spiFileSystem;
+            return this;
+        }
+
+        public ObjectStorageValidateRequest build() {
+            return new ObjectStorageValidateRequest(this);
+        }
+    }
+}

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/objectstorage/ObjectStorageValidateResponse.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/objectstorage/ObjectStorageValidateResponse.java
@@ -1,0 +1,86 @@
+package com.sequenceiq.cloudbreak.cloud.model.objectstorage;
+
+import com.sequenceiq.cloudbreak.cloud.model.base.ResponseStatus;
+
+import java.util.Objects;
+
+public class ObjectStorageValidateResponse {
+
+    private ResponseStatus status;
+
+    private String error;
+
+    public ObjectStorageValidateResponse() {
+    }
+
+    public ObjectStorageValidateResponse(Builder builder) {
+        this.status = builder.status;
+        this.error = builder.error;
+    }
+
+    public ResponseStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(ResponseStatus status) {
+        this.status = status;
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public String toString() {
+        return "ObjectStorageMetadataResponse{" +
+                ", status=" + status +
+                ", error=" + error +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !getClass().equals(o.getClass())) {
+            return false;
+        }
+        ObjectStorageValidateResponse response = (ObjectStorageValidateResponse) o;
+        return Objects.equals(status, response.status) && Objects.equals(error, response.error);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(status, error);
+    }
+
+    public static class Builder {
+
+        private ResponseStatus status;
+
+        private String error;
+
+        public Builder withStatus(ResponseStatus status) {
+            this.status = status;
+            return this;
+        }
+
+        public Builder withError(String error) {
+            this.error = error;
+            return this;
+        }
+
+        public ObjectStorageValidateResponse build() {
+            return new ObjectStorageValidateResponse(this);
+        }
+    }
+}

--- a/cloud-aws/build.gradle
+++ b/cloud-aws/build.gradle
@@ -15,7 +15,6 @@ jar {
   archiveName = 'cloud-aws.jar'
 }
 
-
 dependencies {
   compile project(':cloud-api')
   compile project(':cloud-template')
@@ -35,15 +34,26 @@ dependencies {
   annotationProcessor group: 'org.mapstruct',     name: 'mapstruct-processor',            version: mapstructVersion
 
   testCompile group: 'org.springframework.boot',  name: 'spring-boot-starter-test',       version: springBootVersion
-  testCompile group: 'org.springframework.boot',  name:'spring-boot-starter-freemarker',  version:springBootVersion
-  testCompile (group: 'junit', name: 'junit', version: junitVersion) {
+  testCompile group: 'org.springframework.boot',  name:'spring-boot-starter-freemarker',  version: springBootVersion
+  testCompile (group: 'junit',                    name: 'junit',                          version: junitVersion) {
     exclude group: 'org.hamcrest'
   }
-  testCompile (group: 'org.mockito',             name: 'mockito-core',          version: mockitoVersion) {
+  testCompile group: 'org.junit.jupiter',         name: 'junit-jupiter-api',              version: junitJupiterVersion
+  testCompile group: 'org.junit.jupiter',         name: 'junit-jupiter-params',           version: junitJupiterVersion
+  testCompile (group: 'org.mockito',              name: 'mockito-core',                   version: mockitoVersion) {
     exclude group: 'org.hamcrest'
   }
+  testImplementation group: 'org.mockito',        name: 'mockito-junit-jupiter',          version: mockitoVersion
   testCompile 'org.hamcrest:java-hamcrest:2.0.0.0'
 
+  testRuntime group: 'org.junit.jupiter',         name: 'junit-jupiter-engine',           version: junitJupiterVersion
+  testRuntime group: 'org.junit.vintage',         name: 'junit-vintage-engine',           version: junitJupiterVersion
+}
+
+test {
+  useJUnitPlatform {
+    includeEngines 'junit-jupiter', 'junit-vintage'
+  }
 }
 
 sourceSets {

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsSetup.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsSetup.java
@@ -185,6 +185,7 @@ public class AwsSetup implements Setup {
 
     @Override
     public void validateFileSystem(CloudCredential credential, SpiFileSystem spiFileSystem) {
+
     }
 
     @Override

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/util/AwsIamService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/util/AwsIamService.java
@@ -1,0 +1,259 @@
+package com.sequenceiq.cloudbreak.cloud.aws.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import com.amazonaws.auth.policy.Action;
+import com.amazonaws.auth.policy.Policy;
+import com.amazonaws.auth.policy.Resource;
+import com.amazonaws.auth.policy.Statement;
+import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
+import com.amazonaws.services.identitymanagement.model.EvaluationResult;
+import com.amazonaws.services.identitymanagement.model.GetInstanceProfileRequest;
+import com.amazonaws.services.identitymanagement.model.GetRoleRequest;
+import com.amazonaws.services.identitymanagement.model.InstanceProfile;
+import com.amazonaws.services.identitymanagement.model.NoSuchEntityException;
+import com.amazonaws.services.identitymanagement.model.Role;
+import com.amazonaws.services.identitymanagement.model.ServiceFailureException;
+import com.amazonaws.services.identitymanagement.model.SimulatePrincipalPolicyRequest;
+import com.amazonaws.services.identitymanagement.model.SimulatePrincipalPolicyResult;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.validation.ValidationResult.ValidationResultBuilder;
+
+@Service
+public class AwsIamService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsIamService.class);
+
+    private static final String POLICY_BASE_LOCATION = "definitions/cdp/";
+
+    /**
+     * Validates instance profile ARN and returns an InstanceProfile object if valid
+     * @param iam AmazonIdentityManagement client
+     * @param instanceProfileArn instance profile ARN
+     * @param validationResultBuilder builder for any errors encountered
+     * @return InstanceProfile if instance profile ARN is valid otherwise null
+     */
+    public InstanceProfile getInstanceProfile(AmazonIdentityManagement iam, String instanceProfileArn,
+                                                ValidationResultBuilder validationResultBuilder) {
+        InstanceProfile instanceProfile = null;
+        if (instanceProfileArn != null && instanceProfileArn.contains("/")) {
+            String instanceProfileName = instanceProfileArn.split("/", 2)[1];
+            GetInstanceProfileRequest instanceProfileRequest = new GetInstanceProfileRequest()
+                                                                    .withInstanceProfileName(instanceProfileName);
+            try {
+                instanceProfile = iam.getInstanceProfile(instanceProfileRequest).getInstanceProfile();
+            } catch (NoSuchEntityException | ServiceFailureException e) {
+                String msg = String.format("Instance profile (%s) doesn't exist.", instanceProfileArn);
+                LOGGER.error(msg, e);
+                validationResultBuilder.error(msg);
+            }
+        }
+        return instanceProfile;
+    }
+
+    /**
+     * Returns valid roles from a set of role ARNs
+     * @param iam AmazonIdentityManagement client
+     * @param roleArns set of role ARNs
+     * @param validationResultBuilder builder for any errors encountered
+     * @return set of valid Role objects
+     */
+    public Set<Role> getValidRoles(AmazonIdentityManagement iam, Set<String> roleArns,
+                                    ValidationResultBuilder validationResultBuilder) {
+        return roleArns.stream()
+                    .map(roleArn -> getRole(iam, roleArn, validationResultBuilder))
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toUnmodifiableSet());
+    }
+
+    /**
+     * Validates role ARN and returns an Role object if valid
+     * @param iam AmazonIdentityManagement client
+     * @param roleArn role ARN
+     * @param validationResultBuilder builder for any errors encountered
+     * @return Role if role ARN is valid otherwise null
+     */
+    public Role getRole(AmazonIdentityManagement iam, String roleArn,
+                        ValidationResultBuilder validationResultBuilder) {
+        Role role = null;
+        if (roleArn != null && roleArn.contains("/")) {
+            String roleName = roleArn.split("/", 2)[1];
+            GetRoleRequest roleRequest = new GetRoleRequest().withRoleName(roleName);
+            try {
+                role = iam.getRole(roleRequest).getRole();
+            } catch (NoSuchEntityException | ServiceFailureException e) {
+                String msg = String.format("Role (%s) doesn't exist.", roleArn);
+                LOGGER.debug(msg, e);
+                validationResultBuilder.error(msg);
+            }
+        }
+        return role;
+    }
+
+    /**
+     * Gets the role assume role policy document as a Policy object
+     * @param role Role to evaluate
+     * @return assume role Policy object
+     */
+    public Policy getAssumeRolePolicy(Role role) {
+        Policy policy = null;
+        String assumeRolePolicyDocument = role.getAssumeRolePolicyDocument();
+        if (assumeRolePolicyDocument != null) {
+            try {
+                String decodedAssumeRolePolicyDocument = URLDecoder.decode(assumeRolePolicyDocument,
+                    StandardCharsets.UTF_8);
+                policy = Policy.fromJson(decodedAssumeRolePolicyDocument);
+            } catch (IllegalArgumentException e) {
+                LOGGER.error(String.format("Unable to get policy from role (%s)", role.getArn()), e);
+            }
+        }
+
+        return policy;
+    }
+
+    /**
+     * Replace template with strings from replacements map
+     * @param template string of the template
+     * @param replacements map of simple replacements to make to template
+     * @return template with replacements replaced
+     */
+    String handleTemplateReplacements(String template, Map<String, String> replacements) {
+        String replacedTemplate = template;
+        if (replacedTemplate != null) {
+            for (Entry<String, String> replacement : replacements.entrySet()) {
+                String replacementValue = replacement.getValue() != null ? replacement.getValue() : "";
+                replacedTemplate = replacedTemplate.replace(replacement.getKey(), replacementValue);
+            }
+        }
+        return replacedTemplate;
+    }
+
+    /**
+     * Returns a Policy object that has replacements made to the template json
+     * @param policyFileName Policy template file name
+     * @param replacements map of simple replacements to make to policy template json
+     * @return Policy with replacements made
+     */
+    public Policy getPolicy(String policyFileName, Map<String, String> replacements) {
+        Policy policy = null;
+        try {
+            String policyJsonTemplate = getResourceFileAsString(POLICY_BASE_LOCATION + policyFileName);
+            String policyJson = handleTemplateReplacements(policyJsonTemplate, replacements);
+            if (policyJson != null) {
+                policy = Policy.fromJson(policyJson);
+            }
+        } catch (IOException e) {
+            LOGGER.debug("Unable to load policy json", e);
+        }
+
+        return policy;
+    }
+
+    /**
+     * Returns actions from the given statement
+     * @param statement statement to get actions from
+     * @return sorted set of actions
+     */
+    public SortedSet<String> getStatementActions(Statement statement) {
+        List<Action> actions = statement.getActions();
+        if (actions == null) {
+            return new TreeSet<>();
+        }
+        return statement.getActions().stream()
+                    .map(Action::getActionName)
+                    .collect(Collectors.toCollection(TreeSet::new));
+    }
+
+    /**
+     * Returns resources from the given statement
+     * @param statement statement to get resources from
+     * @return sorted set of resources
+     */
+    public SortedSet<String> getStatementResources(Statement statement) {
+        List<Resource> resources = statement.getResources();
+        if (resources == null) {
+            return new TreeSet<>();
+        }
+        return resources.stream()
+                    .map(Resource::getId)
+                    .collect(Collectors.toCollection(TreeSet::new));
+    }
+
+    /**
+     * Helper method that wraps simulating a principal policy
+     * @param iam AmazonIdentityManagement client
+     * @param policySourceArn arn to to check against
+     * @param actionNames actions to simulate
+     * @param resourceArns resources to simulate
+     * @return List of evaluation results
+     */
+    public List<EvaluationResult> simulatePrincipalPolicy(AmazonIdentityManagement iam,
+                                                            String policySourceArn,
+                                                            Collection<String> actionNames,
+                                                            Collection<String> resourceArns) {
+        SimulatePrincipalPolicyRequest simulatePrincipalPolicyRequest =
+            new SimulatePrincipalPolicyRequest()
+                .withPolicySourceArn(policySourceArn)
+                .withActionNames(actionNames)
+                .withResourceArns(resourceArns);
+        SimulatePrincipalPolicyResult simulatePrincipalPolicyResult =
+            iam.simulatePrincipalPolicy(simulatePrincipalPolicyRequest);
+        return simulatePrincipalPolicyResult.getEvaluationResults();
+    }
+
+    /**
+     * Validates the given roles against the policies
+     * @param iam AmazonIdentityManagement client
+     * @param roles collection of Role objects to check
+     * @param policies collection of Policy objects to check
+     * @return list of evaluation results
+     */
+    public List<EvaluationResult> validateRolePolicies(AmazonIdentityManagement iam, Role role,
+                                                        Collection<Policy> policies) {
+        List<EvaluationResult> evaluationResults = new ArrayList<>();
+        for (Policy policy : policies) {
+            for (Statement statement : policy.getStatements()) {
+                SortedSet<String> actions = getStatementActions(statement);
+                SortedSet<String> resources = getStatementResources(statement);
+                evaluationResults.addAll(simulatePrincipalPolicy(iam, role.getArn(),
+                    actions, resources));
+            }
+        }
+        return evaluationResults;
+    }
+
+    /**
+     * Returns resource file content as a string
+     * @param fileName resource file to read
+     * @return resource content as a string
+     * @throws IOException if unable to read file
+     */
+    String getResourceFileAsString(String fileName) throws IOException {
+        try (InputStream is = AwsIamService.class.getClassLoader().getResourceAsStream(fileName)) {
+            return inputStreamtoString(is);
+        }
+    }
+
+    private String inputStreamtoString(InputStream is) throws IOException {
+        if (is == null) {
+            return null;
+        }
+        return IOUtils.toString(is, StandardCharsets.UTF_8);
+    }
+}

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsDataAccessRolePermissionValidator.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsDataAccessRolePermissionValidator.java
@@ -1,0 +1,41 @@
+package com.sequenceiq.cloudbreak.cloud.aws.validator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.service.identitymapping.AccountMappingSubject;
+import com.sequenceiq.common.api.cloudstorage.StorageLocationBase;
+import com.sequenceiq.common.model.FileSystemType;
+
+@Component
+public class AwsDataAccessRolePermissionValidator extends AwsIDBrokerMappedRolePermissionValidator {
+    @Override
+    Set<String> getUsers() {
+        return AccountMappingSubject.DATA_ACCESS_USERS;
+    }
+
+    @Override
+    List<String> getPolicyFileNames(boolean s3guardEnabled) {
+        List<String> policyFileNames = new ArrayList<>();
+        policyFileNames.add("aws-cdp-bucket-access-policy.json");
+        policyFileNames.add("aws-cdp-datalake-admin-s3-policy.json");
+        if (s3guardEnabled) {
+            policyFileNames.add("aws-cdp-dynamodb-policy.json");
+        }
+
+        return policyFileNames;
+    }
+
+    @Override
+    String getStorageLocationBase(StorageLocationBase location) {
+        return location.getValue().replace(FileSystemType.S3.getProtocol() + "://", "");
+    }
+
+    @Override
+    boolean checkLocation(StorageLocationBase location) {
+        return true;
+    }
+}

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsIDBrokerAssumeRoleValidator.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsIDBrokerAssumeRoleValidator.java
@@ -1,0 +1,61 @@
+package com.sequenceiq.cloudbreak.cloud.aws.validator;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import javax.inject.Inject;
+
+import com.amazonaws.auth.policy.actions.SecurityTokenServiceActions;
+import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
+import com.amazonaws.services.identitymanagement.model.EvaluationResult;
+import com.amazonaws.services.identitymanagement.model.InstanceProfile;
+import com.amazonaws.services.identitymanagement.model.PolicyEvaluationDecisionType;
+import com.amazonaws.services.identitymanagement.model.Role;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.aws.util.AwsIamService;
+import com.sequenceiq.cloudbreak.validation.ValidationResult.ValidationResultBuilder;
+
+@Component
+public class AwsIDBrokerAssumeRoleValidator {
+    static final Collection<String> ASSUME_ROLE_ACTION = Collections.singletonList(
+        SecurityTokenServiceActions.AssumeRole.getActionName());
+
+    @Inject
+    private AwsIamService awsIamService;
+
+    public boolean canAssumeRoles(AmazonIdentityManagement iam, InstanceProfile instanceProfile,
+                                    Collection<Role> roles, ValidationResultBuilder resultBuilder) {
+        SortedSet<String> failedRoles = new TreeSet<>();
+        for (Role role : roles) {
+            if (!canAssumeRole(iam, instanceProfile, role)) {
+                failedRoles.add(role.getArn());
+            }
+        }
+        if (failedRoles.isEmpty()) {
+            return true;
+        } else {
+            resultBuilder.error(
+                String.format("IDBroker instance profile (%s) doesn't have permissions to assume " +
+                                    "the role(s): %s", instanceProfile.getArn(), failedRoles));
+            return false;
+        }
+    }
+
+    boolean canAssumeRole(AmazonIdentityManagement iam, InstanceProfile instanceProfile, Role role) {
+        for (Role instanceProfileRole : instanceProfile.getRoles()) {
+            Collection<String> resources = Collections.singletonList(role.getArn());
+            List<EvaluationResult> evaluationResults = awsIamService.simulatePrincipalPolicy(iam,
+                instanceProfileRole.getArn(), ASSUME_ROLE_ACTION, resources);
+            for (EvaluationResult evaluationResult : evaluationResults) {
+                if (PolicyEvaluationDecisionType.Allowed.toString()
+                        .equals(evaluationResult.getEvalDecision())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsIDBrokerMappedRolePermissionValidator.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsIDBrokerMappedRolePermissionValidator.java
@@ -1,0 +1,155 @@
+package com.sequenceiq.cloudbreak.cloud.aws.validator;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+
+import com.amazonaws.auth.policy.Policy;
+import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
+import com.amazonaws.services.identitymanagement.model.EvaluationResult;
+import com.amazonaws.services.identitymanagement.model.Role;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.cloud.aws.util.AwsIamService;
+import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudS3View;
+import com.sequenceiq.cloudbreak.validation.ValidationResult.ValidationResultBuilder;
+import com.sequenceiq.common.api.cloudstorage.AccountMappingBase;
+import com.sequenceiq.common.api.cloudstorage.StorageLocationBase;
+
+public abstract class AwsIDBrokerMappedRolePermissionValidator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsIDBrokerMappedRolePermissionValidator.class);
+
+    @Inject
+    private AwsIamService awsIamService;
+
+    /**
+     * Returns list of users to filter roles
+     * @return list of user strings
+     */
+    abstract Set<String> getUsers();
+
+    /**
+     * Returns policy file names
+     * @param s3guardEnabled true if s3guard is enabled false otherwise
+     * @return list of policy file names
+     */
+    abstract List<String> getPolicyFileNames(boolean s3guardEnabled);
+
+    /**
+     * Returns the storage location base string
+     * @param location StorageLocationBase to evaluate
+     * @return storage location base string
+     */
+    abstract String getStorageLocationBase(StorageLocationBase location);
+
+    /**
+     * Checks if the location should be checked or not for role permissions
+     * @param location StorageLocationBase to evaluate
+     * @return true if location is valid to check false otherwise
+     */
+    abstract boolean checkLocation(StorageLocationBase location);
+
+    /**
+     * Validates the cloudFileSystem
+     * @param cloudFileSystem cloud file system to evaluate
+     * @param validationResultBuilder builder for any errors encountered
+     */
+    public void validate(AmazonIdentityManagement iam, CloudS3View cloudFileSystem,
+                            ValidationResultBuilder validationResultBuilder) {
+        AccountMappingBase accountMappings = cloudFileSystem.getAccountMapping();
+        if (accountMappings != null) {
+            SortedSet<String> roleArns = getRoleArnsForUsers(getUsers(), accountMappings.getUserMappings());
+            Set<Role> roles = awsIamService.getValidRoles(iam, roleArns, validationResultBuilder);
+
+            boolean s3guardEnabled = cloudFileSystem.getS3GuardDynamoTableName() != null;
+            List<String> policyFileNames = getPolicyFileNames(s3guardEnabled);
+
+            SortedSet<String> failedActions = new TreeSet<>();
+            for (StorageLocationBase location : cloudFileSystem.getLocations()) {
+                if (checkLocation(location)) {
+                    Map<String, String> replacements = getPolicyJsonReplacements(location, cloudFileSystem);
+                    List<Policy> policies = getPolicies(policyFileNames, replacements);
+                    for (Role role : roles) {
+                        List<EvaluationResult> evaluationResults = awsIamService.validateRolePolicies(iam,
+                            role, policies);
+                        failedActions.addAll(getFailedActions(role, evaluationResults));
+                    }
+                }
+            }
+            if (!failedActions.isEmpty()) {
+                validationResultBuilder.error(String.format("The role(s) (%s) don't have the required permissions:%n%s",
+                    String.join(", ", roles.stream().map(Role::getArn).collect(Collectors.toCollection(TreeSet::new))),
+                    String.join("\n", failedActions)));
+            }
+        }
+    }
+
+    /**
+     * Get the replacements necessary for the policy json
+     * @param location StorageLocationBase to get storage paths from
+     * @param cloudFileSystem CloudFileSystem to get dynamodb table name
+     * @return map of simple replacements for policy json
+     */
+    protected Map<String, String> getPolicyJsonReplacements(StorageLocationBase location,
+                                                            CloudS3View cloudFileSystem) {
+        String storageLocationBase = getStorageLocationBase(location);
+        String datalakeBucket = storageLocationBase.split("/", 2)[0];
+        return Map.ofEntries(
+            Map.entry("${STORAGE_LOCATION_BASE}", storageLocationBase),
+            Map.entry("${DATALAKE_BUCKET}", datalakeBucket),
+            Map.entry("${DYNAMODB_TABLE_NAME}", cloudFileSystem.getS3GuardDynamoTableName())
+        );
+    }
+
+    /**
+     * Retrieve the unique set of role arns for the list of provided users
+     * @param users list of users to filter by
+     * @param userMappings user mappings to filter on
+     * @return set of AWS roles
+     */
+    SortedSet<String> getRoleArnsForUsers(Collection<String> users,
+                                            Map<String, String> userMappings) {
+        return userMappings.entrySet().stream()
+                    .filter(m -> users.contains(m.getKey()))
+                    .map(Entry::getValue).collect(Collectors.toCollection(TreeSet::new));
+    }
+
+    /**
+     * Returns Policy objects after the policy json has had replacements
+     * @param policyFileNames policy file names to read before replacement
+     * @param replacements simple replacements to be made to the policy json
+     * @return list of Policy objects after replacements made to policy json
+     */
+    List<Policy> getPolicies(List<String> policyFileNames,
+                                Map<String, String> replacements) {
+        List<Policy> policies = new ArrayList<>(policyFileNames.size());
+        for (String policyFileName : policyFileNames) {
+            Policy policy = awsIamService.getPolicy(policyFileName, replacements);
+            if (policy != null) {
+                policies.add(policy);
+            }
+        }
+        return policies;
+    }
+
+    /**
+     * Finds all the denied results and generates a set of failed actions
+     * @param role Role that was being evaluated
+     * @param evaluationResults result of simulating the policy
+     */
+    SortedSet<String> getFailedActions(Role role, List<EvaluationResult> evaluationResults) {
+        return evaluationResults.stream()
+                    .filter(evaluationResult -> evaluationResult.getEvalDecision().toLowerCase().contains("deny"))
+                    .map(evaluationResult -> String.format("%s:%s:%s", role.getArn(),
+                        evaluationResult.getEvalActionName(), evaluationResult.getEvalResourceName()))
+                    .collect(Collectors.toCollection(TreeSet::new));
+    }
+}

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsIDBrokerObjectStorageValidator.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsIDBrokerObjectStorageValidator.java
@@ -1,0 +1,101 @@
+package com.sequenceiq.cloudbreak.cloud.aws.validator;
+
+import javax.inject.Inject;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
+import com.amazonaws.services.identitymanagement.model.InstanceProfile;
+import com.amazonaws.services.identitymanagement.model.Role;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.aws.util.AwsIamService;
+import com.sequenceiq.cloudbreak.cloud.model.SpiFileSystem;
+import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudFileSystemView;
+import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudS3View;
+import com.sequenceiq.cloudbreak.validation.ValidationResult;
+import com.sequenceiq.cloudbreak.validation.ValidationResult.ValidationResultBuilder;
+import com.sequenceiq.common.api.cloudstorage.AccountMappingBase;
+import com.sequenceiq.common.model.CloudIdentityType;
+
+@Component
+public class AwsIDBrokerObjectStorageValidator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsIDBrokerObjectStorageValidator.class);
+
+    @Inject
+    private AwsInstanceProfileEC2TrustValidator awsInstanceProfileEC2TrustValidator;
+
+    @Inject
+    private AwsIDBrokerAssumeRoleValidator awsIDBrokerAssumeRoleValidator;
+
+    @Inject
+    private AwsDataAccessRolePermissionValidator awsDataAccessRolePermissionValidator;
+
+    @Inject
+    private AwsRangerAuditRolePermissionValidator awsRangerAuditRolePermissionValidator;
+
+    @Inject
+    private AwsLogRolePermissionValidator awsLogRolePermissionValidator;
+
+    @Inject
+    private AwsIamService awsIamService;
+
+    public ValidationResult validateObjectStorage(AmazonIdentityManagement iam,
+                                                    SpiFileSystem spiFileSystem,
+                                                    ValidationResultBuilder resultBuilder) {
+        List<CloudFileSystemView> cloudFileSystems = spiFileSystem.getCloudFileSystems();
+        for (CloudFileSystemView cloudFileSystemView : cloudFileSystems) {
+            CloudS3View cloudFileSystem = (CloudS3View) cloudFileSystemView;
+            String instanceProfileArn = cloudFileSystem.getInstanceProfile();
+            InstanceProfile instanceProfile = awsIamService.getInstanceProfile(iam, instanceProfileArn,
+                resultBuilder);
+            if (instanceProfile != null) {
+                CloudIdentityType cloudIdentityType = cloudFileSystem.getCloudIdentityType();
+                if (CloudIdentityType.ID_BROKER.equals(cloudIdentityType)) {
+                    validateIDBroker(iam, instanceProfile, cloudFileSystem, resultBuilder);
+                } else if (CloudIdentityType.LOG.equals(cloudIdentityType)) {
+                    validateLog(instanceProfile, cloudFileSystem, resultBuilder);
+                }
+            }
+        }
+
+        return resultBuilder.build();
+    }
+
+    private void validateIDBroker(AmazonIdentityManagement iam, InstanceProfile instanceProfile,
+                                    CloudS3View cloudFileSystem, ValidationResultBuilder resultBuilder) {
+        awsInstanceProfileEC2TrustValidator.isTrusted(instanceProfile, resultBuilder);
+
+        Set<Role> allMappedRoles = getAllMappedRoles(iam, cloudFileSystem, resultBuilder);
+        awsIDBrokerAssumeRoleValidator.canAssumeRoles(iam, instanceProfile, allMappedRoles, resultBuilder);
+
+        awsDataAccessRolePermissionValidator.validate(iam, cloudFileSystem, resultBuilder);
+        awsRangerAuditRolePermissionValidator.validate(iam, cloudFileSystem, resultBuilder);
+    }
+
+    private void validateLog(InstanceProfile instanceProfile, CloudS3View cloudFileSystem,
+                                ValidationResultBuilder resultBuilder) {
+        awsInstanceProfileEC2TrustValidator.isTrusted(instanceProfile, resultBuilder);
+
+        //TODO - need to figure out how to get LOGS_LOCATION_BASE value
+        //awsLogRolePermissionValidator.validate(iam, instanceProfile, cloudFileSystem, resultBuilder);
+    }
+
+    Set<Role> getAllMappedRoles(AmazonIdentityManagement iam, CloudFileSystemView cloudFileSystemView,
+                                ValidationResultBuilder resultBuilder) {
+        Set<Role> roles = Collections.emptySet();
+        AccountMappingBase accountMappings = cloudFileSystemView.getAccountMapping();
+        if (accountMappings != null) {
+            SortedSet<String> roleArns = new TreeSet<>();
+            roleArns.addAll(accountMappings.getUserMappings().values());
+            roleArns.addAll(accountMappings.getGroupMappings().values());
+            roles = awsIamService.getValidRoles(iam, roleArns, resultBuilder);
+        }
+        return roles;
+    }
+}

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsInstanceProfileEC2TrustValidator.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsInstanceProfileEC2TrustValidator.java
@@ -1,0 +1,54 @@
+package com.sequenceiq.cloudbreak.cloud.aws.validator;
+
+import java.util.List;
+import javax.inject.Inject;
+
+import com.amazonaws.auth.policy.Action;
+import com.amazonaws.auth.policy.Policy;
+import com.amazonaws.auth.policy.Principal;
+import com.amazonaws.auth.policy.Principal.Services;
+import com.amazonaws.auth.policy.Statement;
+import com.amazonaws.auth.policy.actions.SecurityTokenServiceActions;
+import com.amazonaws.services.identitymanagement.model.InstanceProfile;
+import com.amazonaws.services.identitymanagement.model.Role;
+
+import com.sequenceiq.cloudbreak.cloud.aws.util.AwsIamService;
+import com.sequenceiq.cloudbreak.validation.ValidationResult.ValidationResultBuilder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AwsInstanceProfileEC2TrustValidator {
+    @Inject
+    private AwsIamService awsIamService;
+
+    public boolean isTrusted(InstanceProfile instanceProfile, ValidationResultBuilder resultBuilder) {
+        List<Role> instanceProfileRoles = instanceProfile.getRoles();
+        for (Role role : instanceProfileRoles) {
+            Policy assumeRolePolicy = awsIamService.getAssumeRolePolicy(role);
+            if (assumeRolePolicy != null) {
+                for (Statement statement : assumeRolePolicy.getStatements()) {
+                    if (checkAssumeRoleInActions(statement.getActions()) &&
+                            checkEC2InPrincipals(statement.getPrincipals())) {
+                        return true;
+                    }
+                }
+            }
+        }
+        resultBuilder.error(
+            String.format("The instance profile (%s) doesn't have an EC2 trust relationship.",
+                instanceProfile.getArn()));
+        return false;
+    }
+
+    boolean checkEC2InPrincipals(List<Principal> principals) {
+        return principals
+                .stream()
+                .anyMatch(principal -> "Service".equals(principal.getProvider())
+                                            && Services.AmazonEC2.getServiceId().equals(principal.getId()));
+    }
+
+    boolean checkAssumeRoleInActions(List<Action> actions) {
+        return actions.stream().anyMatch(
+            action -> SecurityTokenServiceActions.AssumeRole.getActionName().equals(action.getActionName()));
+    }
+}

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsLogRolePermissionValidator.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsLogRolePermissionValidator.java
@@ -1,0 +1,64 @@
+package com.sequenceiq.cloudbreak.cloud.aws.validator;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+
+import com.amazonaws.auth.policy.Policy;
+import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
+import com.amazonaws.services.identitymanagement.model.EvaluationResult;
+import com.amazonaws.services.identitymanagement.model.InstanceProfile;
+import com.amazonaws.services.identitymanagement.model.Role;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.aws.util.AwsIamService;
+import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudS3View;
+import com.sequenceiq.cloudbreak.validation.ValidationResult.ValidationResultBuilder;
+
+@Component
+public class AwsLogRolePermissionValidator {
+    @Inject
+    private AwsIamService awsIamService;
+
+    public void validate(AmazonIdentityManagement iam, InstanceProfile instanceProfile,
+                            CloudS3View cloudFileSystem, ValidationResultBuilder validationResultBuilder) {
+        SortedSet<String> failedActions = new TreeSet<>();
+
+        // TODO need to figure out how to get LOGS_LOCATION_BASE value
+        Map<String, String> replacements = Map.ofEntries(
+            Map.entry("${LOGS_LOCATION_BASE}", "")
+        );
+
+        Policy policy = awsIamService.getPolicy("aws-cdp-log-policy.json", replacements);
+        List<Role> roles = instanceProfile.getRoles();
+        List<Policy> policies = Collections.singletonList(policy);
+        for (Role role : roles) {
+            List<EvaluationResult> evaluationResults = awsIamService.validateRolePolicies(iam, role,
+                policies);
+            failedActions.addAll(getFailedActions(role, evaluationResults));
+        }
+
+        if (!failedActions.isEmpty()) {
+            validationResultBuilder.error(String.format("The role(s) (%s) don't have the required permissions:%n%s",
+                String.join(", ", roles.stream().map(Role::getArn).collect(Collectors.toCollection(TreeSet::new))),
+                String.join("\n", failedActions)));
+        }
+    }
+
+    /**
+     * Finds all the denied results and generates a set of failed actions
+     * @param role Role that was being evaluated
+     * @param evaluationResults result of the simulate policy
+     */
+    SortedSet<String> getFailedActions(Role role, List<EvaluationResult> evaluationResults) {
+        return evaluationResults.stream()
+                    .filter(evaluationResult -> evaluationResult.getEvalDecision().toLowerCase().contains("deny"))
+                    .map(evaluationResult -> String.format("%s:%s:%s", role.getArn(),
+                        evaluationResult.getEvalActionName(), evaluationResult.getEvalResourceName()))
+                    .collect(Collectors.toCollection(TreeSet::new));
+    }
+}

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsRangerAuditRolePermissionValidator.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsRangerAuditRolePermissionValidator.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.cloudbreak.cloud.aws.validator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.service.identitymapping.AccountMappingSubject;
+import com.sequenceiq.common.api.cloudstorage.StorageLocationBase;
+import com.sequenceiq.common.model.CloudStorageCdpService;
+import com.sequenceiq.common.model.FileSystemType;
+
+@Component
+public class AwsRangerAuditRolePermissionValidator extends AwsIDBrokerMappedRolePermissionValidator {
+    @Override
+    Set<String> getUsers() {
+        return AccountMappingSubject.RANGER_AUDIT_USERS;
+    }
+
+    @Override
+    List<String> getPolicyFileNames(boolean s3guardEnabled) {
+        List<String> policyFileNames = new ArrayList<>();
+        policyFileNames.add("aws-cdp-bucket-access-policy.json");
+        policyFileNames.add("aws-cdp-ranger-audit-s3-policy.json");
+        if (s3guardEnabled) {
+            policyFileNames.add("aws-cdp-dynamodb-policy.json");
+        }
+
+        return policyFileNames;
+    }
+
+    @Override
+    String getStorageLocationBase(StorageLocationBase location) {
+        return location.getValue()
+                    .replace(FileSystemType.S3.getProtocol() + "://", "")
+                    .replace("/ranger/audit", "");
+    }
+
+    @Override
+    boolean checkLocation(StorageLocationBase location) {
+        return CloudStorageCdpService.RANGER_AUDIT.equals(location.getType());
+    }
+}

--- a/cloud-aws/src/main/resources/definitions/cdp/aws-cdp-bucket-access-policy.json
+++ b/cloud-aws/src/main/resources/definitions/cdp/aws-cdp-bucket-access-policy.json
@@ -1,0 +1,53 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:CreateJob",
+        "s3:GetAccountPublicAccessBlock",
+        "s3:HeadBucket",
+        "s3:ListJobs"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "AllowListingOfDataLakeFolder",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetAccelerateConfiguration",
+        "s3:GetAnalyticsConfiguration",
+        "s3:GetBucketAcl",
+        "s3:GetBucketCORS",
+        "s3:GetBucketLocation",
+        "s3:GetBucketLogging",
+        "s3:GetBucketNotification",
+        "s3:GetBucketPolicy",
+        "s3:GetBucketPolicyStatus",
+        "s3:GetBucketPublicAccessBlock",
+        "s3:GetBucketRequestPayment",
+        "s3:GetBucketTagging",
+        "s3:GetBucketVersioning",
+        "s3:GetBucketWebsite",
+        "s3:GetEncryptionConfiguration",
+        "s3:GetInventoryConfiguration",
+        "s3:GetLifecycleConfiguration",
+        "s3:GetMetricsConfiguration",
+        "s3:GetObject",
+        "s3:GetObjectAcl",
+        "s3:GetObjectTagging",
+        "s3:GetObjectVersion",
+        "s3:GetObjectVersionAcl",
+        "s3:GetObjectVersionTagging",
+        "s3:GetReplicationConfiguration",
+        "s3:ListBucket",
+        "s3:ListBucketMultipartUploads",
+        "s3:ListMultipartUploadParts"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${DATALAKE_BUCKET}",
+        "arn:aws:s3:::${DATALAKE_BUCKET}/*"
+      ]
+    }
+  ]
+}

--- a/cloud-aws/src/main/resources/definitions/cdp/aws-cdp-datalake-admin-s3-policy.json
+++ b/cloud-aws/src/main/resources/definitions/cdp/aws-cdp-datalake-admin-s3-policy.json
@@ -1,0 +1,51 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "VisualEditor3",
+      "Effect": "Allow",
+      "Action": [
+        "s3:AbortMultipartUpload",
+        "s3:DeleteObject",
+        "s3:DeleteObjectVersion",
+        "s3:GetAccelerateConfiguration",
+        "s3:GetAnalyticsConfiguration",
+        "s3:GetBucketAcl",
+        "s3:GetBucketCORS",
+        "s3:GetBucketLocation",
+        "s3:GetBucketLogging",
+        "s3:GetBucketNotification",
+        "s3:GetBucketObjectLockConfiguration",
+        "s3:GetBucketPolicy",
+        "s3:GetBucketPolicyStatus",
+        "s3:GetBucketPublicAccessBlock",
+        "s3:GetBucketRequestPayment",
+        "s3:GetBucketTagging",
+        "s3:GetBucketVersioning",
+        "s3:GetBucketWebsite",
+        "s3:GetEncryptionConfiguration",
+        "s3:GetInventoryConfiguration",
+        "s3:GetLifecycleConfiguration",
+        "s3:GetMetricsConfiguration",
+        "s3:GetObject",
+        "s3:GetObjectAcl",
+        "s3:GetObjectLegalHold",
+        "s3:GetObjectRetention",
+        "s3:GetObjectTagging",
+        "s3:GetObjectVersion",
+        "s3:GetObjectVersionAcl",
+        "s3:GetObjectVersionTagging",
+        "s3:GetReplicationConfiguration",
+        "s3:ListBucket",
+        "s3:ListBucketMultipartUploads",
+        "s3:ListBucketVersions",
+        "s3:ListMultipartUploadParts",
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${STORAGE_LOCATION_BASE}",
+        "arn:aws:s3:::${STORAGE_LOCATION_BASE}/*"
+      ]
+    }
+  ]
+}

--- a/cloud-aws/src/main/resources/definitions/cdp/aws-cdp-dynamodb-policy.json
+++ b/cloud-aws/src/main/resources/definitions/cdp/aws-cdp-dynamodb-policy.json
@@ -1,0 +1,32 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:List*",
+        "dynamodb:DescribeReservedCapacity*",
+        "dynamodb:DescribeLimits",
+        "dynamodb:DescribeTimeToLive"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:BatchGetItem",
+        "dynamodb:BatchWriteItem",
+        "dynamodb:DeleteItem",
+        "dynamodb:DescribeTable",
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:Query",
+        "dynamodb:UpdateItem",
+        "dynamodb:Scan",
+        "dynamodb:TagResource",
+        "dynamodb:UntagResource"
+      ],
+      "Resource": "arn:aws:dynamodb:*:*:table/${DYNAMODB_TABLE_NAME}"
+    }
+  ]
+}

--- a/cloud-aws/src/main/resources/definitions/cdp/aws-cdp-log-policy.json
+++ b/cloud-aws/src/main/resources/definitions/cdp/aws-cdp-log-policy.json
@@ -1,0 +1,15 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:AbortMultipartUpload",
+        "s3:GetObject",
+        "s3:ListMultipartUploadParts",
+        "s3:PutObject"
+      ],
+      "Resource": "arn:aws:s3:::${LOGS_LOCATION_BASE}/*"
+    }
+  ]
+}

--- a/cloud-aws/src/main/resources/definitions/cdp/aws-cdp-ranger-audit-s3-policy.json
+++ b/cloud-aws/src/main/resources/definitions/cdp/aws-cdp-ranger-audit-s3-policy.json
@@ -1,0 +1,24 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "FullObjectAccessUnderAuditDir",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject"
+      ],
+      "Resource": "arn:aws:s3:::${STORAGE_LOCATION_BASE}/ranger/audit/*"
+    },
+    {
+      "Sid": "LimitedAccessToDataLakeBucket",
+      "Effect": "Allow",
+      "Action": [
+        "s3:AbortMultipartUpload",
+        "s3:ListBucket",
+        "s3:ListBucketMultipartUploads"
+      ],
+      "Resource": "arn:aws:s3:::${DATALAKE_BUCKET}"
+    }
+  ]
+}

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/util/AwsIamServiceTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/util/AwsIamServiceTest.java
@@ -1,0 +1,282 @@
+package com.sequenceiq.cloudbreak.cloud.aws.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import com.amazonaws.auth.policy.Policy;
+import com.amazonaws.auth.policy.Principal;
+import com.amazonaws.auth.policy.Resource;
+import com.amazonaws.auth.policy.Statement;
+import com.amazonaws.auth.policy.Statement.Effect;
+import com.amazonaws.auth.policy.actions.S3Actions;
+import com.amazonaws.auth.policy.actions.SecurityTokenServiceActions;
+import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
+import com.amazonaws.services.identitymanagement.model.GetInstanceProfileRequest;
+import com.amazonaws.services.identitymanagement.model.GetInstanceProfileResult;
+import com.amazonaws.services.identitymanagement.model.GetRoleRequest;
+import com.amazonaws.services.identitymanagement.model.GetRoleResult;
+import com.amazonaws.services.identitymanagement.model.InstanceProfile;
+import com.amazonaws.services.identitymanagement.model.NoSuchEntityException;
+import com.amazonaws.services.identitymanagement.model.Role;
+import com.amazonaws.services.identitymanagement.model.ServiceFailureException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.Mock;
+
+import com.sequenceiq.cloudbreak.validation.ValidationResult;
+import com.sequenceiq.cloudbreak.validation.ValidationResult.ValidationResultBuilder;
+
+@ExtendWith(MockitoExtension.class)
+public class AwsIamServiceTest {
+    @Mock
+    private AmazonIdentityManagement iam;
+
+    @InjectMocks
+    private AwsIamService awsIamService;
+
+    @Test
+    public void invalidInstanceProfileArn() {
+        assertThat(awsIamService.getInstanceProfile(iam, null, null)).isNull();
+        assertThat(awsIamService.getInstanceProfile(iam, "", null)).isNull();
+        assertThat(awsIamService.getInstanceProfile(iam, "abc", null)).isNull();
+    }
+
+    @Test
+    public void missingInstanceProfile() {
+        when(iam.getInstanceProfile(any(GetInstanceProfileRequest.class))).thenThrow(NoSuchEntityException.class);
+
+        String instanceProfileArn = "account/missingInstanceProfile";
+        ValidationResultBuilder validationRequestBuilder = new ValidationResultBuilder();
+        InstanceProfile instanceProfile = awsIamService.getInstanceProfile(iam, instanceProfileArn,
+            validationRequestBuilder);
+
+        assertThat(instanceProfile).isNull();
+        ValidationResult validationResult = validationRequestBuilder.build();
+        assertThat(validationResult.hasError()).isTrue();
+        assertThat(validationResult.getErrors()).isEqualTo(
+            Collections.singletonList(String.format("Instance profile (%s) doesn't exist.",
+                instanceProfileArn)));
+    }
+
+    @Test
+    public void instanceProfileServiceFailureException() {
+        when(iam.getInstanceProfile(any(GetInstanceProfileRequest.class))).thenThrow(ServiceFailureException.class);
+
+        String instanceProfileArn = "account/potentialInstanceProfile";
+        ValidationResultBuilder validationRequestBuilder = new ValidationResultBuilder();
+        InstanceProfile instanceProfile = awsIamService.getInstanceProfile(iam, instanceProfileArn,
+            validationRequestBuilder);
+
+        assertThat(instanceProfile).isNull();
+        ValidationResult validationResult = validationRequestBuilder.build();
+        assertThat(validationResult.hasError()).isTrue();
+        assertThat(validationResult.getErrors()).isEqualTo(
+            Collections.singletonList(String.format("Instance profile (%s) doesn't exist.",
+                instanceProfileArn)));
+    }
+
+    @Test
+    public void validInstanceProfile() {
+        String instanceProfileArn = "account/validInstanceProfile";
+
+        InstanceProfile expectedInstanceProfile = new InstanceProfile().withArn(instanceProfileArn);
+        GetInstanceProfileResult getInstanceProfileResult = mock(GetInstanceProfileResult.class);
+        when(getInstanceProfileResult.getInstanceProfile()).thenReturn(expectedInstanceProfile);
+        when(iam.getInstanceProfile(any(GetInstanceProfileRequest.class))).thenReturn(getInstanceProfileResult);
+
+        ValidationResultBuilder validationRequestBuilder = new ValidationResultBuilder();
+        InstanceProfile instanceProfile = awsIamService.getInstanceProfile(iam, instanceProfileArn,
+            validationRequestBuilder);
+
+        assertThat(instanceProfile.getArn()).isEqualTo(instanceProfileArn);
+        assertThat(validationRequestBuilder.build().hasError()).isFalse();
+    }
+
+    @Test
+    public void invalidRoleArn() {
+        assertThat(awsIamService.getRole(iam, null, null)).isNull();
+        assertThat(awsIamService.getRole(iam, "", null)).isNull();
+        assertThat(awsIamService.getRole(iam, "abc", null)).isNull();
+    }
+
+    @Test
+    public void missingRole() {
+        when(iam.getRole(any(GetRoleRequest.class))).thenThrow(NoSuchEntityException.class);
+
+        String roleArn = "account/missingRole";
+        ValidationResultBuilder validationRequestBuilder = new ValidationResultBuilder();
+        Role role = awsIamService.getRole(iam, roleArn, validationRequestBuilder);
+
+        assertThat(role).isNull();
+        ValidationResult validationResult = validationRequestBuilder.build();
+        assertThat(validationResult.hasError()).isTrue();
+        assertThat(validationResult.getErrors()).isEqualTo(
+            Collections.singletonList(String.format("Role (%s) doesn't exist.", roleArn)));
+    }
+
+    @Test
+    public void roleServiceFailureException() {
+        when(iam.getRole(any(GetRoleRequest.class))).thenThrow(ServiceFailureException.class);
+
+        String roleArn = "account/potentialRole";
+        ValidationResultBuilder validationRequestBuilder = new ValidationResultBuilder();
+        Role role = awsIamService.getRole(iam, roleArn, validationRequestBuilder);
+
+        assertThat(role).isNull();
+        ValidationResult validationResult = validationRequestBuilder.build();
+        assertThat(validationResult.hasError()).isTrue();
+        assertThat(validationResult.getErrors()).isEqualTo(
+            Collections.singletonList(String.format("Role (%s) doesn't exist.", roleArn)));
+    }
+
+    @Test
+    public void validRole() {
+        String roleArn = "account/validRole";
+
+        Role expectedRole = new Role().withArn(roleArn);
+        GetRoleResult getRoleResult = mock(GetRoleResult.class);
+        when(getRoleResult.getRole()).thenReturn(expectedRole);
+        when(iam.getRole(any(GetRoleRequest.class))).thenReturn(getRoleResult);
+
+        ValidationResultBuilder validationRequestBuilder = new ValidationResultBuilder();
+        Role role = awsIamService.getRole(iam, roleArn, validationRequestBuilder);
+
+        assertThat(role.getArn()).isEqualTo(roleArn);
+        assertThat(validationRequestBuilder.build().hasError()).isFalse();
+    }
+
+    @Test
+    public void testGetAssumeRolePolicyDocument() throws IOException {
+        String assumeRolePolicyDocument = awsIamService.getResourceFileAsString(
+            "json/aws-assume-role-policy-document.json");
+        String encodedAssumeRolePolicyDocument = URLEncoder.encode(assumeRolePolicyDocument,
+            StandardCharsets.UTF_8);
+
+
+        Statement statement = new Statement(Effect.Allow).withId("1")
+                                    .withPrincipals(new Principal("AWS", "arn:aws:iam::123456890:role/assume-role"))
+                                    .withActions(SecurityTokenServiceActions.AssumeRole);
+        Policy expectedAssumeRolePolicy = new Policy().withStatements(statement);
+
+        Role role = mock(Role.class);
+        when(role.getAssumeRolePolicyDocument()).thenReturn(encodedAssumeRolePolicyDocument);
+
+        Policy assumeRolePolicy = awsIamService.getAssumeRolePolicy(role);
+        assertThat(assumeRolePolicy).isNotNull();
+        assertThat(assumeRolePolicy.toJson()).isEqualTo(expectedAssumeRolePolicy.toJson());
+    }
+
+    @Test
+    public void testInvalidGetAssumeRolePolicyDocument() {
+        assertThat(awsIamService.getAssumeRolePolicy(new Role())).isNull();
+        Role role = new Role().withAssumeRolePolicyDocument("}garbage");
+        assertThat(awsIamService.getAssumeRolePolicy(role)).isNull();
+    }
+
+    @Test
+    public void testHandleTemplateReplacements() {
+        assertThat(awsIamService.handleTemplateReplacements(null, Collections.emptyMap())).isNull();
+        assertThat(awsIamService.handleTemplateReplacements("", Collections.emptyMap())).isEqualTo("");
+        assertThat(awsIamService.handleTemplateReplacements("abc", Collections.emptyMap())).isEqualTo("abc");
+
+        assertThat(awsIamService.handleTemplateReplacements("abc",
+            Collections.singletonMap("abc", "def"))).isEqualTo("def");
+        assertThat(awsIamService.handleTemplateReplacements("abcabc",
+            Collections.singletonMap("abc", "def"))).isEqualTo("defdef");
+
+        Map<String, String> replacements = Map.ofEntries(
+            Map.entry("abc", "def"),
+            Map.entry("ghi", "jkl")
+        );
+        assertThat(awsIamService.handleTemplateReplacements("abc ghi", replacements)).isEqualTo("def jkl");
+    }
+
+    @Test
+    public void testGetPolicy() {
+        assertThat(awsIamService.getPolicy("abc", Collections.emptyMap())).isNull();
+
+        Policy expectedPolicyNoReplacements = new Policy().withStatements(
+            new Statement(Effect.Allow).withId("FullObjectAccessUnderAuditDir")
+                .withActions(S3Actions.GetObject, S3Actions.PutObject)
+                .withResources(new Resource("arn:aws:s3:::${STORAGE_LOCATION_BASE}/ranger/audit/*")),
+            new Statement(Effect.Allow).withId("LimitedAccessToDataLakeBucket")
+                .withActions(S3Actions.AbortMultipartUpload, S3Actions.ListObjects,
+                    S3Actions.ListBucketMultipartUploads)
+                .withResources(new Resource("arn:aws:s3:::${DATALAKE_BUCKET}"))
+        );
+        assertThat(awsIamService.getPolicy("aws-cdp-ranger-audit-s3-policy.json",
+            Collections.emptyMap()).toJson()).isEqualTo(expectedPolicyNoReplacements.toJson());
+
+        Policy expectedPolicyWithReplacements = new Policy().withStatements(
+            new Statement(Effect.Allow).withId("FullObjectAccessUnderAuditDir")
+                .withActions(S3Actions.GetObject, S3Actions.PutObject)
+                .withResources(new Resource("arn:aws:s3:::mybucket/mycluster/ranger/audit/*")),
+            new Statement(Effect.Allow).withId("LimitedAccessToDataLakeBucket")
+                .withActions(S3Actions.AbortMultipartUpload, S3Actions.ListObjects,
+                    S3Actions.ListBucketMultipartUploads)
+                .withResources(new Resource("arn:aws:s3:::mybucket"))
+        );
+
+        Map<String, String> policyReplacements = new HashMap<>();
+        policyReplacements.put("${STORAGE_LOCATION_BASE}", "mybucket/mycluster");
+        policyReplacements.put("${DATALAKE_BUCKET}", "mybucket");
+        assertThat(awsIamService.getPolicy("aws-cdp-ranger-audit-s3-policy.json",
+            policyReplacements).toJson()).isEqualTo(expectedPolicyWithReplacements.toJson());
+    }
+
+    @Test
+    public void testGetStatementActions() {
+        assertThat(awsIamService.getStatementActions(new Statement(Effect.Allow)))
+            .isEqualTo(new TreeSet<>());
+
+        SortedSet<String> expectedSingleAction = new TreeSet<>();
+        expectedSingleAction.add(S3Actions.GetObject.getActionName());
+        Statement statementSingleAction = new Statement(Effect.Allow).withActions(S3Actions.GetObject);
+        assertThat(awsIamService.getStatementActions(statementSingleAction))
+            .isEqualTo(expectedSingleAction);
+
+        SortedSet<String> expectedMultipleActions = new TreeSet<>();
+        expectedMultipleActions.add(S3Actions.GetObject.getActionName());
+        expectedMultipleActions.add(S3Actions.PutObject.getActionName());
+        Statement statementMultipleActions = new Statement(Effect.Allow)
+                                                    .withActions(S3Actions.GetObject, S3Actions.PutObject);
+        assertThat(awsIamService.getStatementActions(statementMultipleActions))
+            .isEqualTo(expectedMultipleActions);
+    }
+
+    @Test
+    public void testGetStatementResources() {
+        assertThat(awsIamService.getStatementResources(new Statement(Effect.Allow)))
+            .isEqualTo(new TreeSet<>());
+
+        SortedSet<String> expectedSingleResource = new TreeSet<>();
+        expectedSingleResource.add("resource1");
+        Statement statementSingleResouce = new Statement(Effect.Allow)
+                                                    .withResources(new Resource("resource1"));
+        assertThat(awsIamService.getStatementResources(statementSingleResouce))
+            .isEqualTo(expectedSingleResource);
+
+        SortedSet<String> expectedMultipleResources = new TreeSet<>();
+        expectedMultipleResources.add("resource1");
+        expectedMultipleResources.add("resource2");
+        Statement statementMultipleResources = new Statement(Effect.Allow)
+                                    .withResources(
+                                        new Resource("resource1"),
+                                        new Resource("resource2"));
+        assertThat(awsIamService.getStatementResources(statementMultipleResources))
+            .isEqualTo(expectedMultipleResources);
+    }
+}

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsDataAccessRolePermissionValidatorTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsDataAccessRolePermissionValidatorTest.java
@@ -1,0 +1,87 @@
+package com.sequenceiq.cloudbreak.cloud.aws.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudS3View;
+import com.sequenceiq.cloudbreak.service.identitymapping.AccountMappingSubject;
+import com.sequenceiq.common.api.cloudstorage.StorageLocationBase;
+import com.sequenceiq.common.model.CloudIdentityType;
+import com.sequenceiq.common.model.FileSystemType;
+
+public class AwsDataAccessRolePermissionValidatorTest extends AwsIDBrokerMappedRolePermissionValidatorTest {
+    private final AwsDataAccessRolePermissionValidator awsDataAccessRolePermissionValidator =
+        new AwsDataAccessRolePermissionValidator();
+
+    @Override
+    public AwsIDBrokerMappedRolePermissionValidator getValidator() {
+        return awsDataAccessRolePermissionValidator;
+    }
+
+    @Override
+    public void testGetUsers() {
+        assertThat(awsDataAccessRolePermissionValidator.getUsers())
+            .isEqualTo(AccountMappingSubject.DATA_ACCESS_USERS);
+    }
+
+    @Override
+    public void testGetPolicyFileNames() {
+        List<String> expectedPolicyFileNamesNoS3Guard = Arrays.asList(
+            "aws-cdp-bucket-access-policy.json",
+            "aws-cdp-datalake-admin-s3-policy.json"
+        );
+        List<String> policyFileNamesNoS3Guard = awsDataAccessRolePermissionValidator
+                                                    .getPolicyFileNames(false);
+        assertThat(policyFileNamesNoS3Guard).isEqualTo(expectedPolicyFileNamesNoS3Guard);
+
+        List<String> expectedPolicyFileNamesS3Guard = Arrays.asList(
+            "aws-cdp-bucket-access-policy.json",
+            "aws-cdp-datalake-admin-s3-policy.json",
+            "aws-cdp-dynamodb-policy.json"
+        );
+        List<String> policyFileNamesS3Guard = awsDataAccessRolePermissionValidator
+                                                    .getPolicyFileNames(true);
+        assertThat(policyFileNamesS3Guard).isEqualTo(expectedPolicyFileNamesS3Guard);
+    }
+
+    @Override
+    public void testGetStorageLocationBase() {
+        String path = "testBucket/ranger/audit";
+        String expectedStorageLocationBase = "testBucket/ranger/audit";
+        StorageLocationBase location = new StorageLocationBase();
+        location.setValue(String.format("%s://%s", FileSystemType.S3.getProtocol(), path));
+        String storageLocationBase = awsDataAccessRolePermissionValidator.getStorageLocationBase(location);
+        assertThat(storageLocationBase).isEqualTo(expectedStorageLocationBase);
+    }
+
+    @Override
+    public void testCheckLocation() {
+        assertThat(awsDataAccessRolePermissionValidator.checkLocation(new StorageLocationBase())).isTrue();
+    }
+
+    @Override
+    public void testGetPolicyJsonReplacements() {
+        String storageLocationBaseStr = "bucket/cluster";
+        String bucket = "bucket";
+        String dynamodbTableName = "tableName";
+
+        Map<String, String> expectedPolicyJsonReplacements = Map.ofEntries(
+            Map.entry("${STORAGE_LOCATION_BASE}", storageLocationBaseStr),
+            Map.entry("${DATALAKE_BUCKET}", bucket),
+            Map.entry("${DYNAMODB_TABLE_NAME}", dynamodbTableName)
+        );
+
+        StorageLocationBase storageLocationBase = new StorageLocationBase();
+        storageLocationBase.setValue(storageLocationBaseStr);
+        CloudS3View cloudFileSystem = new CloudS3View(CloudIdentityType.ID_BROKER);
+        cloudFileSystem.setS3GuardDynamoTableName(dynamodbTableName);
+        Map<String, String> policyJsonReplacements = awsDataAccessRolePermissionValidator
+                                                        .getPolicyJsonReplacements(storageLocationBase,
+                                                            cloudFileSystem);
+
+        assertThat(policyJsonReplacements).isEqualTo(expectedPolicyJsonReplacements);
+    }
+}

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsIDBrokerAssumeRoleValidatorTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsIDBrokerAssumeRoleValidatorTest.java
@@ -1,0 +1,140 @@
+package com.sequenceiq.cloudbreak.cloud.aws.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
+import com.amazonaws.services.identitymanagement.model.EvaluationResult;
+import com.amazonaws.services.identitymanagement.model.InstanceProfile;
+import com.amazonaws.services.identitymanagement.model.PolicyEvaluationDecisionType;
+import com.amazonaws.services.identitymanagement.model.Role;
+import com.amazonaws.services.identitymanagement.model.SimulatePrincipalPolicyRequest;
+import com.amazonaws.services.identitymanagement.model.SimulatePrincipalPolicyResult;
+import com.sequenceiq.cloudbreak.cloud.aws.util.AwsIamService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.sequenceiq.cloudbreak.validation.ValidationResult;
+import com.sequenceiq.cloudbreak.validation.ValidationResult.ValidationResultBuilder;
+
+@ExtendWith(MockitoExtension.class)
+public class AwsIDBrokerAssumeRoleValidatorTest {
+    @Spy
+    private AwsIamService awsIamService;
+
+    @Mock
+    private AmazonIdentityManagement iam;
+
+    @InjectMocks
+    private AwsIDBrokerAssumeRoleValidator awsIDBrokerAssumeRoleValidator;
+
+    @Test
+    public void checkCannotAssumeRole() {
+        Role instanceProfileRole = new Role();
+        InstanceProfile instanceProfile = new InstanceProfile().withRoles(instanceProfileRole);
+
+        Role role = new Role();
+
+        EvaluationResult evalResult = new EvaluationResult()
+                                            .withEvalDecision(PolicyEvaluationDecisionType.ImplicitDeny);
+        when(iam.simulatePrincipalPolicy(any(SimulatePrincipalPolicyRequest.class)))
+            .thenReturn(new SimulatePrincipalPolicyResult().withEvaluationResults(evalResult));
+
+        assertThat(awsIDBrokerAssumeRoleValidator.canAssumeRole(iam, instanceProfile, role)).isFalse();
+    }
+
+    @Test
+    public void checkCanAssumeRole() {
+        Role instanceProfileRole = new Role();
+        InstanceProfile instanceProfile = new InstanceProfile().withRoles(instanceProfileRole);
+
+        Role role = new Role();
+
+        EvaluationResult evalResult = new EvaluationResult()
+                                            .withEvalDecision(PolicyEvaluationDecisionType.Allowed);
+        when(iam.simulatePrincipalPolicy(any(SimulatePrincipalPolicyRequest.class)))
+            .thenReturn(new SimulatePrincipalPolicyResult().withEvaluationResults(evalResult));
+
+        assertThat(awsIDBrokerAssumeRoleValidator.canAssumeRole(iam, instanceProfile, role)).isTrue();
+    }
+
+    @Test
+    public void checkCanAssumeRoles() {
+        Role instanceProfileRole = new Role();
+        InstanceProfile instanceProfile = new InstanceProfile().withRoles(instanceProfileRole);
+
+        Role role = new Role();
+        Collection<Role> roles = Collections.singletonList(role);
+
+        EvaluationResult evalResult = new EvaluationResult()
+                                            .withEvalDecision(PolicyEvaluationDecisionType.Allowed);
+        when(iam.simulatePrincipalPolicy(any(SimulatePrincipalPolicyRequest.class)))
+            .thenReturn(new SimulatePrincipalPolicyResult().withEvaluationResults(evalResult));
+
+        ValidationResultBuilder validationResultBuilder = new ValidationResultBuilder();
+        assertThat(awsIDBrokerAssumeRoleValidator.canAssumeRoles(iam, instanceProfile, roles,
+            validationResultBuilder)).isTrue();
+        assertThat(validationResultBuilder.build().hasError()).isFalse();
+    }
+
+    @Test
+    public void checkCannotAssumeRoles() {
+        Role instanceProfileRole = new Role();
+        InstanceProfile instanceProfile = new InstanceProfile().withArn("instanceProfileArn")
+                                                .withRoles(instanceProfileRole);
+
+        Role role = new Role().withArn("roleArn");
+        Collection<Role> roles = Collections.singletonList(role);
+
+        EvaluationResult evalResult = new EvaluationResult()
+                                            .withEvalDecision(PolicyEvaluationDecisionType.ImplicitDeny);
+        when(iam.simulatePrincipalPolicy(any(SimulatePrincipalPolicyRequest.class)))
+            .thenReturn(new SimulatePrincipalPolicyResult().withEvaluationResults(evalResult));
+
+        ValidationResultBuilder validationResultBuilder = new ValidationResultBuilder();
+        assertThat(awsIDBrokerAssumeRoleValidator.canAssumeRoles(iam, instanceProfile, roles,
+            validationResultBuilder)).isFalse();
+        ValidationResult validationResult = validationResultBuilder.build();
+        assertThat(validationResult.hasError()).isTrue();
+        assertThat(validationResult.getErrors()).isEqualTo(Collections.singletonList(
+            String.format("IDBroker instance profile (%s) doesn't have permissions to assume the role(s): %s",
+                instanceProfile.getArn(), Collections.singletonList(role.getArn()))));
+    }
+
+    @Test
+    public void checkCannotAssumeOneOfTheRoles() {
+        Role instanceProfileRole = new Role();
+        InstanceProfile instanceProfile = new InstanceProfile().withArn("instanceProfileArn")
+                                                .withRoles(instanceProfileRole);
+
+        Role role1 = new Role().withArn("role1Arn");
+        Role role2 = new Role().withArn("role2Arn");
+        Collection<Role> roles = Arrays.asList(role1, role2);
+
+        EvaluationResult evalResult1 = new EvaluationResult()
+                                            .withEvalDecision(PolicyEvaluationDecisionType.Allowed);
+        EvaluationResult evalResult2 = new EvaluationResult()
+                                            .withEvalDecision(PolicyEvaluationDecisionType.ImplicitDeny);
+        when(iam.simulatePrincipalPolicy(any(SimulatePrincipalPolicyRequest.class)))
+            .thenReturn(new SimulatePrincipalPolicyResult().withEvaluationResults(evalResult1))
+            .thenReturn(new SimulatePrincipalPolicyResult().withEvaluationResults(evalResult2));
+
+        ValidationResultBuilder validationResultBuilder = new ValidationResultBuilder();
+        assertThat(awsIDBrokerAssumeRoleValidator.canAssumeRoles(iam, instanceProfile, roles,
+            validationResultBuilder)).isFalse();
+        ValidationResult validationResult = validationResultBuilder.build();
+        assertThat(validationResult.hasError()).isTrue();
+        assertThat(validationResult.getErrors()).isEqualTo(Collections.singletonList(
+            String.format("IDBroker instance profile (%s) doesn't have permissions to assume the role(s): %s",
+                instanceProfile.getArn(), Collections.singletonList(role2.getArn()))));
+    }
+}

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsIDBrokerMappedRolePermissionValidatorTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsIDBrokerMappedRolePermissionValidatorTest.java
@@ -1,0 +1,107 @@
+package com.sequenceiq.cloudbreak.cloud.aws.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
+import com.amazonaws.services.identitymanagement.model.EvaluationResult;
+import com.amazonaws.services.identitymanagement.model.PolicyEvaluationDecisionType;
+import com.amazonaws.services.identitymanagement.model.Role;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public abstract class AwsIDBrokerMappedRolePermissionValidatorTest {
+    @Mock
+    protected AmazonIdentityManagement iam;
+
+    public abstract AwsIDBrokerMappedRolePermissionValidator getValidator();
+
+    @Test
+    public abstract void testGetUsers();
+
+    @Test
+    public abstract void testGetPolicyFileNames();
+
+    @Test
+    public abstract void testGetStorageLocationBase();
+
+    @Test
+    public abstract void testCheckLocation();
+
+    @Test
+    public abstract void testGetPolicyJsonReplacements();
+
+    @Test
+    public void testGetRoleArnsForUsers() {
+        assertThat(getValidator().getRoleArnsForUsers(Collections.emptyList(),
+            Collections.emptyMap())).isEqualTo(Collections.emptySortedSet());
+
+        List<String> users = Arrays.asList("user1", "user2", "user3");
+        assertThat(getValidator().getRoleArnsForUsers(users,
+            Collections.emptyMap())).isEqualTo(Collections.emptySortedSet());
+
+        Map<String, String> userMappings = new TreeMap<>();
+        userMappings.put("user1", "role1");
+        userMappings.put("user2", "role1");
+        userMappings.put("user3", "role2");
+        List<String> allUsers = new ArrayList<>(userMappings.keySet());
+        SortedSet<String> expectedRoles = new TreeSet<>(userMappings.values());
+        assertThat(getValidator().getRoleArnsForUsers(allUsers, userMappings))
+            .isEqualTo(expectedRoles);
+
+        List<String> oneUser = Collections.singletonList("user1");
+        SortedSet<String> expectedOneRole = new TreeSet<>();
+        expectedOneRole.add("role1");
+        assertThat(getValidator().getRoleArnsForUsers(oneUser, userMappings))
+            .isEqualTo(expectedOneRole);
+    }
+
+    @Test
+    public void testPolicies() {
+        assertThat(getValidator().getPolicies(Collections.emptyList(),
+            Collections.emptyMap())).isEqualTo(Collections.emptyList());
+    }
+
+    @Test
+    public void testGetFailedActions() {
+        Role role = new Role().withArn("testRole");
+        EvaluationResult allowEvalResult = new EvaluationResult()
+                                                .withEvalActionName("doAction")
+                                                .withEvalResourceName("goodResource")
+                                                .withEvalDecision(PolicyEvaluationDecisionType.Allowed);
+        EvaluationResult denyEvalResult = new EvaluationResult()
+                                                .withEvalActionName("doAction")
+                                                .withEvalResourceName("badResource")
+                                                .withEvalDecision(PolicyEvaluationDecisionType.ImplicitDeny);
+
+        assertThat(getValidator().getFailedActions(role,
+            Collections.emptyList())).isEqualTo(Collections.emptySortedSet());
+
+        List<EvaluationResult> allowEvalResults = Collections.singletonList(allowEvalResult);
+        assertThat(getValidator().getFailedActions(role,
+            allowEvalResults)).isEqualTo(Collections.emptySortedSet());
+
+        SortedSet<String> expectedFailedActions = new TreeSet<>();
+        expectedFailedActions.add(String.format("%s:%s:%s", role.getArn(),
+            denyEvalResult.getEvalActionName(), denyEvalResult.getEvalResourceName()));
+        List<EvaluationResult> denyEvalResults = Collections.singletonList(denyEvalResult);
+        assertThat(getValidator().getFailedActions(role, denyEvalResults))
+            .isEqualTo(expectedFailedActions);
+
+        List<EvaluationResult> multipleEvalResults = Arrays.asList(denyEvalResult,
+            allowEvalResult, denyEvalResult, denyEvalResult, allowEvalResult);
+        assertThat(getValidator().getFailedActions(role, multipleEvalResults))
+            .isEqualTo(expectedFailedActions);
+    }
+}

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsInstanceProfileEC2TrustValidatorTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsInstanceProfileEC2TrustValidatorTest.java
@@ -1,0 +1,170 @@
+package com.sequenceiq.cloudbreak.cloud.aws.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import com.amazonaws.auth.policy.Policy;
+import com.amazonaws.auth.policy.Principal;
+import com.amazonaws.auth.policy.Principal.Services;
+import com.amazonaws.auth.policy.Statement;
+import com.amazonaws.auth.policy.Statement.Effect;
+import com.amazonaws.auth.policy.actions.S3Actions;
+import com.amazonaws.auth.policy.actions.SecurityTokenServiceActions;
+import com.amazonaws.services.identitymanagement.model.InstanceProfile;
+import com.amazonaws.services.identitymanagement.model.Role;
+import com.sequenceiq.cloudbreak.cloud.aws.util.AwsIamService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.validation.ValidationResult;
+import com.sequenceiq.cloudbreak.validation.ValidationResult.ValidationResultBuilder;
+
+@ExtendWith(MockitoExtension.class)
+public class AwsInstanceProfileEC2TrustValidatorTest {
+    @Spy
+    private AwsIamService awsIamService;
+
+    @InjectMocks
+    private AwsInstanceProfileEC2TrustValidator awsInstanceProfileEC2TrustValidator;
+
+    @Test
+    public void ec2NotInPrincipals() {
+        assertThat(awsInstanceProfileEC2TrustValidator.checkEC2InPrincipals(
+            Collections.singletonList(Principal.All))).isFalse();
+        assertThat(awsInstanceProfileEC2TrustValidator.checkEC2InPrincipals(
+            Collections.singletonList(Principal.AllServices))).isFalse();
+        assertThat(awsInstanceProfileEC2TrustValidator.checkEC2InPrincipals(
+            Collections.singletonList(new Principal("Service", "invalid")))).isFalse();
+        assertThat(awsInstanceProfileEC2TrustValidator.checkEC2InPrincipals(
+            Arrays.asList(
+                Principal.All,
+                Principal.AllServices,
+                new Principal("Service", "invalid")
+            ))).isFalse();
+    }
+
+    @Test
+    public void ec2InPrincipals() {
+        assertThat(awsInstanceProfileEC2TrustValidator.checkEC2InPrincipals(Collections.singletonList(
+            new Principal("Service", Services.AmazonEC2.getServiceId())))).isTrue();
+        assertThat(awsInstanceProfileEC2TrustValidator.checkEC2InPrincipals(
+            Arrays.asList(
+                Principal.AllServices,
+                new Principal("Service", Services.AmazonEC2.getServiceId())
+            ))).isTrue();
+    }
+
+    @Test
+    public void assumeRoleNotInActions() {
+        assertThat(awsInstanceProfileEC2TrustValidator.checkAssumeRoleInActions(
+            Collections.singletonList(S3Actions.CreateBucket))).isFalse();
+        assertThat(awsInstanceProfileEC2TrustValidator.checkAssumeRoleInActions(
+            Collections.singletonList(SecurityTokenServiceActions.AssumeRoleWithSAML))).isFalse();
+        assertThat(awsInstanceProfileEC2TrustValidator.checkAssumeRoleInActions(
+            Arrays.asList(
+                S3Actions.CreateBucket,
+                SecurityTokenServiceActions.AssumeRoleWithSAML
+            ))).isFalse();
+    }
+
+    @Test
+    public void assumeRoleInActions() {
+        assertThat(awsInstanceProfileEC2TrustValidator.checkAssumeRoleInActions(
+            Collections.singletonList(SecurityTokenServiceActions.AssumeRole))).isTrue();
+        assertThat(awsInstanceProfileEC2TrustValidator.checkAssumeRoleInActions(
+            Arrays.asList(
+                S3Actions.CreateBucket,
+                SecurityTokenServiceActions.AssumeRole
+            ))).isTrue();
+    }
+
+    @Test
+    public void invalidInstanceProfileTrustNoRole() {
+        InstanceProfile instanceProfile = new InstanceProfile().withArn("noRoleArn");
+        checkInvalidInstanceProfileTrust(instanceProfile);
+    }
+
+    @Test
+    public void invalidInstanceProfileTrustOneRoleNoPolicy() {
+        Role role = new Role().withArn("roleArn");
+        InstanceProfile instanceProfile = new InstanceProfile().withArn("oneRoleNoPolicy")
+                                                .withRoles(role);
+        checkInvalidInstanceProfileTrust(instanceProfile);
+    }
+
+    @Test
+    public void invalidInstanceProfileTrustOneRoleBadPolicy() {
+        Role role = new Role().withArn("roleArn").withAssumeRolePolicyDocument("");
+        InstanceProfile instanceProfile = new InstanceProfile().withArn("oneRoleBadPolicy")
+                                                .withRoles(role);
+        checkInvalidInstanceProfileTrust(instanceProfile);
+    }
+
+    @Test
+    public void invalidInstanceProfileTrustOneRoleNoTrustPolicy() {
+        Role role = new Role().withArn("roleArn").withAssumeRolePolicyDocument(new Policy().toJson());
+        InstanceProfile instanceProfile = new InstanceProfile().withArn("oneRoleNoTrustPolicy")
+                                                .withRoles(role);
+        checkInvalidInstanceProfileTrust(instanceProfile);
+    }
+
+    @Test
+    public void invalidInstanceProfileTrustMultipleRolesNoTrustPolicy() {
+        Role role1 = new Role().withArn("roleArn").withAssumeRolePolicyDocument(new Policy().toJson());
+        Role role2 = new Role().withArn("roleArn").withAssumeRolePolicyDocument(new Policy().toJson());
+        InstanceProfile instanceProfile = new InstanceProfile().withArn("multipleRolesNoTrustPolicy")
+                                                .withRoles(role1, role2);
+        checkInvalidInstanceProfileTrust(instanceProfile);
+    }
+
+    @Test
+    public void validInstanceProfileTrustOneRoleTrusted() {
+        Policy trustedPolicy = getTrustedPolicy();
+        Role role = new Role().withArn("roleArn").withAssumeRolePolicyDocument(trustedPolicy.toJson());
+        InstanceProfile instanceProfile = new InstanceProfile().withArn("oneRoleTrusted")
+                                                .withRoles(role);
+        checkValidInstanceProfileTrust(instanceProfile);
+    }
+
+    @Test
+    public void validInstanceProfileTrustMultipleRolesTrusted() {
+        Policy untrustedPolicy = new Policy();
+        Role role1 = new Role().withArn("roleArn").withAssumeRolePolicyDocument(untrustedPolicy.toJson());
+        Policy trustedPolicy = getTrustedPolicy();
+        Role role2 = new Role().withArn("roleArn").withAssumeRolePolicyDocument(trustedPolicy.toJson());
+        InstanceProfile instanceProfile = new InstanceProfile().withArn("multipleRolesTrusted")
+                                                .withRoles(role1, role2);
+        checkValidInstanceProfileTrust(instanceProfile);
+    }
+
+    private Policy getTrustedPolicy() {
+        return new Policy().withStatements(
+            new Statement(Effect.Allow)
+                .withActions(SecurityTokenServiceActions.AssumeRole)
+                .withPrincipals(new Principal("Service", Services.AmazonEC2.getServiceId()))
+        );
+    }
+
+    private void checkInvalidInstanceProfileTrust(InstanceProfile instanceProfile) {
+        ValidationResultBuilder validationResultBuilder = new ValidationResultBuilder();
+        assertThat(awsInstanceProfileEC2TrustValidator.isTrusted(instanceProfile,
+            validationResultBuilder)).isFalse();
+        ValidationResult validationResult = validationResultBuilder.build();
+        assertThat(validationResult.hasError()).isTrue();
+        assertThat(validationResult.getErrors()).isEqualTo(Collections.singletonList(
+            String.format("The instance profile (%s) doesn't have an EC2 trust relationship.",
+                instanceProfile.getArn())));
+    }
+
+    private void checkValidInstanceProfileTrust(InstanceProfile instanceProfile) {
+        ValidationResultBuilder validationResultBuilder = new ValidationResultBuilder();
+        assertThat(awsInstanceProfileEC2TrustValidator.isTrusted(instanceProfile,
+            validationResultBuilder)).isTrue();
+        assertThat(validationResultBuilder.build().hasError()).isFalse();
+    }
+}

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsRangerAuditRolePermissionValidatorTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsRangerAuditRolePermissionValidatorTest.java
@@ -1,0 +1,96 @@
+package com.sequenceiq.cloudbreak.cloud.aws.validator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudS3View;
+import com.sequenceiq.cloudbreak.service.identitymapping.AccountMappingSubject;
+import com.sequenceiq.common.api.cloudstorage.StorageLocationBase;
+import com.sequenceiq.common.model.CloudIdentityType;
+import com.sequenceiq.common.model.CloudStorageCdpService;
+import com.sequenceiq.common.model.FileSystemType;
+
+public class AwsRangerAuditRolePermissionValidatorTest extends AwsIDBrokerMappedRolePermissionValidatorTest {
+    private final AwsRangerAuditRolePermissionValidator awsRangerAuditRolePermissionValidator =
+        new AwsRangerAuditRolePermissionValidator();
+
+    @Override
+    public AwsIDBrokerMappedRolePermissionValidator getValidator() {
+        return awsRangerAuditRolePermissionValidator;
+    }
+
+    @Override
+    public void testGetUsers() {
+        assertThat(awsRangerAuditRolePermissionValidator.getUsers())
+            .isEqualTo(AccountMappingSubject.RANGER_AUDIT_USERS);
+    }
+
+    @Override
+    public void testGetPolicyFileNames() {
+        List<String> expectedPolicyFileNamesNoS3Guard = Arrays.asList(
+            "aws-cdp-bucket-access-policy.json",
+            "aws-cdp-ranger-audit-s3-policy.json"
+        );
+        List<String> policyFileNamesNoS3Guard = awsRangerAuditRolePermissionValidator
+                                                    .getPolicyFileNames(false);
+        assertThat(policyFileNamesNoS3Guard).isEqualTo(expectedPolicyFileNamesNoS3Guard);
+
+        List<String> expectedPolicyFileNamesS3Guard = Arrays.asList(
+            "aws-cdp-bucket-access-policy.json",
+            "aws-cdp-ranger-audit-s3-policy.json",
+            "aws-cdp-dynamodb-policy.json"
+        );
+        List<String> policyFileNamesS3Guard = awsRangerAuditRolePermissionValidator
+                                                    .getPolicyFileNames(true);
+        assertThat(policyFileNamesS3Guard).isEqualTo(expectedPolicyFileNamesS3Guard);
+    }
+
+    @Override
+    public void testGetStorageLocationBase() {
+        String path = "testBucket/ranger/audit";
+        String expectedStorageLocationBase = "testBucket";
+        StorageLocationBase location = new StorageLocationBase();
+        location.setValue(String.format("%s://%s", FileSystemType.S3.getProtocol(), path));
+        String storageLocationBase = awsRangerAuditRolePermissionValidator.getStorageLocationBase(location);
+        assertThat(storageLocationBase).isEqualTo(expectedStorageLocationBase);
+    }
+
+    @Override
+    public void testCheckLocation() {
+        assertThat(awsRangerAuditRolePermissionValidator.checkLocation(new StorageLocationBase())).isFalse();
+
+        StorageLocationBase nonRangerAuditLocation = new StorageLocationBase();
+        nonRangerAuditLocation.setType(CloudStorageCdpService.HBASE_ROOT);
+        assertThat(awsRangerAuditRolePermissionValidator.checkLocation(nonRangerAuditLocation)).isFalse();
+
+        StorageLocationBase rangerAuditLocation = new StorageLocationBase();
+        rangerAuditLocation.setType(CloudStorageCdpService.RANGER_AUDIT);
+        assertThat(awsRangerAuditRolePermissionValidator.checkLocation(rangerAuditLocation)).isTrue();
+    }
+
+    @Override
+    public void testGetPolicyJsonReplacements() {
+        String storageLocationBaseStr = "bucket/cluster";
+        String bucket = "bucket";
+        String dynamodbTableName = "tableName";
+
+        Map<String, String> expectedPolicyJsonReplacements = Map.ofEntries(
+            Map.entry("${STORAGE_LOCATION_BASE}", storageLocationBaseStr),
+            Map.entry("${DATALAKE_BUCKET}", bucket),
+            Map.entry("${DYNAMODB_TABLE_NAME}", dynamodbTableName)
+        );
+
+        StorageLocationBase storageLocationBase = new StorageLocationBase();
+        storageLocationBase.setValue(storageLocationBaseStr);
+        CloudS3View cloudFileSystem = new CloudS3View(CloudIdentityType.ID_BROKER);
+        cloudFileSystem.setS3GuardDynamoTableName(dynamodbTableName);
+        Map<String, String> policyJsonReplacements = awsRangerAuditRolePermissionValidator
+                                                        .getPolicyJsonReplacements(storageLocationBase,
+                                                            cloudFileSystem);
+
+        assertThat(policyJsonReplacements).isEqualTo(expectedPolicyJsonReplacements);
+    }
+}

--- a/cloud-aws/src/test/resources/json/aws-assume-role-policy-document.json
+++ b/cloud-aws/src/test/resources/json/aws-assume-role-policy-document.json
@@ -1,0 +1,15 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "1",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          "arn:aws:iam::123456890:role/assume-role"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/cloud-aws/src/test/resources/json/aws-ec2-trust-policy-document.json
+++ b/cloud-aws/src/test/resources/json/aws-ec2-trust-policy-document.json
@@ -1,0 +1,12 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureObjectStorageConnector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureObjectStorageConnector.java
@@ -16,6 +16,8 @@ import com.sequenceiq.cloudbreak.cloud.model.Variant;
 import com.sequenceiq.cloudbreak.cloud.model.base.ResponseStatus;
 import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageMetadataRequest;
 import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageMetadataResponse;
+import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageValidateRequest;
+import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageValidateResponse;
 
 @Service
 public class AzureObjectStorageConnector implements ObjectStorageConnector {
@@ -41,6 +43,11 @@ public class AzureObjectStorageConnector implements ObjectStorageConnector {
                     .build();
         }
 
+    }
+
+    @Override
+    public ObjectStorageValidateResponse validateObjectStorage(ObjectStorageValidateRequest request) {
+        return ObjectStorageValidateResponse.builder().withStatus(ResponseStatus.OK).build();
     }
 
     @Override

--- a/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockObjectStorageConnector.java
+++ b/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockObjectStorageConnector.java
@@ -5,10 +5,13 @@ import java.util.Optional;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.cloud.ObjectStorageConnector;
+import com.sequenceiq.cloudbreak.cloud.model.base.ResponseStatus;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
 import com.sequenceiq.cloudbreak.cloud.model.Variant;
 import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageMetadataRequest;
 import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageMetadataResponse;
+import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageValidateRequest;
+import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageValidateResponse;
 
 @Service
 public class MockObjectStorageConnector implements ObjectStorageConnector {
@@ -18,6 +21,11 @@ public class MockObjectStorageConnector implements ObjectStorageConnector {
         // for mocking it's necessary to pass the environment's location hence please provide it at the end of the storage request separated by a colon
         // e.g.: someStorageLocationStuff:London
         return ObjectStorageMetadataResponse.builder().withRegion(extractRegionFromStoragePath(request.getObjectStoragePath()).orElse(null)).build();
+    }
+
+    @Override
+    public ObjectStorageValidateResponse validateObjectStorage(ObjectStorageValidateRequest request) {
+        return ObjectStorageValidateResponse.builder().withStatus(ResponseStatus.OK).build();
     }
 
     @Override

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/providerservices/CloudProviderServicesV4Endopint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/providerservices/CloudProviderServicesV4Endopint.java
@@ -14,6 +14,8 @@ import com.sequenceiq.cloudbreak.cloud.model.nosql.NoSqlTableMetadataRequest;
 import com.sequenceiq.cloudbreak.cloud.model.nosql.NoSqlTableMetadataResponse;
 import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageMetadataRequest;
 import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageMetadataResponse;
+import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageValidateRequest;
+import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageValidateResponse;
 
 @Path("/v4/cloudprovider")
 @Consumes(MediaType.APPLICATION_JSON)
@@ -23,6 +25,11 @@ public interface CloudProviderServicesV4Endopint {
     @Path("objectstorage/getmetadata")
     @Produces(MediaType.APPLICATION_JSON)
     ObjectStorageMetadataResponse getObjectStorageMetaData(@Valid ObjectStorageMetadataRequest request);
+
+    @POST
+    @Path("objectstorage/validate")
+    @Produces(MediaType.APPLICATION_JSON)
+    ObjectStorageValidateResponse validateObjectStorage(@Valid ObjectStorageValidateRequest request);
 
     @POST
     @Path("nosql/getmetadata")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/CloudProviderServicesV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/CloudProviderServicesV4Controller.java
@@ -12,6 +12,8 @@ import com.sequenceiq.cloudbreak.cloud.model.nosql.NoSqlTableMetadataRequest;
 import com.sequenceiq.cloudbreak.cloud.model.nosql.NoSqlTableMetadataResponse;
 import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageMetadataRequest;
 import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageMetadataResponse;
+import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageValidateRequest;
+import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageValidateResponse;
 import com.sequenceiq.cloudbreak.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.service.cloudprovider.CloudProviderService;
 
@@ -28,6 +30,15 @@ public class CloudProviderServicesV4Controller implements CloudProviderServicesV
     public ObjectStorageMetadataResponse getObjectStorageMetaData(@Valid ObjectStorageMetadataRequest request) {
         try {
             return cloudProviderService.getObjectStorageMetaData(request);
+        } catch (CloudConnectorException e) {
+            throw new BadRequestException(e.getMessage());
+        }
+    }
+
+    @Override
+    public ObjectStorageValidateResponse validateObjectStorage(@Valid ObjectStorageValidateRequest request) {
+        try {
+            return cloudProviderService.validateObjectStorage(request);
         } catch (CloudConnectorException e) {
             throw new BadRequestException(e.getMessage());
         }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cluster/CloudStorageConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cluster/CloudStorageConverter.java
@@ -124,28 +124,42 @@ public class CloudStorageConverter {
         FileSystemType type = null;
         if (cloudStorageRequest.getIdentities() != null && !cloudStorageRequest.getIdentities().isEmpty()) {
             for (StorageIdentityBase storageIdentity : cloudStorageRequest.getIdentities()) {
-                if (storageIdentity != null) {
-                    if (storageIdentity.getAdls() != null) {
-                        cloudFileSystemViews.add(cloudStorageParametersConverter.adlsToCloudView(storageIdentity));
-                        type = FileSystemType.ADLS;
-                    } else if (storageIdentity.getGcs() != null) {
-                        cloudFileSystemViews.add(cloudStorageParametersConverter.gcsToCloudView(storageIdentity));
-                        type = FileSystemType.GCS;
-                    } else if (storageIdentity.getS3() != null) {
-                        cloudFileSystemViews.add(cloudStorageParametersConverter.s3ToCloudView(storageIdentity));
-                        type = FileSystemType.S3;
-                    } else if (storageIdentity.getWasb() != null) {
-                        cloudFileSystemViews.add(cloudStorageParametersConverter.wasbToCloudView(storageIdentity));
-                        type = FileSystemType.WASB;
-                    } else if (storageIdentity.getAdlsGen2() != null) {
-                        cloudFileSystemViews.add(cloudStorageParametersConverter.adlsGen2ToCloudView(storageIdentity));
-                        type = FileSystemType.ADLS_GEN_2;
-                    }
-                }
+                type = getCloudFileSystemView(cloudStorageRequest, cloudFileSystemViews, storageIdentity);
             }
         }
         validateCloudFileSystemViews(cloudFileSystemViews, type);
         return new SpiFileSystem("", type, cloudFileSystemViews);
+    }
+
+    private FileSystemType getCloudFileSystemView(CloudStorageBase cloudStorageRequest,
+                                                    List<CloudFileSystemView> cloudFileSystemViews,
+                                                    StorageIdentityBase storageIdentity) {
+        FileSystemType type = null;
+        if (storageIdentity != null) {
+            CloudFileSystemView cloudFileSystemView = null;
+            if (storageIdentity.getAdls() != null) {
+                cloudFileSystemView = cloudStorageParametersConverter.adlsToCloudView(storageIdentity);
+                type = FileSystemType.ADLS;
+            } else if (storageIdentity.getGcs() != null) {
+                cloudFileSystemView = cloudStorageParametersConverter.gcsToCloudView(storageIdentity);
+                type = FileSystemType.GCS;
+            } else if (storageIdentity.getS3() != null) {
+                cloudFileSystemView = cloudStorageParametersConverter.s3ToCloudView(storageIdentity);
+                type = FileSystemType.S3;
+            } else if (storageIdentity.getWasb() != null) {
+                cloudFileSystemView = cloudStorageParametersConverter.wasbToCloudView(storageIdentity);
+                type = FileSystemType.WASB;
+            } else if (storageIdentity.getAdlsGen2() != null) {
+                cloudFileSystemView = cloudStorageParametersConverter.adlsGen2ToCloudView(storageIdentity);
+                type = FileSystemType.ADLS_GEN_2;
+            }
+            if (cloudFileSystemView != null) {
+                cloudFileSystemView.setAccountMapping(cloudStorageRequest.getAccountMapping());
+                cloudFileSystemView.setLocations(cloudStorageRequest.getLocations());
+                cloudFileSystemViews.add(cloudFileSystemView);
+            }
+        }
+        return type;
     }
 
     private void validateCloudFileSystemViews(List<CloudFileSystemView> cloudFileSystemViews, FileSystemType type) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cloudprovider/CloudProviderService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cloudprovider/CloudProviderService.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.service.cloudprovider;
 
+import com.sequenceiq.cloudbreak.cloud.model.SpiFileSystem;
+import com.sequenceiq.cloudbreak.converter.v4.stacks.cluster.CloudStorageConverter;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.cloud.CloudConnector;
@@ -13,11 +15,18 @@ import com.sequenceiq.cloudbreak.cloud.model.nosql.NoSqlTableMetadataRequest;
 import com.sequenceiq.cloudbreak.cloud.model.nosql.NoSqlTableMetadataResponse;
 import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageMetadataRequest;
 import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageMetadataResponse;
+import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageValidateRequest;
+import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageValidateResponse;
+
+import javax.inject.Inject;
 
 @Service
 public class CloudProviderService {
 
     private final CloudPlatformConnectors cloudPlatformConnectors;
+
+    @Inject
+    private CloudStorageConverter cloudStorageConverter;
 
     public CloudProviderService(CloudPlatformConnectors cloudPlatformConnectors) {
         this.cloudPlatformConnectors = cloudPlatformConnectors;
@@ -26,6 +35,13 @@ public class CloudProviderService {
     public ObjectStorageMetadataResponse getObjectStorageMetaData(ObjectStorageMetadataRequest request) {
         ObjectStorageConnector objectStorageConnector = getCloudConnector(request).objectStorage();
         return objectStorageConnector.getObjectStorageMetadata(request);
+    }
+
+    public ObjectStorageValidateResponse validateObjectStorage(ObjectStorageValidateRequest request) {
+        ObjectStorageConnector objectStorageConnector = getCloudConnector(request).objectStorage();
+        SpiFileSystem spiFileSystem = cloudStorageConverter.requestToSpiFileSystem(request.getCloudStorageRequest());
+        request.setSpiFileSystem(spiFileSystem);
+        return objectStorageConnector.validateObjectStorage(request);
     }
 
     public NoSqlTableMetadataResponse getNoSqlTableMetaData(NoSqlTableMetadataRequest request) {

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/ProvisionerService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/ProvisionerService.java
@@ -48,9 +48,6 @@ public class ProvisionerService {
     private SdxStatusService sdxStatusService;
 
     @Inject
-    private StackRequestManifester stackRequestManifester;
-
-    @Inject
     private StackV4Endpoint stackV4Endpoint;
 
     @Inject
@@ -110,7 +107,6 @@ public class ProvisionerService {
 
     public void startStackProvisioning(Long id, DetailedEnvironmentResponse environment, DatabaseServerStatusV4Response database) {
         sdxClusterRepository.findById(id).ifPresentOrElse(sdxCluster -> {
-            stackRequestManifester.configureStackForSdxCluster(sdxCluster, environment);
             LOGGER.info("Call cloudbreak with stackrequest");
             try {
                 StackV4Request stackV4Request = JsonUtil.readValue(sdxCluster.getStackRequestToCloudbreak(), StackV4Request.class);

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/validation/cloudstorage/CloudStorageValidator.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/validation/cloudstorage/CloudStorageValidator.java
@@ -1,0 +1,63 @@
+package com.sequenceiq.datalake.service.validation.cloudstorage;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.providerservices.CloudProviderServicesV4Endopint;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.base.ResponseStatus;
+import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageValidateRequest;
+import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageValidateResponse;
+import com.sequenceiq.cloudbreak.service.secret.service.SecretService;
+import com.sequenceiq.common.api.cloudstorage.CloudStorageRequest;
+import com.sequenceiq.datalake.controller.exception.BadRequestException;
+import com.sequenceiq.datalake.entity.Credential;
+import com.sequenceiq.datalake.service.validation.converter.CredentialToCloudCredentialConverter;
+import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CloudStorageValidator {
+
+    private final CredentialToCloudCredentialConverter credentialToCloudCredentialConverter;
+
+    private final SecretService secretService;
+
+    private final CloudProviderServicesV4Endopint cloudProviderServicesV4Endpoint;
+
+    public CloudStorageValidator(CredentialToCloudCredentialConverter credentialToCloudCredentialConverter,
+                                    SecretService secretService,
+                                    CloudProviderServicesV4Endopint cloudProviderServicesV4Endpoint) {
+        this.credentialToCloudCredentialConverter = credentialToCloudCredentialConverter;
+        this.secretService = secretService;
+        this.cloudProviderServicesV4Endpoint = cloudProviderServicesV4Endpoint;
+    }
+
+    public void validate(CloudStorageRequest cloudStorageRequest, DetailedEnvironmentResponse environment) {
+        if (cloudStorageRequest != null) {
+            Credential credential = getCredential(environment);
+            CloudCredential cloudCredential = credentialToCloudCredentialConverter.convert(credential);
+
+            ObjectStorageValidateRequest request = createObjectStorageValidateRequest(
+                environment.getCloudPlatform(), cloudCredential, cloudStorageRequest);
+            ObjectStorageValidateResponse response = cloudProviderServicesV4Endpoint
+                                                        .validateObjectStorage(request);
+            if (ResponseStatus.ERROR.equals(response.getStatus())) {
+                throw new BadRequestException(response.getError());
+            }
+        }
+    }
+
+    private ObjectStorageValidateRequest createObjectStorageValidateRequest(
+        String cloudPlatform, CloudCredential credential, CloudStorageRequest cloudStorageRequest) {
+        return ObjectStorageValidateRequest.builder()
+                .withCloudPlatform(cloudPlatform)
+                .withCredential(credential)
+                .withCloudStorageRequest(cloudStorageRequest)
+                .build();
+    }
+
+    private Credential getCredential(DetailedEnvironmentResponse environment) {
+        return new Credential(environment.getCloudPlatform(),
+                environment.getCredential().getName(),
+                secretService.getByResponse(environment.getCredential().getAttributes()),
+                environment.getCredential().getCrn());
+    }
+}

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/StackRequestManifesterTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/StackRequestManifesterTest.java
@@ -24,6 +24,7 @@ import com.sequenceiq.cloudbreak.idbmms.exception.IdbmmsOperationException;
 import com.sequenceiq.cloudbreak.idbmms.model.MappingsConfig;
 import com.sequenceiq.common.api.cloudstorage.AccountMappingBase;
 import com.sequenceiq.common.api.cloudstorage.CloudStorageRequest;
+import com.sequenceiq.datalake.controller.exception.BadRequestException;
 import com.sequenceiq.environment.api.v1.environment.model.base.IdBrokerMappingSource;
 
 @ExtendWith(MockitoExtension.class)
@@ -142,7 +143,7 @@ public class StackRequestManifesterTest {
         clusterV4Request.setCloudStorage(cloudStorage);
 
         Assertions.assertThrows(
-                IdbmmsOperationException.class,
+                BadRequestException.class,
                 () -> underTest.setupCloudStorageAccountMapping(stackV4Request, BAD_ENVIRONMENT_CRN, IdBrokerMappingSource.IDBMMS, CLOUD_PLATFORM_AWS));
     }
 


### PR DESCRIPTION
Adds IDBroker mapping validation for the following scenarios:
* User provided mappings with IDBMMS (does not validate mock mappings)
* Checks IDBroker instance profile exists
* Checks IDBroker instance profile has EC2 trust - ability to be attached to EC2 instance
* Checks IDBroker instance profile role has ability to assume all provided mappings
* Checks log instance profile exists
* Checks log instance profile has EC2 trust - ability to be attached to EC2 instance
* Checks data access user mapped roles for proper permissions (compared against policy with simulate)
* Checks baseline / ranger audit user mapped roles for proper AWS permissions (compared against policy with simulate)

The validation happens before the RDS is created with redbeams and returns an error message that explains what is missing.

Potential follow up items:
* Validate for distrox
* Consolidate other storage validation into one place (prefix and region validation)