### PR TITLE
[CFM-889] Modify repo init to work for ubuntu16 as well

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/repo/cloudera-manager.list
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/repo/cloudera-manager.list
@@ -1,2 +1,2 @@
 # Cloudera Manager {{ salt['pillar.get']('cloudera-manager:repo:version') }}
-deb [arch=amd64] {{ salt['pillar.get']('cloudera-manager:repo:baseUrl') }} xenial-cm{{ salt['pillar.get']('cloudera-manager:repo:version') }} contrib
+deb [arch=amd64 trusted=yes] {{ salt['pillar.get']('cloudera-manager:repo:baseUrl') }} xenial-cm{{ salt['pillar.get']('cloudera-manager:repo:version') }} contrib

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/repo/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/repo/init.sls
@@ -7,7 +7,7 @@
 
 {% elif grains['os_family'] == 'Debian' %}
 
-/etc/apt/sources.list.d/cloudera-manager.list
+/etc/apt/sources.list.d/cloudera-manager.list:
   file.managed:
     - source: salt://cloudera/repo/cloudera-manager.list
     - template: jinja


### PR DESCRIPTION
I am working on CFM-889 to implement ubuntu16 base image. During testing we discover, that repo init is not working for ubuntu16 and this change is necessary for that.