### PR TITLE
CB-4848 Unable to upload huge file to HDFS through Nginx

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/clouderamanager-ssl-user-facing.conf
+++ b/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/clouderamanager-ssl-user-facing.conf
@@ -53,5 +53,7 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
+        # Enable large uploads
+        client_max_body_size 0;
     }
 }


### PR DESCRIPTION
Nginx config client_max_body_size defaults to
1MB which is too small when proxying large
file uploads. Setting client_max_body_size to
0 will not have Nginx check the "Content-Length"
request header. Chunked transfers are enabled
by default so this shouldn't load the entire
upload into memory.