### PR TITLE
CB-4925 Enable EBS encryption for FreeIPA and DL

### DIFF
--- a/auth-connector/build.gradle
+++ b/auth-connector/build.gradle
@@ -33,11 +33,12 @@ dependencies {
     exclude group: 'org.mockito'
     exclude group: 'junit', module: 'junit'
   }
-  testCompile group: 'org.mockito',                     name: 'mockito-core', version: mockitoVersion
+  testCompile group: 'org.mockito',                     name: 'mockito-core',                   version: mockitoVersion
+  testImplementation group: 'org.assertj',              name: 'assertj-core',                   version: assertjVersion
 }
 
 dependencies {
-  testCompile group: 'junit', name: 'junit', version: junitVersion
+  testCompile group: 'junit',                           name: 'junit',                          version: junitVersion
 }
 
 checkstyle {

--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
@@ -8,48 +8,83 @@ import javax.inject.Inject;
 import org.springframework.stereotype.Service;
 
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
+import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.logger.MDCUtils;
 
 @Service
 public class EntitlementService {
 
+    @VisibleForTesting
+    static final String CDP_AZURE = "CDP_AZURE";
+
+    @VisibleForTesting
+    static final String CDP_BASE_IMAGE = "CDP_BASE_IMAGE";
+
+    @VisibleForTesting
+    static final String CDP_AUTOMATIC_USERSYNC_POLLER = "CDP_AUTOMATIC_USERSYNC_POLLER";
+
+    @VisibleForTesting
+    static final String CDP_FREEIPA_HA = "CDP_FREEIPA_HA";
+
+    @VisibleForTesting
+    static final String CLOUDERA_INTERNAL_ACCOUNT = "CLOUDERA_INTERNAL_ACCOUNT";
+
+    @VisibleForTesting
+    static final String CDP_FMS_CLUSTER_PROXY = "CDP_FMS_CLUSTER_PROXY";
+
+    @VisibleForTesting
+    static final String CDP_CLOUD_STORAGE_VALIDATION = "CDP_CLOUD_STORAGE_VALIDATION";
+
+    @VisibleForTesting
+    static final String CDP_RAZ = "CDP_RAZ";
+
+    @VisibleForTesting
+    static final String CDP_RUNTIME_UPGRADE = "CDP_RUNTIME_UPGRADE";
+
+    @VisibleForTesting
+    static final String CDP_FREEIPA_DL_EBS_ENCRYPTION = "CDP_FREEIPA_DL_EBS_ENCRYPTION";
+
     @Inject
     private GrpcUmsClient umsClient;
 
     public boolean azureEnabled(String actorCrn, String accountId) {
-        return isEntitlementRegistered(actorCrn, accountId, "CDP_AZURE");
+        return isEntitlementRegistered(actorCrn, accountId, CDP_AZURE);
     }
 
     public boolean baseImageEnabled(String actorCrn, String accountId) {
-        return isEntitlementRegistered(actorCrn, accountId, "CDP_BASE_IMAGE");
+        return isEntitlementRegistered(actorCrn, accountId, CDP_BASE_IMAGE);
     }
 
     public boolean automaticUsersyncPollerEnabled(String actorCrn, String accountId) {
-        return isEntitlementRegistered(actorCrn, accountId, "CDP_AUTOMATIC_USERSYNC_POLLER");
+        return isEntitlementRegistered(actorCrn, accountId, CDP_AUTOMATIC_USERSYNC_POLLER);
     }
 
     public boolean freeIpaHaEnabled(String actorCrn, String accountID) {
-        return isEntitlementRegistered(actorCrn, accountID, "CDP_FREEIPA_HA");
+        return isEntitlementRegistered(actorCrn, accountID, CDP_FREEIPA_HA);
     }
 
     public boolean internalTenant(String actorCrn, String accountId) {
-        return isEntitlementRegistered(actorCrn, accountId, "CLOUDERA_INTERNAL_ACCOUNT");
+        return isEntitlementRegistered(actorCrn, accountId, CLOUDERA_INTERNAL_ACCOUNT);
     }
 
     public boolean fmsClusterProxyEnabled(String actorCrn, String accountId) {
-        return isEntitlementRegistered(actorCrn, accountId, "CDP_FMS_CLUSTER_PROXY");
+        return isEntitlementRegistered(actorCrn, accountId, CDP_FMS_CLUSTER_PROXY);
     }
 
     public boolean cloudStorageValidationEnabled(String actorCrn, String accountId) {
-        return isEntitlementRegistered(actorCrn, accountId, "CDP_CLOUD_STORAGE_VALIDATION");
+        return isEntitlementRegistered(actorCrn, accountId, CDP_CLOUD_STORAGE_VALIDATION);
     }
 
     public boolean razEnabled(String actorCrn, String accountId) {
-        return isEntitlementRegistered(actorCrn, accountId, "CDP_RAZ");
+        return isEntitlementRegistered(actorCrn, accountId, CDP_RAZ);
     }
 
     public boolean runtimeUpgradeEnabled(String actorCrn, String accountId) {
-        return isEntitlementRegistered(actorCrn, accountId, "CDP_RUNTIME_UPGRADE");
+        return isEntitlementRegistered(actorCrn, accountId, CDP_RUNTIME_UPGRADE);
+    }
+
+    public boolean freeIpaDlEbsEncryptionEnabled(String actorCrn, String accountId) {
+        return isEntitlementRegistered(actorCrn, accountId, CDP_FREEIPA_DL_EBS_ENCRYPTION);
     }
 
     public List<String> getEntitlements(String actorCrn, String accountId) {

--- a/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementServiceTest.java
+++ b/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementServiceTest.java
@@ -1,0 +1,138 @@
+package com.sequenceiq.cloudbreak.auth.altus;
+
+import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_AUTOMATIC_USERSYNC_POLLER;
+import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_AZURE;
+import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_BASE_IMAGE;
+import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_CLOUD_STORAGE_VALIDATION;
+import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_FMS_CLUSTER_PROXY;
+import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_FREEIPA_DL_EBS_ENCRYPTION;
+import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_FREEIPA_HA;
+import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_RAZ;
+import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_RUNTIME_UPGRADE;
+import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CLOUDERA_INTERNAL_ACCOUNT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.Account;
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.Entitlement;
+
+@ExtendWith(MockitoExtension.class)
+class EntitlementServiceTest {
+
+    private static final String ACCOUNT_ID = UUID.randomUUID().toString();
+
+    private static final String ACTOR_CRN = "crn:cdp:iam:us-west-1:" + ACCOUNT_ID + ":user:" + UUID.randomUUID().toString();
+
+    private static final Account ACCOUNT_NO_ENTITLEMENTS = Account.newBuilder().build();
+
+    private static final String ENTITLEMENT_FOO = "FOO";
+
+    private static final String ENTITLEMENT_BAR = "BAR";
+
+    private static final Account ACCOUNT_ENTITLEMENTS_FOO_BAR = createAccountForEntitlements(ENTITLEMENT_FOO, ENTITLEMENT_BAR);
+
+    @Mock
+    private GrpcUmsClient umsClient;
+
+    @InjectMocks
+    private EntitlementService underTest;
+
+    static Object[][] entitlementCheckDataProvider() {
+        return new Object[][]{
+                // testCaseName, entitlementName, function, enabled
+                {"CDP_AZURE == false", CDP_AZURE, (EntitlementCheckFunction) EntitlementService::azureEnabled, false},
+                {"CDP_AZURE == true", CDP_AZURE, (EntitlementCheckFunction) EntitlementService::azureEnabled, true},
+
+                {"CDP_BASE_IMAGE == false", CDP_BASE_IMAGE, (EntitlementCheckFunction) EntitlementService::baseImageEnabled, false},
+                {"CDP_BASE_IMAGE == true", CDP_BASE_IMAGE, (EntitlementCheckFunction) EntitlementService::baseImageEnabled, true},
+
+                {"CDP_AUTOMATIC_USERSYNC_POLLER == false", CDP_AUTOMATIC_USERSYNC_POLLER,
+                        (EntitlementCheckFunction) EntitlementService::automaticUsersyncPollerEnabled, false},
+                {"CDP_AUTOMATIC_USERSYNC_POLLER == true", CDP_AUTOMATIC_USERSYNC_POLLER,
+                        (EntitlementCheckFunction) EntitlementService::automaticUsersyncPollerEnabled, true},
+
+                {"CDP_FREEIPA_HA == false", CDP_FREEIPA_HA, (EntitlementCheckFunction) EntitlementService::freeIpaHaEnabled, false},
+                {"CDP_FREEIPA_HA == true", CDP_FREEIPA_HA, (EntitlementCheckFunction) EntitlementService::freeIpaHaEnabled, true},
+
+                {"CLOUDERA_INTERNAL_ACCOUNT == false", CLOUDERA_INTERNAL_ACCOUNT, (EntitlementCheckFunction) EntitlementService::internalTenant, false},
+                {"CLOUDERA_INTERNAL_ACCOUNT == true", CLOUDERA_INTERNAL_ACCOUNT, (EntitlementCheckFunction) EntitlementService::internalTenant, true},
+
+                {"CDP_FMS_CLUSTER_PROXY == false", CDP_FMS_CLUSTER_PROXY, (EntitlementCheckFunction) EntitlementService::fmsClusterProxyEnabled, false},
+                {"CDP_FMS_CLUSTER_PROXY == true", CDP_FMS_CLUSTER_PROXY, (EntitlementCheckFunction) EntitlementService::fmsClusterProxyEnabled, true},
+
+                {"CDP_CLOUD_STORAGE_VALIDATION == false", CDP_CLOUD_STORAGE_VALIDATION,
+                        (EntitlementCheckFunction) EntitlementService::cloudStorageValidationEnabled, false},
+                {"CDP_CLOUD_STORAGE_VALIDATION == true", CDP_CLOUD_STORAGE_VALIDATION,
+                        (EntitlementCheckFunction) EntitlementService::cloudStorageValidationEnabled, true},
+
+                {"CDP_RAZ == false", CDP_RAZ, (EntitlementCheckFunction) EntitlementService::razEnabled, false},
+                {"CDP_RAZ == true", CDP_RAZ, (EntitlementCheckFunction) EntitlementService::razEnabled, true},
+
+                {"CDP_RUNTIME_UPGRADE == false", CDP_RUNTIME_UPGRADE, (EntitlementCheckFunction) EntitlementService::runtimeUpgradeEnabled, false},
+                {"CDP_RUNTIME_UPGRADE == true", CDP_RUNTIME_UPGRADE, (EntitlementCheckFunction) EntitlementService::runtimeUpgradeEnabled, true},
+
+                {"CDP_FREEIPA_DL_EBS_ENCRYPTION == false", CDP_FREEIPA_DL_EBS_ENCRYPTION,
+                        (EntitlementCheckFunction) EntitlementService::freeIpaDlEbsEncryptionEnabled, false},
+                {"CDP_FREEIPA_DL_EBS_ENCRYPTION == true", CDP_FREEIPA_DL_EBS_ENCRYPTION,
+                        (EntitlementCheckFunction) EntitlementService::freeIpaDlEbsEncryptionEnabled, true},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("entitlementCheckDataProvider")
+    void entitlementEnabledTestWhenNoOtherEntitlementsAreGranted(String testCaseName, String entitlementName, EntitlementCheckFunction function,
+            boolean enabled) {
+        setUpUmsClient(enabled ? createAccountForEntitlements(entitlementName) : ACCOUNT_NO_ENTITLEMENTS);
+        assertThat(function.entitlementEnabled(underTest, ACTOR_CRN, ACCOUNT_ID)).isEqualTo(enabled);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("entitlementCheckDataProvider")
+    void entitlementEnabledTestWhenMultipleOtherEntitlementsAreGranted(String testCaseName, String entitlementName, EntitlementCheckFunction function,
+            boolean enabled) {
+        setUpUmsClient(enabled ? createAccountForEntitlements(ENTITLEMENT_FOO, entitlementName, ENTITLEMENT_BAR) : ACCOUNT_ENTITLEMENTS_FOO_BAR);
+        assertThat(function.entitlementEnabled(underTest, ACTOR_CRN, ACCOUNT_ID)).isEqualTo(enabled);
+    }
+
+    @Test
+    void getEntitlementsTest() {
+        setUpUmsClient(ACCOUNT_ENTITLEMENTS_FOO_BAR);
+        assertThat(underTest.getEntitlements(ACTOR_CRN, ACCOUNT_ID)).containsExactly(ENTITLEMENT_FOO, ENTITLEMENT_BAR);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setUpUmsClient(Account account) {
+        when(umsClient.getAccountDetails(eq(ACTOR_CRN), eq(ACCOUNT_ID), any(Optional.class))).thenReturn(account);
+    }
+
+    private static Account createAccountForEntitlements(String... entitlementNames) {
+        // Protobuf wrappers are all finals, so cannot be mocked
+        Account.Builder builder = Account.newBuilder();
+        Arrays.stream(entitlementNames).forEach(entitlementName -> builder.addEntitlements(createEntitlement(entitlementName)));
+        return builder.build();
+    }
+
+    private static Entitlement createEntitlement(String entitlementName) {
+        return Entitlement.newBuilder().setEntitlementName(entitlementName).build();
+    }
+
+    @FunctionalInterface
+    private interface EntitlementCheckFunction {
+        boolean entitlementEnabled(EntitlementService service, String actorCrn, String accountId);
+    }
+
+}

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/encryption/EncryptedSnapshotService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/encryption/EncryptedSnapshotService.java
@@ -102,13 +102,14 @@ public class EncryptedSnapshotService {
 
     private Optional<String> prepareSnapshotForEncryptionBecauseThatDoesNotExist(AuthenticatedContext ac, CloudStack cloudStack, AwsInstanceView instanceView,
             AmazonEC2Client client, PersistenceNotifier resourceNotifier) {
-
+        LOGGER.debug("Create an encrypted EBS volume for group: '{}'", instanceView.getGroupName());
         CreateVolumeResult volumeResult = client.createVolume(prepareCreateVolumeRequest(ac, instanceView, client, cloudStack));
         String volumeId = volumeResult.getVolume().getVolumeId();
         checkEbsVolumeStatus(ac, client, volumeId);
         saveEncryptedResource(ac, resourceNotifier, ResourceType.AWS_ENCRYPTED_VOLUME, volumeId, instanceView.getGroupName());
         LOGGER.debug("Encrypted EBS volume has been created with id: '{}', for group: '{}'", volumeId, instanceView.getGroupName());
 
+        LOGGER.debug("Create an encrypted snapshot of EBS volume for group: '{}'", instanceView.getGroupName());
         CreateSnapshotResult snapshotResult = client.createSnapshot(prepareCreateSnapshotRequest(volumeResult));
         checkSnapshotReadiness(ac, client, snapshotResult);
         LOGGER.debug("Encrypted snapshot of EBS volume has been created with id: '{}', for group: '{}'", snapshotResult.getSnapshot().getSnapshotId(),

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/resource/AwsVolumeResourceBuilder.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/resource/AwsVolumeResourceBuilder.java
@@ -182,6 +182,8 @@ public class AwsVolumeResourceBuilder extends AbstractAwsComputeBuilder {
         Long ephemeralCount = group.getReferenceInstanceConfiguration().getTemplate().getVolumes().stream()
                 .filter(vol -> AwsDiskType.Ephemeral.value().equalsIgnoreCase(vol.getType())).collect(Collectors.counting());
 
+        LOGGER.debug("Start creating data volumes for stack: '{}' group: '{}'", auth.getCloudContext().getName(), group.getName());
+
         for (CloudResource resource : requestedResources) {
             volumeSetMap.put(resource.getName(), Collections.synchronizedList(new ArrayList<>()));
 
@@ -241,7 +243,7 @@ public class AwsVolumeResourceBuilder extends AbstractAwsComputeBuilder {
 
         return encryptedSnapshotService.createSnapshotIfNeeded(ac, cloudStack, group, resourceNotifier)
                 .orElseThrow(() -> {
-                    String message = String.format("Failed to create Ebs encrypted volume on stack: %s", ac.getCloudContext().getId());
+                    String message = String.format("Failed to create EBS encrypted volume on stack: %s", ac.getCloudContext().getId());
                     return new CloudConnectorException(message);
                 });
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/instance/InstanceGroupRequestToInstanceGroupConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/instance/InstanceGroupRequestToInstanceGroupConverter.java
@@ -31,7 +31,7 @@ public class InstanceGroupRequestToInstanceGroupConverter {
         CloudPlatform cloudPlatform = CloudPlatform.valueOf(cloudPlatformString);
         instanceGroup.setTemplate(source.getInstanceTemplate() == null
                 ? defaultInstanceGroupProvider.createDefaultTemplate(cloudPlatform, accountId)
-                : templateConverter.convert(source.getInstanceTemplate(), cloudPlatform));
+                : templateConverter.convert(source.getInstanceTemplate(), cloudPlatform, accountId));
         instanceGroup.setSecurityGroup(securityGroupConverter.convert(source.getSecurityGroup()));
         instanceGroup.setGroupName(source.getName());
         instanceGroup.setInstanceGroupType(source.getType());

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/instance/DefaultInstanceGroupProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/instance/DefaultInstanceGroupProvider.java
@@ -1,18 +1,34 @@
 package com.sequenceiq.freeipa.service.stack.instance;
 
+import static com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient.INTERNAL_ACTOR_CRN;
+import static java.util.Map.entry;
+
+import java.util.Map;
+
 import javax.inject.Inject;
 
 import org.springframework.stereotype.Service;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.common.converter.MissingResourceNameGenerator;
+import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.common.type.APIResourceType;
+import com.sequenceiq.common.api.type.EncryptionType;
 import com.sequenceiq.freeipa.api.model.ResourceStatus;
 import com.sequenceiq.freeipa.entity.Template;
 import com.sequenceiq.freeipa.service.DefaultRootVolumeSizeProvider;
 
 @Service
 public class DefaultInstanceGroupProvider {
+
+    @VisibleForTesting
+    static final String ATTRIBUTE_VOLUME_ENCRYPTED = "encrypted";
+
+    @VisibleForTesting
+    static final String ATTRIBUTE_VOLUME_ENCRYPTION_TYPE = "type";
+
     @Inject
     private MissingResourceNameGenerator missingResourceNameGenerator;
 
@@ -21,6 +37,9 @@ public class DefaultInstanceGroupProvider {
 
     @Inject
     private DefaultInstanceTypeProvider defaultInstanceTypeProvider;
+
+    @Inject
+    private EntitlementService entitlementService;
 
     public Template createDefaultTemplate(CloudPlatform cloudPlatform, String accountId) {
         Template template = new Template();
@@ -31,6 +50,13 @@ public class DefaultInstanceGroupProvider {
         template.setVolumeSize(0);
         template.setInstanceType(defaultInstanceTypeProvider.getForPlatform(cloudPlatform.name()));
         template.setAccountId(accountId);
+        if (cloudPlatform == CloudPlatform.AWS && entitlementService.freeIpaDlEbsEncryptionEnabled(INTERNAL_ACTOR_CRN, accountId)) {
+            // FIXME Enable EBS encryption with appropriate KMS key
+            template.setAttributes(new Json(Map.<String, Object>ofEntries(
+                    entry(ATTRIBUTE_VOLUME_ENCRYPTED, Boolean.TRUE),
+                    entry(ATTRIBUTE_VOLUME_ENCRYPTION_TYPE, EncryptionType.DEFAULT.name()))));
+        }
         return template;
     }
+
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/instance/template/InstanceTemplateRequestToTemplateConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/instance/template/InstanceTemplateRequestToTemplateConverterTest.java
@@ -1,15 +1,23 @@
 package com.sequenceiq.freeipa.converter.instance.template;
 
-import org.assertj.core.api.Assertions;
+import static com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient.INTERNAL_ACTOR_CRN;
+import static com.sequenceiq.freeipa.converter.instance.template.InstanceTemplateRequestToTemplateConverter.ATTRIBUTE_SPOT_PERCENTAGE;
+import static com.sequenceiq.freeipa.converter.instance.template.InstanceTemplateRequestToTemplateConverter.ATTRIBUTE_VOLUME_ENCRYPTED;
+import static com.sequenceiq.freeipa.converter.instance.template.InstanceTemplateRequestToTemplateConverter.ATTRIBUTE_VOLUME_ENCRYPTION_TYPE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.common.converter.MissingResourceNameGenerator;
+import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.common.api.type.EncryptionType;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceTemplateRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.aws.AwsInstanceTemplateParameters;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.aws.AwsInstanceTemplateSpotParameters;
@@ -22,6 +30,12 @@ class InstanceTemplateRequestToTemplateConverterTest {
 
     private static final CloudPlatform CLOUD_PLATFORM = CloudPlatform.AWS;
 
+    private static final String ACCOUNT_ID = "accountId";
+
+    private static final String INSTANCE_TYPE = "m5.2xlarge";
+
+    private static final int SPOT_PERCENTAGE = 100;
+
     @Mock
     private MissingResourceNameGenerator missingResourceNameGenerator;
 
@@ -31,17 +45,20 @@ class InstanceTemplateRequestToTemplateConverterTest {
     @Mock
     private DefaultInstanceTypeProvider defaultInstanceTypeProvider;
 
+    @Mock
+    private EntitlementService entitlementService;
+
     @InjectMocks
     private InstanceTemplateRequestToTemplateConverter underTest;
 
     @Test
     void shouldSetInstanceTypeWhenProvided() {
         InstanceTemplateRequest source = new InstanceTemplateRequest();
-        source.setInstanceType("m5.2xlarge");
+        source.setInstanceType(INSTANCE_TYPE);
 
-        Template result = underTest.convert(source, CLOUD_PLATFORM);
+        Template result = underTest.convert(source, CLOUD_PLATFORM, ACCOUNT_ID);
 
-        Assertions.assertThat(result.getInstanceType()).isEqualTo(source.getInstanceType());
+        assertThat(result.getInstanceType()).isEqualTo(source.getInstanceType());
     }
 
     @Test
@@ -49,30 +66,92 @@ class InstanceTemplateRequestToTemplateConverterTest {
         String defaultInstanceType = "default";
 
         InstanceTemplateRequest source = new InstanceTemplateRequest();
-        Mockito.when(defaultInstanceTypeProvider.getForPlatform(CLOUD_PLATFORM.name())).thenReturn(defaultInstanceType);
+        when(defaultInstanceTypeProvider.getForPlatform(CLOUD_PLATFORM.name())).thenReturn(defaultInstanceType);
 
-        Template result = underTest.convert(source, CLOUD_PLATFORM);
+        Template result = underTest.convert(source, CLOUD_PLATFORM, ACCOUNT_ID);
 
-        Assertions.assertThat(result.getInstanceType()).isEqualTo(defaultInstanceType);
+        assertThat(result.getInstanceType()).isEqualTo(defaultInstanceType);
     }
 
     @Test
     void shouldSetSpotPercentagePropertyWhenProvided() {
-        int spotPercentage = 100;
+        InstanceTemplateRequest source = new InstanceTemplateRequest();
+        source.setInstanceType(INSTANCE_TYPE);
+        source.setAws(createAwsInstanceTemplateParameters(SPOT_PERCENTAGE));
 
+        Template result = underTest.convert(source, CLOUD_PLATFORM, ACCOUNT_ID);
+
+        Json attributes = result.getAttributes();
+        assertThat(attributes).isNotNull();
+        assertThat(attributes.<Object>getValue(ATTRIBUTE_SPOT_PERCENTAGE)).isEqualTo(SPOT_PERCENTAGE);
+    }
+
+    @Test
+    void shouldNotSetVolumeEncryptionWhenAzure() {
+        InstanceTemplateRequest source = new InstanceTemplateRequest();
+        source.setInstanceType(INSTANCE_TYPE);
+
+        Template result = underTest.convert(source, CloudPlatform.AZURE, ACCOUNT_ID);
+
+        Json attributes = result.getAttributes();
+        assertThat(attributes).isNotNull();
+        assertThat(attributes.<Object>getValue(ATTRIBUTE_VOLUME_ENCRYPTED)).isNull();
+        assertThat(attributes.<Object>getValue(ATTRIBUTE_VOLUME_ENCRYPTION_TYPE)).isNull();
+    }
+
+    @Test
+    void shouldNotSetVolumeEncryptionWhenAwsAndNotEntitled() {
+        InstanceTemplateRequest source = new InstanceTemplateRequest();
+        source.setInstanceType(INSTANCE_TYPE);
+
+        when(entitlementService.freeIpaDlEbsEncryptionEnabled(INTERNAL_ACTOR_CRN, ACCOUNT_ID)).thenReturn(false);
+
+        Template result = underTest.convert(source, CLOUD_PLATFORM, ACCOUNT_ID);
+
+        Json attributes = result.getAttributes();
+        assertThat(attributes).isNotNull();
+        assertThat(attributes.<Object>getValue(ATTRIBUTE_VOLUME_ENCRYPTED)).isNull();
+        assertThat(attributes.<Object>getValue(ATTRIBUTE_VOLUME_ENCRYPTION_TYPE)).isNull();
+    }
+
+    @Test
+    void shouldSetVolumeEncryptionWhenAwsAndEntitled() {
+        InstanceTemplateRequest source = new InstanceTemplateRequest();
+        source.setInstanceType(INSTANCE_TYPE);
+
+        when(entitlementService.freeIpaDlEbsEncryptionEnabled(INTERNAL_ACTOR_CRN, ACCOUNT_ID)).thenReturn(true);
+
+        Template result = underTest.convert(source, CLOUD_PLATFORM, ACCOUNT_ID);
+
+        Json attributes = result.getAttributes();
+        assertThat(attributes).isNotNull();
+        assertThat(attributes.<Object>getValue(ATTRIBUTE_VOLUME_ENCRYPTED)).isEqualTo(Boolean.TRUE);
+        assertThat(attributes.<Object>getValue(ATTRIBUTE_VOLUME_ENCRYPTION_TYPE)).isEqualTo(EncryptionType.DEFAULT.name());
+    }
+
+    @Test
+    void shouldSetVolumeEncryptionAndSpotPercentagePropertyWhenAwsAndEntitledAndSpotPercentageProvided() {
+        InstanceTemplateRequest source = new InstanceTemplateRequest();
+        source.setInstanceType(INSTANCE_TYPE);
+        source.setAws(createAwsInstanceTemplateParameters(SPOT_PERCENTAGE));
+
+        when(entitlementService.freeIpaDlEbsEncryptionEnabled(INTERNAL_ACTOR_CRN, ACCOUNT_ID)).thenReturn(true);
+
+        Template result = underTest.convert(source, CLOUD_PLATFORM, ACCOUNT_ID);
+
+        Json attributes = result.getAttributes();
+        assertThat(attributes).isNotNull();
+        assertThat(attributes.<Object>getValue(ATTRIBUTE_VOLUME_ENCRYPTED)).isEqualTo(Boolean.TRUE);
+        assertThat(attributes.<Object>getValue(ATTRIBUTE_VOLUME_ENCRYPTION_TYPE)).isEqualTo(EncryptionType.DEFAULT.name());
+        assertThat(attributes.<Object>getValue(ATTRIBUTE_SPOT_PERCENTAGE)).isEqualTo(SPOT_PERCENTAGE);
+    }
+
+    private AwsInstanceTemplateParameters createAwsInstanceTemplateParameters(int spotPercentage) {
         AwsInstanceTemplateSpotParameters spot = new AwsInstanceTemplateSpotParameters();
         spot.setPercentage(spotPercentage);
         AwsInstanceTemplateParameters aws = new AwsInstanceTemplateParameters();
         aws.setSpot(spot);
-
-        InstanceTemplateRequest source = new InstanceTemplateRequest();
-        source.setInstanceType("m5.2xlarge");
-        source.setAws(aws);
-
-        Template result = underTest.convert(source, CLOUD_PLATFORM);
-
-        Object resultSpotPercentage = result.getAttributes().getValue("spotPercentage");
-        Assertions.assertThat(resultSpotPercentage).isEqualTo(spotPercentage);
+        return aws;
     }
 
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/instance/DefaultInstanceGroupProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/instance/DefaultInstanceGroupProviderTest.java
@@ -1,0 +1,74 @@
+package com.sequenceiq.freeipa.service.stack.instance;
+
+import static com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient.INTERNAL_ACTOR_CRN;
+import static com.sequenceiq.freeipa.service.stack.instance.DefaultInstanceGroupProvider.ATTRIBUTE_VOLUME_ENCRYPTED;
+import static com.sequenceiq.freeipa.service.stack.instance.DefaultInstanceGroupProvider.ATTRIBUTE_VOLUME_ENCRYPTION_TYPE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.common.converter.MissingResourceNameGenerator;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.common.api.type.EncryptionType;
+import com.sequenceiq.freeipa.entity.Template;
+import com.sequenceiq.freeipa.service.DefaultRootVolumeSizeProvider;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultInstanceGroupProviderTest {
+
+    private static final String ACCOUNT_ID = "accountId";
+
+    @Mock
+    private MissingResourceNameGenerator missingResourceNameGenerator;
+
+    @Mock
+    private DefaultRootVolumeSizeProvider defaultRootVolumeSizeProvider;
+
+    @Mock
+    private DefaultInstanceTypeProvider defaultInstanceTypeProvider;
+
+    @Mock
+    private EntitlementService entitlementService;
+
+    @InjectMocks
+    private DefaultInstanceGroupProvider underTest;
+
+    @Test
+    void createDefaultTemplateTestNoVolumeEncryptionWhenAzure() {
+        Template result = underTest.createDefaultTemplate(CloudPlatform.AZURE, ACCOUNT_ID);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getAttributes()).isNull();
+    }
+
+    @Test
+    void createDefaultTemplateTestNoVolumeEncryptionWhenAwsAndNotEntitled() {
+        when(entitlementService.freeIpaDlEbsEncryptionEnabled(INTERNAL_ACTOR_CRN, ACCOUNT_ID)).thenReturn(false);
+
+        Template result = underTest.createDefaultTemplate(CloudPlatform.AWS, ACCOUNT_ID);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getAttributes()).isNull();
+    }
+
+    @Test
+    void createDefaultTemplateTestVolumeEncryptionAddedWhenAwsAndEntitled() {
+        when(entitlementService.freeIpaDlEbsEncryptionEnabled(INTERNAL_ACTOR_CRN, ACCOUNT_ID)).thenReturn(true);
+
+        Template result = underTest.createDefaultTemplate(CloudPlatform.AWS, ACCOUNT_ID);
+
+        assertThat(result).isNotNull();
+        Json attributes = result.getAttributes();
+        assertThat(attributes).isNotNull();
+        assertThat(attributes.<Object>getValue(ATTRIBUTE_VOLUME_ENCRYPTED)).isEqualTo(Boolean.TRUE);
+        assertThat(attributes.<Object>getValue(ATTRIBUTE_VOLUME_ENCRYPTION_TYPE)).isEqualTo(EncryptionType.DEFAULT.name());
+    }
+
+}

--- a/mock-caas/build.gradle
+++ b/mock-caas/build.gradle
@@ -58,14 +58,16 @@ dependencies {
   compile group:  'org.springframework',          name: 'spring-context-support',         version: springFrameworkVersion
   compile group:  'org.springframework.security', name: 'spring-security-jwt',            version: '1.0.10.RELEASE'
   compile group:  'com.fasterxml.jackson.core',   name: 'jackson-core',                   version: jacksonVersion
-  compile group:  'com.google.protobuf',           name: 'protobuf-java-util',             version: '3.10.0'
+  compile group:  'com.google.protobuf',          name: 'protobuf-java-util',             version: '3.10.0'
   compile group:  'io.jsonwebtoken',              name: 'jjwt',                           version: '0.9.1'
   testCompile group: 'org.mockito',               name: 'mockito-core',                   version: mockitoVersion
   testCompile group: 'org.springframework.boot',  name: 'spring-boot-starter-test',       version: springBootVersion
+  testImplementation group: 'org.assertj',        name: 'assertj-core',                   version: assertjVersion
 
   compile project(':auth-connector')
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: junitVersion
+    testImplementation group: 'org.junit.jupiter',name: 'junit-jupiter-migrationsupport', version: junitJupiterVersion
+    testCompile group: 'junit',                   name: 'junit',                          version: junitVersion
 }

--- a/mock-caas/src/main/java/com/sequenceiq/caas/grpc/service/MockUserManagementService.java
+++ b/mock-caas/src/main/java/com/sequenceiq/caas/grpc/service/MockUserManagementService.java
@@ -182,9 +182,11 @@ public class MockUserManagementService extends UserManagementImplBase {
 
     private static final String CDP_CLOUD_STORAGE_VALIDATION = "CDP_CLOUD_STORAGE_VALIDATION";
 
+    private static final String CDP_RUNTIME_UPGRADE = "CDP_RUNTIME_UPGRADE";
+
     private static final String CDP_RAZ_ENABLEMENT = "CDP_RAZ";
 
-    private static final String RUNTIME_UPGRADE = "CDP_RUNTIME_UPGRADE";
+    private static final String CDP_FREEIPA_DL_EBS_ENCRYPTION = "CDP_FREEIPA_DL_EBS_ENCRYPTION";
 
     private static final String MOCK_RESOURCE = "mock_resource";
 
@@ -234,6 +236,9 @@ public class MockUserManagementService extends UserManagementImplBase {
 
     @Value("${auth.mock.raz.enable}")
     private boolean razEnabled;
+
+    @Value("${auth.mock.freeipadlebsencryption.enable}")
+    private boolean enableFreeIpaDlEbsEncryption;
 
     private String cbLicense;
 
@@ -483,10 +488,13 @@ public class MockUserManagementService extends UserManagementImplBase {
             builder.addEntitlements(createEntitlement(CDP_CLOUD_STORAGE_VALIDATION));
         }
         if (runtimeUpgradeEnabled) {
-            builder.addEntitlements(createEntitlement(RUNTIME_UPGRADE));
+            builder.addEntitlements(createEntitlement(CDP_RUNTIME_UPGRADE));
         }
         if (razEnabled) {
             builder.addEntitlements(createEntitlement(CDP_RAZ_ENABLEMENT));
+        }
+        if (enableFreeIpaDlEbsEncryption) {
+            builder.addEntitlements(createEntitlement(CDP_FREEIPA_DL_EBS_ENCRYPTION));
         }
         responseObserver.onNext(
                 GetAccountResponse.newBuilder()

--- a/mock-caas/src/main/resources/application.yml
+++ b/mock-caas/src/main/resources/application.yml
@@ -18,3 +18,4 @@ auth:
     runtime.upgrade.enable: true
     sshpublickey.file: key.pub
     raz.enable: true
+    freeipadlebsencryption.enable: true


### PR DESCRIPTION
As per one-pager [design doc](https://docs.google.com/document/d/1OK6COfHosg3EA6IQxuV4o1AczzBLAqk2SNgyafJ-x0w/edit) linked to [CB-4925](https://jira.cloudera.com/browse/CB-4925), this PR unconditionally enables the encryption of EBS volumes for FreeIPA and DL clusters (but note the exception below for the latter). Notes:

* This applies to root (always EBS) as well as EBS data volumes. (There is no way to define encryption settings separately in `cloud-api`; they apply to all the volumes of the whole host group when given.)
* The current logic always uses the region-default EBS encryption key. The handling of customer-provided KMS CMK is out of scope here and will be covered in a follow-up JIRA & PR.
* No change to service APIs; settings are currently hard-wired into the service logic. Any possible API enhancement (e.g. to introduce custom encryption key choices) will be, again, treated in a future JIRA & PR. In other words, users have, in general, no way to tweak or disable EBS encryption for FreeIPA and DL clusters.
  * The only exception is the DL logic; `StackRequestManifester` honors any existing `AwsEncryptionV4Parameters` in the incoming `StackV4Request` with `getType() != null`, leaving the input setting untouched. This is only possible when using the `SdxInternalEndpoint`; specifying `getType() == EncryptionType.NONE` will thus always result in unencrypted EBS. On the other hand, the `getType() == null` setting will be overwritten with `EncryptionType.DEFAULT`, which is the path normally encountered when using the public `SdxEndpoint`.
* The above logic is guarded by the new entitlement `CDP_FREEIPA_DL_EBS_ENCRYPTION`. This entitlement gets checked by both FreeIPA and DL Svc; the absence of the entitlement grant will result in the legacy behavior.
* When testing with local CB, `mock-caas` defaults to presenting `CDP_FREEIPA_DL_EBS_ENCRYPTION` always granted. The following VM argument shall be added to `MockCaasApplication` to disable this entitlement: `-Dauth.mock.freeipadlebsencryption.enable=false`.
* Some extra logging have been added to `cloud-aws` and `cloud-template` that help determine the exact time spent with various cloud infra steps due to EBS encryption.
* Unit tests have been added for all logic changes, except for logging related enhancements. These are all based on JUnit 5 and AssertJ, sometimes using `ParameterizedTest`s. The exisiting `InstanceGroupRequestToInstanceGroupConverterTest` and `MockUserManagementServiceTest` have been ported to the above libraries. (The latter also retains the `ExpectedException` `Rule` from JUnit 4 via the experimental `junit-jupiter-migrationsupport` package.)

Follow-up tasks:
* Add customization options in service APIs, including the handling of customer-managed KMS keys. \[No JIRA ticket yet.\]
* Hide cloud provider specific parts of the above FreeIPA and DL logic behind interfaces & respective provider implementations. \[[CB-7455](https://jira.cloudera.com/browse/CB-7455)\]
* The usage of magic string literals (`"encrypted"`, `"type"`, `"key"` and `"spotPercentage"`) for instance template attributes is not best practice. To be discussed how to refactor this by exposing them as public constants (e.g. in `cloud-aws` / `AwsInstanceView`). \[[CB-7365](https://jira.cloudera.com/browse/CB-7365)\]
