### PR TITLE
CB-5275 Use Standard_D8_v3 instance type for OpDB Master node on Azure

### DIFF
--- a/core/src/main/resources/defaults/clustertemplates/azure/azure-opdb-710.json
+++ b/core/src/main/resources/defaults/clustertemplates/azure/azure-opdb-710.json
@@ -27,7 +27,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
+          "instanceType": "Standard_D8_v3",
           "rootVolume": {
             "size": 50
           },


### PR DESCRIPTION
The new clustertemplate was created from an outdated version. 