### PR TITLE
CB-3329 Fix Instance Status for SDX tests

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/BasicSdxTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/BasicSdxTests.java
@@ -20,15 +20,9 @@ import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 
 public class  BasicSdxTests extends AbstractE2ETest {
 
-    protected static final SdxClusterStatusResponse SDX_RUNNING = SdxClusterStatusResponse.RUNNING;
-
-    protected static final String IDBROKER_HOSTGROUP = HostGroupType.IDBROKER.getName();
-
-    protected static final String MASTER_HOSTGROUP = HostGroupType.MASTER.getName();
-
-    private Map<String, InstanceStatus> instancesRegistered = new HashMap<>() {{
-        put(MASTER_HOSTGROUP, InstanceStatus.SERVICES_HEALTHY);
-        put(IDBROKER_HOSTGROUP, InstanceStatus.SERVICES_HEALTHY);
+    private Map<String, InstanceStatus> instancesHealthy = new HashMap<>() {{
+        put(HostGroupType.MASTER.getName(), InstanceStatus.SERVICES_HEALTHY);
+        put(HostGroupType.IDBROKER.getName(), InstanceStatus.SERVICES_HEALTHY);
     }};
 
     @Inject
@@ -57,9 +51,9 @@ public class  BasicSdxTests extends AbstractE2ETest {
         testContext
                 .given(sdx, SdxTestDto.class)
                 .when(sdxTestClient.create(), key(sdx))
-                .await(SDX_RUNNING)
+                .await(SdxClusterStatusResponse.RUNNING)
                 .then((tc, testDto, client) -> {
-                    return waitUtil.waitForSdxInstancesStatus(testDto, client, instancesRegistered);
+                    return waitUtil.waitForSdxInstancesStatus(testDto, client, instancesHealthy);
                 })
                 .validate();
     }
@@ -68,7 +62,7 @@ public class  BasicSdxTests extends AbstractE2ETest {
         return sdxTestClient;
     }
 
-    protected Map<String, InstanceStatus> getSdxInstancesRegisteredState() {
-        return instancesRegistered;
+    protected Map<String, InstanceStatus> getSdxInstancesHealthyState() {
+        return instancesHealthy;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/aws/AwsSdxCloudStorageTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/aws/AwsSdxCloudStorageTests.java
@@ -16,7 +16,6 @@ import com.sequenceiq.it.cloudbreak.util.wait.WaitUtil;
 import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 
 public class AwsSdxCloudStorageTests extends BasicSdxTests {
-    protected static final SdxClusterStatusResponse SDX_DELETED = SdxClusterStatusResponse.DELETED;
 
     @Inject
     private SdxTestClient sdxTestClient;
@@ -39,9 +38,9 @@ public class AwsSdxCloudStorageTests extends BasicSdxTests {
         testContext
                 .given(sdx, SdxTestDto.class).withCloudStorage()
                 .when(sdxTestClient.create(), key(sdx))
-                .await(SDX_RUNNING)
+                .await(SdxClusterStatusResponse.RUNNING)
                 .then((tc, testDto, client) -> {
-                    return waitUtil.waitForSdxInstancesStatus(testDto, client, getSdxInstancesRegisteredState());
+                    return waitUtil.waitForSdxInstancesStatus(testDto, client, getSdxInstancesHealthyState());
                 })
                 .then((tc, testDto, client) -> {
                     return amazonS3Util.list(tc, testDto, client);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/azure/AzureSdxCloudStorageTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/azure/AzureSdxCloudStorageTests.java
@@ -7,8 +7,6 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
@@ -24,21 +22,9 @@ import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 
 public class AzureSdxCloudStorageTests extends AbstractE2ETest {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(AzureSdxCloudStorageTests.class);
-
-    private static final SdxClusterStatusResponse SDX_RUNNING = SdxClusterStatusResponse.RUNNING;
-
-    private static final SdxClusterStatusResponse SDX_DELETED = SdxClusterStatusResponse.DELETED;
-
-    private static final InstanceStatus SERVICES_RUNNING = InstanceStatus.SERVICES_RUNNING;
-
-    private static final String IDBROKER_HOSTGROUP = HostGroupType.IDBROKER.getName();
-
-    private static final String MASTER_HOSTGROUP = HostGroupType.MASTER.getName();
-
-    private Map<String, InstanceStatus> instancesRegistered = new HashMap<String, InstanceStatus>() {{
-        put(MASTER_HOSTGROUP, SERVICES_RUNNING);
-        put(IDBROKER_HOSTGROUP, SERVICES_RUNNING);
+    private Map<String, InstanceStatus> instancesHealthy = new HashMap<String, InstanceStatus>() {{
+        put(HostGroupType.MASTER.getName(), InstanceStatus.SERVICES_HEALTHY);
+        put(HostGroupType.IDBROKER.getName(), InstanceStatus.SERVICES_HEALTHY);
     }};
 
     @Inject
@@ -71,9 +57,9 @@ public class AzureSdxCloudStorageTests extends AbstractE2ETest {
         testContext
                 .given(sdx, SdxTestDto.class).withCloudStorage()
                 .when(sdxTestClient.create(), key(sdx))
-                .await(SDX_RUNNING)
+                .await(SdxClusterStatusResponse.RUNNING)
                 .then((tc, testDto, client) -> {
-                    return waitUtil.waitForSdxInstancesStatus(testDto, client, instancesRegistered);
+                    return waitUtil.waitForSdxInstancesStatus(testDto, client, instancesHealthy);
                 })
                 .then((tc, testDto, client) -> {
                     return azureCloudBlobUtil.listAllFoldersInAContaier(tc, testDto, client);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXClusterCreationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXClusterCreationTest.java
@@ -46,8 +46,6 @@ public class DistroXClusterCreationTest extends AbstractClouderaManagerTest {
 
     private static final String IMAGE_CATALOG_ID = "f6e778fc-7f17-4535-9021-515351df3691";
 
-    private static final SdxClusterStatusResponse SDX_RUNNING = SdxClusterStatusResponse.RUNNING;
-
     private static final String MOCK_HOSTNAME = "mockrdshost";
 
     private static final String CM_FOR_DISTRO_X = "cm4dstrx";
@@ -165,7 +163,7 @@ public class DistroXClusterCreationTest extends AbstractClouderaManagerTest {
                 .given(sdxInternal, SdxInternalTestDto.class).withStackRequest(stack, cluster).withDatabase(sdxDatabaseRequestWithCreateTrue())
                 .withCloudStorage(testStorage()).withEnvironmentKey(key(storageEnvKey))
                 .when(sdxTestClient.createInternal(), key(sdxInternal))
-                .await(SDX_RUNNING)
+                .await(SdxClusterStatusResponse.RUNNING)
                 .given(DIX_NET_KEY, DistroXNetworkTestDto.class)
                 .given(DIX_IMG_KEY, DistroXImageTestDto.class)
                 .withImageCatalog(getImageCatalogName(testContext))
@@ -221,7 +219,7 @@ public class DistroXClusterCreationTest extends AbstractClouderaManagerTest {
                 .given(sdxInternal, SdxInternalTestDto.class).withStackRequest(stack, cluster).withDatabase(sdxDatabaseRequestWithCreateTrue())
                 .withEnvironmentKey(key(envKey))
                 .when(sdxTestClient.createInternal(), key(sdxInternal))
-                .await(SDX_RUNNING)
+                .await(SdxClusterStatusResponse.RUNNING)
                 .given(DIX_NET_KEY, DistroXNetworkTestDto.class)
                 .given(DIX_IMG_KEY, DistroXImageTestDto.class)
                 .withImageCatalog(getImageCatalogName(testContext))

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXClusterStopStartTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXClusterStopStartTest.java
@@ -18,13 +18,10 @@ import com.sequenceiq.it.cloudbreak.dto.distrox.image.DistroXImageTestDto;
 import com.sequenceiq.it.cloudbreak.dto.distrox.instancegroup.DistroXNetworkTestDto;
 import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
 import com.sequenceiq.it.cloudbreak.testcase.mock.clouderamanager.AbstractClouderaManagerTest;
-import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 
 public class DistroXClusterStopStartTest extends AbstractClouderaManagerTest {
 
     private static final String IMAGE_CATALOG_ID = "f6e778fc-7f17-4535-9021-515351df3691";
-
-    private static final SdxClusterStatusResponse SDX_RUNNING = SdxClusterStatusResponse.RUNNING;
 
     private static final String MOCK_HOSTNAME = "mockrdshost";
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxTests.java
@@ -25,10 +25,6 @@ import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 
 public class MockSdxTests extends AbstractIntegrationTest {
 
-    protected static final SdxClusterStatusResponse SDX_RUNNING = SdxClusterStatusResponse.RUNNING;
-
-    protected static final SdxClusterStatusResponse SDX_DELETED = SdxClusterStatusResponse.DELETED;
-
     private static final String TEMPLATE_JSON = "classpath:/templates/sdx-cluster-template.json";
 
     @Inject
@@ -66,9 +62,9 @@ public class MockSdxTests extends AbstractIntegrationTest {
                 .withStackRequest(stack, cluster)
                 .withEnvironmentKey(key(envKey))
                 .when(sdxTestClient.createInternal(), key(sdxInternal))
-                .await(SDX_RUNNING)
+                .await(SdxClusterStatusResponse.RUNNING)
                 .then((tc, testDto, client) -> sdxTestClient.deleteInternal().action(tc, testDto, client))
-                .await(SDX_DELETED)
+                .await(SdxClusterStatusResponse.DELETED)
                 .validate();
     }
 
@@ -104,9 +100,9 @@ public class MockSdxTests extends AbstractIntegrationTest {
                 .withTemplate(ResourceUtil.readResourceAsJson(applicationContext, TEMPLATE_JSON))
                 .withEnvironmentKey(key(envKey))
                 .when(sdxTestClient.createInternal(), key(sdxInternal))
-                .await(SDX_RUNNING)
+                .await(SdxClusterStatusResponse.RUNNING)
                 .then((tc, testDto, client) -> sdxTestClient.deleteInternal().action(tc, testDto, client))
-                .await(SDX_DELETED)
+                .await(SdxClusterStatusResponse.DELETED)
                 .validate();
     }
 
@@ -150,6 +146,6 @@ public class MockSdxTests extends AbstractIntegrationTest {
                 .withStackRequest(stack, cluster)
                 .withEnvironmentKey(key(envKey))
                 .when(sdxTestClient.createInternal(), key(sdxInternal))
-                .await(SDX_RUNNING);
+                .await(SdxClusterStatusResponse.RUNNING);
     }
 }


### PR DESCRIPTION
@lnardai or @sodre90 please review then merge if it is OK for you.

Based on the latest SDX response:
```
{
 ...
  "clusterShape": "LIGHT_DUTY",
  "status": "RUNNING",
  "statusReason": "Datalake is running",
...
  "stackV4Response": {
...
    "status": "AVAILABLE",
...
"instanceGroups": [
      {
        "nodeCount": 1,
        "name": "master",
        "type": "CORE",
...
        "metadata": [
          {
...
            "instanceGroup": "master",
            "instanceStatus": "SERVICES_HEALTHY",
            "instanceType": "GATEWAY_PRIMARY",
            "state": "HEALTHY",
            "mountedVolumes": []
          }
        ],
...
      },
      {
        "nodeCount": 1,
        "name": "idbroker",
        "type": "CORE",
...
        "metadata": [
          {
...
            "instanceGroup": "idbroker",
            "instanceStatus": "SERVICES_HEALTHY",
            "instanceType": "CORE",
            "state": "HEALTHY",
            "mountedVolumes": []
          }
        ],
...
    ],
```
