### PR TITLE
CB-5711. Add zero byte toleration for e2e tests.

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureProperties.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureProperties.java
@@ -181,6 +181,8 @@ public class AzureProperties {
 
         private Boolean secure;
 
+        private Integer zeroBlobLengthToleration = 5;
+
         public String getAccountKey() {
             return accountKey;
         }
@@ -223,6 +225,14 @@ public class AzureProperties {
 
         public void setSecure(Boolean secure) {
             this.secure = secure;
+        }
+
+        public Integer getZeroBlobLengthToleration() {
+            return zeroBlobLengthToleration;
+        }
+
+        public void setZeroBlobLengthToleration(Integer zeroBlobLengthToleration) {
+            this.zeroBlobLengthToleration = zeroBlobLengthToleration;
         }
 
         public static class AdlsGen2 {


### PR DESCRIPTION
blob with content length can be valid, creating a blob and append + flush are different steps against abfs api (see: https://docs.microsoft.com/en-gb/rest/api/storageservices/datalakestoragegen2/path), so it can be a state (if flush fails, there are like 5 sec retries after that) where the content is not appended yet

solution:
add toleration for this error, it should be rare, so if it occurs often, that can be a valid issue.

testing is in progress (not sure the default value will work)
update: seems like setting the value + the default is working as expected