### PR TITLE
CB-2296

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxClusterDetailResponseFilter.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxClusterDetailResponseFilter.java
@@ -1,0 +1,50 @@
+package com.sequenceiq.datalake.controller.sdx;
+
+import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
+
+/*
+ * Responsible for filtering out data from SdxClusterDetailResponse instances.
+ * Although it's a simple operation, implemented as a separate class for readability's sake.
+ */
+public class SdxClusterDetailResponseFilter {
+
+    public static final byte REMOVE_SOLR_DETAILS = 1;
+
+    public static final byte REMOVE_NAMENODE_DETAILS = 2;
+
+    public static final byte REMOVE_WEBHDFS_DETAILS = 4;
+
+    private SdxClusterDetailResponse response;
+
+    private byte filterCriteria;
+
+    private SdxClusterDetailResponseFilter(SdxClusterDetailResponse response) {
+        this.response = response;
+    }
+
+    public static SdxClusterDetailResponseFilter on(SdxClusterDetailResponse sdxClusterDetailResponse) {
+        return new SdxClusterDetailResponseFilter(sdxClusterDetailResponse);
+    }
+
+    public SdxClusterDetailResponseFilter apply(byte filterToApply) {
+        filterCriteria |= filterToApply;
+        return this;
+    }
+
+    public SdxClusterDetailResponse filter() {
+        if (response.getStackV4Response() != null) {
+            response.getStackV4Response().getCluster().getExposedServices().forEach((key, value) -> {
+                value.removeIf(srv ->
+                    (filterApplied(REMOVE_NAMENODE_DETAILS) && srv.getServiceName().contains("NAMENODE")) ||
+                    (filterApplied(REMOVE_SOLR_DETAILS) && srv.getServiceName().contains("SOLR_SERVER")) ||
+                    (filterApplied(REMOVE_WEBHDFS_DETAILS) && srv.getServiceName().contains("MASTER"))
+                );
+            });
+        }
+        return response;
+    }
+
+    private boolean filterApplied(byte filter) {
+        return (filterCriteria & filter) == filter;
+    }
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
@@ -158,7 +158,13 @@ public class SdxController implements SdxEndpoint {
         SdxCluster sdxCluster = sdxService.getSdxByNameInAccount(userCrn, name);
         StackV4Response stackV4Response = sdxService.getDetail(name, entries);
         SdxClusterResponse sdxClusterResponse = sdxClusterConverter.sdxClusterToResponse(sdxCluster);
-        return new SdxClusterDetailResponse(sdxClusterResponse, stackV4Response);
+        SdxClusterDetailResponse sdxClusterDetailResponse = new SdxClusterDetailResponse(sdxClusterResponse, stackV4Response);
+
+        return SdxClusterDetailResponseFilter.on(sdxClusterDetailResponse)
+            .apply(SdxClusterDetailResponseFilter.REMOVE_NAMENODE_DETAILS)
+            .apply(SdxClusterDetailResponseFilter.REMOVE_SOLR_DETAILS)
+            .apply(SdxClusterDetailResponseFilter.REMOVE_WEBHDFS_DETAILS)
+            .filter();
     }
 
     @Override

--- a/datalake/src/test/java/com/sequenceiq/datalake/controller/sdx/SdxControllerTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/controller/sdx/SdxControllerTest.java
@@ -11,6 +11,9 @@ import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,6 +25,9 @@ import org.mockito.internal.util.reflection.FieldSetter;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.cluster.ClusterV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.cluster.gateway.topology.ClusterExposedServiceV4Response;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.datalake.entity.DatalakeStatusEnum;
 import com.sequenceiq.datalake.entity.SdxCluster;
@@ -29,6 +35,7 @@ import com.sequenceiq.datalake.entity.SdxStatusEntity;
 import com.sequenceiq.datalake.service.sdx.SdxService;
 import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
 import com.sequenceiq.notification.NotificationService;
+import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
 import com.sequenceiq.sdx.api.model.SdxClusterRequest;
 import com.sequenceiq.sdx.api.model.SdxClusterResponse;
 import com.sequenceiq.sdx.api.model.SdxClusterShape;
@@ -106,6 +113,28 @@ class SdxControllerTest {
         assertEquals("statusreason", sdxClusterResponse.getStatusReason());
     }
 
+    @Test
+    void filteredClusterDetailsTest() throws Exception {
+
+        SdxCluster sdxCluster = getValidSdxCluster();
+        when(sdxService.getSdxByNameInAccount(anyString(), anyString())).thenReturn(sdxCluster);
+
+        SdxStatusEntity sdxStatusEntity = new SdxStatusEntity();
+        sdxStatusEntity.setStatus(DatalakeStatusEnum.REQUESTED);
+        sdxStatusEntity.setStatusReason("statusreason");
+        sdxStatusEntity.setCreated(1L);
+        when(sdxStatusService.getActualStatusForSdx(sdxCluster)).thenReturn(sdxStatusEntity);
+        FieldSetter.setField(sdxClusterConverter, SdxClusterConverter.class.getDeclaredField("sdxStatusService"), sdxStatusService);
+
+        StackV4Response stackV4Response = getValidStackV4Response();
+        when(sdxService.getDetail(anyString(), any(Set.class))).thenReturn(stackV4Response);
+
+        SdxClusterDetailResponse sdxClusterDetailResponse = ThreadBasedUserCrnProvider.doAs(USER_CRN,
+                () -> sdxController.getDetail("test-sdx-cluster", Stream.of("hardware_info").collect(Collectors.toSet())));
+
+        assertEquals(1, sdxClusterDetailResponse.getStackV4Response().getCluster().getExposedServices().get("cdp-proxy").size());
+    }
+
     private SdxCluster getValidSdxCluster() {
         SdxCluster sdxCluster = new SdxCluster();
         sdxCluster.setClusterName("test-sdx-cluster");
@@ -113,6 +142,30 @@ class SdxControllerTest {
         sdxCluster.setEnvName("test-env");
         sdxCluster.setCrn("crn:sdxcluster");
         return sdxCluster;
+    }
+
+    private StackV4Response getValidStackV4Response() {
+
+        ClusterExposedServiceV4Response nameNode = new ClusterExposedServiceV4Response();
+        nameNode.setServiceName("NAMENODE");
+        ClusterExposedServiceV4Response solrServer = new ClusterExposedServiceV4Response();
+        solrServer.setServiceName("SOLR_SERVER");
+        ClusterExposedServiceV4Response webHdfsUi = new ClusterExposedServiceV4Response();
+        webHdfsUi.setServiceName("MASTER");
+        ClusterExposedServiceV4Response ranger = new ClusterExposedServiceV4Response();
+        ranger.setServiceName("RANGER_ADMIN");
+
+        StackV4Response stackV4Response = new StackV4Response();
+        ClusterV4Response clusterV4Response = new ClusterV4Response();
+        clusterV4Response.setExposedServices(new HashMap<>());
+        stackV4Response.setCluster(clusterV4Response);
+        stackV4Response.getCluster().getExposedServices().put("cdp-proxy",
+                Stream.of(nameNode, solrServer, webHdfsUi, ranger).collect(Collectors.toList())
+        );
+        stackV4Response.getCluster().getExposedServices().put("cdp-proxy-api",
+                Stream.of(nameNode, solrServer, webHdfsUi, ranger).collect(Collectors.toList())
+        );
+        return stackV4Response;
     }
 
 }


### PR DESCRIPTION
Contents of this PR implement the requirements of CB-2296 - namely, they prevent exposing the details of NameNode, Solr Server and WebHDFS UIs on the Datalake details screen.

New tests implemented in: https://github.com/hortonworks/cloudbreak/blob/master/datalake/src/test/java/com/sequenceiq/datalake/controller/sdx/SdxControllerTest.java

Closes CB-2296