### PR TITLE
CB-4899 OpDB 7.0.2 blueprint overcommits memory

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-opdb-702.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-opdb-702.bp
@@ -48,6 +48,12 @@
           {
             "refName": "hdfs-DATANODE-BASE",
             "roleType": "DATANODE",
+            "configs": [
+              {
+                "name": "dfs_datanode_max_locked_memory",
+                "value": "2147483648"
+              }
+            ],
             "base": true
           },
           {
@@ -99,7 +105,7 @@
             "configs": [
               {
                 "name": "hbase_regionserver_java_heapsize",
-                "value": "17179869184"
+                "value": "8589934592"
               },
               {
                 "name": "hbase_bucketcache_ioengine",
@@ -115,7 +121,7 @@
               },
               {
                 "name": "hbase_bucketcache_size",
-                "value": "12288"
+                "value": "9216"
               },
               {
                 "name": "hbase_regionserver_handler_count",


### PR DESCRIPTION
reduce memory allocations to conform to the (overly conservative) CM limit in worker node

Testing done:
use modified blueprint to build DatHub cluster
check that CM doesn't display a warning

Closes #CB-4899