### PR TITLE
CB-4530 CB should use the dedicated property for configuring Hue's kn…

### DIFF
--- a/cloud-aws/src/main/resources/templates/aws-cf-dbstack.ftl
+++ b/cloud-aws/src/main/resources/templates/aws-cf-dbstack.ftl
@@ -109,6 +109,12 @@
       "Type" : "String",
       "MinLength": "1",
       "MaxLength": "200"
+    },
+    "stackowner" : {
+        "Description" : "The instances will have this parameter as an owner tag.",
+        "Type" : "String",
+        "MinLength": "1",
+        "MaxLength": "200"
     }
   },
 
@@ -145,7 +151,8 @@
               "Tags" : [
                     { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
                     { "Key" : "cb-resource-type", "Value" : "${database_resource}" },
-                    { "Key" : "owner", "Value" : { "Ref" : "StackOwner" } }
+                    { "Key" : "owner", "Value" : { "Ref" : "stackowner" } },
+                    { "Key" : "Owner", "Value" : { "Ref" : "StackOwner" } }
               ],
               "VpcId" : { "Ref": "VPCIdParameter" }
             }
@@ -160,7 +167,8 @@
                 "Tags": [
                     { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
                     { "Key" : "cb-resource-type", "Value" : "${database_resource}" },
-                    { "Key" : "owner", "Value" : { "Ref" : "StackOwner" } }
+                    { "Key" : "owner", "Value" : { "Ref" : "stackowner" } },
+                    { "Key" : "Owner", "Value" : { "Ref" : "StackOwner" } }
                 ]
             }
         },
@@ -185,7 +193,8 @@
                 "Tags": [
                     { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
                     { "Key" : "cb-resource-type", "Value" : "${database_resource}" },
-                    { "Key" : "owner", "Value" : { "Ref" : "StackOwner" } }
+                    { "Key" : "owner", "Value" : { "Ref" : "stackowner" } },
+                    { "Key" : "Owner", "Value" : { "Ref" : "StackOwner" } }
                 ],
                 <#if hasSecurityGroup>
                 "VPCSecurityGroups": { "Ref": "VPCSecurityGroupsParameter" }

--- a/cloud-aws/src/main/resources/templates/aws-cf-network.ftl
+++ b/cloud-aws/src/main/resources/templates/aws-cf-network.ftl
@@ -4,6 +4,21 @@
 
   "Description" : "Deploys a Cloudera Data Platform VPC on AWS.",
 
+  "Parameters" : {
+    "StackOwner" : {
+        "Description" : "The instances will have this parameter as an Owner tag.",
+        "Type" : "String",
+        "MinLength": "1",
+        "MaxLength": "200"
+    },
+    "stackowner" : {
+        "Description" : "The instances will have this parameter as an owner tag.",
+        "Type" : "String",
+        "MinLength": "1",
+        "MaxLength": "200"
+    }
+  },
+
   "Resources" : {
 
     "VPC" : {
@@ -15,7 +30,9 @@
         "Tags" : [
           { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
           { "Key" : "Network", "Value" : "Public" },
-          { "Key" : "cb-resource-type", "Value" : "${network_resource}" }
+          { "Key" : "cb-resource-type", "Value" : "${network_resource}" },
+          { "Key" : "owner", "Value" : { "Ref" : "stackowner" } },
+          { "Key" : "Owner", "Value" : { "Ref" : "StackOwner" } }
         ]
       }
     },
@@ -25,7 +42,9 @@
         "Tags" : [
           { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
           { "Key" : "Network", "Value" : "Public" },
-          { "Key" : "cb-resource-type", "Value" : "${network_resource}" }
+          { "Key" : "cb-resource-type", "Value" : "${network_resource}" },
+          { "Key" : "owner", "Value" : { "Ref" : "stackowner" } },
+          { "Key" : "Owner", "Value" : { "Ref" : "StackOwner" } }
         ]
       }
     },
@@ -49,7 +68,9 @@
           { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
           { "Key" : "Network", "Value" : "Public" },
           { "Key" : "cb-resource-type", "Value" : "${network_resource}" },
-          { "Key" : "kubernetes.io/role/elb", "Value" : "1" }
+          { "Key" : "kubernetes.io/role/elb", "Value" : "1" },
+          { "Key" : "owner", "Value" : { "Ref" : "stackowner" } },
+          { "Key" : "Owner", "Value" : { "Ref" : "StackOwner" } }
         ]
       }
     },
@@ -65,7 +86,9 @@
           { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
           { "Key" : "Network", "Value" : "Private" },
           { "Key" : "cb-resource-type", "Value" : "${network_resource}" },
-          { "Key" : "kubernetes.io/role/elb", "Value" : "1" }
+          { "Key" : "kubernetes.io/role/elb", "Value" : "1" },
+          { "Key" : "owner", "Value" : { "Ref" : "stackowner" } },
+          { "Key" : "Owner", "Value" : { "Ref" : "StackOwner" } }
         ]
       }
     },
@@ -90,7 +113,9 @@
         "Tags" : [
           { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
           { "Key" : "Network", "Value" : "Private" },
-          { "Key" : "cb-resource-type", "Value" : "${network_resource}" }
+          { "Key" : "cb-resource-type", "Value" : "${network_resource}" },
+          { "Key" : "owner", "Value" : { "Ref" : "stackowner" } },
+          { "Key" : "Owner", "Value" : { "Ref" : "StackOwner" } }
         ]
       }
     },
@@ -127,7 +152,9 @@
         "Tags" : [
           { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
           { "Key" : "Network", "Value" : "Public" },
-          { "Key" : "cb-resource-type", "Value" : "${network_resource}" }
+          { "Key" : "cb-resource-type", "Value" : "${network_resource}" },
+          { "Key" : "owner", "Value" : { "Ref" : "stackowner" } },
+          { "Key" : "Owner", "Value" : { "Ref" : "StackOwner" } }
         ]
       }
     },

--- a/cloud-aws/src/main/resources/templates/aws-cf-stack.ftl
+++ b/cloud-aws/src/main/resources/templates/aws-cf-stack.ftl
@@ -67,6 +67,13 @@
       "MaxLength": "50"
     },
 
