### PR TITLE
CB-5688 - Cannot stop environment if there is no attached data lake

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/repository/SdxStatusRepository.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/repository/SdxStatusRepository.java
@@ -2,7 +2,9 @@ package com.sequenceiq.datalake.repository;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
@@ -24,5 +26,9 @@ public interface SdxStatusRepository extends CrudRepository<SdxStatusEntity, Lon
     @CheckPermission(action = ResourceAction.READ)
     List<SdxStatusEntity> findDistinctFirstByStatusInAndDatalakeIdInOrderByIdDesc(Collection<DatalakeStatusEnum> datalakeStatusEnums,
             Collection<Long> datalakeId);
+
+    @CheckPermission(action = ResourceAction.READ)
+    @Query("SELECT sdxstatus.datalake.id FROM SdxStatusEntity sdxstatus WHERE sdxstatus.status IN ('DELETED') GROUP BY sdxstatus.datalake.id")
+    Set<Long> findAllSdxClusterIdWhichHasDeletedState();
 
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/status/SdxStatusService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/status/SdxStatusService.java
@@ -6,6 +6,7 @@ import static com.sequenceiq.datalake.entity.DatalakeStatusEnum.DELETED;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -80,6 +81,10 @@ public class SdxStatusService {
         return sdxStatusRepository.findDistinctFirstByStatusInAndDatalakeIdInOrderByIdDesc(datalakeStatusEnums, datalakeIds);
     }
 
+    public Set<Long> findAllSdxClusterIdWhichHasDeletedState() {
+        return sdxStatusRepository.findAllSdxClusterIdWhichHasDeletedState();
+    }
+
     public SdxStatusEntity getActualStatusForSdx(SdxCluster sdxCluster) {
         return sdxStatusRepository.findFirstByDatalakeIsOrderByIdDesc(sdxCluster);
     }
@@ -94,4 +99,5 @@ public class SdxStatusService {
             LOGGER.info("Update {} datalake status in inmemory store to {}", sdxCluster.getClusterName(), PollGroup.POLLABLE.name());
         }
     }
