### PR TITLE
Fix intermittent IT Upscale issue

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/clouderamanager/CMUpscaleWithHttp500ResponsesTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/clouderamanager/CMUpscaleWithHttp500ResponsesTest.java
@@ -147,7 +147,7 @@ public class CMUpscaleWithHttp500ResponsesTest extends AbstractClouderaManagerTe
                                 .pathVariableMapping(":clusterName", clusterName)
                                 .resolve())
                         .exactTimes(1))
-                .then(MockVerification.verify(GET, READ_HOSTS).exactTimes(6))
+                .then(MockVerification.verify(GET, READ_HOSTS).atLeast(6))
                 .then(MockVerification.verify(POST, new ClouderaManagerPathResolver(ADD_HOSTS)
                         .pathVariableMapping(":clusterName", clusterName)
                         .resolve())


### PR DESCRIPTION
fix intermittent issue for upscale tests

Failed Tests: 2 (+2)
mock-tests / newway mock testcases
com.sequenceiq.it.cloudbreak.testcase.mock.clouderamanager.CMStartStopWithHttp500ResponsesTest.testCreateStartStopWithHttp500ErrorsForEachApiCallForTheFirstTime
com.sequenceiq.it.cloudbreak.testcase.mock.clouderamanager.CMUpscaleWithHttp500ResponsesTest.testUpscale