### PR TITLE
[CDPD-5665] Remove Hive, metastore from the blacklist to enable Hue H…

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-702.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-702.bp
@@ -188,7 +188,7 @@
         "serviceConfigs": [
           {
             "name": "hue_service_safety_valve",
-            "value": "[desktop]\napp_blacklist=spark,zookeeper,hbase,impala,search,sqoop,security,hive,metastore,pig"
+            "value": "[desktop]\napp_blacklist=spark,zookeeper,hbase,impala,search,sqoop,security,pig"
           }
         ],
         "roleConfigGroups": [


### PR DESCRIPTION
Revert blacklist for 'hive, metastore' to enable Hue hive Editor on DE cluster

Closes #CDPD-5665
