### PR TITLE
CDPCP-1212 Update password expiration for hashed password codepath

### DIFF
--- a/auth-connector/src/generated/main/grpc/com/cloudera/thunderhead/service/usermanagement/UserManagementGrpc.java
+++ b/auth-connector/src/generated/main/grpc/com/cloudera/thunderhead/service/usermanagement/UserManagementGrpc.java
@@ -957,6 +957,43 @@ public final class UserManagementGrpc {
      return getCreateAccountMethod;
   }
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getCreateTrialAccountMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateTrialAccountRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateTrialAccountResponse> METHOD_CREATE_TRIAL_ACCOUNT = getCreateTrialAccountMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateTrialAccountRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateTrialAccountResponse> getCreateTrialAccountMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateTrialAccountRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateTrialAccountResponse> getCreateTrialAccountMethod() {
+    return getCreateTrialAccountMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateTrialAccountRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateTrialAccountResponse> getCreateTrialAccountMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateTrialAccountRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateTrialAccountResponse> getCreateTrialAccountMethod;
+    if ((getCreateTrialAccountMethod = UserManagementGrpc.getCreateTrialAccountMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getCreateTrialAccountMethod = UserManagementGrpc.getCreateTrialAccountMethod) == null) {
+          UserManagementGrpc.getCreateTrialAccountMethod = getCreateTrialAccountMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateTrialAccountRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateTrialAccountResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "usermanagement.UserManagement", "CreateTrialAccount"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateTrialAccountRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateTrialAccountResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("CreateTrialAccount"))
+                  .build();
+          }
+        }
+     }
+     return getCreateTrialAccountMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getGrantEntitlementMethod()} instead. 
   public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GrantEntitlementRequest,
       com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GrantEntitlementResponse> METHOD_GRANT_ENTITLEMENT = getGrantEntitlementMethodHelper();
@@ -3028,6 +3065,191 @@ public final class UserManagementGrpc {
      }
      return getGetEventGenerationIdsMethod;
   }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getAddActorSshPublicKeyMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AddActorSshPublicKeyRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AddActorSshPublicKeyResponse> METHOD_ADD_ACTOR_SSH_PUBLIC_KEY = getAddActorSshPublicKeyMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AddActorSshPublicKeyRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AddActorSshPublicKeyResponse> getAddActorSshPublicKeyMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AddActorSshPublicKeyRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AddActorSshPublicKeyResponse> getAddActorSshPublicKeyMethod() {
+    return getAddActorSshPublicKeyMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AddActorSshPublicKeyRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AddActorSshPublicKeyResponse> getAddActorSshPublicKeyMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AddActorSshPublicKeyRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AddActorSshPublicKeyResponse> getAddActorSshPublicKeyMethod;
+    if ((getAddActorSshPublicKeyMethod = UserManagementGrpc.getAddActorSshPublicKeyMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getAddActorSshPublicKeyMethod = UserManagementGrpc.getAddActorSshPublicKeyMethod) == null) {
+          UserManagementGrpc.getAddActorSshPublicKeyMethod = getAddActorSshPublicKeyMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AddActorSshPublicKeyRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AddActorSshPublicKeyResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "usermanagement.UserManagement", "AddActorSshPublicKey"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AddActorSshPublicKeyRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AddActorSshPublicKeyResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("AddActorSshPublicKey"))
+                  .build();
+          }
+        }
+     }
+     return getAddActorSshPublicKeyMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getListActorSshPublicKeysMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListActorSshPublicKeysRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListActorSshPublicKeysResponse> METHOD_LIST_ACTOR_SSH_PUBLIC_KEYS = getListActorSshPublicKeysMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListActorSshPublicKeysRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListActorSshPublicKeysResponse> getListActorSshPublicKeysMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListActorSshPublicKeysRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListActorSshPublicKeysResponse> getListActorSshPublicKeysMethod() {
+    return getListActorSshPublicKeysMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListActorSshPublicKeysRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListActorSshPublicKeysResponse> getListActorSshPublicKeysMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListActorSshPublicKeysRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListActorSshPublicKeysResponse> getListActorSshPublicKeysMethod;
+    if ((getListActorSshPublicKeysMethod = UserManagementGrpc.getListActorSshPublicKeysMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getListActorSshPublicKeysMethod = UserManagementGrpc.getListActorSshPublicKeysMethod) == null) {
+          UserManagementGrpc.getListActorSshPublicKeysMethod = getListActorSshPublicKeysMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListActorSshPublicKeysRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListActorSshPublicKeysResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "usermanagement.UserManagement", "ListActorSshPublicKeys"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListActorSshPublicKeysRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListActorSshPublicKeysResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("ListActorSshPublicKeys"))
+                  .build();
+          }
+        }
+     }
+     return getListActorSshPublicKeysMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getDescribeActorSshPublicKeyMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DescribeActorSshPublicKeyRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DescribeActorSshPublicKeyResponse> METHOD_DESCRIBE_ACTOR_SSH_PUBLIC_KEY = getDescribeActorSshPublicKeyMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DescribeActorSshPublicKeyRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DescribeActorSshPublicKeyResponse> getDescribeActorSshPublicKeyMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DescribeActorSshPublicKeyRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DescribeActorSshPublicKeyResponse> getDescribeActorSshPublicKeyMethod() {
+    return getDescribeActorSshPublicKeyMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DescribeActorSshPublicKeyRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DescribeActorSshPublicKeyResponse> getDescribeActorSshPublicKeyMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DescribeActorSshPublicKeyRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DescribeActorSshPublicKeyResponse> getDescribeActorSshPublicKeyMethod;
+    if ((getDescribeActorSshPublicKeyMethod = UserManagementGrpc.getDescribeActorSshPublicKeyMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getDescribeActorSshPublicKeyMethod = UserManagementGrpc.getDescribeActorSshPublicKeyMethod) == null) {
+          UserManagementGrpc.getDescribeActorSshPublicKeyMethod = getDescribeActorSshPublicKeyMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DescribeActorSshPublicKeyRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DescribeActorSshPublicKeyResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "usermanagement.UserManagement", "DescribeActorSshPublicKey"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DescribeActorSshPublicKeyRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DescribeActorSshPublicKeyResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("DescribeActorSshPublicKey"))
+                  .build();
+          }
+        }
+     }
+     return getDescribeActorSshPublicKeyMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getDeleteActorSshPublicKeyMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteActorSshPublicKeyRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteActorSshPublicKeyResponse> METHOD_DELETE_ACTOR_SSH_PUBLIC_KEY = getDeleteActorSshPublicKeyMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteActorSshPublicKeyRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteActorSshPublicKeyResponse> getDeleteActorSshPublicKeyMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteActorSshPublicKeyRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteActorSshPublicKeyResponse> getDeleteActorSshPublicKeyMethod() {
+    return getDeleteActorSshPublicKeyMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteActorSshPublicKeyRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteActorSshPublicKeyResponse> getDeleteActorSshPublicKeyMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteActorSshPublicKeyRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteActorSshPublicKeyResponse> getDeleteActorSshPublicKeyMethod;
+    if ((getDeleteActorSshPublicKeyMethod = UserManagementGrpc.getDeleteActorSshPublicKeyMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getDeleteActorSshPublicKeyMethod = UserManagementGrpc.getDeleteActorSshPublicKeyMethod) == null) {
+          UserManagementGrpc.getDeleteActorSshPublicKeyMethod = getDeleteActorSshPublicKeyMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteActorSshPublicKeyRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteActorSshPublicKeyResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "usermanagement.UserManagement", "DeleteActorSshPublicKey"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteActorSshPublicKeyRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteActorSshPublicKeyResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("DeleteActorSshPublicKey"))
+                  .build();
+          }
+        }
+     }
+     return getDeleteActorSshPublicKeyMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getSetWorkloadPasswordPolicyMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyResponse> METHOD_SET_WORKLOAD_PASSWORD_POLICY = getSetWorkloadPasswordPolicyMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyResponse> getSetWorkloadPasswordPolicyMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyResponse> getSetWorkloadPasswordPolicyMethod() {
+    return getSetWorkloadPasswordPolicyMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyResponse> getSetWorkloadPasswordPolicyMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyResponse> getSetWorkloadPasswordPolicyMethod;
+    if ((getSetWorkloadPasswordPolicyMethod = UserManagementGrpc.getSetWorkloadPasswordPolicyMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getSetWorkloadPasswordPolicyMethod = UserManagementGrpc.getSetWorkloadPasswordPolicyMethod) == null) {
+          UserManagementGrpc.getSetWorkloadPasswordPolicyMethod = getSetWorkloadPasswordPolicyMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "usermanagement.UserManagement", "SetWorkloadPasswordPolicy"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("SetWorkloadPasswordPolicy"))
+                  .build();
+          }
+        }
+     }
+     return getSetWorkloadPasswordPolicyMethod;
+  }
 
   /**
    * Creates a new async stub that supports all call types for the service
@@ -3313,12 +3535,22 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
-     * Create an account.
+     * Create a regular account.
      * </pre>
      */
     public void createAccount(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateAccountRequest request,
         io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateAccountResponse> responseObserver) {
       asyncUnimplementedUnaryCall(getCreateAccountMethodHelper(), responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Create a trial account.
+     * </pre>
+     */
+    public void createTrialAccount(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateTrialAccountRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateTrialAccountResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getCreateTrialAccountMethodHelper(), responseObserver);
     }
 
     /**
@@ -3907,6 +4139,56 @@ public final class UserManagementGrpc {
       asyncUnimplementedUnaryCall(getGetEventGenerationIdsMethodHelper(), responseObserver);
     }
 
+    /**
+     * <pre>
+     * Adds an SSH public key for an actor.
+     * </pre>
+     */
+    public void addActorSshPublicKey(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AddActorSshPublicKeyRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AddActorSshPublicKeyResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getAddActorSshPublicKeyMethodHelper(), responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Lists the SSH public keys for an actor.
+     * </pre>
+     */
+    public void listActorSshPublicKeys(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListActorSshPublicKeysRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListActorSshPublicKeysResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getListActorSshPublicKeysMethodHelper(), responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Describes an SSH public key.
+     * </pre>
+     */
+    public void describeActorSshPublicKey(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DescribeActorSshPublicKeyRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DescribeActorSshPublicKeyResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getDescribeActorSshPublicKeyMethodHelper(), responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Deletes an SSH public key for an actor.
+     * </pre>
+     */
+    public void deleteActorSshPublicKey(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteActorSshPublicKeyRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteActorSshPublicKeyResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getDeleteActorSshPublicKeyMethodHelper(), responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Sets the workload password policy for an account.
+     * </pre>
+     */
+    public void setWorkloadPasswordPolicy(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getSetWorkloadPasswordPolicyMethodHelper(), responseObserver);
+    }
+
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
@@ -4084,6 +4366,13 @@ public final class UserManagementGrpc {
                 com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateAccountRequest,
                 com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateAccountResponse>(
                   this, METHODID_CREATE_ACCOUNT)))
+          .addMethod(
+            getCreateTrialAccountMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateTrialAccountRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateTrialAccountResponse>(
+                  this, METHODID_CREATE_TRIAL_ACCOUNT)))
           .addMethod(
             getGrantEntitlementMethodHelper(),
             asyncUnaryCall(
@@ -4476,6 +4765,41 @@ public final class UserManagementGrpc {
                 com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsRequest,
                 com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsResponse>(
                   this, METHODID_GET_EVENT_GENERATION_IDS)))
+          .addMethod(
+            getAddActorSshPublicKeyMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AddActorSshPublicKeyRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AddActorSshPublicKeyResponse>(
+                  this, METHODID_ADD_ACTOR_SSH_PUBLIC_KEY)))
+          .addMethod(
+            getListActorSshPublicKeysMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListActorSshPublicKeysRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListActorSshPublicKeysResponse>(
+                  this, METHODID_LIST_ACTOR_SSH_PUBLIC_KEYS)))
+          .addMethod(
+            getDescribeActorSshPublicKeyMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DescribeActorSshPublicKeyRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DescribeActorSshPublicKeyResponse>(
+                  this, METHODID_DESCRIBE_ACTOR_SSH_PUBLIC_KEY)))
+          .addMethod(
+            getDeleteActorSshPublicKeyMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteActorSshPublicKeyRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteActorSshPublicKeyResponse>(
+                  this, METHODID_DELETE_ACTOR_SSH_PUBLIC_KEY)))
+          .addMethod(
+            getSetWorkloadPasswordPolicyMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyResponse>(
+                  this, METHODID_SET_WORKLOAD_PASSWORD_POLICY)))
           .build();
     }
   }
