### PR TITLE
CB-5122 FreeIPA's LdapConfig and KerbConfig entity cleanup in case of child environment

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/kafka/KafkaStructuredEventHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/kafka/KafkaStructuredEventHandler.java
@@ -16,12 +16,12 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.concurrent.ListenableFuture;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.sequenceiq.flow.reactor.api.handler.EventHandler;
+import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 import com.sequenceiq.cloudbreak.structuredevent.event.StructuredEvent;
 import com.sequenceiq.cloudbreak.structuredevent.event.StructuredRestCallEvent;
 import com.sequenceiq.cloudbreak.structuredevent.event.rest.RestRequestDetails;
 import com.sequenceiq.cloudbreak.structuredevent.event.rest.RestResponseDetails;
-import com.sequenceiq.cloudbreak.common.json.JsonUtil;
+import com.sequenceiq.flow.reactor.api.handler.EventHandler;
 
 import reactor.bus.Event;
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/CleanupEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/CleanupEvent.java
@@ -18,8 +18,11 @@ public class CleanupEvent extends StackEvent {
 
     private final String clusterName;
 
+    private final String environmentCrn;
+
     @SuppressWarnings("ExecutableStatementCount")
-    public CleanupEvent(Long stackId, Set<String> users, Set<String> hosts, Set<String> roles, String accountId, String operationId, String clusterName) {
+    public CleanupEvent(Long stackId, Set<String> users, Set<String> hosts, Set<String> roles, String accountId, String operationId, String clusterName,
+            String environmentCrn) {
         super(stackId);
         this.users = users;
         this.hosts = hosts;
@@ -27,11 +30,12 @@ public class CleanupEvent extends StackEvent {
         this.accountId = accountId;
         this.operationId = operationId;
         this.clusterName = clusterName;
+        this.environmentCrn = environmentCrn;
     }
 
     @SuppressWarnings("ExecutableStatementCount")
     public CleanupEvent(String selector, Long stackId, Set<String> users, Set<String> hosts, Set<String> roles,
-            String accountId, String operationId, String clusterName) {
+            String accountId, String operationId, String clusterName, String environmentCrn) {
         super(selector, stackId);
         this.users = users;
         this.hosts = hosts;
@@ -39,6 +43,7 @@ public class CleanupEvent extends StackEvent {
         this.accountId = accountId;
         this.operationId = operationId;
         this.clusterName = clusterName;
+        this.environmentCrn = environmentCrn;
     }
 
     public Set<String> getUsers() {
@@ -65,6 +70,10 @@ public class CleanupEvent extends StackEvent {
         return clusterName;
     }
 
+    public String getEnvironmentCrn() {
+        return environmentCrn;
+    }
+
     @Override
     public String toString() {
         return "CleanupEvent{" +
@@ -74,6 +83,7 @@ public class CleanupEvent extends StackEvent {
                 ", accountId='" + accountId + '\'' +
                 ", operationId='" + operationId + '\'' +
                 ", clusterName='" + clusterName + '\'' +
+                ", environmentCrn='" + environmentCrn + '\'' +
                 '}';
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/FreeIpaCleanupActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/FreeIpaCleanupActions.java
@@ -160,8 +160,9 @@ public class FreeIpaCleanupActions {
             @Override
             protected void doExecute(FreeIpaContext context, RemoveRolesResponse payload, Map<Object, Object> variables) {
                 CleanupEvent cleanupEvent = new CleanupEvent(FreeIpaCleanupEvent.CLEANUP_FINISHED_EVENT.event(), payload.getResourceId(), payload.getUsers(),
-                        payload.getHosts(), payload.getRoles(), payload.getAccountId(), payload.getOperationId(), payload.getClusterName());
-                SuccessDetails successDetails = new SuccessDetails(context.getStack().getEnvironmentCrn());
+                        payload.getHosts(), payload.getRoles(), payload.getAccountId(), payload.getOperationId(), payload.getClusterName(),
+                        payload.getEnvironmentCrn());
+                SuccessDetails successDetails = new SuccessDetails(payload.getEnvironmentCrn());
                 successDetails.getAdditionalDetails().put("Hosts", payload.getHosts() == null ? List.of() : new ArrayList<>(payload.getHosts()));
                 successDetails.getAdditionalDetails().put("Users", payload.getUsers() == null ? List.of() : new ArrayList<>(payload.getUsers()));
                 successDetails.getAdditionalDetails().put("Roles", payload.getRoles() == null ? List.of() : new ArrayList<>(payload.getRoles()));
@@ -182,11 +183,12 @@ public class FreeIpaCleanupActions {
             @Override
             protected void doExecute(FreeIpaContext context, CleanupFailureEvent payload, Map<Object, Object> variables) {
                 LOGGER.error("Cleanup failed with payload: " + payload);
-                SuccessDetails successDetails = new SuccessDetails(context.getStack().getEnvironmentCrn());
+                String environmentCrn = payload.getEnvironmentCrn();
+                SuccessDetails successDetails = new SuccessDetails(environmentCrn);
                 successDetails.getAdditionalDetails()
                         .put(payload.getFailedPhase(), payload.getSuccess() == null ? List.of() : new ArrayList<>(payload.getSuccess()));
                 String message = "Cleanup failed during " + payload.getFailedPhase();
-                FailureDetails failureDetails = new FailureDetails(context.getStack().getEnvironmentCrn(), message);
+                FailureDetails failureDetails = new FailureDetails(environmentCrn, message);
                 if (payload.getFailureDetails() != null) {
                     failureDetails.getAdditionalDetails().putAll(payload.getFailureDetails());
                 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/AbstractCleanupEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/AbstractCleanupEvent.java
@@ -6,11 +6,11 @@ public abstract class AbstractCleanupEvent extends CleanupEvent {
 
     public AbstractCleanupEvent(CleanupEvent cleanupEvent) {
         super(cleanupEvent.getResourceId(), cleanupEvent.getUsers(), cleanupEvent.getHosts(), cleanupEvent.getRoles(), cleanupEvent.getAccountId(),
-                cleanupEvent.getOperationId(), cleanupEvent.getClusterName());
+                cleanupEvent.getOperationId(), cleanupEvent.getClusterName(), cleanupEvent.getEnvironmentCrn());
     }
 
     public AbstractCleanupEvent(String selector, CleanupEvent cleanupEvent) {
         super(selector, cleanupEvent.getResourceId(), cleanupEvent.getUsers(), cleanupEvent.getHosts(), cleanupEvent.getRoles(), cleanupEvent.getAccountId(),
-                cleanupEvent.getOperationId(), cleanupEvent.getClusterName());
+                cleanupEvent.getOperationId(), cleanupEvent.getClusterName(), cleanupEvent.getEnvironmentCrn());
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/handler/UserRemoveHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/handler/UserRemoveHandler.java
@@ -42,7 +42,7 @@ public class UserRemoveHandler implements EventHandler<RemoveUsersRequest> {
         RemoveUsersRequest request = event.getData();
         try {
             Pair<Set<String>, Map<String, String>> removeUsersResult =
-                    cleanupService.removeUsers(request.getResourceId(), request.getUsers(), request.getClusterName());
+                    cleanupService.removeUsers(request.getResourceId(), request.getUsers(), request.getClusterName(), request.getEnvironmentCrn());
             RemoveUsersResponse response = new RemoveUsersResponse(request, removeUsersResult.getFirst(), removeUsersResult.getSecond());
             eventBus.notify(response.getUserCleanupFailed().isEmpty()
                             ? EventSelectorUtil.selector(RemoveUsersResponse.class) : EventSelectorUtil.failureSelector(RemoveUsersResponse.class),

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/cleanup/CleanupServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/cleanup/CleanupServiceTest.java
@@ -36,6 +36,8 @@ public class CleanupServiceTest {
 
     private static final long STACK_ID = 1L;
 
+    private static final String ENV_CRN = "envCrn";
+
     @InjectMocks
     private CleanupService cleanupService;
 
@@ -319,7 +321,7 @@ public class CleanupServiceTest {
         when(freeIpaClient.userFindAll()).thenReturn(ipaUsers);
         when(stackService.getStackById(anyLong())).thenReturn(createStack());
 
-        Pair<Set<String>, Map<String, String>> result = cleanupService.removeUsers(STACK_ID, usersNames, "test-wl-1");
+        Pair<Set<String>, Map<String, String>> result = cleanupService.removeUsers(STACK_ID, usersNames, "test-wl-1", ENV_CRN);
 
         verify(freeIpaClient, times(1)).deleteUser("ldapbind-test-wl-1");
         verify(freeIpaClient, times(1)).deleteUser("kerberosbind-test-wl-1");
@@ -348,7 +350,7 @@ public class CleanupServiceTest {
         when(freeIpaClientFactory.getFreeIpaClientForStackId(STACK_ID)).thenReturn(freeIpaClient);
         when(freeIpaClient.userFindAll()).thenReturn(ipaUsers);
 
-        Pair<Set<String>, Map<String, String>> result = cleanupService.removeUsers(STACK_ID, usersNames, "");
+        Pair<Set<String>, Map<String, String>> result = cleanupService.removeUsers(STACK_ID, usersNames, "", ENV_CRN);
 
         verify(freeIpaClient, times(1)).deleteUser("ldapbind-test-wl-1");
         verify(freeIpaClient, times(1)).deleteUser("kerberosbind-test-wl-1");
@@ -378,7 +380,7 @@ public class CleanupServiceTest {
         when(freeIpaClient.userFindAll()).thenReturn(ipaUsers);
         doThrow(new FreeIpaClientException("Connection failed")).when(freeIpaClient).deleteUser(anyString());
 
-        Pair<Set<String>, Map<String, String>> result = cleanupService.removeUsers(STACK_ID, usersNames, "");
+        Pair<Set<String>, Map<String, String>> result = cleanupService.removeUsers(STACK_ID, usersNames, "", ENV_CRN);
 
         verify(freeIpaClient, times(1)).deleteUser("ldapbind-test-wl-1");
         verify(freeIpaClient, times(1)).deleteUser("kerberosbind-test-wl-1");
@@ -410,7 +412,7 @@ public class CleanupServiceTest {
         when(stackService.getStackById(anyLong())).thenReturn(createStack());
         doThrow(new NotFoundException("Kerberos config not found")).when(kerberosConfigService).delete("envCrn", "accountId", "test-wl-1");
 
-        Pair<Set<String>, Map<String, String>> result = cleanupService.removeUsers(STACK_ID, usersNames, "test-wl-1");
+        Pair<Set<String>, Map<String, String>> result = cleanupService.removeUsers(STACK_ID, usersNames, "test-wl-1", ENV_CRN);
 
         verify(freeIpaClient, times(1)).deleteUser("ldapbind-test-wl-1");
         verify(freeIpaClient, times(1)).deleteUser("kerberosbind-test-wl-1");
@@ -441,7 +443,7 @@ public class CleanupServiceTest {
         when(stackService.getStackById(anyLong())).thenReturn(createStack());
         doThrow(new NotFoundException("Ldap config not found")).when(ldapConfigService).delete("envCrn", "accountId", "test-wl-1");
 
-        Pair<Set<String>, Map<String, String>> result = cleanupService.removeUsers(STACK_ID, usersNames, "test-wl-1");
+        Pair<Set<String>, Map<String, String>> result = cleanupService.removeUsers(STACK_ID, usersNames, "test-wl-1", ENV_CRN);
 
         verify(freeIpaClient, times(1)).deleteUser("ldapbind-test-wl-1");
         verify(freeIpaClient, times(1)).deleteUser("kerberosbind-test-wl-1");
@@ -481,7 +483,7 @@ public class CleanupServiceTest {
 
     private Stack createStack() {
         Stack stack = new Stack();
-        stack.setEnvironmentCrn("envCrn");
+        stack.setEnvironmentCrn(ENV_CRN);
         stack.setAccountId("accountId");
         return stack;
     }


### PR DESCRIPTION
In case of child environment the created clusters FreeIPA related resources haven't been cleaned up correctly, the entities were queried for the parent environment and archived in case of cluster termination. This behaviour caused that the clusters recreation have been failed with the same name, due to the existing/not-archived FreeIPA entities the necessary Kerberos/Ldap roles were not propagated to the FreeIPA instance.
The main issue was that the entity cleanup of the two mentioned resources were based on the environment CRN of the parent environment's FreeIPA stack.