### PR TITLE
CB-5339 - Adding automated cloud backups to FreeIPA

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/api/model/Backup.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/api/model/Backup.java
@@ -1,0 +1,68 @@
+package com.sequenceiq.freeipa.api.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
+import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Backup {
+    private String storageLocation;
+
+    private S3CloudStorageV1Parameters s3;
+
+    private AdlsGen2CloudStorageV1Parameters adlsGen2;
+
+    private boolean monthlyFullEnabled;
+
+    private boolean initialFullEnabled;
+
+    private boolean hourlyEnabled;
+
+    public String getStorageLocation() {
+        return storageLocation;
+    }
+
+    public void setStorageLocation(String storageLocation) {
+        this.storageLocation = storageLocation;
+    }
+
+    public S3CloudStorageV1Parameters getS3() {
+        return s3;
+    }
+
+    public void setS3(S3CloudStorageV1Parameters s3) {
+        this.s3 = s3;
+    }
+
+    public AdlsGen2CloudStorageV1Parameters getAdlsGen2() {
+        return adlsGen2;
+    }
+
+    public void setAdlsGen2(AdlsGen2CloudStorageV1Parameters adlsGen2) {
+        this.adlsGen2 = adlsGen2;
+    }
+
+    public boolean isMonthlyFullEnabled() {
+        return monthlyFullEnabled;
+    }
+
+    public void setMonthlyFullEnabled(boolean monthlyFullEnabled) {
+        this.monthlyFullEnabled = monthlyFullEnabled;
+    }
+
+    public boolean isInitialFullEnabled() {
+        return initialFullEnabled;
+    }
+
+    public void setInitialFullEnabled(boolean initialFullEnabled) {
+        this.initialFullEnabled = initialFullEnabled;
+    }
+
+    public boolean isHourlyEnabled() {
+        return hourlyEnabled;
+    }
+
+    public void setHourlyEnabled(boolean hourlyEnabled) {
+        this.hourlyEnabled = hourlyEnabled;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/BackupConfiguration.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/BackupConfiguration.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.freeipa.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class BackupConfiguration {
+    private final boolean monthlyFullEnabled;
+
+    private final boolean runInitialFullAfterInstall;
+
+    private final boolean hourlyEnabled;
+
+    public BackupConfiguration(
+            @Value("${freeipa.backup.full.monthly:true}") boolean monthlyFullEnabled,
+            @Value("${freeipa.backup.full.after_install:true}") boolean runInitialFullAfterInstall,
+            @Value("${freeipa.backup.hourly.enabled:true}") boolean hourlyEnabled) {
+        this.monthlyFullEnabled = monthlyFullEnabled;
+        this.runInitialFullAfterInstall = runInitialFullAfterInstall;
+        this.hourlyEnabled = hourlyEnabled;
+    }
+
+    public boolean isMonthlyFullEnabled() {
+        return monthlyFullEnabled;
+    }
+
+    public boolean isRunInitialFullAfterInstall() {
+        return runInitialFullAfterInstall;
+    }
+
+    public boolean isHourlyEnabled() {
+        return hourlyEnabled;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/backup/BackupConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/backup/BackupConverter.java
@@ -1,0 +1,59 @@
+package com.sequenceiq.freeipa.converter.backup;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
+import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
+import com.sequenceiq.common.api.telemetry.request.LoggingRequest;
+import com.sequenceiq.common.api.telemetry.request.TelemetryRequest;
+import com.sequenceiq.freeipa.api.model.Backup;
+import com.sequenceiq.freeipa.configuration.BackupConfiguration;
+
+@Component
+public class BackupConverter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BackupConverter.class);
+
+    private final boolean freeIpaBackupEnabled;
+
+    private final BackupConfiguration backupConfiguration;
+
+    public BackupConverter(BackupConfiguration backupConfiguration,
+            @Value("${freeipa.backup.enabled:true}") boolean freeIpaBackupEnabled) {
+        this.backupConfiguration = backupConfiguration;
+        this.freeIpaBackupEnabled = freeIpaBackupEnabled;
+    }
+
+    public Backup convert(TelemetryRequest request) {
+        Backup backup = null;
+        if (freeIpaBackupEnabled && request != null && request.getLogging() != null) {
+            backup = new Backup();
+            backup.setMonthlyFullEnabled(backupConfiguration.isMonthlyFullEnabled());
+            backup.setInitialFullEnabled(backupConfiguration.isRunInitialFullAfterInstall());
+            backup.setHourlyEnabled(backupConfiguration.isHourlyEnabled());
+            decorateBackupFromLoggingRequest(backup, request.getLogging());
+        }
+        return backup;
+    }
+
+    private void decorateBackupFromLoggingRequest(Backup backup, LoggingRequest loggingRequest) {
+        if (loggingRequest != null) {
+            backup.setStorageLocation(loggingRequest.getStorageLocation());
+            if (loggingRequest.getS3() != null) {
+                S3CloudStorageV1Parameters s3Params = new S3CloudStorageV1Parameters();
+                s3Params.setInstanceProfile(loggingRequest.getS3().getInstanceProfile());
+                backup.setS3(s3Params);
+            } else if (loggingRequest.getAdlsGen2() != null) {
+                AdlsGen2CloudStorageV1Parameters adlsGen2Params = new AdlsGen2CloudStorageV1Parameters();
+                AdlsGen2CloudStorageV1Parameters adlsGen2FromRequest = loggingRequest.getAdlsGen2();
+                adlsGen2Params.setAccountKey(adlsGen2FromRequest.getAccountKey());
+                adlsGen2Params.setAccountName(adlsGen2FromRequest.getAccountName());
+                adlsGen2Params.setSecure(adlsGen2FromRequest.isSecure());
+                adlsGen2Params.setManagedIdentity(adlsGen2FromRequest.getManagedIdentity());
+                backup.setAdlsGen2(adlsGen2Params);
+            }
+        }
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/CreateFreeIpaRequestToStackConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/CreateFreeIpaRequestToStackConverter.java
@@ -42,6 +42,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.region.Placement
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.create.CreateFreeIpaRequest;
 import com.sequenceiq.freeipa.controller.exception.BadRequestException;
 import com.sequenceiq.freeipa.converter.authentication.StackAuthenticationRequestToStackAuthenticationConverter;
+import com.sequenceiq.freeipa.converter.backup.BackupConverter;
 import com.sequenceiq.freeipa.converter.instance.InstanceGroupRequestToInstanceGroupConverter;
 import com.sequenceiq.freeipa.converter.network.NetworkRequestToNetworkConverter;
 import com.sequenceiq.freeipa.converter.telemetry.TelemetryConverter;
@@ -71,6 +72,9 @@ public class CreateFreeIpaRequestToStackConverter {
 
     @Inject
     private TelemetryConverter telemetryConverter;
+
+    @Inject
+    private BackupConverter backupConverter;
 
     @Inject
     private CrnService crnService;
@@ -114,6 +118,7 @@ public class CreateFreeIpaRequestToStackConverter {
             stack.setNetwork(networkConverter.convert(source.getNetwork()));
         }
         stack.setTelemetry(telemetryConverter.convert(source.getTelemetry()));
+        stack.setBackup(backupConverter.convert(source.getTelemetry()));
         decorateStackWithTunnelAndCcm(stack, source);
         updateOwnerRelatedFields(source, accountId, userFuture, userCrn, stack);
         extendGatewaySecurityGroupWithDefaultGatewayCidrs(stack);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/Stack.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/Stack.java
@@ -32,6 +32,7 @@ import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 import com.sequenceiq.cloudbreak.converter.TunnelConverter;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
 import com.sequenceiq.common.api.type.Tunnel;
+import com.sequenceiq.freeipa.api.model.Backup;
 
 @Entity
 @Table(uniqueConstraints = @UniqueConstraint(columnNames = {"accountid", "environmentcrn", "terminated"}))
@@ -93,6 +94,10 @@ public class Stack {
     @Convert(converter = JsonToString.class)
     @Column(columnDefinition = "TEXT")
     private Json telemetry;
+
+    @Convert(converter = JsonToString.class)
+    @Column(columnDefinition = "TEXT")
+    private Json backup;
 
     @OneToOne(cascade = {CascadeType.ALL}, optional = false)
     private Network network;
@@ -254,6 +259,19 @@ public class Stack {
     public void setTelemetry(Telemetry telemetry) {
         if (telemetry != null) {
             this.telemetry = new Json(telemetry);
+        }
+    }
+
+    public Backup getBackup() {
+        if (backup != null && backup.getValue() != null) {
+            return JsonUtil.readValueOpt(backup.getValue(), Backup.class).orElse(null);
+        }
+        return null;
+    }
+
+    public void setBackup(Backup backup) {
+        if (backup != null) {
+            this.backup = new Json(backup);
         }
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/backup/BackupClusterType.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/backup/BackupClusterType.java
@@ -1,0 +1,15 @@
+package com.sequenceiq.freeipa.service.freeipa.backup;
+
+public enum BackupClusterType {
+    FREEIPA("freeipa");
+
+    private String value;
+
+    BackupClusterType(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return this.value;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/AdlsGen2BackupConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/AdlsGen2BackupConfig.java
@@ -1,0 +1,22 @@
+package com.sequenceiq.freeipa.service.freeipa.backup.cloud;
+
+public class AdlsGen2BackupConfig extends CloudBackupStorageConfig {
+
+    private final String fileSystem;
+
+    private final String account;
+
+    public AdlsGen2BackupConfig(String folderPrefix, String fileSystem, String account) {
+        super(folderPrefix);
+        this.fileSystem = fileSystem;
+        this.account = account;
+    }
+
+    public String getFileSystem() {
+        return fileSystem;
+    }
+
+    public String getAccount() {
+        return account;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/AdlsGen2BackupConfigGenerator.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/AdlsGen2BackupConfigGenerator.java
@@ -1,0 +1,61 @@
+package com.sequenceiq.freeipa.service.freeipa.backup.cloud;
+
+import java.nio.file.Paths;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+
+@Component
+public class AdlsGen2BackupConfigGenerator extends CloudBackupConfigGenerator<AdlsGen2BackupConfig> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AdlsGen2BackupConfigGenerator.class);
+
+    private static final String[] ADLS_GEN2_SCHEME_PREFIXES = {"abfs://", "abfss://"};
+
+    private static final String AZURE_DFS_DOMAIN_SUFFIX = ".dfs.core.windows.net";
+
+    private static final String AZURE_BLOB_STORAGE_SUFFIX = "blob.core.windows.net";
+
+    private static final String AZURE_BLOB_STORAGE_SCHEMA = "https://";
+
+    @Override
+    public String generateBackupLocation(String location, String clusterType,
+            String clusterName, String clusterId) {
+        AdlsGen2BackupConfig adlsGen2BackupConfig = generateBackupConfig(location);
+        String logFolder = resolveBackupFolder(adlsGen2BackupConfig, clusterType, clusterName, clusterId);
+        String hostPart = String.format("%s.%s", adlsGen2BackupConfig.getAccount(), AZURE_BLOB_STORAGE_SUFFIX);
+        String generatedLocation = String.format("%s%s", AZURE_BLOB_STORAGE_SCHEMA,
+                Paths.get(hostPart, adlsGen2BackupConfig.getFileSystem(), logFolder));
+        LOGGER.info("The following ADLS Gen2 base folder location is generated: {} (from {})",
+                generatedLocation, location);
+        return generatedLocation;
+    }
+
+    private AdlsGen2BackupConfig generateBackupConfig(String location) {
+        if (StringUtils.isNotEmpty(location)) {
+            String locationWithoutScheme = getLocationWithoutSchemePrefixes(location, ADLS_GEN2_SCHEME_PREFIXES);
+            String[] locationSplit = locationWithoutScheme.split("@");
+            String[] storageWithSuffix = locationSplit[0].split("/", 2);
+            String folderPrefix = storageWithSuffix.length < 2 ? "" :  "/" + storageWithSuffix[1];
+            if (locationSplit.length < 2) {
+                return new AdlsGen2BackupConfig(folderPrefix, storageWithSuffix[0], null);
+            } else {
+                String[] splitByDomain = locationSplit[1].split(AZURE_DFS_DOMAIN_SUFFIX);
+                String account = splitByDomain[0];
+                if (splitByDomain.length > 1) {
+                    String folderPrefixAfterDomain = splitByDomain[1];
+                    if (StringUtils.isNoneEmpty(folderPrefix, folderPrefixAfterDomain)) {
+                        throw new CloudbreakServiceException(String.format("Invalid ADLS Gen2 path: %s", location));
+                    }
+                    folderPrefix = StringUtils.isNotEmpty(folderPrefixAfterDomain) ? folderPrefixAfterDomain : folderPrefix;
+                }
+                return new AdlsGen2BackupConfig(folderPrefix, storageWithSuffix[0], account);
+            }
+        }
+        throw new CloudbreakServiceException("Storage location parameter is missing for ADLS Gen2");
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/CloudBackupConfigGenerator.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/CloudBackupConfigGenerator.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.freeipa.service.freeipa.backup.cloud;
+
+import java.nio.file.Paths;
+
+import org.apache.commons.lang3.StringUtils;
+
+public abstract class CloudBackupConfigGenerator<T extends CloudBackupStorageConfig> {
+
+    protected static final String CLUSTER_BACKUP_PREFIX = "cluster-backups";
+
+    public abstract String generateBackupLocation(String location, String clusterType,
+            String clusterName, String clusterId);
+
+    String getLocationWithoutSchemePrefixes(String input, String... schemePrefixes) {
+        for (String schemePrefix : schemePrefixes) {
+            if (input.startsWith(schemePrefix)) {
+                String[] splitted = input.split(schemePrefix);
+                if (splitted.length > 1) {
+                    return splitted[1];
+                }
+            }
+        }
+        return input;
+    }
+
+    String resolveBackupFolder(CloudBackupStorageConfig cloudBackupStorageConfig, String clusterType,
+            String clusterName, String clusterId) {
+        String clusterIdentifier = String.format("%s_%s", clusterName, clusterId);
+
+        if (StringUtils.isNotEmpty(cloudBackupStorageConfig.getFolderPrefix())) {
+            return Paths.get(cloudBackupStorageConfig.getFolderPrefix(), CLUSTER_BACKUP_PREFIX, clusterType,
+                    clusterIdentifier).toString();
+        } else {
+            return Paths.get(CLUSTER_BACKUP_PREFIX, clusterType, clusterIdentifier).toString();
+        }
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/CloudBackupFolderResolverService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/CloudBackupFolderResolverService.java
@@ -1,0 +1,60 @@
+package com.sequenceiq.freeipa.service.freeipa.backup.cloud;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.freeipa.api.model.Backup;
+
+@Service
+public class CloudBackupFolderResolverService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CloudBackupFolderResolverService.class);
+
+    private final S3BackupConfigGenerator s3BackupConfigGenerator;
+
+    private final AdlsGen2BackupConfigGenerator adlsGen2BackupConfigGenerator;
+
+    public CloudBackupFolderResolverService(S3BackupConfigGenerator s3BackupConfigGenerator,
+            AdlsGen2BackupConfigGenerator adlsGen2BackupConfigGenerator) {
+        this.s3BackupConfigGenerator = s3BackupConfigGenerator;
+        this.adlsGen2BackupConfigGenerator = adlsGen2BackupConfigGenerator;
+    }
+
+    public void updateStorageLocation(Backup backup, String clusterType,
+            String clusterName, String clusterCrn) {
+        LOGGER.debug("Updating/enriching backup storage locations with cluster data.");
+        if (backup != null  && StringUtils.isNotEmpty(backup.getStorageLocation())) {
+            String storageLocation = backup.getStorageLocation();
+            if (backup.getS3() != null) {
+                storageLocation = resolveS3Location(storageLocation,
+                        clusterType, clusterName, clusterCrn);
+            } else if (backup.getAdlsGen2() != null) {
+                storageLocation = resolveAdlsGen2Location(storageLocation,
+                        clusterType, clusterName, clusterCrn);
+            } else {
+                LOGGER.warn("None of the backup storage location was resolved, "
+                        + "make sure storage type is set properly (currently supported: s3, abfs)");
+            }
+            backup.setStorageLocation(storageLocation);
+        } else {
+            LOGGER.debug("Backup is not set, skipping cloud storage location updates.");
+        }
+    }
+
+    public String resolveS3Location(String location, String clusterType,
+            String clusterName, String clusterCrn) {
+        LOGGER.debug("Start to resolve S3 storage location for telemetry (logging).");
+        return s3BackupConfigGenerator.generateBackupLocation(location,
+                clusterType, clusterName, Crn.fromString(clusterCrn).getResource());
+    }
+
+    public String resolveAdlsGen2Location(String location, String clusterType,
+            String clusterName, String clusterCrn) {
+        LOGGER.debug("Start to resolve ADLS V2 storage location for telemetry (logging).");
+        return adlsGen2BackupConfigGenerator.generateBackupLocation(location,
+                clusterType, clusterName, Crn.fromString(clusterCrn).getResource());
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/CloudBackupStorageConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/CloudBackupStorageConfig.java
@@ -1,0 +1,15 @@
+package com.sequenceiq.freeipa.service.freeipa.backup.cloud;
+
+public class CloudBackupStorageConfig {
+
+    private final String folderPrefix;
+
+    public CloudBackupStorageConfig(String folderPrefix) {
+        this.folderPrefix = folderPrefix;
+    }
+
+    public String getFolderPrefix() {
+        return folderPrefix;
+    }
+
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/S3BackupConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/S3BackupConfig.java
@@ -1,0 +1,15 @@
+package com.sequenceiq.freeipa.service.freeipa.backup.cloud;
+
+public class S3BackupConfig extends CloudBackupStorageConfig {
+
+    private final String bucket;
+
+    public S3BackupConfig(String folderPrefix, String bucket) {
+        super(folderPrefix);
+        this.bucket = bucket;
+    }
+
+    public String getBucket() {
+        return bucket;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/S3BackupConfigGenerator.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/S3BackupConfigGenerator.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.freeipa.service.freeipa.backup.cloud;
+
+import java.nio.file.Paths;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+
+@Component
+public class S3BackupConfigGenerator extends CloudBackupConfigGenerator<S3BackupConfig> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(S3BackupConfigGenerator.class);
+
+    private static final String[] S3_SCHEME_PREFIXES = {"s3://", "s3a://", "s3n://"};
+
+    @Override
+    public String generateBackupLocation(String location, String clusterType, String clusterName, String clusterId) {
+        S3BackupConfig s3BackupConfig = generateBackupConfig(location);
+        String generatedS3Location = S3_SCHEME_PREFIXES[0] + Paths.get(s3BackupConfig.getBucket(),
+                resolveBackupFolder(s3BackupConfig, clusterType, clusterName, clusterId));
+        LOGGER.debug("The following S3 base folder location is generated: {} (from {})",
+                generatedS3Location, location);
+        return generatedS3Location;
+    }
+
+    private S3BackupConfig generateBackupConfig(String location) {
+        if (StringUtils.isNotEmpty(location)) {
+            String locationWithoutScheme = getLocationWithoutSchemePrefixes(location, S3_SCHEME_PREFIXES);
+            String[] locationSplit = locationWithoutScheme.split("/", 2);
+            String folderPrefix = locationSplit.length < 2 ? "" :  locationSplit[1];
+            return new S3BackupConfig(folderPrefix, locationSplit[0]);
+        }
+        throw new CloudbreakServiceException("Storage location parameter is missing for S3");
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaBackupConfigView.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaBackupConfigView.java
@@ -1,0 +1,136 @@
+package com.sequenceiq.freeipa.service.freeipa.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.lang3.ObjectUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FreeIpaBackupConfigView {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FreeIpaBackupConfigView.class);
+
+    private static final String EMPTY_CONFIG_DEFAULT = "";
+
+    private final boolean enabled;
+
+    private final boolean monthlyFullEnabled;
+
+    private final boolean hourlyEnabled;
+
+    private final boolean initialFullEnabled;
+
+    private final String platform;
+
+    private final String location;
+
+    private final String azureInstanceMsi;
+
+    @SuppressWarnings("ExecutableStatementCount")
+    private FreeIpaBackupConfigView(FreeIpaBackupConfigView.Builder builder) {
+        this.enabled = builder.enabled;
+        this.monthlyFullEnabled = builder.monthlyFullEnabled;
+        this.hourlyEnabled = builder.hourlyEnabled;
+        this.initialFullEnabled = builder.initialFullEnabled;
+        this.location = builder.location;
+        this.platform = builder.platform;
+        this.azureInstanceMsi = builder.azureInstanceMsi;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public boolean isMonthlyFullEnabled() {
+        return monthlyFullEnabled;
+    }
+
+    public boolean isHourlyEnabled() {
+        return hourlyEnabled;
+    }
+
+    public boolean isInitialFullEnabled() {
+        return initialFullEnabled;
+    }
+
+    public String getPlatform() {
+        return platform;
+    }
+
+    public String getAzureInstanceMsi() {
+        return azureInstanceMsi;
+    }
+
+    @SuppressWarnings("ExecutableStatementCount")
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("enabled", this.enabled);
+        map.put("location", ObjectUtils.defaultIfNull(this.location, EMPTY_CONFIG_DEFAULT));
+        map.put("monthly_full_enabled", this.monthlyFullEnabled);
+        map.put("hourly_enabled", this.hourlyEnabled);
+        map.put("initial_full_enabled", this.initialFullEnabled);
+        map.put("platform", ObjectUtils.defaultIfNull(this.platform, EMPTY_CONFIG_DEFAULT));
+        return map;
+    }
+
+    public static final class Builder {
+
+        private boolean enabled;
+
+        private boolean monthlyFullEnabled;
+
+        private boolean hourlyEnabled;
+
+        private boolean initialFullEnabled;
+
+        private String location;
+
+        private String platform;
+
+        private String azureInstanceMsi;
+
+        public FreeIpaBackupConfigView build() {
+            return new FreeIpaBackupConfigView(this);
+        }
+
+        public Builder withEnabled(boolean enabled) {
+            this.enabled = enabled;
+            return this;
+        }
+
+        public Builder withMonthlyFullEnabled(boolean monthlyFullEnabled) {
+            this.monthlyFullEnabled = monthlyFullEnabled;
+            return this;
+        }
+
+        public Builder withHourlyEnabled(boolean hourlyEnabled) {
+            this.hourlyEnabled = hourlyEnabled;
+            return this;
+        }
+
+        public Builder withInitialFullEnabled(boolean initialFullEnabled) {
+            this.initialFullEnabled = initialFullEnabled;
+            return this;
+        }
+
+        public Builder withLocation(String location) {
+            this.location = location;
+            return this;
+        }
+
+        public Builder withPlatform(String platform) {
+            this.platform = platform;
+            return this;
+        }
+
+        public Builder withAzureInstanceMsi(String azureInstanceMsi) {
+            this.azureInstanceMsi = azureInstanceMsi;
+            return this;
+        }
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaConfigService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaConfigService.java
@@ -1,0 +1,93 @@
+package com.sequenceiq.freeipa.service.freeipa.config;
+
+import java.util.Map;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.orchestrator.model.Node;
+import com.sequenceiq.freeipa.api.model.Backup;
+import com.sequenceiq.freeipa.entity.FreeIpa;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.GatewayConfigService;
+import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
+import com.sequenceiq.freeipa.service.freeipa.FreeIpaService;
+import com.sequenceiq.freeipa.service.freeipa.backup.cloud.AdlsGen2BackupConfigGenerator;
+import com.sequenceiq.freeipa.service.freeipa.backup.cloud.S3BackupConfigGenerator;
+import com.sequenceiq.freeipa.service.freeipa.dns.ReverseDnsZoneCalculator;
+import com.sequenceiq.freeipa.service.stack.NetworkService;
+
+@Service
+public class FreeIpaConfigService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FreeIpaConfigService.class);
+
+    @Inject
+    private S3BackupConfigGenerator s3BackupConfigGenerator;
+
+    @Inject
+    private AdlsGen2BackupConfigGenerator adlsGen2BackupConfigGenerator;
+
+    @Inject
+    private NetworkService networkService;
+
+    @Inject
+    private ReverseDnsZoneCalculator reverseDnsZoneCalculator;
+
+    @Inject
+    private FreeIpaService freeIpaService;
+
+    @Inject
+    private GatewayConfigService gatewayConfigService;
+
+    @Inject
+    private FreeIpaClientFactory freeIpaClientFactory;
+
+    public FreeIpaConfigView createFreeIpaConfigs(Stack stack, Set<Node> hosts) {
+        final FreeIpaConfigView.Builder builder = new FreeIpaConfigView.Builder();
+
+        FreeIpa freeIpa = freeIpaService.findByStack(stack);
+        Map<String, String> subnetWithCidr = networkService.getFilteredSubnetWithCidr(stack);
+        String reverseZones = reverseDnsZoneCalculator.reverseDnsZoneForCidrs(subnetWithCidr.values());
+
+        return builder
+                .withRealm(freeIpa.getDomain().toUpperCase())
+                .withDomain(freeIpa.getDomain())
+                .withPassword(freeIpa.getAdminPassword())
+                .withReverseZones(reverseZones)
+                .withAdminUser(freeIpaClientFactory.getAdminUser())
+                .withFreeIpaToReplicate(gatewayConfigService.getPrimaryGatewayConfig(stack).getHostname())
+                .withHosts(hosts)
+                .withBackupConfig(determineAndSetBackup(stack))
+                .build();
+    }
+
+    private FreeIpaBackupConfigView determineAndSetBackup(Stack stack) {
+        Backup backup = stack.getBackup();
+        final FreeIpaBackupConfigView.Builder builder = new FreeIpaBackupConfigView.Builder();
+        if (backup != null) {
+            builder.withEnabled(true)
+                    .withMonthlyFullEnabled(backup.isMonthlyFullEnabled())
+                    .withHourlyEnabled(backup.isHourlyEnabled())
+                    .withInitialFullEnabled(backup.isInitialFullEnabled())
+                    .withLocation(backup.getStorageLocation());
+            if (backup.getS3() != null) {
+                builder.withPlatform(CloudPlatform.AWS.name());
+                LOGGER.debug("Backups will be configured to use S3 output.");
+            } else if (backup.getAdlsGen2() != null) {
+                builder.withPlatform(CloudPlatform.AZURE.name())
+                        .withAzureInstanceMsi(backup.getAdlsGen2().getManagedIdentity());
+                LOGGER.debug("Backups will be configured to use Azure Blob storage");
+            }
+        } else {
+            builder.withEnabled(false);
+            LOGGER.debug("Backups will not be configured.");
+        }
+        return builder.build();
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaConfigView.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaConfigView.java
@@ -1,0 +1,165 @@
+package com.sequenceiq.freeipa.service.freeipa.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang3.ObjectUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.orchestrator.model.Node;
+
+public class FreeIpaConfigView {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FreeIpaConfigView.class);
+
+    private static final String EMPTY_CONFIG_DEFAULT = "";
+
+    private final String realm;
+
+    private final String domain;
+
+    private final String password;
+
+    private final String reverseZones;
+
+    private final String adminUser;
+
+    private final String freeipaToReplicate;
+
+    private final Set<Object> hosts;
+
+    private final FreeIpaBackupConfigView backup;
+
+    @SuppressWarnings("ExecutableStatementCount")
+    private FreeIpaConfigView(Builder builder) {
+        this.realm = builder.realm;
+        this.domain = builder.domain;
+        this.password = builder.password;
+        this.reverseZones = builder.reverseZones;
+        this.adminUser = builder.adminUser;
+        this.freeipaToReplicate = builder.freeipaToReplicate;
+        this.hosts = builder.hosts;
+        this.backup = builder.backup;
+    }
+
+    public String getRealm() {
+        return realm;
+    }
+
+    public String getDomain() {
+        return domain;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getReverseZones() {
+        return reverseZones;
+    }
+
+    public String getAdminUser() {
+        return adminUser;
+    }
+
+    public String getFreeipaToReplicate() {
+        return freeipaToReplicate;
+    }
+
+    public Set<Object> getHosts() {
+        return hosts;
+    }
+
+    public FreeIpaBackupConfigView getBackup() {
+        return backup;
+    }
+
+    @SuppressWarnings("ExecutableStatementCount")
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("realm", ObjectUtils.defaultIfNull(this.realm, EMPTY_CONFIG_DEFAULT));
+        map.put("domain", ObjectUtils.defaultIfNull(this.domain, EMPTY_CONFIG_DEFAULT));
+        map.put("password", ObjectUtils.defaultIfNull(this.password, EMPTY_CONFIG_DEFAULT));
+        map.put("reverseZones", ObjectUtils.defaultIfNull(this.reverseZones, EMPTY_CONFIG_DEFAULT));
+        map.put("admin_user", ObjectUtils.defaultIfNull(this.adminUser, EMPTY_CONFIG_DEFAULT));
+        map.put("freeipa_to_replicate", ObjectUtils.defaultIfNull(this.freeipaToReplicate, EMPTY_CONFIG_DEFAULT));
+        if (MapUtils.isNotEmpty(backup.toMap())) {
+            map.put("backup", this.backup.toMap());
+        }
+        if (CollectionUtils.isNotEmpty(this.hosts)) {
+            map.put("hosts", this.hosts);
+        }
+        return map;
+    }
+
+    public static final class Builder {
+
+        private String realm;
+
+        private String domain;
+
+        private String password;
+
+        private String reverseZones;
+
+        private String adminUser;
+
+        private String freeipaToReplicate;
+
+        private Set<Object> hosts;
+
+        private FreeIpaBackupConfigView backup;
+
+        public FreeIpaConfigView build() {
+            return new FreeIpaConfigView(this);
+        }
+
+        public Builder withRealm(String realm) {
+            this.realm = realm;
+            return this;
+        }
+
+        public Builder withDomain(String domain) {
+            this.domain = domain;
+            return this;
+        }
+
+        public Builder withPassword(String password) {
+            this.password = password;
+            return this;
+        }
+
+        public Builder withReverseZones(String reverseZones) {
+            this.reverseZones = reverseZones;
+            return this;
+        }
+
+        public Builder withAdminUser(String adminUser) {
+            this.adminUser = adminUser;
+            return this;
+        }
+
+        public Builder withFreeIpaToReplicate(String freeipaToReplicate) {
+            this.freeipaToReplicate = freeipaToReplicate;
+            return this;
+        }
+
+        public Builder withHosts(Set<Node> hosts) {
+            this.hosts = hosts.stream().map(n ->
+                    Map.of("ip", n.getPrivateIp(),
+                            "fqdn", n.getHostname()))
+                    .collect(Collectors.toSet());
+            return this;
+        }
+
+        public Builder withBackupConfig(FreeIpaBackupConfigView backupConfig) {
+            this.backup = backupConfig;
+            return this;
+        }
+    }
+}

--- a/freeipa/src/main/resources/freeipa-salt/pillar/freeipa/init.sls
+++ b/freeipa/src/main/resources/freeipa-salt/pillar/freeipa/init.sls
@@ -4,3 +4,11 @@ freeipa:
   realm: testrealm
   admin_user: admin
   freeipa_to_replicate:
+  backup:
+    enabled: false
+    monthly_full_enabled: false
+    hourly_enabled: false
+    initial_full_enabled: false
+    platform:
+    location:
+    azure_instance_msi:

--- a/freeipa/src/main/resources/freeipa-salt/salt/fluent/template/input.conf.j2
+++ b/freeipa/src/main/resources/freeipa-salt/salt/fluent/template/input.conf.j2
@@ -106,6 +106,14 @@
   tag {{providerPrefix}}.nginx_error
   read_from_head true
 </source>
+<source>
+  @type tail
+  format none
+  path /var/log/ipabackup.log
+  pos_file /var/log/td-agent/pos/{{providerPrefix}}-ipabackup.log.pos
+  tag {{providerPrefix}}.ipa_backup
+  read_from_head true
+</source>
 </worker>
 {% else %}
 # DATABUS inputs are disabled

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/backups.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/backups.sls
@@ -1,0 +1,46 @@
+/usr/local/bin/freeipa_backup:
+  file.managed:
+    - source: salt://freeipa/scripts/freeipa_backup
+    - user: root
+    - group: root
+    - mode: 750
+
+{% if salt['pillar.get']('freeipa:backup:enabled') %}
+/etc/freeipa_backup.conf:
+  file.managed:
+    - source: salt://freeipa/templates/freeipa_backup.conf.j2
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: 640
+
+{% if salt['pillar.get']('freeipa:backup:monthly_full_enabled') %}
+/etc/cron.monthly/freeipa_backup_monthly:
+  file.managed:
+    - source: salt://freeipa/templates/freeipa_backup_monthly.j2
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: 750
+{% endif %}
+
+{% if salt['pillar.get']('freeipa:backup:hourly_enabled') %}
+/etc/cron.hourly/freeipa_backup_hourly:
+  file.managed:
+    - source: salt://freeipa/templates/freeipa_backup_hourly.j2
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: 750
+{% endif %}
+
+{% if salt['pillar.get']('freeipa:backup:initial_full_enabled') %}
+freeipa_initial_full_backup:
+  cmd.run:
+    - name: /usr/local/bin/freeipa_backup -t FULL -f "{{salt['grains.get']('fqdn')}}/full" && echo $(date +%Y-%m-%d:%H:%M:%S) >> /var/log/freeipa_initial_backup-executed
+    - unless: test -f /var/log/freeipa_initial_backup-executed
+    - require:
+        - file: /usr/local/bin/freeipa_backup
+        - file: /etc/freeipa_backup.conf
+{% endif %}
+{% endif %}

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/common-install.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/common-install.sls
@@ -40,3 +40,5 @@ restart_krb5kdc:
     - name: krb5kdc
     - watch:
       - file: /etc/sysconfig/krb5kdc
+
+

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_backup
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_backup
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Name: freeipa_backup.sh
+# Description: Backup FreeIPA and Upload backup to provided Cloud Location
+################################################################
+
+
+CONFIG_FILE=/etc/freeipa_backup.conf
+
+# Config Defaults
+typeset -A config # init array
+config=( # set default values in config array
+    [backup_location]=""
+    [backup_platform]="LOCAL"
+    [azure_instance_msi]=""
+    [logfile]="/var/log/ipabackup.log"
+    [backup_path]="/var/lib/ipa/backup/"
+)
+
+# Override defaults with config file
+if [ -f $CONFIG_FILE ]; then
+    while read line
+    do
+        if echo $line | grep -F = &>/dev/null
+        then
+            varname=$(echo "$line" | cut -d '=' -f 1)
+            config[$varname]=$(echo "$line" | cut -d '=' -f 2-)
+        fi
+    done < $CONFIG_FILE
+fi
+
+while getopts "t:f:" OPTION; do
+    case $OPTION in
+    t  )
+        TYPE=$OPTARG
+        [[ ! $TYPE =~ FULL|DATA ]] && {
+            echo "Incorrect options provided"
+            exit 1
+        }
+        ;;
+    f  )
+        FOLDER=$OPTARG;;
+    \? ) echo "Unknown option: -$OPTARG" >&2; exit 1;;
+    :  ) echo "Missing option argument for -$OPTARG" >&2; exit 1;;
+    *  ) echo "Unimplemented option: -$OPTARG" >&2; exit 1;;
+    esac
+done
+
+if ((OPTIND == 1))
+then
+    echo "No options specified"
+    exit 1
+fi
+
+if [ -z "$TYPE" ] || [ -z "$FOLDER" ];
+then
+    echo "A type (-t) and a folder -f must be defined" >&2
+    exit 1
+fi
+
+
+LOGFILE="${config[logfile]}"
+DATE_FOLDER="$(date -I)"
+BACKUP_PATH_POSTFIX="${FOLDER}/"
+
+BACKUP_OPTIONS=""
+if [ "$TYPE" = "FULL" ]; then
+    BACKUP_OPTIONS="-q"
+elif [ "$TYPE" = "DATA" ]; then
+    BACKUP_OPTIONS="-q --data --online"
+fi
+
+doLog(){
+    type_of_msg=$(echo $*|cut -d" " -f1)
+    msg=$(echo "$*"|cut -d" " -f2-)
+    [[ $type_of_msg == DEBUG ]] && [[ $do_print_debug_msgs -ne 1 ]] && return
+    [[ $type_of_msg == INFO ]] && type_of_msg="INFO " # one space for aligning
+    [[ $type_of_msg == WARN ]] && type_of_msg="WARN " # as well
+
+    # print to the terminal if we have one
+    test -t 1 && echo "`date "+%Y-%m-%dT%H:%M:%SZ"` $type_of_msg ""$msg"
+    echo "`date "+%Y-%m-%dT%H:%M:%SZ"` $type_of_msg ""$msg" >> $LOGFILE
+}
+
+error_exit()
+{
+    doLog "ERROR $1"
+	exit 1
+}
+
+remove_local_backups() {
+    doLog "INFO Removing local backup copies"
+    find ${config[backup_path]} -name ipa-* -type d  -print0 | xargs -0 /usr/bin/rm -vrf >> $LOGFILE 2>&1 || error_exit "Unable to remove local backup copies"
+}
+
+doLog "INFO Running ${TYPE} IPA backup."
+
+# Perform a backup
+/sbin/ipa-backup $BACKUP_OPTIONS >> $LOGFILE 2>&1 || error_exit "ipa-backup failed! Aborting!"
+
+BACKUP_LOCATION="${config[backup_location]}/${BACKUP_PATH_POSTFIX}"
+doLog "DEBUG Uploading backup to ${BACKUP_LOCATION} on ${config[backup_platform]}"
+
+if [ "${config[backup_platform]}" = "AWS" ]; then
+    doLog "INFO Syncing backups to AWS S3"
+    /usr/bin/aws s3 sync --sse AES256 --no-progress ${config[backup_path]} ${BACKUP_LOCATION} >> $LOGFILE 2>&1 || error_exit "Sync of backups to ${BACKUP_LOCATION} failed!"
+    remove_local_backups
+elif [ "${config[backup_platform]}" = "AZURE" ]; then
+    doLog "INFO  Syncing backups to Azure Blog Storage"
+    /bin/keyctl new_session >> $LOGFILE 2>&1 || error_exit "Unable to setup keyring session"
+    /usr/local/bin/azcopy login --identity --identity-resource-id "${config[azure_instance_msi]}" >> $LOGFILE 2>&1 || error_exit "Unable to login to Azure!"
+    /usr/local/bin/azcopy sync ${config[backup_path]} ${BACKUP_LOCATION} >> $LOGFILE 2>&1 || error_exit "Sync of backups to ${BACKUP_LOCATION} failed!"
+    remove_local_backups
+fi
+
+doLog "INFO Backup completed."

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/settings.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/settings.sls
@@ -1,0 +1,12 @@
+{% set freeipa = {} %}
+     {% set backup_location = salt['pillar.get']('freeipa:backup:location') %}
+     {% set backup_platform = salt['pillar.get']('freeipa:backup:platform') %}
+     {% set azure_instance_msi = salt['pillar.get']('freeipa:backup:azure_instance_msi') %}
+     {% set hostname = salt['grains.get']('fqdn') %}
+
+     {% do freeipa.update({
+         "backup_platform" : backup_platform,
+         "backup_location" : backup_location,
+         "hostname": hostname,
+         "azure_instance_msi": azure_instance_msi
+     }) %}

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/templates/freeipa_backup.conf.j2
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/templates/freeipa_backup.conf.j2
@@ -1,0 +1,4 @@
+{%- from 'freeipa/settings.sls' import freeipa with context -%}
+backup_location={{freeipa.backup_location}}
+backup_platform={{freeipa.backup_platform}}
+azure_instance_msi={{freeipa.azure_instance_msi}}

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/templates/freeipa_backup_hourly.j2
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/templates/freeipa_backup_hourly.j2
@@ -1,0 +1,6 @@
+{%- from 'freeipa/settings.sls' import freeipa with context -%}
+#!/bin/bash
+if [ ! -f /tmp/freeipa_backup_hourly_bypass ]; then
+    /usr/local/bin/freeipa_backup -t DATA -f "{{freeipa.hostname}}/hourly/$(date -I)"
+fi
+

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/templates/freeipa_backup_monthly.j2
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/templates/freeipa_backup_monthly.j2
@@ -1,0 +1,5 @@
+{%- from 'freeipa/settings.sls' import freeipa with context -%}
+#!/bin/bash
+if [ ! -f /tmp/freeipa_backup_monthly_bypass ]; then
+    /usr/local/bin/freeipa_backup -t FULL -f "{{freeipa.hostname}}/full"
+fi

--- a/freeipa/src/main/resources/freeipa-salt/salt/top.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/top.sls
@@ -10,8 +10,10 @@ base:
              - match: grain
              - freeipa.primary-install
              - freeipa.common-install
+             - freeipa.backups
 
            'roles:freeipa_replica':
              - match: grain
              - freeipa.replica-install
              - freeipa.common-install
+             - freeipa.backups

--- a/freeipa/src/main/resources/schema/app/20200307111710_CB-5339_add_backup.sql
+++ b/freeipa/src/main/resources/schema/app/20200307111710_CB-5339_add_backup.sql
@@ -1,0 +1,8 @@
+-- // CB-CB-5339 Add backup to freeipa
+
+ALTER TABLE stack ADD COLUMN IF NOT EXISTS backup text;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE stack DROP COLUMN IF EXISTS backup;

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/backup/BackupConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/backup/BackupConverterTest.java
@@ -1,0 +1,59 @@
+package com.sequenceiq.freeipa.converter.backup;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
+import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
+import com.sequenceiq.common.api.telemetry.request.LoggingRequest;
+import com.sequenceiq.common.api.telemetry.request.TelemetryRequest;
+import com.sequenceiq.freeipa.api.model.Backup;
+import com.sequenceiq.freeipa.configuration.BackupConfiguration;
+
+public class BackupConverterTest {
+
+    private static final String INSTANCE_PROFILE_VALUE = "myInstanceProfile";
+
+    private static final String DATABUS_ENDPOINT = "myCustomEndpoint";
+
+    private BackupConverter underTest;
+
+    @BeforeEach
+    public void setUp() {
+        BackupConfiguration backupConfiguration = new BackupConfiguration(true, true, true);
+        underTest = new BackupConverter(backupConfiguration, true);
+    }
+
+    @Test
+    public void testConvertFromS3Request() {
+        // GIVEN
+        TelemetryRequest telemetryRequest = new TelemetryRequest();
+        LoggingRequest logging = new LoggingRequest();
+        logging.setS3(new S3CloudStorageV1Parameters());
+        logging.setStorageLocation("s3://mybucket");
+        telemetryRequest.setLogging(logging);
+        // WHEN
+        Backup result = underTest.convert(telemetryRequest);
+        // THEN
+        assertThat(result.getStorageLocation(), is("s3://mybucket"));
+    }
+
+    @Test
+    public void testConvertFromAzureRequest() {
+        // GIVEN
+        TelemetryRequest telemetryRequest = new TelemetryRequest();
+        LoggingRequest logging = new LoggingRequest();
+        AdlsGen2CloudStorageV1Parameters adlsGen2CloudStorageV1Parameters = new AdlsGen2CloudStorageV1Parameters();
+        adlsGen2CloudStorageV1Parameters.setAccountKey("someaccount");
+        logging.setAdlsGen2(adlsGen2CloudStorageV1Parameters);
+        logging.setStorageLocation("abfs://mybucket@someaccount");
+        telemetryRequest.setLogging(logging);
+        // WHEN
+        Backup result = underTest.convert(telemetryRequest);
+        // THEN
+        assertThat(result.getStorageLocation(), is("abfs://mybucket@someaccount"));
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/AdlsGen2BackupConfigGeneratorTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/AdlsGen2BackupConfigGeneratorTest.java
@@ -1,0 +1,68 @@
+package com.sequenceiq.freeipa.service.freeipa.backup.cloud;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.sequenceiq.cloudbreak.telemetry.fluent.FluentClusterType;
+
+/**
+ *
+ */
+public class AdlsGen2BackupConfigGeneratorTest {
+
+    @Test
+    public void testSimpleCaseLocation() {
+        AdlsGen2BackupConfigGenerator generator = new AdlsGen2BackupConfigGenerator();
+        String location = generator.generateBackupLocation(
+                "abfs://mycontainer@someaccount.dfs.core.windows.net",
+                FluentClusterType.FREEIPA.value(),
+                "mycluster",
+                "12345");
+        assertEquals("https://someaccount.blob.core.windows.net/mycontainer/cluster-backups/freeipa/mycluster_12345", location);
+    }
+
+    @Test
+    public void testSuppliedFolderLocation() {
+        AdlsGen2BackupConfigGenerator generator = new AdlsGen2BackupConfigGenerator();
+        String location = generator.generateBackupLocation(
+                "abfs://mycontainer/someplace@someaccount.dfs.core.windows.net",
+                FluentClusterType.FREEIPA.value(),
+                "mycluster",
+                "12345");
+        assertEquals("https://someaccount.blob.core.windows.net/mycontainer/someplace/cluster-backups/freeipa/mycluster_12345", location);
+    }
+
+    @Test
+    public void testAbfssLocation() {
+        AdlsGen2BackupConfigGenerator generator = new AdlsGen2BackupConfigGenerator();
+        String location = generator.generateBackupLocation(
+                "abfss://mycontainer@someaccount.dfs.core.windows.net",
+                FluentClusterType.FREEIPA.value(),
+                "mycluster",
+                "12345");
+        assertEquals("https://someaccount.blob.core.windows.net/mycontainer/cluster-backups/freeipa/mycluster_12345", location);
+    }
+
+    @Test
+    public void testNonPrefixedLocation() {
+        AdlsGen2BackupConfigGenerator generator = new AdlsGen2BackupConfigGenerator();
+        String location = generator.generateBackupLocation(
+                "mycontainer@someaccount.dfs.core.windows.net",
+                FluentClusterType.FREEIPA.value(),
+                "mycluster",
+                "12345");
+        assertEquals("https://someaccount.blob.core.windows.net/mycontainer/cluster-backups/freeipa/mycluster_12345", location);
+    }
+
+    @Test
+    public void testMultiFolderLocation() {
+        AdlsGen2BackupConfigGenerator generator = new AdlsGen2BackupConfigGenerator();
+        String location = generator.generateBackupLocation(
+                "abfs://mycontainer/someplace/deeper@someaccount.dfs.core.windows.net",
+                FluentClusterType.FREEIPA.value(),
+                "mycluster",
+                "12345");
+        assertEquals("https://someaccount.blob.core.windows.net/mycontainer/someplace/deeper/cluster-backups/freeipa/mycluster_12345", location);
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/CloudBackupFolderResolverServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/CloudBackupFolderResolverServiceTest.java
@@ -1,0 +1,103 @@
+package com.sequenceiq.freeipa.service.freeipa.backup.cloud;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.sequenceiq.cloudbreak.auth.altus.CrnParseException;
+import com.sequenceiq.cloudbreak.telemetry.fluent.FluentClusterType;
+import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
+import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
+import com.sequenceiq.freeipa.api.model.Backup;
+
+public class CloudBackupFolderResolverServiceTest {
+
+    private CloudBackupFolderResolverService underTest;
+
+    @Before
+    public void setUp() {
+        underTest = new CloudBackupFolderResolverService(new S3BackupConfigGenerator(),
+                new AdlsGen2BackupConfigGenerator());
+    }
+
+    @Test
+    public void testUpdateStorageLocationS3() {
+        // GIVEN
+        Backup backup = createBackup();
+        // WHEN
+        underTest.updateStorageLocation(backup, FluentClusterType.FREEIPA.value(), "mycluster",
+                "crn:cdp:cloudbreak:us-west-1:someone:stack:12345");
+        // THEN
+        assertEquals("s3://mybucket/cluster-backups/freeipa/mycluster_12345", backup.getStorageLocation());
+    }
+
+    @Test
+    public void testUpdateStorageLocationAdlsGen2() {
+        // GIVEN
+        Backup backup = createBackup();
+        backup.setS3(null);
+        backup.setAdlsGen2(new AdlsGen2CloudStorageV1Parameters());
+        backup.setStorageLocation("abfs://mycontainer@someaccount.dfs.core.windows.net");
+        // WHEN
+        underTest.updateStorageLocation(backup, FluentClusterType.FREEIPA.value(), "mycluster",
+                "crn:cdp:cloudbreak:us-west-1:someone:stack:12345");
+        // THEN
+        assertEquals("https://someaccount.blob.core.windows.net/mycontainer/cluster-backups/freeipa/mycluster_12345", backup.getStorageLocation());
+    }
+
+    @Test
+    public void testUpdateStorageLocationAdlsGen2WithoutScheme() {
+        // GIVEN
+        Backup backup = createBackup();
+        backup.setS3(null);
+        backup.setAdlsGen2(new AdlsGen2CloudStorageV1Parameters());
+        backup.setStorageLocation("mycontainer@someaccount");
+        // WHEN
+        underTest.updateStorageLocation(backup, FluentClusterType.FREEIPA.value(), "mycluster",
+                "crn:cdp:cloudbreak:us-west-1:someone:stack:12345");
+        // THEN
+        assertEquals("https://someaccount.blob.core.windows.net/mycontainer/cluster-backups/freeipa/mycluster_12345", backup.getStorageLocation());
+    }
+
+    @Test
+    public void testUpdateStorageLocationWithoutScheme() {
+        // GIVEN
+        Backup backup = createBackup();
+        backup.setStorageLocation("mybucket");
+        // WHEN
+        underTest.updateStorageLocation(backup, FluentClusterType.FREEIPA.value(), "mycluster",
+                "crn:cdp:cloudbreak:us-west-1:someone:stack:12345");
+        // THEN
+        assertEquals("s3://mybucket/cluster-backups/freeipa/mycluster_12345", backup.getStorageLocation());
+    }
+
+    @Test
+    public void testUpdateStorageLocationWithoutBackup() {
+        // GIVEN
+        Backup backup = null;
+        // WHEN
+        underTest.updateStorageLocation(backup, FluentClusterType.FREEIPA.value(), "mycluster",
+                "crn:cdp:cloudbreak:us-west-1:someone:stack:12345");
+        // THEN
+        assertNull(backup);
+    }
+
+    @Test(expected = CrnParseException.class)
+    public void testUpdateStorageLocationWithInvalidCrn() {
+        // GIVEN
+        Backup backup = createBackup();
+        // WHEN
+        underTest.updateStorageLocation(backup, FluentClusterType.FREEIPA.value(), "mycluster",
+                "crn:cdp:cloudbreak:us-west:someone:stack:12345");
+    }
+
+    private Backup createBackup() {
+        Backup backup = new Backup();
+        backup.setS3(new S3CloudStorageV1Parameters());
+        backup.setStorageLocation("s3://mybucket");
+        return backup;
+    }
+
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/S3BackupConfigGeneratorTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/S3BackupConfigGeneratorTest.java
@@ -1,0 +1,68 @@
+package com.sequenceiq.freeipa.service.freeipa.backup.cloud;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.sequenceiq.cloudbreak.telemetry.fluent.FluentClusterType;
+
+/**
+ *
+ */
+public class S3BackupConfigGeneratorTest {
+
+    @Test
+    public void testSimpleCaseLocation() {
+        S3BackupConfigGenerator s3BackupConfigGenerator = new S3BackupConfigGenerator();
+        String location = s3BackupConfigGenerator.generateBackupLocation(
+                "s3://mybucket",
+                FluentClusterType.FREEIPA.value(),
+                "mycluster",
+                "12345");
+        assertEquals("s3://mybucket/cluster-backups/freeipa/mycluster_12345", location);
+    }
+
+    @Test
+    public void testSuppliedFolderLocation() {
+        S3BackupConfigGenerator s3BackupConfigGenerator = new S3BackupConfigGenerator();
+        String location = s3BackupConfigGenerator.generateBackupLocation(
+                "s3://mybucket/something",
+                FluentClusterType.FREEIPA.value(),
+                "mycluster",
+                "12345");
+        assertEquals("s3://mybucket/something/cluster-backups/freeipa/mycluster_12345", location);
+    }
+
+    @Test
+    public void testS3aLocation() {
+        S3BackupConfigGenerator s3BackupConfigGenerator = new S3BackupConfigGenerator();
+        String location = s3BackupConfigGenerator.generateBackupLocation(
+                "s3a://mybucket",
+                FluentClusterType.FREEIPA.value(),
+                "mycluster",
+                "12345");
+        assertEquals("s3://mybucket/cluster-backups/freeipa/mycluster_12345", location);
+    }
+
+    @Test
+    public void testNonPrefixedLocation() {
+        S3BackupConfigGenerator s3BackupConfigGenerator = new S3BackupConfigGenerator();
+        String location = s3BackupConfigGenerator.generateBackupLocation(
+                "mybucket",
+                FluentClusterType.FREEIPA.value(),
+                "mycluster",
+                "12345");
+        assertEquals("s3://mybucket/cluster-backups/freeipa/mycluster_12345", location);
+    }
+
+    @Test
+    public void testMultiFolderLocation() {
+        S3BackupConfigGenerator s3BackupConfigGenerator = new S3BackupConfigGenerator();
+        String location = s3BackupConfigGenerator.generateBackupLocation(
+                "mybucket/something/deeper",
+                FluentClusterType.FREEIPA.value(),
+                "mycluster",
+                "12345");
+        assertEquals("s3://mybucket/something/deeper/cluster-backups/freeipa/mycluster_12345", location);
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaConfigServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaConfigServiceTest.java
@@ -1,0 +1,113 @@
+package com.sequenceiq.freeipa.service.freeipa.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.google.common.collect.ImmutableSet;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.cloudbreak.orchestrator.model.Node;
+import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.AdlsGen2ConfigGenerator;
+import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
+import com.sequenceiq.freeipa.api.model.Backup;
+import com.sequenceiq.freeipa.entity.FreeIpa;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.GatewayConfigService;
+import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
+import com.sequenceiq.freeipa.service.freeipa.FreeIpaService;
+import com.sequenceiq.freeipa.service.freeipa.backup.cloud.S3BackupConfigGenerator;
+import com.sequenceiq.freeipa.service.freeipa.dns.ReverseDnsZoneCalculator;
+import com.sequenceiq.freeipa.service.stack.NetworkService;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FreeIpaConfigServiceTest {
+
+    private static final String DOMAIN = "cloudera.com";
+
+    private static final String HOSTNAME = "foo.cloudera.com";
+
+    private static final String PASSWORD = "foobar";
+
+    private static final String ADMIN = "admin";
+
+    private static final Map<String, String> SUBNET_WITH_CIDR = Map.of("10.117.0.0", "16");
+
+    private static final String REVERSE_ZONE = "117.10.in-addr.arpa.";
+
+    private static final String PRIVATE_IP = "10.117.0.69";
+
+    @Spy
+    private S3BackupConfigGenerator s3ConfigGenerator;
+
+    @Spy
+    private AdlsGen2ConfigGenerator adlsGen2ConfigGenerator;
+
+    @Mock
+    private NetworkService networkService;
+
+    @Mock
+    private ReverseDnsZoneCalculator reverseDnsZoneCalculator;
+
+    @Mock
+    private FreeIpaService freeIpaService;
+
+    @Mock
+    private GatewayConfigService gatewayConfigService;
+
+    @Mock
+    private FreeIpaClientFactory freeIpaClientFactory;
+
+    @InjectMocks
+    private FreeIpaConfigService freeIpaConfigService;
+
+    @Test
+    public void testCreateFreeIpaConfigs() {
+        String backupLocation = "s3://mybucket/test";
+        Backup backup = new Backup();
+        backup.setStorageLocation(backupLocation);
+        backup.setS3(new S3CloudStorageV1Parameters());
+        FreeIpa freeIpa = new FreeIpa();
+        freeIpa.setDomain(DOMAIN);
+        freeIpa.setAdminPassword(PASSWORD);
+        Stack stack = new Stack();
+        stack.setCloudPlatform(CloudPlatform.AWS.name());
+        stack.setBackup(backup);
+
+        when(freeIpaService.findByStack(any())).thenReturn(freeIpa);
+        when(freeIpaClientFactory.getAdminUser()).thenReturn(ADMIN);
+        when(networkService.getFilteredSubnetWithCidr(any())).thenReturn(SUBNET_WITH_CIDR);
+        when(reverseDnsZoneCalculator.reverseDnsZoneForCidrs(any())).thenReturn(REVERSE_ZONE);
+        GatewayConfig gatewayConfig = mock(GatewayConfig.class);
+        when(gatewayConfig.getHostname()).thenReturn(HOSTNAME);
+        when(gatewayConfigService.getPrimaryGatewayConfig(any())).thenReturn(gatewayConfig);
+
+        Node node = new Node(PRIVATE_IP, null, null, null, HOSTNAME, DOMAIN, null);
+        Map<String, String> expectedHost = Map.of("ip", PRIVATE_IP, "fqdn", HOSTNAME);
+        Set<Object> expectedHosts = ImmutableSet.of(expectedHost);
+
+        FreeIpaConfigView freeIpaConfigView = freeIpaConfigService.createFreeIpaConfigs(
+                stack, ImmutableSet.of(node));
+
+        assertEquals(DOMAIN.toUpperCase(), freeIpaConfigView.getRealm());
+        assertEquals(DOMAIN, freeIpaConfigView.getDomain());
+        assertEquals(PASSWORD, freeIpaConfigView.getPassword());
+        assertEquals(REVERSE_ZONE, freeIpaConfigView.getReverseZones());
+        assertEquals(ADMIN, freeIpaConfigView.getAdminUser());
+        assertEquals(HOSTNAME, freeIpaConfigView.getFreeipaToReplicate());
+        assertEquals(backupLocation, freeIpaConfigView.getBackup().getLocation());
+        assertEquals(CloudPlatform.AWS.name(), freeIpaConfigView.getBackup().getPlatform());
+        assertEquals(expectedHosts, freeIpaConfigView.getHosts());
+    }
+}


### PR DESCRIPTION
This adds support for automated backup of the FreeIPA
service.  It backups up to the cloud provider defined
by the telemetry and uses the same logging bucket or
container as well as the Identity.

It will determine the backup directory root pathing
similarly to the way telemetry does.

It stores the backup configuration with the stack so
that as we add its own bucket later on, backward
compatibility can be maintained.

Closes #CB-5339
Closes #CB-5336
Closes #CB-5095

Co-authored-by: holleyism <git@holleyism.com>