### PR TITLE
CDPCP-1601. set-password now uses credentials from control plane

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaCapabilities.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaCapabilities.java
@@ -1,0 +1,19 @@
+package com.sequenceiq.freeipa.client;
+
+import com.sequenceiq.freeipa.client.model.Config;
+
+import java.util.Set;
+
+public class FreeIpaCapabilities {
+
+    // Attribute name to store users passwords (enabled through FreeIPA plugin)
+    private static final String CDP_USER_ATTRIBUTE = "cdpUserAttr";
+
+    private FreeIpaCapabilities() {
+    }
+
+    public static boolean hasSetPasswordHashSupport(Config ipaConfig) {
+        Set<String> ipauserobjectclasses = ipaConfig.getIpauserobjectclasses();
+        return ipauserobjectclasses != null && ipauserobjectclasses.contains(CDP_USER_ATTRIBUTE);
+    }
+}

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/model/Config.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/model/Config.java
@@ -10,9 +10,6 @@ import com.sequenceiq.freeipa.client.deserializer.ListFlatteningDeserializer;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Config {
 
-    // users for password setting in FreeIPA Plugin
-    public static final String CDP_USER_ATTRIBUTE = "cdpUserAttr";
-
     @JsonDeserialize(using = ListFlatteningDeserializer.class)
     private Integer ipamaxusernamelength;
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/user/event/SetPasswordRequest.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/user/event/SetPasswordRequest.java
@@ -9,14 +9,17 @@ public class SetPasswordRequest extends FreeIpaClientRequest<SetPasswordResult> 
 
     private final String username;
 
+    private final String userCrn;
+
     private final String password;
 
     private final Optional<Instant> expirationInstant;
 
-    public SetPasswordRequest(Long stackId, String environment, String username, String password, Optional<Instant> expirationInstant) {
+    public SetPasswordRequest(Long stackId, String environment, String username, String userCrn, String password, Optional<Instant> expirationInstant) {
         super(stackId);
         this.environment = environment;
         this.username = username;
+        this.userCrn = userCrn;
         this.password = password;
         this.expirationInstant = expirationInstant;
     }
@@ -27,6 +30,10 @@ public class SetPasswordRequest extends FreeIpaClientRequest<SetPasswordResult> 
 
     public String getUsername() {
         return username;
+    }
+
+    public String getUserCrn() {
+        return userCrn;
     }
 
     public String getPassword() {
@@ -43,6 +50,7 @@ public class SetPasswordRequest extends FreeIpaClientRequest<SetPasswordResult> 
                 + "stackId='" + getResourceId() + '\''
                 + "environment='" + environment + '\''
                 + "username='" + username + '\''
+                + "userCrn='" + userCrn + '\''
                 + "expirationInstant=" + expirationInstant
                 + '}';
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/user/handler/SetPasswordHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/user/handler/SetPasswordHandler.java
@@ -2,6 +2,14 @@ package com.sequenceiq.freeipa.flow.freeipa.user.handler;
 
 import javax.inject.Inject;
 
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.cloudbreak.auth.security.InternalCrnBuilder;
+import com.sequenceiq.cloudbreak.logger.MDCUtils;
+import com.sequenceiq.freeipa.client.FreeIpaCapabilities;
+import com.sequenceiq.freeipa.client.FreeIpaClientException;
+import com.sequenceiq.freeipa.service.freeipa.user.UmsCredentialProvider;
+import com.sequenceiq.freeipa.service.freeipa.user.kerberos.KrbKeySetEncoder;
+import com.sequenceiq.freeipa.service.freeipa.user.model.WorkloadCredential;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -18,10 +26,16 @@ import com.sequenceiq.freeipa.service.stack.StackService;
 
 import reactor.bus.Event;
 
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Optional;
+
 @Component
 public class SetPasswordHandler implements EventHandler<SetPasswordRequest> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SetPasswordHandler.class);
+
+    private static final String IAM_INTERNAL_ACTOR_CRN = new InternalCrnBuilder(Crn.Service.IAM).getInternalCrnForServiceAsString();
 
     @Inject
     private StackService stackService;
@@ -29,9 +43,20 @@ public class SetPasswordHandler implements EventHandler<SetPasswordRequest> {
     @Inject
     private FreeIpaClientFactory freeIpaClientFactory;
 
+    @Inject
+    private UmsCredentialProvider umsCredentialProvider;
+
     @Override
     public String selector() {
         return EventSelectorUtil.selector(SetPasswordRequest.class);
+    }
+
+    private void setPasswordHashFromUms(FreeIpaClient freeIpaClient, String username, String userCrn,
+                                        Optional<Instant> passwordExpirationInstant) throws IOException, FreeIpaClientException {
+        WorkloadCredential workloadCredential = umsCredentialProvider.getCredentials(userCrn, MDCUtils.getRequestId());
+        String ansEncodedKrbPrincipalKey = KrbKeySetEncoder.getASNEncodedKrbPrincipalKey(workloadCredential.getKeys());
+        freeIpaClient.userSetPasswordHash(username, workloadCredential.getHashedPassword(), ansEncodedKrbPrincipalKey,
+                passwordExpirationInstant);
     }
 
     @Override
@@ -43,7 +68,14 @@ public class SetPasswordHandler implements EventHandler<SetPasswordRequest> {
             MDCBuilder.buildMdcContext(stack);
 
             FreeIpaClient freeIpaClient = freeIpaClientFactory.getFreeIpaClientForStack(stack);
-            freeIpaClient.userSetPasswordWithExpiration(request.getUsername(), request.getPassword(), request.getExpirationInstant());
+            if (FreeIpaCapabilities.hasSetPasswordHashSupport(freeIpaClient.getConfig())) {
+                LOGGER.info("IPA has password hash support, credentials information from UMS will be used.");
+                setPasswordHashFromUms(freeIpaClient, request.getUsername(), request.getUserCrn(), request.getExpirationInstant());
+            } else {
+                LOGGER.info("IPA does not have password hash support, using the provided password directly.");
+                freeIpaClient.userSetPasswordWithExpiration(
+                        request.getUsername(), request.getPassword(), request.getExpirationInstant());
+            }
             SetPasswordResult result = new SetPasswordResult(request);
             request.getResult().onNext(result);
         } catch (Exception e) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/PasswordService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/PasswordService.java
@@ -104,7 +104,7 @@ public class PasswordService {
 
             List<SetPasswordRequest> requests = new ArrayList<>();
             for (Stack stack : stacks) {
-                requests.add(triggerSetPassword(stack, stack.getEnvironmentCrn(), userId, password, expirationInstant));
+                requests.add(triggerSetPassword(stack, stack.getEnvironmentCrn(), userId, userCrn, password, expirationInstant));
             }
 
             List<SuccessDetails> success = new ArrayList<>();
@@ -162,8 +162,9 @@ public class PasswordService {
         }
     }
 
-    private SetPasswordRequest triggerSetPassword(Stack stack, String environment, String username, String password, Optional<Instant> expirationInstant) {
-        SetPasswordRequest request = new SetPasswordRequest(stack.getId(), environment, username, password, expirationInstant);
+    private SetPasswordRequest triggerSetPassword(Stack stack, String environment, String username, String userCrn,
+        String password, Optional<Instant> expirationInstant) {
+        SetPasswordRequest request = new SetPasswordRequest(stack.getId(), environment, username, userCrn, password, expirationInstant);
         freeIpaFlowManager.notify(request);
         return request;
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UmsCredentialProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UmsCredentialProvider.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetActorWorkloadCredentialsResponse;
+import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
+import com.sequenceiq.freeipa.service.freeipa.user.model.WorkloadCredential;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.time.Instant;
+import java.util.Optional;
+
+import static com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient.INTERNAL_ACTOR_CRN;
+
+@Component
+public class UmsCredentialProvider {
+
+    @Inject
+    private GrpcUmsClient grpcUmsClient;
+
+    public WorkloadCredential getCredentials(String userCrn, Optional<String> requestId) {
+        GetActorWorkloadCredentialsResponse response =
+                grpcUmsClient.getActorWorkloadCredentials(INTERNAL_ACTOR_CRN, userCrn, requestId);
+        long expirationDate = response.getPasswordHashExpirationDate();
+        Optional<Instant> expirationInstant = expirationDate == 0 ?
+                Optional.empty() : Optional.of(Instant.ofEpochMilli(expirationDate));
+        return new WorkloadCredential(response.getPasswordHash(), response.getKerberosKeysList(), expirationInstant);
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/freeipa/user/handler/SetPasswordHandlerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/freeipa/user/handler/SetPasswordHandlerTest.java
@@ -1,0 +1,70 @@
+package com.sequenceiq.freeipa.flow.freeipa.user.handler;
+
+import com.sequenceiq.freeipa.client.FreeIpaClient;
+import com.sequenceiq.freeipa.client.FreeIpaClientException;
+import com.sequenceiq.freeipa.client.model.Config;
+import com.sequenceiq.freeipa.flow.freeipa.user.event.SetPasswordRequest;
+import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
+import com.sequenceiq.freeipa.service.stack.StackService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.bus.Event;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+@ExtendWith(MockitoExtension.class)
+class SetPasswordHandlerTest {
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private FreeIpaClientFactory freeIpaClientFactory;
+
+    @InjectMocks
+    private SetPasswordHandler underTest;
+
+    @Test
+    void testWithPasswordHashSupport() throws FreeIpaClientException {
+        SetPasswordRequest request = new SetPasswordRequest(1L, "environment", "username", "userCrn", "password", Optional.empty());
+        FreeIpaClient mockFreeIpaClient = newfreeIpaClient(true);
+        when(freeIpaClientFactory.getFreeIpaClientForStack(any())).thenReturn(mockFreeIpaClient);
+
+        underTest.accept(new Event<>(request));
+
+        verify(mockFreeIpaClient, times(0)).userSetPasswordWithExpiration(any(), any(), any());
+    }
+
+    @Test
+    void testWithoutPasswordHashSupport() throws FreeIpaClientException {
+        SetPasswordRequest request = new SetPasswordRequest(1L, "environment", "username", "userCrn", "password", Optional.empty());
+        FreeIpaClient mockFreeIpaClient = newfreeIpaClient(false);
+        when(freeIpaClientFactory.getFreeIpaClientForStack(any())).thenReturn(mockFreeIpaClient);
+
+        underTest.accept(new Event<>(request));
+
+        verify(mockFreeIpaClient, times(1)).userSetPasswordWithExpiration(any(), any(), any());
+    }
+
+    private FreeIpaClient newfreeIpaClient(boolean hasPasswordHashSuppport) throws FreeIpaClientException {
+        FreeIpaClient mockFreeIpaClient = mock(FreeIpaClient.class);
+        Config config = mock(Config.class);
+        if (hasPasswordHashSuppport) {
+            when(config.getIpauserobjectclasses()).thenReturn(Set.of("cdpUserAttr"));
+        } else {
+            when(config.getIpauserobjectclasses()).thenReturn(Set.of());
+        }
+        when(mockFreeIpaClient.getConfig()).thenReturn(config);
+        return mockFreeIpaClient;
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UmsCredentialProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UmsCredentialProviderTest.java
@@ -1,0 +1,67 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ActorKerberosKey;
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetActorWorkloadCredentialsResponse;
+import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
+import com.sequenceiq.freeipa.service.freeipa.user.model.WorkloadCredential;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+@ExtendWith(MockitoExtension.class)
+class UmsCredentialProviderTest {
+
+    private static final long EXPIRATION_DATE = 1584045866111L;
+
+    private static final String PASSWORD_HASH = "passwordHash";
+
+    private static final ActorKerberosKey ACTOR_KERBEROS_KEY_01 = ActorKerberosKey.newBuilder().build();
+
+    private static final ActorKerberosKey ACTOR_KERBEROS_KEY_02 = ActorKerberosKey.newBuilder().build();
+
+    private static final List<ActorKerberosKey> ACTOR_KERBEROS_KEY_LIST = List.of(ACTOR_KERBEROS_KEY_01, ACTOR_KERBEROS_KEY_02);
+
+    @Mock
+    private GrpcUmsClient grpcUmsClient;
+
+    @InjectMocks
+    private UmsCredentialProvider underTest;
+
+    @Test
+    void testGetCredentials() {
+        GetActorWorkloadCredentialsResponse response = GetActorWorkloadCredentialsResponse.newBuilder()
+                .setPasswordHash(PASSWORD_HASH)
+                .addAllKerberosKeys(ACTOR_KERBEROS_KEY_LIST)
+                .setPasswordHashExpirationDate(EXPIRATION_DATE)
+                .build();
+        when(grpcUmsClient.getActorWorkloadCredentials(any(), eq("user"), any())).thenReturn(response);
+        WorkloadCredential credential = underTest.getCredentials("user", Optional.empty());
+        assertEquals(credential.getHashedPassword(), PASSWORD_HASH);
+        assertEquals(credential.getExpirationDate(), Optional.of(Instant.ofEpochMilli(EXPIRATION_DATE)));
+        assertTrue(credential.getKeys().containsAll(ACTOR_KERBEROS_KEY_LIST));
+    }
+
+    @Test
+    void testGetCredentialsNoExpiration() {
+        GetActorWorkloadCredentialsResponse response = GetActorWorkloadCredentialsResponse.newBuilder()
+                .setPasswordHash(PASSWORD_HASH)
+                .addAllKerberosKeys(ACTOR_KERBEROS_KEY_LIST)
+                .setPasswordHashExpirationDate(0)
+                .build();
+        when(grpcUmsClient.getActorWorkloadCredentials(any(), eq("user"), any())).thenReturn(response);
+        WorkloadCredential credential = underTest.getCredentials("user", Optional.empty());
+        assertEquals(credential.getExpirationDate(), Optional.empty());
+    }
+}


### PR DESCRIPTION
The setPassword call now uses the password hash and keys from UMS
when possible. Note that we plan to deprecate / remove this endpoint
soon, but for now the UI is still calling it and this behavior
will keep the UMS keys consistent with the keys in FreeIPA, which
is desirable for user keytab generation.