### PR TITLE
CB-6526. Allow cluster/env luanch to specify a tag key already specified at the account level as long as the value is identical.

### DIFF
--- a/template-manager-tag/src/main/java/com/sequenceiq/cloudbreak/tag/DefaultCostTaggingService.java
+++ b/template-manager-tag/src/main/java/com/sequenceiq/cloudbreak/tag/DefaultCostTaggingService.java
@@ -113,10 +113,20 @@ public class DefaultCostTaggingService implements CostTagging {
                     .filter(userDefinedResourceTags::containsKey)
                     .collect(Collectors.toSet());
             if (!accountTagsDuplicatedInResourceTags.isEmpty()) {
-                String msg = String.format("The request must not contain tag(s) with key: '%s', because with the same key tag has already been defined "
-                        + "on account level!", String.join(", ", accountTagsDuplicatedInResourceTags));
-                LOGGER.info(msg);
-                throw new AccountTagValidationFailed(msg);
+
+                Set<String> duplicateTagsWithDiffValues = accountTagsDuplicatedInResourceTags
+                    .stream()
+                    .filter(s -> !accountTags.get(s).equals(userDefinedResourceTags.get(s)))
+                    .collect(Collectors.toSet());
+
+                if (!duplicateTagsWithDiffValues.isEmpty()) {
+                    String msg = String.format(
+                        "The request must not contain tag(s) with key: '%s', because with the same key tag has already been defined "
+                            + "on account level!",
+                        String.join(", ", duplicateTagsWithDiffValues));
+                    LOGGER.info(msg);
+                    throw new AccountTagValidationFailed(msg);
+                }
             }
         }
     }

