### PR TITLE
CB-5826 Blueprint version for Livy 2.4.0 is wrong and should be 0.6.0

### DIFF
--- a/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/6.1.json
+++ b/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/6.1.json
@@ -62,7 +62,7 @@
     },
     {
       "name": "LIVY",
-      "version": "2.4.0"
+      "version": "0.5.0"
     },
     {
       "name": "ZEPPELIN",

--- a/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/6.2.json
+++ b/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/6.2.json
@@ -62,7 +62,7 @@
     },
     {
       "name": "LIVY",
-      "version": "2.4.0"
+      "version": "0.5.0"
     },
     {
       "name": "ZEPPELIN",

--- a/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.0.1.json
+++ b/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.0.1.json
@@ -62,7 +62,7 @@
     },
     {
       "name": "LIVY",
-      "version": "2.4.0"
+      "version": "0.5.0"
     },
     {
       "name": "ZEPPELIN",

--- a/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.0.2.json
+++ b/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.0.2.json
@@ -62,7 +62,7 @@
     },
     {
       "name": "LIVY",
-      "version": "2.4.0"
+      "version": "0.5.0"
     },
     {
       "name": "ZEPPELIN",

--- a/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.0.json
+++ b/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.0.json
@@ -62,7 +62,7 @@
     },
     {
       "name": "LIVY",
-      "version": "2.4.0"
+      "version": "0.5.0"
     },
     {
       "name": "ZEPPELIN",

--- a/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.1.json
+++ b/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.1.json
@@ -62,7 +62,7 @@
     },
     {
       "name": "LIVY",
-      "version": "2.4.0"
+      "version": "0.6.0"
     },
     {
       "name": "ZEPPELIN",


### PR DESCRIPTION
CDH 7.1.0 = Livy 0.6.0
CDH <7.1.0 = Livy 0.5.0