### PR TITLE
CB-4551 add phoenix service and configuration opdb blueprint

### DIFF
--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -214,6 +214,7 @@ cb:
                 CDP 1.2 - Data Mart: Apache Impala, Hue=cdp-data-mart-702;
                 CDP 1.2 - Real-time Data Mart: Apache Impala, Hue, Apache Kudu, Apache Spark=cdp-rt-data-mart-702;
                 CDP 1.2 - Operational Database: Apache HBase=cdp-opdb-702;
+                CDP 1.2 - Operational Database: Apache HBase, Phoenix=cdp-opdb-710;
                 CDP 1.2 - SDX Light Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas=cdp-sdx-702;
                 CDP 1.2 - SDX Medium Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas=cdp-sdx-medium-ha-702;
                 CDP 1.2 - Data Engineering Hue HA: Apache Spark, Apache Hive, Hue, Apache Oozie=cdp-data-engineering-hueha-702;

--- a/core/src/main/resources/defaults/blueprints/cdp-opdb-710.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-opdb-710.bp
@@ -1,0 +1,228 @@
+{
+  "description": "CDP 1.2 Operational Database: Apache HBase, Phoenix",
+  "blueprint": {
+    "cdhVersion": "7.1.0",
+    "displayName": "opdb",
+    "services": [
+      {
+        "refName": "zookeeper",
+        "serviceType": "ZOOKEEPER",
+        "roleConfigGroups": [
+          {
+            "refName": "zookeeper-SERVER-BASE",
+            "roleType": "SERVER",
+            "configs": [
+              {
+                "name": "zookeeper_server_java_heapsize",
+                "value": "8589934592"
+              },
+              {
+                "name": "maxClientCnxns",
+                "value": "200"
+              }
+            ],
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "hdfs",
+        "serviceType": "HDFS",
+        "roleConfigGroups": [
+          {
+            "refName": "hdfs-NAMENODE-BASE",
+            "roleType": "NAMENODE",
+            "base": true
+          },
+          {
+            "refName": "hdfs-SECONDARYNAMENODE-BASE",
+            "roleType": "SECONDARYNAMENODE",
+            "configs": [
+              {
+                "name": "fs_checkpoint_dir_list",
+                "value": "/should_not_be_required_in_HA_setup"
+              }
+            ],
+            "base": true
+          },
+          {
+            "refName": "hdfs-DATANODE-BASE",
+            "roleType": "DATANODE",
+            "base": true,
+            "configs": [
+              {
+                "name": "dfs_datanode_max_locked_memory",
+                "value": "2147483648"
+              }
+            ]
+          },
+          {
+            "refName": "hdfs-FAILOVERCONTROLLER-BASE",
+            "roleType": "FAILOVERCONTROLLER",
+            "base": true
+          },
+          {
+            "refName": "hdfs-JOURNALNODE-BASE",
+            "roleType": "JOURNALNODE",
+            "base": true
+          },
+          {
+            "refName": "hdfs-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "hbase",
+        "serviceType": "HBASE",
+        "serviceConfigs": [
+          {
+            "name": "hbase_wal_dir",
+            "value": "/hbase-wals"
+          },
+          {
+            "name": "hbase_service_config_safety_valve",
+            "value": "<property><name>phoenix.schema.isNamespaceMappingEnabled</name><value>true</value></property><property><name>phoenix.functions.allowUserDefinedFunctions</name><value>true</value></property>"
+          }
+        ],
+        "roleConfigGroups": [
+          {
+            "refName": "hbase-MASTER-BASE",
+            "roleType": "MASTER",
+            "configs": [
+              {
+                "name": "hbase_master_java_heapsize",
+                "value": "4294967296"
+              }
+            ],
+            "base": true
+          },
+          {
+            "refName": "hbase-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "configs": [
+              {
+                "name": "hbase_client_config_safety_valve",
+                "value": "<property><name>phoenix.schema.isNamespaceMappingEnabled</name><value>true</value></property><property><name>phoenix.functions.allowUserDefinedFunctions</name><value>true</value></property>"
+              }
+            ],
+            "base": true
+          },
+          {
+            "refName": "hbase-REGIONSERVER-BASE",
+            "roleType": "REGIONSERVER",
+            "configs": [
+              {
+                "name": "hbase_regionserver_java_heapsize",
+                "value": "7516192768"
+              },
+              {
+                "name": "hbase_bucketcache_ioengine",
+                "value": "offheap"
+              },
+              {
+                "name": "hbase_regionserver_global_memstore_upperLimit",
+                "value": "0.25"
+              },
+              {
+                "name": "hfile_block_cache_size",
+                "value": "0.12"
+              },
+              {
+                "name": "hbase_bucketcache_size",
+                "value": "8192"
+              },
+              {
+                "name": "hbase_regionserver_handler_count",
+                "value": "60"
+              },
+              {
+                "name": "hbase_regionserver_maxlogs",
+                "value": "100"
+              },
+              {
+                "name": "hbase_hregion_memstore_block_multiplier",
+                "value": "4"
+              },
+              {
+                "name": "hbase_hstore_blockingStoreFiles",
+                "value": "50"
+              },
+              {
+                "name": "hbase_regionserver_wal_codec",
+                "value": "org.apache.hadoop.hbase.regionserver.wal.IndexedWALEditCodec"
+              }
+            ],
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "phoenix",
+        "serviceType": "PHOENIX",
+        "roleConfigGroups": [
+          {
+            "refName": "phoenix-PHOENIX_QUERY_SERVER-BASE",
+            "roleType": "PHOENIX_QUERY_SERVER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "knox",
+        "serviceType": "KNOX",
+        "roleConfigGroups": [
+          {
+            "base": true,
+            "refName": "knox-KNOX-GATEWAY-BASE",
+            "roleType": "KNOX_GATEWAY"
+          }
+        ]
+      }
+    ],
+    "hostTemplates": [
+      {
+        "refName": "gateway",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "hbase-GATEWAY-BASE",
+          "hdfs-GATEWAY-BASE",
+          "knox-KNOX-GATEWAY-BASE"
+        ]
+      },
+      {
+        "refName": "master",
+        "cardinality": 2,
+        "roleConfigGroupsRefNames": [
+          "hbase-GATEWAY-BASE",
+          "hbase-MASTER-BASE",
+          "hdfs-FAILOVERCONTROLLER-BASE",
+          "hdfs-GATEWAY-BASE",
+          "hdfs-JOURNALNODE-BASE",
+          "hdfs-NAMENODE-BASE",
+          "zookeeper-SERVER-BASE"
+        ]
+      },
+      {
+        "refName": "leader",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "hdfs-JOURNALNODE-BASE",
+          "zookeeper-SERVER-BASE"
+        ]
+      },
+      {
+        "refName": "worker",
+        "cardinality": 3,
+        "roleConfigGroupsRefNames": [
+          "hbase-GATEWAY-BASE",
+          "hbase-REGIONSERVER-BASE",
+          "hdfs-DATANODE-BASE",
+          "hdfs-GATEWAY-BASE",
+          "phoenix-PHOENIX_QUERY_SERVER-BASE"
+        ]
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/aws/aws-opdb-710.json
+++ b/core/src/main/resources/defaults/clustertemplates/aws/aws-opdb-710.json
@@ -1,0 +1,114 @@
+{
+  "name": "Operational Database with Phoenix for AWS",
+  "description": "",
+  "type": "OPERATIONALDATABASE",
+  "featureState": "PREVIEW",
+  "cloudPlatform": "AWS",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "CDP 1.2 - Operational Database: Apache HBase, Phoenix"
+    },
+    "instanceGroups": [
+      {
+        "name": "master",
+        "nodeCount": 2,
+        "recoveryMode": "MANUAL",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "standard"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge",
+          "rootVolume": {
+            "size": 50
+          },
+          "cloudPlatform": "AWS"
+        },
+        "type": "CORE"
+      },
+      {
+        "name": "gateway",
+        "nodeCount": 1,
+        "recoveryMode": "MANUAL",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "standard"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge",
+          "rootVolume": {
+            "size": 50
+          },
+          "cloudPlatform": "AWS"
+        },
+        "type": "GATEWAY"
+      },
+      {
+        "name": "leader",
+        "nodeCount": 1,
+        "recoveryMode": "MANUAL",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "standard"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge",
+          "rootVolume": {
+            "size": 50
+          },
+          "cloudPlatform": "AWS"
+        },
+        "type": "CORE"
+      },
+      {
+        "name": "worker",
+        "nodeCount": 3,
+        "recoveryMode": "MANUAL",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "standard"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge",
+          "rootVolume": {
+            "size": 50
+          },
+          "cloudPlatform": "AWS"
+        },
+        "type": "CORE"
+      }
+    ]
+  }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
@@ -434,7 +434,7 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
         assertNotNull(entity);
         assertNotNull(entity.getResponses());
         long defaultCount = entity.getResponses().stream().filter(template -> ResourceStatus.DEFAULT.equals(template.getStatus())).count();
-        long expectedCount = 13;
+        long expectedCount = 14;
         assertEquals("Should have " + expectedCount + " of default cluster templates.", expectedCount, defaultCount);
         return entity;
     }

--- a/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/service-definitions-minimal.json
+++ b/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/service-definitions-minimal.json
@@ -441,6 +441,18 @@
         }
       ],
       "dependencies": ["ZOOKEEPER"]
+    },
+    {
+      "name": "PHOENIX",
+      "displayName": "Phoenix",
+      "components": [
+        {
+          "name": "PHOENIX_QUERY_SERVER",
+          "groups": ["worker"],
+          "base" : true
+        }
+      ],
+      "dependencies": ["ZOOKEEPER", "HDFS", "HBASE"]
     }
   ]
 }


### PR DESCRIPTION
* add the PQS service to opdb blueprint
* set the hbase_regionserver_wal_codec property
* add the other configs  that Phoenix needs to Hbase client and service safety valve
* set hbase.use.dynamic.jars to false via HBase safety valve
* add Phoenix to service-definitions-minimal.json

Testing done:

built cloudbreak successfully
Built an opdb cluster with the change
Checked that the cluster works
checked that the local phoenix-sqlline client works
checked that phoenix-thin-client (and consequently PQS) works

Closes #CB-4551