--- a/template-manager-tag/src/test/java/com/sequenceiq/cloudbreak/DefaultCostTaggingServiceTest.java
+++ b/template-manager-tag/src/test/java/com/sequenceiq/cloudbreak/DefaultCostTaggingServiceTest.java
@@ -128,7 +128,7 @@ public class DefaultCostTaggingServiceTest {
         CDPTagGenerationRequest tagRequest = tagRequest("AWS", new HashMap<>(), envMap, requestTag);
         try {
             underTest.prepareDefaultTags(tagRequest);
-            Assert.fail("Expected an exception due to conflicting account and user tags");
+            Assert.fail("Expected an exception due to conflicting account and user tags.");
         } catch (AccountTagValidationFailed e) {
             Assert.assertEquals("The request must not contain tag(s) with key: 'owner', because"
                 + " with the same key tag has already been defined on account level!", e.getMessage());

--- a/template-manager-tag/src/test/java/com/sequenceiq/cloudbreak/DefaultCostTaggingServiceTest.java
+++ b/template-manager-tag/src/test/java/com/sequenceiq/cloudbreak/DefaultCostTaggingServiceTest.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak;
 
+import com.sequenceiq.cloudbreak.tag.AccountTagValidationFailed;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -86,10 +87,10 @@ public class DefaultCostTaggingServiceTest {
         envMap.put("apple3", "apple3");
         envMap.put("apple4", "apple4");
         Map<String, String> requestTag = new HashMap<>();
-        envMap.put("pear1", "");
-        envMap.put("", "pear2");
-        envMap.put("pear3", "pear3");
-        envMap.put("pear4", "pear4");
+        requestTag.put("pear1", "");
+        requestTag.put("", "pear2");
+        requestTag.put("pear3", "pear3");
+        requestTag.put("pear4", "pear4");
 
         Map<String, String> result = underTest.mergeTags(mergeRequest("AWS", envMap, requestTag));
 
@@ -100,22 +101,62 @@ public class DefaultCostTaggingServiceTest {
         Assert.assertEquals("apple4", "apple4");
     }
 
+    @Test
+    public void testAccountTagUserTagEquality_noError() {
+        Map<String, String> envMap = new HashMap<>();
+        envMap.put("apple1", "apple1");
+        envMap.put("apple2", "apple2");
+        envMap.put("owner", "owner");
+        Map<String, String> requestTag = new HashMap<>();
+        requestTag.put("pear1", "pear1");
+        requestTag.put("owner", "owner");
+
+        CDPTagGenerationRequest tagRequest = tagRequest("AWS", new HashMap<>(), envMap, requestTag);
+        underTest.prepareDefaultTags(tagRequest);
+    }
+
+    @Test
+    public void testAccountTagUserTagConflict_error() {
+        Map<String, String> envMap = new HashMap<>();
+        envMap.put("apple1", "apple1");
+        envMap.put("apple2", "apple2");
+        envMap.put("owner", "owner");
+        Map<String, String> requestTag = new HashMap<>();
+        requestTag.put("pear1", "pear1");
+        requestTag.put("owner", "conflict");
+
+        CDPTagGenerationRequest tagRequest = tagRequest("AWS", new HashMap<>(), envMap, requestTag);
+        try {
+            underTest.prepareDefaultTags(tagRequest);
+            Assert.fail("Expected an exception due to conflicting account and user tags");
+        } catch (AccountTagValidationFailed e) {
+            Assert.assertEquals("The request must not contain tag(s) with key: 'owner', because"
+                + " with the same key tag has already been defined on account level!", e.getMessage());
+        }
+    }
+
     private CDPTagGenerationRequest tagRequest(String platform) {
         return tagRequest(platform, new HashMap<>(), new HashMap<>());
     }
 
     private CDPTagGenerationRequest tagRequest(String platform, Map<String, String> sourceMap, Map<String, String> accountTags) {
+        return tagRequest(platform, sourceMap, accountTags, new HashMap<>());
+    }
+
+    private CDPTagGenerationRequest tagRequest(String platform, Map<String, String> sourceMap,
+        Map<String, String> accountTags, Map<String, String> userTags) {
         return CDPTagGenerationRequest.Builder.builder()
-                .withEnvironmentCrn("environment-crn")
-                .withCreatorCrn("creator-crn")
-                .withResourceCrn("resource-crn")
-                .withUserName("apache1@apache.com")
-                .withPlatform(platform)
-                .withAccountId("pepsi")
-                .withIsInternalTenant(true)
-                .withSourceMap(sourceMap)
-                .withAccountTags(accountTags)
-                .build();
+            .withEnvironmentCrn("environment-crn")
+            .withCreatorCrn("creator-crn")
+            .withResourceCrn("resource-crn")
+            .withUserName("apache1@apache.com")
+            .withPlatform(platform)
+            .withAccountId("pepsi")
+            .withIsInternalTenant(true)
+            .withSourceMap(sourceMap)
+            .withAccountTags(accountTags)
+            .withUserDefinedTags(userTags)
+            .build();
     }
 
     private CDPTagMergeRequest mergeRequest(String platform, Map<String, String> envMap, Map<String, String> requestTag) {

--- a/template-manager-tag/src/test/java/com/sequenceiq/cloudbreak/DefaultCostTaggingServiceTest.java
+++ b/template-manager-tag/src/test/java/com/sequenceiq/cloudbreak/DefaultCostTaggingServiceTest.java
@@ -116,7 +116,7 @@ public class DefaultCostTaggingServiceTest {
     }
 
     @Test
-    public void testAccountTagUserTagConflictGeneartesError() {
+    public void testAccountTagUserTagConflictGeneratesError() {
         Map<String, String> envMap = new HashMap<>();
         envMap.put("apple1", "apple1");
         envMap.put("apple2", "apple2");

--- a/template-manager-tag/src/test/java/com/sequenceiq/cloudbreak/DefaultCostTaggingServiceTest.java
+++ b/template-manager-tag/src/test/java/com/sequenceiq/cloudbreak/DefaultCostTaggingServiceTest.java
@@ -102,7 +102,7 @@ public class DefaultCostTaggingServiceTest {
     }
 
     @Test
-    public void testAccountTagUserTagEquality_noError() {
+    public void testAccountTagUserTagEqualityNoError() {
         Map<String, String> envMap = new HashMap<>();
         envMap.put("apple1", "apple1");
         envMap.put("apple2", "apple2");
@@ -116,7 +116,7 @@ public class DefaultCostTaggingServiceTest {
     }
 
     @Test
-    public void testAccountTagUserTagConflict_error() {
+    public void testAccountTagUserTagConflictGeneartesError() {
         Map<String, String> envMap = new HashMap<>();
         envMap.put("apple1", "apple1");
         envMap.put("apple2", "apple2");


### PR DESCRIPTION


**DELETE THIS TEMPLATE BEFORE SUBMITTING**

Describe the change you are making here!

Please include tests. Check out these examples:

- https://github.com/hortonworks/cloudbreak/blob/master/core/src/test/java/com/sequenceiq/cloudbreak/service/blueprint/BlueprintLoaderServiceTest.java#L62-L76

Please include a short description. Check out these examples:

- https://github.com/hortonworks/cloudbreak/commit/888b2e2a8887def28a24e26efcd6d9ca5863733a

If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:

Closes #xxx
Closes #xxx