### PR TITLE
CB-6720: Update Ranger configs for CM 7.2+

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
@@ -25,6 +25,8 @@ public class CMRepositoryVersionUtil {
 
     public static final Versioned CLOUDERAMANAGER_VERSION_7_1_1 = () -> "7.1.1";
 
+    public static final Versioned CLOUDERAMANAGER_VERSION_7_2_0 = () -> "7.2.0";
+
     public static final Versioned CFM_VERSION_2_0_0_0 = () -> "2.0.0.0";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CMRepositoryVersionUtil.class);

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerRoleConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerRoleConfigProvider.java
@@ -1,25 +1,25 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.ranger;
 
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_0_1;
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_0;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.inject.Inject;
-
-import org.springframework.stereotype.Component;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.auth.altus.UmsRight;
+import com.sequenceiq.cloudbreak.auth.altus.VirtualGroupRequest;
 import com.sequenceiq.cloudbreak.auth.altus.VirtualGroupService;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRdsRoleConfigProvider;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
-import com.sequenceiq.cloudbreak.auth.altus.VirtualGroupRequest;
 import com.sequenceiq.cloudbreak.template.views.RdsView;
+import java.util.ArrayList;
+import java.util.List;
+import javax.inject.Inject;
+import org.springframework.stereotype.Component;
 
 @Component
 public class RangerRoleConfigProvider extends AbstractRdsRoleConfigProvider {
@@ -27,19 +27,32 @@ public class RangerRoleConfigProvider extends AbstractRdsRoleConfigProvider {
     private VirtualGroupService virtualGroupService;
 
     @Override
+    public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject source) {
+        String cdhVersion = getCdhVersion(source);
+        List<ApiClusterTemplateConfig> configList = new ArrayList<>();
+
+        if (isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERAMANAGER_VERSION_7_2_0)) {
+            RdsView rangerRdsView = getRdsView(source);
+            addDbConfigs(rangerRdsView, configList);
+            configList.add(config("ranger_database_port", rangerRdsView.getPort()));
+        }
+
+        return configList;
+    }
+
+    @Override
     protected List<ApiClusterTemplateConfig> getRoleConfigs(String roleType, TemplatePreparationObject source) {
         switch (roleType) {
             case RangerRoles.RANGER_ADMIN:
+                String cdhVersion = getCdhVersion(source);
                 List<ApiClusterTemplateConfig> configList = new ArrayList<>();
-                RdsView rangerRdsView = getRdsView(source);
-                configList.add(config("ranger_database_host", rangerRdsView.getHost()));
-                configList.add(config("ranger_database_name", rangerRdsView.getDatabaseName()));
-                configList.add(config("ranger_database_type", getRangerDbType(rangerRdsView)));
-                configList.add(config("ranger_database_user", rangerRdsView.getConnectionUserName()));
-                configList.add(config("ranger_database_password", rangerRdsView.getConnectionPassword()));
 
-                String cdhVersion = source.getBlueprintView().getProcessor().getStackVersion() == null ?
-                        "" : source.getBlueprintView().getProcessor().getStackVersion();
+                // In CM 7.2.0 and above, the ranger database parameters have moved to the service
+                // config (see above getServiceConfigs).
+                if (!isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERAMANAGER_VERSION_7_2_0)) {
+                    addDbConfigs(getRdsView(source), configList);
+                }
+
                 if (isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERAMANAGER_VERSION_7_0_1)) {
                     VirtualGroupRequest virtualGroupRequest = source.getVirtualGroupRequest();
                     String adminGroup = virtualGroupService.getVirtualGroup(virtualGroupRequest, UmsRight.RANGER_ADMIN.getRight());
@@ -73,5 +86,18 @@ public class RangerRoleConfigProvider extends AbstractRdsRoleConfigProvider {
             default:
                 throw new CloudbreakServiceException("Unsupported Ranger database type: " + rdsView.getDatabaseVendor().displayName());
         }
+    }
+
+    private String getCdhVersion(TemplatePreparationObject source) {
+        return source.getBlueprintView().getProcessor().getStackVersion() == null ?
+            "" : source.getBlueprintView().getProcessor().getStackVersion();
+    }
+
+    private void addDbConfigs(RdsView rangerRdsView, List<ApiClusterTemplateConfig> configList) {
+        configList.add(config("ranger_database_host", rangerRdsView.getHost()));
+        configList.add(config("ranger_database_name", rangerRdsView.getDatabaseName()));
+        configList.add(config("ranger_database_type", getRangerDbType(rangerRdsView)));
+        configList.add(config("ranger_database_user", rangerRdsView.getConnectionUserName()));
+        configList.add(config("ranger_database_password", rangerRdsView.getConnectionPassword()));
     }
 }

--- a/template-manager-cmtemplate/src/test/resources/input/cb6720.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/cb6720.bp
@@ -1,0 +1,64 @@
+{
+  "cdhVersion": "7.2.0",
+  "displayName": "datalake-ranger-only",
+  "hostTemplates": [
+    {
+      "cardinality": 1,
+      "refName": "master",
+      "roleConfigGroupsRefNames": [
+        "ranger-RANGER_ADMIN-BASE",
+        "ranger-RANGER_TAGSYNC-BASE",
+        "ranger-RANGER_USERSYNC-BASE"
+      ]
+    }
+  ],
+  "services": [
+    {
+      "refName": "ranger",
+      "roleConfigGroups": [
+        {
+          "base": true,
+          "refName": "ranger-RANGER_USERSYNC-BASE",
+          "roleType": "RANGER_USERSYNC"
+        },
+        {
+          "base": true,
+          "refName": "ranger-RANGER_TAGSYNC-BASE",
+          "roleType": "RANGER_TAGSYNC"
+        },
+        {
+          "base": true,
+          "refName": "ranger-RANGER_ADMIN-BASE",
+          "roleType": "RANGER_ADMIN"
+        }
+      ],
+      "serviceConfigs": [
+        {
+          "name": "hdfs_service",
+          "ref": "hdfs"
+        },
+        {
+          "name": "rangeradmin_user_password",
+          "value": "{{{ general.password }}}"
+        },
+        {
+          "name": "rangertagsync_user_password",
+          "value": "{{{ general.password }}}"
+        },
+        {
+          "name": "solr_service",
+          "ref": "solr"
+        },
+        {
+          "name": "rangerusersync_user_password",
+          "value": "{{{ general.password }}}"
+        },
+        {
+          "name": "keyadmin_user_password",
+          "value": "{{{ general.password }}}"
+        }
+      ],
+      "serviceType": "RANGER"
+    }
+  ]
+}


### PR DESCRIPTION
In CM 7.2 and above, ranger db configs moved from
role to service level. Update the cm template to
address for this.

Added unit-tests to verify that correct service templates
are generated.

Closes CB-6720