### PR TITLE
CB-6035: FMS should relogin on failures

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientException.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientException.java
@@ -1,19 +1,27 @@
 package com.sequenceiq.freeipa.client;
 
+import java.util.OptionalInt;
+
 public class FreeIpaClientException extends Exception {
+
+    private final OptionalInt statusCode;
+
     public FreeIpaClientException(String message) {
         super(message);
+        statusCode = OptionalInt.empty();
+    }
+
+    public FreeIpaClientException(String message, int statusCode) {
+        super(message);
+        this.statusCode = OptionalInt.of(statusCode);
     }
 
     public FreeIpaClientException(String message, Throwable cause) {
         super(message, cause);
+        statusCode = OptionalInt.empty();
     }
 
-    public FreeIpaClientException(Throwable cause) {
-
-    }
-
-    public FreeIpaClientException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
-
+    public OptionalInt getStatusCode() {
+        return statusCode;
     }
 }

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/auth/InvalidPasswordException.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/auth/InvalidPasswordException.java
@@ -6,20 +6,4 @@ public class InvalidPasswordException extends FreeIpaClientException {
     public InvalidPasswordException() {
         super("Invalid password");
     }
-
-    public InvalidPasswordException(String message) {
-        super(message);
-    }
-
-    public InvalidPasswordException(Throwable cause) {
-        super(cause);
-    }
-
-    public InvalidPasswordException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
-    public InvalidPasswordException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
-        super(message, cause, enableSuppression, writableStackTrace);
-    }
 }

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/auth/InvalidUserOrRealmException.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/auth/InvalidUserOrRealmException.java
@@ -15,20 +15,4 @@ public class InvalidUserOrRealmException extends FreeIpaClientException {
     public InvalidUserOrRealmException() {
         super("Invalid user or realm");
     }
-
-    public InvalidUserOrRealmException(String message) {
-        super(message);
-    }
-
-    public InvalidUserOrRealmException(Throwable cause) {
-        super(cause);
-    }
-
-    public InvalidUserOrRealmException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
-    public InvalidUserOrRealmException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
-        super(message, cause, enableSuppression, writableStackTrace);
-    }
 }

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/auth/PasswordExpiredException.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/auth/PasswordExpiredException.java
@@ -6,20 +6,4 @@ public class PasswordExpiredException extends FreeIpaClientException {
     public PasswordExpiredException() {
         super("Invalid password");
     }
-
-    public PasswordExpiredException(String message) {
-        super(message);
-    }
-
-    public PasswordExpiredException(Throwable cause) {
-        super(cause);
-    }
-
-    public PasswordExpiredException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
-    public PasswordExpiredException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
-        super(message, cause, enableSuppression, writableStackTrace);
-    }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/GatewayConfigService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/GatewayConfigService.java
@@ -54,7 +54,7 @@ public class GatewayConfigService {
     }
 
     public GatewayConfig getGatewayConfig(Stack stack, InstanceMetaData gatewayInstance) {
-        return tlsSecurityService.buildGatewayConfig(stack.getId(), gatewayInstance, stack.getGatewayport(), getSaltClientConfig(stack), false);
+        return tlsSecurityService.buildGatewayConfig(stack, gatewayInstance, getSaltClientConfig(stack), false);
     }
 
     public String getPrimaryGatewayIp(Stack stack) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/TlsSecurityService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/TlsSecurityService.java
@@ -103,9 +103,8 @@ public class TlsSecurityService {
         saltSecurityConfig.setSaltPasswordVault(saltPassword);
     }
 
