### PR TITLE
CB-6800. Log collection: make salt logs processing configurable (dbus -> disable by default)

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigView.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigView.java
@@ -27,6 +27,8 @@ public class FluentConfigView implements TelemetryConfigView {
 
     private static final Boolean DBUS_DISABLE_STOP_CLUSTER_LOG_COLLECTION_DEFAULT = false;
 
+    private static final Boolean DBUS_INCLUDE_SALT_LOGS_DEFAULT = false;
+
     private static final Integer PARTITION_INTERVAL_DEFAULT = 5;
 
     private final boolean enabled;
@@ -205,6 +207,7 @@ public class FluentConfigView implements TelemetryConfigView {
         map.put("dbusMeteringEnabled", this.meteringEnabled);
         map.put("dbusClusterLogsCollection", this.clusterLogsCollection);
         map.put("dbusClusterLogsCollectionDisableStop", DBUS_DISABLE_STOP_CLUSTER_LOG_COLLECTION_DEFAULT);
+        map.put("dbusIncludeSaltLogs", DBUS_INCLUDE_SALT_LOGS_DEFAULT);
         map.put("user", ObjectUtils.defaultIfNull(this.user, TD_AGENT_USER_DEFAULT));
         map.put("group", ObjectUtils.defaultIfNull(this.group, TD_AGENT_GROUP_DEFAULT));
         map.put("providerPrefix", ObjectUtils.defaultIfNull(this.providerPrefix, PROVIDER_PREFIX_DEFAULT));

--- a/freeipa/src/main/resources/freeipa-salt/salt/fluent/template/input.conf.j2
+++ b/freeipa/src/main/resources/freeipa-salt/salt/fluent/template/input.conf.j2
@@ -18,6 +18,7 @@
   tag {{providerPrefix}}.cloud-init
   read_from_head true
 </source>
+{% if providerPrefix != "databus" or fluent.dbusIncludeSaltLogs %}
 <source>
   @type tail
   format none
@@ -42,6 +43,7 @@
   tag {{providerPrefix}}.salt_api
   read_from_head true
 </source>
+{% endif %}
 <source>
   @type tail
   format none

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/telemetry/TelemetryTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/telemetry/TelemetryTestDto.java
@@ -1,5 +1,8 @@
 package com.sequenceiq.it.cloudbreak.dto.telemetry;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import javax.inject.Inject;
 
 import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
@@ -66,6 +69,9 @@ public class TelemetryTestDto extends AbstractCloudbreakTestDto<TelemetryRequest
         FeaturesRequest featuresRequest = new FeaturesRequest();
         featuresRequest.addClusterLogsCollection(true);
         getRequest().setFeatures(featuresRequest);
+        Map<String, Object> fluentAttributes = new HashMap<>();
+        fluentAttributes.put("dbusIncludeSaltLogs", true);
+        getRequest().setFluentAttributes(fluentAttributes);
         return this;
     }
 }

--- a/orchestrator-salt/src/main/resources/salt-common/pillar/fluent/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/pillar/fluent/init.sls
@@ -27,5 +27,6 @@ fluent:
   dbusClusterLogsCollection: false
   dbusClusterLogsCollectionDisableStop: false
   dbusMeteringEnabled: false
+  dbusIncludeSaltLogs: false
   anonymizationRules:
 

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
@@ -62,6 +62,12 @@
     {% set dbus_metering_enabled = False %}
 {% endif %}
 
+{% if salt['pillar.get']('fluent:dbusIncludeSaltLogs') %}
+    {% set dbus_include_salt_logs = True %}
+{% else %}
+    {% set dbus_include_salt_logs = False %}
+{% endif %}
+
 {% set cluster_name = salt['pillar.get']('fluent:clusterName') %}
 {% set cluster_type = salt['pillar.get']('fluent:clusterType')%}
 {% set cluster_crn = salt['pillar.get']('fluent:clusterCrn')%}
@@ -160,6 +166,7 @@
     "meteringWorkerIndex": metering_worker_index,
     "clusterLogsCollectionWorkerIndex": cluster_logs_collection_worker_index,
     "anonymizationRules": anonymization_rules,
+    "dbusIncludeSaltLogs": dbus_include_salt_logs,
     "region": region,
     "platform": platform,
     "proxyUrl": proxy_url,

--- a/orchestrator-salt/src/main/resources/salt/salt/fluent/template/input.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/fluent/template/input.conf.j2
@@ -18,6 +18,7 @@
   tag {{providerPrefix}}.cloud-init
   read_from_head true
 </source>
+{% if providerPrefix != "databus" or fluent.dbusIncludeSaltLogs %}
 <source>
   @type tail
   format none
@@ -42,6 +43,7 @@
   tag {{providerPrefix}}.salt_api
   read_from_head true
 </source>
+{% endif %}
 <source>
   @type tail
   format none


### PR DESCRIPTION
add new fluent attribute: dbusIncludeSaltLogs (if we want this to be extended to the UI in the future, that can be moved out from here, and put into AccountTelemetry as a real boolean flag)

- do not enable processing of salt logs by default for cluster deployment logs collection
- enable this option for e2e tests