### PR TITLE
CB-5750. Drop oldest fluentd chunks - avoid buffer overflow

### DIFF
--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/output.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/output.conf.j2
@@ -16,8 +16,12 @@
       path /var/log/td-agent/{{fluent.providerPrefix}}
       timekey {{fluent.partitionIntervalMin}}m
       timekey_wait 0s
-      chunk_limit_size 256m
+      total_limit_size  2048MB
+      chunk_limit_size  60m
       flush_at_shutdown true
+      overflow_action drop_oldest_chunk
+      disable_chunk_backup  true
+      retry_timeout 1h
     </buffer>
     utc
     format single_value
@@ -38,8 +42,12 @@
       path /var/log/td-agent/{{fluent.providerPrefix}}_CM_COMMAND
       timekey {{fluent.partitionIntervalMin}}m
       timekey_wait 0s
-      chunk_limit_size 256m
+      total_limit_size  1024MB
+      chunk_limit_size  60m
       flush_at_shutdown true
+      overflow_action drop_oldest_chunk
+      disable_chunk_backup  true
+      retry_timeout 1h
     </buffer>
     utc
     format single_value
@@ -77,8 +85,11 @@
       path /var/log/td-agent/{{fluent.providerPrefix}}
       timekey {{fluent.partitionIntervalMin}}m
       timekey_wait 0s
-      chunk_limit_size 60m
+      total_limit_size  2048MB
+      chunk_limit_size  60m
       flush_at_shutdown true
+      overflow_action   drop_oldest_chunk
+      disable_chunk_backup  true
       retry_type        periodic
       retry_max_times   3
       retry_wait        5s
@@ -116,8 +127,11 @@
       path /var/log/td-agent/{{fluent.providerPrefix}}_CM_COMMAND
       timekey {{fluent.partitionIntervalMin}}m
       timekey_wait 0s
-      chunk_limit_size 60m
+      total_limit_size  1024MB
+      chunk_limit_size  60m
       flush_at_shutdown true
+      overflow_action   drop_oldest_chunk
+      disable_chunk_backup  true
       retry_type        periodic
       retry_max_times   3
       retry_wait        5s


### PR DESCRIPTION
### 4 fluentd config changes

main change is to set the retry timeout (+ if it reaches the 2h limit, drop the backups as well from tmp) + set a total buffer limit (1-2 GB)

retry timeout: 
Default: 72h
The maximum seconds to retry to flush while failing, until plugin discards buffer chunks
- change it to 2h

disable_chunk_backup:
Default: false
Instead of storing unrecoverable chunks in the backup directory, just discard them
- enable this, will only impact /tmp folder

overflow_action
drop_oldest_chunk: drop/purge oldest chunk to accept newly incoming chunk
(default is throw exception)

total_limit_size
Once the total size of stored buffer reached this threshold, all append operations will fail with error (and data will be lost)
- set 1G for CM agent commands and 2G for service logs