### PR TITLE
CB-5150 added parcel manifest checks

### DIFF
--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -358,32 +358,6 @@ cb:
           stack:
             repoid: CDH-6.2.0
             redhat7: https://archive.cloudera.com/cdh6/6.2.0/parcels/
-      "[7.0.0]":
-        parcels:
-          - name: SCHEMAREGISTRY
-            parcel: http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-103/tars/parcel
-            version: 0.8.1.3.0.0.0-103
-            csd:
-              - http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-103/tars/parcel/SCHEMAREGISTRY-0.8.1.jar
-          - name: STREAMS_MESSAGING_MANAGER
-            parcel: http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-103/tars/parcel
-            version: 2.1.0.3.0.0.0-103
-            csd:
-              - http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-103/tars/parcel/STREAMS_MESSAGING_MANAGER-2.1.0.jar
-          - name: CFM
-            parcel: http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-121/tars/parcel
-            version: 2.0.0.0
-            csd:
-              - http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-121/tars/parcel/NIFI-1.10.0.2.0.0.0-121.jar
-              - http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-121/tars/parcel/NIFICA-1.10.0.2.0.0.0-121.jar
-              - http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-121/tars/parcel/NIFIREGISTRY-0.5.0.2.0.0.0-121.jar
-        version: 7.0.0-1.cdh7.0.0.p0.1423385
-        minCM: 7.0
-        repo:
-          stack:
-            repoid: CDH-7.0.0
-            redhat7: http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/1423385/cdh/7.x/parcels/
-            centos7: http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/1423385/cdh/7.x/parcels/
       "[7.0.1]":
         parcels:
           - name: SCHEMAREGISTRY


### PR DESCRIPTION
- e2e test was failing because the parcels got removed due to CM build artifact policy
- we should statically check for the presented URL's so Base images will select the correct urls.