### PR TITLE
CB-6675 reenable notificaiton sending from Datalake

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxNotificationService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxNotificationService.java
@@ -24,7 +24,6 @@ public class SdxNotificationService {
 
     public void send(ResourceEvent resourceEvent, SdxCluster sdx) {
         LOGGER.info("SDX Notification has been sent: {}", resourceEvent);
-        // This is disabled since it causes confusion in the event log, because they are not persisted
-        // notificationService.send(resourceEvent, sdxClusterConverter.sdxClusterToResponse(sdx), sdx.getInitiatorUserCrn());
+        notificationService.send(resourceEvent, sdxClusterConverter.sdxClusterToResponse(sdx), sdx.getInitiatorUserCrn());
     }
 }


### PR DESCRIPTION
- this needs to be enabled since the UI get's the status update from DL through Notifications

// This is disabled since it causes confusion in the event log, because they are not persisted
It's designed that way not to store those updates in the event log