### PR TITLE
CB-5557. Collect CM related service metrics.

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterSecurityService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterSecurityService.java
@@ -18,6 +18,8 @@ public interface ClusterSecurityService {
 
     void setupLdapAndSSO(String primaryGatewayPublicAddress, LdapView ldapConfig, VirtualGroupRequest virtualGroupRequest) throws CloudbreakException;
 
+    void setupMonitoringUser() throws CloudbreakException;
+
     String getCloudbreakClusterUserName();
 
     String getCloudbreakClusterPassword();

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/Features.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/Features.java
@@ -14,6 +14,9 @@ public class Features extends FeaturesBase {
     @JsonProperty("metering")
     private FeatureSetting metering;
 
+    @JsonProperty("monitoring")
+    private FeatureSetting monitoring;
+
     @JsonProperty("useSharedAltusCredential")
     private FeatureSetting useSharedAltusCredential;
 
@@ -23,6 +26,14 @@ public class Features extends FeaturesBase {
 
     public void setMetering(FeatureSetting metering) {
         this.metering = metering;
+    }
+
+    public FeatureSetting getMonitoring() {
+        return monitoring;
+    }
+
+    public void setMonitoring(FeatureSetting monitoring) {
+        this.monitoring = monitoring;
     }
 
     public FeatureSetting getUseSharedAltusCredential() {
@@ -37,6 +48,12 @@ public class Features extends FeaturesBase {
     public void addMetering(boolean enabled) {
         metering = new FeatureSetting();
         metering.setEnabled(enabled);
+    }
+
+    @JsonIgnore
+    public void addMonitoring(boolean enabled) {
+        monitoring = new FeatureSetting();
+        monitoring.setEnabled(enabled);
     }
 
     @JsonIgnore

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/Telemetry.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/Telemetry.java
@@ -75,6 +75,12 @@ public class Telemetry implements Serializable {
     }
 
     @JsonIgnore
+    public boolean isMonitoringFeatureEnabled() {
+        return features != null && features.getMonitoring() != null
+                && features.getMonitoring().isEnabled();
+    }
+
+    @JsonIgnore
     public boolean isClusterLogsCollectionEnabled() {
         return features != null && features.getClusterLogsCollection() != null
                 && features.getClusterLogsCollection().isEnabled();

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/TelemetryClusterDetails.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/TelemetryClusterDetails.java
@@ -1,11 +1,11 @@
-package com.sequenceiq.cloudbreak.telemetry.fluent;
+package com.sequenceiq.cloudbreak.telemetry;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.lang3.ObjectUtils;
 
-public class FluentClusterDetails {
+public class TelemetryClusterDetails {
 
     public static final String CLUSTER_CRN_KEY = "clusterCrn";
 
@@ -25,7 +25,7 @@ public class FluentClusterDetails {
 
     private final String version;
 
-    private FluentClusterDetails(Builder builder) {
+    private TelemetryClusterDetails(Builder builder) {
         this.name = builder.name;
         this.type = builder.type;
         this.crn = builder.crn;
@@ -90,8 +90,8 @@ public class FluentClusterDetails {
             return new Builder();
         }
 
-        public FluentClusterDetails build() {
-            return new FluentClusterDetails(this);
+        public TelemetryClusterDetails build() {
+            return new TelemetryClusterDetails(this);
         }
 
         public Builder withName(String name) {

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/TelemetryConfiguration.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/TelemetryConfiguration.java
@@ -14,12 +14,16 @@ public class TelemetryConfiguration {
 
     private final boolean meteringEnabled;
 
+    private final boolean monitoringEnabled;
+
     public TelemetryConfiguration(AltusDatabusConfiguration altusDatabusConfiguration,
             @Value("${cluster.logs.collection.enabled:false}") boolean clusterLogsCollection,
-            @Value("${metering.enabled:false}") boolean meteringEnabled) {
+            @Value("${metering.enabled:false}") boolean meteringEnabled,
+            @Value("${cluster.monitoring.enabled:false}") boolean monitoringEnabled) {
         this.altusDatabusConfiguration = altusDatabusConfiguration;
         this.clusterLogsCollection = clusterLogsCollection;
         this.meteringEnabled = meteringEnabled;
+        this.monitoringEnabled = monitoringEnabled;
     }
 
     public AltusDatabusConfiguration getAltusDatabusConfiguration() {
@@ -32,5 +36,9 @@ public class TelemetryConfiguration {
 
     public boolean isMeteringEnabled() {
         return meteringEnabled;
+    }
+
+    public boolean isMonitoringEnabled() {
+        return monitoringEnabled;
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigService.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.telemetry.TelemetryClusterDetails;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.AdlsGen2Config;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.AdlsGen2ConfigGenerator;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.S3Config;
@@ -42,12 +43,12 @@ public class FluentConfigService {
         this.adlsGen2ConfigGenerator = adlsGen2ConfigGenerator;
     }
 
-    public FluentConfigView createFluentConfigs(FluentClusterDetails clusterDetails,
+    public FluentConfigView createFluentConfigs(TelemetryClusterDetails clusterDetails,
             boolean databusEnabled, boolean meteringEnabled, Telemetry telemetry) {
         return createFluentConfigs(clusterDetails, databusEnabled, meteringEnabled, telemetry, null);
     }
 
-    public FluentConfigView createFluentConfigs(FluentClusterDetails clusterDetails,
+    public FluentConfigView createFluentConfigs(TelemetryClusterDetails clusterDetails,
             boolean databusEnabled, boolean meteringEnabled, Telemetry telemetry,
             List<AnonymizationRule> anonymizationRules) {
         final FluentConfigView.Builder builder = new FluentConfigView.Builder();

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigView.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigView.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.ObjectUtils;
 
+import com.sequenceiq.cloudbreak.telemetry.TelemetryClusterDetails;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryConfigView;
 import com.sequenceiq.common.api.telemetry.model.AnonymizationRule;
 
@@ -38,7 +39,7 @@ public class FluentConfigView implements TelemetryConfigView {
 
     private final boolean meteringEnabled;
 
-    private final FluentClusterDetails clusterDetails;
+    private final TelemetryClusterDetails clusterDetails;
 
     private final String user;
 
@@ -127,7 +128,7 @@ public class FluentConfigView implements TelemetryConfigView {
         return region;
     }
 
-    public FluentClusterDetails getClusterDetails() {
+    public TelemetryClusterDetails getClusterDetails() {
         return clusterDetails;
     }
 
@@ -250,7 +251,7 @@ public class FluentConfigView implements TelemetryConfigView {
 
         private boolean meteringEnabled;
 
-        private FluentClusterDetails clusterDetails;
+        private TelemetryClusterDetails clusterDetails;
 
         private String user;
 
@@ -402,7 +403,7 @@ public class FluentConfigView implements TelemetryConfigView {
             return this;
         }
 
-        public Builder withClusterDetails(FluentClusterDetails clusterDetails) {
+        public Builder withClusterDetails(TelemetryClusterDetails clusterDetails) {
             this.clusterDetails = clusterDetails;
             return this;
         }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringAuthConfig.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringAuthConfig.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.cloudbreak.telemetry.monitoring;
+
+public class MonitoringAuthConfig {
+
+    private final String username;
+
+    private final char[] password;
+
+    public MonitoringAuthConfig(String username, char[] password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public char[] getPassword() {
+        return password;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringClusterType.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringClusterType.java
@@ -1,0 +1,16 @@
+package com.sequenceiq.cloudbreak.telemetry.monitoring;
+
+public enum MonitoringClusterType {
+
+    CLOUDERA_MANAGER("cloudera_manager"), FREEIPA("freeipa");
+
+    private String value;
+
+    MonitoringClusterType(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return this.value;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfigService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfigService.java
@@ -1,0 +1,42 @@
+package com.sequenceiq.cloudbreak.telemetry.monitoring;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.telemetry.TelemetryClusterDetails;
+
+@Service
+public class MonitoringConfigService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MonitoringConfigService.class);
+
+    public MonitoringConfigView createMonitoringConfig(MonitoringClusterType clusterType,
+            MonitoringAuthConfig authConfig, TelemetryClusterDetails clusterDetails) {
+        final MonitoringConfigView.Builder builder = new MonitoringConfigView.Builder();
+        boolean enabled = false;
+        LOGGER.debug("Tyring to set monitoring configurations.");
+        if (clusterType != null) {
+            builder.withType(clusterType.value());
+        }
+        if (MonitoringClusterType.CLOUDERA_MANAGER.equals(clusterType)) {
+            LOGGER.debug("Setting up monitoring configurations for Cloudera Manager");
+            if (authConfig != null && authConfig.getPassword() != null
+                    && StringUtils.isNoneBlank(authConfig.getUsername(), new String(authConfig.getPassword()))) {
+                enabled = true;
+                builder
+                        .withCMUsername(authConfig.getUsername())
+                        .withCMPassword(authConfig.getPassword());
+                LOGGER.debug("Monitoring for Cloudera Manager has been setup correctly.");
+            } else {
+                LOGGER.debug("Monitoring for Cloudera Manager has invalid authentication configs, Monitoring will be disabled.");
+            }
+        }
+        return builder
+                .withEnabled(enabled)
+                .withClusterDetails(clusterDetails)
+                .build();
+    }
+
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfigView.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfigView.java
@@ -1,0 +1,107 @@
+package com.sequenceiq.cloudbreak.telemetry.monitoring;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.lang3.ObjectUtils;
+
+import com.sequenceiq.cloudbreak.telemetry.TelemetryClusterDetails;
+import com.sequenceiq.cloudbreak.telemetry.TelemetryConfigView;
+
+public class MonitoringConfigView implements TelemetryConfigView {
+
+    private static final String EMPTY_CONFIG_DEFAULT = "";
+
+    private final boolean enabled;
+
+    private final String type;
+
+    private final String cmUsername;
+
+    private final char[] cmPassword;
+
+    private final TelemetryClusterDetails clusterDetails;
+
+    private MonitoringConfigView(Builder builder) {
+        this.enabled = builder.enabled;
+        this.type = builder.type;
+        this.cmUsername = builder.cmUsername;
+        this.cmPassword = builder.cmPassword;
+        this.clusterDetails = builder.clusterDetails;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public String getCmUsername() {
+        return cmUsername;
+    }
+
+    public char[] getCmPassword() {
+        return cmPassword;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public TelemetryClusterDetails getClusterDetails() {
+        return clusterDetails;
+    }
+
+    @Override
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("enabled", this.enabled);
+        map.put("type", ObjectUtils.defaultIfNull(this.type, EMPTY_CONFIG_DEFAULT));
+        map.put("cmUsername", ObjectUtils.defaultIfNull(this.cmUsername, EMPTY_CONFIG_DEFAULT));
+        map.put("cmPassword", ObjectUtils.defaultIfNull(this.cmPassword, EMPTY_CONFIG_DEFAULT));
+        if (this.clusterDetails != null) {
+            map.putAll(clusterDetails.toMap());
+        }
+        return map;
+    }
+
+    public static final class Builder {
+
+        private boolean enabled;
+
+        private String type;
+
+        private String cmUsername;
+
+        private char[] cmPassword;
+
+        private TelemetryClusterDetails clusterDetails;
+
+        public MonitoringConfigView build() {
+            return new MonitoringConfigView(this);
+        }
+
+        public Builder withEnabled(boolean enabled) {
+            this.enabled = enabled;
+            return this;
+        }
+
+        public Builder withType(String type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder withCMUsername(String cmUsername) {
+            this.cmUsername = cmUsername;
+            return this;
+        }
+
+        public Builder withCMPassword(char[] cmPassword) {
+            this.cmPassword = cmPassword;
+            return this;
+        }
+
+        public Builder withClusterDetails(TelemetryClusterDetails clusterDetails) {
+            this.clusterDetails = clusterDetails;
+            return this;
+        }
+    }
+}

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.telemetry.TelemetryClusterDetails;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.AdlsGen2ConfigGenerator;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.S3ConfigGenerator;
 import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
@@ -22,8 +23,8 @@ public class FluentConfigServiceTest {
 
     private static final String PLATFORM_DEFAULT = "AWS";
 
-    private static final FluentClusterDetails DEFAULT_FLUENT_CLUSTER_DETAILS =
-            FluentClusterDetails.Builder.builder().withType(CLUSTER_TYPE_DEFAULT).withPlatform(PLATFORM_DEFAULT).build();
+    private static final TelemetryClusterDetails DEFAULT_FLUENT_CLUSTER_DETAILS =
+            TelemetryClusterDetails.Builder.builder().withType(CLUSTER_TYPE_DEFAULT).withPlatform(PLATFORM_DEFAULT).build();
 
     private FluentConfigService underTest;
 

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfigServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfigServiceTest.java
@@ -1,0 +1,43 @@
+package com.sequenceiq.cloudbreak.telemetry.monitoring;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.sequenceiq.cloudbreak.telemetry.TelemetryClusterDetails;
+
+public class MonitoringConfigServiceTest {
+
+    private MonitoringConfigService underTest;
+
+    @Before
+    public void setUp() {
+        underTest = new MonitoringConfigService();
+    }
+
+    @Test
+    public void testCreateMeteringConfigs() {
+        // GIVEN
+        MonitoringClusterType clusterType = MonitoringClusterType.CLOUDERA_MANAGER;
+        MonitoringAuthConfig authConfig = new MonitoringAuthConfig("user", "pass".toCharArray());
+        TelemetryClusterDetails clusterDetails = TelemetryClusterDetails.Builder.builder()
+                .withCrn("myCrn").build();
+        // WHEN
+        MonitoringConfigView result = underTest.createMonitoringConfig(clusterType, authConfig, clusterDetails);
+        // THEN
+        assertTrue(result.isEnabled());
+        assertEquals("myCrn", result.getClusterDetails().getCrn());
+    }
+
+    @Test
+    public void testCreateMeteringConfigsWithNulls() {
+        // GIVEN
+        // WHEN
+        MonitoringConfigView result = underTest.createMonitoringConfig(null, null, null);
+        // THEN
+        assertFalse(result.isEnabled());
+    }
+}

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/cluster/Cluster.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/cluster/Cluster.java
@@ -120,11 +120,19 @@ public class Cluster implements ProvisionEntity, WorkspaceAwareResource {
 
     @Convert(converter = SecretToString.class)
     @SecretValue
+    private Secret cloudbreakClusterManagerMonitoringUser = Secret.EMPTY;
+
+    @Convert(converter = SecretToString.class)
+    @SecretValue
     private Secret cloudbreakAmbariPassword = Secret.EMPTY;
 
     @Convert(converter = SecretToString.class)
     @SecretValue
     private Secret cloudbreakClusterManagerPassword = Secret.EMPTY;
+
+    @Convert(converter = SecretToString.class)
+    @SecretValue
+    private Secret cloudbreakClusterManagerMonitoringPassword = Secret.EMPTY;
 
     @Convert(converter = SecretToString.class)
     @SecretValue
@@ -462,6 +470,10 @@ public class Cluster implements ProvisionEntity, WorkspaceAwareResource {
         return getIfNotNull(cloudbreakClusterManagerUser, Secret::getSecret);
     }
 
+    public String getCloudbreakClusterManagerMonitoringUser() {
+        return getIfNotNull(cloudbreakClusterManagerMonitoringUser, Secret::getRaw);
+    }
+
     public void setCloudbreakAmbariUser(String cloudbreakAmbariUser) {
         this.cloudbreakAmbariUser = new Secret(cloudbreakAmbariUser);
     }
@@ -473,6 +485,10 @@ public class Cluster implements ProvisionEntity, WorkspaceAwareResource {
 
     public void setCloudbreakClusterManagerUser(String cloudbreakClusterManagerUser) {
         this.cloudbreakClusterManagerUser = new Secret(cloudbreakClusterManagerUser);
+    }
+
+    public void setCloudbreakClusterManagerMonitoringUser(String cloudbreakClusterManagerMonitoringUser) {
+        this.cloudbreakClusterManagerMonitoringUser = new Secret(cloudbreakClusterManagerMonitoringUser);
     }
 
     public String getCloudbreakAmbariPassword() {
@@ -491,6 +507,10 @@ public class Cluster implements ProvisionEntity, WorkspaceAwareResource {
         return getIfNotNull(cloudbreakClusterManagerPassword, Secret::getSecret);
     }
 
+    public String getCloudbreakClusterManagerMonitoringPassword() {
+        return getIfNotNull(cloudbreakClusterManagerMonitoringPassword, Secret::getRaw);
+    }
+
     public void setCloudbreakAmbariPassword(String cloudbreakAmbariPassword) {
         this.cloudbreakAmbariPassword = new Secret(cloudbreakAmbariPassword);
     }
@@ -502,6 +522,10 @@ public class Cluster implements ProvisionEntity, WorkspaceAwareResource {
 
     public void setCloudbreakClusterManagerPassword(String password) {
         cloudbreakClusterManagerPassword = new Secret(password);
+    }
+
+    public void setCloudbreakClusterManagerMonitoringPassword(String cloudbreakClusterManagerMonitoringPassword) {
+        this.cloudbreakClusterManagerMonitoringPassword = new Secret(cloudbreakClusterManagerMonitoringPassword);
     }
 
     public String getDpAmbariUser() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
@@ -47,6 +47,8 @@ public class TelemetryConverter {
 
     private final boolean meteringEnabled;
 
+    private final boolean monitoringEnabled;
+
     private final boolean clusterLogsCollection;
 
     private final boolean useSharedAltusCredential;
@@ -59,6 +61,7 @@ public class TelemetryConverter {
         this.databusEndpoint = configuration.getAltusDatabusConfiguration().getAltusDatabusEndpoint();
         this.useSharedAltusCredential = configuration.getAltusDatabusConfiguration().isUseSharedAltusCredential();
         this.meteringEnabled = configuration.isMeteringEnabled();
+        this.monitoringEnabled = configuration.isMonitoringEnabled();
         this.clusterLogsCollection = configuration.isClusterLogsCollection();
     }
 
@@ -83,7 +86,6 @@ public class TelemetryConverter {
         if (request != null) {
             Logging logging = createLoggingFromRequest(request);
             WorkloadAnalytics workloadAnalytics = createWorkloadAnalyticsFromRequest(request);
-            telemetry = new Telemetry();
             telemetry.setLogging(logging);
             telemetry.setWorkloadAnalytics(workloadAnalytics);
             setWorkloadAnalyticsFeature(telemetry, features);
@@ -91,7 +93,12 @@ public class TelemetryConverter {
             setUseSharedAltusCredential(features);
             telemetry.setFluentAttributes(request.getFluentAttributes());
         }
+        if (monitoringEnabled) {
+            LOGGER.debug("Cluster level monitoring feature is enabled");
+            features.addMonitoring(true);
+        }
         setMeteringFeature(type, features);
+
         if (StringUtils.isNotEmpty(databusEndpoint)) {
             LOGGER.debug("Setting databus endpoint: {}", databusEndpoint);
             telemetry.setDatabusEndpoint(databusEndpoint);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cluster/ClusterV4RequestToClusterConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cluster/ClusterV4RequestToClusterConverter.java
@@ -60,6 +60,9 @@ public class ClusterV4RequestToClusterConverter extends AbstractConversionServic
     @Value("${cb.cm.mgmt.username:cmmgmt}")
     private String cmMgmtUsername;
 
+    @Value("${cb.cm.monitoring.username:cmmonitoring}")
+    private String cmMonitoringUser;
+
     @Inject
     private CloudStorageValidationUtil cloudStorageValidationUtil;
 
@@ -86,6 +89,8 @@ public class ClusterV4RequestToClusterConverter extends AbstractConversionServic
         cluster.setExecutorType(source.getExecutorType());
         cluster.setCloudbreakUser(ambariUserName);
         cluster.setCloudbreakPassword(PasswordUtil.generatePassword());
+        cluster.setCloudbreakClusterManagerMonitoringUser(cmMonitoringUser);
+        cluster.setCloudbreakClusterManagerMonitoringPassword(PasswordUtil.generatePassword());
         cluster.setDpUser(cmMgmtUsername);
         cluster.setDpPassword(PasswordUtil.generatePassword());
         cluster.setDatabaseServerCrn(source.getDatabaseServerCrn());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterBuilderService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterBuilderService.java
@@ -40,6 +40,7 @@ import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterCreationSuccessHandler;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
 import com.sequenceiq.cloudbreak.service.cluster.flow.recipe.RecipeEngine;
+import com.sequenceiq.cloudbreak.service.cluster.flow.telemetry.ClusterMonitoringEngine;
 import com.sequenceiq.cloudbreak.service.datalake.DatalakeResourcesService;
 import com.sequenceiq.cloudbreak.service.hostgroup.HostGroupService;
 import com.sequenceiq.cloudbreak.service.proxy.ProxyConfigDtoService;
@@ -88,6 +89,9 @@ public class ClusterBuilderService {
 
     @Inject
     private RecipeEngine recipeEngine;
+
+    @Inject
+    private ClusterMonitoringEngine clusterMonitoringEngine;
 
     @Inject
     private BlueprintUtils blueprintUtils;
@@ -154,6 +158,10 @@ public class ClusterBuilderService {
         String sdxStackCrn = sdxStack
                 .map(Stack::getResourceCrn)
                 .orElse(null);
+        if (telemetry.isMonitoringFeatureEnabled()) {
+            connector.clusterSecurityService().setupMonitoringUser();
+            clusterMonitoringEngine.installAndStartMonitoring(stack, telemetry);
+        }
 
         KerberosConfig kerberosConfig = kerberosConfigService.get(stack.getEnvironmentCrn(), stack.getName()).orElse(null);
         String template = connector.clusterSetupService().prepareTemplate(instanceMetaDataByHostGroup,

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/telemetry/ClusterMonitoringEngine.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/telemetry/ClusterMonitoringEngine.java
@@ -1,0 +1,53 @@
+package com.sequenceiq.cloudbreak.service.cluster.flow.telemetry;
+
+import static com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterDeletionBasedExitCriteriaModel.clusterDeletionBasedModel;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.cloudbreak.orchestrator.model.Node;
+import com.sequenceiq.cloudbreak.service.CloudbreakException;
+import com.sequenceiq.cloudbreak.service.GatewayConfigService;
+import com.sequenceiq.common.api.telemetry.model.Telemetry;
+
+@Component
+public class ClusterMonitoringEngine {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterMonitoringEngine.class);
+
+    private final HostOrchestrator hostOrchestrator;
+
+    private final GatewayConfigService gatewayConfigService;
+
+    public ClusterMonitoringEngine(HostOrchestrator hostOrchestrator, GatewayConfigService gatewayConfigService) {
+        this.hostOrchestrator = hostOrchestrator;
+        this.gatewayConfigService = gatewayConfigService;
+    }
+
+    public void installAndStartMonitoring(Stack stack, Telemetry telemetry) throws CloudbreakException {
+        if (telemetry != null && telemetry.isMonitoringFeatureEnabled()) {
+            try {
+                LOGGER.info("Install and start monitoring for CM server.");
+                Set<InstanceMetaData> instanceMetaDataSet = stack.getNotDeletedInstanceMetaDataSet();
+                List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
+                Set<Node> allNodes = instanceMetaDataSet.stream()
+                        .map(im -> new Node(im.getPrivateIp(), im.getPublicIp(), im.getInstanceId(),
+                                im.getInstanceGroup().getTemplate().getInstanceType(), im.getDiscoveryFQDN(), im.getInstanceGroup().getGroupName()))
+                        .collect(Collectors.toSet());
+                hostOrchestrator.installAndStartMonitoring(gatewayConfigs, allNodes, clusterDeletionBasedModel(stack.getId(), stack.getCluster().getId()));
+            } catch (CloudbreakOrchestratorFailedException ex) {
+                throw new CloudbreakException(ex);
+            }
+        }
+    }
+}

--- a/core/src/main/resources/schema/app/20200302141501_CB-5557_CM_collect_metrics.sql
+++ b/core/src/main/resources/schema/app/20200302141501_CB-5557_CM_collect_metrics.sql
@@ -1,0 +1,11 @@
+-- // CB-5557 Collect CM related metrics
+-- Migration SQL that makes the change goes here.
+
+alter table cluster add COLUMN cloudbreakClusterManagerMonitoringUser varchar(255);
+alter table cluster add COLUMN cloudbreakClusterManagerMonitoringPassword varchar(255);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+alter table cluster drop COLUMN cloudbreakClusterManagerMonitoringUser;
+alter table cluster drop COLUMN cloudbreakClusterManagerMonitoringPassword;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
@@ -40,7 +40,7 @@ public class TelemetryConverterTest {
     @Before
     public void setUp() {
         AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, true, "****", "****");
-        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true);
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true, true);
         underTest = new TelemetryConverter(telemetryConfiguration, true, true);
     }
 
@@ -77,6 +77,7 @@ public class TelemetryConverterTest {
         assertNotNull(result.getFeatures().getWorkloadAnalytics());
         assertFalse(result.getFeatures().getClusterLogsCollection().isEnabled());
         assertTrue(result.getFeatures().getMetering().isEnabled());
+        assertTrue(result.getFeatures().getMonitoring().isEnabled());
         assertTrue(result.getFeatures().getWorkloadAnalytics().isEnabled());
         assertTrue(result.getFeatures().getUseSharedAltusCredential().isEnabled());
         assertEquals(DATABUS_ENDPOINT, result.getDatabusEndpoint());
@@ -172,7 +173,7 @@ public class TelemetryConverterTest {
         // GIVEN
         SdxClusterResponse sdxClusterResponse = null;
         AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, false, "", null);
-        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true);
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true, false);
         TelemetryConverter converter = new TelemetryConverter(telemetryConfiguration, true, false);
         // WHEN
         TelemetryRequest result = converter.convert(null, sdxClusterResponse);
@@ -243,7 +244,7 @@ public class TelemetryConverterTest {
         sdxClusterResponse.setCrn("crn:cdp:cloudbreak:us-west-1:someone:sdxcluster:sdxId");
         sdxClusterResponse.setName("sdxName");
         AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, false, "", null);
-        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true);
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true, false);
         TelemetryConverter converter = new TelemetryConverter(telemetryConfiguration, false, true);
         // WHEN
         TelemetryRequest result = converter.convert(response, sdxClusterResponse);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/flow/telemetry/ClusterMonitoringEngineTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/flow/telemetry/ClusterMonitoringEngineTest.java
@@ -1,0 +1,105 @@
+package com.sequenceiq.cloudbreak.service.cluster.flow.telemetry;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.sequenceiq.cloudbreak.domain.Template;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.orchestrator.state.ExitCriteriaModel;
+import com.sequenceiq.cloudbreak.service.GatewayConfigService;
+import com.sequenceiq.common.api.telemetry.model.Features;
+import com.sequenceiq.common.api.telemetry.model.Telemetry;
+
+public class ClusterMonitoringEngineTest {
+
+    @InjectMocks
+    private ClusterMonitoringEngine underTest;
+
+    @Mock
+    private HostOrchestrator hostOrchestrator;
+
+    @Mock
+    private GatewayConfigService gatewayConfigService;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        underTest = new ClusterMonitoringEngine(hostOrchestrator, gatewayConfigService);
+    }
+
+    @Test
+    public void testInstallAndStartMonitoring() throws Exception {
+        // GIVEN
+        doNothing().when(hostOrchestrator).installAndStartMonitoring(anyList(), anySet(), any(ExitCriteriaModel.class));
+        // WHEN
+        underTest.installAndStartMonitoring(createStack(), createTelemetry());
+        // THEN
+        verify(hostOrchestrator, times(1)).installAndStartMonitoring(anyList(), anySet(), any(ExitCriteriaModel.class));
+    }
+
+    @Test
+    public void testInstallAndStartMonitoringThrowsException() throws Exception {
+        // GIVEN
+        given(gatewayConfigService.getAllGatewayConfigs(any(Stack.class))).willReturn(null);
+        doThrow(new CloudbreakOrchestratorFailedException("error")).when(hostOrchestrator).installAndStartMonitoring(
+                anyList(), anySet(), any(ExitCriteriaModel.class));
+        // WHEN
+        underTest.installAndStartMonitoring(createStack(), createTelemetry());
+        // THEN
+        verify(gatewayConfigService, times(1)).getAllGatewayConfigs(any(Stack.class));
+    }
+
+    private Telemetry createTelemetry() {
+        Telemetry telemetry = new Telemetry();
+        Features features = new Features();
+        features.addMonitoring(true);
+        telemetry.setFeatures(features);
+        return telemetry;
+    }
+
+    private Stack createStack() {
+        Stack stack = new Stack();
+        stack.setId(1L);
+        InstanceGroup instanceGroup = new InstanceGroup();
+        instanceGroup.setInstanceMetaData(createInstanceMetadataSet());
+        instanceGroup.setTemplate(new Template());
+        stack.setInstanceGroups(Set.of(instanceGroup));
+        Cluster cluster = new Cluster();
+        cluster.setId(1L);
+        stack.setCluster(cluster);
+        return stack;
+    }
+
+    private Set<InstanceMetaData> createInstanceMetadataSet() {
+        Set<InstanceMetaData> instanceMetaDataSet = new HashSet<>();
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+        instanceMetaData.setId(1L);
+        InstanceGroup instanceGroup = new InstanceGroup();
+        Template template = new Template();
+        instanceGroup.setTemplate(template);
+        instanceMetaData.setInstanceGroup(instanceGroup);
+        instanceMetaDataSet.add(instanceMetaData);
+        return instanceMetaDataSet;
+    }
+
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
@@ -28,7 +28,7 @@ import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.idbmms.GrpcIdbmmsClient;
 import com.sequenceiq.cloudbreak.idbmms.exception.IdbmmsOperationException;
 import com.sequenceiq.cloudbreak.idbmms.model.MappingsConfig;
-import com.sequenceiq.cloudbreak.telemetry.fluent.FluentClusterDetails;
+import com.sequenceiq.cloudbreak.telemetry.TelemetryClusterDetails;
 import com.sequenceiq.cloudbreak.telemetry.fluent.FluentConfigView;
 import com.sequenceiq.cloudbreak.util.PasswordUtil;
 import com.sequenceiq.common.api.cloudstorage.AccountMappingBase;
@@ -195,8 +195,8 @@ public class StackRequestManifester {
             }
             if (envTelemetry.getFluentAttributes() != null) {
                 Map<String, Object> fluentAttributes = envTelemetry.getFluentAttributes();
-                if (!fluentAttributes.containsKey(FluentClusterDetails.CLUSTER_CRN_KEY)) {
-                    fluentAttributes.put(FluentClusterDetails.CLUSTER_CRN_KEY, sdxCluster.getCrn());
+                if (!fluentAttributes.containsKey(TelemetryClusterDetails.CLUSTER_CRN_KEY)) {
+                    fluentAttributes.put(TelemetryClusterDetails.CLUSTER_CRN_KEY, sdxCluster.getCrn());
                 }
                 addAzureIdbrokerMsiToTelemetry(fluentAttributes, stackV4Request);
                 telemetryRequest.setFluentAttributes(fluentAttributes);

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/TelemetryApiConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/TelemetryApiConverterTest.java
@@ -33,7 +33,7 @@ public class TelemetryApiConverterTest {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration("", true, "****", "****");
-        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true);
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true, false);
         underTest = new TelemetryApiConverter(telemetryConfiguration);
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaInstallService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaInstallService.java
@@ -24,7 +24,7 @@ import com.sequenceiq.cloudbreak.orchestrator.model.SaltConfig;
 import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
 import com.sequenceiq.cloudbreak.telemetry.databus.DatabusConfigService;
 import com.sequenceiq.cloudbreak.telemetry.databus.DatabusConfigView;
-import com.sequenceiq.cloudbreak.telemetry.fluent.FluentClusterDetails;
+import com.sequenceiq.cloudbreak.telemetry.TelemetryClusterDetails;
 import com.sequenceiq.cloudbreak.telemetry.fluent.FluentClusterType;
 import com.sequenceiq.cloudbreak.telemetry.fluent.FluentConfigService;
 import com.sequenceiq.cloudbreak.telemetry.fluent.FluentConfigView;
@@ -130,7 +130,7 @@ public class FreeIpaInstallService {
         Telemetry telemetry = stack.getTelemetry();
         if (telemetry != null) {
             boolean databusEnabled = telemetry.isClusterLogsCollectionEnabled();
-            final FluentClusterDetails clusterDetails = FluentClusterDetails.Builder.builder()
+            final TelemetryClusterDetails clusterDetails = TelemetryClusterDetails.Builder.builder()
                     .withOwner(stack.getOwner())
                     .withName(stack.getName())
                     .withType(FluentClusterType.FREEIPA.value())

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverterTest.java
@@ -28,7 +28,7 @@ public class TelemetryConverterTest {
     @BeforeEach
     public void setUp() {
         AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, false, "", null);
-        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true);
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true, false);
         underTest = new TelemetryConverter(telemetryConfiguration, true);
     }
 

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
@@ -84,6 +84,9 @@ public interface HostOrchestrator extends HostRecipeExecutor {
     void stopTelemetryAgent(List<GatewayConfig> allGateway, Set<Node> nodes, ExitCriteriaModel exitCriteriaModel)
             throws CloudbreakOrchestratorFailedException;
 
+    void installAndStartMonitoring(List<GatewayConfig> allGateway, Set<Node> nodes, ExitCriteriaModel exitModel)
+            throws CloudbreakOrchestratorFailedException;
+
     void stopClusterManagerAgent(GatewayConfig gatewayConfig, Set<Node> nodes, ExitCriteriaModel exitCriteriaModel, boolean adJoinable, boolean ipaJoinable)
             throws CloudbreakOrchestratorFailedException;
 

--- a/orchestrator-salt/src/main/resources/salt-common/pillar/monitoring/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/pillar/monitoring/init.sls
@@ -1,0 +1,9 @@
+monitoring:
+  enabled: false
+  type:
+  platform:
+  clusterCrn:
+  clusterName:
+  clusterType:
+  clusterVersion:
+  clusterOwner:

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/init.sls
@@ -1,0 +1,114 @@
+{%- from 'monitoring/settings.sls' import monitoring with context %}
+
+{% if monitoring.enabled %}
+
+/opt/metrics-collector:
+  file.directory:
+    - name: /opt/metrics-collector
+    - user: "root"
+    - group: "root"
+    - mode: 755
+    - recurse:
+      - user
+      - group
+      - mode
+
+/etc/metrics-collector:
+  file.directory:
+    - name: /etc/metrics-collector
+    - user: "root"
+    - group: "root"
+    - mode: 755
+
+/etc/metrics-collector/conf:
+  file.directory:
+    - name: /etc/metrics-collector/conf
+    - user: "root"
+    - group: "root"
+    - mode: 740
+
+/var/log/metrics-collector:
+  file.directory:
+    - name: /var/log/metrics-collector
+    - user: "root"
+    - group: "root"
+    - mode: 740
+
+install_pyyaml:
+  cmd.run:
+    - name: pip install PyYAML --ignore-installed
+    - unless: pip list | grep -E 'PyYAML'
+
+{%- if monitoring.type == "cloudera_manager" %}
+install_cm_client:
+  cmd.run:
+    - name: pip install cm-client==40.0.3 --ignore-installed
+    - unless: pip list | grep -E 'cm-client.*40.0.3'
+
+/opt/metrics-collector/cm_metrics_collector.py:
+   file.managed:
+    - source: salt://monitoring/scripts/cm_metrics_collector.py
+    - user: "root"
+    - group: "root"
+    - mode: 740
+{% endif %}
+
+/opt/metrics-collector/metrics_collector.py:
+   file.managed:
+    - source: salt://monitoring/scripts/metrics_collector.py
+    - user: "root"
+    - group: "root"
+    - mode: 740
+
+/opt/metrics-collector/metrics_logger.py:
+   file.managed:
+    - source: salt://monitoring/scripts/metrics_logger.py
+    - user: "root"
+    - group: "root"
+    - mode: 740
+
+/opt/metrics-collector/retry.py:
+   file.managed:
+    - source: salt://monitoring/scripts/retry.py
+    - user: "root"
+    - group: "root"
+    - mode: 740
+
+{%- if monitoring.type == "cloudera_manager" %}
+/etc/metrics-collector/conf/metrics-collector.yaml:
+   file.managed:
+    - source: salt://monitoring/template/metrics-collector.yaml.j2
+    - template: jinja
+    - user: "root"
+    - group: "root"
+    - mode: 600
+
+{% endif %}
+
+{%- if monitoring.is_systemd %}
+/etc/systemd/system/metrics-collector.service:
+   file.managed:
+    - source: salt://monitoring/template/metrics-collector.service.j2
+    - template: jinja
+    - user: "root"
+    - group: "root"
+    - mode: 600
+
+{%- if monitoring.type == "cloudera_manager" %}
+/etc/systemd/system/metrics-collector.d:
+  file.directory:
+    - name: /etc/systemd/system/metrics-collector.d
+    - user: "root"
+    - group: "root"
+    - mode: 740
+{% endif %}
+start_monitoring:
+  service.running:
+    - enable: True
+    - name: metrics-collector
+    - watch:
+       - file: /etc/systemd/system/metrics-collector.service
+{% endif %}
+
+{% endif %}
+

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/scripts/metrics_collector.py
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/scripts/metrics_collector.py
@@ -1,0 +1,32 @@
+import argparse
+import logging
+import time
+import uuid
+import sys
+import yaml
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Python script to generate periodic metrics from a source '
+                    'metrics collector')
+    parser.add_argument('--config', type=str, required=True,
+                        help='Path to metrics collector configuration')
+    args = parser.parse_args()
+    return args
+
+def main():
+    args = parse_args()
+    with open(args.config) as file:
+        config = yaml.load(file)
+        if "clouderaManager" in config:
+            from cm_metrics_collector import ClouderaManagerMetricsCollector
+            ClouderaManagerMetricsCollector(config).start()
+        elif "freeIpa" in config:
+            # TODO
+            pass
+        else:
+            print "Configuration should contain Cloudera Manager or FreeIPA section. Exiting ..."
+            sys.exit(1)
+
+if __name__ == '__main__':
+   main()

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/scripts/metrics_logger.py
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/scripts/metrics_logger.py
@@ -1,0 +1,20 @@
+import json
+import logging
+from logging.handlers import RotatingFileHandler
+
+class MetricsLogger:
+    def __init__(self, name, path, max_bytes, backup_count, debug=False):
+        fmt = '%(message)s'
+        logging.basicConfig(
+                 level=logging.INFO,
+                 format=fmt,
+        )
+        formatter = logging.Formatter(fmt)
+        handler = RotatingFileHandler(path, maxBytes=max_bytes, backupCount=backup_count, mode='a')
+        handler.setLevel(logging.INFO)
+        handler.setFormatter(formatter)
+        self.metrics_logger = logging.getLogger(name)
+        self.metrics_logger.addHandler(handler)
+
+    def process(self, event):
+        self.metrics_logger.info(json.dumps(event))

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/scripts/retry.py
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/scripts/retry.py
@@ -1,0 +1,17 @@
+import time
+import traceback
+
+def retry(func, *args, **kwargs):
+  delay = kwargs.pop("delay", 10)
+  context = kwargs.pop("context", "")
+  logger = kwargs.pop("logger")
+  while True:
+    try:
+      func(*args, **kwargs)
+      return
+    except Exception as e:
+      if logger:
+        logger.error("Error occurred during {0} operation: {1}".format(context, str(traceback.format_exc())))
+    if logger:
+      logger.info("{0}: waiting {1} seconds before retyring again.".format(context, delay))
+    time.sleep(delay)

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/settings.sls
@@ -1,0 +1,45 @@
+{% set monitoring = {} %}
+
+{% if salt['pillar.get']('monitoring:enabled') %}
+    {% set monitoring_enabled = True %}
+{% else %}
+    {% set monitoring_enabled = False %}
+{% endif %}
+
+{% if grains['init'] == 'upstart' %}
+    {% set is_systemd = False %}
+{% else %}
+    {% set is_systemd = True %}
+{% endif %}
+
+{% set platform = salt['pillar.get']('monitoring:platform') %}
+{% set type = salt['pillar.get']('monitoring:type') %}
+{% set cm_username = salt['pillar.get']('monitoring:cmUsername') %}
+{% set cm_password = salt['pillar.get']('monitoring:cmPassword') %}
+
+{% if salt['pillar.get']('monitoring:clusterType') == "datalake" %}
+  {% set cm_cluster_type = "BASE_CLUSTER" %}
+{% else %}
+  {% set cm_cluster_type = "COMPUTE_CLUSTER" %}
+{% endif %}
+
+{% set cluster_crn = salt['pillar.get']('monitoring:clusterCrn') %}
+{% set cluster_name = salt['pillar.get']('monitoring:clusterName') %}
+{% set cluster_version = salt['pillar.get']('monitoring:clusterVersion') %}
+{% set cluster_type = salt['pillar.get']('monitoring:clusterType') %}
+{% set cluster_owner = salt['pillar.get']('monitoring:clusterOwner') %}
+
+{% do monitoring.update({
+    "enabled": monitoring_enabled,
+    "is_systemd": is_systemd,
+    "type": type,
+    "platform": platform,
+    "cmUsername": cm_username,
+    "cmPassword": cm_password,
+    "cmClusterType": cm_cluster_type,
+    "clusterCrn": cluster_crn,
+    "clusterName": cluster_name,
+    "clusterVersion": cluster_version,
+    "clusterType": cluster_type,
+    "clusterOwner": cluster_owner
+}) %}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/template/metrics-collector.service.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/template/metrics-collector.service.j2
@@ -1,0 +1,22 @@
+{%- from 'monitoring/settings.sls' import monitoring with context %}
+[Unit]
+{% if monitoring.type == "cloudera_manager" %}
+After=cloudera-scm-server.service
+Description=Metrics Collector service for Cloudera Manager
+{% else %}
+Description=Metrics Collector service for FreeIPA
+{% endif %}
+
+[Service]
+Type=simple
+Restart=always
+ExecStart=/usr/bin/python2 /opt/metrics-collector/metrics_collector.py --config /etc/metrics-collector/conf/metrics-collector.yaml
+PIDFile=/var/run/metrics-collector.pid
+RestartSec=5
+TimeoutStopSec=5
+SyslogIdentifier=​metrics_collector
+ExecStop=/bin/kill $MAINPID
+SuccessExitStatus=1 143
+
+[Install]
+WantedBy=multi-user.target

--- a/orchestrator-salt/src/main/resources/salt/pillar/top.sls
+++ b/orchestrator-salt/src/main/resources/salt/pillar/top.sls
@@ -65,6 +65,7 @@ base:
     - gateway.init
     - gateway.ldap
     - gateway.settings
+    - monitoring.init
 
   'roles:knox_gateway':
     - match: grain

--- a/orchestrator-salt/src/main/resources/salt/salt/monitoring/scripts/cm_metrics_collector.py
+++ b/orchestrator-salt/src/main/resources/salt/salt/monitoring/scripts/cm_metrics_collector.py
@@ -1,0 +1,222 @@
+import cm_client
+import os
+import json
+import logging
+import signal
+import socket
+import sys
+import time
+import datetime
+import traceback
+from cm_client.rest import ApiException
+from pprint import pprint
+from threading import Timer
+from logging.handlers import RotatingFileHandler
+from metrics_logger import MetricsLogger
+
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+class ClouderaManagerMetricsCollector:
+
+    def __init__(self, config):
+        self.config = config
+        self.logger = logging.getLogger('ClouderaManagerMetricsCollector')
+        self._setup_logging(config)
+        self.logger.info("Load configuration: " + str(config))
+        self.cluster = None
+        self.services = []
+        self.availableMetrics = {}
+        self.serviceMetricsMapFromConfig = {}
+        self._create_service_metrics_map()
+        self._setup_termination_handler()
+        self._setup_metrics_processor(config)
+        self._setup_health_check_metrics_processor(config)
+        cm_client.configuration.username = config["clouderaManager"]["user"]
+        cm_client.configuration.password = config["clouderaManager"]["password"]
+        cm_client.configuration.verify_ssl = False
+        self.cluster_type = config["clouderaManager"]["clusterType"]
+        if socket.gethostname().find('.') >= 0:
+            api_host = socket.gethostname()
+        else:
+            api_host = socket.gethostbyaddr(socket.gethostname())[0]
+        protocol = config["clouderaManager"]["protocol"]
+        port = config["clouderaManager"]["port"]
+        api_version = config["clouderaManager"]["apiVersion"]
+        api_url = protocol + "://" + api_host + ':' + port + '/api/' + api_version
+        self.api_client = cm_client.ApiClient(api_url)
+        self.logger.info("Cloudera Manager Api URL: " + api_url)
+        metrics_api_url = protocol + "://" + api_host + ':' + port + '/api/v5'
+        self.metrics_api_client = cm_client.ApiClient(metrics_api_url)
+        self.logger.info("Cloudera Manager Metrics Api URL: " + metrics_api_url)
+        self.globalFields = config["globalFields"]
+
+    def start(self):
+        self.logger.info("Starting Cloudera Manager Metrics Collector daemon.")
+        self._get_cluster_periodically(self.config['config']['availableClusterUpdatePeriod'])
+        self._get_services_periodically(self.config['config']['availableServicesUpdatePeriod'])
+        self._get_available_metrics_periodically(self.config['config']['availableMetricsUpdatePeriod'] )
+        self._get_metrics_periodically(self.config['config']['metricsCollectPeriod'] )
+
+    def _get_cluster_periodically(self, period):
+        from retry import retry
+        retry(self._get_cluster, logger=self.logger, context="Gather cluster details", delay=30)
+        timer = Timer(period, self._get_cluster_periodically, args=[period])
+        timer.start()
+
+    def _get_services_periodically(self, period):
+        try:
+            self._get_services()
+        except Exception as e:
+            self.logger.error("Error occurred during get_services operation: %s" % str(traceback.format_exc()))
+        timer = Timer(period, self._get_services_periodically, args=[period])
+        timer.start()
+
+    def _get_available_metrics_periodically(self, period):
+        try:
+            self._get_available_metrics()
+        except Exception as e:
+            self.logger.error("Error occurred during get_available_metric operation: %s" % str(traceback.format_exc()))
+        timer = Timer(period, self._get_available_metrics_periodically, args=[period])
+        timer.start()
+
+    def _get_metrics_periodically(self, period):
+        try:
+            self._get_metrics()
+        except Exception as e:
+            self.logger.error("Error occurred during get_metrics operation: %s" % str(traceback.format_exc()))
+        timer = Timer(period, self._get_metrics_periodically, args=[period])
+        timer.start()
+
+    def _get_metrics(self):
+        ts_api_instance = cm_client.TimeSeriesResourceApi(self.api_client)
+        from_time = datetime.datetime.fromtimestamp(time.time() - 180000)
+        to_time = datetime.datetime.fromtimestamp(time.time())
+        if self.services:
+            for service in self.services:
+                metrics_list = self._get_common_service_metrics(service.name)
+                if metrics_list:
+                    tsquery = self._create_metrics_tsquery(service.name, metrics_list)
+                    result = ts_api_instance.query_time_series(_from=from_time, query=tsquery, to=to_time)
+                    if result:
+                        ts_list = result.items[0]
+                        for ts in ts_list.time_series:
+                            metric_event = {}
+                            metric_event["serviceName"] = service.name
+                            metric_event["serviceType"] = service.type
+                            metric_event["name"] = ts.metadata.metric_name
+                            metric_event["longName"] = service.name + "." + ts.metadata.metric_name
+                            for point in ts.data:
+                                d = datetime.datetime.strptime(point.timestamp, "%Y-%m-%dT%H:%M:%S.%fZ")
+                                unixtime = time.mktime(d.timetuple())
+                                metric_event["timestamp"] = unixtime
+                                metric_event["value"] = point.value
+                            self.metrics_processor.process(self._append_global_fields(metric_event))
+
+    def _create_metrics_tsquery(self, service_name, metrics):
+        joined_metrics=', '.join(metrics)
+        return "select %s where serviceName=%s and category = \"SERVICE\"" % (joined_metrics, service_name)
+
+    def _get_common_service_metrics(self, service_name):
+        common_service_metrics = []
+        if service_name in self.serviceMetricsMapFromConfig:
+            service_metrics_from_config = self.serviceMetricsMapFromConfig[service_name]
+            if service_name in self.availableMetrics:
+                available_metrics_for_service = self.availableMetrics[service_name]
+                if available_metrics_for_service:
+                    for service_metric in service_metrics_from_config:
+                         if service_metric in available_metrics_for_service:
+                            common_service_metrics.append(service_metric)
+        return common_service_metrics
+
+    def _get_cluster(self):
+        cluster_api_instance = cm_client.ClustersResourceApi(self.api_client)
+        api_response = cluster_api_instance.read_clusters(view='SUMMARY',  _request_timeout = 20.0)
+        clusterResponse = None
+        for cluster in api_response.items:
+            if cluster.cluster_type == self.cluster_type:
+                clusterResponse = cluster
+        if clusterResponse:
+            self.cluster = clusterResponse
+        else:
+            raise Exception("Not found any clusters yet.")
+
+    def _get_services(self):
+        services_api_instance = cm_client.ServicesResourceApi(self.api_client)
+        api_response = services_api_instance.read_services(self.cluster.name, view='FULL')
+        self.services = api_response.items
+        if self.services:
+            for service in self.services:
+                if service.health_checks:
+                    for health_check in service.health_checks:
+                        health_check_event = {}
+                        health_check_event["serviceName"] = service.name
+                        health_check_event["serviceType"] = service.type
+                        health_check_event["explanation"] = health_check.explanation
+                        health_check_event["name"] = health_check.name
+                        health_check_event["value"] = health_check.summary
+                        health_check_event["timestamp"] = time.time()
+                        self.health_checks_processor.process(self._append_global_fields(health_check_event))
+
+    def _create_service_metrics_map(self):
+        services = self.config["services"]
+        for service in services:
+            name = service["name"]
+            metrics = service["metrics"]
+            self.serviceMetricsMapFromConfig[name] = metrics
+
+    def _get_available_metrics(self):
+       if self.services:
+          new_available_metrics_map = {}
+          for service in self.services:
+              services_api_instance = cm_client.ServicesResourceApi(self.metrics_api_client)
+              metrics_api_response = services_api_instance.get_metrics(self.cluster.name, service.name)
+              new_metrics_list = []
+              for m in metrics_api_response.items:
+                 if m.data:
+                    new_metrics_list.append(m.name)
+              new_available_metrics_map[service.name] = new_metrics_list
+          self.availableMetrics = new_available_metrics_map
+
+    def _setup_metrics_processor(self, config):
+        name = config["jsonMetricsLogger"]['name']
+        path = config["jsonMetricsLogger"]['path']
+        max_bytes = config["jsonMetricsLogger"]['max_bytes']
+        backup_count = config["jsonMetricsLogger"]['backup_count']
+        self.metrics_processor = MetricsLogger(name, path, max_bytes, backup_count)
+
+    def _setup_health_check_metrics_processor(self, config):
+        name = config["jsonHealthChecksLogger"]['name']
+        path = config["jsonHealthChecksLogger"]['path']
+        max_bytes = config["jsonHealthChecksLogger"]['max_bytes']
+        backup_count = config["jsonHealthChecksLogger"]['backup_count']
+        self.health_checks_processor = MetricsLogger(name, path, max_bytes, backup_count)
+
+    def _setup_termination_handler(self):
+        def termination_handler(signum, frame):
+            self.logger.info("Termination called.")
+            sys.exit(0)
+        signal.signal(signal.SIGINT, termination_handler)
+        signal.signal(signal.SIGTERM, termination_handler)
+
+    def _setup_logging(self, config):
+         fmt="%(asctime)s - %(levelname)s - %(name)s - %(message)s"
+         logging.basicConfig(
+             level=logging.INFO,
+             format=fmt,
+         )
+         formatter = logging.Formatter(fmt)
+         name = "ClouderaManagerMetricsCollector"
+         path = config["logger"]['path']
+         max_bytes = config["logger"]['max_bytes']
+         backup_count = config["logger"]['backup_count']
+         handler = RotatingFileHandler(path, maxBytes=max_bytes, backupCount=backup_count, mode='a')
+         handler.setLevel(logging.INFO)
+         handler.setFormatter(formatter)
+         self.logger.addHandler(handler)
+
+    def _append_global_fields(self, obj):
+        if self.globalFields:
+            for key in self.globalFields:
+                obj[key]=self.globalFields[key]
+        return obj

--- a/orchestrator-salt/src/main/resources/salt/salt/monitoring/template/metrics-collector.yaml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/monitoring/template/metrics-collector.yaml.j2
@@ -1,0 +1,42 @@
+{%- from 'monitoring/settings.sls' import monitoring with context %}
+config:
+    metricsCollectPeriod: 120
+    availableClusterUpdatePeriod: 600
+    availableServicesUpdatePeriod: 240
+    availableMetricsUpdatePeriod: 300
+clouderaManager:
+    apiVersion: "v40"
+    user: "{{ monitoring.cmUsername }}"
+    password: "{{ monitoring.cmPassword }}"
+    clusterType: "{{ monitoring.cmClusterType }}"
+    protocol: "https"
+    port: "7183"
+services:
+    - name: hdfs
+      metrics:
+        - jvm_max_memory_mb_across_datanodes
+        - jvm_max_memory_mb_across_namenodes
+        - files_total
+      health_checks:
+roles:
+globalFields:
+    clusterCrn: "{{ monitoring.clusterCrn }}"
+    clusterName: "{{ monitoring.clusterName }}"
+    clusterVersion: "{{ monitoring.clusterVersion }}"
+    clusterType: "{{ monitoring.clusterType }}"
+    platform: "{{ monitoring.platform }}"
+logger:
+    path: /var/log/metrics-collector/metrics-collector.log
+    max_bytes: 10485760
+    backup_count: 10
+    debug: True
+jsonMetricsLogger:
+    name: metrics_logger
+    path: /var/log/metrics-collector/metrics.json
+    max_bytes: 10485760
+    backup_count: 10
+jsonHealthChecksLogger:
+    name: health_checks_logger
+    path: /var/log/metrics-collector/health_checks.json
+    max_bytes: 10485760
+    backup_count: 10


### PR DESCRIPTION
## Changes
- global monitoring setting (not sure, maybe would make sense to add it to the API)
- added cloudbreak monitoring user + password (generate user by CM if monitoring enabled) 
- added python based service that runs as a daemon on CM host. continously checks cluster/service/metrics/health_check api of CM - output: metrics.json and health_checks.json
- renamed FluentClusterDetails -> TelemetryCluster details (because that is re-used)
- install and start monitoring by salt (standalone call) - start monitoring between CM start and cluster install

## Next steps:
- add more metrics per service (decide what we want to collect)
- Implement freeipa metrics collector (ipa-healthcheck app can be used there, it seems in our ipa version, that is not included yet)
- 2 options:
a.) process json logs by fluentd with datadog plugin - datadog credentials should be stored on env side (like in the credentials)
b.) process json logs by fluentd with databus plugin - create a cm monitoring registry on databus side and send data to prometheus
