### PR TITLE
CB-4300 Fix credential list for missing Azure entitlement

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
@@ -282,7 +282,7 @@ public class GrpcUmsClient {
      * @param requestId an optional request Id
      * @return the account associated with this user CRN
      */
-    @Cacheable(cacheNames = "umsAccountCache", key = "{ #actorCrn, #userCrn }")
+    @Cacheable(cacheNames = "umsAccountCache", key = "{ #actorCrn, #accountId }")
     public Account getAccountDetails(String actorCrn, String accountId, Optional<String> requestId) {
         try (ManagedChannelWrapper channelWrapper = makeWrapper()) {
             UmsClient client = makeClient(channelWrapper.getChannel(), actorCrn);

--- a/environment/src/main/java/com/sequenceiq/environment/cache/CredentialCloudPlatformCache.java
+++ b/environment/src/main/java/com/sequenceiq/environment/cache/CredentialCloudPlatformCache.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.environment.cache;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cache.common.AbstractCacheDefinition;
+
+@Service
+public class CredentialCloudPlatformCache extends AbstractCacheDefinition {
+
+    private static final long MAX_ENTRIES = 1000L;
+
+    @Value("${cb.credential.cloud.platform.cache.ttl:15}")
+    private long ttlMinutes;
+
+    @Override
+    protected String getName() {
+        return "credentialCloudPlatformCache";
+    }
+
+    @Override
+    protected long getMaxEntries() {
+        return MAX_ENTRIES;
+    }
+
+    @Override
+    protected long getTimeToLiveSeconds() {
+        return ttlMinutes == 0L ? 1 : TimeUnit.MINUTES.toSeconds(ttlMinutes);
+    }
+
+}

--- a/environment/src/main/java/com/sequenceiq/environment/credential/service/CredentialService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/service/CredentialService.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
@@ -19,6 +20,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
@@ -77,7 +79,15 @@ public class CredentialService extends AbstractCredentialService {
     }
 
     public Set<Credential> listAvailablesByAccountId(String accountId) {
-        return repository.findAllByAccountId(accountId, getEnabledPlatforms());
+        return repository.findAllByAccountId(accountId, getValidPlatformsForAccountId(accountId));
+    }
+
+    @Cacheable(cacheNames = "credentialCloudPlatformCache")
+    public Set<String> getValidPlatformsForAccountId(String accountId) {
+        return getEnabledPlatforms()
+                .stream()
+                .filter(cloudPlatform -> credentialValidator.isCredentialCloudPlatformValid(cloudPlatform, accountId))
+                .collect(Collectors.toSet());
     }
 
     public Credential getByNameForAccountId(String name, String accountId) {

--- a/environment/src/main/java/com/sequenceiq/environment/credential/validation/CredentialValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/validation/CredentialValidator.java
@@ -14,8 +14,10 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.auth.security.InternalCrnBuilder;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.util.ValidationResult;
@@ -29,6 +31,9 @@ import com.sequenceiq.environment.credential.validation.definition.CredentialDef
 
 @Component
 public class CredentialValidator {
+
+    @VisibleForTesting
+    static final String IAM_INTERNAL_ACTOR_CRN = new InternalCrnBuilder(Crn.Service.IAM).getInternalCrnForServiceAsString();
 
     private final Set<String> enabledPlatforms;
 
@@ -53,11 +58,24 @@ public class CredentialValidator {
     }
 
     public void validateCredentialCloudPlatform(String cloudPlatform, String userCrn) {
+        validateCredentialCloudPlatformInternal(cloudPlatform, userCrn, Crn.safeFromString(userCrn).getAccountId());
+    }
+
+    private void validateCredentialCloudPlatformInternal(String cloudPlatform, String userCrn, String accountId) {
         if (!enabledPlatforms.contains(cloudPlatform)) {
             throw new BadRequestException(String.format("There is no such cloud platform as '%s'", cloudPlatform));
         }
-        if (AZURE.name().equalsIgnoreCase(cloudPlatform) && !entitlementService.azureEnabled(userCrn, Crn.safeFromString(userCrn).getAccountId())) {
+        if (AZURE.name().equalsIgnoreCase(cloudPlatform) && !entitlementService.azureEnabled(userCrn, accountId)) {
             throw new BadRequestException("Provisioning in Microsoft Azure is not enabled for this account.");
+        }
+    }
+
+    public boolean isCredentialCloudPlatformValid(String cloudPlatform, String accountId) {
+        try {
+            validateCredentialCloudPlatformInternal(cloudPlatform, IAM_INTERNAL_ACTOR_CRN, accountId);
+            return true;
+        } catch (BadRequestException e) {
+            return false;
         }
     }
 


### PR DESCRIPTION
* `CredentialService.listAvailablesByAccountId()` (called by `CredentialV1Controller.list()`): Filter out all credentials whose cloud platform is not entitled for the target account (besides the former check for being enabled globally in EnvSvc)
* `GrpcUmsClient.getAccountDetails()`: Fix `@Cacheable` key (was likely omitted during a recent method parameter name change).

Tests:
* Unit
* Integration (existing `EnvironmentServiceIntegrationTest`)
* Manual using cbd & IDEA