### PR TITLE
CB-5215 Add postgres traffic check to integration test

### DIFF
--- a/integration-test/scripts/analyse_postgres_stat.jsh
+++ b/integration-test/scripts/analyse_postgres_stat.jsh
@@ -1,0 +1,79 @@
+enum Unit {
+    kB,
+    MB,
+    GB
+}
+
+class Traffic {
+    double kiloBytes;
+
+    Traffic(String value) {
+        Unit unit;
+        if(value.endsWith("kB")) {
+            unit = Unit.kB;
+        } else if(value.endsWith("MB")) {
+            unit = Unit.MB;
+        } else if(value.endsWith("GB")) {
+            unit = Unit.GB;
+        } else {
+            throw new IllegalArgumentException("No unit is present. Value: " + value);
+        }
+        double factor = factor(unit);
+        double bytes = Double.parseDouble(value.replace(unit.name(), ""));
+        this.kiloBytes = bytes * factor;
+    }
+
+    double factor(Unit unit) {
+        switch(unit) {
+            case kB:
+                return 1;
+            case MB:
+                return 1024.0;
+            case GB:
+                return 1024.0 * 1024.0;
+            default:
+                throw new IllegalArgumentException("Unknown unit: " + unit);
+        }
+    }
+
+    double getKiloBytes() {
+        return kiloBytes;
+    }
+
+    double getAsGigaBytes() {
+        return kiloBytes / factor(Unit.GB);
+    }
+
+    boolean isSmallerThan(Traffic traffic) {
+        return this.kiloBytes <= traffic.getKiloBytes();
+    }
+}
+
+try {
+    List<String> pgStat = Files.readAllLines(Paths.get("/tmp/pg_stat_network_io.result"));
+
+    if (pgStat.size() != 1) {
+        throw new IllegalArgumentException("Expected one line for postgres network statistics. Got:" + pgStat);
+    }
+
+    String[] networkIOStat = pgStat.get(0).split("/");
+
+    if(networkIOStat.length != 2) {
+        throw new IllegalArgumentException("Expected two params from postgres network I/O separated by /. Got:" + pgStat);
+    }
+
+    String networkOutput = networkIOStat[1].trim();
+    Traffic maxAllowedPostgresNetworkOutput = new Traffic(System.getenv("INTEGRATION_TEST_MAX_POSTGRES_OUTPUT").trim());
+    Traffic actualPostgresNetworkOutput = new Traffic(networkOutput);
+
+    if (actualPostgresNetworkOutput.isSmallerThan(maxAllowedPostgresNetworkOutput)) {
+        System.out.print("POSTGRES>> OK");
+    } else {
+        System.out.println("POSTGRES>> Max allowed postgres network output: " + maxAllowedPostgresNetworkOutput.getAsGigaBytes() + "GB");
+        System.out.println("POSTGRES>> Actual postgres network output: " + actualPostgresNetworkOutput.getAsGigaBytes() + "GB");
+    }
+} catch(Exception ex) {
+    System.err.println("POSTGRES>> " + ex.getMessage());
+}
+
+/exit

--- a/integration-test/scripts/check-results.sh
+++ b/integration-test/scripts/check-results.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+: ${INTEGRATIONTEST_MAX_PG_NETWORK_OUTPUT:="16GB"}
+
 status_code=0
 
 if [[ "$CIRCLECI" ]]; then
@@ -22,6 +24,22 @@ if [[ "$CIRCLECI" ]]; then
     # Check swagger validation results
     if ! grep -q "is valid against swagger specification 2.0" swagger-validation-result.out; then
         echo -e "\033[0;91m--- !!! THE SWAGGER SPECIFICATION IS INVALID, CHECK \033[1;93mswagger-validation-result.out\033[0;91m FOR RESULTS !!! ---\n"; status_code=1;
+    fi
+
+    if [[ -z "${INTEGRATIONTEST_YARN_QUEUE}" ]] && [[ "$AWS" != true ]]; then
+      docker run --rm \
+       -v "$(pwd)"/scripts/analyse_postgres_stat.jsh:/opt/analyse_postgres_stat.jsh \
+       -v "$(pwd)"/test-output/docker_stats/pg_stat_network_io.result:/tmp/pg_stat_network_io.result \
+       --env INTEGRATION_TEST_MAX_POSTGRES_OUTPUT=${INTEGRATIONTEST_MAX_PG_NETWORK_OUTPUT} \
+       openjdk:11-jdk \
+       jshell /opt/analyse_postgres_stat.jsh > ./test-output/docker_stats/pg_stat_network_io_analysed.result;
+
+      pg_res=$(cat ./test-output/docker_stats/pg_stat_network_io_analysed.result);
+      if [[ "$pg_res" == "POSTGRES>> OK" ]]; then
+        echo -e "\n\033[0;92m+++ Postgres traffic is below ${max_pg_network_output} limit.";
+      else
+        echo -e "\033[0;91m--- !!! Postgres trafic check failed: ${pg_res}"; status_code=1;
+      fi
     fi
 
     # Exit if there are failed tests

