### PR TITLE
CB-6043: FreeIPA management service should retry FreeIPA APIs

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
@@ -89,7 +89,7 @@ public interface FreeIpaV1Endpoint {
     @Produces(MediaType.TEXT_PLAIN)
     @ApiOperation(value = FreeIpaOperationDescriptions.GET_ROOTCERTIFICATE_BY_ENVID, produces = MediaType.TEXT_PLAIN, notes = FreeIpaNotes.FREEIPA_NOTES,
             nickname = "getFreeIpaRootCertificateByEnvironmentV1")
-    String getRootCertificate(@QueryParam("environment") @NotEmpty String environmentCrn);
+    String getRootCertificate(@QueryParam("environment") @NotEmpty String environmentCrn) throws Exception;
 
     @DELETE
     @Path("")

--- a/freeipa-client/build.gradle
+++ b/freeipa-client/build.gradle
@@ -22,6 +22,7 @@ dependencies {
   implementation     group: 'org.apache.commons',               name: 'commons-lang3',               version: apacheCommonsLangVersion
   implementation     group: 'org.bouncycastle',                 name: 'bcprov-jdk15on',              version: bouncycastleVersion
   implementation     group: 'org.bouncycastle',                 name: 'bcpkix-jdk15on',              version: bouncycastleVersion
+  implementation     group: 'org.springframework',              name: 'spring-web',                  version: springFrameworkVersion
   testImplementation group: 'org.mockito',                      name: 'mockito-core',                version: mockitoVersion
   testCompile        group: 'junit',                            name: 'junit',                       version: junitVersion
 }

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
@@ -554,6 +554,10 @@ public class FreeIpaClient {
                 throw new NullPointerException("JSON-RPC response is null");
             }
             return response;
+        } catch (Exception e) {
+            String message = String.format("Invoke FreeIpa failed: %s", e.getLocalizedMessage());
+            LOGGER.error(message, e);
+            throw FreeIpaClientExceptionUtil.convertToRetryableIfNeeded(new FreeIpaClientException(message, e));
         } catch (Throwable throwable) {
             String message = String.format("Invoke FreeIpa failed: %s", throwable.getLocalizedMessage());
             LOGGER.error(message, throwable);

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientException.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientException.java
@@ -21,6 +21,11 @@ public class FreeIpaClientException extends Exception {
         statusCode = OptionalInt.empty();
     }
 
+    public FreeIpaClientException(String message, Throwable cause, OptionalInt statusCode) {
+        super(message, cause);
+        this.statusCode = statusCode;
+    }
+
     public OptionalInt getStatusCode() {
         return statusCode;
     }

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientExceptionUtil.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientExceptionUtil.java
@@ -1,35 +1,244 @@
 package com.sequenceiq.freeipa.client;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.http.HttpStatus;
 
 import com.googlecode.jsonrpc4j.JsonRpcClientException;
 
 public class FreeIpaClientExceptionUtil {
 
-    public static final int NOT_MAPPED_ERROR_CODE = 4000;
+    // See https://github.com/freeipa/freeipa/blob/master/ipalib/errors.py
+    public enum ErrorCodes {
+        PUBLIC_ERROR(900),
+        VERSION_ERROR(901),
+        UNKNOWN_ERROR(902),
+        INTERNAL_ERROR(903),
+        SERVER_INTERNAL_ERROR(904),
+        COMMAND_ERROR(905),
+        SERVER_COMMAND_ERROR(906),
+        NETWORK_ERROR(907),
+        SERVER_NETWORK_ERROR(908),
+        JSON_ERROR(909),
+        XML_RPC_MARSHALL_ERROR(910),
+        REFERER_ERROR(911),
+        ENVIRONMENT_ERROR(912),
+        SYSTEM_ENCODING_ERROR(913),
+        AUTHENTICATION_ERROR(1000),
+        KERBEROS_ERROR(1100),
+        CCACHE_ERROR(1101),
+        SERVICE_ERROR(1102),
+        NO_CACHE_ERROR(1103),
+        TICKET_EXPIRED(1104),
+        BAD_CCACHE_PERMS(1105),
+        BAD_CCACHE_FORMAT(1106),
+        CANNOT_RESOLVE_KDC(1107),
+        SESSION_ERROR(1200),
+        INVALID_SESSION_PASSWORD(1201),
+        PASSWORD_EXPIRED(1202),
+        KRB_PRINCIPAL_EXPIRED(1203),
+        USER_LOCKED(1204),
+        AUTHORIZATION_ERROR(2000),
+        ACI_ERROR(2100),
+        INVOCATION_ERROR(3000),
+        ENCODING_ERROR(3001),
+        BINARY_ENCODING_ERROR(3002),
+        ZERO_ARGUMENT_ERROR(3003),
+        MAX_ARGUMENT_ERROR(3004),
+        OPTION_ERROR(3005),
+        OVERLAP_ERROR(3006),
+        REQUIREMENT_ERROR(3007),
+        CONVERSION_ERROR(3008),
+        VALIDATION_ERROR(3009),
+        NO_SUCH_NAMESPACE_ERROR(3010),
+        PASSWORD_MISMATCH(3011),
+        NOT_IMPLEMENTED_ERROR(3012),
+        NOT_CONFIGURED_ERROR(3013),
+        PROMPT_FAILED(3014),
+        DEPRECATION_ERROR(3015),
+        NOT_A_FOREST_ROOT_ERROR(3016),
+        EXECUTION_ERROR(4000),
+        NOT_FOUND(4001),
+        DUPLICATE_ENTRY(4002),
+        HOST_SERVICE(4003),
+        MALFORMED_SERVICE_PRINCIPAL(4004),
+        REALM_MISMATCH(4005),
+        REQUIRES_ROOT(4006),
+        ALREADY_POSIX_GROUP(4007),
+        MALFORMED_USER_PRINCIPAL(4008),
+        ALREADY_ACTIVE(4009),
+        ALREADY_INACTIVE(4010),
+        HAS_NS_ACCOUNT_LOCK(4011),
+        NOT_GROUP_MEMBER(4012),
+        RECURSIVE_GROUP(4013),
+        ALREADY_GROUP_MEMBER(4014),
+        BASE64_DECODE_ERROR(4015),
+        REMOTE_RETRIEVE_ERROR(4016),
+        SAME_GROUP_ERROR(4017),
+        DEFAULT_GROUP_ERROR(4018),
+        MANAGED_GROUP_ERROR(4020),
+        MANAGED_POLICY_ERROR(4021),
+        FILE_ERROR(4022),
+        NO_CERTIFICATE_ERROR(4023),
+        MANAGED_GROUP_EXISTS_ERROR(4024),
+        REVERSE_MEMBER_ERROR(4025),
+        ATTRIBUTE_VALUE_NOT_FOUND(4026),
+        SINGLE_MATCH_EXPECTED(4027),
+        ALREADY_EXTERNAL_GROUP(4028),
+        EXTERNAL_GROUP_VIOLATION(4029),
+        POSIX_GROUP_VIOLATION(4030),
+        EMPTY_RESULT(4031),
+        INVALID_DOMAIN_LEVEL_ERROR(4032),
+        SERVER_REMOVAL_ERROR(4033),
+        OPERATION_NOT_SUPPORTED_FOR_PRINCIPAL_TYPE(4034),
+        HTTP_REQUEST_ERROR(4035),
+        REDUNDANT_MAPPING_RULE(4036),
+        CSR_TEMPLATE_ERROR(4037),
+        BUILTIN_ERROR(4100),
+        HELP_ERROR(4101),
+        LDAP_ERROR(4200),
+        MIDAIR_COLLISION(4201),
+        EMPTY_MODLIST(4202),
+        DATABASE_ERROR(4203),
+        LIMIT_EXCEEDED(4204),
+        OBJECTCLASS_VIOLATION(4205),
+        NOT_ALLOWED_ON_RDN(4206),
+        ONLY_ONE_VALUE_ALLOWED(4207),
+        INVALID_SYNTAX(4208),
+        BAD_SEARCH_FILTER(4209),
+        NOT_ALLOWED_ON_NON_LEAF(4210),
+        DATABASE_TIMEOUT(4211),
+        TASK_TIMEOUT(4213),
+        TIME_LIMIT_EXCEEDED(4214),
+        SIZE_LIMIT_EXCEEDED(4215),
+        ADMIN_LIMIT_EXCEEDED(4216),
+        CERTIFICATE_ERROR(4300),
+        CERTIFICATE_OPERATION_ERROR(4301),
+        CERTIFICATE_FORMAT_ERROR(4302),
+        MUTUALLY_EXCLUSIVE_ERROR(4303),
+        NON_FATAL_ERROR(4304),
+        ALREADY_REGISTERED_ERROR(4305),
+        NOT_REGISTERED_ERROR(4306),
+        DEPENDENT_ENTRY(4307),
+        LAST_MEMBER_ERROR(4308),
+        PROTECTED_ENTRY_ERROR(4309),
+        CERTIFICATE_INVALID_ERROR(4310),
+        SCHEMA_UP_TO_DATE(4311),
+        DNS_ERROR(4400),
+        DNS_NOT_A_RECORED_ERROR(4019),
+        DNS_DATA_MISMATCH(4212),
+        DNS_RESOLVER_ERROR(4401),
+        TRUST_ERROR(4500),
+        TRUST_TOPOLOGY_CONFLICT_ERROR(4501),
+        GENERIC_ERROR(5000);
 
-    public static final int NOT_FOUND_ERROR_CODE = 4001;
+        private final int value;
 
-    public static final int DUPLICATE_ENTRY_ERROR_CODE = 4002;
+        ErrorCodes(int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return value;
+        }
+    }
+
+    private static final Map<Integer, ErrorCodes> ERROR_CODES_LOOKUP = new HashMap<>();
+
+    private static final Set<ErrorCodes> RETRYABLE_HTTP_CODES = Set.of(
+            ErrorCodes.NETWORK_ERROR,
+            ErrorCodes.SERVER_NETWORK_ERROR,
+            ErrorCodes.REFERER_ERROR,
+            ErrorCodes.AUTHENTICATION_ERROR,
+            ErrorCodes.KERBEROS_ERROR,
+            ErrorCodes.CCACHE_ERROR,
+            ErrorCodes.SERVICE_ERROR,
+            ErrorCodes.NO_CACHE_ERROR,
+            ErrorCodes.TICKET_EXPIRED,
+            ErrorCodes.BAD_CCACHE_PERMS,
+            ErrorCodes.BAD_CCACHE_FORMAT,
+            ErrorCodes.CANNOT_RESOLVE_KDC,
+            ErrorCodes.SESSION_ERROR,
+            ErrorCodes.INVALID_SESSION_PASSWORD,
+            ErrorCodes.AUTHORIZATION_ERROR,
+            ErrorCodes.HTTP_REQUEST_ERROR,
+            ErrorCodes.MIDAIR_COLLISION,
+            ErrorCodes.LIMIT_EXCEEDED,
+            ErrorCodes.DATABASE_TIMEOUT,
+            ErrorCodes.TASK_TIMEOUT,
+            ErrorCodes.TIME_LIMIT_EXCEEDED,
+            ErrorCodes.SIZE_LIMIT_EXCEEDED,
+            ErrorCodes.ADMIN_LIMIT_EXCEEDED,
+            ErrorCodes.NON_FATAL_ERROR,
+            ErrorCodes.GENERIC_ERROR
+    );
+
+    private static Set<Integer> retryableHttpCodes = Set.of(
+            HttpStatus.UNAUTHORIZED,
+            HttpStatus.PROXY_AUTHENTICATION_REQUIRED,
+            HttpStatus.REQUEST_TIMEOUT,
+            HttpStatus.TOO_MANY_REQUESTS,
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            HttpStatus.BAD_GATEWAY,
+            HttpStatus.SERVICE_UNAVAILABLE,
+            HttpStatus.GATEWAY_TIMEOUT,
+            HttpStatus.BANDWIDTH_LIMIT_EXCEEDED,
+            HttpStatus.NETWORK_AUTHENTICATION_REQUIRED
+    )
+            .stream()
+            .map(s -> s.value())
+            .collect(Collectors.toSet());
+
+    static {
+        for (ErrorCodes errorCode : ErrorCodes.values()) {
+            ERROR_CODES_LOOKUP.put(errorCode.value, errorCode);
+        }
+    }
 
     private FreeIpaClientExceptionUtil() {
     }
 
     public static boolean isNotFoundException(FreeIpaClientException e) {
-        return isExceptionWithErrorCode(e, Set.of(NOT_FOUND_ERROR_CODE));
+        return isExceptionWithErrorCode(e, Set.of(ErrorCodes.NOT_FOUND));
     }
 
     public static boolean isDuplicateEntryException(FreeIpaClientException e) {
-        return isExceptionWithErrorCode(e, Set.of(DUPLICATE_ENTRY_ERROR_CODE));
+        return isExceptionWithErrorCode(e, Set.of(ErrorCodes.DUPLICATE_ENTRY));
     }
 
-    public static boolean isExceptionWithErrorCode(FreeIpaClientException e, Set<Integer> errorCodes) {
-        return Optional.ofNullable(e.getCause())
+    public static boolean isExceptionWithErrorCode(FreeIpaClientException e, Set<ErrorCodes> errorCodes) {
+        return Optional.ofNullable(getAncestorCauseBeforeFreeIpaClientExceptions(e))
                 .filter(JsonRpcClientException.class::isInstance)
                 .map(JsonRpcClientException.class::cast)
                 .map(JsonRpcClientException::getCode)
+                .flatMap(c -> Optional.ofNullable(ERROR_CODES_LOOKUP.get(c)))
                 .filter(c -> errorCodes.contains(c))
                 .isPresent();
+    }
+
+    public static FreeIpaClientException convertToRetryableIfNeeded(FreeIpaClientException e) {
+        if (isRetryable(e)) {
+            return new RetryableFreeIpaClientException(e.getLocalizedMessage(), e, e.getStatusCode());
+        } else {
+            return e;
+        }
+    }
+
+    private static boolean isRetryable(FreeIpaClientException e) {
+        return isExceptionWithErrorCode(e, RETRYABLE_HTTP_CODES) ||
+                (e.getStatusCode().isPresent() &&
+                retryableHttpCodes.contains(e.getStatusCode().getAsInt()));
+    }
+
+    public static Throwable getAncestorCauseBeforeFreeIpaClientExceptions(FreeIpaClientException e) {
+        FreeIpaClientException currentException = e;
+        while (currentException.getCause() instanceof FreeIpaClientException) {
+            currentException = (FreeIpaClientException) currentException.getCause();
+        }
+        return currentException.getCause();
     }
 }

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientExceptionWrapper.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientExceptionWrapper.java
@@ -1,0 +1,11 @@
+package com.sequenceiq.freeipa.client;
+
+public class FreeIpaClientExceptionWrapper extends RuntimeException {
+    public FreeIpaClientExceptionWrapper(FreeIpaClientException e) {
+        super(e);
+    }
+
+    public FreeIpaClientException getWrappedException() {
+        return (FreeIpaClientException) getCause();
+    }
+}

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/RetryableFreeIpaClientException.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/RetryableFreeIpaClientException.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.freeipa.client;
+
+import java.util.OptionalInt;
+
+public class RetryableFreeIpaClientException extends FreeIpaClientException {
+
+    public static final String MAX_RETRIES_EXPRESSION = "#{${freeipa.client.retry.retries}}";
+
+    public static final String DELAY_EXPRESSION = "#{${freeipa.client.retry.delay}}";
+
+    public static final String MULTIPLIER_EXPRESSION = "#{${freeipa.client.retry.multiplier}}";
+
+    private final Exception exceptionForRestApi;
+
+    public RetryableFreeIpaClientException(String message, Throwable cause) {
+        super(message, cause);
+        this.exceptionForRestApi = null;
+    }
+
+    public RetryableFreeIpaClientException(String message, Throwable cause, OptionalInt statusCode) {
+        super(message, cause, statusCode);
+        this.exceptionForRestApi = null;
+    }
+
+    public RetryableFreeIpaClientException(String message, RetryableFreeIpaClientException cause, Exception exceptionForRestApi) {
+        super(message, cause, cause.getStatusCode());
+        this.exceptionForRestApi = exceptionForRestApi;
+    }
+
+    public Exception getExceptionForRestApi() {
+        return exceptionForRestApi;
+    }
+}

--- a/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/FreeIpaClientExceptionUtilV1Test.java
+++ b/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/FreeIpaClientExceptionUtilV1Test.java
@@ -1,12 +1,17 @@
 package com.sequenceiq.freeipa.client;
 
+import java.util.Set;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 
 import com.googlecode.jsonrpc4j.JsonRpcClientException;
 
 public class FreeIpaClientExceptionUtilV1Test {
     private static final String MESSAGE = "exception message";
+
+    private static final int AUTHENTICATION_ERROR = 1000;
 
     private static final int NOT_FOUND = 4001;
 
@@ -28,6 +33,76 @@ public class FreeIpaClientExceptionUtilV1Test {
                 new JsonRpcClientException(DUPLICATE_ENTRY, MESSAGE, null))));
         Assertions.assertFalse(FreeIpaClientExceptionUtil.isDuplicateEntryException(new FreeIpaClientException(MESSAGE,
                 new JsonRpcClientException(NOT_FOUND, MESSAGE, null))));
+    }
+
+    @Test
+    public void testIsExceptionWithErrorCode() throws Exception {
+        Assertions.assertFalse(FreeIpaClientExceptionUtil.isExceptionWithErrorCode(
+                new FreeIpaClientException(MESSAGE,
+                        new IllegalStateException(MESSAGE)),
+                Set.of(FreeIpaClientExceptionUtil.ErrorCodes.DUPLICATE_ENTRY)));
+        Assertions.assertFalse(FreeIpaClientExceptionUtil.isExceptionWithErrorCode(
+                new FreeIpaClientException(MESSAGE,
+                        new JsonRpcClientException(NOT_FOUND, MESSAGE, null)),
+                Set.of(FreeIpaClientExceptionUtil.ErrorCodes.DUPLICATE_ENTRY)));
+        Assertions.assertTrue(FreeIpaClientExceptionUtil.isExceptionWithErrorCode(
+                new FreeIpaClientException(MESSAGE,
+                        new JsonRpcClientException(DUPLICATE_ENTRY, MESSAGE, null)),
+                Set.of(FreeIpaClientExceptionUtil.ErrorCodes.DUPLICATE_ENTRY)));
+        Assertions.assertTrue(FreeIpaClientExceptionUtil.isExceptionWithErrorCode(
+                new FreeIpaClientException(MESSAGE,
+                        new JsonRpcClientException(DUPLICATE_ENTRY, MESSAGE, null)),
+                Set.of(FreeIpaClientExceptionUtil.ErrorCodes.DUPLICATE_ENTRY, FreeIpaClientExceptionUtil.ErrorCodes.COMMAND_ERROR)));
+    }
+
+    @Test
+    public void testIsExceptionWithErrorCodeWrappedFreeIpaClientException() throws Exception {
+        Assertions.assertFalse(FreeIpaClientExceptionUtil.isExceptionWithErrorCode(
+                new FreeIpaClientException(MESSAGE, new FreeIpaClientException(MESSAGE,
+                        new IllegalStateException(MESSAGE))),
+                Set.of(FreeIpaClientExceptionUtil.ErrorCodes.DUPLICATE_ENTRY)));
+        Assertions.assertFalse(FreeIpaClientExceptionUtil.isExceptionWithErrorCode(
+                new FreeIpaClientException(MESSAGE, new FreeIpaClientException(MESSAGE,
+                        new JsonRpcClientException(NOT_FOUND, MESSAGE, null))),
+                Set.of(FreeIpaClientExceptionUtil.ErrorCodes.DUPLICATE_ENTRY)));
+        Assertions.assertTrue(FreeIpaClientExceptionUtil.isExceptionWithErrorCode(
+                new FreeIpaClientException(MESSAGE, new FreeIpaClientException(MESSAGE,
+                        new JsonRpcClientException(DUPLICATE_ENTRY, MESSAGE, null))),
+                Set.of(FreeIpaClientExceptionUtil.ErrorCodes.DUPLICATE_ENTRY)));
+        Assertions.assertTrue(FreeIpaClientExceptionUtil.isExceptionWithErrorCode(
+                new FreeIpaClientException("", new FreeIpaClientException(MESSAGE,
+                        new JsonRpcClientException(DUPLICATE_ENTRY, MESSAGE, null))),
+                Set.of(FreeIpaClientExceptionUtil.ErrorCodes.DUPLICATE_ENTRY, FreeIpaClientExceptionUtil.ErrorCodes.COMMAND_ERROR)));
+    }
+
+    @Test
+    public void testConvertToRetryableIfNeeded() throws Exception {
+        Assertions.assertTrue(FreeIpaClientExceptionUtil.convertToRetryableIfNeeded(
+                new FreeIpaClientException(MESSAGE, new JsonRpcClientException(AUTHENTICATION_ERROR, MESSAGE, null)))
+                instanceof RetryableFreeIpaClientException);
+        Assertions.assertFalse(FreeIpaClientExceptionUtil.convertToRetryableIfNeeded(
+                new FreeIpaClientException(MESSAGE, new JsonRpcClientException(NOT_FOUND, MESSAGE, null)))
+                instanceof RetryableFreeIpaClientException);
+        Assertions.assertTrue(FreeIpaClientExceptionUtil.convertToRetryableIfNeeded(
+                new FreeIpaClientException(MESSAGE, HttpStatus.UNAUTHORIZED.value()))
+                instanceof RetryableFreeIpaClientException);
+        Assertions.assertFalse(FreeIpaClientExceptionUtil.convertToRetryableIfNeeded(
+                new FreeIpaClientException(MESSAGE, HttpStatus.OK.value()))
+                instanceof RetryableFreeIpaClientException);
+    }
+
+    @Test
+    public void testGetAncestorCauseBeforeFreeIpaClientExceptions() {
+        Assertions.assertNull(FreeIpaClientExceptionUtil.getAncestorCauseBeforeFreeIpaClientExceptions(new FreeIpaClientException(MESSAGE)));
+        Throwable ancestor = new IllegalStateException(MESSAGE);
+        Assertions.assertEquals(ancestor,
+                FreeIpaClientExceptionUtil.getAncestorCauseBeforeFreeIpaClientExceptions(new FreeIpaClientException(MESSAGE, ancestor)));
+        Assertions.assertEquals(ancestor,
+                FreeIpaClientExceptionUtil.getAncestorCauseBeforeFreeIpaClientExceptions(
+                        new FreeIpaClientException(MESSAGE, new FreeIpaClientException(MESSAGE, ancestor))));
+        Assertions.assertEquals(ancestor,
+                FreeIpaClientExceptionUtil.getAncestorCauseBeforeFreeIpaClientExceptions(
+                        new FreeIpaClientException(MESSAGE, new FreeIpaClientException(MESSAGE, new FreeIpaClientException(MESSAGE, ancestor)))));
     }
 
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientBuilder.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientBuilder.java
@@ -190,11 +190,11 @@ public class FreeIpaClientBuilder {
                     }
                 }
 
