### PR TITLE
CB-4444 Fix token expiration issue (version 1)

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsClient.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsClient.java
@@ -82,22 +82,22 @@ public class AwsClient {
     }
 
     public AmazonEC2Client createAccess(AwsCredentialView awsCredential, String regionName) {
-        AmazonEC2Client client = isRoleAssumeRequired(awsCredential)
-                ? new AmazonEC2Client(credentialClient.retrieveCachedSessionCredentials(awsCredential))
-                : new AmazonEC2Client(createAwsCredentials(awsCredential));
+        AmazonEC2Client client = isRoleAssumeRequired(awsCredential) ?
+                new AmazonEC2Client(createAwsSessionCredentialProvider(awsCredential)) :
+                new AmazonEC2Client(createAwsCredentials(awsCredential));
         client.setRegion(RegionUtils.getRegion(regionName));
         return client;
     }
 
     public AWSSecurityTokenService createAwsSecurityTokenService(AwsCredentialView awsCredential) {
         return isRoleAssumeRequired(awsCredential)
-                ? new AWSSecurityTokenServiceClient(credentialClient.retrieveCachedSessionCredentials(awsCredential))
+                ? new AWSSecurityTokenServiceClient(createAwsSessionCredentialProvider(awsCredential))
                 : new AWSSecurityTokenServiceClient(createAwsCredentials(awsCredential));
     }
 
     public AmazonIdentityManagement createAmazonIdentityManagement(AwsCredentialView awsCredential) {
         return isRoleAssumeRequired(awsCredential)
-                ? new AmazonIdentityManagementClient(credentialClient.retrieveCachedSessionCredentials(awsCredential))
+                ? new AmazonIdentityManagementClient(createAwsSessionCredentialProvider(awsCredential))
                 : new AmazonIdentityManagementClient(createAwsCredentials(awsCredential));
     }
 
@@ -115,9 +115,9 @@ public class AwsClient {
     }
 
     public AmazonCloudFormationClient createCloudFormationClient(AwsCredentialView awsCredential, String regionName) {
-        AmazonCloudFormationClient client = isRoleAssumeRequired(awsCredential)
-                ? new AmazonCloudFormationClient(credentialClient.retrieveCachedSessionCredentials(awsCredential))
-                : new AmazonCloudFormationClient(createAwsCredentials(awsCredential));
+        AmazonCloudFormationClient client = isRoleAssumeRequired(awsCredential) ?
+                new AmazonCloudFormationClient(createAwsSessionCredentialProvider(awsCredential)) :
+                new AmazonCloudFormationClient(createAwsCredentials(awsCredential));
         client.setRegion(RegionUtils.getRegion(regionName));
         return client;
     }
@@ -127,9 +127,9 @@ public class AwsClient {
     }
 
     public AmazonAutoScalingClient createAutoScalingClient(AwsCredentialView awsCredential, String regionName) {
-        AmazonAutoScalingClient client = isRoleAssumeRequired(awsCredential)
-                ? new AmazonAutoScalingClient(credentialClient.retrieveCachedSessionCredentials(awsCredential))
-                : new AmazonAutoScalingClient(createAwsCredentials(awsCredential));
+        AmazonAutoScalingClient client = isRoleAssumeRequired(awsCredential) ?
+                new AmazonAutoScalingClient(createAwsSessionCredentialProvider(awsCredential)) :
+                new AmazonAutoScalingClient(createAwsCredentials(awsCredential));
         client.setRegion(RegionUtils.getRegion(regionName));
         return client;
     }
@@ -227,5 +227,9 @@ public class AwsClient {
             throw new CredentialVerificationException("Missing access or secret key from the credential.");
         }
         return new BasicAWSCredentials(accessKey, secretKey);
+    }
+
+    private AwsSessionCredentialProvider createAwsSessionCredentialProvider(AwsCredentialView awsCredential) {
+        return new AwsSessionCredentialProvider(awsCredential, credentialClient);
     }
 }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsSessionCredentialProvider.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsSessionCredentialProvider.java
