### PR TITLE
fix for CDPD-10364

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-710.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-710.bp
@@ -217,7 +217,7 @@
           },
           {
             "name": "hive_service_config_safety_valve",
-            "value": "<property><name>hive.hook.proto.file.per.event</name><value>true</value></property><property><name>hive.server2.tez.sessions.per.default.queue</name><value>4</value></property>"
+            "value": "<property><name>hive.server2.tez.sessions.per.default.queue</name><value>4</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-710.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-710.bp
@@ -234,6 +234,14 @@
               {
                  "name": "hive_server2_transport_mode",
                  "value": "http"
+              },
+              {
+                 "name": "hiveserver2_mv_files_thread",
+                 "value": 20
+              },
+              {
+                 "name": "hiveserver2_load_dynamic_partitions_thread_count",
+                 "value": 20
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-710.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-710.bp
@@ -58,6 +58,10 @@
           {
             "name": "yarn_admin_acl",
             "value": "yarn,hive,hdfs"
+          },
+          {
+            "name": "yarn_log_aggregation_IFile_remote_app_log_dir",
+            "value": ""
           }
         ],
         "roleConfigGroups": [
@@ -80,7 +84,7 @@
               },
               {
                 "name": "resourcemanager_capacity_scheduler_configuration",
-                "value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property><property><name>yarn.scheduler.capacity.per-node-heartbeat.maximum-offswitch-assignments</name><value>4</value></property></configuration>"
+                "value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property></configuration>"
               }
             ]
           },
@@ -98,6 +102,21 @@
             "refName": "yarn-JOBHISTORY-BASE",
             "roleType": "JOBHISTORY",
             "base": true
+          },
+          {
+            "refName": "yarn-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true,
+            "configs": [
+              {
+                "name": "mapreduce_map_memory_mb",
+                "value": 4096
+              },
+              {
+                "name": "mapreduce_reduce_memory_mb",
+                "value": 4096
+              }
+            ]
           }
         ]
       },
@@ -191,6 +210,14 @@
           {
             "name": "tez_container_size",
             "value": "4096"
+          },
+          {
+            "name": "tez_auto_reducer_parallelism",
+            "value": "false"
+          },
+          {
+            "name": "hive_service_config_safety_valve",
+            "value": "<property><name>hive.hook.proto.file.per.event</name><value>true</value></property><property><name>hive.server2.tez.sessions.per.default.queue</name><value>4</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -333,7 +360,8 @@
           "yarn-RESOURCEMANAGER-BASE",
           "zookeeper-SERVER-BASE",
           "das-DAS_WEBAPP",
-          "das-DAS_EVENT_PROCESSOR"
+          "das-DAS_EVENT_PROCESSOR",
+          "yarn-GATEWAY-BASE"
         ]
       },
       {
@@ -346,7 +374,8 @@
           "tez-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
           "livy-GATEWAY-BASE",
-          "yarn-NODEMANAGER-WORKER"
+          "yarn-NODEMANAGER-WORKER",
+          "yarn-GATEWAY-BASE"
         ]
       },
       {
@@ -357,7 +386,8 @@
           "hive_on_tez-GATEWAY-BASE",
           "tez-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
-          "yarn-NODEMANAGER-COMPUTE"
+          "yarn-NODEMANAGER-COMPUTE",
+          "yarn-GATEWAY-BASE"
         ]
       },
       {
@@ -368,7 +398,8 @@
           "hive_on_tez-GATEWAY-BASE",
           "tez-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
-          "livy-GATEWAY-BASE"
+          "livy-GATEWAY-BASE",
+          "yarn-GATEWAY-BASE"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-720.bp
@@ -213,7 +213,7 @@
           },
           {
             "name": "hive_service_config_safety_valve",
-            "value": "<property><name>hive.hook.proto.file.per.event</name><value>true</value></property><property><name>hive.server2.tez.sessions.per.default.queue</name><value>4</value></property>"
+            "value": "<property><name>hive.server2.tez.sessions.per.default.queue</name><value>4</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-720.bp
@@ -230,6 +230,14 @@
               {
                  "name": "hive_server2_transport_mode",
                  "value": "http"
+              },
+              {
+                 "name": "hiveserver2_mv_files_thread",
+                 "value": 20
+              },
+              {
+                 "name": "hiveserver2_load_dynamic_partitions_thread_count",
+                 "value": 20
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-720.bp
@@ -80,7 +80,7 @@
               },
               {
                 "name": "resourcemanager_capacity_scheduler_configuration",
-                "value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property><property><name>yarn.scheduler.capacity.per-node-heartbeat.maximum-offswitch-assignments</name><value>4</value></property></configuration>"
+                "value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property></configuration>"
               }
             ]
           },
