### PR TITLE
CB-5583 CB-5584 Differentiate resource dependent and independent rights

### DIFF
--- a/authorization-common-api/src/main/java/com/sequenceiq/authorization/RightsConstants.java
+++ b/authorization-common-api/src/main/java/com/sequenceiq/authorization/RightsConstants.java
@@ -2,9 +2,11 @@ package com.sequenceiq.authorization;
 
 public class RightsConstants {
 
-    public static final String ENVIRONMENT_RESOURCE = "environments";
+    public static final String ENVIRONMENTS_RESOURCE = "environments";
 
     public static final String CREDENTIAL_RESOURCE = "credential";
+
+    public static final String CREDENTIALS_RESOURCE = "credentials";
 
     public static final String DATALAKE_RESOURCE = "datalake";
 

--- a/authorization-common-api/src/main/java/com/sequenceiq/authorization/resource/AuthorizationResourceType.java
+++ b/authorization-common-api/src/main/java/com/sequenceiq/authorization/resource/AuthorizationResourceType.java
@@ -8,35 +8,32 @@ import org.apache.commons.lang3.StringUtils;
 import com.sequenceiq.authorization.RightsConstants;
 
 public enum AuthorizationResourceType {
-    DATALAKE("Datalake cluster", RightsConstants.DATALAKE_RESOURCE),
-    ENVIRONMENT("Environment", RightsConstants.ENVIRONMENT_RESOURCE),
-    CREDENTIAL("Credential", RightsConstants.CREDENTIAL_RESOURCE),
-    DATAHUB("Datahub cluster", RightsConstants.DATAHUB_RESOURCE);
+    DATALAKE(RightsConstants.DATALAKE_RESOURCE, RightsConstants.DATALAKE_RESOURCE),
+    ENVIRONMENT(RightsConstants.ENVIRONMENTS_RESOURCE, RightsConstants.ENVIRONMENTS_RESOURCE),
+    CREDENTIAL(RightsConstants.CREDENTIAL_RESOURCE, RightsConstants.CREDENTIALS_RESOURCE),
+    DATAHUB(RightsConstants.DATAHUB_RESOURCE, RightsConstants.DATAHUB_RESOURCE);
 
-    private final String readableName;
+    private final String resourceDependentAuthorizationName;
 
-    private final String authorizationName;
+    private final String resourceIndependentAuthorizationName;
 
-    AuthorizationResourceType(String readableName, String authorizationName) {
-        this.readableName = readableName;
-        this.authorizationName = authorizationName;
+    AuthorizationResourceType(String resourceDependentAuthorizationName, String resourceIndependentAuthorizationName) {
+        this.resourceDependentAuthorizationName = resourceDependentAuthorizationName;
+        this.resourceIndependentAuthorizationName = resourceIndependentAuthorizationName;
     }
 
-    public String getReadableName() {
-        return readableName;
+    public String getResourceDependentAuthorizationName() {
+        return resourceDependentAuthorizationName;
     }
 
-    public String getShortName() {
-        return authorizationName.toLowerCase();
-    }
-
-    public String getAuthorizationName() {
-        return authorizationName;
+    public String getResourceIndependentAuthorizationName() {
+        return resourceIndependentAuthorizationName;
     }
 
     public static Optional<AuthorizationResourceType> getByName(String name) {
         return Arrays.stream(AuthorizationResourceType.values())
-                .filter(resource -> StringUtils.equals(resource.getAuthorizationName(), name))
+                .filter(resource -> StringUtils.equals(resource.getResourceDependentAuthorizationName(), name) ||
+                        StringUtils.equals(resource.getResourceIndependentAuthorizationName(), name))
                 .findAny();
     }
 }

--- a/authorization-common/src/main/java/com/sequenceiq/authorization/resource/RightUtils.java
+++ b/authorization-common/src/main/java/com/sequenceiq/authorization/resource/RightUtils.java
@@ -5,7 +5,11 @@ public class RightUtils {
     private RightUtils() {
     }
 
-    public static String getRight(AuthorizationResourceType resource, AuthorizationResourceAction action) {
-        return resource.getAuthorizationName() + "/" + action.getAuthorizationName();
+    public static String getResourceDependentRight(AuthorizationResourceType resource, AuthorizationResourceAction action) {
+        return resource.getResourceDependentAuthorizationName() + "/" + action.getAuthorizationName();
+    }
+
+    public static String getResourceIndependentRight(AuthorizationResourceType resource, AuthorizationResourceAction action) {
+        return resource.getResourceIndependentAuthorizationName() + "/" + action.getAuthorizationName();
     }
 }

--- a/authorization-common/src/main/java/com/sequenceiq/authorization/service/UmsAuthorizationService.java
+++ b/authorization-common/src/main/java/com/sequenceiq/authorization/service/UmsAuthorizationService.java
@@ -30,7 +30,7 @@ public class UmsAuthorizationService {
     private GrpcUmsClient umsClient;
 
     public void checkRightOfUser(String userCrn, AuthorizationResourceType resourceType, AuthorizationResourceAction action) {
-        String right = RightUtils.getRight(resourceType, action);
+        String right = RightUtils.getResourceIndependentRight(resourceType, action);
         String unauthorizedMessage = String.format("You have no right to perform %s. This requires one of these roles: %s. "
                         + "You can request access through IAM service from an administrator.",
                 right, "PowerUser");
@@ -57,12 +57,12 @@ public class UmsAuthorizationService {
     }
 
     private boolean hasRightOfUser(String userCrn, AuthorizationResourceType resourceType, AuthorizationResourceAction action) {
-        return umsClient.checkRight(userCrn, userCrn, RightUtils.getRight(resourceType, action), getRequestId());
+        return umsClient.checkRight(userCrn, userCrn, RightUtils.getResourceIndependentRight(resourceType, action), getRequestId());
     }
 
     public void checkRightOfUserOnResource(String userCrn, AuthorizationResourceType resource,
             AuthorizationResourceAction action, String resourceCrn) {
-        String right = RightUtils.getRight(resource, action);
+        String right = RightUtils.getResourceDependentRight(resource, action);
         String unauthorizedMessage = String.format("You have no right to perform %s. This requires one of these roles: %s. "
                         + "You can request access through IAM service from an administrator.",
                 right, "PowerUser");
@@ -71,7 +71,7 @@ public class UmsAuthorizationService {
 
     public void checkRightOfUserOnResources(String userCrn, AuthorizationResourceType resource,
             AuthorizationResourceAction action, Collection<String> resourceCrns) {
-        String right = RightUtils.getRight(resource, action);
+        String right = RightUtils.getResourceDependentRight(resource, action);
         String unauthorizedMessage = String.format("You have no right to perform %s. This requires one of these roles: %s. "
                         + "You can request access through IAM service from an administrator.",
                 right, "PowerUser");
@@ -80,7 +80,7 @@ public class UmsAuthorizationService {
 
     private void checkRightOfUserOnResource(String userCrn, AuthorizationResourceType resource, AuthorizationResourceAction action,
             String resourceCrn, String unauthorizedMessage) {
-        if (!umsClient.checkRight(userCrn, userCrn, RightUtils.getRight(resource, action), resourceCrn, getRequestId())) {
+        if (!umsClient.checkRight(userCrn, userCrn, RightUtils.getResourceDependentRight(resource, action), resourceCrn, getRequestId())) {
             LOGGER.error(unauthorizedMessage);
             throw new AccessDeniedException(unauthorizedMessage);
         }
@@ -89,7 +89,7 @@ public class UmsAuthorizationService {
     private void checkRightOfUserOnResources(String userCrn, AuthorizationResourceType resource, AuthorizationResourceAction action,
             Collection<String> resourceCrns, String unauthorizedMessage) {
         Map<String, String> resourceCrnRightMap = resourceCrns.stream().distinct().collect(
-                Collectors.toMap(resourceCrn -> resourceCrn, resourceCrn -> RightUtils.getRight(resource, action)));
+                Collectors.toMap(resourceCrn -> resourceCrn, resourceCrn -> RightUtils.getResourceDependentRight(resource, action)));
         if (!umsClient.hasRights(userCrn, userCrn, resourceCrnRightMap, getRequestId()).stream().allMatch(Boolean::booleanValue)) {
             LOGGER.error(unauthorizedMessage);
             throw new AccessDeniedException(unauthorizedMessage);

--- a/authorization-common/src/test/java/com/sequenceiq/authorization/resource/RightUtilsTest.java
+++ b/authorization-common/src/test/java/com/sequenceiq/authorization/resource/RightUtilsTest.java
@@ -8,11 +8,11 @@ public class RightUtilsTest {
 
     @Test
     public void testGetNonDatahubRight() {
-        assertEquals("environments/write", RightUtils.getRight(AuthorizationResourceType.ENVIRONMENT, AuthorizationResourceAction.WRITE));
+        assertEquals("environments/write", RightUtils.getResourceDependentRight(AuthorizationResourceType.ENVIRONMENT, AuthorizationResourceAction.WRITE));
     }
 
     @Test
     public void testGetDatahubRight() {
-        assertEquals("datahub/write", RightUtils.getRight(AuthorizationResourceType.DATAHUB, AuthorizationResourceAction.WRITE));
+        assertEquals("datahub/write", RightUtils.getResourceDependentRight(AuthorizationResourceType.DATAHUB, AuthorizationResourceAction.WRITE));
     }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/util/base/RightV4.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/util/base/RightV4.java
@@ -7,8 +7,8 @@ public enum RightV4 {
     DISTROX_WRITE(RightsConstants.DATAHUB_RESOURCE, RightsConstants.WRITE_ACTION),
     SDX_READ(RightsConstants.DATALAKE_RESOURCE, RightsConstants.READ_ACTION),
     SDX_WRITE(RightsConstants.DATALAKE_RESOURCE, RightsConstants.WRITE_ACTION),
-    ENVIRONMENT_READ(RightsConstants.ENVIRONMENT_RESOURCE, RightsConstants.READ_ACTION),
-    ENVIRONMENT_WRITE(RightsConstants.ENVIRONMENT_RESOURCE, RightsConstants.WRITE_ACTION);
+    ENVIRONMENT_READ(RightsConstants.ENVIRONMENTS_RESOURCE, RightsConstants.READ_ACTION),
+    ENVIRONMENT_WRITE(RightsConstants.ENVIRONMENTS_RESOURCE, RightsConstants.WRITE_ACTION);
 
     private String resource;
 

--- a/environment/src/main/java/com/sequenceiq/environment/credential/v1/CredentialV1Controller.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/v1/CredentialV1Controller.java
@@ -15,6 +15,7 @@ import com.sequenceiq.authorization.annotation.CheckPermissionByResourceCrn;
 import com.sequenceiq.authorization.annotation.CheckPermissionByResourceName;
 import com.sequenceiq.authorization.annotation.CheckPermissionByResourceNameList;
 import com.sequenceiq.authorization.annotation.CheckPermissionByResourceObject;
+import com.sequenceiq.authorization.annotation.DisableCheckPermissions;
 import com.sequenceiq.authorization.annotation.ResourceName;
 import com.sequenceiq.authorization.annotation.ResourceNameList;
 import com.sequenceiq.authorization.annotation.ResourceObject;
@@ -59,8 +60,9 @@ public class CredentialV1Controller extends NotificationController implements Cr
         this.credentialDeleteService = credentialDeleteService;
     }
 
+    // TODO authz of list methods
     @Override
-    @CheckPermissionByAccount(action = AuthorizationResourceAction.READ)
+    @DisableCheckPermissions
     public CredentialResponses list() {
         String accountId = ThreadBasedUserCrnProvider.getAccountId();
         return new CredentialResponses(

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/EnvironmentAccessChecker.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/EnvironmentAccessChecker.java
@@ -26,10 +26,11 @@ public class EnvironmentAccessChecker {
 
     private static final String IAM_INTERNAL_ACTOR_CRN = new InternalCrnBuilder(Crn.Service.IAM).getInternalCrnForServiceAsString();
 
-    private static final String ACCESS_ENVIRONMENT_RIGHT = RightUtils.getRight(AuthorizationResourceType.ENVIRONMENT,
+    private static final String ACCESS_ENVIRONMENT_RIGHT = RightUtils.getResourceDependentRight(AuthorizationResourceType.ENVIRONMENT,
             AuthorizationResourceAction.ACCESS_ENVIRONMENT);
 
-    private static final String ADMIN_FREEIPA_RIGHT = RightUtils.getRight(AuthorizationResourceType.ENVIRONMENT, AuthorizationResourceAction.ADMIN_FREEIPA);
+    private static final String ADMIN_FREEIPA_RIGHT = RightUtils.getResourceDependentRight(AuthorizationResourceType.ENVIRONMENT,
+            AuthorizationResourceAction.ADMIN_FREEIPA);
 
     private final GrpcUmsClient grpcUmsClient;
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/EnvironmentAccessCheckerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/EnvironmentAccessCheckerTest.java
@@ -69,10 +69,11 @@ class EnvironmentAccessCheckerTest {
         List<AuthorizationProto.RightCheck> capturedRightChecks = argumentCaptor.getValue();
         assertEquals(2, capturedRightChecks.size());
         AuthorizationProto.RightCheck hasAccess = capturedRightChecks.get(0);
-        assertEquals(RightUtils.getRight(AuthorizationResourceType.ENVIRONMENT, AuthorizationResourceAction.ACCESS_ENVIRONMENT), hasAccess.getRight());
+        assertEquals(RightUtils.getResourceDependentRight(AuthorizationResourceType.ENVIRONMENT, AuthorizationResourceAction.ACCESS_ENVIRONMENT),
+                hasAccess.getRight());
         assertEquals(ENV_CRN, hasAccess.getResource());
         AuthorizationProto.RightCheck isAdmin = capturedRightChecks.get(1);
-        assertEquals(RightUtils.getRight(AuthorizationResourceType.ENVIRONMENT, AuthorizationResourceAction.ADMIN_FREEIPA), isAdmin.getRight());
+        assertEquals(RightUtils.getResourceDependentRight(AuthorizationResourceType.ENVIRONMENT, AuthorizationResourceAction.ADMIN_FREEIPA), isAdmin.getRight());
     }
 
     @Test


### PR DESCRIPTION
it seems we need to differentiate completely rights in case of account level check and in case of resource level check
related logic: https://github.infra.cloudera.com/thunderhead/thunderhead/blob/master/services/usermanagement/src/main/java/com/cloudera/thunderhead/service/usermanagement/server/AuthorizationService.java
https://github.infra.cloudera.com/thunderhead/thunderhead/blob/master/services/libs/common/src/main/java/com/cloudera/thunderhead/service/common/authorization/Rights.java