### PR TITLE
CB-5896: Use the IAM service for the CDP_FREEIPA_HA entitlement

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/validation/CreateFreeIpaRequestValidator.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/validation/CreateFreeIpaRequestValidator.java
@@ -19,7 +19,7 @@ import com.sequenceiq.freeipa.util.CrnService;
 @Component
 public class CreateFreeIpaRequestValidator implements Validator<CreateFreeIpaRequest> {
 
-    static final String FREEIPA_INTERNAL_ACTOR_CRN = new InternalCrnBuilder(Crn.Service.FREEIPA).getInternalCrnForServiceAsString();
+    static final String INTERNAL_ACTOR_CRN = new InternalCrnBuilder(Crn.Service.IAM).getInternalCrnForServiceAsString();
 
     @Inject
     private StackService stackService;
@@ -45,7 +45,7 @@ public class CreateFreeIpaRequestValidator implements Validator<CreateFreeIpaReq
         } else {
             int nodesPerInstanceGroup = subject.getInstanceGroups().get(0).getNodeCount();
             if ((nodesPerInstanceGroup > 1 || subject.getInstanceGroups().size() > 1) &&
-                    !entitlementService.freeIpaHaEnabled(FREEIPA_INTERNAL_ACTOR_CRN, accountId)) {
+                    !entitlementService.freeIpaHaEnabled(INTERNAL_ACTOR_CRN, accountId)) {
                 validationBuilder.error("The FreeIPA HA capability is disabled.");
             }
             if (subject.getInstanceGroups().stream().filter(ig -> ig.getNodeCount() != nodesPerInstanceGroup || ig.getNodeCount() < 1).count() > 0) {


### PR DESCRIPTION
This was already reviewed and committed on rc-2.19.
https://github.com/hortonworks/cloudbreak/pull/7481

```
Fix the CDP_FREEIPA_HA entitlement check to use the IAM service as the
internal actor's service. The UMS requires the internal actor to be
IAM.
```

Closes #CB-5896