### PR TITLE
CB-6647. Validate anonymization rules regex before creation.

### DIFF
--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/telemetry/endpoint/AccountTelemetryEndpoint.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/telemetry/endpoint/AccountTelemetryEndpoint.java
@@ -42,7 +42,7 @@ public interface AccountTelemetryEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = AccountTelemetryDescription.POST, produces = MediaType.APPLICATION_JSON,
             notes = AccountTelemetryDescription.POST_NOTES, nickname = "updateAccountTelemetryV1")
-    AccountTelemetryResponse update(AccountTelemetryRequest request);
+    AccountTelemetryResponse update(@Valid AccountTelemetryRequest request);
 
     @GET
     @Path("/default")

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/telemetry/model/request/TestAnonymizationRuleRequest.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/telemetry/model/request/TestAnonymizationRuleRequest.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.environment.api.v1.telemetry.model.request;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -14,7 +16,7 @@ public class TestAnonymizationRuleRequest implements Serializable {
     private String input;
 
     @NotNull
-    private AnonymizationRule rule;
+    private List<AnonymizationRule> rules = new ArrayList<>();
 
     public String getInput() {
         return input;
@@ -24,11 +26,11 @@ public class TestAnonymizationRuleRequest implements Serializable {
         this.input = input;
     }
 
-    public AnonymizationRule getRule() {
-        return rule;
+    public void setRules(List<AnonymizationRule> rules) {
+        this.rules = rules;
     }
 
-    public void setRule(AnonymizationRule rule) {
-        this.rule = rule;
+    public List<AnonymizationRule> getRules() {
+        return rules;
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/telemetry/v1/controller/AccountTelemetryController.java
+++ b/environment/src/main/java/com/sequenceiq/environment/telemetry/v1/controller/AccountTelemetryController.java
@@ -87,7 +87,7 @@ public class AccountTelemetryController extends NotificationController implement
     @CheckPermissionByAccount(action = AuthorizationResourceAction.WRITE)
     public TestAnonymizationRuleResponse testRulePattern(TestAnonymizationRuleRequest request) {
         TestAnonymizationRuleResponse response = new TestAnonymizationRuleResponse();
-        response.setOutput(accountTelemetryService.testRulePattern(request.getRule(), request.getInput()));
+        response.setOutput(accountTelemetryService.testRulePatterns(request.getRules(), request.getInput()));
         return response;
     }
 }

--- a/environment/src/test/java/com/sequenceiq/environment/telemetry/service/AccountTelemetryServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/telemetry/service/AccountTelemetryServiceTest.java
@@ -1,9 +1,12 @@
 package com.sequenceiq.environment.telemetry.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.ArrayList;
 import java.util.Base64;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -11,7 +14,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.exception.BadRequestException;
 import com.sequenceiq.common.api.telemetry.model.AnonymizationRule;
 import com.sequenceiq.environment.telemetry.domain.AccountTelemetry;
@@ -35,47 +37,100 @@ public class AccountTelemetryServiceTest {
     @Test
     public void testRulePattern() {
         // GIVEN
-        String input = "My email card number is: 1111-2222-3333-4444";
-        AnonymizationRule rule = new AnonymizationRule();
-        rule.setReplacement("[REDACTED]");
-        String pattern = "\\d{4}[^\\w]\\d{4}[^\\w]\\d{4}[^\\w]\\d{4}";
-        String encodedPattern = new String(Base64.getEncoder().encode(pattern.getBytes()));
-        rule.setValue(encodedPattern);
+        String input = "My email card number is: 1111-2222-3333-4444 and 55555-11111";
+        List<AnonymizationRule> rules = new ArrayList<>();
+        AnonymizationRule rule1 = new AnonymizationRule();
+        rule1.setReplacement("[REDACTED]");
+        String pattern1 = "\\d{4}[^\\w]\\d{4}[^\\w]\\d{4}[^\\w]\\d{4}";
+        String encodedPattern1 = new String(Base64.getEncoder().encode(pattern1.getBytes()));
+        rule1.setValue(encodedPattern1);
+        AnonymizationRule rule2 = new AnonymizationRule();
+        rule2.setReplacement("[REDACTED]");
+        String pattern2 = "\\d{5}[^\\w]\\d{5}";
+        String encodedPattern2 = new String(Base64.getEncoder().encode(pattern2.getBytes()));
+        rule2.setValue(encodedPattern2);
+        rules.add(rule1);
+        rules.add(rule2);
         // WHEN
-        String output = underTest.testRulePattern(rule, input);
+        String output = underTest.testRulePatterns(rules, input);
         // THEN
-        assertThat(output).isEqualTo("My email card number is: [REDACTED]");
+        assertThat(output).isEqualTo("My email card number is: [REDACTED] and [REDACTED]");
     }
 
     @Test
-    public void testRulePatternNoMatch() {
+    public void testRulePatternsNoMatch() {
         // GIVEN
         String input = "My email card number is: 1111-2222-3333-4444";
+        List<AnonymizationRule> rules = new ArrayList<>();
         AnonymizationRule rule = new AnonymizationRule();
         rule.setReplacement("[REDACTED]");
         String pattern = "\\d{8}[^\\w]\\d{8}[^\\w]\\d{8}[^\\w]\\d{8}";
         String encodedPattern = new String(Base64.getEncoder().encode(pattern.getBytes()));
         rule.setValue(encodedPattern);
+        rules.add(rule);
+        String output = underTest.testRulePatterns(rules, input);
         // THEN
-        assertThrows(NotFoundException.class, () -> {
-            // WHEN
-            underTest.testRulePattern(rule, input);
-        });
+        assertEquals(input, output);
     }
 
     @Test
     public void testRulePatternWithInvalidPattern() {
         // GIVEN
         String input = "My email card number is: 1111-2222-3333-4444";
+        List<AnonymizationRule> rules = new ArrayList<>();
         AnonymizationRule rule = new AnonymizationRule();
         rule.setReplacement("[REDACTED]");
         String pattern = "\\d{8}[^[[";
         String encodedPattern = new String(Base64.getEncoder().encode(pattern.getBytes()));
         rule.setValue(encodedPattern);
+        rules.add(rule);
         // THEN
         assertThrows(BadRequestException.class, () -> {
             // WHEN
-            underTest.testRulePattern(rule, input);
+            underTest.testRulePatterns(rules, input);
+        });
+    }
+
+    @Test
+    public void testValidateRules() {
+        // GIVEN
+        AccountTelemetry telemetry = new AccountTelemetry();
+        List<AnonymizationRule> rules = new ArrayList<>();
+        AnonymizationRule rule = new AnonymizationRule();
+        rule.setReplacement("[REDACTED]");
+        String pattern = "\\d{4}[^\\w]\\d{4}[^\\w]\\d{4}[^\\w]\\d{4}";
+        String encodedPattern = new String(Base64.getEncoder().encode(pattern.getBytes()));
+        rule.setValue(encodedPattern);
+        rules.add(rule);
+        telemetry.setRules(rules);
+        // WHEN
+        underTest.validateAnonymizationRules(telemetry);
+    }
+
+    @Test
+    public void testValidateRulesWithoutRules() {
+        // GIVEN
+        AccountTelemetry telemetry = new AccountTelemetry();
+        // WHEN
+        underTest.validateAnonymizationRules(telemetry);
+    }
+
+    @Test
+    public void testValidateRulesWithInvalidRules() {
+        // GIVEN
+        AccountTelemetry telemetry = new AccountTelemetry();
+        List<AnonymizationRule> rules = new ArrayList<>();
+        AnonymizationRule rule = new AnonymizationRule();
+        rule.setReplacement("[REDACTED]");
+        String pattern = "invalidrule{";
+        String encodedPattern = new String(Base64.getEncoder().encode(pattern.getBytes()));
+        rule.setValue(encodedPattern);
+        rules.add(rule);
+        telemetry.setRules(rules);
+        // THEN
+        assertThrows(BadRequestException.class, () -> {
+            // WHEN
+            underTest.validateAnonymizationRules(telemetry);
         });
     }
 


### PR DESCRIPTION
Add validation before creation (not by validation classes - it's easier like this as pattern validation already used in the service)
+ removed no-match test
+ Use a list of patterns instead one pattern for test anonymization pattern api
+ Add Valid annotation (to make sure anonymization rule contains a value)
+ updated ITs