### PR TITLE
Re-enable 7.0.2 for upgrade

### DIFF
--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxEndpoint.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxEndpoint.java
@@ -24,6 +24,7 @@ import com.sequenceiq.cloudbreak.validation.ValidCrn;
 import com.sequenceiq.cloudbreak.validation.ValidStackNameFormat;
 import com.sequenceiq.cloudbreak.validation.ValidStackNameLength;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
+import com.sequenceiq.sdx.api.model.AdvertisedRuntime;
 import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
 import com.sequenceiq.sdx.api.model.SdxClusterRequest;
 import com.sequenceiq.sdx.api.model.SdxClusterResponse;
@@ -185,6 +186,12 @@ public interface SdxEndpoint {
     List<String> versions();
 
     @GET
+    @Path("/advertisedruntimes")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "list advertised datalake versions", produces = MediaType.APPLICATION_JSON, nickname = "advertisedruntimes")
+    List<AdvertisedRuntime> advertisedRuntimes();
+
+    @GET
     @Path("{name}/check_stack_upgrade")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "checks for upgrade options by name", nickname = "checkForStackUpgradeByName")
@@ -200,7 +207,7 @@ public interface SdxEndpoint {
     @Path("{name}/stack_upgrade/image/{image}")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "upgrades the datalake stack by name", nickname = "upgradeStackByName")
