### PR TITLE
CB-6769: Fix FreeIPA unavailable status when using cluster proxy

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaHostNotAvailableException.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaHostNotAvailableException.java
@@ -5,4 +5,9 @@ public class FreeIpaHostNotAvailableException extends Exception {
     public FreeIpaHostNotAvailableException(String message) {
         super(message);
     }
+
+    public FreeIpaHostNotAvailableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientBuilder.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientBuilder.java
@@ -8,6 +8,7 @@ import java.net.URL;
 import java.security.Security;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.net.ssl.HostnameVerifier;
@@ -15,6 +16,7 @@ import javax.net.ssl.SSLContext;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.Header;
+import org.apache.http.HttpException;
 import org.apache.http.client.CookieStore;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
@@ -65,6 +67,8 @@ public class FreeIpaClientBuilder {
     private static final int READ_TIMEOUT_MILLIS = 60 * 1000 * 5;
 
     private static final int TEST_CONNECTION_READ_TIMEOUT_MILLIS = 5 * 1000;
+
+    private static final Set<Integer> UNAVIALLBE_PING_HTTP_RESPONSES = Set.of(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.SERVICE_UNAVAILABLE.value());
 
     private final PoolingHttpClientConnectionManager connectionManager;
 
@@ -119,7 +123,7 @@ public class FreeIpaClientBuilder {
         this(user, pass, clientConfig, hostname, port, DEFAULT_BASE_PATH, Map.of(), null);
     }
 
-    public FreeIpaClient build(boolean withPing) throws URISyntaxException, IOException, FreeIpaClientException {
+    public FreeIpaClient build(boolean withPing) throws URISyntaxException, IOException, FreeIpaClientException, FreeIpaHostNotAvailableException {
         if (withPing) {
             List<BasicHeader> defaultHeaders = additionalHeaders.entrySet().stream()
                     .map(entry -> new BasicHeader(entry.getKey(), entry.getValue())).collect(Collectors.toList());
@@ -140,8 +144,14 @@ public class FreeIpaClientBuilder {
                 LOGGER.debug("Ping at target: {}", target);
                 HttpHead request = new HttpHead(target);
                 additionalHeaders.forEach(request::addHeader);
-                client.execute(request).close();
+                try (CloseableHttpResponse response = client.execute(request)) {
+                    if (UNAVIALLBE_PING_HTTP_RESPONSES.contains(response.getStatusLine().getStatusCode())) {
+                        throw new HttpException("Ping failed with http status code " + response.getStatusLine().getStatusCode());
+                    }
+                }
                 LOGGER.debug("Freeipa is reachable");
+            } catch (Exception e) {
+                throw new FreeIpaHostNotAvailableException("Ping failed", e);
             }
         }
         String sessionCookie = connect(user, pass, clientConfig.getApiAddress(), port);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/FreeipaChecker.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/FreeipaChecker.java
@@ -9,8 +9,6 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
-import org.apache.http.conn.ConnectTimeoutException;
-import org.apache.http.conn.HttpHostConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -70,7 +68,7 @@ public class FreeipaChecker {
         } catch (FreeIpaClientException e) {
             LOGGER.info("FreeIpaClientException occurred during status fetch: " + e.getMessage(), e);
             Throwable t = FreeIpaClientExceptionUtil.getAncestorCauseBeforeFreeIpaClientExceptions(e);
-            if (t instanceof HttpHostConnectException || t instanceof ConnectTimeoutException || t instanceof FreeIpaHostNotAvailableException) {
+            if (t instanceof FreeIpaHostNotAvailableException) {
                 return new SyncResult("Freeipa is unreachable: " + t.getMessage(), DetailedStackStatus.UNREACHABLE, false);
             }
             return new SyncResult("Freeipa is unhealthy, error occurred: " + e.getMessage(), DetailedStackStatus.UNHEALTHY, false);

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactoryTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactoryTest.java
@@ -22,6 +22,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackSta
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceStatus;
 import com.sequenceiq.freeipa.client.FreeIpaClientException;
+import com.sequenceiq.freeipa.client.FreeIpaHostNotAvailableException;
 import com.sequenceiq.freeipa.entity.FreeIpa;
 import com.sequenceiq.freeipa.entity.InstanceGroup;
 import com.sequenceiq.freeipa.entity.InstanceMetaData;
@@ -116,7 +117,7 @@ class FreeIpaClientFactoryTest {
 
         verify(clusterProxyService, times(1)).isCreateConfigForClusterProxy(stack);
         verify(tlsSecurityService, times(1)).buildTLSClientConfig(any(), any(), any());
-        Assertions.assertEquals(FreeIpaClientException.class, exception.getCause().getClass());
+        Assertions.assertEquals(FreeIpaHostNotAvailableException.class, exception.getCause().getClass());
     }
 
     @Test
@@ -137,7 +138,7 @@ class FreeIpaClientFactoryTest {
 
         verify(clusterProxyService, times(1)).isCreateConfigForClusterProxy(stack);
         verify(tlsSecurityService, times(1)).buildTLSClientConfig(any(), any(), any());
-        Assertions.assertEquals(FreeIpaClientException.class, exception.getCause().getClass());
+        Assertions.assertEquals(FreeIpaHostNotAvailableException.class, exception.getCause().getClass());
     }
 
     @Test


### PR DESCRIPTION
Fix the status reported when FreeIPA is unreachable and cluster proxy
is being used. The status should be unreachable rather than unhealthy.
This fixes the unavailable status when using cluster proxy so that it
reports the same status as direct mode.

This was tested manually by blocking the network to FreeIPA and
checking the status.

Closes #CB-6769