### PR TITLE
CB-6238 downgrading spring boot for integration test

### DIFF
--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}"
+        classpath "org.springframework.boot:spring-boot-gradle-plugin:2.1.8.RELEASE"
     }
 }
 


### PR DESCRIPTION
spring boot jetty server was kind of incompatible with spark server usage of sslcontext. it has been downgraded just in integration tests

Closes 6238