### PR TITLE
CB-2902 datafix for managed publickey

### DIFF
--- a/environment/src/main/resources/schema/app/20191120150142_CB-2902_managed_publickey.sql
+++ b/environment/src/main/resources/schema/app/20191120150142_CB-2902_managed_publickey.sql
@@ -1,0 +1,11 @@
+-- // CB-2902 managed public key add default value
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE environment_authentication ALTER COLUMN managedkey SET DEFAULT false;
+
+UPDATE environment_authentication SET managedkey = false WHERE managedkey IS NULL;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE environment_authentication ALTER COLUMN managedkey DROP DEFAULT;


### PR DESCRIPTION
Set the 'managedkey' flag to false for records inserted by older
codebase