### PR TITLE
CB-4874 Kafka config providers adjusted for CDH 7.0.3

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
@@ -19,6 +19,8 @@ public class CMRepositoryVersionUtil {
 
     public static final Versioned CLOUDERAMANAGER_VERSION_7_0_2 = () -> "7.0.2";
 
+    public static final Versioned CLOUDERAMANAGER_VERSION_7_0_3 = () -> "7.0.3";
+
     public static final Versioned CFM_VERSION_2_0_0_0 = () -> "2.0.0.0";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CMRepositoryVersionUtil.class);

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaAuthConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaAuthConfigProvider.java
@@ -27,14 +27,14 @@ public class KafkaAuthConfigProvider implements CmTemplateComponentConfigProvide
 
     @Override
     public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject source) {
-        KafkaConfigProviderUtils.CdhVersionForStreaming cdhVersion = KafkaConfigProviderUtils.getCdhVersionForStreaming(source);
+        KafkaConfigProviderUtils.KafkaAuthConfigType authType = KafkaConfigProviderUtils.getCdhVersionForStreaming(source).authType();
         LdapView ldapView = source.getLdapConfig().get();
-        switch (cdhVersion) {
-            case VERSION_7_0_2:
+        switch (authType) {
+            case LDAP_AUTH:
                 return ldapConfig(ldapView);
-            case VERSION_7_0_2_2_OR_LATER:
+            case SASL_PAM_AUTH:
                 return ldapAndPamConfig(ldapView);
-            case VERSION_7_0_2_CANNOT_DETERMINE_PATCH:
+            case LDAP_BASE_CONFIG:
                 return generalAuthConfig(ldapView);
             default:
                 return List.of();

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaConfigProviderUtils.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaConfigProviderUtils.java
@@ -1,36 +1,49 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.sequenceiq.cloudbreak.cloud.VersionComparator;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
-import com.sequenceiq.cloudbreak.common.type.Versioned;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 
-import java.util.Comparator;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_0_2;
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_0_3;
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
 
 public class KafkaConfigProviderUtils {
 
     private KafkaConfigProviderUtils() {
     }
 
+    /*
+    TODO: This logic needs to be revised whenever a new CDH version comes out.
+    Some background on this rather complicated versioning scheme:
+    - CDH 7.0.2 contained partial support for Kafka + streaming, not officially released
+    - Full support was originally targeted in 7.1.0
+    - CDH 7.0.3 (datacenter edition) came out with the partial streaming support in 7.0.2
+    - CDH 7.1.0 was delayed and as a result, full support was re-targeted to 7.0.2.2
+    This has lead to the current situation, where the 7.0.2.2 version is based on newer code than the 7.0.3 version.
+    Since it is difficult to predict future CDH releases and their content, the following is assumed on a best-effort basis:
+    - 7.0.x (7.0.4, 7.0.5, ...) versions will use the same logic as 7.0.2 and 7.0.3
+    - 7.1.0 and later versions will use the logic in 7.0.2.2
+    (it may need to be adjusted when a new version comes out)
+     */
     static CdhVersionForStreaming getCdhVersionForStreaming(TemplatePreparationObject source) {
         String cdhVersion = source.getBlueprintView().getProcessor().getVersion().orElse("");
-        Comparator<Versioned> versionComparator = new VersionComparator();
-        int compareResult = versionComparator.compare(() -> cdhVersion, CLOUDERAMANAGER_VERSION_7_0_2);
-        if (compareResult < 0) {
-            return CdhVersionForStreaming.VERSION_PRE_7_0_2;
-        } else if (compareResult > 0) {
-            return CdhVersionForStreaming.VERSION_7_0_2_2_OR_LATER;
-        } else {
+        if (isVersionNewerOrEqualThanLimited(cdhVersion, () -> "7.1.0")) {
+            return CdhVersionForStreaming.VERSION_7_X_0;
+        } else if (isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERAMANAGER_VERSION_7_0_3)) {
+            return CdhVersionForStreaming.VERSION_7_0_X;
+        } else if (isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERAMANAGER_VERSION_7_0_2)) {
             Optional<Integer> patchVersion = getCdhPatchVersion(source);
             return patchVersion.isEmpty()
-                    ? CdhVersionForStreaming.VERSION_7_0_2_CANNOT_DETERMINE_PATCH
-                    : patchVersion.get() >= 2 ? CdhVersionForStreaming.VERSION_7_0_2_2_OR_LATER : CdhVersionForStreaming.VERSION_7_0_2;
+                    ? CdhVersionForStreaming.VERSION_7_0_2_MISSING_PATCH_VERSION
+                    : patchVersion.get() >= 2 ? CdhVersionForStreaming.VERSION_7_0_2_X : CdhVersionForStreaming.VERSION_7_0_2;
+
+        } else {
+            return CdhVersionForStreaming.VERSION_7_0_0;
         }
     }
 
@@ -57,10 +70,35 @@ public class KafkaConfigProviderUtils {
     }
 
     enum CdhVersionForStreaming {
-        VERSION_PRE_7_0_2,
-        VERSION_7_0_2,
-        VERSION_7_0_2_CANNOT_DETERMINE_PATCH,
-        VERSION_7_0_2_2_OR_LATER
+        VERSION_7_0_0(false, KafkaAuthConfigType.NO_AUTH),
+        VERSION_7_0_2(false, KafkaAuthConfigType.LDAP_AUTH),
+        VERSION_7_0_2_MISSING_PATCH_VERSION(false, KafkaAuthConfigType.LDAP_BASE_CONFIG),
+        VERSION_7_0_2_X(true, KafkaAuthConfigType.SASL_PAM_AUTH),
+        VERSION_7_0_X(false, KafkaAuthConfigType.LDAP_AUTH),
+        VERSION_7_X_0(true, KafkaAuthConfigType.SASL_PAM_AUTH);
+
+        private final boolean supportsRangerServiceCreation;
+        private final KafkaAuthConfigType authType;
+
+        CdhVersionForStreaming(boolean supportsCustomRangerServiceName, KafkaAuthConfigType authType) {
+            this.supportsRangerServiceCreation = supportsCustomRangerServiceName;
+            this.authType = authType;
+        }
+
+        boolean supportsRangerServiceCreation() {
+            return supportsRangerServiceCreation;
+        }
+
+        KafkaAuthConfigType authType() {
+            return authType;
+        }
+    }
+
+    enum KafkaAuthConfigType {
+        NO_AUTH,
+        LDAP_BASE_CONFIG,
+        LDAP_AUTH,
+        SASL_PAM_AUTH
     }
 
 }

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaDatahubConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaDatahubConfigProvider.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
-import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaConfigProviderUtils.CdhVersionForStreaming.VERSION_7_0_2_2_OR_LATER;
 
 @Component
 public class KafkaDatahubConfigProvider implements CmTemplateComponentConfigProvider {
@@ -26,14 +25,10 @@ public class KafkaDatahubConfigProvider implements CmTemplateComponentConfigProv
     @Override
     public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject source) {
         ArrayList<ApiClusterTemplateConfig> configs = Lists.newArrayList(config(PRODUCER_METRICS_ENABLE, "true"));
-        if (supportsRangerServiceCreation(source)) {
+        if (KafkaConfigProviderUtils.getCdhVersionForStreaming(source).supportsRangerServiceCreation()) {
             configs.add(config(RANGER_PLUGIN_KAFKA_SERVICE_NAME, GENERATED_RANGER_SERVICE_NAME));
         }
         return configs;
-    }
-
-    private boolean supportsRangerServiceCreation(TemplatePreparationObject source) {
-        return VERSION_7_0_2_2_OR_LATER.equals(KafkaConfigProviderUtils.getCdhVersionForStreaming(source));
     }
 
     @Override

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaAuthConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaAuthConfigProviderTest.java
@@ -104,6 +104,8 @@ class KafkaAuthConfigProviderTest {
                 Arguments.of("7.0.2", cdhParcelVersion("7.0.2", 2), PAM_AUTH_EXPECTED_CONFIGS),
                 Arguments.of("7.0.2", cdhParcelVersion("7.0.2", 3), PAM_AUTH_EXPECTED_CONFIGS),
                 Arguments.of("7.0.2", "irregularCdhVersion-123", GENERAL_AUTH_EXPECTED_CONFIGS),
+                Arguments.of("7.0.3", cdhParcelVersion("7.0.3", 0), LDAP_AUTH_EXPECTED_CONFIGS),
+                Arguments.of("7.0.3", cdhParcelVersion("7.0.3", 3), LDAP_AUTH_EXPECTED_CONFIGS),
                 Arguments.of("7.1.0", cdhParcelVersion("7.1.0", 0), PAM_AUTH_EXPECTED_CONFIGS));
     }
 

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaConfigProviderUtilsTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaConfigProviderUtilsTest.java
@@ -19,10 +19,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaConfigProviderUtils.CdhVersionForStreaming.VERSION_7_0_2_CANNOT_DETERMINE_PATCH;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaConfigProviderUtils.CdhVersionForStreaming.VERSION_7_0_2;
-import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaConfigProviderUtils.CdhVersionForStreaming.VERSION_7_0_2_2_OR_LATER;
-import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaConfigProviderUtils.CdhVersionForStreaming.VERSION_PRE_7_0_2;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaConfigProviderUtils.CdhVersionForStreaming.VERSION_7_0_2_MISSING_PATCH_VERSION;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaConfigProviderUtils.CdhVersionForStreaming.VERSION_7_0_2_X;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaConfigProviderUtils.CdhVersionForStreaming.VERSION_7_0_X;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaConfigProviderUtils.CdhVersionForStreaming.VERSION_7_X_0;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaConfigProviderUtils.CdhVersionForStreaming.VERSION_7_0_0;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -76,19 +78,22 @@ class KafkaConfigProviderUtilsTest {
 
     static Stream<Arguments> testArgs() {
         return Stream.of(
-                Arguments.of("7.0.1", cdhParcelVersion("7.0.1", 5), VERSION_PRE_7_0_2),
-                Arguments.of("7.0.1", null, VERSION_PRE_7_0_2),
-                Arguments.of("7.0.1", "irregular-12345", VERSION_PRE_7_0_2),
+                Arguments.of("7.0.1", cdhParcelVersion("7.0.1", 5), VERSION_7_0_0),
+                Arguments.of("7.0.1", null, VERSION_7_0_0),
+                Arguments.of("7.0.1", "irregular-12345", VERSION_7_0_0),
                 Arguments.of("7.0.2", cdhParcelVersion("7.0.2", 0), VERSION_7_0_2),
                 Arguments.of("7.0.2", cdhParcelVersion("7.0.2", 1), VERSION_7_0_2),
                 Arguments.of("7.0.2", cdhParcelVersion("7.0.2", 1), VERSION_7_0_2),
-                Arguments.of("7.0.2", cdhParcelVersion("7.0.2", 2), VERSION_7_0_2_2_OR_LATER),
-                Arguments.of("7.0.2", cdhParcelVersion("7.0.2", 3), VERSION_7_0_2_2_OR_LATER),
-                Arguments.of("7.0.2", null, VERSION_7_0_2_CANNOT_DETERMINE_PATCH),
-                Arguments.of("7.0.2", "irregular-12345", VERSION_7_0_2_CANNOT_DETERMINE_PATCH),
-                Arguments.of("7.1.0", cdhParcelVersion("7.1.0", 0), VERSION_7_0_2_2_OR_LATER),
-                Arguments.of("7.1.0", null, VERSION_7_0_2_2_OR_LATER),
-                Arguments.of("7.1.0", "irregular-12345", VERSION_7_0_2_2_OR_LATER)
+                Arguments.of("7.0.2", cdhParcelVersion("7.0.2", 2), VERSION_7_0_2_X),
+                Arguments.of("7.0.2", cdhParcelVersion("7.0.2", 3), VERSION_7_0_2_X),
+                Arguments.of("7.0.2", null, VERSION_7_0_2_MISSING_PATCH_VERSION),
+                Arguments.of("7.0.2", "irregular-12345", VERSION_7_0_2_MISSING_PATCH_VERSION),
+                Arguments.of("7.0.3", cdhParcelVersion("7.0.3", 0), VERSION_7_0_X),
+                Arguments.of("7.0.3", cdhParcelVersion("7.0.3", 3), VERSION_7_0_X),
+                Arguments.of("7.0.4", cdhParcelVersion("7.0.4", 0), VERSION_7_0_X),
+                Arguments.of("7.1.0", cdhParcelVersion("7.1.0", 0), VERSION_7_X_0),
+                Arguments.of("7.1.0", null, VERSION_7_X_0),
+                Arguments.of("7.1.0", "irregular-12345", VERSION_7_X_0)
         );
     }
 

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaDatahubConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaDatahubConfigProviderTest.java
@@ -70,6 +70,8 @@ class KafkaDatahubConfigProviderTest {
                 Arguments.of("7.0.2", cdhParcelVersion("7.0.2", 2), CONFIG_WITH_RANGER),
                 Arguments.of("7.0.2", cdhParcelVersion("7.0.2", 3), CONFIG_WITH_RANGER),
                 Arguments.of("7.0.2", "irregularCdhVersion-123", CONFIG_WITHOUT_RANGER),
+                Arguments.of("7.0.3", cdhParcelVersion("7.0.2", 0), CONFIG_WITHOUT_RANGER),
+                Arguments.of("7.0.3", cdhParcelVersion("7.0.2", 3), CONFIG_WITHOUT_RANGER),
                 Arguments.of("7.1.0", cdhParcelVersion("7.1.0", 0), CONFIG_WITH_RANGER));
     }
 


### PR DESCRIPTION
Adjusted Kafka Config providers for the 7.0.3 release. Although this release has higher version number than 7.0.2.2 it yet contains older code and accepts the same configuration as the 7.0.2 version.

Changed `KafkaAuthConfigProvider` and `KafkaDatahubConfigProvider`.

Testing: 
* adjusted Kafka config provider tests.
* tested manual cluster installation with 7.0.2.2 and 7.0.2.

Closes CB-4874