### PR TITLE
CB-4423 KnoxSSO whitelist - make port and path optional

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/knoxsso.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/knoxsso.xml.j2
@@ -130,7 +130,7 @@
         <param>
            <name>knoxsso.redirect.whitelist.regex</name>
            {% if salt['pillar.get']('gateway:userfacingdomain') is defined and salt['pillar.get']('gateway:userfacingdomain')|length > 1 %}
-           <value>^\/.*$;^https?:\/\/(.+\.{{ salt['pillar.get']('gateway:userfacingdomain') }}):[0-9]+\/?.*$</value>
+           <value>^\/.*$;^https?:\/\/(.+\.{{ salt['pillar.get']('gateway:userfacingdomain') }})(?::[0-9]+)?(?:\/.*)?$</value>
            {% else %}
            <value>^.*$</value>
            {% endif %}


### PR DESCRIPTION
Currently the KnoxSSO whitelist checks both port and path. The port and path should both be optional. Added two non capturing optional groups around the port and path.