+    "stackowner" : {
+       "Description" : "The instances will have this parameter as an owner tag.",
+       "Type" : "String",
+       "MinLength": "1",
+       "MaxLength": "200"
+    },
+
     "CBUserData" : {
       "Description" : "User data to be executed",
       "Type" : "String",
@@ -186,6 +193,8 @@
         "Tags" : [
           { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
           { "Key" : "Network", "Value" : "Public" },
+          { "Key" : "owner", "Value" : { "Ref" : "stackowner" }},
+          { "Key" : "Owner", "Value" : { "Ref" : "StackOwner" }},
           { "Key" : "cb-resource-type", "Value" : "${network_resource}" }
         ]
       }
@@ -210,6 +219,8 @@
         "Tags" : [
           { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
           { "Key" : "Network", "Value" : "Public" },
+          { "Key" : "owner", "Value" : { "Ref" : "stackowner" }},
+          { "Key" : "Owner", "Value" : { "Ref" : "StackOwner" }},
           { "Key" : "cb-resource-type", "Value" : "${network_resource}" }
         ]
       }
@@ -223,6 +234,8 @@
         "Tags" : [
           { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
           { "Key" : "Network", "Value" : "Public" },
+          { "Key" : "owner", "Value" : { "Ref" : "stackowner" }},
+          { "Key" : "Owner", "Value" : { "Ref" : "StackOwner" }},
           { "Key" : "cb-resource-type", "Value" : "${network_resource}" }
         ]
       }
@@ -252,6 +265,8 @@
         "Tags" : [
           { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
           { "Key" : "Network", "Value" : "Public" },
+          { "Key" : "owner", "Value" : { "Ref" : "stackowner" }},
+          { "Key" : "Owner", "Value" : { "Ref" : "StackOwner" }},
           { "Key" : "cb-resource-type", "Value" : "${network_resource}" }
         ]
       }
@@ -306,7 +321,8 @@
         "MaxSize" : ${group.instanceCount},
         "DesiredCapacity" : ${group.instanceCount},
         "Tags" : [ { "Key" : "Name", "Value" : { "Fn::Join" : ["-", [ { "Ref" : "StackName" }, "${group.groupName}"]] }, "PropagateAtLaunch" : "true" },
-        		   { "Key" : "owner", "Value" : { "Ref" : "StackOwner" }, "PropagateAtLaunch" : "true" },
+        		   { "Key" : "owner", "Value" : { "Ref" : "stackowner" }, "PropagateAtLaunch" : "true" },
+        		   { "Key" : "Owner", "Value" : { "Ref" : "StackOwner" }, "PropagateAtLaunch" : "true" },
         		   { "Key" : "cb-resource-type", "Value" : "${instance_resource}", "PropagateAtLaunch" : "true" },
         		   { "Key" : "instanceGroup", "Value" : "${group.groupName}", "PropagateAtLaunch" : "true" }]
       }
