### PR TITLE
CDPCP-1848. Better error message on missing keys for getKeytab

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/UserKeytabService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/kerberosmgmt/v1/UserKeytabService.java
@@ -59,6 +59,13 @@ public class UserKeytabService {
         }
     }
 
+    private void validateHasCredentials(GetActorWorkloadCredentialsResponse actorCredentialsResponse) {
+        List<ActorKerberosKey> keyList = actorCredentialsResponse.getKerberosKeysList();
+        if (keyList == null || keyList.isEmpty()) {
+            throw new NotFoundException("Could not retrieve workload credentials. A workload password may not have been set for this user or machine user.");
+        }
+    }
+
     private void validateFreeIPAState(String workloadUsername, String environmentCrn) {
         String accountId = Crn.safeFromString(environmentCrn).getAccountId();
         FreeIpaClient freeIpaClient;
@@ -84,6 +91,9 @@ public class UserKeytabService {
 
         GetActorWorkloadCredentialsResponse getActorWorkloadCredentialsResponse =
                 grpcUmsClient.getActorWorkloadCredentials(INTERNAL_ACTOR_CRN, userCrn, MDCUtils.getRequestId());
+
+        validateHasCredentials(getActorWorkloadCredentialsResponse);
+
         String workloadUsername = getActorWorkloadCredentialsResponse.getWorkloadUsername();
 
         validateFreeIPAState(workloadUsername, environmentCrn);

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/kerberosmgmt/UserKeytabServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/kerberosmgmt/UserKeytabServiceTest.java
@@ -152,4 +152,21 @@ class UserKeytabServiceTest {
         assertEquals(String.format("KerberosConfig for environment '%s' not found.", ENV_CRN), exception.getMessage());
     }
 
+    @Test
+    void testGetKeytabBase64MissingCredentialKeys() {
+        String keytabBase64 = "keytabBase64...";
+
+        setupKerberosConfig();
+
+        GetActorWorkloadCredentialsResponse response = GetActorWorkloadCredentialsResponse.newBuilder()
+                .setWorkloadUsername("workloadUserName")
+                .clearKerberosKeys()
+                .build();
+        when(grpcUmsClient.getActorWorkloadCredentials(any(), any(), any())).thenReturn(response);
+
+        Exception exception =  assertThrows(NotFoundException.class, () -> underTest.getKeytabBase64(USER_CRN, ENV_CRN));
+        assertEquals("Could not retrieve workload credentials. A workload password may not have been set for this user or machine user.",
+                exception.getMessage());
+    }
+
 }


### PR DESCRIPTION
If the actor does not have any credential keys in UMS it indicates they have not set their workload password. A proper error message is now propagated in this situation.