### PR TITLE
CB-5303. Add stop telemetry agents action before termination.

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/recipe/StackPreTerminationHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/recipe/StackPreTerminationHandler.java
@@ -16,6 +16,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.recipe.StackPreTerminationReq
 import com.sequenceiq.cloudbreak.reactor.api.event.recipe.StackPreTerminationSuccess;
 import com.sequenceiq.cloudbreak.service.cluster.flow.PreTerminationStateExecutor;
 import com.sequenceiq.cloudbreak.service.cluster.flow.recipe.RecipeEngine;
+import com.sequenceiq.cloudbreak.service.cluster.flow.telemetry.TelemetryAgentService;
 import com.sequenceiq.cloudbreak.service.hostgroup.HostGroupService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.flow.event.EventSelectorUtil;
@@ -39,6 +40,9 @@ public class StackPreTerminationHandler implements EventHandler<StackPreTerminat
     private RecipeEngine recipeEngine;
 
     @Inject
+    private TelemetryAgentService telemetryAgentService;
+
+    @Inject
     private HostGroupService hostGroupService;
 
     @Inject
@@ -52,6 +56,7 @@ public class StackPreTerminationHandler implements EventHandler<StackPreTerminat
             Cluster cluster = stack.getCluster();
             if (cluster != null) {
                 Set<Recipe> recipesByCluster = hostGroupService.getRecipesByCluster(cluster.getId());
+                telemetryAgentService.stopTelemetryAgent(stack);
                 recipeEngine.executePreTerminationRecipes(stack, recipesByCluster, request.getForced());
                 preTerminationStateExecutor.runPreteraminationTasks(stack);
             }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/telemetry/TelemetryAgentService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/telemetry/TelemetryAgentService.java
