### PR TITLE
CB-6569. Encode (base64) regex input for anonymization rules (log collection)

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigService.java
@@ -1,14 +1,18 @@
 package com.sequenceiq.cloudbreak.telemetry.fluent;
 
+import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryClusterDetails;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.AdlsGen2Config;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.AdlsGen2ConfigGenerator;
@@ -68,8 +72,24 @@ public class FluentConfigService {
         return builder
                 .withEnabled(enabled)
                 .withClusterDetails(clusterDetails)
-                .withAnonymizationRules(anonymizationRules)
+                .withAnonymizationRules(decodeRules(anonymizationRules))
                 .build();
+    }
+
+    @VisibleForTesting
+    List<AnonymizationRule> decodeRules(List<AnonymizationRule> rules) {
+        return Optional.ofNullable(rules)
+                .orElse(new ArrayList<>())
+                .stream()
+                .filter(rule -> StringUtils.isNotBlank(rule.getValue()))
+                .map(rule -> {
+                    AnonymizationRule newRule = new AnonymizationRule();
+                    newRule.setReplacement(rule.getReplacement());
+                    newRule.setValue(new String(Base64.getDecoder().decode(
+                            rule.getValue().getBytes())));
+                    return newRule;
+                })
+                .collect(Collectors.toList());
     }
 
     private boolean determineAndSetLogging(FluentConfigView.Builder builder, Telemetry telemetry, boolean databusEnabled,

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigServiceTest.java
@@ -4,6 +4,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -13,6 +17,7 @@ import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.AdlsGen2ConfigGenerator;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.S3ConfigGenerator;
 import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
+import com.sequenceiq.common.api.telemetry.model.AnonymizationRule;
 import com.sequenceiq.common.api.telemetry.model.Features;
 import com.sequenceiq.common.api.telemetry.model.Logging;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
@@ -276,6 +281,24 @@ public class FluentConfigServiceTest {
         telemetry.setLogging(logging);
         // WHEN
         underTest.createFluentConfigs(DEFAULT_FLUENT_CLUSTER_DETAILS, false, false, telemetry);
+    }
+
+    @Test
+    public void testDecodeAnonymizationRule() {
+        // GIVEN
+        List<AnonymizationRule> rules = new ArrayList<>();
+        AnonymizationRule rule1 = new AnonymizationRule();
+        rule1.setReplacement("replace1");
+        AnonymizationRule rule2 = new AnonymizationRule();
+        rule2.setReplacement("replace2");
+        rule2.setValue(Base64.getEncoder().encodeToString("value2".getBytes()));
+        rules.add(rule1);
+        rules.add(rule2);
+        // WHEN
+        List<AnonymizationRule> finalRules = underTest.decodeRules(rules);
+        // THEN
+        assertEquals(finalRules.size(), 1);
+        assertEquals(finalRules.get(0).getValue(), "value2");
     }
 
     private void setMetering(Telemetry telemetry) {

--- a/environment/src/main/java/com/sequenceiq/environment/telemetry/service/AccountTelemetryService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/telemetry/service/AccountTelemetryService.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.environment.telemetry.service;
 
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -102,15 +103,18 @@ public class AccountTelemetryService {
         List<AnonymizationRule> defaultRules = new ArrayList<>();
 
         AnonymizationRule creditCardWithSepRule = new AnonymizationRule();
-        creditCardWithSepRule.setValue(CREDIT_CARD_PATTERN);
+        creditCardWithSepRule.setValue(
+                Base64.getEncoder().encodeToString(CREDIT_CARD_PATTERN.getBytes()));
         creditCardWithSepRule.setReplacement(CREDIT_CARD_REPLACEMENT);
 
         AnonymizationRule ssnWithSepRule = new AnonymizationRule();
-        ssnWithSepRule.setValue(SSN_PATTERN);
+        ssnWithSepRule.setValue(
+                Base64.getEncoder().encodeToString(SSN_PATTERN.getBytes()));
         ssnWithSepRule.setReplacement(SSN_REPLACEMENT);
 
         AnonymizationRule emailRule = new AnonymizationRule();
-        emailRule.setValue(EMAIL_PATTERN);
+        emailRule.setValue(
+                Base64.getEncoder().encodeToString(EMAIL_PATTERN.getBytes()));
         emailRule.setReplacement(EMAIL_REPLACEMENT);
 
         defaultRules.add(creditCardWithSepRule);

--- a/environment/src/test/java/com/sequenceiq/environment/telemetry/service/AccountTelemetryServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/telemetry/service/AccountTelemetryServiceTest.java
@@ -2,6 +2,7 @@ package com.sequenceiq.environment.telemetry.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Base64;
 import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -44,7 +45,8 @@ public class AccountTelemetryServiceTest {
     private void testPatternWithOutput(AnonymizationRule rule, String input, String startsWith) {
         if (rule.getReplacement().startsWith(startsWith)) {
             // TODO: for now, it can work with java regex - use jregex in the future
-            Pattern p = Pattern.compile(rule.getValue());
+            Pattern p = Pattern.compile(
+                    new String(Base64.getDecoder().decode(rule.getValue().getBytes())));
             boolean found = p.matcher(input).find();
             assertThat(found).isEqualTo(true);
         }


### PR DESCRIPTION
- encode default anonymization rules (no validation yet for inputs)
- decode anonymization rules during salt config generation
- updated tests