### PR TITLE
CB-6225: health check not returning status of all hosts.

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
@@ -52,15 +52,29 @@ public class FreeIpaClient {
 
     private JsonRpcHttpClient jsonRpcHttpClient;
 
-    private String apiVersion;
+    private final String apiVersion;
 
-    public FreeIpaClient(JsonRpcHttpClient jsonRpcHttpClient) {
-        this(jsonRpcHttpClient, DEFAULT_API_VERSION);
+    private final String apiAddress;
+
+    private final String hostname;
+
+    public FreeIpaClient(JsonRpcHttpClient jsonRpcHttpClient, String apiAddress, String hostname) {
+        this(jsonRpcHttpClient, DEFAULT_API_VERSION, apiAddress, hostname);
     }
 
-    public FreeIpaClient(JsonRpcHttpClient jsonRpcHttpClient, String apiVersion) {
+    public FreeIpaClient(JsonRpcHttpClient jsonRpcHttpClient, String apiVersion, String apiAddress, String hostname) {
         this.jsonRpcHttpClient = jsonRpcHttpClient;
         this.apiVersion = apiVersion;
+        this.apiAddress = apiAddress;
+        this.hostname = hostname;
+    }
+
+    public String getApiAddress() {
+        return apiAddress;
+    }
+
+    public String getHostname() {
+        return hostname;
     }
 
     public User userShow(String user) throws FreeIpaClientException {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientBuilder.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientBuilder.java
@@ -78,18 +78,21 @@ public class FreeIpaClientBuilder {
 
     private final int port;
 
+    private final String hostname;
+
     private final HttpClientConfig clientConfig;
 
     private final RequestListener rpcRequestListener;
 
     private Map<String, String> additionalHeaders;
 
-    public FreeIpaClientBuilder(String user, String pass, HttpClientConfig clientConfig, int port, String basePath,
+    public FreeIpaClientBuilder(String user, String pass, HttpClientConfig clientConfig, String hostname, int port, String basePath,
             Map<String, String> additionalHeaders, JsonRpcClient.RequestListener rpcRequestListener) throws Exception {
         this.user = user;
         this.pass = pass;
         this.clientConfig = clientConfig;
         this.port = port;
+        this.hostname = hostname;
 
         if (clientConfig.hasSSLConfigs()) {
             this.sslContext =
@@ -112,8 +115,8 @@ public class FreeIpaClientBuilder {
         this.rpcRequestListener = rpcRequestListener;
     }
 
-    public FreeIpaClientBuilder(String user, String pass, HttpClientConfig clientConfig, int port) throws Exception {
-        this(user, pass, clientConfig, port, DEFAULT_BASE_PATH, Map.of(), null);
+    public FreeIpaClientBuilder(String user, String pass, HttpClientConfig clientConfig, int port, String hostname) throws Exception {
+        this(user, pass, clientConfig, hostname, port, DEFAULT_BASE_PATH, Map.of(), null);
     }
 
     public FreeIpaClient build(boolean withPing) throws URISyntaxException, IOException, FreeIpaClientException {
@@ -156,7 +159,7 @@ public class FreeIpaClientBuilder {
         jsonRpcHttpClient.setHostNameVerifier(hostnameVerifier());
         jsonRpcHttpClient.setReadTimeoutMillis(READ_TIMEOUT_MILLIS);
         jsonRpcHttpClient.setRequestListener(rpcRequestListener);
-        return new FreeIpaClient(jsonRpcHttpClient);
+        return new FreeIpaClient(jsonRpcHttpClient, clientConfig.getApiAddress(), hostname);
     }
 
     private String connect(String user, String pass, String apiAddress, int port)

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/Stack.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/Stack.java
@@ -323,6 +323,12 @@ public class Stack {
                 .collect(Collectors.toList());
     }
 
+    public List<InstanceMetaData> getAllInstanceMetaDataList() {
+        return instanceGroups.stream()
+                .flatMap(instanceGroup -> instanceGroup.getAllInstanceMetaData().stream())
+                .collect(Collectors.toList());
+    }
+
     public String getEnvironmentCrn() {
         return environmentCrn;
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactory.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactory.java
@@ -152,6 +152,7 @@ public class FreeIpaClientFactory {
         return new FreeIpaClientBuilder(ADMIN_USER,
                 freeIpa.getAdminPassword(),
                 httpClientConfig,
+                clusterProxyConfiguration.getClusterProxyHost(),
                 clusterProxyConfiguration.getClusterProxyPort(),
                 clusterProxyPath,
                 ADDITIONAL_CLUSTER_PROXY_HEADERS,
@@ -162,7 +163,8 @@ public class FreeIpaClientFactory {
         HttpClientConfig httpClientConfig = tlsSecurityService.buildTLSClientConfig(
                 stack, instanceMetaData.getPublicIpWrapper(), instanceMetaData);
         FreeIpa freeIpa = freeIpaService.findByStack(stack);
-        return new FreeIpaClientBuilder(ADMIN_USER, freeIpa.getAdminPassword(), httpClientConfig, stack.getGatewayport());
+        return new FreeIpaClientBuilder(ADMIN_USER, freeIpa.getAdminPassword(), httpClientConfig, stack.getGatewayport(),
+                instanceMetaData.getDiscoveryFQDN());
     }
 
     private FreeIpaClientException createFreeIpaStateIsInvalidException(Status stackStatus) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaHealthDetailsService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaHealthDetailsService.java
@@ -1,7 +1,7 @@
 package com.sequenceiq.freeipa.service.stack;
 
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -13,7 +13,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupType;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.HealthDetailsFreeIpaResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.NodeHealthDetails;
@@ -21,7 +20,6 @@ import com.sequenceiq.freeipa.client.FreeIpaClient;
 import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.client.model.RPCMessage;
 import com.sequenceiq.freeipa.client.model.RPCResponse;
-import com.sequenceiq.freeipa.entity.InstanceGroup;
 import com.sequenceiq.freeipa.entity.InstanceMetaData;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
@@ -53,35 +51,45 @@ public class FreeIpaHealthDetailsService {
 
     public HealthDetailsFreeIpaResponse getHealthDetails(String environmentCrn, String accountId) {
         Stack stack = stackService.getByEnvironmentCrnAndAccountIdWithLists(environmentCrn, accountId);
-        InstanceMetaData master = findMaster(stack);
-        Optional<RPCResponse<Boolean>> rpcResponse = Optional.empty();
-        try {
-            rpcResponse = Optional.ofNullable(checkFreeIpaHealth(stack, master));
-        } catch (FreeIpaClientException e) {
-            LOGGER.error("Unable to check the health of FreeIPA.", e);
+        List<InstanceMetaData> instances = stack.getAllInstanceMetaDataList();
+        HealthDetailsFreeIpaResponse response = new HealthDetailsFreeIpaResponse();
+
+        for (InstanceMetaData instance: instances) {
+            if (instance.isAvailable()) {
+                try {
+                    RPCResponse<Boolean> rpcResponse = checkFreeIpaHealth(stack,  instance);
+                    parseMessages(rpcResponse, response);
+                } catch (FreeIpaClientException e) {
+                    addUnreachableResponse(instance, response, e.getLocalizedMessage());
+                    LOGGER.error(String.format("Unable to check the health of FreeIPA instance: %s", instance.getInstanceId()), e);
+                }
+            } else {
+                NodeHealthDetails nodeResponse = new NodeHealthDetails();
+                response.addNodeHealthDetailsFreeIpaResponses(nodeResponse);
+                nodeResponse.setName(instance.getDiscoveryFQDN());
+                nodeResponse.setStatus(instance.getInstanceStatus());
+                nodeResponse.addIssue("Unable to check health as instance is " + instance.getInstanceStatus().name());
+            }
         }
-        return createResponse(stack, rpcResponse, master);
+        return updateResponse(stack, response);
     }
 
-    private HealthDetailsFreeIpaResponse createResponse(Stack stack, Optional<RPCResponse<Boolean>> rpcResponse, InstanceMetaData master) {
-        HealthDetailsFreeIpaResponse response = new HealthDetailsFreeIpaResponse();
+    private void addUnreachableResponse(InstanceMetaData instance, HealthDetailsFreeIpaResponse response, String issue) {
+        NodeHealthDetails nodeResponse = new NodeHealthDetails();
+        response.addNodeHealthDetailsFreeIpaResponses(nodeResponse);
+        nodeResponse.setName(instance.getDiscoveryFQDN());
+        nodeResponse.setStatus(InstanceStatus.UNREACHABLE);
+        nodeResponse.addIssue(issue);
+    }
+
+    private HealthDetailsFreeIpaResponse updateResponse(Stack stack, HealthDetailsFreeIpaResponse response) {
         response.setEnvironmentCrn(stack.getEnvironmentCrn());
         response.setCrn(stack.getResourceCrn());
-        if (rpcResponse.isPresent()) {
-            response.setName((String) rpcResponse.get().getValue());
-            parseMessages(rpcResponse.get(), response);
-            if (isOverallHealthy(response)) {
-                response.setStatus(DetailedStackStatus.PROVISIONED.getStatus());
-            } else {
-                response.setStatus(DetailedStackStatus.UNHEALTHY.getStatus());
-            }
+        response.setName(stack.getName());
+        if (isOverallHealthy(response)) {
+            response.setStatus(DetailedStackStatus.PROVISIONED.getStatus());
         } else {
-            response.setStatus(DetailedStackStatus.UNREACHABLE.getStatus());
-            NodeHealthDetails nodeResponse = new NodeHealthDetails();
-            response.addNodeHealthDetailsFreeIpaResponses(nodeResponse);
-            nodeResponse.setName(master.getDiscoveryFQDN());
-            nodeResponse.setStatus(InstanceStatus.UNREACHABLE);
-            nodeResponse.addIssue("Node is not responding.");
+            response.setStatus(DetailedStackStatus.UNHEALTHY.getStatus());
         }
         updateResponseWithInstanceIds(response, stack);
         return response;
@@ -99,15 +107,9 @@ public class FreeIpaHealthDetailsService {
                 .collect(Collectors.toMap(InstanceMetaData::getDiscoveryFQDN, InstanceMetaData::getInstanceId));
     }
 
-    private InstanceMetaData findMaster(Stack stack) {
-        InstanceGroup masterGroup = stack.getInstanceGroups().stream()
-                .filter(instanceGroup -> InstanceGroupType.MASTER == instanceGroup.getInstanceGroupType()).findFirst().get();
-        return masterGroup.getNotDeletedInstanceMetaDataSet().stream().findFirst().get();
-    }
-
-    private RPCResponse<Boolean> checkFreeIpaHealth(Stack stack, InstanceMetaData master) throws FreeIpaClientException {
+    private RPCResponse<Boolean> checkFreeIpaHealth(Stack stack, InstanceMetaData instance) throws FreeIpaClientException {
         FreeIpaClient freeIpaClient = freeIpaClientFactory.getFreeIpaClientForStack(stack);
-        return freeIpaClient.serverConnCheck(master.getDiscoveryFQDN(), master.getDiscoveryFQDN());
+        return freeIpaClient.serverConnCheck(freeIpaClient.getHostname(), instance.getDiscoveryFQDN());
     }
 
     private boolean isOverallHealthy(HealthDetailsFreeIpaResponse response) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/FreeipaChecker.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/FreeipaChecker.java
@@ -36,7 +36,7 @@ public class FreeipaChecker {
             FreeIpaClient freeIpaClient = checkedMeasure(() -> freeIpaClientFactory.getFreeIpaClientForStackWithPing(stack), LOGGER,
                     ":::Auto sync::: freeipa client is created in {}ms");
             String hostname = getPrimaryHostname(checkableInstances);
-            return checkedMeasure(() -> freeIpaClient.serverConnCheck(hostname, hostname), LOGGER,
+            return checkedMeasure(() -> freeIpaClient.serverConnCheck(freeIpaClient.getApiAddress(), hostname), LOGGER,
                     ":::Auto sync::: freeipa server_conncheck ran in {}ms");
         }, LOGGER, ":::Auto sync::: freeipa server status is checked in {}ms");
     }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/client/FreeIpaClientTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/client/FreeIpaClientTest.java
@@ -23,7 +23,7 @@ class FreeIpaClientTest {
 
     @BeforeEach
     void setUp() {
-        freeIpaClient = new FreeIpaClient(jsonRpcHttpClient);
+        freeIpaClient = new FreeIpaClient(jsonRpcHttpClient, "1.1.1.1", "localhost");
     }
 
     @Test

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaHealthServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaHealthServiceTest.java
@@ -2,13 +2,14 @@ package com.sequenceiq.freeipa.service.stack;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Assert;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -36,15 +37,11 @@ public class FreeIpaHealthServiceTest {
 
     private static final String ACCOUNT_ID = "accountId";
 
-    private static RPCResponse<Boolean> goodResponse;
-
-    private static RPCResponse<Boolean> doubleResponseOneBad;
-
-    private static RPCResponse<Boolean> errorResponse;
-
-    private static Stack stack;
-
     private static FreeIpaClientException ipaClientException;
+
+    private static final String HOST1 = "host1.domain";
+
+    private static final String HOST2 = "host2.domain";
 
     @Mock
     private StackService stackService;
@@ -55,9 +52,9 @@ public class FreeIpaHealthServiceTest {
     @InjectMocks
     private FreeIpaHealthDetailsService underTest;
 
-    private List<RPCMessage> getBaseMessages() {
+    private List<RPCMessage> getBaseMessages(String host) {
         List<RPCMessage> messages = new ArrayList<>();
-        messages.add(newRPCMessage("Check connection from master to remote replica 'freeipa.host.com':"));
+        messages.add(newRPCMessage("Check connection from master to remote replica '" + host + "':"));
         messages.add(newRPCMessage("   Directory Service: Unsecure port (389): OK"));
         messages.add(newRPCMessage("   Directory Service: Secure port (636): OK"));
         messages.add(newRPCMessage("   Directory Service: Secure port (636): OK"));
@@ -76,55 +73,26 @@ public class FreeIpaHealthServiceTest {
         return messages;
     }
 
-    private RPCResponse<Boolean> getGoodPayload() {
-        if (goodResponse == null) {
-            goodResponse = new RPCResponse<>();
-            goodResponse.setResult(Boolean.TRUE);
-            goodResponse.setValue("test.host.name");
-            goodResponse.setMessages(getBaseMessages());
-        }
+    private RPCResponse<Boolean> getGoodPayload(String host) {
+        RPCResponse<Boolean> goodResponse;
+        goodResponse = new RPCResponse<>();
+        goodResponse.setResult(Boolean.TRUE);
+        goodResponse.setValue(host);
+        goodResponse.setMessages(getBaseMessages(host));
         return goodResponse;
     }
 
-    private RPCResponse<Boolean> getErrorPayload() {
-        if (errorResponse == null) {
-            errorResponse = new RPCResponse<>();
-            errorResponse.setResult(Boolean.TRUE);
-            errorResponse.setValue("test.host.name");
-            errorResponse.setMessages(getBaseMessages());
-            errorResponse.getMessages().add(newRPCMessage("Failed to connect to port 464 tcp on 10.1.1.1"));
-            errorResponse.getMessages().add(newRPCMessage("   Kerberos Kpasswd: TCP (464): FAILED"));
-            errorResponse.getMessages().add(newRPCMessage("Failed to connect to port 636 tcp on 10.1.1.1"));
-            errorResponse.getMessages().add(newRPCMessage("   Directory Service: Secure port (636): OK"));
-        }
+    private RPCResponse<Boolean> getErrorPayload(String host) {
+        RPCResponse<Boolean> errorResponse;
+        errorResponse = new RPCResponse<>();
+        errorResponse.setResult(Boolean.TRUE);
+        errorResponse.setValue(host);
+        errorResponse.setMessages(getBaseMessages(host));
+        errorResponse.getMessages().add(newRPCMessage("Failed to connect to port 464 tcp on 10.1.1.1"));
+        errorResponse.getMessages().add(newRPCMessage("   Kerberos Kpasswd: TCP (464): FAILED"));
+        errorResponse.getMessages().add(newRPCMessage("Failed to connect to port 636 tcp on 10.1.1.1"));
+        errorResponse.getMessages().add(newRPCMessage("   Directory Service: Secure port (636): OK"));
         return errorResponse;
-    }
-
-    private RPCResponse<Boolean> getDoublePayload() {
-        if (doubleResponseOneBad == null) {
-            doubleResponseOneBad = new RPCResponse<>();
-            doubleResponseOneBad.setResult(Boolean.TRUE);
-            doubleResponseOneBad.setValue("test.host.name");
-            doubleResponseOneBad.setMessages(getBaseMessages());
-            doubleResponseOneBad.getMessages().add(newRPCMessage("Check connection from master to remote replica 'freeipa2.host.com':"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("   Directory Service: Unsecure port (389): OK"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("   Directory Service: Secure port (636): OK"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("   Directory Service: Secure port (636): OK"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("   Kerberos KDC: TCP (88): OK"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("Failed to connect to port 88 udp on 10.1.1.1"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("   Kerberos KDC: UDP (88): WARNING"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("Failed to connect to port 464 tcp on 10.1.1.1"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("   Kerberos Kpasswd: TCP (464): FAILED"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("Failed to connect to port 464 udp on 10.1.1.1"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("   Kerberos Kpasswd: UDP (464): WARNING"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("   HTTP Server: Unsecure port (80): OK"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("   HTTP Server: Secure port (443): OK"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("The following UDP ports could not be verified as open: 88, 464"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("This can happen if they are already bound to an application"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("and ipa-replica-conncheck cannot attach own UDP responder."));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("Connection from master to replica is OK."));
-        }
-        return doubleResponseOneBad;
     }
 
     private RPCMessage newRPCMessage(String message) {
@@ -134,27 +102,70 @@ public class FreeIpaHealthServiceTest {
         return msg;
     }
 
-    @BeforeAll
-    public static void init() {
-        stack = new Stack();
+    private Stack getGoodStack() {
+        Stack stack = new Stack();
         stack.setResourceCrn(ENVIRONMENT_ID);
         InstanceGroup instanceGroup = new InstanceGroup();
         stack.getInstanceGroups().add(instanceGroup);
         instanceGroup.setInstanceGroupType(InstanceGroupType.MASTER);
         InstanceMetaData instanceMetaData = new InstanceMetaData();
-        instanceMetaData.setDiscoveryFQDN("localhost");
+        instanceMetaData.setInstanceId("i-0123456789");
+        instanceMetaData.setDiscoveryFQDN(HOST1);
+        instanceMetaData.setInstanceStatus(InstanceStatus.CREATED);
+        instanceGroup.setInstanceMetaData(Sets.newHashSet(instanceMetaData));
+        return stack;
+    }
+
+    private Stack getGoodStackTwoInstances() {
+        Stack stack = new Stack();
+        stack.setResourceCrn(ENVIRONMENT_ID);
+        InstanceGroup instanceGroup = new InstanceGroup();
+        stack.getInstanceGroups().add(instanceGroup);
+        instanceGroup.setInstanceGroupType(InstanceGroupType.MASTER);
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+        instanceMetaData.setInstanceId("i-0123456789");
+        instanceMetaData.setDiscoveryFQDN(HOST1);
+        instanceMetaData.setInstanceStatus(InstanceStatus.CREATED);
+        instanceGroup.setInstanceMetaData(Sets.newHashSet(instanceMetaData));
+
+        instanceMetaData = new InstanceMetaData();
+        instanceMetaData.setInstanceId("i-9876543219");
+        instanceMetaData.setDiscoveryFQDN(HOST2);
+        instanceMetaData.setInstanceStatus(InstanceStatus.CREATED);
+        instanceGroup.getInstanceMetaData().add(instanceMetaData);
+        return stack;
+    }
+
+    private Stack getDeletedStack() {
+        Stack stack = new Stack();
+        stack.setResourceCrn(ENVIRONMENT_ID);
+        InstanceGroup instanceGroup = new InstanceGroup();
+        stack.getInstanceGroups().add(instanceGroup);
+        instanceGroup.setInstanceGroupType(InstanceGroupType.MASTER);
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+        instanceMetaData.setInstanceStatus(InstanceStatus.TERMINATED);
         instanceMetaData.setInstanceId("i-0123456789");
         instanceGroup.setInstanceMetaData(Sets.newHashSet(instanceMetaData));
-        instanceMetaData.setDiscoveryFQDN("host.domain");
+        instanceMetaData.setDiscoveryFQDN(HOST1);
+        return stack;
+    }
+
+    private FreeIpaClient getMockFreeIpaClient() {
+        return new FreeIpaClient(null, "1.1.1.1", "testhost");
+    }
+
+    @BeforeAll
+    public static void init() {
         ipaClientException = new FreeIpaClientException("failure");
     }
 
     @Test
     public void testHealthySingleNode() throws Exception {
         FreeIpaClient mockIpaClient = Mockito.mock(FreeIpaClient.class);
-        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(stack);
+        Mockito.when(mockIpaClient.getHostname()).thenReturn("test.host");
+        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(getGoodStack());
         Mockito.when(freeIpaClientFactory.getFreeIpaClientForStack(any())).thenReturn(mockIpaClient);
-        Mockito.when(mockIpaClient.serverConnCheck(anyString(), anyString())).thenReturn(getGoodPayload());
+        Mockito.when(mockIpaClient.serverConnCheck(anyString(), anyString())).thenReturn(getGoodPayload(HOST1));
         HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
         Assert.assertEquals(Status.AVAILABLE, response.getStatus());
         Assert.assertFalse(response.getNodeHealthDetails().isEmpty());
@@ -167,9 +178,10 @@ public class FreeIpaHealthServiceTest {
     @Test
     public void testUnhealthySingleNode() throws Exception {
         FreeIpaClient mockIpaClient = Mockito.mock(FreeIpaClient.class);
-        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(stack);
+        Mockito.when(mockIpaClient.getHostname()).thenReturn("test.host");
+        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(getGoodStack());
         Mockito.when(freeIpaClientFactory.getFreeIpaClientForStack(any())).thenReturn(mockIpaClient);
-        Mockito.when(mockIpaClient.serverConnCheck(anyString(), anyString())).thenReturn(getErrorPayload());
+        Mockito.when(mockIpaClient.serverConnCheck(anyString(), anyString())).thenReturn(getErrorPayload(HOST1));
         HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
         Assert.assertEquals(Status.UNHEALTHY, response.getStatus());
         Assert.assertFalse(response.getNodeHealthDetails().isEmpty());
@@ -182,28 +194,39 @@ public class FreeIpaHealthServiceTest {
     @Test
     public void testUnresponsiveSingleNode() throws Exception {
         FreeIpaClient mockIpaClient = Mockito.mock(FreeIpaClient.class);
-        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(stack);
+        Mockito.when(mockIpaClient.getHostname()).thenReturn("test.host");
+        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(getGoodStack());
         Mockito.when(freeIpaClientFactory.getFreeIpaClientForStack(any())).thenReturn(mockIpaClient);
         Mockito.when(mockIpaClient.serverConnCheck(anyString(), anyString())).thenThrow(ipaClientException);
         HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
-        Assert.assertEquals(Status.UNREACHABLE, response.getStatus());
-        Assert.assertFalse(response.getNodeHealthDetails().isEmpty());
+        Assert.assertEquals(Status.UNHEALTHY, response.getStatus());
+        Assert.assertTrue(response.getNodeHealthDetails().size() == 1);
         for (NodeHealthDetails nodeHealth:response.getNodeHealthDetails()) {
             Assert.assertEquals(InstanceStatus.UNREACHABLE, nodeHealth.getStatus());
             Assert.assertTrue(nodeHealth.getIssues().size() == 1);
-            Assert.assertTrue(nodeHealth.getIssues().get(0).equals("Node is not responding."));
+            Assert.assertTrue(nodeHealth.getIssues().get(0).equals("failure"));
         }
     }
 
     @Test
     public void testUnresponsiveSecondaryNode() throws Exception {
         FreeIpaClient mockIpaClient = Mockito.mock(FreeIpaClient.class);
-        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(stack);
+        Mockito.when(mockIpaClient.getHostname()).thenReturn("test.host");
+        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(getGoodStackTwoInstances());
         Mockito.when(freeIpaClientFactory.getFreeIpaClientForStack(any())).thenReturn(mockIpaClient);
-        Mockito.when(mockIpaClient.serverConnCheck(anyString(), anyString())).thenReturn(getDoublePayload());
+        Mockito.when(mockIpaClient.serverConnCheck(anyString(), eq(HOST1))).thenReturn(getGoodPayload(HOST1));
+        Mockito.when(mockIpaClient.serverConnCheck(anyString(), eq(HOST2))).thenThrow(ipaClientException);
         HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
         Assert.assertEquals(Status.AVAILABLE, response.getStatus());
-        Assert.assertFalse(response.getNodeHealthDetails().isEmpty());
+        Assert.assertTrue(response.getNodeHealthDetails().size() == 2);
     }
 
+    @Test
+    public void testNodeDeletedOnProvider() throws Exception {
+        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(getDeletedStack());
+        HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
+        Assert.assertEquals(Status.UNHEALTHY, response.getStatus());
+        Assert.assertFalse(response.getNodeHealthDetails().isEmpty());
+        Assert.assertTrue(response.getNodeHealthDetails().stream().findFirst().get().getStatus() == InstanceStatus.TERMINATED);
+    }
 }


### PR DESCRIPTION
This patch changes the health check to return individual
health of all HA nodes. The cn of the server_conncheck API
must be the host that the client is connected to. So we
exposed the connected hostname to use as the first parameter
of the API call.

Updated unit test.

Manually validated against 3 node FreeIPA and various levels of failure.

Also fixes:
CB-6226