### PR TITLE
CB-4488 Hide Azure cluster definitions when Azure entitlement is missing

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/template/ClusterTemplateCloudPlatformValidator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/template/ClusterTemplateCloudPlatformValidator.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.cloudbreak.service.template;
+
+import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AZURE;
+
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.auth.security.InternalCrnBuilder;
+
+@Component
+public class ClusterTemplateCloudPlatformValidator {
+
+    @VisibleForTesting
+    static final String IAM_INTERNAL_ACTOR_CRN = new InternalCrnBuilder(Crn.Service.IAM).getInternalCrnForServiceAsString();
+
+    private final Set<String> enabledPlatforms;
+
+    private final EntitlementService entitlementService;
+
+    public ClusterTemplateCloudPlatformValidator(@Value("${cb.enabledplatforms:}") Set<String> enabledPlatforms, EntitlementService entitlementService) {
+        this.enabledPlatforms = enabledPlatforms;
+        this.entitlementService = entitlementService;
+    }
+
+    public boolean isClusterTemplateCloudPlatformValid(String cloudPlatform, String accountId) {
+        return enabledPlatforms.contains(cloudPlatform)
+                && (!AZURE.name().equalsIgnoreCase(cloudPlatform) || entitlementService.azureEnabled(IAM_INTERNAL_ACTOR_CRN, accountId));
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/controller/v4/ClusterTemplateV4ControllerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/controller/v4/ClusterTemplateV4ControllerTest.java
@@ -1,0 +1,47 @@
+package com.sequenceiq.cloudbreak.controller.v4;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.responses.ClusterTemplateViewV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.responses.ClusterTemplateViewV4Responses;
+import com.sequenceiq.cloudbreak.service.blueprint.BlueprintService;
+import com.sequenceiq.cloudbreak.service.template.ClusterTemplateService;
+
+@ExtendWith(MockitoExtension.class)
+class ClusterTemplateV4ControllerTest {
+
+    private static final Long WORKSPACE_ID = 123L;
+
+    @Mock
+    private BlueprintService blueprintService;
+
+    @Mock
+    private ClusterTemplateService clusterTemplateService;
+
+    @InjectMocks
+    private ClusterTemplateV4Controller underTest;
+
+    @Test
+    void testList() {
+        Set<ClusterTemplateViewV4Response> responses = Set.of();
+        when(clusterTemplateService.listInWorkspaceAndCleanUpInvalids(WORKSPACE_ID)).thenReturn(responses);
+
+        ClusterTemplateViewV4Responses result = underTest.list(WORKSPACE_ID);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getResponses()).isSameAs(responses);
+        verify(blueprintService).updateDefaultBlueprintCollection(WORKSPACE_ID);
+        verify(clusterTemplateService).updateDefaultClusterTemplates(WORKSPACE_ID);
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/template/ClusterTemplateCloudPlatformValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/template/ClusterTemplateCloudPlatformValidatorTest.java
@@ -1,0 +1,97 @@
+package com.sequenceiq.cloudbreak.service.template;
+
+import static com.sequenceiq.cloudbreak.service.template.ClusterTemplateCloudPlatformValidator.IAM_INTERNAL_ACTOR_CRN;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+
+@ExtendWith(MockitoExtension.class)
+class ClusterTemplateCloudPlatformValidatorTest {
+
+    private static final String ACCOUNT_ID = UUID.randomUUID().toString();
+
+    private static final String AWS = "AWS";
+
+    private static final String AZURE = "AZURE";
+
+    private static final String FOO = "FOO";
+
+    private static final String GCP = "GCP";
+
+    private static final String AZURE_DISABLED = " & Azure disabled";
+
+    private static final String AZURE_ENABLED = " & Azure enabled";
+
+    private static final Set<String> ENABLED_PLATFORMS_AWS_AZURE = Set.of(AWS, AZURE);
+
+    private static final String ENABLED_PLATFORMS_AWS_AZURE_S = "Enabled platforms {AWS, AZURE} & ";
+
+    private static final Set<String> ENABLED_PLATFORMS_AZURE_GCP = Set.of(AZURE, GCP);
+
+    private static final String ENABLED_PLATFORMS_AZURE_GCP_S = "Enabled platforms {AZURE, GCP} & ";
+
+    private static final Set<String> ENABLED_PLATFORMS_AWS_GCP = Set.of(AWS, GCP);
+
+    private static final String ENABLED_PLATFORMS_AWS_GCP_S = "Enabled platforms {AWS, GCP} & ";
+
+    @Mock
+    private EntitlementService entitlementService;
+
+    private ClusterTemplateCloudPlatformValidator underTest;
+
+    private void setUpUnderTest(Set<String> enabledPlatforms) {
+        underTest = new ClusterTemplateCloudPlatformValidator(enabledPlatforms, entitlementService);
+    }
+
+    // @formatter:off
+    // CHECKSTYLE:OFF
+    static Object[][] validateClusterTemplateCloudPlatformDataProvider() {
+        return new Object[][] {
+                // testCaseName                                             enabledPlatforms                cloudPlatform   azureEnabled    validExpected
+                { ENABLED_PLATFORMS_AWS_AZURE_S + AWS + AZURE_DISABLED,     ENABLED_PLATFORMS_AWS_AZURE,    AWS,            false,          true },
+                { ENABLED_PLATFORMS_AWS_AZURE_S + AZURE + AZURE_DISABLED,   ENABLED_PLATFORMS_AWS_AZURE,    AZURE,          false,          false },
+                { ENABLED_PLATFORMS_AWS_AZURE_S + GCP + AZURE_DISABLED,     ENABLED_PLATFORMS_AWS_AZURE,    GCP,            false,          false },
+                { ENABLED_PLATFORMS_AWS_AZURE_S + FOO + AZURE_DISABLED,     ENABLED_PLATFORMS_AWS_AZURE,    FOO,            false,          false },
+                { ENABLED_PLATFORMS_AWS_AZURE_S + AWS + AZURE_ENABLED,      ENABLED_PLATFORMS_AWS_AZURE,    AWS,            true,           true },
+                { ENABLED_PLATFORMS_AWS_AZURE_S + AZURE + AZURE_ENABLED,    ENABLED_PLATFORMS_AWS_AZURE,    AZURE,          true,           true },
+                { ENABLED_PLATFORMS_AWS_AZURE_S + GCP + AZURE_ENABLED,      ENABLED_PLATFORMS_AWS_AZURE,    GCP,            true,           false },
+                { ENABLED_PLATFORMS_AWS_AZURE_S + FOO + AZURE_ENABLED,      ENABLED_PLATFORMS_AWS_AZURE,    FOO,            true,           false },
+
+                { ENABLED_PLATFORMS_AZURE_GCP_S + AWS + AZURE_DISABLED,     ENABLED_PLATFORMS_AZURE_GCP,    AWS,            false,          false },
+                { ENABLED_PLATFORMS_AZURE_GCP_S + AZURE + AZURE_DISABLED,   ENABLED_PLATFORMS_AZURE_GCP,    AZURE,          false,          false },
+                { ENABLED_PLATFORMS_AZURE_GCP_S + GCP + AZURE_DISABLED,     ENABLED_PLATFORMS_AZURE_GCP,    GCP,            false,          true },
+                { ENABLED_PLATFORMS_AZURE_GCP_S + FOO + AZURE_DISABLED,     ENABLED_PLATFORMS_AZURE_GCP,    FOO,            false,          false },
+                { ENABLED_PLATFORMS_AZURE_GCP_S + AWS + AZURE_ENABLED,      ENABLED_PLATFORMS_AZURE_GCP,    AWS,            true,           false },
+                { ENABLED_PLATFORMS_AZURE_GCP_S + AZURE + AZURE_ENABLED,    ENABLED_PLATFORMS_AZURE_GCP,    AZURE,          true,           true },
+                { ENABLED_PLATFORMS_AZURE_GCP_S + GCP + AZURE_ENABLED,      ENABLED_PLATFORMS_AZURE_GCP,    GCP,            true,           true },
+                { ENABLED_PLATFORMS_AZURE_GCP_S + FOO + AZURE_ENABLED,      ENABLED_PLATFORMS_AZURE_GCP,    FOO,            true,           false },
+
+                { ENABLED_PLATFORMS_AWS_GCP_S + AZURE + AZURE_DISABLED,     ENABLED_PLATFORMS_AWS_GCP,      AZURE,          false,          false },
+                { ENABLED_PLATFORMS_AWS_GCP_S + AZURE + AZURE_ENABLED,      ENABLED_PLATFORMS_AWS_GCP,      AZURE,          true,           false },
+        };
+    }
+    // CHECKSTYLE:ON
+    // @formatter:on
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("validateClusterTemplateCloudPlatformDataProvider")
+    void testIsClusterTemplateCloudPlatformValid(String testCaseName, Set<String> enabledPlatforms, String cloudPlatform, boolean azureEnabled,
+            boolean validExpected) {
+        setUpUnderTest(enabledPlatforms);
+        if (AZURE.equalsIgnoreCase(cloudPlatform)) {
+            lenient().when(entitlementService.azureEnabled(IAM_INTERNAL_ACTOR_CRN, ACCOUNT_ID)).thenReturn(azureEnabled);
+        }
+        assertThat(underTest.isClusterTemplateCloudPlatformValid(cloudPlatform, ACCOUNT_ID)).isEqualTo(validExpected);
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/template/ClusterTemplateServiceFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/template/ClusterTemplateServiceFilterTest.java
@@ -1,22 +1,69 @@
 package com.sequenceiq.cloudbreak.service.template;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import org.junit.jupiter.api.BeforeEach;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Supplier;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.responses.ClusterTemplateViewV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ResourceStatus;
+import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.common.service.TransactionService;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterTemplateView;
+import com.sequenceiq.distrox.v1.distrox.service.EnvironmentServiceDecorator;
 
+@ExtendWith(MockitoExtension.class)
 class ClusterTemplateServiceFilterTest {
 
-    private ClusterTemplateService underTest;
+    private static final String ACCOUNT_ID = UUID.randomUUID().toString();
 
-    @BeforeEach
-    void setUp() {
-        underTest = new ClusterTemplateService();
-    }
+    private static final String AWS = "AWS";
+
+    private static final String AZURE = "AZURE";
+
+    private static final Long WORKSPACE_ID = 123L;
+
+    private static final String TEMPLATE_NAME = "templateName";
+
+    private static final ClusterTemplateViewV4Response CLUSTER_TEMPLATE_VIEW_V4_RESPONSE_AWS = createClusterTemplateViewV4Response(AWS);
+
+    private static final ClusterTemplateViewV4Response CLUSTER_TEMPLATE_VIEW_V4_RESPONSE_AZURE = createClusterTemplateViewV4Response(AZURE);
+
+    @Mock
+    private ClusterTemplateViewService clusterTemplateViewService;
+
+    @Mock
+    private ThreadBasedUserCrnProvider threadBasedUserCrnProvider;
+
+    @Mock
+    private TransactionService transactionService;
+
+    @Mock
+    private ConverterUtil converterUtil;
+
+    @Mock
+    private EnvironmentServiceDecorator environmentServiceDecorator;
+
+    @Mock
+    private ClusterTemplateCloudPlatformValidator cloudPlatformValidator;
+
+    @InjectMocks
+    private ClusterTemplateService underTest;
 
     @Test
     void testIfGettingUsableTemplateWhenTemplateIsDefaultThenTrueShouldCome() {
@@ -48,6 +95,74 @@ class ClusterTemplateServiceFilterTest {
         boolean result = underTest.isUsableClusterTemplate(templateViewV4Response);
 
         assertFalse(result);
+    }
+
+    // @formatter:off
+    // CHECKSTYLE:OFF
+    static Object[][] validateClusterTemplateCloudPlatformDataProvider() {
+        return new Object[][] {
+                // testCaseName         cloudPlatformValid
+                { "invalid platform",   false },
+                { "valid platform",     true },
+        };
+    }
+    // CHECKSTYLE:ON
+    // @formatter:on
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("validateClusterTemplateCloudPlatformDataProvider")
+    void testIsClusterTemplateHasValidCloudPlatform(String testCaseName, boolean cloudPlatformValid) {
+        ClusterTemplateViewV4Response response = new ClusterTemplateViewV4Response();
+        response.setCloudPlatform(AWS);
+
+        when(threadBasedUserCrnProvider.getAccountId()).thenReturn(ACCOUNT_ID);
+        when(cloudPlatformValidator.isClusterTemplateCloudPlatformValid(AWS, ACCOUNT_ID)).thenReturn(cloudPlatformValid);
+
+        boolean result = underTest.isClusterTemplateHasValidCloudPlatform(response);
+
+        assertThat(result).isEqualTo(cloudPlatformValid);
+    }
+
+    // @formatter:off
+    // CHECKSTYLE:OFF
+    static Object[][] listInWorkspaceAndCleanUpInvalidsDataProvider() {
+        return new Object[][] {
+                // testCaseName                 awsEnabled  azureEnabled    expectedResult
+                { "AWS invalid, AZURE invalid", false,      false,          Set.of() },
+                { "AWS valid, AZURE invalid",   true,       false,          Set.of(CLUSTER_TEMPLATE_VIEW_V4_RESPONSE_AWS) },
+                { "AWS invalid, AZURE valid",   false,      true,           Set.of(CLUSTER_TEMPLATE_VIEW_V4_RESPONSE_AZURE) },
+                { "AWS valid, AZURE valid",     true,       true,           Set.of(CLUSTER_TEMPLATE_VIEW_V4_RESPONSE_AWS, CLUSTER_TEMPLATE_VIEW_V4_RESPONSE_AZURE) },
+        };
+    }
+    // CHECKSTYLE:ON
+    // @formatter:on
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("listInWorkspaceAndCleanUpInvalidsDataProvider")
+    void testListInWorkspaceAndCleanUpInvalidsWhenFilteringByCloudPlatform(String testCaseName, boolean awsEnabled, boolean azureEnabled,
+            Set<ClusterTemplateViewV4Response> expectedResult) throws TransactionService.TransactionExecutionException {
+        Set<ClusterTemplateView> views = Set.of(new ClusterTemplateView(), new ClusterTemplateView());
+        Set<ClusterTemplateViewV4Response> responses = Set.of(CLUSTER_TEMPLATE_VIEW_V4_RESPONSE_AWS, CLUSTER_TEMPLATE_VIEW_V4_RESPONSE_AZURE);
+
+        when(transactionService.required(isA(Supplier.class))).thenAnswer(invocation -> invocation.getArgument(0, Supplier.class).get());
+        when(clusterTemplateViewService.findAllActive(WORKSPACE_ID)).thenReturn(views);
+        when(converterUtil.convertAllAsSet(views, ClusterTemplateViewV4Response.class)).thenReturn(responses);
+        when(threadBasedUserCrnProvider.getAccountId()).thenReturn(ACCOUNT_ID);
+        when(cloudPlatformValidator.isClusterTemplateCloudPlatformValid(AWS, ACCOUNT_ID)).thenReturn(awsEnabled);
+        when(cloudPlatformValidator.isClusterTemplateCloudPlatformValid(AZURE, ACCOUNT_ID)).thenReturn(azureEnabled);
+
+        Set<ClusterTemplateViewV4Response> result = underTest.listInWorkspaceAndCleanUpInvalids(WORKSPACE_ID);
+
+        assertThat(result).isEqualTo(expectedResult);
+        verify(environmentServiceDecorator).prepareEnvironments(responses);
+    }
+
+    private static ClusterTemplateViewV4Response createClusterTemplateViewV4Response(String cloudPlatform) {
+        ClusterTemplateViewV4Response response = new ClusterTemplateViewV4Response();
+        response.setName(TEMPLATE_NAME + cloudPlatform);
+        response.setCloudPlatform(cloudPlatform);
+        response.setStatus(ResourceStatus.DEFAULT);
+        return response;
     }
 
 }


### PR DESCRIPTION
* Change to cluster definitions `list()` (GET https://localhost/cloudbreak/v4/0/cluster_templates)
  * Hide Azure cluster definitions when Azure entitlement is missing
  * Hide cluster definitions associated with a disabled / invalid cloud platform
* Add unit tests