### PR TITLE
Fix string format usage since it caused the repair test failure

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRepairAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRepairAction.java
@@ -17,7 +17,7 @@ public class SdxRepairAction implements Action<SdxTestDto, SdxClient> {
 
     @Override
     public SdxTestDto action(TestContext testContext, SdxTestDto testDto, SdxClient client) throws Exception {
-        Log.when(LOGGER, format(" Starting repair on SDX: %s " + testDto.getName()));
+        Log.when(LOGGER, format(" Starting repair on SDX: %s ", testDto.getName()));
         Log.whenJson(LOGGER, " SDX repair request: ", testDto.getSdxRepairRequest());
         client.getSdxClient()
                 .sdxEndpoint()


### PR DESCRIPTION
Unfortunately there was an issue with String.format usage in the repair integration test. This commit fixes it.