--- a/integration-test/src/main/resources/pg_stats/pg_query_stat_template.html
+++ b/integration-test/src/main/resources/pg_stats/pg_query_stat_template.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Query statistics</title>
+    <script src="https://code.jquery.com/jquery-3.4.1.min.js"
+            integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.31.2/js/jquery.tablesorter.min.js"
+            integrity="sha256-WX1A5tGpPfZZ48PgoZX2vpOojjCXsytpCvgPcRPnFKU=" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css"
+          integrity="sha256-l85OmPOjvil/SOvVt3HnSSjzF1TUMyT9eV0c2BzEGzU=" crossorigin="anonymous"/>
+    <style>
+    html {
+      font-size: 1rem;
+    }
+
+    html,
+    body {
+      height: 100vh;
+    }
+
+    * {
+      box-sizing: border-box;
+      font-family: sans-serif;
+    }
+
+    table {
+      border-collapse: collapse;
+      position: relative;
+    }
+
+    th {
+      max-width: 40rem;
+      text-transform: uppercase;
+      padding: 0.75rem;
+      background-color: gray;
+      color: white;
+      position: sticky;
+      top: 0;
+    }
+
+    th:hover {
+      background-color: black;
+    }
+
+    th[align="center"] {
+      text-align: center;
+    }
+
+    td {
+      max-width: 40rem;
+      padding: 0.5rem;
+    }
+
+    td[align="right"] {
+      text-align: right;
+    }
+
+    td[align="left"] {
+      text-align: left;
+    }
+
+    .layout {
+      display: grid;
+      padding: 1rem;
+      grid-template-areas:
+        "desc"
+        "navigator"
+        "tabView";
+      height: 100%;
+      grid-template-columns: 1fr;
+      grid-template-rows: auto auto 1fr;
+    }
+
+    .desc {
+      grid-area: desc;
+      padding: 0 0.5rem;
+    }
+
+    .navigator {
+      grid-area: navigator;
+    }
+
+    .tab {
+      padding: 0.7rem;
+    }
+
+    .tab:hover {
+      background-color: cornflowerblue;
+    }
+
+    .query-table {
+      grid-area: tabView;
+      overflow: scroll;
+      display: none;
+      border: 1px solid black;
+    }
+
+    .docker-stat {
+      grid-area: tabView;
+      overflow: scroll;
+      display: none;
+    }
+
+    .query-table:target {
+      display: block;
+    }
+
+    .docker-stat:target {
+      display: block;
+    }
+
+    .docker-stat>pre {
+      background-color: rgb(240, 240, 240);
+      padding: 1rem;
+    }
+    </style>
+</head>
+
+<body>
+<div class="layout">
+    <p class="desc">Database query statistics. Exported from the <a
+            href="https://www.postgresql.org/docs/9.6/pgstatstatements.html">pg_stat_statements</a> table.</p>
+    <p class="navigator">
+        <a class="tab" href="#cbdb">cbdb stat</a>
+        <a class="tab" href="#docker_stats">docker stats</a>
+    <div id="cbdb" class="query-table">
+        CB_PG_STAT
+    </div>
+    <div id="docker_stats" class="docker-stat">
+        <pre>DOCKER_STAT_RESULT</pre>
+    </div>
+</div>
+
+<script>
+    $(function () {
+      let table = document.querySelector("#cbdb>table");
+      let theaderRow = table.querySelector("tbody>tr");
+      document.querySelector("#cbdb>table>tbody").removeChild(theaderRow);
+      let theader = document.createElement("thead");
+      theader.appendChild(theaderRow);
+      table.insertBefore(theader, table.querySelector("tbody"));
+
+      $("#cbdb>table").tablesorter();
+    });
+</script>
+</body>
+
+</html>


### PR DESCRIPTION
__DB network traffic check__

Configurable check to limit the overall network traffic between cloudbreak and postgres. If the overall traffic is higher than `INTEGRATIONTEST_MAX_PG_NETWORK_OUTPUT (default="16GB")` 
the integration test will fail. The current usage is around 14.4 GB but over time we can bring down the limit with jenkins config.

__Html database query statistics__

Other than that the integration test exports postgres query statistics and stores it as a html artifact so that developers can analyse database usage.