### PR TITLE
CB-4377: Use cluster proxy HA for FreeIPA connections

### DIFF
--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ClusterProxyConfiguration.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ClusterProxyConfiguration.java
@@ -20,14 +20,17 @@ public class ClusterProxyConfiguration {
     @Value("${clusterProxy.url:}")
     private String clusterProxyUrl;
 
-    @Value("${clusterProxy.registerConfigPath:/rpc/forceRegisterConfig}")
+    @Value("${clusterProxy.registerConfigPath}")
     private String registerConfigPath;
 
-    @Value("${clusterProxy.updateConfigPath:/rpc/updateConfig}")
+    @Value("${clusterProxy.updateConfigPath}")
     private String updateConfigPath;
 
-    @Value("${clusterProxy.removeConfigPath:/rpc/removeConfig}")
+    @Value("${clusterProxy.removeConfigPath}")
     private String removeConfigPath;
+
+    @Value("${clusterProxy.readConfigPath}")
+    private String readConfigPath;
 
     private String clusterProxyHost;
 
@@ -95,6 +98,14 @@ public class ClusterProxyConfiguration {
         this.removeConfigPath = removeConfigPath;
     }
 
+    public String getReadConfigPath() {
+        return readConfigPath;
+    }
+
+    public void setReadConfigPath(String readConfigPath) {
+        this.readConfigPath = readConfigPath;
+    }
+
     public String getClusterProxyHost() {
         return clusterProxyHost;
     }
@@ -121,5 +132,9 @@ public class ClusterProxyConfiguration {
 
     public String getRemoveConfigUrl() {
         return clusterProxyUrl + removeConfigPath;
+    }
+
+    public String getReadConfigUrl() {
+        return clusterProxyUrl + readConfigPath;
     }
 }

--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ClusterProxyRegistrationClient.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ClusterProxyRegistrationClient.java
@@ -77,6 +77,22 @@ public class ClusterProxyRegistrationClient {
         }
     }
 
+    public ReadConfigResponse readConfig(String clusterIdentifier) {
+        String readConfigUrl = clusterProxyConfiguration.getReadConfigUrl();
+        try {
+            LOGGER.info("Reading cluster proxy configuration for cluster identifer: {}", clusterIdentifier);
+            ResponseEntity<ReadConfigResponse> response = restTemplate.postForEntity(readConfigUrl,
+                    requestEntity(new ReadConfigRequest(clusterIdentifier)), ReadConfigResponse.class);
+            LOGGER.info("Cluster proxy read configuration response: {}", response);
+            return response.getBody();
+        } catch (Exception e) {
+            String message = String.format("Error reading cluster proxy configuration for cluster identifer '%s' from Cluster Proxy. URL: '%s'",
+                    clusterIdentifier, readConfigUrl);
+            LOGGER.error(message, e);
+            throw new ClusterProxyException(message, e);
+        }
+    }
+
     private HttpEntity<String> requestEntity(ConfigRegistrationRequest proxyConfigRequest) throws JsonProcessingException {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
@@ -90,6 +106,12 @@ public class ClusterProxyRegistrationClient {
     }
 
     private HttpEntity<String> requestEntity(ConfigDeleteRequest proxyConfigRequest) throws JsonProcessingException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return new HttpEntity<>(JsonUtil.writeValueAsString(proxyConfigRequest), headers);
+    }
+
+    private HttpEntity<String> requestEntity(ReadConfigRequest proxyConfigRequest) throws JsonProcessingException {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         return new HttpEntity<>(JsonUtil.writeValueAsString(proxyConfigRequest), headers);

--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ClusterServiceConfig.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ClusterServiceConfig.java
@@ -32,9 +32,12 @@ public class ClusterServiceConfig {
     @JsonProperty
     private String accountId;
 
+    @JsonProperty
+    private ClusterServiceHealthCheck healthCheck;
+
     @JsonCreator
     public ClusterServiceConfig(String serviceName, List<String> endpoints, List<ClusterServiceCredential> credentials, ClientCertificate clientCertificate,
-                                Boolean tlsStrictCheck, Boolean useTunnel, List<Tunnel> tunnels, String accountId) {
+                                Boolean tlsStrictCheck, Boolean useTunnel, List<Tunnel> tunnels, String accountId, ClusterServiceHealthCheck healthCheck) {
         this.name = serviceName;
         this.endpoints = endpoints;
         this.credentials = credentials;
@@ -43,11 +46,17 @@ public class ClusterServiceConfig {
         this.useTunnel = useTunnel;
         this.tunnels = tunnels;
         this.accountId = accountId;
+        this.healthCheck = healthCheck;
     }
 
     public ClusterServiceConfig(String serviceName, List<String> endpoints, List<ClusterServiceCredential> credentials, ClientCertificate clientCertificate,
-                                Boolean tlsStrictCheck) {
-        this(serviceName, endpoints, credentials, clientCertificate, tlsStrictCheck, false, List.of(), null);
+            Boolean tlsStrictCheck) {
+        this(serviceName, endpoints, credentials, clientCertificate, tlsStrictCheck, null);
+    }
+
+    public ClusterServiceConfig(String serviceName, List<String> endpoints, List<ClusterServiceCredential> credentials, ClientCertificate clientCertificate,
+                                Boolean tlsStrictCheck, ClusterServiceHealthCheck healthCheck) {
+        this(serviceName, endpoints, credentials, clientCertificate, tlsStrictCheck, false, List.of(), null, healthCheck);
     }
 
     //CHECKSTYLE:OFF: CyclomaticComplexity
@@ -69,13 +78,14 @@ public class ClusterServiceConfig {
                 Objects.equals(tlsStrictCheck, that.tlsStrictCheck) &&
                 Objects.equals(useTunnel, that.useTunnel) &&
                 Objects.equals(tunnels, that.tunnels) &&
-                Objects.equals(accountId, that.accountId);
+                Objects.equals(accountId, that.accountId) &&
+                Objects.equals(healthCheck,that.healthCheck);
     }
     //CHECKSTYLE:ON
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, endpoints, credentials, clientCertificate, tlsStrictCheck, useTunnel, tunnels, accountId);
+        return Objects.hash(name, endpoints, credentials, clientCertificate, tlsStrictCheck, useTunnel, tunnels, accountId, healthCheck);
     }
 
     @Override
@@ -88,6 +98,7 @@ public class ClusterServiceConfig {
                 + ", useTunnel=" + useTunnel
                 + ", tunnels=" + tunnels
                 + ", accountId=" + accountId
+                + ", healthCheck=" + healthCheck
                 + '}';
     }
 }

