### PR TITLE
CB-6745: Allow FreeIPA health check when the stack is unavailable

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaHostNotAvailableException.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaHostNotAvailableException.java
@@ -1,0 +1,8 @@
+package com.sequenceiq.freeipa.client;
+
+public class FreeIpaHostNotAvailableException extends Exception {
+
+    public FreeIpaHostNotAvailableException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
Fixes the health check so that it is able to run when the stack is
unavailable.

Fixes the stack status so that when it is unavailable it doesn't
bounce between unavailable and unhealthy every minute, but rather it
remains unavailable until it should actually change.

Fixes some exception handling so that it checks the exceptions that
are wrapped inside a FreeIpaClientException.

In addition to updating the tests, this was validated on a cluster
that was stuck in the unavailable status to ensure it became
available after the problem was fixed.

Closes #CB-6745