@@ -4779,13 +5103,24 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
-     * Create an account.
+     * Create a regular account.
      * </pre>
      */
     public void createAccount(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateAccountRequest request,
         io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateAccountResponse> responseObserver) {
       asyncUnaryCall(
           getChannel().newCall(getCreateAccountMethodHelper(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Create a trial account.
+     * </pre>
+     */
+    public void createTrialAccount(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateTrialAccountRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateTrialAccountResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getCreateTrialAccountMethodHelper(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -5429,6 +5764,61 @@ public final class UserManagementGrpc {
       asyncUnaryCall(
           getChannel().newCall(getGetEventGenerationIdsMethodHelper(), getCallOptions()), request, responseObserver);
     }
+
+    /**
+     * <pre>
+     * Adds an SSH public key for an actor.
+     * </pre>
+     */
+    public void addActorSshPublicKey(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AddActorSshPublicKeyRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AddActorSshPublicKeyResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getAddActorSshPublicKeyMethodHelper(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Lists the SSH public keys for an actor.
+     * </pre>
+     */
+    public void listActorSshPublicKeys(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListActorSshPublicKeysRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListActorSshPublicKeysResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getListActorSshPublicKeysMethodHelper(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Describes an SSH public key.
+     * </pre>
+     */
+    public void describeActorSshPublicKey(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DescribeActorSshPublicKeyRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DescribeActorSshPublicKeyResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getDescribeActorSshPublicKeyMethodHelper(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Deletes an SSH public key for an actor.
+     * </pre>
+     */
+    public void deleteActorSshPublicKey(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteActorSshPublicKeyRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteActorSshPublicKeyResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getDeleteActorSshPublicKeyMethodHelper(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Sets the workload password policy for an account.
+     * </pre>
+     */
+    public void setWorkloadPasswordPolicy(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getSetWorkloadPasswordPolicyMethodHelper(), getCallOptions()), request, responseObserver);
+    }
   }
 
   /**
@@ -5706,12 +6096,22 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
-     * Create an account.
+     * Create a regular account.
      * </pre>
      */
     public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateAccountResponse createAccount(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateAccountRequest request) {
       return blockingUnaryCall(
           getChannel(), getCreateAccountMethodHelper(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * Create a trial account.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateTrialAccountResponse createTrialAccount(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateTrialAccountRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getCreateTrialAccountMethodHelper(), getCallOptions(), request);
     }
 
     /**
@@ -6299,6 +6699,56 @@ public final class UserManagementGrpc {
       return blockingUnaryCall(
           getChannel(), getGetEventGenerationIdsMethodHelper(), getCallOptions(), request);
     }
+
+    /**
+     * <pre>
+     * Adds an SSH public key for an actor.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AddActorSshPublicKeyResponse addActorSshPublicKey(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AddActorSshPublicKeyRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getAddActorSshPublicKeyMethodHelper(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * Lists the SSH public keys for an actor.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListActorSshPublicKeysResponse listActorSshPublicKeys(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListActorSshPublicKeysRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getListActorSshPublicKeysMethodHelper(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * Describes an SSH public key.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DescribeActorSshPublicKeyResponse describeActorSshPublicKey(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DescribeActorSshPublicKeyRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getDescribeActorSshPublicKeyMethodHelper(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * Deletes an SSH public key for an actor.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteActorSshPublicKeyResponse deleteActorSshPublicKey(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteActorSshPublicKeyRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getDeleteActorSshPublicKeyMethodHelper(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * Sets the workload password policy for an account.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyResponse setWorkloadPasswordPolicy(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getSetWorkloadPasswordPolicyMethodHelper(), getCallOptions(), request);
+    }
   }
 
   /**
@@ -6600,13 +7050,24 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
-     * Create an account.
+     * Create a regular account.
      * </pre>
      */
     public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateAccountResponse> createAccount(
         com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateAccountRequest request) {
       return futureUnaryCall(
           getChannel().newCall(getCreateAccountMethodHelper(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
+     * Create a trial account.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateTrialAccountResponse> createTrialAccount(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateTrialAccountRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getCreateTrialAccountMethodHelper(), getCallOptions()), request);
     }
 
     /**
@@ -7250,6 +7711,61 @@ public final class UserManagementGrpc {
       return futureUnaryCall(
           getChannel().newCall(getGetEventGenerationIdsMethodHelper(), getCallOptions()), request);
     }
+
+    /**
+     * <pre>
+     * Adds an SSH public key for an actor.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AddActorSshPublicKeyResponse> addActorSshPublicKey(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AddActorSshPublicKeyRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getAddActorSshPublicKeyMethodHelper(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
+     * Lists the SSH public keys for an actor.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListActorSshPublicKeysResponse> listActorSshPublicKeys(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListActorSshPublicKeysRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getListActorSshPublicKeysMethodHelper(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
+     * Describes an SSH public key.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DescribeActorSshPublicKeyResponse> describeActorSshPublicKey(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DescribeActorSshPublicKeyRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getDescribeActorSshPublicKeyMethodHelper(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
+     * Deletes an SSH public key for an actor.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteActorSshPublicKeyResponse> deleteActorSshPublicKey(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteActorSshPublicKeyRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getDeleteActorSshPublicKeyMethodHelper(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
+     * Sets the workload password policy for an account.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyResponse> setWorkloadPasswordPolicy(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getSetWorkloadPasswordPolicyMethodHelper(), getCallOptions()), request);
+    }
   }
 
   private static final int METHODID_INTERACTIVE_LOGIN = 0;
@@ -7277,62 +7793,68 @@ public final class UserManagementGrpc {
   private static final int METHODID_GET_RIGHTS = 22;
   private static final int METHODID_CHECK_RIGHTS = 23;
   private static final int METHODID_CREATE_ACCOUNT = 24;
-  private static final int METHODID_GRANT_ENTITLEMENT = 25;
-  private static final int METHODID_REVOKE_ENTITLEMENT = 26;
-  private static final int METHODID_ASSIGN_ROLE = 27;
-  private static final int METHODID_UNASSIGN_ROLE = 28;
-  private static final int METHODID_LIST_ASSIGNED_ROLES = 29;
-  private static final int METHODID_ASSIGN_RESOURCE_ROLE = 30;
-  private static final int METHODID_UNASSIGN_RESOURCE_ROLE = 31;
-  private static final int METHODID_LIST_ASSIGNED_RESOURCE_ROLES = 32;
-  private static final int METHODID_LIST_ROLES = 33;
-  private static final int METHODID_LIST_RESOURCE_ROLES = 34;
-  private static final int METHODID_LIST_RESOURCE_ASSIGNEES = 35;
-  private static final int METHODID_UPDATE_CLOUDERA_MANAGER_LICENSE_KEY = 36;
-  private static final int METHODID_INITIATE_SUPPORT_CASE = 37;
-  private static final int METHODID_NOTIFY_RESOURCE_DELETED = 38;
-  private static final int METHODID_CREATE_MACHINE_USER = 39;
-  private static final int METHODID_LIST_MACHINE_USERS = 40;
-  private static final int METHODID_DELETE_MACHINE_USER = 41;
-  private static final int METHODID_LIST_RESOURCE_ROLE_ASSIGNMENTS = 42;
-  private static final int METHODID_SET_ACCOUNT_MESSAGES = 43;
-  private static final int METHODID_ACCEPT_TERMS = 44;
-  private static final int METHODID_CLEAR_ACCEPTED_TERMS = 45;
-  private static final int METHODID_DESCRIBE_TERMS = 46;
-  private static final int METHODID_LIST_TERMS = 47;
-  private static final int METHODID_LIST_ENTITLEMENTS = 48;
-  private static final int METHODID_SET_TERMS_ACCEPTANCE_EXPIRY = 49;
-  private static final int METHODID_CONFIRM_AZURE_SUBSCRIPTION_VERIFIED = 50;
-  private static final int METHODID_INSERT_AZURE_SUBSCRIPTION = 51;
-  private static final int METHODID_CREATE_GROUP = 52;
-  private static final int METHODID_DELETE_GROUP = 53;
-  private static final int METHODID_LIST_GROUPS = 54;
-  private static final int METHODID_UPDATE_GROUP = 55;
-  private static final int METHODID_ADD_MEMBER_TO_GROUP = 56;
-  private static final int METHODID_REMOVE_MEMBER_FROM_GROUP = 57;
-  private static final int METHODID_LIST_GROUP_MEMBERS = 58;
-  private static final int METHODID_LIST_GROUPS_FOR_MEMBER = 59;
-  private static final int METHODID_CREATE_CLUSTER_SSH_PRIVATE_KEY = 60;
-  private static final int METHODID_GET_CLUSTER_SSH_PRIVATE_KEY = 61;
-  private static final int METHODID_GET_ASSIGNEE_AUTHORIZATION_INFORMATION = 62;
-  private static final int METHODID_CREATE_IDENTITY_PROVIDER_CONNECTOR = 63;
-  private static final int METHODID_LIST_IDENTITY_PROVIDER_CONNECTORS = 64;
-  private static final int METHODID_DELETE_IDENTITY_PROVIDER_CONNECTOR = 65;
-  private static final int METHODID_DESCRIBE_IDENTITY_PROVIDER_CONNECTOR = 66;
-  private static final int METHODID_UPDATE_IDENTITY_PROVIDER_CONNECTOR = 67;
-  private static final int METHODID_SET_CLOUDERA_SSOLOGIN_ENABLED = 68;
-  private static final int METHODID_GET_ID_PMETADATA_FOR_WORKLOAD_SSO = 69;
-  private static final int METHODID_PROCESS_WORKLOAD_SSOAUTHN_REQ = 70;
-  private static final int METHODID_SET_WORKLOAD_SUBDOMAIN = 71;
-  private static final int METHODID_CREATE_WORKLOAD_MACHINE_USER = 72;
-  private static final int METHODID_DELETE_WORKLOAD_MACHINE_USER = 73;
-  private static final int METHODID_GET_WORKLOAD_ADMINISTRATION_GROUP_NAME = 74;
-  private static final int METHODID_SET_WORKLOAD_ADMINISTRATION_GROUP_NAME = 75;
-  private static final int METHODID_DELETE_WORKLOAD_ADMINISTRATION_GROUP_NAME = 76;
-  private static final int METHODID_LIST_WORKLOAD_ADMINISTRATION_GROUPS = 77;
-  private static final int METHODID_SET_ACTOR_WORKLOAD_CREDENTIALS = 78;
-  private static final int METHODID_GET_ACTOR_WORKLOAD_CREDENTIALS = 79;
-  private static final int METHODID_GET_EVENT_GENERATION_IDS = 80;
+  private static final int METHODID_CREATE_TRIAL_ACCOUNT = 25;
+  private static final int METHODID_GRANT_ENTITLEMENT = 26;
+  private static final int METHODID_REVOKE_ENTITLEMENT = 27;
+  private static final int METHODID_ASSIGN_ROLE = 28;
+  private static final int METHODID_UNASSIGN_ROLE = 29;
+  private static final int METHODID_LIST_ASSIGNED_ROLES = 30;
+  private static final int METHODID_ASSIGN_RESOURCE_ROLE = 31;
+  private static final int METHODID_UNASSIGN_RESOURCE_ROLE = 32;
+  private static final int METHODID_LIST_ASSIGNED_RESOURCE_ROLES = 33;
+  private static final int METHODID_LIST_ROLES = 34;
+  private static final int METHODID_LIST_RESOURCE_ROLES = 35;
+  private static final int METHODID_LIST_RESOURCE_ASSIGNEES = 36;
+  private static final int METHODID_UPDATE_CLOUDERA_MANAGER_LICENSE_KEY = 37;
+  private static final int METHODID_INITIATE_SUPPORT_CASE = 38;
+  private static final int METHODID_NOTIFY_RESOURCE_DELETED = 39;
+  private static final int METHODID_CREATE_MACHINE_USER = 40;
+  private static final int METHODID_LIST_MACHINE_USERS = 41;
+  private static final int METHODID_DELETE_MACHINE_USER = 42;
+  private static final int METHODID_LIST_RESOURCE_ROLE_ASSIGNMENTS = 43;
+  private static final int METHODID_SET_ACCOUNT_MESSAGES = 44;
+  private static final int METHODID_ACCEPT_TERMS = 45;
+  private static final int METHODID_CLEAR_ACCEPTED_TERMS = 46;
+  private static final int METHODID_DESCRIBE_TERMS = 47;
+  private static final int METHODID_LIST_TERMS = 48;
+  private static final int METHODID_LIST_ENTITLEMENTS = 49;
+  private static final int METHODID_SET_TERMS_ACCEPTANCE_EXPIRY = 50;
+  private static final int METHODID_CONFIRM_AZURE_SUBSCRIPTION_VERIFIED = 51;
+  private static final int METHODID_INSERT_AZURE_SUBSCRIPTION = 52;
+  private static final int METHODID_CREATE_GROUP = 53;
+  private static final int METHODID_DELETE_GROUP = 54;
+  private static final int METHODID_LIST_GROUPS = 55;
+  private static final int METHODID_UPDATE_GROUP = 56;
+  private static final int METHODID_ADD_MEMBER_TO_GROUP = 57;
+  private static final int METHODID_REMOVE_MEMBER_FROM_GROUP = 58;
+  private static final int METHODID_LIST_GROUP_MEMBERS = 59;
+  private static final int METHODID_LIST_GROUPS_FOR_MEMBER = 60;
+  private static final int METHODID_CREATE_CLUSTER_SSH_PRIVATE_KEY = 61;
+  private static final int METHODID_GET_CLUSTER_SSH_PRIVATE_KEY = 62;
+  private static final int METHODID_GET_ASSIGNEE_AUTHORIZATION_INFORMATION = 63;
+  private static final int METHODID_CREATE_IDENTITY_PROVIDER_CONNECTOR = 64;
+  private static final int METHODID_LIST_IDENTITY_PROVIDER_CONNECTORS = 65;
+  private static final int METHODID_DELETE_IDENTITY_PROVIDER_CONNECTOR = 66;
+  private static final int METHODID_DESCRIBE_IDENTITY_PROVIDER_CONNECTOR = 67;
+  private static final int METHODID_UPDATE_IDENTITY_PROVIDER_CONNECTOR = 68;
+  private static final int METHODID_SET_CLOUDERA_SSOLOGIN_ENABLED = 69;
+  private static final int METHODID_GET_ID_PMETADATA_FOR_WORKLOAD_SSO = 70;
+  private static final int METHODID_PROCESS_WORKLOAD_SSOAUTHN_REQ = 71;
+  private static final int METHODID_SET_WORKLOAD_SUBDOMAIN = 72;
+  private static final int METHODID_CREATE_WORKLOAD_MACHINE_USER = 73;
+  private static final int METHODID_DELETE_WORKLOAD_MACHINE_USER = 74;
+  private static final int METHODID_GET_WORKLOAD_ADMINISTRATION_GROUP_NAME = 75;
+  private static final int METHODID_SET_WORKLOAD_ADMINISTRATION_GROUP_NAME = 76;
+  private static final int METHODID_DELETE_WORKLOAD_ADMINISTRATION_GROUP_NAME = 77;
+  private static final int METHODID_LIST_WORKLOAD_ADMINISTRATION_GROUPS = 78;
+  private static final int METHODID_SET_ACTOR_WORKLOAD_CREDENTIALS = 79;
+  private static final int METHODID_GET_ACTOR_WORKLOAD_CREDENTIALS = 80;
+  private static final int METHODID_GET_EVENT_GENERATION_IDS = 81;
+  private static final int METHODID_ADD_ACTOR_SSH_PUBLIC_KEY = 82;
+  private static final int METHODID_LIST_ACTOR_SSH_PUBLIC_KEYS = 83;
+  private static final int METHODID_DESCRIBE_ACTOR_SSH_PUBLIC_KEY = 84;
+  private static final int METHODID_DELETE_ACTOR_SSH_PUBLIC_KEY = 85;
+  private static final int METHODID_SET_WORKLOAD_PASSWORD_POLICY = 86;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -7450,6 +7972,10 @@ public final class UserManagementGrpc {
         case METHODID_CREATE_ACCOUNT:
           serviceImpl.createAccount((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateAccountRequest) request,
               (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateAccountResponse>) responseObserver);
+          break;
+        case METHODID_CREATE_TRIAL_ACCOUNT:
+          serviceImpl.createTrialAccount((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateTrialAccountRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateTrialAccountResponse>) responseObserver);
           break;
         case METHODID_GRANT_ENTITLEMENT:
           serviceImpl.grantEntitlement((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GrantEntitlementRequest) request,
@@ -7675,6 +8201,26 @@ public final class UserManagementGrpc {
           serviceImpl.getEventGenerationIds((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsRequest) request,
               (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetEventGenerationIdsResponse>) responseObserver);
           break;
+        case METHODID_ADD_ACTOR_SSH_PUBLIC_KEY:
+          serviceImpl.addActorSshPublicKey((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AddActorSshPublicKeyRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AddActorSshPublicKeyResponse>) responseObserver);
+          break;
+        case METHODID_LIST_ACTOR_SSH_PUBLIC_KEYS:
+          serviceImpl.listActorSshPublicKeys((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListActorSshPublicKeysRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListActorSshPublicKeysResponse>) responseObserver);
+          break;
+        case METHODID_DESCRIBE_ACTOR_SSH_PUBLIC_KEY:
+          serviceImpl.describeActorSshPublicKey((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DescribeActorSshPublicKeyRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DescribeActorSshPublicKeyResponse>) responseObserver);
+          break;
+        case METHODID_DELETE_ACTOR_SSH_PUBLIC_KEY:
+          serviceImpl.deleteActorSshPublicKey((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteActorSshPublicKeyRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.DeleteActorSshPublicKeyResponse>) responseObserver);
+          break;
+        case METHODID_SET_WORKLOAD_PASSWORD_POLICY:
+          serviceImpl.setWorkloadPasswordPolicy((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyResponse>) responseObserver);
+          break;
         default:
           throw new AssertionError();
       }
@@ -7761,6 +8307,7 @@ public final class UserManagementGrpc {
               .addMethod(getGetRightsMethodHelper())
               .addMethod(getCheckRightsMethodHelper())
               .addMethod(getCreateAccountMethodHelper())
+              .addMethod(getCreateTrialAccountMethodHelper())
               .addMethod(getGrantEntitlementMethodHelper())
               .addMethod(getRevokeEntitlementMethodHelper())
               .addMethod(getAssignRoleMethodHelper())
@@ -7817,6 +8364,11 @@ public final class UserManagementGrpc {
               .addMethod(getSetActorWorkloadCredentialsMethodHelper())
               .addMethod(getGetActorWorkloadCredentialsMethodHelper())
               .addMethod(getGetEventGenerationIdsMethodHelper())
+              .addMethod(getAddActorSshPublicKeyMethodHelper())
+              .addMethod(getListActorSshPublicKeysMethodHelper())
+              .addMethod(getDescribeActorSshPublicKeyMethodHelper())
+              .addMethod(getDeleteActorSshPublicKeyMethodHelper())
+              .addMethod(getSetWorkloadPasswordPolicyMethodHelper())
               .build();
         }
       }

--- a/auth-connector/src/main/proto/usermanagement.proto
+++ b/auth-connector/src/main/proto/usermanagement.proto
@@ -122,9 +122,13 @@ service UserManagement {
   rpc CheckRights(CheckRightsRequest)
     returns (CheckRightsResponse) {}
 
-  // Create an account.
+  // Create a regular account.
   rpc CreateAccount (CreateAccountRequest)
     returns (CreateAccountResponse) {}
+
+  // Create a trial account.
+  rpc CreateTrialAccount (CreateTrialAccountRequest)
+    returns (CreateTrialAccountResponse) {}
 
   // Grant Entitlement to an Account
   rpc GrantEntitlement (GrantEntitlementRequest)
@@ -377,6 +381,26 @@ service UserManagement {
   // since tracking started an empty string will be returned instead of an ID.
   rpc GetEventGenerationIds(GetEventGenerationIdsRequest)
     returns (GetEventGenerationIdsResponse) {}
+
+  // Adds an SSH public key for an actor.
+  rpc AddActorSshPublicKey(AddActorSshPublicKeyRequest)
+    returns (AddActorSshPublicKeyResponse) {}
+
+  // Lists the SSH public keys for an actor.
+  rpc ListActorSshPublicKeys(ListActorSshPublicKeysRequest)
+    returns (ListActorSshPublicKeysResponse) {}
+
+  // Describes an SSH public key.
+  rpc DescribeActorSshPublicKey(DescribeActorSshPublicKeyRequest)
+     returns (DescribeActorSshPublicKeyResponse) {}
+
+  // Deletes an SSH public key for an actor.
+  rpc DeleteActorSshPublicKey(DeleteActorSshPublicKeyRequest)
+    returns (DeleteActorSshPublicKeyResponse) {}
+
+  // Sets the workload password policy for an account.
+  rpc SetWorkloadPasswordPolicy (SetWorkloadPasswordPolicyRequest)
+  returns (SetWorkloadPasswordPolicyResponse) {}
 }
 
 // An User is the Altus identity corresponding to an external SFDC contact. Users
@@ -1013,6 +1037,8 @@ message Account {
   // Note that this is ensured to be unique, that is, there will not be two
   // accounts with the same workload sub domain.
   string workloadSubdomain = 14;
+  // The workload password policy.
+  WorkloadPasswordPolicy passwordPolicy = 15;
 }
 
 // Either the accountId or externalAccountId is required to get
@@ -1143,13 +1169,25 @@ message CheckRightsResponse {
 }
 
 message CreateAccountRequest {
+  // The external account ID for the account. This must be an SFDC account ID.
   string externalAccountId = 1;
+  // A base64 encoded Cloudera Manager license to use for the account.
   string clouderaManagerLicenseKey = 2 [(options.FieldExtension.skipLogging) = true];
-  // if none is passed, the default cloudera provider id will be used
+  // The identity provider associated with the account. If none is passed, the
+  // default cloudera identity provider will be used.
   string identityProviderId = 3;
 }
 
 message CreateAccountResponse {
+  Account account = 1;
+}
+
+message CreateTrialAccountRequest {
+  // The okta user ID of the user for which we are creating a trial account.
+  string oktaUserId = 1;
+}
+
+message CreateTrialAccountResponse {
   Account account = 1;
 }
 
@@ -1531,6 +1569,12 @@ message DeleteMachineUserRequest {
 message DeleteMachineUserResponse {
 }
 
+message WorkloadPasswordPolicyStorage {
+  // Account-wide max lifetime, in ms, of actors workload passwords.
+  // The magic value 0 indicates that passwords never expire.
+  uint64 workloadPasswordMaxLifetime = 1;
+}
+
 // Object used to serialize account metadata that does not require its own
 // columns.
 message AccountDetails {
@@ -1541,6 +1585,8 @@ message AccountDetails {
   repeated EntitlementGrant entitlement = 2;
   // Whether login using Cloudera SSO is disabled
   bool clouderaSSOLoginDisabled = 3;
+  // The account workload password policy
+  WorkloadPasswordPolicyStorage passwordPolicy = 4;
 }
 
 // Set Account Messages request object.
@@ -2190,13 +2236,31 @@ message StoredKerberosKey {
   string saltValue = 4;
 }
 
+// A structure to store SSH public keys in dynamo.
+message SshPublicKeyStorage {
+  // The key's ID
+  string id = 1;
+  // The public key. Only populated for DescribeActorSshPublicKeyResponses. This
+  // is the same public key that was used in the call to add the public key, i.e.,
+  // a public key in RFC4253 XDR format.
+  string publicKey = 2 [(options.FieldExtension.skipLogging) = true];
+  // The optional description.
+  string description = 3;
+}
+
 // This is used to serialize all the Actor dynamoDB related information that is
 // not indexed.
 message ActorDetails {
   // The cdp workload password hash, encrypted.
   string encryptedPasswordHash = 1 [(options.FieldExtension.sensitive) = true];
+  // The password hash expiration date, in ms from the Java epoch of
+  // 1970-01-01T00:00:00Z. The value of 0 means that the password hash does
+  // not expire.
+  uint64 encryptedPasswordHashExpirationDate = 4;
   // A list of kerberos keys for the actor.
   repeated StoredKerberosKey kerberosKeys = 2;
+  // A list of ssh public keys for the actor.
+  repeated SshPublicKeyStorage sshPublicKeys = 3;
 }
 
 message SetActorWorkloadCredentialsRequest {
@@ -2230,6 +2294,10 @@ message GetActorWorkloadCredentialsRequest {
 message GetActorWorkloadCredentialsResponse {
   // The password hash.
   string passwordHash = 1 [(options.FieldExtension.sensitive) = true];
+  // The date, in ms from the Java epoch of 1970-01-01T00:00:00Z, when the
+  // password hash expires. A value of 0 indicates that the password hash
+  // never expires.
+  uint64 passwordHashExpirationDate = 3;
   // A list of kerberos keys for the actor.
   repeated ActorKerberosKey kerberosKeys = 2;
 }
@@ -2259,4 +2327,87 @@ message GetEventGenerationIdsResponse {
   // set-workload-password. Empty string if no such event has been occurred since
   // tracking started.
   string lastActorWorkloadCredentialsChangedEventId = 5;
+}
+
+message AddActorSshPublicKeyRequest {
+  // The actor's CRN
+  string actorCrn = 1;
+  // The RSA or ED25519 public SSH key to add. We do not support DSA or ECDSA
+  // public keys. The public key should be in an RFC4253 XDR format, e.g.,
+  // ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqyj3P7cfW/D7xUfvITbq7cDmAfPOq6ZRw2jV6Qq3KXipR/zkEmRz1I38mAHrG+ydX4amVOV1KoylkkAkkeufIqFjsT4GyUhjXcXyYiBIn+BstTz7p+JQQ0uR8UDIdVFjXIhl/KEmUtiCnHlS2LIMlm0AnRmkvM0+xLytZGR2okaRkrDnpXiBu1O1HfjDztQTl+PMfpjoZtRjmgQW+C1DXce7b1AtuRHRGDTR39beZGfIEoJjT2q0BZC3j4VYoEZq2DCrsgeaxBffkm67v2qxW4vnd9GiETZkWp/dOlvPpSt2y2j6INCo2h55KYDXBixsjpyj0BXoKBOda0SIl9ye/ sample_public_key
+  // as produced, for example, by ssh-keygen.
+  string publicKey = 2 [(options.FieldExtension.skipLogging) = true];
+  // An optional description for the public key.
+  string description = 3 [(options.FieldExtension.skipLogging) = true];
+}
+
+message SshPublicKey {
+  //  The Ssh public key CRN
+  string crn = 1;
+  // the ssh public key SHA256 fingerprint. this is identical to the SHA256
+  // produced by running the following command on a public key named 'key.pub':
+  // ssh-keygen -l -E SHA256 -f /home/user/.ssh/key.pub.
+  // Note that ssh-keygen removes any padding bytes from the BASE64 fingerprint
+  // encoding (the '=' characters at the end of the fingerprint) and we will
+  // do the same.
+  string publicKeyFingerprint = 2;
+  // An optional description for the public key
+  string description = 3 [(options.FieldExtension.skipLogging) = true];
+  // The public key. Only populated for DescribeActorSshPublicKeyResponses. This
+  // is the same public key that was given used to add it, i.e., a public key
+  // in RFC4253 XDR format.
+  string publicKey = 4 [(options.FieldExtension.skipLogging) = true];
+}
+
+message AddActorSshPublicKeyResponse {
+  // The SSH public key information.
+  SshPublicKey sshPublicKey = 1;
+}
+
+message ListActorSshPublicKeysRequest {
+  // The actor's CRN
+  string actorCrn = 1;
+}
+
+message ListActorSshPublicKeysResponse {
+  // A list of public keys for the actor.
+  repeated SshPublicKey publicKey = 1;
+}
+
+message DescribeActorSshPublicKeyRequest {
+  // The actor's CRN
+  string actorCrn = 1;
+  // The SSH public key CRN or its SHA256 fingerprint.
+  string crnOrFingerprint = 2;
+}
+
+message DescribeActorSshPublicKeyResponse {
+  // The SSH public key information.
+  SshPublicKey publicKey = 1;
+}
+
+message DeleteActorSshPublicKeyRequest {
+  // The actor's CRN
+  string actorCrn = 1;
+  // The SSH public key CRN or the its SHA256 fingerprint to remove.
+  string crnOrFingerprint = 2;
+}
+
+message DeleteActorSshPublicKeyResponse {
+}
+
+message WorkloadPasswordPolicy {
+  // Account-wide max lifetime, in ms, of actors workload passwords.
+  // The magic value 0 indicates that passwords never expire.
+  uint64 workloadPasswordMaxLifetime = 1;
+}
+
+message SetWorkloadPasswordPolicyRequest {
+  // The account ID
+  string accountId = 1;
+  // The password policy to set.
+  WorkloadPasswordPolicy policy = 2;
+}
+
+message SetWorkloadPasswordPolicyResponse {
 }

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -3,8 +3,10 @@
 
 <module name="Checker">
     <property name="severity" value="error" />
+    <module name="SuppressWarningsFilter" />
     <module name="TreeWalker">
         <property name="tabWidth" value="4" />
+        <module name="SuppressWarningsHolder" />
 
         <!-- Format -->
         <module name="EmptyForIteratorPad" />

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaPostInstallService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaPostInstallService.java
@@ -80,11 +80,11 @@ public class FreeIpaPostInstallService {
 
     private void modifyAdminPasswordExpirationIfNeeded(FreeIpaClient client) throws FreeIpaClientException {
         Optional<User> user = client.userFind(freeIpaClientFactory.getAdminUser());
-        if (user.isPresent() && !FreeIpaClient.PASSWORD_EXPIRATION_DATETIME.equals(user.get().getKrbPasswordExpiration())) {
+        if (user.isPresent() && !FreeIpaClient.MAX_PASSWORD_EXPIRATION_DATETIME.equals(user.get().getKrbPasswordExpiration())) {
             User actualUser = user.get();
             LOGGER.debug(String.format("Modifying user [%s] current password expiration time [%s] to [%s]",
-                    actualUser.getUid(), actualUser.getKrbPasswordExpiration(), FreeIpaClient.PASSWORD_EXPIRATION_DATETIME));
-            client.updateUserPasswordExpiration(actualUser.getUid());
+                    actualUser.getUid(), actualUser.getKrbPasswordExpiration(), FreeIpaClient.MAX_PASSWORD_EXPIRATION_DATETIME));
+            client.updateUserPasswordMaxExpiration(actualUser.getUid());
         } else if (user.isEmpty()) {
             LOGGER.warn(String.format("No [%s] user found!", freeIpaClientFactory.getAdminUser()));
         } else {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserService.java
@@ -26,8 +26,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
@@ -54,6 +52,7 @@ import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
 import com.sequenceiq.freeipa.service.freeipa.user.model.FmsGroup;
 import com.sequenceiq.freeipa.service.freeipa.user.model.FmsUser;
 import com.sequenceiq.freeipa.service.freeipa.user.model.SyncStatusDetail;
+import com.sequenceiq.freeipa.service.freeipa.user.model.UmsUsersState;
 import com.sequenceiq.freeipa.service.freeipa.user.model.UsersState;
 import com.sequenceiq.freeipa.service.freeipa.user.model.UsersStateDifference;
 import com.sequenceiq.freeipa.service.freeipa.user.model.WorkloadCredential;
@@ -141,7 +140,7 @@ public class UserService {
                     new Json(umsEventGenerationIdsProvider.getEventGenerationIds(accountId, requestId)) :
                     null;
 
-            Map<String, UsersState> envToUmsStateMap = umsUsersStateProvider
+            Map<String, UmsUsersState> envToUmsStateMap = umsUsersStateProvider
                     .getEnvToUmsUsersStateMap(accountId, actorCrn, environmentCrns, userCrnFilter, machineUserCrnFilter, requestId);
 
             Collection<SuccessDetails> success = new ConcurrentLinkedQueue<>();
@@ -188,14 +187,15 @@ public class UserService {
         }
     }
 
-    private SyncStatusDetail synchronizeStack(Stack stack, UsersState umsUsersState, Set<String> userCrnFilter, Set<String> machineUserCrnFilter) {
+    private SyncStatusDetail synchronizeStack(Stack stack, UmsUsersState umsUsersState, Set<String> userCrnFilter, Set<String> machineUserCrnFilter) {
         String environmentCrn = stack.getEnvironmentCrn();
         try {
             FreeIpaClient freeIpaClient = freeIpaClientFactory.getFreeIpaClientForStack(stack);
             UsersState ipaUsersState = getIpaUserState(freeIpaClient, umsUsersState, userCrnFilter, machineUserCrnFilter);
             LOGGER.debug("IPA UsersState, found {} users and {} groups", ipaUsersState.getUsers().size(), ipaUsersState.getGroups().size());
 
-            applyStateDifferenceToIpa(stack.getEnvironmentCrn(), freeIpaClient, UsersStateDifference.fromUmsAndIpaUsersStates(umsUsersState, ipaUsersState));
+            applyStateDifferenceToIpa(stack.getEnvironmentCrn(), freeIpaClient,
+                    UsersStateDifference.fromUmsAndIpaUsersStates(umsUsersState.getUsersState(), ipaUsersState));
 
             // Check for the password related attribute (cdpUserAttr) existence and go for password sync.
             processUsersWorkloadCredentials(environmentCrn, umsUsersState, freeIpaClient);
@@ -208,7 +208,7 @@ public class UserService {
     }
 
     @VisibleForTesting
-    UsersState getIpaUserState(FreeIpaClient freeIpaClient, UsersState umsUsersState, Set<String> userCrnFilter, Set<String> machineUserCrnFilter)
+    UsersState getIpaUserState(FreeIpaClient freeIpaClient, UmsUsersState umsUsersState, Set<String> userCrnFilter, Set<String> machineUserCrnFilter)
             throws FreeIpaClientException {
         boolean fullSync = userCrnFilter.isEmpty() && machineUserCrnFilter.isEmpty();
         return fullSync ? freeIpaUsersStateProvider.getUsersState(freeIpaClient) :
@@ -228,7 +228,7 @@ public class UserService {
     }
 
     private void processUsersWorkloadCredentials(
-            String environmentCrn, UsersState umsUsersState, FreeIpaClient freeIpaClient) throws IOException, FreeIpaClientException {
+            String environmentCrn, UmsUsersState umsUsersState, FreeIpaClient freeIpaClient) throws IOException, FreeIpaClientException {
         Config config = freeIpaClient.getConfig();
         if (config.getIpauserobjectclasses() == null || !config.getIpauserobjectclasses().contains(Config.CDP_USER_ATTRIBUTE)) {
             LOGGER.debug("Doesn't seems like having config attribute, no credentials sync required for env:{}", environmentCrn);
@@ -239,7 +239,8 @@ public class UserService {
         LOGGER.debug("Having config attribute, going for credentials sync");
 
         // Should sync for all users and not just diff. At present there is no way to identify that there is a change in password for a user
-        for (FmsUser u : umsUsersState.getUsers()) {
+        UsersState usersState = umsUsersState.getUsersState();
+        for (FmsUser u : usersState.getUsers()) {
             WorkloadCredential workloadCredential = umsUsersState.getUsersWorkloadCredentialMap().get(u.getName());
             if (workloadCredential == null
                     || StringUtils.isEmpty(workloadCredential.getHashedPassword())
@@ -251,12 +252,8 @@ public class UserService {
             LOGGER.debug("Found Credentials for user {}", u.getName());
             String ansEncodedKrbPrincipalKey = KrbKeySetEncoder.getASNEncodedKrbPrincipalKey(workloadCredential.getKeys());
 
-            Map<String, Object> params =
-                    ImmutableMap.of("setattr", ImmutableList.of(
-                            "cdpHashedPassword=" + workloadCredential.getHashedPassword(),
-                            "cdpUnencryptedKrbPrincipalKey=" + ansEncodedKrbPrincipalKey));
-
-            freeIpaClient.userMod(u.getName(), params);
+            freeIpaClient.userSetPasswordHash(u.getName(), workloadCredential.getHashedPassword(),
+                    ansEncodedKrbPrincipalKey, workloadCredential.getExpirationDate());
             LOGGER.debug("Password synced for the user:{}, for the environment: {}", u.getName(), environmentCrn);
         }
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UmsUsersState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UmsUsersState.java
@@ -1,6 +1,65 @@
-// (c) Copyright 2019 Cloudera, Inc. All rights reserved.
-
 package com.sequenceiq.freeipa.service.freeipa.user.model;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
 public class UmsUsersState {
+
+    private final UsersState usersState;
+
+    private final Map<String, WorkloadCredential> usersWorkloadCredentialMap;
+
+    private final Set<FmsUser> requestedWorkloadUsers;
+
+    public UmsUsersState(UsersState usersState, Map<String, WorkloadCredential> usersWorkloadCredentialMap, Set<FmsUser> requestedWorkloadUsers) {
+        this.usersState = requireNonNull(usersState, "UsersState is null");
+        this.usersWorkloadCredentialMap = ImmutableMap.copyOf(requireNonNull(usersWorkloadCredentialMap, "workload credential map is null"));
+        this.requestedWorkloadUsers = ImmutableSet.copyOf(requireNonNull(requestedWorkloadUsers, "requested workload users is null"));
+    }
+
+    public UsersState getUsersState() {
+        return usersState;
+    }
+
+    public Map<String, WorkloadCredential> getUsersWorkloadCredentialMap() {
+        return usersWorkloadCredentialMap;
+    }
+
+    public Set<FmsUser> getRequestedWorkloadUsers() {
+        return requestedWorkloadUsers;
+    }
+
+    public static class Builder {
+        private UsersState usersState;
+
+        private Map<String, WorkloadCredential> workloadCredentialMap = new HashMap<>();
+
+        private Set<FmsUser> requestedWorkloadUsers = new HashSet<>();
+
+        public Builder setUsersState(UsersState usersState) {
+            this.usersState = usersState;
+            return this;
+        }
+
+        public Builder addWorkloadCredentials(String userName, WorkloadCredential creds) {
+            workloadCredentialMap.put(userName, creds);
+            return this;
+        }
+
+        public Builder addRequestedWorkloadUsers(FmsUser user) {
+            requestedWorkloadUsers.add(user);
+            return this;
+        }
+
+        public UmsUsersState build() {
+            return new UmsUsersState(usersState, workloadCredentialMap, requestedWorkloadUsers);
+        }
+    }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UmsUsersState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UmsUsersState.java
@@ -1,0 +1,6 @@
+// (c) Copyright 2019 Cloudera, Inc. All rights reserved.
+
+package com.sequenceiq.freeipa.service.freeipa.user.model;
+
+public class UmsUsersState {
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UsersState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UsersState.java
@@ -2,12 +2,12 @@ package com.sequenceiq.freeipa.service.freeipa.user.model;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 
 public class UsersState {
@@ -17,18 +17,11 @@ public class UsersState {
 
     private Multimap<String, String> groupMembership;
 
-    private Map<String, WorkloadCredential> usersWorkloadCredentialMap;
-
-    private Set<FmsUser> requestedWorkloadUsers = new HashSet<>();
-
     public UsersState(
-        Set<FmsGroup> groups, Set<FmsUser> users, Multimap<String, String> groupMembership,
-        Map<String, WorkloadCredential> usersWorkloadCredentialMap, Set<FmsUser> requestedWorkloadUsers) {
-        this.groups = requireNonNull(groups);
-        this.users = requireNonNull(users);
-        this.groupMembership = requireNonNull(groupMembership);
-        this.usersWorkloadCredentialMap = usersWorkloadCredentialMap;
-        this.requestedWorkloadUsers = requestedWorkloadUsers;
+        Set<FmsGroup> groups, Set<FmsUser> users, Multimap<String, String> groupMembership) {
+        this.groups = ImmutableSet.copyOf(requireNonNull(groups, "groups is null"));
+        this.users = ImmutableSet.copyOf(requireNonNull(users, "users is null"));
+        this.groupMembership = ImmutableMultimap.copyOf(requireNonNull(groupMembership, "group membership is null"));
     }
 
     public Set<FmsGroup> getGroups() {
@@ -41,14 +34,6 @@ public class UsersState {
 
     public Multimap<String, String> getGroupMembership() {
         return groupMembership;
-    }
-
-    public Map<String, WorkloadCredential> getUsersWorkloadCredentialMap() {
-        return usersWorkloadCredentialMap;
-    }
-
-    public Set<FmsUser> getRequestedWorkloadUsers() {
-        return requestedWorkloadUsers;
     }
 
     @Override
@@ -67,33 +52,23 @@ public class UsersState {
 
         private Multimap<String, String> groupMembership = HashMultimap.create();
 
-        private Map<String, WorkloadCredential> workloadCredentialMap = new HashMap<>();
-
-        private Set<FmsUser> requestedWorkloadUsers = new HashSet<>();
-
-        public void addGroup(FmsGroup fmsGroup) {
+        public Builder addGroup(FmsGroup fmsGroup) {
             fmsGroups.add(fmsGroup);
+            return this;
         }
 
-        public void addUser(FmsUser fmsUser) {
+        public Builder addUser(FmsUser fmsUser) {
             fmsUsers.add(fmsUser);
+            return this;
         }
 
-        public void addMemberToGroup(String group, String user) {
+        public Builder addMemberToGroup(String group, String user) {
             groupMembership.put(group, user);
-        }
-
-        public void addWorkloadCredentials(String userName, WorkloadCredential creds) {
-            workloadCredentialMap.put(userName, creds);
+            return this;
         }
 
         public UsersState build() {
-            return new UsersState(fmsGroups, fmsUsers, groupMembership, workloadCredentialMap, requestedWorkloadUsers);
-        }
-
-        public void addRequestedWorkloadUsers(FmsUser user) {
-            requestedWorkloadUsers.add(user);
-
+            return new UsersState(fmsGroups, fmsUsers, groupMembership);
         }
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/WorkloadCredential.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/WorkloadCredential.java
@@ -1,9 +1,11 @@
 package com.sequenceiq.freeipa.service.freeipa.user.model;
 
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ActorKerberosKey;
 import com.google.common.collect.ImmutableList;
-
-import java.util.List;
 
 public class WorkloadCredential {
 
@@ -11,9 +13,12 @@ public class WorkloadCredential {
 
     private final ImmutableList<ActorKerberosKey> keys;
 
-    public WorkloadCredential(String hashedPassword, List<ActorKerberosKey> keys) {
+    private final Optional<Instant> expirationDate;
+
+    public WorkloadCredential(String hashedPassword, List<ActorKerberosKey> keys, Optional<Instant> expirationDate) {
         this.hashedPassword = hashedPassword;
         this.keys = ImmutableList.copyOf(keys);
+        this.expirationDate = expirationDate;
     }
 
     public String getHashedPassword() {
@@ -24,4 +29,7 @@ public class WorkloadCredential {
         return keys;
     }
 
+    public Optional<Instant> getExpirationDate() {
+        return expirationDate;
+    }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/client/FreeIpaClientTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/client/FreeIpaClientTest.java
@@ -1,8 +1,40 @@
 package com.sequenceiq.freeipa.client;
 
-import static org.junit.jupiter.api.Assertions.*;
-// (c) Copyright 2019 Cloudera, Inc. All rights reserved.
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.time.Instant;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.googlecode.jsonrpc4j.JsonRpcHttpClient;
+
+@ExtendWith(MockitoExtension.class)
 class FreeIpaClientTest {
 
+    @Mock
+    private JsonRpcHttpClient jsonRpcHttpClient;
+
+    private FreeIpaClient freeIpaClient;
+
+    @BeforeEach
+    void setUp() {
+        freeIpaClient = new FreeIpaClient(jsonRpcHttpClient);
+    }
+
+    @Test
+    void testFormatDateMax() {
+        assertEquals(FreeIpaClient.MAX_PASSWORD_EXPIRATION_DATETIME, freeIpaClient.formatDate(Optional.empty()));
+    }
+
+    @Test
+    void testFormatDate() {
+        Instant instant = Instant.ofEpochMilli(1576118634916L);
+        String expected = "20191212024354Z";
+        assertEquals(expected, freeIpaClient.formatDate(Optional.of(instant)));
+    }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/client/FreeIpaClientTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/client/FreeIpaClientTest.java
@@ -1,0 +1,8 @@
+package com.sequenceiq.freeipa.client;
+
+import static org.junit.jupiter.api.Assertions.*;
+// (c) Copyright 2019 Cloudera, Inc. All rights reserved.
+
+class FreeIpaClientTest {
+
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserServiceTest.java
@@ -25,7 +25,7 @@ import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.client.model.RPCResponse;
 import com.sequenceiq.freeipa.controller.exception.BadRequestException;
 import com.sequenceiq.freeipa.service.freeipa.user.model.FmsUser;
-import com.sequenceiq.freeipa.service.freeipa.user.model.UsersState;
+import com.sequenceiq.freeipa.service.freeipa.user.model.UmsUsersState;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -99,7 +99,7 @@ class UserServiceTest {
     @Test
     void testFullSyncRetrievesFullIpaState() throws Exception {
         FreeIpaClient freeIpaClient = mock(FreeIpaClient.class);
-        UsersState umsUsersState = mock(UsersState.class);
+        UmsUsersState umsUsersState = mock(UmsUsersState.class);
         underTest.getIpaUserState(freeIpaClient, umsUsersState, Set.of(), Set.of());
         verify(freeIpaUsersStateProvider).getUsersState(any());
     }
@@ -107,7 +107,7 @@ class UserServiceTest {
     @Test
     void testFilteredSyncRetrievesFilteredIpaState() throws Exception {
         FreeIpaClient freeIpaClient = mock(FreeIpaClient.class);
-        UsersState umsUsersState = mock(UsersState.class);
+        UmsUsersState umsUsersState = mock(UmsUsersState.class);
         Set<FmsUser> workloadUsers = mock(Set.class);
         when(umsUsersState.getRequestedWorkloadUsers()).thenReturn(workloadUsers);
         underTest.getIpaUserState(freeIpaClient, umsUsersState, Set.of(USER_CRN), Set.of(MACHINE_USER_CRN));

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/freeipa/UserFindResponse.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/freeipa/UserFindResponse.java
@@ -24,7 +24,7 @@ public class UserFindResponse extends AbstractFreeIpaResponse<Set<User>> {
         user.setDn("admin");
         user.setUid("admin");
         user.setMemberOfGroup(List.of("admins"));
-        user.setKrbPasswordExpiration(FreeIpaClient.PASSWORD_EXPIRATION_DATETIME);
+        user.setKrbPasswordExpiration(FreeIpaClient.MAX_PASSWORD_EXPIRATION_DATETIME);
         return Set.of(user);
     }
 }

--- a/mock-caas/src/main/java/com/sequenceiq/caas/grpc/service/MockUserManagementService.java
+++ b/mock-caas/src/main/java/com/sequenceiq/caas/grpc/service/MockUserManagementService.java
@@ -111,6 +111,8 @@ public class MockUserManagementService extends UserManagementGrpc.UserManagement
 
     private static final String CDP_AUTOMATIC_USERSYNC_POLLER = "CDP_AUTOMATIC_USERSYNC_POLLER";
 
+    private static final long PASSWORD_EXPIRATION_DURATION = 31449600000L;
+
     @Inject
     private JsonUtil jsonUtil;
 
@@ -522,7 +524,10 @@ public class MockUserManagementService extends UserManagementGrpc.UserManagement
             io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement
                     .UserManagementProto.GetActorWorkloadCredentialsResponse> responseObserver) {
 
-        responseObserver.onNext(actorWorkloadCredentialsResponse);
+        GetActorWorkloadCredentialsResponse.Builder builder = GetActorWorkloadCredentialsResponse.newBuilder(actorWorkloadCredentialsResponse);
+        builder.setPasswordHashExpirationDate(System.currentTimeMillis() + PASSWORD_EXPIRATION_DURATION);
+
+        responseObserver.onNext(builder.build());
         responseObserver.onCompleted();
     }
 


### PR DESCRIPTION
The UMS now provides a password expiration time along with the
workload credentials. This value is epoch millis. User sync has
been updated to set this expiration time when setting the hashed
password. The userMod request was refactored, moving the param
map creation into the FreeIpaClient to match the pattern used by
other FreeIpaClient methods.

The UsersState was slightly refactored to split out the UMS-specific
information into a UmsUsersState because the UsersState model is
also used to represent the ipa state.

The Mock user management service has been modified to return an
expiration time that is different from the max expiration time
that the FMS uses.