### PR TITLE
CB-5094: Add connection check for FreeIPA MS to FreeIPA server

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
@@ -20,6 +20,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.doc.FreeIpaNotes;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.doc.FreeIpaOperationDescriptions;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.create.CreateFreeIpaRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.describe.DescribeFreeIpaResponse;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.HealthDetailsFreeIpaResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.list.ListFreeIpaResponse;
 import com.sequenceiq.freeipa.api.v1.operation.model.OperationStatus;
 
@@ -51,6 +52,13 @@ public interface FreeIpaV1Endpoint {
     @ApiOperation(value = FreeIpaOperationDescriptions.LIST_BY_ACCOUNT, produces = MediaType.APPLICATION_JSON, notes = FreeIpaNotes.FREEIPA_NOTES,
             nickname = "listFreeIpaClustersByAccountV1")
     List<ListFreeIpaResponse> list();
+
+    @GET
+    @Path("health")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = FreeIpaOperationDescriptions.HEALTH, produces = MediaType.APPLICATION_JSON, notes = FreeIpaNotes.FREEIPA_NOTES,
+            nickname = "healthV1")
+    HealthDetailsFreeIpaResponse healthDetails(@QueryParam("environment") @NotEmpty String environmentCrn);
 
     @GET
     @Path("ca.crt")

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaOperationDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaOperationDescriptions.java
@@ -11,6 +11,7 @@ public final class FreeIpaOperationDescriptions {
     public static final String STOP = "Stop all FreeIPA stacks that attached to the given environment CRN";
     public static final String REGISTER_WITH_CLUSTER_PROXY = "Registers FreeIPA stack with given environment CRN with cluster proxy";
     public static final String DEREGISTER_WITH_CLUSTER_PROXY = "Deregisters FreeIPA stack with given environment CRN with cluster proxy";
+    public static final String HEALTH = "Provides a detailed health of the FreeIPA stack";
 
     private FreeIpaOperationDescriptions() {
     }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/health/HealthDetailsFreeIpaResponse.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/health/HealthDetailsFreeIpaResponse.java
@@ -1,0 +1,87 @@
+package com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.doc.FreeIpaModelDescriptions;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.service.api.doc.ModelDescriptions;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel("HealthDetailsFreeIpaV1Response")
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class HealthDetailsFreeIpaResponse {
+    @NotNull
+    @ApiModelProperty(value = ModelDescriptions.ENVIRONMENT_CRN, required = true)
+    private String environmentCrn;
+
+    @NotNull
+    @ApiModelProperty(value = FreeIpaModelDescriptions.FREEIPA_NAME, required = true)
+    private String name;
+
+    @NotNull
+    private String crn;
+
+    @NotNull
+    private List<NodeHealthDetails> nodeHealthDetails;
+
+    private Status status;
+
+    public String getEnvironmentCrn() {
+        return environmentCrn;
+    }
+
+    public void setEnvironmentCrn(String environmentCrn) {
+        this.environmentCrn = environmentCrn;
+    }
+
+    public String getCrn() {
+        return crn;
+    }
+
+    public void setCrn(String crn) {
+        this.crn = crn;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<NodeHealthDetails> getNodeHealthDetails() {
+        if (nodeHealthDetails == null) {
+            nodeHealthDetails = new ArrayList<>();
+        }
+        return nodeHealthDetails;
+    }
+
+    public void setNodeHealthDetails(List<NodeHealthDetails> nodeHealthDetails) {
+        this.nodeHealthDetails = nodeHealthDetails;
+    }
+
+    public void addNodeHealthDetailsFreeIpaResponses(NodeHealthDetails nodeHealthDetails) {
+        if (this.nodeHealthDetails == null) {
+            this.nodeHealthDetails = new ArrayList<>();
+        }
+        this.nodeHealthDetails.add(nodeHealthDetails);
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+}

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/health/NodeHealthDetails.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/health/NodeHealthDetails.java
@@ -1,0 +1,61 @@
+package com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+
+import io.swagger.annotations.ApiModel;
+
+@ApiModel("NodeHealthDetails")
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class NodeHealthDetails {
+
+    @NotNull
+    private List<String> issues;
+
+    @NotNull
+    private Status status;
+
+    @NotNull
+    private String name;
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public List<String> getIssues() {
+        if (issues == null) {
+            issues = new ArrayList<>();
+        }
+        return issues;
+    }
+
+    public void setIssues(List<String> issues) {
+        this.issues = issues;
+    }
+
+    public void addIssue(String issue) {
+        if (issues == null) {
+            issues = new ArrayList<>();
+        }
+        issues.add(issue);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaV1Controller.java
@@ -17,6 +17,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.cleanup.CleanupRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.FreeIpaV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.create.CreateFreeIpaRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.describe.DescribeFreeIpaResponse;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.HealthDetailsFreeIpaResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.list.ListFreeIpaResponse;
 import com.sequenceiq.freeipa.api.v1.operation.model.OperationStatus;
 import com.sequenceiq.freeipa.client.FreeIpaClientException;
@@ -29,6 +30,7 @@ import com.sequenceiq.freeipa.service.stack.FreeIpaDescribeService;
 import com.sequenceiq.freeipa.service.stack.FreeIpaListService;
 import com.sequenceiq.freeipa.service.stack.FreeIpaRootCertificateService;
 import com.sequenceiq.freeipa.service.stack.FreeIpaStartService;
+import com.sequenceiq.freeipa.service.stack.FreeIpaHealthDetailsService;
 import com.sequenceiq.freeipa.service.stack.FreeIpaStopService;
 import com.sequenceiq.freeipa.util.CrnService;
 
@@ -48,6 +50,9 @@ public class FreeIpaV1Controller implements FreeIpaV1Endpoint {
 
     @Inject
     private FreeIpaListService freeIpaListService;
+
+    @Inject
+    private FreeIpaHealthDetailsService freeIpaHealthDetailsService;
 
     @Inject
     private FreeIpaRootCertificateService freeIpaRootCertificateService;
@@ -91,6 +96,12 @@ public class FreeIpaV1Controller implements FreeIpaV1Endpoint {
     public List<ListFreeIpaResponse> list() {
         String accountId = crnService.getCurrentAccountId();
         return freeIpaListService.list(accountId);
+    }
+
+    @Override
+    public HealthDetailsFreeIpaResponse healthDetails(String environmentCrn) {
+        String accountId = crnService.getCurrentAccountId();
+        return freeIpaHealthDetailsService.getHealthDetails(environmentCrn, accountId);
     }
 
     @Override

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaHealthDetailsService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaHealthDetailsService.java
@@ -1,0 +1,132 @@
+package com.sequenceiq.freeipa.service.stack;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupType;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.HealthDetailsFreeIpaResponse;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.NodeHealthDetails;
+import com.sequenceiq.freeipa.client.FreeIpaClient;
+import com.sequenceiq.freeipa.client.FreeIpaClientException;
+import com.sequenceiq.freeipa.client.model.RPCMessage;
+import com.sequenceiq.freeipa.client.model.RPCResponse;
+import com.sequenceiq.freeipa.entity.InstanceGroup;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
+
+@Service
+public class FreeIpaHealthDetailsService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FreeIpaHealthDetailsService.class);
+
+    private static final String EXTERNAL_COMMAND_OUTPUT = "ExternalCommandOutput";
+
+    private static final String STATUS_OK = "OK";
+
+    private static final int STATUS_GROUP = 2;
+
+    private static final String MESSAGE_UNAVAILABLE = "Message Unavailable";
+
+    private static final Pattern RESULT_PATTERN = Pattern.compile("(ecure port|: TCP) \\([0-9]*\\): (.*)");
+
+    private static final Pattern NEW_NODE_PATTERN = Pattern.compile("Check connection from master to remote replica '(.[^\']*)");
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private FreeIpaClientFactory freeIpaClientFactory;
+
+    public HealthDetailsFreeIpaResponse getHealthDetails(String environmentCrn, String accountId) {
+        Stack stack = stackService.getByEnvironmentCrnAndAccountIdWithLists(environmentCrn, accountId);
+        String masterCN = findMasterCN(stack);
+        Optional<RPCResponse<Boolean>> rpcResponse = Optional.empty();
+        try {
+            rpcResponse = Optional.ofNullable(checkFreeIpaHealth(stack, masterCN));
+        } catch (FreeIpaClientException e) {
+            LOGGER.error("Unable to check the health of FreeIPA.", e);
+        }
+        return createResponse(stack, rpcResponse);
+    }
+
+    private HealthDetailsFreeIpaResponse createResponse(Stack stack, Optional<RPCResponse<Boolean>> rpcResponse) {
+        HealthDetailsFreeIpaResponse response = new HealthDetailsFreeIpaResponse();
+        response.setEnvironmentCrn(stack.getEnvironmentCrn());
+        response.setCrn(stack.getResourceCrn());
+        if (rpcResponse.isPresent()) {
+            response.setName((String) rpcResponse.get().getValue());
+            parseMessages(rpcResponse.get(), response);
+            if (isOverallHealthy(response)) {
+                response.setStatus(DetailedStackStatus.PROVISIONED.getStatus());
+            } else {
+                response.setStatus(DetailedStackStatus.UNHEALTHY.getStatus());
+            }
+        } else {
+            response.setStatus(DetailedStackStatus.UNREACHABLE.getStatus());
+            NodeHealthDetails nodeResponse = null;
+            nodeResponse = new NodeHealthDetails();
+            response.addNodeHealthDetailsFreeIpaResponses(nodeResponse);
+            nodeResponse.setStatus(Status.UNREACHABLE);
+        }
+        return response;
+    }
+
+    private String findMasterCN(Stack stack) {
+        InstanceGroup masterGroup = stack.getInstanceGroups().stream()
+                .filter(instanceGroup -> InstanceGroupType.MASTER == instanceGroup.getInstanceGroupType()).findFirst().get();
+        return masterGroup.getNotDeletedInstanceMetaDataSet().stream().findFirst().get().getDiscoveryFQDN();
+    }
+
+    private RPCResponse<Boolean> checkFreeIpaHealth(Stack stack, String masterCN) throws FreeIpaClientException {
+        FreeIpaClient freeIpaClient = freeIpaClientFactory.getFreeIpaClientForStack(stack);
+        return freeIpaClient.serverConnCheck(masterCN, masterCN);
+    }
+
+    private boolean isOverallHealthy(HealthDetailsFreeIpaResponse response) {
+        for (NodeHealthDetails node: response.getNodeHealthDetails()) {
+            if (node.getStatus().equals(Status.AVAILABLE)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void parseMessages(RPCResponse<Boolean> rpcResponse, HealthDetailsFreeIpaResponse response) {
+        String precedingMessage = MESSAGE_UNAVAILABLE;
+        NodeHealthDetails nodeResponse = null;
+        for (RPCMessage message : rpcResponse.getMessages()) {
+            Matcher nodeMatcher = NEW_NODE_PATTERN.matcher(message.getMessage());
+            if (nodeMatcher.find()) {
+                nodeResponse = new NodeHealthDetails();
+                response.addNodeHealthDetailsFreeIpaResponses(nodeResponse);
+                nodeResponse.setStatus(Status.AVAILABLE);
+            }
+            if (nodeResponse == null) {
+                LOGGER.info("No node for message: {}" + message.getMessage());
+            } else {
+                // When parsing the messages, if there's an error, the error
+                // appears in the preceding message.
+                if (EXTERNAL_COMMAND_OUTPUT.equals(message.getName())) {
+                    Matcher matcher = RESULT_PATTERN.matcher(message.getMessage());
+                    if (matcher.find()) {
+                        if (!STATUS_OK.equals(matcher.group(STATUS_GROUP))) {
+                            nodeResponse.setStatus(Status.UNHEALTHY);
+                            nodeResponse.addIssue(precedingMessage);
+                        }
+                    }
+                    precedingMessage = message.getMessage();
+                }
+            }
+        }
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaHealthServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaHealthServiceTest.java
@@ -1,0 +1,205 @@
+package com.sequenceiq.freeipa.service.stack;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.google.common.collect.Sets;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupType;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.HealthDetailsFreeIpaResponse;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.NodeHealthDetails;
+import com.sequenceiq.freeipa.client.FreeIpaClient;
+import com.sequenceiq.freeipa.client.FreeIpaClientException;
+import com.sequenceiq.freeipa.client.model.RPCMessage;
+import com.sequenceiq.freeipa.client.model.RPCResponse;
+import com.sequenceiq.freeipa.entity.InstanceGroup;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
+
+@ExtendWith(MockitoExtension.class)
+public class FreeIpaHealthServiceTest {
+    private static final String ENVIRONMENT_ID = "crn:cdp:environments:us-west-1:f39af961-e0ce-4f79-826c-45502efb9ca3:environment:12345-6789";
+
+    private static final String ACCOUNT_ID = "accountId";
+
+    private static RPCResponse<Boolean> goodResponse;
+
+    private static RPCResponse<Boolean> doubleResponseOneBad;
+
+    private static RPCResponse<Boolean> errorResponse;
+
+    private static Stack stack;
+
+    private static FreeIpaClientException ipaClientException;
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private FreeIpaClientFactory freeIpaClientFactory;
+
+    @InjectMocks
+    private FreeIpaHealthDetailsService underTest;
+
+    private List<RPCMessage> getBaseMessages() {
+        List<RPCMessage> messages = new ArrayList<>();
+        messages.add(newRPCMessage("Check connection from master to remote replica 'freeipa.host.com':"));
+        messages.add(newRPCMessage("   Directory Service: Unsecure port (389): OK"));
+        messages.add(newRPCMessage("   Directory Service: Secure port (636): OK"));
+        messages.add(newRPCMessage("   Directory Service: Secure port (636): OK"));
+        messages.add(newRPCMessage("   Kerberos KDC: TCP (88): OK"));
+        messages.add(newRPCMessage("Failed to connect to port 88 udp on 10.1.1.1"));
+        messages.add(newRPCMessage("   Kerberos KDC: UDP (88): WARNING"));
+        messages.add(newRPCMessage("   Kerberos Kpasswd: TCP (464): OK"));
+        messages.add(newRPCMessage("Failed to connect to port 464 udp on 10.1.1.1"));
+        messages.add(newRPCMessage("   Kerberos Kpasswd: UDP (464): WARNING"));
+        messages.add(newRPCMessage("   HTTP Server: Unsecure port (80): OK"));
+        messages.add(newRPCMessage("   HTTP Server: Secure port (443): OK"));
+        messages.add(newRPCMessage("The following UDP ports could not be verified as open: 88, 464"));
+        messages.add(newRPCMessage("This can happen if they are already bound to an application"));
+        messages.add(newRPCMessage("and ipa-replica-conncheck cannot attach own UDP responder."));
+        messages.add(newRPCMessage("Connection from master to replica is OK."));
+        return messages;
+    }
+
+    private RPCResponse<Boolean> getGoodPayload() {
+        if (goodResponse == null) {
+            goodResponse = new RPCResponse<>();
+            goodResponse.setResult(Boolean.TRUE);
+            goodResponse.setValue("test.host.name");
+            goodResponse.setMessages(getBaseMessages());
+        }
+        return goodResponse;
+    }
+
+    private RPCResponse<Boolean> getErrorPayload() {
+        if (errorResponse == null) {
+            errorResponse = new RPCResponse<>();
+            errorResponse.setResult(Boolean.TRUE);
+            errorResponse.setValue("test.host.name");
+            errorResponse.setMessages(getBaseMessages());
+            errorResponse.getMessages().add(newRPCMessage("Failed to connect to port 464 tcp on 10.1.1.1"));
+            errorResponse.getMessages().add(newRPCMessage("   Kerberos Kpasswd: TCP (464): FAILED"));
+            errorResponse.getMessages().add(newRPCMessage("Failed to connect to port 636 tcp on 10.1.1.1"));
+            errorResponse.getMessages().add(newRPCMessage("   Directory Service: Secure port (636): OK"));
+        }
+        return errorResponse;
+    }
+
+    private RPCResponse<Boolean> getDoublePayload() {
+        if (doubleResponseOneBad == null) {
+            doubleResponseOneBad = new RPCResponse<>();
+            doubleResponseOneBad.setResult(Boolean.TRUE);
+            doubleResponseOneBad.setValue("test.host.name");
+            doubleResponseOneBad.setMessages(getBaseMessages());
+            doubleResponseOneBad.getMessages().add(newRPCMessage("Check connection from master to remote replica 'freeipa2.host.com':"));
+            doubleResponseOneBad.getMessages().add(newRPCMessage("   Directory Service: Unsecure port (389): OK"));
+            doubleResponseOneBad.getMessages().add(newRPCMessage("   Directory Service: Secure port (636): OK"));
+            doubleResponseOneBad.getMessages().add(newRPCMessage("   Directory Service: Secure port (636): OK"));
+            doubleResponseOneBad.getMessages().add(newRPCMessage("   Kerberos KDC: TCP (88): OK"));
+            doubleResponseOneBad.getMessages().add(newRPCMessage("Failed to connect to port 88 udp on 10.1.1.1"));
+            doubleResponseOneBad.getMessages().add(newRPCMessage("   Kerberos KDC: UDP (88): WARNING"));
+            doubleResponseOneBad.getMessages().add(newRPCMessage("Failed to connect to port 464 tcp on 10.1.1.1"));
+            doubleResponseOneBad.getMessages().add(newRPCMessage("   Kerberos Kpasswd: TCP (464): FAILED"));
+            doubleResponseOneBad.getMessages().add(newRPCMessage("Failed to connect to port 464 udp on 10.1.1.1"));
+            doubleResponseOneBad.getMessages().add(newRPCMessage("   Kerberos Kpasswd: UDP (464): WARNING"));
+            doubleResponseOneBad.getMessages().add(newRPCMessage("   HTTP Server: Unsecure port (80): OK"));
+            doubleResponseOneBad.getMessages().add(newRPCMessage("   HTTP Server: Secure port (443): OK"));
+            doubleResponseOneBad.getMessages().add(newRPCMessage("The following UDP ports could not be verified as open: 88, 464"));
+            doubleResponseOneBad.getMessages().add(newRPCMessage("This can happen if they are already bound to an application"));
+            doubleResponseOneBad.getMessages().add(newRPCMessage("and ipa-replica-conncheck cannot attach own UDP responder."));
+            doubleResponseOneBad.getMessages().add(newRPCMessage("Connection from master to replica is OK."));
+        }
+        return doubleResponseOneBad;
+    }
+
+    private RPCMessage newRPCMessage(String message) {
+        RPCMessage msg = new RPCMessage();
+        msg.setMessage(message);
+        msg.setName("ExternalCommandOutput");
+        return msg;
+    }
+
+    @BeforeAll
+    public static void init() {
+        stack = new Stack();
+        stack.setResourceCrn(ENVIRONMENT_ID);
+        InstanceGroup instanceGroup = new InstanceGroup();
+        stack.getInstanceGroups().add(instanceGroup);
+        instanceGroup.setInstanceGroupType(InstanceGroupType.MASTER);
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+        instanceGroup.setInstanceMetaData(Sets.newHashSet(instanceMetaData));
+        instanceMetaData.setDiscoveryFQDN("host.domain");
+        ipaClientException = new FreeIpaClientException("failure");
+    }
+
+    @Test
+    public void testHealthySingleNode() throws Exception {
+        FreeIpaClient mockIpaClient = Mockito.mock(FreeIpaClient.class);
+        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(stack);
+        Mockito.when(freeIpaClientFactory.getFreeIpaClientForStack(any())).thenReturn(mockIpaClient);
+        Mockito.when(mockIpaClient.serverConnCheck(anyString(), anyString())).thenReturn(getGoodPayload());
+        HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
+        Assert.assertEquals(Status.AVAILABLE, response.getStatus());
+        Assert.assertFalse(response.getNodeHealthDetails().isEmpty());
+        for (NodeHealthDetails nodeHealth:response.getNodeHealthDetails()) {
+            Assert.assertTrue(nodeHealth.getIssues().isEmpty());
+            Assert.assertEquals(Status.AVAILABLE, nodeHealth.getStatus());
+        }
+    }
+
+    @Test
+    public void testUnhealthySingleNode() throws Exception {
+        FreeIpaClient mockIpaClient = Mockito.mock(FreeIpaClient.class);
+        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(stack);
+        Mockito.when(freeIpaClientFactory.getFreeIpaClientForStack(any())).thenReturn(mockIpaClient);
+        Mockito.when(mockIpaClient.serverConnCheck(anyString(), anyString())).thenReturn(getErrorPayload());
+        HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
+        Assert.assertEquals(Status.UNHEALTHY, response.getStatus());
+        Assert.assertFalse(response.getNodeHealthDetails().isEmpty());
+        for (NodeHealthDetails nodeHealth:response.getNodeHealthDetails()) {
+            Assert.assertFalse(nodeHealth.getIssues().isEmpty());
+            Assert.assertEquals(Status.UNHEALTHY, nodeHealth.getStatus());
+        }
+    }
+
+    @Test
+    public void testUnresponsiveSingleNode() throws Exception {
+        FreeIpaClient mockIpaClient = Mockito.mock(FreeIpaClient.class);
+        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(stack);
+        Mockito.when(freeIpaClientFactory.getFreeIpaClientForStack(any())).thenReturn(mockIpaClient);
+        Mockito.when(mockIpaClient.serverConnCheck(anyString(), anyString())).thenThrow(ipaClientException);
+        HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
+        Assert.assertEquals(Status.UNREACHABLE, response.getStatus());
+        Assert.assertFalse(response.getNodeHealthDetails().isEmpty());
+        for (NodeHealthDetails nodeHealth:response.getNodeHealthDetails()) {
+            Assert.assertTrue(nodeHealth.getIssues().isEmpty());
+            Assert.assertEquals(Status.UNREACHABLE, nodeHealth.getStatus());
+        }
+    }
+
+    @Test
+    public void testUnresponsiveSecondaryNode() throws Exception {
+        FreeIpaClient mockIpaClient = Mockito.mock(FreeIpaClient.class);
+        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(stack);
+        Mockito.when(freeIpaClientFactory.getFreeIpaClientForStack(any())).thenReturn(mockIpaClient);
+        Mockito.when(mockIpaClient.serverConnCheck(anyString(), anyString())).thenReturn(getDoublePayload());
+        HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
+        Assert.assertEquals(Status.AVAILABLE, response.getStatus());
+        Assert.assertFalse(response.getNodeHealthDetails().isEmpty());
+    }
+
+}


### PR DESCRIPTION
This patch adds the ability to get a detailed status
from FreeIPA servers.  This information will be used
by the CLI and UI to provide detailed status information
for the FreeIPA node. This will also fix CB-5333

Ran additional unit tests.  Validated manually against FreeIPA instance.
