### PR TITLE
CB-5636. E2E tests: ABFS logs are missing from idbroker host.

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigView.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigView.java
@@ -9,6 +9,8 @@ import com.sequenceiq.cloudbreak.telemetry.TelemetryConfigView;
 
 public class FluentConfigView implements TelemetryConfigView {
 
+    public static final String AZURE_IDBROKER_INSTANCE_MSI = "azureIdBrokerInstanceMsi";
+
     private static final String LOG_FOLDER_DEFAULT = "/var/log";
 
     private static final String TD_AGENT_USER_DEFAULT = "root";
@@ -57,6 +59,8 @@ public class FluentConfigView implements TelemetryConfigView {
 
     private final String azureInstanceMsi;
 
+    private final String azureIdBrokerInstanceMsi;
+
     private final String azureStorageAccessKey;
 
     private final String s3LogArchiveBucketName;
@@ -88,6 +92,7 @@ public class FluentConfigView implements TelemetryConfigView {
         this.azureContainer = builder.azureContainer;
         this.azureStorageAccount = builder.azureStorageAccount;
         this.azureInstanceMsi = builder.azureInstanceMsi;
+        this.azureIdBrokerInstanceMsi = builder.azureIdBrokerInstanceMsi;
         this.azureStorageAccessKey = builder.azureStorageAccessKey;
         this.overrideAttributes = builder.overrideAttributes;
     }
@@ -152,6 +157,10 @@ public class FluentConfigView implements TelemetryConfigView {
         return azureInstanceMsi;
     }
 
+    public String getAzureIdBrokerInstanceMsi() {
+        return azureIdBrokerInstanceMsi;
+    }
+
     public String getAzureStorageAccessKey() {
         return azureStorageAccessKey;
     }
@@ -204,6 +213,7 @@ public class FluentConfigView implements TelemetryConfigView {
         map.put("azureStorageAccount", ObjectUtils.defaultIfNull(this.azureStorageAccount, EMPTY_CONFIG_DEFAULT));
         map.put("azureStorageAccessKey", ObjectUtils.defaultIfNull(this.azureStorageAccessKey, EMPTY_CONFIG_DEFAULT));
         map.put("azureInstanceMsi", ObjectUtils.defaultIfNull(this.azureInstanceMsi, EMPTY_CONFIG_DEFAULT));
+        map.put(AZURE_IDBROKER_INSTANCE_MSI, ObjectUtils.defaultIfNull(this.azureIdBrokerInstanceMsi, EMPTY_CONFIG_DEFAULT));
         if (this.clusterDetails != null) {
             map.putAll(clusterDetails.toMap());
         }
@@ -260,6 +270,8 @@ public class FluentConfigView implements TelemetryConfigView {
         private String azureContainer;
 
         private String azureInstanceMsi;
+
+        private String azureIdBrokerInstanceMsi;
 
         private String azureStorageAccessKey;
 
@@ -331,6 +343,11 @@ public class FluentConfigView implements TelemetryConfigView {
 
         public Builder withAzureInstanceMsi(String azureInstanceMsi) {
             this.azureInstanceMsi = azureInstanceMsi;
+            return this;
+        }
+
+        public Builder withAzureIdBrokerInstanceMsi(String azureIdBrokerInstanceMsi) {
+            this.azureIdBrokerInstanceMsi = azureIdBrokerInstanceMsi;
             return this;
         }
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
@@ -28,15 +28,18 @@ import com.sequenceiq.cloudbreak.idbmms.GrpcIdbmmsClient;
 import com.sequenceiq.cloudbreak.idbmms.exception.IdbmmsOperationException;
 import com.sequenceiq.cloudbreak.idbmms.model.MappingsConfig;
 import com.sequenceiq.cloudbreak.telemetry.fluent.FluentClusterDetails;
+import com.sequenceiq.cloudbreak.telemetry.fluent.FluentConfigView;
 import com.sequenceiq.cloudbreak.util.PasswordUtil;
 import com.sequenceiq.common.api.cloudstorage.AccountMappingBase;
 import com.sequenceiq.common.api.cloudstorage.CloudStorageRequest;
+import com.sequenceiq.common.api.cloudstorage.StorageIdentityBase;
 import com.sequenceiq.common.api.telemetry.request.FeaturesRequest;
 import com.sequenceiq.common.api.telemetry.request.LoggingRequest;
 import com.sequenceiq.common.api.telemetry.request.TelemetryRequest;
 import com.sequenceiq.common.api.telemetry.response.LoggingResponse;
 import com.sequenceiq.common.api.telemetry.response.TelemetryResponse;
 import com.sequenceiq.common.api.type.InstanceGroupType;
+import com.sequenceiq.common.model.CloudIdentityType;
 import com.sequenceiq.datalake.controller.exception.BadRequestException;
 import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.service.validation.cloudstorage.CloudStorageValidator;
@@ -186,9 +189,26 @@ public class StackRequestManifester {
                 if (!fluentAttributes.containsKey(FluentClusterDetails.CLUSTER_CRN_KEY)) {
                     fluentAttributes.put(FluentClusterDetails.CLUSTER_CRN_KEY, sdxCluster.getCrn());
                 }
+                addAzureIdbrokerMsiToTelemetry(fluentAttributes, stackV4Request);
                 telemetryRequest.setFluentAttributes(fluentAttributes);
             }
             stackV4Request.setTelemetry(telemetryRequest);
+        }
+    }
+
+    void addAzureIdbrokerMsiToTelemetry(Map<String, Object> fluentAttributes, StackV4Request stackRequest) {
+        if (stackRequest.getCluster() != null && stackRequest.getCluster().getCloudStorage() != null
+                && stackRequest.getCluster().getCloudStorage().getIdentities() != null) {
+            List<StorageIdentityBase> identities = stackRequest.getCluster().getCloudStorage().getIdentities();
+            for (StorageIdentityBase identity : identities) {
+                if (CloudIdentityType.ID_BROKER.equals(identity.getType()) && identity.getAdlsGen2() != null) {
+                    if (!fluentAttributes.containsKey(FluentConfigView.AZURE_IDBROKER_INSTANCE_MSI)) {
+                        String idBrokerInstanceMsi = identity.getAdlsGen2().getManagedIdentity();
+                        LOGGER.info("Setting idbroker instance msi for telemetry: {}", idBrokerInstanceMsi);
+                        fluentAttributes.put(FluentConfigView.AZURE_IDBROKER_INSTANCE_MSI, idBrokerInstanceMsi);
+                    }
+                }
+            }
         }
     }
 

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/StackRequestManifesterTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/StackRequestManifesterTest.java
@@ -4,6 +4,9 @@ import static com.sequenceiq.datalake.service.sdx.StackRequestManifester.IAM_INT
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -22,8 +25,12 @@ import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.idbmms.GrpcIdbmmsClient;
 import com.sequenceiq.cloudbreak.idbmms.exception.IdbmmsOperationException;
 import com.sequenceiq.cloudbreak.idbmms.model.MappingsConfig;
+import com.sequenceiq.cloudbreak.telemetry.fluent.FluentConfigView;
 import com.sequenceiq.common.api.cloudstorage.AccountMappingBase;
 import com.sequenceiq.common.api.cloudstorage.CloudStorageRequest;
+import com.sequenceiq.common.api.cloudstorage.StorageIdentityBase;
+import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
+import com.sequenceiq.common.model.CloudIdentityType;
 import com.sequenceiq.datalake.controller.exception.BadRequestException;
 import com.sequenceiq.environment.api.v1.environment.model.base.IdBrokerMappingSource;
 
@@ -76,13 +83,14 @@ public class StackRequestManifesterTest {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         clusterV4Request = new ClusterV4Request();
-        when(stackV4Request.getCluster()).thenReturn(clusterV4Request);
-        when(stackV4Request.getName()).thenReturn(STACK_NAME);
         cloudStorage = new CloudStorageRequest();
     }
 
     @Test
     public void testSetupCloudStorageAccountMappingWhenNoCloudStorage() {
+        when(stackV4Request.getCluster()).thenReturn(clusterV4Request);
+        when(stackV4Request.getName()).thenReturn(STACK_NAME);
+
         underTest.setupCloudStorageAccountMapping(stackV4Request, ENVIRONMENT_CRN, IdBrokerMappingSource.IDBMMS, CLOUD_PLATFORM_AWS);
 
         assertThat(clusterV4Request.getCloudStorage()).isNull();
@@ -90,6 +98,9 @@ public class StackRequestManifesterTest {
 
     @Test
     public void testSetupCloudStorageAccountMappingWhenCloudStorageWithExistingAccountMappingAndEmptyMaps() {
+        when(stackV4Request.getCluster()).thenReturn(clusterV4Request);
+        when(stackV4Request.getName()).thenReturn(STACK_NAME);
+
         clusterV4Request.setCloudStorage(cloudStorage);
         AccountMappingBase accountMapping = new AccountMappingBase();
         cloudStorage.setAccountMapping(accountMapping);
@@ -104,6 +115,8 @@ public class StackRequestManifesterTest {
 
     @Test
     public void testSetupCloudStorageAccountMappingWhenCloudStorageWithExistingAccountMappingAndNonemptyMaps() {
+        when(stackV4Request.getCluster()).thenReturn(clusterV4Request);
+        when(stackV4Request.getName()).thenReturn(STACK_NAME);
         clusterV4Request.setCloudStorage(cloudStorage);
         AccountMappingBase accountMapping = new AccountMappingBase();
         accountMapping.setGroupMappings(Map.ofEntries(Map.entry(GROUP_1, GROUP_ROLE_1)));
@@ -120,6 +133,8 @@ public class StackRequestManifesterTest {
 
     @Test
     public void testSetupCloudStorageAccountMappingWhenCloudStorageWithNoAccountMappingAndIdbmmsSourceAndSuccess() {
+        when(stackV4Request.getCluster()).thenReturn(clusterV4Request);
+        when(stackV4Request.getName()).thenReturn(STACK_NAME);
         when(idbmmsClient.getMappingsConfig(IAM_INTERNAL_ACTOR_CRN, ENVIRONMENT_CRN, Optional.empty())).thenReturn(mappingsConfig);
         when(mappingsConfig.getGroupMappings()).thenReturn(Map.ofEntries(Map.entry(GROUP_2, GROUP_ROLE_2)));
         when(mappingsConfig.getActorMappings()).thenReturn(Map.ofEntries(Map.entry(USER_2, USER_ROLE_2)));
@@ -137,6 +152,8 @@ public class StackRequestManifesterTest {
 
     @Test
     public void testSetupCloudStorageAccountMappingWhenCloudStorageWithNoAccountMappingAndIdbmmsSourceAndFailure() {
+        when(stackV4Request.getCluster()).thenReturn(clusterV4Request);
+        when(stackV4Request.getName()).thenReturn(STACK_NAME);
         when(idbmmsClient.getMappingsConfig(IAM_INTERNAL_ACTOR_CRN, BAD_ENVIRONMENT_CRN, Optional.empty()))
                 .thenThrow(new IdbmmsOperationException("Houston, we have a problem."));
 
@@ -149,6 +166,8 @@ public class StackRequestManifesterTest {
 
     @Test
     public void testSetupCloudStorageAccountMappingWhenCloudStorageWithNoAccountMappingAndMockSourceAndAws() {
+        when(stackV4Request.getCluster()).thenReturn(clusterV4Request);
+        when(stackV4Request.getName()).thenReturn(STACK_NAME);
         clusterV4Request.setCloudStorage(cloudStorage);
 
         underTest.setupCloudStorageAccountMapping(stackV4Request, ENVIRONMENT_CRN, IdBrokerMappingSource.MOCK, CLOUD_PLATFORM_AWS);
@@ -159,6 +178,8 @@ public class StackRequestManifesterTest {
 
     @Test
     public void testSetupCloudStorageAccountMappingWhenCloudStorageWithNoAccountMappingAndMockSourceAndAzure() {
+        when(stackV4Request.getCluster()).thenReturn(clusterV4Request);
+        when(stackV4Request.getName()).thenReturn(STACK_NAME);
         clusterV4Request.setCloudStorage(cloudStorage);
 
         underTest.setupCloudStorageAccountMapping(stackV4Request, ENVIRONMENT_CRN, IdBrokerMappingSource.MOCK, CLOUD_PLATFORM_AZURE);
@@ -169,12 +190,44 @@ public class StackRequestManifesterTest {
 
     @Test
     public void testSetupCloudStorageAccountMappingWhenCloudStorageWithNoAccountMappingAndNoneSource() {
+        when(stackV4Request.getCluster()).thenReturn(clusterV4Request);
+        when(stackV4Request.getName()).thenReturn(STACK_NAME);
         clusterV4Request.setCloudStorage(cloudStorage);
 
         underTest.setupCloudStorageAccountMapping(stackV4Request, ENVIRONMENT_CRN, IdBrokerMappingSource.NONE, CLOUD_PLATFORM_AWS);
 
         assertThat(clusterV4Request.getCloudStorage()).isSameAs(cloudStorage);
         assertThat(clusterV4Request.getCloudStorage().getAccountMapping()).isNull();
+    }
+
+    @Test
+    public void testAddAzureIdbrokerMsiToTelemetry() {
+        Map<String, Object> attributes = new HashMap<>();
+        CloudStorageRequest cloudStorageRequest = new CloudStorageRequest();
+        List<StorageIdentityBase> identities = new ArrayList<>();
+        StorageIdentityBase identity = new StorageIdentityBase();
+        identity.setType(CloudIdentityType.ID_BROKER);
+        AdlsGen2CloudStorageV1Parameters adlsGen2 = new AdlsGen2CloudStorageV1Parameters();
+        adlsGen2.setManagedIdentity("msi");
+        identity.setAdlsGen2(adlsGen2);
+        identities.add(identity);
+        cloudStorageRequest.setIdentities(identities);
+        when(stackV4Request.getCluster()).thenReturn(clusterV4Request);
+        clusterV4Request.setCloudStorage(cloudStorageRequest);
+
+        underTest.addAzureIdbrokerMsiToTelemetry(attributes, stackV4Request);
+
+        assertThat(clusterV4Request.getCloudStorage()).isNotNull();
+        assertThat(attributes.get(FluentConfigView.AZURE_IDBROKER_INSTANCE_MSI)).isEqualTo("msi");
+    }
+
+    @Test
+    public void testAddAzureIdbrokerMsiToTelemetrWithoutCloudStoragey() {
+        Map<String, Object> attributes = new HashMap<>();
+        underTest.addAzureIdbrokerMsiToTelemetry(attributes, stackV4Request);
+
+        assertThat(clusterV4Request.getCloudStorage()).isNull();
+        assertThat(attributes.size()).isEqualTo(0);
     }
 
 }

--- a/orchestrator-salt/src/main/resources/salt-common/pillar/fluent/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/pillar/fluent/init.sls
@@ -22,6 +22,7 @@ fluent:
   azureStorageAccount:
   azureContainer:
   azureInstanceMsi:
+  azureIdBrokerInstanceMsi:
   azureStorageAccessKey:
   dbusReportDeploymentLogs: false
   dbusReportDeploymentLogsDisableStop: false

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/init.sls
@@ -91,7 +91,7 @@ install_fluentd_plugins:
     - template: jinja
     - user: "{{ fluent.user }}"
     - group: "{{ fluent.group }}"
-    - file_mode: 750
+    - mode: '0750'
 
 check_fluentd_plugins:
    cmd.run:
@@ -116,7 +116,7 @@ fluent_stop:
     - template: jinja
     - user: "{{ fluent.user }}"
     - group: "{{ fluent.group }}"
-    - file_mode: 640
+    - mode: '0640'
     - context:
         databusReportDeploymentLogs: "true"
         numberOfWorkers: {{ fluent.numberOfWorkers }}
@@ -127,7 +127,7 @@ fluent_stop:
     - template: jinja
     - user: "{{ fluent.user }}"
     - group: "{{ fluent.group }}"
-    - file_mode: 640
+    - mode: '0640'
     - context:
         databusReportDeploymentLogs: "false"
 {%- if fluent.dbusReportDeploymentLogs and (fluent.numberOfWorkers > 1) %}
@@ -258,7 +258,7 @@ copy_td_agent_conf:
     - template: jinja
     - user: "{{ fluent.user }}"
     - group: "{{ fluent.group }}"
-    - file_mode: 640
+    - mode: 640
 
 fluentd_start_with_update_systemd_units:
   file.copy:

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
@@ -36,6 +36,11 @@
 {% set s3_log_bucket = salt['pillar.get']('fluent:s3LogArchiveBucketName') %}
 {% set azure_container = salt['pillar.get']('fluent:azureContainer') %}
 {% set azure_storage_instance_msi = salt['pillar.get']('fluent:azureInstanceMsi') %}
+{% if salt['pillar.get']('fluent:azureIdBrokerInstanceMsi') %}
+    {% set azure_storage_idbroker_instance_msi = salt['pillar.get']('fluent:azureIdBrokerInstanceMsi') %}
+{% else %}
+    {% set azure_storage_idbroker_instance_msi = salt['pillar.get']('fluent:azureInstanceMsi') %}
+{% endif %}
 {% set azore_storage_account = salt['pillar.get']('fluent:azureStorageAccount') %}
 {% set azure_storage_access_key = salt['pillar.get']('fluent:azureStorageAccessKey') %}
 
@@ -66,7 +71,7 @@
 {% set partition_interval = salt['pillar.get']('fluent:partitionIntervalMin') %}
 {% set cloudera_public_gem_repo = 'https://repository.cloudera.com/cloudera/api/gems/cloudera-gems/' %}
 {% set cloudera_azure_plugin_version = '1.0.1' %}
-{% set cloudera_azure_gen2_plugin_version = '0.2.4' %}
+{% set cloudera_azure_gen2_plugin_version = '0.2.7' %}
 {% set cloudera_databus_plugin_version = '1.0.3' %}
 {% set platform = salt['pillar.get']('fluent:platform') %}
 
@@ -115,6 +120,7 @@
     "azureStorageAccount": azore_storage_account,
     "azureContainer": azure_container,
     "azureInstanceMsi": azure_storage_instance_msi,
+    "azureIdBrokerInstanceMsi": azure_storage_idbroker_instance_msi,
     "azureStorageAccessKey": azure_storage_access_key,
     "dbusReportDeploymentLogs": dbus_report_deployment_logs_enabled,
     "dbusReportDeploymentLogsDisableStop": dbus_report_deployment_logs_disable_stop,

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/output.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/output.conf.j2
@@ -56,7 +56,11 @@
     azure_storage_account    {{fluent.azureStorageAccount}}
     azure_container          {{fluent.azureContainer}}
 {% if fluent.azureInstanceMsi is defined and fluent.azureInstanceMsi is not none and fluent.azureInstanceMsi %}
+    {% if grains['hostgroup'] == "idbroker" %}
+    azure_instance_msi       {{fluent.azureIdBrokerInstanceMsi}}
+    {% else %}
     azure_instance_msi       {{fluent.azureInstanceMsi}}
+    {% endif %}
 {% else %}
     azure_storage_access_key {{fluent.azureStorageAccessKey}}
 {% endif %}
@@ -65,6 +69,8 @@
     azure_object_key_format  %{path}-%{index}.%{file_extension}
     auto_create_container    true
     enable_retry             true
+    failsafe_container_check true
+    startup_fail_on_error    false
 
     <buffer tag,time>
       @type file
@@ -89,7 +95,11 @@
     azure_storage_account    {{fluent.azureStorageAccount}}
     azure_container          {{fluent.azureContainer}}
 {% if fluent.azureInstanceMsi is defined and fluent.azureInstanceMsi is not none and fluent.azureInstanceMsi %}
+    {% if grains['hostgroup'] == "idbroker" %}
+    azure_instance_msi       {{fluent.azureIdBrokerInstanceMsi}}
+    {% else %}
     azure_instance_msi       {{fluent.azureInstanceMsi}}
+    {% endif %}
 {% else %}
     azure_storage_access_key {{fluent.azureStorageAccessKey}}
 {% endif %}
@@ -98,6 +108,8 @@
     azure_object_key_format  %{path}-%{index}.%{file_extension}
     auto_create_container    true
     enable_retry             true
+    failsafe_container_check true
+    startup_fail_on_error    false
 
     <buffer tag,time>
       @type file


### PR DESCRIPTION
Pass idbroker identity for fluentd configs (not the log identity one), technically multiple identities should be assigned, but as we are not doing that just use the idbroker one

- UTs added
- few permission fixes (databus credentials)

cluster testing is in progress