### PR TITLE
CB-6730. Instance groups are not listed in stack response if instancence metadata is attached to it

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceGroupRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceGroupRepository.java
@@ -33,6 +33,7 @@ public interface InstanceGroupRepository extends CrudRepository<InstanceGroup, L
             "WHERE i.instanceGroup.stack.id= :stackId AND i.discoveryFQDN= :hostName AND i.instanceStatus <> 'TERMINATED'")
     Optional<InstanceGroup> findInstanceGroupInStackByHostName(@Param("stackId") Long stackId, @Param("hostName") String hostName);
 
-    @Query("SELECT i FROM InstanceGroup i LEFT JOIN FETCH i.instanceMetaData im WHERE i.stack.id = :stackId AND im.instanceStatus <> 'TERMINATED'")
+    @Query("SELECT i FROM InstanceGroup i LEFT JOIN FETCH i.instanceMetaData im "
+            + "WHERE i.stack.id = :stackId AND (im IS NULL OR im.instanceStatus <> 'TERMINATED')")
     Set<InstanceGroup> findNotTerminatedByStackId(@Param("stackId") Long stackId);
 }


### PR DESCRIPTION
Finding instacegroups without terminated metadata query does not return those instanceGroups that has no instance metadata at all

Solution
-> check if instancemetadata is null  (i have tried with is null and is empty together, but with is null it resulted the same)

after the change,  resize window looks like this (without gateway and compute nodes):

![resize](https://user-images.githubusercontent.com/1231814/80016907-0a5cab80-84d4-11ea-8658-22ecd21a00c9.png)

do not merge yet (only after @daszabo reviewed this, just to make sure getting back instanceGroups are fine if no instanceMetadata is totally fine)