### PR TITLE
CB-5099: FreeIPA changes to support AWS instance recovery

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/PlatformParametersConsts.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/PlatformParametersConsts.java
@@ -20,6 +20,8 @@ public class PlatformParametersConsts {
 
     public static final String REGIONS_SUPPORTED = "regionsSupported";
 
+    public static final String CLOUDWATCH_CREATE_PARAMETER = "createCloudWatchAlarm";
+
     private PlatformParametersConsts() {
 
     }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsClient.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsClient.java
@@ -22,6 +22,7 @@ import com.amazonaws.regions.RegionUtils;
 import com.amazonaws.retry.PredefinedRetryPolicies;
 import com.amazonaws.services.autoscaling.AmazonAutoScalingClient;
 import com.amazonaws.services.cloudformation.AmazonCloudFormationClient;
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.ec2.AmazonEC2Client;
@@ -97,6 +98,14 @@ public class AwsClient {
 
     public AmazonEC2Client getAmazonEC2Client(BasicAWSCredentials basicAWSCredentials) {
         return new AmazonEC2Client(basicAWSCredentials);
+    }
+
+    public AmazonCloudWatchClient createCloudWatchClient(AwsCredentialView awsCredential, String regionName) {
+        AmazonCloudWatchClient client = isRoleAssumeRequired(awsCredential) ?
+                new AmazonCloudWatchClient(createAwsSessionCredentialProvider(awsCredential)) :
+                new AmazonCloudWatchClient(createAwsCredentials(awsCredential));
+        client.setRegion(RegionUtils.getRegion(regionName));
+        return client;
     }
 
     public AWSSecurityTokenService createAwsSecurityTokenService(AwsCredentialView awsCredential) {

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsCloudWatchService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsCloudWatchService.java
@@ -1,0 +1,90 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource;
+
+import static com.sequenceiq.cloudbreak.cloud.PlatformParametersConsts.CLOUDWATCH_CREATE_PARAMETER;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient;
+import com.amazonaws.services.cloudwatch.model.AmazonCloudWatchException;
+import com.amazonaws.services.cloudwatch.model.DeleteAlarmsRequest;
+import com.amazonaws.services.cloudwatch.model.Dimension;
+import com.amazonaws.services.cloudwatch.model.PutMetricAlarmRequest;
+import com.sequenceiq.cloudbreak.cloud.aws.AwsClient;
+import com.sequenceiq.cloudbreak.cloud.aws.view.AwsCredentialView;
+import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+
+@Service
+public class AwsCloudWatchService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsCloudWatchService.class);
+
+    @Value("${freeipa.aws.cloudwatch.suffix:-Status-Check-Failed-System}")
+    private String alarmSuffix;
+
+    @Value("${freeipa.aws.cloudwatch.period:60}")
+    private int cloudwatchPeriod;
+
+    @Value("${freeipa.aws.cloudwatch.evaluationPeriods:2}")
+    private int cloudwatchEvaluationPeriods;
+
+    @Value("${freeipa.aws.cloudwatch.threshold:1.0}")
+    private double cloudwatchThreshhold;
+
+    @Inject
+    private AwsClient awsClient;
+
+    public void addCloudWatchAlarmsForSystemFailures(List<CloudResource> instances, CloudStack stack, String regionName, AwsCredentialView credentialView) {
+        String isCreate = stack.getParameters().get(CLOUDWATCH_CREATE_PARAMETER);
+        if (isCreate != null && isCreate.equals(Boolean.TRUE.toString())) {
+            instances.stream().forEach(instance -> {
+                try {
+                    PutMetricAlarmRequest metricAlarmRequest = new PutMetricAlarmRequest();
+                    metricAlarmRequest.setAlarmActions(Arrays.asList("arn:aws:automate:" + regionName + ":ec2:recover"));
+                    metricAlarmRequest.setAlarmName(instance.getInstanceId() + alarmSuffix);
+                    metricAlarmRequest.setMetricName("StatusCheckFailed_System");
+                    metricAlarmRequest.setStatistic("Maximum");
+                    metricAlarmRequest.setNamespace("AWS/EC2");
+                    metricAlarmRequest.setDimensions(Arrays.asList(new Dimension().withName("InstanceId").withValue(instance.getInstanceId())));
+                    metricAlarmRequest.setPeriod(cloudwatchPeriod);
+                    metricAlarmRequest.setEvaluationPeriods(cloudwatchEvaluationPeriods);
+                    metricAlarmRequest.setThreshold(cloudwatchThreshhold);
+                    metricAlarmRequest.setComparisonOperator("GreaterThanOrEqualToThreshold");
+                    AmazonCloudWatchClient amazonCloudWatchClient = awsClient.createCloudWatchClient(credentialView, regionName);
+                    amazonCloudWatchClient.putMetricAlarm(metricAlarmRequest);
+                    LOGGER.debug("Created cloudwatch alarm for instanceId {}.", instance.getInstanceId());
+                } catch (AmazonCloudWatchException acwe) {
+                    LOGGER.error("Unable to create cloudwatch alarm for instanceId {}: {}", instance.getInstanceId(), acwe.getLocalizedMessage());
+                }
+            });
+        }
+    }
+
+    public void deleteCloudWatchAlarmsForSystemFailures(CloudStack stack, String regionName, AwsCredentialView credentialView) {
+        List<CloudInstance> instances = stack.getGroups().stream()
+                .flatMap(group -> group.getInstances().stream()).collect(Collectors.toList());
+        String isCreate = stack.getParameters().get(CLOUDWATCH_CREATE_PARAMETER);
+        if (isCreate != null && isCreate.equals(Boolean.TRUE.toString())) {
+            instances.stream().forEach(instance -> {
+                try {
+                    DeleteAlarmsRequest deleteAlarmsRequest = new DeleteAlarmsRequest().withAlarmNames(instance.getInstanceId() + alarmSuffix);
+                    AmazonCloudWatchClient amazonCloudWatchClient = awsClient.createCloudWatchClient(credentialView, regionName);
+                    amazonCloudWatchClient.deleteAlarms(deleteAlarmsRequest);
+                    LOGGER.debug("Deleted cloudwatch alarm.-", instance.getInstanceId());
+                } catch (AmazonCloudWatchException acwe) {
+                    LOGGER.error("Unable to delete cloudwatch alarm for instanceId {}: {}", instance.getInstanceId(), acwe.getLocalizedMessage());
+                }
+            });
+        }
+    }
+}

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsLaunchService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsLaunchService.java
@@ -97,6 +97,9 @@ public class AwsLaunchService {
     @Inject
     private AwsTaggingService awsTaggingService;
 
+    @Inject
+    private AwsCloudWatchService awsCloudWatchService;
+
     public List<CloudResourceStatus> launch(AuthenticatedContext ac, CloudStack stack, PersistenceNotifier resourceNotifier,
             AdjustmentType adjustmentType, Long threshold) throws Exception {
         createKeyPair(ac, stack);
@@ -162,6 +165,8 @@ public class AwsLaunchService {
         awsComputeResourceService.buildComputeResourcesForLaunch(ac, stack, adjustmentType, threshold, instances, networkResources);
 
         awsTaggingService.tagRootVolumes(ac, amazonEC2Client, instances, stack.getTags());
+
+        awsCloudWatchService.addCloudWatchAlarmsForSystemFailures(instances, stack, regionName, credentialView);
 
         return awsResourceConnector.check(ac, instances);
     }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsTerminateService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsTerminateService.java
@@ -82,6 +82,9 @@ public class AwsTerminateService {
     @Inject
     private AwsElasticIpService awsElasticIpService;
 
+    @Inject
+    private AwsCloudWatchService awsCloudWatchService;
+
     public List<CloudResourceStatus> terminate(AuthenticatedContext ac, CloudStack stack, List<CloudResource> resources) {
         LOGGER.debug("Deleting stack: {}", ac.getCloudContext().getId());
         AwsCredentialView credentialView = new AwsCredentialView(ac.getCloudCredential());
@@ -90,6 +93,7 @@ public class AwsTerminateService {
         AmazonEC2Client amazonEC2Client = authenticatedContextView.getAmazonEC2Client();
         AmazonCloudFormationClient amazonCloudFormationClient = awsClient.createCloudFormationClient(credentialView, regionName);
 
+        awsCloudWatchService.deleteCloudWatchAlarmsForSystemFailures(stack, regionName, credentialView);
         waitAndDeleteCloudformationStack(ac, stack, resources, amazonCloudFormationClient);
         awsComputeResourceService.deleteComputeResources(ac, stack, resources);
         cleanupEncryptedResources(ac, resources, regionName, amazonEC2Client);

--- a/cloud-aws/src/main/resources/definitions/aws-cb-policy.json
+++ b/cloud-aws/src/main/resources/definitions/aws-cb-policy.json
@@ -11,6 +11,17 @@
       ]
     },
     {
+      "Sid": "CloudWatchMetric",
+      "Action": [
+        "cloudwatch:PutMetricAlarm",
+        "cloudwatch:DeleteAlarms"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    },
+    {
       "Sid": "DynamoDBFull",
       "Action": [
         "dynamodb:*"

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsTerminateServiceIntegrationTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsTerminateServiceIntegrationTest.java
@@ -110,6 +110,9 @@ public class AwsTerminateServiceIntegrationTest {
     private AwsElasticIpService awsElasticIpService;
 
     @Mock
+    private AwsCloudWatchService awsCloudWatchService;
+
+    @Mock
     private AwsComputeResourceService awsComputeResourceService;
 
     @Mock

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsTerminateServiceTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsTerminateServiceTest.java
@@ -110,6 +110,9 @@ public class AwsTerminateServiceTest {
     private AwsElasticIpService awsElasticIpService;
 
     @Mock
+    private AwsCloudWatchService awsCloudWatchService;
+
+    @Mock
     private AwsComputeResourceService awsComputeResourceService;
 
     @Mock

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/cloud/StackToCloudStackConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/cloud/StackToCloudStackConverter.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.freeipa.converter.cloud;
 
+import static com.sequenceiq.cloudbreak.cloud.PlatformParametersConsts.CLOUDWATCH_CREATE_PARAMETER;
 import static com.sequenceiq.cloudbreak.cloud.model.InstanceStatus.CREATE_REQUESTED;
 import static com.sequenceiq.cloudbreak.cloud.model.InstanceStatus.DELETE_REQUESTED;
 import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceStatus.REQUESTED;
@@ -20,6 +21,7 @@ import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
 
@@ -75,6 +77,9 @@ public class StackToCloudStackConverter implements Converter<Stack, CloudStack> 
     @Inject
     private ImageConverter imageConverter;
 
+    @Value("${freeipa.aws.cloudwatch.enabled:true}")
+    private boolean enableCloudwatch;
+
     @Override
     public CloudStack convert(Stack stack) {
         return convert(stack, Collections.emptySet());
@@ -96,8 +101,9 @@ public class StackToCloudStackConverter implements Converter<Stack, CloudStack> 
         Network network = buildNetwork(stack);
         InstanceAuthentication instanceAuthentication = buildInstanceAuthentication(stack.getStackAuthentication());
 
-        return new CloudStack(instanceGroups, network, image, Collections.emptyMap(), getUserDefinedTags(stack), stack.getTemplate(),
-                instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), null);
+        return new CloudStack(instanceGroups, network, image, Map.of(CLOUDWATCH_CREATE_PARAMETER, Boolean.toString(enableCloudwatch)),
+                getUserDefinedTags(stack), stack.getTemplate(), instanceAuthentication, instanceAuthentication.getLoginUserName(),
+                instanceAuthentication.getPublicKey(), null);
     }
 
     public CloudInstance buildInstance(InstanceMetaData instanceMetaData, Template template,


### PR DESCRIPTION
This change adds an automatic cloudwatch alarm during
the instance creation for AWS and removes it during
termination. This is only necessary for AWS as Azure
enables this by default. This enables an instance to
automatically recover when the underlying hardware,
owned by AWS, is faulty.

This was tested manually and verified that only FreeIPA instances receive the cloudwatch alarm.