### PR TITLE
CDPCP-1212. Password expiration set in set password api workflow

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
@@ -161,11 +161,18 @@ public class FreeIpaClient {
         return (User) invoke("user_add", flags, params, User.class).getResult();
     }
 
-    public void userSetPassword(String user, String password) throws FreeIpaClientException {
+    /**
+     * Updates the password and password expiration time for the specified user
+     *
+     * @param user the user
+     * @param password the password
+     * @param expiration Optional of the expiration instant. An empty optional implies the max expiration time
+     */
+    public void userSetPasswordWithExpiration(String user, String password, Optional<Instant> expiration) throws FreeIpaClientException {
         // FreeIPA expires any password that is set by another user. Work around this by
         // performing a separate API call to set the password expiration into the future
         userMod(user, "userpassword", password);
-        updateUserPasswordMaxExpiration(user);
+        updateUserPasswordExpiration(user, expiration);
     }
 
     public void updateUserPasswordExpiration(String user, Optional<Instant> expiration) throws FreeIpaClientException {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/user/event/SetPasswordRequest.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/user/event/SetPasswordRequest.java
@@ -1,5 +1,8 @@
 package com.sequenceiq.freeipa.flow.freeipa.user.event;
 
+import java.time.Instant;
+import java.util.Optional;
+
 public class SetPasswordRequest extends FreeIpaClientRequest<SetPasswordResult> {
 
     private final String environment;
@@ -8,11 +11,14 @@ public class SetPasswordRequest extends FreeIpaClientRequest<SetPasswordResult> 
 
     private final String password;
 
-    public SetPasswordRequest(Long stackId, String environment, String username, String password) {
+    private final Optional<Instant> expirationInstant;
+
+    public SetPasswordRequest(Long stackId, String environment, String username, String password, Optional<Instant> expirationInstant) {
         super(stackId);
         this.environment = environment;
         this.username = username;
         this.password = password;
+        this.expirationInstant = expirationInstant;
     }
 
     public String getEnvironment() {
@@ -27,12 +33,17 @@ public class SetPasswordRequest extends FreeIpaClientRequest<SetPasswordResult> 
         return password;
     }
 
+    public Optional<Instant> getExpirationInstant() {
+        return expirationInstant;
+    }
+
     @Override
     public String toString() {
         return "SetPasswordRequest{"
                 + "stackId='" + getResourceId() + '\''
                 + "environment='" + environment + '\''
                 + "username='" + username + '\''
+                + "expirationInstant=" + expirationInstant
                 + '}';
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/user/handler/SetPasswordHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/user/handler/SetPasswordHandler.java
@@ -43,7 +43,7 @@ public class SetPasswordHandler implements EventHandler<SetPasswordRequest> {
             MDCBuilder.buildMdcContext(stack);
 
             FreeIpaClient freeIpaClient = freeIpaClientFactory.getFreeIpaClientForStack(stack);
-            freeIpaClient.userSetPassword(request.getUsername(), request.getPassword());
+            freeIpaClient.userSetPasswordWithExpiration(request.getUsername(), request.getPassword(), request.getExpirationInstant());
             SetPasswordResult result = new SetPasswordResult(request);
             request.getResult().onNext(result);
         } catch (Exception e) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/kerberos/v1/KerberosConfigV1Service.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/kerberos/v1/KerberosConfigV1Service.java
@@ -103,7 +103,7 @@ public class KerberosConfigV1Service {
                 Optional<User> existinguser = freeIpaClient.userFind(bindUser);
                 User user = existinguser.isPresent() ? existinguser.get() : freeIpaClient.userAdd(bindUser, "service", "account");
                 String password = PasswordUtil.generatePassword();
-                freeIpaClient.userSetPassword(user.getUid(), password);
+                freeIpaClient.userSetPasswordWithExpiration(user.getUid(), password, Optional.empty());
                 freeIpaClient.addRoleMember("Enrollment Administrator", Set.of(user.getUid()), null, null, null, null);
                 freeIpaPermissionService.setPermissions(freeIpaClient);
                 kerberosConfig = kerberosConfigRegisterService.createKerberosConfig(stack.get().getId(), user.getUid(), password, clusterName);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/ldap/v1/LdapConfigV1Service.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/ldap/v1/LdapConfigV1Service.java
@@ -182,7 +182,7 @@ public class LdapConfigV1Service {
                 Optional<User> existinguser = freeIpaClient.userFind(bindUser);
                 User user = existinguser.isPresent() ? existinguser.get() : freeIpaClient.userAdd(bindUser, "service", "account");
                 String password = PasswordUtil.generatePassword();
-                freeIpaClient.userSetPassword(user.getUid(), password);
+                freeIpaClient.userSetPasswordWithExpiration(user.getUid(), password, Optional.empty());
                 ldapConfig = ldapConfigRegisterService.createLdapConfig(stack.get().getId(), user.getDn(), password, clusterName);
             }
             return convertLdapConfigToDescribeLdapConfigResponse(ldapConfig);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UmsUsersState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UmsUsersState.java
@@ -14,9 +14,9 @@ public class UmsUsersState {
 
     private final UsersState usersState;
 
-    private final Map<String, WorkloadCredential> usersWorkloadCredentialMap;
+    private final ImmutableMap<String, WorkloadCredential> usersWorkloadCredentialMap;
 
-    private final Set<FmsUser> requestedWorkloadUsers;
+    private final ImmutableSet<FmsUser> requestedWorkloadUsers;
 
     public UmsUsersState(UsersState usersState, Map<String, WorkloadCredential> usersWorkloadCredentialMap, Set<FmsUser> requestedWorkloadUsers) {
         this.usersState = requireNonNull(usersState, "UsersState is null");
@@ -28,11 +28,11 @@ public class UmsUsersState {
         return usersState;
     }
 
-    public Map<String, WorkloadCredential> getUsersWorkloadCredentialMap() {
+    public ImmutableMap<String, WorkloadCredential> getUsersWorkloadCredentialMap() {
         return usersWorkloadCredentialMap;
     }
 
-    public Set<FmsUser> getRequestedWorkloadUsers() {
+    public ImmutableSet<FmsUser> getRequestedWorkloadUsers() {
         return requestedWorkloadUsers;
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UsersState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UsersState.java
@@ -11,11 +11,11 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 
 public class UsersState {
-    private Set<FmsGroup> groups;
+    private ImmutableSet<FmsGroup> groups;
 
-    private Set<FmsUser> users;
+    private ImmutableSet<FmsUser> users;
 
-    private Multimap<String, String> groupMembership;
+    private ImmutableMultimap<String, String> groupMembership;
 
     public UsersState(
         Set<FmsGroup> groups, Set<FmsUser> users, Multimap<String, String> groupMembership) {
@@ -24,15 +24,15 @@ public class UsersState {
         this.groupMembership = ImmutableMultimap.copyOf(requireNonNull(groupMembership, "group membership is null"));
     }
 
-    public Set<FmsGroup> getGroups() {
+    public ImmutableSet<FmsGroup> getGroups() {
         return groups;
     }
 
-    public Set<FmsUser> getUsers() {
+    public ImmutableSet<FmsUser> getUsers() {
         return users;
     }
 
-    public Multimap<String, String> getGroupMembership() {
+    public ImmutableMultimap<String, String> getGroupMembership() {
         return groupMembership;
     }
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/PasswordServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/PasswordServiceTest.java
@@ -8,9 +8,8 @@ import static org.mockito.Mockito.when;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.function.Supplier;
 
-import org.junit.jupiter.api.BeforeEach;
+import com.sequenceiq.cloudbreak.common.service.Clock;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -27,27 +26,21 @@ class PasswordServiceTest {
 
     private static final String ACCOUNT_ID = UUID.randomUUID().toString();
 
-    private static final String ACTOR_CRN = "crn:iam:us-west-2:" + ACCOUNT_ID + ":user:" + UUID.randomUUID().toString();
-
-    private Supplier<Long> mockTimeSupplier = () -> MOCK_TIME;
-
     @Mock
     private GrpcUmsClient grpcUmsClient;
+
+    @Mock
+    private Clock clock;
 
     @InjectMocks
     private PasswordService underTest;
 
-    @BeforeEach
-    void setUp() {
-        underTest.currentTimeSupplier = mockTimeSupplier;
-    }
-
     @Test
     void testCalculateExpirationTimeNoPasswordPolicy() {
         UserManagementProto.Account account = UserManagementProto.Account.newBuilder().build();
-        when(grpcUmsClient.getAccountDetails(eq(ACTOR_CRN), eq(ACCOUNT_ID), any())).thenReturn(account);
+        when(grpcUmsClient.getAccountDetails(eq(PasswordService.INTERNAL_ACTOR_CRN), eq(ACCOUNT_ID), any())).thenReturn(account);
 
-        assertEquals(Optional.empty(), underTest.calculateExpirationTime(ACTOR_CRN, ACCOUNT_ID));
+        assertEquals(Optional.empty(), underTest.calculateExpirationTime(PasswordService.INTERNAL_ACTOR_CRN, ACCOUNT_ID));
     }
 
     @Test
@@ -57,9 +50,9 @@ class PasswordServiceTest {
                         .setWorkloadPasswordMaxLifetime(0)
                         .build())
                 .build();
-        when(grpcUmsClient.getAccountDetails(eq(ACTOR_CRN), eq(ACCOUNT_ID), any())).thenReturn(account);
+        when(grpcUmsClient.getAccountDetails(eq(PasswordService.INTERNAL_ACTOR_CRN), eq(ACCOUNT_ID), any())).thenReturn(account);
 
-        assertEquals(Optional.empty(), underTest.calculateExpirationTime(ACTOR_CRN, ACCOUNT_ID));
+        assertEquals(Optional.empty(), underTest.calculateExpirationTime(PasswordService.INTERNAL_ACTOR_CRN, ACCOUNT_ID));
     }
 
     @Test
@@ -71,8 +64,9 @@ class PasswordServiceTest {
                         .setWorkloadPasswordMaxLifetime(lifetime)
                         .build())
                 .build();
-        when(grpcUmsClient.getAccountDetails(eq(ACTOR_CRN), eq(ACCOUNT_ID), any())).thenReturn(account);
+        when(clock.getCurrentInstant()).thenReturn(Instant.ofEpochMilli(MOCK_TIME));
+        when(grpcUmsClient.getAccountDetails(eq(PasswordService.INTERNAL_ACTOR_CRN), eq(ACCOUNT_ID), any())).thenReturn(account);
 
-        assertEquals(Optional.of(Instant.ofEpochMilli(MOCK_TIME + lifetime)), underTest.calculateExpirationTime(ACTOR_CRN, ACCOUNT_ID));
+        assertEquals(Optional.of(Instant.ofEpochMilli(MOCK_TIME + lifetime)), underTest.calculateExpirationTime(PasswordService.INTERNAL_ACTOR_CRN, ACCOUNT_ID));
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/PasswordServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/PasswordServiceTest.java
@@ -1,0 +1,78 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
+import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
+
+@ExtendWith(MockitoExtension.class)
+class PasswordServiceTest {
+
+    private static final long MOCK_TIME = 1576171731141L;
+
+    private static final String ACCOUNT_ID = UUID.randomUUID().toString();
+
+    private static final String ACTOR_CRN = "crn:iam:us-west-2:" + ACCOUNT_ID + ":user:" + UUID.randomUUID().toString();
+
+    private Supplier<Long> mockTimeSupplier = () -> MOCK_TIME;
+
+    @Mock
+    private GrpcUmsClient grpcUmsClient;
+
+    @InjectMocks
+    private PasswordService underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest.currentTimeSupplier = mockTimeSupplier;
+    }
+
+    @Test
+    void testCalculateExpirationTimeNoPasswordPolicy() {
+        UserManagementProto.Account account = UserManagementProto.Account.newBuilder().build();
+        when(grpcUmsClient.getAccountDetails(eq(ACTOR_CRN), eq(ACCOUNT_ID), any())).thenReturn(account);
+
+        assertEquals(Optional.empty(), underTest.calculateExpirationTime(ACTOR_CRN, ACCOUNT_ID));
+    }
+
+    @Test
+    void testCalculateExpirationTime0PasswordPolicy() {
+        UserManagementProto.Account account = UserManagementProto.Account.newBuilder()
+                .setPasswordPolicy(UserManagementProto.WorkloadPasswordPolicy.newBuilder()
+                        .setWorkloadPasswordMaxLifetime(0)
+                        .build())
+                .build();
+        when(grpcUmsClient.getAccountDetails(eq(ACTOR_CRN), eq(ACCOUNT_ID), any())).thenReturn(account);
+
+        assertEquals(Optional.empty(), underTest.calculateExpirationTime(ACTOR_CRN, ACCOUNT_ID));
+    }
+
+    @Test
+    void testCalculateExpirationTimePasswordPolicy() {
+        long lifetime = 18276435L;
+
+        UserManagementProto.Account account = UserManagementProto.Account.newBuilder()
+                .setPasswordPolicy(UserManagementProto.WorkloadPasswordPolicy.newBuilder()
+                        .setWorkloadPasswordMaxLifetime(lifetime)
+                        .build())
+                .build();
+        when(grpcUmsClient.getAccountDetails(eq(ACTOR_CRN), eq(ACCOUNT_ID), any())).thenReturn(account);
+
+        assertEquals(Optional.of(Instant.ofEpochMilli(MOCK_TIME + lifetime)), underTest.calculateExpirationTime(ACTOR_CRN, ACCOUNT_ID));
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.freeipa.client.FreeIpaClient;
@@ -108,7 +109,7 @@ class UserServiceTest {
     void testFilteredSyncRetrievesFilteredIpaState() throws Exception {
         FreeIpaClient freeIpaClient = mock(FreeIpaClient.class);
         UmsUsersState umsUsersState = mock(UmsUsersState.class);
-        Set<FmsUser> workloadUsers = mock(Set.class);
+        ImmutableSet<FmsUser> workloadUsers = mock(ImmutableSet.class);
         when(umsUsersState.getRequestedWorkloadUsers()).thenReturn(workloadUsers);
         underTest.getIpaUserState(freeIpaClient, umsUsersState, Set.of(USER_CRN), Set.of(MACHINE_USER_CRN));
         verify(freeIpaUsersStateProvider).getFilteredFreeIPAState(any(), eq(workloadUsers));


### PR DESCRIPTION
The password expiration time is not included as part of the set password
request. The PasswordService retrieves the password policy from the UMS and
calculates the expiration Instant. The SetPasswordHandler calls the FreeIpaClient
with the expiration Instant when setting the password.
