### PR TITLE
CB-5734 Additional Validations for DistroX Autoscale API

### DIFF
--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/v1/AlertEndpoint.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/v1/AlertEndpoint.java
@@ -77,14 +77,13 @@ public interface AlertEndpoint {
     @Path("time")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = AlertOpDescription.TIME_BASED_POST, produces = MediaType.APPLICATION_JSON, notes = TIME_BASED_NOTES)
-    TimeAlertResponse createTimeAlert(@PathParam("clusterId") Long clusterId, @Valid TimeAlertRequest json) throws ParseException;
+    TimeAlertResponse createTimeAlert(@PathParam("clusterId") Long clusterId, @Valid TimeAlertRequest json);
 
     @PUT
     @Path("time/{alertId}")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = AlertOpDescription.TIME_BASED_PUT, produces = MediaType.APPLICATION_JSON, notes = TIME_BASED_NOTES)
-    TimeAlertResponse updateTimeAlert(@PathParam("clusterId") Long clusterId, @PathParam("alertId") Long alertId, @Valid TimeAlertRequest json)
-            throws ParseException;
+    TimeAlertResponse updateTimeAlert(@PathParam("clusterId") Long clusterId, @PathParam("alertId") Long alertId, @Valid TimeAlertRequest json);
 
     @GET
     @Path("time")
@@ -139,14 +138,13 @@ public interface AlertEndpoint {
     @Path("load")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = AlertOpDescription.LOAD_BASED_POST, produces = MediaType.APPLICATION_JSON, notes = LOAD_BASED_NOTES)
-    LoadAlertResponse createLoadAlert(@PathParam("clusterId") Long clusterId, @Valid LoadAlertRequest json) throws ParseException;
+    LoadAlertResponse createLoadAlert(@PathParam("clusterId") Long clusterId, @Valid LoadAlertRequest json);
 
     @PUT
     @Path("load/{alertId}")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = AlertOpDescription.LOAD_BASED_PUT, produces = MediaType.APPLICATION_JSON, notes = LOAD_BASED_NOTES)
-    LoadAlertResponse updateLoadAlert(@PathParam("clusterId") Long clusterId, @PathParam("alertId") Long alertId, @Valid LoadAlertRequest json)
-            throws ParseException;
+    LoadAlertResponse updateLoadAlert(@PathParam("clusterId") Long clusterId, @PathParam("alertId") Long alertId, @Valid LoadAlertRequest json);
 
     @GET
     @Path("load")

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/v1/DistroXAutoScaleClusterV1Endpoint.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/v1/DistroXAutoScaleClusterV1Endpoint.java
@@ -2,7 +2,6 @@ package com.sequenceiq.periscope.api.endpoint.v1;
 
 import static com.sequenceiq.periscope.doc.ApiDescription.CLUSTERS_DESCRIPTION;
 
-import java.text.ParseException;
 import java.util.List;
 
 import javax.validation.Valid;
@@ -51,14 +50,14 @@ public interface DistroXAutoScaleClusterV1Endpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = ClusterOpDescription.CLUSTER_SET_AUTOSCALE_STATE, produces = MediaType.APPLICATION_JSON, notes = DistroXClusterNotes.NOTES)
     DistroXAutoscaleClusterResponse updateAutoscaleConfigByClusterCrn(@PathParam("crn") String clusterCrn,
-            @ValidDistroXAutoscaleRequest @Valid DistroXAutoscaleClusterRequest autoscaleClusterRequest) throws ParseException;
+            @ValidDistroXAutoscaleRequest @Valid DistroXAutoscaleClusterRequest autoscaleClusterRequest);
 
     @POST
     @Path("name/{name}/autoscaleconfig")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = ClusterOpDescription.CLUSTER_SET_AUTOSCALE_STATE, produces = MediaType.APPLICATION_JSON, notes = DistroXClusterNotes.NOTES)
     DistroXAutoscaleClusterResponse updateAutoscaleConfigByClusterName(@PathParam("name") String clusterName,
-            @ValidDistroXAutoscaleRequest @Valid DistroXAutoscaleClusterRequest autoscaleClusterRequest) throws ParseException;
+            @ValidDistroXAutoscaleRequest @Valid DistroXAutoscaleClusterRequest autoscaleClusterRequest);
 
     @DELETE
     @Path("name/{name}")

--- a/autoscale/src/main/java/com/sequenceiq/periscope/repository/ClusterRepository.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/repository/ClusterRepository.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.periscope.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -17,9 +18,9 @@ public interface ClusterRepository extends CrudRepository<Cluster, Long> {
 
     Cluster findByStackId(@Param("stackId") Long stackId);
 
-    Cluster findByStackCrn(@Param("stackCrn") String stackCrn);
+    Optional<Cluster> findByStackCrn(@Param("stackCrn") String stackCrn);
 
-    Cluster findByStackName(@Param("stackName") String stackName);
+    Optional<Cluster> findByStackName(@Param("stackName") String stackName);
 
     @Query("SELECT c.stackCrn FROM Cluster c WHERE c.id = :id")
     String findStackCrnById(@Param("id") Long id);
@@ -44,5 +45,4 @@ public interface ClusterRepository extends CrudRepository<Cluster, Long> {
     @Modifying
     @Query("UPDATE Cluster c SET c.periscopeNodeId = NULL WHERE c.periscopeNodeId = :periscopeNodeId")
     void deallocateClustersOfNode(@Param("periscopeNodeId") String periscopeNodeId);
-
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/ClusterService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/ClusterService.java
@@ -7,6 +7,7 @@ import static org.springframework.util.StringUtils.isEmpty;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.StreamSupport;
 
 import javax.annotation.PostConstruct;
@@ -129,11 +130,11 @@ public class ClusterService {
         return clusterRepository.findByStackId(stackId);
     }
 
-    public Cluster findOneByStackCrn(String stackCrn) {
+    public Optional<Cluster> findOneByStackCrn(String stackCrn) {
         return  clusterRepository.findByStackCrn(stackCrn);
     }
 
-    public Cluster findOneByStackName(String stackName) {
+    public Optional<Cluster> findOneByStackName(String stackName) {
         return  clusterRepository.findByStackName(stackName);
     }
 


### PR DESCRIPTION
CB-5734 Additional Validations
1. Load Based Scaling Enabled only for clusters with cluster-proxy tunnel.
2. Additional Validation for invalid crn or name.