### PR TITLE
CB-5588 Enable Knox HA proxy for Schema Registry

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -344,6 +344,13 @@
                  <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
              </param>
              {%- endif %}
+
+             {% if 'SCHEMA-REGISTRY' in exposed and 'SCHEMA_REGISTRY_SERVER' in salt['pillar.get']('gateway:location') -%}
+             <param>
+                 <name>SCHEMA-REGISTRY</name>
+                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
+             </param>
+             {%- endif %}
          </provider>
 
     </gateway>

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
@@ -195,6 +195,12 @@
                  <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
              </param>
              {%- endif %}
+             {% if 'SCHEMA-REGISTRY' in exposed and 'SCHEMA_REGISTRY_SERVER' in salt['pillar.get']('gateway:location') -%}
+             <param>
+                 <name>SCHEMA-REGISTRY</name>
+                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
+             </param>
+             {%- endif %}
         </provider>
     </gateway>
 


### PR DESCRIPTION
Enabled HA proxying for Schema Registry in the Knox topology template.

Tested manually (installed a cluster with 2 Schema Registry instances, checked UI and API with either of the instances down)

Closes CB-5588