+
 }

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxServiceTestBase.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxServiceTestBase.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.datalake.service.sdx;
+
+public abstract class SdxServiceTestBase {
+
+    protected static final String TEST_USER_CRN = "crn:cdp:iam:us-west-1:hortonworks:user:perdos@hortonworks.com";
+
+    protected static final String TEST_ENVIRONMENT_CRN = "crn:cdp:environments:us-west-1:default:environment:e438a2db-d650-4132-ae62-242c5ba2f784";
+
+    protected static final String TEST_ENVIRONMENT_NAME = "someEnvironment";
+
+    protected SdxServiceTestBase() {
+    }
+
+    public String getTestUserCrn() {
+        return TEST_USER_CRN;
+    }
+
+    public String getTestEnvironmentCrn() {
+        return TEST_ENVIRONMENT_CRN;
+    }
+
+    public String getTestEnvironmentName() {
+        return TEST_ENVIRONMENT_NAME;
+    }
+
+}

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/list/SdxListServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/list/SdxListServiceTest.java
@@ -1,0 +1,175 @@
+package com.sequenceiq.datalake.service.sdx.list;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.sequenceiq.datalake.entity.SdxCluster;
+import com.sequenceiq.datalake.repository.SdxClusterRepository;
+import com.sequenceiq.datalake.service.sdx.SdxService;
+import com.sequenceiq.datalake.service.sdx.SdxServiceTestBase;
+import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
+
+class SdxListServiceTest extends SdxServiceTestBase {
+
+    @Mock
+    private SdxClusterRepository sdxClusterRepository;
+
+    @Mock
+    private SdxStatusService sdxStatusService;
+
+    @InjectMocks
+    private SdxService underTest;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    @DisplayName("Test listSdxByEnvCrn when no cluster found which has DELETED status but has no deleted timestamp then the result list shouldn't be " +
+            "touched or filtered")
+    void testListSdxByEnvCrnWhenNoClusterFoundWichHasDeletedStatusButHasNoDeletedTimestampThenTheResultListShouldBeTheSameAsItComesFromTheRepository() {
+        SdxCluster cluster = createClusterWithIdAndDeletedTimeStamp(1L);
+
+        when(sdxClusterRepository.findByAccountIdAndEnvCrnAndDeletedIsNull(any(), any())).thenReturn(List.of(cluster));
+        when(sdxStatusService.findAllSdxClusterIdWhichHasDeletedState()).thenReturn(Collections.emptySet());
+
+        List<SdxCluster> result = underTest.listSdxByEnvCrn(getTestUserCrn(), getTestEnvironmentCrn());
+
+        assertNotNull(result);
+        assertEquals(1L, result.size());
+        assertEquals(cluster, result.get(0));
+
+        verify(sdxClusterRepository, times(1)).findByAccountIdAndEnvCrnAndDeletedIsNull(any(), any());
+        verify(sdxStatusService, times(1)).findAllSdxClusterIdWhichHasDeletedState();
+    }
+
+    @Test
+    @DisplayName("Test listSdxByEnvCrn when one cluster found which has DELETED status and has no deleted timestamp then it's going to be filtered out from " +
+            "the result list.")
+    void testListSdxByEnvCrnWhenOneClusterFoundWichHasDeletedStatusAndHasNoDeletedTimestampThenItShouldBeFilteredOutFromTheResultList() {
+        SdxCluster actuallyRunningCluster = createClusterWithIdAndDeletedTimeStamp(1L);
+        SdxCluster corruptedCluster = createClusterWithIdAndDeletedTimeStamp(2L);
+
+        when(sdxClusterRepository.findByAccountIdAndEnvCrnAndDeletedIsNull(any(), any())).thenReturn(List.of(actuallyRunningCluster, corruptedCluster));
+        when(sdxStatusService.findAllSdxClusterIdWhichHasDeletedState()).thenReturn(Set.of(corruptedCluster.getId()));
+
+        List<SdxCluster> result = underTest.listSdxByEnvCrn(getTestUserCrn(), getTestEnvironmentCrn());
+
+        assertNotNull(result);
+        assertEquals(1L, result.size());
+        assertEquals(actuallyRunningCluster, result.get(0));
+
+        verify(sdxClusterRepository, times(1)).findByAccountIdAndEnvCrnAndDeletedIsNull(any(), any());
+        verify(sdxStatusService, times(1)).findAllSdxClusterIdWhichHasDeletedState();
+    }
+
+    @Test
+    @DisplayName("Test listSdx when the provided environment name is not null and no cluster found which has DELETED status but has no deleted " +
+            "timestamp then the result list shouldn't be touched or filtered")
+    void testListSdxWithNotEmptyEnvNameAndNoCorruptedCluster() {
+        SdxCluster cluster = createClusterWithIdAndDeletedTimeStamp(1L);
+
+        when(sdxClusterRepository.findByAccountIdAndEnvNameAndDeletedIsNull(any(), eq(getTestEnvironmentName()))).thenReturn(List.of(cluster));
+        when(sdxStatusService.findAllSdxClusterIdWhichHasDeletedState()).thenReturn(Collections.emptySet());
+
+        List<SdxCluster> result = underTest.listSdx(getTestUserCrn(), getTestEnvironmentName());
+
+        assertNotNull(result);
+        assertEquals(1L, result.size());
+        assertEquals(cluster, result.get(0));
+
+        verify(sdxClusterRepository, times(1)).findByAccountIdAndEnvNameAndDeletedIsNull(any(), any());
+        verify(sdxClusterRepository, times(1)).findByAccountIdAndEnvNameAndDeletedIsNull(any(), eq(getTestEnvironmentName()));
+        verify(sdxClusterRepository, times(0)).findByAccountIdAndDeletedIsNull(any());
+        verify(sdxStatusService, times(1)).findAllSdxClusterIdWhichHasDeletedState();
+    }
+
+    @Test
+    @DisplayName("Test listSdx when the provided environment name is not null and one cluster found which has DELETED status but has no deleted " +
+            "timestamp then it's going to be filtered out from the result list.")
+    void testListSdxWithNotEmptyEnvNameAndOneCorruptedCluster() {
+        SdxCluster actuallyRunningCluster = createClusterWithIdAndDeletedTimeStamp(1L);
+        SdxCluster corruptedCluster = createClusterWithIdAndDeletedTimeStamp(2L);
+
+        when(sdxClusterRepository.findByAccountIdAndEnvNameAndDeletedIsNull(any(), eq(getTestEnvironmentName())))
+                .thenReturn(List.of(actuallyRunningCluster, corruptedCluster));
+        when(sdxStatusService.findAllSdxClusterIdWhichHasDeletedState()).thenReturn(Set.of(corruptedCluster.getId()));
+
+        List<SdxCluster> result = underTest.listSdx(getTestUserCrn(), getTestEnvironmentName());
+
+        assertNotNull(result);
+        assertEquals(1L, result.size());
+        assertEquals(actuallyRunningCluster, result.get(0));
+
+        verify(sdxClusterRepository, times(1)).findByAccountIdAndEnvNameAndDeletedIsNull(any(), any());
+        verify(sdxClusterRepository, times(1)).findByAccountIdAndEnvNameAndDeletedIsNull(any(), eq(getTestEnvironmentName()));
+        verify(sdxClusterRepository, times(0)).findByAccountIdAndDeletedIsNull(any());
+        verify(sdxStatusService, times(1)).findAllSdxClusterIdWhichHasDeletedState();
+    }
+
+    @Test
+    @DisplayName("Test listSdx when the provided environment name is null and no cluster found which has DELETED status but has no deleted " +
+            "timestamp then the result list shouldn't be touched or filtered")
+    void testListSdxWithEmptyEnvNameAndNoCorruptedCluster() {
+        SdxCluster cluster = createClusterWithIdAndDeletedTimeStamp(1L);
+
+        when(sdxClusterRepository.findByAccountIdAndDeletedIsNull(any())).thenReturn(List.of(cluster));
+        when(sdxStatusService.findAllSdxClusterIdWhichHasDeletedState()).thenReturn(Collections.emptySet());
+
+        List<SdxCluster> result = underTest.listSdx(getTestUserCrn(), null);
+
+        assertNotNull(result);
+        assertEquals(1L, result.size());
+        assertEquals(cluster, result.get(0));
+
+        verify(sdxClusterRepository, times(0)).findByAccountIdAndEnvNameAndDeletedIsNull(any(), any());
+        verify(sdxClusterRepository, times(1)).findByAccountIdAndDeletedIsNull(any());
+        verify(sdxStatusService, times(1)).findAllSdxClusterIdWhichHasDeletedState();
+    }
+
+    @Test
+    @DisplayName("Test listSdx when the provided environment name is null and one cluster found which has DELETED status but has no deleted " +
+            "timestamp then it's going to be filtered out from the result list.")
+    void testListSdxWithEmptyEnvNameAndOneCorruptedCluster() {
+        SdxCluster actuallyRunningCluster = createClusterWithIdAndDeletedTimeStamp(1L);
+        SdxCluster corruptedCluster = createClusterWithIdAndDeletedTimeStamp(2L);
+
+        when(sdxClusterRepository.findByAccountIdAndDeletedIsNull(any())).thenReturn(List.of(actuallyRunningCluster, corruptedCluster));
+        when(sdxStatusService.findAllSdxClusterIdWhichHasDeletedState()).thenReturn(Set.of(corruptedCluster.getId()));
+
+        List<SdxCluster> result = underTest.listSdx(getTestUserCrn(), null);
+
+        assertNotNull(result);
+        assertEquals(1L, result.size());
+        assertEquals(actuallyRunningCluster, result.get(0));
+
+        verify(sdxClusterRepository, times(0)).findByAccountIdAndEnvNameAndDeletedIsNull(any(), any());
+        verify(sdxClusterRepository, times(1)).findByAccountIdAndDeletedIsNull(any());
+        verify(sdxStatusService, times(1)).findAllSdxClusterIdWhichHasDeletedState();
+    }
+
+    private SdxCluster createClusterWithIdAndDeletedTimeStamp(Long id) {
+        SdxCluster cluster = new SdxCluster();
+        cluster.setId(id);
+        cluster.setDeleted(null);
+        return cluster;
+    }
+
+}


### PR DESCRIPTION
it's merely a workaround for an edge case when the deletion timestamp has not set at the end of SDX cluster deletion. we weren't able to reproduce the root cause but with this, the designated environment could be stopped even if the timestamp is missing, and makes the handling of this deleted state more flexible.