### PR TITLE
CB-5896: Add CDP_FREEIPA_HA entitlement check.

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ To run Auth Mock from the command line, run the following Gradle command:
 
 ```
 ./gradlew :mock-caas:bootRun -PjvmArgs="\
+-Dserver.port=10080 \
 -Dauth.config.dir=<CBD_LOCAL_ETC> \
 -Dspring.config.location=$(pwd)/mock-caas/src/main/resources/application.yml"
 ```

--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
@@ -32,6 +32,10 @@ public class EntitlementService {
         return isEntitlementRegistered(actorCrn, accountId, "CDP_AUTOMATIC_USERSYNC_POLLER");
     }
 
+    public boolean freeIpaHaEnabled(String actorCrn, String accountID) {
+        return isEntitlementRegistered(actorCrn, accountID, "CDP_FREEIPA_HA");
+    }
+
     public boolean internalTenant(String actorCrn, String accountId) {
         return isEntitlementRegistered(actorCrn, accountId, "CLOUDERA_INTERNAL_ACCOUNT");
     }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/controller/validation/CreateFreeIpaRequestValidatorTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/controller/validation/CreateFreeIpaRequestValidatorTest.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.freeipa.controller.validation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -15,6 +16,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.validation.ValidationResult;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.create.CreateFreeIpaRequest;
@@ -41,6 +43,9 @@ class CreateFreeIpaRequestValidatorTest {
     @MockBean
     private CrnService crnService;
 
+    @MockBean
+    private EntitlementService entitlementService;
+
     @BeforeEach
     void setUp() {
         when(crnService.getCurrentAccountId()).thenReturn(ACCOUNT_ID);
@@ -48,6 +53,7 @@ class CreateFreeIpaRequestValidatorTest {
 
     @Test
     void validateShouldNotContainErrors() {
+        when(entitlementService.freeIpaHaEnabled(any(), any())).thenReturn(Boolean.TRUE);
         CreateFreeIpaRequest request = new CreateFreeIpaRequest();
         InstanceGroupRequest instanceGroupRequest = new InstanceGroupRequest();
         instanceGroupRequest.setNodeCount(1);
@@ -59,7 +65,34 @@ class CreateFreeIpaRequestValidatorTest {
     }
 
     @Test
+    void validateShouldNotContainErrorsForHA() {
+        when(entitlementService.freeIpaHaEnabled(any(), any())).thenReturn(Boolean.TRUE);
+        CreateFreeIpaRequest request = new CreateFreeIpaRequest();
+        InstanceGroupRequest instanceGroupRequest = new InstanceGroupRequest();
+        instanceGroupRequest.setNodeCount(2);
+        request.setInstanceGroups(List.of(instanceGroupRequest));
+
+        ValidationResult result = underTest.validate(request);
+
+        assertThat(result.hasError()).isFalse();
+    }
+
+    @Test
+    void validateShouldContainErrorsWhenHaEntitlementIsNotEnabled() {
+        when(entitlementService.freeIpaHaEnabled(any(), any())).thenReturn(Boolean.FALSE);
+        CreateFreeIpaRequest request = new CreateFreeIpaRequest();
+        InstanceGroupRequest instanceGroupRequest = new InstanceGroupRequest();
+        instanceGroupRequest.setNodeCount(2);
+        request.setInstanceGroups(List.of(instanceGroupRequest));
+
+        ValidationResult result = underTest.validate(request);
+
+        assertThat(result.hasError()).isTrue();
+    }
+
+    @Test
     void validateShouldContainErrorsWhenThereAreNoInstanceGroups() {
+        when(entitlementService.freeIpaHaEnabled(any(), any())).thenReturn(Boolean.TRUE);
         CreateFreeIpaRequest request = new CreateFreeIpaRequest();
 
         ValidationResult result = underTest.validate(request);
@@ -69,6 +102,7 @@ class CreateFreeIpaRequestValidatorTest {
 
     @Test
     void validateShouldContainErrorsWhenThereAreZeroNodes() {
+        when(entitlementService.freeIpaHaEnabled(any(), any())).thenReturn(Boolean.TRUE);
         CreateFreeIpaRequest request = new CreateFreeIpaRequest();
         InstanceGroupRequest instanceGroupRequest = new InstanceGroupRequest();
         instanceGroupRequest.setNodeCount(0);
@@ -81,6 +115,7 @@ class CreateFreeIpaRequestValidatorTest {
 
     @Test
     void validateShouldContainErrorsWhenThereAreTooManyNodes() {
+        when(entitlementService.freeIpaHaEnabled(any(), any())).thenReturn(Boolean.TRUE);
         CreateFreeIpaRequest request = new CreateFreeIpaRequest();
         InstanceGroupRequest instanceGroupRequest = new InstanceGroupRequest();
         instanceGroupRequest.setNodeCount(5);
@@ -93,6 +128,7 @@ class CreateFreeIpaRequestValidatorTest {
 
     @Test
     void validateShouldContainErrorsWhenThereAreTooManyInstanceGroups() {
+        when(entitlementService.freeIpaHaEnabled(any(), any())).thenReturn(Boolean.TRUE);
         CreateFreeIpaRequest request = new CreateFreeIpaRequest();
         InstanceGroupRequest instanceGroupRequest = new InstanceGroupRequest();
         instanceGroupRequest.setNodeCount(1);

--- a/mock-caas/src/main/java/com/sequenceiq/caas/grpc/service/MockUserManagementService.java
+++ b/mock-caas/src/main/java/com/sequenceiq/caas/grpc/service/MockUserManagementService.java
@@ -125,6 +125,8 @@ public class MockUserManagementService extends UserManagementGrpc.UserManagement
 
     private static final String LOCAL_DEV = "LOCAL_DEV";
 
+    private static final String CDP_FREEIPA_HA = "CDP_FREEIPA_HA";
+
     @Inject
     private JsonUtil jsonUtil;
 
@@ -157,6 +159,9 @@ public class MockUserManagementService extends UserManagementGrpc.UserManagement
 
     @Value("${auth.mock.baseimage.enable}")
     private boolean enableBaseImages;
+
+    @Value("${auth.mock.freeipa.ha.enable}")
+    private boolean enableFreeIpaHa;
 
     private String cbLicense;
 
@@ -377,6 +382,9 @@ public class MockUserManagementService extends UserManagementGrpc.UserManagement
         }
         if (enableBaseImages) {
             builder.addEntitlements(createEntitlement(CDP_BASE_IMAGE));
+        }
+        if (enableFreeIpaHa) {
+            builder.addEntitlements(createEntitlement(CDP_FREEIPA_HA));
         }
         responseObserver.onNext(
                 GetAccountResponse.newBuilder()

--- a/mock-caas/src/main/resources/application.yml
+++ b/mock-caas/src/main/resources/application.yml
@@ -14,3 +14,4 @@ auth:
     baseimage.enable: true
     event-generation:
       expiration-minutes: 10
+    freeipa.ha.enable: true


### PR DESCRIPTION
This was already reviewed in the rc-2.19 branch.
https://github.com/hortonworks/cloudbreak/pull/7466

```
Check the CDP_FREEIPA_HA entitlement when creating FreeIPA HA
clusters.

Fixed the readme for the running the mock-caas.
```

Closes #CB-5896
