### PR TITLE
CB-6544 do not check dns records in every highstate

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/ipa.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/ipa.sls
@@ -53,8 +53,8 @@ removing_dns_entries:
 
 add_dns_record:
   cmd.run:
-    - name: echo $PW | kinit {{salt['pillar.get']('sssd-ipa:principal')}} && ipa dnsrecord-add {{salt['pillar.get']('sssd-ipa:domain')}}. $(hostname) --a-rec=$(hostname -i) --a-create-reverse
-    - unless: echo $PW | kinit {{salt['pillar.get']('sssd-ipa:principal')}} && ipa dnsrecord-find {{salt['pillar.get']('sssd-ipa:domain')}} --a-rec=$(hostname -i)
+    - name: echo $PW | kinit {{salt['pillar.get']('sssd-ipa:principal')}} && ipa dnsrecord-add {{salt['pillar.get']('sssd-ipa:domain')}}. $(hostname) --a-rec=$(hostname -i) --a-create-reverse && echo $(date +%Y-%m-%d:%H:%M:%S) >> /var/log/dnsrecord-add-executed
+    - unless: test -f /var/log/dnsrecord-add-executed || { echo $PW | kinit {{salt['pillar.get']('sssd-ipa:principal')}} && ipa dnsrecord-find {{salt['pillar.get']('sssd-ipa:domain')}} --a-rec=$(hostname -i); }
     - env:
         - PW: "{{salt['pillar.get']('sssd-ipa:password')}}"
 


### PR DESCRIPTION
When we query IPA from a lot of instances in parallel, some cases the IPA server gives a DNS Zone not found error:
```
{
        "error": {
            "code": 4001,
            "data": {
                "reason": "krisz-en.xcu2-8y8x.wl.cloudera.site.: DNS zone not found"
            },
            "message": "krisz-en.xcu2-8y8x.wl.cloudera.site.: DNS zone not found",
            "name": "NotFound"
        },
        "id": 0,
        "principal": "HTTP/ipaserver0.krisz-en.xcu2-8y8x.wl.cloudera.site@KRISZ-EN.XCU2-8Y8X.WL.CLOUDERA.SITE",
        "result": null,
        "version": "4.6.5"
    }
```
This is not a timeout in the cli, but an actual IPA server response. To avoid this we shouldn't actually query IPA all the time. + it save a lot of time durring highstate