### PR TITLE
CB-4886 Add feature flag for IDBroker mapping validation

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
@@ -119,8 +119,7 @@ public class StackRequestManifester {
             setupClusterRequest(stackRequest);
             prepareTelemetryForStack(stackRequest, environment, sdxCluster);
             setupCloudStorageAccountMapping(stackRequest, environment.getCrn(), environment.getIdBrokerMappingSource(), environment.getCloudPlatform());
-            // TODO put this behind a feature flag
-            //cloudStorageValidator.validate(stackRequest.getCluster().getCloudStorage(), environment);
+            cloudStorageValidator.validate(stackRequest.getCluster().getCloudStorage(), environment);
             return stackRequest;
         } catch (IOException e) {
             LOGGER.error("Can not parse JSON to stack request");

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/validation/cloudstorage/CloudStorageValidator.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/validation/cloudstorage/CloudStorageValidator.java
@@ -15,6 +15,7 @@ import com.sequenceiq.common.api.cloudstorage.CloudStorageRequest;
 import com.sequenceiq.datalake.controller.exception.BadRequestException;
 import com.sequenceiq.datalake.entity.Credential;
 import com.sequenceiq.datalake.service.validation.converter.CredentialToCloudCredentialConverter;
+import com.sequenceiq.environment.api.v1.environment.model.base.CloudStorageValidation;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 
 @Component
@@ -36,6 +37,12 @@ public class CloudStorageValidator {
     }
 
     public void validate(CloudStorageRequest cloudStorageRequest, DetailedEnvironmentResponse environment) {
+        if (CloudStorageValidation.DISABLED.equals(environment.getCloudStorageValidation())) {
+            LOGGER.info("Due to cloud storage validation not being enabled, not validating cloudStorageRequest: {}",
+                    JsonUtil.writeValueAsStringSilent(cloudStorageRequest));
+            return;
+        }
+
         LOGGER.info("Validating cloudStorageRequest: {}", JsonUtil.writeValueAsStringSilent(cloudStorageRequest));
         if (cloudStorageRequest != null) {
             Credential credential = getCredential(environment);

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
@@ -55,6 +55,9 @@ public class EnvironmentModelDescription {
     public static final String LOG_CLOUD_STORAGE = "Cloud storage configuration for this environment. Service logs will be stored in the defined location.";
 
     public static final String IDBROKER_MAPPING_SOURCE = "IDBroker mapping source.";
+
+    public static final String CLOUD_STORAGE_VALIDATION = "Cloud storage validation enabled or not.";
+
     public static final String ADMIN_GROUP_NAME = "Name of the admin group to be used for all the services.";
 
     public static final String AWS_PARAMETERS = "AWS Specific parameters.";

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/base/CloudStorageValidation.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/base/CloudStorageValidation.java
@@ -1,0 +1,6 @@
+package com.sequenceiq.environment.api.v1.environment.model.base;
+
+public enum CloudStorageValidation {
+    ENABLED,
+    DISABLED
+}

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/EnvironmentEditRequest.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/EnvironmentEditRequest.java
@@ -6,6 +6,7 @@ import javax.validation.constraints.Size;
 import com.sequenceiq.common.api.telemetry.request.TelemetryRequest;
 import com.sequenceiq.environment.api.doc.ModelDescriptions;
 import com.sequenceiq.environment.api.doc.environment.EnvironmentModelDescription;
+import com.sequenceiq.environment.api.v1.environment.model.base.CloudStorageValidation;
 import com.sequenceiq.environment.api.v1.environment.model.base.IdBrokerMappingSource;
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsEnvironmentParameters;
 
@@ -33,6 +34,9 @@ public class EnvironmentEditRequest {
 
     @ApiModelProperty(EnvironmentModelDescription.IDBROKER_MAPPING_SOURCE)
     private IdBrokerMappingSource idBrokerMappingSource;
+
+    @ApiModelProperty(EnvironmentModelDescription.CLOUD_STORAGE_VALIDATION)
+    private CloudStorageValidation cloudStorageValidation;
 
     @ApiModelProperty(EnvironmentModelDescription.ADMIN_GROUP_NAME)
     private String adminGroupName;
@@ -87,6 +91,14 @@ public class EnvironmentEditRequest {
 
     public void setIdBrokerMappingSource(IdBrokerMappingSource idBrokerMappingSource) {
         this.idBrokerMappingSource = idBrokerMappingSource;
+    }
+
+    public CloudStorageValidation getCloudStorageValidation() {
+        return cloudStorageValidation;
+    }
+
+    public void setCloudStorageValidation(CloudStorageValidation cloudStorageValidation) {
+        this.cloudStorageValidation = cloudStorageValidation;
     }
 
     public String getAdminGroupName() {

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/EnvironmentRequest.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/EnvironmentRequest.java
@@ -19,6 +19,7 @@ import com.sequenceiq.common.api.type.Tunnel;
 import com.sequenceiq.environment.api.doc.ModelDescriptions;
 import com.sequenceiq.environment.api.doc.environment.EnvironmentModelDescription;
 import com.sequenceiq.environment.api.v1.environment.model.base.IdBrokerMappingSource;
+import com.sequenceiq.environment.api.v1.environment.model.base.CloudStorageValidation;
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsEnvironmentParameters;
 
 import io.swagger.annotations.ApiModel;
@@ -79,6 +80,9 @@ public class EnvironmentRequest extends EnvironmentBaseRequest implements Creden
 
     @ApiModelProperty(EnvironmentModelDescription.IDBROKER_MAPPING_SOURCE)
     private IdBrokerMappingSource idBrokerMappingSource = IdBrokerMappingSource.IDBMMS;
+
+    @ApiModelProperty(EnvironmentModelDescription.CLOUD_STORAGE_VALIDATION)
+    private CloudStorageValidation cloudStorageValidation = CloudStorageValidation.DISABLED;
 
     @ApiModelProperty(EnvironmentModelDescription.ADMIN_GROUP_NAME)
     private String adminGroupName;
@@ -198,6 +202,14 @@ public class EnvironmentRequest extends EnvironmentBaseRequest implements Creden
 
     public void setIdBrokerMappingSource(IdBrokerMappingSource idBrokerMappingSource) {
         this.idBrokerMappingSource = idBrokerMappingSource;
+    }
+
+    public CloudStorageValidation getCloudStorageValidation() {
+        return cloudStorageValidation;
+    }
+
+    public void setCloudStorageValidation(CloudStorageValidation cloudStorageValidation) {
+        this.cloudStorageValidation = cloudStorageValidation;
     }
 
     public String getAdminGroupName() {

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/DetailedEnvironmentResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/DetailedEnvironmentResponse.java
@@ -8,6 +8,7 @@ import com.sequenceiq.common.api.type.Tunnel;
 import com.sequenceiq.environment.api.doc.environment.EnvironmentModelDescription;
 import com.sequenceiq.environment.api.v1.credential.model.response.CredentialResponse;
 import com.sequenceiq.environment.api.v1.environment.model.base.IdBrokerMappingSource;
+import com.sequenceiq.environment.api.v1.environment.model.base.CloudStorageValidation;
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsEnvironmentParameters;
 
 import io.swagger.annotations.ApiModel;
@@ -69,6 +70,8 @@ public class DetailedEnvironmentResponse extends EnvironmentBaseResponse {
         private String adminGroupName;
 
         private IdBrokerMappingSource idBrokerMappingSource;
+
+        private CloudStorageValidation cloudStorageValidation;
 
         private AwsEnvironmentParameters aws;
 
@@ -180,6 +183,11 @@ public class DetailedEnvironmentResponse extends EnvironmentBaseResponse {
             return this;
         }
 
+        public Builder withCloudStorageValidation(CloudStorageValidation cloudStorageValidation) {
+            this.cloudStorageValidation = cloudStorageValidation;
+            return this;
+        }
+
         public Builder withAdminGroupName(String adminGroupName) {
             this.adminGroupName = adminGroupName;
             return this;
@@ -226,6 +234,7 @@ public class DetailedEnvironmentResponse extends EnvironmentBaseResponse {
             detailedEnvironmentResponse.setSecurityAccess(securityAccess);
             detailedEnvironmentResponse.setTunnel(tunnel);
             detailedEnvironmentResponse.setIdBrokerMappingSource(idBrokerMappingSource);
+            detailedEnvironmentResponse.setCloudStorageValidation(cloudStorageValidation);
             detailedEnvironmentResponse.setAdminGroupName(adminGroupName);
             detailedEnvironmentResponse.setAws(aws);
             detailedEnvironmentResponse.setTags(tag);

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentBaseResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentBaseResponse.java
@@ -6,6 +6,7 @@ import com.sequenceiq.common.api.type.Tunnel;
 import com.sequenceiq.environment.api.doc.ModelDescriptions;
 import com.sequenceiq.environment.api.doc.environment.EnvironmentModelDescription;
 import com.sequenceiq.environment.api.v1.environment.model.base.IdBrokerMappingSource;
+import com.sequenceiq.environment.api.v1.environment.model.base.CloudStorageValidation;
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsEnvironmentParameters;
 
 import io.swagger.annotations.ApiModel;
@@ -65,6 +66,9 @@ public abstract class EnvironmentBaseResponse {
 
     @ApiModelProperty(EnvironmentModelDescription.IDBROKER_MAPPING_SOURCE)
     private IdBrokerMappingSource idBrokerMappingSource;
+
+    @ApiModelProperty(EnvironmentModelDescription.CLOUD_STORAGE_VALIDATION)
+    private CloudStorageValidation cloudStorageValidation;
 
     @ApiModelProperty(EnvironmentModelDescription.ADMIN_GROUP_NAME)
     private String adminGroupName;
@@ -223,6 +227,14 @@ public abstract class EnvironmentBaseResponse {
 
     public void setIdBrokerMappingSource(IdBrokerMappingSource idBrokerMappingSource) {
         this.idBrokerMappingSource = idBrokerMappingSource;
+    }
+
+    public CloudStorageValidation getCloudStorageValidation() {
+        return cloudStorageValidation;
+    }
+
+    public void setCloudStorageValidation(CloudStorageValidation cloudStorageValidation) {
+        this.cloudStorageValidation = cloudStorageValidation;
     }
 
     public String getAdminGroupName() {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/domain/ExperimentalFeatures.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/domain/ExperimentalFeatures.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.sequenceiq.environment.api.v1.environment.model.base.IdBrokerMappingSource;
 import com.sequenceiq.common.api.type.Tunnel;
+import com.sequenceiq.environment.api.v1.environment.model.base.CloudStorageValidation;
 
 @Embeddable
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -22,6 +23,9 @@ public class ExperimentalFeatures implements Serializable {
     @Enumerated(EnumType.STRING)
     @Column(name = "idbroker_mapping_source")
     private IdBrokerMappingSource idBrokerMappingSource;
+
+    @Enumerated(EnumType.STRING)
+    private CloudStorageValidation cloudStorageValidation;
 
     public Tunnel getTunnel() {
         return tunnel;
@@ -39,9 +43,17 @@ public class ExperimentalFeatures implements Serializable {
         this.idBrokerMappingSource = idBrokerMappingSource;
     }
 
+    public CloudStorageValidation getCloudStorageValidation() {
+        return cloudStorageValidation;
+    }
+
+    public void setCloudStorageValidation(CloudStorageValidation cloudStorageValidation) {
+        this.cloudStorageValidation = cloudStorageValidation;
+    }
+
     @JsonIgnore
     public boolean isEmpty() {
-        return tunnel == null && idBrokerMappingSource == null;
+        return tunnel == null && idBrokerMappingSource == null && cloudStorageValidation == null;
     }
 
     public static Builder builder() {
@@ -53,6 +65,8 @@ public class ExperimentalFeatures implements Serializable {
         private Tunnel tunnel;
 
         private IdBrokerMappingSource idBrokerMappingSource;
+
+        private CloudStorageValidation cloudStorageValidation;
 
         private Builder() {
         }
@@ -67,10 +81,16 @@ public class ExperimentalFeatures implements Serializable {
             return this;
         }
 
+        public Builder withCloudStorageValidation(CloudStorageValidation cloudStorageValidation) {
+            this.cloudStorageValidation = cloudStorageValidation;
+            return this;
+        }
+
         public ExperimentalFeatures build() {
             ExperimentalFeatures experimentalFeatures = new ExperimentalFeatures();
             experimentalFeatures.setTunnel(tunnel);
             experimentalFeatures.setIdBrokerMappingSource(idBrokerMappingSource);
+            experimentalFeatures.setCloudStorageValidation(cloudStorageValidation);
             return experimentalFeatures;
         }
     }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentEditDto.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentEditDto.java
@@ -2,6 +2,7 @@ package com.sequenceiq.environment.environment.dto;
 
 import com.sequenceiq.common.api.type.Tunnel;
 import com.sequenceiq.environment.api.v1.environment.model.base.IdBrokerMappingSource;
+import com.sequenceiq.environment.api.v1.environment.model.base.CloudStorageValidation;
 import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentTelemetry;
 import com.sequenceiq.environment.network.dto.NetworkDto;
 import com.sequenceiq.environment.parameters.dto.ParametersDto;
@@ -24,6 +25,8 @@ public class EnvironmentEditDto {
 
     private final IdBrokerMappingSource idBrokerMappingSource;
 
+    private final CloudStorageValidation cloudStorageValidation;
+
     private final String adminGroupName;
 
     private final ParametersDto parameters;
@@ -37,6 +40,7 @@ public class EnvironmentEditDto {
             SecurityAccessDto securityAccess,
             Tunnel tunnel,
             IdBrokerMappingSource idBrokerMappingSource,
+            CloudStorageValidation cloudStorageValidation,
             String adminGroupName,
             ParametersDto parameters) {
         this.description = description;
@@ -47,6 +51,7 @@ public class EnvironmentEditDto {
         this.securityAccess = securityAccess;
         this.tunnel = tunnel;
         this.idBrokerMappingSource = idBrokerMappingSource;
+        this.cloudStorageValidation = cloudStorageValidation;
         this.adminGroupName = adminGroupName;
         this.parameters = parameters;
     }
@@ -83,6 +88,10 @@ public class EnvironmentEditDto {
         return idBrokerMappingSource;
     }
 
+    public CloudStorageValidation getCloudStorageValidation() {
+        return cloudStorageValidation;
+    }
+
     public String getAdminGroupName() {
         return adminGroupName;
     }
@@ -111,6 +120,8 @@ public class EnvironmentEditDto {
         private Tunnel tunnel;
 
         private IdBrokerMappingSource idBrokerMappingSource;
+
+        private CloudStorageValidation cloudStorageValidation;
 
         private String adminGroupName;
 
@@ -159,6 +170,11 @@ public class EnvironmentEditDto {
             return this;
         }
 
+        public EnvironmentEditDtoBuilder withCloudStorageValidation(CloudStorageValidation cloudStorageValidation) {
+            this.cloudStorageValidation = cloudStorageValidation;
+            return this;
+        }
+
         public EnvironmentEditDtoBuilder withAdminGroupName(String adminGroupName) {
             this.adminGroupName = adminGroupName;
             return this;
@@ -171,7 +187,7 @@ public class EnvironmentEditDto {
 
         public EnvironmentEditDto build() {
             return new EnvironmentEditDto(description, accountId, network, authentication, telemetry, securityAccess, tunnel, idBrokerMappingSource,
-                    adminGroupName, parameters);
+                    cloudStorageValidation, adminGroupName, parameters);
         }
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentModificationService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentModificationService.java
@@ -13,6 +13,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.validation.ValidationResult;
 import com.sequenceiq.environment.api.v1.environment.model.base.IdBrokerMappingSource;
+import com.sequenceiq.environment.api.v1.environment.model.base.CloudStorageValidation;
 import com.sequenceiq.environment.credential.domain.Credential;
 import com.sequenceiq.environment.credential.service.CredentialService;
 import com.sequenceiq.environment.environment.domain.Environment;
@@ -104,6 +105,7 @@ public class EnvironmentModificationService {
         editAuthenticationIfChanged(editDto, env);
         editSecurityAccessIfChanged(editDto, env);
         editIdBrokerMappingSource(editDto, env);
+        editCloudStorageValidation(editDto, env);
         editTunnelIfChanged(editDto, env);
         editEnvironmentParameters(editDto, env);
         Environment saved = environmentService.save(env);
@@ -204,6 +206,15 @@ public class EnvironmentModificationService {
         if (idBrokerMappingSource != null) {
             ExperimentalFeatures experimentalFeaturesJson = environment.getExperimentalFeaturesJson();
             experimentalFeaturesJson.setIdBrokerMappingSource(idBrokerMappingSource);
+            environment.setExperimentalFeaturesJson(experimentalFeaturesJson);
+        }
+    }
+
+    private void editCloudStorageValidation(EnvironmentEditDto editDto, Environment environment) {
+        CloudStorageValidation cloudStorageValidation = editDto.getCloudStorageValidation();
+        if (cloudStorageValidation != null) {
+            ExperimentalFeatures experimentalFeaturesJson = environment.getExperimentalFeaturesJson();
+            experimentalFeaturesJson.setCloudStorageValidation(cloudStorageValidation);
             environment.setExperimentalFeaturesJson(experimentalFeaturesJson);
         }
     }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/EnvironmentApiConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/EnvironmentApiConverter.java
@@ -137,6 +137,7 @@ public class EnvironmentApiConverter {
                 .withCrn(createCrn(ThreadBasedUserCrnProvider.getAccountId()))
                 .withExperimentalFeatures(ExperimentalFeatures.builder()
                         .withIdBrokerMappingSource(request.getIdBrokerMappingSource())
+                        .withCloudStorageValidation(request.getCloudStorageValidation())
                         .withTunnel(tunnelConverter.convert(request.getTunnel()))
                         .build())
                 .withParameters(getIfNotNull(request.getAws(), this::awsParamsToParametersDto))
@@ -303,6 +304,7 @@ public class EnvironmentApiConverter {
                 .withRegions(regionConverter.convertRegions(environmentDto.getRegions()))
                 .withTunnel(environmentDto.getExperimentalFeatures().getTunnel())
                 .withIdBrokerMappingSource(environmentDto.getExperimentalFeatures().getIdBrokerMappingSource())
+                .withCloudStorageValidation(environmentDto.getExperimentalFeatures().getCloudStorageValidation())
                 .withAdminGroupName(environmentDto.getAdminGroupName())
                 .withAws(getIfNotNull(environmentDto.getParameters(), this::awsEnvParamsToAwsEnvironmentParams))
                 .withParentEnvironmentCrn(environmentDto.getParentEnvironmentCrn())
@@ -405,6 +407,7 @@ public class EnvironmentApiConverter {
                 .withDescription(request.getDescription())
                 .withAccountId(ThreadBasedUserCrnProvider.getAccountId())
                 .withIdBrokerMappingSource(request.getIdBrokerMappingSource())
+                .withCloudStorageValidation(request.getCloudStorageValidation())
                 .withAdminGroupName(request.getAdminGroupName());
         NullUtil.doIfNotNull(request.getNetwork(), network -> builder.withNetwork(networkRequestToDto(network)));
         NullUtil.doIfNotNull(request.getAuthentication(), authentication -> builder.withAuthentication(authenticationRequestToDto(authentication)));

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
@@ -20,6 +20,7 @@ import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.common.api.telemetry.request.TelemetryRequest;
 import com.sequenceiq.environment.api.v1.environment.endpoint.EnvironmentEndpoint;
 import com.sequenceiq.environment.api.v1.environment.model.base.IdBrokerMappingSource;
+import com.sequenceiq.environment.api.v1.environment.model.base.CloudStorageValidation;
 import com.sequenceiq.environment.api.v1.environment.model.request.AttachedFreeIpaRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentAuthenticationRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentChangeCredentialRequest;
@@ -101,7 +102,8 @@ public class EnvironmentTestDto
                 .withCredentialName(getTestContext().get(CredentialTestDto.class).getName())
                 .withAuthentication(DUMMY_SSH_KEY)
                 .withCloudplatform(getCloudPlatform().toString())
-                .withIdBrokerMappingSource(IdBrokerMappingSource.MOCK);
+                .withIdBrokerMappingSource(IdBrokerMappingSource.MOCK)
+                .withCloudStorageValidation(CloudStorageValidation.ENABLED);
     }
 
     public EnvironmentTestDto withCreateFreeIpa(Boolean create) {
@@ -124,6 +126,11 @@ public class EnvironmentTestDto
 
     public EnvironmentTestDto withIdBrokerMappingSource(IdBrokerMappingSource idBrokerMappingSource) {
         getRequest().setIdBrokerMappingSource(idBrokerMappingSource);
+        return this;
+    }
+
+    public EnvironmentTestDto withCloudStorageValidation(CloudStorageValidation cloudStorageValidation) {
+        getRequest().setCloudStorageValidation(cloudStorageValidation);
         return this;
     }
 


### PR DESCRIPTION
Adds a feature flag for cloud storage validation which includes the IDBroker mapping validation. It is disabled by default. The validation is enabled by modifying the environment creation request. CB-5768 is for switching to enabled by default.