### PR TITLE
CB-5207 Refactor keytab generation

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/model/Service.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/model/Service.java
@@ -13,8 +13,7 @@ public class Service {
 
     private String dn;
 
-    @JsonDeserialize(using = ListFlatteningDeserializer.class)
-    private String krbprincipalname;
+    private List<String> krbprincipalname;
 
     @JsonDeserialize(using = ListFlatteningDeserializer.class)
     private String krbcanonicalname;
@@ -33,11 +32,11 @@ public class Service {
         this.dn = dn;
     }
 
-    public String getKrbprincipalname() {
+    public List<String> getKrbprincipalname() {
         return krbprincipalname;
     }
 
-    public void setKrbprincipalname(String krbprincipalname) {
+    public void setKrbprincipalname(List<String> krbprincipalname) {
         this.krbprincipalname = krbprincipalname;
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/KerberosMgmtRoleComponent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/KerberosMgmtRoleComponent.java
@@ -52,11 +52,11 @@ public class KerberosMgmtRoleComponent {
             addPrivilegesToRole(roleRequest.getPrivileges(), ipaClient, role);
             role = ipaClient.showRole(role.getCn());
             Set<String> servicesToAssignRole = service.stream()
-                    .filter(s -> !s.getMemberOfRole().stream().anyMatch(member -> member.contains(roleRequest.getRoleName())))
-                    .map(Service::getKrbprincipalname)
+                    .filter(s -> s.getMemberOfRole().stream().noneMatch(member -> member.contains(roleRequest.getRoleName())))
+                    .map(Service::getKrbcanonicalname)
                     .collect(Collectors.toSet());
             Set<String> hostsToAssignRole = host.stream()
-                    .filter(h -> !h.getMemberOfRole().stream().anyMatch(member -> member.contains(roleRequest.getRoleName())))
+                    .filter(h -> h.getMemberOfRole().stream().noneMatch(member -> member.contains(roleRequest.getRoleName())))
                     .map(Host::getFqdn)
                     .collect(Collectors.toSet());
             ipaClient.addRoleMember(role.getCn(), null, null, hostsToAssignRole, null, servicesToAssignRole);

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/kerberosmgmt/KerberosMgmtRoleComponentV1Test.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/kerberosmgmt/KerberosMgmtRoleComponentV1Test.java
@@ -87,7 +87,7 @@ public class KerberosMgmtRoleComponentV1Test {
     @Test
     public void testAddRoleAndPrivilegesForServiceWithoutRole() throws Exception {
         Service service = new Service();
-        service.setKrbprincipalname(SERVICE);
+        service.setKrbprincipalname(List.of(SERVICE));
         RoleRequest roleRequest = null;
         new KerberosMgmtRoleComponent().addRoleAndPrivileges(Optional.of(service), Optional.empty(), roleRequest, mockIpaClient);
         Mockito.verifyZeroInteractions(mockIpaClient);
@@ -96,7 +96,8 @@ public class KerberosMgmtRoleComponentV1Test {
     @Test
     public void testAddRoleAndPrivilegesForServiceWithRole() throws Exception {
         Service service = new Service();
-        service.setKrbprincipalname(SERVICE);
+        service.setKrbprincipalname(List.of(SERVICE));
+        service.setKrbcanonicalname(SERVICE);
         RoleRequest roleRequest = new RoleRequest();
         roleRequest.setRoleName(ROLE);
         Set<String> privileges = new HashSet<>();

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/kerberosmgmt/KerberosMgmtV1ServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/kerberosmgmt/KerberosMgmtV1ServiceTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -120,7 +121,7 @@ public class KerberosMgmtV1ServiceTest {
         host.setFqdn(HOST);
         host.setKrbprincipalname(HOST_PRINCIPAL);
         service = new Service();
-        service.setKrbprincipalname(SERVICE_PRINCIPAL);
+        service.setKrbprincipalname(List.of(SERVICE_PRINCIPAL));
         service.setKrbcanonicalname(SERVICE_PRINCIPAL);
         keytab = new Keytab();
         keytab.setKeytab(KEYTAB);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/freeipa/ServiceFindResponse.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/freeipa/ServiceFindResponse.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.it.cloudbreak.mock.freeipa;
 
+import java.util.List;
 import java.util.Set;
 
 import org.springframework.stereotype.Component;
@@ -20,7 +21,7 @@ public class ServiceFindResponse extends AbstractFreeIpaResponse<Set<Service>> {
     protected Set<Service> handleInternal(Request request, Response response) {
         Service service = new Service();
         service.setDn("admin");
-        service.setKrbprincipalname("dummy");
+        service.setKrbprincipalname(List.of("dummy"));
         service.setKrbcanonicalname("dummy");
         return Set.of(service);
     }


### PR DESCRIPTION
refector keytab generation:
- don't try to create services/hosts if already exists, so we can reduce error logs
- use krbcanonicalname instead of krbprincipalname