### PR TITLE
CB-5104: ephemeral volumes not supported by Azure (take two)

### DIFF
--- a/core/src/main/resources/defaults/clustertemplates/azure/azure-rt-datamart-710.json
+++ b/core/src/main/resources/defaults/clustertemplates/azure/azure-rt-datamart-710.json
@@ -92,9 +92,9 @@
         "template": {
           "attachedVolumes": [
             {
-              "count": 1,
-              "size": 7500,
-              "type": "ephemeral"
+              "count": 7,
+              "size": 1000,
+              "type": "StandardSSD_LRS"
             }
           ],
           "azure": {
@@ -118,9 +118,9 @@
         "template": {
           "attachedVolumes": [
             {
-              "count": 1,
-              "size": 7500,
-              "type": "ephemeral"
+              "count": 7,
+              "size": 1000,
+              "type": "StandardSSD_LRS"
             }
           ],
           "azure": {


### PR DESCRIPTION
When commit 0f3e5b69e2 added 7.1.0 variants of all of the cluster
definitions, it didn't incorporate the fix from commit 3badaf2e50 into the
RT-DM cluster def.

This commit rectifies that omission.
