### PR TITLE
CB-1141 Add the ability of the FMS to provision multiple FreeIPA nodes

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
@@ -34,6 +34,8 @@ import com.sequenceiq.freeipa.client.model.Privilege;
 import com.sequenceiq.freeipa.client.model.RPCResponse;
 import com.sequenceiq.freeipa.client.model.Role;
 import com.sequenceiq.freeipa.client.model.Service;
+import com.sequenceiq.freeipa.client.model.TopologySegment;
+import com.sequenceiq.freeipa.client.model.TopologySuffix;
 import com.sequenceiq.freeipa.client.model.User;
 
 public class FreeIpaClient {
@@ -553,4 +555,37 @@ public class FreeIpaClient {
     public void updatePasswordPolicy(Map<String, Object> params) throws FreeIpaClientException {
         invoke("pwpolicy_mod", Collections.emptyList(), params, Object.class);
     }
+
+    public List<TopologySuffix> findAllTopologySuffixes() throws FreeIpaClientException {
+        List<String> flags = List.of();
+        Map<String, Object> params = Map.of();
+        ParameterizedType type = TypeUtils
+                .parameterize(List.class, TopologySuffix.class);
+        return (List<TopologySuffix>) invoke("topologysuffix_find", flags, params, type).getResult();
+    }
+
+    public List<TopologySegment> findTopologySegments(String topologySuffixCn) throws FreeIpaClientException {
+        List<String> flags = List.of(topologySuffixCn);
+        Map<String, Object> params = Map.of();
+        ParameterizedType type = TypeUtils
+                .parameterize(List.class, TopologySegment.class);
+        return (List<TopologySegment>) invoke("topologysegment_find", flags, params, type).getResult();
+    }
+
+    public TopologySegment addTopologySegment(String topologySuffixCn, TopologySegment topologySegment) throws FreeIpaClientException {
+        List<String> flags = List.of(topologySuffixCn, topologySegment.getCn());
+        Map<String, Object> params = Map.of(
+            "iparepltoposegmentleftnode", topologySegment.getLeftNode(),
+            "iparepltoposegmentrightnode", topologySegment.getRightNode(),
+            "iparepltoposegmentdirection", topologySegment.getDirection()
+        );
+        return (TopologySegment) invoke("topologysegment_add", flags, params, TopologySegment.class).getResult();
+    }
+
+    public TopologySegment deleteTopologySegment(String topologySuffixCn, TopologySegment topologySegment) throws FreeIpaClientException {
+        List<String> flags = List.of(topologySuffixCn, topologySegment.getCn());
+        Map<String, Object> params = Map.of();
+        return (TopologySegment) invoke("topologysegment_del", flags, params, TopologySegment.class).getResult();
+    }
+
 }

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/model/TopologySegment.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/model/TopologySegment.java
@@ -1,0 +1,66 @@
+package com.sequenceiq.freeipa.client.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.sequenceiq.freeipa.client.deserializer.ListFlatteningDeserializer;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TopologySegment {
+    @JsonDeserialize(using = ListFlatteningDeserializer.class)
+    private String cn;
+
+    @JsonDeserialize(using = ListFlatteningDeserializer.class)
+    @JsonProperty(value = "iparepltoposegmentleftnode")
+    private String leftNode;
+
+    @JsonDeserialize(using = ListFlatteningDeserializer.class)
+    @JsonProperty(value = "iparepltoposegmentrightnode")
+    private String rightNode;
+
+    @JsonDeserialize(using = ListFlatteningDeserializer.class)
+    @JsonProperty(value = "iparepltoposegmentdirection")
+    private String direction;
+
+    public String getCn() {
+        return cn;
+    }
+
+    public void setCn(String cn) {
+        this.cn = cn;
+    }
+
+    public String getLeftNode() {
+        return leftNode;
+    }
+
+    public void setLeftNode(String leftNode) {
+        this.leftNode = leftNode;
+    }
+
+    public String getRightNode() {
+        return rightNode;
+    }
+
+    public void setRightNode(String rightNode) {
+        this.rightNode = rightNode;
+    }
+
+    public String getDirection() {
+        return direction;
+    }
+
+    public void setDirection(String direction) {
+        this.direction = direction;
+    }
+
+    @Override
+    public String toString() {
+        return "TopologySegment{"
+                + "cn='" + cn + '\''
+                + ",leftNode='" + leftNode + '\''
+                + ",rightNode='" + rightNode + '\''
+                + ",direction='" + direction + '\''
+                + '}';
+    }
+}

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/model/TopologySuffix.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/model/TopologySuffix.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.freeipa.client.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.sequenceiq.freeipa.client.deserializer.ListFlatteningDeserializer;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TopologySuffix {
+    @JsonDeserialize(using = ListFlatteningDeserializer.class)
+    private String cn;
+
+    private String dn;
+
+    public String getCn() {
+        return cn;
+    }
+
+    public void setCn(String cn) {
+        this.cn = cn;
+    }
+
+    public String getDn() {
+        return dn;
+    }
+
+    public void setDn(String dn) {
+        this.dn = dn;
+    }
+
+    @Override
+    public String toString() {
+        return "TopologySuffix{"
+                + "cn='" + cn + '\''
+                + ",dn='" + dn + '\''
+                + '}';
+    }
+}

--- a/freeipa/build.gradle
+++ b/freeipa/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     exclude group: 'junit'
   }
   testImplementation group: 'org.junit.jupiter',         name: 'junit-jupiter-api'
