### PR TITLE
CB-5960: Fix FreeIPA provisioning error 400 No required SSL ...

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/provision/action/StackProvisionService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/provision/action/StackProvisionService.java
@@ -132,7 +132,7 @@ public class StackProvisionService {
         Set<InstanceMetaData> instanceMetaDataSet =
                 stack.getInstanceGroups().stream().flatMap(instanceGroup -> instanceGroup.getAllInstanceMetaData().stream()).collect(Collectors.toSet());
         for (InstanceMetaData gwInstance : instanceMetaDataSet) {
-            tlsSetupService.setupTls(stack.getId());
+            tlsSetupService.setupTls(stack.getId(), gwInstance);
         }
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/TlsSetupService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/TlsSetupService.java
@@ -1,9 +1,10 @@
 package com.sequenceiq.freeipa.service;
 
 
+import static com.sequenceiq.cloudbreak.exception.NotFoundException.notFound;
+
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
-import java.util.Set;
 
 import javax.inject.Inject;
 import javax.net.ssl.SSLContext;
@@ -52,16 +53,14 @@ public class TlsSetupService {
     @Inject
     private StackRepository stackRepository;
 
-    public void setupTls(Long stackId) throws CloudbreakException {
+    public void setupTls(Long stackId, InstanceMetaData gwInstance) throws CloudbreakException {
         try {
             SavingX509TrustManager x509TrustManager = new SavingX509TrustManager();
             TrustManager[] trustManagers = {x509TrustManager};
             SSLContext sslContext = SslConfigurator.newInstance().createSSLContext();
             sslContext.init(null, trustManagers, new SecureRandom());
             Client client = RestClientUtil.createClient(sslContext, false);
-            Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataRepository.findAllInStack(stackId);
-            InstanceMetaData instanceMetaData = instanceMetaDataSet.iterator().next();
-            String ip = instanceMetaData.getPublicIpWrapper();
+            String ip = gwInstance.getPublicIpWrapper();
             Stack stack = stackRepository.findById(stackId).get();
             Integer gatewayPort = stack.getGatewayport();
             LOGGER.debug("Trying to fetch the server's certificate: {}:{}", ip, gatewayPort);
@@ -72,12 +71,18 @@ public class TlsSetupService {
             nginxTarget.path("/").request().get().close();
             X509Certificate[] chain = x509TrustManager.getChain();
             String serverCert = PkiUtil.convert(chain[0]);
-            instanceMetaData.setServerCert(BaseEncoding.base64().encode(serverCert.getBytes()));
-            instanceMetaDataRepository.save(instanceMetaData);
+            InstanceMetaData metaData = getInstanceMetaData(gwInstance);
+            metaData.setServerCert(BaseEncoding.base64().encode(serverCert.getBytes()));
+            instanceMetaDataRepository.save(metaData);
         } catch (Exception e) {
             throw new CloudbreakException("Failed to retrieve the server's certificate from Nginx."
                     + " Please check your security group is open enough and Management Console can access your VPC and subnet"
                     + " Please also Make sure your Subnets can route to the internet and you have public DNS and IP options enabled", e);
         }
+    }
+
+    private InstanceMetaData getInstanceMetaData(InstanceMetaData gwInstance) {
+        return instanceMetaDataRepository.findById(gwInstance.getId())
+                .orElseThrow(notFound("Instance metadata", gwInstance.getId()));
     }
 }


### PR DESCRIPTION
certificate was sent

**This was already reviewed and merged onto rc-2.19.
https://github.com/hortonworks/cloudbreak/pull/7506**

Wait for nginx to start on all FreeIPA gateway nodes. Then save the
certificate for each of them. Previously a random node was checked
one time for each node in the cluster and that node's certificate was
saved.

This was tested locally by deploying 50 clusters without the the
"400 No required SSL certificate was sent" error. Although the
issue was intermittent, it occurred regularly enough that the problem
has likely been resolved.

Closes #CB-5960