### PR TITLE
CB-4871. Use different fluentd workers for different outputs.

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/fluent/template/input.conf.j2
+++ b/freeipa/src/main/resources/freeipa-salt/salt/fluent/template/input.conf.j2
@@ -1,6 +1,7 @@
 {%- from 'fluent/settings.sls' import fluent with context %}
 # CONFIGURED BY SALT - do not edit
 {% if providerPrefix != "databus" or fluent.dbusReportDeploymentLogs %}
+<worker {{ workerIndex }}>
 <source>
   @type tail
   format none
@@ -89,6 +90,7 @@
   tag {{providerPrefix}}.pki_transactions
   read_from_head true
 </source>
+</worker>
 {% else %}
 # DATABUS inputs are disabled
 {% endif %}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/init.sls
@@ -106,6 +106,7 @@ fluent_stop:
     - file_mode: 640
     - context:
         databusReportDeploymentLogs: "true"
+        numberOfWorkers: {{ fluent.numberOfWorkers }}
 
 /etc/td-agent/td-agent_simple_profile.conf:
   file.managed:
@@ -116,6 +117,7 @@ fluent_stop:
     - file_mode: 640
     - context:
         databusReportDeploymentLogs: "false"
+        numberOfWorkers: {{ fluent.numberOfWorkers }}
 
 copy_td_agent_conf:
   cmd.run:
@@ -137,6 +139,7 @@ copy_td_agent_conf:
     - file_mode: 640
     - context:
         providerPrefix: {{ fluent.providerPrefix }}
+        workerIndex: {{ fluent.cloudStorageWorkerIndex }}
 {% endif %}
 
 /etc/td-agent/databus_metering.conf:
@@ -156,6 +159,7 @@ copy_td_agent_conf:
     - file_mode: 640
     - context:
         providerPrefix: "databus"
+        workerIndex: {{ fluent.reportDeploymentLogsWorkerIndex }}
 
 /etc/td-agent/output_databus.conf:
   file.managed:

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
@@ -55,6 +55,23 @@
 {% set service_path_log_suffix = '%Y-%m-%d/%H/\${tag[1]}-#{Socket.gethostname}-%M' %}
 {% set cm_command_path_log_suffix = '%Y-%m-%d/%H/CM_COMMAND-\${tag[6]}-\${tag[1]}-#{Socket.gethostname}-%M' %}
 
+{% set number_of_workers=0 %}
+{% set cloud_storage_worker_index=0 %}
+{% set metering_worker_index=0 %}
+{% set report_deployment_logs_worker_index=0 %}
+{% if cloud_storage_logging_enabled %}
+{%   set cloud_storage_worker_index=number_of_workers %}
+{%   set number_of_workers=number_of_workers+1 %}
+{% endif %}
+{% if dbus_metering_enabled %}
+{%   set metering_worker_index=number_of_workers %}
+{%   set number_of_workers=number_of_workers+1 %}
+{% endif %}
+{% if dbus_report_deployment_logs_enabled %}
+{%   set report_deployment_logs_worker_index=number_of_workers %}
+{%   set number_of_workers=number_of_workers+1 %}
+{% endif %}
+
 {% do fluent.update({
     "enabled": fluent_enabled,
     "is_systemd" : is_systemd,
@@ -81,5 +98,9 @@
     "clouderaPublicGemRepo": cloudera_public_gem_repo,
     "clouderaAzurePluginVersion": cloudera_azure_plugin_version,
     "clouderaDatabusPluginVersion": cloudera_databus_plugin_version,
+    "numberOfWorkers": number_of_workers,
+    "cloudStorageWorkerIndex": cloud_storage_worker_index,
+    "meteringWorkerIndex": metering_worker_index,
+    "reportDeploymentLogsWorkerIndex": report_deployment_logs_worker_index,
     "platform": platform
 }) %}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/databus_metering.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/databus_metering.conf.j2
@@ -1,6 +1,7 @@
 {%- from 'fluent/settings.sls' import fluent with context %}
 {%- from 'databus/settings.sls' import databus with context %}
 {%- if databus.valid and fluent.dbusMeteringEnabled %}
