### PR TITLE
CB-4760 Add Phoenix Query Server to Knox configuration

### DIFF
--- a/core-api/src/main/resources/definitions/exposed-services.json
+++ b/core-api/src/main/resources/definitions/exposed-services.json
@@ -475,6 +475,19 @@
       "apiIncluded": false,
       "visibleForDatalake": true,
       "visibleForDatahub": true
+    },
+    {
+      "name": "PHOENIX_QUERY_SERVER",
+      "displayName": "Phoenix Query Server",
+      "serviceName": "PHOENIX_QUERY_SERVER",
+      "knoxService": "AVATICA",
+      "knoxUrl": "/avatica/",
+      "ssoSupported": false,
+      "port": 8765,
+      "tlsPort": 8765,
+      "apiOnly": true,
+      "apiIncluded": true,
+      "visible": true
     }
   ]
 }

--- a/core-api/src/test/java/com/sequenceiq/cloudbreak/api/service/ExposedServiceCollectorTest.java
+++ b/core-api/src/test/java/com/sequenceiq/cloudbreak/api/service/ExposedServiceCollectorTest.java
@@ -102,6 +102,7 @@ class ExposedServiceCollectorTest {
                 "NIFI_NODE",
                 "NIFI_REGISTRY_SERVER",
                 "OOZIE_SERVER",
+                "PHOENIX_QUERY_SERVER",
                 "PROFILER_ADMIN_AGENT",
                 "PROFILER_METRICS_AGENT",
                 "PROFILER_SCHEDULER_AGENT",
@@ -121,6 +122,7 @@ class ExposedServiceCollectorTest {
         underTest.init();
         assertThat(underTest.getAllKnoxExposed()).containsExactlyInAnyOrder(
                 "ATLAS",
+                "AVATICA",
                 "CM-API",
                 "CM-UI",
                 "DAS",
@@ -160,6 +162,7 @@ class ExposedServiceCollectorTest {
         underTest.init();
         assertThat(underTest.getAllServicePorts(false)).containsOnly(
                 Map.entry("ATLAS", 21000),
+                Map.entry("AVATICA", 8765),
                 Map.entry("CM-API", 7180),
                 Map.entry("CM-UI", 7180),
                 Map.entry("DAS", 30800),
@@ -200,6 +203,7 @@ class ExposedServiceCollectorTest {
         underTest.init();
         assertThat(underTest.getAllServicePorts(true)).containsOnly(
                 Map.entry("ATLAS", 31443),
+                Map.entry("AVATICA", 8765),
                 Map.entry("CM-API", 7183),
                 Map.entry("CM-UI", 7183),
                 Map.entry("DAS", 30800),

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
@@ -49,6 +49,10 @@
                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
             </param>
             <param>
+                <name>avatica.acl</name>
+                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+            </param>
+            <param>
                 <name>cm-api.acl</name>
                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
             </param>
@@ -186,6 +190,12 @@
             {% if 'NIFI_REST' in exposed and 'NIFI_NODE' in salt['pillar.get']('gateway:location') -%}
              <param>
                  <name>NIFI</name>
+                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
+             </param>
+            {%- endif %}
+            {% if 'AVATICA' in exposed and 'PHOENIX_QUERY_SERVER' in salt['pillar.get']('gateway:location') -%}
+             <param>
+                 <name>AVATICA</name>
                  <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
              </param>
              {%- endif %}
@@ -402,12 +412,23 @@
 
     {% if 'SCHEMA_REGISTRY_SERVER' in salt['pillar.get']('gateway:location') -%}
     {% if 'SCHEMA-REGISTRY' in exposed -%}
-        <service>
-            <role>SCHEMA-REGISTRY</role>
-            {% for hostloc in salt['pillar.get']('gateway:location')['SCHEMA_REGISTRY_SERVER'] -%}
-            <url>{{ protocol }}://{{ hostloc }}:{{ ports['SCHEMA-REGISTRY'] }}</url>
-            {%- endfor %}
-        </service>
+    <service>
+        <role>SCHEMA-REGISTRY</role>
+        {% for hostloc in salt['pillar.get']('gateway:location')['SCHEMA_REGISTRY_SERVER'] -%}
+        <url>{{ protocol }}://{{ hostloc }}:{{ ports['SCHEMA-REGISTRY'] }}</url>
+        {%- endfor %}
+    </service>
+    {%- endif %}
+    {%- endif %}
+
+    {% if 'PHOENIX_QUERY_SERVER' in salt['pillar.get']('gateway:location') -%}
+    {% if 'AVATICA' in exposed -%}
+    <service>
+        <role>AVATICA</role>
+        {% for hostloc in salt['pillar.get']('gateway:location')['PHOENIX_QUERY_SERVER'] -%}
+        <url>{{ protocol }}://{{ hostloc }}:{{ ports['AVATICA'] }}</url>
+        {%- endfor %}
+    </service>
     {%- endif %}
     {%- endif %}
 


### PR DESCRIPTION
Add Phoenix Query Server to the list of services that CB pre-configures in Knox

Testing done on a local rc-2.19 CB instance

* Created environment
* Created OpDB DataHub with latest CM and CDH
* Checked that /var/lib/knox/gateway/conf/topologies/cdp-proxy-api.xml contains the correct URLs for the PQS instances
* Exported the Knox certificate to local machine
* Connected from DBeaver with the Phoenix Thin client driver JAR with the following JDBC URL:
jdbc:phoenix:thin:url=https://10.97.84.213/stoty-local-opdb/cdp-proxy-api/avatica;serialization=PROTOBUF;authentication=BASIC;truststore=/Users/stoty/x/gateway.truststore;truststore_password=bububu;avatica_user=stoty;avatica_password=redacted
* Checked that I can issue SQL commands successfully

Closes CB-4760
