### PR TITLE
CB-4444 Fix token expiration issue (version 2)

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsSessionCredentialClient.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsSessionCredentialClient.java
@@ -13,6 +13,7 @@ import com.amazonaws.SdkClientException;
 import com.amazonaws.auth.BasicSessionCredentials;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
 import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
@@ -62,6 +63,14 @@ public class AwsSessionCredentialClient {
             LOGGER.error("Unable to assume role. Check exception for details.", e);
             throw e;
         }
+    }
+
+    STSAssumeRoleSessionCredentialsProvider createSTSAssumeRoleSessionCredentialsProvider(AwsCredentialView awsCredential) {
+        String externalId = awsCredential.getExternalId();
+        return new STSAssumeRoleSessionCredentialsProvider.Builder(awsCredential.getRoleArn(), roleSessionName)
+                .withExternalId(StringUtils.isEmpty(externalId) ? deprecatedExternalId : externalId)
+                .withRoleSessionDurationSeconds(DEFAULT_SESSION_CREDENTIALS_DURATION)
+                .build();
     }
 
     private AWSSecurityTokenService awsSecurityTokenServiceClient(AwsCredentialView awsCredential) {


### PR DESCRIPTION
Use credential provider with aws client builders instead of deprecated client creation -> clients always accessing credentials through credential providers (with depricated client -> it creates a static credential provider without refresh function, and that is used there)

Solution 2

Pros:
- using aws built-in credential provider
- no need of aws credential caching

Cons:
- token refresh happens based on token expiration time by refresh caller (less frequent - also not sure what happens if expiration time is really close, is a client call happening after that or not)
- aws sts service will .live (per aws credential) until the aws clients are referenced (not sure it really matters..as we are nowhere calling any shutdown on the aws clients anywhere) - from the doc, credential provider should be close-t after it's not used

(note, not tested too well yet + if it will be acceptable, i will change the base branch to rc-2.15 if it's needed)

solution 1:  https://github.com/hortonworks/cloudbreak/pull/6771