### PR TITLE
CB-4366 Nginx should allow underscores in header names

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/nginx/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/nginx/init.sls
@@ -34,6 +34,13 @@
 
 {% endif %}
 
+ensure_underscores_in_headers_nginx_conf:
+  file.line:
+    - name: /etc/nginx/nginx.conf
+    - mode: ensure
+    - content:     underscores_in_headers on;
+    - after: ^http {$
+
 {% if "manager_server" in grains.get('roles', []) %}
 {%- from 'cloudera/manager/settings.sls' import cloudera_manager with context %}
 


### PR DESCRIPTION
Nginx by default prevents underscores in header names.
The HTTP spec allows underscores in headers. This change
configures Nginx to allow underscores in headers. It needs
to be configured at the top level since there are multiple
Nginx server config blocks.

http://nginx.org/en/docs/http/ngx_http_core_module.html#underscores_in_headers

Some additional background on underscores in headers can
be found here:

https://stackoverflow.com/questions/22856136/why-http-servers-forbid-underscores-in-http-header-names