@@ -1,0 +1,49 @@
+package com.sequenceiq.cloudbreak.service.cluster.flow.telemetry;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterDeletionBasedExitCriteriaModel;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.cloudbreak.orchestrator.model.Node;
+import com.sequenceiq.cloudbreak.service.GatewayConfigService;
+
+@Component
+public class TelemetryAgentService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TelemetryAgentService.class);
+
+    private final HostOrchestrator hostOrchestrator;
+
+    private final GatewayConfigService gatewayConfigService;
+
+    public TelemetryAgentService(HostOrchestrator hostOrchestrator, GatewayConfigService gatewayConfigService) {
+        this.hostOrchestrator = hostOrchestrator;
+        this.gatewayConfigService = gatewayConfigService;
+    }
+
+    public void stopTelemetryAgent(Stack stack) {
+        try {
+            Set<InstanceMetaData> instanceMetaDataSet = stack.getNotDeletedInstanceMetaDataSet();
+            List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
+            Set<Node> allNodes = instanceMetaDataSet.stream()
+                    .map(im -> new Node(im.getPrivateIp(), im.getPublicIp(), im.getInstanceId(),
+                            im.getInstanceGroup().getTemplate().getInstanceType(), im.getDiscoveryFQDN(), im.getInstanceGroup().getGroupName()))
+                    .collect(Collectors.toSet());
+            hostOrchestrator.stopTelemetryAgent(gatewayConfigs, allNodes, ClusterDeletionBasedExitCriteriaModel.nonCancellableModel());
+        } catch (CloudbreakOrchestratorFailedException e) {
+            LOGGER.warn("Non-critical error during stopping telemetry agent", e);
+        } catch (Exception e) {
+            LOGGER.error("Error during stopping telemetry agent", e);
+        }
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/flow/telemetry/TelemetryAgentServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/flow/telemetry/TelemetryAgentServiceTest.java
@@ -1,0 +1,89 @@
+package com.sequenceiq.cloudbreak.service.cluster.flow.telemetry;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.sequenceiq.cloudbreak.domain.Template;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.orchestrator.state.ExitCriteriaModel;
+import com.sequenceiq.cloudbreak.service.GatewayConfigService;
+
+public class TelemetryAgentServiceTest {
+
+    @InjectMocks
+    private TelemetryAgentService underTest;
+
+    @Mock
+    private HostOrchestrator hostOrchestrator;
+
+    @Mock
+    private GatewayConfigService gatewayConfigService;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        underTest = new TelemetryAgentService(hostOrchestrator, gatewayConfigService);
+    }
+
+    @Test
+    public void testStopTelemetryAgent() throws Exception {
+        // GIVEN
+        doNothing().when(hostOrchestrator).stopTelemetryAgent(anyList(), anySet(), any(ExitCriteriaModel.class));
+        // WHEN
+        underTest.stopTelemetryAgent(createStack());
+        // THEN
+        verify(hostOrchestrator, times(1)).stopTelemetryAgent(anyList(), anySet(), any(ExitCriteriaModel.class));
+    }
+
+    @Test
+    public void testStopTelemetryAgentThrowsException() throws Exception {
+        // GIVEN
+        given(gatewayConfigService.getAllGatewayConfigs(any(Stack.class))).willReturn(null);
+        doThrow(new CloudbreakOrchestratorFailedException("error")).when(hostOrchestrator).stopTelemetryAgent(anyList(), anySet(), any(ExitCriteriaModel.class));
+        // WHEN
+        underTest.stopTelemetryAgent(createStack());
+        // THEN
+        verify(gatewayConfigService, times(1)).getAllGatewayConfigs(any(Stack.class));
+    }
+
+    private Stack createStack() {
+        Stack stack = new Stack();
+        stack.setId(1L);
+        InstanceGroup instanceGroup = new InstanceGroup();
+        instanceGroup.setInstanceMetaData(createInstanceMetadataSet());
+        instanceGroup.setTemplate(new Template());
+        stack.setInstanceGroups(Set.of(instanceGroup));
+        return stack;
+    }
+
+    private Set<InstanceMetaData> createInstanceMetadataSet() {
+        Set<InstanceMetaData> instanceMetaDataSet = new HashSet<>();
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+        instanceMetaData.setId(1L);
+        InstanceGroup instanceGroup = new InstanceGroup();
+        Template template = new Template();
+        instanceGroup.setTemplate(template);
+        instanceMetaData.setInstanceGroup(instanceGroup);
+        instanceMetaDataSet.add(instanceMetaData);
+        return instanceMetaDataSet;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/StackTerminationEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/StackTerminationEvent.java
@@ -5,12 +5,14 @@ import com.sequenceiq.flow.core.FlowEvent;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.freeipa.flow.stack.termination.event.ccm.CcmKeyDeregistrationFinished;
 import com.sequenceiq.freeipa.flow.stack.termination.event.clusterproxy.ClusterProxyDeregistrationFinished;
+import com.sequenceiq.freeipa.flow.stack.termination.event.telemetry.StopTelemetryAgentFinished;
 import com.sequenceiq.freeipa.flow.stack.termination.event.ums.RemoveMachineUserFinished;
 
 public enum StackTerminationEvent implements FlowEvent {
     TERMINATION_EVENT("STACK_TERMINATE_TRIGGER_EVENT"),
     CLUSTER_PROXY_DEREGISTRATION_FINISHED_EVENT(EventSelectorUtil.selector(ClusterProxyDeregistrationFinished.class)),
     CCM_KEY_DEREGISTRATION_FINISHED_EVENT(EventSelectorUtil.selector(CcmKeyDeregistrationFinished.class)),
+    STOP_TELEMETRY_AGENT_FINISHED_EVENT(EventSelectorUtil.selector(StopTelemetryAgentFinished.class)),
     REMOVE_MACHINE_USER_FINISHED_EVENT(EventSelectorUtil.selector(RemoveMachineUserFinished.class)),
     TERMINATION_FINISHED_EVENT(EventSelectorUtil.selector(TerminateStackResult.class)),
     TERMINATION_FAILED_EVENT(EventSelectorUtil.failureSelector(TerminateStackResult.class)),

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/StackTerminationFlowConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/StackTerminationFlowConfig.java
@@ -4,6 +4,7 @@ import static com.sequenceiq.freeipa.flow.stack.termination.StackTerminationEven
 import static com.sequenceiq.freeipa.flow.stack.termination.StackTerminationEvent.CLUSTER_PROXY_DEREGISTRATION_FINISHED_EVENT;
 import static com.sequenceiq.freeipa.flow.stack.termination.StackTerminationEvent.REMOVE_MACHINE_USER_FINISHED_EVENT;
 import static com.sequenceiq.freeipa.flow.stack.termination.StackTerminationEvent.STACK_TERMINATION_FAIL_HANDLED_EVENT;
+import static com.sequenceiq.freeipa.flow.stack.termination.StackTerminationEvent.STOP_TELEMETRY_AGENT_FINISHED_EVENT;
 import static com.sequenceiq.freeipa.flow.stack.termination.StackTerminationEvent.TERMINATION_EVENT;
 import static com.sequenceiq.freeipa.flow.stack.termination.StackTerminationEvent.TERMINATION_FAILED_EVENT;
 import static com.sequenceiq.freeipa.flow.stack.termination.StackTerminationEvent.TERMINATION_FINALIZED_EVENT;
@@ -13,6 +14,7 @@ import static com.sequenceiq.freeipa.flow.stack.termination.StackTerminationStat
 import static com.sequenceiq.freeipa.flow.stack.termination.StackTerminationState.FINAL_STATE;
 import static com.sequenceiq.freeipa.flow.stack.termination.StackTerminationState.INIT_STATE;
 import static com.sequenceiq.freeipa.flow.stack.termination.StackTerminationState.REMOVE_MACHINE_USER_STATE;
+import static com.sequenceiq.freeipa.flow.stack.termination.StackTerminationState.STOP_TELEMETRY_AGENT_STATE;
 import static com.sequenceiq.freeipa.flow.stack.termination.StackTerminationState.TERMINATION_FAILED_STATE;
 import static com.sequenceiq.freeipa.flow.stack.termination.StackTerminationState.TERMINATION_FINISHED_STATE;
 import static com.sequenceiq.freeipa.flow.stack.termination.StackTerminationState.TERMINATION_STATE;
@@ -30,7 +32,8 @@ public class StackTerminationFlowConfig extends AbstractFlowConfiguration<StackT
     private static final List<Transition<StackTerminationState, StackTerminationEvent>> TRANSITIONS =
             new Builder<StackTerminationState, StackTerminationEvent>()
                     .defaultFailureEvent(TERMINATION_FAILED_EVENT)
-                    .from(INIT_STATE).to(DEREGISTER_CLUSTERPROXY_STATE).event(TERMINATION_EVENT).noFailureEvent()
+                    .from(INIT_STATE).to(STOP_TELEMETRY_AGENT_STATE).event(TERMINATION_EVENT).noFailureEvent()
+                    .from(STOP_TELEMETRY_AGENT_STATE).to(DEREGISTER_CLUSTERPROXY_STATE).event(STOP_TELEMETRY_AGENT_FINISHED_EVENT).noFailureEvent()
                     .from(DEREGISTER_CLUSTERPROXY_STATE).to(DEREGISTER_CCMKEY_STATE).event(CLUSTER_PROXY_DEREGISTRATION_FINISHED_EVENT).noFailureEvent()
                     .from(DEREGISTER_CCMKEY_STATE).to(REMOVE_MACHINE_USER_STATE).event(CCM_KEY_DEREGISTRATION_FINISHED_EVENT).noFailureEvent()
                     .from(REMOVE_MACHINE_USER_STATE).to(TERMINATION_STATE).event(REMOVE_MACHINE_USER_FINISHED_EVENT).noFailureEvent()

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/StackTerminationState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/StackTerminationState.java
@@ -8,11 +8,13 @@ import com.sequenceiq.freeipa.flow.stack.termination.action.MachineUserRemoveAct
 import com.sequenceiq.freeipa.flow.stack.termination.action.StackTerminationAction;
 import com.sequenceiq.freeipa.flow.stack.termination.action.StackTerminationFailureAction;
 import com.sequenceiq.freeipa.flow.stack.termination.action.StackTerminationFinishedAction;
+import com.sequenceiq.freeipa.flow.stack.termination.action.StopTelemetryAgentAction;
 
 public enum StackTerminationState implements FlowState {
     INIT_STATE,
     DEREGISTER_CLUSTERPROXY_STATE(DeregisterClusterProxyAction.class),
     DEREGISTER_CCMKEY_STATE(DeregisterCcmKeyAction.class),
+    STOP_TELEMETRY_AGENT_STATE(StopTelemetryAgentAction.class),
     REMOVE_MACHINE_USER_STATE(MachineUserRemoveAction.class),
     TERMINATION_STATE(StackTerminationAction.class),
     TERMINATION_FAILED_STATE(StackTerminationFailureAction.class),

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/action/StopTelemetryAgentAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/action/StopTelemetryAgentAction.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.freeipa.flow.stack.termination.action;
+
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.freeipa.flow.stack.termination.StackTerminationContext;
+import com.sequenceiq.freeipa.flow.stack.termination.event.TerminationEvent;
+import com.sequenceiq.freeipa.flow.stack.termination.event.telemetry.StopTelemetryAgentRequest;
+
+@Component("StopTelemetryAgentAction")
+public class StopTelemetryAgentAction extends AbstractStackTerminationAction<TerminationEvent> {
+
+    public StopTelemetryAgentAction() {
+        super(TerminationEvent.class);
+    }
+
+    @Override
+    protected void doExecute(StackTerminationContext context, TerminationEvent payload, Map<Object, Object> variables) throws Exception {
+        StopTelemetryAgentRequest request = new StopTelemetryAgentRequest(payload.getResourceId(), payload.getForced());
+        sendEvent(context, request);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/event/telemetry/StopTelemetryAgentFinished.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/event/telemetry/StopTelemetryAgentFinished.java
@@ -1,0 +1,11 @@
+package com.sequenceiq.freeipa.flow.stack.termination.event.telemetry;
+
+import com.sequenceiq.flow.event.EventSelectorUtil;
+import com.sequenceiq.freeipa.flow.stack.termination.event.TerminationEvent;
+
+public class StopTelemetryAgentFinished extends TerminationEvent {
+
+    public StopTelemetryAgentFinished(Long stackId, Boolean forced) {
+        super(EventSelectorUtil.selector(StopTelemetryAgentFinished.class), stackId, forced);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/event/telemetry/StopTelemetryAgentRequest.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/event/telemetry/StopTelemetryAgentRequest.java
@@ -1,0 +1,11 @@
+package com.sequenceiq.freeipa.flow.stack.termination.event.telemetry;
+
+import com.sequenceiq.flow.event.EventSelectorUtil;
+import com.sequenceiq.freeipa.flow.stack.termination.event.TerminationEvent;
+
+public class StopTelemetryAgentRequest extends TerminationEvent {
+
+    public StopTelemetryAgentRequest(Long stackId, Boolean forced) {
+        super(EventSelectorUtil.selector(StopTelemetryAgentRequest.class), stackId, forced);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/handler/StopTelemetryAgentHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/handler/StopTelemetryAgentHandler.java
@@ -1,0 +1,47 @@
+package com.sequenceiq.freeipa.flow.stack.termination.handler;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.flow.event.EventSelectorUtil;
+import com.sequenceiq.flow.reactor.api.handler.EventHandler;
+import com.sequenceiq.freeipa.flow.stack.termination.event.telemetry.StopTelemetryAgentFinished;
+import com.sequenceiq.freeipa.flow.stack.termination.event.telemetry.StopTelemetryAgentRequest;
+import com.sequenceiq.freeipa.service.TelemetryAgentService;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+import reactor.bus.Event;
+import reactor.bus.EventBus;
+
+@Component
+public class StopTelemetryAgentHandler implements EventHandler<StopTelemetryAgentRequest> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StopTelemetryAgentHandler.class);
+
+    @Inject
+    private EventBus eventBus;
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private TelemetryAgentService telemetryAgentService;
+
+    @Override
+    public String selector() {
+        return EventSelectorUtil.selector(StopTelemetryAgentRequest.class);
+    }
+
+    @Override
+    public void accept(Event<StopTelemetryAgentRequest> event) {
+        StopTelemetryAgentRequest request = event.getData();
+        LOGGER.info("Stop telemetry agents gracefully (if needed)...");
+        telemetryAgentService.stopTelemetryAgent(request.getResourceId());
+        StopTelemetryAgentFinished response = new StopTelemetryAgentFinished(request.getResourceId(), request.getForced());
+        eventBus.notify(EventSelectorUtil.selector(StopTelemetryAgentFinished.class),
+                new Event<>(event.getHeaders(), response));
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/orchestrator/StackBasedExitCriteriaModel.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/orchestrator/StackBasedExitCriteriaModel.java
@@ -11,6 +11,10 @@ public class StackBasedExitCriteriaModel extends ExitCriteriaModel {
         this.stackId = stackId;
     }
 
+    public static ExitCriteriaModel nonCancellableModel() {
+        return new StackBasedExitCriteriaModel(null);
+    }
+
     public Optional<Long> getStackId() {
         return Optional.ofNullable(stackId);
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/TelemetryAgentService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/TelemetryAgentService.java
@@ -1,0 +1,59 @@
+package com.sequenceiq.freeipa.service;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.cloudbreak.orchestrator.model.Node;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.orchestrator.StackBasedExitCriteriaModel;
+import com.sequenceiq.freeipa.repository.InstanceMetaDataRepository;
+import com.sequenceiq.freeipa.repository.StackRepository;
+
+@Service
+public class TelemetryAgentService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TelemetryAgentService.class);
+
+    private final HostOrchestrator hostOrchestrator;
+
+    private final GatewayConfigService gatewayConfigService;
+
+    private final StackRepository stackRepository;
+
+    private final InstanceMetaDataRepository instanceMetaDataRepository;
+
+    public TelemetryAgentService(HostOrchestrator hostOrchestrator, GatewayConfigService gatewayConfigService,
+            StackRepository stackRepository, InstanceMetaDataRepository instanceMetaDataRepository) {
+        this.hostOrchestrator = hostOrchestrator;
+        this.gatewayConfigService = gatewayConfigService;
+        this.stackRepository = stackRepository;
+        this.instanceMetaDataRepository = instanceMetaDataRepository;
+    }
+
+    public void stopTelemetryAgent(Long stackId) {
+        try {
+            Stack stack = stackRepository.findById(stackId).get();
+            Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataRepository.findAllInStack(stackId);
+            List<GatewayConfig> gatewayConfigs = gatewayConfigService.getGatewayConfigs(stack, instanceMetaDataSet);
+            Set<Node> allNodes = instanceMetaDataSet.stream()
+                    .map(im -> new Node(im.getPrivateIp(), im.getPublicIp(), im.getInstanceId(),
+                            im.getInstanceGroup().getTemplate().getInstanceType(), im.getDiscoveryFQDN(), im.getInstanceGroup().getGroupName()))
+                    .collect(Collectors.toSet());
+            hostOrchestrator.stopTelemetryAgent(gatewayConfigs, allNodes,  StackBasedExitCriteriaModel.nonCancellableModel());
+        } catch (CloudbreakOrchestratorFailedException e) {
+            LOGGER.warn("Non-critical error during stopping telemetry agent", e);
+        } catch (Exception e) {
+            LOGGER.error("Error during stopping telemetry agent", e);
+        }
+    }
+
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/TelemetryAgentServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/TelemetryAgentServiceTest.java
@@ -1,0 +1,98 @@
+package com.sequenceiq.freeipa.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.orchestrator.state.ExitCriteriaModel;
+import com.sequenceiq.freeipa.entity.InstanceGroup;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.entity.Template;
+import com.sequenceiq.freeipa.repository.InstanceMetaDataRepository;
+import com.sequenceiq.freeipa.repository.StackRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class TelemetryAgentServiceTest {
+
+    @InjectMocks
+    private TelemetryAgentService underTest;
+
+    @Mock
+    private HostOrchestrator hostOrchestrator;
+
+    @Mock
+    private GatewayConfigService gatewayConfigService;
+
+    @Mock
+    private StackRepository stackRepository;
+
+    @Mock
+    private InstanceMetaDataRepository instanceMetaDataRepository;
+
+    @BeforeEach
+    public void setUp() {
+        underTest = new TelemetryAgentService(hostOrchestrator, gatewayConfigService, stackRepository, instanceMetaDataRepository);
+    }
+
+    @Test
+    public void testStopTelemetryAgent() throws Exception {
+        // GIVEN
+        given(stackRepository.findById(1L)).willReturn(Optional.of(createStack()));
+        given(instanceMetaDataRepository.findAllInStack(1L)).willReturn(createInstanceMetadataSet());
+        doNothing().when(hostOrchestrator).stopTelemetryAgent(anyList(), anySet(), any(ExitCriteriaModel.class));
+        // WHEN
+        underTest.stopTelemetryAgent(1L);
+        // THEN
+        verify(hostOrchestrator, times(1)).stopTelemetryAgent(anyList(), anySet(), any(ExitCriteriaModel.class));
+    }
+
+    @Test
+    public void testStopTelemetryAgentThrowsException() throws Exception {
+        // GIVEN
+        given(stackRepository.findById(1L)).willReturn(Optional.of(createStack()));
+        given(instanceMetaDataRepository.findAllInStack(1L)).willReturn(createInstanceMetadataSet());
+        doThrow(new CloudbreakOrchestratorFailedException("error")).when(hostOrchestrator).stopTelemetryAgent(anyList(), anySet(), any(ExitCriteriaModel.class));
+        // WHEN
+        underTest.stopTelemetryAgent(1L);
+        // THEN
+        verify(stackRepository, times(1)).findById(1L);
+    }
+
+    private Stack createStack() {
+        Stack stack = new Stack();
+        stack.setId(1L);
+        return stack;
+    }
+
+    private Set<InstanceMetaData> createInstanceMetadataSet() {
+        Set<InstanceMetaData> instanceMetaDataSet = new HashSet<>();
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+        instanceMetaData.setId(1L);
+        InstanceGroup instanceGroup = new InstanceGroup();
+        Template template = new Template();
+        instanceGroup.setTemplate(template);
+        instanceMetaData.setInstanceGroup(instanceGroup);
+        instanceMetaDataSet.add(instanceMetaData);
+        return instanceMetaDataSet;
+    }
+
+}

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
@@ -81,6 +81,9 @@ public interface HostOrchestrator extends HostRecipeExecutor {
     Map<String, Map<String, String>> formatAndMountDisksOnNodes(List<GatewayConfig> allGateway, Set<Node> targets, Set<Node> allNodes,
             ExitCriteriaModel exitModel, String platformVariant) throws CloudbreakOrchestratorFailedException;
 
+    void stopTelemetryAgent(List<GatewayConfig> allGateway, Set<Node> nodes, ExitCriteriaModel exitCriteriaModel)
+            throws CloudbreakOrchestratorFailedException;
+
     void stopClusterManagerAgent(GatewayConfig gatewayConfig, Set<Node> nodes, ExitCriteriaModel exitCriteriaModel, boolean adJoinable, boolean ipaJoinable)
             throws CloudbreakOrchestratorFailedException;
 

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/checker/StateAllRunner.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/checker/StateAllRunner.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.cloudbreak.orchestrator.salt.poller.checker;
+
+import java.util.Set;
+
+import com.sequenceiq.cloudbreak.orchestrator.model.Node;
+import com.sequenceiq.cloudbreak.orchestrator.salt.client.SaltConnector;
+import com.sequenceiq.cloudbreak.orchestrator.salt.poller.BaseSaltJobRunner;
+import com.sequenceiq.cloudbreak.orchestrator.salt.states.SaltStates;
+
+public class StateAllRunner extends BaseSaltJobRunner {
+
+    private final String state;
+
+    public StateAllRunner(Set<String> targetHostnames, Set<Node> allNode, String state) {
+        super(targetHostnames, allNode);
+        this.state = state;
+    }
+
+    @Override
+    public String submit(SaltConnector saltConnector) throws SaltJobFailedException {
+        return SaltStates.applyStateAll(saltConnector, state).getJid();
+    }
+
+    @Override
+    public String toString() {
+        return "StateAllRunner{" + super.toString() + ", state: " + this.state + "}'";
+    }
+}

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStates.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStates.java
@@ -48,10 +48,6 @@ public class SaltStates {
     private SaltStates() {
     }
 
-    public static String mountDisks(SaltConnector sc) {
-        return applyStateAll(sc, "disks.format-and-mount").getJid();
-    }
-
     public static Map<String, String> getUuidList(SaltConnector sc) {
         ApplyResponse applyResponse = applyStateAllSync(sc, "disks.get-uuid-list");
         List<Map<String, JsonNode>> result = (List<Map<String, JsonNode>>) applyResponse.getResult();
@@ -235,7 +231,7 @@ public class SaltStates {
         return sc.run(target, "state.apply", LOCAL_ASYNC, ApplyResponse.class, service);
     }
 
-    private static ApplyResponse applyStateAll(SaltConnector sc, String service) {
+    public static ApplyResponse applyStateAll(SaltConnector sc, String service) {
         return applyState(sc, service, Glob.ALL);
     }
 


### PR DESCRIPTION
Shutdown in some cases are too agressive or too fast (like for AWS) and the shutdown scripts are not finishing for td-agent on the nodes.
Solution for that is to run fluent.agent-stop.sls salt script on the nodes before termination
- Add as an action for freeipa
- Add as an another task for core code (to pre stack termination)

If command fails, that should not be considered as an error, so put the salt execution in try catch block and just log the errors 

tested manually