### PR TITLE
CDPCP-1534. Expose UserSyncStatus through describe freeipa api

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaModelDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaModelDescriptions.java
@@ -18,6 +18,7 @@ public class FreeIpaModelDescriptions {
     public static final String USE_CCM = "whether to use CCM for communicating with the freeipa instance";
     public static final String TUNNEL = "Configuration that the connection going directly or with cluster proxy or with ccm and cluster proxy.";
     public static final String TAGS = "Tags for freeipa server.";
+    public static final String USERSYNC_STATUS_DETAILS = "user sync status details for the environment";
 
     private FreeIpaModelDescriptions() {
     }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/describe/DescribeFreeIpaResponse.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/describe/DescribeFreeIpaResponse.java
@@ -17,6 +17,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.Instanc
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.NetworkResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.region.PlacementResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.security.StackAuthenticationResponse;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.usersync.UserSyncStatusResponse;
 import com.sequenceiq.service.api.doc.ModelDescriptions;
 
 import io.swagger.annotations.ApiModel;
@@ -78,6 +79,9 @@ public class DescribeFreeIpaResponse {
 
     @ApiModelProperty(value = FreeIpaModelDescriptions.CLOUD_STORAGE)
     private CloudStorageResponse cloudStorage;
+
+    @ApiModelProperty(value = FreeIpaModelDescriptions.USERSYNC_STATUS_DETAILS)
+    private UserSyncStatusResponse userSyncStatus;
 
     public String getEnvironmentCrn() {
         return environmentCrn;
@@ -205,5 +209,13 @@ public class DescribeFreeIpaResponse {
 
     public void setCloudPlatform(String cloudPlatform) {
         this.cloudPlatform = cloudPlatform;
+    }
+
+    public UserSyncStatusResponse getUserSyncStatus() {
+        return userSyncStatus;
+    }
+
+    public void setUserSyncStatus(UserSyncStatusResponse userSyncStatus) {
+        this.userSyncStatus = userSyncStatus;
     }
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/usersync/UserSyncStatusResponse.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/usersync/UserSyncStatusResponse.java
@@ -1,0 +1,52 @@
+package com.sequenceiq.freeipa.api.v1.freeipa.stack.model.usersync;
+
+import java.util.Map;
+
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.google.common.collect.ImmutableMap;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.doc.UserModelDescriptions;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel("UserSyncStatusV1Response")
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class UserSyncStatusResponse {
+    @ApiModelProperty(value = UserModelDescriptions.USERSYNC_ID)
+    private String lastStartedUserSyncId;
+
+    @ApiModelProperty(value = UserModelDescriptions.USERSYNC_ID)
+    private String lastSuccessfulUserSyncId;
+
+    @NotNull
+    @ApiModelProperty(value = UserModelDescriptions.USERSYNC_ID)
+    private Map<String, String> eventGenerationIds;
+
+    public String getLastStartedUserSyncId() {
+        return lastStartedUserSyncId;
+    }
+
+    public void setLastStartedUserSyncId(String lastStartedUserSyncId) {
+        this.lastStartedUserSyncId = lastStartedUserSyncId;
+    }
+
+    public String getLastSuccessfulUserSyncId() {
+        return lastSuccessfulUserSyncId;
+    }
+
+    public void setLastSuccessfulUserSyncId(String lastSuccessfulUserSyncId) {
+        this.lastSuccessfulUserSyncId = lastSuccessfulUserSyncId;
+    }
+
+    public Map<String, String> getEventGenerationIds() {
+        return eventGenerationIds;
+    }
+
+    public void setEventGenerationIds(Map<String, String> eventGenerationIds) {
+        this.eventGenerationIds = ImmutableMap.copyOf(eventGenerationIds);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/StackToDescribeFreeIpaResponseConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/StackToDescribeFreeIpaResponseConverter.java
@@ -26,9 +26,11 @@ import com.sequenceiq.freeipa.converter.image.ImageToImageSettingsResponseConver
 import com.sequenceiq.freeipa.converter.instance.InstanceGroupToInstanceGroupResponseConverter;
 import com.sequenceiq.freeipa.converter.network.NetworkToNetworkResponseConverter;
 import com.sequenceiq.freeipa.converter.telemetry.TelemetryConverter;
+import com.sequenceiq.freeipa.converter.usersync.UserSyncStatusToUserSyncStatusResponseConverter;
 import com.sequenceiq.freeipa.entity.FreeIpa;
 import com.sequenceiq.freeipa.entity.Image;
 import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.entity.UserSyncStatus;
 import com.sequenceiq.freeipa.service.config.FreeIpaDomainUtils;
 
 @Component
@@ -52,7 +54,10 @@ public class StackToDescribeFreeIpaResponseConverter {
     @Inject
     private TelemetryConverter telemetryConverter;
 
-    public DescribeFreeIpaResponse convert(Stack stack, Image image, FreeIpa freeIpa) {
+    @Inject
+    private UserSyncStatusToUserSyncStatusResponseConverter userSyncStatusConverter;
+
+    public DescribeFreeIpaResponse convert(Stack stack, Image image, FreeIpa freeIpa, UserSyncStatus userSyncStatus) {
         DescribeFreeIpaResponse describeFreeIpaResponse = new DescribeFreeIpaResponse();
         describeFreeIpaResponse.setName(stack.getName());
         describeFreeIpaResponse.setEnvironmentCrn(stack.getEnvironmentCrn());
@@ -71,6 +76,7 @@ public class StackToDescribeFreeIpaResponseConverter {
         decoreateFreeIpaServerResponseWithLoadBalancedHost(stack, describeFreeIpaResponse.getFreeIpa(), freeIpa);
         describeFreeIpaResponse.setAppVersion(stack.getAppVersion());
         decorateWithCloudStorgeAndTelemetry(stack, describeFreeIpaResponse);
+        Optional.ofNullable(userSyncStatus).ifPresent(u -> describeFreeIpaResponse.setUserSyncStatus(userSyncStatusConverter.convert(u)));
         return describeFreeIpaResponse;
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/usersync/UserSyncStatusToUserSyncStatusResponseConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/usersync/UserSyncStatusToUserSyncStatusResponseConverter.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.freeipa.converter.usersync;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.usersync.UserSyncStatusResponse;
+import com.sequenceiq.freeipa.entity.UserSyncStatus;
+import com.sequenceiq.freeipa.service.freeipa.user.model.UmsEventGenerationIds;
+
+@Component
+public class UserSyncStatusToUserSyncStatusResponseConverter implements Converter<UserSyncStatus, UserSyncStatusResponse> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserSyncStatusToUserSyncStatusResponseConverter.class);
+
+    @Override
+    public UserSyncStatusResponse convert(UserSyncStatus userSyncStatus) {
+        UserSyncStatusResponse response = new UserSyncStatusResponse();
+        Optional.ofNullable(userSyncStatus.getLastStartedFullSync()).ifPresent(op -> response.setLastStartedUserSyncId(op.getOperationId()));
+        Optional.ofNullable(userSyncStatus.getLastSuccessfulFullSync()).ifPresent(op -> response.setLastSuccessfulUserSyncId(op.getOperationId()));
+        Optional.ofNullable(userSyncStatus.getUmsEventGenerationIds()).ifPresent(eids -> {
+            try {
+                response.setEventGenerationIds(eids.get(UmsEventGenerationIds.class).getEventGenerationIds());
+            } catch (IOException e) {
+                LOGGER.warn("Failed to convert event generation ids [{}] for environment '{}'",
+                        userSyncStatus.getUmsEventGenerationIds(), userSyncStatus.getStack().getEnvironmentCrn());
+            }
+        });
+        return response;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UmsEventGenerationIdsProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UmsEventGenerationIdsProvider.java
@@ -24,7 +24,7 @@ public class UmsEventGenerationIdsProvider {
     enum EventMapping {
         LAST_ROLE_ASSIGNMENT_EVENT_ID("lastRoleAssignmentEventId", GetEventGenerationIdsResponse::getLastRoleAssignmentEventId),
         LAST_RESOURCE_ROLE_ASSIGNMENT_EVENT_ID("lastResourceRoleAssignmentEventId", GetEventGenerationIdsResponse::getLastResourceRoleAssignmentEventId),
-        LAST_GROUP_MEMBERHSIP_CHANGED_EVENT_ID("lastGroupMembershipChangedEventId", GetEventGenerationIdsResponse::getLastGroupMembershipChangedEventId),
+        LAST_GROUP_MEMBERSHIP_CHANGED_EVENT_ID("lastGroupMembershipChangedEventId", GetEventGenerationIdsResponse::getLastGroupMembershipChangedEventId),
         LAST_ACTOR_DELETED_EVENT_ID("lastActorDeletedEventId", GetEventGenerationIdsResponse::getLastActorDeletedEventId),
         LAST_ACTOR_WORKLOAD_CREDENTIALS_CHANGED_EVENT_ID("lastActorWorkloadCredentialsChangedEventId",
                 GetEventGenerationIdsResponse::getLastActorWorkloadCredentialsChangedEventId);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncService.java
@@ -18,7 +18,6 @@ import java.util.stream.Stream;
 
 import javax.inject.Inject;
 
-import com.sequenceiq.freeipa.client.FreeIpaCapabilities;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,6 +41,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SuccessDetails;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizationStatus;
 import com.sequenceiq.freeipa.api.v1.operation.model.OperationState;
 import com.sequenceiq.freeipa.api.v1.operation.model.OperationType;
+import com.sequenceiq.freeipa.client.FreeIpaCapabilities;
 import com.sequenceiq.freeipa.client.FreeIpaClient;
 import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.client.model.RPCResponse;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncStatusService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncStatusService.java
@@ -28,4 +28,9 @@ public class UserSyncStatusService {
             return userSyncStatusRepository.save(userSyncStatus);
         });
     }
+
+    public UserSyncStatus findByStack(Stack stack) {
+        return userSyncStatusRepository.getByStack(stack).orElse(null);
+    }
+
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaCreationService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaCreationService.java
@@ -152,7 +152,7 @@ public class FreeIpaCreationService {
                     new StackEvent(FlowChainTriggers.PROVISION_TRIGGER_EVENT, stackImageFreeIpaTuple.getLeft().getId()));
             InMemoryStateStore.putStack(stack.getId(), PollGroup.POLLABLE);
             return stackToDescribeFreeIpaResponseConverter
-                    .convert(stackImageFreeIpaTuple.getLeft(), stackImageFreeIpaTuple.getMiddle(), stackImageFreeIpaTuple.getRight());
+                    .convert(stackImageFreeIpaTuple.getLeft(), stackImageFreeIpaTuple.getMiddle(), stackImageFreeIpaTuple.getRight(), null);
         } catch (TransactionService.TransactionExecutionException e) {
             LOGGER.error("Creation of FreeIPA failed", e);
             throw new BadRequestException("Creation of FreeIPA failed: " + e.getCause().getMessage(), e);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaDescribeService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaDescribeService.java
@@ -9,7 +9,9 @@ import com.sequenceiq.freeipa.converter.stack.StackToDescribeFreeIpaResponseConv
 import com.sequenceiq.freeipa.entity.FreeIpa;
 import com.sequenceiq.freeipa.entity.Image;
 import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.entity.UserSyncStatus;
 import com.sequenceiq.freeipa.service.freeipa.FreeIpaService;
+import com.sequenceiq.freeipa.service.freeipa.user.UserSyncStatusService;
 import com.sequenceiq.freeipa.service.image.ImageService;
 
 @Service
@@ -25,12 +27,16 @@ public class FreeIpaDescribeService {
     private FreeIpaService freeIpaService;
 
     @Inject
+    private UserSyncStatusService userSyncStatusService;
+
+    @Inject
     private StackToDescribeFreeIpaResponseConverter stackToDescribeFreeIpaResponseConverter;
 
     public DescribeFreeIpaResponse describe(String environmentCrn, String accountId) {
         Stack stack = stackService.getByEnvironmentCrnAndAccountIdWithLists(environmentCrn, accountId);
         Image image = imageService.getByStack(stack);
         FreeIpa freeIpa = freeIpaService.findByStack(stack);
-        return stackToDescribeFreeIpaResponseConverter.convert(stack, image, freeIpa);
+        UserSyncStatus userSyncStatus = userSyncStatusService.findByStack(stack);
+        return stackToDescribeFreeIpaResponseConverter.convert(stack, image, freeIpa, userSyncStatus);
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/stack/StackToDescribeFreeIpaResponseConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/stack/StackToDescribeFreeIpaResponseConverterTest.java
@@ -20,17 +20,20 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.Instanc
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceMetaDataResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.security.StackAuthenticationResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.describe.DescribeFreeIpaResponse;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.usersync.UserSyncStatusResponse;
 import com.sequenceiq.freeipa.converter.authentication.StackAuthenticationToStackAuthenticationResponseConverter;
 import com.sequenceiq.freeipa.converter.freeipa.FreeIpaToFreeIpaServerResponseConverter;
 import com.sequenceiq.freeipa.converter.image.ImageToImageSettingsResponseConverter;
 import com.sequenceiq.freeipa.converter.instance.InstanceGroupToInstanceGroupResponseConverter;
 import com.sequenceiq.freeipa.converter.network.NetworkToNetworkResponseConverter;
 import com.sequenceiq.freeipa.converter.telemetry.TelemetryConverter;
+import com.sequenceiq.freeipa.converter.usersync.UserSyncStatusToUserSyncStatusResponseConverter;
 import com.sequenceiq.freeipa.entity.FreeIpa;
 import com.sequenceiq.freeipa.entity.Image;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.entity.StackAuthentication;
 import com.sequenceiq.freeipa.entity.StackStatus;
+import com.sequenceiq.freeipa.entity.UserSyncStatus;
 
 @ExtendWith(MockitoExtension.class)
 class StackToDescribeFreeIpaResponseConverterTest {
@@ -52,6 +55,8 @@ class StackToDescribeFreeIpaResponseConverterTest {
     private static final InstanceGroupResponse INSTANCE_GROUP_RESPONSE = new InstanceGroupResponse();
 
     private static final List<InstanceGroupResponse> INSTANCE_GROUP_RESPONSES = List.of(INSTANCE_GROUP_RESPONSE);
+
+    private static final UserSyncStatusResponse USERSYNC_STATUS_RESPONSE = new UserSyncStatusResponse();
 
     private static final Status STATUS = Status.AVAILABLE;
 
@@ -90,6 +95,9 @@ class StackToDescribeFreeIpaResponseConverterTest {
     @Mock
     private TelemetryConverter telemetryConverter;
 
+    @Mock
+    private UserSyncStatusToUserSyncStatusResponseConverter userSyncStatusConverter;
+
     @BeforeAll
     static void initInstanceGroupResponse() {
         InstanceMetaDataResponse instanceMetaDataResponse = new InstanceMetaDataResponse();
@@ -104,12 +112,14 @@ class StackToDescribeFreeIpaResponseConverterTest {
         Image image = new Image();
         FreeIpa freeIpa = new FreeIpa();
         freeIpa.setDomain(DOMAIN);
+        UserSyncStatus userSyncStatus = new UserSyncStatus();
         when(authenticationResponseConverter.convert(stack.getStackAuthentication())).thenReturn(STACK_AUTHENTICATION_RESPONSE);
         when(imageSettingsResponseConverter.convert(image)).thenReturn(IMAGE_SETTINGS_RESPONSE);
         when(freeIpaServerResponseConverter.convert(freeIpa)).thenReturn(freeIpaServerResponse);
         when(instanceGroupConverter.convert(stack.getInstanceGroups())).thenReturn(INSTANCE_GROUP_RESPONSES);
+        when(userSyncStatusConverter.convert(userSyncStatus)).thenReturn(USERSYNC_STATUS_RESPONSE);
 
-        DescribeFreeIpaResponse result = underTest.convert(stack, image, freeIpa);
+        DescribeFreeIpaResponse result = underTest.convert(stack, image, freeIpa, userSyncStatus);
 
         assertThat(result)
                 .returns(NAME, DescribeFreeIpaResponse::getName)
@@ -125,8 +135,9 @@ class StackToDescribeFreeIpaResponseConverterTest {
                 .returns(STATUS_REASON, DescribeFreeIpaResponse::getStatusReason)
                 .returns(STATUS_STRING, DescribeFreeIpaResponse::getStatusString)
                 // TODO decorateFreeIpaServerResponseWithIps
-                .returns(APP_VERSION, DescribeFreeIpaResponse::getAppVersion);
+                .returns(APP_VERSION, DescribeFreeIpaResponse::getAppVersion)
                 // TODO decorateWithCloudStorgeAndTelemetry
+                .returns(USERSYNC_STATUS_RESPONSE, DescribeFreeIpaResponse::getUserSyncStatus);
 
         assertThat(freeIpaServerResponse)
                 .returns(Set.of(SERVER_IP), FreeIpaServerResponse::getServerIp)

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/usersync/UserSyncStatusToUserSyncStatusResponseConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/usersync/UserSyncStatusToUserSyncStatusResponseConverterTest.java
@@ -1,0 +1,72 @@
+package com.sequenceiq.freeipa.converter.usersync;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.usersync.UserSyncStatusResponse;
+import com.sequenceiq.freeipa.entity.Operation;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.entity.UserSyncStatus;
+import com.sequenceiq.freeipa.service.freeipa.user.model.UmsEventGenerationIds;
+
+class UserSyncStatusToUserSyncStatusResponseConverterTest {
+
+    private UserSyncStatusToUserSyncStatusResponseConverter underTest = new UserSyncStatusToUserSyncStatusResponseConverter();
+
+    @Test
+    void convertJsonException() throws IOException {
+        Json eventGenerationIds = mock(Json.class);
+        IOException e = new IOException("test exception");
+        when(eventGenerationIds.get(any(Class.class))).thenThrow(e);
+
+        UserSyncStatus status = new UserSyncStatus();
+        status.setStack(mock(Stack.class));
+        status.setUmsEventGenerationIds(eventGenerationIds);
+
+        UserSyncStatusResponse response = underTest.convert(status);
+
+        assertThat(response)
+                .returns(null, UserSyncStatusResponse::getLastStartedUserSyncId)
+                .returns(null, UserSyncStatusResponse::getLastSuccessfulUserSyncId)
+                .returns(null, UserSyncStatusResponse::getEventGenerationIds);
+    }
+
+    @Test
+    void convert() {
+        String requestedId = UUID.randomUUID().toString();
+        Operation requested = new Operation();
+        requested.setOperationId(requestedId);
+
+        String successfulId = UUID.randomUUID().toString();
+        Operation successful = new Operation();
+        successful.setOperationId(successfulId);
+
+        Map<String, String> eventGenerationIdMap = Map.of(
+                "key1", "value1",
+                "key2", "value2"
+        );
+        UmsEventGenerationIds eventGenerationIds = new UmsEventGenerationIds();
+        eventGenerationIds.setEventGenerationIds(eventGenerationIdMap);
+
+        UserSyncStatus status = new UserSyncStatus();
+        status.setLastStartedFullSync(requested);
+        status.setLastSuccessfulFullSync(successful);
+        status.setUmsEventGenerationIds(new Json(eventGenerationIds));
+
+        UserSyncStatusResponse response = underTest.convert(status);
+
+        assertThat(response)
+                .returns(requestedId, UserSyncStatusResponse::getLastStartedUserSyncId)
+                .returns(successfulId, UserSyncStatusResponse::getLastSuccessfulUserSyncId)
+                .returns(eventGenerationIdMap, UserSyncStatusResponse::getEventGenerationIds);
+    }
+}


### PR DESCRIPTION
The last started and last successful operation ids are exposed through
the describe freeipa api. Also included are the event generation ids
for the last successful full sync. This information can be user to
determine whether an environment is up-to-date by comparing with the
event generation ids from the UMS.
