### PR TITLE
CB-5562 Add length validation for StackAuthenticationRequest

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/StackAuthenticationV4Base.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/StackAuthenticationV4Base.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base;
 
+import javax.validation.constraints.Size;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.JsonEntity;
 import com.sequenceiq.cloudbreak.doc.ModelDescriptions.StackAuthenticationBase;
@@ -9,12 +11,15 @@ import io.swagger.annotations.ApiModelProperty;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class StackAuthenticationV4Base implements JsonEntity {
 
+    @Size(max = 2048, message = "The length of the publicKey has to be smaller than 2048")
     @ApiModelProperty(StackAuthenticationBase.PUBLIC_KEY)
     private String publicKey;
 
+    @Size(max = 255, message = "The length of the publicKeyId has to be smaller than 255")
     @ApiModelProperty(StackAuthenticationBase.PUBLIC_KEY_ID)
     private String publicKeyId;
 
+    @Size(max = 32, message = "The length of the loginUserName has to be smaller than 32")
     @ApiModelProperty(StackAuthenticationBase.LOGIN_USERNAME)
     private String loginUserName;
 

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/StackV4Request.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/StackV4Request.java
@@ -62,6 +62,7 @@ public class StackV4Request extends StackV4Base {
     private List<InstanceGroupV4Request> instanceGroups = new ArrayList<>();
 
     @NotNull(message = "You should define authentication for stack!")
+    @Valid
     @ApiModelProperty(StackModelDescription.AUTHENTICATION)
     private StackAuthenticationV4Request authentication;
 

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/security/StackAuthenticationBase.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/security/StackAuthenticationBase.java
@@ -1,16 +1,22 @@
 package com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.security;
 
+import javax.validation.constraints.Size;
+
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.doc.FreeIpaModelDescriptions.StackAuthenticationModelDescription;
 
 import io.swagger.annotations.ApiModelProperty;
 
 public abstract class StackAuthenticationBase {
+
+    @Size(max = 2048, message = "The length of the publicKey has to be smaller than 2048")
     @ApiModelProperty(StackAuthenticationModelDescription.PUBLIC_KEY)
     private String publicKey;
 
+    @Size(max = 255, message = "The length of the publicKeyId has to be smaller than 255")
     @ApiModelProperty(StackAuthenticationModelDescription.PUBLIC_KEY_ID)
     private String publicKeyId;
 
+    @Size(max = 32, message = "The length of the loginUserName has to be smaller than 32")
     @ApiModelProperty(StackAuthenticationModelDescription.LOGIN_USERNAME)
     private String loginUserName;
 

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/create/CreateFreeIpaRequest.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/create/CreateFreeIpaRequest.java
@@ -46,6 +46,7 @@ public class CreateFreeIpaRequest {
     private List<InstanceGroupRequest> instanceGroups;
 
     @NotNull
+    @Valid
     @ApiModelProperty(value = FreeIpaModelDescriptions.AUTHENTICATION, required = true)
     private StackAuthenticationRequest authentication;
 


### PR DESCRIPTION
Added length validation for StackAuthenticationRequest. The max length for publicKey is 2048, for publicKeyId it is 255 and for loginUserName it is 32.