+  testImplementation group: 'org.junit.jupiter',         name: 'junit-jupiter-params',           version: junitJupiterVersion
   testRuntime        group: 'org.junit.jupiter',         name: 'junit-jupiter-engine'
   testImplementation group: 'org.mockito',               name: 'mockito-core'
   testImplementation group: 'org.mockito',               name: 'mockito-junit-jupiter'

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaPostInstallService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaPostInstallService.java
@@ -58,8 +58,12 @@ public class FreeIpaPostInstallService {
     @Inject
     private FreeIpaPermissionService freeIpaPermissionService;
 
+    @Inject
+    private FreeIpaTopologyService freeIpaTopologyService;
+
     public void postInstallFreeIpa(Long stackId) throws Exception {
         LOGGER.debug("Performing post-install configuration for stack {}", stackId);
+        freeIpaTopologyService.updateReplicationTopology(stackId);
         Stack stack = stackService.getStackById(stackId);
         FreeIpaClient freeIpaClient = freeIpaClientFactory.getFreeIpaClientForStack(stack);
         Set<Permission> permission = freeIpaClient.findPermission(SET_PASSWORD_EXPIRATION_PERMISSION);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaTopologyService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaTopologyService.java
@@ -1,0 +1,164 @@
+package com.sequenceiq.freeipa.service.freeipa.flow;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.sequenceiq.freeipa.client.FreeIpaClient;
+import com.sequenceiq.freeipa.client.FreeIpaClientException;
+import com.sequenceiq.freeipa.client.model.TopologySegment;
+import com.sequenceiq.freeipa.client.model.TopologySuffix;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
+import com.sequenceiq.freeipa.service.stack.StackService;
+import org.springframework.stereotype.Service;
+
+import javax.inject.Inject;
+import java.util.Iterator;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+class FreeIpaTopologyService {
+
+    private static final Integer MAX_REPLICATION_CONNECTIONS = 4;
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private FreeIpaClientFactory freeIpaClientFactory;
+
+    public void updateReplicationTopology(Long stackId) throws FreeIpaClientException {
+        Stack stack = stackService.getByIdWithListsInTransaction(stackId);
+        Set<String> allNodesFqdn = stack.getNotDeletedInstanceMetaDataSet().stream()
+                .map(InstanceMetaData::getDiscoveryFQDN)
+                .collect(Collectors.toSet());
+        FreeIpaClient freeIpaClient = freeIpaClientFactory.getFreeIpaClientForStack(stack);
+        Set<TopologySegment> topology = generateTopology(allNodesFqdn).stream()
+                .map(pair -> {
+                    TopologySegment s = new TopologySegment();
+                    s.setDirection("both");
+                    s.setLeftNode(pair.getLeft());
+                    s.setRightNode(pair.getRight());
+                    s.setCn(String.format("%s-to-%s", pair.getLeft(), pair.getRight()));
+                    return s;
+                }).collect(Collectors.toSet());
+        List<TopologySuffix> topologySuffixes = freeIpaClient.findAllTopologySuffixes();
+        for (TopologySuffix topologySuffix : topologySuffixes) {
+            createMissingSegments(freeIpaClient, topologySuffix.getCn(), topology);
+            removeExtraSegements(freeIpaClient, topologySuffix.getCn(), topology);
+        }
+    }
+
+    @VisibleForTesting
+    Set<UnorderedPair> generateTopology(Set<String> nodes) {
+        Map<String, Integer> connectionRemaining = nodes.stream()
+                .sorted()
+                .collect(Collectors.toMap(n -> n, n -> MAX_REPLICATION_CONNECTIONS, (k, v) -> v, LinkedHashMap::new));
+        Set<UnorderedPair> ret = new HashSet<>();
+        Iterator<String> itr2 = null;
+        for (Map.Entry<String, Integer> entry : connectionRemaining.entrySet()) {
+            String node = entry.getKey();
+            Integer remainingConnectionsForNode = entry.getValue();
+            for (int i = remainingConnectionsForNode; i > 0; i--) {
+                // Note: It is not possible for itr2 to reference on object with 0 remaining connections
+                // because itr2 is after the node iterator and the node iterator is checked for
+                // remaining connections.
+                if (itr2 == null || !itr2.hasNext()) {
+                    itr2 = getIteratorAfterCurrentNode(node, connectionRemaining.keySet());
+                    if (!itr2.hasNext()) {
+                        break;
+                    }
+                }
+                String node2 = itr2.next();
+                connectionRemaining.put(node2, connectionRemaining.get(node2) - 1);
+                ret.add(new UnorderedPair(node, node2));
+            }
+        }
+        return ret;
+    }
+
+    @SuppressWarnings("checkstyle:EmptyBlock")
+    private Iterator<String> getIteratorAfterCurrentNode(String node, Set<String> keySet) {
+        Iterator<String> ret = keySet.iterator();
+        while (ret.hasNext()) {
+            if (ret.next().equals(node)) {
+                break;
+            }
+        }
+        return ret;
+    }
+
+    private void createMissingSegments(FreeIpaClient freeIpaClient, String topologySuffixCn, Set<TopologySegment> topology) throws FreeIpaClientException {
+        Set<UnorderedPair> existingTopology = freeIpaClient.findTopologySegments(topologySuffixCn).stream()
+                .map(segment -> new UnorderedPair(segment.getLeftNode(), segment.getRightNode()))
+                .collect(Collectors.toSet());
+        Set<TopologySegment> segmentsToAdd = topology.stream()
+                .filter(segment -> !existingTopology.contains(new UnorderedPair(segment.getLeftNode(), segment.getRightNode())))
+                .collect(Collectors.toSet());
+        for (TopologySegment segment : segmentsToAdd) {
+            freeIpaClient.addTopologySegment(topologySuffixCn, segment);
+        }
+    }
+
+    private void removeExtraSegements(FreeIpaClient freeIpaClient, String topologySuffixCn, Set<TopologySegment> topology) throws FreeIpaClientException {
+        Set<UnorderedPair> topologyToKeep = topology.stream()
+                .map(segment -> new UnorderedPair(segment.getLeftNode(), segment.getRightNode()))
+                .collect(Collectors.toSet());
+        Set<TopologySegment> segmentsToRemove = freeIpaClient.findTopologySegments(topologySuffixCn).stream()
+                .filter(segment -> !topologyToKeep.contains(new UnorderedPair(segment.getLeftNode(), segment.getRightNode())))
+                .collect(Collectors.toSet());
+        for (TopologySegment segment : segmentsToRemove) {
+            freeIpaClient.deleteTopologySegment(topologySuffixCn, segment);
+        }
+    }
+
+    @VisibleForTesting
+    static class UnorderedPair {
+        private final String left;
+
+        private final String right;
+
+        UnorderedPair(String item1, String item2) {
+            if (item1.compareTo(item2) < 0) {
+                this.left = item1;
+                this.right = item2;
+            } else {
+                this.left = item2;
+                this.right = item1;
+            }
+        }
+
+        String getLeft() {
+            return left;
+        }
+
+        String getRight() {
+            return right;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || !(obj instanceof UnorderedPair)) {
+                return false;
+            }
+
+            UnorderedPair other = (UnorderedPair) obj;
+
+            return left.equals(other.left) && right.equals(other.right);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(left, right);
+        }
+    }
+
+}

--- a/freeipa/src/main/resources/freeipa-salt/pillar/freeipa/init.sls
+++ b/freeipa/src/main/resources/freeipa-salt/pillar/freeipa/init.sls
@@ -2,3 +2,5 @@ freeipa:
   domain: testdomain
   password: pwpwpw
   realm: testrealm
+  admin_user: admin
+  freeipa_to_replicate:

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/common-install.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/common-install.sls
@@ -1,0 +1,29 @@
+one_week_next_update_grace_period:
+  file.replace:
+    - name: /var/lib/pki/pki-tomcat/ca/conf/CS.cfg
+    - pattern: ^ca[.]crl[.]MasterCRL[.]nextUpdateGracePeriod=.*
+    - repl: ca.crl.MasterCRL.nextUpdateGracePeriod=10080
+    - unless: grep "^ca[.]crl[.]MasterCRL[.]nextUpdateGracePeriod=10080$" /var/lib/pki/pki-tomcat/ca/conf/CS.cfg
+
+restart_pki-tomcat:
+  service.running:
+    - name: pki-tomcatd@pki-tomcat
+    - onlyif: test -f /etc/ipa/default.conf
+    - watch:
+      - file: /var/lib/pki/pki-tomcat/ca/conf/CS.cfg
+
+/usr/lib/python2.7/site-packages/ipaserver/plugins/getkeytab.py:
+  file.managed:
+    - makedirs: True
+    - user: root
+    - group: root
+    - mode: 644
+    - source: salt://freeipa/scripts/getkeytab.py
+    - onlyif: test -f /etc/ipa/default.conf
+
+restart_freeipa_after_plugin_change:
+  service.running:
+    - name: ipa
+    - onlyif: test -f /etc/ipa/default.conf
+    - watch:
+      - file: /usr/lib/python2.7/site-packages/ipaserver/plugins/getkeytab.py

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/init.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/init.sls
@@ -9,6 +9,15 @@ net.ipv6.conf.lo.disable_ipv6:
   sysctl.present:
     - value: 0
 
+{% for host in salt['pillar.get']('freeipa:hosts') %}
+/etc/hosts/{{ host['fqdn'] }}:
+  host.present:
+    - ip:
+      - {{ host['ip'] }}
+    - names:
+      - {{ host['fqdn'] }}
+{% endfor %}
+
 /opt/salt/scripts/freeipa_install.sh:
   file.managed:
     - makedirs: True
@@ -18,27 +27,10 @@ net.ipv6.conf.lo.disable_ipv6:
     - source: salt://freeipa/scripts/freeipa_install.sh
     - template: jinja
 
-install-freeipa:
-  cmd.run:
-    - name: /opt/salt/scripts/freeipa_install.sh && echo $(date +%Y-%m-%d:%H:%M:%S) >> /var/log/freeipa_install-executed
-    - env:
-        - FPW: {{salt['pillar.get']('freeipa:password')}}
-        - DOMAIN: {{salt['pillar.get']('freeipa:domain')}}
-        - REALM: {{salt['pillar.get']('freeipa:realm')}}
-    - unless: test -f /var/log/freeipa_install-executed
-    - require:
-        - file: /opt/salt/scripts/freeipa_install.sh
-
-/usr/lib/python2.7/site-packages/ipaserver/plugins/getkeytab.py:
+/opt/salt/scripts/freeipa_replica_install.sh:
   file.managed:
     - makedirs: True
     - user: root
     - group: root
-    - mode: 644
-    - source: salt://freeipa/scripts/getkeytab.py
-
-restart_freeipa_after_plugin_change:
-  service.running:
-    - name: ipa
-    - watch:
-      - file: /usr/lib/python2.7/site-packages/ipaserver/plugins/getkeytab.py
+    - mode: 700
+    - source: salt://freeipa/scripts/freeipa_replica_install.sh

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/primary-install.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/primary-install.sls
@@ -1,0 +1,10 @@
+install-freeipa:
+  cmd.run:
+    - name: /opt/salt/scripts/freeipa_install.sh && echo $(date +%Y-%m-%d:%H:%M:%S) >> /var/log/freeipa_install-executed
+    - env:
+        - FPW: {{salt['pillar.get']('freeipa:password')}}
+        - DOMAIN: {{salt['pillar.get']('freeipa:domain')}}
+        - REALM: {{salt['pillar.get']('freeipa:realm')}}
+    - unless: test -f /var/log/freeipa_install-executed
+    - require:
+        - file: /opt/salt/scripts/freeipa_install.sh

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/replica-install.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/replica-install.sls
@@ -1,0 +1,12 @@
+install-freeipa-replica:
+  cmd.run:
+    - name: /opt/salt/scripts/freeipa_replica_install.sh && echo $(date +%Y-%m-%d:%H:%M:%S) >> /var/log/freeipa_install-executed
+    - env:
+        - FPW: {{salt['pillar.get']('freeipa:password')}}
+        - DOMAIN: {{salt['pillar.get']('freeipa:domain')}}
+        - REALM: {{salt['pillar.get']('freeipa:realm')}}
+        - ADMIN_USER: {{salt['pillar.get']('freeipa:admin_user')}}
+        - FREEIPA_TO_REPLICATE: {{salt['pillar.get']('freeipa:freeipa_to_replicate')}}
+    - unless: test -f /var/log/freeipa_install-executed
+    - require:
+        - file: /opt/salt/scripts/freeipa_install.sh

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_replica_install.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_replica_install.sh
@@ -5,17 +5,16 @@ set -e
 FQDN=$(hostname -f)
 IPADDR=$(hostname -i)
 
-ipa-server-install \
+ipa-replica-install \
+          --server $FREEIPA_TO_REPLICATE \
+          --setup-ca \
           --realm $REALM \
           --domain $DOMAIN \
           --hostname $FQDN \
-          -a $FPW \
-          -p $FPW \
+          --principal $ADMIN_USER \
+          --admin-password $FPW \
           --setup-dns \
           --auto-reverse \
-{%- for zone in salt['pillar.get']('freeipa:reverseZones').split(',') %}
-          --reverse-zone {{ zone }} \
-{%- endfor %}
           --allow-zone-overlap \
           --ssh-trust-dns \
           --mkhomedir \

--- a/freeipa/src/main/resources/freeipa-salt/salt/top.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/top.sls
@@ -5,3 +5,13 @@ base:
              - freeipa
              - freeipa.services
              - dns
+
+           'roles:freeipa_primary':
+             - match: grain
+             - freeipa.primary-install
+             - freeipa.common-install
+
+           'roles:freeipa_replica':
+             - match: grain
+             - freeipa.replica-install
+             - freeipa.common-install

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaTopologyServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaTopologyServiceTest.java
@@ -1,0 +1,174 @@
+package com.sequenceiq.freeipa.service.freeipa.flow;
+
+import com.sequenceiq.freeipa.client.FreeIpaClient;
+import com.sequenceiq.freeipa.client.FreeIpaClientException;
+import com.sequenceiq.freeipa.client.model.TopologySegment;
+import com.sequenceiq.freeipa.client.model.TopologySuffix;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
+import com.sequenceiq.freeipa.service.stack.StackService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+@ExtendWith(MockitoExtension.class)
+class FreeIpaTopologyServiceTest {
+
+    @InjectMocks
+    private FreeIpaTopologyService underTest;
+
+    @Mock
+    private FreeIpaClient freeIpaClient;
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private Stack stack;
+
+    @Mock
+    private FreeIpaClientFactory freeIpaClientFactory;
+
+    @Test
+    void testGenerateTopology() throws FreeIpaClientException {
+        Set<String> nodes = new HashSet<>();
+        assertSetEquivlance(underTest.generateTopology(Set.of("")), Set.of());
+        nodes.add("node1");
+        assertSetEquivlance(underTest.generateTopology(nodes), Set.of());
+        nodes.add("node2");
+        assertSetEquivlance(underTest.generateTopology(nodes), Set.of(
+                new FreeIpaTopologyService.UnorderedPair("node1", "node2")));
+        nodes.add("node3");
+        assertSetEquivlance(underTest.generateTopology(nodes), Set.of(
+                new FreeIpaTopologyService.UnorderedPair("node1", "node2"),
+                new FreeIpaTopologyService.UnorderedPair("node1", "node3"),
+                new FreeIpaTopologyService.UnorderedPair("node2", "node3")));
+        nodes.add("node4");
+        assertSetEquivlance(underTest.generateTopology(nodes), Set.of(
+                new FreeIpaTopologyService.UnorderedPair("node1", "node2"),
+                new FreeIpaTopologyService.UnorderedPair("node1", "node3"),
+                new FreeIpaTopologyService.UnorderedPair("node1", "node4"),
+                new FreeIpaTopologyService.UnorderedPair("node2", "node3"),
+                new FreeIpaTopologyService.UnorderedPair("node2", "node4"),
+                new FreeIpaTopologyService.UnorderedPair("node3", "node4")));
+        nodes.add("node5");
+        assertSetEquivlance(underTest.generateTopology(nodes), Set.of(
+                new FreeIpaTopologyService.UnorderedPair("node1", "node2"),
+                new FreeIpaTopologyService.UnorderedPair("node1", "node3"),
+                new FreeIpaTopologyService.UnorderedPair("node1", "node4"),
+                new FreeIpaTopologyService.UnorderedPair("node1", "node5"),
+                new FreeIpaTopologyService.UnorderedPair("node2", "node3"),
+                new FreeIpaTopologyService.UnorderedPair("node2", "node4"),
+                new FreeIpaTopologyService.UnorderedPair("node2", "node5"),
+                new FreeIpaTopologyService.UnorderedPair("node3", "node4"),
+                new FreeIpaTopologyService.UnorderedPair("node3", "node5"),
+                new FreeIpaTopologyService.UnorderedPair("node4", "node5")));
+        nodes.add("node6");
+        assertSetEquivlance(underTest.generateTopology(nodes), Set.of(
+                new FreeIpaTopologyService.UnorderedPair("node1", "node2"),
+                new FreeIpaTopologyService.UnorderedPair("node1", "node3"),
+                new FreeIpaTopologyService.UnorderedPair("node1", "node4"),
+                new FreeIpaTopologyService.UnorderedPair("node1", "node5"),
+                new FreeIpaTopologyService.UnorderedPair("node2", "node6"),
+                new FreeIpaTopologyService.UnorderedPair("node2", "node3"),
+                new FreeIpaTopologyService.UnorderedPair("node2", "node4"),
+                new FreeIpaTopologyService.UnorderedPair("node3", "node5"),
+                new FreeIpaTopologyService.UnorderedPair("node3", "node6"),
+                new FreeIpaTopologyService.UnorderedPair("node4", "node5"),
+                new FreeIpaTopologyService.UnorderedPair("node4", "node6"),
+                new FreeIpaTopologyService.UnorderedPair("node5", "node6")));
+        nodes.add("node7");
+        assertSetEquivlance(underTest.generateTopology(nodes), Set.of(
+                new FreeIpaTopologyService.UnorderedPair("node1", "node2"),
+                new FreeIpaTopologyService.UnorderedPair("node1", "node3"),
+                new FreeIpaTopologyService.UnorderedPair("node1", "node4"),
+                new FreeIpaTopologyService.UnorderedPair("node1", "node5"),
+                new FreeIpaTopologyService.UnorderedPair("node2", "node6"),
+                new FreeIpaTopologyService.UnorderedPair("node2", "node7"),
+                new FreeIpaTopologyService.UnorderedPair("node2", "node3"),
+                new FreeIpaTopologyService.UnorderedPair("node3", "node4"),
+                new FreeIpaTopologyService.UnorderedPair("node3", "node5"),
+                new FreeIpaTopologyService.UnorderedPair("node4", "node6"),
+                new FreeIpaTopologyService.UnorderedPair("node4", "node7"),
+                new FreeIpaTopologyService.UnorderedPair("node5", "node6"),
+                new FreeIpaTopologyService.UnorderedPair("node5", "node7"),
+                new FreeIpaTopologyService.UnorderedPair("node6", "node7")));
+    }
+
+    private void assertSetEquivlance(Set<?> s1, Set<?> s2) {
+        Assertions.assertNotNull(s1);
+        Assertions.assertNotNull(s2);
+        Assertions.assertEquals(s1.size(), s2.size());
+        Assertions.assertTrue(s1.containsAll(s2));
+    }
+
+    private static Object[][] testUpdateReplicationTopologyParameters() {
+        // Parameters: numNodes, expectedSegmentsToAdd, expectedSegementsToRemove
+        return new Object[][] {
+                { 1, 0, 0},
+                { 2, 0, 0},
+                { 3, 1, 0},
+                { 4, 3, 0},
+                { 5, 6, 0},
+                { 6, 8, 1},
+                { 7, 10, 2}
+        };
+    }
+
+    @MethodSource("testUpdateReplicationTopologyParameters")
+    @ParameterizedTest(name = "Run {index}: numNodes={0}, expectedSegmentsToAdd={1}, expectedSegmentsToRemove={2}")
+    void testUpdateReplicationTopology(int numNodes, int expectedSegmentsToAdd, int expectedSegmentsToRemove) throws FreeIpaClientException {
+        Mockito.when(stackService.getByIdWithListsInTransaction(Mockito.anyLong())).thenReturn(stack);
+        Set<InstanceMetaData> imSet = new HashSet<>();
+        for (int i = 0; i < numNodes; i++) {
+            InstanceMetaData im = new InstanceMetaData();
+            im.setDiscoveryFQDN(String.format("ipaserver%d.example.com", i));
+            imSet.add(im);
+        }
+        Mockito.when(stack.getNotDeletedInstanceMetaDataSet()).thenReturn(imSet);
+        Mockito.when(freeIpaClientFactory.getFreeIpaClientForStack(Mockito.any())).thenReturn(freeIpaClient);
+        TopologySuffix caSuffix = new TopologySuffix();
+        caSuffix.setCn("ca");
+        TopologySuffix domainSuffix = new TopologySuffix();
+        domainSuffix.setCn("domain");
+        Mockito.when(freeIpaClient.findAllTopologySuffixes()).thenReturn(List.of(caSuffix, domainSuffix));
+        List<TopologySegment> topologySegments1 = new LinkedList<>();
+        for (int i = 1; i < numNodes; i++) {
+            TopologySegment segment = new TopologySegment();
+            segment.setLeftNode("ipaserver0.example.com");
+            segment.setRightNode(String.format("ipaserver%d.example.com", i));
+            topologySegments1.add(segment);
+        }
+        List<TopologySegment> topologySegments2 = new LinkedList<>();
+        topologySegments2.addAll(topologySegments1);
+        Mockito.when(freeIpaClient.findTopologySegments(Mockito.anyString()))
+                .thenReturn(topologySegments1)
+                .thenReturn(topologySegments1)
+                .thenReturn(topologySegments2)
+                .thenReturn(topologySegments2);
+        if (expectedSegmentsToAdd > 0) {
+            Mockito.when(freeIpaClient.addTopologySegment(Mockito.anyString(), Mockito.any())).thenReturn(new TopologySegment());
+        }
+        if (expectedSegmentsToRemove > 0) {
+            Mockito.when(freeIpaClient.deleteTopologySegment(Mockito.anyString(), Mockito.any())).thenReturn(new TopologySegment());
+        }
+        underTest.updateReplicationTopology(1L);
+        Mockito.verify(freeIpaClient, Mockito.times(expectedSegmentsToAdd)).addTopologySegment(Mockito.eq("ca"), Mockito.any());
+        Mockito.verify(freeIpaClient, Mockito.times(expectedSegmentsToAdd)).addTopologySegment(Mockito.eq("domain"), Mockito.any());
+        Mockito.verify(freeIpaClient, Mockito.times(expectedSegmentsToRemove)).deleteTopologySegment(Mockito.eq("ca"), Mockito.any());
+        Mockito.verify(freeIpaClient, Mockito.times(expectedSegmentsToRemove)).deleteTopologySegment(Mockito.eq("domain"), Mockito.any());
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/freeipa/TopologySegmentFindResponse.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/freeipa/TopologySegmentFindResponse.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.it.cloudbreak.mock.freeipa;
+
+import java.util.Set;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.freeipa.client.model.TopologySegment;
+
+import spark.Request;
+import spark.Response;
+
+@Component
+public class TopologySegmentFindResponse extends AbstractFreeIpaResponse<Set<TopologySegment>> {
+    @Override
+    public String method() {
+        return "topologysegment_find";
+    }
+
+    @Override
+    protected Set<TopologySegment> handleInternal(Request request, Response response) {
+        return Set.of();
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/freeipa/TopologySuffixFindResponse.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/freeipa/TopologySuffixFindResponse.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.it.cloudbreak.mock.freeipa;
+
+import java.util.Set;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.freeipa.client.model.TopologySuffix;
+
+import spark.Request;
+import spark.Response;
+
+@Component
+public class TopologySuffixFindResponse extends AbstractFreeIpaResponse<Set<TopologySuffix>> {
+    @Override
+    public String method() {
+        return "topologysuffix_find";
+    }
+
+    @Override
+    protected Set<TopologySuffix> handleInternal(Request request, Response response) {
+        TopologySuffix suffix = new TopologySuffix();
+        suffix.setCn("dummy");
+        suffix.setDn("dummy");
+        return Set.of(suffix);
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/KerberosConfigTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/KerberosConfigTest.java
@@ -149,7 +149,7 @@ public class KerberosConfigTest extends AbstractIntegrationTest {
             public List<Assertion<StackTestDto, CloudbreakClient>> getAssertions() {
                 List<Assertion<StackTestDto, CloudbreakClient>> verifications = new LinkedList<>();
                 verifications.add(clusterTemplatePostToCMContains("enableKerberos").exactTimes(1));
-                verifications.add(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(SALT_HIGHSTATE).exactTimes(4));
+                verifications.add(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(SALT_HIGHSTATE).exactTimes(5));
                 return verifications;
             }
 
@@ -176,7 +176,7 @@ public class KerberosConfigTest extends AbstractIntegrationTest {
             public List<Assertion<StackTestDto, CloudbreakClient>> getAssertions() {
                 List<Assertion<StackTestDto, CloudbreakClient>> verifications = new LinkedList<>();
                 verifications.add(clusterTemplatePostToCMContains("enableKerberos").exactTimes(1));
-                verifications.add(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(SALT_HIGHSTATE).exactTimes(4));
+                verifications.add(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(SALT_HIGHSTATE).exactTimes(5));
                 return verifications;
             }
 
@@ -201,6 +201,7 @@ public class KerberosConfigTest extends AbstractIntegrationTest {
             public List<Assertion<StackTestDto, CloudbreakClient>> getAssertions() {
                 List<Assertion<StackTestDto, CloudbreakClient>> verifications = new LinkedList<>();
                 verifications.add(clusterTemplatePostToCMContains("enableKerberos").exactTimes(1));
+                verifications.add(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(SALT_HIGHSTATE).exactTimes(5));
                 return verifications;
             }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/RecipeClusterTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/RecipeClusterTest.java
@@ -154,10 +154,10 @@ public class RecipeClusterTest extends AbstractIntegrationTest {
                 .replaceInstanceGroups(INSTANCE_GROUP_ID)
                 .when(stackTestClient.createV4())
                 .await(STACK_AVAILABLE)
-                .then(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(HIGHSTATE).exactTimes(4))
+                .then(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(HIGHSTATE).exactTimes(5))
                 .when(stackTestClient.deleteV4())
                 .await(STACK_DELETED)
-                .then(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(HIGHSTATE).exactTimes(6))
+                .then(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(HIGHSTATE).exactTimes(7))
                 .validate();
     }
 
@@ -220,7 +220,7 @@ public class RecipeClusterTest extends AbstractIntegrationTest {
                 .await(STACK_AVAILABLE)
                 .when(StackScalePostAction.valid().withDesiredCount(mock.getDesiredWorkerCount()))
                 .await(STACK_AVAILABLE)
-                .then(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(HIGHSTATE).exactTimes(7))
+                .then(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(HIGHSTATE).exactTimes(8))
                 .validate();
     }
 
@@ -263,7 +263,7 @@ public class RecipeClusterTest extends AbstractIntegrationTest {
                 .await(STACK_AVAILABLE)
                 .when(StackScalePostAction.valid().withDesiredCount(mock.getDesiredWorkerCount()))
                 .await(STACK_AVAILABLE)
-                .then(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(HIGHSTATE).exactTimes(7))
+                .then(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(HIGHSTATE).exactTimes(8))
                 .validate();
     }
 

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
@@ -69,6 +69,9 @@ public interface HostOrchestrator extends HostRecipeExecutor {
     void changePrimaryGateway(GatewayConfig formerGateway, GatewayConfig newPrimaryGateway, List<GatewayConfig> allGatewayConfigs, Set<Node> allNodes,
             ExitCriteriaModel exitCriteriaModel) throws CloudbreakOrchestratorException;
 
+    void installFreeIPA(GatewayConfig primaryGateway, List<GatewayConfig> allGatewayConfigs, Set<Node> allNodes,
+                        ExitCriteriaModel exitCriteriaModel) throws CloudbreakOrchestratorException;
+
     void leaveDomain(GatewayConfig gatewayConfig, Set<Node> allNodes, String roleToRemove, String roleToAdd, ExitCriteriaModel exitCriteriaModel)
             throws CloudbreakOrchestratorFailedException;
 


### PR DESCRIPTION
This adds support to the FreeIPA management service to support
provisioning multiple instances, but this does not change the
environment service which is hardcoded to 1 instance.

The primary gateway is chosen as the CA master, the CRL master, the
node for configuring the FreeIPA servers, and the first FreeIPA node
to be installed.

All the other FreeIPA nodes are installed next as a part of the
FreeIPA install step. During the FreeIPA post install, the network
topology is updated to be a more complete mesh with a maximum of 4
replication agreements.

This was tested manually by setting the MASTER_NODE_COUNT in
FreeIpaCreationHandler.java (which is not included in this change).