### PR TITLE
Add '@PathParam' to crnByName endpoint

### DIFF
--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/endpoint/EnvironmentEndpoint.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/endpoint/EnvironmentEndpoint.java
@@ -55,7 +55,7 @@ public interface EnvironmentEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = EnvironmentOpDescription.GET_CRN_BY_NAME, produces = MediaType.APPLICATION_JSON, notes = ENVIRONMENT_NOTES,
             nickname = "getCrnByNameV1")
-    EnvironmentCrnResponse getCrnByName(String environmentName);
+    EnvironmentCrnResponse getCrnByName(@PathParam("name") String environmentName);
 
     @DELETE
     @Path("/name/{name}")


### PR DESCRIPTION
i got the following error during cb-cli swagger generation:

```bash
2019/11/29 16:45:40 validating spec /Users/oliverszabo/GoProjects/src/github.com/hortonworks/cb-cli/build/swagger.json
The swagger spec at "/Users/oliverszabo/GoProjects/src/github.com/hortonworks/cb-cli/build/swagger.json" is invalid against swagger specification 2.0. see errors :
- path param "{name}" has no parameter definition

make: *** [generate-swagger-environment-docker] Error 1
```
so i added the path param to this endpoint
