### PR TITLE
CDPCP-1533. CDPCP-1534. Expose full usersync information

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaModelDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaModelDescriptions.java
@@ -18,6 +18,7 @@ public class FreeIpaModelDescriptions {
     public static final String USE_CCM = "whether to use CCM for communicating with the freeipa instance";
     public static final String TUNNEL = "Configuration that the connection going directly or with cluster proxy or with ccm and cluster proxy.";
     public static final String TAGS = "Tags for freeipa server.";
+    public static final String USERSYNC_STATUS_DETAILS = "user sync status details for the environment";
 
     private FreeIpaModelDescriptions() {
     }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/describe/DescribeFreeIpaResponse.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/describe/DescribeFreeIpaResponse.java
@@ -17,6 +17,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.Instanc
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.NetworkResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.region.PlacementResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.security.StackAuthenticationResponse;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.usersync.UserSyncStatusResponse;
 import com.sequenceiq.service.api.doc.ModelDescriptions;
 
 import io.swagger.annotations.ApiModel;
@@ -78,6 +79,9 @@ public class DescribeFreeIpaResponse {
 
     @ApiModelProperty(value = FreeIpaModelDescriptions.CLOUD_STORAGE)
     private CloudStorageResponse cloudStorage;
+
+    @ApiModelProperty(value = FreeIpaModelDescriptions.USERSYNC_STATUS_DETAILS)
+    private UserSyncStatusResponse userSyncStatus;
 
     public String getEnvironmentCrn() {
         return environmentCrn;
@@ -205,5 +209,13 @@ public class DescribeFreeIpaResponse {
 
     public void setCloudPlatform(String cloudPlatform) {
         this.cloudPlatform = cloudPlatform;
+    }
+
+    public UserSyncStatusResponse getUserSyncStatus() {
+        return userSyncStatus;
+    }
+
+    public void setUserSyncStatus(UserSyncStatusResponse userSyncStatus) {
+        this.userSyncStatus = userSyncStatus;
     }
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/usersync/UserSyncStatusResponse.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/usersync/UserSyncStatusResponse.java
@@ -1,0 +1,52 @@
+package com.sequenceiq.freeipa.api.v1.freeipa.stack.model.usersync;
+
+import java.util.Map;
+
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.google.common.collect.ImmutableMap;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.doc.UserModelDescriptions;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel("UserSyncStatusV1Response")
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class UserSyncStatusResponse {
+    @ApiModelProperty(value = UserModelDescriptions.USERSYNC_ID)
+    private String lastRequestedUserSyncId;
+
+    @ApiModelProperty(value = UserModelDescriptions.USERSYNC_ID)
+    private String lastSuccessfulUserSyncId;
+
+    @NotNull
+    @ApiModelProperty(value = UserModelDescriptions.USERSYNC_ID)
+    private Map<String, String> eventGenerationIds;
+
+    public String getLastRequestedUserSyncId() {
+        return lastRequestedUserSyncId;
+    }
+
+    public void setLastRequestedUserSyncId(String lastRequestedUserSyncId) {
+        this.lastRequestedUserSyncId = lastRequestedUserSyncId;
+    }
+
+    public String getLastSuccessfulUserSyncId() {
+        return lastSuccessfulUserSyncId;
+    }
+
+    public void setLastSuccessfulUserSyncId(String lastSuccessfulUserSyncId) {
+        this.lastSuccessfulUserSyncId = lastSuccessfulUserSyncId;
+    }
+
+    public Map<String, String> getEventGenerationIds() {
+        return eventGenerationIds;
+    }
+
+    public void setEventGenerationIds(Map<String, String> eventGenerationIds) {
+        this.eventGenerationIds = ImmutableMap.copyOf(eventGenerationIds);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/StackToDescribeFreeIpaResponseConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/StackToDescribeFreeIpaResponseConverter.java
@@ -26,9 +26,11 @@ import com.sequenceiq.freeipa.converter.image.ImageToImageSettingsResponseConver
 import com.sequenceiq.freeipa.converter.instance.InstanceGroupToInstanceGroupResponseConverter;
 import com.sequenceiq.freeipa.converter.network.NetworkToNetworkResponseConverter;
 import com.sequenceiq.freeipa.converter.telemetry.TelemetryConverter;
+import com.sequenceiq.freeipa.converter.usersync.UserSyncStatusToUserSyncStatusResponseConverter;
 import com.sequenceiq.freeipa.entity.FreeIpa;
 import com.sequenceiq.freeipa.entity.Image;
 import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.entity.UserSyncStatus;
 
 @Component
 public class StackToDescribeFreeIpaResponseConverter {
@@ -51,7 +53,10 @@ public class StackToDescribeFreeIpaResponseConverter {
     @Inject
     private TelemetryConverter telemetryConverter;
 
-    public DescribeFreeIpaResponse convert(Stack stack, Image image, FreeIpa freeIpa) {
+    @Inject
+    private UserSyncStatusToUserSyncStatusResponseConverter userSyncStatusConverter;
+
+    public DescribeFreeIpaResponse convert(Stack stack, Image image, FreeIpa freeIpa, UserSyncStatus userSyncStatus) {
         DescribeFreeIpaResponse describeFreeIpaResponse = new DescribeFreeIpaResponse();
         describeFreeIpaResponse.setName(stack.getName());
         describeFreeIpaResponse.setEnvironmentCrn(stack.getEnvironmentCrn());
@@ -69,6 +74,7 @@ public class StackToDescribeFreeIpaResponseConverter {
         decorateFreeIpaServerResponseWithIps(describeFreeIpaResponse.getFreeIpa(), describeFreeIpaResponse.getInstanceGroups());
         describeFreeIpaResponse.setAppVersion(stack.getAppVersion());
         decorateWithCloudStorgeAndTelemetry(stack, describeFreeIpaResponse);
+        Optional.ofNullable(userSyncStatus).ifPresent(u -> describeFreeIpaResponse.setUserSyncStatus(userSyncStatusConverter.convert(u)));
         return describeFreeIpaResponse;
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/usersync/UserSyncStatusToUserSyncStatusResponseConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/usersync/UserSyncStatusToUserSyncStatusResponseConverter.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.freeipa.converter.usersync;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.usersync.UserSyncStatusResponse;
+import com.sequenceiq.freeipa.entity.UserSyncStatus;
+import com.sequenceiq.freeipa.service.freeipa.user.model.UmsEventGenerationIds;
+
+@Component
+public class UserSyncStatusToUserSyncStatusResponseConverter implements Converter<UserSyncStatus, UserSyncStatusResponse> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserSyncStatusToUserSyncStatusResponseConverter.class);
+
+    @Override
+    public UserSyncStatusResponse convert(UserSyncStatus userSyncStatus) {
+        UserSyncStatusResponse response = new UserSyncStatusResponse();
+        Optional.ofNullable(userSyncStatus.getLastRequestedFullSync()).ifPresent(op -> response.setLastRequestedUserSyncId(op.getOperationId()));
+        Optional.ofNullable(userSyncStatus.getLastSuccessfulFullSync()).ifPresent(op -> response.setLastSuccessfulUserSyncId(op.getOperationId()));
+        Optional.ofNullable(userSyncStatus.getUmsEventGenerationIds()).ifPresent(eids -> {
+            try {
+                response.setEventGenerationIds(eids.get(UmsEventGenerationIds.class).getEventGenerationIds());
+            } catch (IOException e) {
+                LOGGER.warn("Failed to convert event generation ids [{}] for environment '{}'",
+                        userSyncStatus.getUmsEventGenerationIds(), userSyncStatus.getStack().getEnvironmentCrn());
+            }
+        });
+        return response;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/UserSyncStatus.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/UserSyncStatus.java
@@ -28,9 +28,11 @@ public class UserSyncStatus implements AccountIdAwareResource {
     @Column(columnDefinition = "TEXT")
     private Json umsEventGenerationIds;
 
-    private Long lastFullSyncStartTime;
+    @OneToOne
+    private Operation lastRequestedFullSync;
 
-    private Long lastFullSyncEndTime;
+    @OneToOne
+    private Operation lastSuccessfulFullSync;
 
     public UserSyncStatus() {
     }
@@ -63,20 +65,20 @@ public class UserSyncStatus implements AccountIdAwareResource {
         this.umsEventGenerationIds = umsEventGenerationIds;
     }
 
-    public Long getLastFullSyncStartTime() {
-        return lastFullSyncStartTime;
+    public Operation getLastRequestedFullSync() {
+        return lastRequestedFullSync;
     }
 
-    public void setLastFullSyncStartTime(Long lastFullSyncStartTime) {
-        this.lastFullSyncStartTime = lastFullSyncStartTime;
+    public void setLastRequestedFullSync(Operation lastRequestedFullSync) {
+        this.lastRequestedFullSync = lastRequestedFullSync;
     }
 
-    public Long getLastFullSyncEndTime() {
-        return lastFullSyncEndTime;
+    public Operation getLastSuccessfulFullSync() {
+        return lastSuccessfulFullSync;
     }
 
-    public void setLastFullSyncEndTime(Long lastFullSyncEndTime) {
-        this.lastFullSyncEndTime = lastFullSyncEndTime;
+    public void setLastSuccessfulFullSync(Operation lastSuccessfulFullSync) {
+        this.lastSuccessfulFullSync = lastSuccessfulFullSync;
     }
 
     @Override

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UmsEventGenerationIdsProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UmsEventGenerationIdsProvider.java
@@ -26,7 +26,7 @@ public class UmsEventGenerationIdsProvider {
     enum EventMapping {
         LAST_ROLE_ASSIGNMENT_EVENT_ID("lastRoleAssignmentEventId", GetEventGenerationIdsResponse::getLastRoleAssignmentEventId),
         LAST_RESOURCE_ROLE_ASSIGNMENT_EVENT_ID("lastResourceRoleAssignmentEventId", GetEventGenerationIdsResponse::getLastResourceRoleAssignmentEventId),
-        LAST_GROUP_MEMBERHSIP_CHANGED_EVENT_ID("lastGroupMembershipChangedEventId", GetEventGenerationIdsResponse::getLastGroupMembershipChangedEventId),
+        LAST_GROUP_MEMBERSHIP_CHANGED_EVENT_ID("lastGroupMembershipChangedEventId", GetEventGenerationIdsResponse::getLastGroupMembershipChangedEventId),
         LAST_ACTOR_DELETED_EVENT_ID("lastActorDeletedEventId", GetEventGenerationIdsResponse::getLastActorDeletedEventId),
         LAST_ACTOR_WORKLOAD_CREDENTIALS_CHANGED_EVENT_ID("lastActorWorkloadCredentialsChangedEventId",
                 GetEventGenerationIdsResponse::getLastActorWorkloadCredentialsChangedEventId);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncStatusService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncStatusService.java
@@ -20,6 +20,10 @@ public class UserSyncStatusService {
         return userSyncStatusRepository.save(userSyncStatus);
     }
 
+    public UserSyncStatus findByStack(Stack stack) {
+        return userSyncStatusRepository.getByStack(stack).orElse(null);
+    }
+
     public UserSyncStatus getOrCreateForStack(Stack stack) {
         return userSyncStatusRepository.getByStack(stack).orElseGet(() -> {
             UserSyncStatus userSyncStatus = new UserSyncStatus();

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/poller/CooldownChecker.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/poller/CooldownChecker.java
@@ -18,8 +18,9 @@ class CooldownChecker {
 
     public boolean isCooldownExpired(UserSyncStatus userSyncStatus, Instant cooldownThresholdTime) {
         boolean cool = userSyncStatus == null ||
-                userSyncStatus.getLastFullSyncStartTime() == null ||
-                Instant.ofEpochMilli(userSyncStatus.getLastFullSyncStartTime()).isBefore(cooldownThresholdTime);
+                userSyncStatus.getLastRequestedFullSync() == null ||
+                userSyncStatus.getLastRequestedFullSync().getStartTime() == null ||
+                Instant.ofEpochMilli(userSyncStatus.getLastRequestedFullSync().getStartTime()).isBefore(cooldownThresholdTime);
         if (LOGGER.isDebugEnabled()) {
             Stack stack = userSyncStatus.getStack();
             LOGGER.debug("Synchronization to Environment {} in Account {} {} been run since {}", stack.getEnvironmentCrn(),

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaCreationService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaCreationService.java
@@ -111,7 +111,6 @@ public class FreeIpaCreationService {
         stack.setAppVersion(appVersion);
         GetPlatformTemplateRequest getPlatformTemplateRequest = templateService.triggerGetTemplate(stack, credential);
 
-
         Telemetry telemetry = stack.getTelemetry();
         cloudStorageFolderResolverService.updateStorageLocation(telemetry,
                 FluentClusterType.FREEIPA.value(), stack.getName(), stack.getResourceCrn());
@@ -136,7 +135,7 @@ public class FreeIpaCreationService {
                     new StackEvent(FlowChainTriggers.PROVISION_TRIGGER_EVENT, stackImageFreeIpaTuple.getLeft().getId()));
             InMemoryStateStore.putStack(stack.getId(), PollGroup.POLLABLE);
             return stackToDescribeFreeIpaResponseConverter
-                    .convert(stackImageFreeIpaTuple.getLeft(), stackImageFreeIpaTuple.getMiddle(), stackImageFreeIpaTuple.getRight());
+                    .convert(stackImageFreeIpaTuple.getLeft(), stackImageFreeIpaTuple.getMiddle(), stackImageFreeIpaTuple.getRight(), null);
         } catch (TransactionService.TransactionExecutionException e) {
             LOGGER.error("Creation of FreeIPA failed", e);
             throw new BadRequestException("Creation of FreeIPA failed: " + e.getCause().getMessage(), e);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaDescribeService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaDescribeService.java
@@ -9,7 +9,9 @@ import com.sequenceiq.freeipa.converter.stack.StackToDescribeFreeIpaResponseConv
 import com.sequenceiq.freeipa.entity.FreeIpa;
 import com.sequenceiq.freeipa.entity.Image;
 import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.entity.UserSyncStatus;
 import com.sequenceiq.freeipa.service.freeipa.FreeIpaService;
+import com.sequenceiq.freeipa.service.freeipa.user.UserSyncStatusService;
 import com.sequenceiq.freeipa.service.image.ImageService;
 
 @Service
@@ -25,12 +27,16 @@ public class FreeIpaDescribeService {
     private FreeIpaService freeIpaService;
 
     @Inject
+    private UserSyncStatusService userSyncStatusService;
+
+    @Inject
     private StackToDescribeFreeIpaResponseConverter stackToDescribeFreeIpaResponseConverter;
 
     public DescribeFreeIpaResponse describe(String environmentCrn, String accountId) {
         Stack stack = stackService.getByEnvironmentCrnAndAccountIdWithLists(environmentCrn, accountId);
         Image image = imageService.getByStack(stack);
         FreeIpa freeIpa = freeIpaService.findByStack(stack);
-        return stackToDescribeFreeIpaResponseConverter.convert(stack, image, freeIpa);
+        UserSyncStatus userSyncStatus = userSyncStatusService.findByStack(stack);
+        return stackToDescribeFreeIpaResponseConverter.convert(stack, image, freeIpa, userSyncStatus);
     }
 }

--- a/freeipa/src/main/resources/schema/app/20200228133843_CDPCP-1533_add_operation_to_usersync_status.sql
+++ b/freeipa/src/main/resources/schema/app/20200228133843_CDPCP-1533_add_operation_to_usersync_status.sql
@@ -1,0 +1,24 @@
+-- // CDPCP-1533 Add Operation to usersync status. The lastfullsyncstarttime
+-- // and lastfullsyncendtime columns dropped because they are redundant with
+-- // the information stored in lastrequestedfullsync and lastsuccessfulfullsync.
+
+ALTER TABLE usersyncstatus
+    ADD COLUMN IF NOT EXISTS lastrequestedfullsync_id bigint
+        CONSTRAINT fk_usersyncstatus_lastrequestedoperationid
+        REFERENCES operation,
+    ADD COLUMN IF NOT EXISTS lastsuccessfulfullsync_id bigint
+        CONSTRAINT fk_usersyncstatus_lastsuccessfuloperationid
+        REFERENCES operation,
+    DROP COLUMN IF EXISTS lastfullsyncstarttime,
+    DROP COLUMN IF EXISTS lastfullsyncendtime;
+
+-- //@UNDO
+
+ALTER TABLE usersyncstatus
+    ADD COLUMN IF NOT EXISTS lastfullsyncstarttime bigint,
+    ADD COLUMN IF NOT EXISTS lastfullsyncendtime bigint,
+    DROP COLUMN IF EXISTS lastrequestedfullsync_id,
+    DROP COLUMN IF EXISTS lastsuccessfulfullsync_id;
+
+COMMENT on COLUMN usersyncstatus.lastfullsyncstarttime is 'UTC milliseconds from java epoch';
+COMMENT on COLUMN usersyncstatus.lastfullsyncendtime is 'UTC milliseconds from java epoch';

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/stack/StackToDescribeFreeIpaResponseConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/stack/StackToDescribeFreeIpaResponseConverterTest.java
@@ -17,17 +17,20 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.image.ImageSetti
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.security.StackAuthenticationResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.describe.DescribeFreeIpaResponse;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.usersync.UserSyncStatusResponse;
 import com.sequenceiq.freeipa.converter.authentication.StackAuthenticationToStackAuthenticationResponseConverter;
 import com.sequenceiq.freeipa.converter.freeipa.FreeIpaToFreeIpaServerResponseConverter;
 import com.sequenceiq.freeipa.converter.image.ImageToImageSettingsResponseConverter;
 import com.sequenceiq.freeipa.converter.instance.InstanceGroupToInstanceGroupResponseConverter;
 import com.sequenceiq.freeipa.converter.network.NetworkToNetworkResponseConverter;
 import com.sequenceiq.freeipa.converter.telemetry.TelemetryConverter;
+import com.sequenceiq.freeipa.converter.usersync.UserSyncStatusToUserSyncStatusResponseConverter;
 import com.sequenceiq.freeipa.entity.FreeIpa;
 import com.sequenceiq.freeipa.entity.Image;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.entity.StackAuthentication;
 import com.sequenceiq.freeipa.entity.StackStatus;
+import com.sequenceiq.freeipa.entity.UserSyncStatus;
 
 @ExtendWith(MockitoExtension.class)
 class StackToDescribeFreeIpaResponseConverterTest {
@@ -49,6 +52,8 @@ class StackToDescribeFreeIpaResponseConverterTest {
     private static final FreeIpaServerResponse FREE_IPA_SERVER_RESPONSE = new FreeIpaServerResponse();
 
     private static final List<InstanceGroupResponse> INSTANCE_GROUP_RESPONSES = List.of(new InstanceGroupResponse());
+
+    private static final UserSyncStatusResponse USERSYNC_STATUS_RESPONSE = new UserSyncStatusResponse();
 
     private static final Status STATUS = Status.AVAILABLE;
 
@@ -79,17 +84,22 @@ class StackToDescribeFreeIpaResponseConverterTest {
     @Mock
     private TelemetryConverter telemetryConverter;
 
+    @Mock
+    private UserSyncStatusToUserSyncStatusResponseConverter userSyncStatusConverter;
+
     @Test
     void convert() {
         Stack stack = createStack();
         Image image = new Image();
         FreeIpa freeIpa = new FreeIpa();
+        UserSyncStatus userSyncStatus = new UserSyncStatus();
         when(authenticationResponseConverter.convert(stack.getStackAuthentication())).thenReturn(STACK_AUTHENTICATION_RESPONSE);
         when(imageSettingsResponseConverter.convert(image)).thenReturn(IMAGE_SETTINGS_RESPONSE);
         when(freeIpaServerResponseConverter.convert(freeIpa)).thenReturn(FREE_IPA_SERVER_RESPONSE);
         when(instanceGroupConverter.convert(stack.getInstanceGroups())).thenReturn(INSTANCE_GROUP_RESPONSES);
+        when(userSyncStatusConverter.convert(userSyncStatus)).thenReturn(USERSYNC_STATUS_RESPONSE);
 
-        DescribeFreeIpaResponse result = underTest.convert(stack, image, freeIpa);
+        DescribeFreeIpaResponse result = underTest.convert(stack, image, freeIpa, userSyncStatus);
 
         assertThat(result)
                 .returns(NAME, DescribeFreeIpaResponse::getName)
@@ -105,8 +115,9 @@ class StackToDescribeFreeIpaResponseConverterTest {
                 .returns(STATUS_REASON, DescribeFreeIpaResponse::getStatusReason)
                 .returns(STATUS_STRING, DescribeFreeIpaResponse::getStatusString)
                 // TODO decorateFreeIpaServerResponseWithIps
-                .returns(APP_VERSION, DescribeFreeIpaResponse::getAppVersion);
+                .returns(APP_VERSION, DescribeFreeIpaResponse::getAppVersion)
                 // TODO decorateWithCloudStorgeAndTelemetry
+                .returns(USERSYNC_STATUS_RESPONSE, DescribeFreeIpaResponse::getUserSyncStatus);
     }
 
     private Stack createStack() {

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/usersync/UserSyncStatusToUserSyncStatusResponseConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/usersync/UserSyncStatusToUserSyncStatusResponseConverterTest.java
@@ -1,0 +1,72 @@
+package com.sequenceiq.freeipa.converter.usersync;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.usersync.UserSyncStatusResponse;
+import com.sequenceiq.freeipa.entity.Operation;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.entity.UserSyncStatus;
+import com.sequenceiq.freeipa.service.freeipa.user.model.UmsEventGenerationIds;
+
+class UserSyncStatusToUserSyncStatusResponseConverterTest {
+
+    private UserSyncStatusToUserSyncStatusResponseConverter underTest = new UserSyncStatusToUserSyncStatusResponseConverter();
+
+    @Test
+    void convertJsonException() throws IOException {
+        Json eventGenerationIds = mock(Json.class);
+        IOException e = new IOException("test exception");
+        when(eventGenerationIds.get(any(Class.class))).thenThrow(e);
+
+        UserSyncStatus status = new UserSyncStatus();
+        status.setStack(mock(Stack.class));
+        status.setUmsEventGenerationIds(eventGenerationIds);
+
+        UserSyncStatusResponse response = underTest.convert(status);
+
+        assertThat(response)
+                .returns(null, UserSyncStatusResponse::getLastRequestedUserSyncId)
+                .returns(null, UserSyncStatusResponse::getLastSuccessfulUserSyncId)
+                .returns(null, UserSyncStatusResponse::getEventGenerationIds);
+    }
+
+    @Test
+    void convert() {
+        String requestedId = UUID.randomUUID().toString();
+        Operation requested = new Operation();
+        requested.setOperationId(requestedId);
+
+        String successfulId = UUID.randomUUID().toString();
+        Operation successful = new Operation();
+        successful.setOperationId(successfulId);
+
+        Map<String, String> eventGenerationIdMap = Map.of(
+                "key1", "value1",
+                "key2", "value2"
+        );
+        UmsEventGenerationIds eventGenerationIds = new UmsEventGenerationIds();
+        eventGenerationIds.setEventGenerationIds(eventGenerationIdMap);
+
+        UserSyncStatus status = new UserSyncStatus();
+        status.setLastRequestedFullSync(requested);
+        status.setLastSuccessfulFullSync(successful);
+        status.setUmsEventGenerationIds(new Json(eventGenerationIds));
+
+        UserSyncStatusResponse response = underTest.convert(status);
+
+        assertThat(response)
+                .returns(requestedId, UserSyncStatusResponse::getLastRequestedUserSyncId)
+                .returns(successfulId, UserSyncStatusResponse::getLastSuccessfulUserSyncId)
+                .returns(eventGenerationIdMap, UserSyncStatusResponse::getEventGenerationIds);
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/poller/CooldownCheckerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/poller/CooldownCheckerTest.java
@@ -2,11 +2,14 @@ package com.sequenceiq.freeipa.service.freeipa.user.poller;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.time.Instant;
 
 import org.junit.jupiter.api.Test;
 
+import com.sequenceiq.freeipa.entity.Operation;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.entity.UserSyncStatus;
 
@@ -15,12 +18,23 @@ class CooldownCheckerTest {
     private CooldownChecker underTest = new CooldownChecker();
 
     @Test
-    void testIsCool() throws Exception {
+    void testIsCoolNoPreviousSync() throws Exception {
+        Stack stack = UserSyncPollerTestUtils.createStack();
+        UserSyncStatus userSyncStatus = UserSyncPollerTestUtils.createUserSyncStatus(stack);
+        Instant cooldownExpiration = Instant.now();
+
+        assertTrue(underTest.isCooldownExpired(userSyncStatus, cooldownExpiration));
+    }
+
+    @Test
+    void testIsCoolOldPreviousSync() throws Exception {
         Stack stack = UserSyncPollerTestUtils.createStack();
         UserSyncStatus userSyncStatus = UserSyncPollerTestUtils.createUserSyncStatus(stack);
         Instant cooldownExpiration = Instant.now();
         long lastStartTime = cooldownExpiration.toEpochMilli() - 1L;
-        userSyncStatus.setLastFullSyncStartTime(lastStartTime);
+        Operation lastRequestedOperation = mock(Operation.class);
+        when(lastRequestedOperation.getStartTime()).thenReturn(lastStartTime);
+        userSyncStatus.setLastRequestedFullSync(lastRequestedOperation);
 
         assertTrue(underTest.isCooldownExpired(userSyncStatus, cooldownExpiration));
     }
@@ -31,7 +45,9 @@ class CooldownCheckerTest {
         UserSyncStatus userSyncStatus = UserSyncPollerTestUtils.createUserSyncStatus(stack);
         Instant cooldownExpiration = Instant.now();
         long lastStartTime = cooldownExpiration.toEpochMilli() + 1L;
-        userSyncStatus.setLastFullSyncStartTime(lastStartTime);
+        Operation lastRequestedOperation = mock(Operation.class);
+        when(lastRequestedOperation.getStartTime()).thenReturn(lastStartTime);
+        userSyncStatus.setLastRequestedFullSync(lastRequestedOperation);
 
         assertFalse(underTest.isCooldownExpired(userSyncStatus, cooldownExpiration));
     }


### PR DESCRIPTION
UserSyncStatus has been modified to link to the last requested
and last successful Operations run for that environment. The
lasfullsyncstarttime and lastfullsyncendtime columns are removed
since that information can be found in the linked Operations.

The UserSyncStatus is added to the DescribeFreeIpaResponse to
expose this information through the "describe" API.
