### PR TITLE
CB-6035: FMS should relogin on failures

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
@@ -52,15 +52,29 @@ public class FreeIpaClient {
 
     private JsonRpcHttpClient jsonRpcHttpClient;
 
-    private String apiVersion;
+    private final String apiVersion;
 
-    public FreeIpaClient(JsonRpcHttpClient jsonRpcHttpClient) {
-        this(jsonRpcHttpClient, DEFAULT_API_VERSION);
+    private final String apiAddress;
+
+    private final String hostname;
+
+    public FreeIpaClient(JsonRpcHttpClient jsonRpcHttpClient, String apiAddress, String hostname) {
+        this(jsonRpcHttpClient, DEFAULT_API_VERSION, apiAddress, hostname);
     }
 
-    public FreeIpaClient(JsonRpcHttpClient jsonRpcHttpClient, String apiVersion) {
+    public FreeIpaClient(JsonRpcHttpClient jsonRpcHttpClient, String apiVersion, String apiAddress, String hostname) {
         this.jsonRpcHttpClient = jsonRpcHttpClient;
         this.apiVersion = apiVersion;
+        this.apiAddress = apiAddress;
+        this.hostname = hostname;
+    }
+
+    public String getApiAddress() {
+        return apiAddress;
+    }
+
+    public String getHostname() {
+        return hostname;
     }
 
     public User userShow(String user) throws FreeIpaClientException {

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientException.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientException.java
@@ -1,19 +1,27 @@
 package com.sequenceiq.freeipa.client;
 
+import java.util.OptionalInt;
+
 public class FreeIpaClientException extends Exception {
+
+    private final OptionalInt statusCode;
+
     public FreeIpaClientException(String message) {
         super(message);
+        statusCode = OptionalInt.empty();
+    }
+
+    public FreeIpaClientException(String message, int statusCode) {
+        super(message);
+        this.statusCode = OptionalInt.of(statusCode);
     }
 
     public FreeIpaClientException(String message, Throwable cause) {
         super(message, cause);
+        statusCode = OptionalInt.empty();
     }
 
-    public FreeIpaClientException(Throwable cause) {
-
-    }
-
-    public FreeIpaClientException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
-
+    public OptionalInt getStatusCode() {
+        return statusCode;
     }
 }

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/auth/InvalidPasswordException.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/auth/InvalidPasswordException.java
@@ -6,20 +6,4 @@ public class InvalidPasswordException extends FreeIpaClientException {
     public InvalidPasswordException() {
         super("Invalid password");
     }
-
-    public InvalidPasswordException(String message) {
-        super(message);
-    }
-
-    public InvalidPasswordException(Throwable cause) {
-        super(cause);
-    }
-
-    public InvalidPasswordException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
-    public InvalidPasswordException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
-        super(message, cause, enableSuppression, writableStackTrace);
-    }
 }

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/auth/InvalidUserOrRealmException.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/auth/InvalidUserOrRealmException.java
@@ -15,20 +15,4 @@ public class InvalidUserOrRealmException extends FreeIpaClientException {
     public InvalidUserOrRealmException() {
         super("Invalid user or realm");
     }
-
-    public InvalidUserOrRealmException(String message) {
-        super(message);
-    }
-
-    public InvalidUserOrRealmException(Throwable cause) {
-        super(cause);
-    }
-
-    public InvalidUserOrRealmException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
-    public InvalidUserOrRealmException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
-        super(message, cause, enableSuppression, writableStackTrace);
-    }
 }

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/auth/PasswordExpiredException.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/auth/PasswordExpiredException.java
@@ -6,20 +6,4 @@ public class PasswordExpiredException extends FreeIpaClientException {
     public PasswordExpiredException() {
         super("Invalid password");
     }
-
-    public PasswordExpiredException(String message) {
-        super(message);
-    }
-
-    public PasswordExpiredException(Throwable cause) {
-        super(cause);
-    }
-
-    public PasswordExpiredException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
-    public PasswordExpiredException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
-        super(message, cause, enableSuppression, writableStackTrace);
-    }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/Stack.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/Stack.java
@@ -305,6 +305,12 @@ public class Stack {
                 .collect(Collectors.toList());
     }
 
+    public List<InstanceMetaData> getAllInstanceMetaDataList() {
+        return instanceGroups.stream()
+                .flatMap(instanceGroup -> instanceGroup.getAllInstanceMetaData().stream())
+                .collect(Collectors.toList());
+    }
+
     public String getEnvironmentCrn() {
         return environmentCrn;
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/GatewayConfigService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/GatewayConfigService.java
@@ -54,7 +54,7 @@ public class GatewayConfigService {
     }
 
     public GatewayConfig getGatewayConfig(Stack stack, InstanceMetaData gatewayInstance) {
-        return tlsSecurityService.buildGatewayConfig(stack.getId(), gatewayInstance, stack.getGatewayport(), getSaltClientConfig(stack), false);
+        return tlsSecurityService.buildGatewayConfig(stack, gatewayInstance, getSaltClientConfig(stack), false);
     }
 
     public String getPrimaryGatewayIp(Stack stack) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/TlsSecurityService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/TlsSecurityService.java
@@ -103,9 +103,8 @@ public class TlsSecurityService {
         saltSecurityConfig.setSaltPasswordVault(saltPassword);
     }
 
-    public GatewayConfig buildGatewayConfig(Long stackId, InstanceMetaData gatewayInstance, Integer gatewayPort,
+    public GatewayConfig buildGatewayConfig(Stack stack, InstanceMetaData gatewayInstance,
             SaltClientConfig saltClientConfig, Boolean knoxGatewayEnabled) {
-        Stack stack = stackService.getStackById(stackId);
         SecurityConfig securityConfig = securityConfigService.findOneByStack(stack);
         String connectionIp = getGatewayIp(securityConfig, gatewayInstance, stack);
         HttpClientConfig conf = buildTLSClientConfig(stack, connectionIp, gatewayInstance);
@@ -113,7 +112,7 @@ public class TlsSecurityService {
         String saltSignPrivateKeyB64 = saltSecurityConfig.getSaltSignPrivateKeyVault();
         GatewayConfig gatewayConfig =
                 new GatewayConfig(connectionIp, gatewayInstance.getPublicIpWrapper(), gatewayInstance.getPrivateIp(), gatewayInstance.getDiscoveryFQDN(),
-                        getGatewayPort(gatewayPort, stack), gatewayInstance.getInstanceId(), conf.getServerCert(),
+                        getGatewayPort(stack.getGatewayport(), stack), gatewayInstance.getInstanceId(), conf.getServerCert(),
                         conf.getClientCert(), conf.getClientKey(), saltClientConfig.getSaltPassword(), saltClientConfig.getSaltBootPassword(),
                         saltClientConfig.getSignatureKeyPem(), knoxGatewayEnabled,
                         InstanceMetadataType.GATEWAY_PRIMARY.equals(gatewayInstance.getInstanceMetadataType()),

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactory.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactory.java
@@ -1,23 +1,30 @@
 package com.sequenceiq.freeipa.service.freeipa;
 
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import com.googlecode.jsonrpc4j.JsonRpcClient;
 import com.sequenceiq.cloudbreak.client.HttpClientConfig;
 import com.sequenceiq.cloudbreak.clusterproxy.ClusterProxyConfiguration;
-import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.client.ClusterProxyErrorRpcListener;
 import com.sequenceiq.freeipa.client.FreeIpaClient;
 import com.sequenceiq.freeipa.client.FreeIpaClientBuilder;
 import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.entity.FreeIpa;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.service.GatewayConfigService;
 import com.sequenceiq.freeipa.service.TlsSecurityService;
@@ -70,42 +77,75 @@ public class FreeIpaClientFactory {
         return String.format("%s%s", clusterProxyService.getProxyPath(freeIpaClusterCrn), FreeIpaClientBuilder.DEFAULT_BASE_PATH);
     }
 
-    public FreeIpaClient getFreeIpaClientForStack(Stack stack) throws FreeIpaClientException {
-        LOGGER.debug("Creating FreeIpaClient for stack {}", stack.getResourceCrn());
+    private FreeIpaClient getFreeIpaClient(Stack stack, boolean withPing) throws FreeIpaClientException {
+        stack = stackService.getByIdWithListsInTransaction(stack.getId());
         Status stackStatus = stack.getStackStatus().getStatus();
         if (!stackStatus.isFreeIpaUnreachableStatus()) {
             try {
                 if (clusterProxyService.isCreateConfigForClusterProxy(stack)) {
-                    return getFreeIpaClientBuilderForClusterProxy(stack).build();
+                    return getFreeIpaClientBuilderForClusterProxy(stack).build(withPing);
                 } else {
-                    return getFreeIpaClientBuilder(stack).build();
+                    return createClientForDirectConnection(stack, withPing);
                 }
             } catch (Exception e) {
-                throw new FreeIpaClientException("Couldn't build FreeIPA client. "
-                        + "Check if the FreeIPA security rules have not changed and the instance is in running state. " + e.getLocalizedMessage(), e);
+                throw createFreeIpaUnableToBuildClient(e);
             }
         } else {
             throw createFreeIpaStateIsInvalidException(stackStatus);
         }
     }
 
+    private FreeIpaClient createClientForDirectConnection(Stack stack, boolean withPing) throws Exception {
+        Optional<FreeIpaClient> client = Optional.empty();
+        for (Iterator<InstanceMetaData> instanceIterator = getAllInstances(stack).iterator(); instanceIterator.hasNext() && client.isEmpty();) {
+            InstanceMetaData instanceMetaData = instanceIterator.next();
+            client = getFreeIpaClient(stack, instanceMetaData, withPing, !instanceIterator.hasNext());
+        }
+        return client.orElseThrow(() -> createFreeIpaUnableToBuildClient(new IllegalStateException("No FreeIPA client was available")));
+    }
+
+    private Optional<FreeIpaClient> getFreeIpaClient(Stack stack, InstanceMetaData instanceMetaData, boolean withPing, boolean lastInstance) throws Exception {
+        Optional<FreeIpaClient> client = Optional.empty();
+        try {
+            client = Optional.of(getFreeIpaClientBuilder(stack, instanceMetaData).build(withPing));
+        } catch (FreeIpaClientException e) {
+            handleException(instanceMetaData, e, () -> canTryAnotherInstance(lastInstance, e));
+        } catch (IOException e) {
+            handleException(instanceMetaData, e, () -> canTryAnotherInstance(lastInstance, e));
+        }
+        return client;
+    }
+
+    private void handleException(InstanceMetaData instanceMetaData, Exception e, Supplier<Boolean> canTryAnotherInstanceSupplier) throws FreeIpaClientException {
+        LOGGER.error("Unable to contact FreeIPA node {}.", instanceMetaData.getPublicIpWrapper(), e);
+        if (!canTryAnotherInstanceSupplier.get()) {
+            throw createFreeIpaUnableToBuildClient(e);
+        }
+    }
+
+    private boolean canTryAnotherInstance(boolean lastInstance, FreeIpaClientException e) {
+        return !lastInstance &&
+                e.getStatusCode().isPresent() &&
+                e.getStatusCode().getAsInt() == HttpStatus.UNAUTHORIZED.value();
+    }
+
+    private boolean canTryAnotherInstance(boolean lastInstance, IOException e) {
+        return !lastInstance;
+    }
+
+    private List<InstanceMetaData> getAllInstances(Stack stack) {
+        return stack.getInstanceGroups().stream().flatMap(instanceGroup ->
+                instanceGroup.getInstanceMetaData().stream()).collect(Collectors.toList());
+    }
+
+    public FreeIpaClient getFreeIpaClientForStack(Stack stack) throws FreeIpaClientException {
+        LOGGER.debug("Creating FreeIpaClient for stack {}", stack.getResourceCrn());
+        return getFreeIpaClient(stack, false);
+    }
+
     public FreeIpaClient getFreeIpaClientForStackWithPing(Stack stack) throws Exception {
         LOGGER.debug("Ping the login endpoint and creating FreeIpaClient for stack {}", stack.getResourceCrn());
-        Status stackStatus = stack.getStackStatus().getStatus();
-        if (!stackStatus.isFreeIpaUnreachableStatus()) {
-            try {
-                if (clusterProxyService.isCreateConfigForClusterProxy(stack)) {
-                    return getFreeIpaClientBuilderForClusterProxy(stack).buildWithPing();
-                } else {
-                    return getFreeIpaClientBuilder(stack).buildWithPing();
-                }
-            } catch (Exception e) {
-                throw new FreeIpaClientException("Couldn't build FreeIPA client. "
-                        + "Check if the FreeIPA security rules have not changed and the instance is in running state. " + e.getLocalizedMessage(), e);
-            }
-        } else {
-            throw createFreeIpaStateIsInvalidException(stackStatus);
-        }
+        return getFreeIpaClient(stack, true);
     }
 
     private FreeIpaClientBuilder getFreeIpaClientBuilderForClusterProxy(Stack stack) throws Exception {
@@ -115,27 +155,33 @@ public class FreeIpaClientFactory {
 
         return new FreeIpaClientBuilder(ADMIN_USER,
                 freeIpa.getAdminPassword(),
-                freeIpa.getDomain().toUpperCase(),
                 httpClientConfig,
+                clusterProxyConfiguration.getClusterProxyHost(),
                 clusterProxyConfiguration.getClusterProxyPort(),
                 clusterProxyPath,
                 ADDITIONAL_CLUSTER_PROXY_HEADERS,
                 CLUSTER_PROXY_ERROR_LISTENER);
     }
 
-    private FreeIpaClientBuilder getFreeIpaClientBuilder(Stack stack) throws Exception {
-        GatewayConfig gatewayConfig = gatewayConfigService.getPrimaryGatewayConfig(stack);
-        HttpClientConfig httpClientConfig = tlsSecurityService.buildTLSClientConfigForPrimaryGateway(
-                stack, gatewayConfig.getPublicAddress());
+    private FreeIpaClientBuilder getFreeIpaClientBuilder(Stack stack, InstanceMetaData instanceMetaData) throws Exception {
+        HttpClientConfig httpClientConfig = tlsSecurityService.buildTLSClientConfig(
+                stack, instanceMetaData.getPublicIpWrapper(), instanceMetaData);
         FreeIpa freeIpa = freeIpaService.findByStack(stack);
-        return new FreeIpaClientBuilder(ADMIN_USER, freeIpa.getAdminPassword(), freeIpa.getDomain().toUpperCase(),
-                httpClientConfig, stack.getGatewayport());
+        return new FreeIpaClientBuilder(ADMIN_USER, freeIpa.getAdminPassword(), httpClientConfig, stack.getGatewayport(),
+                instanceMetaData.getDiscoveryFQDN());
     }
 
     private FreeIpaClientException createFreeIpaStateIsInvalidException(Status stackStatus) {
         String message = String.format("Couldn't build FreeIPA client. Because FreeIPA is in invalid state: '%s'", stackStatus);
         LOGGER.warn(message);
         return new FreeIpaClientException(message);
+    }
+
+    private FreeIpaClientException createFreeIpaUnableToBuildClient(Exception e) {
+        String message = String.format("Couldn't build FreeIPA client. "
+                + "Check if the FreeIPA security rules have not changed and the instance is in running state. " + e.getLocalizedMessage());
+        LOGGER.error(message);
+        return new FreeIpaClientException(message, e);
     }
 
     public String getAdminUser() {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/FreeipaChecker.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/FreeipaChecker.java
@@ -36,7 +36,7 @@ public class FreeipaChecker {
             FreeIpaClient freeIpaClient = checkedMeasure(() -> freeIpaClientFactory.getFreeIpaClientForStackWithPing(stack), LOGGER,
                     ":::Auto sync::: freeipa client is created in {}ms");
             String hostname = getPrimaryHostname(checkableInstances);
-            return checkedMeasure(() -> freeIpaClient.serverConnCheck(hostname, hostname), LOGGER,
+            return checkedMeasure(() -> freeIpaClient.serverConnCheck(freeIpaClient.getApiAddress(), hostname), LOGGER,
                     ":::Auto sync::: freeipa server_conncheck ran in {}ms");
         }, LOGGER, ":::Auto sync::: freeipa server status is checked in {}ms");
     }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/client/FreeIpaClientTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/client/FreeIpaClientTest.java
@@ -23,7 +23,7 @@ class FreeIpaClientTest {
 
     @BeforeEach
     void setUp() {
-        freeIpaClient = new FreeIpaClient(jsonRpcHttpClient);
+        freeIpaClient = new FreeIpaClient(jsonRpcHttpClient, "1.1.1.1", "localhost");
     }
 
     @Test

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactoryTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactoryTest.java
@@ -4,6 +4,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,17 +17,23 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.client.FreeIpaClientException;
+import com.sequenceiq.freeipa.entity.InstanceGroup;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.entity.StackStatus;
 import com.sequenceiq.freeipa.service.GatewayConfigService;
 import com.sequenceiq.freeipa.service.TlsSecurityService;
 import com.sequenceiq.freeipa.service.stack.ClusterProxyService;
+import com.sequenceiq.freeipa.service.stack.StackService;
 
 @ExtendWith(MockitoExtension.class)
 class FreeIpaClientFactoryTest {
 
     @Mock
     private ClusterProxyService clusterProxyService;
+
+    @Mock
+    private StackService stackService;
 
     @Mock
     private FreeIpaService freeIpaService;
@@ -40,7 +49,8 @@ class FreeIpaClientFactoryTest {
 
     @Test
     void getFreeIpaClientForStackShouldThrowExceptionWhenStackStatusIsUnreachable() {
-        Stack stack = new Stack();
+        Stack stack = createStack();
+        when(stackService.getByIdWithListsInTransaction(stack.getId())).thenReturn(stack);
         Status unreachableState = Status.FREEIPA_UNREACHABLE_STATUSES.stream().findAny().get();
         StackStatus stackStatus = new StackStatus(stack, unreachableState, "The FreeIPA instance is unreachable.", DetailedStackStatus.UNREACHABLE);
         stack.setStackStatus(stackStatus);
@@ -50,7 +60,8 @@ class FreeIpaClientFactoryTest {
 
     @Test
     void getFreeIpaClientForStackShouldReturnClientWhenStackStatusIsValid() throws FreeIpaClientException {
-        Stack stack = new Stack();
+        Stack stack = createStack();
+        when(stackService.getByIdWithListsInTransaction(stack.getId())).thenReturn(stack);
         Status unreachableState = Status.AVAILABLE;
         StackStatus stackStatus = new StackStatus(stack, unreachableState, "The FreeIPA instance is reachable.", DetailedStackStatus.AVAILABLE);
         stack.setStackStatus(stackStatus);
@@ -64,7 +75,8 @@ class FreeIpaClientFactoryTest {
 
     @Test
     void getFreeIpaClientForStackWithPingShouldThrowExceptionWhenStackStatusIsUnreachable() {
-        Stack stack = new Stack();
+        Stack stack = createStack();
+        when(stackService.getByIdWithListsInTransaction(stack.getId())).thenReturn(stack);
         Status unreachableState = Status.AVAILABLE;
         StackStatus stackStatus = new StackStatus(stack, unreachableState, "The FreeIPA instance is reachable.", DetailedStackStatus.AVAILABLE);
         stack.setStackStatus(stackStatus);
@@ -78,11 +90,26 @@ class FreeIpaClientFactoryTest {
 
     @Test
     void getFreeIpaClientForStackWithPingShouldReturnClientWhenStackStatusIsValid() {
-        Stack stack = new Stack();
+        Stack stack = createStack();
+        when(stackService.getByIdWithListsInTransaction(stack.getId())).thenReturn(stack);
         Status unreachableState = Status.FREEIPA_UNREACHABLE_STATUSES.stream().findAny().get();
         StackStatus stackStatus = new StackStatus(stack, unreachableState, "The FreeIPA instance is unreachable.", DetailedStackStatus.UNREACHABLE);
         stack.setStackStatus(stackStatus);
 
         Assertions.assertThrows(FreeIpaClientException.class, () -> underTest.getFreeIpaClientForStackWithPing(stack));
+    }
+
+    private Stack createStack() {
+        Stack stack = new Stack();
+        Set<InstanceGroup> instanceGroups = new HashSet<>();
+        stack.setInstanceGroups(instanceGroups);
+        InstanceGroup group = new InstanceGroup();
+        instanceGroups.add(group);
+        Set<InstanceMetaData> metaDatas = new HashSet<>();
+        group.setInstanceMetaData(metaDatas);
+        InstanceMetaData metaData = new InstanceMetaData();
+        metaDatas.add(metaData);
+        metaData.setPrivateIp("1.1.1.1");
+        return stack;
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaHealthServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaHealthServiceTest.java
@@ -2,13 +2,14 @@ package com.sequenceiq.freeipa.service.stack;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Assert;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -36,15 +37,11 @@ public class FreeIpaHealthServiceTest {
 
     private static final String ACCOUNT_ID = "accountId";
 
-    private static RPCResponse<Boolean> goodResponse;
-
-    private static RPCResponse<Boolean> doubleResponseOneBad;
-
-    private static RPCResponse<Boolean> errorResponse;
-
-    private static Stack stack;
-
     private static FreeIpaClientException ipaClientException;
+
+    private static final String HOST1 = "host1.domain";
+
+    private static final String HOST2 = "host2.domain";
 
     @Mock
     private StackService stackService;
@@ -55,9 +52,9 @@ public class FreeIpaHealthServiceTest {
     @InjectMocks
     private FreeIpaHealthDetailsService underTest;
 
-    private List<RPCMessage> getBaseMessages() {
+    private List<RPCMessage> getBaseMessages(String host) {
         List<RPCMessage> messages = new ArrayList<>();
-        messages.add(newRPCMessage("Check connection from master to remote replica 'freeipa.host.com':"));
+        messages.add(newRPCMessage("Check connection from master to remote replica '" + host + "':"));
         messages.add(newRPCMessage("   Directory Service: Unsecure port (389): OK"));
         messages.add(newRPCMessage("   Directory Service: Secure port (636): OK"));
         messages.add(newRPCMessage("   Directory Service: Secure port (636): OK"));
@@ -76,55 +73,26 @@ public class FreeIpaHealthServiceTest {
         return messages;
     }
 
-    private RPCResponse<Boolean> getGoodPayload() {
-        if (goodResponse == null) {
-            goodResponse = new RPCResponse<>();
-            goodResponse.setResult(Boolean.TRUE);
-            goodResponse.setValue("test.host.name");
-            goodResponse.setMessages(getBaseMessages());
-        }
+    private RPCResponse<Boolean> getGoodPayload(String host) {
+        RPCResponse<Boolean> goodResponse;
+        goodResponse = new RPCResponse<>();
+        goodResponse.setResult(Boolean.TRUE);
+        goodResponse.setValue(host);
+        goodResponse.setMessages(getBaseMessages(host));
         return goodResponse;
     }
 
-    private RPCResponse<Boolean> getErrorPayload() {
-        if (errorResponse == null) {
-            errorResponse = new RPCResponse<>();
-            errorResponse.setResult(Boolean.TRUE);
-            errorResponse.setValue("test.host.name");
-            errorResponse.setMessages(getBaseMessages());
-            errorResponse.getMessages().add(newRPCMessage("Failed to connect to port 464 tcp on 10.1.1.1"));
-            errorResponse.getMessages().add(newRPCMessage("   Kerberos Kpasswd: TCP (464): FAILED"));
-            errorResponse.getMessages().add(newRPCMessage("Failed to connect to port 636 tcp on 10.1.1.1"));
-            errorResponse.getMessages().add(newRPCMessage("   Directory Service: Secure port (636): OK"));
-        }
+    private RPCResponse<Boolean> getErrorPayload(String host) {
+        RPCResponse<Boolean> errorResponse;
+        errorResponse = new RPCResponse<>();
+        errorResponse.setResult(Boolean.TRUE);
+        errorResponse.setValue(host);
+        errorResponse.setMessages(getBaseMessages(host));
+        errorResponse.getMessages().add(newRPCMessage("Failed to connect to port 464 tcp on 10.1.1.1"));
+        errorResponse.getMessages().add(newRPCMessage("   Kerberos Kpasswd: TCP (464): FAILED"));
+        errorResponse.getMessages().add(newRPCMessage("Failed to connect to port 636 tcp on 10.1.1.1"));
+        errorResponse.getMessages().add(newRPCMessage("   Directory Service: Secure port (636): OK"));
         return errorResponse;
-    }
-
-    private RPCResponse<Boolean> getDoublePayload() {
-        if (doubleResponseOneBad == null) {
-            doubleResponseOneBad = new RPCResponse<>();
-            doubleResponseOneBad.setResult(Boolean.TRUE);
-            doubleResponseOneBad.setValue("test.host.name");
-            doubleResponseOneBad.setMessages(getBaseMessages());
-            doubleResponseOneBad.getMessages().add(newRPCMessage("Check connection from master to remote replica 'freeipa2.host.com':"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("   Directory Service: Unsecure port (389): OK"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("   Directory Service: Secure port (636): OK"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("   Directory Service: Secure port (636): OK"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("   Kerberos KDC: TCP (88): OK"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("Failed to connect to port 88 udp on 10.1.1.1"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("   Kerberos KDC: UDP (88): WARNING"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("Failed to connect to port 464 tcp on 10.1.1.1"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("   Kerberos Kpasswd: TCP (464): FAILED"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("Failed to connect to port 464 udp on 10.1.1.1"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("   Kerberos Kpasswd: UDP (464): WARNING"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("   HTTP Server: Unsecure port (80): OK"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("   HTTP Server: Secure port (443): OK"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("The following UDP ports could not be verified as open: 88, 464"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("This can happen if they are already bound to an application"));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("and ipa-replica-conncheck cannot attach own UDP responder."));
-            doubleResponseOneBad.getMessages().add(newRPCMessage("Connection from master to replica is OK."));
-        }
-        return doubleResponseOneBad;
     }
 
     private RPCMessage newRPCMessage(String message) {
@@ -134,27 +102,70 @@ public class FreeIpaHealthServiceTest {
         return msg;
     }
 
-    @BeforeAll
-    public static void init() {
-        stack = new Stack();
+    private Stack getGoodStack() {
+        Stack stack = new Stack();
         stack.setResourceCrn(ENVIRONMENT_ID);
         InstanceGroup instanceGroup = new InstanceGroup();
         stack.getInstanceGroups().add(instanceGroup);
         instanceGroup.setInstanceGroupType(InstanceGroupType.MASTER);
         InstanceMetaData instanceMetaData = new InstanceMetaData();
-        instanceMetaData.setDiscoveryFQDN("localhost");
+        instanceMetaData.setInstanceId("i-0123456789");
+        instanceMetaData.setDiscoveryFQDN(HOST1);
+        instanceMetaData.setInstanceStatus(InstanceStatus.CREATED);
+        instanceGroup.setInstanceMetaData(Sets.newHashSet(instanceMetaData));
+        return stack;
+    }
+
+    private Stack getGoodStackTwoInstances() {
+        Stack stack = new Stack();
+        stack.setResourceCrn(ENVIRONMENT_ID);
+        InstanceGroup instanceGroup = new InstanceGroup();
+        stack.getInstanceGroups().add(instanceGroup);
+        instanceGroup.setInstanceGroupType(InstanceGroupType.MASTER);
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+        instanceMetaData.setInstanceId("i-0123456789");
+        instanceMetaData.setDiscoveryFQDN(HOST1);
+        instanceMetaData.setInstanceStatus(InstanceStatus.CREATED);
+        instanceGroup.setInstanceMetaData(Sets.newHashSet(instanceMetaData));
+
+        instanceMetaData = new InstanceMetaData();
+        instanceMetaData.setInstanceId("i-9876543219");
+        instanceMetaData.setDiscoveryFQDN(HOST2);
+        instanceMetaData.setInstanceStatus(InstanceStatus.CREATED);
+        instanceGroup.getInstanceMetaData().add(instanceMetaData);
+        return stack;
+    }
+
+    private Stack getDeletedStack() {
+        Stack stack = new Stack();
+        stack.setResourceCrn(ENVIRONMENT_ID);
+        InstanceGroup instanceGroup = new InstanceGroup();
+        stack.getInstanceGroups().add(instanceGroup);
+        instanceGroup.setInstanceGroupType(InstanceGroupType.MASTER);
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+        instanceMetaData.setInstanceStatus(InstanceStatus.TERMINATED);
         instanceMetaData.setInstanceId("i-0123456789");
         instanceGroup.setInstanceMetaData(Sets.newHashSet(instanceMetaData));
-        instanceMetaData.setDiscoveryFQDN("host.domain");
+        instanceMetaData.setDiscoveryFQDN(HOST1);
+        return stack;
+    }
+
+    private FreeIpaClient getMockFreeIpaClient() {
+        return new FreeIpaClient(null, "1.1.1.1", "testhost");
+    }
+
+    @BeforeAll
+    public static void init() {
         ipaClientException = new FreeIpaClientException("failure");
     }
 
     @Test
     public void testHealthySingleNode() throws Exception {
         FreeIpaClient mockIpaClient = Mockito.mock(FreeIpaClient.class);
-        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(stack);
+        Mockito.when(mockIpaClient.getHostname()).thenReturn("test.host");
+        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(getGoodStack());
         Mockito.when(freeIpaClientFactory.getFreeIpaClientForStack(any())).thenReturn(mockIpaClient);
-        Mockito.when(mockIpaClient.serverConnCheck(anyString(), anyString())).thenReturn(getGoodPayload());
+        Mockito.when(mockIpaClient.serverConnCheck(anyString(), anyString())).thenReturn(getGoodPayload(HOST1));
         HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
         Assert.assertEquals(Status.AVAILABLE, response.getStatus());
         Assert.assertFalse(response.getNodeHealthDetails().isEmpty());
@@ -167,9 +178,10 @@ public class FreeIpaHealthServiceTest {
     @Test
     public void testUnhealthySingleNode() throws Exception {
         FreeIpaClient mockIpaClient = Mockito.mock(FreeIpaClient.class);
-        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(stack);
+        Mockito.when(mockIpaClient.getHostname()).thenReturn("test.host");
+        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(getGoodStack());
         Mockito.when(freeIpaClientFactory.getFreeIpaClientForStack(any())).thenReturn(mockIpaClient);
-        Mockito.when(mockIpaClient.serverConnCheck(anyString(), anyString())).thenReturn(getErrorPayload());
+        Mockito.when(mockIpaClient.serverConnCheck(anyString(), anyString())).thenReturn(getErrorPayload(HOST1));
         HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
         Assert.assertEquals(Status.UNHEALTHY, response.getStatus());
         Assert.assertFalse(response.getNodeHealthDetails().isEmpty());
@@ -182,27 +194,40 @@ public class FreeIpaHealthServiceTest {
     @Test
     public void testUnresponsiveSingleNode() throws Exception {
         FreeIpaClient mockIpaClient = Mockito.mock(FreeIpaClient.class);
-        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(stack);
+        Mockito.when(mockIpaClient.getHostname()).thenReturn("test.host");
+        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(getGoodStack());
         Mockito.when(freeIpaClientFactory.getFreeIpaClientForStack(any())).thenReturn(mockIpaClient);
         Mockito.when(mockIpaClient.serverConnCheck(anyString(), anyString())).thenThrow(ipaClientException);
         HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
-        Assert.assertEquals(Status.UNREACHABLE, response.getStatus());
-        Assert.assertFalse(response.getNodeHealthDetails().isEmpty());
+        Assert.assertEquals(Status.UNHEALTHY, response.getStatus());
+        Assert.assertTrue(response.getNodeHealthDetails().size() == 1);
         for (NodeHealthDetails nodeHealth:response.getNodeHealthDetails()) {
-            Assert.assertTrue(nodeHealth.getIssues().isEmpty());
+            Assert.assertTrue(!nodeHealth.getIssues().isEmpty());
             Assert.assertEquals(InstanceStatus.UNREACHABLE, nodeHealth.getStatus());
+            Assert.assertTrue(nodeHealth.getIssues().size() == 1);
+            Assert.assertTrue(nodeHealth.getIssues().get(0).equals("failure"));
         }
     }
 
     @Test
     public void testUnresponsiveSecondaryNode() throws Exception {
         FreeIpaClient mockIpaClient = Mockito.mock(FreeIpaClient.class);
-        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(stack);
+        Mockito.when(mockIpaClient.getHostname()).thenReturn("test.host");
+        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(getGoodStackTwoInstances());
         Mockito.when(freeIpaClientFactory.getFreeIpaClientForStack(any())).thenReturn(mockIpaClient);
-        Mockito.when(mockIpaClient.serverConnCheck(anyString(), anyString())).thenReturn(getDoublePayload());
+        Mockito.when(mockIpaClient.serverConnCheck(anyString(), eq(HOST1))).thenReturn(getGoodPayload(HOST1));
+        Mockito.when(mockIpaClient.serverConnCheck(anyString(), eq(HOST2))).thenThrow(ipaClientException);
         HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
         Assert.assertEquals(Status.AVAILABLE, response.getStatus());
-        Assert.assertFalse(response.getNodeHealthDetails().isEmpty());
+        Assert.assertTrue(response.getNodeHealthDetails().size() == 2);
     }
 
+    @Test
+    public void testNodeDeletedOnProvider() throws Exception {
+        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(getDeletedStack());
+        HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
+        Assert.assertEquals(Status.UNHEALTHY, response.getStatus());
+        Assert.assertFalse(response.getNodeHealthDetails().isEmpty());
+        Assert.assertTrue(response.getNodeHealthDetails().stream().findFirst().get().getStatus() == InstanceStatus.TERMINATED);
+    }
 }


### PR DESCRIPTION
This PR is cherry pick of 2 commits that are already in master, and 1 PR that has been approved but not merged.

This change adds goes through all instances in the
stack when trying to get a FreeIPA client unless the
loging is incorrect.

Co-authored-by: Jamison Bennett <jamison.bennnett@gmail.com>
(cherry picked from commit fc6106fd3014918669aa5ab19ec4f56e0d527072)

CB-6251: Could not reboot stopped FreeIPA

This change adjusts the reboot to properly reboot only started instances and
to call start on stopped instances. Because of AWS lifecycle
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-lifecycle.html
other statuses cannot be started or rebooted.

(cherry picked from commit 50f8a95712e150c95c005a19f225e95f23e0b5cc)

CB-6225: health check not returning status of all hosts.

This patch changes the health check to return individual
health of all HA nodes. The cn of the server_conncheck API
must be the host that the client is connected to. So we
exposed the connected hostname to use as the first parameter
of the API call.

(cherry picked from commit c16131f88d4ed6c4962b158792f19c8cb199d57e)

Ran unit tests and manually verified with 3 node cluster.