### PR TITLE
CB-4946. Update fluentd azure storage plugin version

### DIFF
--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
@@ -49,7 +49,7 @@
 {% set partition_interval = salt['pillar.get']('fluent:partitionIntervalMin') %}
 {% set cloudera_public_gem_repo = 'https://repository.cloudera.com/cloudera/api/gems/cloudera-gems/' %}
 {% set cloudera_azure_plugin_version = '1.0.1' %}
-{% set cloudera_azure_gen2_plugin_version = '0.1.1' %}
+{% set cloudera_azure_gen2_plugin_version = '0.2.2' %}
 {% set cloudera_databus_plugin_version = '1.0.2' %}
 {% set platform = salt['pillar.get']('fluent:platform') %}
 


### PR DESCRIPTION
compression is supported from 0.2.x, so updating the azure storage plugin version for that

testingdone