### PR TITLE
CB-4709 Fix for Sync, when CM is not available

### DIFF
--- a/cluster-ambari/src/main/java/com/sequenceiq/cloudbreak/ambari/status/AmbariClusterStatusService.java
+++ b/cluster-ambari/src/main/java/com/sequenceiq/cloudbreak/ambari/status/AmbariClusterStatusService.java
@@ -11,6 +11,7 @@ import javax.inject.Inject;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import com.sequenceiq.ambari.client.AmbariClient;
 import com.sequenceiq.cloudbreak.ambari.AmbariClientFactory;
@@ -74,5 +75,14 @@ public class AmbariClusterStatusService implements ClusterStatusService {
     @Override
     public Map<String, String> getHostStatusesRaw() {
         return ambariClient.getHostStatuses();
+    }
+
+    @Override
+    public boolean isClusterManagerRunning() {
+        try {
+            return !StringUtils.isEmpty(ambariClient.healthCheck());
+        } catch (Exception e) {
+            return false;
+        }
     }
 }

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterStatusService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterStatusService.java
@@ -20,4 +20,6 @@ public interface ClusterStatusService {
     Map<String, ClusterManagerState> getExtendedHostStatuses();
 
     Map<String, String> getHostStatusesRaw();
+
+    boolean isClusterManagerRunning();
 }

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusService.java
@@ -203,7 +203,7 @@ public class ClouderaManagerClusterStatusService implements ClusterStatusService
 
     @Override
     public ClusterStatusResult getStatus(boolean blueprintPresent) {
-        if (!isCMRunning()) {
+        if (!isClusterManagerRunning()) {
             return ClusterStatusResult.of(ClusterStatus.AMBARISERVER_NOT_RUNNING);
         } else if (blueprintPresent) {
             return determineClusterStatus(stack);
@@ -297,7 +297,8 @@ public class ClouderaManagerClusterStatusService implements ClusterStatusService
                         mapping(ApiRole::getName, toList())));
     }
 
