### PR TITLE
CB-5904: Fix FreeIPA provisioning error 400 No required SSL ...

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/provision/action/StackProvisionService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/provision/action/StackProvisionService.java
@@ -132,7 +132,7 @@ public class StackProvisionService {
         Set<InstanceMetaData> instanceMetaDataSet =
                 stack.getInstanceGroups().stream().flatMap(instanceGroup -> instanceGroup.getAllInstanceMetaData().stream()).collect(Collectors.toSet());
         for (InstanceMetaData gwInstance : instanceMetaDataSet) {
-            tlsSetupService.setupTls(stack.getId());
+            tlsSetupService.setupTls(stack.getId(), gwInstance);
         }
     }
 


### PR DESCRIPTION
certificate was sent

Wait for nginx to start on all FreeIPA gateway nodes. Then save the
certificate for each of them. Previously a random node was checked
one time for each node in the cluster and that node's certificate was
saved.

This was tested locally by deploying 50 clusters without the the
"400 No required SSL certificate was sent" error. Although the
issue was intermittent, it occurred regularly enough that the problem
has likely been resolved.

Closes #CB-5904