### PR TITLE
Add backup and restore scripts for DL postgres db.

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/backup_db.sh
@@ -3,7 +3,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ $# -ne 5 ] || [ $# -ne 6 ]; then
+if [ $# -ne 5 ] && [ $# -ne 6 ]; then
   echo "Invalid inputs provided"
   echo "Script accepts 5 inputs:"
   echo "  1. Cloud Provider (azure | aws)"
@@ -17,9 +17,9 @@ if [ $# -ne 5 ] || [ $# -ne 6 ]; then
 fi
 
 CLOUD_PROVIDER="$1"
-HOST="$2"
-PORT="$3"
-BACKUP_LOCATION=$(echo "$4"| sed "s/\/\+$//g") # Clear trailng '/' (if present) for later path joining.
+BACKUP_LOCATION=$(echo "$2"| sed "s/\/\+$//g") # Clear trailng '/' (if present) for later path joining.
+HOST="$3"
+PORT="$4"
 USERNAME="$5"
 export PGPASSWORD="$6" # We can provide the password to pg_dump through this variable, or in ~/.pgpass
 
@@ -83,7 +83,7 @@ run_aws_backup () {
   dump_to_s3 "ranger"
 }
 
-doLog "INFO Starting backup to ${$BACKUP_LOCATION}"
+doLog "INFO Starting backup to ${BACKUP_LOCATION}"
 
 if [[ "$CLOUD_PROVIDER" = "azure" ]]; then
   run_azure_backup
@@ -93,4 +93,5 @@ else
   errorExit "Unknown cloud provider: ${CLOUD_PROVIDER}"
 fi
 
-doLog "INFO Completed backup ${$BACKUP_LOCATION}"
+doLog "INFO Completed backup ${BACKUP_LOCATION}"
+

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/backup_db.sh
@@ -3,15 +3,16 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ $# -ne 6 ]; then
+if [$# -ne 5] || [ $# -ne 6 ]; then
   echo "Invalid inputs provided"
-  echo "Script accepts six inputs:"
+  echo "Script accepts 5 inputs:"
   echo "  1. Cloud Provider (azure | aws)"
-  echo "  2. Object Storage Service url to place backups."
+  echo "  2. Object Storage Service url to retrieve backups."
   echo "  3. PostgreSQL host name."
   echo "  4. PostgreSQL port."
   echo "  5. PostgreSQL user name."
-  echo "  6. PostgreSQL password."
+  echo
+  echo "  Optional: PostgreSQL password."
   exit 1
 fi
 

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/backup_db.sh
@@ -23,7 +23,6 @@ BACKUP_LOCATION="$4"
 USERNAME="$5"
 export PGPASSWORD="$6" # We can provide the password to pg_dump through this variable, or in ~/.pgpass
 
-BACKUP_DATE=$(date '+%Y-%m-%dT%H:%M:%SZ')
 LOGFILE=/var/log/dl_postgres_backup.log
 
 echo "Logs at ${LOGFILE}"
@@ -62,7 +61,7 @@ dump_to_azure() {
 }
 run_azure_backup () {
   BACKUPS_DIR="/var/tmp/" # Is this appropriate for keeping backups that are staged before uploading to Azure Blob Storage?
-  DATE_DIR=${BACKUPS_DIR}/${BACKUP_DATE}
+  DATE_DIR=${BACKUPS_DIR}/$(date '+%Y-%m-%dT%H:%M:%SZ')
   mkdir -p "$DATE_DIR" || error_exit "Could not create local directory for backups."
 
   azcopy login --identity || errorExit "Could not login to Azure"
@@ -86,7 +85,7 @@ run_aws_backup () {
   dump_to_s3 "ranger"
 }
 
-doLog "INFO Starting backup ${BACKUP_DATE}"
+doLog "INFO Starting backup to ${$BACKUP_LOCATION}"
 
 if [[ "$CLOUD_PROVIDER" = "azure" ]]; then
   run_azure_backup
@@ -96,4 +95,4 @@ else
   errorExit "Unknown cloud provider: ${CLOUD_PROVIDER}"
 fi
 
-doLog "INFO Completed backup ${BACKUP_DATE}"
+doLog "INFO Completed backup ${$BACKUP_LOCATION}"

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/backup_db.sh
@@ -3,7 +3,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [$# -ne 5] || [ $# -ne 6 ]; then
+if [ $# -ne 5 ] || [ $# -ne 6 ]; then
   echo "Invalid inputs provided"
   echo "Script accepts 5 inputs:"
   echo "  1. Cloud Provider (azure | aws)"

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/backup_db.sh
@@ -5,11 +5,11 @@ set -o pipefail
 
 if [ $# -ne 6 ]; then
   echo "Invalid inputs provided"
-  echo "Script accepts five inputs:"
+  echo "Script accepts six inputs:"
   echo "  1. Cloud Provider (azure | aws)"
-  echo "  2. PostgreSQL host name."
-  echo "  3. PostgreSQL port."
-  echo "  4. Object Storage Service url to place backups."
+  echo "  2. Object Storage Service url to place backups."
+  echo "  3. PostgreSQL host name."
+  echo "  4. PostgreSQL port."
   echo "  5. PostgreSQL user name."
   echo "  6. PostgreSQL password."
   exit 1

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/backup_db.sh
@@ -60,7 +60,7 @@ dump_to_azure() {
   doLog "INFO ${SERVICE} dumped to "
 }
 run_azure_backup () {
-  BACKUPS_DIR="/var/tmp/" # Is this appropriate for keeping backups that are staged before uploading to Azure Blob Storage?
+  BACKUPS_DIR="/var/tmp/"
   DATE_DIR=${BACKUPS_DIR}/$(date '+%Y-%m-%dT%H:%M:%SZ')
   mkdir -p "$DATE_DIR" || error_exit "Could not create local directory for backups."
 

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/backup_db.sh
@@ -19,7 +19,7 @@ fi
 CLOUD_PROVIDER="$1"
 HOST="$2"
 PORT="$3"
-BACKUP_LOCATION="$4"
+BACKUP_LOCATION=$(echo "$4"| sed "s/\/\+$//g") # Clear trailng '/' (if present) for later path joining.
 USERNAME="$5"
 export PGPASSWORD="$6" # We can provide the password to pg_dump through this variable, or in ~/.pgpass
 
@@ -50,7 +50,6 @@ dump_to_azure() {
   pg_dump --host="$HOST" --port="$PORT" --username="$USERNAME" --dbname="$SERVICE" --format=custom --file="$LOCAL_BACKUP" >>$LOGFILE 2>&1 || errorExit "Unable to dump ${SERVICE}"
 
   doLog "INFO Uploading to ${BACKUP_LOCATION}"
-  # todo: strip trailing slash from BACKUP_LOCATION if it's there
   AZURE_LOCATION="${BACKUP_LOCATION}/${SERVICE}_backup"
   azcopy copy "$LOCAL_BACKUP" "$AZURE_LOCATION" >>$LOGFILE 2>&1 || errorExit "Unable to upload $SERVICE backup"
   doLog "INFO Completed upload to ${BACKUP_LOCATION}"
@@ -73,7 +72,6 @@ run_azure_backup () {
 
 dump_to_s3() {
   SERVICE=$1
-  # todo: strip trailing slash from BACKUP_LOCATION if it's there
   S3_LOCATION="${BACKUP_LOCATION}/${SERVICE}_backup"
   doLog "INFO Dumping ${SERVICE} to ${S3_LOCATION}"
   # todo: Specify a good compression level with `-Z 1...9`

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/backup_db.sh
@@ -47,7 +47,7 @@ dump_to_azure() {
   SERVICE="$1"
   doLog "INFO Dumping ${SERVICE}"
   LOCAL_BACKUP=${DATE_DIR}/${SERVICE}_backup
-  pg_dump --host="$HOST" --port="$PORT" --username="$USERNAME" --dbname="$SERVICE" --format=custom --file="$LOCAL_BACKUP" >>$LOGFILE 2>&1 || errorExit "Unable to dump ${SERVICE}"
+  pg_dump --host="$HOST" --port="$PORT" --username="$USERNAME" --dbname="$SERVICE" --format=plain >>$LOGFILE 2>&1 || errorExit "Unable to dump ${SERVICE}"
 
   doLog "INFO Uploading to ${BACKUP_LOCATION}"
   AZURE_LOCATION="${BACKUP_LOCATION}/${SERVICE}_backup"
@@ -75,7 +75,7 @@ dump_to_s3() {
   S3_LOCATION="${BACKUP_LOCATION}/${SERVICE}_backup"
   doLog "INFO Dumping ${SERVICE} to ${S3_LOCATION}"
   # todo: Specify a good compression level with `-Z 1...9`
-  pg_dump --host="$HOST" --port="$PORT" --username="$USERNAME" --dbname="${SERVICE}" --format=custom --data-only 2>>$LOGFILE | /usr/bin/aws s3 cp --sse AES256 --no-progress - "${S3_LOCATION}" 2>>$LOGFILE || errorExit "Unable to dump ${SERVICE}."
+  pg_dump --host="$HOST" --port="$PORT" --username="$USERNAME" --dbname="${SERVICE}" --format=plain 2>>$LOGFILE | /usr/bin/aws s3 cp --sse AES256 --no-progress - "${S3_LOCATION}" 2>>$LOGFILE || errorExit "Unable to dump ${SERVICE}."
   doLog "INFO ${SERVICE} dumped to ${S3_LOCATION}"
 }
 run_aws_backup () {

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/backup_db.sh
@@ -51,7 +51,7 @@ dump_to_azure() {
 
   doLog "INFO Uploading to ${BACKUP_LOCATION}"
   # todo: strip trailing slash from BACKUP_LOCATION if it's there
-  AZURE_LOCATION="${BACKUP_LOCATION}/${BACKUP_DATE}/${SERVICE}_backup"
+  AZURE_LOCATION="${BACKUP_LOCATION}/${SERVICE}_backup"
   azcopy copy "$LOCAL_BACKUP" "$AZURE_LOCATION" >>$LOGFILE 2>&1 || errorExit "Unable to upload $SERVICE backup"
   doLog "INFO Completed upload to ${BACKUP_LOCATION}"
 
@@ -74,7 +74,7 @@ run_azure_backup () {
 dump_to_s3() {
   SERVICE=$1
   # todo: strip trailing slash from BACKUP_LOCATION if it's there
-  S3_LOCATION="${BACKUP_LOCATION}/${BACKUP_DATE}/${SERVICE}_backup"
+  S3_LOCATION="${BACKUP_LOCATION}/${SERVICE}_backup"
   doLog "INFO Dumping ${SERVICE} to ${S3_LOCATION}"
   # todo: Specify a good compression level with `-Z 1...9`
   pg_dump --host="$HOST" --port="$PORT" --username="$USERNAME" --dbname="${SERVICE}" --format=custom --data-only 2>>$LOGFILE | /usr/bin/aws s3 cp --sse AES256 --no-progress - "${S3_LOCATION}" 2>>$LOGFILE || errorExit "Unable to dump ${SERVICE}."

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/backup_db.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [ $# -ne 6 ]; then
+  echo "Invalid inputs provided"
+  echo "Script accepts five inputs:"
+  echo "  1. Cloud Provider (azure | aws)"
+  echo "  2. PostgreSQL host name."
+  echo "  3. PostgreSQL port."
+  echo "  4. Object Storage Service url to place backups."
+  echo "  5. PostgreSQL user name."
+  echo "  6. PostgreSQL password."
+  exit 1
+fi
+
+CLOUD_PROVIDER="$1"
+HOST="$2"
+PORT="$3"
+BACKUP_LOCATION="$4"
+USERNAME="$5"
+export PGPASSWORD="$6" # We can provide the password to pg_dump through this variable, or in ~/.pgpass
+
+BACKUP_DATE=$(date '+%Y-%m-%dT%H:%M:%SZ')
+LOGFILE=/var/log/dl_postgres_backup.log
+
+echo "Logs at ${LOGFILE}"
+
+doLog() {
+  type_of_msg=$(echo $* | cut -d" " -f1)
+  msg=$(echo "$*" | cut -d" " -f2-)
+  [[ $type_of_msg == INFO ]] && type_of_msg="INFO " # one space for aligning
+  [[ $type_of_msg == WARN ]] && type_of_msg="WARN " # as well
+
+  # print to the terminal if we have one
+  test -t 1 && echo "$(date "+%Y-%m-%dT%H:%M:%SZ") $type_of_msg ""$msg"
+  echo "$(date "+%Y-%m-%dT%H:%M:%SZ") $type_of_msg ""$msg" >>$LOGFILE
+}
+
+errorExit() {
+  doLog "ERROR $1"
+  exit 1
+}
+
+dump_to_azure() {
+  SERVICE="$1"
+  doLog "INFO Dumping ${SERVICE}"
+  LOCAL_BACKUP=${DATE_DIR}/${SERVICE}_backup
+  pg_dump --host="$HOST" --port="$PORT" --username="$USERNAME" --dbname="$SERVICE" --format=custom --file="$LOCAL_BACKUP" >>$LOGFILE 2>&1 || errorExit "Unable to dump ${SERVICE}"
+
+  doLog "INFO Uploading to ${BACKUP_LOCATION}"
+  # todo: strip trailing slash from BACKUP_LOCATION if it's there
+  AZURE_LOCATION="${BACKUP_LOCATION}/${BACKUP_DATE}/${SERVICE}_backup"
+  azcopy copy "$LOCAL_BACKUP" "$AZURE_LOCATION" >>$LOGFILE 2>&1 || errorExit "Unable to upload $SERVICE backup"
+  doLog "INFO Completed upload to ${BACKUP_LOCATION}"
+
+  rm -v "$LOCAL_BACKUP" >>$LOGFILE 2>&1
+
+  doLog "INFO ${SERVICE} dumped to "
+}
+run_azure_backup () {
+  BACKUPS_DIR="/var/tmp/" # Is this appropriate for keeping backups that are staged before uploading to Azure Blob Storage?
+  DATE_DIR=${BACKUPS_DIR}/${BACKUP_DATE}
+  mkdir -p "$DATE_DIR" || error_exit "Could not create local directory for backups."
+
+  azcopy login --identity || errorExit "Could not login to Azure"
+  dump_to_azure "hive"
+  dump_to_azure "ranger"
+
+  rmdir -v "$DATE_DIR" >>$LOGFILE 2>&1
+}
+
+dump_to_s3() {
+  SERVICE=$1
+  # todo: strip trailing slash from BACKUP_LOCATION if it's there
+  S3_LOCATION="${BACKUP_LOCATION}/${BACKUP_DATE}/${SERVICE}_backup"
+  doLog "INFO Dumping ${SERVICE} to ${S3_LOCATION}"
+  # todo: Specify a good compression level with `-Z 1...9`
+  pg_dump --host="$HOST" --port="$PORT" --username="$USERNAME" --dbname="${SERVICE}" --format=custom --data-only 2>>$LOGFILE | /usr/bin/aws s3 cp --sse AES256 --no-progress - "${S3_LOCATION}" 2>>$LOGFILE || errorExit "Unable to dump ${SERVICE}."
+  doLog "INFO ${SERVICE} dumped to ${S3_LOCATION}"
+}
+run_aws_backup () {
+  dump_to_s3 "hive"
+  dump_to_s3 "ranger"
+}
+
+doLog "INFO Starting backup ${BACKUP_DATE}"
+
+if [[ "$CLOUD_PROVIDER" = "azure" ]]; then
+  run_azure_backup
+elif [[ "$CLOUD_PROVIDER" = "aws" ]]; then
+  run_aws_backup
+else
+  errorExit "Unknown cloud provider: ${CLOUD_PROVIDER}"
+fi
+
+doLog "INFO Completed backup ${BACKUP_DATE}"

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/backup_db.sh
@@ -17,7 +17,7 @@ if [ $# -ne 5 ] && [ $# -ne 6 ]; then
 fi
 
 CLOUD_PROVIDER="$1"
-BACKUP_LOCATION=$(echo "$2"| sed "s/\/\+$//g") # Clear trailng '/' (if present) for later path joining.
+BACKUP_LOCATION=$(echo "$2"| sed 's/\/\+$//g') # Clear trailng '/' (if present) for later path joining.
 HOST="$3"
 PORT="$4"
 USERNAME="$5"
@@ -47,7 +47,7 @@ dump_to_azure() {
   SERVICE="$1"
   doLog "INFO Dumping ${SERVICE}"
   LOCAL_BACKUP=${DATE_DIR}/${SERVICE}_backup
-  pg_dump --host="$HOST" --port="$PORT" --username="$USERNAME" --dbname="$SERVICE" --format=plain >>$LOGFILE 2>&1 || errorExit "Unable to dump ${SERVICE}"
+  pg_dump --host="$HOST" --port="$PORT" --username="$USERNAME" --dbname="$SERVICE" --format=plain --file="$LOCAL_BACKUP" >>$LOGFILE 2>&1 || errorExit "Unable to dump ${SERVICE}"
 
   doLog "INFO Uploading to ${BACKUP_LOCATION}"
   AZURE_LOCATION="${BACKUP_LOCATION}/${SERVICE}_backup"
@@ -94,4 +94,3 @@ else
 fi
 
 doLog "INFO Completed backup ${BACKUP_LOCATION}"
-

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/backup_db.sh
@@ -9,7 +9,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ $# -ne 5 ] && [ $# -ne 6 ]; then
+if [ $# -ne 5 ]; then
   echo "Invalid inputs provided"
   echo "Script accepts 5 inputs:"
   echo "  1. Cloud Provider (azure | aws)"
@@ -17,8 +17,6 @@ if [ $# -ne 5 ] && [ $# -ne 6 ]; then
   echo "  3. PostgreSQL host name."
   echo "  4. PostgreSQL port."
   echo "  5. PostgreSQL user name."
-  echo
-  echo "  Optional: PostgreSQL password."
   exit 1
 fi
 
@@ -27,7 +25,6 @@ BACKUP_LOCATION=$(echo "$2" | sed 's/\/\+$//g') # Clear trailng '/' (if present)
 HOST="$3"
 PORT="$4"
 USERNAME="$5"
-export PGPASSWORD="$6" # We can provide the password to pg_dump through this variable, or in ~/.pgpass
 
 LOGFILE=/var/log/dl_postgres_backup.log
 
@@ -99,4 +96,3 @@ else
 fi
 
 doLog "INFO Completed backup ${BACKUP_LOCATION}"
-

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/restore_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/restore_db.sh
@@ -19,14 +19,14 @@ fi
 CLOUD_PROVIDER="$1"
 HOST="$2"
 PORT="$3"
-CLOUD_LOCATION="$4"
+CLOUD_LOCATION=$(echo "$4"| sed "s/\/\+$//g") # Clear trailng '/' (if present) for later path joining.
 USERNAME="$5"
 export PGPASSWORD="$6" # We can provide the password to pg_dump through this variable, or in ~/.pgpass
 
 LOGFILE=/var/log/dl_postgres_restore.log
 echo "Logs at ${LOGFILE}"
 
-BACKUPS_DIR="/var/tmp/postgres_restore_staging" # Is this appropriate for keeping backups that are staged before uploading to Azure Blob Storage?
+BACKUPS_DIR="/var/tmp/postgres_restore_staging"
 
 doLog() {
   type_of_msg=$(echo $* | cut -d" " -f1)

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/restore_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/restore_db.sh
@@ -50,7 +50,6 @@ restore_db_from_local() {
 
   doLog "INFO Restoring $SERVICE"
 
-  # Can't run a drop statement in a multi-statment cli command. Thus two additiona lines of `psql`
   psql --host="$HOST" --port="$PORT" --dbname="postgres" --username="$USERNAME" -v ON_ERROR_STOP=on << EOF
 drop database ${SERVICE};
 create database ${SERVICE};

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/restore_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/restore_db.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [ $# -ne 6 ]; then
+  echo "Invalid inputs provided"
+  echo "Script accepts five inputs:"
+  echo "  1. Cloud Provider (azure | aws)"
+  echo "  2. PostgreSQL host name."
+  echo "  3. PostgreSQL port."
+  echo "  4. Object Storage Service url to retrieve backups."
+  echo "  5. PostgreSQL user name."
+  echo "  6. PostgreSQL password."
+  exit 1
+fi
+
+CLOUD_PROVIDER="$1"
+HOST="$2"
+PORT="$3"
+CLOUD_LOCATION="$4"
+USERNAME="$5"
+export PGPASSWORD="$6" # We can provide the password to pg_dump through this variable, or in ~/.pgpass
+
+LOGFILE=/var/log/dl_postgres_restore.log
+echo "Logs at ${LOGFILE}"
+
+BACKUPS_DIR="/var/tmp/postgres_restore_staging" # Is this appropriate for keeping backups that are staged before uploading to Azure Blob Storage?
+
+doLog() {
+  type_of_msg=$(echo $* | cut -d" " -f1)
+  msg=$(echo "$*" | cut -d" " -f2-)
+  [[ $type_of_msg == INFO ]] && type_of_msg="INFO " # one space for aligning
+  [[ $type_of_msg == WARN ]] && type_of_msg="WARN " # as well
+
+  # print to the terminal if we have one
+  test -t 1 && echo "$(date "+%Y-%m-%dT%H:%M:%SZ") $type_of_msg ""$msg"
+  echo "$(date "+%Y-%m-%dT%H:%M:%SZ") $type_of_msg ""$msg" >>$LOGFILE
+}
+
+errorExit() {
+  doLog "ERROR $1"
+  exit 1
+}
+
+restore_db_from_local() {
+  SERVICE=$1
+  BACKUP="${BACKUPS_DIR}/${SERVICE}_backup"
+  LIST_FILE="${BACKUPS_DIR}/${SERVICE}_list"
+
+  doLog "INFO Restoring $SERVICE"
+  pg_restore -l "$BACKUP" | sed -e "s/\(.*0 0 COMMENT - EXTENSION plpgsql\)/;\1/" >"$LIST_FILE" # We have to drop a problematic COMMENT added by RDS backups.
+  pg_restore --clean --if-exists --host="$HOST" --port="$PORT" --dbname="$SERVICE" --username="$USERNAME" --use-list="$LIST_FILE" "$BACKUP" >>$LOGFILE 2>&1 || errorExit "Unable to restore ${SERVICE}"
+  doLog "INFO Succesfully restored ${SERVICE}"
+}
+
+run_azure_restore() {
+  mkdir -p "$BACKUPS_DIR"
+  azcopy login --identity >>$LOGFILE 2>&1 || errorExit "Could not login to Azure"
+  azcopy copy "$CLOUD_LOCATION"/* "$BACKUPS_DIR" >>$LOGFILE 2>&1 || errorExit "Could not copy backups from Azure."
+  restore_db_from_local "hive"
+  restore_db_from_local "ranger"
+  rm -rfv "$BACKUPS_DIR" >>$LOGFILE 2>&1
+}
+
+restore_db_from_s3() {
+  SERVICE="$1"
+  BACKUP="${BACKUPS_DIR}/${SERVICE}_backup"
+  LIST_FILE="${BACKUPS_DIR}/${SERVICE}_list"
+
+  doLog "INFO Copying ${CLOUD_LOCATION}/${SERVICE}_backup"
+  aws s3 cp "${CLOUD_LOCATION}/${SERVICE}_backup" "$BACKUPS_DIR" || errorExit "Could not copy $SERVICE backup from AWS S3."
+
+  doLog "INFO Restoring $SERVICE"
+  pg_restore -l "$BACKUP" | sed -e "s/\(.*0 0 COMMENT - EXTENSION plpgsql\)/;\1/" >"$LIST_FILE" # We have to drop a problematic COMMENT added by RDS backups.
+  pg_restore --clean --if-exists --host="$HOST" --port="$PORT" --dbname="$SERVICE" --username="$USERNAME" --use-list="$LIST_FILE" "$BACKUP" >>$LOGFILE 2>&1 || errorExit "Unable to restore ${SERVICE}"
+  doLog "INFO Succesfully restored ${SERVICE}"
+}
+
+run_aws_restore () {
+  mkdir -p "$BACKUPS_DIR"
+  restore_db_from_s3 "hive"
+  restore_db_from_s3 "ranger"
+  rm -rfv "$BACKUPS_DIR" >>$LOGFILE 2>&1
+}
+
+if [[ "$CLOUD_PROVIDER" == "azure" ]]; then
+  run_azure_restore
+elif [[ "$CLOUD_PROVIDER" == "aws" ]]; then
+  run_aws_restore
+else
+  errorExit "Unknown cloud provider: ${CLOUD_PROVIDER}"
+fi
+
+doLog "INFO Completed restore."

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/restore_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/restore_db.sh
@@ -3,7 +3,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ $# -ne 5 ] || [ $# -ne 6 ]; then
+if [ $# -ne 5 ] && [ $# -ne 6 ]; then
   echo "Invalid inputs provided"
   echo "Script accepts 5 inputs:"
   echo "  1. Cloud Provider (azure | aws)"
@@ -17,9 +17,9 @@ if [ $# -ne 5 ] || [ $# -ne 6 ]; then
 fi
 
 CLOUD_PROVIDER="$1"
-HOST="$2"
-PORT="$3"
-CLOUD_LOCATION=$(echo "$4"| sed "s/\/\+$//g") # Clear trailng '/' (if present) for later path joining.
+CLOUD_LOCATION=$(echo "$2"| sed "s/\/\+$//g") # Clear trailng '/' (if present) for later path joining.
+HOST="$3"
+PORT="$4"
 USERNAME="$5"
 export PGPASSWORD="$6" # We can provide the password to pg_dump through this variable, or in ~/.pgpass
 
@@ -94,3 +94,4 @@ else
 fi
 
 doLog "INFO Completed restore."
+

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/restore_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/restore_db.sh
@@ -3,7 +3,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [$# -ne 5] || [ $# -ne 6 ]; then
+if [ $# -ne 5 ] || [ $# -ne 6 ]; then
   echo "Invalid inputs provided"
   echo "Script accepts 5 inputs:"
   echo "  1. Cloud Provider (azure | aws)"

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/restore_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/restore_db.sh
@@ -51,8 +51,10 @@ restore_db_from_local() {
   doLog "INFO Restoring $SERVICE"
 
   # Can't run a drop statement in a multi-statment cli command. Thus two additiona lines of `psql`
-  psql --host="$HOST" --port="$PORT" --dbname="postgres" --username="$USERNAME" -c "drop database ${SERVICE};"
-  psql --host="$HOST" --port="$PORT" --dbname="postgres" --username="$USERNAME" -c "create database ${SERVICE};"
+  psql --host="$HOST" --port="$PORT" --dbname="postgres" --username="$USERNAME" -v ON_ERROR_STOP=on << EOF
+drop database ${SERVICE};
+create database ${SERVICE};
+EOF
   psql --host="$HOST" --port="$PORT" --dbname="$SERVICE" --username="$USERNAME" < "$BACKUP" >>$LOGFILE 2>&1 || errorExit "Unable to restore ${SERVICE}"
   doLog "INFO Succesfully restored ${SERVICE}"
 }

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/restore_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/restore_db.sh
@@ -3,15 +3,16 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ $# -ne 6 ]; then
+if [$# -ne 5] || [ $# -ne 6 ]; then
   echo "Invalid inputs provided"
-  echo "Script accepts six inputs:"
+  echo "Script accepts 5 inputs:"
   echo "  1. Cloud Provider (azure | aws)"
   echo "  2. Object Storage Service url to retrieve backups."
   echo "  3. PostgreSQL host name."
   echo "  4. PostgreSQL port."
   echo "  5. PostgreSQL user name."
-  echo "  6. PostgreSQL password."
+  echo
+  echo "  Optional: PostgreSQL password."
   exit 1
 fi
 

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/restore_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/restore_db.sh
@@ -5,11 +5,11 @@ set -o pipefail
 
 if [ $# -ne 6 ]; then
   echo "Invalid inputs provided"
-  echo "Script accepts five inputs:"
+  echo "Script accepts six inputs:"
   echo "  1. Cloud Provider (azure | aws)"
-  echo "  2. PostgreSQL host name."
-  echo "  3. PostgreSQL port."
-  echo "  4. Object Storage Service url to retrieve backups."
+  echo "  2. Object Storage Service url to retrieve backups."
+  echo "  3. PostgreSQL host name."
+  echo "  4. PostgreSQL port."
   echo "  5. PostgreSQL user name."
   echo "  6. PostgreSQL password."
   exit 1

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/restore_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/restore_db.sh
@@ -8,7 +8,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ $# -ne 5 ] && [ $# -ne 6 ]; then
+if [ $# -ne 5 ]; then
   echo "Invalid inputs provided"
   echo "Script accepts 5 inputs:"
   echo "  1. Cloud Provider (azure | aws)"
@@ -16,8 +16,6 @@ if [ $# -ne 5 ] && [ $# -ne 6 ]; then
   echo "  3. PostgreSQL host name."
   echo "  4. PostgreSQL port."
   echo "  5. PostgreSQL user name."
-  echo
-  echo "  Optional: PostgreSQL password."
   exit 1
 fi
 
@@ -26,7 +24,6 @@ CLOUD_LOCATION=$(echo "$2" | sed 's/\/\+$//g') # Clear trailng '/' (if present) 
 HOST="$3"
 PORT="$4"
 USERNAME="$5"
-export PGPASSWORD="$6" # We can provide the password to pg_dump through this variable, or in ~/.pgpass
 
 LOGFILE=/var/log/dl_postgres_restore.log
 echo "Logs at ${LOGFILE}"
@@ -87,5 +84,3 @@ else
 fi
 
 doLog "INFO Completed restore."
-
-

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/restore_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/restore_db.sh
@@ -17,12 +17,11 @@ if [ $# -ne 5 ] && [ $# -ne 6 ]; then
 fi
 
 CLOUD_PROVIDER="$1"
-CLOUD_LOCATION=$(echo "$2"| sed "s/\/\+$//g") # Clear trailng '/' (if present) for later path joining.
+CLOUD_LOCATION=$(echo "$2" | sed 's/\/\+$//g') # Clear trailng '/' (if present) for later path joining.
 HOST="$3"
 PORT="$4"
 USERNAME="$5"
 export PGPASSWORD="$6" # We can provide the password to pg_dump through this variable, or in ~/.pgpass
-
 LOGFILE=/var/log/dl_postgres_restore.log
 echo "Logs at ${LOGFILE}"
 
@@ -50,10 +49,8 @@ restore_db_from_local() {
 
   doLog "INFO Restoring $SERVICE"
 
-  psql --host="$HOST" --port="$PORT" --dbname="postgres" --username="$USERNAME" -v ON_ERROR_STOP=on << EOF
-drop database ${SERVICE};
-create database ${SERVICE};
-EOF
+  psql --host="$HOST" --port="$PORT" --dbname="postgres" --username="$USERNAME" -c "drop database ${SERVICE};"
+  psql --host="$HOST" --port="$PORT" --dbname="postgres" --username="$USERNAME" -c "create database ${SERVICE};"
   psql --host="$HOST" --port="$PORT" --dbname="$SERVICE" --username="$USERNAME" < "$BACKUP" >>$LOGFILE 2>&1 || errorExit "Unable to restore ${SERVICE}"
   doLog "INFO Succesfully restored ${SERVICE}"
 }
@@ -84,5 +81,3 @@ else
 fi
 
 doLog "INFO Completed restore."
-
-

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/restore_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/restore_db.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+# restore_db.sh
+# This script uses the 'psql' cli to drop hive and ranger databases, create them, then read in a plain SQL file to restore data.
+# We use the `azcopy copy` and `aws s3 cp` commands to copy backups from Azure or AWS respectively.
+# When using either cloud provider, the plaintext SQL files are first copied to the local filesystem, then fed into psql.
+
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -22,6 +27,7 @@ HOST="$3"
 PORT="$4"
 USERNAME="$5"
 export PGPASSWORD="$6" # We can provide the password to pg_dump through this variable, or in ~/.pgpass
+
 LOGFILE=/var/log/dl_postgres_restore.log
 echo "Logs at ${LOGFILE}"
 
@@ -81,3 +87,5 @@ else
 fi
 
 doLog "INFO Completed restore."
+
+


### PR DESCRIPTION
Create bash scripts to run PostgreSQL dump and restore against `hive` and `ranger` databases.
* Add `backup_db.sh`
* Add `restore_db.sh`

Scripts accept:
1. Cloud Provider (azure | aws)
2. PostgreSQL host name.
3. PostgreSQL port.
4. Object Storage Service url to save backups.
5. PostgreSQL user name.
6. PostgreSQL password.

The backup script stores backups in the Cloud Object storage under a Date String prefix, e.g. `s3://backup-bucket/2020-04-28T18:12:53Z`.

Storage service URLs are different when doing backup versus restore. The parent folder is specified for backup, while the particular date folder should be specified for restore.
* Backup to `s3://backup-bucket`
* Restore from `s3://backup-bucket/2020-04-28T18:12:53Z`

The backup script:
1. Runs `pg_dump`, outputting to a local file
2. Copies the dump to Cloud Storage

Restore does the reverse:
1. Copies a dump from Cloud storage to the master instance.
2. Modifies the `list` file to remove some DB objects from restoration.
3. Runs `pg_restore` using the local dump file.