### PR TITLE
CB-3210. Fix telemetry conversion after refactor

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
@@ -123,7 +123,7 @@ public class TelemetryConverter {
         TelemetryRequest telemetryRequest = new TelemetryRequest();
         if (telemetry != null) {
             LoggingRequest loggingRequest = createLoggingRequestFromSource(telemetry);
-            WorkloadAnalyticsRequest waRequest = createWorkloadAnalyticsRequestFromSource(telemetry, telemetryRequest);
+            WorkloadAnalyticsRequest waRequest = createWorkloadAnalyticsRequestFromSource(telemetry);
             FeaturesRequest featuresRequest = createFeaturesRequestFromSource(telemetry);
 
             telemetryRequest.setWorkloadAnalytics(waRequest);
@@ -202,13 +202,12 @@ public class TelemetryConverter {
         return featuresRequest;
     }
 
-    private WorkloadAnalyticsRequest createWorkloadAnalyticsRequestFromSource(Telemetry telemetry, TelemetryRequest telemetryRequest) {
+    private WorkloadAnalyticsRequest createWorkloadAnalyticsRequestFromSource(Telemetry telemetry) {
         WorkloadAnalyticsRequest waRequest = null;
         WorkloadAnalytics workloadAnalytics = telemetry.getWorkloadAnalytics();
         if (workloadAnalytics != null) {
             waRequest = new WorkloadAnalyticsRequest();
             waRequest.setAttributes(workloadAnalytics.getAttributes());
-            telemetryRequest.setWorkloadAnalytics(waRequest);
         }
         return waRequest;
     }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/TelemetryApiConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/TelemetryApiConverter.java
@@ -54,7 +54,7 @@ public class TelemetryApiConverter {
         if (telemetry != null) {
             LoggingResponse loggingResponse = createLoggingResponseFromSource(telemetry);
             WorkloadAnalyticsResponse waResponse = createWorkloadAnalyticsResponseFromSource(telemetry);
-            FeaturesResponse featuresResponse = createFeaturesResponseFromSource(telemetry, response);
+            FeaturesResponse featuresResponse = createFeaturesResponseFromSource(telemetry);
 
             response = new TelemetryResponse();
             response.setLogging(loggingResponse);
@@ -66,13 +66,12 @@ public class TelemetryApiConverter {
         return response;
     }
 
-    private FeaturesResponse createFeaturesResponseFromSource(EnvironmentTelemetry telemetry, TelemetryResponse response) {
+    private FeaturesResponse createFeaturesResponseFromSource(EnvironmentTelemetry telemetry) {
         FeaturesResponse featuresResponse = null;
         if (telemetry.getFeatures() != null) {
             featuresResponse = new FeaturesResponse();
             featuresResponse.setReportDeploymentLogs(telemetry.getFeatures().getReportDeploymentLogs());
             featuresResponse.setWorkloadAnalytics(telemetry.getFeatures().getWorkloadAnalytics());
-            response.setFeatures(featuresResponse);
         }
         return featuresResponse;
     }


### PR DESCRIPTION
in telemetry api converter, one of the field setting is passed, if features are filled -> cause nullpointer

in telemetry converter there is a similar method, it does not cause anything but removing the request object from there as well 