### PR TITLE
CB-4915 update AWS default zone provider defaults to Virginia us-east-1

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsClient.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsClient.java
@@ -140,6 +140,7 @@ public class AwsClient {
         return AmazonS3ClientBuilder.standard()
                 .withCredentials(getCredentialProvider(awsCredential))
                 .withRegion(awsDefaultZoneProvider.getDefaultZone(awsCredential))
+                .withForceGlobalBucketAccessEnabled(Boolean.TRUE)
                 .build();
     }
 

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsDefaultZoneProvider.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsDefaultZoneProvider.java
@@ -9,7 +9,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 @Service
 public class AwsDefaultZoneProvider {
 
-    @Value("${cb.aws.zone.parameter.default:eu-west-1}")
+    @Value("${cb.aws.zone.parameter.default:us-east-1}")
     private String awsZoneParameterDefault;
 
     @Value("${cb.aws.gov.zone.parameter.default:us-gov-west-1}")


### PR DESCRIPTION
This reverts commit bf0fd882324bc61fe174db775bee888fe54c63a6.

**Changes:**
 - Set `us-east-1` as default region for AWS clients
 - Workaround for cross-origin behaviour of AWS S3 client: https://github.com/aws/aws-sdk-java/issues/1451#issuecomment-360281381 