+<worker {{ fluent.meteringWorkerIndex }}>
 <source>
   @type tail
   format none
@@ -34,6 +35,7 @@
     </buffer>
   </store>
 </match>
+</worker>
 {% elif fluent.dbusMeteringEnabled %}
 # DBUS settings are not valid - check dbus credentials file
 {% else %}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/output.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/output.conf.j2
@@ -1,5 +1,6 @@
 {%- from 'fluent/settings.sls' import fluent with context %}
 {% if fluent.providerPrefix == "s3" %}
+<worker {{ fluent.cloudStorageWorkerIndex }}>
 <match {{fluent.providerPrefix}}.*>
   @type copy
   <store ignore_error>
@@ -44,7 +45,9 @@
     format single_value
   </store>
 </match>
+</worker>
 {% elif fluent.providerPrefix == "abfs" %}
+<worker {{ fluent.cloudStorageWorkerIndex }}>
 <match {{fluent.providerPrefix}}.*>
   @type copy
   <store ignore_error>
@@ -105,8 +108,11 @@
     format single_value
   </store>
 </match>
+</worker>
 {% else %}
+<worker {{ cloudStorageWorkerIndex }}>
 <match {{fluent.providerPrefix}}.*>
   @type stdout
 </match>
+</worker>
 {% endif %}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/output_databus.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/output_databus.conf.j2
@@ -1,6 +1,7 @@
 {%- from 'fluent/settings.sls' import fluent with context %}
 {%- from 'databus/settings.sls' import databus with context %}
 {%- if databus.valid and fluent.dbusReportDeploymentLogs %}
+<worker {{ fluent.reportDeploymentLogsWorkerIndex }}>
 <match databus**>
   @type copy
   <store ignore_error>
@@ -17,7 +18,7 @@
 
     <buffer tag,time>
       @type file
-      path /var/log/td-agent/databus_metering
+      path /var/log/td-agent/databus_service_logs
       timekey 1m
       timekey_wait 0s
       chunk_limit_size 600k
@@ -25,6 +26,7 @@
     </buffer>
   </store>
 </match>
+</worker>
 {% elif fluent.dbusReportDeploymentLogs %}
 # DBUS settings are not valid - check dbus credentials file
 {% else %}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/td-agent.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/td-agent.conf.j2
@@ -1,5 +1,8 @@
 {%- from 'fluent/settings.sls' import fluent with context %}
 # CONFIGURED BY SALT - do not edit
+<system>
+  workers {{ numberOfWorkers }}
+</system>
 {% if databusReportDeploymentLogs == "true" %}# DATABUS - CLUSTER BUNDLE LOGS ENABLED - do not edit{% endif %}
 {% if fluent.cloudStorageLoggingEnabled %}
 @include input.conf

--- a/orchestrator-salt/src/main/resources/salt/salt/fluent/template/input.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/fluent/template/input.conf.j2
@@ -1,6 +1,7 @@
 {%- from 'fluent/settings.sls' import fluent with context %}
 # CONFIGURED BY SALT - do not edit
 {% if providerPrefix != "databus" or fluent.dbusReportDeploymentLogs %}
+<worker {{ workerIndex }}>
 <source>
   @type tail
   format none
@@ -449,6 +450,7 @@
   tag {{providerPrefix}}.AUTOSSH
   read_from_head true
 </source>
+</worker>
 {% else %}
 # DATABUS inputs are disabled
 {% endif %}


### PR DESCRIPTION
Use multiple workers for fluentd

### Why?
there can be situations when s3 or abfs output or policies are misconfigured in a way that can cause fatal issues for fluentd (regarding buffers for example), but that can cause that the databus part of fluentd won't work because of that kind of errors. (that means metering can stop because of some specific cloud storage issues) - or same is true for OOM errors
solution for that:
- run fluentd in different processes for different outputs
see more: https://docs.fluentd.org/deployment/multi-process-workers

workers needs to be indexed (from 0...n), and also to number of workers needs to match the configurations, so adding a small logic to `fluent/settings.sls`  to calculate the number of workers + use the right indexes (any of output can be disabled, so we need a counter here)