### PR TITLE
DISTX-397 For DE HA template use HA external database

### DIFF
--- a/core/src/main/resources/defaults/clustertemplates/aws/aws-dataengineering-ha-702.json
+++ b/core/src/main/resources/defaults/clustertemplates/aws/aws-dataengineering-ha-702.json
@@ -8,6 +8,9 @@
     "cluster": {
       "blueprintName": "CDP 1.2 - Data Engineering: HA: Apache Spark, Apache Hive, Apache Oozie"
     },
+    "externalDatabase": {
+      "availabilityType": "HA"
+    },
     "instanceGroups": [{
       "nodeCount": 1,
       "name": "manager",

--- a/core/src/main/resources/defaults/clustertemplates/aws/aws-dataengineering-ha-710.json
+++ b/core/src/main/resources/defaults/clustertemplates/aws/aws-dataengineering-ha-710.json
@@ -8,6 +8,9 @@
     "cluster": {
       "blueprintName": "7.1.0 - Data Engineering: HA: Apache Spark, Apache Hive, Apache Oozie"
     },
+    "externalDatabase": {
+      "availabilityType": "HA"
+    },
     "instanceGroups": [{
       "nodeCount": 1,
       "name": "manager",

--- a/core/src/main/resources/defaults/clustertemplates/aws/aws-dataengineering-ha-711.json
+++ b/core/src/main/resources/defaults/clustertemplates/aws/aws-dataengineering-ha-711.json
@@ -8,6 +8,9 @@
     "cluster": {
       "blueprintName": "7.1.1 - Data Engineering: HA: Apache Spark, Apache Hive, Apache Oozie"
     },
+    "externalDatabase": {
+      "availabilityType": "HA"
+    },
     "instanceGroups": [{
       "nodeCount": 1,
       "name": "manager",

--- a/core/src/main/resources/defaults/clustertemplates/aws/aws-dataengineering-ha-720.json
+++ b/core/src/main/resources/defaults/clustertemplates/aws/aws-dataengineering-ha-720.json
@@ -8,6 +8,9 @@
     "cluster": {
       "blueprintName": "7.2.0 - Data Engineering: HA: Apache Spark, Apache Hive, Apache Oozie"
     },
+    "externalDatabase": {
+      "availabilityType": "HA"
+    },
     "instanceGroups": [{
       "nodeCount": 1,
       "name": "manager",

--- a/core/src/main/resources/defaults/clustertemplates/azure/azure-dataengineering-ha-702.json
+++ b/core/src/main/resources/defaults/clustertemplates/azure/azure-dataengineering-ha-702.json
@@ -8,6 +8,9 @@
     "cluster": {
       "blueprintName": "CDP 1.2 - Data Engineering: HA: Apache Spark, Apache Hive, Apache Oozie"
     },
+    "externalDatabase": {
+      "availabilityType": "HA"
+    },
     "instanceGroups": [
       {
         "nodeCount": 1,

--- a/core/src/main/resources/defaults/clustertemplates/azure/azure-dataengineering-ha-710.json
+++ b/core/src/main/resources/defaults/clustertemplates/azure/azure-dataengineering-ha-710.json
@@ -8,6 +8,9 @@
     "cluster": {
       "blueprintName": "7.1.0 - Data Engineering: HA: Apache Spark, Apache Hive, Apache Oozie"
     },
+    "externalDatabase": {
+      "availabilityType": "HA"
+    },
     "instanceGroups": [
       {
         "nodeCount": 1,

--- a/core/src/main/resources/defaults/clustertemplates/azure/azure-dataengineering-ha-711.json
+++ b/core/src/main/resources/defaults/clustertemplates/azure/azure-dataengineering-ha-711.json
@@ -8,6 +8,9 @@
     "cluster": {
       "blueprintName": "7.1.1 - Data Engineering: HA: Apache Spark, Apache Hive, Apache Oozie"
     },
+    "externalDatabase": {
+      "availabilityType": "HA"
+    },
     "instanceGroups": [
       {
         "nodeCount": 1,

--- a/core/src/main/resources/defaults/clustertemplates/azure/azure-dataengineering-ha-720.json
+++ b/core/src/main/resources/defaults/clustertemplates/azure/azure-dataengineering-ha-720.json
@@ -8,6 +8,9 @@
     "cluster": {
       "blueprintName": "7.2.0 - Data Engineering: HA: Apache Spark, Apache Hive, Apache Oozie"
     },
+    "externalDatabase": {
+      "availabilityType": "HA"
+    },
     "instanceGroups": [
       {
         "nodeCount": 1,


### PR DESCRIPTION
1. From 2.20 there is support for the external database via CLI or cluster definition.
2. Adding the external database to be of type HA. We do not have multi-az clusters in the HA template, still choosing HA type because the NON_HA database in a HA cluster sounds odd.
3. This does not work in the private stack, it looks like this feature is undergoing modification in 2.20 itself CB-6137.

make