### PR TITLE
CB-5520: Health check provide a message in instance issues when the node is UNREACHABLE

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaHealthDetailsService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaHealthDetailsService.java
@@ -81,6 +81,7 @@ public class FreeIpaHealthDetailsService {
             response.addNodeHealthDetailsFreeIpaResponses(nodeResponse);
             nodeResponse.setName(master.getDiscoveryFQDN());
             nodeResponse.setStatus(InstanceStatus.UNREACHABLE);
+            nodeResponse.addIssue("Node is not responding.");
         }
         updateResponseWithInstanceIds(response, stack);
         return response;

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaHealthServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaHealthServiceTest.java
@@ -189,8 +189,9 @@ public class FreeIpaHealthServiceTest {
         Assert.assertEquals(Status.UNREACHABLE, response.getStatus());
         Assert.assertFalse(response.getNodeHealthDetails().isEmpty());
         for (NodeHealthDetails nodeHealth:response.getNodeHealthDetails()) {
-            Assert.assertTrue(nodeHealth.getIssues().isEmpty());
             Assert.assertEquals(InstanceStatus.UNREACHABLE, nodeHealth.getStatus());
+            Assert.assertTrue(nodeHealth.getIssues().size() == 1);
+            Assert.assertTrue(nodeHealth.getIssues().get(0).equals("Node is not responding."));
         }
     }
 


### PR DESCRIPTION
This patch adds an issue entry when the node is UNREACHABLE.  This is to provide better end user messaging with the health check.

Updated and ran unit tests as well as verified with local freeipa against AWS instance.