### PR TITLE
CB-4524 IDBroker mapping validation - handle case of no DynamoDB table

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsIDBrokerMappedRolePermissionValidator.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsIDBrokerMappedRolePermissionValidator.java
@@ -102,10 +102,12 @@ public abstract class AwsIDBrokerMappedRolePermissionValidator {
                                                             CloudS3View cloudFileSystem) {
         String storageLocationBase = getStorageLocationBase(location);
         String datalakeBucket = storageLocationBase.split("/", 2)[0];
+        String dynamodbTableName = cloudFileSystem.getS3GuardDynamoTableName() != null ?
+                                        cloudFileSystem.getS3GuardDynamoTableName() : "";
         return Map.ofEntries(
             Map.entry("${STORAGE_LOCATION_BASE}", storageLocationBase),
             Map.entry("${DATALAKE_BUCKET}", datalakeBucket),
-            Map.entry("${DYNAMODB_TABLE_NAME}", cloudFileSystem.getS3GuardDynamoTableName())
+            Map.entry("${DYNAMODB_TABLE_NAME}", dynamodbTableName)
         );
     }
 

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsDataAccessRolePermissionValidatorTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsDataAccessRolePermissionValidatorTest.java
@@ -84,4 +84,25 @@ public class AwsDataAccessRolePermissionValidatorTest extends AwsIDBrokerMappedR
 
         assertThat(policyJsonReplacements).isEqualTo(expectedPolicyJsonReplacements);
     }
+
+    @Override
+    public void testGetPolicyJsonReplacementsNoDynamodb() {
+        String storageLocationBaseStr = "bucket/cluster";
+        String bucket = "bucket";
+
+        Map<String, String> expectedPolicyJsonReplacements = Map.ofEntries(
+            Map.entry("${STORAGE_LOCATION_BASE}", storageLocationBaseStr),
+            Map.entry("${DATALAKE_BUCKET}", bucket),
+            Map.entry("${DYNAMODB_TABLE_NAME}", "")
+        );
+
+        StorageLocationBase storageLocationBase = new StorageLocationBase();
+        storageLocationBase.setValue(storageLocationBaseStr);
+        CloudS3View cloudFileSystem = new CloudS3View(CloudIdentityType.ID_BROKER);
+        Map<String, String> policyJsonReplacements = awsDataAccessRolePermissionValidator
+                                                        .getPolicyJsonReplacements(storageLocationBase,
+                                                            cloudFileSystem);
+
+        assertThat(policyJsonReplacements).isEqualTo(expectedPolicyJsonReplacements);
+    }
 }

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsIDBrokerMappedRolePermissionValidatorTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsIDBrokerMappedRolePermissionValidatorTest.java
@@ -43,6 +43,9 @@ public abstract class AwsIDBrokerMappedRolePermissionValidatorTest {
     public abstract void testGetPolicyJsonReplacements();
 
     @Test
+    public abstract void testGetPolicyJsonReplacementsNoDynamodb();
+
+    @Test
     public void testGetRoleArnsForUsers() {
         assertThat(getValidator().getRoleArnsForUsers(Collections.emptyList(),
             Collections.emptyMap())).isEqualTo(Collections.emptySortedSet());

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsRangerAuditRolePermissionValidatorTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsRangerAuditRolePermissionValidatorTest.java
@@ -93,4 +93,25 @@ public class AwsRangerAuditRolePermissionValidatorTest extends AwsIDBrokerMapped
 
         assertThat(policyJsonReplacements).isEqualTo(expectedPolicyJsonReplacements);
     }
+
+    @Override
+    public void testGetPolicyJsonReplacementsNoDynamodb() {
+        String storageLocationBaseStr = "bucket/cluster";
+        String bucket = "bucket";
+
+        Map<String, String> expectedPolicyJsonReplacements = Map.ofEntries(
+            Map.entry("${STORAGE_LOCATION_BASE}", storageLocationBaseStr),
+            Map.entry("${DATALAKE_BUCKET}", bucket),
+            Map.entry("${DYNAMODB_TABLE_NAME}", "")
+        );
+
+        StorageLocationBase storageLocationBase = new StorageLocationBase();
+        storageLocationBase.setValue(storageLocationBaseStr);
+        CloudS3View cloudFileSystem = new CloudS3View(CloudIdentityType.ID_BROKER);
+        Map<String, String> policyJsonReplacements = awsRangerAuditRolePermissionValidator
+                                                        .getPolicyJsonReplacements(storageLocationBase,
+                                                            cloudFileSystem);
+
+        assertThat(policyJsonReplacements).isEqualTo(expectedPolicyJsonReplacements);
+    }
 }


### PR DESCRIPTION
When no DynamoDB table is specified, IDBroker mapping validation should not fail.