### PR TITLE
CB-5958: Add cloudwatch check to health check

### DIFF
--- a/cloud-aws/src/main/resources/definitions/aws-cb-policy.json
+++ b/cloud-aws/src/main/resources/definitions/aws-cb-policy.json
@@ -14,7 +14,8 @@
       "Sid": "CloudWatchMetric",
       "Action": [
         "cloudwatch:PutMetricAlarm",
-        "cloudwatch:DeleteAlarms"
+        "cloudwatch:DeleteAlarms",
+        "cloudwatch:DescribeAlarms"
       ],
       "Effect": "Allow",
       "Resource": [


### PR DESCRIPTION
This patch just adds the privileges to be able to run the
aws command to retrieve the cloudwatch alarm.  The actual
check will be included as part of the RPM for the health
agent.

