### PR TITLE
CB-6494: Update FreeIPA backup scripts to provide status

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_backup
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_backup
@@ -6,6 +6,13 @@ set -x
 
 CONFIG_FILE=/etc/freeipa_backup.conf
 
+if [ -z "$CRON_BACKUP" ]
+then
+    BACKUP_MODE="MANUAL"
+else
+    BACKUP_MODE="CRON"
+fi
+
 # Config Defaults
 typeset -A config # init array
 config=( # set default values in config array
@@ -13,6 +20,7 @@ config=( # set default values in config array
     [backup_platform]="LOCAL"
     [azure_instance_msi]=""
     [logfile]="/var/log/ipabackup.log"
+    [statusfile]="/var/log/ipabackup_status.log"
     [backup_path]="/var/lib/ipa/backup"
     [http_proxy]=""
 )
@@ -61,6 +69,7 @@ then
 fi
 
 LOGFILE="${config[logfile]}"
+STATUSFILE="${config[statusfile]}"
 DATE_FOLDER="$(date -I)"
 BACKUP_PATH_POSTFIX="${FOLDER}"
 
@@ -83,10 +92,19 @@ doLog(){
     echo "`date "+%Y-%m-%dT%H:%M:%SZ"` $type_of_msg ""$msg" >> $LOGFILE
 }
 
+doStatus(){
+    type_of_msg=$(echo $*|cut -d" " -f1)
+    msg=$(echo "$*"|cut -d" " -f2-)
+    [[ $type_of_msg == INFO ]] && type_of_msg="INFO " # one space for aligning
+
+    echo "`date "+%Y-%m-%dT%H:%M:%SZ"` $type_of_msg "$BACKUP_MODE" ""$msg" > $STATUSFILE
+}
+
 error_exit()
 {
     doLog "ERROR $1"
-	exit 1
+    doStatus "ERROR $1"
+    exit 1
 }
 
 remove_local_backups() {
@@ -123,3 +141,4 @@ elif [[ "${config[backup_platform]}" = "AZURE" ]]; then
 fi
 
 doLog "INFO Backup completed."
+doStatus "INFO Backup succeeded."

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/templates/freeipa_backup_hourly.j2
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/templates/freeipa_backup_hourly.j2
@@ -1,6 +1,6 @@
 {%- from 'freeipa/settings.sls' import freeipa with context -%}
 #!/bin/bash
 if [ ! -f /tmp/freeipa_backup_hourly_bypass ]; then
-    /usr/local/bin/freeipa_backup -t DATA -f "{{freeipa.hostname}}/hourly/$(date -I)"
+    CRON_BACKUP=true /usr/local/bin/freeipa_backup -t DATA -f "{{freeipa.hostname}}/hourly/$(date -I)"
 fi
 

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/templates/freeipa_backup_monthly.j2
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/templates/freeipa_backup_monthly.j2
@@ -1,5 +1,5 @@
 {%- from 'freeipa/settings.sls' import freeipa with context -%}
 #!/bin/bash
 if [ ! -f /tmp/freeipa_backup_monthly_bypass ]; then
-    /usr/local/bin/freeipa_backup -t FULL -f "{{freeipa.hostname}}/full"
+    CRON_BACKUP=true /usr/local/bin/freeipa_backup -t FULL -f "{{freeipa.hostname}}/full"
 fi


### PR DESCRIPTION
This change enables the backup script to report a single
line status. This enables easier parsing of the last
backup status for the health checks.

Local deployment and validation.
