### PR TITLE
Revert "DISTX-415 Reduce the amount of time it takes to add new nodes"

### DIFF
--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/common/type/RecipeExecutionPhase.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/common/type/RecipeExecutionPhase.java
@@ -4,6 +4,8 @@ import com.sequenceiq.cloudbreak.common.model.recipe.RecipeType;
 
 public enum RecipeExecutionPhase {
 
+    PRE("pre"),
+    POST("post"),
     PRE_CLOUDERA_MANAGER_START("pre-cloudera-manager-start"),
     PRE_TERMINATION("pre-termination"),
     POST_CLOUDERA_MANAGER_START("post-cloudera-manager-start"),
@@ -31,7 +33,13 @@ public enum RecipeExecutionPhase {
     }
 
     public boolean isPreRecipe() {
-        return this != POST_CLUSTER_INSTALL;
+        switch (this) {
+            case POST_CLUSTER_INSTALL:
+            case POST:
+                return false;
+            default:
+                return true;
+        }
     }
 
     public boolean isPostRecipe() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/KerberosConfigTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/KerberosConfigTest.java
@@ -149,7 +149,7 @@ public class KerberosConfigTest extends AbstractIntegrationTest {
             public List<Assertion<StackTestDto, CloudbreakClient>> getAssertions() {
                 List<Assertion<StackTestDto, CloudbreakClient>> verifications = new LinkedList<>();
                 verifications.add(clusterTemplatePostToCMContains("enableKerberos").exactTimes(1));
-                verifications.add(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(SALT_HIGHSTATE).exactTimes(3));
+                verifications.add(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(SALT_HIGHSTATE).exactTimes(5));
                 return verifications;
             }
 
@@ -176,7 +176,7 @@ public class KerberosConfigTest extends AbstractIntegrationTest {
             public List<Assertion<StackTestDto, CloudbreakClient>> getAssertions() {
                 List<Assertion<StackTestDto, CloudbreakClient>> verifications = new LinkedList<>();
                 verifications.add(clusterTemplatePostToCMContains("enableKerberos").exactTimes(1));
-                verifications.add(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(SALT_HIGHSTATE).exactTimes(3));
+                verifications.add(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(SALT_HIGHSTATE).exactTimes(5));
                 return verifications;
             }
 
@@ -201,7 +201,7 @@ public class KerberosConfigTest extends AbstractIntegrationTest {
             public List<Assertion<StackTestDto, CloudbreakClient>> getAssertions() {
                 List<Assertion<StackTestDto, CloudbreakClient>> verifications = new LinkedList<>();
                 verifications.add(clusterTemplatePostToCMContains("enableKerberos").exactTimes(1));
-                verifications.add(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(SALT_HIGHSTATE).exactTimes(3));
+                verifications.add(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(SALT_HIGHSTATE).exactTimes(5));
                 return verifications;
             }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/RecipeClusterTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/RecipeClusterTest.java
@@ -154,10 +154,10 @@ public class RecipeClusterTest extends AbstractIntegrationTest {
                 .replaceInstanceGroups(INSTANCE_GROUP_ID)
                 .when(stackTestClient.createV4())
                 .await(STACK_AVAILABLE)
-                .then(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(HIGHSTATE).exactTimes(3))
+                .then(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(HIGHSTATE).exactTimes(5))
                 .when(stackTestClient.deleteV4())
                 .await(STACK_DELETED)
-                .then(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(HIGHSTATE).exactTimes(4))
+                .then(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(HIGHSTATE).exactTimes(7))
                 .validate();
     }
 
@@ -220,7 +220,7 @@ public class RecipeClusterTest extends AbstractIntegrationTest {
                 .await(STACK_AVAILABLE)
                 .when(StackScalePostAction.valid().withDesiredCount(mock.getDesiredWorkerCount()))
                 .await(STACK_AVAILABLE)
-                .then(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(HIGHSTATE).exactTimes(4))
+                .then(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(HIGHSTATE).exactTimes(8))
                 .validate();
     }
 
@@ -263,7 +263,7 @@ public class RecipeClusterTest extends AbstractIntegrationTest {
                 .await(STACK_AVAILABLE)
                 .when(StackScalePostAction.valid().withDesiredCount(mock.getDesiredWorkerCount()))
                 .await(STACK_AVAILABLE)
-                .then(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(HIGHSTATE).exactTimes(4))
+                .then(MockVerification.verify(HttpMethod.POST, SaltMock.SALT_RUN).bodyContains(HIGHSTATE).exactTimes(8))
                 .validate();
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/clouderamanager/CMUpscaleWithHttp500ResponsesTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/clouderamanager/CMUpscaleWithHttp500ResponsesTest.java
@@ -141,7 +141,7 @@ public class CMUpscaleWithHttp500ResponsesTest extends AbstractClouderaManagerTe
                 .then(MockVerification.verify(POST, ITResponse.SALT_API_ROOT + "/run").bodyContains("fun=saltutil.sync_all").atLeast(1))
                 .then(MockVerification.verify(POST, ITResponse.SALT_API_ROOT + "/run").bodyContains("fun=mine.update").atLeast(1))
                 .then(MockVerification.verify(POST, ITResponse.SALT_API_ROOT + "/run").bodyContains("fun=state.highstate").atLeast(2))
-                .then(MockVerification.verify(POST, ITResponse.SALT_API_ROOT + "/run").bodyContains("fun=grains.remove").exactTimes(4))
+                .then(MockVerification.verify(POST, ITResponse.SALT_API_ROOT + "/run").bodyContains("fun=grains.remove").exactTimes(6))
                 .then(MockVerification.verify(GET,
                         new ClouderaManagerPathResolver(LIST_HOSTS)
                                 .pathVariableMapping(":clusterName", clusterName)

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
@@ -861,25 +861,34 @@ public class SaltOrchestrator implements HostOrchestrator {
     @SuppressFBWarnings("REC_CATCH_EXCEPTION")
     private void executeRecipes(GatewayConfig gatewayConfig, Set<Node> allNodes, ExitCriteriaModel exitCriteriaModel, RecipeExecutionPhase phase, boolean forced)
             throws CloudbreakOrchestratorFailedException, CloudbreakOrchestratorTimeoutException {
+        boolean postRecipe = phase.isPostRecipe();
         int maxRetry = forced ? maxRetryRecipeForced : maxRetryRecipe;
         try (SaltConnector sc = createSaltConnector(gatewayConfig)) {
             // add 'recipe' grain to all nodes
             Set<String> targetHostnames = allNodes.stream().map(Node::getHostname).collect(Collectors.toSet());
             saltCommandRunner.runSaltCommand(sc, new GrainAddRunner(targetHostnames, allNodes, "recipes", phase.value()), exitCriteriaModel, maxRetry,
                     exitCriteria);
-            saltCommandRunner.runSaltCommand(sc, new SyncAllRunner(targetHostnames, allNodes), exitCriteriaModel, maxRetry, exitCriteria);
-            StateAllRunner stateAllRunner = new StateAllRunner(targetHostnames, allNodes, "recipes." + phase.value());
-            OrchestratorBootstrap saltJobIdTracker = new SaltJobIdTracker(sc, stateAllRunner);
-            Callable<Boolean> saltJobRunBootstrapRunner = saltRunner.runner(saltJobIdTracker, exitCriteria, exitCriteriaModel, maxRetry, false);
-            saltJobRunBootstrapRunner.call();
+
+            // Add Deprecated 'PRE/POST' recipe execution for backward compatibility (since version 2.2.0)
+            if (postRecipe) {
+                saltCommandRunner.runSaltCommand(sc, new GrainAddRunner(targetHostnames, allNodes, "recipes", RecipeExecutionPhase.POST.value()),
+                        exitCriteriaModel, maxRetry, exitCriteria);
+            } else {
+                saltCommandRunner.runSaltCommand(sc, new GrainAddRunner(targetHostnames, allNodes, "recipes", RecipeExecutionPhase.PRE.value()),
+                        exitCriteriaModel, maxRetry, exitCriteria);
+            }
+
+            Set<String> allHostnames = allNodes.stream().map(Node::getHostname).collect(Collectors.toSet());
+            saltCommandRunner.runSaltCommand(sc, new SyncAllRunner(allHostnames, allNodes), exitCriteriaModel, maxRetry, exitCriteria);
+            runNewService(sc, new HighStateRunner(allHostnames, allNodes), exitCriteriaModel, maxRetryRecipe, true);
         } catch (CloudbreakOrchestratorTimeoutException e) {
             LOGGER.info("Recipe execution timeout. {}", phase, e);
             throw e;
         } catch (CloudbreakOrchestratorFailedException e) {
-            LOGGER.info("Orchestration error occurred during execution of recipes.", e);
+            LOGGER.info("Orchestration error occurred during executing highstate (for recipes).", e);
             throw e;
         } catch (Exception e) {
-            LOGGER.info("Unknown error occurred during execution of recipes.", e);
+            LOGGER.info("Unknown error occurred during executing highstate (for recipes).", e);
             throw new CloudbreakOrchestratorFailedException(e);
         } finally {
             try (SaltConnector sc = new SaltConnector(gatewayConfig, saltErrorResolver, restDebug)) {
@@ -887,6 +896,15 @@ public class SaltOrchestrator implements HostOrchestrator {
                 Set<String> targetHostnames = allNodes.stream().map(Node::getHostname).collect(Collectors.toSet());
                 saltCommandRunner.runSaltCommand(sc, new GrainRemoveRunner(targetHostnames, allNodes, "recipes", phase.value()), exitCriteriaModel,
                         maxRetry, exitCriteria);
+
+                // Remove Deprecated 'PRE/POST' recipe execution for backward compatibility (since version 2.2.0)
+                if (postRecipe) {
+                    saltCommandRunner.runSaltCommand(sc, new GrainRemoveRunner(
+                            targetHostnames, allNodes, "recipes", RecipeExecutionPhase.POST.value()), exitCriteriaModel, maxRetry, exitCriteria);
+                } else {
+                    saltCommandRunner.runSaltCommand(sc, new GrainRemoveRunner(
+                            targetHostnames, allNodes, "recipes", RecipeExecutionPhase.PRE.value()), exitCriteriaModel, maxRetry, exitCriteria);
+                }
             } catch (Exception e) {
                 LOGGER.info("Error occurred during removing recipe roles.", e);
                 throw new CloudbreakOrchestratorFailedException(e);


### PR DESCRIPTION
This commit broke cluster creation if there are actually recipes added as part of the definition.

This leaves the kinit added to ipa leave command for CB-6703

```
/bin/bash: /opt/scripts/recipe-runner.sh: No such file or directory
```

This reverts commit a2c4195f