### PR TITLE
CB-4438 Realistic mock IDBroker mapping service user list

### DIFF
--- a/cloud-common/build.gradle
+++ b/cloud-common/build.gradle
@@ -66,10 +66,21 @@ dependencies {
     compile group: 'net.sf.json-lib',                       name: 'json-lib',                       version: '2.4',  classifier: 'jdk15'
 
     testCompile group: 'junit',                             name: 'junit',                          version: junitVersion
+    testCompile group: 'org.junit.jupiter',                 name: 'junit-jupiter-api',              version: junitJupiterVersion
+    testCompile group: 'org.junit.jupiter',                 name: 'junit-jupiter-params',           version: junitJupiterVersion
     testCompile group: 'org.mockito',                       name: 'mockito-core',                   version: mockitoVersion
+    testImplementation group: 'org.mockito',                name: 'mockito-junit-jupiter',          version: mockitoVersion
     testCompile group: 'org.springframework.boot',          name: 'spring-boot-starter-test',       version: springBootVersion
     testCompile group: 'org.awaitility',                    name: 'awaitility',                     version: '3.1.6'
 
+    testRuntime group: 'org.junit.jupiter',                 name: 'junit-jupiter-engine',           version: junitJupiterVersion
+    testRuntime group: 'org.junit.vintage',                 name: 'junit-vintage-engine',           version: junitJupiterVersion
+}
+
+test {
+  useJUnitPlatform {
+    includeEngines 'junit-jupiter', 'junit-vintage'
+  }
 }
 
 task testJar(type: Jar, dependsOn: testClasses) {

--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/service/identitymapping/AccountMappingSubject.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/service/identitymapping/AccountMappingSubject.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.cloudbreak.service.identitymapping;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class AccountMappingSubject {
+
+    /**
+     * Immutable set of data access service users. Always disjoint from {@link #RANGER_AUDIT_USERS}.
+     *
+     * Adapted from {@code com.cloudera.thunderhead.service.idbrokermappingmanagement.server.IdBrokerMappingManagementService.DATA_ACCESS_SERVICES}.
+     */
+    public static final Set<String> DATA_ACCESS_USERS = Set.of("hbase", "hdfs", "hive", "impala", "yarn", "dpprofiler", "zeppelin", "kudu", "hue");
+
+    /**
+     * Immutable set of service users that are not data access ones but do need Ranger Audit access. Always disjoint from {@link #DATA_ACCESS_USERS}.
+     *
+     * Adapted from {@code com.cloudera.thunderhead.service.idbrokermappingmanagement.server.IdBrokerMappingManagementService.BASELINE_SERVICES}.
+     */
+    public static final Set<String> RANGER_AUDIT_USERS = Set.of("kafka", "solr", "knox", "atlas");
+
+    /**
+     * Convenience immutable set comprising the union of {@link #DATA_ACCESS_USERS} and {@link #RANGER_AUDIT_USERS}.
+     */
+    public static final Set<String> DATA_ACCESS_AND_RANGER_AUDIT_USERS;
+
+    static {
+        Set<String> dataAccessAndRangerAuditUsers = new HashSet<>(DATA_ACCESS_USERS);
+        dataAccessAndRangerAuditUsers.addAll(RANGER_AUDIT_USERS);
+        DATA_ACCESS_AND_RANGER_AUDIT_USERS = Collections.unmodifiableSet(dataAccessAndRangerAuditUsers);
+    }
+
+    private AccountMappingSubject() {
+        // Prohibit instantiation
+    }
+
+}

--- a/cloud-common/src/test/java/com/sequenceiq/cloudbreak/service/identitymapping/AccountMappingSubjectTest.java
+++ b/cloud-common/src/test/java/com/sequenceiq/cloudbreak/service/identitymapping/AccountMappingSubjectTest.java
@@ -1,0 +1,22 @@
+package com.sequenceiq.cloudbreak.service.identitymapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class AccountMappingSubjectTest {
+
+    @Test
+    void testDisjunctiveUserSets() {
+        assertThat(AccountMappingSubject.DATA_ACCESS_USERS).doesNotContainAnyElementsOf(AccountMappingSubject.RANGER_AUDIT_USERS);
+    }
+
+    @Test
+    void testUserSetsUnion() {
+        assertThat(AccountMappingSubject.DATA_ACCESS_AND_RANGER_AUDIT_USERS).containsAll(AccountMappingSubject.DATA_ACCESS_USERS);
+        assertThat(AccountMappingSubject.DATA_ACCESS_AND_RANGER_AUDIT_USERS).containsAll(AccountMappingSubject.RANGER_AUDIT_USERS);
+        assertThat(AccountMappingSubject.DATA_ACCESS_AND_RANGER_AUDIT_USERS)
+                .hasSize(AccountMappingSubject.DATA_ACCESS_USERS.size() + AccountMappingSubject.RANGER_AUDIT_USERS.size());
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/identitymapping/AwsMockAccountMappingService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/identitymapping/AwsMockAccountMappingService.java
@@ -4,8 +4,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
-import javax.inject.Inject;
-
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
@@ -22,51 +20,19 @@ public class AwsMockAccountMappingService {
 
     private static final String FIXED_IAM_ROLE = "arn:aws:iam::${accountId}:role/mock-idbroker-admin-role";
 
-    private static final Map<String, String> MOCK_IDBROKER_USER_MAPPINGS = Map.ofEntries(
-            Map.entry("accumulo", FIXED_IAM_ROLE),
-            Map.entry("ambari-qa", FIXED_IAM_ROLE),
-            Map.entry("ams", FIXED_IAM_ROLE),
-            Map.entry("atlas", FIXED_IAM_ROLE),
-            Map.entry("docker", FIXED_IAM_ROLE),
-            Map.entry("dpprofiler", FIXED_IAM_ROLE),
-            Map.entry("falcon", FIXED_IAM_ROLE),
-            Map.entry("flume", FIXED_IAM_ROLE),
-            Map.entry("hbase", FIXED_IAM_ROLE),
-            Map.entry("hcat", FIXED_IAM_ROLE),
-            Map.entry("hdfs", FIXED_IAM_ROLE),
-            Map.entry("hive", FIXED_IAM_ROLE),
-            Map.entry("httpfs", FIXED_IAM_ROLE),
-            Map.entry("hue", FIXED_IAM_ROLE),
-            Map.entry("impala", FIXED_IAM_ROLE),
-            Map.entry("infra-solr", FIXED_IAM_ROLE),
-            Map.entry("kafka", FIXED_IAM_ROLE),
-            Map.entry("kms", FIXED_IAM_ROLE),
-            Map.entry("knox", FIXED_IAM_ROLE),
-            Map.entry("kudu", FIXED_IAM_ROLE),
-            Map.entry("livy", FIXED_IAM_ROLE),
-            Map.entry("mahout", FIXED_IAM_ROLE),
-            Map.entry("mapred", FIXED_IAM_ROLE),
-            Map.entry("oozie", FIXED_IAM_ROLE),
-            Map.entry("ranger", FIXED_IAM_ROLE),
-            Map.entry("sentry", FIXED_IAM_ROLE),
-            Map.entry("slider", FIXED_IAM_ROLE),
-            Map.entry("solr", FIXED_IAM_ROLE),
-            Map.entry("spark", FIXED_IAM_ROLE),
-            Map.entry("sqoop", FIXED_IAM_ROLE),
-            Map.entry("storm", FIXED_IAM_ROLE),
-            Map.entry("tez", FIXED_IAM_ROLE),
-            Map.entry("yarn", FIXED_IAM_ROLE),
-            Map.entry("yarn-ats", FIXED_IAM_ROLE),
-            Map.entry("ycloudadm", FIXED_IAM_ROLE),
-            Map.entry("zeppelin", FIXED_IAM_ROLE),
-            Map.entry("zookeeper", FIXED_IAM_ROLE)
-    );
+    private static final Map<String, String> MOCK_IDBROKER_USER_MAPPINGS = AccountMappingSubject.DATA_ACCESS_AND_RANGER_AUDIT_USERS
+            .stream()
+            .map(user -> Map.entry(user, FIXED_IAM_ROLE))
+            .collect(Collectors.toUnmodifiableMap(Entry::getKey, Entry::getValue));
 
-    @Inject
-    private CloudPlatformConnectors cloudPlatformConnectors;
+    private final CloudPlatformConnectors cloudPlatformConnectors;
 
-    @Inject
-    private CredentialToCloudCredentialConverter credentialConverter;
+    private final CredentialToCloudCredentialConverter credentialConverter;
+
+    public AwsMockAccountMappingService(CloudPlatformConnectors cloudPlatformConnectors, CredentialToCloudCredentialConverter credentialConverter) {
+        this.cloudPlatformConnectors = cloudPlatformConnectors;
+        this.credentialConverter = credentialConverter;
+    }
 
     public Map<String, String> getGroupMappings(String region, Credential credential, String adminGroupName) {
         String accountId = getAccountId(region, credential);
@@ -92,8 +58,8 @@ public class AwsMockAccountMappingService {
         return cloudPlatformConnectors.get(Platform.platform(platform), Variant.variant(platform)).identityService();
     }
 
-    private Map<String, String> replaceAccountId(Map<String, String> mapping, String accountId) {
-        return mapping.entrySet()
+    private Map<String, String> replaceAccountId(Map<String, String> mappings, String accountId) {
+        return mappings.entrySet()
                 .stream()
                 .map(e -> Map.entry(e.getKey(), e.getValue().replace("${accountId}", accountId)))
                 .collect(Collectors.toMap(Entry::getKey, Entry::getValue));

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/identitymapping/AzureMockAccountMappingService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/identitymapping/AzureMockAccountMappingService.java
@@ -4,14 +4,10 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
-import javax.inject.Inject;
-
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
-import com.sequenceiq.cloudbreak.converter.spi.CredentialToCloudCredentialConverter;
 import com.sequenceiq.cloudbreak.dto.credential.Credential;
 
 @Component
@@ -22,51 +18,10 @@ public class AzureMockAccountMappingService {
     private static final String FIXED_MANAGED_IDENTITY = "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupId}/" +
             "providers/Microsoft.ManagedIdentity/userAssignedIdentities/mock-idbroker-admin-identity";
 
-    private static final Map<String, String> MOCK_IDBROKER_USER_MAPPINGS = Map.ofEntries(
-            Map.entry("accumulo", FIXED_MANAGED_IDENTITY),
-            Map.entry("ambari-qa", FIXED_MANAGED_IDENTITY),
-            Map.entry("ams", FIXED_MANAGED_IDENTITY),
-            Map.entry("atlas", FIXED_MANAGED_IDENTITY),
-            Map.entry("docker", FIXED_MANAGED_IDENTITY),
-            Map.entry("dpprofiler", FIXED_MANAGED_IDENTITY),
-            Map.entry("falcon", FIXED_MANAGED_IDENTITY),
-            Map.entry("flume", FIXED_MANAGED_IDENTITY),
-            Map.entry("hbase", FIXED_MANAGED_IDENTITY),
-            Map.entry("hcat", FIXED_MANAGED_IDENTITY),
-            Map.entry("hdfs", FIXED_MANAGED_IDENTITY),
-            Map.entry("hive", FIXED_MANAGED_IDENTITY),
-            Map.entry("httpfs", FIXED_MANAGED_IDENTITY),
-            Map.entry("hue", FIXED_MANAGED_IDENTITY),
-            Map.entry("impala", FIXED_MANAGED_IDENTITY),
-            Map.entry("infra-solr", FIXED_MANAGED_IDENTITY),
-            Map.entry("kafka", FIXED_MANAGED_IDENTITY),
-            Map.entry("kms", FIXED_MANAGED_IDENTITY),
-            Map.entry("knox", FIXED_MANAGED_IDENTITY),
-            Map.entry("kudu", FIXED_MANAGED_IDENTITY),
-            Map.entry("livy", FIXED_MANAGED_IDENTITY),
-            Map.entry("mahout", FIXED_MANAGED_IDENTITY),
-            Map.entry("mapred", FIXED_MANAGED_IDENTITY),
-            Map.entry("oozie", FIXED_MANAGED_IDENTITY),
-            Map.entry("ranger", FIXED_MANAGED_IDENTITY),
-            Map.entry("sentry", FIXED_MANAGED_IDENTITY),
-            Map.entry("slider", FIXED_MANAGED_IDENTITY),
-            Map.entry("solr", FIXED_MANAGED_IDENTITY),
-            Map.entry("spark", FIXED_MANAGED_IDENTITY),
-            Map.entry("sqoop", FIXED_MANAGED_IDENTITY),
-            Map.entry("storm", FIXED_MANAGED_IDENTITY),
-            Map.entry("tez", FIXED_MANAGED_IDENTITY),
-            Map.entry("yarn", FIXED_MANAGED_IDENTITY),
-            Map.entry("yarn-ats", FIXED_MANAGED_IDENTITY),
-            Map.entry("ycloudadm", FIXED_MANAGED_IDENTITY),
-            Map.entry("zeppelin", FIXED_MANAGED_IDENTITY),
-            Map.entry("zookeeper", FIXED_MANAGED_IDENTITY)
-    );
-
-    @Inject
-    private CloudPlatformConnectors cloudPlatformConnectors;
-
-    @Inject
-    private CredentialToCloudCredentialConverter credentialConverter;
+    private static final Map<String, String> MOCK_IDBROKER_USER_MAPPINGS = AccountMappingSubject.DATA_ACCESS_AND_RANGER_AUDIT_USERS
+            .stream()
+            .map(user -> Map.entry(user, FIXED_MANAGED_IDENTITY))
+            .collect(Collectors.toUnmodifiableMap(Entry::getKey, Entry::getValue));
 
     public Map<String, String> getGroupMappings(String resourceGroup, Credential credential, String adminGroupName) {
         String subscriptionId = credential.getAzure().getSubscriptionId();
@@ -82,8 +37,8 @@ public class AzureMockAccountMappingService {
         return replacePlaceholders(MOCK_IDBROKER_USER_MAPPINGS, resourceGroup, subscriptionId);
     }
 
-    private Map<String, String> replacePlaceholders(Map<String, String> mapping, String resourceGroup, String subscriptionId) {
-        return mapping.entrySet()
+    private Map<String, String> replacePlaceholders(Map<String, String> mappings, String resourceGroup, String subscriptionId) {
+        return mappings.entrySet()
                 .stream()
                 .map(e -> Map.entry(e.getKey(), e.getValue().
                         replace("${subscriptionId}", subscriptionId).

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/identitymapping/AwsMockAccountMappingServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/identitymapping/AwsMockAccountMappingServiceTest.java
@@ -1,0 +1,88 @@
+package com.sequenceiq.cloudbreak.service.identitymapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cloud.CloudConnector;
+import com.sequenceiq.cloudbreak.cloud.IdentityService;
+import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.Platform;
+import com.sequenceiq.cloudbreak.cloud.model.Variant;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.converter.spi.CredentialToCloudCredentialConverter;
+import com.sequenceiq.cloudbreak.dto.credential.Credential;
+
+@ExtendWith(MockitoExtension.class)
+class AwsMockAccountMappingServiceTest {
+
+    private static final String REGION = "region";
+
+    private static final String ADMIN_GROUP_NAME = "adminGroupName";
+
+    private static final String ACCOUNT_ID = "accountId";
+
+    private static final String IAM_ROLE = "arn:aws:iam::" + ACCOUNT_ID + ":role/mock-idbroker-admin-role";
+
+    @Mock
+    private CloudPlatformConnectors cloudPlatformConnectors;
+
+    @Mock
+    private CredentialToCloudCredentialConverter credentialConverter;
+
+    @Mock
+    private CloudCredential cloudCredential;
+
+    @Mock
+    private CloudConnector cloudConnector;
+
+    @Mock
+    private IdentityService identityService;
+
+    @InjectMocks
+    private AwsMockAccountMappingService underTest;
+
+    private Credential credential;
+
+    @BeforeEach
+    void setUp() {
+        credential = Credential.builder().cloudPlatform(CloudPlatform.AWS.name()).build();
+        when(credentialConverter.convert(credential)).thenReturn(cloudCredential);
+        when(cloudPlatformConnectors.get(any(Platform.class), any(Variant.class))).thenReturn(cloudConnector);
+        when(cloudConnector.identityService()).thenReturn(identityService);
+        when(identityService.getAccountId(REGION, cloudCredential)).thenReturn(ACCOUNT_ID);
+    }
+
+    @Test
+    void testGetUserMappings() {
+        Map<String, String> userMappings = underTest.getUserMappings(REGION, credential);
+        assertThat(userMappings).isNotNull();
+        AccountMappingSubject.DATA_ACCESS_AND_RANGER_AUDIT_USERS.forEach(user -> assertThat(userMappings).contains(Map.entry(user, IAM_ROLE)));
+        assertThat(userMappings).hasSize(AccountMappingSubject.DATA_ACCESS_AND_RANGER_AUDIT_USERS.size());
+    }
+
+    @Test
+    void testGetGroupMappingsWhenSuccess() {
+        Map<String, String> groupMappings = underTest.getGroupMappings(REGION, credential, ADMIN_GROUP_NAME);
+        assertThat(groupMappings).isNotNull();
+        assertThat(groupMappings).containsOnly(Map.entry(ADMIN_GROUP_NAME, IAM_ROLE));
+    }
+
+    @Test
+    void testGetGroupMappingsWhenAdminGroupIsMissing() {
+        assertThrows(CloudbreakServiceException.class, () -> underTest.getGroupMappings(REGION, credential, null));
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/identitymapping/AzureMockAccountMappingServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/identitymapping/AzureMockAccountMappingServiceTest.java
@@ -1,0 +1,60 @@
+package com.sequenceiq.cloudbreak.service.identitymapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.dto.credential.Credential;
+import com.sequenceiq.cloudbreak.dto.credential.azure.AzureCredentialAttributes;
+
+class AzureMockAccountMappingServiceTest {
+
+    private static final String ADMIN_GROUP_NAME = "adminGroupName";
+
+    private static final String SUBSCRIPTION_ID = "subscriptionId";
+
+    private static final String RESOURCE_GROUP = "resourceGroup";
+
+    private static final String MANAGED_IDENTITY = "/subscriptions/" + SUBSCRIPTION_ID + "/resourceGroups/" + RESOURCE_GROUP +
+            "/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mock-idbroker-admin-identity";
+
+    private AzureMockAccountMappingService underTest;
+
+    private Credential credential;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new AzureMockAccountMappingService();
+        credential = Credential.builder()
+                .cloudPlatform(CloudPlatform.AZURE.name())
+                .azure(AzureCredentialAttributes.builder().subscriptionId(SUBSCRIPTION_ID).build())
+                .build();
+    }
+
+    @Test
+    void testGetUserMappings() {
+        Map<String, String> userMappings = underTest.getUserMappings(RESOURCE_GROUP, credential);
+        assertThat(userMappings).isNotNull();
+        AccountMappingSubject.DATA_ACCESS_AND_RANGER_AUDIT_USERS.forEach(user -> assertThat(userMappings).contains(Map.entry(user, MANAGED_IDENTITY)));
+        assertThat(userMappings).hasSize(AccountMappingSubject.DATA_ACCESS_AND_RANGER_AUDIT_USERS.size());
+    }
+
+    @Test
+    void testGetGroupMappingsWhenSuccess() {
+        Map<String, String> groupMappings = underTest.getGroupMappings(RESOURCE_GROUP, credential, ADMIN_GROUP_NAME);
+        assertThat(groupMappings).isNotNull();
+        assertThat(groupMappings).containsOnly(Map.entry(ADMIN_GROUP_NAME, MANAGED_IDENTITY));
+    }
+
+    @Test
+    void testGetGroupMappingsWhenAdminGroupIsMissing() {
+        assertThrows(CloudbreakServiceException.class, () -> underTest.getGroupMappings(RESOURCE_GROUP, credential, null));
+    }
+
+}


### PR DESCRIPTION
Contents:
* Extract Data Access and Ranger Audit service user sets into the new utility class `AccountMappingSubject`
  * Located in module `cloud-common` so that it becomes available to `AwsIDBrokerObjectStorageValidator` of #6639
  * Matches the corresponding collections of IDBMMS
* Replace field injection with constructor injection in `AwsMockAccountMappingService`
* Eliminate superfluous injected dependencies in `AzureMockAccountMappingService`
* Construct mappings in `AwsMockAccountMappingService` and `AzureMockAccountMappingService` using the user set of `AccountMappingSubject`
* Add JUnit 5 support to module `cloud-common`, while keeping JUnit 4 dependencies as well for legacy tests
* Add JUnit 5 unit tests for all classes involved