--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ClusterServiceHealthCheck.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ClusterServiceHealthCheck.java
@@ -1,0 +1,60 @@
+package com.sequenceiq.cloudbreak.clusterproxy;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ClusterServiceHealthCheck {
+    @JsonProperty
+    private int intervalInSec;
+
+    @JsonProperty
+    private String endpointSuffix;
+
+    @JsonProperty
+    private int timeoutInSec;
+
+    @JsonProperty
+    private int healthyStatusCode;
+
+    @JsonCreator
+    public ClusterServiceHealthCheck(int intervalInSec, String endpointSuffix, int timeoutInSec, int healthyStatusCode) {
+        this.intervalInSec = intervalInSec;
+        this.endpointSuffix = endpointSuffix;
+        this.timeoutInSec = timeoutInSec;
+        this.healthyStatusCode = healthyStatusCode;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ClusterServiceHealthCheck that = (ClusterServiceHealthCheck) o;
+
+        return intervalInSec == that.intervalInSec &&
+                Objects.equals(endpointSuffix, that.endpointSuffix) &&
+                timeoutInSec == that.timeoutInSec &&
+                healthyStatusCode == that.healthyStatusCode;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(intervalInSec, endpointSuffix, timeoutInSec, healthyStatusCode);
+    }
+
+    @Override
+    public String toString() {
+        return "ClusterServiceHealthCheck{" +
+                "intervalInSec='" + intervalInSec +
+                "', endpointSuffix='" + endpointSuffix +
+                "', timeoutInSec='" + timeoutInSec +
+                "', healthyStatusCode='" + healthyStatusCode +
+                "'}";
+    }
+}

