### PR TITLE
CB-6816. Do not downgrade fluent plugins on newer images.

### DIFF
--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/check_fluent_plugins.sh.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/check_fluent_plugins.sh.j2
@@ -26,11 +26,11 @@ function check_and_install_plugin() {
   local version=$3
   check_command="/opt/td-agent/embedded/bin/fluent-gem list -i ${plugin}"
   if [[ ! -z "${version}" ]]; then
-    check_command="$check_command -v ${version}"
-    echo "Checking plugin ${plugin} with the right version ${version}"
+    check_command="$check_command -v '>=${version}'"
+    echo "Checking plugin ${plugin} with the right minimal version ${version}"
   fi
   echo "Run check command: $check_command"
-  local result=$($check_command)
+  local result=$(eval "$check_command")
   echo "Check ${plugin} command output: $result"
   if [[ "$result" == "false" ]]; then
     echo "Plugin ${plugin} does not exist, installing it..."


### PR DESCRIPTION
it is required to avoid this situation:
- older Cluster (like 2.19)
- newer image (as some changes were required for 2.20, as we are building images from master -> for a newer 2.19, probably we will upgrade some binaries/plugins there)
- when applying 2.19 salt script -> in the newer image, it's possible there are newer plugins, this check plugins script will delete those plugins and will re-install the old versions.
(of course that will be fixed from CB 2.20...just described that problem with a 2.19 example)