### PR TITLE
CB-6687 Atlas cdp-proxy-api URL is not correct in CB UI

### DIFF
--- a/core-api/src/main/resources/definitions/exposed-services.json
+++ b/core-api/src/main/resources/definitions/exposed-services.json
@@ -136,6 +136,20 @@
       "port": 21000,
       "tlsPort": 31443,
       "apiOnly": false,
+      "apiIncluded": false,
+      "visibleForDatalake": true,
+      "visibleForDatahub": true
+    },
+    {
+      "name": "ATLAS_API",
+      "displayName": "Atlas",
+      "serviceName": "ATLAS_SERVER",
+      "knoxService": "ATLAS_API",
+      "knoxUrl": "/atlas/api/atlas/",
+      "ssoSupported": false,
+      "port": 21000,
+      "tlsPort": 31443,
+      "apiOnly": true,
       "apiIncluded": true,
       "visibleForDatalake": true,
       "visibleForDatahub": true

--- a/core-api/src/test/java/com/sequenceiq/cloudbreak/api/service/ExposedServiceCollectorTest.java
+++ b/core-api/src/test/java/com/sequenceiq/cloudbreak/api/service/ExposedServiceCollectorTest.java
@@ -82,6 +82,7 @@ class ExposedServiceCollectorTest {
         assertThat(underTest.getAllServiceNames()).containsExactlyInAnyOrder(
                 "ALL",
                 "ATLAS_SERVER",
+                "ATLAS_SERVER",
                 "CM-API",
                 "CM-UI",
                 "DAS_WEBAPP",
@@ -124,6 +125,7 @@ class ExposedServiceCollectorTest {
         underTest.init();
         assertThat(underTest.getAllKnoxExposed()).containsExactlyInAnyOrder(
                 "ATLAS",
+                "ATLAS_API",
                 "AVATICA",
                 "CM-API",
                 "CM-UI",
@@ -166,6 +168,7 @@ class ExposedServiceCollectorTest {
         underTest.init();
         assertThat(underTest.getAllServicePorts(false)).containsOnly(
                 Map.entry("ATLAS", 21000),
+                Map.entry("ATLAS_API", 21000),
                 Map.entry("AVATICA", 8765),
                 Map.entry("CM-API", 7180),
                 Map.entry("CM-UI", 7180),
@@ -208,6 +211,7 @@ class ExposedServiceCollectorTest {
         underTest.init();
         assertThat(underTest.getAllServicePorts(true)).containsOnly(
                 Map.entry("ATLAS", 31443),
+                Map.entry("ATLAS_API", 31443),
                 Map.entry("AVATICA", 8765),
                 Map.entry("CM-API", 7183),
                 Map.entry("CM-UI", 7183),
@@ -266,9 +270,10 @@ class ExposedServiceCollectorTest {
     void getKnoxServicesForComponentsReturnsCMServicesAndForImpalaDebugUIAsWell() {
         underTest.init();
         Collection<ExposedService> components = underTest.knoxServicesForComponents(Set.of("ATLAS_SERVER", "IMPALAD"));
-        assertThat(components).hasSize(5);
+        assertThat(components).hasSize(6);
         assertThat(components.stream().map(ExposedService::getName)).containsExactlyInAnyOrder(
                 "ATLAS",
+                "ATLAS_API",
                 "CLOUDERA_MANAGER",
                 "CLOUDERA_MANAGER_UI",
                 "IMPALA",

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
@@ -115,7 +115,7 @@
             <role>ha</role>
             <name>HaProvider</name>
             <enabled>true</enabled>
-            {% if 'ATLAS' in exposed and 'ATLAS_SERVER' in salt['pillar.get']('gateway:location') -%}
+            {% if 'ATLAS_API' in exposed and 'ATLAS_SERVER' in salt['pillar.get']('gateway:location') -%}
             <param>
                 <name>ATLAS-API</name>
                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
@@ -215,11 +215,11 @@
     </gateway>
 
     {% if 'ATLAS_SERVER' in salt['pillar.get']('gateway:location') -%}
-    {% if 'ATLAS' in exposed -%}
+    {% if 'ATLAS_API' in exposed -%}
     <service>
         <role>ATLAS-API</role>
         {% for hostloc in salt['pillar.get']('gateway:location')['ATLAS_SERVER'] -%}
-        <url>{{ protocol }}://{{ hostloc }}:{{ ports['ATLAS'] }}</url>
+        <url>{{ protocol }}://{{ hostloc }}:{{ ports['ATLAS_API'] }}</url>
         {%- endfor %}
     </service>
     {%- endif %}


### PR DESCRIPTION
Fixed the Atlas cdp-proxy-api url to point to the correct base path.