### PR TITLE
CB-4676 Nifi knox does not populated in the CM template

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
@@ -2,11 +2,15 @@ package com.sequenceiq.cloudbreak.cmtemplate;
 
 import java.util.Comparator;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.sequenceiq.cloudbreak.cloud.VersionComparator;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
 import com.sequenceiq.cloudbreak.common.type.Versioned;
 
 public class CMRepositoryVersionUtil {
+
     public static final Versioned CLOUDERAMANAGER_VERSION_6_3_0 = () -> "6.3.0";
 
     public static final Versioned CLOUDERAMANAGER_VERSION_6_4_0 = () -> "6.4.0";
@@ -19,27 +23,34 @@ public class CMRepositoryVersionUtil {
 
     public static final Versioned CFM_VERSION_2_0_0_0 = () -> "2.0.0.0";
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(CMRepositoryVersionUtil.class);
+
     private CMRepositoryVersionUtil() {
     }
 
     public static boolean isEnableKerberosSupportedViaBlueprint(ClouderaManagerRepo clouderaManagerRepoDetails) {
+        LOGGER.info("ClouderaManagerRepos compared for kerberos enablement");
         return isVersionNewerOrEqualThanLimited(clouderaManagerRepoDetails::getVersion, CLOUDERAMANAGER_VERSION_6_3_0);
     }
 
     public static boolean isKeepHostTemplateSupportedViaBlueprint(ClouderaManagerRepo clouderaManagerRepoDetails) {
+        LOGGER.info("ClouderaManagerRepos compared for host template");
         return isVersionNewerOrEqualThanLimited(clouderaManagerRepoDetails::getVersion, CLOUDERAMANAGER_VERSION_6_3_0);
     }
 
     public static boolean isKnoxGatewaySupported(ClouderaManagerRepo clouderaManagerRepoDetails) {
+        LOGGER.info("ClouderaManagerRepos compared for knox gateway support");
         return isVersionNewerOrEqualThanLimited(clouderaManagerRepoDetails::getVersion, CLOUDERAMANAGER_VERSION_6_4_0);
     }
 
     public static boolean isVersionNewerOrEqualThanLimited(Versioned currentVersion, Versioned limitedAPIVersion) {
+        LOGGER.info("Compared: Versioned {} with Versioned {}", currentVersion.getVersion(), limitedAPIVersion.getVersion());
         Comparator<Versioned> versionComparator = new VersionComparator();
         return versionComparator.compare(currentVersion, limitedAPIVersion) > -1;
     }
 
     public static boolean isVersionNewerOrEqualThanLimited(String currentVersion, Versioned limitedAPIVersion) {
+        LOGGER.info("Compared: String version {} with Versioned {}", currentVersion, limitedAPIVersion.getVersion());
         return isVersionNewerOrEqualThanLimited(() -> currentVersion, limitedAPIVersion);
     }
 }

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/nifi/NifiKnoxRoleConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/nifi/NifiKnoxRoleConfigProvider.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
@@ -22,6 +24,8 @@ import com.sequenceiq.cloudbreak.template.views.ClusterExposedServiceView;
 @Component
 public class NifiKnoxRoleConfigProvider extends AbstractRoleConfigProvider {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(NifiKnoxRoleConfigProvider.class);
+
     private static final String PROXY_CONTEXT_PATH = "nifi.web.proxy.context.path";
 
     private static final String NIFI_UI_KNOX_URL = "nifi.ui.knox.url";
@@ -30,17 +34,19 @@ public class NifiKnoxRoleConfigProvider extends AbstractRoleConfigProvider {
 
     @Override
     public List<ApiClusterTemplateConfig> getRoleConfigs(String roleType, TemplatePreparationObject source) {
+        LOGGER.info("add property values for NifiKnoxRoleConfigProvider");
         String clusterName = source.getGeneralClusterConfigs().getClusterName();
         String topologyName = source.getGatewayView().getTopologyName();
         List<ApiClusterTemplateConfig> configs = new ArrayList<>();
 
         configs.add(config(PROXY_CONTEXT_PATH, String.format("%s/%s/nifi-app", clusterName, topologyName)));
+        LOGGER.debug("PROXY_CONTEXT_PATH added to template");
 
         Optional<ClouderaManagerProduct> cfm = getClouderaManagerProduct(source);
         Optional<ClusterExposedServiceView> nifi = getNifi(source);
 
-        if (cfm.isPresent() && isVersionNewerOrEqualThanLimited(cfm.get().getVersion(), CFM_VERSION_2_0_0_0)
-            && nifi.isPresent()) {
+        if (cfm.isPresent() && isVersionNewerOrEqualThanLimited(cfm.get().getVersion(), CFM_VERSION_2_0_0_0) && nifi.isPresent()) {
+            LOGGER.debug("NIFI_UI_KNOX_URL added to template");
             configs.add(config(NIFI_UI_KNOX_URL, nifi.get().getServiceUrl()));
         }
         return configs;
@@ -48,21 +54,31 @@ public class NifiKnoxRoleConfigProvider extends AbstractRoleConfigProvider {
 
     private Optional<ClusterExposedServiceView> getNifi(TemplatePreparationObject source) {
         if (source.getExposedServices() != null && !source.getExposedServices().isEmpty()) {
-            return source.getExposedServices().get("cdp-proxy")
+            Optional<ClusterExposedServiceView> nifi = source.getExposedServices().get("cdp-proxy")
                     .stream()
                     .filter(e -> e.getKnoxService().equalsIgnoreCase(ExposedService.NIFI.name()))
                     .findFirst();
+            if (nifi.isEmpty()) {
+                LOGGER.info("Nifi is not presented as an Exposed service");
+            }
+            return nifi;
         }
+        LOGGER.info("Exposed service null or empty for NifiKnoxRoleConfigProvider");
         return Optional.empty();
     }
 
     private Optional<ClouderaManagerProduct> getClouderaManagerProduct(TemplatePreparationObject source) {
         if (source.getProductDetailsView() != null) {
-            source.getProductDetailsView().getProducts()
+            Optional<ClouderaManagerProduct> cfm = source.getProductDetailsView().getProducts()
                     .stream()
                     .filter(e -> e.getName().equalsIgnoreCase(CFM))
                     .findFirst();
+            if (cfm.isEmpty()) {
+                LOGGER.info("CFM is not presented as a Production");
+            }
+            return cfm;
         }
+        LOGGER.info("Product null for NifiKnoxRoleConfigProvider");
         return Optional.empty();
     }
 


### PR DESCRIPTION
Missing `return` keyword, logs are added