### PR TITLE
DISTX-316. Support cloudwatch / fluentd plugin upgrade & small refactor (Preview / POC)

### DIFF
--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/base/LoggingBase.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/base/LoggingBase.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
 import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
 import com.sequenceiq.common.api.telemetry.doc.TelemetryModelDescription;
+import com.sequenceiq.common.api.telemetry.model.CloudwatchParams;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -27,6 +28,9 @@ public abstract class LoggingBase implements Serializable {
 
     @ApiModelProperty(TelemetryModelDescription.TELEMETRY_LOGGING_ADLS_GEN_2_ATTRIBUTES)
     private AdlsGen2CloudStorageV1Parameters adlsGen2;
+
+    @ApiModelProperty(TelemetryModelDescription.TELEMETRY_LOGGING_CLOUDWATCH_ATTRIBUTES)
+    private CloudwatchParams cloudwatch;
 
     public String getStorageLocation() {
         return storageLocation;
@@ -50,5 +54,13 @@ public abstract class LoggingBase implements Serializable {
 
     public void setAdlsGen2(AdlsGen2CloudStorageV1Parameters adlsGen2) {
         this.adlsGen2 = adlsGen2;
+    }
+
+    public CloudwatchParams getCloudwatch() {
+        return cloudwatch;
+    }
+
+    public void setCloudwatch(CloudwatchParams cloudwatch) {
+        this.cloudwatch = cloudwatch;
     }
 }

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/doc/TelemetryModelDescription.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/doc/TelemetryModelDescription.java
@@ -10,8 +10,11 @@ public class TelemetryModelDescription {
     public static final String TELEMETRY_METERING = "Telemetry metering feature setting";
     public static final String TELEMETRY_LOGGING_S3_ATTRIBUTES = "telemetry - logging s3 attributes";
     public static final String TELEMETRY_LOGGING_ADLS_GEN_2_ATTRIBUTES = "telemetry - logging adls gen2 attributes";
+    public static final String TELEMETRY_LOGGING_CLOUDWATCH_ATTRIBUTES = "telemetry - logging cloudwatch attributes";
     public static final String TELEMETRY_LOGGING_STORAGE_LOCATION = "telemetry - logging storage location / container";
     public static final String TELEMETRY_REPORT_DEPLOYMENT_LOGS_ENABLED = "enable cluster deployment log reporting.";
+    public static final String TELEMETRY_CLOUDWATCH_PARAMS = "telemetry - cloudwatch releated parameters";
+    public static final String TELEMETRY_CLOUDWATCH_PARAMS_REGION = "telemetry - cloudwatch related AWS region (should be used only outside of AWS platform)";
 
     private TelemetryModelDescription() {
     }

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/CloudwatchParams.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/CloudwatchParams.java
@@ -1,0 +1,63 @@
+package com.sequenceiq.common.api.telemetry.model;
+
+import java.io.Serializable;
+
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.sequenceiq.common.api.telemetry.doc.TelemetryModelDescription;
+
+import io.swagger.annotations.ApiModelProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CloudwatchParams implements Serializable {
+
+    @ApiModelProperty
+    @NotNull
+    private String instanceProfile;
+
+    @ApiModelProperty(TelemetryModelDescription.TELEMETRY_CLOUDWATCH_PARAMS_REGION)
+    private String region;
+
+    @ApiModelProperty(TelemetryModelDescription.TELEMETRY_CLOUDWATCH_PARAMS)
+    private CloudwatchStreamKey streamKey = CloudwatchStreamKey.HOSTNAME;
+
+    public String getInstanceProfile() {
+        return instanceProfile;
+    }
+
+    public void setInstanceProfile(String instanceProfile) {
+        this.instanceProfile = instanceProfile;
+    }
+
+    public CloudwatchStreamKey getStreamKey() {
+        return streamKey;
+    }
+
+    public void setStreamKey(CloudwatchStreamKey streamKey) {
+        this.streamKey = streamKey;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public void setRegion(String region) {
+        this.region = region;
+    }
+
+    @JsonIgnore
+    public static CloudwatchParams copy(CloudwatchParams cloudwatchParams) {
+        CloudwatchParams newCloudwatchParams = null;
+        if (cloudwatchParams != null) {
+            newCloudwatchParams = new CloudwatchParams();
+            newCloudwatchParams.setStreamKey(cloudwatchParams.getStreamKey());
+            newCloudwatchParams.setInstanceProfile(cloudwatchParams.getInstanceProfile());
+            newCloudwatchParams.setRegion(cloudwatchParams.getRegion());
+        }
+        return newCloudwatchParams;
+    }
+}

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/CloudwatchStreamKey.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/CloudwatchStreamKey.java
@@ -1,0 +1,20 @@
+package com.sequenceiq.common.api.telemetry.model;
+
+/**
+ * For logging, Cloudwatch streams will be created based on this key
+ */
+public enum CloudwatchStreamKey {
+
+    HOSTNAME("hostname"),
+    COMPONENT("component");
+
+    private String value;
+
+    CloudwatchStreamKey(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return this.value;
+    }
+}

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/Logging.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/Logging.java
@@ -15,6 +15,8 @@ public class Logging implements Serializable {
 
     private AdlsGen2CloudStorageV1Parameters adlsGen2;
 
+    private CloudwatchParams cloudwatch;
+
     public String getStorageLocation() {
         return storageLocation;
     }
@@ -37,5 +39,13 @@ public class Logging implements Serializable {
 
     public void setAdlsGen2(AdlsGen2CloudStorageV1Parameters adlsGen2) {
         this.adlsGen2 = adlsGen2;
+    }
+
+    public CloudwatchParams getCloudwatch() {
+        return cloudwatch;
+    }
+
+    public void setCloudwatch(CloudwatchParams cloudwatch) {
+        this.cloudwatch = cloudwatch;
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentClusterDetails.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentClusterDetails.java
@@ -1,0 +1,128 @@
+package com.sequenceiq.cloudbreak.telemetry.fluent;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.lang3.ObjectUtils;
+
+public class FluentClusterDetails {
+
+    public static final String CLUSTER_CRN_KEY = "clusterCrn";
+
+    private static final String CLUSTER_TYPE_DEFAULT = "datahub";
+
+    private static final String EMPTY_CONFIG_DEFAULT = "";
+
+    private final String name;
+
+    private final String type;
+
+    private final String crn;
+
+    private final String owner;
+
+    private final String platform;
+
+    private final String version;
+
+    private FluentClusterDetails(Builder builder) {
+        this.name = builder.name;
+        this.type = builder.type;
+        this.crn = builder.crn;
+        this.owner = builder.owner;
+        this.platform = builder.platform;
+        this.version = builder.version;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getCrn() {
+        return crn;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public String getPlatform() {
+        return platform;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("platform", ObjectUtils.defaultIfNull(this.platform, EMPTY_CONFIG_DEFAULT));
+        map.put("clusterName", this.name);
+        map.put("clusterType", ObjectUtils.defaultIfNull(this.type, CLUSTER_TYPE_DEFAULT));
+        map.put(CLUSTER_CRN_KEY, this.crn);
+        map.put("clusterOwner", this.owner);
+        map.put("clusterVersion", this.version);
+        return map;
+    }
+
+    public static final class Builder {
+
+        private String name;
+
+        private String type;
+
+        private String crn;
+
+        private String owner;
+
+        private String platform;
+
+        private String version;
+
+        private Builder() {
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public FluentClusterDetails build() {
+            return new FluentClusterDetails(this);
+        }
+
+        public Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder withType(String type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder withCrn(String crn) {
+            this.crn = crn;
+            return this;
+        }
+
+        public Builder withOwner(String owner) {
+            this.owner = owner;
+            return this;
+        }
+
+        public Builder withPlatform(String platform) {
+            this.platform = platform;
+            return this;
+        }
+
+        public Builder withVersion(String version) {
+            this.version = version;
+            return this;
+        }
+
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/cloud/CloudStorageFolderResolverService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/cloud/CloudStorageFolderResolverService.java
@@ -39,7 +39,7 @@ public class CloudStorageFolderResolverService {
                         clusterType, clusterName, clusterCrn);
             } else {
                 LOGGER.warn("None of the telemetry logging storage location was resolved, "
-                        + "make sure storage type is set properly (currently supported: s3, wasb)");
+                        + "make sure storage type is set properly (currently supported: s3, abfs)");
             }
             logging.setStorageLocation(storageLocation);
         } else {

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigServiceTest.java
@@ -23,6 +23,9 @@ public class FluentConfigServiceTest {
 
     private static final String PLATFORM_DEFAULT = "AWS";
 
+    private static final FluentClusterDetails DEFAULT_FLUENT_CLUSTER_DETAILS =
+            FluentClusterDetails.Builder.builder().withType(CLUSTER_TYPE_DEFAULT).withPlatform(PLATFORM_DEFAULT).build();
+
     private FluentConfigService underTest;
 
     @Before
@@ -39,8 +42,8 @@ public class FluentConfigServiceTest {
         Telemetry telemetry = new Telemetry();
         telemetry.setLogging(logging);
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
-                false, false, telemetry);
+        FluentConfigView result = underTest.createFluentConfigs(
+                DEFAULT_FLUENT_CLUSTER_DETAILS, false, false, telemetry);
         // THEN
         assertTrue(result.isEnabled());
         assertTrue(result.isCloudStorageLoggingEnabled());
@@ -57,8 +60,8 @@ public class FluentConfigServiceTest {
         Telemetry telemetry = new Telemetry();
         telemetry.setLogging(logging);
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
-                false, false, telemetry);
+        FluentConfigView result = underTest.createFluentConfigs(
+                DEFAULT_FLUENT_CLUSTER_DETAILS, false, false, telemetry);
         // THEN
         assertTrue(result.isEnabled());
         assertTrue(result.isCloudStorageLoggingEnabled());
@@ -75,8 +78,8 @@ public class FluentConfigServiceTest {
         Telemetry telemetry = new Telemetry();
         telemetry.setLogging(logging);
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
-                false, false, telemetry);
+        FluentConfigView result = underTest.createFluentConfigs(
+                DEFAULT_FLUENT_CLUSTER_DETAILS, false, false, telemetry);
         // THEN
         assertTrue(result.isEnabled());
         assertTrue(result.isCloudStorageLoggingEnabled());
@@ -93,8 +96,8 @@ public class FluentConfigServiceTest {
         Telemetry telemetry = new Telemetry();
         telemetry.setLogging(logging);
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
-                false, false, telemetry);
+        FluentConfigView result = underTest.createFluentConfigs(
+                DEFAULT_FLUENT_CLUSTER_DETAILS, false, false, telemetry);
         // THEN
         assertTrue(result.isEnabled());
         assertTrue(result.isCloudStorageLoggingEnabled());
@@ -113,8 +116,8 @@ public class FluentConfigServiceTest {
         Telemetry telemetry = new Telemetry();
         telemetry.setLogging(logging);
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
-                false, false, telemetry);
+        FluentConfigView result = underTest.createFluentConfigs(
+                DEFAULT_FLUENT_CLUSTER_DETAILS, false, false, telemetry);
         // THEN
         assertTrue(result.isEnabled());
         assertTrue(result.isCloudStorageLoggingEnabled());
@@ -135,8 +138,8 @@ public class FluentConfigServiceTest {
         Telemetry telemetry = new Telemetry();
         telemetry.setLogging(logging);
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
-                false, false, telemetry);
+        FluentConfigView result = underTest.createFluentConfigs(
+                DEFAULT_FLUENT_CLUSTER_DETAILS, false, false, telemetry);
         // THEN
         assertTrue(result.isEnabled());
         assertEquals("myAccountKey", result.getAzureStorageAccessKey());
@@ -156,8 +159,8 @@ public class FluentConfigServiceTest {
         Telemetry telemetry = new Telemetry();
         telemetry.setLogging(logging);
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
-                false, false, telemetry);
+        FluentConfigView result = underTest.createFluentConfigs(
+                DEFAULT_FLUENT_CLUSTER_DETAILS, false, false, telemetry);
         // THEN
         assertTrue(result.isEnabled());
         assertEquals("myAccountKey", result.getAzureStorageAccessKey());
@@ -176,8 +179,8 @@ public class FluentConfigServiceTest {
         Telemetry telemetry = new Telemetry();
         telemetry.setLogging(logging);
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
-                false, false, telemetry);
+        FluentConfigView result = underTest.createFluentConfigs(
+                DEFAULT_FLUENT_CLUSTER_DETAILS, false, false, telemetry);
         // THEN
         assertTrue(result.isEnabled());
         assertEquals("myAccountKey", result.getAzureStorageAccessKey());
@@ -192,8 +195,8 @@ public class FluentConfigServiceTest {
         setMetering(telemetry);
         telemetry.setDatabusEndpoint("myEndpoint");
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
-                true, true, telemetry);
+        FluentConfigView result = underTest.createFluentConfigs(
+                DEFAULT_FLUENT_CLUSTER_DETAILS, true, true, telemetry);
         // THEN
         assertTrue(result.isEnabled());
         assertTrue(result.isMeteringEnabled());
@@ -205,8 +208,8 @@ public class FluentConfigServiceTest {
         Telemetry telemetry = new Telemetry();
         setMetering(telemetry);
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
-                false, false, telemetry);
+        FluentConfigView result = underTest.createFluentConfigs(
+                DEFAULT_FLUENT_CLUSTER_DETAILS, false, false, telemetry);
         // THEN
         assertFalse(result.isEnabled());
         assertFalse(result.isMeteringEnabled());
@@ -218,8 +221,7 @@ public class FluentConfigServiceTest {
         Telemetry telemetry = new Telemetry();
         setMetering(telemetry);
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
-                false, false, telemetry);
+        FluentConfigView result = underTest.createFluentConfigs(DEFAULT_FLUENT_CLUSTER_DETAILS, false, false, telemetry);
         // THEN
         assertFalse(result.isEnabled());
         assertFalse(result.isMeteringEnabled());
@@ -231,8 +233,7 @@ public class FluentConfigServiceTest {
         Telemetry telemetry = new Telemetry();
         setReportDeploymentLogs(telemetry);
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
-                true, false, telemetry);
+        FluentConfigView result = underTest.createFluentConfigs(DEFAULT_FLUENT_CLUSTER_DETAILS, true, false, telemetry);
         // THEN
         assertTrue(result.isEnabled());
         assertTrue(result.isReportClusterDeploymentLogs());
@@ -244,8 +245,8 @@ public class FluentConfigServiceTest {
         Telemetry telemetry = new Telemetry();
         setReportDeploymentLogs(telemetry);
         // WHEN
-        FluentConfigView result = underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
-                false, true, telemetry);
+        FluentConfigView result = underTest.createFluentConfigs(
+                DEFAULT_FLUENT_CLUSTER_DETAILS, false, true, telemetry);
         // THEN
         assertFalse(result.isEnabled());
         assertFalse(result.isReportClusterDeploymentLogs());
@@ -260,8 +261,7 @@ public class FluentConfigServiceTest {
         Telemetry telemetry = new Telemetry();
         telemetry.setLogging(logging);
         // WHEN
-        underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
-                false, false, telemetry);
+        underTest.createFluentConfigs(DEFAULT_FLUENT_CLUSTER_DETAILS, false, false, telemetry);
     }
 
     @Test(expected = CloudbreakServiceException.class)
@@ -275,8 +275,7 @@ public class FluentConfigServiceTest {
         Telemetry telemetry = new Telemetry();
         telemetry.setLogging(logging);
         // WHEN
-        underTest.createFluentConfigs(CLUSTER_TYPE_DEFAULT, PLATFORM_DEFAULT,
-                false, false, telemetry);
+        underTest.createFluentConfigs(DEFAULT_FLUENT_CLUSTER_DETAILS, false, false, telemetry);
     }
 
     private void setMetering(Telemetry telemetry) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.common.api.telemetry.model.CloudwatchParams;
 import com.sequenceiq.common.api.telemetry.model.Features;
 import com.sequenceiq.common.api.telemetry.model.Logging;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
@@ -219,6 +220,7 @@ public class TelemetryConverter {
             loggingRequest = new LoggingRequest();
             loggingRequest.setS3(logging.getS3());
             loggingRequest.setAdlsGen2(logging.getAdlsGen2());
+            loggingRequest.setCloudwatch(CloudwatchParams.copy(logging.getCloudwatch()));
             loggingRequest.setStorageLocation(logging.getStorageLocation());
         }
         return loggingRequest;
@@ -251,6 +253,7 @@ public class TelemetryConverter {
             logging.setStorageLocation(loggingRequest.getStorageLocation());
             logging.setS3(loggingRequest.getS3());
             logging.setAdlsGen2(loggingRequest.getAdlsGen2());
+            logging.setCloudwatch(CloudwatchParams.copy(loggingRequest.getCloudwatch()));
         }
         return logging;
     }
@@ -276,6 +279,7 @@ public class TelemetryConverter {
             loggingResponse.setStorageLocation(logging.getStorageLocation());
             loggingResponse.setS3(logging.getS3());
             loggingResponse.setAdlsGen2(logging.getAdlsGen2());
+            loggingResponse.setCloudwatch(CloudwatchParams.copy(logging.getCloudwatch()));
         }
         return loggingResponse;
     }
@@ -311,6 +315,7 @@ public class TelemetryConverter {
             loggingRequest.setStorageLocation(loggingResponse.getStorageLocation());
             loggingRequest.setS3(loggingResponse.getS3());
             loggingRequest.setAdlsGen2(loggingResponse.getAdlsGen2());
+            loggingRequest.setCloudwatch(loggingResponse.getCloudwatch());
         }
         return loggingRequest;
     }
@@ -336,9 +341,9 @@ public class TelemetryConverter {
                 LOGGER.debug("Fill report deployment logs setting from telemetry feature request");
                 features.setReportDeploymentLogs(request.getFeatures().getReportDeploymentLogs());
             } else {
-                LOGGER.debug("Auto-fill report deployment logs telemetry settings as it is set, but missing from the request.");
+                LOGGER.debug("Auto-filling report deployment logs telemetry settings as it is set, but missing from the request.");
                 FeatureSetting reportDeploymentLogsFeature = new FeatureSetting();
-                reportDeploymentLogsFeature.setEnabled(true);
+                reportDeploymentLogsFeature.setEnabled(false);
                 features.setReportDeploymentLogs(reportDeploymentLogsFeature);
             }
         } else {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
@@ -125,6 +125,22 @@ public class TelemetryConverterTest {
         // WHEN
         Telemetry result = underTest.convert(telemetryRequest, StackType.WORKLOAD);
         // THEN
+        assertFalse(result.getFeatures().getReportDeploymentLogs().isEnabled());
+        assertTrue(result.getFeatures().getMetering().isEnabled());
+    }
+
+    @Test
+    public void testConvertFromRequestWithFeatures() {
+        // GIVEN
+        TelemetryRequest telemetryRequest = new TelemetryRequest();
+        FeatureSetting reportDeploymentLog = new FeatureSetting();
+        reportDeploymentLog.setEnabled(true);
+        FeaturesRequest features = new FeaturesRequest();
+        features.setReportDeploymentLogs(reportDeploymentLog);
+        telemetryRequest.setFeatures(features);
+        // WHEN
+        Telemetry result = underTest.convert(telemetryRequest, StackType.WORKLOAD);
+        // THEN
         assertTrue(result.getFeatures().getReportDeploymentLogs().isEnabled());
         assertTrue(result.getFeatures().getMetering().isEnabled());
     }
@@ -136,7 +152,7 @@ public class TelemetryConverterTest {
         // WHEN
         Telemetry result = underTest.convert(telemetryRequest, StackType.DATALAKE);
         // THEN
-        assertTrue(result.getFeatures().getReportDeploymentLogs().isEnabled());
+        assertFalse(result.getFeatures().getReportDeploymentLogs().isEnabled());
         assertNull(result.getFeatures().getMetering());
     }
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/CloudStorageManifester.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/CloudStorageManifester.java
@@ -21,6 +21,7 @@ import com.sequenceiq.common.api.cloudstorage.CloudStorageRequest;
 import com.sequenceiq.common.api.cloudstorage.S3Guard;
 import com.sequenceiq.common.api.cloudstorage.StorageIdentityBase;
 import com.sequenceiq.common.api.cloudstorage.StorageLocationBase;
+import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
 import com.sequenceiq.common.api.telemetry.response.LoggingResponse;
 import com.sequenceiq.common.model.CloudIdentityType;
 import com.sequenceiq.common.model.CloudStorageCdpService;
@@ -96,6 +97,11 @@ public class CloudStorageManifester {
                 log.setS3(logging.getS3());
             } else if (logging.getAdlsGen2() != null) {
                 log.setAdlsGen2(logging.getAdlsGen2());
+            } else if (logging.getCloudwatch() != null) {
+                LOGGER.debug("Cloudwatch will act as s3 storage identity!");
+                S3CloudStorageV1Parameters s3CloudwatchParams = new S3CloudStorageV1Parameters();
+                s3CloudwatchParams.setInstanceProfile(logging.getCloudwatch().getInstanceProfile());
+                log.setS3(s3CloudwatchParams);
             }
             cloudStorageRequest.getIdentities().add(log);
         }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
@@ -35,12 +35,15 @@ import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.idbmms.GrpcIdbmmsClient;
 import com.sequenceiq.cloudbreak.idbmms.exception.IdbmmsOperationException;
 import com.sequenceiq.cloudbreak.idbmms.model.MappingsConfig;
+import com.sequenceiq.cloudbreak.telemetry.fluent.FluentClusterDetails;
 import com.sequenceiq.cloudbreak.util.PasswordUtil;
 import com.sequenceiq.common.api.cloudstorage.AccountMappingBase;
 import com.sequenceiq.common.api.cloudstorage.CloudStorageRequest;
 import com.sequenceiq.common.api.telemetry.request.FeaturesRequest;
 import com.sequenceiq.common.api.telemetry.request.LoggingRequest;
 import com.sequenceiq.common.api.telemetry.request.TelemetryRequest;
+import com.sequenceiq.common.api.telemetry.response.LoggingResponse;
+import com.sequenceiq.common.api.telemetry.response.TelemetryResponse;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.datalake.controller.exception.BadRequestException;
 import com.sequenceiq.datalake.entity.SdxCluster;
@@ -118,7 +121,7 @@ public class StackRequestManifester {
             setupAuthentication(environment, stackRequest);
             setupSecurityAccess(environment, stackRequest);
             setupClusterRequest(stackRequest);
-            prepareTelemetryForStack(stackRequest, environment);
+            prepareTelemetryForStack(stackRequest, environment, sdxCluster);
             setupCloudStorageAccountMapping(stackRequest, environment.getCrn(), environment.getIdBrokerMappingSource(), environment.getCloudPlatform());
             cloudStorageValidator.validate(stackRequest.getCluster().getCloudStorage(), environment);
             return stackRequest;
@@ -224,20 +227,31 @@ public class StackRequestManifester {
         }
     }
 
-    private void prepareTelemetryForStack(StackV4Request stackV4Request, DetailedEnvironmentResponse environment) {
-        if (environment.getTelemetry() != null && environment.getTelemetry().getLogging() != null) {
+    private void prepareTelemetryForStack(StackV4Request stackV4Request,
+            DetailedEnvironmentResponse environment, SdxCluster sdxCluster) {
+        TelemetryResponse envTelemetry = environment.getTelemetry();
+        if (envTelemetry != null && envTelemetry.getLogging() != null) {
             TelemetryRequest telemetryRequest = new TelemetryRequest();
             LoggingRequest loggingRequest = new LoggingRequest();
-            loggingRequest.setS3(environment.getTelemetry().getLogging().getS3());
-            loggingRequest.setAdlsGen2(environment.getTelemetry().getLogging().getAdlsGen2());
-            loggingRequest.setStorageLocation(environment.getTelemetry().getLogging().getStorageLocation());
+            LoggingResponse envLogging =  envTelemetry.getLogging();
+            loggingRequest.setS3(envLogging.getS3());
+            loggingRequest.setAdlsGen2(envLogging.getAdlsGen2());
+            loggingRequest.setCloudwatch(envLogging.getCloudwatch());
+            loggingRequest.setStorageLocation(envLogging.getStorageLocation());
             telemetryRequest.setLogging(loggingRequest);
-            if (environment.getTelemetry().getFeatures() != null
-                    && environment.getTelemetry().getFeatures().getReportDeploymentLogs() != null) {
+            if (envTelemetry.getFeatures() != null
+                    && envTelemetry.getFeatures().getReportDeploymentLogs() != null) {
                 FeaturesRequest featuresRequest = new FeaturesRequest();
                 featuresRequest.setReportDeploymentLogs(
                         environment.getTelemetry().getFeatures().getReportDeploymentLogs());
                 telemetryRequest.setFeatures(featuresRequest);
+            }
+            if (envTelemetry.getFluentAttributes() != null) {
+                Map<String, Object> fluentAttributes = envTelemetry.getFluentAttributes();
+                if (!fluentAttributes.containsKey(FluentClusterDetails.CLUSTER_CRN_KEY)) {
+                    fluentAttributes.put(FluentClusterDetails.CLUSTER_CRN_KEY, sdxCluster.getCrn());
+                }
+                telemetryRequest.setFluentAttributes(fluentAttributes);
             }
             stackV4Request.setTelemetry(telemetryRequest);
         }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/telemetry/EnvironmentLogging.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/telemetry/EnvironmentLogging.java
@@ -5,6 +5,7 @@ import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
+import com.sequenceiq.common.api.telemetry.model.CloudwatchParams;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -15,6 +16,8 @@ public class EnvironmentLogging implements Serializable {
     private S3CloudStorageParameters s3;
 
     private AdlsGen2CloudStorageV1Parameters adlsGen2;
+
+    private CloudwatchParams cloudwatch;
 
     public String getStorageLocation() {
         return storageLocation;
@@ -38,5 +41,13 @@ public class EnvironmentLogging implements Serializable {
 
     public void setAdlsGen2(AdlsGen2CloudStorageV1Parameters adlsGen2) {
         this.adlsGen2 = adlsGen2;
+    }
+
+    public CloudwatchParams getCloudwatch() {
+        return cloudwatch;
+    }
+
+    public void setCloudwatch(CloudwatchParams cloudwatch) {
+        this.cloudwatch = cloudwatch;
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/TelemetryApiConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/TelemetryApiConverter.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
+import com.sequenceiq.common.api.telemetry.model.CloudwatchParams;
 import com.sequenceiq.common.api.telemetry.request.FeaturesRequest;
 import com.sequenceiq.common.api.telemetry.request.LoggingRequest;
 import com.sequenceiq.common.api.telemetry.request.TelemetryRequest;
@@ -74,14 +75,9 @@ public class TelemetryApiConverter {
         if (logging != null) {
             loggingRequest = new LoggingRequest();
             loggingRequest.setStorageLocation(logging.getStorageLocation());
-            if (logging.getS3() != null) {
-                S3CloudStorageV1Parameters s3Params = convertS3(logging.getS3());
-                loggingRequest.setS3(s3Params);
-            }
-            if (logging.getAdlsGen2() != null) {
-                AdlsGen2CloudStorageV1Parameters adlsGen2Params = convertAdlsV2(logging.getAdlsGen2());
-                loggingRequest.setAdlsGen2(adlsGen2Params);
-            }
+            loggingRequest.setS3(convertS3(logging.getS3()));
+            loggingRequest.setAdlsGen2(convertAdlsV2(logging.getAdlsGen2()));
+            loggingRequest.setCloudwatch(CloudwatchParams.copy(logging.getCloudwatch()));
         }
         return loggingRequest;
     }
@@ -112,6 +108,7 @@ public class TelemetryApiConverter {
             logging.setStorageLocation(loggingRequest.getStorageLocation());
             logging.setS3(convertS3(loggingRequest.getS3()));
             logging.setAdlsGen2(convertAdlsV2(loggingRequest.getAdlsGen2()));
+            logging.setCloudwatch(CloudwatchParams.copy(loggingRequest.getCloudwatch()));
         }
         return logging;
     }
@@ -163,6 +160,7 @@ public class TelemetryApiConverter {
             loggingResponse.setStorageLocation(logging.getStorageLocation());
             loggingResponse.setS3(convertS3(logging.getS3()));
             loggingResponse.setAdlsGen2(convertAdlsV2(logging.getAdlsGen2()));
+            loggingResponse.setCloudwatch(CloudwatchParams.copy(logging.getCloudwatch()));
         }
         return loggingResponse;
     }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/cloudstorage/EnvironmentLogStorageLocationValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/cloudstorage/EnvironmentLogStorageLocationValidator.java
@@ -19,10 +19,15 @@ public class EnvironmentLogStorageLocationValidator {
         this.cloudStorageLocationValidator = cloudStorageLocationValidator;
     }
 
+    /**
+     * Validate telemetry related logging storage location.
+     * Currently, filter out cloudwatch (or any other cloud logging service) related validations
+     */
     public ValidationResult validateTelemetryLoggingStorageLocation(Environment environment) {
         ValidationResultBuilder resultBuilder = new ValidationResultBuilder();
         Optional.ofNullable(environment.getTelemetry())
                 .map(EnvironmentTelemetry::getLogging)
+                .filter(logging -> logging.getCloudwatch() == null)
                 .map(EnvironmentLogging::getStorageLocation)
                 .ifPresent(location -> cloudStorageLocationValidator.validate(location, environment, resultBuilder));
         return resultBuilder.build();

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/cloud/StackToCloudStackConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/cloud/StackToCloudStackConverter.java
@@ -265,6 +265,10 @@ public class StackToCloudStackConverter implements Converter<Stack, CloudStack> 
                     adlsGen2View.setSecure(adlsGen2Params.isSecure());
                     adlsGen2View.setManagedIdentity(adlsGen2Params.getManagedIdentity());
                     return Optional.of(adlsGen2View);
+                } else if (logging.getCloudwatch() != null) {
+                    CloudS3View s3View = new CloudS3View(CloudIdentityType.LOG);
+                    s3View.setInstanceProfile(logging.getCloudwatch().getInstanceProfile());
+                    return Optional.of(s3View);
                 }
             }
         }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverter.java
@@ -1,10 +1,13 @@
 package com.sequenceiq.freeipa.converter.telemetry;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
+import com.sequenceiq.common.api.telemetry.model.CloudwatchParams;
 import com.sequenceiq.common.api.telemetry.model.Features;
 import com.sequenceiq.common.api.telemetry.model.Logging;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
@@ -18,6 +21,8 @@ import com.sequenceiq.common.api.type.FeatureSetting;
 
 @Component
 public class TelemetryConverter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TelemetryConverter.class);
 
     private final boolean freeIpaTelemetryEnabled;
 
@@ -73,6 +78,8 @@ public class TelemetryConverter {
                 adlsGen2Params.setSecure(adlsGen2FromRequest.isSecure());
                 adlsGen2Params.setManagedIdentity(adlsGen2FromRequest.getManagedIdentity());
                 logging.setAdlsGen2(adlsGen2Params);
+            } else if (loggingRequest.getCloudwatch() != null) {
+                logging.setCloudwatch(CloudwatchParams.copy(loggingRequest.getCloudwatch()));
             }
         }
         return logging;
@@ -94,6 +101,8 @@ public class TelemetryConverter {
                 adlsGen2Params.setSecure(logging.getAdlsGen2().isSecure());
                 adlsGen2Params.setManagedIdentity(logging.getAdlsGen2().getManagedIdentity());
                 loggingResponse.setAdlsGen2(adlsGen2Params);
+            } else if (logging.getCloudwatch() != null) {
+                loggingResponse.setCloudwatch(CloudwatchParams.copy(logging.getCloudwatch()));
             }
         }
         return loggingResponse;
@@ -105,9 +114,11 @@ public class TelemetryConverter {
             features = new Features();
             if (featuresRequest != null && featuresRequest.getReportDeploymentLogs() != null) {
                 features.setReportDeploymentLogs(featuresRequest.getReportDeploymentLogs());
+                LOGGER.debug("Fill report deployment log settings from feature request");
             } else {
+                LOGGER.debug("Auto-fill report deployment logs settings with defaults. (disabled)");
                 FeatureSetting reportDeploymentLogsFeature = new FeatureSetting();
-                reportDeploymentLogsFeature.setEnabled(true);
+                reportDeploymentLogsFeature.setEnabled(false);
                 features.setReportDeploymentLogs(reportDeploymentLogsFeature);
             }
         }

--- a/orchestrator-salt/src/main/resources/salt-common/pillar/fluent/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/pillar/fluent/init.sls
@@ -6,16 +6,23 @@ fluent:
   agentLogFolderPrefix: /var/log
   serviceLogFolderPrefix: /var/log
   platform:
+  region:
   providerPrefix: "stdout"
   partitionIntervalMin: 5
   logFolderName: cluster-logs
+  clusterName:
+  clusterType: datahub
+  clusterCrn:
+  clusterOwner:
+  clusterVersion:
   cloudStorageLoggingEnabled: false
+  cloudLoggingServiceEnabled: false
   s3LogArchiveBucketName:
+  cloudwatchStreamKey: hostname
   azureStorageAccount:
   azureContainer:
   azureInstanceMsi:
   azureStorageAccessKey:
-  dbusAppName: datahub
   dbusReportDeploymentLogs: false
   dbusReportDeploymentLogsDisableStop: false
   dbusMeteringEnabled: false

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/check_fluent_plugins.sh.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/check_fluent_plugins.sh.j2
@@ -1,0 +1,51 @@
+{%- from 'fluent/settings.sls' import fluent with context %}
+#!/bin/sh
+
+function install_plugin() {
+  local plugin=$1
+  local custom_repo=$2
+  local version=$3
+
+  install_command="/opt/td-agent/embedded/bin/fluent-gem install ${plugin}"
+  if [[ "${custom_repo}" == "true" ]]; then
+     install_command="${install_command} -s  {{ fluent.clouderaPublicGemRepo }}"
+  fi
+
+  if [[ ! -z "${version}" ]]; then
+     install_command="${install_command} -v ${version}"
+     /opt/td-agent/embedded/bin/fluent-gem uninstall "${plugin}"
+  fi
+  echo "Run install command: ${install_command}"
+  command_result=$(${install_command})
+  echo "Install ${plugin} command output: ${command_result}"
+}
+
+function check_and_install_plugin() {
+  local plugin=$1
+  local custom_repo=$2
+  local version=$3
+  check_command="/opt/td-agent/embedded/bin/fluent-gem list -i ${plugin}"
+  if [[ ! -z "${version}" ]]; then
+    check_command="$check_command -v ${version}"
+    echo "Checking plugin ${plugin} with the right version ${version}"
+  fi
+  echo "Run check command: $check_command"
+  local result=$($check_command)
+  echo "Check ${plugin} command output: $result"
+  if [[ "$result" == "false" ]]; then
+    echo "Plugin ${plugin} does not exist, installing it..."
+    install_plugin "${plugin}" "${custom_repo}" "${version}"
+  else
+    echo "Plugin ${plugin} exists."
+  fi
+}
+
+function main() {
+  {% if fluent.platform == 'AZURE' %}
+  check_and_install_plugin "fluent-plugin-azurestorage" "true" "{{ fluent.clouderaAzurePluginVersion }}"
+  {% endif %}
+  check_and_install_plugin "fluent-plugin-databus" "true" "{{ fluent.clouderaDatabusPluginVersion }}"
+  check_and_install_plugin "fluent-plugin-detect-exceptions" "false" ""
+}
+
+main ${1+"$@"}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/databus_metering.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/databus_metering.conf.j2
@@ -20,7 +20,7 @@
     debug                            false
     endpoint                         "{{ databus.endpoint }}"
     event_message_field              message
-    headers                          app:{{ fluent.dbusAppName }}
+    headers                          app:{{ fluent.clusterType }}
     stream_name                      Metering
     partition_key                    "#{Socket.gethostname}"
 

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/filter.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/filter.conf.j2
@@ -1,0 +1,60 @@
+{%- from 'fluent/settings.sls' import fluent with context %}
+
+<match **fluent**>
+   @type null
+</match>
+
+<filter {{providerPrefix}}**>
+    @type record_transformer
+    <record>
+      raw_tag ${tag}
+    </record>
+</filter>
+
+<match {{providerPrefix}}**>
+   @type rewrite_tag_filter
+   <rule>
+      key raw_tag
+      pattern ^(.+)$
+      tag raw.processed.$1
+   </rule>
+</match>
+
+# try to catch exceptions for non custom logs
+<match raw.processed.{{providerPrefix}}**>
+   @type detect_exceptions
+   remove_tag_prefix raw
+   message message
+   multiline_flush_interval 0.1
+</match>
+<filter processed.{{providerPrefix}}.**>
+  @type record_transformer
+  enable_ruby true
+  <record>
+    component ${tag.split(".")[2].downcase}
+  </record>
+</filter>
+<filter processed.{{providerPrefix}}_CM_COMMAND.**>
+  @type record_transformer
+  enable_ruby true
+  <record>
+    component cm_agent_command
+    cm_agent_command_id ${tag.split(".")[7]}
+  </record>
+</filter>
+<filter processed.{{providerPrefix}}**>
+  @type record_transformer
+  enable_ruby true
+  <record>
+    context {"clusterName": "{{ fluent.clusterName }}", "clusterType": "{{ fluent.clusterType }}", "clusterCrn": "{{ fluent.clusterCrn }}", "clusterOwner": "{{ fluent.clusterOwner }}", "clusterVersion": "{{ fluent.clusterVersion }}" }
+    hostname "#{Socket.gethostname}"
+    @message ${record['message']}
+    {% if providerPrefix == "databus" %}
+    @timestamp ${time.to_datetime.strftime("%Y-%m-%dT%H:%M:%S.%NZ")}
+    {% endif %}
+  </record>
+</filter>
+<filter processed.{{providerPrefix}}**>
+   @type record_transformer
+   remove_keys {% if providerPrefix != "databus" %}time,{% endif %}timestamp,message,raw_tag
+</filter>

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/output.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/output.conf.j2
@@ -105,6 +105,32 @@
     format single_value
   </store>
 </match>
+{% elif fluent.providerPrefix == "cloudwatch" %}
+<match **{{fluent.providerPrefix}}**>
+  @type cloudwatch_logs
+  log_group_name {{fluent.logFolderName}}
+  log_stream_name_key {{fluent.cloudwatchStreamKey}}
+  auto_create_stream true
+  retention_in_days 7
+  put_log_events_retry_limit 20
+  concurrency 5
+  region {{ fluent.region }}
+  <buffer tag>
+     @type file
+     path /var/log/td-agent/{{fluent.providerPrefix}}
+     flush_mode               "interval"
+     flush_thread_count       10
+     flush_interval           "10s"
+     flush_at_shutdown        true
+     chunk_limit_size         "2M"
+   </buffer>
+   <inject>
+      time_type         string
+      time_key          @timestamp
+      time_format       %Y-%m-%dT%H:%M:%S.%NZ
+   </inject>
+</match>
+
 {% else %}
 <match {{fluent.providerPrefix}}.*>
   @type stdout

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/output_databus.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/output_databus.conf.j2
@@ -1,7 +1,7 @@
 {%- from 'fluent/settings.sls' import fluent with context %}
 {%- from 'databus/settings.sls' import databus with context %}
 {%- if databus.valid and fluent.dbusReportDeploymentLogs %}
-<match databus**>
+<match processed.databus**>
   @type copy
   <store ignore_error>
     @type                            databus
@@ -10,14 +10,13 @@
     credential_file_reload_interval  60
     debug                            false
     endpoint                         "{{ databus.endpoint }}"
-    event_message_field              message
-    headers                          app:{{ fluent.dbusAppName }}
+    headers                          app:{{ fluent.clusterType }}
     stream_name                      LogCollection
     partition_key                    "#{Socket.gethostname}"
 
     <buffer tag,time>
       @type file
-      path /var/log/td-agent/databus_metering
+      path /var/log/td-agent/databus_service_logs
       timekey 1m
       timekey_wait 0s
       chunk_limit_size 600k

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/td-agent.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/td-agent.conf.j2
@@ -1,16 +1,20 @@
 {%- from 'fluent/settings.sls' import fluent with context %}
 # CONFIGURED BY SALT - do not edit
 {% if databusReportDeploymentLogs == "true" %}# DATABUS - CLUSTER BUNDLE LOGS ENABLED - do not edit{% endif %}
-{% if fluent.cloudStorageLoggingEnabled %}
+{% if fluent.cloudStorageLoggingEnabled or fluent.cloudLoggingServiceEnabled %}
 @include input.conf
 {% endif %}
 {% if databusReportDeploymentLogs == "true" %}
 @include input_databus.conf
 {% endif %}
 @include databus_metering.conf
+{% if fluent.cloudLoggingServiceEnabled %}
+@include filter.conf
+{% endif %}
 {% if databusReportDeploymentLogs == "true" %}
+@include filter_databus.conf
 @include output_databus.conf
 {% endif %}
-{% if fluent.cloudStorageLoggingEnabled %}
+{% if fluent.cloudStorageLoggingEnabled or fluent.cloudLoggingServiceEnabled %}
 @include output.conf
 {% endif %}


### PR DESCRIPTION
- upgrade fluentd plugins at startup (check versions where needed, also uses custom repo if required for the plugin)
- add cloudwatch support as log service (use the cloud storage identity there) -> main reason, could be useful for e2e tests for node service logs (using cloud storage instance profile + storageLocation as cloudwatch log group) - hack here to handle cloudwatch output as s3 from cloud api perspective as instance profile stuff is built around cloud storage (would require larger change to support a different kind of log identity) - of course objectstorage validations are skipped if cloudwatch is used
- add stream key for cloudwatch (default host) - that determines which key should be used for creating the stream, in the example i have used component, but host is the default (for larger cluster it's better to handle the throughput by host, not by component)
- add new filters -> detect-exceptipons , for log service streams, in the end we want to send data to ES, but we do not want to send lines one-by-one especially for stack traces (for java apps), so we will try to cacth those multiline messages, aslo append the actual dates for the outputs (as we do not know the patterns) - this feature can be useful for the databus output as well (in order to append specific headers)
- small refactor -> FluentClusterDetails object, as in FluentConfigService the number of inputs stated to grow, would make sense to use an object there with a builder (regarding the cluster related inputs)
- upgrade databus plugin version, i have found an encoding bug, that i have fixed

cloudwatch example for sdx cluster: 
![cloudwatch_poc](https://user-images.githubusercontent.com/1231814/69967323-6e2c0b00-1518-11ea-9741-a1d58abc6814.png)

one record looks like this:
```json
{
    "component": "hdfs-datanode",
    "cluster": "oszabo-local-dl-3",
    "cluster_type": "datalake",
    "cluster_crn": "crn:cdp:datalake:us-west-1:cloudera:datalake:c4cac7f4-ade2-444c-8e51-83923d484fb3",
    "cluster_owner": "crn:cdp:iam:us-west-1:cloudera:user:oszabo@cloudera.com",
    "cluster_version": "2.17.0-dev.38-1-g014e082",
    "host": "oszabo-local-dl-3-master1",
    "@message": "2019-12-02 14:13:10,283 INFO org.apache.hadoop.hdfs.server.datanode.DataNode: Receiving BP-490250763-10.65.65.116-1575295912401:blk_1073741825_1001 src: /10.65.65.116:51001 dest: /10.65.65.116:1004",
    "@timestamp": "2019-12-02T14:13:10.284170550Z"
}
```

Tested against freeipa/datalake/datahub

