### PR TITLE
CB-6307 Use pip list --no-index to avoid calls out to the internet

### DIFF
--- a/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/monitoring/init.sls
@@ -37,13 +37,13 @@
 install_pyyaml:
   cmd.run:
     - name: pip install PyYAML --ignore-installed
-    - unless: pip list | grep -E 'PyYAML'
+    - unless: pip list --no-index | grep -E 'PyYAML'
 
 {%- if monitoring.type == "cloudera_manager" %}
 install_cm_client:
   cmd.run:
     - name: pip install cm-client==40.0.3 --ignore-installed
-    - unless: pip list | grep -E 'cm-client.*40.0.3'
+    - unless: pip list --no-index | grep -E 'cm-client.*40.0.3'
 
 /opt/metrics-collector/cm_metrics_collector.py:
    file.managed:

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/init.sls
@@ -12,7 +12,7 @@ install-cloudera-manager-agent:
 install-psycopg2:
   cmd.run:
     - name: pip install psycopg2==2.7.5 --ignore-installed
-    - unless: pip list | grep -E 'psycopg2.*2.7.5'
+    - unless: pip list --no-index | grep -E 'psycopg2.*2.7.5'
 
 replace_server_host:
   file.replace:


### PR DESCRIPTION
Currently when pip is first invoked, the pip cache
is populated by reaching out to the internet. Using
--no-index will avoid this call out to pypi and
prevent the call out to the internet.

This is an optimization only. If pypi access is
blocked, then this won't fail even without using
--no-index. This prevents the call from happening
at all.