### PR TITLE
OPSAPS-54824 Honor the safety valve settings in both blueprint and ge…

### DIFF
--- a/template-manager-cmtemplate/src/test/resources/input/clouderamanager-existing-conf.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/clouderamanager-existing-conf.bp
@@ -156,13 +156,25 @@
         {
           "refName": "spark_on_yarn-GATEWAY-BASE",
           "roleType": "GATEWAY",
-          "base": true
+          "base": true,
+          "configs": [
+              {
+                "name": "spark-conf/spark-defaults.conf_client_config_safety_valve",
+                "value": "spark.yarn.access.hadoopFileSystems=s3a://expn-cis-sandbox-prod-cdp-us-east-1"
+              }
+          ]
         }
       ]
     },
     {
       "refName": "hive",
       "serviceType": "HIVE",
+      "serviceConfigs": [
+        {
+            "name": "hive_service_config_safety_valve",
+            "value": "<property><name>hive.metastore.server.filter.enabled</name><value>true</value></property> <property><name>hive.metastore.filter.hook</name><value>org.apache.hadoop.hive.ql.security.authorization.plugin.metastore.HiveMetaStoreAuthorizer</value></property>"
+        }
+      ],
       "roleConfigGroups": [
         {
           "refName": "hive-GATEWAY-BASE",


### PR DESCRIPTION
…nerated configs.

1. CB-1452 gave precedence to the values set in the blueprint.
2. At the moment some s3 and dynamodb settings by cloudbreak are in core site safety valve settings.
3. Customers like Experian have custom blueprint templates and want to set the encryption keys via core site safety valve settings, so the s3 and dynamodb settings are not being set by cloudbreak.
4. This is a blocker for setting the encryption keys for the s3 bucket by Experian.
5. The tricky bit is we have safety valve for XML and properties file. Though not used in CB there are also command line safety valves.
6. We do not treat resourcemanager_capacity_scheduler_configuration as a safety valve setting because the name does not end with _safety_valve and it does not follow the safety valve XML format (it starts with <configuration> tag).
7. We do not handle the appending of safety valve configs defined as variables. There is only one such usage in Hue for CDPD versions 7.0.2 and below, which are deprecated and removed.

./gradlew build