### PR TITLE
CB-4749. Add global databus secret/access keys to skip machine user generation

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/service/AltusIAMService.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/service/AltusIAMService.java
@@ -2,11 +2,13 @@ package com.sequenceiq.cloudbreak.auth.altus.service;
 
 import java.util.Optional;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
+import com.sequenceiq.cloudbreak.altus.AltusDatabusConfiguration;
 import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
 import com.sequenceiq.cloudbreak.auth.altus.model.AltusCredential;
 
@@ -15,16 +17,36 @@ public class AltusIAMService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AltusIAMService.class);
 
+    private final boolean useSharedAltusCredential;
+
+    private final String sharedAltusAccessKey;
+
+    private final char[] sharedAltusSecretKey;
+
     private final GrpcUmsClient umsClient;
 
-    public AltusIAMService(GrpcUmsClient umsClient) {
+    public AltusIAMService(GrpcUmsClient umsClient,
+            AltusDatabusConfiguration altusDatabusConfiguration) {
         this.umsClient = umsClient;
+        this.useSharedAltusCredential = altusDatabusConfiguration.isUseSharedAltusCredential();
+        this.sharedAltusAccessKey = altusDatabusConfiguration.getSharedAccessKey();
+        this.sharedAltusSecretKey = altusDatabusConfiguration.getSharedSecretKey();
     }
 
     /**
      * Generate machine user with access keys
      */
-    public Optional<AltusCredential> generateMachineUserWithAccessKey(String machineUserName, String actorCrn) {
+    public Optional<AltusCredential> generateMachineUserWithAccessKey(String machineUserName, String actorCrn, boolean useSharedCredential) {
+        if (useSharedAltusCredential) {
+            LOGGER.debug("Use shared altus credential is turned on for generating altus credential and access keys.");
+            if (areDatabusCredentialsFilled(useSharedCredential)) {
+                LOGGER.debug("Access and secret keys are set manually application wide for Databus, skip machine user and access key generation");
+                return Optional.of(new AltusCredential(sharedAltusAccessKey, sharedAltusSecretKey));
+            } else {
+                LOGGER.debug("Use shared credential global config credential is set, but no shared access/secret keypair is used.");
+            }
+        }
+
         return Optional.of(umsClient.createMachineUserAndGenerateKeys(
                 machineUserName,
                 actorCrn,
@@ -32,16 +54,32 @@ public class AltusIAMService {
                 UserManagementProto.AccessKeyType.Value.ED25519));
     }
 
+    public Optional<AltusCredential> generateMachineUserWithAccessKey(String machineUserName, String actorCrn) {
+        return generateMachineUserWithAccessKey(machineUserName, actorCrn, false);
+    }
+
     /**
      * Delete machine user with its access keys (and unassign databus role if required)
      */
-    public void clearMachineUser(String machineUserName, String actorCrn) {
+    public void clearMachineUser(String machineUserName, String actorCrn, boolean useSharedCredential) {
         try {
-            umsClient.clearMachineUserWithAccessKeysAndRole(machineUserName, actorCrn, umsClient.getBuiltInDatabusRoleCrn());
+            if (useSharedAltusCredential && areDatabusCredentialsFilled(useSharedCredential)) {
+                LOGGER.debug("Access and secret keys are set manually application wide for Databus, skip machine user cleanup.");
+            } else {
+                umsClient.clearMachineUserWithAccessKeysAndRole(machineUserName, actorCrn, umsClient.getBuiltInDatabusRoleCrn());
+            }
         } catch (Exception e) {
             LOGGER.warn("Cluster Databus resource cleanup failed (fluent - databus user). It is not a fatal issue, "
                     + "but note that you could have remaining UMS resources for your account", e);
         }
+    }
+
+    public void clearMachineUser(String machineUserName, String actorCrn) {
+        clearMachineUser(machineUserName, actorCrn, false);
+    }
+
+    private boolean areDatabusCredentialsFilled(boolean useSharedCredential) {
+        return useSharedCredential && sharedAltusSecretKey != null && sharedAltusSecretKey.length > 0 && StringUtils.isNotBlank(sharedAltusAccessKey);
     }
 
 }

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/base/FeaturesBase.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/base/FeaturesBase.java
@@ -18,6 +18,10 @@ public abstract class FeaturesBase implements Serializable {
     @ApiModelProperty(TelemetryModelDescription.TELEMETRY_REPORT_DEPLOYMENT_LOGS_ENABLED)
     private FeatureSetting reportDeploymentLogs;
 
+    @JsonProperty("useSharedAltusCredential")
+    @ApiModelProperty(TelemetryModelDescription.TELEMETRY_USE_SHARED_ALTUS_CREDENTIAL_ENABLED)
+    private FeatureSetting useSharedAltusCredential;
+
     public FeatureSetting getWorkloadAnalytics() {
         return workloadAnalytics;
     }
@@ -32,5 +36,13 @@ public abstract class FeaturesBase implements Serializable {
 
     public void setReportDeploymentLogs(FeatureSetting reportDeploymentLogs) {
         this.reportDeploymentLogs = reportDeploymentLogs;
+    }
+
+    public FeatureSetting getUseSharedAltusCredential() {
+        return useSharedAltusCredential;
+    }
+
+    public void setUseSharedAltusCredential(FeatureSetting useSharedAltusCredential) {
+        this.useSharedAltusCredential = useSharedAltusCredential;
     }
 }

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/doc/TelemetryModelDescription.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/doc/TelemetryModelDescription.java
@@ -13,8 +13,9 @@ public class TelemetryModelDescription {
     public static final String TELEMETRY_LOGGING_CLOUDWATCH_ATTRIBUTES = "telemetry - logging cloudwatch attributes";
     public static final String TELEMETRY_LOGGING_STORAGE_LOCATION = "telemetry - logging storage location / container";
     public static final String TELEMETRY_REPORT_DEPLOYMENT_LOGS_ENABLED = "enable cluster deployment log reporting.";
-    public static final String TELEMETRY_CLOUDWATCH_PARAMS = "telemetry - cloudwatch releated parameters";
-    public static final String TELEMETRY_CLOUDWATCH_PARAMS_REGION = "telemetry - cloudwatch related AWS region (should be used only outside of AWS platform)";
+    public static final String TELEMETRY_CLOUDWATCH_PARAMS = "telemetry - CloudWatch releated parameters";
+    public static final String TELEMETRY_CLOUDWATCH_PARAMS_REGION = "telemetry - CloudWatch related AWS region (should be used only outside of AWS platform)";
+    public static final String TELEMETRY_USE_SHARED_ALTUS_CREDENTIAL_ENABLED = "enable shared Altus credential usage";
 
     private TelemetryModelDescription() {
     }

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/Telemetry.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/Telemetry.java
@@ -80,4 +80,10 @@ public class Telemetry implements Serializable {
                 && features.getReportDeploymentLogs().isEnabled();
     }
 
+    @JsonIgnore
+    public boolean isUseSharedAltusCredentialEnabled() {
+        return features != null && features.getUseSharedAltusCredential() != null
+                && features.getUseSharedAltusCredential().isEnabled();
+    }
+
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/altus/AltusDatabusConfiguration.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/altus/AltusDatabusConfiguration.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.cloudbreak.altus;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AltusDatabusConfiguration {
+
+    private final String altusDatabusEndpoint;
+
+    private final boolean useSharedAltusCredential;
+
+    private final String sharedAccessKey;
+
+    private final char[] sharedSecretKey;
+
+    public AltusDatabusConfiguration(
+            @Value("${altus.databus.endpoint:}") String altusDatabusEndpoint,
+            @Value("${altus.databus.shared.credential.enabled:false}") boolean useSharedAltusCredential,
+            @Value("${altus.databus.shared.accessKey:}") String sharedAccessKey,
+            @Value("${altus.databus.shared.secretKey:}") String sharedSecretKey) {
+        this.altusDatabusEndpoint = altusDatabusEndpoint;
+        this.useSharedAltusCredential = useSharedAltusCredential;
+        this.sharedAccessKey = sharedAccessKey;
+        this.sharedSecretKey = StringUtils.isBlank(sharedSecretKey) ? null : sharedSecretKey.toCharArray();
+    }
+
+    public String getAltusDatabusEndpoint() {
+        return altusDatabusEndpoint;
+    }
+
+    public boolean isUseSharedAltusCredential() {
+        return useSharedAltusCredential;
+    }
+
+    public String getSharedAccessKey() {
+        return sharedAccessKey;
+    }
+
+    public char[] getSharedSecretKey() {
+        return sharedSecretKey;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/TelemetryConfiguration.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/TelemetryConfiguration.java
@@ -1,0 +1,36 @@
+package com.sequenceiq.cloudbreak.telemetry;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+import com.sequenceiq.cloudbreak.altus.AltusDatabusConfiguration;
+
+@Configuration
+public class TelemetryConfiguration {
+
+    private final AltusDatabusConfiguration altusDatabusConfiguration;
+
+    private final boolean reportDeploymentLogs;
+
+    private final boolean meteringEnabled;
+
+    public TelemetryConfiguration(AltusDatabusConfiguration altusDatabusConfiguration,
+            @Value("${cluster.deployment.logs.report:false}") boolean reportDeploymentLogs,
+            @Value("${metering.enabled:false}") boolean meteringEnabled) {
+        this.altusDatabusConfiguration = altusDatabusConfiguration;
+        this.reportDeploymentLogs = reportDeploymentLogs;
+        this.meteringEnabled = meteringEnabled;
+    }
+
+    public AltusDatabusConfiguration getAltusDatabusConfiguration() {
+        return altusDatabusConfiguration;
+    }
+
+    public boolean isReportDeploymentLogs() {
+        return reportDeploymentLogs;
+    }
+
+    public boolean isMeteringEnabled() {
+        return meteringEnabled;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/altus/AltusMachineUserService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/altus/AltusMachineUserService.java
@@ -28,7 +28,8 @@ public class AltusMachineUserService {
     public Optional<AltusCredential> generateDatabusMachineUserForFluent(Stack stack, Telemetry telemetry) {
         if (isMeteringOrDeploymentReportingSupported(stack, telemetry)) {
             return altusIAMService.generateMachineUserWithAccessKey(
-                    getFluentDatabusMachineUserName(stack), stack.getCreator().getUserCrn());
+                    getFluentDatabusMachineUserName(stack), stack.getCreator().getUserCrn(),
+                    telemetry.isUseSharedAltusCredentialEnabled());
         }
         return Optional.empty();
     }
@@ -40,7 +41,7 @@ public class AltusMachineUserService {
         if (isMeteringOrDeploymentReportingSupported(stack, telemetry)) {
             String machineUserName = getFluentDatabusMachineUserName(stack);
             String userCrn = stack.getCreator().getUserCrn();
-            altusIAMService.clearMachineUser(machineUserName, userCrn);
+            altusIAMService.clearMachineUser(machineUserName, userCrn, telemetry.isUseSharedAltusCredentialEnabled());
         }
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
@@ -12,7 +12,9 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.sequenceiq.cloudbreak.altus.AltusDatabusConfiguration;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.telemetry.TelemetryConfiguration;
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
 import com.sequenceiq.common.api.telemetry.model.Features;
 import com.sequenceiq.common.api.telemetry.model.Logging;
@@ -38,7 +40,9 @@ public class TelemetryConverterTest {
 
     @Before
     public void setUp() {
-        underTest = new TelemetryConverter(true, true, true, true, DATABUS_ENDPOINT);
+        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, false, "", null);
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true);
+        underTest = new TelemetryConverter(telemetryConfiguration, true, true);
     }
 
     @Test
@@ -173,7 +177,9 @@ public class TelemetryConverterTest {
     public void testConvertFromEnvAndSdxResponseWithDefaultDisabled() {
         // GIVEN
         SdxClusterResponse sdxClusterResponse = null;
-        TelemetryConverter converter = new TelemetryConverter(true, false, true, true, DATABUS_ENDPOINT);
+        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, false, "", null);
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true);
+        TelemetryConverter converter = new TelemetryConverter(telemetryConfiguration, true, false);
         // WHEN
         TelemetryRequest result = converter.convert(null, sdxClusterResponse);
         // THEN
@@ -244,7 +250,9 @@ public class TelemetryConverterTest {
         SdxClusterResponse sdxClusterResponse = new SdxClusterResponse();
         sdxClusterResponse.setCrn("crn:cdp:cloudbreak:us-west-1:someone:sdxcluster:sdxId");
         sdxClusterResponse.setName("sdxName");
-        TelemetryConverter converter = new TelemetryConverter(false, true, true, true, DATABUS_ENDPOINT);
+        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, false, "", null);
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true);
+        TelemetryConverter converter = new TelemetryConverter(telemetryConfiguration, false, true);
         // WHEN
         TelemetryRequest result = converter.convert(response, sdxClusterResponse);
         // THEN

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/altus/AltusMachineUserServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/altus/AltusMachineUserServiceTest.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.service.altus;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -62,24 +63,24 @@ public class AltusMachineUserServiceTest {
     public void testCreateMachineUserAndGenerateKeys() {
         // GIVEN
         Optional<AltusCredential> altusCredential = Optional.of(new AltusCredential("accessKey", "secretKey".toCharArray()));
-        when(altusIAMService.generateMachineUserWithAccessKey(any(), any())).thenReturn(altusCredential);
+        when(altusIAMService.generateMachineUserWithAccessKey(any(), any(), anyBoolean())).thenReturn(altusCredential);
 
         // WHEN
         underTest.generateDatabusMachineUserForFluent(stack, telemetry);
 
         // THEN
         assertEquals("secretKey", new String(altusCredential.get().getPrivateKey()));
-        verify(altusIAMService, times(1)).generateMachineUserWithAccessKey(any(), any());
+        verify(altusIAMService, times(1)).generateMachineUserWithAccessKey(any(), any(), anyBoolean());
     }
 
     @Test
     public void testCleanupMachineUser() {
         // GIVEN
-        doNothing().when(altusIAMService).clearMachineUser(any(), any());
+        doNothing().when(altusIAMService).clearMachineUser(any(), any(), anyBoolean());
         // WHEN
         underTest.clearFluentMachineUser(stack, telemetry);
 
         // THEN
-        verify(altusIAMService, times(1)).clearMachineUser(any(), any());
+        verify(altusIAMService, times(1)).clearMachineUser(any(), any(), anyBoolean());
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/telemetry/EnvironmentFeatures.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/telemetry/EnvironmentFeatures.java
@@ -14,6 +14,8 @@ public class EnvironmentFeatures implements Serializable {
 
     private FeatureSetting reportDeploymentLogs;
 
+    private FeatureSetting useSharedAltusCredential;
+
     public FeatureSetting getReportDeploymentLogs() {
         return reportDeploymentLogs;
     }
@@ -28,5 +30,13 @@ public class EnvironmentFeatures implements Serializable {
 
     public void setWorkloadAnalytics(FeatureSetting workloadAnalytics) {
         this.workloadAnalytics = workloadAnalytics;
+    }
+
+    public FeatureSetting getUseSharedAltusCredential() {
+        return useSharedAltusCredential;
+    }
+
+    public void setUseSharedAltusCredential(FeatureSetting useSharedAltusCredential) {
+        this.useSharedAltusCredential = useSharedAltusCredential;
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/TelemetryApiConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/TelemetryApiConverter.java
@@ -2,9 +2,9 @@ package com.sequenceiq.environment.environment.v1;
 
 import java.util.HashMap;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.telemetry.TelemetryConfiguration;
 import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
 import com.sequenceiq.common.api.telemetry.model.CloudwatchParams;
@@ -27,12 +27,11 @@ public class TelemetryApiConverter {
 
     private final boolean reportDeploymentLogs;
 
-    private final String databusEndpoint;
+    private final boolean useSharedAltusCredential;
 
-    public TelemetryApiConverter(@Value("${cluster.deployment.logs.report:false}") boolean reportDeploymentLogs,
-            @Value("${altus.databus.endpoint:}") String databusEndpoint) {
-        this.reportDeploymentLogs = reportDeploymentLogs;
-        this.databusEndpoint = databusEndpoint;
+    public TelemetryApiConverter(TelemetryConfiguration configuration) {
+        this.reportDeploymentLogs = configuration.isReportDeploymentLogs();
+        this.useSharedAltusCredential = configuration.getAltusDatabusConfiguration().isUseSharedAltusCredential();
     }
 
     public EnvironmentTelemetry convert(TelemetryRequest request) {
@@ -87,6 +86,7 @@ public class TelemetryApiConverter {
         if (features != null) {
             featuresRequest = new FeaturesRequest();
             featuresRequest.setReportDeploymentLogs(features.getReportDeploymentLogs());
+            featuresRequest.setUseSharedAltusCredential(features.getUseSharedAltusCredential());
         }
         return featuresRequest;
     }
@@ -97,6 +97,7 @@ public class TelemetryApiConverter {
             featuresResponse = new FeaturesResponse();
             featuresResponse.setReportDeploymentLogs(features.getReportDeploymentLogs());
             featuresResponse.setWorkloadAnalytics(features.getWorkloadAnalytics());
+            featuresResponse.setUseSharedAltusCredential(features.getUseSharedAltusCredential());
         }
         return featuresResponse;
     }
@@ -117,6 +118,9 @@ public class TelemetryApiConverter {
         EnvironmentFeatures features = null;
         if (featuresRequest != null) {
             features = new EnvironmentFeatures();
+            if (useSharedAltusCredential) {
+                features.setUseSharedAltusCredential(featuresRequest.getUseSharedAltusCredential());
+            }
             if (reportDeploymentLogs) {
                 final FeatureSetting reportDeploymentLogs;
                 if (featuresRequest.getReportDeploymentLogs() != null) {

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/TelemetryApiConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/TelemetryApiConverterTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
 
+import com.sequenceiq.cloudbreak.altus.AltusDatabusConfiguration;
+import com.sequenceiq.cloudbreak.telemetry.TelemetryConfiguration;
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
 import com.sequenceiq.common.api.telemetry.request.FeaturesRequest;
 import com.sequenceiq.common.api.telemetry.request.LoggingRequest;
@@ -31,7 +33,9 @@ public class TelemetryApiConverterTest {
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        underTest = new TelemetryApiConverter(true, "http://mydatabus.endpoint.com");
+        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration("", false, "", null);
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true);
+        underTest = new TelemetryApiConverter(telemetryConfiguration);
     }
 
     @Test

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/handler/MachineUserRemoveHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/handler/MachineUserRemoveHandler.java
@@ -51,7 +51,7 @@ public class MachineUserRemoveHandler implements EventHandler<RemoveMachineUserR
         Stack stack = stackService.getStackById(stackId);
         Telemetry telemetry = stack.getTelemetry();
         if (telemetry != null && telemetry.isReportDeploymentLogsFeatureEnabled()) {
-            altusMachineUserService.cleanupMachineUser(stack);
+            altusMachineUserService.cleanupMachineUser(stack, telemetry);
         } else {
             LOGGER.info("Machine user cleanup is not needed.");
         }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/AltusMachineUserService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/AltusMachineUserService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.auth.altus.model.AltusCredential;
 import com.sequenceiq.cloudbreak.auth.altus.service.AltusIAMService;
+import com.sequenceiq.common.api.telemetry.model.Telemetry;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.util.CrnService;
 
@@ -24,16 +25,16 @@ public class AltusMachineUserService {
         this.crnService = crnService;
     }
 
-    public Optional<AltusCredential> createMachineUserWithAccessKeys(Stack stack) {
+    public Optional<AltusCredential> createMachineUserWithAccessKeys(Stack stack, Telemetry telemetry) {
         String userCrn = crnService.getUserCrn();
         String machineUserName = getFluentMachineUser(stack);
-        return altusIAMService.generateMachineUserWithAccessKey(machineUserName, userCrn);
+        return altusIAMService.generateMachineUserWithAccessKey(machineUserName, userCrn, telemetry.isUseSharedAltusCredentialEnabled());
     }
 
-    public void cleanupMachineUser(Stack stack) {
+    public void cleanupMachineUser(Stack stack, Telemetry telemetry) {
         String userCrn = crnService.getUserCrn();
         String machineUserName = getFluentMachineUser(stack);
-        altusIAMService.clearMachineUser(machineUserName, userCrn);
+        altusIAMService.clearMachineUser(machineUserName, userCrn, telemetry.isUseSharedAltusCredentialEnabled());
     }
 
     private String getFluentMachineUser(Stack stack) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaInstallService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaInstallService.java
@@ -104,7 +104,7 @@ public class FreeIpaInstallService {
                     databusEnabled, false, telemetry);
             servicePillarConfig.put("fluent", new SaltPillarProperties("/fluent/init.sls", Collections.singletonMap("fluent", fluentConfigView.toMap())));
             if (databusEnabled) {
-                Optional<AltusCredential> credential = altusMachineUserService.createMachineUserWithAccessKeys(stack);
+                Optional<AltusCredential> credential = altusMachineUserService.createMachineUserWithAccessKeys(stack, telemetry);
                 String accessKey = credential.map(AltusCredential::getAccessKey).orElse(null);
                 char[] privateKey = credential.map(AltusCredential::getPrivateKey).orElse(null);
                 DatabusConfigView databusConfigView = databusConfigService.createDatabusConfigs(accessKey, privateKey,

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverterTest.java
@@ -7,6 +7,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.sequenceiq.cloudbreak.altus.AltusDatabusConfiguration;
+import com.sequenceiq.cloudbreak.telemetry.TelemetryConfiguration;
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
 import com.sequenceiq.common.api.telemetry.model.Logging;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
@@ -26,7 +28,9 @@ public class TelemetryConverterTest {
 
     @BeforeEach
     public void setUp() {
-        underTest = new TelemetryConverter(true, true, DATABUS_ENDPOINT);
+        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, false, "", null);
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true);
+        underTest = new TelemetryConverter(telemetryConfiguration, true);
     }
 
     @Test

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/RedbeamsApplication.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/RedbeamsApplication.java
@@ -10,6 +10,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableJpaRepositories(basePackages = {"com.sequenceiq.redbeams", "com.sequenceiq.flow", "com.sequenceiq.cloudbreak.ha.repository"})
 @SpringBootApplication(scanBasePackages = {"com.sequenceiq.redbeams",
         "com.sequenceiq.authorization",
+        "com.sequenceiq.cloudbreak.altus",
         "com.sequenceiq.cloudbreak.auth",
         "com.sequenceiq.cloudbreak.auth.altus",
         "com.sequenceiq.cloudbreak.auth.filter",


### PR DESCRIPTION
- add global config to enable to use a common altus credential for all cb cluster (that should be enabled for e2e environments)
- the shared altus credential is only used if that is set in telemetry request (as a feature setting) - if the global config is disabled, you cannot enable that feature
- access / secret key can be set in the configuration (use char array for the secret key)
- as many configurations passed to the converters, create config objects instead of extending the parameters (Telemetry + Altus config object)