--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ReadConfigEndpoint.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ReadConfigEndpoint.java
@@ -1,0 +1,76 @@
+package com.sequenceiq.cloudbreak.clusterproxy;
+
+import java.util.Objects;
+
+public class ReadConfigEndpoint {
+    private String endpointId;
+
+    private String status;
+
+    private String endpoint;
+
+    private String updatedTime;
+
+    public String getEndpointId() {
+        return endpointId;
+    }
+
+    public void setEndpointId(String endpointId) {
+        this.endpointId = endpointId;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public String getUpdatedTime() {
+        return updatedTime;
+    }
+
+    public void setUpdatedTime(String updatedTime) {
+        this.updatedTime = updatedTime;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ReadConfigEndpoint that = (ReadConfigEndpoint) o;
+
+        return Objects.equals(endpointId, that.endpointId) &&
+                Objects.equals(status, that.status) &&
+                Objects.equals(endpoint, that.endpoint) &&
+                Objects.equals(updatedTime, that.updatedTime);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(endpointId, status, endpoint, updatedTime);
+    }
+
+    @Override
+    public String toString() {
+        return "ReadConfigEndpoint{" +
+                "endpointId='" + endpointId + '\'' +
+                ", status='" + status + '\'' +
+                ", endpoint='" + endpoint + '\'' +
+                ", updatedTime='" + updatedTime + "\'}";
+    }
+}

--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ReadConfigRequest.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ReadConfigRequest.java
@@ -1,0 +1,40 @@
+package com.sequenceiq.cloudbreak.clusterproxy;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ReadConfigRequest {
+    @JsonProperty
+    private String clusterCrn;
+
+    @JsonCreator
+    public ReadConfigRequest(String clusterCrn) {
+        this.clusterCrn = clusterCrn;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ReadConfigRequest that = (ReadConfigRequest) o;
+
+        return Objects.equals(clusterCrn, that.clusterCrn);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(clusterCrn);
+    }
+
+    @Override
+    public String toString() {
+        return "ReadConfigRequest{clusterCrn='" + clusterCrn + '\'' + '}';
+    }
+}

--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ReadConfigResponse.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ReadConfigResponse.java
@@ -1,0 +1,51 @@
+package com.sequenceiq.cloudbreak.clusterproxy;
+
+import java.util.List;
+import java.util.Objects;
+
+public class ReadConfigResponse {
+    private String crn;
+
+    private List<ReadConfigService> services;
+
+    public String getCrn() {
+        return crn;
+    }
+
+    public void setCrn(String crn) {
+        this.crn = crn;
+    }
+
+    public List<ReadConfigService> getServices() {
+        return services;
+    }
+
+    public void setServices(List<ReadConfigService> services) {
+        this.services = services;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ReadConfigResponse that = (ReadConfigResponse) o;
+
+        return Objects.equals(crn, that.crn) &&
+                Objects.equals(services, that.services);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(crn, services);
+    }
+
+    @Override
+    public String toString() {
+        return "ReadConfigResponse{crn='" + crn + '\'' + ", services=" + services + '}';
+    }
+}

--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ReadConfigService.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ReadConfigService.java
@@ -1,0 +1,51 @@
+package com.sequenceiq.cloudbreak.clusterproxy;
+
+import java.util.List;
+import java.util.Objects;
+
+public class ReadConfigService {
+    private String name;
+
+    private List<ReadConfigEndpoint> endpoints;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<ReadConfigEndpoint> getEndpoints() {
+        return endpoints;
+    }
+
+    public void setEndpoints(List<ReadConfigEndpoint> endpoints) {
+        this.endpoints = endpoints;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ReadConfigService that = (ReadConfigService) o;
+
+        return Objects.equals(name, that.name) &&
+                Objects.equals(endpoints, that.endpoints);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, endpoints);
+    }
+
+    @Override
+    public String toString() {
+        return "ReadConfigEndpoint{name='" + name + '\'' + ", endpoints=" + endpoints + '}';
+    }
+}

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -476,6 +476,7 @@ cb:
 clusterProxy:
   url: http://localhost:10180/cluster-proxy
   enabled: true
