### PR TITLE
CB-5240 Refactor byName and byCrn methods in StackService, StackCommo…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/config/generator/OfflineStateGenerator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/config/generator/OfflineStateGenerator.java
@@ -428,6 +428,11 @@ public class OfflineStateGenerator {
         }
 
         @Override
+        public Optional<Long> findIdByCrnAndWorkspaceId(String name, Long workspaceId) {
+            return Optional.empty();
+        }
+
+        @Override
         public Set<StackListItem> findByWorkspaceId(Long id, String environmentCrn, List<StackType> stackTypes) {
             return null;
         }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
@@ -207,6 +207,10 @@ public interface StackRepository extends WorkspaceResourceRepository<Stack, Long
     @Query("SELECT s.id FROM Stack s WHERE s.name= :name AND s.workspace.id= :workspaceId AND s.terminated = null")
     Optional<Long> findIdByNameAndWorkspaceId(@Param("name") String name, @Param("workspaceId") Long workspaceId);
 
+    @DisableCheckPermissions
+    @Query("SELECT s.id FROM Stack s WHERE s.resourceCrn= :crn AND s.workspace.id= :workspaceId AND s.terminated = null")
+    Optional<Long> findIdByCrnAndWorkspaceId(@Param("crn") String crn, @Param("workspaceId") Long workspaceId);
+
     @CheckPermissionsByWorkspaceId
     @Query("SELECT s.id as id, "
             + "s.resourceCrn as resourceCrn, "

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/blueprint/BlueprintService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/blueprint/BlueprintService.java
@@ -117,7 +117,7 @@ public class BlueprintService extends AbstractWorkspaceAwareResourceService<Blue
         return nameOrCrn.hasName()
                 ? super.deleteByNameFromWorkspace(nameOrCrn.getName(), workspaceId)
                 : delete(blueprintRepository.findByResourceCrnAndWorkspaceId(nameOrCrn.getCrn(), workspaceId)
-                .orElseThrow(() -> notFound("blueprint", nameOrCrn.toString()).get()));
+                .orElseThrow(() -> notFound("blueprint", nameOrCrn.getCrn()).get()));
     }
 
     public Blueprint getByWorkspace(@NotNull NameOrCrn nameOrCrn, Long workspaceId) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/UpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/UpgradeService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
 
 import com.google.common.collect.Sets;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.image.ImageSettingsV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.ImageInfoV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Response;
