### PR TITLE
CB-5904: Use CA DNS name for Kerberos and LDAP

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaModelDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaModelDescriptions.java
@@ -89,5 +89,7 @@ public class FreeIpaModelDescriptions {
         public static final String HOSTNAME = "Base hostname for FreeIPA servers";
         public static final String ADMIN_GROUP_NAME = "Name of the admin group to be used for all the services.";
         public static final String TAGS = "Tags on freeipa.";
+        public static final String FREEIPA_HOST = "A DNS load balanced FQDN to the FreeIPA servers";
+        public static final String FREEIPA_PORT = "The port for the load balanced FQDN to the FreeIPA servers";
     }
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/FreeIpaServerResponse.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/FreeIpaServerResponse.java
@@ -16,6 +16,12 @@ public class FreeIpaServerResponse extends FreeIpaServerBase {
     @ApiModelProperty(FreeIpaServerSettingsModelDescriptions.SERVER_IP)
     private Set<String> serverIp = new HashSet<>();
 
+    @ApiModelProperty(FreeIpaServerSettingsModelDescriptions.FREEIPA_HOST)
+    private String freeIpaHost;
+
+    @ApiModelProperty(FreeIpaServerSettingsModelDescriptions.FREEIPA_PORT)
+    private Integer freeIpaPort;
+
     public Set<String> getServerIp() {
         return serverIp;
     }
@@ -23,4 +29,21 @@ public class FreeIpaServerResponse extends FreeIpaServerBase {
     public void setServerIp(Set<String> serverIp) {
         this.serverIp = serverIp;
     }
+
+    public String getFreeIpaHost() {
+        return freeIpaHost;
+    }
+
+    public void setFreeIpaHost(String freeIpaHost) {
+        this.freeIpaHost = freeIpaHost;
+    }
+
+    public Integer getFreeIpaPort() {
+        return freeIpaPort;
+    }
+
+    public void setFreeIpaPort(Integer freeIpaPort) {
+        this.freeIpaPort = freeIpaPort;
+    }
+
 }

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
@@ -468,6 +468,19 @@ public class FreeIpaClient {
         return (DnsZone) invoke("dnszone_add", flags, params, DnsZone.class).getResult();
     }
 
+    public DnsRecord getDnsRecord(String dnsZoneName, String recordName) throws FreeIpaClientException {
+        List<String> flags = List.of(dnsZoneName, recordName);
+        Map<String, Object> params = Map.of();
+        return (DnsRecord) invoke("dnsrecord_show", flags, params, DnsRecord.class).getResult();
+    }
+
+    public DnsRecord addDnsCnameRecord(String dnsZoneName, String recordName, String cnameRecord) throws FreeIpaClientException {
+        List<String> flags = List.of(dnsZoneName, recordName);
+        Map<String, Object> params = Map.of(
+                "cnamerecord", Set.of(cnameRecord + "."));
+        return (DnsRecord) invoke("dnsrecord_add", flags, params, DnsRecord.class).getResult();
+    }
+
     public RPCResponse<Object> deleteDnsZone(String... dnsZoneNames) throws FreeIpaClientException {
         List<String> flags = List.of(dnsZoneNames);
         Map<String, Object> params = Map.of();

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/StackToDescribeFreeIpaResponseConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/StackToDescribeFreeIpaResponseConverter.java
@@ -29,6 +29,7 @@ import com.sequenceiq.freeipa.converter.telemetry.TelemetryConverter;
 import com.sequenceiq.freeipa.entity.FreeIpa;
 import com.sequenceiq.freeipa.entity.Image;
 import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.config.FreeIpaDomainUtils;
 
 @Component
 public class StackToDescribeFreeIpaResponseConverter {
@@ -67,6 +68,7 @@ public class StackToDescribeFreeIpaResponseConverter {
         describeFreeIpaResponse.setStatusString(stack.getStackStatus().getStatusString());
         describeFreeIpaResponse.setStatusReason(stack.getStackStatus().getStatusReason());
         decorateFreeIpaServerResponseWithIps(describeFreeIpaResponse.getFreeIpa(), describeFreeIpaResponse.getInstanceGroups());
+        decoreateFreeIpaServerResponseWithLoadBalancedHost(stack, describeFreeIpaResponse.getFreeIpa(), freeIpa);
         describeFreeIpaResponse.setAppVersion(stack.getAppVersion());
         decorateWithCloudStorgeAndTelemetry(stack, describeFreeIpaResponse);
         return describeFreeIpaResponse;
@@ -95,6 +97,13 @@ public class StackToDescribeFreeIpaResponseConverter {
                 cloudStorageResponse.setIdentities(identities);
                 response.setCloudStorage(cloudStorageResponse);
             }
+        }
+    }
+
+    private void decoreateFreeIpaServerResponseWithLoadBalancedHost(Stack stack, FreeIpaServerResponse freeIpaServerResponse, FreeIpa freeIpa) {
+        if (Objects.nonNull(freeIpaServerResponse)) {
+            freeIpaServerResponse.setFreeIpaHost(FreeIpaDomainUtils.getFreeIpaFqdn(freeIpa.getDomain()));
+            freeIpaServerResponse.setFreeIpaPort(stack.getGatewayport());
         }
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/config/FreeIpaDomainUtils.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/config/FreeIpaDomainUtils.java
@@ -1,0 +1,60 @@
+package com.sequenceiq.freeipa.service.config;
+
+public class FreeIpaDomainUtils {
+
+    private static final String IPA_CA_HOST = "ipa-ca";
+
+    private static final String KDC_HOST = "kdc";
+
+    private static final String KERBEROS_HOST = "kerberos";
+
+    private static final String LDAP_HOST = "ldap";
+
+    private static final String FREEIPA_HOST = "freeipa";
+
+    private static final String SEPARATOR = ".";
+
+    private FreeIpaDomainUtils() {
+    }
+
+    public static String getKerberosFqdn(String domain) {
+        return buildFqdn(KERBEROS_HOST, domain);
+    }
+
+    public static String getKerberosHost() {
+        return KERBEROS_HOST;
+    }
+
+    public static String getKdcFqdn(String domain) {
+        return buildFqdn(KDC_HOST, domain);
+    }
+
+    public static String getKdcHost() {
+        return KDC_HOST;
+    }
+
+    public static String getLdapFqdn(String domain) {
+        return buildFqdn(LDAP_HOST, domain);
+    }
+
+    public static String getLdapHost() {
+        return LDAP_HOST;
+    }
+
+    public static String getFreeIpaFqdn(String domain) {
+        return buildFqdn(FREEIPA_HOST, domain);
+    }
+
+    public static String getFreeIpaHost() {
+        return FREEIPA_HOST;
+    }
+
+    public static String getBuiltInFreeIpaDnsLoadBalancedName(String domain) {
+        return buildFqdn(IPA_CA_HOST, domain);
+    }
+
+    private static String buildFqdn(String host, String domain) {
+        return host + SEPARATOR + domain;
+    }
+
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/config/KerberosConfigRegisterService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/config/KerberosConfigRegisterService.java
@@ -40,8 +40,7 @@ public class KerberosConfigRegisterService extends AbstractConfigRegister {
             environmentCrn = stack.getEnvironmentCrn();
         }
         KerberosConfig kerberosConfig = new KerberosConfig();
-        InstanceMetaData master = getMasterInstance(stack);
-        kerberosConfig.setAdminUrl(master.getDiscoveryFQDN());
+        kerberosConfig.setAdminUrl(FreeIpaDomainUtils.getKerberosFqdn(freeIpa.getDomain()));
         kerberosConfig.setDomain(freeIpa.getDomain());
         kerberosConfig.setEnvironmentCrn(environmentCrn);
         kerberosConfig.setName(stack.getName());
@@ -52,8 +51,7 @@ public class KerberosConfigRegisterService extends AbstractConfigRegister {
                 .flatMap(instanceGroup -> instanceGroup.getNotDeletedInstanceMetaDataSet().stream()).collect(Collectors.toSet());
         String allFreeIpaIpJoined = allNotDeletedInstances.stream().map(InstanceMetaData::getPrivateIp).collect(Collectors.joining(","));
         kerberosConfig.setNameServers(allFreeIpaIpJoined);
-        String allNotDeletedIpaInstanceFQDNJoined = allNotDeletedInstances.stream().map(InstanceMetaData::getDiscoveryFQDN).collect(Collectors.joining(","));
-        kerberosConfig.setUrl(allNotDeletedIpaInstanceFQDNJoined);
+        kerberosConfig.setUrl(FreeIpaDomainUtils.getKdcFqdn(freeIpa.getDomain()));
         kerberosConfig.setPassword(StringUtils.isBlank(password) ? freeIpa.getAdminPassword() : password);
         kerberosConfig.setClusterName(clusterName);
         return kerberosConfigService.createKerberosConfig(kerberosConfig, stack.getAccountId());

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/config/LdapConfigRegisterService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/config/LdapConfigRegisterService.java
@@ -68,7 +68,7 @@ public class LdapConfigRegisterService extends AbstractConfigRegister {
         ldapConfig.setUserSearchBase(USER_SEARCH_BASE + domainComponent);
         ldapConfig.setGroupSearchBase(GROUP_SEARCH_BASE + domainComponent);
         ldapConfig.setUserDnPattern(USER_DN_PATTERN + domainComponent);
-        ldapConfig.setServerHost(getMasterInstance(stack).getDiscoveryFQDN());
+        ldapConfig.setServerHost(FreeIpaDomainUtils.getLdapFqdn(freeIpa.getDomain()));
         ldapConfig.setProtocol(PROTOCOL);
         ldapConfig.setServerPort(SERVER_PORT);
         ldapConfig.setDomain(freeIpa.getDomain());

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/DnsLoadBalanceSetupService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/DnsLoadBalanceSetupService.java
@@ -1,0 +1,49 @@
+package com.sequenceiq.freeipa.service.freeipa.flow;
+
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.freeipa.client.FreeIpaClient;
+import com.sequenceiq.freeipa.client.FreeIpaClientException;
+import com.sequenceiq.freeipa.client.FreeIpaClientExceptionUtil;
+import com.sequenceiq.freeipa.entity.FreeIpa;
+import com.sequenceiq.freeipa.service.config.FreeIpaDomainUtils;
+
+@Component
+public class DnsLoadBalanceSetupService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DnsLoadBalanceSetupService.class);
+
+    public void addDnsLoadBalancedEntries(FreeIpaClient client, FreeIpa freeIpa) throws FreeIpaClientException {
+        String domain = freeIpa.getDomain();
+        String loadBalancedName = FreeIpaDomainUtils.getBuiltInFreeIpaDnsLoadBalancedName(domain);
+        Set<String> cnames = Set.of(
+                FreeIpaDomainUtils.getKdcHost(),
+                FreeIpaDomainUtils.getKerberosHost(),
+                FreeIpaDomainUtils.getLdapHost(),
+                FreeIpaDomainUtils.getFreeIpaHost());
+
+        for (String cname : cnames) {
+            if (!hasDnsRecord(client, domain, cname)) {
+                client.addDnsCnameRecord(domain, cname, loadBalancedName);
+                LOGGER.debug("Added DNS cname for {}", cname);
+            } else {
+                LOGGER.debug("Skipping adding DNS cname for {} because it already exists", cname);
+            }
+        }
+    }
+
+    private boolean hasDnsRecord(FreeIpaClient client, String domain, String cname) throws FreeIpaClientException {
+        try {
+            client.getDnsRecord(domain, cname);
+            return true;
+        } catch (FreeIpaClientException e) {
+            if (FreeIpaClientExceptionUtil.isNotFoundException(e)) {
+                return false;
+            }
+            throw e;
+        }
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/config/KerberosConfigRegisterServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/config/KerberosConfigRegisterServiceTest.java
@@ -69,8 +69,8 @@ class KerberosConfigRegisterServiceTest {
         KerberosConfig kerberosConfig = kerberosConfigArgumentCaptor.getValue();
         assertEquals(stack.getName(), kerberosConfig.getName());
         assertEquals(stack.getEnvironmentCrn(), kerberosConfig.getEnvironmentCrn());
-        assertEquals(instanceMetaData.getDiscoveryFQDN(), kerberosConfig.getUrl());
-        assertEquals(instanceMetaData.getDiscoveryFQDN(), kerberosConfig.getAdminUrl());
+        assertEquals("kdc.testdomain.local", kerberosConfig.getUrl());
+        assertEquals("kerberos.testdomain.local", kerberosConfig.getAdminUrl());
         assertEquals(instanceMetaData.getPrivateIp(), kerberosConfig.getNameServers());
         assertEquals(freeIpa.getAdminPassword(), kerberosConfig.getPassword());
         assertEquals(freeIpa.getDomain(), kerberosConfig.getDomain());

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/config/LdapConfigRegisterServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/config/LdapConfigRegisterServiceTest.java
@@ -87,7 +87,7 @@ class LdapConfigRegisterServiceTest {
         assertEquals(ldapConfig.getUserSearchBase(), USER_SEARCH_BASE + domainComponent);
         assertEquals(ldapConfig.getGroupSearchBase(), GROUP_SEARCH_BASE + domainComponent);
         assertEquals(ldapConfig.getUserDnPattern(), USER_DN_PATTERN + domainComponent);
-        assertEquals(ldapConfig.getServerHost(), instanceMetaData.getDiscoveryFQDN());
+        assertEquals(ldapConfig.getServerHost(), "ldap.testdomain.local");
         assertEquals(ldapConfig.getProtocol(), PROTOCOL);
         assertEquals(ldapConfig.getServerPort(), SERVER_PORT);
         assertEquals(ldapConfig.getDomain(), freeIpa.getDomain());

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/flow/DnsLoadBalanceSetupServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/flow/DnsLoadBalanceSetupServiceTest.java
@@ -1,0 +1,65 @@
+package com.sequenceiq.freeipa.service.freeipa.flow;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.googlecode.jsonrpc4j.JsonRpcClientException;
+import com.sequenceiq.freeipa.client.FreeIpaClient;
+import com.sequenceiq.freeipa.client.FreeIpaClientException;
+import com.sequenceiq.freeipa.client.model.DnsRecord;
+import com.sequenceiq.freeipa.entity.FreeIpa;
+
+@ExtendWith(MockitoExtension.class)
+class DnsLoadBalanceSetupServiceTest {
+
+    private static final int NOT_FOUND = 4001;
+
+    private static final String DOMAIN = "example.com";
+
+    private static final String CNAME = "ipa-ca.example.com";
+
+    private static final Set<String> DNS_RECORDS = Set.of("ldap", "kdc", "kerberos", "freeipa");
+
+    private static final DnsRecord DNS_RECORD = new DnsRecord();
+
+    private static final FreeIpaClientException NOT_FOUND_EXCEPTION =
+            new FreeIpaClientException("not found", new JsonRpcClientException(NOT_FOUND, "not found", null));
+
+    private static final FreeIpa FREEIPA = new FreeIpa();
+
+    @InjectMocks
+    private DnsLoadBalanceSetupService underTest;
+
+    @Mock
+    private FreeIpaClient freeIpaClient;
+
+    @BeforeAll
+    static void setupFreeIpa() {
+        FREEIPA.setDomain(DOMAIN);
+    }
+
+    @Test
+    void testAddDnsLoadBalancedEntriesWhenTheyDontExist() throws FreeIpaClientException {
+        Mockito.when(freeIpaClient.getDnsRecord(Mockito.any(), Mockito.any())).thenThrow(NOT_FOUND_EXCEPTION);
+        Mockito.when(freeIpaClient.addDnsCnameRecord(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(DNS_RECORD);
+        underTest.addDnsLoadBalancedEntries(freeIpaClient, FREEIPA);
+        for (String dnsRecord : DNS_RECORDS) {
+            Mockito.verify(freeIpaClient).addDnsCnameRecord(DOMAIN, dnsRecord, CNAME);
+        }
+    }
+
+    @Test
+    void testAddDnsLoadBalancedEntriesWhenTheyAlreadyExist() throws FreeIpaClientException {
+        Mockito.when(freeIpaClient.getDnsRecord(Mockito.any(), Mockito.any())).thenReturn(DNS_RECORD);
+        underTest.addDnsLoadBalancedEntries(freeIpaClient, FREEIPA);
+        Mockito.verify(freeIpaClient, Mockito.never()).addDnsCnameRecord(Mockito.any(), Mockito.any(), Mockito.any());
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/freeipa/DnsRecordAddResponse.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/freeipa/DnsRecordAddResponse.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.it.cloudbreak.mock.freeipa;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.freeipa.client.model.DnsRecord;
+
+import spark.Request;
+import spark.Response;
+
+@Component
+public class DnsRecordAddResponse extends AbstractFreeIpaResponse<DnsRecord> {
+    @Override
+    public String method() {
+        return "dnsrecord_add";
+    }
+
+    @Override
+    protected DnsRecord handleInternal(Request request, Response response) {
+        DnsRecord dnsRecord = new DnsRecord();
+        dnsRecord.setIdnsname("localhost");
+        return dnsRecord;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/freeipa/DnsRecordShowResponse.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/freeipa/DnsRecordShowResponse.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.it.cloudbreak.mock.freeipa;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.freeipa.client.model.DnsRecord;
+
+import spark.Request;
+import spark.Response;
+
+@Component
+public class DnsRecordShowResponse extends AbstractFreeIpaResponse<DnsRecord> {
+    @Override
+    public String method() {
+        return "dnsrecord_show";
+    }
+
+    @Override
+    protected DnsRecord handleInternal(Request request, Response response) {
+        DnsRecord dnsRecord = new DnsRecord();
+        dnsRecord.setIdnsname("localhost");
+        return dnsRecord;
+    }
+}


### PR DESCRIPTION
The kerberos configuration and ldap configuration will use a DNS load
balanced entry. This will allow a failed client to reconnect to a
different server.

Some of the unit tests were updated and it was manually tested with an
LDAP client. The LDAP client tries the first DNS entry and on failure,
it can retry. FreeIPA returns the entries in a random order, so it
will eventually try a working node. Java can be configured to cache
good and bad nodes.

Closes #CB-5904