### PR TITLE
CB-5533 Add dex to the CRN service types

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/auth/altus/Crn.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/auth/altus/Crn.java
@@ -159,7 +159,8 @@ public class Crn {
         FREEIPA("freeipa", NON_ADMIN_SERVICE),
         DATAHUB("datahub", NON_ADMIN_SERVICE),
         DATALAKE("datalake", NON_ADMIN_SERVICE),
-        ML("ml", NON_ADMIN_SERVICE);
+        ML("ml", NON_ADMIN_SERVICE),
+        DEX("dex", NON_ADMIN_SERVICE);
 
         private static final ImmutableMap<String, Service> FROM_STRING;
 


### PR DESCRIPTION
    The CRN validation now allows "dex" service type.
    
    This was tested with a local deployment of cloudbreak.

Closes #CB-5533