@@ -98,6 +98,21 @@
             "refName": "yarn-JOBHISTORY-BASE",
             "roleType": "JOBHISTORY",
             "base": true
+          },
+          {
+            "refName": "yarn-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true,
+            "configs": [
+              {
+                "name": "mapreduce_map_memory_mb",
+                "value": 4096
+              },
+              {
+                "name": "mapreduce_reduce_memory_mb",
+                "value": 4096
+              }
+            ]
           }
         ]
       },
@@ -191,6 +206,14 @@
           {
             "name": "tez_container_size",
             "value": "4096"
+          },
+          {
+            "name": "tez_auto_reducer_parallelism",
+            "value": "false"
+          },
+          {
+            "name": "hive_service_config_safety_valve",
+            "value": "<property><name>hive.hook.proto.file.per.event</name><value>true</value></property><property><name>hive.server2.tez.sessions.per.default.queue</name><value>4</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -333,7 +356,8 @@
           "yarn-RESOURCEMANAGER-BASE",
           "zookeeper-SERVER-BASE",
           "das-DAS_WEBAPP",
-          "das-DAS_EVENT_PROCESSOR"
+          "das-DAS_EVENT_PROCESSOR",
+          "yarn-GATEWAY-BASE"
         ]
       },
       {
@@ -346,7 +370,8 @@
           "tez-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
           "livy-GATEWAY-BASE",
-          "yarn-NODEMANAGER-WORKER"
+          "yarn-NODEMANAGER-WORKER",
+          "yarn-GATEWAY-BASE"
         ]
       },
       {
@@ -357,7 +382,8 @@
           "hive_on_tez-GATEWAY-BASE",
           "tez-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
-          "yarn-NODEMANAGER-COMPUTE"
+          "yarn-NODEMANAGER-COMPUTE",
+          "yarn-GATEWAY-BASE"
         ]
       },
       {
@@ -368,7 +394,8 @@
           "hive_on_tez-GATEWAY-BASE",
           "tez-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
-          "livy-GATEWAY-BASE"
+          "livy-GATEWAY-BASE",
+          "yarn-GATEWAY-BASE"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-710.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-710.bp
@@ -116,6 +116,14 @@
               {
                 "name": "hive_server2_transport_mode",
                 "value": "http"
+              },
+              {
+                 "name": "hiveserver2_mv_files_thread",
+                 "value": 20
+              },
+              {
+                 "name": "hiveserver2_load_dynamic_partitions_thread_count",
+                 "value": 20
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-710.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-710.bp
@@ -88,6 +88,20 @@
         "refName": "hive",
         "serviceType": "HIVE_ON_TEZ",
         "displayName": "Hive",
+        "serviceConfigs": [
+          {
+            "name": "tez_container_size",
+            "value": "4096"
+          },
+          {
+            "name": "tez_auto_reducer_parallelism",
+            "value": "false"
+          },
+          {
+            "name": "hive_service_config_safety_valve",
+            "value": "<property><name>hive.hook.proto.file.per.event</name><value>true</value></property><property><name>hive.server2.tez.sessions.per.default.queue</name><value>4</value></property>"
+          }
+        ],
         "roleConfigGroups": [
           {
             "refName": "hive-GATEWAY-BASE",
@@ -163,6 +177,10 @@
           {
             "name": "yarn_admin_acl",
             "value": "yarn,hive,hdfs"
+          },
+          {
+            "name": "yarn_log_aggregation_IFile_remote_app_log_dir",
+            "value": ""
           }
         ],
         "roleConfigGroups": [
@@ -185,7 +203,7 @@
               },
               {
                 "name": "resourcemanager_capacity_scheduler_configuration",
-                "value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property><property><name>yarn.scheduler.capacity.per-node-heartbeat.maximum-offswitch-assignments</name><value>4</value></property></configuration>"
+                "value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property></configuration>"
               }
             ]
           },
@@ -203,6 +221,21 @@
             "refName": "yarn-JOBHISTORY-BASE",
             "roleType": "JOBHISTORY",
             "base": true
+          },
+          {
+            "refName": "yarn-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true,
+            "configs": [
+              {
+                "name": "mapreduce_map_memory_mb",
+                "value": 4096
+              },
+              {
+                "name": "mapreduce_reduce_memory_mb",
+                "value": 4096
+              }
+            ]
           }
         ]
       },
