### PR TITLE
CDPD-10605 HBase UI link incorrect redirection

### DIFF
--- a/core-api/src/main/resources/definitions/exposed-services.json
+++ b/core-api/src/main/resources/definitions/exposed-services.json
@@ -257,7 +257,7 @@
       "displayName": "HBase UI",
       "serviceName": "MASTER",
       "knoxService": "HBASEUI",
-      "knoxUrl": "/hbase/webui/master/",
+      "knoxUrl": "/hbase/webui/master",
       "ssoSupported": true,
       "port": 16010,
       "tlsPort": 16010,


### PR DESCRIPTION
Remove trailing slash from HBase UI link to workaround a Knox bug

Testing done: Checked from Firefox that the 
https://psomogyi-opdb-gateway3.psomogyi.xcu2-8y8x.dev.cldr.work/psomogyi-opdb/cdp-proxy/hbase/webui/master?host=psomogyi-opdb-master4.psomogyi.xcu2-8y8x.dev.cldr.work&port=16010 URL works.
The trailing slash was removed after hbase/webui/master