### PR TITLE
CB-5725 Child environment detach should remove reverse DNS zone from FreeIPA

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeIpaCreationHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeIpaCreationHandler.java
@@ -94,8 +94,6 @@ public class FreeIpaCreationHandler extends EventSenderAwareHandler<EnvironmentD
 
     private final CloudPlatformConnectors connectors;
 
-    private String yarnNetworkCidr;
-
     private Set<String> enabledChildPlatforms;
 
     public FreeIpaCreationHandler(
@@ -109,7 +107,6 @@ public class FreeIpaCreationHandler extends EventSenderAwareHandler<EnvironmentD
             FreeIpaServerRequestProvider freeIpaServerRequestProvider,
             TelemetryApiConverter telemetryApiConverter,
             CloudPlatformConnectors connectors,
-            @Value("${environment.freeipa.yarnNetworkCidr}") String yarnNetworkCidr,
             @Value("${environment.enabledChildPlatforms}") Set<String> enabledChildPlatforms) {
         super(eventSender);
         this.environmentService = environmentService;
@@ -121,7 +118,6 @@ public class FreeIpaCreationHandler extends EventSenderAwareHandler<EnvironmentD
         this.freeIpaServerRequestProvider = freeIpaServerRequestProvider;
         this.telemetryApiConverter = telemetryApiConverter;
         this.connectors = connectors;
-        this.yarnNetworkCidr = yarnNetworkCidr;
         this.enabledChildPlatforms = enabledChildPlatforms;
     }
 
@@ -181,7 +177,7 @@ public class FreeIpaCreationHandler extends EventSenderAwareHandler<EnvironmentD
 
                 AddDnsZoneForSubnetsRequest addDnsZoneForSubnetsRequest = new AddDnsZoneForSubnetsRequest();
                 addDnsZoneForSubnetsRequest.setEnvironmentCrn(parentEnvironmentCrn);
-                addDnsZoneForSubnetsRequest.setSubnets(Collections.singletonList(yarnNetworkCidr));
+                addDnsZoneForSubnetsRequest.setSubnets(Collections.singletonList(environmentDto.getNetwork().getNetworkCidr()));
 
                 dnsV1Endpoint.addDnsZoneForSubnets(addDnsZoneForSubnetsRequest);
             }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeIpaCreationHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeIpaCreationHandler.java
@@ -94,7 +94,7 @@ public class FreeIpaCreationHandler extends EventSenderAwareHandler<EnvironmentD
 
     private final CloudPlatformConnectors connectors;
 
-    private String yarnNetowrkCidr;
+    private String yarnNetworkCidr;
 
     private Set<String> enabledChildPlatforms;
 
@@ -109,7 +109,7 @@ public class FreeIpaCreationHandler extends EventSenderAwareHandler<EnvironmentD
             FreeIpaServerRequestProvider freeIpaServerRequestProvider,
             TelemetryApiConverter telemetryApiConverter,
             CloudPlatformConnectors connectors,
-            @Value("${environment.freeipa.yarnNetworkCidr}") String yarnNetowrkCidr,
+            @Value("${environment.freeipa.yarnNetworkCidr}") String yarnNetworkCidr,
             @Value("${environment.enabledChildPlatforms}") Set<String> enabledChildPlatforms) {
         super(eventSender);
         this.environmentService = environmentService;
@@ -121,7 +121,7 @@ public class FreeIpaCreationHandler extends EventSenderAwareHandler<EnvironmentD
         this.freeIpaServerRequestProvider = freeIpaServerRequestProvider;
         this.telemetryApiConverter = telemetryApiConverter;
         this.connectors = connectors;
-        this.yarnNetowrkCidr = yarnNetowrkCidr;
+        this.yarnNetworkCidr = yarnNetworkCidr;
         this.enabledChildPlatforms = enabledChildPlatforms;
     }
 
@@ -181,7 +181,7 @@ public class FreeIpaCreationHandler extends EventSenderAwareHandler<EnvironmentD
 
                 AddDnsZoneForSubnetsRequest addDnsZoneForSubnetsRequest = new AddDnsZoneForSubnetsRequest();
                 addDnsZoneForSubnetsRequest.setEnvironmentCrn(parentEnvironmentCrn);
