### PR TITLE
CB-6833. Send node metrics to CdpVmMetrics kinesis stream (by fluentd).

### DIFF
--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/base/FeaturesBase.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/base/FeaturesBase.java
@@ -19,6 +19,10 @@ public abstract class FeaturesBase implements Serializable {
     @ApiModelProperty(TelemetryModelDescription.TELEMETRY_CLUSTER_LOGS_COLLECTION_ENABLED)
     private FeatureSetting clusterLogsCollection;
 
+    @JsonProperty("monitoring")
+    @ApiModelProperty(TelemetryModelDescription.TELEMETRY_CLUSTER_MONITORING_ENABLED)
+    private FeatureSetting monitoring;
+
     public FeatureSetting getWorkloadAnalytics() {
         return workloadAnalytics;
     }
@@ -35,6 +39,14 @@ public abstract class FeaturesBase implements Serializable {
         this.clusterLogsCollection = clusterLogsCollection;
     }
 
+    public FeatureSetting getMonitoring() {
+        return monitoring;
+    }
+
+    public void setMonitoring(FeatureSetting monitoring) {
+        this.monitoring = monitoring;
+    }
+
     @JsonIgnore
     public void addWorkloadAnalytics(boolean enabled) {
         workloadAnalytics = new FeatureSetting();
@@ -45,5 +57,11 @@ public abstract class FeaturesBase implements Serializable {
     public void addClusterLogsCollection(boolean enabled) {
         clusterLogsCollection = new FeatureSetting();
         clusterLogsCollection.setEnabled(enabled);
+    }
+
+    @JsonIgnore
+    public void addMonitoring(boolean enabled) {
+        monitoring = new FeatureSetting();
+        monitoring.setEnabled(enabled);
     }
 }

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/doc/TelemetryModelDescription.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/doc/TelemetryModelDescription.java
@@ -13,6 +13,7 @@ public class TelemetryModelDescription {
     public static final String TELEMETRY_LOGGING_CLOUDWATCH_ATTRIBUTES = "telemetry - logging cloudwatch attributes";
     public static final String TELEMETRY_LOGGING_STORAGE_LOCATION = "telemetry - logging storage location / container";
     public static final String TELEMETRY_CLUSTER_LOGS_COLLECTION_ENABLED = "enable cluster logs collection";
+    public static final String TELEMETRY_CLUSTER_MONITORING_ENABLED = "enable monitoring for cluster services";
     public static final String TELEMETRY_CLOUDWATCH_PARAMS = "telemetry - CloudWatch releated parameters";
     public static final String TELEMETRY_CLOUDWATCH_PARAMS_REGION = "telemetry - CloudWatch related AWS region (should be used only outside of AWS platform)";
     public static final String TELEMETRY_USE_SHARED_ALTUS_CREDENTIAL_ENABLED = "enable shared Altus credential usage";

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/Telemetry.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/Telemetry.java
@@ -87,6 +87,11 @@ public class Telemetry implements Serializable {
     }
 
     @JsonIgnore
+    public boolean isAnyDataBusBasedFeatureEnablred() {
+        return  isMonitoringFeatureEnabled() || isClusterLogsCollectionEnabled() || isMeteringFeatureEnabled();
+    }
+
+    @JsonIgnore
     public boolean isUseSharedAltusCredentialEnabled() {
         return features != null && features.getUseSharedAltusCredential() != null
                 && features.getUseSharedAltusCredential().isEnabled();

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigService.java
@@ -117,11 +117,11 @@ public class FluentConfigService {
         }
         builder.withCloudStorageLoggingEnabled(cloudStorageLoggingEnabled)
                 .withCloudLoggingServiceEnabled(cloudLogServiceLoggingEnabled);
-        boolean databusLogEnabled = fillMeteringAndClusterLogCollectionConfigs(telemetry, databusEnabled, meteringEnabled, builder);
+        boolean databusLogEnabled = fillDiagnosticsConfigs(telemetry, databusEnabled, meteringEnabled, builder);
         return cloudStorageLoggingEnabled || databusLogEnabled || cloudLogServiceLoggingEnabled;
     }
 
-    private boolean fillMeteringAndClusterLogCollectionConfigs(Telemetry telemetry, boolean databusEnabled,
+    private boolean fillDiagnosticsConfigs(Telemetry telemetry, boolean databusEnabled,
             boolean meteringEnabled, FluentConfigView.Builder builder) {
         boolean validDatabusLogging = false;
         if (meteringEnabled || telemetry.isClusterLogsCollectionEnabled()) {
@@ -133,6 +133,11 @@ public class FluentConfigService {
             if (databusEnabled && telemetry.isClusterLogsCollectionEnabled()) {
                 builder.withClusterLogsCollection(true);
                 LOGGER.debug("Fluent based cluster log collection is enabled.");
+                validDatabusLogging = true;
+            }
+            if (databusEnabled && telemetry.isMonitoringFeatureEnabled()) {
+                builder.withMonitoringEnabled(true);
+                LOGGER.debug("Fluent based cluster monitoring is enabled.");
                 validDatabusLogging = true;
             }
         }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigView.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigView.java
@@ -41,6 +41,8 @@ public class FluentConfigView implements TelemetryConfigView {
 
     private final boolean meteringEnabled;
 
+    private final boolean monitoringEnabled;
+
     private final TelemetryClusterDetails clusterDetails;
 
     private final String user;
@@ -85,6 +87,7 @@ public class FluentConfigView implements TelemetryConfigView {
         this.cloudLoggingServiceEnabled = builder.cloudLoggingServiceEnabled;
         this.clusterLogsCollection = builder.clusterLogsCollection;
         this.meteringEnabled = builder.meteringEnabled;
+        this.monitoringEnabled = builder.monitoringEnabled;
         this.clusterDetails = builder.clusterDetails;
         this.user = builder.user;
         this.group = builder.group;
@@ -194,6 +197,10 @@ public class FluentConfigView implements TelemetryConfigView {
         return meteringEnabled;
     }
 
+    public boolean isMonitoringEnabled() {
+        return monitoringEnabled;
+    }
+
     public Map<String, Object> getOverrideAttributes() {
         return this.overrideAttributes;
     }
@@ -205,6 +212,7 @@ public class FluentConfigView implements TelemetryConfigView {
         map.put("cloudStorageLoggingEnabled", this.cloudStorageLoggingEnabled);
         map.put("cloudLoggingServiceEnabled", this.cloudLoggingServiceEnabled);
         map.put("dbusMeteringEnabled", this.meteringEnabled);
+        map.put("dbusMonitoringEnabled", this.monitoringEnabled);
         map.put("dbusClusterLogsCollection", this.clusterLogsCollection);
         map.put("dbusClusterLogsCollectionDisableStop", DBUS_DISABLE_STOP_CLUSTER_LOG_COLLECTION_DEFAULT);
         map.put("dbusIncludeSaltLogs", DBUS_INCLUDE_SALT_LOGS_DEFAULT);
@@ -253,6 +261,8 @@ public class FluentConfigView implements TelemetryConfigView {
         private boolean clusterLogsCollection;
 
         private boolean meteringEnabled;
+
+        private boolean monitoringEnabled;
 
         private TelemetryClusterDetails clusterDetails;
 
@@ -383,6 +393,11 @@ public class FluentConfigView implements TelemetryConfigView {
 
         public Builder withClusterLogsCollection(boolean clusterLogsCollection) {
             this.clusterLogsCollection = clusterLogsCollection;
+            return this;
+        }
+
+        public Builder withMonitoringEnabled(boolean monitoringEnabled) {
+            this.monitoringEnabled = monitoringEnabled;
             return this;
         }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
@@ -90,6 +90,7 @@ public class TelemetryConverter {
             telemetry.setWorkloadAnalytics(workloadAnalytics);
             setWorkloadAnalyticsFeature(telemetry, features);
             setClusterLogsCollection(request, features);
+            setMonitoring(request, features);
             setUseSharedAltusCredential(features);
             telemetry.setFluentAttributes(request.getFluentAttributes());
         }
@@ -119,6 +120,10 @@ public class TelemetryConverter {
             if (featuresResponse != null) {
                 LOGGER.debug("Setting cluster logs collection response (telemetry) based on environment response.");
                 featuresRequest.setClusterLogsCollection(featuresResponse.getClusterLogsCollection());
+            }
+            if (featuresResponse != null) {
+                LOGGER.debug("Setting cluster monitoring response (telemetry) based on environment response.");
+                featuresRequest.setMonitoring(featuresResponse.getMonitoring());
             }
             telemetryRequest.setFluentAttributes(response.getFluentAttributes());
         }
@@ -211,6 +216,7 @@ public class TelemetryConverter {
             featuresRequest = new FeaturesRequest();
             featuresRequest.setWorkloadAnalytics(features.getWorkloadAnalytics());
             featuresRequest.setClusterLogsCollection(features.getClusterLogsCollection());
+            featuresRequest.setMonitoring(features.getMonitoring());
         }
         return featuresRequest;
     }
@@ -313,6 +319,7 @@ public class TelemetryConverter {
             FeaturesResponse featuresResponse = new FeaturesResponse();
             featuresResponse.setWorkloadAnalytics(features.getWorkloadAnalytics());
             featuresResponse.setClusterLogsCollection(features.getClusterLogsCollection());
+            featuresResponse.setMonitoring(features.getMonitoring());
             featuresResponse.setMetering(features.getMetering());
             featuresResponse.setUseSharedAltusCredential(features.getUseSharedAltusCredential());
             response.setFeatures(featuresResponse);
@@ -360,6 +367,21 @@ public class TelemetryConverter {
         } else {
             LOGGER.debug("Cluster logs collection feature is disabled. Set feature as false.");
             features.addClusterLogsCollection(false);
+        }
+    }
+
+    private void setMonitoring(TelemetryRequest request, Features features) {
+        if (monitoringEnabled) {
+            if (request.getFeatures() != null && request.getFeatures().getMonitoring() != null) {
+                LOGGER.debug("Fill cluster monitoring setting from telemetry feature request");
+                features.setMonitoring(request.getFeatures().getMonitoring());
+            } else {
+                LOGGER.debug("Auto-filling cluster monitoring telemetry settings as it is set, but missing from the request.");
+                features.addMonitoring(false);
+            }
+        } else {
+            LOGGER.debug("Cluster monitoring feature is disabled. Set feature as false.");
+            features.addMonitoring(false);
         }
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/altus/AltusMachineUserService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/altus/AltusMachineUserService.java
@@ -26,7 +26,7 @@ public class AltusMachineUserService {
      * Generate machine user for fluentd - databus communication
      */
     public Optional<AltusCredential> generateDatabusMachineUserForFluent(Stack stack, Telemetry telemetry) {
-        if (isMeteringOrDeploymentReportingSupported(stack, telemetry)) {
+        if (isMeteringOrAnyDataBusBasedFeatureSupported(stack, telemetry)) {
             return altusIAMService.generateMachineUserWithAccessKey(
                     getFluentDatabusMachineUserName(stack), stack.getCreator().getUserCrn(),
                     telemetry.isUseSharedAltusCredentialEnabled());
@@ -38,7 +38,7 @@ public class AltusMachineUserService {
      * Delete machine user with its access keys (and unassign databus role if required)
      */
     public void clearFluentMachineUser(Stack stack, Telemetry telemetry) {
-        if (isMeteringOrDeploymentReportingSupported(stack, telemetry)) {
+        if (isMeteringOrAnyDataBusBasedFeatureSupported(stack, telemetry)) {
             String machineUserName = getFluentDatabusMachineUserName(stack);
             String userCrn = stack.getCreator().getUserCrn();
             altusIAMService.clearMachineUser(machineUserName, userCrn, telemetry.isUseSharedAltusCredentialEnabled());
@@ -46,8 +46,8 @@ public class AltusMachineUserService {
     }
 
     // for datalake metering is not supported/required right now
-    private boolean isMeteringOrDeploymentReportingSupported(Stack stack, Telemetry telemetry) {
-        return telemetry != null && (telemetry.isClusterLogsCollectionEnabled() || (telemetry.isMeteringFeatureEnabled()
+    private boolean isMeteringOrAnyDataBusBasedFeatureSupported(Stack stack, Telemetry telemetry) {
+        return telemetry != null && (telemetry.isAnyDataBusBasedFeatureEnablred() || (telemetry.isMeteringFeatureEnabled()
                 && !StackType.DATALAKE.equals(stack.getType())));
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
@@ -68,6 +68,7 @@ public class TelemetryConverterTest {
         WorkloadAnalyticsRequest workloadAnalyticsRequest = new WorkloadAnalyticsRequest();
         FeaturesRequest featuresRequest = new FeaturesRequest();
         featuresRequest.addClusterLogsCollection(false);
+        featuresRequest.addMonitoring(true);
         telemetryRequest.setLogging(logging);
         telemetryRequest.setFeatures(featuresRequest);
         telemetryRequest.setWorkloadAnalytics(workloadAnalyticsRequest);
@@ -179,6 +180,7 @@ public class TelemetryConverterTest {
         TelemetryRequest result = converter.convert(null, sdxClusterResponse);
         // THEN
         assertNull(result.getWorkloadAnalytics());
+        assertNull(result.getFeatures().getMonitoring());
         assertNotNull(result.getFeatures());
         assertFalse(result.getFeatures().getWorkloadAnalytics().isEnabled());
     }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
@@ -189,6 +189,7 @@ public class StackRequestManifester {
             if (envTelemetry.getFeatures() != null) {
                 FeaturesRequest featuresRequest = new FeaturesRequest();
                 featuresRequest.setClusterLogsCollection(envTelemetry.getFeatures().getClusterLogsCollection());
+                featuresRequest.setMonitoring(envTelemetry.getFeatures().getMonitoring());
                 telemetryRequest.setFeatures(featuresRequest);
             }
             if (envTelemetry.getFluentAttributes() != null) {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/telemetry/EnvironmentFeatures.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/telemetry/EnvironmentFeatures.java
@@ -17,6 +17,8 @@ public class EnvironmentFeatures implements Serializable {
 
     private FeatureSetting useSharedAltusCredential;
 
+    private FeatureSetting monitoring;
+
     public FeatureSetting getClusterLogsCollection() {
         return clusterLogsCollection;
     }
@@ -41,6 +43,14 @@ public class EnvironmentFeatures implements Serializable {
         this.useSharedAltusCredential = useSharedAltusCredential;
     }
 
+    public FeatureSetting getMonitoring() {
+        return monitoring;
+    }
+
+    public void setMonitoring(FeatureSetting monitoring) {
+        this.monitoring = monitoring;
+    }
+
     @JsonIgnore
     public void addWorkloadAnalytics(boolean enabled) {
         workloadAnalytics = new FeatureSetting();
@@ -51,6 +61,12 @@ public class EnvironmentFeatures implements Serializable {
     public void addClusterLogsCollection(boolean enabled) {
         clusterLogsCollection = new FeatureSetting();
         clusterLogsCollection.setEnabled(enabled);
+    }
+
+    @JsonIgnore
+    public void addMonitoring(boolean enabled) {
+        monitoring = new FeatureSetting();
+        monitoring.setEnabled(enabled);
     }
 
     @JsonIgnore

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/TelemetryApiConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/TelemetryApiConverter.java
@@ -28,10 +28,13 @@ public class TelemetryApiConverter {
 
     private final boolean clusterLogsCollection;
 
+    private final boolean monitoringEnabled;
+
     private final boolean useSharedAltusCredential;
 
     public TelemetryApiConverter(TelemetryConfiguration configuration) {
         this.clusterLogsCollection = configuration.isClusterLogsCollection();
+        this.monitoringEnabled = configuration.isMonitoringEnabled();
         this.useSharedAltusCredential = configuration.getAltusDatabusConfiguration().isUseSharedAltusCredential();
     }
 
@@ -88,6 +91,7 @@ public class TelemetryApiConverter {
         if (features != null) {
             featuresRequest = new FeaturesRequest();
             featuresRequest.setClusterLogsCollection(features.getClusterLogsCollection());
+            featuresRequest.setMonitoring(features.getMonitoring());
         }
         return featuresRequest;
     }
@@ -97,6 +101,7 @@ public class TelemetryApiConverter {
         if (features != null) {
             featuresResponse = new FeaturesResponse();
             featuresResponse.setClusterLogsCollection(features.getClusterLogsCollection());
+            featuresResponse.setMonitoring(features.getMonitoring());
             featuresResponse.setWorkloadAnalytics(features.getWorkloadAnalytics());
             featuresResponse.setUseSharedAltusCredential(features.getUseSharedAltusCredential());
         }
@@ -122,16 +127,8 @@ public class TelemetryApiConverter {
             if (useSharedAltusCredential) {
                 features.addUseSharedAltusredential(true);
             }
-            if (clusterLogsCollection) {
-                if (accountFeatures.getClusterLogsCollection() != null) {
-                    features.setClusterLogsCollection(accountFeatures.getClusterLogsCollection());
-                }
-                if (featuresRequest.getClusterLogsCollection() != null) {
-                    features.setClusterLogsCollection(featuresRequest.getClusterLogsCollection());
-                } else {
-                    features.addClusterLogsCollection(false);
-                }
-            }
+            setClusterLogsCollectionFromAccountAndRequest(featuresRequest, accountFeatures, features);
+            setMonitoringFromAccountAndRequest(featuresRequest, accountFeatures, features);
             if (accountFeatures.getWorkloadAnalytics() != null) {
                 features.setWorkloadAnalytics(accountFeatures.getWorkloadAnalytics());
             }
@@ -140,6 +137,32 @@ public class TelemetryApiConverter {
             }
         }
         return features;
+    }
+
+    private void setClusterLogsCollectionFromAccountAndRequest(FeaturesRequest featuresRequest, Features accountFeatures, EnvironmentFeatures features) {
+        if (clusterLogsCollection) {
+            if (accountFeatures.getClusterLogsCollection() != null) {
+                features.setClusterLogsCollection(accountFeatures.getClusterLogsCollection());
+            }
+            if (featuresRequest.getClusterLogsCollection() != null) {
+                features.setClusterLogsCollection(featuresRequest.getClusterLogsCollection());
+            } else {
+                features.addClusterLogsCollection(false);
+            }
+        }
+    }
+
+    private void setMonitoringFromAccountAndRequest(FeaturesRequest featuresRequest, Features accountFeatures, EnvironmentFeatures features) {
+        if (monitoringEnabled) {
+            if (accountFeatures.getMonitoring() != null) {
+                features.setMonitoring(featuresRequest.getMonitoring());
+            }
+            if (featuresRequest.getMonitoring() != null) {
+                features.setMonitoring(featuresRequest.getMonitoring());
+            } else {
+                features.addMonitoring(false);
+            }
+        }
     }
 
     private EnvironmentWorkloadAnalytics createWorkloadAnalyticsFromRequest(WorkloadAnalyticsRequest request) {

--- a/environment/src/main/java/com/sequenceiq/environment/telemetry/service/AccountTelemetryService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/telemetry/service/AccountTelemetryService.java
@@ -86,6 +86,7 @@ public class AccountTelemetryService {
                 finalFeatures = new Features();
                 finalFeatures.setClusterLogsCollection(features.getClusterLogsCollection());
                 finalFeatures.setWorkloadAnalytics(features.getWorkloadAnalytics());
+                finalFeatures.setMonitoring(features.getMonitoring());
                 if (newFeatures.getClusterLogsCollection() != null) {
                     LOGGER.debug("Account telemetry feature request contains log collection feature " +
                             "for account {} (set: {})", accountId, newFeatures.getClusterLogsCollection().isEnabled());
@@ -95,6 +96,11 @@ public class AccountTelemetryService {
                     LOGGER.debug("Account telemetry feature request contains workload analytics feature " +
                             "for account {} (set: {})", accountId, newFeatures.getWorkloadAnalytics().isEnabled());
                     finalFeatures.setWorkloadAnalytics(newFeatures.getWorkloadAnalytics());
+                }
+                if (newFeatures.getMonitoring() != null) {
+                    LOGGER.debug("Account telemetry feature request contains monitoring feature " +
+                            "for account {} (set: {})", accountId, newFeatures.getMonitoring().isEnabled());
+                    finalFeatures.setMonitoring(newFeatures.getMonitoring());
                 }
             }
             telemetry.setFeatures(finalFeatures);

--- a/environment/src/main/java/com/sequenceiq/environment/telemetry/v1/converter/AccountTelemetryConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/telemetry/v1/converter/AccountTelemetryConverter.java
@@ -37,6 +37,7 @@ public class AccountTelemetryConverter {
         if (source != null) {
             response = new FeaturesResponse();
             response.setClusterLogsCollection(source.getClusterLogsCollection());
+            response.setMonitoring(source.getMonitoring());
             response.setWorkloadAnalytics(source.getWorkloadAnalytics());
         }
         return response;
@@ -47,6 +48,7 @@ public class AccountTelemetryConverter {
         if (request != null) {
             features = new Features();
             features.setClusterLogsCollection(request.getClusterLogsCollection());
+            features.setMonitoring(request.getMonitoring());
             features.setWorkloadAnalytics(request.getWorkloadAnalytics());
         }
         return features;

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/TelemetryApiConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/TelemetryApiConverterTest.java
@@ -34,7 +34,7 @@ public class TelemetryApiConverterTest {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration("", true, "****", "****");
-        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true, false);
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true, true);
         underTest = new TelemetryApiConverter(telemetryConfiguration);
     }
 
@@ -51,6 +51,7 @@ public class TelemetryApiConverterTest {
         FeaturesRequest fr = new FeaturesRequest();
         fr.addClusterLogsCollection(true);
         fr.addWorkloadAnalytics(true);
+        fr.addMonitoring(true);
         telemetryRequest.setFeatures(fr);
         // WHEN
         EnvironmentTelemetry result = underTest.convert(telemetryRequest, new Features());
@@ -59,6 +60,7 @@ public class TelemetryApiConverterTest {
         assertTrue(result.getFeatures().getClusterLogsCollection().isEnabled());
         assertTrue(result.getFeatures().getWorkloadAnalytics().isEnabled());
         assertTrue(result.getFeatures().getUseSharedAltusCredential().isEnabled());
+        assertTrue(result.getFeatures().getMonitoring().isEnabled());
     }
 
     @Test
@@ -150,6 +152,7 @@ public class TelemetryApiConverterTest {
         logging.setS3(s3Params);
         EnvironmentFeatures features = new EnvironmentFeatures();
         features.addClusterLogsCollection(false);
+        features.addMonitoring(true);
         EnvironmentTelemetry telemetry = new EnvironmentTelemetry();
         telemetry.setLogging(logging);
         telemetry.setFeatures(features);
@@ -158,6 +161,7 @@ public class TelemetryApiConverterTest {
         // THEN
         assertNotNull(result.getFeatures());
         assertFalse(result.getFeatures().getClusterLogsCollection().isEnabled());
+        assertTrue(result.getFeatures().getMonitoring().isEnabled());
         assertEquals(INSTANCE_PROFILE_VALUE, result.getLogging().getS3().getInstanceProfile());
     }
 

--- a/orchestrator-salt/src/main/resources/salt-common/pillar/fluent/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/pillar/fluent/init.sls
@@ -27,6 +27,7 @@ fluent:
   dbusClusterLogsCollection: false
   dbusClusterLogsCollectionDisableStop: false
   dbusMeteringEnabled: false
+  dbusMonitoringEnabled: false
   dbusIncludeSaltLogs: false
   anonymizationRules:
 

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/init.sls
@@ -168,6 +168,14 @@ copy_td_agent_conf:
     - group: "{{ fluent.group }}"
     - mode: 640
 
+/etc/td-agent/databus_monitoring.conf:
+   file.managed:
+    - source: salt://fluent/template/databus_monitoring.conf.j2
+    - template: jinja
+    - user: "{{ fluent.user }}"
+    - group: "{{ fluent.group }}"
+    - mode: 640
+
 /etc/td-agent/input_databus.conf:
   file.managed:
     - source: salt://fluent/template/input.conf.j2

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
@@ -62,6 +62,12 @@
     {% set dbus_metering_enabled = False %}
 {% endif %}
 
+{% if salt['pillar.get']('fluent:dbusMonitoringEnabled') %}
+    {% set dbus_monitoring_enabled = True %}
+{% else %}
+    {% set dbus_monitoring_enabled = False %}
+{% endif %}
+
 {% if salt['pillar.get']('fluent:dbusIncludeSaltLogs') %}
     {% set dbus_include_salt_logs = True %}
 {% else %}
@@ -89,12 +95,17 @@
 {% set cloud_storage_worker_index=0 %}
 {% set metering_worker_index=0 %}
 {% set cluster_logs_collection_worker_index=0 %}
+{% set monitoring_worker_index=0 %}
 {% if cloud_storage_logging_enabled or cloud_logging_service_enabled %}
 {%   set cloud_storage_worker_index=number_of_workers %}
 {%   set number_of_workers=number_of_workers+1 %}
 {% endif %}
 {% if dbus_metering_enabled %}
 {%   set metering_worker_index=number_of_workers %}
+{%   set number_of_workers=number_of_workers+1 %}
+{% endif %}
+{% if dbus_monitoring_enabled %}
+{%   set monitoring_worker_index=number_of_workers %}
 {%   set number_of_workers=number_of_workers+1 %}
 {% endif %}
 {% if dbus_cluster_logs_collection_enabled %}
@@ -156,6 +167,7 @@
     "dbusClusterLogsCollection": dbus_cluster_logs_collection_enabled,
     "dbusClusterLogsCollectionDisableStop": dbus_cluster_logs_collection_disable_stop,
     "dbusMeteringEnabled": dbus_metering_enabled,
+    "dbusMonitoringEnabled": dbus_monitoring_enabled,
     "clouderaPublicGemRepo": cloudera_public_gem_repo,
     "clouderaAzurePluginVersion": cloudera_azure_plugin_version,
     "clouderaAzureGen2PluginVersion": cloudera_azure_gen2_plugin_version,
@@ -164,6 +176,7 @@
     "numberOfWorkers": number_of_workers,
     "cloudStorageWorkerIndex": cloud_storage_worker_index,
     "meteringWorkerIndex": metering_worker_index,
+    "monitoringWorkerIndex": monitoring_worker_index,
     "clusterLogsCollectionWorkerIndex": cluster_logs_collection_worker_index,
     "anonymizationRules": anonymization_rules,
     "dbusIncludeSaltLogs": dbus_include_salt_logs,

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/databus_monitoring.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/databus_monitoring.conf.j2
@@ -1,0 +1,49 @@
+{%- from 'fluent/settings.sls' import fluent with context %}
+{%- from 'databus/settings.sls' import databus with context %}
+{%- if databus.valid and fluent.dbusMonitoringEnabled %}
+<worker {{ fluent.monitoringWorkerIndex }}>
+<source>
+  @type tail
+  format none
+  path ["/var/log/metrics-collector/health_checks.json", "/var/log/metrics-collector/metrics.json"]
+  pos_file /var/log/metrics-collector/metrics-collector.pos
+  tag metrics.metrics-jsons
+  read_from_head true
+</source>
+
+<match metrics.*>
+  @type copy
+  <store ignore_error>
+    @type                            databus
+    credential_file                  /etc/td-agent/databus_credential
+    credential_profile_name          dbus
+    credential_file_reload_interval  60
+    debug                            false
+    endpoint                         "{{ databus.endpoint }}"
+    event_message_field              message
+    headers                          app:{{ fluent.clusterType }}
+    stream_name                      CdpVmMetrics
+    partition_key                    "#{Socket.gethostname}"
+    {%- if fluent.proxyUrl %}
+    proxy_url                        "{{ fluent.proxyUrl }}"
+    {%- if fluent.proxyAuth %}
+    proxy_username                   "{{ fluent.proxyUser }}"
+    proxy_password                   "{{ fluent.proxyPassword }}"
+    {% endif %}
+    {% endif %}
+    <buffer tag,time>
+      @type file
+      path /var/log/td-agent/monitoring_databus
+      timekey 1m
+      timekey_wait 0s
+      chunk_limit_size 600k
+      flush_at_shutdown true
+    </buffer>
+  </store>
+</match>
+</worker>
+{% elif fluent.dbusMonitoringEnabled %}
+# DBUS settings are not valid - check dbus credentials file
+{% else %}
+# DBUS monitoring is disabled
+{% endif %}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/td-agent.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/td-agent.conf.j2
@@ -11,6 +11,7 @@
 @include input_databus.conf
 {% endif %}
 @include databus_metering.conf
+@include databus_monitoring.conf
 {% if fluent.cloudLoggingServiceEnabled %}
 @include filter.conf
 {% endif %}


### PR DESCRIPTION
skipping freeipa metrics (as those are not done yat). so only included core + env converters (not the freeipa one)