### PR TITLE
CB-4802 Update displayed component versions for OpDB components

### DIFF
--- a/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.0.1.json
+++ b/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.0.1.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "HBASE",
-      "version": "2.2.2"
+      "version": "2.2.1"
     },
     {
       "name": "YARN",

--- a/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.0.2.json
+++ b/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.0.2.json
@@ -14,11 +14,11 @@
     },
     {
       "name": "ZOOKEEPER",
-      "version": "3.4.6"
+      "version": "3.5.5"
     },
     {
       "name": "HBASE",
-      "version": "2.2.2"
+      "version": "2.2.1"
     },
     {
       "name": "YARN",
@@ -70,7 +70,7 @@
     },
     {
       "name": "KNOX",
-      "version": "1.0.0"
+      "version": "1.3.0"
     },
     {
       "name": "RANGER",

--- a/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.0.json
+++ b/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.0.json
@@ -14,11 +14,11 @@
     },
     {
       "name": "ZOOKEEPER",
-      "version": "3.4.5"
+      "version": "3.4.6"
     },
     {
       "name": "HBASE",
-      "version": "2.2.2"
+      "version": "2.2.0"
     },
     {
       "name": "YARN",

--- a/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.1.json
+++ b/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.1.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "ZOOKEEPER",
-      "version": "3.4.6"
+      "version": "3.5.5"
     },
     {
       "name": "HBASE",
@@ -70,7 +70,7 @@
     },
     {
       "name": "KNOX",
-      "version": "1.0.0"
+      "version": "1.3.0"
     },
     {
       "name": "RANGER",
@@ -99,6 +99,10 @@
     {
       "name": "DAS",
       "version": "1.4.2"
+    },
+    {
+      "name": "PHOENIX",
+      "version": "5.0.0"
     }
   ],
   "version": "7.1.0",


### PR DESCRIPTION
also add Phoenix to compinent version list for CDH 7.1

Updates the descriptors that specify the component versions to display.
Adds Phoenix to 7.1 descriptor

I have used the versions from the POM, even though they may not be accurate. I left the HBase version in 7.1 alone, because while it does not match the POM version, it matches reality.

Test:
Start modified CB

Check that the UI displays the new versions on DataHub creation screen
Check that the UI display Phoenix with logo and correct version on DataHub creation screen

Closes #CB-4802