@@ -323,7 +356,8 @@
           "hms-GATEWAY-BASE",
           "livy-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
-          "tez-GATEWAY-BASE"
+          "tez-GATEWAY-BASE",
+          "yarn-GATEWAY-BASE"
         ]
       },
       {
@@ -343,7 +377,8 @@
           "tez-GATEWAY-BASE",
           "yarn-RESOURCEMANAGER-BASE",
           "hdfs-JOURNALNODE-BASE",
-          "zookeeper-SERVER-BASE"
+          "zookeeper-SERVER-BASE",
+          "yarn-GATEWAY-BASE"
         ]
       },
       {
@@ -366,7 +401,8 @@
           "das-DAS_WEBAPP",
           "knox-KNOX_GATEWAY-BASE",
           "hdfs-JOURNALNODE-BASE",
-          "zookeeper-SERVER-BASE"
+          "zookeeper-SERVER-BASE",
+          "yarn-GATEWAY-BASE"
         ]
       },
       {
@@ -379,7 +415,8 @@
           "livy-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
           "tez-GATEWAY-BASE",
-          "yarn-NODEMANAGER-WORKER"
+          "yarn-NODEMANAGER-WORKER",
+          "yarn-GATEWAY-BASE"
         ]
       },
       {
@@ -391,7 +428,8 @@
           "livy-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
           "tez-GATEWAY-BASE",
-          "yarn-NODEMANAGER-COMPUTE"
+          "yarn-NODEMANAGER-COMPUTE",
+          "yarn-GATEWAY-BASE"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-710.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-710.bp
@@ -99,7 +99,7 @@
           },
           {
             "name": "hive_service_config_safety_valve",
-            "value": "<property><name>hive.hook.proto.file.per.event</name><value>true</value></property><property><name>hive.server2.tez.sessions.per.default.queue</name><value>4</value></property>"
+            "value": "<property><name>hive.server2.tez.sessions.per.default.queue</name><value>4</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-720.bp
@@ -88,6 +88,20 @@
         "refName": "hive",
         "serviceType": "HIVE_ON_TEZ",
         "displayName": "Hive",
+        "serviceConfigs": [
+          {
+            "name": "tez_container_size",
+            "value": "4096"
+          },
+          {
+            "name": "tez_auto_reducer_parallelism",
+            "value": "false"
+          },
+          {
+            "name": "hive_service_config_safety_valve",
+            "value": "<property><name>hive.hook.proto.file.per.event</name><value>true</value></property><property><name>hive.server2.tez.sessions.per.default.queue</name><value>4</value></property>"
+          }
+        ],
         "roleConfigGroups": [
           {
             "refName": "hive-GATEWAY-BASE",
@@ -185,7 +199,7 @@
               },
               {
                 "name": "resourcemanager_capacity_scheduler_configuration",
-                "value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property><property><name>yarn.scheduler.capacity.per-node-heartbeat.maximum-offswitch-assignments</name><value>4</value></property></configuration>"
+                "value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property></configuration>"
               }
             ]
           },
@@ -203,6 +217,21 @@
             "refName": "yarn-JOBHISTORY-BASE",
             "roleType": "JOBHISTORY",
             "base": true
+          },
+          {
+            "refName": "yarn-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true,
+            "configs": [
+              {
+                "name": "mapreduce_map_memory_mb",
+                "value": 4096
+              },
+              {
+                "name": "mapreduce_reduce_memory_mb",
+                "value": 4096
+              }
+            ]
           }
         ]
       },
