### PR TITLE
CDPCP-1533. Add operations to usersyncstatus

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/UserSyncStatus.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/UserSyncStatus.java
@@ -32,6 +32,12 @@ public class UserSyncStatus implements AccountIdAwareResource {
 
     private Long lastFullSyncEndTime;
 
+    @OneToOne
+    private Operation lastStartedFullSync;
+
+    @OneToOne
+    private Operation lastSuccessfulFullSync;
+
     public UserSyncStatus() {
     }
 
@@ -63,20 +69,56 @@ public class UserSyncStatus implements AccountIdAwareResource {
         this.umsEventGenerationIds = umsEventGenerationIds;
     }
 
+    /**
+     * Gets the last full sync start time.
+     * @deprecated information returned is redundant with {@link #getLastRequestedFullSync()}
+     */
+    @Deprecated
     public Long getLastFullSyncStartTime() {
         return lastFullSyncStartTime;
     }
 
+    /**
+     * Sets the last full sync start time.
+     * @deprecated information set is redundant with {@link #setLastRequestedFullSync(Operation)}
+     */
+    @Deprecated
     public void setLastFullSyncStartTime(Long lastFullSyncStartTime) {
         this.lastFullSyncStartTime = lastFullSyncStartTime;
     }
 
+    /**
+     * Sets the last full sync end time.
+     * @deprecated information returned is redundant with {@link #getLastSuccessfulFullSync()}
+     */
+    @Deprecated
     public Long getLastFullSyncEndTime() {
         return lastFullSyncEndTime;
     }
 
+    /**
+     * Sets the last full sync end time.
+     * @deprecated information set is redundant with {@link #setLastSuccessfulFullSync(Operation)}
+     */
+    @Deprecated
     public void setLastFullSyncEndTime(Long lastFullSyncEndTime) {
         this.lastFullSyncEndTime = lastFullSyncEndTime;
+    }
+
+    public Operation getLastStartedFullSync() {
+        return lastStartedFullSync;
+    }
+
+    public void setLastStartedFullSync(Operation lastStartedFullSync) {
+        this.lastStartedFullSync = lastStartedFullSync;
+    }
+
+    public Operation getLastSuccessfulFullSync() {
+        return lastSuccessfulFullSync;
+    }
+
+    public void setLastSuccessfulFullSync(Operation lastSuccessfulFullSync) {
+        this.lastSuccessfulFullSync = lastSuccessfulFullSync;
     }
 
     @Override

--- a/freeipa/src/main/resources/schema/app/20200313110708_CDPCP-1533_store_operations_in_user_sync_status.sql
+++ b/freeipa/src/main/resources/schema/app/20200313110708_CDPCP-1533_store_operations_in_user_sync_status.sql
@@ -1,0 +1,18 @@
+-- // CDPCP-1533 Add columns for storing operations in
+-- //            user sync status
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE usersyncstatus
+    ADD COLUMN IF NOT EXISTS laststartedfullsync_id bigint
+        CONSTRAINT fk_usersyncstatus_laststartedoperationid
+        REFERENCES operation,
+    ADD COLUMN IF NOT EXISTS lastsuccessfulfullsync_id bigint
+        CONSTRAINT fk_usersyncstatus_lastsuccessfuloperationid
+        REFERENCES operation;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE usersyncstatus
+    DROP COLUMN IF EXISTS laststartedfullsync_id,
+    DROP COLUMN IF EXISTS lastsuccessfulfullsync_id;

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/poller/CooldownCheckerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/poller/CooldownCheckerTest.java
@@ -1,12 +1,14 @@
 package com.sequenceiq.freeipa.service.freeipa.user.poller;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
 
 import org.junit.jupiter.api.Test;
 
+import com.sequenceiq.freeipa.entity.Operation;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.entity.UserSyncStatus;
 
@@ -15,7 +17,47 @@ class CooldownCheckerTest {
     private CooldownChecker underTest = new CooldownChecker();
 
     @Test
-    void testIsCool() throws Exception {
+    void testNullThrows() {
+        assertThrows(NullPointerException.class, () -> underTest.isCooldownExpired(null, Instant.now()));
+    }
+
+    @Test
+    void testNoStartTimeIsCool() {
+        Stack stack = UserSyncPollerTestUtils.createStack();
+        UserSyncStatus userSyncStatus = UserSyncPollerTestUtils.createUserSyncStatus(stack);
+        Instant cooldownExpiration = Instant.now();
+
+        assertTrue(underTest.isCooldownExpired(userSyncStatus, cooldownExpiration));
+    }
+
+    @Test
+    void testIsCool() {
+        Stack stack = UserSyncPollerTestUtils.createStack();
+        UserSyncStatus userSyncStatus = UserSyncPollerTestUtils.createUserSyncStatus(stack);
+        Instant cooldownExpiration = Instant.now();
+        long lastStartTime = cooldownExpiration.toEpochMilli() - 1L;
+        Operation lastRequestedOperation = new Operation();
+        lastRequestedOperation.setStartTime(lastStartTime);
+        userSyncStatus.setLastStartedFullSync(lastRequestedOperation);
+
+        assertTrue(underTest.isCooldownExpired(userSyncStatus, cooldownExpiration));
+    }
+
+    @Test
+    void testIsNotCool() {
+        Stack stack = UserSyncPollerTestUtils.createStack();
+        UserSyncStatus userSyncStatus = UserSyncPollerTestUtils.createUserSyncStatus(stack);
+        Instant cooldownExpiration = Instant.now();
+        long lastStartTime = cooldownExpiration.toEpochMilli() + 1L;
+        Operation lastRequestedOperation = new Operation();
+        lastRequestedOperation.setStartTime(lastStartTime);
+        userSyncStatus.setLastStartedFullSync(lastRequestedOperation);
+
+        assertFalse(underTest.isCooldownExpired(userSyncStatus, cooldownExpiration));
+    }
+
+    @Test
+    void testIsCoolDeprecated() {
         Stack stack = UserSyncPollerTestUtils.createStack();
         UserSyncStatus userSyncStatus = UserSyncPollerTestUtils.createUserSyncStatus(stack);
         Instant cooldownExpiration = Instant.now();
@@ -26,7 +68,7 @@ class CooldownCheckerTest {
     }
 
     @Test
-    void testIsNotCool() throws Exception {
+    void testIsNotCoolDeprecated() {
         Stack stack = UserSyncPollerTestUtils.createStack();
         UserSyncStatus userSyncStatus = UserSyncPollerTestUtils.createUserSyncStatus(stack);
         Instant cooldownExpiration = Instant.now();
@@ -36,4 +78,18 @@ class CooldownCheckerTest {
         assertFalse(underTest.isCooldownExpired(userSyncStatus, cooldownExpiration));
     }
 
+    @Test
+    void testIsCoolPrefersOperation() {
+        Stack stack = UserSyncPollerTestUtils.createStack();
+        UserSyncStatus userSyncStatus = UserSyncPollerTestUtils.createUserSyncStatus(stack);
+        Instant cooldownExpiration = Instant.now();
+        long coolTime = cooldownExpiration.toEpochMilli() - 1L;
+        long notCoolTime = cooldownExpiration.toEpochMilli() + 1L;
+        Operation lastRequestedOperation = new Operation();
+        lastRequestedOperation.setStartTime(coolTime);
+        userSyncStatus.setLastStartedFullSync(lastRequestedOperation);
+        userSyncStatus.setLastFullSyncStartTime(notCoolTime);
+
+        assertTrue(underTest.isCooldownExpired(userSyncStatus, cooldownExpiration));
+    }
 }


### PR DESCRIPTION
First part to the rolling update of the freeipa database schema
for tracking user sync status.

This commit adds the requested and successful operations to the
usersync status. The new lastrequestedoperation field is preferred
but lastsyncstarttime field is still used as a
fallback when calculating whether a stack is "cool" for the purposes
of automatic user sync polling.
