### PR TITLE
CB-4653 disable Kafka auth config for datalake

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaAuthConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaAuthConfigProvider.java
@@ -7,6 +7,7 @@ import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.c
 
 import java.util.List;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import org.springframework.stereotype.Component;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
@@ -60,7 +61,9 @@ public class KafkaAuthConfigProvider implements CmTemplateComponentConfigProvide
 
     @Override
     public boolean isConfigurationNeeded(CmTemplateProcessor cmTemplateProcessor, TemplatePreparationObject source) {
-        return source.getLdapConfig().isPresent() && cmTemplateProcessor.isRoleTypePresentInService(getServiceType(), getRoleTypes());
+        return StackType.WORKLOAD.equals(source.getStackType())
+                && source.getLdapConfig().isPresent()
+                && cmTemplateProcessor.isRoleTypePresentInService(getServiceType(), getRoleTypes());
     }
 
     @Override


### PR DESCRIPTION
PR to disable Kafka auth config provider for datalake clusters. There are two reasons to do this:
1. It is not needed for data lakes, only workload clusters
2. It prevents a breaking config change to be rolled out.

Testing:
- Rewrote KafkaAuthConfigProviderTest