### PR TITLE
CB 4250 - Enable PAM Authentication for Kafka from CHD Version 7.1.0

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
@@ -15,6 +15,8 @@ public class CMRepositoryVersionUtil {
 
     public static final Versioned CLOUDERAMANAGER_VERSION_7_0_2 = () -> "7.0.2";
 
+    public static final Versioned CLOUDERAMANAGER_VERSION_7_1_0 = () -> "7.1.0";
+
     public static final Versioned CFM_VERSION_2_0_0_0 = () -> "2.0.0.0";
 
     private CMRepositoryVersionUtil() {

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaAuthConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaAuthConfigProvider.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka;
 
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_0_2;
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_1_0;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
 
@@ -15,7 +16,7 @@ import com.sequenceiq.cloudbreak.dto.LdapView;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 
 @Component
-public class KafkaLdapConfigProvider implements CmTemplateComponentConfigProvider {
+public class KafkaAuthConfigProvider implements CmTemplateComponentConfigProvider {
 
     private static final String LDAP_AUTH_URL = "ldap.auth.url";
 
@@ -23,17 +24,38 @@ public class KafkaLdapConfigProvider implements CmTemplateComponentConfigProvide
 
     private static final String LDAP_AUTH_ENABLE = "ldap.auth.enable";
 
+    private static final String SASL_AUTH_METHOD = "sasl.plain.auth";
+
     @Override
     public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject source) {
         String cdhVersion = templateProcessor.getVersion().orElse("");
-        if (isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERAMANAGER_VERSION_7_0_2)) {
-            LdapView ldapView = source.getLdapConfig().get();
-            return List.of(
-                    config(LDAP_AUTH_ENABLE, "true"),
-                    config(LDAP_AUTH_URL, ldapView.getConnectionURL()),
-                    config(LDAP_AUTH_USER_DN_TEMPLATE, ldapView.getUserDnPattern()));
-        }
-        return List.of();
+        LdapView ldapView = source.getLdapConfig().get();
+
+        return supportsPam(cdhVersion) ? ldapAndPamConfig(ldapView) :
+                supportsLdap(cdhVersion) ? ldapConfig(ldapView) : List.of();
+    }
+
+    private boolean supportsLdap(String cdhVersion) {
+        return isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERAMANAGER_VERSION_7_0_2);
+    }
+
+    private boolean supportsPam(String cdhVersion) {
+        return isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERAMANAGER_VERSION_7_1_0);
+    }
+
+    private List<ApiClusterTemplateConfig> ldapConfig(LdapView ldapView) {
+        return generalLdapConfig(ldapView, config(LDAP_AUTH_ENABLE, "true"));
+    }
+
+    private List<ApiClusterTemplateConfig> ldapAndPamConfig(LdapView ldapView) {
+        return generalLdapConfig(ldapView, config(SASL_AUTH_METHOD, "PAM"));
+    }
+
+    private List<ApiClusterTemplateConfig> generalLdapConfig(LdapView ldapView, ApiClusterTemplateConfig additionalConfig) {
+        return List.of(
+            config(LDAP_AUTH_URL, ldapView.getConnectionURL()),
+            config(LDAP_AUTH_USER_DN_TEMPLATE, ldapView.getUserDnPattern()),
+            additionalConfig);
     }
 
     @Override

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaAuthConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaAuthConfigProviderTest.java
@@ -8,7 +8,9 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
+import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,27 +24,55 @@ import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject.Builder;
 
 @ExtendWith(MockitoExtension.class)