-                throw new FreeIpaClientException(String.format("Encountered unexpected response from "
-                        + "FreeIPA; details:%n%n"
+                throw FreeIpaClientExceptionUtil.convertToRetryableIfNeeded(new FreeIpaClientException(String.format(
+                        "Encountered unexpected response from FreeIPA; details:%n%n"
                         + "code: %s%n"
                         + "headers: %s", response.getStatusLine().getStatusCode(), response.getAllHeaders()),
-                        response.getStatusLine().getStatusCode());
+                        response.getStatusLine().getStatusCode()));
             }
         }
         Cookie sessionCookie = cookieStore.getCookies().stream().filter(cookie -> "ipa_session".equalsIgnoreCase(cookie.getName())).findFirst().get();

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/client/RetryableFreeIpaClientService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/client/RetryableFreeIpaClientService.java
@@ -1,0 +1,19 @@
+package com.sequenceiq.freeipa.client;
+
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.util.CheckedFunction;
+
+@Service
+public class RetryableFreeIpaClientService {
+
+    @Retryable(value = RetryableFreeIpaClientException.class,
+            maxAttemptsExpression = RetryableFreeIpaClientException.MAX_RETRIES_EXPRESSION,
+            backoff = @Backoff(delayExpression = RetryableFreeIpaClientException.DELAY_EXPRESSION,
+                    multiplierExpression = RetryableFreeIpaClientException.MULTIPLIER_EXPRESSION))
+    public <T> T invokeWithRetries(CheckedFunction<Void, T, Exception> f) throws Exception {
+        return f.apply(null);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/DnsV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/DnsV1Controller.java
@@ -7,6 +7,8 @@ import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
 
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Controller;
 
 import com.sequenceiq.authorization.annotation.CheckPermissionByAccount;
@@ -18,6 +20,7 @@ import com.sequenceiq.freeipa.api.v1.dns.model.AddDnsZoneForSubnetIdsRequest;
 import com.sequenceiq.freeipa.api.v1.dns.model.AddDnsZoneForSubnetsRequest;
 import com.sequenceiq.freeipa.api.v1.dns.model.AddDnsZoneForSubnetsResponse;
 import com.sequenceiq.freeipa.client.FreeIpaClientException;
+import com.sequenceiq.freeipa.client.RetryableFreeIpaClientException;
 import com.sequenceiq.freeipa.service.freeipa.dns.DnsRecordService;
 import com.sequenceiq.freeipa.service.freeipa.dns.DnsZoneService;
 import com.sequenceiq.freeipa.util.CrnService;
@@ -43,6 +46,10 @@ public class DnsV1Controller implements DnsV1Endpoint {
 
     @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.WRITE)
+    @Retryable(value = RetryableFreeIpaClientException.class,
+            maxAttemptsExpression = RetryableFreeIpaClientException.MAX_RETRIES_EXPRESSION,
+            backoff = @Backoff(delayExpression = RetryableFreeIpaClientException.DELAY_EXPRESSION,
+                    multiplierExpression = RetryableFreeIpaClientException.MULTIPLIER_EXPRESSION))
     public AddDnsZoneForSubnetsResponse addDnsZoneForSubnetIds(@Valid AddDnsZoneForSubnetIdsRequest request) throws FreeIpaClientException {
         String accountId = crnService.getCurrentAccountId();
         return dnsZoneService.addDnsZonesForSubnetIds(request, accountId);
@@ -50,6 +57,10 @@ public class DnsV1Controller implements DnsV1Endpoint {
 
     @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.READ)
+    @Retryable(value = RetryableFreeIpaClientException.class,
+            maxAttemptsExpression = RetryableFreeIpaClientException.MAX_RETRIES_EXPRESSION,
+            backoff = @Backoff(delayExpression = RetryableFreeIpaClientException.DELAY_EXPRESSION,
+                    multiplierExpression = RetryableFreeIpaClientException.MULTIPLIER_EXPRESSION))
     public Set<String> listDnsZones(String environmentCrn) throws FreeIpaClientException {
         String accountId = crnService.getCurrentAccountId();
         return dnsZoneService.listDnsZones(environmentCrn, accountId);
@@ -57,6 +68,10 @@ public class DnsV1Controller implements DnsV1Endpoint {
 
     @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.WRITE)
+    @Retryable(value = RetryableFreeIpaClientException.class,
+            maxAttemptsExpression = RetryableFreeIpaClientException.MAX_RETRIES_EXPRESSION,
+            backoff = @Backoff(delayExpression = RetryableFreeIpaClientException.DELAY_EXPRESSION,
+                    multiplierExpression = RetryableFreeIpaClientException.MULTIPLIER_EXPRESSION))
     public void deleteDnsZoneBySubnet(String environmentCrn, String subnet) throws FreeIpaClientException {
         String accountId = crnService.getCurrentAccountId();
         dnsZoneService.deleteDnsZoneBySubnet(environmentCrn, accountId, subnet);
@@ -64,6 +79,10 @@ public class DnsV1Controller implements DnsV1Endpoint {
 
     @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.WRITE)
+    @Retryable(value = RetryableFreeIpaClientException.class,
+            maxAttemptsExpression = RetryableFreeIpaClientException.MAX_RETRIES_EXPRESSION,
+            backoff = @Backoff(delayExpression = RetryableFreeIpaClientException.DELAY_EXPRESSION,
+                    multiplierExpression = RetryableFreeIpaClientException.MULTIPLIER_EXPRESSION))
     public void deleteDnsZoneBySubnetId(String environmentCrn, String networkId, String subnetId) throws FreeIpaClientException {
         String accountId = crnService.getCurrentAccountId();
         dnsZoneService.deleteDnsZoneBySubnetId(environmentCrn, accountId, networkId, subnetId);
@@ -71,6 +90,10 @@ public class DnsV1Controller implements DnsV1Endpoint {
 
     @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.WRITE)
+    @Retryable(value = RetryableFreeIpaClientException.class,
+            maxAttemptsExpression = RetryableFreeIpaClientException.MAX_RETRIES_EXPRESSION,
+            backoff = @Backoff(delayExpression = RetryableFreeIpaClientException.DELAY_EXPRESSION,
+                    multiplierExpression = RetryableFreeIpaClientException.MULTIPLIER_EXPRESSION))
     public void deleteDnsRecordsByFqdn(@NotEmpty String environmentCrn, @NotEmpty List<String> fqdns) throws FreeIpaClientException {
         String accountId = crnService.getCurrentAccountId();
         dnsRecordService.deleteDnsRecordByFqdn(environmentCrn, accountId, fqdns);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/AbstractFreeIpaCleanupAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/AbstractFreeIpaCleanupAction.java
@@ -9,10 +9,7 @@ import org.springframework.statemachine.StateContext;
 
 import com.sequenceiq.cloudbreak.common.event.Payload;
 import com.sequenceiq.flow.core.FlowParameters;
-import com.sequenceiq.freeipa.client.FreeIpaClient;
-import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.entity.FreeIpa;
-import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.flow.stack.AbstractStackAction;
 import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
 import com.sequenceiq.freeipa.service.freeipa.FreeIpaService;
@@ -43,10 +40,6 @@ public abstract class AbstractFreeIpaCleanupAction<P extends Payload> extends Ab
     @Override
     protected Object getFailurePayload(P payload, Optional<FreeIpaContext> flowContext, Exception ex) {
         return null;
-    }
-
-    protected FreeIpaClient getFreeIpaClient(Stack stack) throws FreeIpaClientException {
-        return freeIpaClientFactory.getFreeIpaClientForStack(stack);
     }
 
     protected CleanupService getCleanupService() {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/KerberosMgmtV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/KerberosMgmtV1Controller.java
@@ -7,6 +7,8 @@ import javax.validation.constraints.NotEmpty;
 
 import com.sequenceiq.authorization.service.UmsAuthorizationService;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.util.CheckedFunction;
+import com.sequenceiq.freeipa.client.RetryableFreeIpaClientException;
 import com.sequenceiq.freeipa.controller.exception.BadRequestException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,8 +26,9 @@ import com.sequenceiq.freeipa.api.v1.kerberosmgmt.model.HostRequest;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.model.ServiceKeytabRequest;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.model.ServiceKeytabResponse;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.model.ServicePrincipalRequest;
-import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.kerberosmgmt.exception.DeleteException;
+import com.sequenceiq.freeipa.kerberosmgmt.exception.KeytabCreationException;
+import com.sequenceiq.freeipa.client.RetryableFreeIpaClientService;
 import com.sequenceiq.freeipa.util.CrnService;
 
 @Controller
@@ -36,6 +39,10 @@ public class KerberosMgmtV1Controller implements KerberosMgmtV1Endpoint {
     private static final Logger LOGGER = LoggerFactory.getLogger(KerberosMgmtV1Controller.class);
 
     private static final String GET_USER_KEYTAB_RIGHT = "environments/getKeytab";
+
+    private static final String KEYTAB_CREATION_FAILED = "Keytab creation failed.";
+
+    private static final String DELETION_FAILED = "Deletion failed.";
 
     @Inject
     private KerberosMgmtV1Service kerberosMgmtV1Service;
@@ -49,40 +56,57 @@ public class KerberosMgmtV1Controller implements KerberosMgmtV1Endpoint {
     @Inject
     private UmsAuthorizationService umsAuthorizationService;
 
+    @Inject
+    private RetryableFreeIpaClientService retryableFreeIpaClientService;
+
     @CheckPermissionByAccount(action = AuthorizationResourceAction.WRITE)
-    public ServiceKeytabResponse generateServiceKeytab(@Valid ServiceKeytabRequest request) throws FreeIpaClientException {
-        String accountId = crnService.getCurrentAccountId();
-        return kerberosMgmtV1Service.generateServiceKeytab(request, accountId);
+    public ServiceKeytabResponse generateServiceKeytab(@Valid ServiceKeytabRequest request) throws KeytabCreationException {
+        return retryableWithKeytabCreationException((Void v) -> {
+            String accountId = crnService.getCurrentAccountId();
+            return kerberosMgmtV1Service.generateServiceKeytab(request, accountId);
+        });
     }
 
     @CheckPermissionByAccount(action = AuthorizationResourceAction.READ)
-    public ServiceKeytabResponse getServiceKeytab(@Valid ServiceKeytabRequest request) throws FreeIpaClientException {
-        String accountId = crnService.getCurrentAccountId();
-        return kerberosMgmtV1Service.getExistingServiceKeytab(request, accountId);
+    public ServiceKeytabResponse getServiceKeytab(@Valid ServiceKeytabRequest request) throws KeytabCreationException {
+        return retryableWithKeytabCreationException((Void v) -> {
+            String accountId = crnService.getCurrentAccountId();
+            return kerberosMgmtV1Service.getExistingServiceKeytab(request, accountId);
+        });
     }
 
     @CheckPermissionByAccount(action = AuthorizationResourceAction.WRITE)
-    public HostKeytabResponse generateHostKeytab(@Valid HostKeytabRequest request) throws FreeIpaClientException {
-        String accountId = crnService.getCurrentAccountId();
-        return kerberosMgmtV1Service.generateHostKeytab(request, accountId);
+    public HostKeytabResponse generateHostKeytab(@Valid HostKeytabRequest request) throws KeytabCreationException {
+        return retryableWithKeytabCreationException((Void v) -> {
+            String accountId = crnService.getCurrentAccountId();
+            return kerberosMgmtV1Service.generateHostKeytab(request, accountId);
+        });
     }
 
     @CheckPermissionByAccount(action = AuthorizationResourceAction.READ)
-    public HostKeytabResponse getHostKeytab(@Valid HostKeytabRequest request) throws FreeIpaClientException {
-        String accountId = crnService.getCurrentAccountId();
-        return kerberosMgmtV1Service.getExistingHostKeytab(request, accountId);
+    public HostKeytabResponse getHostKeytab(@Valid HostKeytabRequest request) throws KeytabCreationException {
+        return retryableWithKeytabCreationException((Void v) -> {
+            String accountId = crnService.getCurrentAccountId();
+            return kerberosMgmtV1Service.getExistingHostKeytab(request, accountId);
+        });
     }
 
     @CheckPermissionByAccount(action = AuthorizationResourceAction.WRITE)
-    public void deleteServicePrincipal(@Valid ServicePrincipalRequest request) throws FreeIpaClientException, DeleteException {
-        String accountId = crnService.getCurrentAccountId();
-        kerberosMgmtV1Service.deleteServicePrincipal(request, accountId);
+    public void deleteServicePrincipal(@Valid ServicePrincipalRequest request) throws DeleteException {
+        retryableWithDeletionException((Void v) -> {
+            String accountId = crnService.getCurrentAccountId();
+            kerberosMgmtV1Service.deleteServicePrincipal(request, accountId);
+            return null;
+        });
     }
 
     @CheckPermissionByAccount(action = AuthorizationResourceAction.WRITE)
-    public void deleteHost(@Valid HostRequest request) throws FreeIpaClientException, DeleteException {
-        String accountId = crnService.getCurrentAccountId();
-        kerberosMgmtV1Service.deleteHost(request, accountId);
+    public void deleteHost(@Valid HostRequest request) throws DeleteException {
+        retryableWithDeletionException((Void v) -> {
+            String accountId = crnService.getCurrentAccountId();
+            kerberosMgmtV1Service.deleteHost(request, accountId);
+            return null;
+        });
     }
 
     @CheckPermissionByAccount(action = AuthorizationResourceAction.WRITE)
@@ -115,4 +139,39 @@ public class KerberosMgmtV1Controller implements KerberosMgmtV1Endpoint {
         return userCrn;
     }
 
+    private <T> T retryableWithKeytabCreationException(CheckedFunction<Void, T, Exception> f) throws KeytabCreationException {
+        try {
+            return retryableFreeIpaClientService.invokeWithRetries(f);
+        } catch (KeytabCreationException e) {
+            throw e;
+        } catch (RetryableFreeIpaClientException e) {
+            LOGGER.error("internal server error", e);
+            Exception exceptionForRestApi = e.getExceptionForRestApi();
+            if (exceptionForRestApi instanceof KeytabCreationException) {
+                throw (KeytabCreationException) exceptionForRestApi;
+            }
+            throw new KeytabCreationException(KEYTAB_CREATION_FAILED);
+        } catch (Exception e2) {
+            LOGGER.error("internal server error", e2);
+            throw new KeytabCreationException(KEYTAB_CREATION_FAILED);
+        }
+    }
+
+    private <T> T retryableWithDeletionException(CheckedFunction<Void, T, Exception> f) throws DeleteException {
+        try {
+            return retryableFreeIpaClientService.invokeWithRetries(f);
+        } catch (DeleteException e) {
+            throw e;
+        } catch (RetryableFreeIpaClientException e) {
+            LOGGER.error("internal server error", e);
+            Exception exceptionForRestApi = e.getExceptionForRestApi();
+            if (exceptionForRestApi instanceof DeleteException) {
+                throw (DeleteException) exceptionForRestApi;
+            }
+            throw new DeleteException(DELETION_FAILED);
+        } catch (Exception e2) {
+            LOGGER.error("internal server error", e2);
+            throw new DeleteException(DELETION_FAILED);
+        }
+    }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/dns/DnsZoneService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/dns/DnsZoneService.java
@@ -17,6 +17,7 @@ import com.sequenceiq.freeipa.api.v1.dns.model.AddDnsZoneForSubnetsRequest;
 import com.sequenceiq.freeipa.api.v1.dns.model.AddDnsZoneForSubnetsResponse;
 import com.sequenceiq.freeipa.client.FreeIpaClient;
 import com.sequenceiq.freeipa.client.FreeIpaClientException;
+import com.sequenceiq.freeipa.client.RetryableFreeIpaClientException;
 import com.sequenceiq.freeipa.client.model.DnsZoneList;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
@@ -49,6 +50,8 @@ public class DnsZoneService {
                 client.addReverseDnsZone(subnet);
                 response.getSuccess().add(subnet);
                 LOGGER.debug("Subnet [{}] added", subnet);
+            } catch (RetryableFreeIpaClientException e) {
+                throw e;
             } catch (FreeIpaClientException e) {
                 LOGGER.warn("Can't add subnet's [{}] reverse DNS zone", subnet, e);
                 response.getFailed().put(subnet, e.getMessage());
@@ -93,6 +96,8 @@ public class DnsZoneService {
                     response.getSuccess().add(subnet.getKey());
                     LOGGER.debug("Subnet [{}] added", subnet);
                 }
+            } catch (RetryableFreeIpaClientException e) {
+                throw e;
             } catch (FreeIpaClientException e) {
                 LOGGER.warn("Can't add subnet's [{}] reverse DNS zone", subnet, e);
                 response.getFailed().put(subnet.getKey(), e.getMessage());

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaPostInstallService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaPostInstallService.java
@@ -67,9 +67,9 @@ public class FreeIpaPostInstallService {
 
     public void postInstallFreeIpa(Long stackId) throws Exception {
         LOGGER.debug("Performing post-install configuration for stack {}", stackId);
-        freeIpaTopologyService.updateReplicationTopology(stackId);
         Stack stack = stackService.getStackById(stackId);
         FreeIpaClient freeIpaClient = freeIpaClientFactory.getFreeIpaClientForStack(stack);
+        freeIpaTopologyService.updateReplicationTopology(stackId, freeIpaClient);
         Set<Permission> permission = freeIpaClient.findPermission(SET_PASSWORD_EXPIRATION_PERMISSION);
         if (permission.isEmpty()) {
             freeIpaClient.addPasswordExpirationPermission(SET_PASSWORD_EXPIRATION_PERMISSION);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaTopologyService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaTopologyService.java
@@ -7,7 +7,6 @@ import com.sequenceiq.freeipa.client.model.TopologySegment;
 import com.sequenceiq.freeipa.client.model.TopologySuffix;
 import com.sequenceiq.freeipa.entity.InstanceMetaData;
 import com.sequenceiq.freeipa.entity.Stack;
-import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
 import com.sequenceiq.freeipa.service.stack.StackService;
 import org.springframework.stereotype.Service;
 
@@ -29,15 +28,11 @@ class FreeIpaTopologyService {
     @Inject
     private StackService stackService;
 
-    @Inject
-    private FreeIpaClientFactory freeIpaClientFactory;
-
-    public void updateReplicationTopology(Long stackId) throws FreeIpaClientException {
+    public void updateReplicationTopology(Long stackId, FreeIpaClient freeIpaClient) throws FreeIpaClientException {
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
         Set<String> allNodesFqdn = stack.getNotDeletedInstanceMetaDataSet().stream()
                 .map(InstanceMetaData::getDiscoveryFQDN)
                 .collect(Collectors.toSet());
-        FreeIpaClient freeIpaClient = freeIpaClientFactory.getFreeIpaClientForStack(stack);
         Set<TopologySegment> topology = generateTopology(allNodesFqdn).stream()
                 .map(pair -> {
                     TopologySegment s = new TopologySegment();

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaRootCertificateService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaRootCertificateService.java
@@ -5,6 +5,7 @@ import javax.inject.Inject;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.freeipa.client.FreeIpaClient;
+import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
 
@@ -21,7 +22,7 @@ public class FreeIpaRootCertificateService {
     @Inject
     private StackService stackService;
 
-    public String getRootCertificate(String environmentCrn, String accountId) throws Exception {
+    public String getRootCertificate(String environmentCrn, String accountId) throws FreeIpaClientException {
         Stack stack = stackService.getByEnvironmentCrnAndAccountId(environmentCrn, accountId);
         FreeIpaClient client = freeIpaClientFactory.getFreeIpaClientForStack(stack);
 

--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -30,7 +30,12 @@ management:
 
 freeipa:
   cert.dir: /certs/
-  client.id: freeipa
+  client:
+    id: freeipa
+    retry:
+      delay: 500
+      multipler: 2
+      retries: 5
   default.gateway.cidr: 0.0.0.0/0
   structuredevent:
     rest:

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaTopologyServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaTopologyServiceTest.java
@@ -6,7 +6,6 @@ import com.sequenceiq.freeipa.client.model.TopologySegment;
 import com.sequenceiq.freeipa.client.model.TopologySuffix;
 import com.sequenceiq.freeipa.entity.InstanceMetaData;
 import com.sequenceiq.freeipa.entity.Stack;
-import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
 import com.sequenceiq.freeipa.service.stack.StackService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -37,9 +36,6 @@ class FreeIpaTopologyServiceTest {
 
     @Mock
     private Stack stack;
-
-    @Mock
-    private FreeIpaClientFactory freeIpaClientFactory;
 
     @Test
     void testGenerateTopology() throws FreeIpaClientException {
@@ -138,7 +134,6 @@ class FreeIpaTopologyServiceTest {
             imSet.add(im);
         }
         Mockito.when(stack.getNotDeletedInstanceMetaDataSet()).thenReturn(imSet);
-        Mockito.when(freeIpaClientFactory.getFreeIpaClientForStack(Mockito.any())).thenReturn(freeIpaClient);
         TopologySuffix caSuffix = new TopologySuffix();
         caSuffix.setCn("ca");
         TopologySuffix domainSuffix = new TopologySuffix();
@@ -164,7 +159,7 @@ class FreeIpaTopologyServiceTest {
         if (expectedSegmentsToRemove > 0) {
             Mockito.when(freeIpaClient.deleteTopologySegment(Mockito.anyString(), Mockito.any())).thenReturn(new TopologySegment());
         }
-        underTest.updateReplicationTopology(1L);
+        underTest.updateReplicationTopology(1L, freeIpaClient);
         Mockito.verify(freeIpaClient, Mockito.times(expectedSegmentsToAdd)).addTopologySegment(Mockito.eq("ca"), Mockito.any());
         Mockito.verify(freeIpaClient, Mockito.times(expectedSegmentsToAdd)).addTopologySegment(Mockito.eq("domain"), Mockito.any());
         Mockito.verify(freeIpaClient, Mockito.times(expectedSegmentsToRemove)).deleteTopologySegment(Mockito.eq("ca"), Mockito.any());


### PR DESCRIPTION
When an instance of FreeIPA fails, the FreeIPA management service will
retry with a delay. When cluster proxy mode is used with FreeIPA HA,
the delay will allow cluster proxy to switch over to a working
instance of FreeIPA.

Retries are performed on the FreeIPA management service APIs, but not
flows nor user sync.

Retries are only performed with certain errors occur that have a
reasonable chance of succeeding on a retry.

Closes #CB-6043