### PR TITLE
CB-5089 Move tez's jar location to cloudstorage

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/tez/TezRoleConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/tez/TezRoleConfigProvider.java
@@ -1,17 +1,21 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.tez;
 
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.core.CoreConfigProvider.CORE_DEFAULTFS;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive.HiveMetastoreCloudStorageServiceConfigProvider.HMS_METASTORE_EXTERNAL_DIR;
 
-import java.util.List;
-
-import org.springframework.stereotype.Component;
-
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.google.common.annotations.VisibleForTesting;
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRoleConfigProvider;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.cloudbreak.template.filesystem.StorageLocationView;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
 
 @Component
 public class TezRoleConfigProvider extends AbstractRoleConfigProvider {
@@ -22,16 +26,50 @@ public class TezRoleConfigProvider extends AbstractRoleConfigProvider {
 
     private static final String TEZ_LOGGING_PROTO_BASE_DIR_SUFFIX = "/sys.db";
 
+    private static final String TEZ_LIB_URIS = "tez.lib.uris";
+
+    private static final String USER_TEZ_DIR = "/user/tez/";
+
+    private static final String TEZ_TAR_GZ = "tez.tar.gz";
+
+    @VisibleForTesting
+    static String getTezLibUri(String path, TemplatePreparationObject source) {
+        path = path.replaceAll("/?$", "");
+        path += USER_TEZ_DIR;
+        path += getCdhVersion(source);
+        path += TEZ_TAR_GZ;
+        return path;
+    }
+
+    @VisibleForTesting
+    static String getCdhVersion(TemplatePreparationObject source) {
+        if (source.getProductDetailsView() != null && source.getProductDetailsView().getProducts() != null) {
+            Optional<ClouderaManagerProduct> cdh = source.getProductDetailsView().getProducts()
+                    .stream()
+                    .filter(e -> "CDH".equalsIgnoreCase(e.getName()))
+                    .findFirst();
+            return cdh.isEmpty() ? "" : cdh.get().getVersion() + '/';
+        }
+        return "";
+    }
+
     @Override
     protected List<ApiClusterTemplateConfig> getRoleConfigs(String roleType, TemplatePreparationObject source) {
         switch (roleType) {
             case TezRoles.GATEWAY:
-                return ConfigUtils.getStorageLocationForServiceProperty(source, HMS_METASTORE_EXTERNAL_DIR)
-                        .map(location ->
-                                location.getValue().replaceAll("/?$", "") + TEZ_LOGGING_PROTO_BASE_DIR_SUFFIX)
-                        .map(logDir -> List.of(config(TEZ_CONF_CLIENT_SAFETY_VALVE,
-                                ConfigUtils.getSafetyValveProperty(TEZ_LOGGING_PROTO_BASE_DIR_PARAM, logDir))))
-                        .orElseGet(List::of);
+                String tezLoggingUrisSafetyValueProperty  = ConfigUtils.getStorageLocationForServiceProperty(source, HMS_METASTORE_EXTERNAL_DIR)
+                        .map(location -> location.getValue().replaceAll("/?$", "") + TEZ_LOGGING_PROTO_BASE_DIR_SUFFIX)
+                        .map(logDir -> ConfigUtils.getSafetyValveProperty(TEZ_LOGGING_PROTO_BASE_DIR_PARAM, logDir))
+                        .orElse("");
+
+                String tezLibUrisSafetyValueProperty = ConfigUtils.getStorageLocationForServiceProperty(source, CORE_DEFAULTFS)
+                        .map(StorageLocationView::getValue)
+                        .map(fs -> ConfigUtils.getSafetyValveProperty(TEZ_LIB_URIS, getTezLibUri(fs, source)))
+                        .orElse("");
+
+                String value = tezLoggingUrisSafetyValueProperty + tezLibUrisSafetyValueProperty;
+
+                return "".equals(value) ? List.of() : List.of(config(TEZ_CONF_CLIENT_SAFETY_VALVE, value));
             default:
                 return List.of();
         }

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/tez/TezRoleConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/tez/TezRoleConfigProviderTest.java
@@ -1,15 +1,17 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.tez;
 
-import static org.junit.Assert.assertEquals;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.core.CoreConfigProvider.CORE_DEFAULTFS;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
@@ -23,15 +25,18 @@ import com.sequenceiq.cloudbreak.util.FileReaderUtils;
 import com.sequenceiq.common.api.filesystem.S3FileSystem;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 
-@RunWith(MockitoJUnitRunner.class)
 public class TezRoleConfigProviderTest {
 
     private final TezRoleConfigProvider underTest = new TezRoleConfigProvider();
 
     @Test
     public void testGetTezClientRoleConfigs() {
-        validateClientConfig("s3a://hive/warehouse/external", "s3a://hive/warehouse/external/sys.db");
-        validateClientConfig("s3a://hive/warehouse/external/", "s3a://hive/warehouse/external/sys.db");
+        validateClientConfig("s3a://hive/warehouse/external",
+                "s3a://datahubName", "s3a://hive/warehouse/external/sys.db",
+                "s3a://datahubName/user/tez/7.0.2-1.cdh7.0.2.p2.1711788/tez.tar.gz");
+        validateClientConfig("s3a://hive/warehouse/external/",
+                "s3a://datahubName/", "s3a://hive/warehouse/external/sys.db",
+                "s3a://datahubName/user/tez/7.0.2-1.cdh7.0.2.p2.1711788/tez.tar.gz");
     }
 
     @Test
@@ -42,21 +47,23 @@ public class TezRoleConfigProviderTest {
 
         Map<String, List<ApiClusterTemplateConfig>> roleConfigs = underTest.getRoleConfigs(cmTemplateProcessor, preparationObject);
         List<ApiClusterTemplateConfig> tezConfigs = roleConfigs.get("tez-GATEWAY-BASE");
-        assertEquals(0, tezConfigs.size());
+        assertThat(tezConfigs).hasSize(0);
     }
 
-    protected void validateClientConfig(String hmsExternalDirLocation, String protoDirLocation) {
-        TemplatePreparationObject preparationObject = getTemplatePreparationObject(hmsExternalDirLocation);
+    protected void validateClientConfig(String hmsExternalDirLocation, String datahubDirLocation, String protoDirLocation, String tezLibUri) {
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject(hmsExternalDirLocation, datahubDirLocation);
         String inputJson = getBlueprintText("input/clouderamanager-ds.bp");
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
 
         Map<String, List<ApiClusterTemplateConfig>> roleConfigs = underTest.getRoleConfigs(cmTemplateProcessor, preparationObject);
         List<ApiClusterTemplateConfig> tezConfigs = roleConfigs.get("tez-GATEWAY-BASE");
 
-        assertEquals(1, tezConfigs.size());
-        assertEquals("tez-conf/tez-site.xml_client_config_safety_valve", tezConfigs.get(0).getName());
-        assertEquals("<property><name>tez.history.logging.proto-base-dir</name><value>"
-                + protoDirLocation + "</value></property>", tezConfigs.get(0).getValue());
+        assertThat(tezConfigs).hasSize(1);
+        assertThat(tezConfigs.get(0).getName()).isEqualTo("tez-conf/tez-site.xml_client_config_safety_valve");
+        assertThat(tezConfigs.get(0).getValue()).contains("<property><name>tez.history.logging.proto-base-dir</name><value>"
+                + protoDirLocation + "</value></property>");
+        assertThat(tezConfigs.get(0).getValue()).contains("<property><name>tez.lib.uris</name><value>"
+                + tezLibUri + "</value></property>");
     }
 
     private TemplatePreparationObject getTemplatePreparationObject(String... locations) {
@@ -69,11 +76,23 @@ public class TezRoleConfigProviderTest {
             hmsExternalWarehouseDir.setProperty("hive.metastore.warehouse.external.dir");
             hmsExternalWarehouseDir.setValue(locations[0]);
             storageLocations.add(new StorageLocationView(hmsExternalWarehouseDir));
+
+            StorageLocation datahubDirLocation = new StorageLocation();
+            datahubDirLocation.setProperty(CORE_DEFAULTFS);
+            datahubDirLocation.setValue(locations[1]);
+            storageLocations.add(new StorageLocationView(datahubDirLocation));
         }
         S3FileSystemConfigurationsView fileSystemConfigurationsView =
                 new S3FileSystemConfigurationsView(new S3FileSystem(), storageLocations, false);
 
+        ArrayList<ClouderaManagerProduct> products = new ArrayList<>();
+        ClouderaManagerProduct cdh = new ClouderaManagerProduct();
+        cdh.setName("cdh");
+        cdh.setVersion("7.0.2-1.cdh7.0.2.p2.1711788");
+        products.add(cdh);
+
         return Builder.builder().withFileSystemConfigurationView(fileSystemConfigurationsView)
+                .withProductDetails(new ClouderaManagerRepo(), products)
                 .withHostgroupViews(Set.of(master, worker)).build();
     }
 


### PR DESCRIPTION
    1. Right now this jar is stored in HDFS using CM command https://github.infra.cloudera.com/Starship/cmf/blob/cdpd-master/web/src/main/java/com/cloudera/cmf/service/tez/TezUploadTarCommand.java#L84
    2. Adding a safety valve for tez.lib.uris property to set the location to a cloudstorage.
    3. The directory structure follows what is in CM already.
    4. We need to change the CM code to use this property instead of the HDFS location hardcoding. Once that is promoted we can promote this change.
    5. Have the tez jar isolated into datahub location, to prevent issues arising from concurrent creation of datahub clusters.
    6. Moved to Junit5.
    
    ./gradlew clean build
