### PR TITLE
CB-6380. Do not persist telemetry component for stack with template type

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverter.java
@@ -122,6 +122,7 @@ public class StackV4RequestToStackConverter extends AbstractConversionServiceAwa
             convertAsStack(source, stack);
             updateCloudPlatformAndRelatedFields(source, stack, environment);
             setNetworkIfApplicable(source, stack, environment);
+            stack.getComponents().add(getTelemetryComponent(stack, source));
         }
         Map<String, Object> asMap = providerParameterCalculator.get(source).asMap();
         if (asMap != null) {
@@ -139,8 +140,6 @@ public class StackV4RequestToStackConverter extends AbstractConversionServiceAwa
         stack.setInstanceGroups(convertInstanceGroups(source, stack));
         measure(() -> updateCluster(source, stack, workspace),
                 LOGGER, "Converted cluster and updated the stack in {} ms for stack {}", source.getName());
-        stack.getComponents().add(getTelemetryComponent(stack, source));
-
         stack.setGatewayPort(source.getGatewayPort());
         stack.setUuid(UUID.randomUUID().toString());
         stack.setType(source.getType());

--- a/core/src/main/resources/schema/app/20200408152731_CB-6380_Do_not_persist_telemetry_for_stack_template.sql
+++ b/core/src/main/resources/schema/app/20200408152731_CB-6380_Do_not_persist_telemetry_for_stack_template.sql
@@ -1,0 +1,7 @@
+-- // CB-6380 Do not persist telemetry component for stack with template type
+-- Migration SQL that makes the change goes here.
+
+DELETE FROM component WHERE componenttype = 'TELEMETRY' AND stack_id IN (SELECT id FROM stack WHERE type = 'TEMPLATE')
+
+-- //@UNDO
+-- SQL to undo the change goes here.


### PR DESCRIPTION
- do not add telemetry component for stacks with type 'TEMPLATE'
- remove already existing ones from DB

tested against dtahub deployments with default cluster definitions + custom ones
