### PR TITLE
CB-5752 OpDB 7.1.0 cluster definitions out of sync for AWS and Azure

### DIFF
--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -214,7 +214,6 @@ cb:
         CDP 1.2 - Data Mart: Apache Impala, Hue=cdp-data-mart-702;
         CDP 1.2 - Real-time Data Mart: Apache Impala, Hue, Apache Kudu, Apache Spark=cdp-rt-data-mart-702;
         CDP 1.2 - Operational Database: Apache HBase=cdp-opdb-702;
-        CDP 1.2 - Operational Database: Apache HBase, Phoenix=cdp-opdb-710;
         CDP 1.2 - SDX Light Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas=cdp-sdx-702;
         CDP 1.2 - SDX Medium Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas=cdp-sdx-medium-ha-702;
         CDP 1.2 - Streams Messaging Heavy Duty: Apache Kafka, Schema Registry, Streams Messaging Manager=cdp-streaming-702;
@@ -222,7 +221,6 @@ cb:
         7.1.0 - Data Engineering: Apache Spark, Apache Hive, Apache Oozie=cdp-data-engineering-710;
         7.1.0 - Data Mart: Apache Impala, Hue=cdp-data-mart-710;
         7.1.0 - Real-time Data Mart: Apache Impala, Hue, Apache Kudu, Apache Spark=cdp-rt-data-mart-710;
-        7.1.0 - Operational Database: Apache HBase=cdp-opdb-710;
         7.1.0 - Operational Database: Apache HBase, Phoenix=cdp-opdb-710;
         7.1.0 - SDX Light Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas=cdp-sdx-710;
         7.1.0 - SDX Medium Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas=cdp-sdx-medium-ha-710;

--- a/core/src/main/resources/defaults/clustertemplates/aws/aws-opdb-710.json
+++ b/core/src/main/resources/defaults/clustertemplates/aws/aws-opdb-710.json
@@ -1,8 +1,8 @@
 {
-  "name": "7.1.0 - Operational Database with Phoenix for AWS",
+  "name": "7.1.0 - Operational Database with SQL for AWS",
   "description": "",
   "type": "OPERATIONALDATABASE",
-  "featureState": "PREVIEW",
+  "featureState": "RELEASED",
   "cloudPlatform": "AWS",
   "distroXTemplate": {
     "cluster": {

--- a/core/src/main/resources/defaults/clustertemplates/azure/azure-opdb-710.json
+++ b/core/src/main/resources/defaults/clustertemplates/azure/azure-opdb-710.json
@@ -1,11 +1,12 @@
 {
-  "name": "7.1.0 - Operational Database for Azure",
+  "name": "7.1.0 - Operational Database with SQL for Azure",
   "description": "",
   "type": "OPERATIONALDATABASE",
+  "featureState": "RELEASED",
   "cloudPlatform": "AZURE",
   "distroXTemplate": {
     "cluster": {
-      "blueprintName": "7.1.0 - Operational Database: Apache HBase"
+      "blueprintName": "7.1.0 - Operational Database: Apache HBase, Phoenix"
     },
     "instanceGroups": [
       {

--- a/core/src/main/resources/schema/app/20200228140101_CB-5752_rename_template.sql
+++ b/core/src/main/resources/schema/app/20200228140101_CB-5752_rename_template.sql
@@ -1,0 +1,15 @@
+-- // CB-5752 OpDB 7.1.0 cluster definitions out of sync for AWS and Azure
+-- Migration SQL that makes the change goes here.
+
+UPDATE clustertemplate SET name = '7.1.0 - Operational Database with SQL for AWS' WHERE status = 'DEFAULT' AND name = '7.1.0 - Operational Database with Phoenix for AWS';
+UPDATE clustertemplate SET name = '7.1.0 - Operational Database with SQL for Azure' WHERE status = 'DEFAULT' AND name = '7.1.0 - Operational Database for Azure';
+UPDATE blueprint SET status='DEFAULT_DELETED' WHERE name = '7.1.0 - Operational Database: Apache HBase';
+UPDATE blueprint SET status='DEFAULT_DELETED' WHERE name = 'CDP 1.2 - Operational Database: Apache HBase, Phoenix';
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+UPDATE clustertemplate SET name = '7.1.0 - Operational Database with Phoenix for AWS' WHERE status = 'DEFAULT' AND name = '7.1.0 - Operational Database with SQL for AWS';
+UPDATE clustertemplate SET name = '7.1.0 - Operational Database for Azure' WHERE status = 'DEFAULT' AND name = '7.1.0 - Operational Database with SQL for Azure';
+UPDATE blueprint SET status='DEFAULT' WHERE name = '7.1.0 - Operational Database: Apache HBase';
+UPDATE blueprint SET status='DEFAULT' WHERE name = 'CDP 1.2 - Operational Database: Apache HBase, Phoenix';


### PR DESCRIPTION
for both the AWS and Azure definitions:
* change the name of the definition
* set featureState to RELEASED
*set bluePrintName to match the name of the 7.1.0 blueprint

removed old duplicate 7.1.0 references from application.yml

testing done:

Started local cloudbreak
created environment
checked that the 7.1.0 AWS definition appears with the correct name
built the OpDB cluster
checked that uses the intended blueprint (with Phoenix)

Closes #CB-5752