### PR TITLE
CB-4867 fix Nifi versions

### DIFF
--- a/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.0.1.json
+++ b/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.0.1.json
@@ -82,11 +82,11 @@
     },
     {
       "name": "NIFI",
-      "version": "0.7.0"
+      "version": "1.10.0"
     },
     {
       "name": "NIFIREGISTRY",
-      "version": "0.4.0"
+      "version": "0.5.0"
     },
     {
       "name": "SCHEMAREGISTRY",

--- a/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.0.2.json
+++ b/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.0.2.json
@@ -82,11 +82,11 @@
     },
     {
       "name": "NIFI",
-      "version": "0.7.0"
+      "version": "1.10.0"
     },
     {
       "name": "NIFIREGISTRY",
-      "version": "0.4.0"
+      "version": "0.5.0"
     },
     {
       "name": "SCHEMAREGISTRY",

--- a/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.0.json
+++ b/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.0.json
@@ -82,11 +82,11 @@
     },
     {
       "name": "NIFI",
-      "version": "0.7.0"
+      "version": "1.10.0"
     },
     {
       "name": "NIFIREGISTRY",
-      "version": "0.4.0"
+      "version": "0.5.0"
     }
   ],
   "version": "7.0.0",

--- a/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.1.json
+++ b/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.1.json
@@ -82,11 +82,11 @@
     },
     {
       "name": "NIFI",
-      "version": "0.7.0"
+      "version": "1.10.0"
     },
     {
       "name": "NIFIREGISTRY",
-      "version": "0.4.0"
+      "version": "0.5.0"
     },
     {
       "name": "SCHEMAREGISTRY",


### PR DESCRIPTION
Fix for Nifi and Nifi Registry version display on Cloudbreak UI.

Nifi version is changed from 0.7.0 to 1.10.0
Nifi Registry version is changed from 0.4.0 to 0.5.0

Testing: checked manually on UI.

Closes CB-4867
