### PR TITLE
Fix typo in topology.xml.j2

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -666,7 +666,7 @@
         <url>{{ protocol }}://{{ hostloc }}:{{ ports['IMPALA_DEBUG_UI'] }}</url>
         {%- endfor %}
     </service>
-    {%- endif %}SharedServiceConfigProviderTest.java
+    {%- endif %}
     {%- endif %}
 
     {% if 'KUDU_MASTER' in salt['pillar.get']('gateway:location') -%}


### PR DESCRIPTION
Remove copy/paste typo. This is only on master. I checked rc-2.15 and rc-2.16. Looks like it came in as part of https://github.com/hortonworks/cloudbreak/commit/c1de8da699d7e678279011a5706741ba3f89e0ac by mistake.