### PR TITLE
CB-6094 Disable Knox CM auto discovery

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxGatewayConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxGatewayConfigProvider.java
@@ -64,6 +64,8 @@ public class KnoxGatewayConfigProvider extends AbstractRoleConfigProvider {
 
     private static final String DEFAULT_TOPOLOGY = "cdp-proxy";
 
+    private static final String GATEWAY_CM_AUTO_DISCOVERY_ENABLED = "gateway_auto_discovery_enabled";
+
     @Inject
     private VirtualGroupService virtualGroupService;
 
@@ -83,6 +85,7 @@ public class KnoxGatewayConfigProvider extends AbstractRoleConfigProvider {
                 config.add(config(KNOX_MASTER_SECRET, masterSecret));
                 config.add(config(GATEWAY_DEFAULT_TOPOLOGY_NAME, topologyName));
                 config.add(config(GATEWAY_ADMIN_GROUPS, adminGroup));
+                config.add(config(GATEWAY_CM_AUTO_DISCOVERY_ENABLED, "false"));
                 if (gateway != null) {
                     config.add(config(GATEWAY_PATH, gateway.getPath()));
                     config.add(config(SIGNING_KEYSTORE_NAME, SIGNING_JKS));

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxGatewayConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxGatewayConfigProviderTest.java
@@ -161,6 +161,7 @@ public class KnoxGatewayConfigProviderTest {
                         config("gateway_default_topology_name",
                             gateway.getTopologies().iterator().next().getTopologyName()),
                         config("gateway_knox_admin_groups", ""),
+                        config("gateway_auto_discovery_enabled", "false"),
                         config("gateway_path", gateway.getPath()),
                         config("gateway_signing_keystore_name", "signing.jks"),
                         config("gateway_signing_keystore_type", "JKS"),
@@ -191,7 +192,8 @@ public class KnoxGatewayConfigProviderTest {
                 List.of(
                         config("gateway_master_secret", gcc.getPassword()),
                         config("gateway_default_topology_name", "cdp-proxy"),
-                        config("gateway_knox_admin_groups", "")
+                        config("gateway_knox_admin_groups", ""),
+                        config("gateway_auto_discovery_enabled", "false")
                 ),
                 underTest.getRoleConfigs(KnoxRoles.KNOX_GATEWAY, source)
         );
@@ -224,6 +226,7 @@ public class KnoxGatewayConfigProviderTest {
                 config("gateway_master_secret", gateway.getKnoxMasterSecret()),
                 config("gateway_default_topology_name", "cdp-proxy"),
                 config("gateway_knox_admin_groups", "knox_admins"),
+                config("gateway_auto_discovery_enabled", "false"),
                 config("gateway_path", gateway.getPath()),
                 config("gateway_signing_keystore_name", "signing.jks"),
                 config("gateway_signing_keystore_type", "JKS"),


### PR DESCRIPTION
As part of CDP DC, Knox is doing CM discovery of topologies which was previously disabled. However this should be disabled for CDP public cloud. This sets the config to back to false for CDP public cloud only.