### PR TITLE
CDPCP-1561. Allow internal actor to call user sync endpoint

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/doc/UserModelDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/doc/UserModelDescriptions.java
@@ -11,6 +11,7 @@ public class UserModelDescriptions {
     public static final String USERSYNC_STARTTIME = "User synchronization operation start time";
     public static final String USERSYNC_ENDTIME = "User synchronization operation end time";
     public static final String USERSYNC_ERROR = "error information about operation failure";
+    public static final String USERSYNC_ACCOUNT_ID = "The id of the account to run sync on";
     public static final String SUCCESS_ENVIRONMENTS = "details about environments where operation succeeded";
     public static final String FAILURE_ENVIRONMENTS = "details about environments where operation failed";
     public static final String USER_PASSWORD = "the user's password";

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SynchronizeAllUsersRequest.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SynchronizeAllUsersRequest.java
@@ -18,6 +18,9 @@ public class SynchronizeAllUsersRequest extends SynchronizeOperationRequestBase 
     @ApiModelProperty(value = UserModelDescriptions.USERSYNC_USER_CRNS)
     private Set<String> users = new HashSet<>();
 
+    @ApiModelProperty(value = UserModelDescriptions.USERSYNC_ACCOUNT_ID)
+    private String accountId;
+
     public SynchronizeAllUsersRequest() {
     }
 
@@ -42,11 +45,20 @@ public class SynchronizeAllUsersRequest extends SynchronizeOperationRequestBase 
         this.users = users;
     }
 
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public void setAccountId(String accountId) {
+        this.accountId = accountId;
+    }
+
     @Override
     public String toString() {
         return "SynchronizeAllUsersRequest{"
                 + "machineUsers=" + machineUsers
                 + ", users=" + users
+                + ", accountId=" + accountId
                 + ", " + super.fieldsToString()
                 + '}';
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncService.java
@@ -402,6 +402,16 @@ public class UserSyncService {
         validateCrnFilter(environmentCrnFilter, Crn.ResourceType.ENVIRONMENT);
         validateCrnFilter(userCrnFilter, Crn.ResourceType.USER);
         validateCrnFilter(machineUserCrnFilter, Crn.ResourceType.MACHINE_USER);
+        validateSameAccount(accountId, Iterables.concat(environmentCrnFilter, userCrnFilter, machineUserCrnFilter));
+    }
+
+    private void validateSameAccount(String accountId, Iterable<String> crns) {
+        crns.forEach(crnString -> {
+            Crn crn = Crn.safeFromString(crnString);
+            if (!accountId.equals(crn.getAccountId())) {
+                throw new BadRequestException(String.format("Crn %s is not in the expected account %s", crnString, accountId));
+            }
+        });
     }
 
     @VisibleForTesting

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncServiceTest.java
@@ -114,6 +114,14 @@ class UserSyncServiceTest {
     }
 
     @Test
+    void testValidateParametersWrongAccount() {
+        String differentAccount = UUID.randomUUID().toString();
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            underTest.validateParameters(differentAccount, USER_CRN, Set.of(ENV_CRN), Set.of(), Set.of());
+        });
+    }
+
+    @Test
     void testValidateCrnFilter() {
         underTest.validateCrnFilter(Set.of(ENV_CRN), Crn.ResourceType.ENVIRONMENT);
     }


### PR DESCRIPTION
Previously the accountId to sync was inferred from the calling
user, which doesn't work when the calling user is the internal
actor. This is fixed by including accountId as an optional
parameter to the user sync request.