### PR TITLE
CB-6376 azure_instance_msi missing from backup configuration for FreeIPA

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaBackupConfigView.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaBackupConfigView.java
@@ -75,6 +75,7 @@ public class FreeIpaBackupConfigView {
         map.put("hourly_enabled", this.hourlyEnabled);
         map.put("initial_full_enabled", this.initialFullEnabled);
         map.put("platform", ObjectUtils.defaultIfNull(this.platform, EMPTY_CONFIG_DEFAULT));
+        map.put("azure_instance_msi", ObjectUtils.defaultIfNull(this.azureInstanceMsi, EMPTY_CONFIG_DEFAULT));
         return map;
     }
 


### PR DESCRIPTION
This adds the azure_instance_msi to the pillar that was missing.

Closes #CB-6376