### PR TITLE
CB-5515 Select only the instance group in MetadataSetupService

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/UpdateStackRequestV2ToUpdateStackRequestConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/UpdateStackRequestV2ToUpdateStackRequestConverter.java
@@ -24,7 +24,7 @@ public class UpdateStackRequestV2ToUpdateStackRequestConverter extends AbstractC
     public UpdateStackV4Request convert(StackScaleV4Request source) {
         UpdateStackV4Request updateStackJson = new UpdateStackV4Request();
         updateStackJson.setWithClusterEvent(true);
-        Optional<InstanceGroup> instanceGroup = instanceGroupService.findOneByGroupNameInStack(source.getStackId(), source.getGroup());
+        Optional<InstanceGroup> instanceGroup = instanceGroupService.findOneWithInstanceMetadataByGroupNameInStack(source.getStackId(), source.getGroup());
         if (instanceGroup.isPresent()) {
             InstanceGroupAdjustmentV4Request instanceGroupAdjustmentJson = new InstanceGroupAdjustmentV4Request();
             instanceGroupAdjustmentJson.setInstanceGroup(source.getGroup());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapperErrorHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapperErrorHandler.java
@@ -76,8 +76,9 @@ public class ClusterBootstrapperErrorHandler {
             for (Node missingNode : missingNodes) {
                 InstanceMetaData instanceMetaData =
                         instanceMetaDataService.findNotTerminatedByPrivateAddress(stack.getId(), missingNode.getPrivateIp())
-                        .orElseThrow(NotFoundException.notFound("instanceMetaData", missingNode.getPrivateIp()));
-                InstanceGroup ig = instanceGroupService.findOneByGroupNameInStack(stack.getId(), instanceMetaData.getInstanceGroup().getGroupName())
+                                .orElseThrow(NotFoundException.notFound("instanceMetaData", missingNode.getPrivateIp()));
+                InstanceGroup ig = instanceGroupService.findOneWithInstanceMetadataByGroupNameInStack(stack.getId(),
+                        instanceMetaData.getInstanceGroup().getGroupName())
                         .orElseThrow(NotFoundException.notFound("instanceGroup", instanceMetaData.getInstanceGroup().getGroupName()));
                 if (ig.getNodeCount() < 1) {
                     throw new CloudbreakOrchestratorFailedException(cloudbreakMessagesService.getMessage(

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleActions.java
@@ -207,7 +207,7 @@ public class StackUpscaleActions {
                     throws TransactionExecutionException {
                 Set<String> upscaleCandidateAddresses = stackUpscaleService.finishExtendMetadata(context.getStack(), context.getAdjustment(), payload);
                 variables.put(UPSCALE_CANDIDATE_ADDRESSES, upscaleCandidateAddresses);
-                InstanceGroup ig = instanceGroupService.findOneByGroupNameInStack(payload.getResourceId(), context.getInstanceGroupName())
+                InstanceGroup ig = instanceGroupService.findOneWithInstanceMetadataByGroupNameInStack(payload.getResourceId(), context.getInstanceGroupName())
                         .orElseThrow(NotFoundException.notFound("instanceGroup", context.getInstanceGroupName()));
                 if (InstanceGroupType.GATEWAY == ig.getInstanceGroupType()) {
                     Stack stack = stackService.getByIdWithListsInTransaction(context.getStack().getId());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceGroupRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceGroupRepository.java
@@ -24,11 +24,10 @@ public interface InstanceGroupRepository extends DisabledBaseRepository<Instance
 
     @EntityGraph(value = "InstanceGroup.instanceMetaData", type = EntityGraphType.LOAD)
     @Query("SELECT i from InstanceGroup i WHERE i.stack.id = :stackId AND i.groupName = :groupName")
-    Optional<InstanceGroup> findOneByGroupNameInStack(@Param("stackId") Long stackId, @Param("groupName") String groupName);
+    Optional<InstanceGroup> findOneWithInstanceMetadataByGroupNameInStack(@Param("stackId") Long stackId, @Param("groupName") String groupName);
 
     Set<InstanceGroup> findBySecurityGroup(SecurityGroup securityGroup);
 
-    @EntityGraph(value = "InstanceGroup.instanceMetaData", type = EntityGraphType.LOAD)
     Set<InstanceGroup> findByStackId(@Param("stackId") Long stackId);
 
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/InstanceGroupService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/InstanceGroupService.java
@@ -49,8 +49,8 @@ public class InstanceGroupService {
                 }).collect(Collectors.toSet());
     }
 
-    public Optional<InstanceGroup> findOneByGroupNameInStack(Long stackId, String groupName) {
-        return repository.findOneByGroupNameInStack(stackId, groupName);
+    public Optional<InstanceGroup> findOneWithInstanceMetadataByGroupNameInStack(Long stackId, String groupName) {
+        return repository.findOneWithInstanceMetadataByGroupNameInStack(stackId, groupName);
     }
 
     public InstanceGroup save(InstanceGroup instanceGroup) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/MetadataSetupServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/MetadataSetupServiceTest.java
@@ -1,0 +1,199 @@
+package com.sequenceiq.cloudbreak.service.stack.flow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceMetadataType;
+import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
+import com.sequenceiq.cloudbreak.cloud.model.CloudInstanceMetaData;
+import com.sequenceiq.cloudbreak.cloud.model.CloudVmInstanceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.CloudVmMetaDataStatus;
+import com.sequenceiq.cloudbreak.cloud.model.Image;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.common.service.Clock;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.service.image.ImageService;
+import com.sequenceiq.cloudbreak.service.stack.InstanceGroupService;
+import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MetadataSetupServiceTest {
+
+    private static final Long STACK_ID = 1L;
+
+    private static final String GROUP_NAME = "GROUP_NAME";
+
+    private static final Long PRIVATE_ID = 2L;
+
+    private static final String SUBNET_ID = "SUBNET_ID";
+
+    private static final String INSTANCE_NAME = "INSTANCE_NAME";
+
+    private static final String PRIVATE_IP = "PRIVATE_IP";
+
+    private static final String PUBLIC_IP = "PUBLIC_IP";
+
+    private static final int SSH_PORT = 22;
+
+    private static final String LOCALITY_INDICATOR = "LOCALITY_INDICATOR";
+
+    private static final Long INSTANCE_GROUP_ID = 3L;
+
+    private static final long CURRENT_TIME = System.currentTimeMillis();
+
+    private static final com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus CREATED =
+            com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus.CREATED;
+
+    private static final com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus TERMINATED =
+            com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus.TERMINATED;
+
+    private static final com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus SERVICES_RUNNING =
+            com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus.SERVICES_RUNNING;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Mock
+    private ImageService imageService;
+
+    @Mock
+    private InstanceGroupService instanceGroupService;
+
+    @Mock
+    private InstanceMetaDataService instanceMetaDataService;
+
+    @Mock
+    private Clock clock;
+
+    @InjectMocks
+    private MetadataSetupService underTest;
+
+    @Captor
+    private ArgumentCaptor<InstanceMetaData> captor;
+
+    @Test
+    public void shouldNotSaveInstancesWhenImageNotFound() throws CloudbreakImageNotFoundException {
+        Stack stack = new Stack();
+        stack.setId(STACK_ID);
+        Iterable<CloudVmMetaDataStatus> cloudVmMetaDataStatuses = getCloudVmMetaDataStatuses(InstanceStatus.CREATED);
+        doThrow(CloudbreakImageNotFoundException.class).when(imageService).getImage(STACK_ID);
+
+        expectedException.expectMessage("Instance metadata collection failed");
+        expectedException.expect(CloudbreakServiceException.class);
+
+        underTest.saveInstanceMetaData(stack, cloudVmMetaDataStatuses, CREATED);
+    }
+
+    @Test
+    public void testOneNewInstance() throws CloudbreakImageNotFoundException {
+        Stack stack = new Stack();
+        stack.setId(STACK_ID);
+        Image image = getEmptyImage();
+        when(imageService.getImage(STACK_ID)).thenReturn(image);
+        InstanceGroup instanceGroup = new InstanceGroup();
+        instanceGroup.setId(INSTANCE_GROUP_ID);
+        instanceGroup.setGroupName(GROUP_NAME);
+        Set<InstanceGroup> instanceGroupSet = new TreeSet<>();
+        instanceGroupSet.add(instanceGroup);
+        when(instanceGroupService.findByStackId(anyLong())).thenReturn(instanceGroupSet);
+        when(clock.getCurrentTimeMillis()).thenReturn(CURRENT_TIME);
+        Iterable<CloudVmMetaDataStatus> cloudVmMetaDataStatuses = getCloudVmMetaDataStatuses(InstanceStatus.CREATED);
+
+        int newInstances = underTest.saveInstanceMetaData(stack, cloudVmMetaDataStatuses, CREATED);
+
+        assertEquals(1, newInstances);
+        verify(imageService).getImage(STACK_ID);
+        verify(instanceGroupService).findByStackId(STACK_ID);
+        verify(instanceMetaDataService).save(captor.capture());
+        InstanceMetaData instanceMetaData = captor.getValue();
+        assertCommonProperties(instanceMetaData);
+        assertEquals(CREATED, instanceMetaData.getInstanceStatus());
+        assertNotNull(instanceMetaData.getImage());
+    }
+
+    @Test
+    public void testOneTerminatedInstance() throws CloudbreakImageNotFoundException {
+        Stack stack = new Stack();
+        stack.setId(STACK_ID);
+        Image image = getEmptyImage();
+        when(imageService.getImage(STACK_ID)).thenReturn(image);
+        InstanceGroup instanceGroup = new InstanceGroup();
+        instanceGroup.setId(INSTANCE_GROUP_ID);
+        instanceGroup.setGroupName(GROUP_NAME);
+        Set<InstanceGroup> instanceGroupSet = new TreeSet<>();
+        instanceGroupSet.add(instanceGroup);
+        when(instanceGroupService.findByStackId(anyLong())).thenReturn(instanceGroupSet);
+        when(clock.getCurrentTimeMillis()).thenReturn(CURRENT_TIME);
+        Iterable<CloudVmMetaDataStatus> cloudVmMetaDataStatuses = getCloudVmMetaDataStatuses(InstanceStatus.TERMINATED);
+
+        int newInstances = underTest.saveInstanceMetaData(stack, cloudVmMetaDataStatuses, SERVICES_RUNNING);
+
+        assertEquals(0, newInstances);
+        verify(imageService).getImage(STACK_ID);
+        verify(instanceGroupService).findByStackId(STACK_ID);
+        verify(instanceMetaDataService).save(captor.capture());
+        InstanceMetaData instanceMetaData = captor.getValue();
+        assertCommonProperties(instanceMetaData);
+        assertEquals(TERMINATED, instanceMetaData.getInstanceStatus());
+        assertNull(instanceMetaData.getImage());
+    }
+
+    private Image getEmptyImage() {
+        return new Image(null, null, null, null, null, null, null, null);
+    }
+
+    private Iterable<CloudVmMetaDataStatus> getCloudVmMetaDataStatuses(InstanceStatus instanceStatus) {
+        InstanceTemplate instanceTemplate = new InstanceTemplate(null, GROUP_NAME, PRIVATE_ID, List.of(), null, Map.of(), null, null);
+        Map<String, Object> params = new HashMap<>();
+        params.put(CloudInstance.SUBNET_ID, SUBNET_ID);
+        params.put(CloudInstance.INSTANCE_NAME, INSTANCE_NAME);
+        CloudInstance cloudInstance = new CloudInstance(null, instanceTemplate, null, params);
+        CloudVmInstanceStatus cloudVmInstanceStatus = new CloudVmInstanceStatus(cloudInstance, instanceStatus);
+        CloudInstanceMetaData cloudInstanceMetaData = new CloudInstanceMetaData(PRIVATE_IP, PUBLIC_IP, SSH_PORT, LOCALITY_INDICATOR);
+        CloudVmMetaDataStatus cloudVmMetaDataStatus = new CloudVmMetaDataStatus(cloudVmInstanceStatus, cloudInstanceMetaData);
+        return List.of(cloudVmMetaDataStatus);
+    }
+
+    private void assertCommonProperties(InstanceMetaData instanceMetaData) {
+        assertEquals(PRIVATE_IP, instanceMetaData.getPrivateIp());
+        assertEquals(PUBLIC_IP, instanceMetaData.getPublicIp());
+        assertEquals(SSH_PORT, instanceMetaData.getSshPort());
+        assertEquals(LOCALITY_INDICATOR, instanceMetaData.getLocalityIndicator());
+        assertEquals(INSTANCE_GROUP_ID, instanceMetaData.getInstanceGroup().getId());
+        assertNull(instanceMetaData.getInstanceId());
+        assertEquals(PRIVATE_ID, instanceMetaData.getPrivateId());
+        assertEquals(CURRENT_TIME, instanceMetaData.getStartDate());
+        assertEquals(SUBNET_ID, instanceMetaData.getSubnetId());
+        assertEquals(INSTANCE_NAME, instanceMetaData.getInstanceName());
+        assertEquals(Boolean.FALSE, instanceMetaData.getAmbariServer());
+        assertEquals(Boolean.FALSE, instanceMetaData.getClusterManagerServer());
+        assertEquals(InstanceMetadataType.CORE, instanceMetaData.getInstanceMetadataType());
+    }
+
+}


### PR DESCRIPTION
The number of calls are different because I didn't wait the entire cluster delete [here](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXClusterStopStartTest.java#L56) . But the number of rows returned clearly show the improvement.

__Before:__

<table>
    <tr>
        <th>userid
        </th>
        <th>dbid
        </th>
        <th>queryid
        </th>
        <th>query
        </th>
        <th>calls
        </th>
        <th>total_time
        </th>
        <th>min_time
        </th>
        <th>max_time
        </th>
        <th>mean_time
        </th>
        <th>stddev_time
        </th>
        <th>rows
        </th>
        <th>shared_blks_hit
        </th>
        <th>shared_blks_read
        </th>
        <th>shared_blks_dirtied
        </th>
        <th>shared_blks_written
        </th>
        <th>local_blks_hit
        </th>
        <th>local_blks_read
        </th>
        <th>local_blks_dirtied
        </th>
        <th>local_blks_written
        </th>
        <th>temp_blks_read
        </th>
        <th>temp_blks_written
        </th>
        <th>blk_read_time
        </th>
        <th>blk_write_time
        </th>
    </tr>
    <tr>
        <td>10</td>
        <td>16384</td>
        <td>1917741353</td>
        <td>select instancegr0_.id as id1_19_0_, instanceme1_.id as id1_20_1_, instancegr0_.attributes
            as attribut3_19_0_, instancegr0_.groupName as groupNam2_19_0_, instancegr0_.instanceGroupType as
            instance4_19_0_, instancegr0_.securityGroup_id as security6_19_0_, instancegr0_.stack_id as
            stack_id5_19_0_, instancegr0_.template_id as template7_19_0_, instanceme1_.ambariServer as
            ambariSe5_20_1_, instanceme1_.clusterManagerServer as clusterM6_20_1_, instanceme1_.discoveryFQDN as
            discover7_20_1_, instanceme1_.image as image8_20_1_, instanceme1_.instanceGroup_id as instanc20_20_1_,
            instanceme1_.instanceId as instance9_20_1_, instanceme1_.instanceMetadataType as instanc10_20_1_,
            instanceme1_.instanceName as instance2_20_1_, instanceme1_.instanceStatus as instance3_20_1_,
            instanceme1_.localityIndicator as localit11_20_1_, instanceme1_.privateId as private12_20_1_,
            instanceme1_.privateIp as private13_20_1_, instanceme1_.publicIp as publicI14_20_1_,
            instanceme1_.serverCert as serverC15_20_1_, instanceme1_.sshPort as sshPort16_20_1_,
            instanceme1_.startDate as startDa17_20_1_, instanceme1_.statusReason as statusRe4_20_1_,
            instanceme1_.subnetId as subnetI18_20_1_, instanceme1_.terminationDate as termina19_20_1_,
            instanceme1_.instanceGroup_id as instanc20_20_0__, instanceme1_.id as id1_20_0__ from
            public.InstanceGroup instancegr0_ left outer join public.InstanceMetaData instanceme1_ on
            instancegr0_.id=instanceme1_.instanceGroup_id where instancegr0_.stack_id=$1 and
            instancegr0_.groupName=$2</td>
        <td>3908</td>
        <td>93885.6009999998</td>
        <td>0.043</td>
        <td>277.997</td>
        <td>24.0239511258956</td>
        <td>15.3250671060999</td>
        <td>1767066</td>
        <td>5771599</td>
        <td>0</td>
        <td>0</td>
        <td>0</td>
        <td>0</td>
        <td>0</td>
        <td>0</td>
        <td>0</td>
        <td>0</td>
        <td>0</td>
        <td>0</td>
        <td>0</td>
    </tr>
</table>

__After:__

<table>
    <th>userid
    </th>
    <th> dbid
    </th>
    <th> queryid
    </th>
    <th> query
    </th>
    <th>calls
    </th>
    <th> total_time
    </th>
    <th> min_time
    </th>
    <th>max_time
    </th>
    <th>mean_time
    </th>
    <th>stddev_time
    </th>
    <th>rows
    </th>
    <th>shared_blks_hit
    </th>
    <th>shared_blks_read
    </th>
    <th>shared_blks_dirtied
    </th>
    <th>shared_blks_written
    </th>
    <th>local_blks_hit
    </th>
    <th>local_blks_read
    </th>
    <th>local_blks_dirtied
    </th>
    <th>local_blks_written
    </th>
    <th>temp_blks_read
    </th>
    <th>temp_blks_written
    </th>
    <th>blk_read_time
    </th>
    <th>blk_write_time
    </th>
    </tr>
    <tr>
        <td>10</td>
        <td>16384</td>
        <td>1840018446</td>
        <td>select instancegr0_.id as id1_19_, instancegr0_.attributes as attribut2_19_,
            instancegr0_.groupName as groupNam3_19_, instancegr0_.instanceGroupType as instance4_19_,
            instancegr0_.securityGroup_id as security5_19_, instancegr0_.stack_id as stack_id6_19_,
            instancegr0_.template_id as template7_19_ from public.InstanceGroup instancegr0_ where
            instancegr0_.stack_id=$1 and instancegr0_.groupName=$2</td>
        <td>3621</td>
        <td>159.059000000001</td>
        <td>0.024</td>
        <td>5.467</td>
        <td>0.0439268157967412</td>
        <td>0.100386917321639</td>
        <td>3621</td>
        <td>7242</td>
        <td>0</td>
        <td>0</td>
        <td>0</td>
        <td>0</td>
        <td>0</td>
        <td>0</td>
        <td>0</td>
        <td>0</td>
        <td>0</td>
        <td>0</td>
        <td>0</td>
    </tr>
</table>