### PR TITLE
CDPCP-1549. Fix issue where user sync failure is not recorded

### DIFF
--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/concurrent/ActorCrnTaskDecorator.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/concurrent/ActorCrnTaskDecorator.java
@@ -1,0 +1,22 @@
+package com.sequenceiq.cloudbreak.concurrent;
+
+import static java.util.Objects.requireNonNull;
+
+import org.springframework.core.task.TaskDecorator;
+
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+
+/**
+ * Task decorator that propagates the actor CRN from the caller to
+ * the running task.
+ */
+public class ActorCrnTaskDecorator implements TaskDecorator {
+    @Override
+    public Runnable decorate(Runnable runnable) {
+        requireNonNull(runnable, "runnable is null");
+        String actorCrn = ThreadBasedUserCrnProvider.getUserCrn();
+        return () -> {
+            ThreadBasedUserCrnProvider.doAs(actorCrn, runnable);
+        };
+    }
+}

--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/concurrent/CompositeTaskDecorator.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/concurrent/CompositeTaskDecorator.java
@@ -1,0 +1,36 @@
+package com.sequenceiq.cloudbreak.concurrent;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import org.springframework.core.task.TaskDecorator;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Task decorator that composes multiple task decorators.
+ */
+public class CompositeTaskDecorator implements TaskDecorator {
+
+    private final ImmutableList<TaskDecorator> decorators;
+
+    /**
+     * Create a CompositeTaskDecorator from the list of task decorators.
+     *
+     * @param decorators a list of task decorators to apply, from innermost to outermost.
+     */
+    public CompositeTaskDecorator(List<TaskDecorator> decorators) {
+        requireNonNull(decorators, "decorators is null");
+        this.decorators = ImmutableList.copyOf(decorators);
+    }
+
+    @Override
+    public Runnable decorate(Runnable runnable) {
+        Runnable decoratedRunnable = requireNonNull(runnable, "runnable is null");
+        for (TaskDecorator decorator : decorators) {
+            decoratedRunnable = decorator.decorate(decoratedRunnable);
+        }
+        return decoratedRunnable;
+    }
+}

--- a/cloud-common/src/test/java/com/sequenceiq/cloudbreak/concurrent/ActorCrnTaskDecoratorTest.java
+++ b/cloud-common/src/test/java/com/sequenceiq/cloudbreak/concurrent/ActorCrnTaskDecoratorTest.java
@@ -1,0 +1,41 @@
+package com.sequenceiq.cloudbreak.concurrent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+
+class ActorCrnTaskDecoratorTest {
+    private static final String ACCOUNT_ID = UUID.randomUUID().toString();
+
+    private static final String ACTOR_CRN = "crn:cdp:iam:us-west-1:"
+            + ACCOUNT_ID + ":user:" + UUID.randomUUID().toString();
+
+    private ActorCrnTaskDecorator underTest = new ActorCrnTaskDecorator();
+
+    @BeforeEach
+    void setUp() {
+        assertNull(ThreadBasedUserCrnProvider.getUserCrn());
+    }
+
+    @Test
+    void decorateWithActorCrn() {
+        ThreadBasedUserCrnProvider.doAs(ACTOR_CRN, () -> assertRunnableWithActorCrn(ACTOR_CRN));
+    }
+
+    @Test
+    void decorateWithNoActorCrn() {
+        assertRunnableWithActorCrn(null);
+    }
+
+    private void assertRunnableWithActorCrn(String expectedUserCrn) {
+        underTest.decorate(() -> {
+            assertEquals(expectedUserCrn, ThreadBasedUserCrnProvider.getUserCrn());
+        }).run();
+    }
+}

