### PR TITLE
CB-4957 Can't perform Data Lake OS Upgrade if Data Hub added to the environment

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/UpgradeOptionV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/UpgradeOptionV4Response.java
@@ -6,6 +6,8 @@ public class UpgradeOptionV4Response {
 
     private ImageInfoV4Response upgrade;
 
+    private String reason;
+
     public UpgradeOptionV4Response() {
     }
 
@@ -23,5 +25,13 @@ public class UpgradeOptionV4Response {
 
     public void setUpgrade(ImageInfoV4Response upgrade) {
         this.upgrade = upgrade;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/UpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/UpgradeService.java
@@ -126,35 +126,34 @@ public class UpgradeService {
     private UpgradeOptionV4Response getUpgradeOption(Stack stack, Long workspaceId, User user)
             throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
         Image image = componentConfigProviderService.getImage(stack.getId());
-        if (clusterService.repairSupported(stack) && attachedClustersStoppedOrDeleted(stack)) {
+        UpgradeOptionV4Response upgradeResponse;
+        if (clusterService.repairSupported(stack)) {
             StatedImage latestImage = getLatestImage(workspaceId, stack, image, user);
             if (!Objects.equals(image.getImageId(), latestImage.getImage().getUuid())) {
-                return upgradeable(image, latestImage, stack);
+                if (attachedClustersStoppedOrDeleted(stack)) {
+                    upgradeResponse = upgradeable(image, latestImage, stack);
+                } else {
+                    upgradeResponse = upgradeableAfterAction(image, latestImage, stack, "Please stop connected DataHub clusters before upgrade.");
+                }
             } else {
-                return notUpgradable(image);
+                upgradeResponse = notUpgradable(image);
             }
         } else {
-            return notUpgradable(image);
+            upgradeResponse = notUpgradable(image);
         }
+        return upgradeResponse;
     }
 
     private boolean attachedClustersStoppedOrDeleted(Stack stack) {
         StackViewV4Responses stackViewV4Responses = distroXV1Endpoint.list(null, stack.getEnvironmentCrn());
         for (StackViewV4Response stackViewV4Response : stackViewV4Responses.getResponses()) {
-            if (!(UPGRADEABLE_ATTACHED_DISTRO_X_STATES.contains(stack.getStatus())
-                    || UPGRADEABLE_ATTACHED_DISTRO_X_STATES.contains(getClusterStatus(stackViewV4Response)))) {
+            if (!UPGRADEABLE_ATTACHED_DISTRO_X_STATES.contains(stackViewV4Response.getStatus())
+                    || (stackViewV4Response.getCluster() != null
+                    && !UPGRADEABLE_ATTACHED_DISTRO_X_STATES.contains(stackViewV4Response.getCluster().getStatus()))) {
                 return false;
             }
         }
         return true;
-    }
-
-    private Status getClusterStatus(StackViewV4Response stack) {
-        if (stack.getCluster() == null) {
-            return null;
-        } else {
-            return stack.getCluster().getStatus();
-        }
     }
 
     private StatedImage getLatestImage(Long workspaceId, Stack stack, Image image, User user)
@@ -190,7 +189,24 @@ public class UpgradeService {
         return response;
     }
 
+    private UpgradeOptionV4Response upgradeableAfterAction(Image image, StatedImage latestImage, Stack stack, String reason)
+            throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
+        UpgradeOptionV4Response response = notUpgradable(image, reason);
+        ImageInfoV4Response upgradeImageInfo = new ImageInfoV4Response(
+                latestImage.getImage().getImageSetsByProvider().get(stack.getPlatformVariant().toLowerCase()).get(stack.getRegion()),
+                latestImage.getImage().getUuid(),
+                latestImage.getImageCatalogName(),
+                latestImage.getImage().getCreated()
+        );
+        response.setUpgrade(upgradeImageInfo);
+        return response;
+    }
+
     private UpgradeOptionV4Response notUpgradable(Image image) throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
+        return notUpgradable(image, null);
+    }
+
+    private UpgradeOptionV4Response notUpgradable(Image image, String reason) throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
         ImageInfoV4Response currentImageInfo = new ImageInfoV4Response(
                 image.getImageName(),
                 image.getImageId(),
@@ -198,6 +214,7 @@ public class UpgradeService {
                 imageCatalogService.getImage(image.getImageCatalogUrl(), image.getImageCatalogName(), image.getImageId()).getImage().getCreated());
         UpgradeOptionV4Response upgradeOptionV4Response = new UpgradeOptionV4Response();
         upgradeOptionV4Response.setCurrent(currentImageInfo);
+        upgradeOptionV4Response.setReason(reason);
         return upgradeOptionV4Response;
     }
 


### PR DESCRIPTION
Return reason when upgrade is allowed after datahub cluster stop.

__Note:__
Frontend change is necessary for this change to work properly.