### PR TITLE
CB-4951 CreateTable is missing from DynamoDB policy

### DIFF
--- a/cloud-aws/src/main/resources/definitions/cdp/aws-cdp-dynamodb-policy.json
+++ b/cloud-aws/src/main/resources/definitions/cdp/aws-cdp-dynamodb-policy.json
@@ -16,6 +16,7 @@
       "Action": [
         "dynamodb:BatchGetItem",
         "dynamodb:BatchWriteItem",
+        "dynamodb:CreateTable",
         "dynamodb:DeleteItem",
         "dynamodb:DescribeTable",
         "dynamodb:GetItem",


### PR DESCRIPTION
CB-3513 mistakenly removed the CreateTable
permission from the DynamoDB policy. This
puts back the missing permission so S3Guard
works as expected to create the table.