--- a/cloud-common/src/test/java/com/sequenceiq/cloudbreak/concurrent/CompositeTaskDecoratorTest.java
+++ b/cloud-common/src/test/java/com/sequenceiq/cloudbreak/concurrent/CompositeTaskDecoratorTest.java
@@ -1,0 +1,98 @@
+package com.sequenceiq.cloudbreak.concurrent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.springframework.core.task.TaskDecorator;
+
+class CompositeTaskDecoratorTest {
+
+    @Test
+    void testNullDecorators() {
+        assertThrows(NullPointerException.class, () -> {
+            new CompositeTaskDecorator(null);
+        });
+    }
+
+    @Test
+    void testNoDecorators() {
+        CompositeTaskDecorator underTest = new CompositeTaskDecorator(List.of());
+        Runnable runnable = () -> { };
+        Runnable decoratedRunnable = underTest.decorate(runnable);
+        assertEquals(runnable, decoratedRunnable);
+    }
+
+    @Test
+    void testOneDecorator() {
+        DoSomething before = mock(DoSomething.class);
+        DoSomething after = mock(DoSomething.class);
+        Runnable runnable = mock(Runnable.class);
+        InOrder inOrder = Mockito.inOrder(before, after, runnable);
+
+        CompositeTaskDecorator underTest = new CompositeTaskDecorator(List.of(TestDecorator.around(before, after)));
+        Runnable decoratedRunnable = underTest.decorate(runnable);
+
+        decoratedRunnable.run();
+
+        inOrder.verify(before).doSomething();
+        inOrder.verify(runnable).run();
+        inOrder.verify(after).doSomething();
+    }
+
+    @Test
+    void testMultipleDecorators() {
+        DoSomething before1 = mock(DoSomething.class);
+        DoSomething after1 = mock(DoSomething.class);
+        DoSomething before2 = mock(DoSomething.class);
+        DoSomething after2 = mock(DoSomething.class);
+        Runnable runnable = mock(Runnable.class);
+        InOrder inOrder = Mockito.inOrder(before1, after1, before2, after2, runnable);
+
+        CompositeTaskDecorator underTest = new CompositeTaskDecorator(List.of(
+                TestDecorator.around(before1, after1),
+                TestDecorator.around(before2, after2)));
+        Runnable decoratedRunnable = underTest.decorate(runnable);
+
+        decoratedRunnable.run();
+
+        inOrder.verify(before2).doSomething();
+        inOrder.verify(before1).doSomething();
+        inOrder.verify(runnable).run();
+        inOrder.verify(after1).doSomething();
+        inOrder.verify(after2).doSomething();
+    }
+
+    private static class TestDecorator implements TaskDecorator {
+        private final DoSomething before;
+
+        private final DoSomething after;
+
+        TestDecorator(DoSomething before, DoSomething after) {
+            this.before = before;
+            this.after = after;
+        }
+
+        @Override
+        public Runnable decorate(Runnable runnable) {
+            return () -> {
+                before.doSomething();
+                runnable.run();
+                after.doSomething();
+            };
+        }
+
+        private static TestDecorator around(DoSomething before, DoSomething after) {
+            return new TestDecorator(before, after);
+        }
+    }
+
+    private interface DoSomething {
+        void doSomething();
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/UsersyncConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/UsersyncConfig.java
@@ -1,12 +1,16 @@
 package com.sequenceiq.freeipa.configuration;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
+import com.sequenceiq.cloudbreak.concurrent.CompositeTaskDecorator;
 import com.sequenceiq.cloudbreak.concurrent.MDCCleanerTaskDecorator;
+import com.sequenceiq.cloudbreak.concurrent.ActorCrnTaskDecorator;
 
 @Configuration
 public class UsersyncConfig {
@@ -25,7 +29,9 @@ public class UsersyncConfig {
         executor.setCorePoolSize(usersyncCorePoolSize);
         executor.setQueueCapacity(usersyncQueueCapacity);
         executor.setThreadNamePrefix("usersyncExecutor-");
-        executor.setTaskDecorator(new MDCCleanerTaskDecorator());
+        executor.setTaskDecorator(
+                new CompositeTaskDecorator(
+                        List.of(new MDCCleanerTaskDecorator(), new ActorCrnTaskDecorator())));
         executor.initialize();
         return executor;
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/repository/UserSyncStatusRepository.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/repository/UserSyncStatusRepository.java
@@ -18,4 +18,8 @@ public interface UserSyncStatusRepository extends BaseCrudRepository<UserSyncSta
 
     @CheckPermission(action = ResourceAction.READ)
     Optional<UserSyncStatus> getByStack(Stack stack);
+
+    @Override
+    @CheckPermission(action = ResourceAction.READ)
+    <S extends UserSyncStatus> S save(S entity);
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncService.java
@@ -29,8 +29,10 @@ import org.springframework.util.CollectionUtils;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.auth.altus.CrnParseException;
+import com.sequenceiq.cloudbreak.auth.security.InternalCrnBuilder;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.cloudbreak.logger.MDCUtils;
@@ -66,6 +68,8 @@ import com.sequenceiq.freeipa.util.KrbKeySetEncoder;
 public class UserSyncService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UserSyncService.class);
+
+    private static final String INTERNAL_USER_CRN = new InternalCrnBuilder(Crn.Service.IAM).getInternalCrnForServiceAsString();
 
     @VisibleForTesting
     @Value("${freeipa.usersync.max-subjects-per-request}")
@@ -119,24 +123,26 @@ public class UserSyncService {
         LOGGER.info("Starting operation [{}] with status [{}]", operationId, operationState);
 
         if (operationState == OperationState.RUNNING) {
-            tryWithOperationCleanup(operationId, accountId, () -> {
-                boolean fullSync = userCrnFilter.isEmpty() && machineUserCrnFilter.isEmpty();
-                if (fullSync) {
-                    long currentTime = Instant.now().toEpochMilli();
-                    stacks.forEach(stack -> {
-                        UserSyncStatus userSyncStatus = userSyncStatusService.getOrCreateForStack(stack);
-                        userSyncStatus.setLastFullSyncStartTime(currentTime);
-                        userSyncStatusService.save(userSyncStatus);
-                    });
-                }
-                asyncSynchronizeUsers(operation.getOperationId(), accountId, actorCrn, stacks, userCrnFilter, machineUserCrnFilter, fullSync);
-            });
+            tryWithOperationCleanup(operationId, accountId, () ->
+                ThreadBasedUserCrnProvider.doAs(INTERNAL_USER_CRN, () -> {
+                    boolean fullSync = userCrnFilter.isEmpty() && machineUserCrnFilter.isEmpty();
+                    if (fullSync) {
+                        long currentTime = Instant.now().toEpochMilli();
+                        stacks.forEach(stack -> {
+                            UserSyncStatus userSyncStatus = userSyncStatusService.getOrCreateForStack(stack);
+                            userSyncStatus.setLastFullSyncStartTime(currentTime);
+                            userSyncStatusService.save(userSyncStatus);
+                        });
+                    }
+                    asyncSynchronizeUsers(operation.getOperationId(), accountId, actorCrn, stacks, userCrnFilter, machineUserCrnFilter, fullSync);
+                }));
         }
 
         return operation;
     }
 
-    private void asyncSynchronizeUsers(String operationId, String accountId, String actorCrn, List<Stack> stacks,
+    @VisibleForTesting
+    void asyncSynchronizeUsers(String operationId, String accountId, String actorCrn, List<Stack> stacks,
             Set<String> userCrnFilter, Set<String> machineUserCrnFilter, boolean fullSync) {
 
         MDCBuilder.addFlowId(operationId);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/operation/OperationAcceptor.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/operation/OperationAcceptor.java
@@ -30,7 +30,9 @@ public abstract class OperationAcceptor {
 
         for (Operation o : runningOperations) {
             if (o.getId() < operation.getId() && doOperationsConflict(operation, o)) {
-                rejectionReasons.add(String.format(CONFLICT_REASON, o.getOperationId(), o.getUserList(), o.getEnvironmentList()));
+                rejectionReasons.add(String.format(CONFLICT_REASON, o.getOperationId(),
+                        o.getUserList().isEmpty() ? "[all users]" : o.getUserList(),
+                        o.getEnvironmentList().isEmpty() ? "[all environments]" : o.getEnvironmentList()));
             }
         }
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/configuration/UsersyncConfigTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/configuration/UsersyncConfigTest.java
@@ -1,0 +1,51 @@
+package com.sequenceiq.freeipa.configuration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.UUID;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.cloudbreak.logger.MDCUtils;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = UsersyncConfig.class)
+@TestPropertySource(properties = {
+        "freeipa.usersync.threadpool.core.size=1",
+        "freeipa.usersync.threadpool.capacity.size=10"
+})
+class UsersyncConfigTest {
+    private static final String ACCOUNT_ID = UUID.randomUUID().toString();
+
+    private static final String USER_CRN = "crn:cdp:iam:us-west-1:"
+            + ACCOUNT_ID + ":user:" + UUID.randomUUID().toString();
+
+    @Inject
+    @Qualifier(UsersyncConfig.USERSYNC_TASK_EXECUTOR)
+    AsyncTaskExecutor usersyncTaskExecutor;
+
+    @Test
+    void testAsyncTaskExecutorDecoration() throws Exception {
+        String expectedRequestId = "requestId";
+        MDCBuilder.addRequestId(expectedRequestId);
+        ThreadBasedUserCrnProvider.setUserCrn(USER_CRN);
+
+        Future<?> future = usersyncTaskExecutor.submit(() -> {
+                assertEquals(expectedRequestId, MDCUtils.getRequestId().get());
+                assertEquals(USER_CRN, ThreadBasedUserCrnProvider.getUserCrn());
+            });
+        future.get(1L, TimeUnit.SECONDS);
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncServiceTest.java
@@ -1,12 +1,21 @@
 package com.sequenceiq.freeipa.service.freeipa.user;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -21,13 +30,22 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.cloudbreak.auth.security.InternalCrnBuilder;
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationState;
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationType;
 import com.sequenceiq.freeipa.client.FreeIpaClient;
 import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.client.model.RPCResponse;
 import com.sequenceiq.freeipa.controller.exception.BadRequestException;
+import com.sequenceiq.freeipa.entity.Operation;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.entity.UserSyncStatus;
 import com.sequenceiq.freeipa.service.freeipa.user.model.FmsUser;
 import com.sequenceiq.freeipa.service.freeipa.user.model.UmsUsersState;
+import com.sequenceiq.freeipa.service.operation.OperationService;
+import com.sequenceiq.freeipa.service.stack.StackService;
 
 @ExtendWith(MockitoExtension.class)
 class UserSyncServiceTest {
@@ -47,10 +65,21 @@ class UserSyncServiceTest {
     private static final String MACHINE_USER_CRN = "crn:cdp:iam:us-west-1:"
             + ACCOUNT_ID + ":machineUser:" + UUID.randomUUID().toString();
 
+    private static final String INTERNAL_USER_CRN = new InternalCrnBuilder(Crn.Service.IAM).getInternalCrnForServiceAsString();
+
     private static final int MAX_SUBJECTS_PER_REQUEST = 10;
 
     @Mock
+    StackService stackService;
+
+    @Mock
+    OperationService operationService;
+
+    @Mock
     FreeIpaUsersStateProvider freeIpaUsersStateProvider;
+
+    @Mock
+    UserSyncStatusService userSyncStatusService;
 
     @InjectMocks
     UserSyncService underTest;
@@ -157,6 +186,34 @@ class UserSyncServiceTest {
                 throw new RuntimeException(e);
             }
         });
+    }
+
+    @Test
+    void testAsyncSynchronizeUsersUsesInternalCrn() {
+        Stack stack = mock(Stack.class);
+        when(stack.getEnvironmentCrn()).thenReturn(ENV_CRN);
+        when(stackService.getMultipleByEnvironmentCrnAndAccountId(anySet(), anyString())).thenReturn(List.of(stack));
+        Operation operation = mock(Operation.class);
+        when(operation.getStatus()).thenReturn(OperationState.RUNNING);
+        when(operation.getOperationId()).thenReturn("operationId");
+        when(operationService.startOperation(anyString(), any(OperationType.class), anyCollection(), anyCollection()))
+                .thenReturn(operation);
+        UserSyncStatus userSyncStatus = mock(UserSyncStatus.class);
+        when(userSyncStatusService.getOrCreateForStack(any(Stack.class))).thenReturn(userSyncStatus);
+        when(userSyncStatusService.save(userSyncStatus)).thenReturn(userSyncStatus);
+
+        UserSyncService spyService = spy(underTest);
+
+        doAnswer(invocation -> {
+            assertEquals(INTERNAL_USER_CRN, ThreadBasedUserCrnProvider.getUserCrn());
+            return null;
+        })
+                .when(spyService).asyncSynchronizeUsers(anyString(), anyString(), anyString(), anyList(), anySet(), anySet(), anyBoolean());
+
+        spyService.synchronizeUsers("accountId", "actorCrn",
+                Set.of(), Set.of(), Set.of());
+
+        verify(spyService).asyncSynchronizeUsers(anyString(), anyString(), anyString(), anyList(), anySet(), anySet(), anyBoolean());
     }
 
     private Multimap<String, String> setupGroupMapping(int numGroups, int numPerGroup) {


### PR DESCRIPTION
This PR contains two commits to address the behavior exhibited in CDPCP-1549.

CDPCP-1549. Run user sync internals as internal user

An authorization mismatch between the Operation db and the UserSyncStatus
db resulted in a bug where a user sync operation can be accepted, but
will fail when saving the user sync status. This commit changes the
authorization behavior so that authoriation is only performed on acceptance
of the sync operation. All the user sync internals are run as the internal
user.

CDPCP-1549. Catch and fail user sync operation

There was a gap where exceptions could cause user sync to fail but
not be recorded in the Operation database. This would prevent another
user sync from being accepted even though the current user sync was
not actually running. Eventually, the operation would be TIMEDOUT,
allowing another user sync to be accepted.

This commit closes the gap by catching all RuntimeExceptions and
recording the failure in the Operation database.

Testing: manual
1. created a machine user w/o write rights. verified that user sync was accepted but failed w/o updating the operation to FAILED.
2. Added change to catch and fail user sync. verified that user sync was accepted then failed
3. Added change to run user sync internals as internal user. verified that user sync was accepted and runs