### PR TITLE
Add logging for UMS resource deletion (notify resource deletion & virtual group cleanup)

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
@@ -505,8 +505,10 @@ public class GrpcUmsClient {
     // @CacheEvict(cacheNames = {"umsUserRightsCache", "umsUserRoleAssigmentsCache", "umsResourceAssigneesCache"}, key = "#userCrn")
     public void notifyResourceDeleted(String userCrn, String resourceCrn, Optional<String> requestId) {
         try (ManagedChannelWrapper channelWrapper = makeWrapper()) {
+            LOGGER.debug("Notify UMS about resource ('{}') was deleted", resourceCrn);
             UmsClient client = makeClient(channelWrapper.getChannel(), userCrn);
             client.notifyResourceDeleted(requestId.orElse(UUID.randomUUID().toString()), resourceCrn);
+            LOGGER.debug("Notify resource delete UMS call has been finished for resource crn: {} (by {})", resourceCrn, userCrn);
         }
     }
 

--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/VirtualGroupService.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/VirtualGroupService.java
@@ -48,7 +48,9 @@ public class VirtualGroupService {
     public void cleanupVirtualGroups(String accountId, String environmentCrn) {
         for (UmsRight right : UmsRight.values()) {
             try {
+                LOGGER.debug("Start deleting virtual groups from UMS for environment '{}'", environmentCrn);
                 grpcUmsClient.deleteWorkloadAdministrationGroupName(IAM_INTERNAL_ACTOR_CRN, accountId, Optional.empty(), right.getRight(), environmentCrn);
+                LOGGER.debug("Virtual groups deletion from UMS has been finished successfully for environment '{}'", environmentCrn);
             } catch (RuntimeException ex) {
                 LOGGER.warn("UMS virtualgroup delete failed (this is not critical)", ex);
             }


### PR DESCRIPTION
- without proper logging i have no idea which call get stucked. 
https://github.com/hortonworks/cloudbreak/blob/master/environment/src/main/java/com/sequenceiq/environment/environment/flow/deletion/handler/EnvironmentUMSResourceDeleteHandler.java#L71
based on the logs the problematic flow never reached the catch part or the code below that, also on next run it went through to finished state