### PR TITLE
CB-4466. Configureble Datalake RDB instance types (in static templates)

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/configuration/AppConfig.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/configuration/AppConfig.java
@@ -1,9 +1,12 @@
 package com.sequenceiq.datalake.configuration;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
+import java.util.stream.StreamSupport;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -13,9 +16,14 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.AbstractEnvironment;
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.MutablePropertySources;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.util.PropertyPlaceholderHelper;
 
 import com.google.common.collect.ImmutableMap;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
@@ -64,6 +72,9 @@ public class AppConfig implements AsyncConfigurer {
     @Inject
     private ThreadBasedRequestIdProvider threadBasedRequestIdProvider;
 
+    @Inject
+    private Environment environment;
+
     @Bean
     public CloudbreakApiClientParams cloudbreakApiClientParams() {
         return new CloudbreakApiClientParams(restDebug, certificateValidation, ignorePreValidation, cloudbreakUrl);
@@ -82,9 +93,12 @@ public class AppConfig implements AsyncConfigurer {
     @Bean
     public Map<DatabaseConfigKey, DatabaseConfig> databaseConfigs() throws IOException {
         ImmutableMap.Builder<DatabaseConfigKey, DatabaseConfig> builder = new ImmutableMap.Builder<>();
+        Properties properties = getAllProperties();
+        PropertyPlaceholderHelper propertyPlaceholderHelper =
+                new PropertyPlaceholderHelper("${", "}", ":", false);
         for (CloudPlatform cloudPlatform : CloudPlatform.values()) {
             for (SdxClusterShape sdxClusterShape : SdxClusterShape.values()) {
-                Optional<DatabaseConfig> dbConfig = readDbConfig(cloudPlatform, sdxClusterShape);
+                Optional<DatabaseConfig> dbConfig = readDbConfig(cloudPlatform, sdxClusterShape, properties, propertyPlaceholderHelper);
                 if (dbConfig.isPresent()) {
                     builder.put(new DatabaseConfigKey(cloudPlatform, sdxClusterShape), dbConfig.get());
                 }
@@ -93,7 +107,8 @@ public class AppConfig implements AsyncConfigurer {
         return builder.build();
     }
 
-    private Optional<DatabaseConfig> readDbConfig(CloudPlatform cloudPlatform, SdxClusterShape sdxClusterShape) throws IOException {
+    private Optional<DatabaseConfig> readDbConfig(CloudPlatform cloudPlatform, SdxClusterShape sdxClusterShape,
+            Properties properties, PropertyPlaceholderHelper propertyPlaceholderHelper) throws IOException {
         String resourcePath = String.format("sdx/%s/database-%s-template.json",
             cloudPlatform.toString().toLowerCase(Locale.US),
             sdxClusterShape.toString().toLowerCase(Locale.US).replaceAll("_", "-"));
@@ -102,7 +117,25 @@ public class AppConfig implements AsyncConfigurer {
             LOGGER.debug("No readable database config found for cloud platform {}, cluster shape {}: skipping",
                 cloudPlatform, sdxClusterShape);
             return Optional.empty();
+        } else {
+            LOGGER.debug("Resolving placeholder properties in {}", resourcePath);
+            databaseTemplateJson = propertyPlaceholderHelper.replacePlaceholders(databaseTemplateJson, properties);
         }
         return Optional.of(JsonUtil.readValue(databaseTemplateJson, DatabaseConfig.class));
+    }
+
+    private Properties getAllProperties() {
+        Properties springProperties = new Properties();
+        MutablePropertySources propSrcs = ((AbstractEnvironment) environment).getPropertySources();
+        StreamSupport.stream(propSrcs.spliterator(), false)
+                .filter(ps -> ps instanceof EnumerablePropertySource)
+                .map(ps -> ((EnumerablePropertySource) ps).getPropertyNames())
+                .flatMap(Arrays::stream)
+                .forEach(propName -> {
+                    String envPropValue = environment.getProperty(propName);
+                    springProperties.setProperty(propName, envPropValue);
+                    springProperties.setProperty(propName.toLowerCase().replace("_", "."), envPropValue);
+                });
+        return springProperties;
     }
 }

--- a/datalake/src/main/resources/sdx/aws/database-light-duty-template.json
+++ b/datalake/src/main/resources/sdx/aws/database-light-duty-template.json
@@ -1,5 +1,5 @@
 {
-  "instanceType": "db.m5.large",
+  "instanceType": "${sdx.rdb.aws.lightduty.instance.type:db.m5.large}",
   "vendor": "postgres",
   "volumeSize": 100
 }


### PR DESCRIPTION
that is only a draft
- replace properties (dynamic way - so it can be named anything) in static definitions (use the actual default one, maybe would make more sense to use cheaper instances by default...that would be cheaper fore development) -> these can be set as env vars in helm charts -> use different values for different envs
- I have provided only one example, probably we should fill all the templates + volume size can be configurable as well
