### PR TITLE
CB-6716. Account telemetry: rules could be not base64 encoded in envi…

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigService.java
@@ -64,6 +64,10 @@ public class FluentConfigService {
                 );
             }
             enabled = determineAndSetLogging(builder, telemetry, databusEnabled, meteringEnabled);
+            if (telemetry.isClusterLogsCollectionEnabled()) {
+                LOGGER.debug("Set anonymization rules (only for cluster log collection)");
+                builder.withAnonymizationRules(decodeRules(anonymizationRules));
+            }
         }
         if (!enabled) {
             LOGGER.debug("Fluent based logging is disabled");
@@ -72,7 +76,6 @@ public class FluentConfigService {
         return builder
                 .withEnabled(enabled)
                 .withClusterDetails(clusterDetails)
-                .withAnonymizationRules(decodeRules(anonymizationRules))
                 .build();
     }
 


### PR DESCRIPTION
…ronment response during upgrade.

It's possible if Environment service has not yet upgraded but CB/FreeIPA already upgraded, the Environment telemetry response is not base64 encoded, but CB/FreeIPA will tries to decode it, it can fail with invalid character exception.

Simple fix for this for now:
only use decoding if cluster log collection is enabled for the deployment. That feature is not yet enabled for 2.20, so for ongoing deployments, this won't be called at all.

after 2.21 upgrade, that change can be reverted, so anonymiziation rules can be used by other telemetry features (if it will be needed)