### PR TITLE
CDPCP-624. Prevent cross-account queries for operation status

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/OperationV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/OperationV1Controller.java
@@ -5,23 +5,24 @@ import javax.validation.constraints.NotNull;
 
 import org.springframework.stereotype.Controller;
 
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.freeipa.api.v1.operation.OperationV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.operation.model.OperationStatus;
-import com.sequenceiq.freeipa.service.operation.OperationStatusService;
-import com.sequenceiq.freeipa.util.CrnService;
+import com.sequenceiq.freeipa.converter.operation.OperationToOperationStatusConverter;
+import com.sequenceiq.freeipa.service.operation.OperationService;
 
 @Controller
 public class OperationV1Controller implements OperationV1Endpoint {
 
     @Inject
-    private OperationStatusService operationService;
+    private OperationService operationService;
 
     @Inject
-    private CrnService crnService;
+    private OperationToOperationStatusConverter operationToOperationStatusConverter;
 
     @Override
     public OperationStatus getOperationStatus(@NotNull String operationId) {
-        String accountId = crnService.getCurrentAccountId();
-        return operationService.getOperationStatus(operationId, accountId);
+        String accountId = ThreadBasedUserCrnProvider.getAccountId();
+        return operationToOperationStatusConverter.convert(operationService.getOperationForAccountIdAndOperationId(accountId, operationId));
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/UserV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/UserV1Controller.java
@@ -19,9 +19,10 @@ import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeAllUsersReque
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeUserRequest;
 import com.sequenceiq.freeipa.controller.exception.BadRequestException;
 import com.sequenceiq.freeipa.controller.exception.SyncOperationAlreadyRunningException;
+import com.sequenceiq.freeipa.converter.freeipa.user.OperationToSyncOperationStatus;
 import com.sequenceiq.freeipa.service.freeipa.user.PasswordService;
 import com.sequenceiq.freeipa.service.freeipa.user.UserSyncService;
-import com.sequenceiq.freeipa.service.operation.OperationStatusService;
+import com.sequenceiq.freeipa.service.operation.OperationService;
 
 @Controller
 public class UserV1Controller implements UserV1Endpoint {
@@ -35,7 +36,10 @@ public class UserV1Controller implements UserV1Endpoint {
     private PasswordService passwordService;
 
     @Inject
-    private OperationStatusService operationStatusService;
+    private OperationService operationService;
+
+    @Inject
+    private OperationToSyncOperationStatus operationToSyncOperationStatus;
 
     @Override
     public SyncOperationStatus synchronizeUser(SynchronizeUserRequest request) {
@@ -56,8 +60,10 @@ public class UserV1Controller implements UserV1Endpoint {
             default:
                 throw new BadRequestException(String.format("UserCrn %s is not of resoure type USER or MACHINE_USER", userCrn));
         }
-        return checkOperationRejected(userSyncService.synchronizeUsers(accountId, userCrn, environmentCrnFilter,
-                userCrnFilter, machineUserCrnFilter));
+        return checkOperationRejected(
+                operationToSyncOperationStatus.convert(
+                        userSyncService.synchronizeUsers(accountId, userCrn, environmentCrnFilter,
+                userCrnFilter, machineUserCrnFilter)));
     }
 
     @Override
@@ -66,8 +72,10 @@ public class UserV1Controller implements UserV1Endpoint {
         String accountId = ThreadBasedUserCrnProvider.getAccountId();
         LOGGER.debug("synchronizeAllUsers() requested for account {}", accountId);
 
-        return checkOperationRejected(userSyncService.synchronizeUsers(accountId, userCrn, nullToEmpty(request.getEnvironments()),
-                nullToEmpty(request.getUsers()), nullToEmpty(request.getMachineUsers())));
+        return checkOperationRejected(
+                operationToSyncOperationStatus.convert(
+                        userSyncService.synchronizeUsers(accountId, userCrn, nullToEmpty(request.getEnvironments()),
+                                nullToEmpty(request.getUsers()), nullToEmpty(request.getMachineUsers()))));
     }
 
     @Override
@@ -76,14 +84,18 @@ public class UserV1Controller implements UserV1Endpoint {
         String accountId = ThreadBasedUserCrnProvider.getAccountId();
         LOGGER.debug("setPassword() requested for user {} in account {}", userCrn, accountId);
 
-        return checkOperationRejected(passwordService.setPassword(accountId, userCrn, userCrn, request.getPassword(),
-                nullToEmpty(request.getEnvironments())));
+        return checkOperationRejected(
+                operationToSyncOperationStatus.convert(
+                        passwordService.setPassword(accountId, userCrn, userCrn, request.getPassword(), nullToEmpty(request.getEnvironments()))));
     }
 
     @Override
     public SyncOperationStatus getSyncOperationStatus(@NotNull String operationId) {
-        LOGGER.debug("getSyncOperationStatus() requested for operation {}", operationId);
-        return operationStatusService.getSyncOperationStatus(operationId);
+        checkUserCrn();
+        String accountId = ThreadBasedUserCrnProvider.getAccountId();
+        LOGGER.debug("getSyncOperationStatus() requested for operation '{}' in account '{}'", operationId, accountId);
+        return operationToSyncOperationStatus.convert(
+                operationService.getOperationForAccountIdAndOperationId(accountId, operationId));
     }
 
     private SyncOperationStatus checkOperationRejected(SyncOperationStatus syncOperationStatus) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/FreeIpaCleanupActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/FreeIpaCleanupActions.java
@@ -35,7 +35,7 @@ import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.users.RemoveUsersReques
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.users.RemoveUsersResponse;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.vault.RemoveVaultEntriesRequest;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.vault.RemoveVaultEntriesResponse;
-import com.sequenceiq.freeipa.service.operation.OperationStatusService;
+import com.sequenceiq.freeipa.service.operation.OperationService;
 
 @Configuration
 public class FreeIpaCleanupActions {
@@ -155,7 +155,7 @@ public class FreeIpaCleanupActions {
         return new AbstractFreeIpaCleanupAction<>(RemoveRolesResponse.class) {
 
             @Inject
-            private OperationStatusService operationStatusService;
+            private OperationService operationService;
 
             @Override
             protected void doExecute(FreeIpaContext context, RemoveRolesResponse payload, Map<Object, Object> variables) {
@@ -165,7 +165,7 @@ public class FreeIpaCleanupActions {
                 successDetails.getAdditionalDetails().put("Hosts", payload.getHosts() == null ? List.of() : new ArrayList<>(payload.getHosts()));
                 successDetails.getAdditionalDetails().put("Users", payload.getUsers() == null ? List.of() : new ArrayList<>(payload.getUsers()));
                 successDetails.getAdditionalDetails().put("Roles", payload.getRoles() == null ? List.of() : new ArrayList<>(payload.getRoles()));
-                operationStatusService.completeOperation(payload.getOperationId(), List.of(successDetails), Collections.emptyList());
+                operationService.completeOperation(payload.getOperationId(), List.of(successDetails), Collections.emptyList());
                 LOGGER.info("Cleanup successfully finished with: " + successDetails);
                 sendEvent(context, cleanupEvent);
             }
@@ -177,7 +177,7 @@ public class FreeIpaCleanupActions {
         return new AbstractFreeIpaCleanupAction<>(CleanupFailureEvent.class) {
 
             @Inject
-            private OperationStatusService operationStatusService;
+            private OperationService operationService;
 
             @Override
             protected void doExecute(FreeIpaContext context, CleanupFailureEvent payload, Map<Object, Object> variables) {
@@ -190,7 +190,7 @@ public class FreeIpaCleanupActions {
                 if (payload.getFailureDetails() != null) {
                     failureDetails.getAdditionalDetails().putAll(payload.getFailureDetails());
                 }
-                operationStatusService.failOperation(payload.getOperationId(), message, List.of(successDetails), List.of(failureDetails));
+                operationService.failOperation(payload.getOperationId(), message, List.of(successDetails), List.of(failureDetails));
                 sendEvent(context, FreeIpaCleanupEvent.CLEANUP_FAILURE_HANDLED_EVENT.event(), payload);
             }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/cleanup/CleanupService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/cleanup/CleanupService.java
@@ -45,7 +45,7 @@ import com.sequenceiq.freeipa.ldap.LdapConfigService;
 import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
 import com.sequenceiq.freeipa.service.freeipa.flow.FreeIpaFlowManager;
 import com.sequenceiq.freeipa.service.freeipa.host.HostDeletionService;
-import com.sequenceiq.freeipa.service.operation.OperationStatusService;
+import com.sequenceiq.freeipa.service.operation.OperationService;
 import com.sequenceiq.freeipa.service.stack.StackService;
 
 @Service
@@ -66,7 +66,7 @@ public class CleanupService {
     private FreeIpaFlowManager flowManager;
 
     @Inject
-    private OperationStatusService operationStatusService;
+    private OperationService operationService;
 
     @Inject
     private OperationToOperationStatusConverter operationToOperationStatusConverter;
@@ -84,7 +84,7 @@ public class CleanupService {
         Stack stack = stackService.getByEnvironmentCrnAndAccountIdWithLists(request.getEnvironmentCrn(), accountId);
         MDCBuilder.buildMdcContext(stack);
         Operation operation =
-                operationStatusService.startOperation(accountId, OperationType.CLEANUP, Set.of(stack.getEnvironmentCrn()), Collections.emptySet());
+                operationService.startOperation(accountId, OperationType.CLEANUP, Set.of(stack.getEnvironmentCrn()), Collections.emptySet());
         CleanupEvent cleanupEvent = new CleanupEvent(FreeIpaCleanupEvent.CLEANUP_EVENT.event(), stack.getId(), request.getUsers(),
                 request.getHosts(), request.getRoles(), operation.getOperationId(), request.getClusterName());
         flowManager.notify(FreeIpaCleanupEvent.CLEANUP_EVENT.event(), cleanupEvent);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/poller/UserSyncPoller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/poller/UserSyncPoller.java
@@ -23,7 +23,7 @@ import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.auth.security.InternalCrnBuilder;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
-import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SyncOperationStatus;
+import com.sequenceiq.freeipa.entity.Operation;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.entity.UserSyncStatus;
 import com.sequenceiq.freeipa.service.freeipa.user.UmsEventGenerationIdsProvider;
@@ -121,7 +121,7 @@ public class UserSyncPoller {
                     cooldownChecker.isCooldownExpired(userSyncStatus, cooldownThresholdTime)) {
                 LOGGER.debug("Environment {} in Account {} is not in sync.",
                         stack.getEnvironmentCrn(), stack.getAccountId());
-                SyncOperationStatus operation = userSyncService.synchronizeUsers(stack.getAccountId(), INTERNAL_ACTOR_CRN,
+                Operation operation = userSyncService.synchronizeUsers(stack.getAccountId(), INTERNAL_ACTOR_CRN,
                         Set.of(stack.getEnvironmentCrn()), Set.of(), Set.of());
                 LOGGER.debug("User Sync request resulted in operation {}", operation);
             } else {


### PR DESCRIPTION
This commit renames the existing OperationStatusService to OperationService.

Entity conversion into API models has been moved to the controllers so
that all internal code works with the Operation entity instead.

An account id must always be specified when retrieving an operation from
the database. The controller for the getSyncOperationStatus api gets the
account id from the caller (i.e., from the x-cdp-actor header). This ensures
that no actor can retrieve operation status for any account other than its
own account. Since the request does not include an account
parameter, there is no way for an internal actor to request status of
an operation in a different account.
