### PR TITLE
CB-5293. Periscope access for totalHosts in CM (2.18)

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ClusterManagerException.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ClusterManagerException.java
@@ -1,0 +1,7 @@
+package com.sequenceiq.periscope.monitor.evaluator;
+
+public class ClusterManagerException extends RuntimeException {
+    public ClusterManagerException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ClusterManagerTotalHostsEvaluator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ClusterManagerTotalHostsEvaluator.java
@@ -1,0 +1,10 @@
+package com.sequenceiq.periscope.monitor.evaluator;
+
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.ClusterManagerVariant;
+
+public interface ClusterManagerTotalHostsEvaluator {
+    ClusterManagerVariant getSupportedClusterManagerVariant();
+
+    int getTotalHosts(Cluster cluster);
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ambari/AmbariTotalHostsEvaluator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ambari/AmbariTotalHostsEvaluator.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.periscope.monitor.evaluator.ambari;
+
+import com.sequenceiq.ambari.client.AmbariClient;
+import com.sequenceiq.periscope.aspects.RequestLogging;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.ClusterManagerVariant;
+import com.sequenceiq.periscope.monitor.evaluator.ClusterManagerTotalHostsEvaluator;
+import com.sequenceiq.periscope.service.AmbariClientProvider;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+
+@Component("AmbariTotalHostsEvaluator")
+@Scope("prototype")
+public class AmbariTotalHostsEvaluator implements ClusterManagerTotalHostsEvaluator {
+    @Inject
+    private AmbariClientProvider ambariClientProvider;
+
+    @Inject
+    private RequestLogging ambariRequestLogging;
+
+    @Override
+    public ClusterManagerVariant getSupportedClusterManagerVariant() {
+        return ClusterManagerVariant.AMBARI;
+    }
+
+    @Override
+    public int getTotalHosts(Cluster cluster) {
+        AmbariClient ambariClient = ambariClientProvider.createAmbariClient(cluster);
+        return ambariRequestLogging.logging(ambariClient::getClusterHosts, "clusterHosts").size();
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/cm/ClouderaManagerTotalHostsEvaluator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/cm/ClouderaManagerTotalHostsEvaluator.java
@@ -1,0 +1,63 @@
+package com.sequenceiq.periscope.monitor.evaluator.cm;
+
+import com.cloudera.api.swagger.HostsResourceApi;
+import com.cloudera.api.swagger.client.ApiClient;
+import com.sequenceiq.cloudbreak.client.HttpClientConfig;
+import com.sequenceiq.cloudbreak.cm.DataView;
+import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiClientProvider;
+import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
+import com.sequenceiq.cloudbreak.service.secret.service.SecretService;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.ClusterManager;
+import com.sequenceiq.periscope.domain.ClusterManagerVariant;
+import com.sequenceiq.periscope.monitor.evaluator.ClusterManagerTotalHostsEvaluator;
+import com.sequenceiq.periscope.service.security.TlsHttpClientConfigurationService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+
+@Component("ClouderaManagerTotalHostsEvaluator")
+@Scope("prototype")
+public class ClouderaManagerTotalHostsEvaluator implements ClusterManagerTotalHostsEvaluator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerTotalHostsEvaluator.class);
+
+    @Inject
+    private TlsHttpClientConfigurationService tlsHttpClientConfigurationService;
+
+    @Inject
+    private SecretService secretService;
+
+    @Inject
+    private ClouderaManagerApiClientProvider clouderaManagerApiClientProvider;
+
+    @Inject
+    private ClouderaManagerApiFactory clouderaManagerApiFactory;
+
+    @Override
+    public ClusterManagerVariant getSupportedClusterManagerVariant() {
+        return ClusterManagerVariant.CLOUDERA_MANAGER;
+    }
+
+    @Override
+    public int getTotalHosts(Cluster cluster) {
+        try {
+            Long clusterId = cluster.getId();
+            LOGGER.debug("Checking number of total hosts for cluster {}.", clusterId);
+            HttpClientConfig httpClientConfig = tlsHttpClientConfigurationService.buildTLSClientConfig(cluster.getStackCrn(),
+                    cluster.getClusterManager().getHost(), cluster.getTunnel());
+            ClusterManager cm = cluster.getClusterManager();
+            String user = secretService.get(cm.getUser());
+            String pass = secretService.get(cm.getPass());
+            ApiClient client = clouderaManagerApiClientProvider.getClient(Integer.valueOf(cm.getPort()), user, pass, httpClientConfig);
+            HostsResourceApi hostsResourceApi = clouderaManagerApiFactory.getHostsResourceApi(client);
+            return hostsResourceApi.readHosts(DataView.FULL.name()).getItems().size();
+        } catch (Exception e) {
+            LOGGER.info("Failed to retrieve number of total hosts. Original message: {}", e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/cm/ClouderaManagerTotalHostsEvaluator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/cm/ClouderaManagerTotalHostsEvaluator.java
@@ -10,6 +10,7 @@ import com.sequenceiq.cloudbreak.service.secret.service.SecretService;
 import com.sequenceiq.periscope.domain.Cluster;
 import com.sequenceiq.periscope.domain.ClusterManager;
 import com.sequenceiq.periscope.domain.ClusterManagerVariant;
+import com.sequenceiq.periscope.monitor.evaluator.ClusterManagerException;
 import com.sequenceiq.periscope.monitor.evaluator.ClusterManagerTotalHostsEvaluator;
 import com.sequenceiq.periscope.service.security.TlsHttpClientConfigurationService;
 import org.slf4j.Logger;
@@ -54,10 +55,10 @@ public class ClouderaManagerTotalHostsEvaluator implements ClusterManagerTotalHo
             String pass = secretService.get(cm.getPass());
             ApiClient client = clouderaManagerApiClientProvider.getClient(Integer.valueOf(cm.getPort()), user, pass, httpClientConfig);
             HostsResourceApi hostsResourceApi = clouderaManagerApiFactory.getHostsResourceApi(client);
-            return hostsResourceApi.readHosts(DataView.FULL.name()).getItems().size();
+            return hostsResourceApi.readHosts(DataView.SUMMARY.name()).getItems().size();
         } catch (Exception e) {
             LOGGER.info("Failed to retrieve number of total hosts. Original message: {}", e.getMessage());
-            throw new RuntimeException(e);
+            throw new ClusterManagerException("Failed to retrieve number of total hosts", e);
         }
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/evaluator/TotalHostsEvaluatorService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/evaluator/TotalHostsEvaluatorService.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.periscope.service.evaluator;
+
+import com.sequenceiq.periscope.domain.ClusterManagerVariant;
+import com.sequenceiq.periscope.monitor.evaluator.ClusterManagerTotalHostsEvaluator;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+public class TotalHostsEvaluatorService {
+
+    @Inject
+    private List<ClusterManagerTotalHostsEvaluator> totalHostsEvaluators;
+
+    private Map<ClusterManagerVariant, ClusterManagerTotalHostsEvaluator> map;
+
+    @PostConstruct
+    public void init() {
+        map = buildMap();
+    }
+
+    public ClusterManagerTotalHostsEvaluator get(ClusterManagerVariant variant) {
+        return map.get(variant);
+    }
+
+    private Map<ClusterManagerVariant, ClusterManagerTotalHostsEvaluator> buildMap() {
+        return totalHostsEvaluators.stream()
+                .collect(Collectors.toMap(
+                        ClusterManagerTotalHostsEvaluator::getSupportedClusterManagerVariant,
+                        hostHealthEvaluator -> hostHealthEvaluator
+                ));
+    }
+
+}

--- a/autoscale/src/main/resources/logback.xml
+++ b/autoscale/src/main/resources/logback.xml
@@ -40,7 +40,7 @@
         <appender-ref ref="STDOUT"/>
     </root>
 
-    <logger name="com.sequenceiq" level="${PERISCOPE_LOG_LEVEL:-INFO}" additivity="false">
+    <logger name="com.sequenceiq" level="${PERISCOPE_LOG_LEVEL:-DEBUG}" additivity="false">
         <appender-ref ref="PERISCOPE_NODEID_BASED"/>
         <appender-ref ref="STDOUT"/>
     </logger>


### PR DESCRIPTION
Enables Periscope to retrieve getTotalHosts from a CM cluster. Previous it was Ambari-only, but this patch adds another level of abstraction which makes the call transparent for the caller and supports both cluster managers.

No tests added, but recommendations are welcome.