@@ -323,7 +352,8 @@
           "hms-GATEWAY-BASE",
           "livy-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
-          "tez-GATEWAY-BASE"
+          "tez-GATEWAY-BASE",
+          "yarn-GATEWAY-BASE"
         ]
       },
       {
@@ -343,7 +373,8 @@
           "tez-GATEWAY-BASE",
           "yarn-RESOURCEMANAGER-BASE",
           "hdfs-JOURNALNODE-BASE",
-          "zookeeper-SERVER-BASE"
+          "zookeeper-SERVER-BASE",
+          "yarn-GATEWAY-BASE"
         ]
       },
       {
@@ -366,7 +397,8 @@
           "das-DAS_WEBAPP",
           "knox-KNOX_GATEWAY-BASE",
           "hdfs-JOURNALNODE-BASE",
-          "zookeeper-SERVER-BASE"
+          "zookeeper-SERVER-BASE",
+          "yarn-GATEWAY-BASE"
         ]
       },
       {
@@ -379,7 +411,8 @@
           "livy-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
           "tez-GATEWAY-BASE",
-          "yarn-NODEMANAGER-WORKER"
+          "yarn-NODEMANAGER-WORKER",
+          "yarn-GATEWAY-BASE"
         ]
       },
       {
@@ -391,7 +424,8 @@
           "livy-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
           "tez-GATEWAY-BASE",
-          "yarn-NODEMANAGER-COMPUTE"
+          "yarn-NODEMANAGER-COMPUTE",
+          "yarn-GATEWAY-BASE"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-720.bp
@@ -116,6 +116,14 @@
               {
                 "name": "hive_server2_transport_mode",
                 "value": "http"
+              },
+              {
+                 "name": "hiveserver2_mv_files_thread",
+                 "value": 20
+              },
+              {
+                 "name": "hiveserver2_load_dynamic_partitions_thread_count",
+                 "value": 20
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-720.bp
@@ -99,7 +99,7 @@
           },
           {
             "name": "hive_service_config_safety_valve",
-            "value": "<property><name>hive.hook.proto.file.per.event</name><value>true</value></property><property><name>hive.server2.tez.sessions.per.default.queue</name><value>4</value></property>"
+            "value": "<property><name>hive.server2.tez.sessions.per.default.queue</name><value>4</value></property>"
           }
         ],
         "roleConfigGroups": [


### PR DESCRIPTION
CDPD-10364: Have tuned hive, yarn, mapreduce configs in DE & DE HA template as per JIRA 
[CDPD-10364](https://jira.cloudera.com/browse/CDPD-10364)


List of tuned configs are -
HIVE
-----

[CDPD-9787](https://jira.cloudera.com/browse/CDPD-9787)
hive.tez.auto.reducer.parallelism=false

[CDPD-9860](https://jira.cloudera.com/browse/CDPD-9860)
hive.server2.tez.sessions.per.default.queue=4

hive.mv.files.thread=20
hive.load.dynamic.partitions.thread=20

YARN
------
[CDPD-9916](https://jira.cloudera.com/browse/CDPD-9916)
Set this only for 7.1.0 template as 7.2.0 already has the fix

yarn.log-aggregation.IFile.remote-app-log-dir to empty

[CDPD-9874](https://jira.cloudera.com/browse/CDPD-9874)
For below config removed yarn.scheduler.capacity.per-node-heartbeat.maximum-offswitch-assignments=4 entry from cluster template so that it goes to default value of 1

yarn.scheduler.capacity.per-node-heartbeat.maximum-offswitch-assignments=1

MapReduce
------------

Also added yarn-GATEWAY-BASE role config 
[OPSAPS-55437](https://jira.cloudera.com/browse/OPSAPS-55437)

mapreduce.map.memory.mb=4GB
mapreduce.reduce.memory.mb=4GB

Testing done:

- I created custom template from DE & DE HA templates with tuned values in mow-dev. And launched clusters couple of times. There were no issues. Noticed changes were applied.
- Ran some beeline queries, they worked fine.

Closes #CDPD-10364

