### PR TITLE
CB-5250. Add nginx logs to log collection

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/fluent/template/input.conf.j2
+++ b/freeipa/src/main/resources/freeipa-salt/salt/fluent/template/input.conf.j2
@@ -90,6 +90,22 @@
   tag {{providerPrefix}}.pki_transactions
   read_from_head true
 </source>
+<source>
+  @type tail
+  format none
+  path /var/log/nginx/access.log
+  pos_file /var/log/td-agent/pos/{{providerPrefix}}-nginx-access.log.pos
+  tag {{providerPrefix}}.nginx_access
+  read_from_head true
+</source>
+<source>
+  @type tail
+  format none
+  path /var/log/nginx/error.log
+  pos_file /var/log/td-agent/pos/{{providerPrefix}}-nginx-error.log.pos
+  tag {{providerPrefix}}.nginx_error
+  read_from_head true
+</source>
 </worker>
 {% else %}
 # DATABUS inputs are disabled

--- a/orchestrator-salt/src/main/resources/salt/salt/fluent/template/input.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/fluent/template/input.conf.j2
@@ -532,6 +532,22 @@
   tag {{providerPrefix}}.AUTOSSH
   read_from_head true
 </source>
+<source>
+  @type tail
+  format none
+  path /var/log/nginx/access.log
+  pos_file /var/log/td-agent/pos/{{providerPrefix}}-nginx-access.log.pos
+  tag {{providerPrefix}}.nginx_access
+  read_from_head true
+</source>
+<source>
+  @type tail
+  format none
+  path /var/log/nginx/error.log
+  pos_file /var/log/td-agent/pos/{{providerPrefix}}-nginx-error.log.pos
+  tag {{providerPrefix}}.nginx_error
+  read_from_head true
+</source>
 </worker>
 {% else %}
 # DATABUS inputs are disabled


### PR DESCRIPTION
collect nginx access and error logs, based on a freeipa cluster, the logs are the following:
- /var/log/nginx/access.log
- /var/log/nginx/error.log