@@ -1,0 +1,66 @@
+package com.sequenceiq.cloudbreak.cloud.aws;
+
+import java.util.Date;
+
+import org.joda.time.DateTime;
+import org.joda.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.sequenceiq.cloudbreak.cloud.aws.view.AwsCredentialView;
+
+public class AwsSessionCredentialProvider implements AWSCredentialsProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsSessionCredentialProvider.class);
+
+    private static final int FORCE_TOKEN_REFRESH_TIME_IN_MIN_DEFAULT = 5;
+
+    private final AwsCredentialView awsCredentialView;
+
+    private final AwsSessionCredentialClient awsSessionCredentialClient;
+
+    private final boolean expirationTimeCheck;
+
+    private final Integer forceTokenRefreshTimeInMin;
+
+    public AwsSessionCredentialProvider(AwsCredentialView awsCredentialView,
+            AwsSessionCredentialClient awsSessionCredentialClient) {
+        this(awsCredentialView, awsSessionCredentialClient, false, FORCE_TOKEN_REFRESH_TIME_IN_MIN_DEFAULT);
+    }
+
+    public AwsSessionCredentialProvider(AwsCredentialView awsCredentialView,
+            AwsSessionCredentialClient awsSessionCredentialClient,
+            boolean expirationTimeCheck, Integer forceTokenRefreshTimeInMin) {
+        this.awsCredentialView = awsCredentialView;
+        this.awsSessionCredentialClient = awsSessionCredentialClient;
+        this.expirationTimeCheck = expirationTimeCheck;
+        this.forceTokenRefreshTimeInMin = forceTokenRefreshTimeInMin;
+    }
+
+    @Override
+    public AWSCredentials getCredentials() {
+        AwsSessionCredentials sessionCredentials = awsSessionCredentialClient.retrieveCachedSessionCredentials(awsCredentialView);
+        sessionCredentials = checkExpirationTime(sessionCredentials);
+        return sessionCredentials;
+    }
+
+    private AwsSessionCredentials checkExpirationTime(AwsSessionCredentials sessionCredentials) {
+        final Date expirationTime = sessionCredentials.getExpiration();
+        if (expirationTimeCheck && expirationTime != null) {
+            DateTime expirationDateTime = new DateTime(expirationTime);
+            DateTime nowDateTime = new DateTime(new Date());
+            if (expirationDateTime.isAfter(nowDateTime.toDate().getTime()) ||
+                    new Duration(expirationDateTime, nowDateTime).getStandardMinutes() < forceTokenRefreshTimeInMin) {
+                LOGGER.debug("Force retrieving session credentials because of expiration time is too close.");
+                sessionCredentials = awsSessionCredentialClient.retrieveSessionCredentials(awsCredentialView);
+            }
+        }
+        return sessionCredentials;
+    }
+
+    @Override
+    public void refresh() {
+    }
+}

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsSessionCredentials.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsSessionCredentials.java
@@ -1,0 +1,19 @@
+package com.sequenceiq.cloudbreak.cloud.aws;
+
+import java.util.Date;
+
+import com.amazonaws.auth.BasicSessionCredentials;
+
+public class AwsSessionCredentials extends BasicSessionCredentials {
+
+    private final Date expiration;
+
+    public AwsSessionCredentials(String awsAccessKey, String awsSecretKey, String sessionToken, Date expiration) {
+        super(awsAccessKey, awsSecretKey, sessionToken);
+        this.expiration = expiration;
+    }
+
+    public Date getExpiration() {
+        return expiration;
+    }
+}


### PR DESCRIPTION
Use credential provider with aws client builders instead of deprecated client creation -> clients always accessing credentials through credential providers (with depricated client -> it creates a static credential provider without refresh function, and that is used there)

Solution 1

Pros:
- we can refresh the token more often (based on our custom cache), even if expiration time is close (can be configurable)
- log expiration time for role arn

Cons:
- custom credential provider

(note, not tested too well yet + if it will be acceptable, i will change the base branch to rc-2.15 if it's needed)

solution 2:  https://github.com/hortonworks/cloudbreak/pull/6772