-    private boolean isCMRunning() {
+    @Override
+    public boolean isClusterManagerRunning() {
         try {
             clouderaManagerApiFactory.getClouderaManagerResourceApi(client).getVersion();
             return true;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterService.java
@@ -12,6 +12,7 @@ import static com.sequenceiq.cloudbreak.cloud.model.component.StackRepoDetails.R
 import static com.sequenceiq.cloudbreak.cloud.model.component.StackRepoDetails.VDF_REPO_KEY_PREFIX;
 import static com.sequenceiq.cloudbreak.exception.NotFoundException.notFound;
 import static com.sequenceiq.cloudbreak.util.SqlUtil.getProperSqlErrorMessage;
+import static java.util.stream.Collectors.joining;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -75,6 +76,7 @@ import com.sequenceiq.cloudbreak.common.service.TransactionService.TransactionEx
 import com.sequenceiq.cloudbreak.common.service.TransactionService.TransactionRuntimeExecutionException;
 import com.sequenceiq.cloudbreak.common.type.APIResourceType;
 import com.sequenceiq.cloudbreak.common.type.ClusterManagerState;
+import com.sequenceiq.cloudbreak.common.type.ClusterManagerState.ClusterManagerStatus;
 import com.sequenceiq.cloudbreak.common.type.ComponentType;
 import com.sequenceiq.cloudbreak.converter.scheduler.StatusToPollGroupConverter;
 import com.sequenceiq.cloudbreak.converter.util.GatewayConvertUtil;
@@ -948,29 +950,55 @@ public class ClusterService {
     public Cluster updateClusterMetadata(Long stackId) {
         Stack stack = stackService.getById(stackId);
         ClusterApi connector = clusterApiConnectors.getConnector(stack);
-        Map<String, ClusterManagerState> hostStatuses = connector.clusterStatusService().getExtendedHostStatuses();
         Set<InstanceMetaData> notTerminatedInstanceMetaDatas = instanceMetaDataService.findNotTerminatedForStack(stackId);
-        try {
-            return transactionService.required(() -> {
-                for (InstanceMetaData instanceMetaData : notTerminatedInstanceMetaDatas) {
-                    if (instanceMetaData.getInstanceStatus().equals(InstanceStatus.SERVICES_RUNNING)) {
-                        ClusterManagerState clusterManagerState = hostStatuses.get(instanceMetaData.getDiscoveryFQDN());
-                        InstanceStatus newState = ClusterManagerState.ClusterManagerStatus.HEALTHY.equals(clusterManagerState.getClusterManagerStatus()) ?
-                                InstanceStatus.SERVICES_HEALTHY : InstanceStatus.SERVICES_UNHEALTHY;
-                        instanceMetaData.setInstanceStatus(newState);
-                        instanceMetaData.setStatusReason(clusterManagerState.getStatusReason());
-                        instanceMetaDataService.save(instanceMetaData);
-                        // TODO: don't send events one by one and save all of the instancemetadata with one repo call
-                        eventService.fireCloudbreakEvent(stack.getId(), AVAILABLE.name(),
-                                cloudbreakMessagesService.getMessage(Msg.CLUSTER_HOST_STATUS_UPDATED.code(),
-                                        Arrays.asList(instanceMetaData.getDiscoveryFQDN(), newState.name())));
-                    }
-                }
-                return stack.getCluster();
-            });
-        } catch (TransactionExecutionException e) {
-            throw new TransactionRuntimeExecutionException(e);
+        if (!connector.clusterStatusService().isClusterManagerRunning()) {
+            InstanceMetaData cmInstance = updateClusterManagerHostStatus(notTerminatedInstanceMetaDatas);
+            eventService.fireCloudbreakEvent(stack.getId(), AVAILABLE.name(), cloudbreakMessagesService.getMessage(Msg.CLUSTER_HOST_STATUS_UPDATED.code(),
+                    Arrays.asList(cmInstance.getDiscoveryFQDN(), cmInstance.getInstanceStatus().name())));
+            return stack.getCluster();
+        } else {
+            Map<String, ClusterManagerState> hostStatuses = connector.clusterStatusService().getExtendedHostStatuses();
+            try {
+                return transactionService.required(() -> {
+                    List<InstanceMetaData> updatedInstanceMetaData = updateInstanceStatuses(notTerminatedInstanceMetaDatas, hostStatuses);
+                    instanceMetaDataService.saveAll(updatedInstanceMetaData);
+                    fireHostStatusUpdateNotification(stack, updatedInstanceMetaData);
+                    return stack.getCluster();
+                });
+            } catch (TransactionExecutionException e) {
+                throw new TransactionRuntimeExecutionException(e);
+            }
         }
+    }
+
+    private InstanceMetaData updateClusterManagerHostStatus(Set<InstanceMetaData> notTerminatedInstanceMetaDatas) {
+        InstanceMetaData cmInstance = notTerminatedInstanceMetaDatas.stream().filter(InstanceMetaData::getClusterManagerServer).findFirst()
+                .orElseThrow(() -> new CloudbreakServiceException("Cluster manager inaccessible, and the corresponding instance metadata not found."));
+        cmInstance.setInstanceStatus(InstanceStatus.SERVICES_UNHEALTHY);
+        cmInstance.setStatusReason("Cluster manager inaccessible.");
+        instanceMetaDataService.save(cmInstance);
+        return cmInstance;
+    }
+
+    private void fireHostStatusUpdateNotification(Stack stack, List<InstanceMetaData> updatedInstanceMetaData) {
+        String hostNotificationMessage = updatedInstanceMetaData.stream()
+                .map(instanceMetaData -> cloudbreakMessagesService.getMessage(Msg.CLUSTER_HOST_STATUS_UPDATED.code(),
+                        Arrays.asList(instanceMetaData.getDiscoveryFQDN(), instanceMetaData.getInstanceStatus().name())))
+                .collect(joining("; "));
+        eventService.fireCloudbreakEvent(stack.getId(), AVAILABLE.name(), hostNotificationMessage);
+    }
+
+    private List<InstanceMetaData> updateInstanceStatuses(Set<InstanceMetaData> notTerminatedInstanceMetaDatas, Map<String, ClusterManagerState> hostStatuses) {
+        return notTerminatedInstanceMetaDatas.stream()
+                .filter(instanceMetaData -> InstanceStatus.SERVICES_RUNNING.equals(instanceMetaData.getInstanceStatus()))
+                .map(instanceMetaData -> {
+                    ClusterManagerState clusterManagerState = hostStatuses.get(instanceMetaData.getDiscoveryFQDN());
+                    InstanceStatus newState = ClusterManagerStatus.HEALTHY.equals(clusterManagerState.getClusterManagerStatus()) ?
+                            InstanceStatus.SERVICES_HEALTHY : InstanceStatus.SERVICES_UNHEALTHY;
+                    instanceMetaData.setInstanceStatus(newState);
+                    instanceMetaData.setStatusReason(clusterManagerState.getStatusReason());
+                    return instanceMetaData;
+                }).collect(Collectors.toList());
     }
 
     public Cluster recreate(Stack stack, String blueprintName, Set<HostGroup> hostGroups, boolean validateBlueprint,


### PR DESCRIPTION
1. Check CM accessibility, before checking hosts, during sync flow. If CM is not available, set its state to unhealthy and send notification
2. Aggregated host saves and notification sending for multiple hosts for optimization