-                addDnsZoneForSubnetsRequest.setSubnets(Collections.singletonList(yarnNetowrkCidr));
+                addDnsZoneForSubnetsRequest.setSubnets(Collections.singletonList(yarnNetworkCidr));
 
                 dnsV1Endpoint.addDnsZoneForSubnets(addDnsZoneForSubnetsRequest);
             }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/deletion/handler/freeipa/FreeIpaDeletionHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/deletion/handler/freeipa/FreeIpaDeletionHandler.java
@@ -124,8 +124,8 @@ public class FreeIpaDeletionHandler extends EventSenderAwareHandler<EnvironmentD
         List<String> siblingEnvironmentNames = environmentService.findNameWithAccountIdAndParentEnvIdAndArchivedIsFalse(
                 environment.getAccountId(),
                 environment.getParentEnvironment().getId());
-        return siblingEnvironmentNames.stream()
-                .noneMatch(siblingName -> !siblingName.equals(environment.getName()));
+        siblingEnvironmentNames.remove(environment.getName());
+        return siblingEnvironmentNames.isEmpty();
     }
 
     private void deleteFreeIpa(Environment environment) {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/repository/EnvironmentRepository.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/repository/EnvironmentRepository.java
@@ -66,4 +66,11 @@ public interface EnvironmentRepository extends BaseJpaRepository<Environment, Lo
             + "WHERE pe.id = :parentEnvironmentId AND e.accountId = :accountId AND e.archived = false")
     List<String> findNameWithAccountIdAndParentEnvIdAndArchivedIsFalse(@Param("accountId") String accountId,
         @Param("parentEnvironmentId") Long parentEnvironmentId);
