### PR TITLE
CB-5371. Feature refactor & (E2E) remove use shared credential from the API (request)

### DIFF
--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/base/FeaturesBase.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/base/FeaturesBase.java
@@ -2,6 +2,7 @@ package com.sequenceiq.common.api.telemetry.base;
 
 import java.io.Serializable;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.common.api.telemetry.doc.TelemetryModelDescription;
 import com.sequenceiq.common.api.type.FeatureSetting;
@@ -17,10 +18,6 @@ public abstract class FeaturesBase implements Serializable {
     @JsonProperty("reportDeploymentLogs")
     @ApiModelProperty(TelemetryModelDescription.TELEMETRY_REPORT_DEPLOYMENT_LOGS_ENABLED)
     private FeatureSetting reportDeploymentLogs;
-
-    @JsonProperty("useSharedAltusCredential")
-    @ApiModelProperty(TelemetryModelDescription.TELEMETRY_USE_SHARED_ALTUS_CREDENTIAL_ENABLED)
-    private FeatureSetting useSharedAltusCredential;
 
     public FeatureSetting getWorkloadAnalytics() {
         return workloadAnalytics;
@@ -38,11 +35,15 @@ public abstract class FeaturesBase implements Serializable {
         this.reportDeploymentLogs = reportDeploymentLogs;
     }
 
-    public FeatureSetting getUseSharedAltusCredential() {
-        return useSharedAltusCredential;
+    @JsonIgnore
+    public void addWorkloadAnalytics(boolean enabled) {
+        workloadAnalytics = new FeatureSetting();
+        workloadAnalytics.setEnabled(enabled);
     }
 
-    public void setUseSharedAltusCredential(FeatureSetting useSharedAltusCredential) {
-        this.useSharedAltusCredential = useSharedAltusCredential;
+    @JsonIgnore
+    public void addReportDeploymentLogs(boolean enabled) {
+        reportDeploymentLogs = new FeatureSetting();
+        reportDeploymentLogs.setEnabled(enabled);
     }
 }

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/Features.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/Features.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.common.api.telemetry.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -13,11 +14,34 @@ public class Features extends FeaturesBase {
     @JsonProperty("metering")
     private FeatureSetting metering;
 
+    @JsonProperty("useSharedAltusCredential")
+    private FeatureSetting useSharedAltusCredential;
+
     public FeatureSetting getMetering() {
         return metering;
     }
 
     public void setMetering(FeatureSetting metering) {
         this.metering = metering;
+    }
+
+    public FeatureSetting getUseSharedAltusCredential() {
+        return useSharedAltusCredential;
+    }
+
+    public void setUseSharedAltusCredential(FeatureSetting useSharedAltusCredential) {
+        this.useSharedAltusCredential = useSharedAltusCredential;
+    }
+
+    @JsonIgnore
+    public void addMetering(boolean enabled) {
+        metering = new FeatureSetting();
+        metering.setEnabled(enabled);
+    }
+
+    @JsonIgnore
+    public void addUseSharedAltusCredential(boolean enabled) {
+        useSharedAltusCredential = new FeatureSetting();
+        useSharedAltusCredential.setEnabled(enabled);
     }
 }

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/response/FeaturesResponse.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/response/FeaturesResponse.java
@@ -17,11 +17,23 @@ public class FeaturesResponse extends FeaturesBase {
     @ApiModelProperty(TelemetryModelDescription.TELEMETRY_METERING)
     private FeatureSetting metering;
 
+    @JsonProperty("useSharedAltusCredential")
+    @ApiModelProperty(TelemetryModelDescription.TELEMETRY_USE_SHARED_ALTUS_CREDENTIAL_ENABLED)
+    private FeatureSetting useSharedAltusCredential;
+
     public FeatureSetting getMetering() {
         return metering;
     }
 
     public void setMetering(FeatureSetting metering) {
         this.metering = metering;
+    }
+
+    public FeatureSetting getUseSharedAltusCredential() {
+        return useSharedAltusCredential;
+    }
+
+    public void setUseSharedAltusCredential(FeatureSetting useSharedAltusCredential) {
+        this.useSharedAltusCredential = useSharedAltusCredential;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
@@ -88,7 +88,7 @@ public class TelemetryConverter {
             telemetry.setWorkloadAnalytics(workloadAnalytics);
             setWorkloadAnalyticsFeature(telemetry, features);
             setReportDeploymentLogs(request, features);
-            setUseSharedAltusCredential(request, features);
+            setUseSharedAltusCredential(features);
             telemetry.setFluentAttributes(request.getFluentAttributes());
         }
         setMeteringFeature(type, features);
@@ -112,8 +112,6 @@ public class TelemetryConverter {
             if (featuresResponse != null) {
                 LOGGER.debug("Setting report deployment logs response (telemetry) based on environment response.");
                 featuresRequest.setReportDeploymentLogs(featuresResponse.getReportDeploymentLogs());
-                LOGGER.debug("Setting use shared altus credential feature based on environment response.");
-                featuresRequest.setUseSharedAltusCredential(featuresResponse.getUseSharedAltusCredential());
             }
             telemetryRequest.setFluentAttributes(response.getFluentAttributes());
         }
@@ -206,7 +204,6 @@ public class TelemetryConverter {
             featuresRequest = new FeaturesRequest();
             featuresRequest.setWorkloadAnalytics(features.getWorkloadAnalytics());
             featuresRequest.setReportDeploymentLogs(features.getReportDeploymentLogs());
-            featuresRequest.setUseSharedAltusCredential(features.getUseSharedAltusCredential());
         }
         return featuresRequest;
     }
@@ -237,9 +234,7 @@ public class TelemetryConverter {
     private void setMeteringFeature(StackType type, Features features) {
         if (meteringEnabled && StackType.WORKLOAD.equals(type)) {
             LOGGER.debug("Setting metering for workload cluster (as metering is enabled)");
-            FeatureSetting metering = new FeatureSetting();
-            metering.setEnabled(true);
-            features.setMetering(metering);
+            features.addMetering(true);
         } else {
             LOGGER.debug("Metering feature is disabled - global setting; {}, stack type: {}", meteringEnabled, type);
         }
@@ -248,9 +243,7 @@ public class TelemetryConverter {
     private void setWorkloadAnalyticsFeature(Telemetry telemetry, Features features) {
         if (telemetry.getWorkloadAnalytics() != null) {
             LOGGER.debug("Setting workload analytics feature settings as workload analytics request exists.");
-            FeatureSetting waFeature = new FeatureSetting();
-            waFeature.setEnabled(true);
-            features.setWorkloadAnalytics(waFeature);
+            features.addWorkloadAnalytics(true);
         } else {
             LOGGER.debug("Workload analytics feature is not enabled.");
         }
@@ -355,22 +348,18 @@ public class TelemetryConverter {
                 features.setReportDeploymentLogs(request.getFeatures().getReportDeploymentLogs());
             } else {
                 LOGGER.debug("Auto-filling report deployment logs telemetry settings as it is set, but missing from the request.");
-                FeatureSetting reportDeploymentLogsFeature = new FeatureSetting();
-                reportDeploymentLogsFeature.setEnabled(false);
-                features.setReportDeploymentLogs(reportDeploymentLogsFeature);
+                features.addReportDeploymentLogs(false);
             }
         } else {
             LOGGER.debug("Report deployment logs feature is disabled. Set feature as false.");
-            FeatureSetting reportDeploymentLogsFeature = new FeatureSetting();
-            reportDeploymentLogsFeature.setEnabled(false);
-            features.setReportDeploymentLogs(reportDeploymentLogsFeature);
+            features.addReportDeploymentLogs(false);
         }
     }
 
-    private void setUseSharedAltusCredential(TelemetryRequest request, Features features) {
-        if (useSharedAltusCredential && request.getFeatures() != null && request.getFeatures().getUseSharedAltusCredential() != null) {
-            LOGGER.debug("Fill shared altus credential setting from telemetry feature request");
-            features.setUseSharedAltusCredential(request.getFeatures().getUseSharedAltusCredential());
+    private void setUseSharedAltusCredential(Features features) {
+        if (useSharedAltusCredential) {
+            LOGGER.debug("Fill shared altus credential setting as that is enabled globally");
+            features.addUseSharedAltusCredential(true);
         }
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
@@ -27,7 +27,6 @@ import com.sequenceiq.common.api.telemetry.request.WorkloadAnalyticsRequest;
 import com.sequenceiq.common.api.telemetry.response.FeaturesResponse;
 import com.sequenceiq.common.api.telemetry.response.LoggingResponse;
 import com.sequenceiq.common.api.telemetry.response.TelemetryResponse;
-import com.sequenceiq.common.api.type.FeatureSetting;
 import com.sequenceiq.sdx.api.model.SdxClusterResponse;
 
 public class TelemetryConverterTest {
@@ -68,12 +67,7 @@ public class TelemetryConverterTest {
         logging.setS3(new S3CloudStorageV1Parameters());
         WorkloadAnalyticsRequest workloadAnalyticsRequest = new WorkloadAnalyticsRequest();
         FeaturesRequest featuresRequest = new FeaturesRequest();
-        FeatureSetting reportDeploymentLogs = new FeatureSetting();
-        reportDeploymentLogs.setEnabled(false);
-        featuresRequest.setReportDeploymentLogs(reportDeploymentLogs);
-        FeatureSetting useSharedCredential = new FeatureSetting();
-        useSharedCredential.setEnabled(true);
-        featuresRequest.setUseSharedAltusCredential(useSharedCredential);
+        featuresRequest.addReportDeploymentLogs(false);
         telemetryRequest.setLogging(logging);
         telemetryRequest.setFeatures(featuresRequest);
         telemetryRequest.setWorkloadAnalytics(workloadAnalyticsRequest);
@@ -99,10 +93,8 @@ public class TelemetryConverterTest {
         Telemetry telemetry = new Telemetry();
         telemetry.setLogging(logging);
         Features features = new Features();
-        FeatureSetting reportDeploymentLogs = new FeatureSetting();
-        reportDeploymentLogs.setEnabled(true);
         features.setWorkloadAnalytics(null);
-        features.setReportDeploymentLogs(reportDeploymentLogs);
+        features.addReportDeploymentLogs(true);
         telemetry.setFeatures(features);
         // WHEN
         TelemetryResponse result = underTest.convert(telemetry);
@@ -141,10 +133,8 @@ public class TelemetryConverterTest {
     public void testConvertFromRequestWithFeatures() {
         // GIVEN
         TelemetryRequest telemetryRequest = new TelemetryRequest();
-        FeatureSetting reportDeploymentLog = new FeatureSetting();
-        reportDeploymentLog.setEnabled(true);
         FeaturesRequest features = new FeaturesRequest();
-        features.setReportDeploymentLogs(reportDeploymentLog);
+        features.addReportDeploymentLogs(true);
         telemetryRequest.setFeatures(features);
         // WHEN
         Telemetry result = underTest.convert(telemetryRequest, StackType.WORKLOAD);
@@ -236,9 +226,7 @@ public class TelemetryConverterTest {
         sdxClusterResponse.setCrn("crn:cdp:cloudbreak:us-west-1:someone:sdxcluster:sdxId");
         sdxClusterResponse.setName("sdxName");
         FeaturesResponse featuresResponse = new FeaturesResponse();
-        FeatureSetting waSetting = new FeatureSetting();
-        waSetting.setEnabled(false);
-        featuresResponse.setWorkloadAnalytics(waSetting);
+        featuresResponse.addWorkloadAnalytics(false);
         response.setFeatures(featuresResponse);
         // WHEN
         TelemetryRequest result = underTest.convert(response, sdxClusterResponse);
@@ -267,10 +255,8 @@ public class TelemetryConverterTest {
     public void testConvertFromEnvAndSdxResponseWithReportDeploymentLogsEnabled() {
         // GIVEN
         TelemetryResponse response = new TelemetryResponse();
-        FeatureSetting reportDeploymentLogs = new FeatureSetting();
-        reportDeploymentLogs.setEnabled(true);
         FeaturesResponse featuresResponse = new FeaturesResponse();
-        featuresResponse.setReportDeploymentLogs(reportDeploymentLogs);
+        featuresResponse.addReportDeploymentLogs(true);
         response.setFeatures(featuresResponse);
         // WHEN
         TelemetryRequest result = underTest.convert(response, null);
@@ -282,10 +268,8 @@ public class TelemetryConverterTest {
     public void testConvertFromEnvAndSdxResponseWithReportDeploymentLogsDisabled() {
         // GIVEN
         TelemetryResponse response = new TelemetryResponse();
-        FeatureSetting reportDeploymentLogs = new FeatureSetting();
-        reportDeploymentLogs.setEnabled(false);
         FeaturesResponse featuresResponse = new FeaturesResponse();
-        featuresResponse.setReportDeploymentLogs(reportDeploymentLogs);
+        featuresResponse.addReportDeploymentLogs(false);
         response.setFeatures(featuresResponse);
         // WHEN
         TelemetryRequest result = underTest.convert(response, null);
@@ -302,9 +286,7 @@ public class TelemetryConverterTest {
         logging.setS3(new S3CloudStorageV1Parameters());
         telemetry.setLogging(logging);
         Features features = new Features();
-        FeatureSetting reportDeploymentLogs = new FeatureSetting();
-        reportDeploymentLogs.setEnabled(true);
-        features.setReportDeploymentLogs(reportDeploymentLogs);
+        features.addReportDeploymentLogs(true);
         telemetry.setFeatures(features);
         WorkloadAnalytics workloadAnalytics = new WorkloadAnalytics();
         Map<String, Object> waAttributes = new HashMap<>();

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
@@ -178,7 +178,6 @@ public class StackRequestManifester {
             if (envTelemetry.getFeatures() != null) {
                 FeaturesRequest featuresRequest = new FeaturesRequest();
                 featuresRequest.setReportDeploymentLogs(envTelemetry.getFeatures().getReportDeploymentLogs());
-                featuresRequest.setUseSharedAltusCredential(envTelemetry.getFeatures().getUseSharedAltusCredential());
                 telemetryRequest.setFeatures(featuresRequest);
             }
             if (envTelemetry.getFluentAttributes() != null) {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/telemetry/EnvironmentFeatures.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/telemetry/EnvironmentFeatures.java
@@ -2,6 +2,7 @@ package com.sequenceiq.environment.environment.dto.telemetry;
 
 import java.io.Serializable;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.common.api.type.FeatureSetting;
@@ -38,5 +39,23 @@ public class EnvironmentFeatures implements Serializable {
 
     public void setUseSharedAltusCredential(FeatureSetting useSharedAltusCredential) {
         this.useSharedAltusCredential = useSharedAltusCredential;
+    }
+
+    @JsonIgnore
+    public void addWorkloadAnalytics(boolean enabled) {
+        workloadAnalytics = new FeatureSetting();
+        workloadAnalytics.setEnabled(enabled);
+    }
+
+    @JsonIgnore
+    public void addReportDeploymentLogs(boolean enabled) {
+        reportDeploymentLogs = new FeatureSetting();
+        reportDeploymentLogs.setEnabled(enabled);
+    }
+
+    @JsonIgnore
+    public void addUseSharedAltusredential(boolean enabled) {
+        useSharedAltusCredential = new FeatureSetting();
+        useSharedAltusCredential.setEnabled(enabled);
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/TelemetryApiConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/TelemetryApiConverter.java
@@ -15,7 +15,6 @@ import com.sequenceiq.common.api.telemetry.response.FeaturesResponse;
 import com.sequenceiq.common.api.telemetry.response.LoggingResponse;
 import com.sequenceiq.common.api.telemetry.response.TelemetryResponse;
 import com.sequenceiq.common.api.telemetry.response.WorkloadAnalyticsResponse;
-import com.sequenceiq.common.api.type.FeatureSetting;
 import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentFeatures;
 import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentLogging;
 import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentTelemetry;
@@ -86,7 +85,6 @@ public class TelemetryApiConverter {
         if (features != null) {
             featuresRequest = new FeaturesRequest();
             featuresRequest.setReportDeploymentLogs(features.getReportDeploymentLogs());
-            featuresRequest.setUseSharedAltusCredential(features.getUseSharedAltusCredential());
         }
         return featuresRequest;
     }
@@ -119,17 +117,14 @@ public class TelemetryApiConverter {
         if (featuresRequest != null) {
             features = new EnvironmentFeatures();
             if (useSharedAltusCredential) {
-                features.setUseSharedAltusCredential(featuresRequest.getUseSharedAltusCredential());
+                features.addUseSharedAltusredential(true);
             }
             if (reportDeploymentLogs) {
-                final FeatureSetting reportDeploymentLogs;
                 if (featuresRequest.getReportDeploymentLogs() != null) {
-                    reportDeploymentLogs = featuresRequest.getReportDeploymentLogs();
+                    features.setReportDeploymentLogs(featuresRequest.getReportDeploymentLogs());
                 } else {
-                    reportDeploymentLogs = new FeatureSetting();
-                    reportDeploymentLogs.setEnabled(false);
+                    features.addReportDeploymentLogs(false);
                 }
-                features.setReportDeploymentLogs(reportDeploymentLogs);
             }
             if (featuresRequest.getWorkloadAnalytics() != null) {
                 features.setWorkloadAnalytics(featuresRequest.getWorkloadAnalytics());

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/TelemetryApiConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/TelemetryApiConverterTest.java
@@ -18,7 +18,6 @@ import com.sequenceiq.common.api.telemetry.request.LoggingRequest;
 import com.sequenceiq.common.api.telemetry.request.TelemetryRequest;
 import com.sequenceiq.common.api.telemetry.request.WorkloadAnalyticsRequest;
 import com.sequenceiq.common.api.telemetry.response.TelemetryResponse;
-import com.sequenceiq.common.api.type.FeatureSetting;
 import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentFeatures;
 import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentLogging;
 import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentTelemetry;
@@ -49,15 +48,8 @@ public class TelemetryApiConverterTest {
         telemetryRequest.setLogging(loggingRequest);
         telemetryRequest.setWorkloadAnalytics(new WorkloadAnalyticsRequest());
         FeaturesRequest fr = new FeaturesRequest();
-        FeatureSetting fsReportLogs = new FeatureSetting();
-        fsReportLogs.setEnabled(true);
-        FeatureSetting fsWorladAnalytics = new FeatureSetting();
-        fsWorladAnalytics.setEnabled(true);
-        FeatureSetting fsUseSharedCredential = new FeatureSetting();
-        fsUseSharedCredential.setEnabled(true);
-        fr.setReportDeploymentLogs(fsReportLogs);
-        fr.setWorkloadAnalytics(fsWorladAnalytics);
-        fr.setUseSharedAltusCredential(fsUseSharedCredential);
+        fr.addReportDeploymentLogs(true);
+        fr.addWorkloadAnalytics(true);
         telemetryRequest.setFeatures(fr);
         // WHEN
         EnvironmentTelemetry result = underTest.convert(telemetryRequest);
@@ -95,9 +87,7 @@ public class TelemetryApiConverterTest {
         // GIVEN
         TelemetryRequest telemetryRequest = new TelemetryRequest();
         FeaturesRequest fr = new FeaturesRequest();
-        FeatureSetting waFeature = new FeatureSetting();
-        waFeature.setEnabled(true);
-        fr.setWorkloadAnalytics(waFeature);
+        fr.addWorkloadAnalytics(true);
         telemetryRequest.setFeatures(fr);
         // WHEN
         EnvironmentTelemetry result = underTest.convert(telemetryRequest);
@@ -110,9 +100,7 @@ public class TelemetryApiConverterTest {
         // GIVEN
         TelemetryRequest telemetryRequest = new TelemetryRequest();
         FeaturesRequest fr = new FeaturesRequest();
-        FeatureSetting waFeature = new FeatureSetting();
-        waFeature.setEnabled(false);
-        fr.setWorkloadAnalytics(waFeature);
+        fr.addWorkloadAnalytics(false);
         telemetryRequest.setFeatures(fr);
         // WHEN
         EnvironmentTelemetry result = underTest.convert(telemetryRequest);
@@ -160,9 +148,7 @@ public class TelemetryApiConverterTest {
         s3Params.setInstanceProfile(INSTANCE_PROFILE_VALUE);
         logging.setS3(s3Params);
         EnvironmentFeatures features = new EnvironmentFeatures();
-        FeatureSetting reportDeploymentLogs = new FeatureSetting();
-        reportDeploymentLogs.setEnabled(false);
-        features.setReportDeploymentLogs(reportDeploymentLogs);
+        features.addReportDeploymentLogs(false);
         EnvironmentTelemetry telemetry = new EnvironmentTelemetry();
         telemetry.setLogging(logging);
         telemetry.setFeatures(features);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverter.java
@@ -18,7 +18,6 @@ import com.sequenceiq.common.api.telemetry.request.TelemetryRequest;
 import com.sequenceiq.common.api.telemetry.response.FeaturesResponse;
 import com.sequenceiq.common.api.telemetry.response.LoggingResponse;
 import com.sequenceiq.common.api.telemetry.response.TelemetryResponse;
-import com.sequenceiq.common.api.type.FeatureSetting;
 
 @Component
 public class TelemetryConverter {
@@ -119,14 +118,11 @@ public class TelemetryConverter {
                 LOGGER.debug("Fill report deployment log settings from feature request");
             } else {
                 LOGGER.debug("Auto-fill report deployment logs settings with defaults. (disabled)");
-                FeatureSetting reportDeploymentLogsFeature = new FeatureSetting();
-                reportDeploymentLogsFeature.setEnabled(false);
-                features.setReportDeploymentLogs(reportDeploymentLogsFeature);
+                features.addReportDeploymentLogs(false);
             }
         }
-        if (useSharedAltusCredential && featuresRequest != null
-                && featuresRequest.getUseSharedAltusCredential() != null) {
-            features.setUseSharedAltusCredential(featuresRequest.getUseSharedAltusCredential());
+        if (useSharedAltusCredential) {
+            features.addUseSharedAltusCredential(true);
         }
         return features;
     }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverterTest.java
@@ -1,8 +1,8 @@
 package com.sequenceiq.freeipa.converter.telemetry;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,7 +16,6 @@ import com.sequenceiq.common.api.telemetry.request.FeaturesRequest;
 import com.sequenceiq.common.api.telemetry.request.LoggingRequest;
 import com.sequenceiq.common.api.telemetry.request.TelemetryRequest;
 import com.sequenceiq.common.api.telemetry.response.TelemetryResponse;
-import com.sequenceiq.common.api.type.FeatureSetting;
 
 public class TelemetryConverterTest {
 
@@ -40,9 +39,7 @@ public class TelemetryConverterTest {
         LoggingRequest logging = new LoggingRequest();
         logging.setS3(new S3CloudStorageV1Parameters());
         FeaturesRequest featuresRequest = new FeaturesRequest();
-        FeatureSetting reportDeploymentLogs = new FeatureSetting();
-        reportDeploymentLogs.setEnabled(false);
-        featuresRequest.setReportDeploymentLogs(reportDeploymentLogs);
+        featuresRequest.addReportDeploymentLogs(false);
         telemetryRequest.setLogging(logging);
         telemetryRequest.setFeatures(featuresRequest);
         // WHEN

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/telemetry/TelemetryTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/telemetry/TelemetryTestDto.java
@@ -8,7 +8,6 @@ import com.sequenceiq.common.api.telemetry.request.FeaturesRequest;
 import com.sequenceiq.common.api.telemetry.request.LoggingRequest;
 import com.sequenceiq.common.api.telemetry.request.TelemetryRequest;
 import com.sequenceiq.common.api.telemetry.response.TelemetryResponse;
-import com.sequenceiq.common.api.type.FeatureSetting;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.cloud.v4.aws.AwsCloudProvider;
 import com.sequenceiq.it.cloudbreak.cloud.v4.azure.AzureCloudProvider;
@@ -65,12 +64,7 @@ public class TelemetryTestDto extends AbstractCloudbreakTestDto<TelemetryRequest
 
     public TelemetryTestDto withReportClusterLogs() {
         FeaturesRequest featuresRequest = new FeaturesRequest();
-        FeatureSetting reportDeploymentLogs = new FeatureSetting();
-        reportDeploymentLogs.setEnabled(true);
-        FeatureSetting useSharedCredential = new FeatureSetting();
-        useSharedCredential.setEnabled(true);
-        featuresRequest.setReportDeploymentLogs(reportDeploymentLogs);
-        featuresRequest.setUseSharedAltusCredential(useSharedCredential);
+        featuresRequest.addReportDeploymentLogs(true);
         getRequest().setFeatures(featuresRequest);
         return this;
     }


### PR DESCRIPTION
- remove use shared credential from the API

#### WHY?

Right now, it's not enough to set use altus credential globally in order to use a shared altus credential instead of communicate with UMS, you also need to provide this "ask" in the request. 
That works fine for e2e tests but not for the GUI test, as that option should be always hidden.
So make sense to remove from the API - at least the request part. (respone is kept so we can see on the API if that is used)

also refactor features object to set wrapper objects more easily