### PR TITLE
CB-5768 Add entitlement and enable feature flag for IDBroker mapping validation

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
@@ -44,6 +44,10 @@ public class EntitlementService {
         return isEntitlementRegistered(actorCrn, accountId, "CDP_FMS_CLUSTER_PROXY");
     }
 
+    public boolean cloudStorageValidationEnabled(String actorCrn, String accountId) {
+        return isEntitlementRegistered(actorCrn, accountId, "CDP_CLOUD_STORAGE_VALIDATION");
+    }
+
     public List<String> getEntitlements(String actorCrn, String accountId) {
         return getAccount(actorCrn, accountId).getEntitlementsList()
                 .stream()

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
@@ -31,6 +31,7 @@ import com.sequenceiq.cloudbreak.idbmms.model.MappingsConfig;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryClusterDetails;
 import com.sequenceiq.cloudbreak.telemetry.fluent.FluentConfigView;
 import com.sequenceiq.cloudbreak.util.PasswordUtil;
+import com.sequenceiq.cloudbreak.validation.ValidationResult;
 import com.sequenceiq.common.api.cloudstorage.AccountMappingBase;
 import com.sequenceiq.common.api.cloudstorage.CloudStorageRequest;
 import com.sequenceiq.common.api.cloudstorage.StorageIdentityBase;
@@ -119,7 +120,7 @@ public class StackRequestManifester {
             setupClusterRequest(stackRequest);
             prepareTelemetryForStack(stackRequest, environment, sdxCluster);
             setupCloudStorageAccountMapping(stackRequest, environment.getCrn(), environment.getIdBrokerMappingSource(), environment.getCloudPlatform());
-            cloudStorageValidator.validate(stackRequest.getCluster().getCloudStorage(), environment);
+            cloudStorageValidator.validate(stackRequest.getCluster().getCloudStorage(), environment, new ValidationResult.ValidationResultBuilder());
             return stackRequest;
         } catch (IOException e) {
             LOGGER.error("Can not parse JSON to stack request");

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/validation/cloudstorage/CloudStorageValidatorTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/validation/cloudstorage/CloudStorageValidatorTest.java
@@ -1,0 +1,80 @@
+package com.sequenceiq.datalake.service.validation.cloudstorage;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.providerservices.CloudProviderServicesV4Endopint;
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.service.secret.service.SecretService;
+import com.sequenceiq.cloudbreak.validation.ValidationResult.ValidationResultBuilder;
+import com.sequenceiq.common.api.cloudstorage.CloudStorageRequest;
+import com.sequenceiq.environment.api.v1.environment.model.base.CloudStorageValidation;
+import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
+
+@ExtendWith(MockitoExtension.class)
+public class CloudStorageValidatorTest {
+
+    private static final String ACCOUNT_ID = UUID.randomUUID().toString();
+
+    private static final String USER_CRN = "crn:cdp:iam:us-west-1:"
+            + ACCOUNT_ID + ":user:" + UUID.randomUUID().toString();
+
+    @Mock
+    private EntitlementService entitlementService;
+
+    @Mock
+    private SecretService secretService;
+
+    @Mock
+    private CloudProviderServicesV4Endopint cloudProviderServicesEndpoint;
+
+    @Mock
+    private DetailedEnvironmentResponse environment;
+
+    @InjectMocks
+    private CloudStorageValidator underTest;
+
+    @BeforeAll
+    static void setUp() {
+        ThreadBasedUserCrnProvider.setUserCrn(USER_CRN);
+    }
+
+    @Test
+    public void validateEnvironmentRequestCloudStorageValidationDisabled() {
+        CloudStorageRequest cloudStorageRequest = new CloudStorageRequest();
+        when(environment.getCloudStorageValidation()).thenReturn(CloudStorageValidation.DISABLED);
+        ValidationResultBuilder validationResultBuilder = new ValidationResultBuilder();
+        underTest.validate(cloudStorageRequest, environment, validationResultBuilder);
+        assertFalse(validationResultBuilder.build().hasError());
+    }
+
+    @Test
+    public void validateEnvironmentRequestCloudStorageValidationNoEntitlement() {
+        CloudStorageRequest cloudStorageRequest = new CloudStorageRequest();
+        when(environment.getCloudStorageValidation()).thenReturn(CloudStorageValidation.ENABLED);
+        when(entitlementService.cloudStorageValidationEnabled(any(), any())).thenReturn(false);
+        ValidationResultBuilder validationResultBuilder = new ValidationResultBuilder();
+        underTest.validate(cloudStorageRequest, environment, validationResultBuilder);
+        assertFalse(validationResultBuilder.build().hasError());
+    }
+
+    @Test
+    public void validateEnvironmentRequestCloudStorageValidationMissingEntitlement() {
+        CloudStorageRequest cloudStorageRequest = new CloudStorageRequest();
+        when(environment.getCloudStorageValidation()).thenReturn(CloudStorageValidation.ENABLED);
+        ValidationResultBuilder validationResultBuilder = new ValidationResultBuilder();
+        underTest.validate(cloudStorageRequest, environment, validationResultBuilder);
+        assertFalse(validationResultBuilder.build().hasError());
+    }
+}

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/EnvironmentRequest.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/EnvironmentRequest.java
@@ -82,7 +82,7 @@ public class EnvironmentRequest extends EnvironmentBaseRequest implements Creden
     private IdBrokerMappingSource idBrokerMappingSource = IdBrokerMappingSource.IDBMMS;
 
     @ApiModelProperty(EnvironmentModelDescription.CLOUD_STORAGE_VALIDATION)
-    private CloudStorageValidation cloudStorageValidation = CloudStorageValidation.DISABLED;
+    private CloudStorageValidation cloudStorageValidation = CloudStorageValidation.ENABLED;
 
     @ApiModelProperty(EnvironmentModelDescription.ADMIN_GROUP_NAME)
     private String adminGroupName;

--- a/mock-caas/src/main/java/com/sequenceiq/caas/grpc/service/MockUserManagementService.java
+++ b/mock-caas/src/main/java/com/sequenceiq/caas/grpc/service/MockUserManagementService.java
@@ -127,6 +127,8 @@ public class MockUserManagementService extends UserManagementGrpc.UserManagement
 
     private static final String CDP_FREEIPA_HA = "CDP_FREEIPA_HA";
 
+    private static final String CDP_CLOUD_STORAGE_VALIDATION = "CDP_CLOUD_STORAGE_VALIDATION";
+
     private static final String MOCK_RESOURCE = "mock_resource";
 
     @Inject
@@ -164,6 +166,9 @@ public class MockUserManagementService extends UserManagementGrpc.UserManagement
 
     @Value("${auth.mock.freeipa.ha.enable}")
     private boolean enableFreeIpaHa;
+
+    @Value("${auth.mock.cloudstoragevalidation.enable}")
+    private boolean enableCloudStorageValidation;
 
     private String cbLicense;
 
@@ -387,6 +392,9 @@ public class MockUserManagementService extends UserManagementGrpc.UserManagement
         }
         if (enableFreeIpaHa) {
             builder.addEntitlements(createEntitlement(CDP_FREEIPA_HA));
+        }
+        if (enableCloudStorageValidation) {
+            builder.addEntitlements(createEntitlement(CDP_CLOUD_STORAGE_VALIDATION));
         }
         responseObserver.onNext(
                 GetAccountResponse.newBuilder()

--- a/mock-caas/src/main/resources/application.yml
+++ b/mock-caas/src/main/resources/application.yml
@@ -15,3 +15,4 @@ auth:
     event-generation:
       expiration-minutes: 10
     freeipa.ha.enable: true
+    cloudstoragevalidation.enable: true


### PR DESCRIPTION
Adds IDBroker mapping validation as an entitlement and defaults the feature flag of environment request to true for IDBroker mapping validation. This lays the way to enable this per tenant in CDP in case there are issues with SimulatePrincipalPolicy due to IAM limits or other AWS issues (altus found that SimulatePrincipalPolicy is not always accurate). 