### PR TITLE
CB-5174. Use shared altus credential is not always set if enabled

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
@@ -112,6 +112,8 @@ public class TelemetryConverter {
             if (featuresResponse != null) {
                 LOGGER.debug("Setting report deployment logs response (telemetry) based on environment response.");
                 featuresRequest.setReportDeploymentLogs(featuresResponse.getReportDeploymentLogs());
+                LOGGER.debug("Setting use shared altus credential feature based on environment response.");
+                featuresRequest.setUseSharedAltusCredential(featuresResponse.getUseSharedAltusCredential());
             }
             telemetryRequest.setFluentAttributes(response.getFluentAttributes());
         }
@@ -204,6 +206,7 @@ public class TelemetryConverter {
             featuresRequest = new FeaturesRequest();
             featuresRequest.setWorkloadAnalytics(features.getWorkloadAnalytics());
             featuresRequest.setReportDeploymentLogs(features.getReportDeploymentLogs());
+            featuresRequest.setUseSharedAltusCredential(features.getUseSharedAltusCredential());
         }
         return featuresRequest;
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
@@ -40,7 +40,7 @@ public class TelemetryConverterTest {
 
     @Before
     public void setUp() {
-        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, false, "", null);
+        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, true, "****", "****");
         TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true);
         underTest = new TelemetryConverter(telemetryConfiguration, true, true);
     }
@@ -71,6 +71,9 @@ public class TelemetryConverterTest {
         FeatureSetting reportDeploymentLogs = new FeatureSetting();
         reportDeploymentLogs.setEnabled(false);
         featuresRequest.setReportDeploymentLogs(reportDeploymentLogs);
+        FeatureSetting useSharedCredential = new FeatureSetting();
+        useSharedCredential.setEnabled(true);
+        featuresRequest.setUseSharedAltusCredential(useSharedCredential);
         telemetryRequest.setLogging(logging);
         telemetryRequest.setFeatures(featuresRequest);
         telemetryRequest.setWorkloadAnalytics(workloadAnalyticsRequest);
@@ -81,6 +84,7 @@ public class TelemetryConverterTest {
         assertFalse(result.getFeatures().getReportDeploymentLogs().isEnabled());
         assertTrue(result.getFeatures().getMetering().isEnabled());
         assertTrue(result.getFeatures().getWorkloadAnalytics().isEnabled());
+        assertTrue(result.getFeatures().getUseSharedAltusCredential().isEnabled());
         assertEquals(DATABUS_ENDPOINT, result.getDatabusEndpoint());
         assertEquals(DATABUS_ENDPOINT, result.getWorkloadAnalytics().getDatabusEndpoint());
     }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
@@ -175,11 +175,10 @@ public class StackRequestManifester {
             loggingRequest.setCloudwatch(envLogging.getCloudwatch());
             loggingRequest.setStorageLocation(envLogging.getStorageLocation());
             telemetryRequest.setLogging(loggingRequest);
-            if (envTelemetry.getFeatures() != null
-                    && envTelemetry.getFeatures().getReportDeploymentLogs() != null) {
+            if (envTelemetry.getFeatures() != null) {
                 FeaturesRequest featuresRequest = new FeaturesRequest();
-                featuresRequest.setReportDeploymentLogs(
-                        environment.getTelemetry().getFeatures().getReportDeploymentLogs());
+                featuresRequest.setReportDeploymentLogs(envTelemetry.getFeatures().getReportDeploymentLogs());
+                featuresRequest.setUseSharedAltusCredential(envTelemetry.getFeatures().getUseSharedAltusCredential());
                 telemetryRequest.setFeatures(featuresRequest);
             }
             if (envTelemetry.getFluentAttributes() != null) {

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/TelemetryApiConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/TelemetryApiConverterTest.java
@@ -33,7 +33,7 @@ public class TelemetryApiConverterTest {
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration("", false, "", null);
+        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration("", true, "****", "****");
         TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true);
         underTest = new TelemetryApiConverter(telemetryConfiguration);
     }
@@ -53,8 +53,11 @@ public class TelemetryApiConverterTest {
         fsReportLogs.setEnabled(true);
         FeatureSetting fsWorladAnalytics = new FeatureSetting();
         fsWorladAnalytics.setEnabled(true);
+        FeatureSetting fsUseSharedCredential = new FeatureSetting();
+        fsUseSharedCredential.setEnabled(true);
         fr.setReportDeploymentLogs(fsReportLogs);
         fr.setWorkloadAnalytics(fsWorladAnalytics);
+        fr.setUseSharedAltusCredential(fsUseSharedCredential);
         telemetryRequest.setFeatures(fr);
         // WHEN
         EnvironmentTelemetry result = underTest.convert(telemetryRequest);
@@ -62,6 +65,7 @@ public class TelemetryApiConverterTest {
         assertEquals(INSTANCE_PROFILE_VALUE, result.getLogging().getS3().getInstanceProfile());
         assertTrue(result.getFeatures().getReportDeploymentLogs().isEnabled());
         assertTrue(result.getFeatures().getWorkloadAnalytics().isEnabled());
+        assertTrue(result.getFeatures().getUseSharedAltusCredential().isEnabled());
     }
 
     @Test

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverter.java
@@ -133,7 +133,7 @@ public class TelemetryConverter {
 
     private FeaturesResponse createFeaturesResponseFromSource(Features features) {
         FeaturesResponse featuresResponse = null;
-        if (features != null && features.getReportDeploymentLogs() != null) {
+        if (features != null) {
             featuresResponse = new FeaturesResponse();
             featuresResponse.setReportDeploymentLogs(features.getReportDeploymentLogs());
             featuresResponse.setUseSharedAltusCredential(features.getUseSharedAltusCredential());


### PR DESCRIPTION
altus shared credential is not set on the API for every use case
- fix converters on the right place
- add some UT changes