-class KafkaLdapConfigProviderTest {
+class KafkaAuthConfigProviderTest {
 
     private static final String V7_0_1 = "7.0.1";
 
     private static final String V7_0_2 = "7.0.2";
 
-    private KafkaLdapConfigProvider underTest;
+    private static final String V7_0_99 = "7.0.99";
+
+    private static final String V7_1_0 = "7.1.0";
+
+    private static final String V7_X_0 = "7.x.0";
+
+    private static final Iterable<String> NO_AUTH_VERSIONS = Lists.newArrayList(null, V7_0_1);
+
+    private static final Iterable<String> LDAP_AUTH_VERSIONS = Set.of(V7_0_2, V7_0_99);
+
+    private static final Iterable<String> PAM_AUTH_VERSIONS = Set.of(V7_1_0, V7_X_0);
+
+    private static final Set<ApiClusterTemplateConfig> NO_AUTH_EXPECTED_CONFIGS = Set.of();
+
+    private static final Set<ApiClusterTemplateConfig> LDAP_AUTH_EXPECTED_CONFIGS = Set.of(
+            config("ldap.auth.url", "protocol://host:1234"),
+            config("ldap.auth.user.dn.template", "pattern"),
+            config("ldap.auth.enable", "true"));
+
+    private static final Set<ApiClusterTemplateConfig> PAM_AUTH_EXPECTED_CONFIGS = Set.of(
+            config("ldap.auth.url", "protocol://host:1234"),
+            config("ldap.auth.user.dn.template", "pattern"),
+            config("sasl.plain.auth", "PAM"));
+
+    private KafkaAuthConfigProvider underTest;
 
     @Mock
     private CmTemplateProcessor cmTemplateProcessor;
 
     @BeforeEach
     void setUp() {
-        underTest = new KafkaLdapConfigProvider();
+        underTest = new KafkaAuthConfigProvider();
     }
 
-    @Test
-    void getServiceConfigs() {
-        when(cmTemplateProcessor.getVersion()).thenReturn(Optional.of(V7_0_2));
+    private static ApiClusterTemplateConfig config(String name, String value) {
+        ApiClusterTemplateConfig cfg = new ApiClusterTemplateConfig();
+        cfg.setName(name);
+        cfg.setValue(value);
+        return cfg;
+    }
 
-        TemplatePreparationObject tpo = Builder.builder()
+    private static TemplatePreparationObject createTemplatePreparationObject() {
+        return Builder.builder()
                 .withLdapConfig(LdapViewBuilder.aLdapView()
                         .withProtocol("protocol")
                         .withServerPort(1234)
@@ -50,39 +80,30 @@ class KafkaLdapConfigProviderTest {
                         .withUserDnPattern("pattern")
                         .build())
                 .build();
-
-        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(cmTemplateProcessor, tpo);
-
-        ApiClusterTemplateConfig exp1 = new ApiClusterTemplateConfig();
-        exp1.setName("ldap.auth.url");
-        exp1.setValue("protocol://host:1234");
-
-        ApiClusterTemplateConfig exp2 = new ApiClusterTemplateConfig();
-        exp2.setName("ldap.auth.user.dn.template");
-        exp2.setValue("pattern");
-
-        ApiClusterTemplateConfig exp3 = new ApiClusterTemplateConfig();
-        exp3.setName("ldap.auth.enable");
-        exp3.setValue("true");
-
-        assertThat(serviceConfigs).hasSameElementsAs(List.of(exp1, exp2, exp3));
     }
 
     @Test
-    void getServiceConfigsWrongVersion() {
-        when(cmTemplateProcessor.getVersion()).thenReturn(Optional.of(V7_0_1));
+    void getServiceConfigsNoAuth() {
+        testGetServiceConfigs(NO_AUTH_VERSIONS, NO_AUTH_EXPECTED_CONFIGS);
+    }
 
-        TemplatePreparationObject tpo = Builder.builder()
-                .withLdapConfig(LdapViewBuilder.aLdapView()
-                        .withProtocol("protocol")
-                        .withServerPort(1234)
-                        .withServerHost("host")
-                        .withUserDnPattern("pattern")
-                        .build())
-                .build();
+    @Test
+    void getServiceConfigsLdap() {
+        testGetServiceConfigs(LDAP_AUTH_VERSIONS, LDAP_AUTH_EXPECTED_CONFIGS);
+    }
 
-        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(cmTemplateProcessor, tpo);
-        assertThat(serviceConfigs).isEmpty();
+    @Test
+    void getServiceConfigsPam() {
+        testGetServiceConfigs(PAM_AUTH_VERSIONS, PAM_AUTH_EXPECTED_CONFIGS);
+    }
+
+    private void testGetServiceConfigs(Iterable<String> versions, Iterable<ApiClusterTemplateConfig> expectedConfigs) {
+        for (String version: versions) {
+            when(cmTemplateProcessor.getVersion()).thenReturn(Optional.ofNullable(version));
+            TemplatePreparationObject tpo = createTemplatePreparationObject();
+            List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(cmTemplateProcessor, tpo);
+            assertThat(serviceConfigs).as("Expected configs for cdh version: %s", version).hasSameElementsAs(expectedConfigs);
+        }
     }
 
     @Test


### PR DESCRIPTION
Description:
- Renamed  KafkaLdapConfigProvider to KafkaAuthConfigProvider
- Changed the logic so that PAM authentication will be used as of CDH 7.1.0. Previous logic for CDH between 7.02 and 7.1.0 is kept.

Tests:
- Rewrote unit tests: KafkaAuthConfigProviderTests
- Tested the following cases manually: CM 7.02 - CDH 7.0.2, CM 7.10 - CDH 7.02, CM 7.1.0 - CDH 7.1.0

Closes CB 4250