### PR TITLE
CB-6333 Remove dependency on ListBucket (List Objects)

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_backup
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_backup
@@ -96,19 +96,20 @@ doLog "INFO Running ${TYPE} IPA backup."
 
 # Perform a backup
 /sbin/ipa-backup $BACKUP_OPTIONS >> $LOGFILE 2>&1 || error_exit "ipa-backup failed! Aborting!"
+BACKUPDIR=$(basename $(ls -td ${config[backup_path]}/ipa-* | head -1))
 
 BACKUP_LOCATION="${config[backup_location]}/${BACKUP_PATH_POSTFIX}"
 doLog "DEBUG Uploading backup to ${BACKUP_LOCATION} on ${config[backup_platform]}"
 
 if [ "${config[backup_platform]}" = "AWS" ]; then
     doLog "INFO Syncing backups to AWS S3"
-    /usr/bin/aws s3 sync --sse AES256 --no-progress ${config[backup_path]} ${BACKUP_LOCATION} >> $LOGFILE 2>&1 || error_exit "Sync of backups to ${BACKUP_LOCATION} failed!"
+    /usr/bin/aws s3 cp --recursive --sse AES256 --no-progress ${config[backup_path]}${BACKUPDIR} ${BACKUP_LOCATION}/${BACKUPDIR} >> $LOGFILE 2>&1 || error_exit "Sync of backups to ${BACKUP_LOCATION} failed!"
     remove_local_backups
 elif [ "${config[backup_platform]}" = "AZURE" ]; then
     doLog "INFO  Syncing backups to Azure Blog Storage"
     /bin/keyctl new_session >> $LOGFILE 2>&1 || error_exit "Unable to setup keyring session"
     /usr/local/bin/azcopy login --identity --identity-resource-id "${config[azure_instance_msi]}" >> $LOGFILE 2>&1 || error_exit "Unable to login to Azure!"
-    /usr/local/bin/azcopy sync ${config[backup_path]} ${BACKUP_LOCATION} >> $LOGFILE 2>&1 || error_exit "Sync of backups to ${BACKUP_LOCATION} failed!"
+    /usr/local/bin/azcopy copy ${config[backup_path]}/${BACKUPDIR} ${BACKUP_LOCATION} --recursive=true >> $LOGFILE 2>&1 || error_exit "Sync of backups to ${BACKUP_LOCATION} failed!"
     remove_local_backups
 fi
 


### PR DESCRIPTION
This changes the command to upload the backups to the cloud provider
to be a simple copy instead of a sync to that a ListBucket permission
is not needed.

Closes #CB-6333