### PR TITLE
CB-5320 Add cluster template for OpDb with Phoenix for Azure

### DIFF
--- a/core/src/main/resources/defaults/clustertemplates/azure/azure-opdb-710.json
+++ b/core/src/main/resources/defaults/clustertemplates/azure/azure-opdb-710.json
@@ -1,9 +1,9 @@
 {
-  "name": "Operational Database with SQL for AWS",
+  "name": "Operational Database with SQL for Azure",
   "description": "",
   "type": "OPERATIONALDATABASE",
   "featureState": "PREVIEW",
-  "cloudPlatform": "AWS",
+  "cloudPlatform": "AZURE",
   "distroXTemplate": {
     "cluster": {
       "blueprintName": "CDP 1.2 - Operational Database: Apache HBase, Phoenix"
@@ -18,19 +18,21 @@
             {
               "count": 1,
               "size": 100,
-              "type": "standard"
+              "type": "StandardSSD_LRS"
             }
           ],
-          "aws": {
-            "encryption": {
-              "type": "NONE"
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
             }
           },
-          "instanceType": "m5.2xlarge",
+          "instanceType": "Standard_D8_v3",
           "rootVolume": {
             "size": 50
           },
-          "cloudPlatform": "AWS"
+          "cloudPlatform": "AZURE"
         },
         "type": "CORE"
       },
@@ -43,19 +45,21 @@
             {
               "count": 1,
               "size": 100,
-              "type": "standard"
+              "type": "StandardSSD_LRS"
             }
           ],
-          "aws": {
-            "encryption": {
-              "type": "NONE"
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
             }
           },
-          "instanceType": "m5.2xlarge",
+          "instanceType": "Standard_D8_v3",
           "rootVolume": {
             "size": 50
           },
-          "cloudPlatform": "AWS"
+          "cloudPlatform": "AZURE"
         },
         "type": "GATEWAY"
       },
@@ -68,19 +72,21 @@
             {
               "count": 1,
               "size": 100,
-              "type": "standard"
+              "type": "StandardSSD_LRS"
             }
           ],
-          "aws": {
-            "encryption": {
-              "type": "NONE"
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
             }
           },
-          "instanceType": "m5.2xlarge",
+          "instanceType": "Standard_D8_v3",
           "rootVolume": {
             "size": 50
           },
-          "cloudPlatform": "AWS"
+          "cloudPlatform": "AZURE"
         },
         "type": "CORE"
       },
@@ -93,19 +99,21 @@
             {
               "count": 1,
               "size": 100,
-              "type": "standard"
+              "type": "StandardSSD_LRS"
             }
           ],
-          "aws": {
-            "encryption": {
-              "type": "NONE"
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
             }
           },
-          "instanceType": "m5.2xlarge",
+          "instanceType": "Standard_D8_v3",
           "rootVolume": {
             "size": 50
           },
-          "cloudPlatform": "AWS"
+          "cloudPlatform": "AZURE"
         },
         "type": "CORE"
       }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
@@ -434,7 +434,7 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
         assertNotNull(entity);
         assertNotNull(entity.getResponses());
         long defaultCount = entity.getResponses().stream().filter(template -> ResourceStatus.DEFAULT.equals(template.getStatus())).count();
-        long expectedCount = 14;
+        long expectedCount = 15;
         assertEquals("Should have " + expectedCount + " of default cluster templates.", expectedCount, defaultCount);
         return entity;
     }


### PR DESCRIPTION
This is extending CB-4551 to Azure.

In CB-4551 we have added a new OpDB blueprint that adds Phoenix, but we have only added the cluster blueprint for AWS.

This patch adds the cluster blueprint for Azure as well.

The blueprint is mostly identical to the existing opdb 7.0.2 Azure blueprint, save that it refers to the newer blueprint, and it includes the approved, but not yet merged CB-5275 fix.

Testing done:

Since I have been unable to get a local Cloudbreak instance working with Azure, I used the mow-dev environment, where created an environment on azure, uploaded the blueprint, and built an OpDB DH cluster with the latest CM and CDPD.

I have run a simple Phoenix smoke test on the cluster, and it passed. 

Since the existing Azure OpDB cluster template, and this one only differs in the referred blueprint, I expect that this was sufficient testing.

Closes #CB-5320
