### PR TITLE
CDPSDX-1379 Use 100 worker krb5kdc processes for FreeIPA

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/init.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/init.sls
@@ -34,3 +34,16 @@ net.ipv6.conf.lo.disable_ipv6:
     - group: root
     - mode: 700
     - source: salt://freeipa/scripts/freeipa_replica_install.sh
+
+set_number_of_krb5kdc_workers:
+  file.replace:
+    - name: /etc/sysconfig/krb5kdc
+    - pattern: ^KRB5KDC_ARGS=.*
+    - repl: KRB5KDC_ARGS='-w 100'
+    - unless: grep "^KRB5KDC_ARGS='-w 100'$" /etc/sysconfig/krb5kdc
+
+restart_krb5kdc:
+  service.running:
+    - name: krb5kdc
+    - watch:
+      - file: /etc/sysconfig/krb5kdc


### PR DESCRIPTION
The FreeIPA installation starts krb5kdc with the argument "-w 100",
which starts 100 worker processes. The previous value of 2 worker
processes were insufficient for the CDP clusters and it results in
errors that weren't easily diagnosed from the types of issues that
occurred when Kerberos was under a load.

Each worker process consumes about 0.26 MB of memory, so this
increases memory usage by 26MB.

This was tested by creating an environment, logging into the FreeIPA
instance, and checking the number of krb5kdc processes.

Closes #CDPSDX-1379