-    void upgradeStackByName(@PathParam("name") String name,  @PathParam("image") String imageId);
+    void upgradeStackByName(@PathParam("name") String name, @PathParam("image") String imageId);
 
     @POST
     @Path("/crn/{crn}/stack_upgrade/image/{image}")

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/AdvertisedRuntime.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/AdvertisedRuntime.java
@@ -1,0 +1,52 @@
+package com.sequenceiq.sdx.api.model;
+
+import java.util.Objects;
+
+public class AdvertisedRuntime {
+
+    private String runtimeVersion;
+
+    private boolean defaultRuntimeVersion;
+
+    public String getRuntimeVersion() {
+        return runtimeVersion;
+    }
+
+    public void setRuntimeVersion(String runtimeVersion) {
+        this.runtimeVersion = runtimeVersion;
+    }
+
+    public boolean isDefaultRuntimeVersion() {
+        return defaultRuntimeVersion;
+    }
+
+    public void setDefaultRuntimeVersion(boolean defaultRuntimeVersion) {
+        this.defaultRuntimeVersion = defaultRuntimeVersion;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AdvertisedRuntime that = (AdvertisedRuntime) o;
+        return defaultRuntimeVersion == that.defaultRuntimeVersion &&
+                Objects.equals(runtimeVersion, that.runtimeVersion);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(runtimeVersion, defaultRuntimeVersion);
+    }
+
+    @Override
+    public String toString() {
+        return "AdvertisedRuntime{" +
+                "runtimeVersion='" + runtimeVersion + '\'' +
+                ", defaultRuntimeVersion=" + defaultRuntimeVersion +
+                '}';
+    }
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
@@ -34,6 +34,7 @@ import com.sequenceiq.datalake.service.sdx.stop.SdxStopService;
 import com.sequenceiq.datalake.service.upgrade.SdxStackUpgradeService;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.sdx.api.endpoint.SdxEndpoint;
+import com.sequenceiq.sdx.api.model.AdvertisedRuntime;
 import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
 import com.sequenceiq.sdx.api.model.SdxClusterRequest;
 import com.sequenceiq.sdx.api.model.SdxClusterResponse;
@@ -264,6 +265,11 @@ public class SdxController implements SdxEndpoint {
     @CheckPermissionByAccount(action = AuthorizationResourceAction.READ)
     public List<String> versions() {
         return cdpConfigService.getDatalakeVersions();
+    }
+
+    @Override
+    public List<AdvertisedRuntime> advertisedRuntimes() {
+        return cdpConfigService.getAdvertisedRuntimes();
     }
 
     @Override

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -20,7 +20,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -103,9 +102,6 @@ public class SdxService implements ResourceIdProvider, ResourceBasedCrnProvider 
 
     @Inject
     private FlowCancelService flowCancelService;
-
-    @Value("${sdx.default.runtime:7.1.0}")
-    private String defaultRuntime;
 
     public Set<Long> findByResourceIdsAndStatuses(Set<Long> resourceIds, Set<DatalakeStatusEnum> statuses) {
         LOGGER.info("Searching for SDX cluster by ids and statuses.");
@@ -229,7 +225,7 @@ public class SdxService implements ResourceIdProvider, ResourceBasedCrnProvider 
         } else if (stackV4Request != null) {
             return null;
         } else {
-            return defaultRuntime;
+            return cdpConfigService.getDefaultRuntime();
         }
     }
 

--- a/datalake/src/main/resources/runtime/7.0.2/aws/light_duty.json
+++ b/datalake/src/main/resources/runtime/7.0.2/aws/light_duty.json
@@ -1,0 +1,52 @@
+{
+  "cluster": {
+    "blueprintName": "CDP 1.2 - SDX Light Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas",
+    "validateBlueprint": false
+  },
+  "customDomain": {
+    "domainName": "cloudera.site",
+    "hostgroupNameAsHostname": true
+  },
+  "instanceGroups": [
+    {
+      "name": "idbroker",
+      "template": {
+        "instanceType": "t3.medium",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 100,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 50
+        }
+      },
+      "nodeCount": 1,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "master",
+      "template": {
+        "instanceType": "m5.2xlarge",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 1,
+      "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    }
+  ]
+}

--- a/datalake/src/main/resources/runtime/7.0.2/aws/medium_duty_ha.json
+++ b/datalake/src/main/resources/runtime/7.0.2/aws/medium_duty_ha.json
@@ -1,0 +1,92 @@
+{
+  "cluster": {
+    "blueprintName": "CDP 1.2 - SDX Medium Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas",
+    "validateBlueprint": false
+  },
+  "customDomain": {
+    "domainName": "cloudera.site",
+    "hostgroupNameAsHostname": true
+  },
+  "instanceGroups": [
+    {
+      "name": "master",
+      "template": {
+        "instanceType": "m5.4xlarge",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 2,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "alpha",
+      "template": {
+        "instanceType": "m5.2xlarge",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 2,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "gateway",
+      "template": {
+        "instanceType": "m5.4xlarge",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 1,
+      "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "idbroker",
+      "template": {
+        "instanceType": "t3.medium",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 100,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 50
+        }
+      },
+      "nodeCount": 2,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    }
+  ]
+}

--- a/datalake/src/main/resources/runtime/7.0.2/azure/light_duty.json
+++ b/datalake/src/main/resources/runtime/7.0.2/azure/light_duty.json
@@ -1,0 +1,52 @@
+{
+  "cluster": {
+    "blueprintName": "CDP 1.2 - SDX Light Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas",
+    "validateBlueprint": false
+  },
+  "customDomain": {
+    "domainName": "cloudera.site",
+    "hostgroupNameAsHostname": true
+  },
+  "instanceGroups": [
+    {
+      "name": "idbroker",
+      "template": {
+        "instanceType": "Standard_D2s_v3",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 100,
+            "type": "StandardSSD_LRS"
+          }
+        ],
+        "rootVolume": {
+          "size": 50
+        }
+      },
+      "nodeCount": 1,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "master",
+      "template": {
+        "instanceType": "Standard_D8s_v3",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "StandardSSD_LRS"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 1,
+      "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    }
+  ]
+}

--- a/datalake/src/main/resources/runtime/7.0.2/azure/medium_duty_ha.json
+++ b/datalake/src/main/resources/runtime/7.0.2/azure/medium_duty_ha.json
@@ -1,0 +1,92 @@
+{
+  "cluster": {
+    "blueprintName": "CDP 1.2 - SDX Medium Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas",
+    "validateBlueprint": false
+  },
+  "customDomain": {
+    "domainName": "cloudera.site",
+    "hostgroupNameAsHostname": true
+  },
+  "instanceGroups": [
+    {
+      "name": "master",
+      "template": {
+        "instanceType": "Standard_D16s_v3",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "StandardSSD_LRS"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 2,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "alpha",
+      "template": {
+        "instanceType": "Standard_D16s_v3",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "StandardSSD_LRS"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 2,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "gateway",
+      "template": {
+        "instanceType": "Standard_D16s_v3",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "StandardSSD_LRS"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 1,
+      "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "idbroker",
+      "template": {
+        "instanceType": "Standard_D2s_v3",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 100,
+            "type": "StandardSSD_LRS"
+          }
+        ],
+        "rootVolume": {
+          "size": 50
+        }
+      },
+      "nodeCount": 2,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    }
+  ]
+}

--- a/datalake/src/main/resources/runtime/7.0.2/mock/light_duty.json
+++ b/datalake/src/main/resources/runtime/7.0.2/mock/light_duty.json
@@ -1,0 +1,64 @@
+{
+  "cluster": {
+    "blueprintName": "CDP 1.2 - SDX Light Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas",
+    "validateBlueprint": false
+  },
+  "gatewayPort": 9401,
+  "network": {
+    "mock": {
+      "vpcId": "mock-me-once-more",
+      "internetGatewayId": "youshallnotpass",
+      "subnetId": "1234567"
+    }
+  },
+  "image": {
+    "catalog": "mock-static-sdx-image-catalog",
+    "id": "f6e778fc-7f17-4535-9021-515351df3691"
+  },
+  "customDomain": {
+    "domainName": "cloudera.site",
+    "hostgroupNameAsHostname": true
+  },
+  "instanceGroups": [
+    {
+      "name": "idbroker",
+      "template": {
+        "instanceType": "large",
+        "rootVolume": {
+          "size": 50
+        },
+        "attachedVolumes": [
+          {
+            "size": 100,
+            "count": 1,
+            "type": "magnetic"
+          }
+        ]
+      },
+      "nodeCount": 1,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "master",
+      "template": {
+        "instanceType": "large",
+        "rootVolume": {
+          "size": 50
+        },
+        "attachedVolumes": [
+          {
+            "size": 100,
+            "count": 1,
+            "type": "magnetic"
+          }
+        ]
+      },
+      "nodeCount": 1,
+      "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    }
+  ]
+}

--- a/datalake/src/main/resources/runtime/7.0.2/yarn/light_duty.json
+++ b/datalake/src/main/resources/runtime/7.0.2/yarn/light_duty.json
@@ -1,0 +1,34 @@
+{
+  "cluster": {
+    "blueprintName": "CDP 1.2 - SDX Light Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas",
+    "validateBlueprint": false
+  },
+  "customDomain": {
+    "domainName": "cloudera.site",
+    "hostgroupNameAsHostname": true
+  },
+  "instanceGroups": [
+    {
+      "name": "idbroker",
+      "template": {
+        "yarn": {
+          "cpus": 4,
+          "memory": 16384
+        }
+      },
+      "nodeCount": 1,
+      "type": "CORE"
+    },
+    {
+      "name": "master",
+      "template": {
+        "yarn": {
+          "cpus": 4,
+          "memory": 16384
+        }
+      },
+      "nodeCount": 1,
+      "type": "GATEWAY"
+    }
+  ]
+}

--- a/datalake/src/main/resources/runtime/7.0.2/yarn/medium_duty_ha.json
+++ b/datalake/src/main/resources/runtime/7.0.2/yarn/medium_duty_ha.json
@@ -1,0 +1,56 @@
+{
+  "cluster": {
+    "blueprintName": "CDP 1.2 - SDX Light Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas",
+    "validateBlueprint": false
+  },
+  "customDomain": {
+    "domainName": "cloudera.site",
+    "hostgroupNameAsHostname": true
+  },
+  "instanceGroups": [
+    {
+      "name": "master",
+      "template": {
+        "yarn": {
+          "cpus": 4,
+          "memory": 16384
+        }
+      },
+      "nodeCount": 2,
+      "type": "CORE"
+    },
+    {
+      "name": "alpha",
+      "template": {
+        "yarn": {
+          "cpus": 4,
+          "memory": 16384
+        }
+      },
+      "nodeCount": 2,
+      "type": "CORE"
+    },
+    {
+      "name": "gateway",
+      "template": {
+        "yarn": {
+          "cpus": 4,
+          "memory": 16384
+        }
+      },
+      "nodeCount": 1,
+      "type": "CORE"
+    },
+    {
+      "name": "idbroker",
+      "template": {
+        "yarn": {
+          "cpus": 4,
+          "memory": 16384
+        }
+      },
+      "nodeCount": 2,
+      "type": "CORE"
+    }
+  ]
+}

--- a/datalake/src/test/java/com/sequenceiq/datalake/configuration/CDPConfigTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/configuration/CDPConfigTest.java
@@ -1,9 +1,11 @@
 package com.sequenceiq.datalake.configuration;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -11,22 +13,28 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.datalake.service.sdx.CDPConfigKey;
+import com.sequenceiq.sdx.api.model.AdvertisedRuntime;
 import com.sequenceiq.sdx.api.model.SdxClusterShape;
 
 @ExtendWith(MockitoExtension.class)
 class CDPConfigTest {
 
     @Spy
-    private Set<String> unsupportedRuntimes;
+    private Set<String> advertisedRuntimes;
+
+    @Spy
+    private Set<String> supportedRuntimes;
 
     @InjectMocks
     private CDPConfigService cdpConfigService;
 
     @Test
     void cdpStackRequests() {
+        when(supportedRuntimes.isEmpty()).thenReturn(true);
         cdpConfigService.initCdpStackRequests();
         assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.LIGHT_DUTY, "7.0.2")));
         assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.LIGHT_DUTY, "7.1.0")));
@@ -45,8 +53,10 @@ class CDPConfigTest {
     }
 
     @Test
-    void cdpDisabledStackRequests() {
-        when(unsupportedRuntimes.contains("7.0.2")).thenReturn(true);
+    void cdpEnableStackRequests() {
+        when(supportedRuntimes.isEmpty()).thenReturn(false);
+        when(supportedRuntimes.contains("7.0.2")).thenReturn(false);
+        when(supportedRuntimes.contains("7.1.0")).thenReturn(true);
         cdpConfigService.initCdpStackRequests();
         assertNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.LIGHT_DUTY, "7.0.2")));
         assertNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.MEDIUM_DUTY_HA, "7.0.2")));
