### PR TITLE
CB-6038 DatalakeStatusEnum and SdxClusterStatusResponse enums are out…

### DIFF
--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterStatusResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterStatusResponse.java
@@ -28,5 +28,6 @@ public enum SdxClusterStatusResponse {
     STOP_IN_PROGRESS,
     STOP_FAILED,
     STOPPED,
-    CLUSTER_AMBIGUOUS
+    CLUSTER_AMBIGUOUS,
+    SYNC_FAILED
 }


### PR DESCRIPTION
… of sync

