### PR TITLE
CB-5317 Skip cleanup in case of image validation catalog

### DIFF
--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -443,13 +443,13 @@ cb:
               - http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-161/tars/parcel/NIFI-1.10.0.2.0.0.0-161.jar
               - http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-161/tars/parcel/NIFICA-1.10.0.2.0.0.0-161.jar
               - http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-161/tars/parcel/NIFIREGISTRY-0.5.0.2.0.0.0-161.jar
-        version: 7.1.0-1.cdh7.1.0.p0.1888074
+        version: 7.1.0-1.cdh7.1.0.p0.1922354
         minCM: 7.1
         repo:
           stack:
             repoid: CDH-7.1.0
-            redhat7: http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/1888074/cdh/7.x/parcels/
-            centos7: http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/1888074/cdh/7.x/parcels/
+            redhat7: http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/1922354/cdh/7.x/parcels/
+            centos7: http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/1922354/cdh/7.x/parcels/
 
   workspace.service.cache.ttl: 15
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/imagecatalog/ImageCatalogTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/imagecatalog/ImageCatalogTestDto.java
@@ -25,6 +25,8 @@ public class ImageCatalogTestDto extends AbstractCloudbreakTestDto<ImageCatalogV
 
     private ImagesV4Response imagesV4Response;
 
+    private Boolean skipCleanup = Boolean.FALSE;
+
     public ImageCatalogTestDto(TestContext testContext) {
         super(new ImageCatalogV4Request(), testContext);
     }
@@ -46,6 +48,11 @@ public class ImageCatalogTestDto extends AbstractCloudbreakTestDto<ImageCatalogV
 
     public ImageCatalogTestDto withUrl(String url) {
         getRequest().setUrl(url);
+        return this;
+    }
+
+    public ImageCatalogTestDto withoutCleanup() {
+        setSkipCleanup(Boolean.TRUE);
         return this;
     }
 
@@ -73,9 +80,15 @@ public class ImageCatalogTestDto extends AbstractCloudbreakTestDto<ImageCatalogV
         this.imagesV4Response = imagesV4Response;
     }
 
+    public void setSkipCleanup(Boolean skipCleanup) {
+        this.skipCleanup = skipCleanup;
+    }
+
     @Override
     public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
-        delete(context, getResponse(), cloudbreakClient);
+        if (!skipCleanup) {
+            delete(context, getResponse(), cloudbreakClient);
+        }
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/AbstractIntegrationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/AbstractIntegrationTest.java
@@ -133,6 +133,7 @@ public abstract class AbstractIntegrationTest extends AbstractMinimalTest {
         testContext.given(ImageCatalogTestDto.class)
                 .withUrl(url)
                 .withName(name)
+                .withoutCleanup()
                 .when(imageCatalogTestClient.createIfNotExistV4());
     }
 


### PR DESCRIPTION
We do not have to delete image validation source catalog aftet test, thus I added a logic to skip cleanup in this case