@@ -65,23 +75,69 @@ class CDPConfigTest {
     }
 
     @Test
-    void cdpDisabledEveryStackRequests() {
-        when(unsupportedRuntimes.contains("7.0.2")).thenReturn(true);
-        when(unsupportedRuntimes.contains("7.1.0")).thenReturn(true);
+    void cdpEnableEveryStackRequests() {
+        when(supportedRuntimes.isEmpty()).thenReturn(false);
+        when(supportedRuntimes.contains("7.0.2")).thenReturn(true);
+        when(supportedRuntimes.contains("7.1.0")).thenReturn(true);
         cdpConfigService.initCdpStackRequests();
-        assertNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.LIGHT_DUTY, "7.0.2")));
-        assertNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.MEDIUM_DUTY_HA, "7.0.2")));
-        assertNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AZURE, SdxClusterShape.LIGHT_DUTY, "7.0.2")));
-        assertNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AZURE, SdxClusterShape.MEDIUM_DUTY_HA, "7.0.2")));
-        assertNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.YARN, SdxClusterShape.LIGHT_DUTY, "7.0.2")));
-        assertNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.YARN, SdxClusterShape.MEDIUM_DUTY_HA, "7.0.2")));
-        assertNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.MOCK, SdxClusterShape.LIGHT_DUTY, "7.0.2")));
-        assertNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.LIGHT_DUTY, "7.1.0")));
-        assertNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.MEDIUM_DUTY_HA, "7.1.0")));
-        assertNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AZURE, SdxClusterShape.LIGHT_DUTY, "7.1.0")));
-        assertNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AZURE, SdxClusterShape.MEDIUM_DUTY_HA, "7.1.0")));
-        assertNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.YARN, SdxClusterShape.LIGHT_DUTY, "7.1.0")));
-        assertNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.YARN, SdxClusterShape.MEDIUM_DUTY_HA, "7.1.0")));
-        assertNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.MOCK, SdxClusterShape.LIGHT_DUTY, "7.1.0")));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.LIGHT_DUTY, "7.0.2")));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.MEDIUM_DUTY_HA, "7.0.2")));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AZURE, SdxClusterShape.LIGHT_DUTY, "7.0.2")));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AZURE, SdxClusterShape.MEDIUM_DUTY_HA, "7.0.2")));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.YARN, SdxClusterShape.LIGHT_DUTY, "7.0.2")));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.YARN, SdxClusterShape.MEDIUM_DUTY_HA, "7.0.2")));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.MOCK, SdxClusterShape.LIGHT_DUTY, "7.0.2")));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.LIGHT_DUTY, "7.1.0")));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.MEDIUM_DUTY_HA, "7.1.0")));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AZURE, SdxClusterShape.LIGHT_DUTY, "7.1.0")));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AZURE, SdxClusterShape.MEDIUM_DUTY_HA, "7.1.0")));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.YARN, SdxClusterShape.LIGHT_DUTY, "7.1.0")));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.YARN, SdxClusterShape.MEDIUM_DUTY_HA, "7.1.0")));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.MOCK, SdxClusterShape.LIGHT_DUTY, "7.1.0")));
+    }
+
+    @Test
+    void testEmptyAdvertisedRuntimes() {
+        ReflectionTestUtils.setField(cdpConfigService, "defaultRuntime", "7.1.0");
+
+        when(supportedRuntimes.isEmpty()).thenReturn(false);
+        when(supportedRuntimes.contains("7.0.2")).thenReturn(true);
+        when(supportedRuntimes.contains("7.1.0")).thenReturn(true);
+
+        when(advertisedRuntimes.isEmpty()).thenReturn(true);
+
+        cdpConfigService.initCdpStackRequests();
+
+        List<AdvertisedRuntime> expected = List.of(rt("7.0.2", false), rt("7.1.0", true));
+        List<AdvertisedRuntime> actual = cdpConfigService.getAdvertisedRuntimes();
+
+        assertArrayEquals(expected.toArray(), actual.toArray());
+    }
+
+    @Test
+    void testAdvertisedRuntimes() {
+        ReflectionTestUtils.setField(cdpConfigService, "defaultRuntime", "7.1.0");
+
+        when(supportedRuntimes.isEmpty()).thenReturn(false);
+        when(supportedRuntimes.contains("7.0.2")).thenReturn(true);
+        when(supportedRuntimes.contains("7.1.0")).thenReturn(true);
+
+        when(advertisedRuntimes.isEmpty()).thenReturn(false);
+        when(advertisedRuntimes.contains("7.0.2")).thenReturn(false);
+        when(advertisedRuntimes.contains("7.1.0")).thenReturn(true);
+
+        cdpConfigService.initCdpStackRequests();
+
+        List<AdvertisedRuntime> expected = List.of(rt("7.1.0", true));
+        List<AdvertisedRuntime> actual = cdpConfigService.getAdvertisedRuntimes();
+
+        assertArrayEquals(expected.toArray(), actual.toArray());
+    }
+
+    private AdvertisedRuntime rt(String version, boolean defaultVersion) {
+        AdvertisedRuntime advertisedRuntime = new AdvertisedRuntime();
+        advertisedRuntime.setRuntimeVersion(version);
+        advertisedRuntime.setDefaultRuntimeVersion(defaultVersion);
+        return advertisedRuntime;
     }
 }

