### PR TITLE
CB-5408. Apply anonymization rules on td-agent configs (by Salt)

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.auth.altus;
 
 import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -32,6 +33,7 @@ import com.sequenceiq.cloudbreak.auth.altus.model.AltusCredential;
 import com.sequenceiq.cloudbreak.auth.security.InternalCrnBuilder;
 import com.sequenceiq.cloudbreak.grpc.ManagedChannelWrapper;
 import com.sequenceiq.cloudbreak.logger.MDCUtils;
+import com.sequenceiq.common.api.telemetry.model.AnonymizationRule;
 
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -451,6 +453,18 @@ public class GrpcUmsClient {
             LOGGER.info("Deleting access keys for {}", machineUserCrn);
             client.deleteAccessKeys(UUID.randomUUID().toString(), accessKeys, actorCrn);
         }
+    }
+
+    /**
+     * Gather anonymization rules for a specific account
+     * NOTE: not supported yet on UMS side
+     * @param accountId account that owns the anonymization rules
+     * @param actorCrn actor that requests to gather the anonymization rules
+     * @return a list of anonymization rules for an UMS account
+     */
+    public List<AnonymizationRule> getAnonymizationRules(String accountId, String actorCrn) {
+        LOGGER.debug("Try getting anonymization rules for {} by {}", accountId, actorCrn);
+        return new ArrayList<>();
     }
 
     private ManagedChannelWrapper makeWrapper() {

--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/service/AltusIAMService.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/service/AltusIAMService.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.auth.altus.service;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
@@ -11,6 +12,7 @@ import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
 import com.sequenceiq.cloudbreak.altus.AltusDatabusConfiguration;
 import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
 import com.sequenceiq.cloudbreak.auth.altus.model.AltusCredential;
+import com.sequenceiq.common.api.telemetry.model.AnonymizationRule;
 
 @Service
 public class AltusIAMService {
@@ -72,6 +74,10 @@ public class AltusIAMService {
             LOGGER.warn("Cluster Databus resource cleanup failed (fluent - databus user). It is not a fatal issue, "
                     + "but note that you could have remaining UMS resources for your account", e);
         }
+    }
+
+    public List<AnonymizationRule> getAnonymizationRules(String accountId, String actorCrn) {
+        return umsClient.getAnonymizationRules(accountId, actorCrn);
     }
 
     public void clearMachineUser(String machineUserName, String actorCrn) {

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/AnonymizationRule.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/AnonymizationRule.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.common.api.telemetry.model;
+
+import java.io.Serializable;
+
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AnonymizationRule implements Serializable {
+
+    @NotNull
+    private String value;
+
+    private String replacement = "[REDACTED]";
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String getReplacement() {
+        return replacement;
+    }
+
+    public void setReplacement(String replacement) {
+        this.replacement = replacement;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigService.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.telemetry.fluent;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
@@ -13,6 +14,7 @@ import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.AdlsGen2ConfigGenerator;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.S3Config;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.S3ConfigGenerator;
 import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
+import com.sequenceiq.common.api.telemetry.model.AnonymizationRule;
 import com.sequenceiq.common.api.telemetry.model.CloudwatchParams;
 import com.sequenceiq.common.api.telemetry.model.CloudwatchStreamKey;
 import com.sequenceiq.common.api.telemetry.model.Logging;
@@ -42,6 +44,12 @@ public class FluentConfigService {
 
     public FluentConfigView createFluentConfigs(FluentClusterDetails clusterDetails,
             boolean databusEnabled, boolean meteringEnabled, Telemetry telemetry) {
+        return createFluentConfigs(clusterDetails, databusEnabled, meteringEnabled, telemetry, null);
+    }
+
+    public FluentConfigView createFluentConfigs(FluentClusterDetails clusterDetails,
+            boolean databusEnabled, boolean meteringEnabled, Telemetry telemetry,
+            List<AnonymizationRule> anonymizationRules) {
         final FluentConfigView.Builder builder = new FluentConfigView.Builder();
         boolean enabled = false;
         if (telemetry != null) {
@@ -59,6 +67,7 @@ public class FluentConfigService {
         return builder
                 .withEnabled(enabled)
                 .withClusterDetails(clusterDetails)
+                .withAnonymizationRules(anonymizationRules)
                 .build();
     }
 

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigView.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigView.java
@@ -1,11 +1,14 @@
 package com.sequenceiq.cloudbreak.telemetry.fluent;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.ObjectUtils;
 
 import com.sequenceiq.cloudbreak.telemetry.TelemetryConfigView;
+import com.sequenceiq.common.api.telemetry.model.AnonymizationRule;
 
 public class FluentConfigView implements TelemetryConfigView {
 
@@ -65,6 +68,8 @@ public class FluentConfigView implements TelemetryConfigView {
 
     private final String logFolderName;
 
+    private final List<AnonymizationRule> anonymizationRules;
+
     private final Map<String, Object> overrideAttributes;
 
     private FluentConfigView(Builder builder) {
@@ -89,6 +94,7 @@ public class FluentConfigView implements TelemetryConfigView {
         this.azureStorageAccount = builder.azureStorageAccount;
         this.azureInstanceMsi = builder.azureInstanceMsi;
         this.azureStorageAccessKey = builder.azureStorageAccessKey;
+        this.anonymizationRules = builder.anonymizationRules;
         this.overrideAttributes = builder.overrideAttributes;
     }
 
@@ -207,6 +213,9 @@ public class FluentConfigView implements TelemetryConfigView {
         if (this.clusterDetails != null) {
             map.putAll(clusterDetails.toMap());
         }
+        if (CollectionUtils.isNotEmpty(this.anonymizationRules)) {
+            map.put("anonymizationRules", this.anonymizationRules);
+        }
         if (this.overrideAttributes != null) {
             for (Map.Entry<String, Object> entry : this.overrideAttributes.entrySet()) {
                 if (!"enabled".equalsIgnoreCase(entry.getKey())
@@ -262,6 +271,8 @@ public class FluentConfigView implements TelemetryConfigView {
         private String azureInstanceMsi;
 
         private String azureStorageAccessKey;
+
+        private List<AnonymizationRule> anonymizationRules;
 
         private Map<String, Object> overrideAttributes;
 
@@ -376,6 +387,11 @@ public class FluentConfigView implements TelemetryConfigView {
 
         public Builder withClusterDetails(FluentClusterDetails clusterDetails) {
             this.clusterDetails = clusterDetails;
+            return this;
+        }
+
+        public Builder withAnonymizationRules(List<AnonymizationRule> anonymizationRules) {
+            this.anonymizationRules = anonymizationRules;
             return this;
         }
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/altus/AltusAnonymizationRulesService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/altus/AltusAnonymizationRulesService.java
@@ -1,0 +1,24 @@
+package com.sequenceiq.cloudbreak.service.altus;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.cloudbreak.auth.altus.service.AltusIAMService;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.common.api.telemetry.model.AnonymizationRule;
+
+@Component
+public class AltusAnonymizationRulesService {
+
+    private final AltusIAMService altusIAMService;
+
+    public AltusAnonymizationRulesService(AltusIAMService altusIAMService) {
+        this.altusIAMService = altusIAMService;
+    }
+
+    public List<AnonymizationRule> getAnonymizationRules(Stack stack) {
+        return altusIAMService.getAnonymizationRules(Crn.safeFromString(stack.getResourceCrn()).getAccountId(), stack.getCreator().getUserCrn());
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecoratorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecoratorTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
@@ -25,6 +26,7 @@ import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
+import com.sequenceiq.cloudbreak.service.altus.AltusAnonymizationRulesService;
 import com.sequenceiq.cloudbreak.service.altus.AltusMachineUserService;
 import com.sequenceiq.cloudbreak.telemetry.databus.DatabusConfigService;
 import com.sequenceiq.cloudbreak.telemetry.databus.DatabusConfigView;
@@ -52,6 +54,9 @@ public class TelemetryDecoratorTest {
     @Mock
     private AltusMachineUserService altusMachineUserService;
 
+    @Mock
+    private AltusAnonymizationRulesService altusAnonymizationRulesService;
+
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
@@ -59,7 +64,7 @@ public class TelemetryDecoratorTest {
         given(altusMachineUserService.generateDatabusMachineUserForFluent(any(Stack.class), any(Telemetry.class)))
                 .willReturn(Optional.of(altusCredential));
         underTest = new TelemetryDecorator(databusConfigService, fluentConfigService,
-                meteringConfigService, altusMachineUserService, "1.0.0");
+                meteringConfigService, altusMachineUserService, altusAnonymizationRulesService, "1.0.0");
     }
 
     @Test
@@ -90,7 +95,7 @@ public class TelemetryDecoratorTest {
         assertEquals(results.get("platform"), CloudPlatform.AWS.name());
         assertEquals(results.get("user"), "root");
         verify(fluentConfigService, times(1)).createFluentConfigs(any(FluentClusterDetails.class),
-                anyBoolean(), anyBoolean(), any(Telemetry.class));
+                anyBoolean(), anyBoolean(), any(Telemetry.class), anyList());
         verify(meteringConfigService, times(1)).createMeteringConfigs(anyBoolean(), anyString(), anyString(), anyString(),
                 anyString());
     }
@@ -211,7 +216,7 @@ public class TelemetryDecoratorTest {
         given(databusConfigService.createDatabusConfigs(anyString(), any(), isNull(), isNull()))
                 .willReturn(databusConfigView);
         given(fluentConfigService.createFluentConfigs(any(FluentClusterDetails.class),
-                anyBoolean(), anyBoolean(), any(Telemetry.class)))
+                anyBoolean(), anyBoolean(), any(Telemetry.class), anyList()))
                 .willReturn(fluentConfigView);
         given(meteringConfigService.createMeteringConfigs(anyBoolean(), anyString(), anyString(), anyString(),
                 anyString())).willReturn(meteringConfigView);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/AltusAnonymizationRulesService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/AltusAnonymizationRulesService.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.freeipa.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.auth.altus.service.AltusIAMService;
+import com.sequenceiq.common.api.telemetry.model.AnonymizationRule;
+import com.sequenceiq.freeipa.util.CrnService;
+
+@Service
+public class AltusAnonymizationRulesService {
+
+    private final CrnService crnService;
+
+    private final AltusIAMService altusIAMService;
+
+    public AltusAnonymizationRulesService(CrnService crnService, AltusIAMService altusIAMService) {
+        this.crnService = crnService;
+        this.altusIAMService = altusIAMService;
+    }
+
+    public List<AnonymizationRule> getAnonymizationRules() {
+        return altusIAMService.getAnonymizationRules(crnService.getCurrentAccountId(), crnService.getUserCrn());
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaInstallService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaInstallService.java
@@ -11,8 +11,8 @@ import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Service;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.auth.altus.model.AltusCredential;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
@@ -28,11 +28,13 @@ import com.sequenceiq.cloudbreak.telemetry.fluent.FluentClusterDetails;
 import com.sequenceiq.cloudbreak.telemetry.fluent.FluentClusterType;
 import com.sequenceiq.cloudbreak.telemetry.fluent.FluentConfigService;
 import com.sequenceiq.cloudbreak.telemetry.fluent.FluentConfigView;
+import com.sequenceiq.common.api.telemetry.model.AnonymizationRule;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
 import com.sequenceiq.freeipa.entity.FreeIpa;
 import com.sequenceiq.freeipa.entity.InstanceMetaData;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.orchestrator.StackBasedExitCriteriaModel;
+import com.sequenceiq.freeipa.service.AltusAnonymizationRulesService;
 import com.sequenceiq.freeipa.service.AltusMachineUserService;
 import com.sequenceiq.freeipa.service.GatewayConfigService;
 import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
@@ -70,6 +72,9 @@ public class FreeIpaInstallService {
 
     @Inject
     private DatabusConfigService databusConfigService;
+
+    @Inject
+    private AltusAnonymizationRulesService altusAnonymizationRulesService;
 
     @Inject
     private AltusMachineUserService altusMachineUserService;
@@ -133,9 +138,9 @@ public class FreeIpaInstallService {
                     .withPlatform(stack.getCloudPlatform())
                     .withVersion(version)
                     .build();
-
+            List<AnonymizationRule> rules = altusAnonymizationRulesService.getAnonymizationRules();
             FluentConfigView fluentConfigView = fluentConfigService.createFluentConfigs(clusterDetails,
-                    databusEnabled, false, telemetry);
+                    databusEnabled, false, telemetry, rules);
             servicePillarConfig.put("fluent", new SaltPillarProperties("/fluent/init.sls", Collections.singletonMap("fluent", fluentConfigView.toMap())));
             if (databusEnabled) {
                 Optional<AltusCredential> credential = altusMachineUserService.createMachineUserWithAccessKeys(stack, telemetry);

--- a/orchestrator-salt/src/main/resources/salt-common/pillar/fluent/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/pillar/fluent/init.sls
@@ -26,4 +26,5 @@ fluent:
   dbusClusterLogsCollection: false
   dbusClusterLogsCollectionDisableStop: false
   dbusMeteringEnabled: false
+  anonymizationRules:
 

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
@@ -68,7 +68,7 @@
 {% set cloudera_azure_plugin_version = '1.0.1' %}
 {% set cloudera_azure_gen2_plugin_version = '0.2.4' %}
 {% set cloudera_databus_plugin_version = '1.0.3' %}
-{% set redaction_plugin_version = '0.1.1' %}
+{% set redaction_plugin_version = '0.1.2' %}
 {% set platform = salt['pillar.get']('fluent:platform') %}
 
 {% set service_path_log_suffix = '%Y-%m-%d/%H/\${tag[1]}-#{Socket.gethostname}-%M' %}
@@ -89,6 +89,11 @@
 {% if dbus_cluster_logs_collection_enabled %}
 {%   set cluster_logs_collection_worker_index=number_of_workers %}
 {%   set number_of_workers=number_of_workers+1 %}
+{% endif %}
+
+{% set anonymization_rules=[] %}
+{% if salt['pillar.get']('fluent:anonymizationRules') %}
+{%   set anonymization_rules = salt['pillar.get']('fluent:anonymizationRules') %}
 {% endif %}
 
 {% do fluent.update({
@@ -129,6 +134,7 @@
     "cloudStorageWorkerIndex": cloud_storage_worker_index,
     "meteringWorkerIndex": metering_worker_index,
     "clusterLogsCollectionWorkerIndex": cluster_logs_collection_worker_index,
+    "anonymizationRules": anonymization_rules,
     "region": region,
     "platform": platform
 }) %}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/filter.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/filter.conf.j2
@@ -27,6 +27,20 @@
    message message
    multiline_flush_interval 0.1
 </match>
+{% if fluent.anonymizationRules %}
+<filter processed.{{providerPrefix}}**>
+   @type redaction
+   {% for rule in fluent.anonymizationRules %}
+     {% set regex_value = rule["value"] %}
+     {% set replacement = rule["replacement"] if rule["replacement"] else "[REDACTED]" %}
+   <rule>
+     key message
+     pattern {{ regex_value }}
+     replace "{{ replacement }}"
+   </rule>
+   {% endfor %}
+</filter>
+{% endif %}
 <filter processed.{{providerPrefix}}.**>
   @type record_transformer
   enable_ruby true


### PR DESCRIPTION
Anonymization rules skeleton if the anonymization rules is defined on UMS account side (that part gives back null)

Notes:
- UMS is not supporting this option yet, so the method always gives back null
- As anonymization rules field is empty it will be missing from the salt config, so technicallly this change won't do anything until UMS side is not implemented (but i have tried out this by manually set the objects and set it through salt)
- If UMS side is done, only change here will be to transform the UMS response to our object format (that can be done in UMS client, as it was done for Altus credential - if that happens, maybe the model can be moved to auth-connector...but for know it's good at its actual place as that is related with telemetry)
- maybe later makes sense to persist the rules for DataLake/DataHub/FreeIPA, just to show how the cluster was deployed