### PR TITLE
CDPD-7598 Add gateway roles to Leader

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-opdb-702.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-opdb-702.bp
@@ -183,6 +183,8 @@
         "refName": "leader",
         "cardinality": 1,
         "roleConfigGroupsRefNames": [
+          "hbase-GATEWAY-BASE",
+          "hdfs-GATEWAY-BASE",
           "hdfs-JOURNALNODE-BASE",
           "zookeeper-SERVER-BASE"
         ]

--- a/core/src/main/resources/defaults/blueprints/cdp-opdb-710.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-opdb-710.bp
@@ -208,6 +208,8 @@
         "refName": "leader",
         "cardinality": 1,
         "roleConfigGroupsRefNames": [
+          "hbase-GATEWAY-BASE",
+          "hdfs-GATEWAY-BASE",
           "hdfs-JOURNALNODE-BASE",
           "zookeeper-SERVER-BASE"
         ]


### PR DESCRIPTION
**Summary**
Add hbase-GATEWAY-BASE and hdfs-GATEWAY-BASE roles to Leader node for OpDB blueprints.

**Testing**
Added custom template to mow-dev environment and created an OpDB cluster from it. Logged in to the leader node and executed a couple of HBase commands from the shell.