### PR TITLE
CB-5306. Global options to customize default values of telemetry logging features

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/altus/AltusDatabusConfiguration.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/altus/AltusDatabusConfiguration.java
@@ -11,6 +11,8 @@ public class AltusDatabusConfiguration {
 
     private final boolean useSharedAltusCredential;
 
+    private final boolean useSharedAltusCredentialDefaultValue;
+
     private final String sharedAccessKey;
 
     private final char[] sharedSecretKey;
@@ -18,10 +20,12 @@ public class AltusDatabusConfiguration {
     public AltusDatabusConfiguration(
             @Value("${altus.databus.endpoint:}") String altusDatabusEndpoint,
             @Value("${altus.databus.shared.credential.enabled:false}") boolean useSharedAltusCredential,
+            @Value("${altus.databus.shared.credential.default:false}") boolean useSharedAltusCredentialDefaultValue,
             @Value("${altus.databus.shared.accessKey:}") String sharedAccessKey,
             @Value("${altus.databus.shared.secretKey:}") String sharedSecretKey) {
         this.altusDatabusEndpoint = altusDatabusEndpoint;
         this.useSharedAltusCredential = useSharedAltusCredential;
+        this.useSharedAltusCredentialDefaultValue = useSharedAltusCredentialDefaultValue;
         this.sharedAccessKey = sharedAccessKey;
         this.sharedSecretKey = StringUtils.isBlank(sharedSecretKey) ? null : sharedSecretKey.toCharArray();
     }
@@ -32,6 +36,10 @@ public class AltusDatabusConfiguration {
 
     public boolean isUseSharedAltusCredential() {
         return useSharedAltusCredential;
+    }
+
+    public boolean getUseSharedAltusCredentialDefaultValue() {
+        return useSharedAltusCredentialDefaultValue;
     }
 
     public String getSharedAccessKey() {

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/TelemetryConfiguration.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/TelemetryConfiguration.java
@@ -14,12 +14,16 @@ public class TelemetryConfiguration {
 
     private final boolean meteringEnabled;
 
+    private final boolean reportDeploymentLogsDefaultValue;
+
     public TelemetryConfiguration(AltusDatabusConfiguration altusDatabusConfiguration,
             @Value("${cluster.deployment.logs.report:false}") boolean reportDeploymentLogs,
-            @Value("${metering.enabled:false}") boolean meteringEnabled) {
+            @Value("${metering.enabled:false}") boolean meteringEnabled,
+            @Value("${cluster.deployment.logs.report.default:false}") boolean reportDeploymentLogsDefaultValue) {
         this.altusDatabusConfiguration = altusDatabusConfiguration;
         this.reportDeploymentLogs = reportDeploymentLogs;
         this.meteringEnabled = meteringEnabled;
+        this.reportDeploymentLogsDefaultValue = reportDeploymentLogsDefaultValue;
     }
 
     public AltusDatabusConfiguration getAltusDatabusConfiguration() {
@@ -32,5 +36,9 @@ public class TelemetryConfiguration {
 
     public boolean isMeteringEnabled() {
         return meteringEnabled;
+    }
+
+    public boolean getReportDeploymentLogsDefaultValue() {
+        return reportDeploymentLogsDefaultValue;
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
@@ -40,8 +40,8 @@ public class TelemetryConverterTest {
 
     @Before
     public void setUp() {
-        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, true, "****", "****");
-        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true);
+        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, true, false, "****", "****");
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true, false);
         underTest = new TelemetryConverter(telemetryConfiguration, true, true);
     }
 
@@ -181,8 +181,8 @@ public class TelemetryConverterTest {
     public void testConvertFromEnvAndSdxResponseWithDefaultDisabled() {
         // GIVEN
         SdxClusterResponse sdxClusterResponse = null;
-        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, false, "", null);
-        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true);
+        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, false, false, "", null);
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true, false);
         TelemetryConverter converter = new TelemetryConverter(telemetryConfiguration, true, false);
         // WHEN
         TelemetryRequest result = converter.convert(null, sdxClusterResponse);
@@ -254,8 +254,8 @@ public class TelemetryConverterTest {
         SdxClusterResponse sdxClusterResponse = new SdxClusterResponse();
         sdxClusterResponse.setCrn("crn:cdp:cloudbreak:us-west-1:someone:sdxcluster:sdxId");
         sdxClusterResponse.setName("sdxName");
-        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, false, "", null);
-        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true);
+        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, false, false, "", null);
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true, false);
         TelemetryConverter converter = new TelemetryConverter(telemetryConfiguration, false, true);
         // WHEN
         TelemetryRequest result = converter.convert(response, sdxClusterResponse);

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/TelemetryApiConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/TelemetryApiConverter.java
@@ -29,9 +29,16 @@ public class TelemetryApiConverter {
 
     private final boolean useSharedAltusCredential;
 
+    private final boolean reportDeploymentLogsDefaultValue;
+
+    private final boolean useSharedAltusCredentialDefaultValue;
+
     public TelemetryApiConverter(TelemetryConfiguration configuration) {
         this.reportDeploymentLogs = configuration.isReportDeploymentLogs();
         this.useSharedAltusCredential = configuration.getAltusDatabusConfiguration().isUseSharedAltusCredential();
+        this.reportDeploymentLogsDefaultValue = configuration.getReportDeploymentLogsDefaultValue();
+        this.useSharedAltusCredentialDefaultValue = configuration.getAltusDatabusConfiguration()
+                .getUseSharedAltusCredentialDefaultValue();
     }
 
     public EnvironmentTelemetry convert(TelemetryRequest request) {
@@ -119,7 +126,14 @@ public class TelemetryApiConverter {
         if (featuresRequest != null) {
             features = new EnvironmentFeatures();
             if (useSharedAltusCredential) {
-                features.setUseSharedAltusCredential(featuresRequest.getUseSharedAltusCredential());
+                final FeatureSetting useSharedAltusCredentialFeature;
+                if (featuresRequest.getUseSharedAltusCredential() != null) {
+                    useSharedAltusCredentialFeature = featuresRequest.getUseSharedAltusCredential();
+                } else {
+                    useSharedAltusCredentialFeature = new FeatureSetting();
+                    useSharedAltusCredentialFeature.setEnabled(useSharedAltusCredentialDefaultValue);
+                }
+                features.setUseSharedAltusCredential(useSharedAltusCredentialFeature);
             }
             if (reportDeploymentLogs) {
                 final FeatureSetting reportDeploymentLogs;
@@ -127,7 +141,7 @@ public class TelemetryApiConverter {
                     reportDeploymentLogs = featuresRequest.getReportDeploymentLogs();
                 } else {
                     reportDeploymentLogs = new FeatureSetting();
-                    reportDeploymentLogs.setEnabled(false);
+                    reportDeploymentLogs.setEnabled(reportDeploymentLogsDefaultValue);
                 }
                 features.setReportDeploymentLogs(reportDeploymentLogs);
             }

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/TelemetryApiConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/TelemetryApiConverterTest.java
@@ -33,8 +33,8 @@ public class TelemetryApiConverterTest {
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration("", true, "****", "****");
-        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true);
+        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration("", true, false, "****", "****");
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true, false);
         underTest = new TelemetryApiConverter(telemetryConfiguration);
     }
 
@@ -172,6 +172,21 @@ public class TelemetryApiConverterTest {
         assertNotNull(result.getFeatures());
         assertFalse(result.getFeatures().getReportDeploymentLogs().isEnabled());
         assertEquals(INSTANCE_PROFILE_VALUE, result.getLogging().getS3().getInstanceProfile());
+    }
+
+    @Test
+    public void testConvertWithDefaultFeatureValues() {
+        // GIVEN
+        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration("", true, true, "****", "****");
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true, true);
+        TelemetryApiConverter converter = new TelemetryApiConverter(telemetryConfiguration);
+        TelemetryRequest telemetryRequest = new TelemetryRequest();
+        telemetryRequest.setFeatures(new FeaturesRequest());
+        // WHEN
+        EnvironmentTelemetry result = converter.convert(telemetryRequest);
+        // THEN
+        assertNotNull(result.getFeatures());
+        assertTrue(result.getFeatures().getReportDeploymentLogs().isEnabled());
     }
 
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverterTest.java
@@ -28,8 +28,8 @@ public class TelemetryConverterTest {
 
     @BeforeEach
     public void setUp() {
-        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, false, "", null);
-        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true);
+        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, false, false, "", null);
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true, false);
         underTest = new TelemetryConverter(telemetryConfiguration, true);
     }
 


### PR DESCRIPTION
add global options to set features (if those are not provided at all on the UI), could be useful for e2e testing