### PR TITLE
SRE-5408 Small steps toward allowing large number of AWS SDX cluster creations happen in parallel.

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/AwsBackoffSyncPollingScheduler.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/AwsBackoffSyncPollingScheduler.java
@@ -1,7 +1,9 @@
 package com.sequenceiq.cloudbreak.cloud.aws.scheduler;
 
+import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -20,13 +22,15 @@ public class AwsBackoffSyncPollingScheduler<T> {
 
     private static final int POLLING_INTERVAL = 5;
 
-    private static final int MAX_POLLING_INTERVAL = 10;
+    private static final int MAX_POLLING_INTERVAL = 50;
 
     private static final int MAX_POLLING_ATTEMPT = 1000;
 
-    private static final int FAILURE_TOLERANT_ATTEMPT = 3;
+    private static final int FAILURE_TOLERANT_ATTEMPT = 10;
 
     private static final String THROTTLING_ERROR_CODE = "Throttling";
+
+    private static final Random RANDOM = ThreadLocalRandom.current();
 
     @Inject
     @Qualifier("cloudApiListeningScheduledExecutorService")
@@ -53,7 +57,8 @@ public class AwsBackoffSyncPollingScheduler<T> {
                 }
             } catch (Exception ex) {
                 if (ex.getMessage().contains(THROTTLING_ERROR_CODE)) {
-                    multipliedInterval = multipliedInterval >= MAX_POLLING_INTERVAL ? MAX_POLLING_INTERVAL : multipliedInterval * 2;
+                    multipliedInterval =
+                            multipliedInterval >= MAX_POLLING_INTERVAL ? MAX_POLLING_INTERVAL : (multipliedInterval * 2) + RANDOM.nextInt(POLLING_INTERVAL);
 
                 } else {
                     actualFailureTolerant++;


### PR DESCRIPTION
1. In PR #7227 we reduced the throttling and request limit exceeded issues for describe images.
2. In this PR, we are fixing the next two offenders, those are describe CF stacks and events.
3. All these were already nicely wrapped in a backoff scheduler with reset.
4. In this PR increased the time lag between resets, added a jitter and made the code to be more tolerant of request limit exceeded errors.

./gradlew clean build