### PR TITLE
CSP-879: Knox proxy errors while uploading jar files

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/clouderamanager-ssl-user-facing.conf
+++ b/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/clouderamanager-ssl-user-facing.conf
@@ -49,6 +49,7 @@ server {
         proxy_set_header   Referer https://$host/;
         proxy_set_header   X-Forwarded-Host $server_name;
         proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_set_header   Expect $http_expect;
         # Ensure that websockets work
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
Changes the user facing Nginx conf to accept "Expect" header. This is helpful in uploading in large files. Currently it does not allow the header to pass through and Knox fails the request.

> Caused by: org.apache.http.client.NonRepeatableRequestException: Cannot retry request with a non-repeatable request entity.
>         at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:226)
>         at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:185)