--- a/datalake/src/test/java/com/sequenceiq/datalake/configuration/CDPConfigTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/configuration/CDPConfigTest.java
@@ -28,25 +28,25 @@ class CDPConfigTest {
     @Test
     void cdpStackRequests() {
         cdpConfigService.initCdpStackRequests();
-//        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.LIGHT_DUTY, "7.0.2")));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.LIGHT_DUTY, "7.0.2")));
         assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.LIGHT_DUTY, "7.1.0")));
-//        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.MEDIUM_DUTY_HA, "7.0.2")));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.MEDIUM_DUTY_HA, "7.0.2")));
         assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.MEDIUM_DUTY_HA, "7.1.0")));
-//        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AZURE, SdxClusterShape.LIGHT_DUTY, "7.0.2")));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AZURE, SdxClusterShape.LIGHT_DUTY, "7.0.2")));
         assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AZURE, SdxClusterShape.LIGHT_DUTY, "7.1.0")));
-//        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AZURE, SdxClusterShape.MEDIUM_DUTY_HA, "7.0.2")));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AZURE, SdxClusterShape.MEDIUM_DUTY_HA, "7.0.2")));
         assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AZURE, SdxClusterShape.MEDIUM_DUTY_HA, "7.1.0")));
-//        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.YARN, SdxClusterShape.LIGHT_DUTY, "7.0.2")));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.YARN, SdxClusterShape.LIGHT_DUTY, "7.0.2")));
         assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.YARN, SdxClusterShape.LIGHT_DUTY, "7.1.0")));
