### PR TITLE
CDPCP-1359. Usersync handles users with empty groups

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/model/User.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/model/User.java
@@ -81,7 +81,7 @@ public class User {
                 + ", sn='" + sn + '\''
                 + ", uid='" + uid + '\''
                 + ", givenname='" + givenname + '\''
-                + ", memberOfGroup=" + memberOfGroup + '\''
+                + ", memberOfGroup='" + memberOfGroup + '\''
                 + ", krbPasswordExpiration='" + krbPasswordExpiration + '\''
                 + '}';
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/FreeIpaUsersStateProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/FreeIpaUsersStateProvider.java
@@ -36,9 +36,13 @@ public class FreeIpaUsersStateProvider {
                 .filter(user -> !IPA_ONLY_USERS.contains(user.getUid()))
                 .forEach(user -> {
                     builder.addUser(fromIpaUser(user));
-                    user.getMemberOfGroup().stream()
-                            .filter(group -> !IPA_ONLY_GROUPS.contains(group))
-                            .forEach(group -> builder.addMemberToGroup(group, user.getUid()));
+                    if (null != user.getMemberOfGroup()) {
+                        user.getMemberOfGroup().stream()
+                                .filter(group -> !IPA_ONLY_GROUPS.contains(group))
+                                .forEach(group -> builder.addMemberToGroup(group, user.getUid()));
+                    } else {
+                        LOGGER.warn("User {} is not a member of any groups.", user.getUid());
+                    }
                 });
 
         freeIpaClient.groupFindAll().stream()

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/FreeIpaUsersStateProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/FreeIpaUsersStateProviderTest.java
@@ -88,6 +88,25 @@ class FreeIpaUsersStateProviderTest {
     }
 
     @Test
+    void testGetUserStateUserWithNullGroups() throws Exception {
+        String username = "userNull";
+        Set<com.sequenceiq.freeipa.client.model.User> usersFindAll = Set.of(createIpaUser(username, null));
+
+        Set<com.sequenceiq.freeipa.client.model.Group> groupsFindAll = FreeIpaUsersStateProvider.IPA_ONLY_GROUPS.stream()
+                .map(this::createIpaGroup)
+                .collect(Collectors.toSet());
+
+        when(freeIpaClient.userFindAll()).thenReturn(usersFindAll);
+        when(freeIpaClient.groupFindAll()).thenReturn(groupsFindAll);
+
+        UsersState ipaState = underTest.getUsersState(freeIpaClient);
+
+        assertEquals(1, ipaState.getUsers().size());
+        FmsUser ipaUser = ipaState.getUsers().asList().get(0);
+        assertEquals(username, ipaUser.getName());
+    }
+
+    @Test
     void testFromIpaUser() {
         com.sequenceiq.freeipa.client.model.User ipaUser = createIpaUser("uid", List.of("group1", "group2"));
 


### PR DESCRIPTION
Users with empty groups would cause a NullPointerException when
constructing the FreeIPA users state model. Failure constructing this
model will prevent usersync from progressing on that environment.

This commit adds a null-check and logs a warning if we see a user that
is not a member of any groups. We generally don't expect to see this
condition because all users are part of the ipausers group by default.
However, it is possible for someone to modify a user directly in ipa
and we need to protect the usersync process against this case.
