### PR TITLE
CDPCP-1113. User sync checks rights for access to environment

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/AuthorizationClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/AuthorizationClient.java
@@ -48,6 +48,24 @@ public class AuthorizationClient {
         );
     }
 
+    public boolean hasRight(String requestId, String userCrn, String right, String resource) {
+        checkNotNull(requestId);
+        checkNotNull(userCrn);
+        checkNotNull(right);
+
+        AuthorizationProto.HasRightsRequest.Builder requestBuilder = AuthorizationProto.HasRightsRequest.newBuilder()
+                .setActorCrn(userCrn);
+
+        AuthorizationProto.RightCheck.Builder rightCheckBuilder = AuthorizationProto.RightCheck.newBuilder().setRight(right);
+        if (!StringUtils.isEmpty(resource)) {
+            rightCheckBuilder.setResource(resource);
+        }
+        requestBuilder.addCheck(rightCheckBuilder.build());
+
+        AuthorizationProto.HasRightsResponse response = newStub(requestId).hasRights(requestBuilder.build());
+        return response.getResultList().get(0);
+    }
+
     /**
      * Creates a new stub with the appropriate metadata injecting interceptors.
      *

--- a/authorization-common-api/src/main/java/com/sequenceiq/authorization/RightsConstants.java
+++ b/authorization-common-api/src/main/java/com/sequenceiq/authorization/RightsConstants.java
@@ -12,6 +12,8 @@ public class RightsConstants {
 
     public static final String WRITE_ACTION = "write";
 
+    public static final String ACCESS_ENVIRONMENT_ACTION = "accessEnvironment";
+
     private RightsConstants() {
 
     }

--- a/authorization-common/src/main/java/com/sequenceiq/authorization/resource/ResourceAction.java
+++ b/authorization-common/src/main/java/com/sequenceiq/authorization/resource/ResourceAction.java
@@ -11,7 +11,8 @@ public enum ResourceAction {
     READ(RightsConstants.READ_ACTION),
     WRITE(RightsConstants.WRITE_ACTION),
     // manage action is obsolete, used only in workspace authz
-    MANAGE("manage");
+    MANAGE("manage"),
+    ACCESS_ENVIRONMENT(RightsConstants.ACCESS_ENVIRONMENT_ACTION);
 
     private String authorizationName;
 


### PR DESCRIPTION
This commit changes user sync to use rights instead of roles for
determining access to the environment. A hasRights method was
added to the GrpcUmsClient and AuthorizationClient to support this
use case since hasRights is a better match than checkRight.
