### PR TITLE
CB-3857: add Kudu web UI to list of access-controlled Knox endpoints

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -85,6 +85,10 @@
                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
             </param>
             <param>
+                <name>kuduui.acl</name>
+                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+            </param>
+            <param>
                 <name>jobhistoryui.acl</name>
                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
             </param>


### PR DESCRIPTION
Right now, any user may access the Kudu web UI; we need to ensure that Knox
enforces its access control mechanisms appropriately.

Even though commit 9e33314bf99 added all endpoints en masse, the Kudu web UI
endpoint was added two weeks prior in commit 409a0cf8c9, so it's conceivable
that the first commit missed the second.
