### PR TITLE
CB-6245. Add change environment level telemetry features endpoints (by env crn/name)

### DIFF
--- a/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentOpDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentOpDescription.java
@@ -13,6 +13,8 @@ public class EnvironmentOpDescription {
     public static final String DELETE_MULTIPLE_BY_CRN = "Delete multiple environment by CRNs. Only possible if no cluster is running in the environments.";
     public static final String CHANGE_CREDENTIAL_BY_NAME = "Changes the credential of the environment and the clusters in the environment of a given name.";
     public static final String CHANGE_CREDENTIAL_BY_CRN = "Changes the credential of the environment and the clusters in the environment of a given CRN.";
+    public static final String CHANGE_TELEMETRY_FEATURES_BY_NAME = "Changes telemetry features(s) of the environment in the environment of a given name.";
+    public static final String CHANGE_TELEMETRY_FEATURES_BY_CRN = "Changes telemetry features(s) of the environment in the environment of a given CRN.";
     public static final String CHANGE_NETWORK = "Changes the network of the environment.";
     public static final String REGISTER_EXTERNAL_DATALAKE = "Register external datalake.";
     public static final String EDIT_BY_NAME = "Edit an environment by name. Location, regions and description can be changed.";

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/endpoint/EnvironmentEndpoint.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/endpoint/EnvironmentEndpoint.java
@@ -19,6 +19,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
+import com.sequenceiq.common.api.telemetry.request.FeaturesRequest;
 import com.sequenceiq.environment.api.doc.environment.EnvironmentOpDescription;
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentChangeCredentialRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentEditRequest;
@@ -91,6 +92,13 @@ public interface EnvironmentEndpoint {
             nickname = "changeCredentialInEnvironmentV1")
     DetailedEnvironmentResponse changeCredentialByEnvironmentName(@PathParam("name") String environmentName, @Valid EnvironmentChangeCredentialRequest request);
 
+    @PUT
+    @Path("/name/{name}/change_telemetry_features")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = EnvironmentOpDescription.CHANGE_TELEMETRY_FEATURES_BY_NAME, produces = MediaType.APPLICATION_JSON, notes = ENVIRONMENT_NOTES,
+            nickname = "changeTelemetryFeaturesInEnvironmentV1ByName")
+    DetailedEnvironmentResponse changeTelemetryFeaturesByEnvironmentName(@PathParam("name") String environmentName, @Valid FeaturesRequest request);
+
     @POST
     @Path("/name/{name}/cli_create")
     @Produces(MediaType.APPLICATION_JSON)
@@ -132,6 +140,13 @@ public interface EnvironmentEndpoint {
     @ApiOperation(value = EnvironmentOpDescription.CHANGE_CREDENTIAL_BY_CRN, produces = MediaType.APPLICATION_JSON, notes = ENVIRONMENT_NOTES,
             nickname = "changeCredentialInEnvironmentV1ByCrn")
     DetailedEnvironmentResponse changeCredentialByEnvironmentCrn(@PathParam("crn") String crn, @Valid EnvironmentChangeCredentialRequest request);
+
+    @PUT
+    @Path("/crn/{crn}/change_telemetry_features")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = EnvironmentOpDescription.CHANGE_TELEMETRY_FEATURES_BY_CRN, produces = MediaType.APPLICATION_JSON, notes = ENVIRONMENT_NOTES,
+            nickname = "changeTelemetryFeaturesInEnvironmentV1ByCrn")
+    DetailedEnvironmentResponse changeTelemetryFeaturesByEnvironmentCrn(@PathParam("crn") String crn, @Valid FeaturesRequest request);
 
     @POST
     @Path("/name/{name}/start")

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/EnvironmentApiConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/EnvironmentApiConverter.java
@@ -22,6 +22,7 @@ import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.util.NullUtil;
+import com.sequenceiq.common.api.telemetry.request.FeaturesRequest;
 import com.sequenceiq.common.api.type.Tunnel;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkAwsParams;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkAzureParams;
@@ -62,6 +63,7 @@ import com.sequenceiq.environment.environment.dto.EnvironmentDto;
 import com.sequenceiq.environment.environment.dto.EnvironmentEditDto;
 import com.sequenceiq.environment.environment.dto.LocationDto;
 import com.sequenceiq.environment.environment.dto.SecurityAccessDto;
+import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentFeatures;
 import com.sequenceiq.environment.network.dao.domain.RegistrationType;
 import com.sequenceiq.environment.network.dto.AwsParams;
 import com.sequenceiq.environment.network.dto.AzureParams;
