### PR TITLE
CB-5668 aws-cdp-log-policy.json missing ListBucket for LOGS_LOCATION_BASE resource

### DIFF
--- a/cloud-aws/src/main/resources/definitions/cdp/aws-cdp-log-policy.json
+++ b/cloud-aws/src/main/resources/definitions/cdp/aws-cdp-log-policy.json
@@ -4,6 +4,13 @@
     {
       "Effect": "Allow",
       "Action": [
+        "s3:ListBucket"
+      ],
+      "Resource": "arn:aws:s3:::${LOGS_BUCKET}"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
         "s3:AbortMultipartUpload",
         "s3:GetObject",
         "s3:ListMultipartUploadParts",


### PR DESCRIPTION
The policy linked from the documentation is missing `ListBucket`

https://docs.cloudera.com/management-console/cloud/environments/topics/mc-idbroker-minimum-setup.html