### PR TITLE
CDPCP-1015. Usersync uses separate threadpool

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/Status.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/Status.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common;
 
-import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 
 public enum Status {
     REQUESTED,
@@ -26,18 +27,24 @@ public enum Status {
     MAINTENANCE_MODE_ENABLED,
     UNKNOWN;
 
+    public static final Collection<Status> AVAILABLE_STATUSES = List.of(AVAILABLE, MAINTENANCE_MODE_ENABLED);
+
+    public static final Collection<Status> REMOVABLE_STATUSES = List.of(AVAILABLE, UPDATE_FAILED, CREATE_FAILED, ENABLE_SECURITY_FAILED, DELETE_FAILED,
+            DELETE_COMPLETED, STOPPED, START_FAILED, STOP_FAILED);
+
+    public static final Collection<Status> FAILED_STATUSES = List.of(UPDATE_FAILED, CREATE_FAILED, ENABLE_SECURITY_FAILED, DELETE_FAILED, START_FAILED,
+            STOP_FAILED);
+
     public boolean isRemovableStatus() {
-        return Arrays.asList(AVAILABLE, UPDATE_FAILED, CREATE_FAILED, ENABLE_SECURITY_FAILED, DELETE_FAILED,
-                DELETE_COMPLETED, STOPPED, START_FAILED, STOP_FAILED).contains(this);
+        return REMOVABLE_STATUSES.contains(this);
     }
 
     public boolean isFailed() {
-        return Arrays.asList(UPDATE_FAILED, CREATE_FAILED, ENABLE_SECURITY_FAILED, DELETE_FAILED, START_FAILED, STOP_FAILED)
-                .contains(this);
+        return FAILED_STATUSES.contains(this);
     }
 
     public boolean isAvailable() {
-        return Arrays.asList(AVAILABLE, MAINTENANCE_MODE_ENABLED).contains(this);
+        return AVAILABLE_STATUSES.contains(this);
     }
 
     public boolean isSuccessfullyDeleted() {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/UsersyncConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/UsersyncConfig.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.freeipa.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import com.sequenceiq.cloudbreak.concurrent.MDCCleanerTaskDecorator;
+
+@Configuration
+public class UsersyncConfig {
+
+    public static final String USERSYNC_TASK_EXECUTOR = "USERSYNC_TASK_EXECUTOR";
+
+    @Value("${freeipa.usersync.threadpool.core.size}")
+    private int usersyncCorePoolSize;
+
+    @Value("${freeipa.usersync.threadpool.capacity.size}")
+    private int usersyncQueueCapacity;
+
+    @Bean(name = USERSYNC_TASK_EXECUTOR)
+    public AsyncTaskExecutor usersyncTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(usersyncCorePoolSize);
+        executor.setQueueCapacity(usersyncQueueCapacity);
+        executor.setThreadNamePrefix("usersyncExecutor-");
+        executor.setTaskDecorator(new MDCCleanerTaskDecorator());
+        executor.initialize();
+        return executor;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/repository/StackRepository.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/repository/StackRepository.java
@@ -15,6 +15,7 @@ import com.sequenceiq.authorization.repository.CheckPermission;
 import com.sequenceiq.authorization.resource.AuthorizationResource;
 import com.sequenceiq.authorization.resource.AuthorizationResourceType;
 import com.sequenceiq.authorization.resource.ResourceAction;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.dto.StackIdWithStatus;
 import com.sequenceiq.freeipa.entity.Stack;
 
@@ -70,4 +71,19 @@ public interface StackRepository extends BaseJpaRepository<Stack, Long> {
     @Override
     @Query("SELECT s FROM Stack s WHERE s.id = :id")
     Optional<Stack> findById(@Param("id") Long id);
+
+    @CheckPermission(action = ResourceAction.READ)
+    @Query("SELECT s FROM Stack s WHERE s.stackStatus.status IN :stackStatuses AND s.terminated = -1 ")
+    List<Stack> findAllWithStatuses(@Param("stackStatuses") Collection<Status> stackStatuses);
+
+    @CheckPermission(action = ResourceAction.READ)
+    @Query("SELECT s FROM Stack s WHERE s.accountId = :accountId AND s.stackStatus.status IN :stackStatuses AND s.terminated = -1 ")
+    List<Stack> findByAccountIdWithStatuses(@Param("accountId") String accountId, @Param("stackStatuses") Collection<Status> stackStatuses);
+
+    @CheckPermission(action = ResourceAction.READ)
+    @Query("SELECT s FROM Stack s WHERE s.accountId = :accountId AND s.environmentCrn IN :environmentCrns " +
+            "AND s.stackStatus.status IN :stackStatuses AND s.terminated = -1 ")
+    List<Stack> findMultipleByEnvironmentCrnAndAccountIdWithStatuses(
+            @Param("environmentCrns") Collection<String> environmentCrns, @Param("accountId") String accountId,
+            @Param("stackStatuses") Collection<Status> stackStatuses);
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/PasswordService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/PasswordService.java
@@ -10,6 +10,7 @@ import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.stereotype.Service;
 
@@ -24,6 +25,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SuccessDetails;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SyncOperationStatus;
 import com.sequenceiq.freeipa.api.v1.operation.model.OperationState;
 import com.sequenceiq.freeipa.api.v1.operation.model.OperationType;
+import com.sequenceiq.freeipa.configuration.UsersyncConfig;
 import com.sequenceiq.freeipa.controller.exception.NotFoundException;
 import com.sequenceiq.freeipa.converter.freeipa.user.OperationToSyncOperationStatus;
 import com.sequenceiq.freeipa.entity.Operation;
@@ -53,6 +55,7 @@ public class PasswordService {
     private GrpcUmsClient umsClient;
 
     @Inject
+    @Qualifier(UsersyncConfig.USERSYNC_TASK_EXECUTOR)
     private AsyncTaskExecutor asyncTaskExecutor;
 
     @Inject

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserService.java
@@ -20,6 +20,7 @@ import javax.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.stereotype.Service;
@@ -44,6 +45,7 @@ import com.sequenceiq.freeipa.client.FreeIpaClient;
 import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.client.model.Config;
 import com.sequenceiq.freeipa.client.model.RPCResponse;
+import com.sequenceiq.freeipa.configuration.UsersyncConfig;
 import com.sequenceiq.freeipa.controller.exception.BadRequestException;
 import com.sequenceiq.freeipa.controller.exception.NotFoundException;
 import com.sequenceiq.freeipa.converter.freeipa.user.OperationToSyncOperationStatus;
@@ -69,7 +71,7 @@ public class UserService {
     private static final int DEFAULT_MAX_SUBJECTS_PER_REQUEST = 10;
 
     @VisibleForTesting
-    @Value("${freeipa.syncoperation.max-subjects-per-request:10}")
+    @Value("${freeipa.usersync.max-subjects-per-request}")
     int maxSubjectsPerRequest = DEFAULT_MAX_SUBJECTS_PER_REQUEST;
 
     @Inject
@@ -85,6 +87,7 @@ public class UserService {
     private FreeIpaUsersStateProvider freeIpaUsersStateProvider;
 
     @Inject
+    @Qualifier(UsersyncConfig.USERSYNC_TASK_EXECUTOR)
     private AsyncTaskExecutor asyncTaskExecutor;
 
     @Inject

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
@@ -9,6 +9,7 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.controller.exception.NotFoundException;
 import com.sequenceiq.freeipa.dto.StackIdWithStatus;
 import com.sequenceiq.freeipa.entity.Stack;
@@ -47,7 +48,11 @@ public class StackService {
     }
 
     public List<Stack> getMultipleByEnvironmentCrnAndAccountId(Collection<String> environmentCrns, String accountId) {
-        return stackRepository.findMultipleByEnvironmentCrnAndAccountId(environmentCrns, accountId);
+        if (environmentCrns.isEmpty()) {
+            return getAllByAccountId(accountId);
+        } else {
+            return stackRepository.findMultipleByEnvironmentCrnAndAccountId(environmentCrns, accountId);
+        }
     }
 
     public Optional<Stack> findByEnvironmentCrnAndAccountId(String environmentCrn, String accountId) {
@@ -73,5 +78,21 @@ public class StackService {
 
     public List<StackIdWithStatus> getStatuses(Set<Long> stackIds) {
         return stackRepository.findStackStatusesWithoutAuth(stackIds);
+    }
+
+    public List<Stack> findAllWithStatuses(Collection<Status> statuses) {
+        return stackRepository.findAllWithStatuses(statuses);
+    }
+
+    public List<Stack> findAllByAccountIdWithStatuses(String accountId, Collection<Status> statuses) {
+        return stackRepository.findByAccountIdWithStatuses(accountId, statuses);
+    }
+
+    public List<Stack> findMultipleByEnvironmentCrnAndAccountIdWithStatuses(Collection<String> environmentCrns, String accountId, Collection<Status> statuses) {
+        if (environmentCrns.isEmpty()) {
+            return findAllByAccountIdWithStatuses(accountId, statuses);
+        } else {
+            return stackRepository.findMultipleByEnvironmentCrnAndAccountIdWithStatuses(environmentCrns, accountId, statuses);
+        }
     }
 }

--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -65,16 +65,20 @@ freeipa:
     max-failures-before-lock: 10
     failure-reset-interval: 3
     lockout-duration: 10
-  syncoperation:
-    max-subjects-per-request: 10
+  operation:
     cleanup:
       timeout-millis: 1800000
       initial-delay-millis: 60000
       fixed-delay-millis: 60000
+  usersync:
+    max-subjects-per-request: 10
     poller:
       enabled: true
       initial-delay-millis: 60000
       fixed-delay-millis: 300000
+    threadpool:
+      core.size: 100
+      capacity.size: 4000
 
 info:
   app:

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UsersyncPollerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UsersyncPollerTest.java
@@ -20,6 +20,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.entity.UserSyncStatus;
 import com.sequenceiq.freeipa.service.freeipa.user.model.UmsEventGenerationIds;
@@ -107,7 +108,7 @@ class UsersyncPollerTest {
         Stack stack = new Stack();
         stack.setAccountId(ACCOUNT_ID);
         stack.setEnvironmentCrn(ENVIRONMENT_CRN);
-        when(stackService.findAllRunning()).thenReturn(List.of(stack));
+        when(stackService.findAllWithStatuses(Status.AVAILABLE_STATUSES)).thenReturn(List.of(stack));
         return stack;
     }
 


### PR DESCRIPTION
A separate threadpool is configured for use by the UserService and PasswordService.
Minor related configuration improvements are included:
- UsersyncPoller bean is conditionally created instead of checking the enabled flag
- application.yml is updated to move relevant configuration properties under freeipa.usersync