+  readConfigPath: /rpc/readConfig
   registerConfigPath: /rpc/forceRegisterConfig
   updateConfigPath: /rpc/updateConfig
   removeConfigPath: /rpc/removeConfig

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/client/CookieAndStickyId.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/client/CookieAndStickyId.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.freeipa.client;
+
+import java.util.Optional;
+
+public class CookieAndStickyId {
+
+    private String cookie;
+
+    private Optional<String> stickyId;
+
+    CookieAndStickyId(String cookie, Optional<String> stickyId) {
+        this.cookie = cookie;
+        this.stickyId = stickyId;
+    }
+
+    public String getCookie() {
+        return cookie;
+    }
+
+    public Optional<String> getStickyId() {
+        return stickyId;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientBuilder.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientBuilder.java
@@ -6,8 +6,10 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.security.Security;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -17,6 +19,7 @@ import javax.net.ssl.SSLContext;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpException;
+import org.apache.http.NameValuePair;
 import org.apache.http.client.CookieStore;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
@@ -90,8 +93,16 @@ public class FreeIpaClientBuilder {
 
     private Map<String, String> additionalHeaders;
 
+    private Map<String, String> additionalHeadersStickySessionFirstRpc;
+
+    private Map<String, String> additionalHeadersStickySession;
+
+    private Optional<String> stickyIdHeader;
+
     public FreeIpaClientBuilder(String user, String pass, HttpClientConfig clientConfig, String hostname, int port, String basePath,
-            Map<String, String> additionalHeaders, JsonRpcClient.RequestListener rpcRequestListener) throws Exception {
+            Map<String, String> additionalHeaders, Map<String, String> additionalHeadersStickySessionFirstRpc,
+            Map<String, String> additionalHeadersStickySession, Optional<String> stickyIdHeader, JsonRpcClient.RequestListener rpcRequestListener)
+            throws Exception {
         this.user = user;
         this.pass = pass;
         this.clientConfig = clientConfig;
@@ -116,14 +127,18 @@ public class FreeIpaClientBuilder {
 
         this.basePath = basePath;
         this.additionalHeaders = Map.copyOf(additionalHeaders);
+        this.additionalHeadersStickySessionFirstRpc = Map.copyOf(additionalHeadersStickySessionFirstRpc);
+        this.additionalHeadersStickySession = Map.copyOf(additionalHeadersStickySession);
+        this.stickyIdHeader = stickyIdHeader;
         this.rpcRequestListener = rpcRequestListener;
     }
 
     public FreeIpaClientBuilder(String user, String pass, HttpClientConfig clientConfig, int port, String hostname) throws Exception {
-        this(user, pass, clientConfig, hostname, port, DEFAULT_BASE_PATH, Map.of(), null);
+        this(user, pass, clientConfig, hostname, port, DEFAULT_BASE_PATH, Map.of(), Map.of(), Map.of(), Optional.empty(), null);
     }
 
     public FreeIpaClient build(boolean withPing) throws URISyntaxException, IOException, FreeIpaClientException, FreeIpaHostNotAvailableException {
+        Optional<String> stickyId = Optional.empty();
         if (withPing) {
             List<BasicHeader> defaultHeaders = additionalHeaders.entrySet().stream()
                     .map(entry -> new BasicHeader(entry.getKey(), entry.getValue())).collect(Collectors.toList());
@@ -144,22 +159,23 @@ public class FreeIpaClientBuilder {
                 LOGGER.debug("Ping at target: {}", target);
                 HttpHead request = new HttpHead(target);
                 additionalHeaders.forEach(request::addHeader);
+                additionalHeadersStickySessionFirstRpc.forEach(request::addHeader);
                 try (CloseableHttpResponse response = client.execute(request)) {
                     if (UNAVIALLBE_PING_HTTP_RESPONSES.contains(response.getStatusLine().getStatusCode())) {
                         throw new HttpException("Ping failed with http status code " + response.getStatusLine().getStatusCode());
                     }
+                    stickyId = getStickIdFromHeaders(response);
                 }
                 LOGGER.debug("Freeipa is reachable");
             } catch (Exception e) {
                 throw new FreeIpaHostNotAvailableException("Ping failed", e);
             }
         }
-        String sessionCookie = connect(user, pass, clientConfig.getApiAddress(), port);
+        CookieAndStickyId cookieAndStickyId = connect(user, pass, clientConfig.getApiAddress(), port, stickyIdHeader, stickyId);
+        String sessionCookie = cookieAndStickyId.getCookie();
+        stickyId = cookieAndStickyId.getStickyId();
 
-        Map<String, String> headers = ImmutableMap.<String, String>builder()
-                .put("Cookie", "ipa_session=" + sessionCookie)
-                .putAll(additionalHeaders)
-                .build();
+        Map<String, String> headers = buildHeaders(sessionCookie, stickyId);
 
         JsonRpcHttpClient jsonRpcHttpClient = new JsonRpcHttpClient(ObjectMapperBuilder.getObjectMapper(),
                 getIpaUrl(clientConfig.getApiAddress(), port, basePath, "/session/json"), headers);
@@ -174,17 +190,20 @@ public class FreeIpaClientBuilder {
         return new FreeIpaClient(jsonRpcHttpClient, clientConfig.getApiAddress(), hostname);
     }
 
-    private String connect(String user, String pass, String apiAddress, int port)
+    private CookieAndStickyId connect(String user, String pass, String apiAddress, int port, Optional<String> stickyIdHeader, Optional<String> stickyId)
             throws IOException, URISyntaxException, FreeIpaClientException {
 
+        Map<String, String> stickyHeaders = createStickyHeaders(stickyId);
         URI target = getIpaUrl(apiAddress, port, basePath, "/session/login_password").toURI();
         LOGGER.debug("Connecting for user: {} at target: {}", user, target);
 
         HttpPost post = getPost(target);
+        stickyHeaders.forEach(post::addHeader);
         post.setEntity(new UrlEncodedFormEntity(List.of(new BasicNameValuePair("user", user), new BasicNameValuePair("password", pass))));
 
         CookieStore cookieStore = new BasicCookieStore();
         try (CloseableHttpResponse response = execute(post, cookieStore)) {
+            stickyId = getStickIdFromHeaders(response);
             if (response.getStatusLine().getStatusCode() != HttpStatus.OK.value()) {
                 if (response.getStatusLine().getStatusCode() == HttpStatus.UNAUTHORIZED.value()) {
 
@@ -213,7 +232,7 @@ public class FreeIpaClientBuilder {
             }
         }
         Cookie sessionCookie = cookieStore.getCookies().stream().filter(cookie -> "ipa_session".equalsIgnoreCase(cookie.getName())).findFirst().get();
-        return sessionCookie.getValue();
+        return new CookieAndStickyId(sessionCookie.getValue(), stickyId);
     }
 
     private SSLContext setupSSLContext(String clientCert, String clientKey, String serverCert) throws Exception {
@@ -270,5 +289,31 @@ public class FreeIpaClientBuilder {
 
     private static HostnameVerifier hostnameVerifier() {
         return (s, sslSession) -> true;
+    }
+
+    private Map<String, String> createStickyHeaders(Optional<String> stickyId) {
+        Map<String, String> stickyHeaders = new HashMap<>();
+        if (stickyId.isEmpty()) {
+            stickyHeaders.putAll(additionalHeadersStickySessionFirstRpc);
+        } else {
+            stickyHeaders.putAll(additionalHeadersStickySession);
+            stickyHeaders.put(stickyIdHeader.get(), stickyId.get());
+        }
+        return stickyHeaders;
+    }
+
+    private Map<String, String> buildHeaders(String sessionCookie, Optional<String> stickyId) {
+        ImmutableMap.Builder<String, String> headersBuidler = ImmutableMap.<String, String>builder()
+                .put("Cookie", "ipa_session=" + sessionCookie)
+                .putAll(additionalHeaders)
+                .putAll(additionalHeadersStickySession);
+        if (stickyIdHeader.isPresent() && stickyId.isPresent()) {
+            headersBuidler.put(stickyIdHeader.get(), stickyId.get());
+        }
+        return headersBuidler.build();
+    }
+
+    private Optional<String> getStickIdFromHeaders(CloseableHttpResponse response) {
+        return stickyIdHeader.flatMap(s -> Optional.ofNullable(response.getLastHeader(s)).map(NameValuePair::getValue));
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/provision/handler/ClusterProxyUpdateRegistrationHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/provision/handler/ClusterProxyUpdateRegistrationHandler.java
@@ -38,7 +38,7 @@ public class ClusterProxyUpdateRegistrationHandler implements EventHandler<Clust
         ClusterProxyUpdateRegistrationRequest request = event.getData();
         Selectable response;
         try {
-            clusterProxyService.updateFreeIpaRegistration(request.getResourceId());
+            clusterProxyService.updateFreeIpaRegistrationAndWait(request.getResourceId());
             response = new ClusterProxyUpdateRegistrationSuccess(request.getResourceId());
         } catch (Exception e) {
             LOGGER.error("Updating Cluster Proxy registration has failed", e);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/polling/clusterproxy/ServiceEndpointHealthListenerTask.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/polling/clusterproxy/ServiceEndpointHealthListenerTask.java
@@ -1,0 +1,64 @@
+package com.sequenceiq.freeipa.service.polling.clusterproxy;
+
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.clusterproxy.ClusterProxyRegistrationClient;
+import com.sequenceiq.cloudbreak.clusterproxy.ReadConfigEndpoint;
+import com.sequenceiq.cloudbreak.clusterproxy.ReadConfigResponse;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.polling.StatusCheckerTask;
+
+@Component
+public class ServiceEndpointHealthListenerTask implements StatusCheckerTask<ServiceEndpointHealthPollerObject> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ServiceEndpointHealthListenerTask.class);
+
+    private static final Set<String> HEALTHY_STATUSES = Set.of("UP");
+
+    @Override
+    public boolean checkStatus(ServiceEndpointHealthPollerObject serviceEndpointHealthPollerObject) {
+        boolean healthy = false;
+        String clusterIdentifer = serviceEndpointHealthPollerObject.getClusterIdentifier();
+        LOGGER.debug("Check cluter proxy endpoint health for {}.", clusterIdentifer);
+        try {
+            ClusterProxyRegistrationClient client = serviceEndpointHealthPollerObject.getClient();
+            ReadConfigResponse response = client.readConfig(clusterIdentifer);
+            if (response != null) {
+                long stillWaitingForHealthyCount = response.getServices().stream()
+                        .flatMap(service -> service.getEndpoints().stream())
+                        .filter(endpoint -> endpoint.getStatus() != null)
+                        .map(ReadConfigEndpoint::getStatus)
+                        .filter(status -> !HEALTHY_STATUSES.contains(status))
+                        .count();
+                healthy = stillWaitingForHealthyCount == 0;
+            }
+        } catch (Exception e) {
+            LOGGER.debug("Failed to check cluter proxy endpoint health for {}, error: {}", clusterIdentifer, e.getMessage());
+        }
+        return healthy;
+    }
+
+    @Override
+    public void handleTimeout(ServiceEndpointHealthPollerObject clusterProxyHealthPollerObject) {
+        throw new CloudbreakServiceException("Operation timed out. Failed to check cluster proxy endpoint health.");
+    }
+
+    @Override
+    public String successMessage(ServiceEndpointHealthPollerObject clusterProxyHealthPollerObject) {
+        return "Cluster proxy service endpoint is healthy.";
+    }
+
+    @Override
+    public boolean exitPolling(ServiceEndpointHealthPollerObject clusterProxyHealthPollerObject) {
+        return false;
+    }
+
+    @Override
+    public void handleException(Exception e) {
+        LOGGER.error("Cluster proxy error", e);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/polling/clusterproxy/ServiceEndpointHealthPollerObject.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/polling/clusterproxy/ServiceEndpointHealthPollerObject.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.freeipa.service.polling.clusterproxy;
+
+import com.sequenceiq.cloudbreak.clusterproxy.ClusterProxyRegistrationClient;
+
+public class ServiceEndpointHealthPollerObject {
+
+    private final String clusterIdentifier;
+
+    private final ClusterProxyRegistrationClient client;
+
+    public ServiceEndpointHealthPollerObject(String clusterIdentifier, ClusterProxyRegistrationClient client) {
+        this.clusterIdentifier = clusterIdentifier;
+        this.client = client;
+    }
+
+    public String getClusterIdentifier() {
+        return clusterIdentifier;
+    }
+
+    public ClusterProxyRegistrationClient getClient() {
+        return client;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/ClusterProxyService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/ClusterProxyService.java
@@ -11,26 +11,35 @@ import javax.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.clusterproxy.ClientCertificate;
 import com.sequenceiq.cloudbreak.clusterproxy.ClusterProxyConfiguration;
 import com.sequenceiq.cloudbreak.clusterproxy.ClusterProxyRegistrationClient;
 import com.sequenceiq.cloudbreak.clusterproxy.ClusterServiceConfig;
+import com.sequenceiq.cloudbreak.clusterproxy.ClusterServiceHealthCheck;
 import com.sequenceiq.cloudbreak.clusterproxy.ConfigRegistrationRequestBuilder;
 import com.sequenceiq.cloudbreak.clusterproxy.ConfigRegistrationResponse;
 import com.sequenceiq.cloudbreak.clusterproxy.TunnelEntry;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.cloudbreak.polling.PollingService;
 import com.sequenceiq.cloudbreak.service.secret.vault.VaultConfigException;
 import com.sequenceiq.cloudbreak.service.secret.vault.VaultSecret;
 import com.sequenceiq.common.api.type.Tunnel;
+import com.sequenceiq.freeipa.entity.FreeIpa;
 import com.sequenceiq.freeipa.entity.SecurityConfig;
 import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.repository.InstanceMetaDataRepository;
 import com.sequenceiq.freeipa.service.GatewayConfigService;
 import com.sequenceiq.freeipa.service.SecurityConfigService;
 import com.sequenceiq.freeipa.service.TlsSecurityService;
+import com.sequenceiq.freeipa.service.polling.clusterproxy.ServiceEndpointHealthListenerTask;
+import com.sequenceiq.freeipa.service.polling.clusterproxy.ServiceEndpointHealthPollerObject;
 import com.sequenceiq.freeipa.util.ClusterProxyServiceAvailabilityChecker;
+import com.sequenceiq.freeipa.service.config.FreeIpaDomainUtils;
+import com.sequenceiq.freeipa.service.freeipa.FreeIpaService;
 import com.sequenceiq.freeipa.vault.FreeIpaCertVaultComponent;
 
 @Service
@@ -49,6 +58,26 @@ public class ClusterProxyService {
     private static final String GATEWAY_SERVICE_TYPE = "GATEWAY";
 
     private static final String NGINX_PROTOCOL = "https";
+
+    private static final int MILLIS_PER_SEC = 1000;
+
+    @Value("${clusterProxy.intervalInSec}")
+    private int intervalInSec;
+
+    @Value("${clusterProxy.healthStatusEndpoint}")
+    private String healthStatusEndpoint;
+
+    @Value("${clusterProxy.timeoutInSec}")
+    private int timeoutInSec;
+
+    @Value("${clusterProxy.healthyStatusCode}")
+    private int healthyStatusCode;
+
+    @Value("${clusterProxy.maxAttempts}")
+    private int maxAttempts;
+
+    @Value("${clusterProxy.maxFailure}")
+    private int maxFailure;
 
     @Inject
     private StackService stackService;
@@ -74,19 +103,31 @@ public class ClusterProxyService {
     @Inject
     private SecurityConfigService securityConfigService;
 
+    @Inject
+    private InstanceMetaDataRepository instanceMetaDataRepository;
+
+    @Inject
+    private FreeIpaService freeIpaService;
+
+    @Inject
+    private PollingService<ServiceEndpointHealthPollerObject> serviceEndpointHealthPollingService;
+
+    @Inject
+    private ServiceEndpointHealthListenerTask serviceEndpointHealthListenerTask;
+
     public Optional<ConfigRegistrationResponse> registerFreeIpa(String accountId, String environmentCrn) {
-        return registerFreeIpa(stackService.getByEnvironmentCrnAndAccountId(environmentCrn, accountId), false);
+        return registerFreeIpa(stackService.getByEnvironmentCrnAndAccountId(environmentCrn, accountId), false, false);
     }
 
-    public Optional<ConfigRegistrationResponse> updateFreeIpaRegistration(Long stackId) {
-        return registerFreeIpa(stackService.getStackById(stackId), false);
+    public Optional<ConfigRegistrationResponse> updateFreeIpaRegistrationAndWait(Long stackId) {
+        return registerFreeIpa(stackService.getStackById(stackId), false, true);
     }
 
     public Optional<ConfigRegistrationResponse> registerBootstrapFreeIpa(Long stackId) {
-        return registerFreeIpa(stackService.getStackById(stackId), true);
+        return registerFreeIpa(stackService.getStackById(stackId), true, false);
     }
 
-    private Optional<ConfigRegistrationResponse> registerFreeIpa(Stack stack, boolean bootstrap) {
+    private Optional<ConfigRegistrationResponse> registerFreeIpa(Stack stack, boolean bootstrap, boolean waitForGoodHealth) {
 
         if (!clusterProxyConfiguration.isClusterProxyIntegrationEnabled()) {
             LOGGER.debug("Cluster Proxy integration disabled. Skipping registering FreeIpa [{}]", stack);
@@ -119,6 +160,10 @@ public class ClusterProxyService {
                 .withTunnelEntries(createTunnelEntries(stack, tunnelGatewayConfigs))
                 .withAccountId(stack.getAccountId());
         ConfigRegistrationResponse response = clusterProxyRegistrationClient.registerConfig(requestBuilder.build());
+
+        if (waitForGoodHealth) {
+            pollForGoodHealth(stack);
+        }
 
         stackUpdater.updateClusterProxyRegisteredFlag(stack, true);
 
@@ -169,9 +214,21 @@ public class ClusterProxyService {
 
     private List<ClusterServiceConfig> createDnsMappedServiceConfigs(Stack stack, List<GatewayConfig> gatewayConfigs, ClientCertificate clientCertificate,
             boolean usePrivateIpToTls) {
-        return gatewayConfigs.stream()
+        List<ClusterServiceConfig> serviceConfigs = gatewayConfigs.stream()
                 .map(gatewayConfig -> createServiceConfig(stack, gatewayConfig.getHostname(), gatewayConfig, clientCertificate, usePrivateIpToTls))
                 .collect(Collectors.toList());
+        List<String> endpoints = gatewayConfigs.stream()
+                .map(gatewayConfig -> getNginxEndpointForRegistration(stack, gatewayConfig, usePrivateIpToTls))
+                .collect(Collectors.toList());
+        FreeIpa freeIpa = freeIpaService.findByStack(stack);
+        serviceConfigs.add(new ClusterServiceConfig(FreeIpaDomainUtils.getFreeIpaFqdn(freeIpa.getDomain()),
+                endpoints,
+                List.of(),
+                clientCertificate,
+                NO_TLS_STRICT_CHECK,
+                new ClusterServiceHealthCheck(intervalInSec, healthStatusEndpoint, timeoutInSec, healthyStatusCode)
+        ));
+        return serviceConfigs;
     }
 
     private List<TunnelEntry> createTunnelEntries(Stack stack, List<GatewayConfig> gatewayConfigs) {
@@ -193,12 +250,10 @@ public class ClusterProxyService {
         return String.format("%s/proxy/%s/%s", clusterProxyConfiguration.getClusterProxyBasePath(), crn, FREEIPA_SERVICE_NAME);
     }
 
-    public String getProxyPath(Stack stack, String serviceName) {
-        if (ClusterProxyServiceAvailabilityChecker.isDnsBasedServiceNameAvailable(stack)) {
-            return String.format("%s/proxy/%s/%s", clusterProxyConfiguration.getClusterProxyBasePath(), stack.getResourceCrn(), serviceName);
-        } else {
-            return getProxyPath(stack.getResourceCrn());
-        }
+    public String getProxyPath(Stack stack, Optional<String> serviceName) {
+        FreeIpa freeIpa = freeIpaService.findByStack(stack);
+        String proxyServiceName = serviceName.orElse(FreeIpaDomainUtils.getFreeIpaFqdn(freeIpa.getDomain()));
+        return String.format("%s/proxy/%s/%s", clusterProxyConfiguration.getClusterProxyBasePath(), stack.getResourceCrn(), proxyServiceName);
     }
 
     private String vaultPath(String vaultSecretJsonString) {
@@ -227,6 +282,12 @@ public class ClusterProxyService {
             ipAddresss = gatewayConfig.getPrivateAddress();
         }
         return String.format("%s://%s:%d", NGINX_PROTOCOL, ipAddresss, stack.getGatewayport());
+    }
+
+    public void pollForGoodHealth(Stack stack) {
+        serviceEndpointHealthPollingService.pollWithTimeout(
+                serviceEndpointHealthListenerTask, new ServiceEndpointHealthPollerObject(stack.getResourceCrn(), clusterProxyRegistrationClient),
+                intervalInSec * MILLIS_PER_SEC, maxAttempts, maxFailure);
     }
 
 }

--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -225,7 +225,15 @@ cb:
 clusterProxy:
   url: http://localhost:10180/cluster-proxy
   enabled: true
+  readConfigPath: /rpc/readConfig
   registerConfigPath: /rpc/forceRegisterConfig
   updateConfigPath: /rpc/updateConfig
   removeConfigPath: /rpc/removeConfig
+  intervalInSec: 5
+  healthStatusEndpoint: /ipa/session/login_password
+  timeoutInSec: 5
+  # the login page returns a 400, update this after CDPAM-609 which will provide a better health check
+  healthyStatusCode: 400
+  maxAttempts: 3
+  maxFailure: 1
 


### PR DESCRIPTION
DEPENDS ON: https://github.com/hortonworks/cloudbreak-deployer/pull/657

Use cluster proxy HA for FreeIPA connections. Configure cluster proxy
to monitor the FreeIPA health using the login page. A better health
check is being developed, but the login will at least allow cluster
proxy to determine if FreeIPA is reachable.

Use a sticky session to maintain the connection to a specific FreeIPA
instance.

When provisioning, wait for the HA endpoint provide a good status
before continuing to provision.

This was tested manually, by stopping nginx on one node and performing
FreeIPA management service requests to FreeIPA. Then the first node
was brought back up and the same thing was done after bringing the
second node down.

Closes #CB-4377