### PR TITLE
CB-4683 Fix gradle Eclipse IDE project generation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -180,4 +180,20 @@ subprojects {
       url "https://repository.cloudera.com/cloudera/list/cm-private/"
     }
   }
+
+  eclipse {
+    classpath {
+      file.whenMerged {
+        cp -> if (project.hasProperty('protobuf')) {
+          cp.entries = cp.entries.findAll { element -> !element.getPath().startsWith('src/generated')}
+          cp.entries.addAll(
+            [
+              new org.gradle.plugins.ide.eclipse.model.SourceFolder('src/generated/main/java', null),
+              new org.gradle.plugins.ide.eclipse.model.SourceFolder('src/generated/main/grpc', null)
+            ]
+          )
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Adds an eclipse specific fixup function to the root gradle.build file that removes the erronous  eclipse classpath entries for protobuf generated code, and adds the correct classpath entries.

The function is only ever run by the eclipse project setup gradle plugin, so it should have minimal risk.

testing done:

run './gradlew eclipse', import the project into eclipse. 
Eclipse does not have dependency problems with the fix.

run './gradlew build'
check that the build completes.

Closes #CB-4683