### PR TITLE
Fix a type error in the java.security file path while checking for th…

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/java/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/java/init.sls
@@ -19,7 +19,7 @@ set_dns_negativ_ttl:
     - name: {{ java_home }}/jre/lib/security/java.security
     - pattern: "#?networkaddress.cache.negative.ttl=.*"
     - repl: "networkaddress.cache.negative.ttl=0"
-    - unless: cat {{ java_home }}/lib/security/java.security | grep ^networkaddress.cache.negative.ttl=0$
+    - unless: cat {{ java_home }}/jre/lib/security/java.security | grep ^networkaddress.cache.negative.ttl=0$
 
 /etc/jmx_exporter:
   file.recurse:


### PR DESCRIPTION
…e completeness of the salt execution.

1. Saw this error while troubleshooting another issue. [a]
2. Trying to understand the implication of why it continues to work.

[a]

```
2020-04-03 21:55:14,696 [salt.utils.lazy  :100 ][DEBUG   ][11345] Could not LazyLoad file.mod_run_check: 'file.mod_run_check' is not available.
2020-04-03 21:55:14,696 [salt.loaded.int.module.cmdmod:394 ][INFO    ][11345] Executing command 'cat /usr/lib/jvm/java/lib/security/java.security | grep ^networkaddress.cache.negative.ttl=0$' in directory '/root'
2020-04-03 21:55:14,703 [salt.loaded.int.module.cmdmod:695 ][DEBUG   ][11345] stdout: cat: /usr/lib/jvm/java/lib/security/java.security: No such file or directory
2020-04-03 21:55:14,703 [salt.loaded.int.module.cmdmod:699 ][DEBUG   ][11345] retcode: 1
2020-04-03 21:55:14,704 [salt.state       :854 ][DEBUG   ][11345] Last command return code: 1
2020-04-03 21:55:14,714 [salt.state       :290 ][INFO    ][11345] File changed:
---
+++
@@ -323,7 +323,7 @@
 # results for 10 seconds.
 #
 #
-networkaddress.cache.negative.ttl=10
+networkaddress.cache.negative.ttl=0

 #
 # Properties to configure OCSP for certificate revocation checking

2020-04-03 21:55:14,714 [salt.state       :1934][INFO    ][11345] Completed state [/usr/lib/jvm/java/jre/lib/security/java.security] at time 21:55:14.714295 duration_in_ms=21.521

```