### PR TITLE
DISTX-415 Reduce the amount of time it takes to add new nodes

### DIFF
--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/common/type/RecipeExecutionPhase.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/common/type/RecipeExecutionPhase.java
@@ -4,8 +4,6 @@ import com.sequenceiq.cloudbreak.common.model.recipe.RecipeType;
 
 public enum RecipeExecutionPhase {
 
-    PRE("pre"),
-    POST("post"),
     PRE_CLOUDERA_MANAGER_START("pre-cloudera-manager-start"),
     PRE_TERMINATION("pre-termination"),
     POST_CLOUDERA_MANAGER_START("post-cloudera-manager-start"),
@@ -33,13 +31,7 @@ public enum RecipeExecutionPhase {
     }
 
     public boolean isPreRecipe() {
-        switch (this) {
-            case POST_CLUSTER_INSTALL:
-            case POST:
-                return false;
-            default:
-                return true;
-        }
+        return this != POST_CLUSTER_INSTALL;
     }
 
     public boolean isPostRecipe() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/KerberosConfigTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/KerberosConfigTest.java
@@ -149,7 +149,7 @@ public class KerberosConfigTest extends AbstractIntegrationTest {
             public List<Assertion<StackTestDto, CloudbreakClient>> getAssertions() {
                 List<Assertion<StackTestDto, CloudbreakClient>> verifications = new LinkedList<>();
                 verifications.add(clusterTemplatePostToCMContains("enableKerberos").exactTimes(1));
-                verifications.add(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(SALT_HIGHSTATE).exactTimes(5));
+                verifications.add(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(SALT_HIGHSTATE).exactTimes(3));
                 return verifications;
             }
 
@@ -176,7 +176,7 @@ public class KerberosConfigTest extends AbstractIntegrationTest {
             public List<Assertion<StackTestDto, CloudbreakClient>> getAssertions() {
                 List<Assertion<StackTestDto, CloudbreakClient>> verifications = new LinkedList<>();
                 verifications.add(clusterTemplatePostToCMContains("enableKerberos").exactTimes(1));
-                verifications.add(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(SALT_HIGHSTATE).exactTimes(5));
+                verifications.add(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(SALT_HIGHSTATE).exactTimes(3));
                 return verifications;
             }
 
@@ -201,7 +201,7 @@ public class KerberosConfigTest extends AbstractIntegrationTest {
             public List<Assertion<StackTestDto, CloudbreakClient>> getAssertions() {
                 List<Assertion<StackTestDto, CloudbreakClient>> verifications = new LinkedList<>();
                 verifications.add(clusterTemplatePostToCMContains("enableKerberos").exactTimes(1));
-                verifications.add(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(SALT_HIGHSTATE).exactTimes(5));
+                verifications.add(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(SALT_HIGHSTATE).exactTimes(3));
                 return verifications;
             }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/RecipeClusterTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/RecipeClusterTest.java
@@ -154,10 +154,10 @@ public class RecipeClusterTest extends AbstractIntegrationTest {
                 .replaceInstanceGroups(INSTANCE_GROUP_ID)
                 .when(stackTestClient.createV4())
                 .await(STACK_AVAILABLE)
-                .then(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(HIGHSTATE).exactTimes(5))
+                .then(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(HIGHSTATE).exactTimes(3))
                 .when(stackTestClient.deleteV4())
                 .await(STACK_DELETED)
-                .then(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(HIGHSTATE).exactTimes(7))
+                .then(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(HIGHSTATE).exactTimes(4))
                 .validate();
     }
 
@@ -220,7 +220,7 @@ public class RecipeClusterTest extends AbstractIntegrationTest {
                 .await(STACK_AVAILABLE)
                 .when(StackScalePostAction.valid().withDesiredCount(mock.getDesiredWorkerCount()))
                 .await(STACK_AVAILABLE)
-                .then(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(HIGHSTATE).exactTimes(8))
+                .then(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(HIGHSTATE).exactTimes(4))
                 .validate();
     }
 
@@ -263,7 +263,7 @@ public class RecipeClusterTest extends AbstractIntegrationTest {
                 .await(STACK_AVAILABLE)
                 .when(StackScalePostAction.valid().withDesiredCount(mock.getDesiredWorkerCount()))
                 .await(STACK_AVAILABLE)
-                .then(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(HIGHSTATE).exactTimes(8))
+                .then(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(HIGHSTATE).exactTimes(4))
                 .validate();
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/clouderamanager/CMUpscaleWithHttp500ResponsesTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/clouderamanager/CMUpscaleWithHttp500ResponsesTest.java
@@ -141,7 +141,7 @@ public class CMUpscaleWithHttp500ResponsesTest extends AbstractClouderaManagerTe
                 .then(MockVerification.verify(POST, ITResponse.SALT_API_ROOT + "/run").bodyContains("fun=saltutil.sync_all").atLeast(1))
                 .then(MockVerification.verify(POST, ITResponse.SALT_API_ROOT + "/run").bodyContains("fun=mine.update").atLeast(1))
                 .then(MockVerification.verify(POST, ITResponse.SALT_API_ROOT + "/run").bodyContains("fun=state.highstate").atLeast(2))
-                .then(MockVerification.verify(POST, ITResponse.SALT_API_ROOT + "/run").bodyContains("fun=grains.remove").exactTimes(6))
+                .then(MockVerification.verify(POST, ITResponse.SALT_API_ROOT + "/run").bodyContains("fun=grains.remove").exactTimes(4))
                 .then(MockVerification.verify(GET,
                         new ClouderaManagerPathResolver(LIST_HOSTS)
                                 .pathVariableMapping(":clusterName", clusterName)

--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/ipa-leave.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/ipa-leave.sls
@@ -29,8 +29,10 @@ remove_cm_service_account:
 leave-ipa:
   cmd.run:
 {% if metadata.platform != 'YARN' %}
-    - name: ipa host-del {{ salt['grains.get']('fqdn') }} --updatedns && ipa-client-install --uninstall -U
+    - name: echo $PW | kinit {{ salt['pillar.get']('sssd-ipa:principal') }} && ipa host-del {{ salt['grains.get']('fqdn') }} --updatedns && ipa-client-install --uninstall -U
 {% else %}
-    - name: runuser -l root -c 'ipa host-del {{ salt['grains.get']('fqdn') }} --updatedns && ipa-client-install --uninstall -U'
+    - name: runuser -l root -c 'echo $PW | kinit {{ salt['pillar.get']('sssd-ipa:principal') }} && ipa host-del {{ salt['grains.get']('fqdn') }} --updatedns && ipa-client-install --uninstall -U'
 {% endif %}
     - onlyif: ipa env
+    - env:
+        - PW: "{{salt['pillar.get']('sssd-ipa:password')}}"


### PR DESCRIPTION
1. In this commit, we optimize the salt execution times by removing the `high state apply` after each phase of recipe execution.
2. There is only one high state apply in all the nodes after a scale-up.
3. We could still optimize the individual scripts like metering which always removes and adds the same package in all the nodes of the cluster for every scale-up.
4. This is the first time modifying something in salt, so I will focus on further optimization after getting initial feedback.
5. Also removed the deprecated pre/post-execution phases. Made sure that there are no existing salt scripts for such phases.

./gradlew build && test scale-up in a private stack to see the time getting reduced from 5 mins to 4 mins.