### PR TITLE
CB-6782 Fix Azure Id Broker role assigmnent validation

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/AzureIDBrokerObjectStorageValidator.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/AzureIDBrokerObjectStorageValidator.java
@@ -142,7 +142,7 @@ public class AzureIDBrokerObjectStorageValidator {
                 .stream()
                 .dropWhile(mappedIdentity -> roleAssignments
                         .stream()
-                        .anyMatch(roleAssignment -> roleAssignment.principalId().equals(mappedIdentity.id())))
+                        .anyMatch(roleAssignment -> roleAssignment.principalId().equals(mappedIdentity.principalId())))
                 .forEach(identityWithNoAssignment -> addError(resultBuilder,
                         String.format("Identity with id %s has no role assignment.", identityWithNoAssignment.id())));
     }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/AzureIDBrokerObjectStorageValidatorTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/validator/AzureIDBrokerObjectStorageValidatorTest.java
@@ -244,9 +244,12 @@ public class AzureIDBrokerObjectStorageValidatorTest {
         identityPagedList.add(logger);
         when(client.listIdentities()).thenReturn(identityPagedList);
 
+        final String wrongAssumerIdentityPrincipalid = "489e3729-aed1-4d54-a95b-b231b70d383f";
+        final String wrongLoggerIdentityPrincipalid = "61a70b9b-7331-4fa3-8717-2652fc70434e";
+
         new RoleASsignmentBuilder(client)
-                .withAssignment(ASSUMER_IDENTITY_PRINCIPAL_ID, SUBSCRIPTION_FULL_ID)
-                .withAssignment(LOG_IDENTITY_PRINCIPAL_ID, STORAGE_RESOURCE_GROUP_NAME);
+                .withAssignment(wrongAssumerIdentityPrincipalid, SUBSCRIPTION_FULL_ID)
+                .withAssignment(wrongLoggerIdentityPrincipalid, STORAGE_RESOURCE_GROUP_NAME);
 
         ValidationResultBuilder resultBuilder = new ValidationResultBuilder();
 
@@ -254,7 +257,7 @@ public class AzureIDBrokerObjectStorageValidatorTest {
 
         ValidationResult validationResult = resultBuilder.build();
         assertTrue(validationResult.hasError());
-        assertEquals(2, validationResult.getErrors().size());
+        assertEquals(4, validationResult.getErrors().size());
         List<String> actual = validationResult.getErrors();
         assertTrue(actual.stream().anyMatch(item ->
                 item.equals(String.format("Identity with id %s has no role assignment.", USER_IDENTITY_1))));


### PR DESCRIPTION
AzureIDBrokerObjectStorageValidator compared uuid style id's (principal id's) with path style id's (fully qualified resource id's). Fix compares principal id's with principal id's during validation.

Tests:
- Updated AzureIDBrokerObjectStorageValidatorTest
- Tested Azure datalake creation manually.

Closes CB-6782
