### PR TITLE
CB-6066 - Remove WebAppSec cors.enabled from topology.xml.j2

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -6,16 +6,6 @@
         <!-- {{ exposed }} -->
 
         <provider>
-            <role>webappsec</role>
-            <name>WebAppSec</name>
-            <enabled>true</enabled>
-            <param>
-                <name>cors.enabled</name>
-                <value>true</value>
-            </param>
-        </provider>
-
-        <provider>
            <role>federation</role>
            <name>SSOCookieProvider</name>
            <enabled>true</enabled>


### PR DESCRIPTION
This removes cors.enabled=true from the topology.xml. I am working on testing this on some real clusters. 