+
+    @CheckPermission(action = ResourceAction.READ)
+    @Query("SELECT e FROM Environment e "
+            + "JOIN e.parentEnvironment pe "
+            + "WHERE pe.id = :parentEnvironmentId AND e.accountId = :accountId AND e.archived = false")
+    List<Environment> findAllByAccountIdAndParentEnvIdAndArchivedIsFalse(@Param("accountId") String accountId,
+            @Param("parentEnvironmentId") Long parentEnvironmentId);
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentService.java
@@ -272,4 +272,8 @@ public class EnvironmentService implements ResourceIdProvider {
     public List<String> findNameWithAccountIdAndParentEnvIdAndArchivedIsFalse(String accountId, Long parentEnvironmentId) {
         return environmentRepository.findNameWithAccountIdAndParentEnvIdAndArchivedIsFalse(accountId, parentEnvironmentId);
     }
+
+    public List<Environment> findAllByAccountIdAndParentEnvIdAndArchivedIsFalse(String accountId, Long parentEnvironmentId) {
+        return environmentRepository.findAllByAccountIdAndParentEnvIdAndArchivedIsFalse(accountId, parentEnvironmentId);
+    }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/network/dao/domain/YarnNetwork.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/dao/domain/YarnNetwork.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.environment.network.dao.domain;
 
+import java.util.Objects;
+
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 
@@ -19,5 +21,15 @@ public class YarnNetwork extends BaseNetwork {
     @Override
     public String getNetworkId() {
         return null;
+    }
+
+    /**
+     * Needed to prevent overriding the value set in {@link com.sequenceiq.environment.network.v1.converter.YarnEnvironmentNetworkConverter} with a null value
+     */
+    @Override
+    public void setNetworkCidr(String networkCidr) {
+        if (Objects.nonNull(networkCidr)) {
+            super.setNetworkCidr(networkCidr);
+        }
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/network/v1/converter/YarnEnvironmentNetworkConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/v1/converter/YarnEnvironmentNetworkConverter.java
@@ -2,6 +2,7 @@ package com.sequenceiq.environment.network.v1.converter;
 
 import java.util.Map;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.cloud.model.network.CreatedCloudNetwork;
@@ -15,9 +16,13 @@ import com.sequenceiq.environment.network.dto.YarnParams;
 @Component
 public class YarnEnvironmentNetworkConverter extends EnvironmentBaseNetworkConverter {
 
+    @Value("${cb.yarn.networkCidr}")
+    private String yarnNetworkCidr;
+
     @Override
     BaseNetwork createProviderSpecificNetwork(NetworkDto network) {
         YarnNetwork yarnNetwork = new YarnNetwork();
+        yarnNetwork.setNetworkCidr(yarnNetworkCidr);
         if (network.getYarn() != null) {
             yarnNetwork.setQueue(network.getYarn().getQueue());
         }

--- a/environment/src/main/resources/application.yml
+++ b/environment/src/main/resources/application.yml
@@ -73,7 +73,6 @@ environment:
     url: http://localhost:8090
     contextPath: /freeipa
     supportedPlatforms: AWS,AZURE
-    yarnNetworkCidr: 172.27.0.0/16
   sdx:
     url: http://localhost:8086
     contextPath: /dl
@@ -112,6 +111,7 @@ cb:
     domain: default.com
     defaultQueue: "default"
     defaultLifeTime: -1
+    networkCidr: 172.27.0.0/16
   os:
     enable.autoimport: true
     import:

--- a/environment/src/test/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeIpaCreationHandlerTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeIpaCreationHandlerTest.java
@@ -28,6 +28,7 @@ import com.sequenceiq.environment.environment.dto.EnvironmentDto;
 import com.sequenceiq.environment.environment.service.EnvironmentService;
 import com.sequenceiq.environment.environment.service.freeipa.FreeIpaService;
 import com.sequenceiq.environment.environment.v1.TelemetryApiConverter;
+import com.sequenceiq.environment.network.dto.NetworkDto;
 import com.sequenceiq.flow.reactor.api.event.BaseNamedFlowEvent;
 import com.sequenceiq.flow.reactor.api.event.EventSender;
 import com.sequenceiq.freeipa.api.v1.dns.DnsV1Endpoint;
@@ -93,7 +94,6 @@ public class FreeIpaCreationHandlerTest {
                 freeIpaServerRequestProvider,
                 telemetryApiConverter,
                 connectors,
-                YARN_NETWORK_CIDR,
                 Collections.singleton(CloudPlatform.YARN.name()));
     }
 
@@ -156,6 +156,9 @@ public class FreeIpaCreationHandlerTest {
         environmentDto.setResourceCrn(ENVIRONMENT_CRN);
         environmentDto.setParentEnvironmentCrn(PARENT_ENVIRONMENT_CRN);
         environmentDto.setCloudPlatform(CloudPlatform.YARN.name());
+        environmentDto.setNetwork(NetworkDto.builder()
+                .withNetworkCidr(YARN_NETWORK_CIDR)
+                .build());
 
         return environmentDto;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/yarn/YarnCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/yarn/YarnCloudProvider.java
@@ -154,7 +154,8 @@ public class YarnCloudProvider extends AbstractCloudProvider {
 
     @Override
     public EnvironmentNetworkTestDto network(EnvironmentNetworkTestDto network) {
-        return network.withYarn(environmentNetworkParameters());
+        return network.withNetworkCIDR(yarnProperties.getNetworkCidr())
+                .withYarn(environmentNetworkParameters());
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/yarn/YarnProperties.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/yarn/YarnProperties.java
@@ -17,6 +17,8 @@ public class YarnProperties {
 
     private String queue;
 
+    private String networkCidr;
+
     private String blueprintCdhVersion;
 
     private final Credential credential = new Credential();
@@ -63,6 +65,14 @@ public class YarnProperties {
 
     public void setQueue(String queue) {
         this.queue = queue;
+    }
+
+    public String getNetworkCidr() {
+        return networkCidr;
+    }
+
+    public void setNetworkCidr(String networkCidr) {
+        this.networkCidr = networkCidr;
     }
 
     public Credential getCredential() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
@@ -224,7 +224,7 @@ public class EnvironmentTestDto
             getRequest().setParentEnvironmentName(parentEnvDto.getName());
             order = ORDER - 1;
         }
-        return this;
+        return withNetwork();
     }
 
     public Collection<SimpleEnvironmentResponse> getResponseSimpleEnvSet() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/freeipa/DnsZoneAddResponse.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/freeipa/DnsZoneAddResponse.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.it.cloudbreak.mock.freeipa;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.freeipa.client.model.DnsZone;
+
+import spark.Request;
+import spark.Response;
+
+@Component
+public class DnsZoneAddResponse extends AbstractFreeIpaResponse<DnsZone> {
+    @Override
+    public String method() {
+        return "dnszone_add";
+    }
+
+    @Override
+    protected DnsZone handleInternal(Request request, Response response) {
+        return new DnsZone();
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/freeipa/DnsZoneDelResponse.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/freeipa/DnsZoneDelResponse.java
@@ -1,0 +1,19 @@
+package com.sequenceiq.it.cloudbreak.mock.freeipa;
+
+import org.springframework.stereotype.Component;
+
+import spark.Request;
+import spark.Response;
+
+@Component
+public class DnsZoneDelResponse extends AbstractFreeIpaResponse<Object> {
+    @Override
+    public String method() {
+        return "dnszone_del";
+    }
+
+    @Override
+    protected Object handleInternal(Request request, Response response) {
+        return "";
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/AbstractIntegrationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/AbstractIntegrationTest.java
@@ -123,6 +123,8 @@ public abstract class AbstractIntegrationTest extends AbstractMinimalTest {
         dynamicRouteStack.get(ITResponse.FREEIPA_ROOT + "/host_find", freeIpaRouteHandler);
         dynamicRouteStack.get(ITResponse.FREEIPA_ROOT + "/service_find", freeIpaRouteHandler);
         dynamicRouteStack.get(ITResponse.FREEIPA_ROOT + "/dnszone_find", freeIpaRouteHandler);
+        dynamicRouteStack.get(ITResponse.FREEIPA_ROOT + "/dnszone_add", freeIpaRouteHandler);
+        dynamicRouteStack.get(ITResponse.FREEIPA_ROOT + "/dnszone_del", freeIpaRouteHandler);
         dynamicRouteStack.get(ITResponse.FREEIPA_ROOT + "/dnsrecord_find", freeIpaRouteHandler);
         dynamicRouteStack.get(ITResponse.FREEIPA_ROOT + "/host_del", freeIpaRouteHandler);
         dynamicRouteStack.get(ITResponse.FREEIPA_ROOT + "/role_find", freeIpaRouteHandler);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/FreeIpaCreationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/FreeIpaCreationTest.java
@@ -36,10 +36,9 @@ public class FreeIpaCreationTest extends AbstractIntegrationTest {
     @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
     @Description(
             given = "environment is present",
-            when = "calling a freeipe creation",
-            then = "freeipa sould be available with kerberos and ldap config")
+            when = "calling a freeipa creation",
+            then = "freeipa should be available with kerberos and ldap config")
     public void testCreateFreeIpa(MockedTestContext testContext) {
-        MockedTestContext mockedTestContext = (MockedTestContext) testContext;
         DynamicRouteStack dynamicRouteStack = testContext.getModel().getClouderaManagerMock().getDynamicRouteStack();
         dynamicRouteStack.post(ITResponse.FREEIPA_ROOT + "/session/login_password", (request, response) -> {
             response.cookie("ipa_session", "dummysession");
@@ -47,7 +46,7 @@ public class FreeIpaCreationTest extends AbstractIntegrationTest {
         });
         dynamicRouteStack.post(ITResponse.FREEIPA_ROOT + "/session/json", freeIpaRouteHandler);
         testContext
-                .given(FreeIPATestDto.class).withCatalog(mockedTestContext.getImageCatalogMockServerSetup().getFreeIpaImageCatalogUrl())
+                .given(FreeIPATestDto.class).withCatalog(testContext.getImageCatalogMockServerSetup().getFreeIpaImageCatalogUrl())
                 .when(freeIPATestClient.create())
                 .await(Status.AVAILABLE)
                 .then(FreeIpaKerberosTestAssertion.validate())

--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -262,6 +262,7 @@ integrationtest:
       volumeSize: 0
       volumeCount: 0
     queue: cloudbreak-tests
+    networkCidr: 172.27.0.0/16
     baseimage:
       imageId:
 


### PR DESCRIPTION
CB-5725
Child environment detach should remove reverse DNS zone from FreeIPA

Depends on https://github.com/hortonworks/cloudbreak/pull/7312 