### PR TITLE
CDPCP-624. Prevent cross-account queries for operation status

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/OperationV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/OperationV1Controller.java
@@ -5,23 +5,25 @@ import javax.validation.constraints.NotNull;
 
 import org.springframework.stereotype.Controller;
 
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.freeipa.api.v1.operation.OperationV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.operation.model.OperationStatus;
+import com.sequenceiq.freeipa.converter.operation.OperationToOperationStatusConverter;
 import com.sequenceiq.freeipa.service.operation.OperationStatusService;
-import com.sequenceiq.freeipa.util.CrnService;
 
 @Controller
 public class OperationV1Controller implements OperationV1Endpoint {
 
     @Inject
-    private OperationStatusService operationService;
+    private OperationStatusService operationStatusService;
 
     @Inject
-    private CrnService crnService;
+    private OperationToOperationStatusConverter operationToOperationStatusConverter;
 
     @Override
     public OperationStatus getOperationStatus(@NotNull String operationId) {
-        String accountId = crnService.getCurrentAccountId();
-        return operationService.getOperationStatus(operationId, accountId);
+        String actorCrn = ThreadBasedUserCrnProvider.getUserCrn();
+        String accountId = ThreadBasedUserCrnProvider.getAccountId();
+        return operationToOperationStatusConverter.convert(operationStatusService.getOperationForAccountIdAndOperationId(actorCrn, accountId, operationId));
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/FreeIpaCleanupActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/FreeIpaCleanupActions.java
@@ -35,7 +35,7 @@ import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.users.RemoveUsersReques
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.users.RemoveUsersResponse;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.vault.RemoveVaultEntriesRequest;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.vault.RemoveVaultEntriesResponse;
-import com.sequenceiq.freeipa.service.operation.OperationStatusService;
+import com.sequenceiq.freeipa.service.operation.OperationService;
 
 @Configuration
 public class FreeIpaCleanupActions {
@@ -155,7 +155,7 @@ public class FreeIpaCleanupActions {
         return new AbstractFreeIpaCleanupAction<>(RemoveRolesResponse.class) {
 
             @Inject
-            private OperationStatusService operationStatusService;
+            private OperationService operationService;
 
             @Override
             protected void doExecute(FreeIpaContext context, RemoveRolesResponse payload, Map<Object, Object> variables) {
@@ -165,7 +165,7 @@ public class FreeIpaCleanupActions {
                 successDetails.getAdditionalDetails().put("Hosts", payload.getHosts() == null ? List.of() : new ArrayList<>(payload.getHosts()));
                 successDetails.getAdditionalDetails().put("Users", payload.getUsers() == null ? List.of() : new ArrayList<>(payload.getUsers()));
                 successDetails.getAdditionalDetails().put("Roles", payload.getRoles() == null ? List.of() : new ArrayList<>(payload.getRoles()));
-                operationStatusService.completeOperation(payload.getOperationId(), List.of(successDetails), Collections.emptyList());
+                operationService.completeOperation(payload.getOperationId(), List.of(successDetails), Collections.emptyList());
                 LOGGER.info("Cleanup successfully finished with: " + successDetails);
                 sendEvent(context, cleanupEvent);
             }
@@ -177,7 +177,7 @@ public class FreeIpaCleanupActions {
         return new AbstractFreeIpaCleanupAction<>(CleanupFailureEvent.class) {
 
             @Inject
-            private OperationStatusService operationStatusService;
+            private OperationService operationService;
 
             @Override
             protected void doExecute(FreeIpaContext context, CleanupFailureEvent payload, Map<Object, Object> variables) {
@@ -190,7 +190,7 @@ public class FreeIpaCleanupActions {
                 if (payload.getFailureDetails() != null) {
                     failureDetails.getAdditionalDetails().putAll(payload.getFailureDetails());
                 }
-                operationStatusService.failOperation(payload.getOperationId(), message, List.of(successDetails), List.of(failureDetails));
+                operationService.failOperation(payload.getOperationId(), message, List.of(successDetails), List.of(failureDetails));
                 sendEvent(context, FreeIpaCleanupEvent.CLEANUP_FAILURE_HANDLED_EVENT.event(), payload);
             }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/cleanup/CleanupService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/cleanup/CleanupService.java
@@ -45,7 +45,7 @@ import com.sequenceiq.freeipa.ldap.LdapConfigService;
 import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
 import com.sequenceiq.freeipa.service.freeipa.flow.FreeIpaFlowManager;
 import com.sequenceiq.freeipa.service.freeipa.host.HostDeletionService;
-import com.sequenceiq.freeipa.service.operation.OperationStatusService;
+import com.sequenceiq.freeipa.service.operation.OperationService;
 import com.sequenceiq.freeipa.service.stack.StackService;
 
 @Service
@@ -66,7 +66,7 @@ public class CleanupService {
     private FreeIpaFlowManager flowManager;
 
     @Inject
-    private OperationStatusService operationStatusService;
+    private OperationService operationService;
 
     @Inject
     private OperationToOperationStatusConverter operationToOperationStatusConverter;
@@ -84,7 +84,7 @@ public class CleanupService {
         Stack stack = stackService.getByEnvironmentCrnAndAccountIdWithLists(request.getEnvironmentCrn(), accountId);
         MDCBuilder.buildMdcContext(stack);
         Operation operation =
-                operationStatusService.startOperation(accountId, OperationType.CLEANUP, Set.of(stack.getEnvironmentCrn()), Collections.emptySet());
+                operationService.startOperation(accountId, OperationType.CLEANUP, Set.of(stack.getEnvironmentCrn()), Collections.emptySet());
         CleanupEvent cleanupEvent = new CleanupEvent(FreeIpaCleanupEvent.CLEANUP_EVENT.event(), stack.getId(), request.getUsers(),
                 request.getHosts(), request.getRoles(), operation.getOperationId(), request.getClusterName());
         flowManager.notify(FreeIpaCleanupEvent.CLEANUP_EVENT.event(), cleanupEvent);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/poller/UserSyncPoller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/poller/UserSyncPoller.java
@@ -23,7 +23,7 @@ import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.auth.security.InternalCrnBuilder;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
-import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SyncOperationStatus;
+import com.sequenceiq.freeipa.entity.Operation;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.entity.UserSyncStatus;
 import com.sequenceiq.freeipa.service.freeipa.user.UmsEventGenerationIdsProvider;
@@ -121,7 +121,7 @@ public class UserSyncPoller {
                     cooldownChecker.isCooldownExpired(userSyncStatus, cooldownThresholdTime)) {
                 LOGGER.debug("Environment {} in Account {} is not in sync.",
                         stack.getEnvironmentCrn(), stack.getAccountId());
-                SyncOperationStatus operation = userSyncService.synchronizeUsers(stack.getAccountId(), INTERNAL_ACTOR_CRN,
+                Operation operation = userSyncService.synchronizeUsers(stack.getAccountId(), INTERNAL_ACTOR_CRN,
                         Set.of(stack.getEnvironmentCrn()), Set.of(), Set.of());
                 LOGGER.debug("User Sync request resulted in operation {}", operation);
             } else {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/operation/OperationService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/operation/OperationService.java
@@ -1,0 +1,121 @@
+package com.sequenceiq.freeipa.service.operation;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.FailureDetails;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SuccessDetails;
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationState;
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationType;
+import com.sequenceiq.freeipa.controller.exception.NotFoundException;
+import com.sequenceiq.freeipa.entity.Operation;
+import com.sequenceiq.freeipa.repository.OperationRepository;
+import com.sequenceiq.freeipa.service.freeipa.user.AcceptResult;
+
+@Service
+public class OperationService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(OperationService.class);
+
+    @Inject
+    private OperationRepository operationRepository;
+
+    @Inject
+    private List<OperationAcceptor> operationAcceptorList;
+
+    private Map<OperationType, OperationAcceptor> operationAcceptorMap = new HashMap<>();
+
+    @PostConstruct
+    public void init() {
+        operationAcceptorList.stream()
+                .peek(a -> LOGGER.info("Registering acceptor for {}", a.selector()))
+                .forEach(a -> operationAcceptorMap.put(a.selector(), a));
+
+        for (OperationType operationType : OperationType.values()) {
+            if (!operationAcceptorMap.containsKey(operationType)) {
+                throw new IllegalStateException("No Acceptor injected for OperationType " + operationType);
+            }
+        }
+    }
+
+    public Operation startOperation(String accountId, OperationType operationType,
+            Collection<String> environmentCrns, Collection<String> userCrns) {
+        Operation operation = requestOperation(accountId, operationType, environmentCrns, userCrns);
+        OperationAcceptor acceptor = operationAcceptorMap.get(operationType);
+
+        AcceptResult acceptResult = acceptor.accept(operation);
+        if (acceptResult.isAccepted()) {
+            operation = acceptOperation(operation);
+        } else {
+            operation = rejectOperation(operation, acceptResult.getRejectionMessage().orElse("Rejected for unspecified reason."));
+        }
+
+        return operationRepository.save(operation);
+    }
+
+    public Operation completeOperation(String operationId, Collection<SuccessDetails> success, Collection<FailureDetails> failure) {
+        Operation operation = getOperationForOperationId(operationId);
+        operation.setStatus(OperationState.COMPLETED);
+        operation.setSuccessList(List.copyOf(success));
+        operation.setFailureList(List.copyOf(failure));
+        operation.setEndTime(System.currentTimeMillis());
+        return operationRepository.save(operation);
+    }
+
+    public Operation failOperation(String operationId, String failureMessage, Collection<SuccessDetails> success, Collection<FailureDetails> failure) {
+        Operation operation = getOperationForOperationId(operationId);
+        operation.setStatus(OperationState.FAILED);
+        operation.setError(failureMessage);
+        operation.setEndTime(System.currentTimeMillis());
+        operation.setSuccessList(List.copyOf(success));
+        operation.setFailureList(List.copyOf(failure));
+        return operationRepository.save(operation);
+    }
+
+    public Operation failOperation(String operationId, String failureMessage) {
+        return failOperation(operationId, failureMessage, Collections.emptyList(), Collections.emptyList());
+    }
+
+    private Operation requestOperation(String accountId, OperationType operationType,
+            Collection<String> environmentCrns, Collection<String> userCrns) {
+        Operation operation = new Operation();
+        operation.setOperationId(UUID.randomUUID().toString());
+        operation.setStatus(OperationState.REQUESTED);
+        operation.setAccountId(accountId);
+        operation.setOperationType(operationType);
+        operation.setEnvironmentList(List.copyOf(environmentCrns));
+        operation.setUserList(List.copyOf(userCrns));
+        return operationRepository.save(operation);
+    }
+
+    private Operation acceptOperation(Operation operation) {
+        operation.setStatus(OperationState.RUNNING);
+        return operation;
+    }
+
+    private Operation rejectOperation(Operation operation, String reason) {
+        operation.setStatus(OperationState.REJECTED);
+        operation.setEndTime(System.currentTimeMillis());
+        operation.setError(reason);
+        return operation;
+    }
+
+    private Operation getOperationForOperationId(String operationId) {
+        Optional<Operation> syncOperationOptional = operationRepository.findByOperationId(operationId);
+        if (!syncOperationOptional.isPresent()) {
+            throw NotFoundException.notFound("Operation", operationId).get();
+        }
+        return syncOperationOptional.get();
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/operation/OperationStatusService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/operation/OperationStatusService.java
@@ -1,32 +1,18 @@
 package com.sequenceiq.freeipa.service.operation;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 
-import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-import com.sequenceiq.freeipa.api.v1.freeipa.user.model.FailureDetails;
-import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SuccessDetails;
-import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SyncOperationStatus;
-import com.sequenceiq.freeipa.api.v1.operation.model.OperationState;
-import com.sequenceiq.freeipa.api.v1.operation.model.OperationStatus;
-import com.sequenceiq.freeipa.api.v1.operation.model.OperationType;
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.cloudbreak.auth.security.InternalCrnBuilder;
 import com.sequenceiq.freeipa.controller.exception.NotFoundException;
-import com.sequenceiq.freeipa.converter.freeipa.user.OperationToSyncOperationStatus;
-import com.sequenceiq.freeipa.converter.operation.OperationToOperationStatusConverter;
 import com.sequenceiq.freeipa.entity.Operation;
 import com.sequenceiq.freeipa.repository.OperationRepository;
-import com.sequenceiq.freeipa.service.freeipa.user.AcceptResult;
 
 @Service
 public class OperationStatusService {
@@ -35,114 +21,17 @@ public class OperationStatusService {
     @Inject
     private OperationRepository operationRepository;
 
-    @Inject
-    private OperationToSyncOperationStatus operationToSyncOperationStatus;
-
-    @Inject
-    private OperationToOperationStatusConverter operationToOperationStatusConverter;
-
-    @Inject
-    private List<OperationAcceptor> operationAcceptorList;
-
-    private Map<OperationType, OperationAcceptor> operationAcceptorMap = new HashMap<>();
-
-    @PostConstruct
-    public void init() {
-        operationAcceptorList.stream()
-                .peek(a -> LOGGER.info("Registering acceptor for {}", a.selector()))
-                .forEach(a -> operationAcceptorMap.put(a.selector(), a));
-
-        for (OperationType operationType : OperationType.values()) {
-            if (!operationAcceptorMap.containsKey(operationType)) {
-                throw new IllegalStateException("No Acceptor injected for OperationType " + operationType);
+    public Operation getOperationForAccountIdAndOperationId(String actorCrn, String accountId, String operationId) {
+        if (InternalCrnBuilder.isInternalCrn(actorCrn) || Crn.safeFromString(actorCrn).getAccountId().equals(accountId)) {
+            Optional<Operation> operationOptional = operationRepository.findByOperationIdAndAccountId(operationId, accountId);
+            if (!operationOptional.isPresent()) {
+                LOGGER.info("Operation [{}] in account [{}] not found", operationId, accountId);
+                throw NotFoundException.notFound("Operation", operationId).get();
             }
-        }
-    }
-
-    public Operation startOperation(String accountId, OperationType operationType,
-            Collection<String> environmentCrns, Collection<String> userCrns) {
-        Operation operation = requestOperation(accountId, operationType, environmentCrns, userCrns);
-        OperationAcceptor acceptor = operationAcceptorMap.get(operationType);
-
-        AcceptResult acceptResult = acceptor.accept(operation);
-        if (acceptResult.isAccepted()) {
-            operation = acceptOperation(operation);
+            return operationOptional.get();
         } else {
-            operation = rejectOperation(operation, acceptResult.getRejectionMessage().orElse("Rejected for unspecified reason."));
+            LOGGER.warn("ActorCRN {} attempting to retrieve operation '{}' in different account '{}' ", actorCrn, operationId, accountId);
+            throw NotFoundException.notFound("Operation", operationId).get();
         }
-
-        return operationRepository.save(operation);
-    }
-
-    public Operation completeOperation(String operationId, Collection<SuccessDetails> success, Collection<FailureDetails> failure) {
-        Operation operation = getOperationForOperationId(operationId);
-        operation.setStatus(OperationState.COMPLETED);
-        operation.setSuccessList(List.copyOf(success));
-        operation.setFailureList(List.copyOf(failure));
-        operation.setEndTime(System.currentTimeMillis());
-        return operationRepository.save(operation);
-    }
-
-    public Operation failOperation(String operationId, String failureMessage, Collection<SuccessDetails> success, Collection<FailureDetails> failure) {
-        Operation operation = getOperationForOperationId(operationId);
-        operation.setStatus(OperationState.FAILED);
-        operation.setError(failureMessage);
-        operation.setEndTime(System.currentTimeMillis());
-        operation.setSuccessList(List.copyOf(success));
-        operation.setFailureList(List.copyOf(failure));
-        return operationRepository.save(operation);
-    }
-
-    public Operation failOperation(String operationId, String failureMessage) {
-        return failOperation(operationId, failureMessage, Collections.emptyList(), Collections.emptyList());
-    }
-
-    public SyncOperationStatus getSyncOperationStatus(String operationId) {
-        return operationToSyncOperationStatus.convert(getOperationForOperationId(operationId));
-    }
-
-    public OperationStatus getOperationStatus(String operationId, String accountId) {
-        return operationToOperationStatusConverter.convert(getOperationForOperationId(operationId));
-    }
-
-    private Operation requestOperation(String accountId, OperationType operationType,
-            Collection<String> environmentCrns, Collection<String> userCrns) {
-        Operation operation = new Operation();
-        operation.setOperationId(UUID.randomUUID().toString());
-        operation.setStatus(OperationState.REQUESTED);
-        operation.setAccountId(accountId);
-        operation.setOperationType(operationType);
-        operation.setEnvironmentList(List.copyOf(environmentCrns));
-        operation.setUserList(List.copyOf(userCrns));
-        return operationRepository.save(operation);
-    }
-
-    private Operation acceptOperation(Operation operation) {
-        operation.setStatus(OperationState.RUNNING);
-        return operation;
-    }
-
-    private Operation rejectOperation(Operation operation, String reason) {
-        operation.setStatus(OperationState.REJECTED);
-        operation.setEndTime(System.currentTimeMillis());
-        operation.setError(reason);
-        return operation;
-    }
-
-    private Operation getOperationForOperationId(String operationId) {
-        Optional<Operation> syncOperationOptional = operationRepository.findByOperationId(operationId);
-        if (!syncOperationOptional.isPresent()) {
-            throw NotFoundException.notFound("Operation", "operationId").get();
-        }
-        return syncOperationOptional.get();
-    }
-
-    private Operation getOperationForOperationIdAndAccountId(String operationId, String accountId) {
-        Optional<Operation> operationOptional = operationRepository.findByOperationIdAndAccountId(operationId, accountId);
-        if (!operationOptional.isPresent()) {
-            LOGGER.info("Operation [{}] in account [{}] not found", operationId, accountId);
-            throw NotFoundException.notFound("Operation", "operationId").get();
-        }
-        return operationOptional.get();
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/controller/UserV1ControllerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/controller/UserV1ControllerTest.java
@@ -1,9 +1,9 @@
 package com.sequenceiq.freeipa.controller;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -25,6 +25,8 @@ import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizationStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeAllUsersRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeUserRequest;
 import com.sequenceiq.freeipa.controller.exception.SyncOperationAlreadyRunningException;
+import com.sequenceiq.freeipa.converter.freeipa.user.OperationToSyncOperationStatus;
+import com.sequenceiq.freeipa.entity.Operation;
 import com.sequenceiq.freeipa.service.freeipa.user.PasswordService;
 import com.sequenceiq.freeipa.service.freeipa.user.UserSyncService;
 import com.sequenceiq.freeipa.service.operation.OperationStatusService;
@@ -52,35 +54,44 @@ public class UserV1ControllerTest {
     @Mock
     private OperationStatusService operationStatusService;
 
+    @Mock
+    private OperationToSyncOperationStatus operationToSyncOperationStatus;
+
     @Test
     void synchronizeUser() {
+        Operation operation = mock(Operation.class);
+        when(userSyncService.synchronizeUsers(any(), any(), any(), any(), any())).thenReturn(operation);
         SyncOperationStatus status = mock(SyncOperationStatus.class);
-        when(userSyncService.synchronizeUsers(any(), any(), any(), any(), any())).thenReturn(status);
+        when(operationToSyncOperationStatus.convert(operation)).thenReturn(status);
 
         SynchronizeUserRequest request = mock(SynchronizeUserRequest.class);
 
-        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.synchronizeUser(request));
+        assertEquals(status, ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.synchronizeUser(request)));
 
         verify(userSyncService, times(1)).synchronizeUsers(ACCOUNT_ID, USER_CRN, Set.of(), Set.of(USER_CRN), Set.of());
     }
 
     @Test
     void synchronizeUserMachineUser() {
+        Operation operation = mock(Operation.class);
+        when(userSyncService.synchronizeUsers(any(), any(), any(), any(), any())).thenReturn(operation);
         SyncOperationStatus status = mock(SyncOperationStatus.class);
-        when(userSyncService.synchronizeUsers(any(), any(), any(), any(), any())).thenReturn(status);
+        when(operationToSyncOperationStatus.convert(operation)).thenReturn(status);
 
         SynchronizeUserRequest request = mock(SynchronizeUserRequest.class);
 
-        ThreadBasedUserCrnProvider.doAs(MACHINE_USER_CRN, () -> underTest.synchronizeUser(request));
+        assertEquals(status, ThreadBasedUserCrnProvider.doAs(MACHINE_USER_CRN, () -> underTest.synchronizeUser(request)));
 
         verify(userSyncService, times(1)).synchronizeUsers(ACCOUNT_ID, MACHINE_USER_CRN, Set.of(), Set.of(), Set.of(MACHINE_USER_CRN));
     }
 
     @Test
     void synchronizeUserRejected() {
+        Operation operation = mock(Operation.class);
+        when(userSyncService.synchronizeUsers(ACCOUNT_ID, USER_CRN, Set.of(), Set.of(USER_CRN), Set.of())).thenReturn(operation);
         SyncOperationStatus status = mock(SyncOperationStatus.class);
         when(status.getStatus()).thenReturn(SynchronizationStatus.REJECTED);
-        when(userSyncService.synchronizeUsers(ACCOUNT_ID, USER_CRN, Set.of(), Set.of(USER_CRN), Set.of())).thenReturn(status);
+        when(operationToSyncOperationStatus.convert(operation)).thenReturn(status);
 
         SynchronizeUserRequest request = mock(SynchronizeUserRequest.class);
 
@@ -97,10 +108,12 @@ public class UserV1ControllerTest {
         request.setUsers(users);
         request.setMachineUsers(machineUsers);
 
+        Operation operation = mock(Operation.class);
+        when(userSyncService.synchronizeUsers(any(), any(), any(), any(), any())).thenReturn(operation);
         SyncOperationStatus status = mock(SyncOperationStatus.class);
-        when(userSyncService.synchronizeUsers(any(), any(), any(), any(), any())).thenReturn(status);
+        when(operationToSyncOperationStatus.convert(operation)).thenReturn(status);
 
-        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.synchronizeAllUsers(request));
+        assertEquals(status, ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.synchronizeAllUsers(request)));
 
         verify(userSyncService, times(1)).synchronizeUsers(ACCOUNT_ID, USER_CRN, environments, users, machineUsers);
     }
@@ -113,9 +126,11 @@ public class UserV1ControllerTest {
         request.setEnvironments(environments);
         request.setUsers(users);
 
+        Operation operation = mock(Operation.class);
+        when(userSyncService.synchronizeUsers(ACCOUNT_ID, USER_CRN, environments, users, Set.of())).thenReturn(operation);
         SyncOperationStatus status = mock(SyncOperationStatus.class);
         when(status.getStatus()).thenReturn(SynchronizationStatus.REJECTED);
-        when(userSyncService.synchronizeUsers(ACCOUNT_ID, USER_CRN, environments, users, Set.of())).thenReturn(status);
+        when(operationToSyncOperationStatus.convert(operation)).thenReturn(status);
 
         assertThrows(SyncOperationAlreadyRunningException.class,
                 () -> ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.synchronizeAllUsers(request)));
@@ -125,22 +140,14 @@ public class UserV1ControllerTest {
     void getStatus() {
         String operationId = "testId";
 
-        underTest.getSyncOperationStatus(operationId);
-
-        verify(operationStatusService, times(1)).getSyncOperationStatus(operationId);
-    }
-
-    @Test
-    void getStatusRejected() {
-        String operationId = "testId";
-
+        Operation operation = mock(Operation.class);
+        when(operationStatusService.getOperationForAccountIdAndOperationId(USER_CRN, ACCOUNT_ID, operationId)).thenReturn(operation);
         SyncOperationStatus status = mock(SyncOperationStatus.class);
-        when(operationStatusService.getSyncOperationStatus(operationId)).thenReturn(status);
+        when(operationToSyncOperationStatus.convert(operation)).thenReturn(status);
 
-        underTest.getSyncOperationStatus(operationId);
+        assertEquals(status, ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.getSyncOperationStatus(operationId)));
 
-        verify(operationStatusService, times(1)).getSyncOperationStatus(operationId);
-        verify(status, never()).getStatus();
+        verify(operationStatusService, times(1)).getOperationForAccountIdAndOperationId(USER_CRN, ACCOUNT_ID, operationId);
     }
 
     @Test
@@ -149,10 +156,12 @@ public class UserV1ControllerTest {
         SetPasswordRequest request = mock(SetPasswordRequest.class);
         when(request.getPassword()).thenReturn(password);
 
+        Operation operation = mock(Operation.class);
+        when(passwordService.setPassword(any(), any(), any(), any(), any())).thenReturn(operation);
         SyncOperationStatus status = mock(SyncOperationStatus.class);
-        when(passwordService.setPassword(any(), any(), any(), any(), any())).thenReturn(status);
+        when(operationToSyncOperationStatus.convert(operation)).thenReturn(status);
 
-        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.setPassword(request));
+        assertEquals(status, ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.setPassword(request)));
 
         verify(passwordService, times(1)).setPassword(ACCOUNT_ID, USER_CRN, USER_CRN, password, new HashSet<>());
     }
@@ -163,9 +172,11 @@ public class UserV1ControllerTest {
         SetPasswordRequest request = mock(SetPasswordRequest.class);
         when(request.getPassword()).thenReturn(password);
 
+        Operation operation = mock(Operation.class);
+        when(passwordService.setPassword(ACCOUNT_ID, USER_CRN, USER_CRN, password, new HashSet<>())).thenReturn(operation);
         SyncOperationStatus status = mock(SyncOperationStatus.class);
         when(status.getStatus()).thenReturn(SynchronizationStatus.REJECTED);
-        when(passwordService.setPassword(ACCOUNT_ID, USER_CRN, USER_CRN, password, new HashSet<>())).thenReturn(status);
+        when(operationToSyncOperationStatus.convert(operation)).thenReturn(status);
 
         assertThrows(SyncOperationAlreadyRunningException.class, () -> ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.setPassword(request)));
     }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/operation/OperationStatusServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/operation/OperationStatusServiceTest.java
@@ -1,0 +1,71 @@
+package com.sequenceiq.freeipa.service.operation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.cloudbreak.auth.security.InternalCrnBuilder;
+import com.sequenceiq.freeipa.controller.exception.NotFoundException;
+import com.sequenceiq.freeipa.entity.Operation;
+import com.sequenceiq.freeipa.repository.OperationRepository;
+
+@ExtendWith(MockitoExtension.class)
+class OperationStatusServiceTest {
+    private static final String ACCOUNT_ID = UUID.randomUUID().toString();
+
+    private static final String USER_CRN = "crn:cdp:iam:us-west-1:" + ACCOUNT_ID + ":user:" + UUID.randomUUID().toString();
+
+    private static final String INTERNAL_USER_CRN = new InternalCrnBuilder(Crn.Service.IAM).getInternalCrnForServiceAsString();
+
+    @Mock
+    OperationRepository operationRepository;
+
+    @InjectMocks
+    OperationStatusService underTest;
+
+    @Test
+    void getOperationFound() {
+        String operationId = UUID.randomUUID().toString();
+        Operation operation = mock(Operation.class);
+        when(operationRepository.findByOperationIdAndAccountId(operationId, ACCOUNT_ID)).thenReturn(Optional.of(operation));
+
+        assertEquals(operation, underTest.getOperationForAccountIdAndOperationId(USER_CRN, ACCOUNT_ID, operationId));
+    }
+
+    @Test
+    void getOperationNotFound() {
+        String operationId = UUID.randomUUID().toString();
+        when(operationRepository.findByOperationIdAndAccountId(operationId, ACCOUNT_ID)).thenReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class, () -> underTest.getOperationForAccountIdAndOperationId(USER_CRN, ACCOUNT_ID, operationId));
+    }
+
+    @Test
+    void getOperationInternalUser() {
+        String operationId = UUID.randomUUID().toString();
+        Operation operation = mock(Operation.class);
+        when(operationRepository.findByOperationIdAndAccountId(operationId, ACCOUNT_ID)).thenReturn(Optional.of(operation));
+
+        assertEquals(operation, underTest.getOperationForAccountIdAndOperationId(INTERNAL_USER_CRN, ACCOUNT_ID, operationId));
+    }
+
+    @Test
+    void getOperationWrongAccount() {
+        String operationId = UUID.randomUUID().toString();
+        String wrongAccountId = UUID.randomUUID().toString();
+
+        assertThrows(NotFoundException.class, () -> underTest.getOperationForAccountIdAndOperationId(USER_CRN, wrongAccountId, operationId));
+    }
+
+}


### PR DESCRIPTION
A check has been added to ensure that only an internal actor or an
actor in the same account can see the operation status of an operation
in that account. One difference in behavior is that the UserV1Controller
gets the account id for the request from the requesting user (i.e.,
the x-cdp-actor header). Since the request does not include an account
parameter, there is no way for an internal actor to request status of
an operation in a different account.

This commit splits the existing OperationStatusService into two services
to clarify the division of responsibilities. 

OperationService - provides methods for working with the operation table,
i.e., requesting, accepting, completing, or failing an operation.

OperationStatusService - retrieves operation entities.. The retrieval 
method now requires both an actor crn and account id in addition to the
operation id. A NotFoundException is thrown if the actor crn does not 
match the account id. Internal actors are allowed to query for operations
in any account.

Entity conversion into API models has been moved to the controllers so
that all internal code works with the Operation entity instead.
