### PR TITLE
CB-4598 KnoxSSO cookie should be scoped to the Knox host only

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/knoxsso.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/knoxsso.xml.j2
@@ -122,6 +122,16 @@
             <name>knoxsso.cookie.secure.only</name>
             <value>true</value>
         </param>
+        {% if salt['pillar.get']('gateway:userfacingfqdn') is defined and salt['pillar.get']('gateway:userfacingfqdn')|length > 1 %}
+        <!--
+        Scope the KnoxSSO cookie to the Knox host only instead of auto determining the cookie domain.
+        The value * is special and means replace it with the domain of the request itself.
+        -->
+        <param>
+            <name>knoxsso.cookie.domain.suffix</name>
+            <value>*</value>
+        </param>
+        {% endif %}
         <param>
             <!-- 24 hours in milliseconds = 86400000 -->
             <name>knoxsso.token.ttl</name>


### PR DESCRIPTION
Right now the KnoxSSO cookie is scoped across the domain of the Knox host. Since multiple clusters share that domain with different Knox signing keys, this causes cookie scoping issues. The short term fix is to scope the cookie to the Knox host since only the Knox host reads this cookie right now.

We only want this to happen when a user facing domain is generated to prevent any issues with testing.