### PR TITLE
CB-5764 Port 7.0.2 streaming templates to 7.1.0

### DIFF
--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -226,6 +226,8 @@ cb:
         7.1.0 - Operational Database: Apache HBase, Phoenix=cdp-opdb-710;
         7.1.0 - SDX Light Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas=cdp-sdx-710;
         7.1.0 - SDX Medium Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas=cdp-sdx-medium-ha-710;
+        7.1.0 - Streams Messaging Heavy Duty: Apache Kafka, Schema Registry, Streams Messaging Manager=cdp-streaming-710;
+        7.1.0 - Streams Messaging Light Duty: Apache Kafka, Schema Registry, Streams Messaging Manager=cdp-streaming-small-710;
 
   clustertemplate.defaults:
   template.defaults: minviable-gcp,minviable-azure-managed-disks,minviable-aws

--- a/core/src/main/resources/defaults/blueprints/cdp-streaming-710.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-streaming-710.bp
@@ -1,0 +1,101 @@
+{
+  "description": "7.1.0 - Streams Messaging Heavy Duty with Apache Kafka, Schema Registry, Streams Messaging Manager",
+  "blueprint": {
+    "cdhVersion": "7.1.0",
+    "displayName": "streams-messaging",
+    "services": [
+      {
+        "refName": "streams_messaging_manager",
+        "serviceType": "STREAMS_MESSAGING_MANAGER",
+        "roleConfigGroups": [
+          {
+            "refName": "streams_messaging_manager-STREAMS_MESSAGING_MANAGER_SERVER-BASE",
+            "roleType": "STREAMS_MESSAGING_MANAGER_SERVER",
+            "base": true
+          },
+          {
+            "refName": "streams_messaging_manager-STREAMS_MESSAGING_MANAGER_UI-BASE",
+            "roleType": "STREAMS_MESSAGING_MANAGER_UI",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "core_settings",
+        "serviceType": "CORE_SETTINGS",
+        "roleConfigGroups": [
+          {
+            "refName": "core_settings-STORAGEOPERATIONS-BASE",
+            "roleType": "STORAGEOPERATIONS",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "kafka",
+        "serviceType": "KAFKA",
+        "roleConfigGroups": [
+          {
+            "refName": "kafka-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          },
+          {
+            "refName": "kafka-KAFKA_BROKER-BASE",
+            "roleType": "KAFKA_BROKER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "zookeeper",
+        "serviceType": "ZOOKEEPER",
+        "roleConfigGroups": [
+          {
+            "refName": "zookeeper-SERVER-BASE",
+            "roleType": "SERVER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "schemaregistry",
+        "serviceType": "SCHEMAREGISTRY",
+        "roleConfigGroups": [
+          {
+            "refName": "schemaregistry-SCHEMA_REGISTRY_SERVER-BASE",
+            "roleType": "SCHEMA_REGISTRY_SERVER",
+            "base": true
+          }
+        ]
+      }
+    ],
+    "hostTemplates": [
+      {
+        "refName": "master",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "core_settings-STORAGEOPERATIONS-BASE",
+          "schemaregistry-SCHEMA_REGISTRY_SERVER-BASE",
+          "streams_messaging_manager-STREAMS_MESSAGING_MANAGER_SERVER-BASE",
+          "streams_messaging_manager-STREAMS_MESSAGING_MANAGER_UI-BASE"
+        ]
+      },
+      {
+        "refName": "broker",
+        "cardinality": 3,
+        "roleConfigGroupsRefNames": [
+          "kafka-GATEWAY-BASE",
+          "kafka-KAFKA_BROKER-BASE"
+        ]
+      },
+      {
+        "refName": "quorum",
+        "cardinality": 3,
+        "roleConfigGroupsRefNames": [
+          "zookeeper-SERVER-BASE"
+        ]
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/blueprints/cdp-streaming-small-710.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-streaming-small-710.bp
@@ -1,0 +1,95 @@
+{
+  "description": "7.1.0 - Streams Messaging Light Duty with Apache Kafka, Schema Registry, Streams Messaging Manager",
+  "blueprint": {
+    "cdhVersion": "7.1.0",
+    "displayName": "streams-messaging",
+    "services": [
+      {
+        "refName": "streams_messaging_manager",
+        "serviceType": "STREAMS_MESSAGING_MANAGER",
+        "roleConfigGroups": [
+          {
+            "refName": "streams_messaging_manager-STREAMS_MESSAGING_MANAGER_SERVER-BASE",
+            "roleType": "STREAMS_MESSAGING_MANAGER_SERVER",
+            "base": true
+          },
+          {
+            "refName": "streams_messaging_manager-STREAMS_MESSAGING_MANAGER_UI-BASE",
+            "roleType": "STREAMS_MESSAGING_MANAGER_UI",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "core_settings",
+        "serviceType": "CORE_SETTINGS",
+        "roleConfigGroups": [
+          {
+            "refName": "core_settings-STORAGEOPERATIONS-BASE",
+            "roleType": "STORAGEOPERATIONS",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "kafka",
+        "serviceType": "KAFKA",
+        "roleConfigGroups": [
+          {
+            "refName": "kafka-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          },
+          {
+            "refName": "kafka-KAFKA_BROKER-BASE",
+            "roleType": "KAFKA_BROKER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "zookeeper",
+        "serviceType": "ZOOKEEPER",
+        "roleConfigGroups": [
+          {
+            "refName": "zookeeper-SERVER-BASE",
+            "roleType": "SERVER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "schemaregistry",
+        "serviceType": "SCHEMAREGISTRY",
+        "roleConfigGroups": [
+          {
+            "refName": "schemaregistry-SCHEMA_REGISTRY_SERVER-BASE",
+            "roleType": "SCHEMA_REGISTRY_SERVER",
+            "base": true
+          }
+        ]
+      }
+    ],
+    "hostTemplates": [
+      {
+        "refName": "master",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "core_settings-STORAGEOPERATIONS-BASE",
+          "schemaregistry-SCHEMA_REGISTRY_SERVER-BASE",
+          "streams_messaging_manager-STREAMS_MESSAGING_MANAGER_SERVER-BASE",
+          "streams_messaging_manager-STREAMS_MESSAGING_MANAGER_UI-BASE"
+        ]
+      },
+      {
+        "refName": "broker",
+        "cardinality": 3,
+        "roleConfigGroupsRefNames": [
+          "kafka-GATEWAY-BASE",
+          "kafka-KAFKA_BROKER-BASE",
+          "zookeeper-SERVER-BASE"
+        ]
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/aws/aws-streaming-710.json
+++ b/core/src/main/resources/defaults/clustertemplates/aws/aws-streaming-710.json
@@ -1,0 +1,72 @@
+{
+  "name": "7.1.0 - Streams Messaging Heavy Duty for AWS",
+  "description": "",
+  "type": "STREAMING",
+  "cloudPlatform": "AWS",
+  "featureState": "PREVIEW",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.1.0 - Streams Messaging Heavy Duty: Apache Kafka, Schema Registry, Streams Messaging Manager"
+    },
+    "instanceGroups": [
+      {
+        "name": "master",
+        "template": {
+          "instanceType": "m5.2xlarge",
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "standard"
+            }
+          ],
+          "rootVolume": {
+            "size": 100
+          }
+        },
+        "nodeCount": 1,
+        "type": "GATEWAY",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "quorum",
+        "template": {
+          "instanceType": "m5.2xlarge",
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "standard"
+            }
+          ],
+          "rootVolume": {
+            "size": 50
+          }
+        },
+        "nodeCount": 3,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "broker",
+        "template": {
+          "instanceType": "m5.2xlarge",
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 1000,
+              "type": "st1"
+            }
+          ],
+          "rootVolume": {
+            "size": 50
+          }
+        },
+        "nodeCount": 3,
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "recipeNames": []
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/aws/aws-streaming-small-710.json
+++ b/core/src/main/resources/defaults/clustertemplates/aws/aws-streaming-small-710.json
@@ -1,0 +1,53 @@
+{
+  "name": "7.1.0 - Streams Messaging Light Duty for AWS",
+  "description": "",
+  "type": "STREAMING",
+  "cloudPlatform": "AWS",
+  "featureState": "PREVIEW",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.1.0 - Streams Messaging Light Duty: Apache Kafka, Schema Registry, Streams Messaging Manager"
+    },
+    "instanceGroups": [
+      {
+        "name": "master",
+        "template": {
+          "instanceType": "m5.2xlarge",
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "standard"
+            }
+          ],
+          "rootVolume": {
+            "size": 100
+          }
+        },
+        "nodeCount": 1,
+        "type": "GATEWAY",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "broker",
+        "template": {
+          "instanceType": "m5.2xlarge",
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 500,
+              "type": "st1"
+            }
+          ],
+          "rootVolume": {
+            "size": 50
+          }
+        },
+        "nodeCount": 3,
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "recipeNames": []
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/azure/azure-streaming-710.json
+++ b/core/src/main/resources/defaults/clustertemplates/azure/azure-streaming-710.json
@@ -1,0 +1,63 @@
+{
+  "name": "7.1.0 - Streams Messaging Heavy Duty for Azure",
+  "description": "",
+  "type": "STREAMING",
+  "cloudPlatform": "AZURE",
+  "featureState": "PREVIEW",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.1.0 - Streams Messaging Heavy Duty: Apache Kafka, Schema Registry, Streams Messaging Manager"
+    },
+    "instanceGroups": [
+      {
+        "name": "master",
+        "template": {
+          "instanceType": "Standard_D8_v3",
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "StandardSSD_LRS"
+            }
+          ]
+        },
+        "nodeCount": 1,
+        "type": "GATEWAY",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "quorum",
+        "template": {
+          "instanceType": "Standard_D8_v3",
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "StandardSSD_LRS"
+            }
+          ]
+        },
+        "nodeCount": 3,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "broker",
+        "template": {
+          "instanceType": "Standard_D8_v3",
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 1000,
+              "type": "StandardSSD_LRS"
+            }
+          ]
+        },
+        "nodeCount": 3,
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "recipeNames": []
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/azure/azure-streaming-small-710.json
+++ b/core/src/main/resources/defaults/clustertemplates/azure/azure-streaming-small-710.json
@@ -1,0 +1,47 @@
+{
+  "name": "7.1.0 - Streams Messaging Light Duty for Azure",
+  "description": "",
+  "type": "STREAMING",
+  "cloudPlatform": "AZURE",
+  "featureState": "PREVIEW",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.1.0 - Streams Messaging Light Duty: Apache Kafka, Schema Registry, Streams Messaging Manager"
+    },
+    "instanceGroups": [
+      {
+        "name": "master",
+        "template": {
+          "instanceType": "Standard_D8_v3",
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "StandardSSD_LRS"
+            }
+          ]
+        },
+        "nodeCount": 1,
+        "type": "GATEWAY",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "broker",
+        "template": {
+          "instanceType": "Standard_D8_v3",
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 500,
+              "type": "StandardSSD_LRS"
+            }
+          ]
+        },
+        "nodeCount": 3,
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "recipeNames": []
+      }
+    ]
+  }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
@@ -434,7 +434,7 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
         assertNotNull(entity);
         assertNotNull(entity.getResponses());
         long defaultCount = entity.getResponses().stream().filter(template -> ResourceStatus.DEFAULT.equals(template.getStatus())).count();
-        long expectedCount = 20;
+        long expectedCount = 24;
         assertEquals("Should have " + expectedCount + " of default cluster templates.", expectedCount, defaultCount);
         return entity;
     }


### PR DESCRIPTION
Ported the 7.0.2 streaming templates to 7.1.0.

Testing: tested manually on AWS and Azure. Both the light duty and the heavy duty template installed successfully.


Closes CB-5764