### PR TITLE
DISTX-432 Fix Zookeeper issue during DE HA master node repair.

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-702.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-702.bp
@@ -7,6 +7,12 @@
       {
         "refName": "zookeeper",
         "serviceType": "ZOOKEEPER",
+        "serviceConfigs": [
+          {
+            "name": "zookeeper_datadir_autocreate",
+            "value": "true"
+          }
+        ],
         "roleConfigGroups": [
           {
             "refName": "zookeeper-SERVER-BASE",

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-710.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-710.bp
@@ -7,6 +7,12 @@
       {
         "refName": "zookeeper",
         "serviceType": "ZOOKEEPER",
+        "serviceConfigs": [
+          {
+            "name": "zookeeper_datadir_autocreate",
+            "value": "true"
+          }
+        ],
         "roleConfigGroups": [
           {
             "refName": "zookeeper-SERVER-BASE",

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-711.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-711.bp
@@ -7,6 +7,12 @@
       {
         "refName": "zookeeper",
         "serviceType": "ZOOKEEPER",
+        "serviceConfigs": [
+          {
+            "name": "zookeeper_datadir_autocreate",
+            "value": "true"
+          }
+        ],
         "roleConfigGroups": [
           {
             "refName": "zookeeper-SERVER-BASE",

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-720.bp
@@ -7,6 +7,12 @@
       {
         "refName": "zookeeper",
         "serviceType": "ZOOKEEPER",
+        "serviceConfigs": [
+          {
+            "name": "zookeeper_datadir_autocreate",
+            "value": "true"
+          }
+        ],
         "roleConfigGroups": [
           {
             "refName": "zookeeper-SERVER-BASE",


### PR DESCRIPTION
1. DE HA templates started supporting DH master node repair.
2. Zookeeper expects a new folder with -2 suffix, but it does not exist because the auto-create setting is false.
3. Tested this manually in a cluster.