### PR TITLE
CB-5296. No metering heartbeats after reboot

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/metering/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/metering/init.sls
@@ -59,6 +59,14 @@ stop_metering_heartbeat_application:
     - group: "root"
     - file_mode: 640
 
+/etc/systemd/system/metering-heartbeat-application.service:
+  file.managed:
+    - source: salt://metering/template/metering-heartbeat-application.service.j2
+    - template: jinja
+    - user: "root"
+    - group: "root"
+    - file_mode: 640
+
 start_metering_heartbeat_application:
   service.running:
     - enable: True

--- a/orchestrator-salt/src/main/resources/salt/salt/metering/template/metering-heartbeat-application.service.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/metering/template/metering-heartbeat-application.service.j2
@@ -1,0 +1,15 @@
+{%- from 'metering/settings.sls' import metering with context %}
+[Unit]
+Description=Metering heartbeat application
+StartLimitIntervalSec=0
+After=td-agent.service
+
+[Service]
+Type=simple
+Restart=always
+ExecStart=/opt/metering-heartbeat --configFile /etc/metering/generate_heartbeats.ini
+PIDFile=/var/run/heartbeat_producer.pid
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
override default heartbeat monitoring application service definition (will be fixed later on thunderhead side) as metering stops after reboot with the current definition