### PR TITLE
CDPD-10146 [opdb] Store Yarn app logs on object store

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-opdb-710.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-opdb-710.bp
@@ -183,6 +183,12 @@
       {
         "refName": "yarn",
         "serviceType": "YARN",
+        "serviceConfigs": [
+          {
+            "name": "yarn_log_aggregation_IFile_remote_app_log_dir_suffix",
+            "value": ""
+          }
+        ],
         "roleConfigGroups": [
           {
             "refName": "yarn-RESOURCEMANAGER-BASE",


### PR DESCRIPTION
Yarn stores the application logs on the local filesystem due to OPSAPS-54760. As a workaround to store these logs on the object store the config needs to be set as empty.

Testing: Created cluster from custom blueprint and executed a CompactionTool MapReduce job. The container logs were available on S3 filesystem.