@@ -71,8 +73,8 @@ import com.sequenceiq.environment.network.dto.YarnParams;
 import com.sequenceiq.environment.network.service.SubnetIdProvider;
 import com.sequenceiq.environment.parameters.dto.AwsParametersDto;
 import com.sequenceiq.environment.parameters.dto.ParametersDto;
-import com.sequenceiq.environment.telemetry.service.AccountTelemetryService;
 import com.sequenceiq.environment.proxy.v1.converter.ProxyConfigToProxyResponseConverter;
+import com.sequenceiq.environment.telemetry.service.AccountTelemetryService;
 
 @Component
 public class EnvironmentApiConverter {
@@ -476,5 +478,12 @@ public class EnvironmentApiConverter {
         response.setEnvironmentName(environmentName);
         response.setEnvironmentCrn(crn);
         return response;
+    }
+
+    public EnvironmentFeatures convertToEnvironmentTelemetryFeatures(FeaturesRequest featuresRequest) {
+        EnvironmentFeatures features = new EnvironmentFeatures();
+        features.setWorkloadAnalytics(featuresRequest.getWorkloadAnalytics());
+        features.setClusterLogsCollection(featuresRequest.getClusterLogsCollection());
+        return features;
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/EnvironmentController.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/EnvironmentController.java
@@ -18,6 +18,7 @@ import com.sequenceiq.authorization.resource.AuthorizationResourceType;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.security.internal.InternalReady;
 import com.sequenceiq.cloudbreak.auth.security.internal.TenantAwareParam;
+import com.sequenceiq.common.api.telemetry.request.FeaturesRequest;
 import com.sequenceiq.environment.api.v1.environment.endpoint.EnvironmentEndpoint;
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentChangeCredentialRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentEditRequest;
@@ -32,6 +33,7 @@ import com.sequenceiq.environment.environment.dto.EnvironmentChangeCredentialDto
 import com.sequenceiq.environment.environment.dto.EnvironmentCreationDto;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
 import com.sequenceiq.environment.environment.dto.EnvironmentEditDto;
+import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentFeatures;
 import com.sequenceiq.environment.environment.service.EnvironmentCreationService;
 import com.sequenceiq.environment.environment.service.EnvironmentDeletionService;
 import com.sequenceiq.environment.environment.service.EnvironmentModificationService;
@@ -189,10 +191,28 @@ public class EnvironmentController implements EnvironmentEndpoint {
 
     @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.WRITE)
+    public DetailedEnvironmentResponse changeTelemetryFeaturesByEnvironmentName(String name, @Valid FeaturesRequest request) {
+        String accountId = ThreadBasedUserCrnProvider.getAccountId();
+        EnvironmentFeatures features = environmentApiConverter.convertToEnvironmentTelemetryFeatures(request);
+        EnvironmentDto result = environmentModificationService.changeTelemetryFeaturesByEnvironmentName(accountId, name, features);
+        return environmentApiConverter.dtoToDetailedResponse(result);
+    }
+
+    @Override
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.WRITE)
     public DetailedEnvironmentResponse changeCredentialByEnvironmentCrn(String crn, @Valid EnvironmentChangeCredentialRequest request) {
         String accountId = ThreadBasedUserCrnProvider.getAccountId();
         EnvironmentDto result = environmentModificationService.changeCredentialByEnvironmentCrn(accountId, crn,
                 environmentApiConverter.convertEnvironmentChangeCredentialDto(request));
+        return environmentApiConverter.dtoToDetailedResponse(result);
+    }
+
+    @Override
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.WRITE)
+    public DetailedEnvironmentResponse changeTelemetryFeaturesByEnvironmentCrn(String crn, @Valid FeaturesRequest request) {
+        String accountId = ThreadBasedUserCrnProvider.getAccountId();
+        EnvironmentFeatures features = environmentApiConverter.convertToEnvironmentTelemetryFeatures(request);
+        EnvironmentDto result = environmentModificationService.changeTelemetryFeaturesByEnvironmentCrn(accountId, crn, features);
         return environmentApiConverter.dtoToDetailedResponse(result);
     }
 


### PR DESCRIPTION
add "change_telemetry_features" by env crn and env name
use in a similar way as credential is used.
problem with edit request. if in telemetry, something is null, its not clear that should be deleted or changed.
by adding new endpoints for feature:
- if feature is missing from the input, that is not changed
- if feature is filled, that is updated

also on UI or on public API side, it's a bit problematic to update one feature as we need to send the exact same telemetry request back with the changed properties. That means on UI/Public API we need to make sure to iterate through on the request, put everything in the response (we cannot miss anything, so it needs more maintenance)