@@ -379,7 +395,11 @@
       "Type" : "AWS::EC2::SecurityGroup",
       "Properties" : {
         "GroupDescription" : "Allow access from web and bastion as well as outbound HTTP and HTTPS traffic",
-        "Tags" : [{ "Key" : "cb-resource-type", "Value" : "${securitygroup_resource}"}],
+        "Tags" : [
+            { "Key" : "cb-resource-type", "Value" : "${securitygroup_resource}" },
+            { "Key" : "owner", "Value" : { "Ref" : "stackowner" }},
+            { "Key" : "Owner", "Value" : { "Ref" : "StackOwner" }}
+        ],
         <#if existingVPC>
         "VpcId" : { "Ref" : "VPCId" },
         <#else>

--- a/cloud-aws/src/test/resources/json/aws-cf-network-private-subnet.json
+++ b/cloud-aws/src/test/resources/json/aws-cf-network-private-subnet.json
@@ -1,447 +1,572 @@
 {
-    "AWSTemplateFormatVersion":"2010-09-09",
-    "Description":"Deploys a Cloudera Data Platform VPC on AWS.",
-    "Resources":{
-        "VPC":{
-            "Type":"AWS::EC2::VPC",
-            "Properties":{
-                "CidrBlock":"0.0.0.0/16",
-                "EnableDnsSupport":"true",
-                "EnableDnsHostnames":"true",
-                "Tags":[
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Deploys a Cloudera Data Platform VPC on AWS.",
+    "Parameters": {
+        "StackOwner": {
+            "Description": "The instances will have this parameter as an Owner tag.",
+            "Type": "String",
+            "MinLength": "1",
+            "MaxLength": "200"
+        },
+        "stackowner": {
+            "Description": "The instances will have this parameter as an owner tag.",
+            "Type": "String",
+            "MinLength": "1",
+            "MaxLength": "200"
+        }
+    },
+    "Resources": {
+        "VPC": {
+            "Type": "AWS::EC2::VPC",
+            "Properties": {
+                "CidrBlock": "0.0.0.0/16",
+                "EnableDnsSupport": "true",
+                "EnableDnsHostnames": "true",
+                "Tags": [
                     {
-                        "Key":"Application",
-                        "Value":{
-                            "Ref":"AWS::StackId"
+                        "Key": "Application",
+                        "Value": {
+                            "Ref": "AWS::StackId"
                         }
                     },
                     {
-                        "Key":"Network",
-                        "Value":"Public"
+                        "Key": "Network",
+                        "Value": "Public"
                     },
                     {
-                        "Key":"cb-resource-type",
-                        "Value":"NETWORK"
+                        "Key": "cb-resource-type",
+                        "Value": "NETWORK"
+                    },
+                    {
+                        "Key": "owner",
+                        "Value": {
+                            "Ref": "stackowner"
+                        }
+                    },
+                    {
+                        "Key": "Owner",
+                        "Value": {
+                            "Ref": "StackOwner"
+                        }
                     }
                 ]
             }
         },
-        "InternetGateway":{
-            "Type":"AWS::EC2::InternetGateway",
-            "Properties":{
-                "Tags":[
+        "InternetGateway": {
+            "Type": "AWS::EC2::InternetGateway",
+            "Properties": {
+                "Tags": [
                     {
-                        "Key":"Application",
-                        "Value":{
-                            "Ref":"AWS::StackId"
+                        "Key": "Application",
+                        "Value": {
+                            "Ref": "AWS::StackId"
                         }
                     },
                     {
-                        "Key":"Network",
-                        "Value":"Public"
+                        "Key": "Network",
+                        "Value": "Public"
                     },
                     {
-                        "Key":"cb-resource-type",
-                        "Value":"NETWORK"
+                        "Key": "cb-resource-type",
+                        "Value": "NETWORK"
+                    },
+                    {
+                        "Key": "owner",
+                        "Value": {
+                            "Ref": "stackowner"
+                        }
+                    },
+                    {
+                        "Key": "Owner",
+                        "Value": {
+                            "Ref": "StackOwner"
+                        }
                     }
                 ]
             }
         },
-        "AttachGateway":{
-            "Type":"AWS::EC2::VPCGatewayAttachment",
-            "Properties":{
-                "VpcId":{
-                    "Ref":"VPC"
+        "AttachGateway": {
+            "Type": "AWS::EC2::VPCGatewayAttachment",
+            "Properties": {
+                "VpcId": {
+                    "Ref": "VPC"
                 },
-                "InternetGatewayId":{
-                    "Ref":"InternetGateway"
+                "InternetGatewayId": {
+                    "Ref": "InternetGateway"
                 }
             }
         },
-        "PublicSubnet0":{
-            "Type":"AWS::EC2::Subnet",
-            "Properties":{
-                "MapPublicIpOnLaunch":"true",
-                "CidrBlock":"2.2.2.2/24",
-                "VpcId":{
-                    "Ref":"VPC"
+        "PublicSubnet0": {
+            "Type": "AWS::EC2::Subnet",
+            "Properties": {
+                "MapPublicIpOnLaunch": "true",
+                "CidrBlock": "2.2.2.2/24",
+                "VpcId": {
+                    "Ref": "VPC"
                 },
-                "AvailabilityZone":"az1",
-                "Tags":[
+                "AvailabilityZone": "az1",
+                "Tags": [
                     {
-                        "Key":"Application",
-                        "Value":{
-                            "Ref":"AWS::StackId"
+                        "Key": "Application",
+                        "Value": {
+                            "Ref": "AWS::StackId"
                         }
                     },
                     {
-                        "Key":"Network",
-                        "Value":"Public"
+                        "Key": "Network",
+                        "Value": "Public"
                     },
                     {
-                        "Key":"cb-resource-type",
-                        "Value":"NETWORK"
+                        "Key": "cb-resource-type",
+                        "Value": "NETWORK"
                     },
                     {
-                        "Key":"kubernetes.io/role/elb",
-                        "Value":"1"
+                        "Key": "kubernetes.io/role/elb",
+                        "Value": "1"
+                    },
+                    {
+                        "Key": "owner",
+                        "Value": {
+                            "Ref": "stackowner"
+                        }
+                    },
+                    {
+                        "Key": "Owner",
+                        "Value": {
+                            "Ref": "StackOwner"
+                        }
                     }
                 ]
             }
         },
-        "PrivateSubnet0":{
-            "Type":"AWS::EC2::Subnet",
-            "Properties":{
-                "MapPublicIpOnLaunch":"false",
-                "CidrBlock":"2.2.2.2/24",
-                "VpcId":{
-                    "Ref":"VPC"
+        "PrivateSubnet0": {
+            "Type": "AWS::EC2::Subnet",
+            "Properties": {
+                "MapPublicIpOnLaunch": "false",
+                "CidrBlock": "2.2.2.2/24",
+                "VpcId": {
+                    "Ref": "VPC"
                 },
-                "AvailabilityZone":"az1",
-                "Tags":[
+                "AvailabilityZone": "az1",
+                "Tags": [
                     {
-                        "Key":"Application",
-                        "Value":{
-                            "Ref":"AWS::StackId"
+                        "Key": "Application",
+                        "Value": {
+                            "Ref": "AWS::StackId"
                         }
                     },
                     {
-                        "Key":"Network",
-                        "Value":"Private"
+                        "Key": "Network",
+                        "Value": "Private"
                     },
                     {
-                        "Key":"cb-resource-type",
-                        "Value":"NETWORK"
+                        "Key": "cb-resource-type",
+                        "Value": "NETWORK"
                     },
                     {
-                        "Key":"kubernetes.io/role/elb",
-                        "Value":"1"
+                        "Key": "kubernetes.io/role/elb",
+                        "Value": "1"
+                    },
+                    {
+                        "Key": "owner",
+                        "Value": {
+                            "Ref": "stackowner"
+                        }
+                    },
+                    {
+                        "Key": "Owner",
+                        "Value": {
+                            "Ref": "StackOwner"
+                        }
                     }
                 ]
             }
         },
-        "NatGateway0EIP":{
-            "Type":"AWS::EC2::EIP",
-            "DependsOn":"AttachGateway",
-            "Properties":{
-                "Domain":{
-                    "Ref":"VPC"
+        "NatGateway0EIP": {
+            "Type": "AWS::EC2::EIP",
+            "DependsOn": "AttachGateway",
+            "Properties": {
+                "Domain": {
+                    "Ref": "VPC"
                 }
             }
         },
-        "NatGateway0":{
-            "Type":"AWS::EC2::NatGateway",
-            "Properties":{
-                "AllocationId":{
-                    "Fn::GetAtt":[ "NatGateway0EIP", "AllocationId" ]
+        "NatGateway0": {
+            "Type": "AWS::EC2::NatGateway",
+            "Properties": {
+                "AllocationId": {
+                    "Fn::GetAtt": [
+                        "NatGateway0EIP",
+                        "AllocationId"
+                    ]
                 },
-                "SubnetId":{
-                    "Ref":"PublicSubnet0"
+                "SubnetId": {
+                    "Ref": "PublicSubnet0"
                 }
             }
         },
-        "PrivateRouteTable0":{
-            "Type":"AWS::EC2::RouteTable",
-            "Properties":{
-                "VpcId":{
-                    "Ref":"VPC"
+        "PrivateRouteTable0": {
+            "Type": "AWS::EC2::RouteTable",
+            "Properties": {
+                "VpcId": {
+                    "Ref": "VPC"
                 },
-                "Tags":[
+                "Tags": [
                     {
-                        "Key":"Application",
-                        "Value":{
-                            "Ref":"AWS::StackId"
+                        "Key": "Application",
+                        "Value": {
+                            "Ref": "AWS::StackId"
                         }
                     },
                     {
-                        "Key":"Network",
-                        "Value":"Private"
+                        "Key": "Network",
+                        "Value": "Private"
                     },
                     {
-                        "Key":"cb-resource-type",
-                        "Value":"NETWORK"
+                        "Key": "cb-resource-type",
+                        "Value": "NETWORK"
+                    },
+                    {
+                        "Key": "owner",
+                        "Value": {
+                            "Ref": "stackowner"
+                        }
+                    },
+                    {
+                        "Key": "Owner",
+                        "Value": {
+                            "Ref": "StackOwner"
+                        }
                     }
                 ]
             }
         },
-        "PrivateSubnetRouteTableAssociation0":{
-            "Type":"AWS::EC2::SubnetRouteTableAssociation",
-            "Properties":{
-                "SubnetId":{
-                    "Ref":"PrivateSubnet0"
+        "PrivateSubnetRouteTableAssociation0": {
+            "Type": "AWS::EC2::SubnetRouteTableAssociation",
+            "Properties": {
+                "SubnetId": {
+                    "Ref": "PrivateSubnet0"
                 },
-                "RouteTableId":{
-                    "Ref":"PrivateRouteTable0"
+                "RouteTableId": {
+                    "Ref": "PrivateRouteTable0"
                 }
             }
         },
-        "PrivateRoute0":{
-            "Type":"AWS::EC2::Route",
-            "DependsOn":[
+        "PrivateRoute0": {
+            "Type": "AWS::EC2::Route",
+            "DependsOn": [
                 "PrivateRouteTable0",
                 "AttachGateway"
             ],
-            "Properties":{
-                "DestinationCidrBlock":"0.0.0.0/0",
-                "RouteTableId":{
-                    "Ref":"PrivateRouteTable0"
+            "Properties": {
+                "DestinationCidrBlock": "0.0.0.0/0",
+                "RouteTableId": {
+                    "Ref": "PrivateRouteTable0"
                 },
-                "NatGatewayId":{
-                    "Ref":"NatGateway0"
+                "NatGatewayId": {
+                    "Ref": "NatGateway0"
                 }
             }
         },
-        "PublicSubnetRouteTableAssociation0":{
-            "Type":"AWS::EC2::SubnetRouteTableAssociation",
-            "Properties":{
-                "SubnetId":{
-                    "Ref":"PublicSubnet0"
+        "PublicSubnetRouteTableAssociation0": {
+            "Type": "AWS::EC2::SubnetRouteTableAssociation",
+            "Properties": {
+                "SubnetId": {
+                    "Ref": "PublicSubnet0"
                 },
-                "RouteTableId":{
-                    "Ref":"PublicRouteTable"
+                "RouteTableId": {
+                    "Ref": "PublicRouteTable"
                 }
             }
         },
-        "PublicSubnet1":{
-            "Type":"AWS::EC2::Subnet",
-            "Properties":{
-                "MapPublicIpOnLaunch":"true",
-                "CidrBlock":"2.2.2.2/24",
-                "VpcId":{
-                    "Ref":"VPC"
+        "PublicSubnet1": {
+            "Type": "AWS::EC2::Subnet",
+            "Properties": {
+                "MapPublicIpOnLaunch": "true",
+                "CidrBlock": "2.2.2.2/24",
+                "VpcId": {
+                    "Ref": "VPC"
                 },
-                "AvailabilityZone":"az2",
-                "Tags":[
+                "AvailabilityZone": "az2",
+                "Tags": [
                     {
-                        "Key":"Application",
-                        "Value":{
-                            "Ref":"AWS::StackId"
+                        "Key": "Application",
+                        "Value": {
+                            "Ref": "AWS::StackId"
                         }
                     },
                     {
-                        "Key":"Network",
-                        "Value":"Public"
+                        "Key": "Network",
+                        "Value": "Public"
                     },
                     {
-                        "Key":"cb-resource-type",
-                        "Value":"NETWORK"
+                        "Key": "cb-resource-type",
+                        "Value": "NETWORK"
                     },
                     {
-                        "Key":"kubernetes.io/role/elb",
-                        "Value":"1"
+                        "Key": "kubernetes.io/role/elb",
+                        "Value": "1"
+                    },
+                    {
+                        "Key": "owner",
+                        "Value": {
+                            "Ref": "stackowner"
+                        }
+                    },
+                    {
+                        "Key": "Owner",
+                        "Value": {
+                            "Ref": "StackOwner"
+                        }
                     }
                 ]
             }
         },
-        "PrivateSubnet1":{
-            "Type":"AWS::EC2::Subnet",
-            "Properties":{
-                "MapPublicIpOnLaunch":"false",
-                "CidrBlock":"2.2.2.2/24",
-                "VpcId":{
-                    "Ref":"VPC"
+        "PrivateSubnet1": {
+            "Type": "AWS::EC2::Subnet",
+            "Properties": {
+                "MapPublicIpOnLaunch": "false",
+                "CidrBlock": "2.2.2.2/24",
+                "VpcId": {
+                    "Ref": "VPC"
                 },
-                "AvailabilityZone":"az2",
-                "Tags":[
+                "AvailabilityZone": "az2",
+                "Tags": [
                     {
-                        "Key":"Application",
-                        "Value":{
-                            "Ref":"AWS::StackId"
+                        "Key": "Application",
+                        "Value": {
+                            "Ref": "AWS::StackId"
                         }
                     },
                     {
-                        "Key":"Network",
-                        "Value":"Private"
+                        "Key": "Network",
+                        "Value": "Private"
                     },
                     {
-                        "Key":"cb-resource-type",
-                        "Value":"NETWORK"
+                        "Key": "cb-resource-type",
+                        "Value": "NETWORK"
                     },
                     {
-                        "Key":"kubernetes.io/role/elb",
-                        "Value":"1"
+                        "Key": "kubernetes.io/role/elb",
+                        "Value": "1"
+                    },
+                    {
+                        "Key": "owner",
+                        "Value": {
+                            "Ref": "stackowner"
+                        }
+                    },
+                    {
+                        "Key": "Owner",
+                        "Value": {
+                            "Ref": "StackOwner"
+                        }
                     }
                 ]
             }
         },
-        "NatGateway1EIP":{
-            "Type":"AWS::EC2::EIP",
-            "DependsOn":"AttachGateway",
-            "Properties":{
-                "Domain":{
-                    "Ref":"VPC"
+        "NatGateway1EIP": {
+            "Type": "AWS::EC2::EIP",
+            "DependsOn": "AttachGateway",
+            "Properties": {
+                "Domain": {
+                    "Ref": "VPC"
                 }
             }
         },
-        "NatGateway1":{
-            "Type":"AWS::EC2::NatGateway",
-            "Properties":{
-                "AllocationId":{
-                    "Fn::GetAtt":[
+        "NatGateway1": {
+            "Type": "AWS::EC2::NatGateway",
+            "Properties": {
+                "AllocationId": {
+                    "Fn::GetAtt": [
                         "NatGateway1EIP",
                         "AllocationId"
                     ]
                 },
-                "SubnetId":{
-                    "Ref":"PublicSubnet1"
+                "SubnetId": {
+                    "Ref": "PublicSubnet1"
                 }
             }
         },
-        "PrivateRouteTable1":{
-            "Type":"AWS::EC2::RouteTable",
-            "Properties":{
-                "VpcId":{
-                    "Ref":"VPC"
+        "PrivateRouteTable1": {
+            "Type": "AWS::EC2::RouteTable",
+            "Properties": {
+                "VpcId": {
+                    "Ref": "VPC"
                 },
-                "Tags":[
+                "Tags": [
                     {
-                        "Key":"Application",
-                        "Value":{
-                            "Ref":"AWS::StackId"
+                        "Key": "Application",
+                        "Value": {
+                            "Ref": "AWS::StackId"
                         }
                     },
                     {
-                        "Key":"Network",
-                        "Value":"Private"
+                        "Key": "Network",
+                        "Value": "Private"
                     },
                     {
-                        "Key":"cb-resource-type",
-                        "Value":"NETWORK"
+                        "Key": "cb-resource-type",
+                        "Value": "NETWORK"
+                    },
+                    {
+                        "Key": "owner",
+                        "Value": {
+                            "Ref": "stackowner"
+                        }
+                    },
+                    {
+                        "Key": "Owner",
+                        "Value": {
+                            "Ref": "StackOwner"
+                        }
                     }
                 ]
             }
         },
-        "PrivateSubnetRouteTableAssociation1":{
-            "Type":"AWS::EC2::SubnetRouteTableAssociation",
-            "Properties":{
-                "SubnetId":{
-                    "Ref":"PrivateSubnet1"
+        "PrivateSubnetRouteTableAssociation1": {
+            "Type": "AWS::EC2::SubnetRouteTableAssociation",
+            "Properties": {
+                "SubnetId": {
+                    "Ref": "PrivateSubnet1"
                 },
-                "RouteTableId":{
-                    "Ref":"PrivateRouteTable1"
+                "RouteTableId": {
+                    "Ref": "PrivateRouteTable1"
                 }
             }
         },
-        "PrivateRoute1":{
-            "Type":"AWS::EC2::Route",
-            "DependsOn":[
+        "PrivateRoute1": {
+            "Type": "AWS::EC2::Route",
+            "DependsOn": [
                 "PrivateRouteTable1",
                 "AttachGateway"
             ],
-            "Properties":{
-                "DestinationCidrBlock":"0.0.0.0/0",
-                "RouteTableId":{
-                    "Ref":"PrivateRouteTable1"
+            "Properties": {
+                "DestinationCidrBlock": "0.0.0.0/0",
+                "RouteTableId": {
+                    "Ref": "PrivateRouteTable1"
                 },
-                "NatGatewayId":{
-                    "Ref":"NatGateway1"
+                "NatGatewayId": {
+                    "Ref": "NatGateway1"
                 }
             }
         },
-        "PublicSubnetRouteTableAssociation1":{
-            "Type":"AWS::EC2::SubnetRouteTableAssociation",
-            "Properties":{
-                "SubnetId":{
-                    "Ref":"PublicSubnet1"
+        "PublicSubnetRouteTableAssociation1": {
+            "Type": "AWS::EC2::SubnetRouteTableAssociation",
+            "Properties": {
+                "SubnetId": {
+                    "Ref": "PublicSubnet1"
                 },
-                "RouteTableId":{
-                    "Ref":"PublicRouteTable"
+                "RouteTableId": {
+                    "Ref": "PublicRouteTable"
                 }
             }
         },
-        "PublicRouteTable":{
-            "Type":"AWS::EC2::RouteTable",
-            "Properties":{
-                "VpcId":{
-                    "Ref":"VPC"
+        "PublicRouteTable": {
+            "Type": "AWS::EC2::RouteTable",
+            "Properties": {
+                "VpcId": {
+                    "Ref": "VPC"
                 },
-                "Tags":[
+                "Tags": [
                     {
-                        "Key":"Application",
-                        "Value":{
-                            "Ref":"AWS::StackId"
+                        "Key": "Application",
+                        "Value": {
+                            "Ref": "AWS::StackId"
                         }
                     },
                     {
-                        "Key":"Network",
-                        "Value":"Public"
+                        "Key": "Network",
+                        "Value": "Public"
                     },
                     {
-                        "Key":"cb-resource-type",
-                        "Value":"NETWORK"
+                        "Key": "cb-resource-type",
+                        "Value": "NETWORK"
+                    },
+                    {
+                        "Key": "owner",
+                        "Value": {
+                            "Ref": "stackowner"
+                        }
+                    },
+                    {
+                        "Key": "Owner",
+                        "Value": {
+                            "Ref": "StackOwner"
+                        }
                     }
                 ]
             }
         },
-        "PublicRoute":{
-            "Type":"AWS::EC2::Route",
-            "DependsOn":[
+        "PublicRoute": {
+            "Type": "AWS::EC2::Route",
+            "DependsOn": [
                 "PublicRouteTable",
                 "AttachGateway"
             ],
-            "Properties":{
-                "RouteTableId":{
-                    "Ref":"PublicRouteTable"
+            "Properties": {
+                "RouteTableId": {
+                    "Ref": "PublicRouteTable"
                 },
-                "DestinationCidrBlock":"0.0.0.0/0",
-                "GatewayId":{
-                    "Ref":"InternetGateway"
+                "DestinationCidrBlock": "0.0.0.0/0",
+                "GatewayId": {
+                    "Ref": "InternetGateway"
                 }
             }
         }
     },
-    "Outputs":{
-        "PublicSubnetId0":{
-            "Value":{
-                "Ref":"PublicSubnet0"
+    "Outputs": {
+        "PublicSubnetId0": {
+            "Value": {
+                "Ref": "PublicSubnet0"
             }
         },
-        "PublicSubnetCidr0":{
-            "Value":"2.2.2.2/24"
+        "PublicSubnetCidr0": {
+            "Value": "2.2.2.2/24"
         },
-        "PrivateSubnetId0":{
-            "Value":{
-                "Ref":"PrivateSubnet0"
+        "PrivateSubnetId0": {
+            "Value": {
+                "Ref": "PrivateSubnet0"
             }
         },
-        "PrivateSubnetCidr0":{
-            "Value":"2.2.2.2/24"
+        "PrivateSubnetCidr0": {
+            "Value": "2.2.2.2/24"
         },
-        "Az0":{
-            "Value":{
-                "Fn::GetAtt":[
+        "Az0": {
+            "Value": {
+                "Fn::GetAtt": [
                     "PublicSubnet0",
                     "AvailabilityZone"
                 ]
             }
         },
-        "PublicSubnetId1":{
-            "Value":{
-                "Ref":"PublicSubnet1"
+        "PublicSubnetId1": {
+            "Value": {
+                "Ref": "PublicSubnet1"
             }
         },
-        "PublicSubnetCidr1":{
-            "Value":"2.2.2.2/24"
+        "PublicSubnetCidr1": {
+            "Value": "2.2.2.2/24"
         },
-        "PrivateSubnetId1":{
-            "Value":{
-                "Ref":"PrivateSubnet1"
+        "PrivateSubnetId1": {
+            "Value": {
+                "Ref": "PrivateSubnet1"
             }
         },
-        "PrivateSubnetCidr1":{
-            "Value":"2.2.2.2/24"
+        "PrivateSubnetCidr1": {
+            "Value": "2.2.2.2/24"
         },
-        "Az1":{
-            "Value":{
-                "Fn::GetAtt":[
+        "Az1": {
+            "Value": {
+                "Fn::GetAtt": [
                     "PublicSubnet1",
                     "AvailabilityZone"
                 ]
             }
         },
-        "CreatedVpc":{
-            "Value":{
-                "Ref":"VPC"
+        "CreatedVpc": {
+            "Value": {
+                "Ref": "VPC"
             }
         }
     }

--- a/cloud-aws/src/test/resources/json/aws-cf-network.json
+++ b/cloud-aws/src/test/resources/json/aws-cf-network.json
@@ -1,6 +1,20 @@
 {
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "Deploys a Cloudera Data Platform VPC on AWS.",
+    "Parameters": {
+        "StackOwner": {
+            "Description": "The instances will have this parameter as an Owner tag.",
+            "Type": "String",
+            "MinLength": "1",
+            "MaxLength": "200"
+        },
+        "stackowner": {
+            "Description": "The instances will have this parameter as an owner tag.",
+            "Type": "String",
+            "MinLength": "1",
+            "MaxLength": "200"
+        }
+    },
     "Resources": {
         "VPC": {
             "Type": "AWS::EC2::VPC",
@@ -22,6 +36,18 @@
                     {
                         "Key": "cb-resource-type",
                         "Value": "NETWORK"
+                    },
+                    {
+                        "Key": "owner",
+                        "Value": {
+                            "Ref": "stackowner"
+                        }
+                    },
+                    {
+                        "Key": "Owner",
+                        "Value": {
+                            "Ref": "StackOwner"
+                        }
                     }
                 ]
             }
@@ -43,6 +69,18 @@
                     {
                         "Key": "cb-resource-type",
                         "Value": "NETWORK"
+                    },
+                    {
+                        "Key": "owner",
+                        "Value": {
+                            "Ref": "stackowner"
+                        }
+                    },
+                    {
+                        "Key": "Owner",
+                        "Value": {
+                            "Ref": "StackOwner"
+                        }
                     }
                 ]
             }
@@ -85,6 +123,18 @@
                     {
                         "Key": "kubernetes.io/role/elb",
                         "Value": "1"
+                    },
+                    {
+                        "Key": "owner",
+                        "Value": {
+                            "Ref": "stackowner"
+                        }
+                    },
+                    {
+                        "Key": "Owner",
+                        "Value": {
+                            "Ref": "StackOwner"
+                        }
                     }
                 ]
             }
@@ -127,6 +177,18 @@
                     {
                         "Key": "kubernetes.io/role/elb",
                         "Value": "1"
+                    },
+                    {
+                        "Key": "owner",
+                        "Value": {
+                            "Ref": "stackowner"
+                        }
+                    },
+                    {
+                        "Key": "Owner",
+                        "Value": {
+                            "Ref": "StackOwner"
+                        }
                     }
                 ]
             }
@@ -162,6 +224,18 @@
                     {
                         "Key": "cb-resource-type",
                         "Value": "NETWORK"
+                    },
+                    {
+                        "Key": "owner",
+                        "Value": {
+                            "Ref": "stackowner"
+                        }
+                    },
+                    {
+                        "Key": "Owner",
+                        "Value": {
+                            "Ref": "StackOwner"
+                        }
                     }
                 ]
             }

--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/common/service/DefaultCostTaggingService.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/common/service/DefaultCostTaggingService.java
@@ -8,9 +8,9 @@ import static com.sequenceiq.cloudbreak.common.type.CloudbreakResourceType.NOSQL
 import static com.sequenceiq.cloudbreak.common.type.CloudbreakResourceType.SECURITY;
 import static com.sequenceiq.cloudbreak.common.type.CloudbreakResourceType.STORAGE;
 import static com.sequenceiq.cloudbreak.common.type.CloudbreakResourceType.TEMPLATE;
-import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CB_CREATION_TIMESTAMP;
-import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CB_USER_NAME;
-import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CB_VERSION;
+import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CDP_CREATION_TIMESTAMP;
+import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CDP_USER_NAME;
+import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CDP_CB_VERSION;
 import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.OWNER;
 
 import java.util.HashMap;
@@ -77,12 +77,12 @@ public class DefaultCostTaggingService {
 
     public Map<String, String> prepareDefaultTags(String cbUser, Map<String, String> sourceMap, String platform) {
         Map<String, String> result = new HashMap<>();
-        result.put(transform(CB_USER_NAME.key(), platform), transform(cbUser, platform));
-        result.put(transform(CB_VERSION.key(), platform), transform(cbVersion, platform));
+        result.put(transform(CDP_USER_NAME.key(), platform), transform(cbUser, platform));
+        result.put(transform(CDP_CB_VERSION.key(), platform), transform(cbVersion, platform));
         if (sourceMap == null || Strings.isNullOrEmpty(sourceMap.get(transform(OWNER.key(), platform)))) {
             result.put(transform(OWNER.key(), platform), transform(cbUser, platform));
         }
-        result.put(transform(CB_CREATION_TIMESTAMP.key(), platform), transform(String.valueOf(clock.getCurrentInstant().getEpochSecond()), platform));
+        result.put(transform(CDP_CREATION_TIMESTAMP.key(), platform), transform(String.valueOf(clock.getCurrentInstant().getEpochSecond()), platform));
         return result;
     }
 
@@ -94,7 +94,7 @@ public class DefaultCostTaggingService {
 
     private Map<String, String> prepareResourceTag(CloudbreakResourceType cloudbreakResourceType) {
         Map<String, String> result = new HashMap<>();
-        result.put(DefaultApplicationTag.CB_RESOURCE_TYPE.key(), cloudbreakResourceType.key());
+        result.put(DefaultApplicationTag.CDP_RESOURCE_TYPE.key(), cloudbreakResourceType.key());
         return result;
     }
 }

--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/common/type/DefaultApplicationTag.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/common/type/DefaultApplicationTag.java
@@ -3,12 +3,12 @@ package com.sequenceiq.cloudbreak.common.type;
 public enum DefaultApplicationTag {
 
     OWNER("Owner"),
-    CB_USER_NAME("cb-user-name"),
-    CB_VERSION("cb-version"),
-    CB_ACOUNT_NAME("cb-account-name"),
-    CB_RESOURCE_TYPE("cb-resource-type"),
-    CB_CREATION_TIMESTAMP("cb-creation-timestamp"),
-    CB_CREATION_DATETIME_UTC("cb-creation-datetime-utc");
+    CDP_USER_NAME("cdp-user-name"),
+    CDP_CB_VERSION("cdp-cb-version"),
+    CDP_ACOUNT_NAME("cdp-account-name"),
+    CDP_RESOURCE_TYPE("cdp-resource-type"),
+    CDP_CREATION_TIMESTAMP("cdp-creation-timestamp"),
+    CDP_CREATION_DATETIME_UTC("cdp-creation-datetime-utc");
 
     private final String key;
 

--- a/cloud-common/src/test/java/com/sequenceiq/cloudbreak/common/service/DefaultCostTaggingServiceTest.java
+++ b/cloud-common/src/test/java/com/sequenceiq/cloudbreak/common/service/DefaultCostTaggingServiceTest.java
@@ -52,10 +52,10 @@ public class DefaultCostTaggingServiceTest {
         Map<String, String> result = underTest.prepareDefaultTags(CB_USER, new HashMap<>(), CloudConstants.AWS);
 
         Assert.assertEquals(4L, result.size());
-        Assert.assertEquals("apache1@apache.com", result.get(DefaultApplicationTag.CB_USER_NAME.key()));
-        Assert.assertEquals("2.2.0", result.get(DefaultApplicationTag.CB_VERSION.key()));
+        Assert.assertEquals("apache1@apache.com", result.get(DefaultApplicationTag.CDP_USER_NAME.key()));
+        Assert.assertEquals("2.2.0", result.get(DefaultApplicationTag.CDP_CB_VERSION.key()));
         Assert.assertEquals("apache1@apache.com", result.get(DefaultApplicationTag.OWNER.key()));
-        Assert.assertEquals(String.valueOf(epochSeconds), result.get("cb-creation-timestamp"));
+        Assert.assertEquals(String.valueOf(epochSeconds), result.get("cdp-creation-timestamp"));
     }
 
     @Test
@@ -66,10 +66,10 @@ public class DefaultCostTaggingServiceTest {
         Map<String, String> result = underTest.prepareDefaultTags(CB_USER, new HashMap<>(), CloudConstants.GCP);
 
         Assert.assertEquals(4L, result.size());
-        Assert.assertEquals("apache1", result.get(DefaultApplicationTag.CB_USER_NAME.key()));
-        Assert.assertEquals("2-2-0", result.get(DefaultApplicationTag.CB_VERSION.key()));
+        Assert.assertEquals("apache1", result.get(DefaultApplicationTag.CDP_USER_NAME.key()));
+        Assert.assertEquals("2-2-0", result.get(DefaultApplicationTag.CDP_CB_VERSION.key()));
         Assert.assertEquals("apache1", result.get(DefaultApplicationTag.OWNER.key().toLowerCase()));
-        Assert.assertEquals(String.valueOf(epochSeconds), result.get("cb-creation-timestamp"));
+        Assert.assertEquals(String.valueOf(epochSeconds), result.get("cdp-creation-timestamp"));
     }
 
     @Test
@@ -82,58 +82,58 @@ public class DefaultCostTaggingServiceTest {
         Map<String, String> result = underTest.prepareDefaultTags(CB_USER, sourceMap, CloudConstants.AZURE);
 
         Assert.assertEquals(3L, result.size());
-        Assert.assertEquals("apache1@apache.com", result.get(DefaultApplicationTag.CB_USER_NAME.key()));
-        Assert.assertEquals("2.2.0", result.get(DefaultApplicationTag.CB_VERSION.key()));
+        Assert.assertEquals("apache1@apache.com", result.get(DefaultApplicationTag.CDP_USER_NAME.key()));
+        Assert.assertEquals("2.2.0", result.get(DefaultApplicationTag.CDP_CB_VERSION.key()));
         Assert.assertNull(result.get(DefaultApplicationTag.OWNER.key()));
-        Assert.assertEquals(String.valueOf(epochSeconds), result.get("cb-creation-timestamp"));
+        Assert.assertEquals(String.valueOf(epochSeconds), result.get("cdp-creation-timestamp"));
     }
 
     @Test
     public void testPrepareInstanceTaggingShouldReturnAMapWithSingleEntry() {
         Map<String, String> result = underTest.prepareInstanceTagging();
         Assert.assertEquals(1L, result.size());
-        Assert.assertEquals(result.get(DefaultApplicationTag.CB_RESOURCE_TYPE.key()), CloudbreakResourceType.INSTANCE.key());
+        Assert.assertEquals(result.get(DefaultApplicationTag.CDP_RESOURCE_TYPE.key()), CloudbreakResourceType.INSTANCE.key());
     }
 
     @Test
     public void testPrepareTemplateTaggingShouldReturnAMapWithSingleEntry() {
         Map<String, String> result = underTest.prepareTemplateTagging();
         Assert.assertEquals(1L, result.size());
-        Assert.assertEquals(result.get(DefaultApplicationTag.CB_RESOURCE_TYPE.key()), CloudbreakResourceType.TEMPLATE.key());
+        Assert.assertEquals(result.get(DefaultApplicationTag.CDP_RESOURCE_TYPE.key()), CloudbreakResourceType.TEMPLATE.key());
     }
 
     @Test
     public void testPrepareStorageTaggingShouldReturnAMapWithSingleEntry() {
         Map<String, String> result = underTest.prepareStorageTagging();
         Assert.assertEquals(1L, result.size());
-        Assert.assertEquals(result.get(DefaultApplicationTag.CB_RESOURCE_TYPE.key()), CloudbreakResourceType.STORAGE.key());
+        Assert.assertEquals(result.get(DefaultApplicationTag.CDP_RESOURCE_TYPE.key()), CloudbreakResourceType.STORAGE.key());
     }
 
     @Test
     public void testPrepareDiskTaggingShouldReturnAMapWithSingleEntry() {
         Map<String, String> result = underTest.prepareDiskTagging();
         Assert.assertEquals(1L, result.size());
-        Assert.assertEquals(result.get(DefaultApplicationTag.CB_RESOURCE_TYPE.key()), CloudbreakResourceType.DISK.key());
+        Assert.assertEquals(result.get(DefaultApplicationTag.CDP_RESOURCE_TYPE.key()), CloudbreakResourceType.DISK.key());
     }
 
     @Test
     public void testPrepareIpTaggingShouldReturnAMapWithSingleEntry() {
         Map<String, String> result = underTest.prepareIpTagging();
         Assert.assertEquals(1L, result.size());
-        Assert.assertEquals(result.get(DefaultApplicationTag.CB_RESOURCE_TYPE.key()), CloudbreakResourceType.IP.key());
+        Assert.assertEquals(result.get(DefaultApplicationTag.CDP_RESOURCE_TYPE.key()), CloudbreakResourceType.IP.key());
     }
 
     @Test
     public void testPrepareNetworkTaggingShouldReturnAMapWithSingleEntry() {
         Map<String, String> result = underTest.prepareNetworkTagging();
         Assert.assertEquals(1L, result.size());
-        Assert.assertEquals(result.get(DefaultApplicationTag.CB_RESOURCE_TYPE.key()), CloudbreakResourceType.NETWORK.key());
+        Assert.assertEquals(result.get(DefaultApplicationTag.CDP_RESOURCE_TYPE.key()), CloudbreakResourceType.NETWORK.key());
     }
 
     @Test
     public void testPrepareSecurityTaggingShouldReturnAMapWithSingleEntry() {
         Map<String, String> result = underTest.prepareSecurityTagging();
         Assert.assertEquals(1L, result.size());
-        Assert.assertEquals(result.get(DefaultApplicationTag.CB_RESOURCE_TYPE.key()), CloudbreakResourceType.SECURITY.key());
+        Assert.assertEquals(result.get(DefaultApplicationTag.CDP_RESOURCE_TYPE.key()), CloudbreakResourceType.SECURITY.key());
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverterTest.java
@@ -1,8 +1,8 @@
 package com.sequenceiq.cloudbreak.converter.v4.stacks;
 
-import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CB_CREATION_TIMESTAMP;
-import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CB_USER_NAME;
-import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CB_VERSION;
+import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CDP_CREATION_TIMESTAMP;
+import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CDP_USER_NAME;
+import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CDP_CB_VERSION;
 import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.OWNER;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -204,7 +204,8 @@ public class StackV4RequestToStackConverterTest extends AbstractJsonConverterTes
         ReflectionTestUtils.setField(underTest, "defaultRegions", "AWS:eu-west-2");
         StackV4Request request = getRequest("stack-without-tags.json");
 
-        Map<String, String> defaultTags = Map.of(CB_USER_NAME.key(), "test", CB_VERSION.key(), "test", OWNER.key(), "test", CB_CREATION_TIMESTAMP.key(), "test");
+        Map<String, String> defaultTags = Map.of(CDP_USER_NAME.key(), "test", CDP_CB_VERSION.key(), "test", OWNER.key(),
+                "test", CDP_CREATION_TIMESTAMP.key(), "test");
         given(defaultCostTaggingService.prepareDefaultTags(anyString(), anyMap(), anyString())).willReturn(defaultTags);
         given(credentialClientService.getByName(anyString())).willReturn(credential);
         given(credentialClientService.getByCrn(anyString())).willReturn(credential);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/CostTaggingService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/CostTaggingService.java
@@ -7,9 +7,9 @@ import static com.sequenceiq.cloudbreak.common.type.CloudbreakResourceType.NETWO
 import static com.sequenceiq.cloudbreak.common.type.CloudbreakResourceType.SECURITY;
 import static com.sequenceiq.cloudbreak.common.type.CloudbreakResourceType.STORAGE;
 import static com.sequenceiq.cloudbreak.common.type.CloudbreakResourceType.TEMPLATE;
-import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CB_CREATION_TIMESTAMP;
-import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CB_USER_NAME;
-import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CB_VERSION;
+import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CDP_CREATION_TIMESTAMP;
+import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CDP_USER_NAME;
+import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CDP_CB_VERSION;
 import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.OWNER;
 
 import java.util.HashMap;
@@ -73,12 +73,12 @@ public class CostTaggingService {
 
     public Map<String, String> prepareDefaultTags(String user, Map<String, String> sourceMap, String platform) {
         Map<String, String> result = new HashMap<>();
-        result.put(transform(CB_USER_NAME.key(), platform), transform(user, platform));
-        result.put(transform(CB_VERSION.key(), platform), transform(version, platform));
+        result.put(transform(CDP_USER_NAME.key(), platform), transform(user, platform));
+        result.put(transform(CDP_CB_VERSION.key(), platform), transform(version, platform));
         if (sourceMap == null || Strings.isNullOrEmpty(sourceMap.get(transform(OWNER.key(), platform)))) {
             result.put(transform(OWNER.key(), platform), transform(user, platform));
         }
-        result.put(transform(CB_CREATION_TIMESTAMP.key(), platform), transform(String.valueOf(clock.getCurrentInstant().getEpochSecond()), platform));
+        result.put(transform(CDP_CREATION_TIMESTAMP.key(), platform), transform(String.valueOf(clock.getCurrentInstant().getEpochSecond()), platform));
         return result;
     }
 
@@ -90,7 +90,7 @@ public class CostTaggingService {
 
     private Map<String, String> prepareResourceTag(CloudbreakResourceType cloudbreakResourceType) {
         Map<String, String> result = new HashMap<>();
-        result.put(DefaultApplicationTag.CB_RESOURCE_TYPE.key(), cloudbreakResourceType.key());
+        result.put(DefaultApplicationTag.CDP_RESOURCE_TYPE.key(), cloudbreakResourceType.key());
         return result;
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverter.java
@@ -1,8 +1,8 @@
 package com.sequenceiq.redbeams.converter.stack;
 
-import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CB_CREATION_TIMESTAMP;
-import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CB_USER_NAME;
-import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CB_VERSION;
+import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CDP_CREATION_TIMESTAMP;
+import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CDP_USER_NAME;
+import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CDP_CB_VERSION;
 import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.OWNER;
 import static com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.AllocateDatabaseServerV4Request.RDS_NAME_MAX_LENGTH;
 
@@ -270,10 +270,10 @@ public class AllocateDatabaseServerV4RequestToDBStackConverter {
 //        String user = ownerCrn.getUserId();
 
         Map<String, String> defaultTags = new HashMap<>();
-        defaultTags.put(safeTagString(CB_USER_NAME.key(), cloudPlatform), safeTagString(userEmail, cloudPlatform));
-        defaultTags.put(safeTagString(CB_VERSION.key(), cloudPlatform), safeTagString(version, cloudPlatform));
+        defaultTags.put(safeTagString(CDP_USER_NAME.key(), cloudPlatform), safeTagString(userEmail, cloudPlatform));
+        defaultTags.put(safeTagString(CDP_CB_VERSION.key(), cloudPlatform), safeTagString(version, cloudPlatform));
         defaultTags.put(safeTagString(OWNER.key(), cloudPlatform), safeTagString(userEmail, cloudPlatform));
-        defaultTags.put(safeTagString(CB_CREATION_TIMESTAMP.key(), cloudPlatform),
+        defaultTags.put(safeTagString(CDP_CREATION_TIMESTAMP.key(), cloudPlatform),
                 safeTagString(String.valueOf(now), cloudPlatform));
 
         return new Json(new StackTags(new HashMap<>(), new HashMap<>(), defaultTags));

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverterTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverterTest.java
@@ -1,8 +1,8 @@
 package com.sequenceiq.redbeams.converter.stack;
 
-import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CB_CREATION_TIMESTAMP;
-import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CB_USER_NAME;
-import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CB_VERSION;
+import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CDP_CREATION_TIMESTAMP;
+import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CDP_USER_NAME;
+import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.CDP_CB_VERSION;
 import static com.sequenceiq.cloudbreak.common.type.DefaultApplicationTag.OWNER;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
@@ -183,10 +183,10 @@ public class AllocateDatabaseServerV4RequestToDBStackConverterTest {
         Json tags = dbStack.getTags();
         StackTags stackTags = tags.get(StackTags.class);
         Map<String, String> defaultTags = stackTags.getDefaultTags();
-        assertEquals(USER_EMAIL, defaultTags.get(CB_USER_NAME.key()));
+        assertEquals(USER_EMAIL, defaultTags.get(CDP_USER_NAME.key()));
         assertEquals(USER_EMAIL, defaultTags.get(OWNER.key()));
-        assertEquals(String.valueOf(NOW.getEpochSecond()), defaultTags.get(CB_CREATION_TIMESTAMP.key()));
-        assertEquals(VERSION, defaultTags.get(CB_VERSION.key()));
+        assertEquals(String.valueOf(NOW.getEpochSecond()), defaultTags.get(CDP_CREATION_TIMESTAMP.key()));
+        assertEquals(VERSION, defaultTags.get(CDP_CB_VERSION.key()));
 
         assertEquals(Status.REQUESTED, dbStack.getStatus());
         assertEquals(DetailedDBStackStatus.PROVISION_REQUESTED, dbStack.getDbStackStatus().getDetailedDBStackStatus());

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hue/HueConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hue/HueConfigProviderTest.java
@@ -209,7 +209,7 @@ public class HueConfigProviderTest {
                 new SimpleEntry<>("hue-hue_database_type", DB_PROVIDER),
                 new SimpleEntry<>("hue-hue_database_user", USER_NAME),
                 new SimpleEntry<>("hue-hue_database_password", PASSWORD),
-                new SimpleEntry<>("knox_proxyhosts.java ", proxyHostsExpected));
+                new SimpleEntry<>("knox_proxyhosts", proxyHostsExpected));
     }
 
     @Test


### PR DESCRIPTION
After the OPSAPS-53148 has been finished the Hue related config providers on CB side should use the dedicated `knox_proxyhosts` property instead of overriding the safety valve with ini styled values.

@biharitomi can you please check that the logicc is valid ? 