### PR TITLE
CB-4942 Knox - Increase connection and read timeout values for Impala

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
@@ -347,6 +347,14 @@
         {% for hostloc in salt['pillar.get']('gateway:location')['IMPALAD'] -%}
         <url>{{ protocol }}://{{ hostloc }}:{{ ports['IMPALA'] }}</url>
         {%- endfor %}
+        <param>
+            <name>httpclient.connectionTimeout</name>
+            <value>5m</value>
+        </param>
+        <param>
+            <name>httpclient.socketTimeout</name>
+            <value>5m</value>
+        </param>
     </service>
     {%- endif %}
     {%- endif %}


### PR DESCRIPTION
Increase the connection/read timeout from 20s to 5m for Impala Hiveserver2