### PR TITLE
CB-6514 AWS Datalake deployment on mow-dev is failing with HV000028 U…

### DIFF
--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxInternalClusterRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxInternalClusterRequest.java
@@ -1,12 +1,9 @@
 package com.sequenceiq.sdx.api.model;
 
-import javax.validation.Valid;
-
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackV4Request;
 
 public class SdxInternalClusterRequest extends SdxClusterRequest {
 
-    @Valid
     private StackV4Request stackV4Request;
 
     public StackV4Request getStackV4Request() {


### PR DESCRIPTION
@bergerdenes I saw you put the annotation on this field, but in case of sdx internal, name comes from pathparam, people usually don't put it into the input json but validation is on it within stackv4request, thus lot of people experienced issue with sdx internal. Since I do not want to make people fill this info twice, I removed the annotation for now. (cloudbreak will validate the stackrequest anyway)