-//        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.YARN, SdxClusterShape.MEDIUM_DUTY_HA, "7.0.2")));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.YARN, SdxClusterShape.MEDIUM_DUTY_HA, "7.0.2")));
         assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.YARN, SdxClusterShape.MEDIUM_DUTY_HA, "7.1.0")));
-//        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.MOCK, SdxClusterShape.LIGHT_DUTY, "7.0.2")));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.MOCK, SdxClusterShape.LIGHT_DUTY, "7.0.2")));
         assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.MOCK, SdxClusterShape.LIGHT_DUTY, "7.1.0")));
     }
 
     @Test
     void cdpDisabledStackRequests() {
-//        when(unsupportedRuntimes.contains("7.0.2")).thenReturn(true);
+        when(unsupportedRuntimes.contains("7.0.2")).thenReturn(true);
         cdpConfigService.initCdpStackRequests();
         assertNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.LIGHT_DUTY, "7.0.2")));
         assertNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.MEDIUM_DUTY_HA, "7.0.2")));
@@ -66,7 +66,7 @@ class CDPConfigTest {
 
     @Test
     void cdpDisabledEveryStackRequests() {
-        // when(unsupportedRuntimes.contains("7.0.2")).thenReturn(true);
+        when(unsupportedRuntimes.contains("7.0.2")).thenReturn(true);
         when(unsupportedRuntimes.contains("7.1.0")).thenReturn(true);
         cdpConfigService.initCdpStackRequests();
         assertNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.LIGHT_DUTY, "7.0.2")));


### PR DESCRIPTION
This is not going to have any effect on Mow Dev -> Prod, although it will help us to execute the upgrade tests easier in local dev.

Just set up -Ddatalake.supported.runtime=  in datalake. If you enable it, unfortunately, you need to be sure that you use the runtime dropdown on the UI because the 7.0.2 is selected as default. It is going to be solved with some UI changes in the near future.