### PR TITLE
CDPCP-1028. Throw exception on cluster proxy error in FMS

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/client/ClusterProxyError.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/client/ClusterProxyError.java
@@ -1,0 +1,41 @@
+package com.sequenceiq.freeipa.client;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ClusterProxyError {
+
+    private final String status;
+
+    private final String code;
+
+    private final String message;
+
+    @JsonCreator
+    public ClusterProxyError(@JsonProperty("status") String status, @JsonProperty("code") String code, @JsonProperty("message") String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String toString() {
+        return "ClusterProxyError{" +
+                "status='" + status + '\'' +
+                ", code='" + code + '\'' +
+                ", message='" + message + '\'' +
+                '}';
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/client/ClusterProxyErrorRpcListener.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/client/ClusterProxyErrorRpcListener.java
@@ -1,0 +1,43 @@
+package com.sequenceiq.freeipa.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.googlecode.jsonrpc4j.JsonRpcClient;
+import com.sequenceiq.cloudbreak.clusterproxy.ClusterProxyException;
+
+import java.util.Optional;
+
+public class ClusterProxyErrorRpcListener implements JsonRpcClient.RequestListener {
+
+    private Optional<ClusterProxyError> deserializeAsClusteProxyError(ObjectNode objectNode) {
+        ObjectMapper mapper = new ObjectMapper();
+        ClusterProxyError clusterProxyError;
+        try {
+            clusterProxyError = mapper.treeToValue(objectNode, ClusterProxyError.class);
+            if (!clusterProxyError.getCode().contains("cluster-proxy")) {
+                return Optional.empty();
+            }
+        } catch (Exception ex) {
+            return Optional.empty();
+        }
+        return Optional.of(clusterProxyError);
+    }
+
+    private void throwIfClusterProxyError(ObjectNode node) {
+        Optional<ClusterProxyError> clusterProxyError = deserializeAsClusteProxyError(node);
+        if (clusterProxyError.isPresent()) {
+            throw new ClusterProxyException(String.format("Cluster proxy service returned error: %s", clusterProxyError.get()));
+        }
+    }
+
+    @Override
+    public void onBeforeRequestSent(JsonRpcClient client, ObjectNode request) {
+        // no op
+    }
+
+    @Override
+    public void onBeforeResponseProcessed(JsonRpcClient client, ObjectNode response) {
+        throwIfClusterProxyError(response);
+    }
+
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientBuilder.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientBuilder.java
@@ -13,6 +13,7 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 
 import com.google.common.collect.ImmutableMap;
+import com.googlecode.jsonrpc4j.JsonRpcClient;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.Header;
 import org.apache.http.client.CookieStore;
@@ -73,10 +74,12 @@ public class FreeIpaClientBuilder {
 
     private final HttpClientConfig clientConfig;
 
+    private final JsonRpcClient.RequestListener rpcRequestListener;
+
     private Map<String, String> additionalHeaders;
 
     public FreeIpaClientBuilder(String user, String pass, String realm, HttpClientConfig clientConfig, int port, String basePath,
-                                Map<String, String> additionalHeaders) throws Exception {
+                                Map<String, String> additionalHeaders, JsonRpcClient.RequestListener rpcRequestListener) throws Exception {
         this.user = user;
         this.pass = pass;
         this.realm = realm;
@@ -101,11 +104,12 @@ public class FreeIpaClientBuilder {
 
         this.basePath = basePath;
         this.additionalHeaders = Map.copyOf(additionalHeaders);
+        this.rpcRequestListener = rpcRequestListener;
     }
 
     public FreeIpaClientBuilder(String user, String pass, String realm,
                                 HttpClientConfig clientConfig, int port) throws Exception {
-        this(user, pass, realm, clientConfig, port, DEFAULT_BASE_PATH, Map.of());
+        this(user, pass, realm, clientConfig, port, DEFAULT_BASE_PATH, Map.of(), null);
     }
 
     public FreeIpaClient build() throws URISyntaxException, FreeIpaClientException, IOException {
@@ -125,6 +129,7 @@ public class FreeIpaClientBuilder {
 
         jsonRpcHttpClient.setHostNameVerifier(hostnameVerifier());
         jsonRpcHttpClient.setReadTimeoutMillis(READ_TIMEOUT_MILLIS);
+        jsonRpcHttpClient.setRequestListener(rpcRequestListener);
         return new FreeIpaClient(jsonRpcHttpClient);
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactory.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactory.java
@@ -4,6 +4,8 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import com.googlecode.jsonrpc4j.JsonRpcClient;
+import com.sequenceiq.freeipa.client.ClusterProxyErrorRpcListener;
 import com.sequenceiq.freeipa.service.config.FmsClusterProxyEnablement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,6 +31,8 @@ public class FreeIpaClientFactory {
     private static final String ADMIN_USER = "admin";
 
     private static final Map<String, String> ADDITIONAL_CLUSTER_PROXY_HEADERS =  Map.of("Proxy-Ignore-Auth", "true");
+
+    private static final JsonRpcClient.RequestListener CLUSTER_PROXY_ERROR_LISTENER = new ClusterProxyErrorRpcListener();
 
     @Inject
     private ClusterProxyConfiguration clusterProxyConfiguration;
@@ -75,12 +79,13 @@ public class FreeIpaClientFactory {
                 String clusterProxyPath = toClusterProxyBasepath(stack.getResourceCrn());
 
                 return new FreeIpaClientBuilder(ADMIN_USER,
-                    freeIpa.getAdminPassword(),
-                    freeIpa.getDomain().toUpperCase(),
-                    httpClientConfig,
-                    clusterProxyConfiguration.getClusterProxyPort(),
-                    clusterProxyPath,
-                    ADDITIONAL_CLUSTER_PROXY_HEADERS).build();
+                        freeIpa.getAdminPassword(),
+                        freeIpa.getDomain().toUpperCase(),
+                        httpClientConfig,
+                        clusterProxyConfiguration.getClusterProxyPort(),
+                        clusterProxyPath,
+                        ADDITIONAL_CLUSTER_PROXY_HEADERS,
+                        CLUSTER_PROXY_ERROR_LISTENER).build();
             } else {
                 GatewayConfig gatewayConfig = gatewayConfigService.getPrimaryGatewayConfig(stack);
                 HttpClientConfig httpClientConfig = tlsSecurityService.buildTLSClientConfigForPrimaryGateway(

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/client/ClusterProxyErrorRpcListenerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/client/ClusterProxyErrorRpcListenerTest.java
@@ -1,0 +1,59 @@
+package com.sequenceiq.freeipa.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.sequenceiq.cloudbreak.clusterproxy.ClusterProxyException;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ClusterProxyErrorRpcListenerTest {
+
+    private static final String JSON
+            = "{\"status\":504,\"code\":\"cluster-proxy.proxy.timeout\",\"message\":\"Error message\"}";
+
+    private static final String JSON_MISSING_STATUS_FIELD
+            = "{\"code\":\"cluster-proxy.proxy.timeout\",\"message\":\"Error message\"}";
+
+    private static final String JSON_MISSING_CODE_FIELD
+            = "{\"status\":504,\"message\":\"Error message\"}";
+
+    private static final String JSON_CODE_WITHOUT_CLUSTER_PROXY_PREFIX
+            = "{\"status\":504,\"code\":\"asdf\",\"message\":\"Error message\"}";
+
+    private final ClusterProxyErrorRpcListener clusterProxyErrorRpcListener = new ClusterProxyErrorRpcListener();
+
+    private ObjectNode toObjectNode(String jsonString) throws IOException {
+        return (ObjectNode) new ObjectMapper().readTree(jsonString);
+    }
+
+    @Test
+    public void testClusterProxyError() throws IOException {
+        ObjectNode jsonNode = toObjectNode(JSON);
+        assertThrows(ClusterProxyException.class, () -> {
+            clusterProxyErrorRpcListener.onBeforeResponseProcessed(null, jsonNode);
+        });
+    }
+
+    @Test
+    public void testClusterProxyErrorMissingField() throws IOException {
+        ObjectNode jsonNode = toObjectNode(JSON_MISSING_STATUS_FIELD);
+        assertThrows(ClusterProxyException.class, () -> {
+            clusterProxyErrorRpcListener.onBeforeResponseProcessed(null, jsonNode);
+        });
+    }
+
+    @Test
+    public void testClusterProxyErrorNoStatusCode() throws IOException {
+        ObjectNode jsonNode = toObjectNode(JSON_MISSING_CODE_FIELD);
+        clusterProxyErrorRpcListener.onBeforeResponseProcessed(null, jsonNode);
+    }
+
+    @Test
+    public void testClusterProxyErroCodeWithoutClusterProxyPrefix() throws IOException {
+        ObjectNode jsonNode = toObjectNode(JSON_CODE_WITHOUT_CLUSTER_PROXY_PREFIX);
+        clusterProxyErrorRpcListener.onBeforeResponseProcessed(null, jsonNode);
+    }
+}


### PR DESCRIPTION
The JSON RPC client we use for FMS returns a null when there
is an HTTP error and the error response body doesn't conform
to json rpc standards. This is not ideal behavior because the
cluster proxy may return an HTTP error that has valid json
body but not valid json rpc format.

To surface cluster proxy errors, we now throw an error if the
json in the RPC response matches what we expect the cluster
proxy errors to look like.