### PR TITLE
CB-4625. Fix AWS throttling errors during credential verification

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsClient.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsClient.java
@@ -36,6 +36,7 @@ import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonAutoScalingRetryClient;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonCloudFormationRetryClient;
+import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonIdentityManagementRetryClient;
 import com.sequenceiq.cloudbreak.cloud.aws.view.AwsCredentialView;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
@@ -93,6 +94,10 @@ public class AwsClient {
         return isRoleAssumeRequired(awsCredential)
                 ? new AWSSecurityTokenServiceClient(createAwsSessionCredentialProvider(awsCredential))
                 : new AWSSecurityTokenServiceClient(createAwsCredentials(awsCredential));
+    }
+
+    public AmazonIdentityManagementRetryClient createAmazonIdentityManagementRetryClient(AwsCredentialView awsCredential) {
+        return new AmazonIdentityManagementRetryClient(createAmazonIdentityManagement(awsCredential), retry);
     }
 
     public AmazonIdentityManagement createAmazonIdentityManagement(AwsCredentialView awsCredential) {

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/cache/AwsCredentialCachingConfig.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/cache/AwsCredentialCachingConfig.java
@@ -1,0 +1,55 @@
+package com.sequenceiq.cloudbreak.cloud.aws.cache;
+
+import java.lang.reflect.Method;
+
+import org.springframework.cache.interceptor.SimpleKey;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cache.common.AbstractCacheDefinition;
+import com.sequenceiq.cloudbreak.cloud.aws.view.AwsCredentialView;
+
+/**
+ * Credential cache based on role or access key that can be used to skip unnecessary AWS verification calls
+ */
+@Service
+public class AwsCredentialCachingConfig extends AbstractCacheDefinition {
+
+    public static final String TEMPORARY_AWS_CREDENTIAL_VERIFIER_CACHE = "temporary_aws_credential_verifier";
+
+    private static final long TTL_IN_SECONDS = 5L;
+
+    private static final long MAX_ENTRIES = 1000L;
+
+    @Override
+    public String getName() {
+        return TEMPORARY_AWS_CREDENTIAL_VERIFIER_CACHE;
+    }
+
+    @Override
+    public long getMaxEntries() {
+        return MAX_ENTRIES;
+    }
+
+    @Override
+    public long getTimeToLiveSeconds() {
+        return TTL_IN_SECONDS;
+    }
+
+    @Override
+    public Class<?> type() {
+        return AwsCredentialView.class;
+    }
+
+    @Override
+    public Object generateKey(Object target, Method method, Object... params) {
+        if (params.length == 1) {
+            AwsCredentialView param = (AwsCredentialView) params[0];
+            if (param.getRoleArn() != null) {
+                return param.getRoleArn();
+            } else if (param.getAccessKey() != null) {
+                return param.getAccessKey();
+            }
+        }
+        return SimpleKey.EMPTY;
+    }
+}

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/client/AmazonIdentityManagementRetryClient.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/client/AmazonIdentityManagementRetryClient.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.cloudbreak.cloud.aws.client;
+
+import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
+import com.amazonaws.services.identitymanagement.model.SimulatePrincipalPolicyRequest;
+import com.amazonaws.services.identitymanagement.model.SimulatePrincipalPolicyResult;
+import com.sequenceiq.cloudbreak.service.Retry;
+
+public class AmazonIdentityManagementRetryClient extends AmazonRetryClient {
+
+    private final AmazonIdentityManagement client;
+
+    private final Retry retry;
+
+    public AmazonIdentityManagementRetryClient(AmazonIdentityManagement client, Retry retry) {
+        this.client = client;
+        this.retry = retry;
+    }
+
+    public SimulatePrincipalPolicyResult simulatePrincipalPolicy(SimulatePrincipalPolicyRequest request) {
+        return retry.testWith1SecDelayMax5Times(() -> mapThrottlingError(() -> client.simulatePrincipalPolicy(request)));
+    }
+
+}

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsCredentialVerifierTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsCredentialVerifierTest.java
@@ -25,7 +25,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
 import com.amazonaws.services.identitymanagement.model.EvaluationResult;
 import com.amazonaws.services.identitymanagement.model.SimulatePrincipalPolicyRequest;
 import com.amazonaws.services.identitymanagement.model.SimulatePrincipalPolicyResult;
@@ -34,6 +33,7 @@ import com.amazonaws.services.securitytoken.model.GetCallerIdentityRequest;
 import com.amazonaws.services.securitytoken.model.GetCallerIdentityResult;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
+import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonIdentityManagementRetryClient;
 import com.sequenceiq.cloudbreak.cloud.aws.view.AwsCredentialView;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 
@@ -59,8 +59,8 @@ public class AwsCredentialVerifierTest {
         awsParameters.put("secretKey", "b");
         CloudCredential cloudCredential = new CloudCredential("id", "name", awsParameters);
 
-        AmazonIdentityManagement amazonIdentityManagement = mock(AmazonIdentityManagement.class);
-        when(awsClient.createAmazonIdentityManagement(any(AwsCredentialView.class))).thenReturn(amazonIdentityManagement);
+        AmazonIdentityManagementRetryClient amazonIdentityManagement = mock(AmazonIdentityManagementRetryClient.class);
+        when(awsClient.createAmazonIdentityManagementRetryClient(any(AwsCredentialView.class))).thenReturn(amazonIdentityManagement);
 
         AWSSecurityTokenService awsSecurityTokenService = mock(AWSSecurityTokenService.class);
         GetCallerIdentityResult getCallerIdentityResult = new GetCallerIdentityResult();
@@ -114,8 +114,8 @@ public class AwsCredentialVerifierTest {
         awsParameters.put("secretKey", "b");
         CloudCredential cloudCredential = new CloudCredential("id", "name", awsParameters);
 
-        AmazonIdentityManagement amazonIdentityManagement = mock(AmazonIdentityManagement.class);
-        when(awsClient.createAmazonIdentityManagement(any(AwsCredentialView.class))).thenReturn(amazonIdentityManagement);
+        AmazonIdentityManagementRetryClient amazonIdentityManagement = mock(AmazonIdentityManagementRetryClient.class);
+        when(awsClient.createAmazonIdentityManagementRetryClient(any(AwsCredentialView.class))).thenReturn(amazonIdentityManagement);
 
         AWSSecurityTokenService awsSecurityTokenService = mock(AWSSecurityTokenService.class);
         GetCallerIdentityResult getCallerIdentityResult = new GetCallerIdentityResult();

--- a/common/src/main/java/com/sequenceiq/cloudbreak/service/Retry.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/service/Retry.java
@@ -8,6 +8,8 @@ public interface Retry {
 
     <T> T testWith2SecDelayMax15Times(Supplier<T> action) throws ActionFailedException;
 
+    <T> T testWith1SecDelayMax5Times(Supplier<T> action) throws ActionFailedException;
+
     class ActionFailedException extends RuntimeException {
         public ActionFailedException() {
         }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/service/RetryService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/service/RetryService.java
@@ -24,4 +24,14 @@ public class RetryService implements Retry {
     public <T> T testWith2SecDelayMax15Times(Supplier<T> action) throws ActionFailedException {
         return action.get();
     }
+
+    @Override
+    @Retryable(
+            value = ActionFailedException.class,
+            maxAttempts = 5,
+            backoff = @Backoff(delay = 1000, multiplier = 2, maxDelay = 10000)
+    )
+    public <T> T testWith1SecDelayMax5Times(Supplier<T> action) throws ActionFailedException {
+        return action.get();
+    }
 }

--- a/flow/src/test/java/com/sequenceiq/cloudbreak/service/HeartbeatServiceTest.java
+++ b/flow/src/test/java/com/sequenceiq/cloudbreak/service/HeartbeatServiceTest.java
@@ -448,6 +448,11 @@ public class HeartbeatServiceTest {
             public <T> T testWith2SecDelayMax15Times(Supplier<T> action) throws ActionFailedException {
                 return null;
             }
+
+            @Override
+            public <T> T testWith1SecDelayMax5Times(Supplier<T> action) throws ActionFailedException {
+                return null;
+            }
         }
 
         Set<FlowLog> flowLogs = new HashSet<>(getFlowLogs(2, 5000));
@@ -481,6 +486,11 @@ public class HeartbeatServiceTest {
 
             @Override
             public <T> T testWith2SecDelayMax15Times(Supplier<T> action) throws ActionFailedException {
+                return null;
+            }
+
+            @Override
+            public <T> T testWith1SecDelayMax5Times(Supplier<T> action) throws ActionFailedException {
                 return null;
             }
         }


### PR DESCRIPTION
- creating 5 second cache for verification (in order to not use aws client too often, especially problematic in parallel scenarios - like creating multiple credentials for e2e tests )
- also adding retry around request exceeded calls -> that can avoid throttling errors if an another application uses the same aws account for iam operations -> added 1 sec / 5 times retry as well as the issue happened during create credential actions (2 sec delay with 15 times will be too large there)