### PR TITLE
CDPCP-1735. Error message when getting user keytab on older FreeIPA

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/exception/UnsupportedException.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/exception/UnsupportedException.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.freeipa.controller.exception;
+
+import java.util.Objects;
+
+public class UnsupportedException extends RuntimeException {
+    public UnsupportedException(String message) {
+        super(message);
+    }
+
+    public UnsupportedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o instanceof UnsupportedException) {
+            return getMessage().equals(((Throwable) o).getMessage());
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getMessage());
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/mapper/UnsupportedExceptionMapper.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/mapper/UnsupportedExceptionMapper.java
@@ -1,0 +1,20 @@
+package com.sequenceiq.freeipa.controller.mapper;
+
+import com.sequenceiq.freeipa.controller.exception.UnsupportedException;
+import org.springframework.stereotype.Component;
+
+import javax.ws.rs.core.Response.Status;
+
+@Component
+public class UnsupportedExceptionMapper extends BaseExceptionMapper<UnsupportedException> {
+
+    @Override
+    Status getResponseStatus() {
+        return Status.FORBIDDEN;
+    }
+
+    @Override
+    Class<UnsupportedException> getExceptionType() {
+        return UnsupportedException.class;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/UserKeytabService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/UserKeytabService.java
@@ -8,10 +8,12 @@ import java.util.Optional;
 
 import javax.inject.Inject;
 
+import com.sequenceiq.freeipa.client.FreeIpaCapabilities;
 import com.sequenceiq.freeipa.client.FreeIpaClient;
 import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.client.model.User;
 import com.sequenceiq.freeipa.controller.exception.NotFoundException;
+import com.sequenceiq.freeipa.controller.exception.UnsupportedException;
 import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,11 +59,14 @@ public class UserKeytabService {
         }
     }
 
-    private void validateWorkloadUserInEnvironment(String workloadUsername, String environmentCrn) {
+    private void validateFreeIPAState(String workloadUsername, String environmentCrn) {
         String accountId = Crn.safeFromString(environmentCrn).getAccountId();
         FreeIpaClient freeIpaClient;
         try {
             freeIpaClient = freeIpaClientFactory.getFreeIpaClientByAccountAndEnvironment(environmentCrn, accountId);
+            if (!FreeIpaCapabilities.hasSetPasswordHashSupport(freeIpaClient.getConfig())) {
+                throw new UnsupportedException("User keytab retrieval requires a newer environment and FreeIPA version");
+            }
             Optional<User> user = freeIpaClient.userFind(workloadUsername);
             if (user.isEmpty()) {
                 throw new NotFoundException(String.format("Workload user %s has not been synced into environment %s", workloadUsername, environmentCrn));
@@ -80,7 +85,8 @@ public class UserKeytabService {
         GetActorWorkloadCredentialsResponse getActorWorkloadCredentialsResponse =
                 grpcUmsClient.getActorWorkloadCredentials(INTERNAL_ACTOR_CRN, userCrn, MDCUtils.getRequestId());
         String workloadUsername = getActorWorkloadCredentialsResponse.getWorkloadUsername();
-        validateWorkloadUserInEnvironment(workloadUsername, environmentCrn);
+
+        validateFreeIPAState(workloadUsername, environmentCrn);
 
         List<ActorKerberosKey> actorKerberosKeys = getActorWorkloadCredentialsResponse.getKerberosKeysList();
         return userKeytabGenerator.generateKeytabBase64(workloadUsername, realm, actorKerberosKeys);


### PR DESCRIPTION
The user keytabs we generate are only valid on FreeIPAs that have password
hash support. This change returns an appropriate error based on this.