-    public GatewayConfig buildGatewayConfig(Long stackId, InstanceMetaData gatewayInstance, Integer gatewayPort,
+    public GatewayConfig buildGatewayConfig(Stack stack, InstanceMetaData gatewayInstance,
             SaltClientConfig saltClientConfig, Boolean knoxGatewayEnabled) {
-        Stack stack = stackService.getStackById(stackId);
         SecurityConfig securityConfig = securityConfigService.findOneByStack(stack);
         String connectionIp = getGatewayIp(securityConfig, gatewayInstance, stack);
         HttpClientConfig conf = buildTLSClientConfig(stack, connectionIp, gatewayInstance);
@@ -113,7 +112,7 @@ public class TlsSecurityService {
         String saltSignPrivateKeyB64 = saltSecurityConfig.getSaltSignPrivateKeyVault();
         GatewayConfig gatewayConfig =
                 new GatewayConfig(connectionIp, gatewayInstance.getPublicIpWrapper(), gatewayInstance.getPrivateIp(), gatewayInstance.getDiscoveryFQDN(),
-                        getGatewayPort(gatewayPort, stack), gatewayInstance.getInstanceId(), conf.getServerCert(),
+                        getGatewayPort(stack.getGatewayport(), stack), gatewayInstance.getInstanceId(), conf.getServerCert(),
                         conf.getClientCert(), conf.getClientKey(), saltClientConfig.getSaltPassword(), saltClientConfig.getSaltBootPassword(),
                         saltClientConfig.getSignatureKeyPem(), knoxGatewayEnabled,
                         InstanceMetadataType.GATEWAY_PRIMARY.equals(gatewayInstance.getInstanceMetadataType()),

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactoryTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactoryTest.java
@@ -4,6 +4,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,17 +17,23 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.client.FreeIpaClientException;
+import com.sequenceiq.freeipa.entity.InstanceGroup;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.entity.StackStatus;
 import com.sequenceiq.freeipa.service.GatewayConfigService;
 import com.sequenceiq.freeipa.service.TlsSecurityService;
 import com.sequenceiq.freeipa.service.stack.ClusterProxyService;
+import com.sequenceiq.freeipa.service.stack.StackService;
 
 @ExtendWith(MockitoExtension.class)
 class FreeIpaClientFactoryTest {
 
     @Mock
     private ClusterProxyService clusterProxyService;
+
+    @Mock
+    private StackService stackService;
 
     @Mock
     private FreeIpaService freeIpaService;
@@ -40,7 +49,8 @@ class FreeIpaClientFactoryTest {
 
     @Test
     void getFreeIpaClientForStackShouldThrowExceptionWhenStackStatusIsUnreachable() {
-        Stack stack = new Stack();
+        Stack stack = createStack();
+        when(stackService.getByIdWithListsInTransaction(stack.getId())).thenReturn(stack);
         Status unreachableState = Status.FREEIPA_UNREACHABLE_STATUSES.stream().findAny().get();
         StackStatus stackStatus = new StackStatus(stack, unreachableState, "The FreeIPA instance is unreachable.", DetailedStackStatus.UNREACHABLE);
         stack.setStackStatus(stackStatus);
@@ -50,7 +60,8 @@ class FreeIpaClientFactoryTest {
 
     @Test
     void getFreeIpaClientForStackShouldReturnClientWhenStackStatusIsValid() throws FreeIpaClientException {
-        Stack stack = new Stack();
+        Stack stack = createStack();
+        when(stackService.getByIdWithListsInTransaction(stack.getId())).thenReturn(stack);
         Status unreachableState = Status.AVAILABLE;
         StackStatus stackStatus = new StackStatus(stack, unreachableState, "The FreeIPA instance is reachable.", DetailedStackStatus.AVAILABLE);
         stack.setStackStatus(stackStatus);
@@ -64,7 +75,8 @@ class FreeIpaClientFactoryTest {
 
     @Test
     void getFreeIpaClientForStackWithPingShouldThrowExceptionWhenStackStatusIsUnreachable() {
-        Stack stack = new Stack();
+        Stack stack = createStack();
+        when(stackService.getByIdWithListsInTransaction(stack.getId())).thenReturn(stack);
         Status unreachableState = Status.AVAILABLE;
         StackStatus stackStatus = new StackStatus(stack, unreachableState, "The FreeIPA instance is reachable.", DetailedStackStatus.AVAILABLE);
         stack.setStackStatus(stackStatus);
@@ -78,11 +90,26 @@ class FreeIpaClientFactoryTest {
 
     @Test
     void getFreeIpaClientForStackWithPingShouldReturnClientWhenStackStatusIsValid() {
-        Stack stack = new Stack();
+        Stack stack = createStack();
+        when(stackService.getByIdWithListsInTransaction(stack.getId())).thenReturn(stack);
         Status unreachableState = Status.FREEIPA_UNREACHABLE_STATUSES.stream().findAny().get();
         StackStatus stackStatus = new StackStatus(stack, unreachableState, "The FreeIPA instance is unreachable.", DetailedStackStatus.UNREACHABLE);
         stack.setStackStatus(stackStatus);
 
         Assertions.assertThrows(FreeIpaClientException.class, () -> underTest.getFreeIpaClientForStackWithPing(stack));
+    }
+
+    private Stack createStack() {
+        Stack stack = new Stack();
+        Set<InstanceGroup> instanceGroups = new HashSet<>();
+        stack.setInstanceGroups(instanceGroups);
+        InstanceGroup group = new InstanceGroup();
+        instanceGroups.add(group);
+        Set<InstanceMetaData> metaDatas = new HashSet<>();
+        group.setInstanceMetaData(metaDatas);
+        InstanceMetaData metaData = new InstanceMetaData();
+        metaDatas.add(metaData);
+        metaData.setPrivateIp("1.1.1.1");
+        return stack;
     }
 }


### PR DESCRIPTION
This change adds an automatic retry on the FreeIpaClientFactory
getFreeIpaClient* methods.  These methods perform a login.
Manually verified by blocking http/https ports.  This is necessary
in FreeIPA HA environments where there might be a failover and
the client should retry.

