### PR TITLE
Azure region name and displayName should be different [DRAFT]

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/CloudConnector.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/CloudConnector.java
@@ -87,6 +87,22 @@ public interface CloudConnector<R> extends CloudPlatformAware {
     NetworkConnector networkConnector();
 
     /**
+     * Giving back a valid provider display name. (because of CB-5013)
+     *
+     * @return the string object
+     */
+    String regionToDisplayName(String region);
+
+    /**
+     * Giving back a valid provider region. (because of CB-5013)
+     *
+     * @return the string object
+     */
+    default String displayNameToRegion(String displayName) {
+        return regionToDisplayName(displayName);
+    }
+
+    /**
      * Access to the {@link IdentityService} object.
      *
      * @return the {@link IdentityService} object

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/Coordinate.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/Coordinate.java
@@ -8,12 +8,15 @@ public class Coordinate {
 
     private final Double latitude;
 
+    private final String key;
+
     private final boolean k8sSupported;
 
-    private Coordinate(Double longitude, Double latitude, String displayName, boolean k8sSupported) {
+    private Coordinate(Double longitude, Double latitude, String displayName, String key, boolean k8sSupported) {
         this.longitude = longitude;
         this.latitude = latitude;
         this.displayName = displayName;
+        this.key = key;
         this.k8sSupported = k8sSupported;
     }
 
@@ -33,8 +36,12 @@ public class Coordinate {
         return k8sSupported;
     }
 
-    public static Coordinate coordinate(String longitude, String latitude, String  displayName, boolean k8sSupported) {
-        return new Coordinate(Double.parseDouble(longitude), Double.parseDouble(latitude), displayName, k8sSupported);
+    public String getKey() {
+        return key;
+    }
+
+    public static Coordinate coordinate(String longitude, String latitude, String  displayName, String key, boolean k8sSupported) {
+        return new Coordinate(Double.parseDouble(longitude), Double.parseDouble(latitude), displayName, key, k8sSupported);
     }
 
     public static Coordinate defaultCoordinate() {
@@ -42,6 +49,7 @@ public class Coordinate {
                 Double.parseDouble("36.7477169"),
                 Double.parseDouble("-119.7729841"),
                 "California (West US)",
+                "us-west-1",
                 false);
     }
 }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsConnector.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsConnector.java
@@ -144,6 +144,11 @@ public class AwsConnector implements CloudConnector<Object> {
     }
 
     @Override
+    public String regionToDisplayName(String region) {
+        return region;
+    }
+
+    @Override
     public IdentityService identityService() {
         return awsIdentityService;
     }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsPlatformResources.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsPlatformResources.java
@@ -290,11 +290,18 @@ public class AwsPlatformResources implements PlatformResources {
         try {
             RegionCoordinateSpecifications regionCoordinateSpecifications = JsonUtil.readValue(displayNames, RegionCoordinateSpecifications.class);
             for (RegionCoordinateSpecification regionCoordinateSpecification : regionCoordinateSpecifications.getItems()) {
+                Optional<Entry<Region, DisplayName>> region = regionDisplayNames
+                        .entrySet()
+                        .stream()
+                        .filter(e -> e.getValue().value().equalsIgnoreCase(regionCoordinateSpecification.getName()))
+                        .findFirst();
+
                 regionCoordinates.put(region(regionCoordinateSpecification.getName()),
                         coordinate(
                                 regionCoordinateSpecification.getLongitude(),
                                 regionCoordinateSpecification.getLatitude(),
                                 regionCoordinateSpecification.getDisplayName(),
+                                region.isPresent() ? region.get().getKey().value() : regionCoordinateSpecification.getDisplayName(),
                                 regionCoordinateSpecification.isK8sSupported()));
             }
         } catch (IOException ignored) {

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureConnector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureConnector.java
@@ -8,6 +8,7 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Service;
 
+import com.microsoft.azure.management.resources.fluentcore.arm.Region;
 import com.sequenceiq.cloudbreak.cloud.Authenticator;
 import com.sequenceiq.cloudbreak.cloud.CloudConnector;
 import com.sequenceiq.cloudbreak.cloud.CloudConstant;
@@ -147,6 +148,16 @@ public class AzureConnector implements CloudConnector<Map<String, Map<String, Ob
     @Override
     public NetworkConnector networkConnector() {
         return azureNetworkConnector;
+    }
+
+    @Override
+    public String regionToDisplayName(String region) {
+        return Region.findByLabelOrName(region).label();
+    }
+
+    @Override
+    public String displayNameToRegion(String displayName) {
+        return Region.findByLabelOrName(displayName).name();
     }
 
     @Override

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePlatformResources.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePlatformResources.java
@@ -94,8 +94,10 @@ public class AzurePlatformResources implements PlatformResources {
         Map<String, Set<CloudNetwork>> result = new HashMap<>();
 
         for (Network network : client.getNetworks()) {
-            String actualRegion = network.region().label();
-            if (regionMatch(actualRegion, region)) {
+            String actualRegionLabel = network.region().label();
+            String actualRegionName = network.region().name();
+
+            if (regionMatch(actualRegionLabel, region) || regionMatch(actualRegionName, region)) {
                 Set<CloudSubnet> subnets = new HashSet<>();
                 for (Entry<String, Subnet> subnet : network.subnets().entrySet()) {
                     subnets.add(new CloudSubnet(subnet.getKey(), subnet.getKey(), null, subnet.getValue().addressPrefix()));
@@ -106,7 +108,8 @@ public class AzurePlatformResources implements PlatformResources {
                 properties.put("resourceGroupName", network.resourceGroupName());
 
                 CloudNetwork cloudNetwork = new CloudNetwork(network.name(), network.id(), subnets, properties);
-                result.computeIfAbsent(actualRegion, s -> new HashSet<>()).add(cloudNetwork);
+                result.computeIfAbsent(actualRegionLabel, s -> new HashSet<>()).add(cloudNetwork);
+                result.computeIfAbsent(actualRegionName, s -> new HashSet<>()).add(cloudNetwork);
             }
         }
         if (result.isEmpty() && Objects.nonNull(region)) {
@@ -153,13 +156,15 @@ public class AzurePlatformResources implements PlatformResources {
     }
 
     private void convertAndAddToResult(Region region, Map<String, Set<CloudSecurityGroup>> result, NetworkSecurityGroup securityGroup) {
-        String actualRegion = securityGroup.region().label();
-        if (regionMatch(actualRegion, region)) {
+        String actualRegionName = securityGroup.region().name();
+        String actualRegionLabel = securityGroup.region().label();
+        if (regionMatch(actualRegionName, region) || regionMatch(actualRegionLabel, region)) {
             Map<String, Object> properties = new HashMap<>();
             properties.put("resourceGroupName", securityGroup.resourceGroupName());
             properties.put("networkInterfaceIds", securityGroup.networkInterfaceIds());
             CloudSecurityGroup cloudSecurityGroup = new CloudSecurityGroup(securityGroup.name(), securityGroup.id(), properties);
-            result.computeIfAbsent(actualRegion, s -> new HashSet<>()).add(cloudSecurityGroup);
+            result.computeIfAbsent(actualRegionName, s -> new HashSet<>()).add(cloudSecurityGroup);
+            result.computeIfAbsent(actualRegionLabel, s -> new HashSet<>()).add(cloudSecurityGroup);
         }
     }
 

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
@@ -495,7 +495,9 @@ public class AzureClient {
         String imageName = CustomVMImageNameProvider.get(region, vhdName);
         PagedList<VirtualMachineCustomImage> customImageList = getCustomImageList(resourceGroup);
         Optional<VirtualMachineCustomImage> virtualMachineCustomImage = customImageList.stream()
-                .filter(customImage -> customImage.name().equals(imageName) && customImage.region().label().equals(region)).findFirst();
+                .filter(customImage -> customImage.name().equals(imageName)
+                        && (customImage.region().name().equals(region)
+                        || customImage.region().label().equals(region))).findFirst();
         if (virtualMachineCustomImage.isPresent()) {
             LOGGER.debug("Custom image found in '{}' resource group with name '{}'", resourceGroup, imageName);
             return virtualMachineCustomImage.get().id();
@@ -667,7 +669,8 @@ public class AzureClient {
     public List<Identity> listIdentitiesByRegion(String region) {
         return listIdentities()
                 .stream()
-                .filter(identity -> identity.region().label().equalsIgnoreCase(region))
+                .filter(identity -> identity.region().label().equalsIgnoreCase(region)
+                        || identity.region().name().equalsIgnoreCase(region))
                 .collect(Collectors.toList());
     }
 

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureRegionProvider.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureRegionProvider.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.cloud.azure.resource;
 
+import static com.microsoft.azure.management.resources.fluentcore.arm.Region.findByLabelOrName;
 import static com.sequenceiq.cloudbreak.cloud.model.Coordinate.coordinate;
 import static com.sequenceiq.cloudbreak.cloud.model.Region.region;
 
@@ -94,6 +95,7 @@ public class AzureRegionProvider {
                                 regionCoordinateSpecification.getLongitude(),
                                 regionCoordinateSpecification.getLatitude(),
                                 regionCoordinateSpecification.getName(),
+                                findByLabelOrName(regionCoordinateSpecification.getName()).name(),
                                 regionCoordinateSpecification.isK8sSupported()));
             }
         } catch (IOException ignored) {

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpConnector.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpConnector.java
@@ -121,4 +121,9 @@ public class GcpConnector implements CloudConnector<List<CloudResource>> {
         return null;
     }
 
+    @Override
+    public String regionToDisplayName(String region) {
+        return region;
+    }
+
 }

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpPlatformResources.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpPlatformResources.java
@@ -110,6 +110,7 @@ public class GcpPlatformResources implements PlatformResources {
                                 regionCoordinateSpecification.getLongitude(),
                                 regionCoordinateSpecification.getLatitude(),
                                 regionCoordinateSpecification.getDisplayName(),
+                                regionCoordinateSpecification.getName(),
                                 regionCoordinateSpecification.isK8sSupported()));
             }
         } catch (IOException ignored) {

--- a/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockConnector.java
+++ b/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockConnector.java
@@ -129,6 +129,11 @@ public class MockConnector implements CloudConnector<Object> {
     }
 
     @Override
+    public String regionToDisplayName(String region) {
+        return region;
+    }
+
+    @Override
     public ObjectStorageConnector objectStorage() {
         return mockObjectStorageConnector;
     }

--- a/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockPlatformResources.java
+++ b/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockPlatformResources.java
@@ -129,6 +129,7 @@ public class MockPlatformResources implements PlatformResources {
                                 regionCoordinateSpecification.getLongitude(),
                                 regionCoordinateSpecification.getLatitude(),
                                 regionCoordinateSpecification.getDisplayName(),
+                                regionCoordinateSpecification.getDisplayName(),
                                 regionCoordinateSpecification.isK8sSupported()));
             }
         } catch (IOException ignored) {

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/common/OpenStackPlatformResources.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/common/OpenStackPlatformResources.java
@@ -109,6 +109,7 @@ public class OpenStackPlatformResources implements PlatformResources {
                                 regionCoordinateSpecification.getLongitude(),
                                 regionCoordinateSpecification.getLatitude(),
                                 regionCoordinateSpecification.getDisplayName(),
+                                regionCoordinateSpecification.getDisplayName(),
                                 regionCoordinateSpecification.isK8sSupported()));
             }
         } catch (IOException ignored) {

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/heat/OpenStackHeatConnector.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/heat/OpenStackHeatConnector.java
@@ -131,4 +131,9 @@ public class OpenStackHeatConnector implements CloudConnector<Object> {
     public NetworkConnector networkConnector() {
         return null;
     }
+
+    @Override
+    public String regionToDisplayName(String region) {
+        return region;
+    }
 }

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/nativ/OpenStackNativeConnector.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/nativ/OpenStackNativeConnector.java
@@ -126,4 +126,9 @@ public class OpenStackNativeConnector implements CloudConnector<List<CloudResour
         return null;
     }
 
+    @Override
+    public String regionToDisplayName(String region) {
+        return region;
+    }
+
 }

--- a/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/init/CloudPlatformConnectorsTest.java
+++ b/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/init/CloudPlatformConnectorsTest.java
@@ -169,5 +169,10 @@ public class CloudPlatformConnectorsTest {
         public NetworkConnector networkConnector() {
             return null;
         }
+
+        @Override
+        public String regionToDisplayName(String region) {
+            return region;
+        }
     }
 }

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnConnector.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnConnector.java
@@ -114,4 +114,9 @@ public class YarnConnector implements CloudConnector<Object> {
     public NetworkConnector networkConnector() {
         return null;
     }
+
+    @Override
+    public String regionToDisplayName(String region) {
+        return region;
+    }
 }

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnPlatformResources.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnPlatformResources.java
@@ -64,6 +64,7 @@ public class YarnPlatformResources implements PlatformResources {
                                 regionCoordinateSpecification.getLongitude(),
                                 regionCoordinateSpecification.getLatitude(),
                                 regionCoordinateSpecification.getDisplayName(),
+                                regionCoordinateSpecification.getDisplayName(),
                                 regionCoordinateSpecification.isK8sSupported()));
             }
         } catch (IOException ignored) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageService.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.service.image;
 
+import static com.sequenceiq.cloudbreak.cloud.model.Platform.platform;
 import static com.sequenceiq.cloudbreak.common.type.ComponentType.CDH_PRODUCT_DETAILS;
 
 import java.io.IOException;
@@ -28,6 +29,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableSet;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.image.ImageSettingsV4Request;
 import com.sequenceiq.cloudbreak.aspect.Measure;
+import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
@@ -75,6 +77,9 @@ public class ImageService {
 
     @Inject
     private PreWarmParcelParser preWarmParcelParser;
+
+    @Inject
+    private CloudPlatformConnectors cloudPlatformConnectors;
 
     public Image getImage(Long stackId) throws CloudbreakImageNotFoundException {
         return componentConfigProviderService.getImage(stackId);
@@ -183,9 +188,10 @@ public class ImageService {
     public String determineImageName(String platformString, String region, com.sequenceiq.cloudbreak.cloud.model.catalog.Image imgFromCatalog)
             throws CloudbreakImageNotFoundException {
         Optional<Map<String, String>> imagesForPlatform = findStringKeyWithEqualsIgnoreCase(platformString, imgFromCatalog.getImageSetsByProvider());
+        String translatedRegion = cloudPlatformConnectors.getDefault(platform(platformString.toUpperCase())).regionToDisplayName(region);
         if (imagesForPlatform.isPresent()) {
             Map<String, String> imagesByRegion = imagesForPlatform.get();
-            Optional<String> imageNameOpt = findStringKeyWithEqualsIgnoreCase(region, imagesByRegion);
+            Optional<String> imageNameOpt = findStringKeyWithEqualsIgnoreCase(translatedRegion, imagesByRegion);
             if (!imageNameOpt.isPresent()) {
                 imageNameOpt = findStringKeyWithEqualsIgnoreCase(DEFAULT_REGION, imagesByRegion);
             }
@@ -193,7 +199,7 @@ public class ImageService {
                 return imageNameOpt.get();
             }
             String msg = String.format("Virtual machine image couldn't be found in image: '%s' for the selected platform: '%s' and region: '%s'.",
-                    imgFromCatalog, platformString, region);
+                    imgFromCatalog, platformString, translatedRegion);
             throw new CloudbreakImageNotFoundException(msg);
         }
         String msg = String.format("The selected image: '%s' doesn't contain virtual machine image for the selected platform: '%s'.",

--- a/environment/src/main/java/com/sequenceiq/environment/configuration/api/FreeIpaApiConfig.java
+++ b/environment/src/main/java/com/sequenceiq/environment/configuration/api/FreeIpaApiConfig.java
@@ -12,7 +12,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
-import com.sequenceiq.environment.environment.flow.creation.handler.freeipa.FreeIpaNetworkProvider;
+import com.sequenceiq.environment.environment.flow.creation.handler.freeipa.network.FreeIpaNetworkProvider;
 import com.sequenceiq.freeipa.api.client.internal.FreeIpaApiClientParams;
 
 @Configuration

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeIpaCreationHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeIpaCreationHandler.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.environment.environment.flow.creation.handler.freeipa;
 
+import static com.sequenceiq.cloudbreak.cloud.model.Platform.platform;
 import static com.sequenceiq.cloudbreak.polling.PollingResult.SUCCESS;
 import static com.sequenceiq.cloudbreak.util.NullUtil.doIfNotNull;
 import static com.sequenceiq.environment.environment.flow.creation.event.EnvCreationHandlerSelectors.CREATE_FREEIPA_EVENT;
@@ -20,6 +21,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.google.common.base.Strings;
+import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
+import com.sequenceiq.cloudbreak.cloud.model.Platform;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.polling.PollingResult;
 import com.sequenceiq.cloudbreak.polling.PollingService;
@@ -33,6 +36,7 @@ import com.sequenceiq.environment.environment.dto.EnvironmentDto;
 import com.sequenceiq.environment.environment.dto.SecurityAccessDto;
 import com.sequenceiq.environment.environment.flow.creation.event.EnvCreationEvent;
 import com.sequenceiq.environment.environment.flow.creation.event.EnvCreationFailureEvent;
+import com.sequenceiq.environment.environment.flow.creation.handler.freeipa.network.FreeIpaNetworkProvider;
 import com.sequenceiq.environment.environment.service.EnvironmentService;
 import com.sequenceiq.environment.environment.service.freeipa.FreeIpaService;
 import com.sequenceiq.environment.environment.v1.TelemetryApiConverter;
@@ -83,6 +87,8 @@ public class FreeIpaCreationHandler extends EventSenderAwareHandler<EnvironmentD
 
     private final TelemetryApiConverter telemetryApiConverter;
 
+    private final CloudPlatformConnectors connectors;
+
     public FreeIpaCreationHandler(
             EventSender eventSender,
             EnvironmentService environmentService,
@@ -92,7 +98,8 @@ public class FreeIpaCreationHandler extends EventSenderAwareHandler<EnvironmentD
             Map<CloudPlatform, FreeIpaNetworkProvider> freeIpaNetworkProviderMapByCloudPlatform,
             PollingService<FreeIpaPollerObject> freeIpaPollingService,
             FreeIpaServerRequestProvider freeIpaServerRequestProvider,
-            TelemetryApiConverter telemetryApiConverter) {
+            TelemetryApiConverter telemetryApiConverter,
+            CloudPlatformConnectors connectors) {
         super(eventSender);
         this.environmentService = environmentService;
         this.freeIpaService = freeIpaService;
@@ -102,6 +109,7 @@ public class FreeIpaCreationHandler extends EventSenderAwareHandler<EnvironmentD
         this.freeIpaPollingService = freeIpaPollingService;
         this.freeIpaServerRequestProvider = freeIpaServerRequestProvider;
         this.telemetryApiConverter = telemetryApiConverter;
+        this.connectors = connectors;
     }
 
     @Override
@@ -187,7 +195,9 @@ public class FreeIpaCreationHandler extends EventSenderAwareHandler<EnvironmentD
 
     private void setPlacementAndNetwork(EnvironmentDto environment, CreateFreeIpaRequest createFreeIpaRequest) {
         PlacementRequest placementRequest = new PlacementRequest();
-        placementRequest.setRegion(environment.getRegions().iterator().next().getName());
+        String region = environment.getRegions().iterator().next().getName();
+        Platform platform = platform(environment.getCloudPlatform().toUpperCase());
+        placementRequest.setRegion(connectors.getDefault(platform).regionToDisplayName(region));
         createFreeIpaRequest.setPlacement(placementRequest);
 
         FreeIpaNetworkProvider freeIpaNetworkProvider = freeIpaNetworkProviderMapByCloudPlatform

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/network/FreeIpaAwsNetworkProvider.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/network/FreeIpaAwsNetworkProvider.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.environment.environment.flow.creation.handler.freeipa;
+package com.sequenceiq.environment.environment.flow.creation.handler.freeipa.network;
 
 import java.util.Set;
 

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/network/FreeIpaAzureNetworkProvider.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/network/FreeIpaAzureNetworkProvider.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.environment.environment.flow.creation.handler.freeipa;
+package com.sequenceiq.environment.environment.flow.creation.handler.freeipa.network;
 
 import java.util.Set;
 

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/network/FreeIpaNetworkProvider.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/network/FreeIpaNetworkProvider.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.environment.environment.flow.creation.handler.freeipa;
+package com.sequenceiq.environment.environment.flow.creation.handler.freeipa.network;
 
 import java.util.Set;
 

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentService.java
@@ -116,13 +116,18 @@ public class EnvironmentService implements ResourceIdProvider {
 
     public void setRegions(Environment environment, Set<String> requestedRegions, CloudRegions cloudRegions) {
         Set<Region> regionSet = new HashSet<>();
-        Map<com.sequenceiq.cloudbreak.cloud.model.Region, String> displayNames = cloudRegions.getDisplayNames();
-        for (com.sequenceiq.cloudbreak.cloud.model.Region r : cloudRegions.getCloudRegions().keySet()) {
-            if (requestedRegions.contains(r.getRegionName())) {
+        for (String requestedRegion : requestedRegions) {
+            Optional<Map.Entry<com.sequenceiq.cloudbreak.cloud.model.Region, Coordinate>> coordinateEntry =
+                    cloudRegions.getCoordinates()
+                            .entrySet()
+                            .stream()
+                            .filter(e -> e.getKey().getRegionName().equals(requestedRegion))
+                            .findFirst();
+            if (coordinateEntry.isPresent()) {
                 Region region = new Region();
-                region.setName(r.getRegionName());
-                String displayName = displayNames.get(r);
-                region.setDisplayName(isEmpty(displayName) ? r.getRegionName() : displayName);
+                region.setName(coordinateEntry.get().getValue().getKey());
+                String displayName = coordinateEntry.get().getValue().getDisplayName();
+                region.setDisplayName(isEmpty(displayName) ? coordinateEntry.get().getKey().getRegionName() : displayName);
                 regionSet.add(region);
             }
         }
@@ -141,12 +146,12 @@ public class EnvironmentService implements ResourceIdProvider {
         if (requestedLocation != null) {
             Coordinate coordinate = cloudRegions.getCoordinates().get(region(requestedLocation.getName()));
             if (coordinate != null) {
-                environment.setLocation(requestedLocation.getName());
+                environment.setLocation(coordinate.getKey());
                 environment.setLocationDisplayName(coordinate.getDisplayName());
                 environment.setLatitude(coordinate.getLatitude());
                 environment.setLongitude(coordinate.getLongitude());
             } else if (requestedLocation.getLatitude() != null && requestedLocation.getLongitude() != null) {
-                environment.setLocation(requestedLocation.getName());
+                environment.setLocation(requestedLocation.getDisplayName());
                 environment.setLocationDisplayName(requestedLocation.getDisplayName());
                 environment.setLatitude(requestedLocation.getLatitude());
                 environment.setLongitude(requestedLocation.getLongitude());

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentServiceTest.java
@@ -152,16 +152,16 @@ class EnvironmentServiceTest {
     public void setRegions() {
         environmentServiceUnderTest.setRegions(environment, Set.of("r1"), EnvironmentTestData.getCloudRegions());
         String resultText = environment.getRegions().getValue();
-        assertTrue(resultText.contains("{\"name\":\"r1\",\"displayName\":\"region 1\"}"));
-        assertFalse(resultText.contains("{\"name\":\"r2\",\"displayName\":\"region 2\"}"));
+        assertTrue(resultText.contains("{\"name\":\"region-1\",\"displayName\":\"Here\"}"));
+        assertFalse(resultText.contains("{\"name\":\"region2\",\"displayName\":\"region 2\"}"));
     }
 
     @Test
     public void setRegionsTwoRegions() {
         environmentServiceUnderTest.setRegions(environment, Set.of("r1", "r2"), EnvironmentTestData.getCloudRegions());
         String resultText = environment.getRegions().getValue();
-        assertTrue(resultText.contains("{\"name\":\"r1\",\"displayName\":\"region 1\"}"));
-        assertTrue(resultText.contains("{\"name\":\"r2\",\"displayName\":\"region 2\"}"));
+        assertTrue(resultText.contains("{\"name\":\"region-1\",\"displayName\":\"Here\"}"));
+        assertTrue(resultText.contains("{\"name\":\"region-2\",\"displayName\":\"There\"}"));
     }
 
     @Test

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentTestData.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentTestData.java
@@ -126,8 +126,8 @@ public class EnvironmentTestData {
     public static CloudRegions getCloudRegions() {
         List<Region> regions = List.of(Region.region("r1"), Region.region("r2"));
         List<String> displayNames = List.of("region 1", "region 2");
-        List<Coordinate> coordinates = List.of(Coordinate.coordinate("1", "2", "Here", false),
-                Coordinate.coordinate("2", "2", "There", false));
+        List<Coordinate> coordinates = List.of(Coordinate.coordinate("1", "2", "Here", "region-1", false),
+                Coordinate.coordinate("2", "2", "There", "region-2", false));
         List<List<AvailabilityZone>> availabilityZones = List.of(List.of(AvailabilityZone.availabilityZone("r1z1")),
                 List.of(AvailabilityZone.availabilityZone("r2z1")));
 


### PR DESCRIPTION
Draft only PR
Currently the Azure environments using the region display name as a name field. This does not cause any problem on our side (we are using the nameOrLabel method) but DWX and other Experiences would like to use the compressed name which is already presented in Azure SDK as name property.
We should modify this in our object to be consistent.