@@ -75,10 +76,10 @@ public class UpgradeService {
     @Inject
     private TransactionService transactionService;
 
-    public UpgradeOptionV4Response getUpgradeOptionByStackName(Long workspaceId, String stackName, User user) {
+    public UpgradeOptionV4Response getUpgradeOptionByStackNameOrCrn(Long workspaceId, NameOrCrn nameOrCrn, User user) {
         try {
             return transactionService.required(() -> {
-                Optional<Stack> stack = stackService.findStackByNameAndWorkspaceId(stackName, workspaceId);
+                Optional<Stack> stack = stackService.findStackByNameOrCrnAndWorkspaceId(nameOrCrn, workspaceId);
                 if (stack.isPresent()) {
                     try {
                         return getUpgradeOption(stack.get(), workspaceId, user);
@@ -86,7 +87,7 @@ public class UpgradeService {
                         throw new BadRequestException(e.getMessage());
                     }
                 } else {
-                    throw notFoundException("Stack", stackName);
+                    throw notFoundException("Stack", nameOrCrn.toString());
                 }
             });
         } catch (TransactionExecutionException e) {

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXV1Controller.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXV1Controller.java
@@ -147,7 +147,7 @@ public class DistroXV1Controller implements DistroXV1Endpoint {
         Set<NameOrCrn> nameOrCrns = multiDeleteRequest.getNames().stream()
                 .map(name -> NameOrCrn.ofName(name))
                 .collect(Collectors.toSet());
-        nameOrCrns.forEach(accessDto -> stackOperations.delete(accessDto, workspaceService.getForCurrentUser().getId(), forced));
+        nameOrCrns.forEach(nameOrCrn -> stackOperations.delete(nameOrCrn, workspaceService.getForCurrentUser().getId(), forced));
     }
 
     private void multideleteByCrn(DistroXMultiDeleteV1Request multiDeleteRequest, Boolean forced) {
@@ -380,8 +380,8 @@ public class DistroXV1Controller implements DistroXV1Endpoint {
         return distroXV1RequestToCreateAWSClusterRequestConverter.convert(request);
     }
 
-    private StackV4Request getStackV4Request(NameOrCrn accessDto) {
-        return stackOperations.getRequest(accessDto, workspaceService.getForCurrentUser().getId());
+    private StackV4Request getStackV4Request(NameOrCrn nameOrCrn) {
+        return stackOperations.getRequest(nameOrCrn, workspaceService.getForCurrentUser().getId());
     }
 
     private Object getCreateAWSClusterRequest(StackV4Request stackV4Request) {

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/StackOperationsTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/StackOperationsTest.java
@@ -3,9 +3,6 @@ package com.sequenceiq.distrox.v1.distrox;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
@@ -106,68 +103,48 @@ public class StackOperationsTest {
     }
 
     @Test
-    public void testDeleteWhenDtoNameFilledAndForcedTrueThenDeleteCalled() {
-        underTest.delete(NameOrCrn.ofName(stack.getName()), stack.getWorkspace().getId(), true);
+    public void testDeleteWhenForcedTrueThenDeleteCalled() {
+        NameOrCrn nameOrCrn = NameOrCrn.ofName(stack.getName());
 
-        verify(stackCommonService, times(1)).deleteWithKerberosByNameInWorkspace(anyString(), anyLong(), anyBoolean());
-        verify(stackCommonService, times(1)).deleteWithKerberosByNameInWorkspace(stack.getName(), stack.getWorkspace().getId(), true);
-        verify(stackCommonService, times(0)).deleteWithKerberosByCrnInWorkspace(anyString(), anyLong(), anyBoolean());
+        underTest.delete(nameOrCrn, stack.getWorkspace().getId(), true);
+
+        verify(stackCommonService, times(1)).deleteWithKerberosInWorkspace(nameOrCrn, stack.getWorkspace().getId(), true);
     }
 
     @Test
-    public void testDeleteWhenDtoNameFilledAndForcedFalseThenDeleteCalled() {
-        underTest.delete(NameOrCrn.ofName(stack.getName()), stack.getWorkspace().getId(), false);
+    public void testDeleteWhenForcedFalseThenDeleteCalled() {
+        NameOrCrn nameOrCrn = NameOrCrn.ofName(stack.getName());
 
-        verify(stackCommonService, times(1)).deleteWithKerberosByNameInWorkspace(anyString(), anyLong(), anyBoolean());
-        verify(stackCommonService, times(1)).deleteWithKerberosByNameInWorkspace(stack.getName(), stack.getWorkspace().getId(), false);
-        verify(stackCommonService, times(0)).deleteWithKerberosByCrnInWorkspace(anyString(), anyLong(), anyBoolean());
+        underTest.delete(nameOrCrn, stack.getWorkspace().getId(), false);
+
+        verify(stackCommonService, times(1)).deleteWithKerberosInWorkspace(nameOrCrn, stack.getWorkspace().getId(), false);
     }
 
     @Test
-    public void testDeleteWhenDtoCrnFilledAndForcedTrueThenDeleteCalled() {
-        underTest.delete(NameOrCrn.ofCrn(stack.getResourceCrn()), stack.getWorkspace().getId(), true);
-
-        verify(stackCommonService, times(1)).deleteWithKerberosByCrnInWorkspace(anyString(), anyLong(), anyBoolean());
-        verify(stackCommonService, times(1)).deleteWithKerberosByCrnInWorkspace(stack.getResourceCrn(), stack.getWorkspace().getId(), true);
-        verify(stackCommonService, times(0)).deleteWithKerberosByNameInWorkspace(anyString(), anyLong(), anyBoolean());
-    }
-
-    @Test
-    public void testDeleteWhenDtoCrnFilledAndForcedFalseThenDeleteCalled() {
-        underTest.delete(NameOrCrn.ofCrn(stack.getResourceCrn()), stack.getWorkspace().getId(), false);
-
-        verify(stackCommonService, times(1)).deleteWithKerberosByCrnInWorkspace(anyString(), anyLong(), anyBoolean());
-        verify(stackCommonService, times(1)).deleteWithKerberosByCrnInWorkspace(stack.getResourceCrn(), stack.getWorkspace().getId(), false);
-        verify(stackCommonService, times(0)).deleteWithKerberosByNameInWorkspace(anyString(), anyLong(), anyBoolean());
-    }
-
-    @Test
-    public void testGetWhenDtoNameFilledThenProperGetCalled() {
+    public void testGetWhenNameOrCrnNameFilledThenProperGetCalled() {
         StackV4Response expected = stackResponse();
-        when(stackCommonService.findStackByNameAndWorkspaceId(stack.getName(), stack.getWorkspace().getId(), STACK_ENTRIES, STACK_TYPE))
+        NameOrCrn nameOrCrn = NameOrCrn.ofName(stack.getName());
+        when(stackCommonService.findStackByNameOrCrnAndWorkspaceId(nameOrCrn, stack.getWorkspace().getId(), STACK_ENTRIES, STACK_TYPE))
                 .thenReturn(expected);
 
-        StackV4Response result = underTest.get(NameOrCrn.ofName(stack.getName()), stack.getWorkspace().getId(), STACK_ENTRIES, STACK_TYPE);
+        StackV4Response result = underTest.get(nameOrCrn, stack.getWorkspace().getId(), STACK_ENTRIES, STACK_TYPE);
 
         assertEquals(expected, result);
-        verify(stackCommonService, times(1)).findStackByNameAndWorkspaceId(anyString(), anyLong(), anySet(), any());
-        verify(stackCommonService, times(1)).findStackByNameAndWorkspaceId(stack.getName(), stack.getWorkspace().getId(), STACK_ENTRIES, STACK_TYPE);
-        verify(stackCommonService, times(0)).findStackByCrnAndWorkspaceId(anyString(), anyLong(), anySet(), any());
+        verify(stackCommonService, times(1)).findStackByNameOrCrnAndWorkspaceId(nameOrCrn, stack.getWorkspace().getId(), STACK_ENTRIES, STACK_TYPE);
     }
 
     @Test
-    public void testGetWhenDtoCrnFilledThenProperGetCalled() {
+    public void testGetWhenNameOrCrnCrnFilledThenProperGetCalled() {
         StackV4Response expected = stackResponse();
-        when(stackCommonService.findStackByCrnAndWorkspaceId(stack.getResourceCrn(), stack.getWorkspace().getId(), STACK_ENTRIES, STACK_TYPE))
+        NameOrCrn nameOrCrn = NameOrCrn.ofCrn(stack.getResourceCrn());
+        when(stackCommonService.findStackByNameOrCrnAndWorkspaceId(nameOrCrn, stack.getWorkspace().getId(), STACK_ENTRIES, STACK_TYPE))
                 .thenReturn(expected);
 
-        StackV4Response result = underTest.get(NameOrCrn.ofCrn(stack.getResourceCrn()), stack.getWorkspace().getId(), STACK_ENTRIES, STACK_TYPE);
+        StackV4Response result = underTest.get(nameOrCrn, stack.getWorkspace().getId(), STACK_ENTRIES, STACK_TYPE);
 
         assertEquals(expected, result);
-        verify(stackCommonService, times(1)).findStackByCrnAndWorkspaceId(anyString(), anyLong(), anySet(), any());
-        verify(stackCommonService, times(1)).findStackByCrnAndWorkspaceId(
-                stack.getResourceCrn(), stack.getWorkspace().getId(), STACK_ENTRIES, STACK_TYPE);
-        verify(stackCommonService, times(0)).findStackByNameAndWorkspaceId(anyString(), anyLong(), anySet(), any());
+        verify(stackCommonService, times(1)).findStackByNameOrCrnAndWorkspaceId(
+                nameOrCrn, stack.getWorkspace().getId(), STACK_ENTRIES, STACK_TYPE);
     }
 
     @Test


### PR DESCRIPTION
For a description please see problem description at: https://github.com/hortonworks/cloudbreak/pull/7128

This refactor contains changes only where resourceAccessDto was already used. 
Methods that still use String name or String crn need to be changed => a later refactorign step.