### PR TITLE
CDPCP-624. Require accountId when retrieving Operation

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/CleanupEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/CleanupEvent.java
@@ -12,24 +12,31 @@ public class CleanupEvent extends StackEvent {
 
     private final Set<String> roles;
 
+    private final String accountId;
+
     private final String operationId;
 
     private final String clusterName;
 
-    public CleanupEvent(Long stackId, Set<String> users, Set<String> hosts, Set<String> roles, String operationId, String clusterName) {
+    @SuppressWarnings("ExecutableStatementCount")
+    public CleanupEvent(Long stackId, Set<String> users, Set<String> hosts, Set<String> roles, String accountId, String operationId, String clusterName) {
         super(stackId);
         this.users = users;
         this.hosts = hosts;
         this.roles = roles;
+        this.accountId = accountId;
         this.operationId = operationId;
         this.clusterName = clusterName;
     }
 
-    public CleanupEvent(String selector, Long stackId, Set<String> users, Set<String> hosts, Set<String> roles, String operationId, String clusterName) {
+    @SuppressWarnings("ExecutableStatementCount")
+    public CleanupEvent(String selector, Long stackId, Set<String> users, Set<String> hosts, Set<String> roles,
+            String accountId, String operationId, String clusterName) {
         super(selector, stackId);
         this.users = users;
         this.hosts = hosts;
         this.roles = roles;
+        this.accountId = accountId;
         this.operationId = operationId;
         this.clusterName = clusterName;
     }
@@ -46,6 +53,10 @@ public class CleanupEvent extends StackEvent {
         return roles;
     }
 
+    public String getAccountId() {
+        return accountId;
+    }
+
     public String getOperationId() {
         return operationId;
     }
@@ -60,6 +71,7 @@ public class CleanupEvent extends StackEvent {
                 "users=" + users +
                 ", hosts=" + hosts +
                 ", roles=" + roles +
+                ", accountId='" + accountId + '\'' +
                 ", operationId='" + operationId + '\'' +
                 ", clusterName='" + clusterName + '\'' +
                 '}';

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/FreeIpaCleanupActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/FreeIpaCleanupActions.java
@@ -160,12 +160,12 @@ public class FreeIpaCleanupActions {
             @Override
             protected void doExecute(FreeIpaContext context, RemoveRolesResponse payload, Map<Object, Object> variables) {
                 CleanupEvent cleanupEvent = new CleanupEvent(FreeIpaCleanupEvent.CLEANUP_FINISHED_EVENT.event(), payload.getResourceId(), payload.getUsers(),
-                        payload.getHosts(), payload.getRoles(), payload.getOperationId(), payload.getClusterName());
+                        payload.getHosts(), payload.getRoles(), payload.getAccountId(), payload.getOperationId(), payload.getClusterName());
                 SuccessDetails successDetails = new SuccessDetails(context.getStack().getEnvironmentCrn());
                 successDetails.getAdditionalDetails().put("Hosts", payload.getHosts() == null ? List.of() : new ArrayList<>(payload.getHosts()));
                 successDetails.getAdditionalDetails().put("Users", payload.getUsers() == null ? List.of() : new ArrayList<>(payload.getUsers()));
                 successDetails.getAdditionalDetails().put("Roles", payload.getRoles() == null ? List.of() : new ArrayList<>(payload.getRoles()));
-                operationService.completeOperation(payload.getOperationId(), List.of(successDetails), Collections.emptyList());
+                operationService.completeOperation(payload.getAccountId(), payload.getOperationId(), List.of(successDetails), Collections.emptyList());
                 LOGGER.info("Cleanup successfully finished with: " + successDetails);
                 sendEvent(context, cleanupEvent);
             }
@@ -190,7 +190,7 @@ public class FreeIpaCleanupActions {
                 if (payload.getFailureDetails() != null) {
                     failureDetails.getAdditionalDetails().putAll(payload.getFailureDetails());
                 }
-                operationService.failOperation(payload.getOperationId(), message, List.of(successDetails), List.of(failureDetails));
+                operationService.failOperation(payload.getAccountId(), payload.getOperationId(), message, List.of(successDetails), List.of(failureDetails));
                 sendEvent(context, FreeIpaCleanupEvent.CLEANUP_FAILURE_HANDLED_EVENT.event(), payload);
             }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/AbstractCleanupEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/AbstractCleanupEvent.java
@@ -5,12 +5,12 @@ import com.sequenceiq.freeipa.flow.freeipa.cleanup.CleanupEvent;
 public abstract class AbstractCleanupEvent extends CleanupEvent {
 
     public AbstractCleanupEvent(CleanupEvent cleanupEvent) {
-        super(cleanupEvent.getResourceId(), cleanupEvent.getUsers(), cleanupEvent.getHosts(), cleanupEvent.getRoles(), cleanupEvent.getOperationId(),
-                cleanupEvent.getClusterName());
+        super(cleanupEvent.getResourceId(), cleanupEvent.getUsers(), cleanupEvent.getHosts(), cleanupEvent.getRoles(), cleanupEvent.getAccountId(),
+                cleanupEvent.getOperationId(), cleanupEvent.getClusterName());
     }
 
     public AbstractCleanupEvent(String selector, CleanupEvent cleanupEvent) {
-        super(selector, cleanupEvent.getResourceId(), cleanupEvent.getUsers(), cleanupEvent.getHosts(), cleanupEvent.getRoles(), cleanupEvent.getOperationId(),
-                cleanupEvent.getClusterName());
+        super(selector, cleanupEvent.getResourceId(), cleanupEvent.getUsers(), cleanupEvent.getHosts(), cleanupEvent.getRoles(), cleanupEvent.getAccountId(),
+                cleanupEvent.getOperationId(), cleanupEvent.getClusterName());
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/cleanup/CleanupService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/cleanup/CleanupService.java
@@ -86,7 +86,7 @@ public class CleanupService {
         Operation operation =
                 operationService.startOperation(accountId, OperationType.CLEANUP, Set.of(stack.getEnvironmentCrn()), Collections.emptySet());
         CleanupEvent cleanupEvent = new CleanupEvent(FreeIpaCleanupEvent.CLEANUP_EVENT.event(), stack.getId(), request.getUsers(),
-                request.getHosts(), request.getRoles(), operation.getOperationId(), request.getClusterName());
+                request.getHosts(), request.getRoles(), accountId, operation.getOperationId(), request.getClusterName());
         flowManager.notify(FreeIpaCleanupEvent.CLEANUP_EVENT.event(), cleanupEvent);
         return operationToOperationStatusConverter.convert(operation);
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/PasswordService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/PasswordService.java
@@ -123,12 +123,12 @@ public class PasswordService {
                     failure.add(new FailureDetails(request.getEnvironment(), e.getLocalizedMessage()));
                 }
             }
-            operationService.completeOperation(operationId, success, failure);
+            operationService.completeOperation(accountId, operationId, success, failure);
         } catch (InterruptedException e) {
-            operationService.failOperation(operationId, e.getLocalizedMessage());
+            operationService.failOperation(accountId, operationId, e.getLocalizedMessage());
             Thread.currentThread().interrupt();
         } catch (RuntimeException e) {
-            operationService.failOperation(operationId, e.getLocalizedMessage());
+            operationService.failOperation(accountId, operationId, e.getLocalizedMessage());
             throw e;
         }
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncService.java
@@ -180,10 +180,10 @@ public class UserSyncService {
                     failure.add(new FailureDetails(envCrn, e.getLocalizedMessage()));
                 }
             });
-            operationService.completeOperation(operationId, success, failure);
+            operationService.completeOperation(accountId, operationId, success, failure);
         } catch (RuntimeException e) {
             LOGGER.error("User sync operation {} failed with error:", operationId, e);
-            operationService.failOperation(operationId, e.getLocalizedMessage());
+            operationService.failOperation(accountId, operationId, e.getLocalizedMessage());
             throw e;
         }
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/operation/OperationService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/operation/OperationService.java
@@ -64,8 +64,8 @@ public class OperationService {
         return operationRepository.save(operation);
     }
 
-    public Operation completeOperation(String operationId, Collection<SuccessDetails> success, Collection<FailureDetails> failure) {
-        Operation operation = getOperationForOperationId(operationId);
+    public Operation completeOperation(String accountId, String operationId, Collection<SuccessDetails> success, Collection<FailureDetails> failure) {
+        Operation operation = getOperationForAccountIdAndOperationId(accountId, operationId);
         operation.setStatus(OperationState.COMPLETED);
         operation.setSuccessList(List.copyOf(success));
         operation.setFailureList(List.copyOf(failure));
@@ -73,8 +73,9 @@ public class OperationService {
         return operationRepository.save(operation);
     }
 
-    public Operation failOperation(String operationId, String failureMessage, Collection<SuccessDetails> success, Collection<FailureDetails> failure) {
-        Operation operation = getOperationForOperationId(operationId);
+    public Operation failOperation(String accountId, String operationId, String failureMessage, Collection<SuccessDetails> success,
+            Collection<FailureDetails> failure) {
+        Operation operation = getOperationForAccountIdAndOperationId(accountId, operationId);
         operation.setStatus(OperationState.FAILED);
         operation.setError(failureMessage);
         operation.setEndTime(System.currentTimeMillis());
@@ -83,8 +84,8 @@ public class OperationService {
         return operationRepository.save(operation);
     }
 
-    public Operation failOperation(String operationId, String failureMessage) {
-        return failOperation(operationId, failureMessage, Collections.emptyList(), Collections.emptyList());
+    public Operation failOperation(String accountId, String operationId, String failureMessage) {
+        return failOperation(accountId, operationId, failureMessage, Collections.emptyList(), Collections.emptyList());
     }
 
     public Operation getOperationForAccountIdAndOperationId(String accountId, String operationId) {
@@ -118,13 +119,5 @@ public class OperationService {
         operation.setEndTime(System.currentTimeMillis());
         operation.setError(reason);
         return operation;
-    }
-
-    private Operation getOperationForOperationId(String operationId) {
-        Optional<Operation> syncOperationOptional = operationRepository.findByOperationId(operationId);
-        if (!syncOperationOptional.isPresent()) {
-            throw NotFoundException.notFound("Operation", operationId).get();
-        }
-        return syncOperationOptional.get();
     }
 }


### PR DESCRIPTION
This commit removes the OperationService method that retrieves
Operations by operation id only. An accountId is now always required.

This is a follow-on to PR https://github.com/hortonworks/cloudbreak/pull/7160