### PR TITLE
CDPCP-1561. Always accept single user sync operation

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncAcceptor.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncAcceptor.java
@@ -22,9 +22,15 @@ public class UserSyncAcceptor extends OperationAcceptor {
     }
 
     /**
-     * Returns whether two user sync operations conflict. User sync conflicts are asymmetrical. User-
-     * filtered operations should be rejected if there is a full sync running for that environment because
-     * it is redundant. Full sync is not rejected due to a user-filtered sync, but only for other full syncs.
+     * Returns whether two user sync operations conflict. User sync conflicts are asymmetrical and
+     * defined as follows:
+     * 1) A full sync is not rejected due to a user-filtered sync, but only for other full syncs.
+     * 2) User-filtered operations in general should be rejected if there is a full sync running for
+     * that environment because it is redundant. We make a special exception to this rule when there's
+     * a single user.
+     * 3) When there's request to sync a single user we always let it through. This lets us apply the
+     * changes to a user right away without needing to wait for a potentially long full sync to
+     * finish first.
      *
      * @param operation this sync operation
      * @param other another running sync operation
@@ -32,7 +38,9 @@ public class UserSyncAcceptor extends OperationAcceptor {
      */
     @Override
     protected boolean doOperationsConflict(Operation operation, Operation other) {
-        if (!operation.getUserList().isEmpty()) {
+        if (operation.getUserList().size() == 1) {
+            return true;
+        } else if (!operation.getUserList().isEmpty()) {
             return super.doOperationsConflict(operation, other);
         } else {
             return other.getUserList().isEmpty() && doEnvironmentsConflict(operation, other);


### PR DESCRIPTION
When changes are applied to a single user (like setting credential,
or deleting user) we would like to immediatly sync them instead
of needing to wait for potentially long full sync to finish first.
This change lets single user sync operations to always be accepted
even when full syncs are running.