### PR TITLE
CB-5236. Increase number of open files for td-agent (make it persistent after restart)

### DIFF
--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/init.sls
@@ -245,6 +245,21 @@ copy_td_agent_conf:
 {% endif %}
 
 {%- if fluent.is_systemd %}
+/etc/systemd/system/td-agent.d:
+  file.directory:
+    - name: /etc/systemd/system/td-agent.d
+    - user: "{{ fluent.user }}"
+    - group: "{{ fluent.group }}"
+    - mode: 740
+
+/etc/systemd/system/td-agent.d/override.conf:
+   file.managed:
+    - source: salt://fluent/template/override.conf.j2
+    - template: jinja
+    - user: "{{ fluent.user }}"
+    - group: "{{ fluent.group }}"
+    - file_mode: 640
+
 fluentd_start_with_update_systemd_units:
   file.copy:
     - name: /etc/systemd/system/td-agent.service

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/override.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/override.conf.j2
@@ -1,0 +1,2 @@
+[Service]
+LimitNOFILE=65536


### PR DESCRIPTION
we are setting ulimit for open files for fluentd at startup, but if you are restarting td-agent manually or after a system reboot, it wont use that dynamically set values (by salt), we can make it persistent by adding an override.conf to /etc/systemd/system/td-agent.d/override.conf: 

tested, output for fluentd agter calling fluent.init salt state:
```bash
cat /proc/<td_agent_pid>/limits
Limit                     Soft Limit           Hard Limit           Units
Max cpu time              unlimited            unlimited            seconds
Max file size             unlimited            unlimited            bytes
Max data size             unlimited            unlimited            bytes
Max stack size            8388608              unlimited            bytes
Max core file size        0                    unlimited            bytes
Max resident set          unlimited            unlimited            bytes
Max processes             124659               124659               processes
Max open files            65536                65536                files
Max locked memory         65536                65536                bytes
Max address space         unlimited            unlimited            bytes
Max file locks            unlimited            unlimited            locks
Max pending signals       124659               124659               signals
Max msgqueue size         819200               819200               bytes
Max nice priority         0                    0
Max realtime priority     0                    0
Max realtime timeout      unlimited            unlimited            us
```