### PR TITLE
CB-5643 Periscope is unable to call FreeIPA endpoints with internal CRN

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/kerberos/v1/KerberosConfigV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/kerberos/v1/KerberosConfigV1Controller.java
@@ -1,21 +1,23 @@
 package com.sequenceiq.freeipa.kerberos.v1;
 
+import com.sequenceiq.cloudbreak.auth.security.internal.InternalReady;
+import com.sequenceiq.cloudbreak.auth.security.internal.ResourceCrn;
+import com.sequenceiq.freeipa.api.v1.kerberos.KerberosConfigV1Endpoint;
+import com.sequenceiq.freeipa.api.v1.kerberos.model.create.CreateKerberosConfigRequest;
+import com.sequenceiq.freeipa.api.v1.kerberos.model.describe.DescribeKerberosConfigResponse;
+import com.sequenceiq.freeipa.util.CrnService;
+import com.sequenceiq.notification.NotificationController;
+import org.springframework.stereotype.Controller;
+
 import javax.inject.Inject;
 import javax.transaction.Transactional;
 import javax.transaction.Transactional.TxType;
 import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
 
-import org.springframework.stereotype.Controller;
-
-import com.sequenceiq.freeipa.api.v1.kerberos.KerberosConfigV1Endpoint;
-import com.sequenceiq.freeipa.api.v1.kerberos.model.create.CreateKerberosConfigRequest;
-import com.sequenceiq.freeipa.api.v1.kerberos.model.describe.DescribeKerberosConfigResponse;
-import com.sequenceiq.freeipa.util.CrnService;
-import com.sequenceiq.notification.NotificationController;
-
 @Controller
 @Transactional(TxType.NEVER)
+@InternalReady
 public class KerberosConfigV1Controller extends NotificationController implements KerberosConfigV1Endpoint {
     @Inject
     private KerberosConfigV1Service kerberosConfigV1Service;
@@ -29,7 +31,7 @@ public class KerberosConfigV1Controller extends NotificationController implement
     }
 
     @Override
-    public DescribeKerberosConfigResponse getForCluster(@NotEmpty String environmentCrn, @NotEmpty String clusterName) throws Exception {
+    public DescribeKerberosConfigResponse getForCluster(@NotEmpty @ResourceCrn String environmentCrn, @NotEmpty String clusterName) throws Exception {
         String accountId = crnService.getCurrentAccountId();
         return kerberosConfigV1Service.getForCluster(environmentCrn, accountId, clusterName);
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/ldap/v1/LdapConfigV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/ldap/v1/LdapConfigV1Controller.java
@@ -1,11 +1,7 @@
 package com.sequenceiq.freeipa.ldap.v1;
 
-import javax.inject.Inject;
-import javax.transaction.Transactional;
-import javax.transaction.Transactional.TxType;
-
-import org.springframework.stereotype.Controller;
-
+import com.sequenceiq.cloudbreak.auth.security.internal.InternalReady;
+import com.sequenceiq.cloudbreak.auth.security.internal.ResourceCrn;
 import com.sequenceiq.freeipa.api.v1.ldap.LdapConfigV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.ldap.model.create.CreateLdapConfigRequest;
 import com.sequenceiq.freeipa.api.v1.ldap.model.describe.DescribeLdapConfigResponse;
@@ -14,9 +10,15 @@ import com.sequenceiq.freeipa.api.v1.ldap.model.test.TestLdapConfigResponse;
 import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.util.CrnService;
 import com.sequenceiq.notification.NotificationController;
+import org.springframework.stereotype.Controller;
+
+import javax.inject.Inject;
+import javax.transaction.Transactional;
+import javax.transaction.Transactional.TxType;
 
 @Controller
 @Transactional(TxType.NEVER)
+@InternalReady
 public class LdapConfigV1Controller extends NotificationController implements LdapConfigV1Endpoint {
     @Inject
     private LdapConfigV1Service ldapConfigV1Service;
@@ -30,7 +32,7 @@ public class LdapConfigV1Controller extends NotificationController implements Ld
     }
 
     @Override
-    public DescribeLdapConfigResponse getForCluster(String environmentCrn, String clusterName) throws FreeIpaClientException {
+    public DescribeLdapConfigResponse getForCluster(@ResourceCrn String environmentCrn, String clusterName) throws FreeIpaClientException {
         String accountId = crnService.getCurrentAccountId();
         return ldapConfigV1Service.getForCluster(environmentCrn, accountId, clusterName);
     }


### PR DESCRIPTION
As part of HBase Autoscaling initiative we came across a bug in Periscope: LDAP and Kerberos services haven't been prepared to accept Internal CRNs which is a must for Periscope to work properly.

This patch enables the required endpoint for Internal usage.

No tests added yet, but recommendations are welcome.

Closes CB-5643