### PR TITLE
CB-6720: Update Ranger configs for CM 7.2+

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
@@ -25,6 +25,8 @@ public class CMRepositoryVersionUtil {
 
     public static final Versioned CLOUDERAMANAGER_VERSION_7_1_1 = () -> "7.1.1";
 
+    public static final Versioned CLOUDERAMANAGER_VERSION_7_2_0 = () -> "7.2.0";
+
     public static final Versioned CFM_VERSION_2_0_0_0 = () -> "2.0.0.0";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CMRepositoryVersionUtil.class);

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerRoleConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerRoleConfigProvider.java
@@ -1,25 +1,25 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.ranger;
 
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_0_1;
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_0;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.inject.Inject;
-
-import org.springframework.stereotype.Component;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.auth.altus.UmsRight;
+import com.sequenceiq.cloudbreak.auth.altus.VirtualGroupRequest;
 import com.sequenceiq.cloudbreak.auth.altus.VirtualGroupService;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRdsRoleConfigProvider;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
-import com.sequenceiq.cloudbreak.auth.altus.VirtualGroupRequest;
 import com.sequenceiq.cloudbreak.template.views.RdsView;
+import java.util.ArrayList;
+import java.util.List;
+import javax.inject.Inject;
+import org.springframework.stereotype.Component;
 
 @Component
 public class RangerRoleConfigProvider extends AbstractRdsRoleConfigProvider {
@@ -27,19 +27,30 @@ public class RangerRoleConfigProvider extends AbstractRdsRoleConfigProvider {
     private VirtualGroupService virtualGroupService;
 
     @Override
+    public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject source) {
+        String cdhVersion = getCdhVersion(source);
+        List<ApiClusterTemplateConfig> configList = new ArrayList<>();
+
+        if (isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERAMANAGER_VERSION_7_2_0)) {
+            addDbConfigs(getRdsView(source), configList);
+        }
+
+        return configList;
+    }
+
+    @Override
     protected List<ApiClusterTemplateConfig> getRoleConfigs(String roleType, TemplatePreparationObject source) {
         switch (roleType) {
             case RangerRoles.RANGER_ADMIN:
+                String cdhVersion = getCdhVersion(source);
                 List<ApiClusterTemplateConfig> configList = new ArrayList<>();
-                RdsView rangerRdsView = getRdsView(source);
-                configList.add(config("ranger_database_host", rangerRdsView.getHost()));
-                configList.add(config("ranger_database_name", rangerRdsView.getDatabaseName()));
-                configList.add(config("ranger_database_type", getRangerDbType(rangerRdsView)));
-                configList.add(config("ranger_database_user", rangerRdsView.getConnectionUserName()));
-                configList.add(config("ranger_database_password", rangerRdsView.getConnectionPassword()));
 
-                String cdhVersion = source.getBlueprintView().getProcessor().getStackVersion() == null ?
-                        "" : source.getBlueprintView().getProcessor().getStackVersion();
+                // In CM 7.2.0 and above, the ranger database parameters have moved to the service
+                // config (see above getServiceConfigs).
+                if (!isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERAMANAGER_VERSION_7_2_0)) {
+                    addDbConfigs(getRdsView(source), configList);
+                }
+
                 if (isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERAMANAGER_VERSION_7_0_1)) {
                     VirtualGroupRequest virtualGroupRequest = source.getVirtualGroupRequest();
                     String adminGroup = virtualGroupService.getVirtualGroup(virtualGroupRequest, UmsRight.RANGER_ADMIN.getRight());
@@ -73,5 +84,18 @@ public class RangerRoleConfigProvider extends AbstractRdsRoleConfigProvider {
             default:
                 throw new CloudbreakServiceException("Unsupported Ranger database type: " + rdsView.getDatabaseVendor().displayName());
         }
+    }
+
+    private String getCdhVersion(TemplatePreparationObject source) {
+        return source.getBlueprintView().getProcessor().getStackVersion() == null ?
+            "" : source.getBlueprintView().getProcessor().getStackVersion();
+    }
+
+    private void addDbConfigs(RdsView rangerRdsView, List<ApiClusterTemplateConfig> configList) {
+        configList.add(config("ranger_database_host", rangerRdsView.getHost()));
+        configList.add(config("ranger_database_name", rangerRdsView.getDatabaseName()));
+        configList.add(config("ranger_database_type", getRangerDbType(rangerRdsView)));
+        configList.add(config("ranger_database_user", rangerRdsView.getConnectionUserName()));
+        configList.add(config("ranger_database_password", rangerRdsView.getConnectionPassword()));
     }
 }

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerRoleConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerRoleConfigProviderTest.java
@@ -65,20 +65,20 @@ public class RangerRoleConfigProviderTest {
 
     @Test
     public void testGetRangerAdminDefaultPolicyGroups() {
-        validateGetRangerAdminDefaultPolicyGroups("6.9.0", 5);
-        validateGetRangerAdminDefaultPolicyGroups("6.x.0", 5);
-        validateGetRangerAdminDefaultPolicyGroups("7.0.0", 5);
-        validateGetRangerAdminDefaultPolicyGroups("", 5);
+        validateGetRangerAdminDefaultPolicyGroups("6.9.0", 5, 0);
+        validateGetRangerAdminDefaultPolicyGroups("6.x.0", 5, 0);
+        validateGetRangerAdminDefaultPolicyGroups("7.0.0", 5, 0);
+        validateGetRangerAdminDefaultPolicyGroups("", 5, 0);
 
-        validateGetRangerAdminDefaultPolicyGroups("7.x.0", 6);
-        validateGetRangerAdminDefaultPolicyGroups("7.0.1", 6);
-        validateGetRangerAdminDefaultPolicyGroups("7.1.0", 6);
-        validateGetRangerAdminDefaultPolicyGroups("7.2.0", 6);
-        validateGetRangerAdminDefaultPolicyGroups("7.3.1", 6);
-        validateGetRangerAdminDefaultPolicyGroups("8.1.0", 6);
+        validateGetRangerAdminDefaultPolicyGroups("7.0.1", 6, 0);
+        validateGetRangerAdminDefaultPolicyGroups("7.1.0", 6, 0);
+        validateGetRangerAdminDefaultPolicyGroups("7.1.x", 6, 0);
+        validateGetRangerAdminDefaultPolicyGroups("7.2.0", 1, 5);
+        validateGetRangerAdminDefaultPolicyGroups("7.3.1", 1, 5);
+        validateGetRangerAdminDefaultPolicyGroups("8.1.0", 1, 5);
     }
 
-    private void validateGetRangerAdminDefaultPolicyGroups(String cdhVersion, int expectedConfigCount) {
+    private void validateGetRangerAdminDefaultPolicyGroups(String cdhVersion, int expectedRoleConfigCount, int expectedSvcConfigCount) {
         HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, 1);
         HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, 2);
 
@@ -101,9 +101,12 @@ public class RangerRoleConfigProviderTest {
 
         Map<String, List<ApiClusterTemplateConfig>> roleConfigs = underTest.getRoleConfigs(cmTemplateProcessor, preparationObject);
         List<ApiClusterTemplateConfig> masterRangerAdmin = roleConfigs.get("ranger-RANGER_ADMIN-BASE");
-        assertEquals(expectedConfigCount, masterRangerAdmin.size());
+        assertEquals(expectedRoleConfigCount, masterRangerAdmin.size());
 
-        if (expectedConfigCount == 6) {
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(cmTemplateProcessor, preparationObject);
+        assertEquals(expectedSvcConfigCount, serviceConfigs.size());
+
+        if (expectedRoleConfigCount == 6) {
             assertEquals("ranger.default.policy.groups", masterRangerAdmin.get(5).getName());
             assertEquals(ldapAdminGroup, masterRangerAdmin.get(5).getValue());
         }


### PR DESCRIPTION
In CM 7.2 and above, ranger db configs moved from
role to service level. Update the cm template to
address for this.

Tested locally with unit-tests. Functional tests not completed.