### PR TITLE
CB-4967 added 2 unit tests for cb and freeipa to verify all salt files

### DIFF
--- a/freeipa/build.gradle
+++ b/freeipa/build.gradle
@@ -103,6 +103,7 @@ dependencies {
   runtime project(':cloud-aws')
   runtime project(':cloud-mock')
   runtime project(':cloud-azure')
+  testCompile group: 'com.hubspot.jinjava', name: 'jinjava', version: jinjavaVersion
 }
 
 bootRun {

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/FreeipaJinjaTester.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/FreeipaJinjaTester.java
@@ -1,0 +1,59 @@
+package com.sequenceiq.freeipa;
+
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.DirectoryFileFilter;
+import org.apache.commons.io.filefilter.RegexFileFilter;
+import org.junit.Test;
+import org.springframework.core.io.ClassPathResource;
+
+import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateError;
+import com.sequenceiq.cloudbreak.util.FileReaderUtils;
+
+public class FreeipaJinjaTester {
+
+    @Test
+    public void verifyFreeipaSaltFilesFiles() throws IOException {
+        Collection<File> files = collectAllSlsFiles("freeipa-salt");
+        assertTrue("At least one sls file should be verified", files.size() > 0);
+        for (File slsFile : files) {
+            verifySingleSaltFile(slsFile.toPath());
+        }
+    }
+
+    private Collection<File> collectAllSlsFiles(String salt) throws IOException {
+        File file = new ClassPathResource(salt).getFile();
+        return FileUtils.listFiles(
+                file,
+                new RegexFileFilter("^(.*.sls)"),
+                DirectoryFileFilter.DIRECTORY
+        );
+    }
+
+    private void verifySingleSaltFile(Path path) throws IOException {
+        String file = FileReaderUtils.readFileFromPath(path);
+        Jinjava jinjava = new Jinjava();
+        JinjavaInterpreter interpreter = jinjava.newInterpreter();
+        interpreter.parse(file);
+        List<TemplateError> errors = interpreter.getErrors();
+        if (!errors.isEmpty()) {
+            StringBuilder errorMsg = new StringBuilder();
+            errorMsg.append("Jinja validation failed for sls file: " + path);
+            errorMsg.append("\n");
+            errors.forEach(error -> errorMsg.append(error));
+            fail(errorMsg.toString());
+        }
+    }
+
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -56,6 +56,7 @@ dnsjavaVersion=2.1.7
 snakeYamlVersion=1.23
 okhttpVersion=3.12.2
 cdpSdkVersion=0.9.5
+jinjavaVersion=2.5.2
 
 repoUrl=http://repo.hortonworks.com/content/repositories/releases/
 cdpRepoUrl=https://repository.cloudera.com/artifactory/cloudera-repos/

--- a/orchestrator-salt/build.gradle
+++ b/orchestrator-salt/build.gradle
@@ -38,4 +38,6 @@ dependencies {
     testCompile (group: 'junit',                    name: 'junit',                          version: junitVersion) {
         exclude group: 'org.hamcrest'
     }
+
+    testCompile group: 'com.hubspot.jinjava', name: 'jinjava', version: jinjavaVersion
 }

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/CbJinjaTester.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/CbJinjaTester.java
@@ -1,0 +1,65 @@
+package com.sequenceiq.cloudbreak.orchestrator.salt;
+
+
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.DirectoryFileFilter;
+import org.apache.commons.io.filefilter.RegexFileFilter;
+import org.junit.Test;
+import org.springframework.core.io.ClassPathResource;
+
+import com.hubspot.jinjava.Jinjava;
+import com.hubspot.jinjava.interpret.JinjavaInterpreter;
+import com.hubspot.jinjava.interpret.TemplateError;
+import com.sequenceiq.cloudbreak.util.FileReaderUtils;
+
+public class CbJinjaTester {
+
+    @Test
+    public void verifyCbSaltFilesFiles() throws IOException {
+        Collection<File> files = collectAllSlsFiles("salt");
+        for (File slsFile : files) {
+            verifySingleSaltFile(slsFile.toPath());
+        }
+    }
+
+    @Test
+    public void verifyCbSaltCommonFilesFiles() throws IOException {
+        Collection<File> files = collectAllSlsFiles("salt-common");
+        for (File slsFile : files) {
+            verifySingleSaltFile(slsFile.toPath());
+        }
+    }
+
+    private Collection<File> collectAllSlsFiles(String salt) throws IOException {
+        File file = new ClassPathResource(salt).getFile();
+        return FileUtils.listFiles(
+                file,
+                new RegexFileFilter("^(.*.sls)"),
+                DirectoryFileFilter.DIRECTORY
+        );
+    }
+
+    private void verifySingleSaltFile(Path path) throws IOException {
+        String file = FileReaderUtils.readFileFromPath(path);
+        Jinjava jinjava = new Jinjava();
+        JinjavaInterpreter interpreter = jinjava.newInterpreter();
+        interpreter.parse(file);
+        List<TemplateError> errors = interpreter.getErrors();
+        if (!errors.isEmpty()) {
+            StringBuilder errorMsg = new StringBuilder();
+            errorMsg.append("Jinja validation failed for sls file: " + path);
+            errorMsg.append("\n");
+            errors.forEach(error -> errorMsg.append(error));
+            fail(errorMsg.toString());
+        }
+    }
+
+}


### PR DESCRIPTION
- should check all sls files in cb and freeipa modules
Error message example:
`java.lang.AssertionError: Jinja validation failed for sls file: .../orchestrator-salt/out/production/resources/salt/salt/docker/init.sls
TemplateError{severity=FATAL, reason=SYNTAX_ERROR, item=OTHER, message='Syntax error in '{% easdasdndif %}': Unknown tag: easdasdndif', fieldName='easdasdndif', lineno=13, startPosition=1, scopeDepth=1, category=UNKNOWN, categoryErrors=null}TemplateError{severity=FATAL, reason=SYNTAX_ERROR, item=OTHER, message='Syntax error in '{% if salt['pillar.get']('docker:enableContainerExecutor') %}': Missing end tag: endif for tag defined as: {% if salt['pillar.get']('docker:enableContainerExecutor') %}', fieldName='{% if salt['pillar.get']('docker:enableContainerExecutor') %}', lineno=1, startPosition=1, scopeDepth=1, category=UNKNOWN, categoryErrors=null}
`
or
`java.lang.AssertionError: Jinja validation failed for sls file: .../orchestrator-salt/out/production/resources/salt/salt/docker/init.sls
TemplateError{severity=WARNING, reason=SYNTAX_ERROR, item=TAG, message='Missing start tag', fieldName='endif', lineno=13, startPosition=1, scopeDepth=1, category=UNKNOWN, categoryErrors=null}
`