### PR TITLE
Revert "CB-4917 Change instance type and disk in OpDB DataHub"

### DIFF
--- a/core/src/main/resources/defaults/clustertemplates/azure/azure-opdb-702.json
+++ b/core/src/main/resources/defaults/clustertemplates/azure/azure-opdb-702.json
@@ -98,7 +98,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "Premium_LRS"
+              "type": "StandardSSD_LRS"
             }
           ],
           "azure": {
@@ -108,7 +108,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_DS4_v2",
+          "instanceType": "Standard_D8_v3",
           "rootVolume": {
             "size": 50
           },


### PR DESCRIPTION
This reverts commit b0eb36743b07060ad0b293aeecd94ae85253930c.
Instance type Standard_DS4_v2 is not supported by product.
see: CB-4012

followup:
CB-5197