### PR TITLE
DISTX-397 DE HA template co-locate JN and ZK nodes to masters and manager

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-702.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-702.bp
@@ -341,7 +341,9 @@
           "livy-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
           "tez-GATEWAY-BASE",
-          "yarn-RESOURCEMANAGER-BASE"
+          "yarn-RESOURCEMANAGER-BASE",
+          "hdfs-JOURNALNODE-BASE",
+          "zookeeper-SERVER-BASE"
         ]
       },
       {
@@ -362,7 +364,9 @@
           "zeppelin-ZEPPELIN_SERVER-BASE",
           "das-DAS_EVENT_PROCESSOR",
           "das-DAS_WEBAPP",
-          "knox-KNOX_GATEWAY-BASE"
+          "knox-KNOX_GATEWAY-BASE",
+          "hdfs-JOURNALNODE-BASE",
+          "zookeeper-SERVER-BASE"
         ]
       },
       {
@@ -388,14 +392,6 @@
           "spark_on_yarn-GATEWAY-BASE",
           "tez-GATEWAY-BASE",
           "yarn-NODEMANAGER-COMPUTE"
-        ]
-      },
-      {
-        "refName": "quorum",
-        "cardinality": 3,
-        "roleConfigGroupsRefNames": [
-          "hdfs-JOURNALNODE-BASE",
-          "zookeeper-SERVER-BASE"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-710.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-710.bp
@@ -341,7 +341,9 @@
           "livy-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
           "tez-GATEWAY-BASE",
-          "yarn-RESOURCEMANAGER-BASE"
+          "yarn-RESOURCEMANAGER-BASE",
+          "hdfs-JOURNALNODE-BASE",
+          "zookeeper-SERVER-BASE"
         ]
       },
       {
@@ -362,7 +364,9 @@
           "zeppelin-ZEPPELIN_SERVER-BASE",
           "das-DAS_EVENT_PROCESSOR",
           "das-DAS_WEBAPP",
-          "knox-KNOX_GATEWAY-BASE"
+          "knox-KNOX_GATEWAY-BASE",
+          "hdfs-JOURNALNODE-BASE",
+          "zookeeper-SERVER-BASE"
         ]
       },
       {
@@ -388,14 +392,6 @@
           "spark_on_yarn-GATEWAY-BASE",
           "tez-GATEWAY-BASE",
           "yarn-NODEMANAGER-COMPUTE"
-        ]
-      },
-      {
-        "refName": "quorum",
-        "cardinality": 3,
-        "roleConfigGroupsRefNames": [
-          "hdfs-JOURNALNODE-BASE",
-          "zookeeper-SERVER-BASE"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-711.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-711.bp
@@ -341,7 +341,9 @@
           "livy-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
           "tez-GATEWAY-BASE",
-          "yarn-RESOURCEMANAGER-BASE"
+          "yarn-RESOURCEMANAGER-BASE",
+          "hdfs-JOURNALNODE-BASE",
+          "zookeeper-SERVER-BASE"
         ]
       },
       {
@@ -362,7 +364,9 @@
           "zeppelin-ZEPPELIN_SERVER-BASE",
           "das-DAS_EVENT_PROCESSOR",
           "das-DAS_WEBAPP",
-          "knox-KNOX_GATEWAY-BASE"
+          "knox-KNOX_GATEWAY-BASE",
+          "hdfs-JOURNALNODE-BASE",
+          "zookeeper-SERVER-BASE"
         ]
       },
       {
@@ -388,14 +392,6 @@
           "spark_on_yarn-GATEWAY-BASE",
           "tez-GATEWAY-BASE",
           "yarn-NODEMANAGER-COMPUTE"
-        ]
-      },
-      {
-        "refName": "quorum",
-        "cardinality": 3,
-        "roleConfigGroupsRefNames": [
-          "hdfs-JOURNALNODE-BASE",
-          "zookeeper-SERVER-BASE"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/clustertemplates/aws/aws-dataengineering-ha-702.json
+++ b/core/src/main/resources/defaults/clustertemplates/aws/aws-dataengineering-ha-702.json
@@ -70,26 +70,6 @@
       },
       {
         "nodeCount": 3,
-        "name": "quorum",
-        "type": "CORE",
-        "recoveryMode": "MANUAL",
-        "template": {
-          "aws": {},
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
-          "attachedVolumes": [{
-            "size": 100,
-            "count": 1,
-            "type": "standard"
-          }],
-          "cloudPlatform": "AWS"
-        },
-        "recipeNames": []
-      },
-      {
-        "nodeCount": 3,
         "name": "worker",
         "type": "CORE",
         "recoveryMode": "MANUAL",

--- a/core/src/main/resources/defaults/clustertemplates/aws/aws-dataengineering-ha-710.json
+++ b/core/src/main/resources/defaults/clustertemplates/aws/aws-dataengineering-ha-710.json
@@ -70,26 +70,6 @@
       },
       {
         "nodeCount": 3,
-        "name": "quorum",
-        "type": "CORE",
-        "recoveryMode": "MANUAL",
-        "template": {
-          "aws": {},
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
-          "attachedVolumes": [{
-            "size": 100,
-            "count": 1,
-            "type": "standard"
-          }],
-          "cloudPlatform": "AWS"
-        },
-        "recipeNames": []
-      },
-      {
-        "nodeCount": 3,
         "name": "worker",
         "type": "CORE",
         "recoveryMode": "MANUAL",

--- a/core/src/main/resources/defaults/clustertemplates/aws/aws-dataengineering-ha-711.json
+++ b/core/src/main/resources/defaults/clustertemplates/aws/aws-dataengineering-ha-711.json
@@ -70,26 +70,6 @@
       },
       {
         "nodeCount": 3,
-        "name": "quorum",
-        "type": "CORE",
-        "recoveryMode": "MANUAL",
-        "template": {
-          "aws": {},
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
-          "attachedVolumes": [{
-            "size": 100,
-            "count": 1,
-            "type": "standard"
-          }],
-          "cloudPlatform": "AWS"
-        },
-        "recipeNames": []
-      },
-      {
-        "nodeCount": 3,
         "name": "worker",
         "type": "CORE",
         "recoveryMode": "MANUAL",

--- a/core/src/main/resources/defaults/clustertemplates/azure/azure-dataengineering-ha-702.json
+++ b/core/src/main/resources/defaults/clustertemplates/azure/azure-dataengineering-ha-702.json
@@ -10,35 +10,6 @@
     },
     "instanceGroups": [
       {
-        "nodeCount": 3,
-        "name": "quorum",
-        "type": "CORE",
-        "recoveryMode": "MANUAL",
-        "template": {
-          "azure": {
-            "availabilitySet": {
-              "name": "",
-              "faultDomainCount": 2,
-              "updateDomainCount": 20
-            }
-          },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
-          "attachedVolumes": [
-            {
-              "size": 100,
-              "count": 1,
-              "type": "StandardSSD_LRS"
-            }
-          ],
-          "cloudPlatform": "AZURE"
-        },
-        "recipeNames": [],
-        "cloudPlatform": "AZURE"
-      },
-      {
         "nodeCount": 1,
         "name": "manager",
         "type": "GATEWAY",

--- a/core/src/main/resources/defaults/clustertemplates/azure/azure-dataengineering-ha-710.json
+++ b/core/src/main/resources/defaults/clustertemplates/azure/azure-dataengineering-ha-710.json
@@ -10,35 +10,6 @@
     },
     "instanceGroups": [
       {
-        "nodeCount": 3,
-        "name": "quorum",
-        "type": "CORE",
-        "recoveryMode": "MANUAL",
-        "template": {
-          "azure": {
-            "availabilitySet": {
-              "name": "",
-              "faultDomainCount": 2,
-              "updateDomainCount": 20
-            }
-          },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
-          "attachedVolumes": [
-            {
-              "size": 100,
-              "count": 1,
-              "type": "StandardSSD_LRS"
-            }
-          ],
-          "cloudPlatform": "AZURE"
-        },
-        "recipeNames": [],
-        "cloudPlatform": "AZURE"
-      },
-      {
         "nodeCount": 1,
         "name": "manager",
         "type": "GATEWAY",

--- a/core/src/main/resources/defaults/clustertemplates/azure/azure-dataengineering-ha-711.json
+++ b/core/src/main/resources/defaults/clustertemplates/azure/azure-dataengineering-ha-711.json
@@ -10,35 +10,6 @@
     },
     "instanceGroups": [
       {
-        "nodeCount": 3,
-        "name": "quorum",
-        "type": "CORE",
-        "recoveryMode": "MANUAL",
-        "template": {
-          "azure": {
-            "availabilitySet": {
-              "name": "",
-              "faultDomainCount": 2,
-              "updateDomainCount": 20
-            }
-          },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
-          "attachedVolumes": [
-            {
-              "size": 100,
-              "count": 1,
-              "type": "StandardSSD_LRS"
-            }
-          ],
-          "cloudPlatform": "AZURE"
-        },
-        "recipeNames": [],
-        "cloudPlatform": "AZURE"
-      },
-      {
         "nodeCount": 1,
         "name": "manager",
         "type": "GATEWAY",


### PR DESCRIPTION
1. CB-5660 added the ability to have JN across node groups.
2. Tested the template and the fix for CB-5660 works for the DE HA template in a private stack.