### PR TITLE
CB-5254: Add ability to reboot a single FreeIPA instance.

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/InstanceConnector.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/InstanceConnector.java
@@ -26,7 +26,7 @@ public interface InstanceConnector {
     List<CloudVmInstanceStatus> start(AuthenticatedContext authenticatedContext, List<CloudResource> resources, List<CloudInstance> vms);
 
     /**
-     * Stop instances. You can start instances trough this method. It does not need to wait/block until the VM instances are stopped, but it can return
+     * Stop instances. You can stop instances trough this method. It does not need to wait/block until the VM instances are stopped, but it can return
      * immediately and the {@link #check(AuthenticatedContext, List)} method is invoked to check regularly whether the VM instances have already been stopped
      * or not.
      *
@@ -37,6 +37,17 @@ public interface InstanceConnector {
      * @return status of instances
      */
     List<CloudVmInstanceStatus> stop(AuthenticatedContext authenticatedContext, List<CloudResource> resources, List<CloudInstance> vms);
+
+    /**
+     * Reboot instances. You can reboot instances through this method. It does not need to wait/block until the VM instances are rebooted, but it can return
+     * immediately and the {@link #check(AuthenticatedContext, List)} method is invoked to check regularly whether the VM instances have already been started
+     * after a reboot or not.
+     *
+     * @param authenticatedContext the authenticated context which holds the client object
+     * @param instanceIds          a VM instances that need to be rebooted.
+     * @return status of instances
+     */
+    List<CloudVmInstanceStatus> reboot(AuthenticatedContext authenticatedContext, List<CloudInstance> instanceIds);
 
     /**
      * Invoked to check whether the instances have already reached a StatusGroup.PERMANENT state.

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
@@ -462,6 +462,10 @@ public class AzureClient {
         return handleAuthException(() -> azure.virtualMachines().startAsync(resourceGroup, vmName));
     }
 
+    public Completable rebootVirtualMachineAsync(String resourceGroup, String vmName) {
+        return handleAuthException(() -> azure.virtualMachines().restartAsync(resourceGroup, vmName));
+    }
+
     public void stopVirtualMachine(String resourceGroup, String vmName) {
         handleAuthException(() -> azure.virtualMachines().powerOff(resourceGroup, vmName));
     }

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpInstanceConnector.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpInstanceConnector.java
@@ -33,6 +33,11 @@ public class GcpInstanceConnector extends AbstractInstanceConnector {
     private boolean verifyHostKey;
 
     @Override
+    public List<CloudVmInstanceStatus> reboot(AuthenticatedContext authenticatedContext, List<CloudInstance> vms) {
+        throw new CloudOperationNotSupportedException("Reboot instances operation is not supported on GCP");
+    }
+
+    @Override
     public List<CloudVmInstanceStatus> check(AuthenticatedContext ac, List<CloudInstance> vms) {
         List<CloudVmInstanceStatus> statuses = new ArrayList<>();
         CloudCredential credential = ac.getCloudCredential();

--- a/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockInstanceConnector.java
+++ b/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockInstanceConnector.java
@@ -70,6 +70,24 @@ public class MockInstanceConnector implements InstanceConnector {
     }
 
     @Override
+    public List<CloudVmInstanceStatus> reboot(AuthenticatedContext authenticatedContext, List<CloudInstance> vms) {
+        List<CloudVmInstanceStatus> cloudVmInstanceStatuses = new ArrayList<>();
+        for (CloudInstance instance : vms) {
+            CloudVmInstanceStatus instanceStatus = getVmInstanceStatus(authenticatedContext, instance, "start");
+            cloudVmInstanceStatuses.add(instanceStatus);
+        }
+
+        MockCredentialView mockCredentialView = mockCredentialViewFactory.createCredetialView(authenticatedContext.getCloudCredential());
+        LOGGER.info("start instance statuses to mock spi, server address: " + mockCredentialView.getMockEndpoint());
+        try {
+            Unirest.post(mockCredentialView.getMockEndpoint() + "/spi/reboot_instances").asString();
+        } catch (UnirestException e) {
+            LOGGER.error("Error when instances got started", e);
+        }
+        return cloudVmInstanceStatuses;
+    }
+
+    @Override
     public List<CloudVmInstanceStatus> check(AuthenticatedContext authenticatedContext, List<CloudInstance> vms) {
 
         try {

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/heat/OpenStackInstanceConnector.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/heat/OpenStackInstanceConnector.java
@@ -58,6 +58,11 @@ public class OpenStackInstanceConnector implements InstanceConnector {
     }
 
     @Override
+    public List<CloudVmInstanceStatus> reboot(AuthenticatedContext authenticatedContext, List<CloudInstance> vms) {
+        throw new CloudOperationNotSupportedException("Reboot instances operation is not supported on OpenStack");
+    }
+
+    @Override
     public List<CloudVmInstanceStatus> check(AuthenticatedContext ac, List<CloudInstance> vms) {
         List<CloudVmInstanceStatus> statuses = new ArrayList<>();
         OSClient<?> osClient = openStackClient.createOSClient(ac);

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/nativ/OpenStackNativeInstanceConnector.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/nativ/OpenStackNativeInstanceConnector.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudOperationNotSupportedException;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudVmInstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
@@ -27,6 +28,11 @@ public class OpenStackNativeInstanceConnector extends AbstractInstanceConnector 
 
     @Inject
     private OpenStackClient openStackClient;
+
+    @Override
+    public List<CloudVmInstanceStatus> reboot(AuthenticatedContext authenticatedContext, List<CloudInstance> vms) {
+        throw new CloudOperationNotSupportedException("Reboot instances operation is not supported on OpenStack");
+    }
 
     @Override
     public List<CloudVmInstanceStatus> check(AuthenticatedContext ac, List<CloudInstance> vms) {

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/instance/RebootInstancesRequest.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/instance/RebootInstancesRequest.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.cloudbreak.cloud.event.instance;
+
+import java.util.List;
+
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformRequest;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
+
+public class RebootInstancesRequest<T> extends CloudPlatformRequest<T> {
+
+    private final List<CloudInstance> cloudInstances;
+
+    public RebootInstancesRequest(CloudContext cloudContext, CloudCredential cloudCredential,
+            List<CloudInstance> cloudInstances) {
+        super(cloudContext, cloudCredential);
+        this.cloudInstances = cloudInstances;
+    }
+
+    public List<CloudInstance> getCloudInstances() {
+        return cloudInstances;
+    }
+
+    @Override
+    public String toString() {
+        super.toString();
+        return "RebootInstancesRequest{cloudInstances=" + cloudInstances + "}";
+    }
+}

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/instance/RebootInstancesResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/instance/RebootInstancesResult.java
@@ -1,0 +1,30 @@
+package com.sequenceiq.cloudbreak.cloud.event.instance;
+
+import java.util.List;
+
+import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
+
+public class RebootInstancesResult extends CloudPlatformResult {
+
+    private InstancesStatusResult results;
+
+    private List<String> instanceIds;
+
+    public RebootInstancesResult(Long resourceId, InstancesStatusResult results) {
+        super(resourceId);
+        this.results = results;
+    }
+
+    public RebootInstancesResult(String statusReason, Exception errorDetails, Long resourceId, List<String> instanceIds) {
+        super(statusReason, errorDetails, resourceId);
+        this.instanceIds = instanceIds;
+    }
+
+    public InstancesStatusResult getResults() {
+        return results;
+    }
+
+    public List<String> getInstanceIds() {
+        return instanceIds;
+    }
+}

--- a/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/handler/RebootInstanceHandler.java
+++ b/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/handler/RebootInstanceHandler.java
@@ -1,0 +1,60 @@
+package com.sequenceiq.cloudbreak.cloud.handler;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.CloudConnector;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.event.instance.InstancesStatusResult;
+import com.sequenceiq.cloudbreak.cloud.event.instance.RebootInstancesRequest;
+import com.sequenceiq.cloudbreak.cloud.event.instance.RebootInstancesResult;
+import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
+import com.sequenceiq.cloudbreak.cloud.model.CloudVmInstanceStatus;
+
+import reactor.bus.Event;
+import reactor.bus.EventBus;
+
+@Component
+public class RebootInstanceHandler implements CloudPlatformEventHandler<RebootInstancesRequest> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RebootInstanceHandler.class);
+
+    @Inject
+    private CloudPlatformConnectors cloudPlatformConnectors;
+
+    @Inject
+    private EventBus eventBus;
+
+    @Override
+    public Class<RebootInstancesRequest> type() {
+        return RebootInstancesRequest.class;
+    }
+
+    @Override
+    public void accept(Event<RebootInstancesRequest> event) {
+        LOGGER.debug("Received event: {}", event);
+        RebootInstancesRequest<RebootInstancesResult> request = event.getData();
+        CloudContext cloudContext = request.getCloudContext();
+        try {
+            CloudConnector<?> connector = cloudPlatformConnectors.get(cloudContext.getPlatformVariant());
+            AuthenticatedContext authenticatedContext = connector.authentication().authenticate(cloudContext, request.getCloudCredential());
+            List<CloudVmInstanceStatus> cloudVmInstanceStatuses = connector.instances().reboot(authenticatedContext, request.getCloudInstances());
+            InstancesStatusResult statusResult = new InstancesStatusResult(cloudContext, cloudVmInstanceStatuses);
+            RebootInstancesResult result = new RebootInstancesResult(request.getResourceId(), statusResult);
+            request.getResult().onNext(result);
+            eventBus.notify(result.selector(), new Event<>(event.getHeaders(), result));
+        } catch (Exception e) {
+            RebootInstancesResult failure = new RebootInstancesResult("Failed to reboot instances", e, request.getResourceId(),
+                    request.getCloudInstances().stream().map(instance -> instance.getInstanceId()).collect(Collectors.toList()));
+            request.getResult().onNext(failure);
+            eventBus.notify(failure.selector(), new Event<>(event.getHeaders(), failure));
+        }
+    }
+}

--- a/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/testcontext/TestApplicationContext.java
+++ b/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/testcontext/TestApplicationContext.java
@@ -169,6 +169,8 @@ public class TestApplicationContext {
                 .thenReturn(Collections.singletonList(new CloudVmInstanceStatus(cloudInstance, InstanceStatus.STARTED)));
         when(instanceConnector.stop(any(), any(), any()))
                 .thenReturn(Collections.singletonList(new CloudVmInstanceStatus(cloudInstance, InstanceStatus.STOPPED)));
+        when(instanceConnector.reboot(any(), any()))
+                .thenReturn(Collections.singletonList(new CloudVmInstanceStatus(cloudInstance, InstanceStatus.STARTED)));
         when(instanceConnector.getConsoleOutput(any(), eq(cloudInstance)))
                 .thenReturn(g.getSshFingerprint() + "    RSA/n-----END SSH HOST KEY FINGERPRINTS-----");
         when(instanceConnector.getConsoleOutput(any(), eq(cloudInstanceBad)))

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnInstanceConnector.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnInstanceConnector.java
@@ -28,6 +28,11 @@ public class YarnInstanceConnector implements InstanceConnector {
     }
 
     @Override
+    public List<CloudVmInstanceStatus> reboot(AuthenticatedContext authenticatedContext, List<CloudInstance> vms) {
+        throw new CloudOperationNotSupportedException("Reboot instances operation is not supported on YARN");
+    }
+
+    @Override
     public List<CloudVmInstanceStatus> check(AuthenticatedContext authenticatedContext, List<CloudInstance> vms) {
         throw new CloudOperationNotSupportedException("Instances' states check operation is not supported on YARN");
     }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
@@ -24,6 +24,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.describe.DescribeFreeIp
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.detachchildenv.DetachChildEnvironmentRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.HealthDetailsFreeIpaResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.list.ListFreeIpaResponse;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.reboot.RebootInstancesRequest;
 import com.sequenceiq.freeipa.api.v1.operation.model.OperationStatus;
 
 import io.swagger.annotations.Api;
@@ -75,6 +76,13 @@ public interface FreeIpaV1Endpoint {
     @ApiOperation(value = FreeIpaOperationDescriptions.HEALTH, produces = MediaType.APPLICATION_JSON, notes = FreeIpaNotes.FREEIPA_NOTES,
             nickname = "healthV1")
     HealthDetailsFreeIpaResponse healthDetails(@QueryParam("environment") @NotEmpty String environmentCrn);
+
+    @POST
+    @Path("reboot")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = FreeIpaOperationDescriptions.REBOOT, produces = MediaType.APPLICATION_JSON, notes = FreeIpaNotes.FREEIPA_NOTES,
+            nickname = "rebootV1")
+    void rebootInstances(@Valid RebootInstancesRequest request) throws Exception;
 
     @GET
     @Path("ca.crt")

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaOperationDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaOperationDescriptions.java
@@ -14,6 +14,7 @@ public final class FreeIpaOperationDescriptions {
     public static final String REGISTER_WITH_CLUSTER_PROXY = "Registers FreeIPA stack with given environment CRN with cluster proxy";
     public static final String DEREGISTER_WITH_CLUSTER_PROXY = "Deregisters FreeIPA stack with given environment CRN with cluster proxy";
     public static final String HEALTH = "Provides a detailed health of the FreeIPA stack";
+    public static final String REBOOT = "Reboot one or more instances";
 
     private FreeIpaOperationDescriptions() {
     }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/instance/InstanceStatus.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/instance/InstanceStatus.java
@@ -1,5 +1,14 @@
 package com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance;
 
+import java.util.Collection;
+import java.util.List;
+
 public enum InstanceStatus {
-    REQUESTED, CREATED, UNREGISTERED, REGISTERED, DECOMMISSIONED, TERMINATED, DELETED_ON_PROVIDER_SIDE, FAILED, STOPPED
+    REQUESTED, CREATED, UNREGISTERED, REGISTERED, DECOMMISSIONED, TERMINATED, DELETED_ON_PROVIDER_SIDE, FAILED, STOPPED, REBOOTING, UNREACHABLE;
+
+    public static final Collection<InstanceStatus> AVAILABLE_STATUSES = List.of(CREATED);
+
+    public boolean isAvailable() {
+        return AVAILABLE_STATUSES.contains(this);
+    }
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/health/NodeHealthDetails.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/health/NodeHealthDetails.java
@@ -7,7 +7,7 @@ import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceStatus;
 
 import io.swagger.annotations.ApiModel;
 
@@ -20,7 +20,7 @@ public class NodeHealthDetails {
     private List<String> issues;
 
     @NotNull
-    private Status status;
+    private InstanceStatus status;
 
     @NotNull
     private String name;
@@ -28,11 +28,11 @@ public class NodeHealthDetails {
     @NotNull
     private String instanceId;
 
-    public Status getStatus() {
+    public InstanceStatus getStatus() {
         return status;
     }
 
-    public void setStatus(Status status) {
+    public void setStatus(InstanceStatus status) {
         this.status = status;
     }
 

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/reboot/RebootInstancesRequest.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/reboot/RebootInstancesRequest.java
@@ -1,0 +1,51 @@
+package com.sequenceiq.freeipa.api.v1.freeipa.stack.model.reboot;
+
+import java.util.List;
+
+import javax.validation.constraints.NotEmpty;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.sequenceiq.service.api.doc.ModelDescriptions;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel("RebootInstancesV1Request")
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RebootInstancesRequest {
+    @NotEmpty
+    @ApiModelProperty(value = ModelDescriptions.ENVIRONMENT_CRN, required = true)
+    private String environmentCrn;
+
+    @ApiModelProperty(value = ModelDescriptions.FORCE_REBOOT, required = false)
+    private boolean forceReboot;
+
+    @ApiModelProperty(value = ModelDescriptions.INSTANCE_ID, required = false)
+    private List<String> instanceIds;
+
+    public String getEnvironmentCrn() {
+        return environmentCrn;
+    }
+
+    public void setEnvironmentCrn(String environmentCrn) {
+        this.environmentCrn = environmentCrn;
+    }
+
+    public boolean isForceReboot() {
+        return forceReboot;
+    }
+
+    public void setForceReboot(boolean forceReboot) {
+        this.forceReboot = forceReboot;
+    }
+
+    public List<String> getInstanceIds() {
+        return instanceIds;
+    }
+
+    public void setInstanceIds(List<String> instanceIds) {
+        this.instanceIds = instanceIds;
+    }
+}

--- a/freeipa-api/src/main/java/com/sequenceiq/service/api/doc/ModelDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/service/api/doc/ModelDescriptions.java
@@ -10,6 +10,8 @@ public class ModelDescriptions {
     public static final String PARENT_ENVIRONMENT_CRN = "CRN of the parent environment";
     public static final String CHILD_ENVIRONMENT_CRN = "CRN of the child environment";
     public static final String CLUSTER_CRN = "CRN of the cluster";
+    public static final String INSTANCE_ID = "ID of the instance";
+    public static final String FORCE_REBOOT = "Reboot instance regardless of status";
 
     public static final String USER_CRN = "CRN of a user. It is optional as it will be available in \"x-cdp-actor-crn\" header in the request.";
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaV1Controller.java
@@ -23,6 +23,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.describe.DescribeFreeIp
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.detachchildenv.DetachChildEnvironmentRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.HealthDetailsFreeIpaResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.list.ListFreeIpaResponse;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.reboot.RebootInstancesRequest;
 import com.sequenceiq.freeipa.api.v1.operation.model.OperationStatus;
 import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.controller.exception.BadRequestException;
@@ -39,6 +40,7 @@ import com.sequenceiq.freeipa.service.stack.FreeIpaListService;
 import com.sequenceiq.freeipa.service.stack.FreeIpaRootCertificateService;
 import com.sequenceiq.freeipa.service.stack.FreeIpaStartService;
 import com.sequenceiq.freeipa.service.stack.FreeIpaStopService;
+import com.sequenceiq.freeipa.service.stack.RebootInstancesService;
 import com.sequenceiq.freeipa.util.CrnService;
 
 @Controller
@@ -70,6 +72,9 @@ public class FreeIpaV1Controller implements FreeIpaV1Endpoint {
 
     @Inject
     private CleanupService cleanupService;
+
+    @Inject
+    private RebootInstancesService rebootInstancesService;
 
     @Inject
     private CrnService crnService;
@@ -164,6 +169,13 @@ public class FreeIpaV1Controller implements FreeIpaV1Endpoint {
     public OperationStatus cleanup(@Valid CleanupRequest request) throws FreeIpaClientException {
         String accountId = crnService.getCurrentAccountId();
         return cleanupService.cleanup(accountId, request);
+    }
+
+    @Override
+    @CheckPermissionByAccount
+    public void rebootInstances(@Valid RebootInstancesRequest request) throws FreeIpaClientException {
+        String accountId = crnService.getCurrentAccountId();
+        rebootInstancesService.rebootInstances(accountId, request);
     }
 
     @Override

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/InstanceMetaData.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/InstanceMetaData.java
@@ -138,6 +138,10 @@ public class InstanceMetaData {
         return InstanceStatus.CREATED.equals(instanceStatus);
     }
 
+    public boolean isAvailable() {
+        return instanceStatus.isAvailable();
+    }
+
     public boolean isFailed() {
         return InstanceStatus.FAILED.equals(instanceStatus);
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/failure/RebootInstancesResultToCleanupFailureEventConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/failure/RebootInstancesResultToCleanupFailureEventConverter.java
@@ -1,0 +1,18 @@
+package com.sequenceiq.freeipa.flow.freeipa.cleanup.event.failure;
+
+import com.sequenceiq.cloudbreak.cloud.event.instance.RebootInstancesResult;
+import com.sequenceiq.flow.core.PayloadConverter;
+import com.sequenceiq.freeipa.flow.instance.InstanceFailureEvent;
+
+public class RebootInstancesResultToCleanupFailureEventConverter implements PayloadConverter<InstanceFailureEvent> {
+    @Override
+    public boolean canConvert(Class<?> sourceClass) {
+        return RebootInstancesResult.class.isAssignableFrom(sourceClass);
+    }
+
+    @Override
+    public InstanceFailureEvent convert(Object payload) {
+        RebootInstancesResult result = (RebootInstancesResult) payload;
+        return new InstanceFailureEvent(result.getResourceId(), result.getErrorDetails(), result.getInstanceIds());
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/InstanceEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/InstanceEvent.java
@@ -1,0 +1,52 @@
+package com.sequenceiq.freeipa.flow.instance;
+
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.sequenceiq.cloudbreak.common.event.AcceptResult;
+import com.sequenceiq.cloudbreak.common.event.Acceptable;
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.flow.event.EventSelectorUtil;
+
+import reactor.rx.Promise;
+
+public class InstanceEvent implements Selectable, Acceptable {
+    private final String selector;
+
+    private final Long resourceId;
+
+    private final Promise<AcceptResult> accepted;
+
+    private final List<String> instanceIds;
+
+    public InstanceEvent(Long id) {
+        this(null, id, null);
+    }
+
+    public InstanceEvent(String selector, Long resourceId, List<String> instanceIds) {
+        this.selector = selector;
+        this.resourceId = resourceId;
+        this.instanceIds = instanceIds;
+        accepted = new Promise<>();
+    }
+
+    @Override
+    public Long getResourceId() {
+        return resourceId;
+    }
+
+    public List<String> getInstanceIds() {
+        return instanceIds;
+    }
+
+    @Override
+    public String selector() {
+        return StringUtils.isNotEmpty(selector) ? selector : EventSelectorUtil.selector(getClass());
+    }
+
+    @Override
+    public Promise<AcceptResult> accepted() {
+        return accepted;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/InstanceFailureEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/InstanceFailureEvent.java
@@ -1,0 +1,18 @@
+package com.sequenceiq.freeipa.flow.instance;
+
+import java.util.List;
+
+public class InstanceFailureEvent extends InstanceEvent {
+
+    private final Exception exception;
+
+    public InstanceFailureEvent(Long resourceId, Exception exception, List<String> instanceIds) {
+        super(null, resourceId, instanceIds);
+        this.exception = exception;
+    }
+
+    public Exception getException() {
+        return exception;
+    }
+
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/RebootContext.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/RebootContext.java
@@ -1,0 +1,54 @@
+package com.sequenceiq.freeipa.flow.instance.reboot;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.flow.core.CommonContext;
+import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
+import com.sequenceiq.freeipa.entity.Stack;
+
+public class RebootContext extends CommonContext {
+    private final Stack stack;
+
+    private final List<InstanceMetaData> instanceMetaDataList;
+
+    private final CloudContext cloudContext;
+
+    private final CloudCredential cloudCredential;
+
+    public RebootContext(FlowParameters flowParameters, Stack stack, List<InstanceMetaData> instanceMetaDataList,
+            CloudContext cloudContext, CloudCredential cloudCredential) {
+        super(flowParameters);
+        this.stack = stack;
+        this.instanceMetaDataList = instanceMetaDataList;
+        this.cloudContext = cloudContext;
+        this.cloudCredential = cloudCredential;
+    }
+
+    public Stack getStack() {
+        return stack;
+    }
+
+    public List<InstanceMetaData> getInstanceMetaDataList() {
+        return instanceMetaDataList;
+    }
+
+    public CloudContext getCloudContext() {
+        return cloudContext;
+    }
+
+    public CloudCredential getCloudCredential() {
+        return cloudCredential;
+    }
+
+    public String getInstanceIds() {
+        return getInstanceMetaDataList().stream().map(instanceMetaData -> instanceMetaData.getInstanceId()).collect(Collectors.joining(","));
+    }
+
+    public List<String> getInstanceIdList() {
+        return getInstanceMetaDataList().stream().map(instanceMetaData -> instanceMetaData.getInstanceId()).collect(Collectors.toList());
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/RebootEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/RebootEvent.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.freeipa.flow.instance.reboot;
+
+import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
+import com.sequenceiq.cloudbreak.cloud.event.instance.RebootInstancesResult;
+import com.sequenceiq.flow.core.FlowEvent;
+
+public enum RebootEvent implements FlowEvent {
+    REBOOT_EVENT("REBOOT_TRIGGER_EVENT"),
+    REBOOT_FINISHED_EVENT(CloudPlatformResult.selector(RebootInstancesResult.class)),
+    REBOOT_FAILURE_EVENT(CloudPlatformResult.failureSelector(RebootInstancesResult.class)),
+    REBOOT_FINALIZED_EVENT("REBOOTFINALIZED"),
+    REBOOT_FAIL_HANDLED_EVENT("REBOOTFAILHANDLED");
+
+    private final String event;
+
+    RebootEvent(String event) {
+        this.event = event;
+    }
+
+    @Override
+    public String event() {
+        return event;
+    }
+
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/RebootFlowConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/RebootFlowConfig.java
@@ -1,0 +1,66 @@
+package com.sequenceiq.freeipa.flow.instance.reboot;
+
+import static com.sequenceiq.freeipa.flow.instance.reboot.RebootEvent.REBOOT_EVENT;
+import static com.sequenceiq.freeipa.flow.instance.reboot.RebootEvent.REBOOT_FAILURE_EVENT;
+import static com.sequenceiq.freeipa.flow.instance.reboot.RebootEvent.REBOOT_FAIL_HANDLED_EVENT;
+import static com.sequenceiq.freeipa.flow.instance.reboot.RebootEvent.REBOOT_FINALIZED_EVENT;
+import static com.sequenceiq.freeipa.flow.instance.reboot.RebootEvent.REBOOT_FINISHED_EVENT;
+import static com.sequenceiq.freeipa.flow.instance.reboot.RebootState.FINAL_STATE;
+import static com.sequenceiq.freeipa.flow.instance.reboot.RebootState.INIT_STATE;
+import static com.sequenceiq.freeipa.flow.instance.reboot.RebootState.REBOOT_FAILED_STATE;
+import static com.sequenceiq.freeipa.flow.instance.reboot.RebootState.REBOOT_FINISHED_STATE;
+import static com.sequenceiq.freeipa.flow.instance.reboot.RebootState.REBOOT_STATE;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
+import com.sequenceiq.flow.core.config.AbstractFlowConfiguration.Transition.Builder;
+
+@Component
+public class RebootFlowConfig extends AbstractFlowConfiguration<RebootState, RebootEvent> {
+
+    private static final List<Transition<RebootState, RebootEvent>> TRANSITIONS = new Builder<RebootState, RebootEvent>()
+            .defaultFailureEvent(REBOOT_FAILURE_EVENT)
+            .from(INIT_STATE).to(REBOOT_STATE).event(REBOOT_EVENT).defaultFailureEvent()
+            .from(REBOOT_STATE).to(REBOOT_FINISHED_STATE).event(REBOOT_FINISHED_EVENT).defaultFailureEvent()
+            .from(REBOOT_FINISHED_STATE).to(FINAL_STATE).event(REBOOT_FINALIZED_EVENT).defaultFailureEvent()
+            .build();
+
+    private static final FlowEdgeConfig<RebootState, RebootEvent> EDGE_CONFIG =
+            new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, REBOOT_FAILED_STATE, REBOOT_FAIL_HANDLED_EVENT);
+
+    public RebootFlowConfig() {
+        super(RebootState.class, RebootEvent.class);
+    }
+
+    @Override
+    public RebootEvent[] getEvents() {
+        return RebootEvent.values();
+    }
+
+    @Override
+    public RebootEvent[] getInitEvents() {
+        return new RebootEvent[] {
+                REBOOT_EVENT
+        };
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Reboot instance";
+    }
+
+    @Override
+    protected List<Transition<RebootState, RebootEvent>> getTransitions() {
+        return TRANSITIONS;
+    }
+
+    @Override
+    protected FlowEdgeConfig<RebootState, RebootEvent> getEdgeConfig() {
+        return EDGE_CONFIG;
+    }
+
+}
+

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/RebootService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/RebootService.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.freeipa.flow.instance.reboot;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.event.instance.RebootInstancesResult;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceStatus;
+import com.sequenceiq.freeipa.service.stack.RebootInstancesService;
+import com.sequenceiq.freeipa.service.stack.instance.InstanceMetaDataService;
+
+@Component
+public class RebootService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RebootService.class);
+
+    @Inject
+    private InstanceMetaDataService instanceMetaDataService;
+
+    @Inject
+    private RebootInstancesService rebootInstancesService;
+
+    public void startInstanceReboot(RebootContext context) {
+        instanceMetaDataService.updateStatus(context.getStack(), context.getInstanceIdList(), InstanceStatus.REBOOTING);
+    }
+
+    public void handleInstanceRebootError(RebootContext context) {
+        instanceMetaDataService.updateStatus(context.getStack(), context.getInstanceIdList(), InstanceStatus.FAILED);
+        LOGGER.error("Reboot failed for instances: {}", context.getInstanceIds());
+    }
+
+    public void finishInstanceReboot(RebootContext context, RebootInstancesResult rebootInstancesResult) {
+        instanceMetaDataService.updateStatus(context.getStack(), context.getInstanceIdList(), InstanceStatus.CREATED);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/RebootState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/RebootState.java
@@ -1,0 +1,14 @@
+package com.sequenceiq.freeipa.flow.instance.reboot;
+
+import com.sequenceiq.flow.core.FlowState;
+
+public enum RebootState implements FlowState {
+    INIT_STATE,
+    REBOOT_FAILED_STATE,
+    REBOOT_STATE,
+    REBOOT_FINISHED_STATE,
+    FINAL_STATE;
+
+    RebootState() {
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/action/AbstractRebootAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/action/AbstractRebootAction.java
@@ -1,0 +1,20 @@
+package com.sequenceiq.freeipa.flow.instance.reboot.action;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.common.event.Payload;
+import com.sequenceiq.freeipa.flow.instance.reboot.RebootContext;
+import com.sequenceiq.freeipa.flow.instance.reboot.RebootEvent;
+import com.sequenceiq.freeipa.flow.instance.reboot.RebootState;
+import com.sequenceiq.freeipa.flow.stack.AbstractStackAction;
+
+public abstract class AbstractRebootAction<P extends Payload>
+        extends AbstractStackAction<RebootState, RebootEvent, RebootContext, P>  {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractRebootAction.class);
+
+    protected AbstractRebootAction(Class<P> payloadClass) {
+        super(payloadClass);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/action/RebootActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/action/RebootActions.java
@@ -1,0 +1,190 @@
+package com.sequenceiq.freeipa.flow.instance.reboot.action;
+
+import static com.sequenceiq.cloudbreak.cloud.model.AvailabilityZone.availabilityZone;
+import static com.sequenceiq.cloudbreak.cloud.model.Location.location;
+import static com.sequenceiq.cloudbreak.cloud.model.Region.region;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.statemachine.StateContext;
+import org.springframework.statemachine.action.Action;
+
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.event.instance.RebootInstancesRequest;
+import com.sequenceiq.cloudbreak.cloud.event.instance.RebootInstancesResult;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
+import com.sequenceiq.cloudbreak.cloud.model.Location;
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.flow.core.PayloadConverter;
+import com.sequenceiq.freeipa.converter.cloud.CredentialToCloudCredentialConverter;
+import com.sequenceiq.freeipa.converter.cloud.InstanceMetaDataToCloudInstanceConverter;
+import com.sequenceiq.freeipa.dto.Credential;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.failure.RebootInstancesResultToCleanupFailureEventConverter;
+import com.sequenceiq.freeipa.flow.instance.InstanceEvent;
+import com.sequenceiq.freeipa.flow.instance.InstanceFailureEvent;
+import com.sequenceiq.freeipa.flow.instance.reboot.RebootContext;
+import com.sequenceiq.freeipa.flow.instance.reboot.RebootEvent;
+import com.sequenceiq.freeipa.flow.instance.reboot.RebootService;
+import com.sequenceiq.freeipa.flow.instance.reboot.RebootState;
+import com.sequenceiq.freeipa.repository.InstanceMetaDataRepository;
+import com.sequenceiq.freeipa.service.CredentialService;
+import com.sequenceiq.freeipa.service.stack.StackService;
+import com.sequenceiq.freeipa.service.stack.instance.InstanceMetaDataService;
+
+@Configuration
+public class RebootActions {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RebootActions.class);
+
+    @Inject
+    private RebootService rebootService;
+
+    @Inject
+    private InstanceMetaDataToCloudInstanceConverter metadataConverter;
+
+    @Inject
+    private CredentialService credentialService;
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private InstanceMetaDataService instanceMetaDataService;
+
+    @Inject
+    private InstanceMetaDataRepository instanceMetaDataRepository;
+
+    @Inject
+    private CredentialToCloudCredentialConverter credentialConverter;
+
+    @Inject
+    @Qualifier("conversionService")
+    private ConversionService conversionService;
+
+    @Bean(name = "REBOOT_STATE")
+    public Action<?, ?> rebootAction() {
+        return new AbstractRebootAction<>(InstanceEvent.class) {
+            @Override
+            protected void doExecute(RebootContext context, InstanceEvent payload, Map<Object, Object> variables) {
+                rebootService.startInstanceReboot(context);
+                sendEvent(context);
+                LOGGER.info("Starting reboot for {}", context.getInstanceIds());
+            }
+
+            @Override
+            protected Object getFailurePayload(InstanceEvent payload, Optional<RebootContext> flowContext, Exception ex) {
+                return new InstanceFailureEvent(payload.getResourceId(), ex, payload.getInstanceIds());
+            }
+
+            @Override
+            protected Selectable createRequest(RebootContext context) {
+                List<CloudInstance> cloudInstances = context.getInstanceMetaDataList().stream().map(instanceMetaData ->
+                        conversionService.convert(instanceMetaData, CloudInstance.class)).collect(Collectors.toList());
+                return new RebootInstancesRequest<>(context.getCloudContext(), context.getCloudCredential(), cloudInstances);
+            }
+
+            @Override
+            protected RebootContext createFlowContext(FlowParameters flowParameters, StateContext<RebootState, RebootEvent> stateContext,
+                    InstanceEvent payload) {
+                Long stackId = payload.getResourceId();
+                Stack stack = stackService.getStackById(stackId);
+                List<InstanceMetaData> instances = instanceMetaDataRepository.findAllInStack(stackId).stream()
+                        .filter(instanceMetaData -> payload.getInstanceIds().contains(instanceMetaData.getInstanceId())).collect(Collectors.toList());
+                MDCBuilder.buildMdcContext(stack);
+
+                Location location = location(region(stack.getRegion()), availabilityZone(stack.getAvailabilityZone()));
+                CloudContext cloudContext = new CloudContext(stack.getId(), stack.getName(), stack.getCloudPlatform(), stack.getCloudPlatform(),
+                        location, stack.getOwner(), stack.getAccountId());
+                Credential credential = credentialService.getCredentialByEnvCrn(stack.getEnvironmentCrn());
+                CloudCredential cloudCredential = credentialConverter.convert(credential);
+                return new RebootContext(flowParameters, stack, instances, cloudContext, cloudCredential);
+            }
+        };
+    }
+
+    @Bean(name = "REBOOT_FINISHED_STATE")
+    public Action<?, ?> rebootFinishedAction() {
+        return new AbstractRebootAction<>(RebootInstancesResult.class) {
+            @Override
+            protected void doExecute(RebootContext context, RebootInstancesResult payload, Map<Object, Object> variables) {
+                rebootService.finishInstanceReboot(context, payload);
+                LOGGER.info("Finished rebooting {}.", context.getInstanceIds());
+                sendEvent(context);
+            }
+
+            @Override
+            protected Object getFailurePayload(RebootInstancesResult payload, Optional<RebootContext> flowContext, Exception ex) {
+                return new InstanceFailureEvent(payload.getResourceId(), ex, payload.getInstanceIds());
+            }
+
+            @Override
+            protected Selectable createRequest(RebootContext context) {
+                return new InstanceEvent(RebootEvent.REBOOT_FINALIZED_EVENT.event(), context.getStack().getId(), context.getInstanceIdList());
+            }
+
+            @Override
+            protected RebootContext createFlowContext(FlowParameters flowParameters, StateContext<RebootState,
+                    RebootEvent> stateContext, RebootInstancesResult payload) {
+                List<InstanceMetaData> instances = payload.getResults().getResults().stream().map(instance -> {
+                    InstanceMetaData md = new InstanceMetaData();
+                    md.setInstanceId(instance.getCloudInstance().getInstanceId());
+                    return md;
+                }).collect(Collectors.toList());
+                Long stackId = payload.getResourceId();
+                Stack stack = stackService.getStackById(stackId);
+                return new RebootContext(flowParameters, stack, instances, null, null);
+                }
+        };
+    }
+
+    @Bean(name = "REBOOT_FAILED_STATE")
+    public Action<?, ?> rebootFailureAction() {
+        return new AbstractRebootAction<>(InstanceFailureEvent.class) {
+            @Override
+            protected void doExecute(RebootContext context, InstanceFailureEvent payload, Map<Object, Object> variables) {
+                rebootService.handleInstanceRebootError(context);
+                LOGGER.error("Rebooting failed for {}.", context.getInstanceIds());
+                sendEvent(context, new InstanceEvent(RebootEvent.REBOOT_FAIL_HANDLED_EVENT.event(), context.getStack().getId(), context.getInstanceIdList()));
+            }
+
+            @Override
+            protected RebootContext createFlowContext(FlowParameters flowParameters, StateContext<RebootState,
+                    RebootEvent> stateContext, InstanceFailureEvent payload) {
+                Long stackId = payload.getResourceId();
+                Stack stack = stackService.getStackById(stackId);
+
+                return new RebootContext(flowParameters, stack, payload.getInstanceIds().stream().map(instanceId -> {
+                    InstanceMetaData md = new InstanceMetaData();
+                    md.setInstanceId(instanceId);
+                    return md;
+                }).collect(Collectors.toList()), null, null);
+            }
+
+            @Override
+            protected Object getFailurePayload(InstanceFailureEvent payload, Optional<RebootContext> flowContext, Exception ex) {
+                return new InstanceFailureEvent(payload.getResourceId(), ex, payload.getInstanceIds());
+            }
+
+            @Override
+            protected void initPayloadConverterMap(List<PayloadConverter<InstanceFailureEvent>> payloadConverters) {
+                payloadConverters.add(new RebootInstancesResultToCleanupFailureEventConverter());
+            }
+        };
+    }
+
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/repository/InstanceMetaDataRepository.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/repository/InstanceMetaDataRepository.java
@@ -25,7 +25,7 @@ public interface InstanceMetaDataRepository extends CrudRepository<InstanceMetaD
     @Query("SELECT i FROM InstanceMetaData i WHERE i.instanceGroup.stack.id= :stackId")
     Set<InstanceMetaData> findAllInStack(@Param("stackId") Long stackId);
 
-    @Query("SELECT i FROM InstanceMetaData i WHERE i.instanceId= :instanceId AND i.instanceGroup.stack.id= :stackId")
+    @Query("SELECT i FROM InstanceMetaData i WHERE i.instanceId = :instanceId AND i.instanceGroup.stack.id= :stackId")
     InstanceMetaData findByInstanceId(@Param("stackId") Long stackId, @Param("instanceId") String instanceId);
 
     @Query("SELECT i FROM InstanceMetaData i WHERE i.instanceGroup.stack.id= :stackId AND i.discoveryFQDN= :hostName AND i.instanceStatus <> 'TERMINATED'")

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaHealthDetailsService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaHealthDetailsService.java
@@ -12,10 +12,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupType;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.HealthDetailsFreeIpaResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.NodeHealthDetails;
 import com.sequenceiq.freeipa.client.FreeIpaClient;
@@ -81,7 +80,7 @@ public class FreeIpaHealthDetailsService {
             NodeHealthDetails nodeResponse = new NodeHealthDetails();
             response.addNodeHealthDetailsFreeIpaResponses(nodeResponse);
             nodeResponse.setName(master.getDiscoveryFQDN());
-            nodeResponse.setStatus(Status.UNREACHABLE);
+            nodeResponse.setStatus(InstanceStatus.UNREACHABLE);
         }
         updateResponseWithInstanceIds(response, stack);
         return response;
@@ -112,7 +111,7 @@ public class FreeIpaHealthDetailsService {
 
     private boolean isOverallHealthy(HealthDetailsFreeIpaResponse response) {
         for (NodeHealthDetails node: response.getNodeHealthDetails()) {
-            if (node.getStatus().equals(Status.AVAILABLE)) {
+            if (node.getStatus().equals(InstanceStatus.CREATED)) {
                 return true;
             }
         }
@@ -127,7 +126,7 @@ public class FreeIpaHealthDetailsService {
             if (nodeMatcher.find()) {
                 nodeResponse = new NodeHealthDetails();
                 response.addNodeHealthDetailsFreeIpaResponses(nodeResponse);
-                nodeResponse.setStatus(Status.AVAILABLE);
+                nodeResponse.setStatus(InstanceStatus.CREATED);
                 nodeResponse.setName(nodeMatcher.group(NODE_GROUP));
             }
             if (nodeResponse == null) {
@@ -139,7 +138,7 @@ public class FreeIpaHealthDetailsService {
                     Matcher matcher = RESULT_PATTERN.matcher(message.getMessage());
                     if (matcher.find()) {
                         if (!STATUS_OK.equals(matcher.group(STATUS_GROUP))) {
-                            nodeResponse.setStatus(Status.UNHEALTHY);
+                            nodeResponse.setStatus(InstanceStatus.FAILED);
                             nodeResponse.addIssue(precedingMessage);
                         }
                     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/RebootInstancesService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/RebootInstancesService.java
@@ -1,0 +1,112 @@
+package com.sequenceiq.freeipa.service.stack;
+
+import static com.sequenceiq.freeipa.flow.instance.reboot.RebootEvent.REBOOT_EVENT;
+import static java.util.function.Predicate.not;
+
+import java.text.MessageFormat;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceStatus;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.NodeHealthDetails;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.reboot.RebootInstancesRequest;
+import com.sequenceiq.freeipa.controller.exception.BadRequestException;
+import com.sequenceiq.freeipa.controller.exception.NotFoundException;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.flow.instance.InstanceEvent;
+import com.sequenceiq.freeipa.service.freeipa.flow.FreeIpaFlowManager;
+import com.sequenceiq.freeipa.service.stack.instance.InstanceMetaDataService;
+
+@Service
+public class RebootInstancesService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RebootInstancesService.class);
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private FreeIpaFlowManager flowManager;
+
+    @Inject
+    private FreeIpaHealthDetailsService healthDetailsService;
+
+    @Inject
+    private InstanceMetaDataService instanceMetaDataService;
+
+    private Map<String, InstanceStatus> getInstanceHealthMap(String accountId, RebootInstancesRequest request) {
+        return healthDetailsService.getHealthDetails(request.getEnvironmentCrn(), accountId).getNodeHealthDetails().stream()
+                .collect(Collectors.toMap(NodeHealthDetails::getInstanceId, NodeHealthDetails::getStatus));
+    }
+
+    private Collection<String> getValidInstanceIds(Collection<String> allInstances, Collection<String> instanceIds) {
+        if (instanceIds == null || instanceIds.isEmpty()) {
+            return allInstances;
+        } else {
+            Collection<String> validInstanceIds = instanceIds.stream().filter(allInstances::contains).collect(Collectors.toSet());
+            if (validInstanceIds.size() != instanceIds.size()) {
+                String badIds = instanceIds.stream()
+                        .filter(not(allInstances::contains)).collect(Collectors.joining(","));
+                String msg = MessageFormat.format("Invalid instanceIds in request {0}.", badIds);
+                LOGGER.error(msg);
+                throw new BadRequestException(msg);
+            }
+            return validInstanceIds;
+        }
+    }
+
+    private Map<String, InstanceMetaData> getInstancesToReboot(Map<String, InstanceMetaData> allInstances,
+            String accountId, RebootInstancesRequest request) {
+        Collection<String> validInstanceIds = getValidInstanceIds(allInstances.keySet(), request.getInstanceIds());
+        Map<String, InstanceStatus> healthMap =
+                request.isForceReboot() ? Collections.emptyMap() : getInstanceHealthMap(accountId, request);
+
+        Map<String, InstanceMetaData> instancesToReboot = validInstanceIds.stream()
+                .filter(instanceId -> request.isForceReboot() || (healthMap.get(instanceId) != null && !healthMap.get(instanceId).isAvailable()))
+                .collect(Collectors.toMap(Function.identity(), instanceId -> allInstances.get(instanceId)));
+        if (instancesToReboot.keySet().size() != validInstanceIds.size()) {
+            LOGGER.info("Not rebooting instances {} because force reboot was not selected.", validInstanceIds.stream()
+                    .filter(instance -> !instancesToReboot.keySet().contains(instance)).collect(Collectors.joining(",")));
+        }
+        return instancesToReboot;
+    }
+
+    private Map<String, InstanceMetaData> getAllInstancesFromStack(Stack stack) {
+        return stack.getInstanceGroups().stream().flatMap(instanceGroup -> instanceGroup.getInstanceMetaData().stream())
+                .collect(Collectors.toMap(InstanceMetaData::getInstanceId, Function.identity()));
+    }
+
+    /**
+     * If no instance passed in request, reboot all bad instances
+     * If instances passed in request, reboot all valid passed bad instances
+     * If force and instances passed in request, reboot all valid passed instances
+     * If force and no instances passed in request, reboot all instances
+     * @param accountId - The account id for the instance to reboot.
+     * @param request - A RebootInstanceRequest containing request parameters.
+     */
+    public void rebootInstances(String accountId, RebootInstancesRequest request) {
+        Stack stack = stackService.getByEnvironmentCrnAndAccountIdWithLists(request.getEnvironmentCrn(), accountId);
+        MDCBuilder.buildMdcContext(stack);
+        Map<String, InstanceMetaData> allInstancesByInstanceId = getAllInstancesFromStack(stack);
+        Map<String, InstanceMetaData> instancesToReboot = getInstancesToReboot(allInstancesByInstanceId, accountId, request);
+
+        if (instancesToReboot.keySet().size() > 0) {
+            instanceMetaDataService.updateStatus(stack, instancesToReboot.keySet().stream().collect(Collectors.toList()), InstanceStatus.REBOOTING);
+            flowManager.notify(REBOOT_EVENT.event(), new InstanceEvent(REBOOT_EVENT.event(), stack.getId(),
+                    instancesToReboot.keySet().stream().collect(Collectors.toList())));
+        } else {
+            throw new NotFoundException("No unhealthy instances to reboot.  Maybe use the force option.");
+        }
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/controller/FreeIpaV1ControllerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/controller/FreeIpaV1ControllerTest.java
@@ -25,19 +25,22 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.validation.ValidationResult;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.FreeIpaServerBase;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.create.CreateFreeIpaRequest;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.list.ListFreeIpaResponse;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.detachchildenv.DetachChildEnvironmentRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.attachchildenv.AttachChildEnvironmentRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.create.CreateFreeIpaRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.detachchildenv.DetachChildEnvironmentRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.list.ListFreeIpaResponse;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.reboot.RebootInstancesRequest;
+import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.controller.exception.BadRequestException;
-import com.sequenceiq.freeipa.controller.validation.CreateFreeIpaRequestValidator;
 import com.sequenceiq.freeipa.controller.validation.AttachChildEnvironmentRequestValidator;
+import com.sequenceiq.freeipa.controller.validation.CreateFreeIpaRequestValidator;
 import com.sequenceiq.freeipa.service.stack.ChildEnvironmentService;
 import com.sequenceiq.freeipa.service.stack.FreeIpaCreationService;
 import com.sequenceiq.freeipa.service.stack.FreeIpaDeletionService;
 import com.sequenceiq.freeipa.service.stack.FreeIpaDescribeService;
 import com.sequenceiq.freeipa.service.stack.FreeIpaListService;
 import com.sequenceiq.freeipa.service.stack.FreeIpaRootCertificateService;
+import com.sequenceiq.freeipa.service.stack.RebootInstancesService;
 import com.sequenceiq.freeipa.util.CrnService;
 
 @ExtendWith(MockitoExtension.class)
@@ -61,6 +64,9 @@ class FreeIpaV1ControllerTest {
 
     @Mock
     private FreeIpaDescribeService describeService;
+
+    @Mock
+    private RebootInstancesService rebootInstancesService;
 
     @Mock
     private FreeIpaListService freeIpaListService;
@@ -184,5 +190,14 @@ class FreeIpaV1ControllerTest {
         underTest.detachChildEnvironment(request);
 
         verify(childEnvironmentService).detachChildEnvironment(request, ACCOUNT_ID);
+    }
+
+    @Test
+    void reboot() throws FreeIpaClientException {
+        when(crnService.getCurrentAccountId()).thenReturn(ACCOUNT_ID);
+        RebootInstancesRequest rebootInstancesRequest = new RebootInstancesRequest();
+
+        underTest.rebootInstances(rebootInstancesRequest);
+        verify(rebootInstancesService, times(1)).rebootInstances(crnService.getCurrentAccountId(), rebootInstancesRequest);
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/instance/InstanceMetaDataServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/instance/InstanceMetaDataServiceTest.java
@@ -1,0 +1,90 @@
+package com.sequenceiq.freeipa.service.instance;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.google.common.collect.Sets;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupType;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceStatus;
+import com.sequenceiq.freeipa.entity.InstanceGroup;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.repository.InstanceMetaDataRepository;
+import com.sequenceiq.freeipa.repository.StackRepository;
+import com.sequenceiq.freeipa.service.stack.instance.InstanceMetaDataService;
+
+@ExtendWith(MockitoExtension.class)
+public class InstanceMetaDataServiceTest {
+
+    private static final String ENVIRONMENT_ID = "crn:cdp:environments:us-west-1:f39af961-e0ce-4f79-826c-45502efb9ca3:environment:12345-6789";
+
+    private static final String ACCOUNT_ID = "accountId";
+
+    private static Stack stack;
+
+    @InjectMocks
+    private InstanceMetaDataService underTest;
+
+    @Mock
+    private StackRepository stackRepository;
+
+    @Mock
+    private InstanceMetaDataRepository instanceMetaDataRepository;
+
+    @BeforeAll
+    public static void init() {
+        stack = new Stack();
+        stack.setResourceCrn(ENVIRONMENT_ID);
+        stack.setId(1L);
+        InstanceGroup instanceGroup = new InstanceGroup();
+        stack.getInstanceGroups().add(instanceGroup);
+        instanceGroup.setInstanceGroupType(InstanceGroupType.MASTER);
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+        instanceGroup.setInstanceMetaData(Sets.newHashSet(instanceMetaData));
+        instanceMetaData.setDiscoveryFQDN("host1.domain");
+        instanceMetaData.setInstanceId("instance_1");
+        instanceMetaData = new InstanceMetaData();
+        instanceMetaData.setDiscoveryFQDN("host2.domain");
+        instanceMetaData.setInstanceId("instance_2");
+        instanceGroup.getInstanceMetaData().add(instanceMetaData);
+    }
+
+    private Set<InstanceMetaData> getInstancesFromStack() {
+        return stack.getInstanceGroups().stream()
+                .flatMap(instanceGroup -> instanceGroup.getInstanceMetaData().stream()).collect(Collectors.toSet());
+    }
+
+    @Test
+    public void testUpdateStatusSuccess() {
+        when(instanceMetaDataRepository.findAllInStack(1L)).thenReturn(getInstancesFromStack());
+        underTest.updateStatus(stack, List.of("instance_1"), InstanceStatus.CREATED);
+        verify(instanceMetaDataRepository, times(1)).save(any());
+    }
+
+    @Test
+    public void testUpdateMultipleStatusSuccess() {
+        when(instanceMetaDataRepository.findAllInStack(1L)).thenReturn(getInstancesFromStack());
+        underTest.updateStatus(stack, List.of("instance_1", "instance_2"), InstanceStatus.CREATED);
+        verify(instanceMetaDataRepository, times(2)).save(any());
+    }
+
+    @Test
+    public void testUpdateStatusInvalidId() {
+        when(instanceMetaDataRepository.findAllInStack(1L)).thenReturn(getInstancesFromStack());
+        underTest.updateStatus(stack, List.of("instance_a"), InstanceStatus.CREATED);
+        verify(instanceMetaDataRepository, times(0)).save(any());
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/instance/RebootInstanceServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/instance/RebootInstanceServiceTest.java
@@ -1,0 +1,221 @@
+package com.sequenceiq.freeipa.service.instance;
+
+import static com.sequenceiq.freeipa.flow.instance.reboot.RebootEvent.REBOOT_EVENT;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.google.common.collect.Sets;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupType;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceStatus;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.HealthDetailsFreeIpaResponse;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.NodeHealthDetails;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.reboot.RebootInstancesRequest;
+import com.sequenceiq.freeipa.client.FreeIpaClientException;
+import com.sequenceiq.freeipa.controller.exception.BadRequestException;
+import com.sequenceiq.freeipa.controller.exception.NotFoundException;
+import com.sequenceiq.freeipa.entity.InstanceGroup;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.flow.instance.InstanceEvent;
+import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
+import com.sequenceiq.freeipa.service.freeipa.flow.FreeIpaFlowManager;
+import com.sequenceiq.freeipa.service.stack.FreeIpaHealthDetailsService;
+import com.sequenceiq.freeipa.service.stack.RebootInstancesService;
+import com.sequenceiq.freeipa.service.stack.StackService;
+import com.sequenceiq.freeipa.service.stack.instance.InstanceMetaDataService;
+
+@ExtendWith(MockitoExtension.class)
+public class RebootInstanceServiceTest {
+
+    private static final String ENVIRONMENT_ID1 = "crn:cdp:environments:us-west-1:f39af961-e0ce-4f79-826c-45502efb9ca3:environment:12345-6789";
+
+    private static final String ENVIRONMENT_ID2 = "crn:cdp:environments:us-west-1:f39af961-e0ce-4f79-826c-45502efb9ca3:environment:98765-4321";
+
+    private static final String ACCOUNT_ID = "accountId";
+
+    private static FreeIpaClientException ipaClientException;
+
+    private static Stack stack1;
+
+    private static Stack stack2;
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private FreeIpaClientFactory freeIpaClientFactory;
+
+    @Mock
+    private FreeIpaHealthDetailsService healthDetailsService;
+
+    @Mock
+    private InstanceMetaDataService instanceMetaDataService;
+
+    @InjectMocks
+    private RebootInstancesService underTest;
+
+    @Mock
+    private FreeIpaFlowManager flowManager;
+
+    @BeforeAll
+    public static void init() {
+        ipaClientException = new FreeIpaClientException("failure");
+
+        stack1 = new Stack();
+        stack1.setResourceCrn(ENVIRONMENT_ID1);
+        InstanceGroup instanceGroup = new InstanceGroup();
+        stack1.getInstanceGroups().add(instanceGroup);
+        instanceGroup.setInstanceGroupType(InstanceGroupType.MASTER);
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+        instanceGroup.setInstanceMetaData(Sets.newHashSet(instanceMetaData));
+        instanceMetaData.setDiscoveryFQDN("host.domain");
+        instanceMetaData.setInstanceId("instance_1");
+
+        stack2 = new Stack();
+        stack2.setResourceCrn(ENVIRONMENT_ID2);
+        instanceGroup = new InstanceGroup();
+        stack2.getInstanceGroups().add(instanceGroup);
+        instanceGroup.setInstanceGroupType(InstanceGroupType.MASTER);
+        instanceMetaData = new InstanceMetaData();
+        instanceGroup.setInstanceMetaData(Sets.newHashSet(instanceMetaData));
+        instanceMetaData.setDiscoveryFQDN("host1.domain");
+        instanceMetaData.setInstanceId("instance_1");
+        instanceMetaData = new InstanceMetaData();
+        instanceGroup.getInstanceMetaData().add(instanceMetaData);
+        instanceMetaData.setDiscoveryFQDN("host2.domain");
+        instanceMetaData.setInstanceId("instance_2");
+    }
+
+    private HealthDetailsFreeIpaResponse getMockDetails1() {
+        HealthDetailsFreeIpaResponse healthDetailsFreeIpaResponse = new HealthDetailsFreeIpaResponse();
+        healthDetailsFreeIpaResponse.setCrn(ENVIRONMENT_ID1);
+        healthDetailsFreeIpaResponse.setName("test");
+        healthDetailsFreeIpaResponse.setStatus(Status.AVAILABLE);
+        NodeHealthDetails nodeHealthDetails = new NodeHealthDetails();
+        nodeHealthDetails.setInstanceId("instance_1");
+        nodeHealthDetails.setStatus(InstanceStatus.TERMINATED);
+        healthDetailsFreeIpaResponse.addNodeHealthDetailsFreeIpaResponses(nodeHealthDetails);
+        return healthDetailsFreeIpaResponse;
+    }
+
+    private HealthDetailsFreeIpaResponse getMockDetails2() {
+        HealthDetailsFreeIpaResponse healthDetailsFreeIpaResponse = new HealthDetailsFreeIpaResponse();
+        healthDetailsFreeIpaResponse.setCrn(ENVIRONMENT_ID2);
+        healthDetailsFreeIpaResponse.setName("test");
+        healthDetailsFreeIpaResponse.setStatus(Status.AVAILABLE);
+        NodeHealthDetails nodeHealthDetails = new NodeHealthDetails();
+        nodeHealthDetails.setInstanceId("instance_1");
+        nodeHealthDetails.setStatus(InstanceStatus.CREATED);
+        healthDetailsFreeIpaResponse.addNodeHealthDetailsFreeIpaResponses(nodeHealthDetails);
+        nodeHealthDetails = new NodeHealthDetails();
+        nodeHealthDetails.setInstanceId("instance_2");
+        nodeHealthDetails.setStatus(InstanceStatus.UNREACHABLE);
+        healthDetailsFreeIpaResponse.addNodeHealthDetailsFreeIpaResponses(nodeHealthDetails);
+        return healthDetailsFreeIpaResponse;
+    }
+
+    @Test
+    public void testBasicSuccessReboot() throws Exception {
+        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(stack1);
+        Mockito.when(healthDetailsService.getHealthDetails(any(), any())).thenReturn(getMockDetails1());
+        RebootInstancesRequest rebootInstancesRequest = new RebootInstancesRequest();
+        rebootInstancesRequest.setEnvironmentCrn(ENVIRONMENT_ID1);
+        underTest.rebootInstances(ACCOUNT_ID, rebootInstancesRequest);
+
+        ArgumentCaptor<InstanceEvent> terminationEventArgumentCaptor = ArgumentCaptor.forClass(InstanceEvent.class);
+        verify(flowManager, times(1)).notify(eq(REBOOT_EVENT.event()), terminationEventArgumentCaptor.capture());
+    }
+
+    @Test
+    public void testInstancesSuccessReboot() throws Exception {
+        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(stack1);
+        Mockito.when(healthDetailsService.getHealthDetails(any(), any())).thenReturn(getMockDetails1());
+        RebootInstancesRequest rebootInstancesRequest = new RebootInstancesRequest();
+        rebootInstancesRequest.setEnvironmentCrn(ENVIRONMENT_ID1);
+        rebootInstancesRequest.setInstanceIds(Arrays.asList("instance_1"));
+        underTest.rebootInstances(ACCOUNT_ID, rebootInstancesRequest);
+
+        ArgumentCaptor<InstanceEvent> terminationEventArgumentCaptor = ArgumentCaptor.forClass(InstanceEvent.class);
+        verify(flowManager, times(1)).notify(eq(REBOOT_EVENT.event()), terminationEventArgumentCaptor.capture());
+    }
+
+    @Test
+    public void testInvalidInstancesReboot() throws Exception {
+        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(stack1);
+        RebootInstancesRequest rebootInstancesRequest = new RebootInstancesRequest();
+        rebootInstancesRequest.setEnvironmentCrn(ENVIRONMENT_ID1);
+        rebootInstancesRequest.setInstanceIds(Arrays.asList("bad_instance"));
+        Exception expected = assertThrows(BadRequestException.class, () -> {
+            underTest.rebootInstances(ACCOUNT_ID, rebootInstancesRequest);
+                });
+        assertTrue(expected.getLocalizedMessage().equals("Invalid instanceIds in request bad_instance."));
+    }
+
+    @Test
+    public void testForceInstancesSuccessReboot() throws Exception {
+        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(stack1);
+        RebootInstancesRequest rebootInstancesRequest = new RebootInstancesRequest();
+        rebootInstancesRequest.setEnvironmentCrn(ENVIRONMENT_ID1);
+        rebootInstancesRequest.setInstanceIds(Arrays.asList("instance_1"));
+        rebootInstancesRequest.setForceReboot(true);
+        underTest.rebootInstances(ACCOUNT_ID, rebootInstancesRequest);
+
+        ArgumentCaptor<InstanceEvent> terminationEventArgumentCaptor = ArgumentCaptor.forClass(InstanceEvent.class);
+        verify(flowManager, times(1)).notify(eq(REBOOT_EVENT.event()), terminationEventArgumentCaptor.capture());
+    }
+
+    @Test
+    public void testNonForceAvailableInstanceReboot() throws Exception {
+        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(stack2);
+        Mockito.when(healthDetailsService.getHealthDetails(any(), any())).thenReturn(getMockDetails2());
+        RebootInstancesRequest rebootInstancesRequest = new RebootInstancesRequest();
+        rebootInstancesRequest.setEnvironmentCrn(ENVIRONMENT_ID2);
+        rebootInstancesRequest.setInstanceIds(Arrays.asList("instance_1"));
+        Exception expected = assertThrows(NotFoundException.class, () -> {
+                    underTest.rebootInstances(ACCOUNT_ID, rebootInstancesRequest);
+                });
+        assertTrue(expected.getLocalizedMessage().equals("No unhealthy instances to reboot.  Maybe use the force option."));
+        ArgumentCaptor<InstanceEvent> terminationEventArgumentCaptor = ArgumentCaptor.forClass(InstanceEvent.class);
+        verify(flowManager, times(0)).notify(eq(REBOOT_EVENT.event()), terminationEventArgumentCaptor.capture());
+    }
+
+    @Test
+    public void testNonForceMultiInstanceReboot() throws Exception {
+        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(stack2);
+        Mockito.when(healthDetailsService.getHealthDetails(any(), any())).thenReturn(getMockDetails2());
+        RebootInstancesRequest rebootInstancesRequest = new RebootInstancesRequest();
+        rebootInstancesRequest.setEnvironmentCrn(ENVIRONMENT_ID2);
+        underTest.rebootInstances(ACCOUNT_ID, rebootInstancesRequest);
+        ArgumentCaptor<InstanceEvent> terminationEventArgumentCaptor = ArgumentCaptor.forClass(InstanceEvent.class);
+        verify(flowManager, times(1)).notify(eq(REBOOT_EVENT.event()), terminationEventArgumentCaptor.capture());
+    }
+
+    @Test
+    public void testForceMultiInstanceReboot() throws Exception {
+        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(stack2);
+        RebootInstancesRequest rebootInstancesRequest = new RebootInstancesRequest();
+        rebootInstancesRequest.setEnvironmentCrn(ENVIRONMENT_ID2);
+        rebootInstancesRequest.setForceReboot(true);
+        underTest.rebootInstances(ACCOUNT_ID, rebootInstancesRequest);
+        ArgumentCaptor<InstanceEvent> terminationEventArgumentCaptor = ArgumentCaptor.forClass(InstanceEvent.class);
+        verify(flowManager, times(1)).notify(eq(REBOOT_EVENT.event()), terminationEventArgumentCaptor.capture());
+    }
+
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaHealthServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaHealthServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.google.common.collect.Sets;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupType;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.HealthDetailsFreeIpaResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.NodeHealthDetails;
 import com.sequenceiq.freeipa.client.FreeIpaClient;
@@ -159,7 +160,7 @@ public class FreeIpaHealthServiceTest {
         Assert.assertFalse(response.getNodeHealthDetails().isEmpty());
         for (NodeHealthDetails nodeHealth:response.getNodeHealthDetails()) {
             Assert.assertTrue(nodeHealth.getIssues().isEmpty());
-            Assert.assertEquals(Status.AVAILABLE, nodeHealth.getStatus());
+            Assert.assertEquals(InstanceStatus.CREATED, nodeHealth.getStatus());
         }
     }
 
@@ -174,7 +175,7 @@ public class FreeIpaHealthServiceTest {
         Assert.assertFalse(response.getNodeHealthDetails().isEmpty());
         for (NodeHealthDetails nodeHealth:response.getNodeHealthDetails()) {
             Assert.assertFalse(nodeHealth.getIssues().isEmpty());
-            Assert.assertEquals(Status.UNHEALTHY, nodeHealth.getStatus());
+            Assert.assertEquals(InstanceStatus.FAILED, nodeHealth.getStatus());
         }
     }
 
@@ -189,7 +190,7 @@ public class FreeIpaHealthServiceTest {
         Assert.assertFalse(response.getNodeHealthDetails().isEmpty());
         for (NodeHealthDetails nodeHealth:response.getNodeHealthDetails()) {
             Assert.assertTrue(nodeHealth.getIssues().isEmpty());
-            Assert.assertEquals(Status.UNREACHABLE, nodeHealth.getStatus());
+            Assert.assertEquals(InstanceStatus.UNREACHABLE, nodeHealth.getStatus());
         }
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/model/SPIMock.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/model/SPIMock.java
@@ -27,6 +27,8 @@ public class SPIMock extends AbstractModelMock {
 
     public static final String START_INSTANCE = "/:instanceid/start";
 
+    public static final String REBOOT_INSTANCE = "/:instanceid/reboot";
+
     public static final String CLOUD_INSTANCE_STATUSES = "/cloud_instance_statuses";
 
     public static final String CLOUD_METADATA_STATUSES = "/cloud_metadata_statuses";
@@ -34,6 +36,8 @@ public class SPIMock extends AbstractModelMock {
     public static final String START_INSTANCES = "/start_instances";
 
     public static final String STOP_INSTANCES = "/stop_instances";
+
+    public static final String REBOOT_INSTANCES = "/reboot_instances";
 
     private DynamicRouteStack dynamicRouteStack;
 
@@ -73,6 +77,14 @@ public class SPIMock extends AbstractModelMock {
         });
     }
 
+    private void getMockProviderRebootStatus() {
+        dynamicRouteStack.get(MOCK_ROOT + REBOOT_INSTANCE, (request, response) -> {
+            String instanceid = request.params("instanceid");
+            CloudInstance instance = new CloudInstance(instanceid, null, null);
+            return new CloudVmInstanceStatus(instance, InstanceStatus.STARTED);
+        });
+    }
+
     private void postMockProviderTerminateInstance(Map<String, CloudVmMetaDataStatus> instanceMap) {
         dynamicRouteStack.post(MOCK_ROOT + TERMINATE_INSTANCES, (request, response) -> {
             List<CloudInstance> cloudInstances = new Gson().fromJson(request.body(), new TypeToken<List<CloudInstance>>() {
@@ -92,6 +104,13 @@ public class SPIMock extends AbstractModelMock {
 
     private void postMockProviderStartInstance(DefaultModel model) {
         dynamicRouteStack.post(MOCK_ROOT + START_INSTANCES, (request, response) -> {
+            model.startAllInstances();
+            return null;
+        });
+    }
+
+    private void postMockProviderRebootInstance(DefaultModel model) {
+        dynamicRouteStack.post(MOCK_ROOT + REBOOT_INSTANCES, (request, response) -> {
             model.startAllInstances();
             return null;
         });


### PR DESCRIPTION
This patch adds the APIs and flows to support requesting
a reboot of a single instance of a FreeIPA cluster.

https://github.com/hortonworks/cloudbreak/commit/7bedab08331049d704829df0b1a6bfc9c9e6f5cf?diff=split#diff-bb2a2c4ffdd122b890ccd439056e72c4

https://github.com/hortonworks/cloudbreak/commit/7bedab08331049d704829df0b1a6bfc9c9e6f5cf?diff=split#diff-a17be58a8a607f24bfc72b427ea2b4ec
