### PR TITLE
CSP-803, Streaming is preview,fix sersion for SMM,SR

### DIFF
--- a/core/src/main/resources/defaults/clustertemplates/aws/aws-streaming-702.json
+++ b/core/src/main/resources/defaults/clustertemplates/aws/aws-streaming-702.json
@@ -3,6 +3,7 @@
   "description": "",
   "type": "STREAMING",
   "cloudPlatform": "AWS",
+  "featureState": "PREVIEW",
   "distroXTemplate": {
     "cluster": {
       "blueprintName": "CDP 1.2 - Streams Messaging Heavy Duty: Apache Kafka, Schema Registry, Streams Messaging Manager"

--- a/core/src/main/resources/defaults/clustertemplates/aws/aws-streaming-small-702.json
+++ b/core/src/main/resources/defaults/clustertemplates/aws/aws-streaming-small-702.json
@@ -3,6 +3,7 @@
   "description": "",
   "type": "STREAMING",
   "cloudPlatform": "AWS",
+  "featureState": "PREVIEW",
   "distroXTemplate": {
     "cluster": {
       "blueprintName": "CDP 1.2 - Streams Messaging Light Duty: Apache Kafka, Schema Registry, Streams Messaging Manager"

--- a/core/src/main/resources/defaults/clustertemplates/azure/azure-streaming-702.json
+++ b/core/src/main/resources/defaults/clustertemplates/azure/azure-streaming-702.json
@@ -3,6 +3,7 @@
   "description": "",
   "type": "STREAMING",
   "cloudPlatform": "AZURE",
+  "featureState": "PREVIEW",
   "distroXTemplate": {
     "cluster": {
       "blueprintName": "CDP 1.2 - Streams Messaging Heavy Duty: Apache Kafka, Schema Registry, Streams Messaging Manager"

--- a/core/src/main/resources/defaults/clustertemplates/azure/azure-streaming-small-702.json
+++ b/core/src/main/resources/defaults/clustertemplates/azure/azure-streaming-small-702.json
@@ -3,6 +3,7 @@
   "description": "",
   "type": "STREAMING",
   "cloudPlatform": "AZURE",
+  "featureState": "PREVIEW",
   "distroXTemplate": {
     "cluster": {
       "blueprintName": "CDP 1.2 - Streams Messaging Light Duty: Apache Kafka, Schema Registry, Streams Messaging Manager"

--- a/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.0.1.json
+++ b/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.0.1.json
@@ -90,11 +90,11 @@
     },
     {
       "name": "SCHEMAREGISTRY",
-      "version": "4.0.0"
+      "version": "0.8.1"
     },
     {
       "name": "STREAMS_MESSAGING_MANAGER",
-      "version": "1.0.0"
+      "version": "2.1.0"
     }
   ],
   "version": "7.0.1",

--- a/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.0.2.json
+++ b/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.0.2.json
@@ -90,11 +90,11 @@
     },
     {
       "name": "SCHEMAREGISTRY",
-      "version": "4.0.0"
+      "version": "0.8.1"
     },
     {
       "name": "STREAMS_MESSAGING_MANAGER",
-      "version": "1.0.0"
+      "version": "2.1.0"
     },
     {
       "name": "DAS",

--- a/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.1.json
+++ b/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.1.json
@@ -90,11 +90,11 @@
     },
     {
       "name": "SCHEMAREGISTRY",
-      "version": "4.0.0"
+      "version": "0.8.1"
     },
     {
       "name": "STREAMS_MESSAGING_MANAGER",
-      "version": "1.0.0"
+      "version": "2.1.0"
     },
     {
       "name": "DAS",


### PR DESCRIPTION
- Added "PREVIEW" label to the streaming clusters
- Fixed SMM (1.0.0 -> 2.1.0)and SR (4.0.0 -> 0.8.1) versions, from 

Testing:
Checked out the changes manually on the UI.

Closes CSP-803