### PR TITLE
CDPCP-2043. Remove groups that don't exist in control plane from IPA

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaChecks.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaChecks.java
@@ -1,0 +1,36 @@
+package com.sequenceiq.freeipa.client;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+public class FreeIpaChecks {
+    /* Users in this list should not be added/deleted. */
+    public static final List<String> IPA_PROTECTED_USERS = List.of("admin");
+
+    /* Groups in this list should not be added/deleted. */
+    public static final List<String> IPA_PROTECTED_GROUPS = List.of("admins", "editors", "ipausers", "trust admins");
+
+    /* Group membership in these groups should not be changed. */
+    public static final List<String> IPA_UNMANAGED_GROUPS = List.of("editors", "ipausers", "trust admins");
+
+    private FreeIpaChecks() {
+    }
+
+    public static void checkUserNotProtected(String user, Supplier<String> errorMessage) throws FreeIpaClientException {
+        if (IPA_PROTECTED_USERS.contains(user)) {
+            throw new FreeIpaClientException(errorMessage.get());
+        }
+    }
+
+    public static void checkGroupNotProtected(String group, Supplier<String> errorMessage) throws FreeIpaClientException {
+        if (IPA_PROTECTED_GROUPS.contains(group)) {
+            throw new FreeIpaClientException(errorMessage.get());
+        }
+    }
+
+    public static void checkGroupNotUnmanaged(String group, Supplier<String> errorMessage) throws FreeIpaClientException {
+        if (IPA_UNMANAGED_GROUPS.contains(group)) {
+            throw new FreeIpaClientException(errorMessage.get());
+        }
+    }
+}

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
@@ -159,6 +159,7 @@ public class FreeIpaClient {
     }
 
     public User deleteUser(String userUid) throws FreeIpaClientException {
+        FreeIpaChecks.checkUserNotProtected(userUid, () -> String.format("User '%s' is protected and cannot be deleted from FreeIPA", userUid));
         List<Object> flags = List.of(userUid);
         Map<String, Object> params = Map.of();
         return (User) invoke("user_del", flags, params, User.class).getResult();
@@ -171,6 +172,7 @@ public class FreeIpaClient {
     }
 
     public User userAdd(String user, String firstName, String lastName) throws FreeIpaClientException {
+        FreeIpaChecks.checkUserNotProtected(user, () -> String.format("User '%s' is protected and cannot be added to FreeIPA", user));
         List<Object> flags = List.of(user);
         Map<String, Object> params = Map.of(
                 "givenname", firstName,
@@ -237,12 +239,14 @@ public class FreeIpaClient {
     }
 
     public Group groupAdd(String group) throws FreeIpaClientException {
+        FreeIpaChecks.checkGroupNotProtected(group, () -> String.format("Group '%s' is protected and cannot be added to FreeIPA", group));
         List<Object> flags = List.of(group);
         Map<String, Object> params = Map.of();
         return (Group) invoke("group_add", flags, params, Group.class).getResult();
     }
 
     public void deleteGroup(String group) throws FreeIpaClientException {
+        FreeIpaChecks.checkGroupNotProtected(group, () -> String.format("Group '%s' is protected and cannot be deleted from FreeIPA", group));
         List<Object> flags = List.of(group);
         Map<String, Object> params = Map.of();
         invoke("group_del", flags, params, Object.class);
@@ -285,6 +289,7 @@ public class FreeIpaClient {
     //}
     // TODO the response to this API call not currently deserializable
     public RPCResponse<Object> groupAddMembers(String group, Collection<String> users) throws FreeIpaClientException {
+        FreeIpaChecks.checkGroupNotUnmanaged(group, () -> String.format("Group '%s' is not managed and membership cannot be changed", group));
         List<Object> flags = List.of(group);
         Map<String, Object> params = Map.of(
                 "user", users
@@ -293,6 +298,7 @@ public class FreeIpaClient {
     }
 
     public RPCResponse<Object> groupRemoveMembers(String group, Collection<String> users) throws FreeIpaClientException {
+        FreeIpaChecks.checkGroupNotUnmanaged(group, () -> String.format("Group '%s' is not managed and membership cannot be changed", group));
         List<Object> flags = List.of(group);
         Map<String, Object> params = Map.of(
                 "user", users

--- a/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/FreeIpaChecksTest.java
+++ b/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/FreeIpaChecksTest.java
@@ -1,0 +1,60 @@
+package com.sequenceiq.freeipa.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class FreeIpaChecksTest {
+
+    @Test
+    void checkUserNotProtectedPasses() throws FreeIpaClientException {
+        String errMessage = "user protected";
+        FreeIpaChecks.checkUserNotProtected("clark", () -> errMessage);
+    }
+
+    @Test
+    void checkUserNotProtectedThrows() {
+        String errMessage = "user protected";
+        for (String user : FreeIpaChecks.IPA_PROTECTED_USERS) {
+            Exception e = assertThrows(FreeIpaClientException.class, () ->
+                FreeIpaChecks.checkUserNotProtected(user, () -> errMessage)
+            );
+            assertEquals(errMessage, e.getMessage());
+        }
+    }
+
+    @Test
+    void checkGroupNotProtectedPasses() throws FreeIpaClientException {
+        String errMessage = "group protected";
+        FreeIpaChecks.checkGroupNotProtected("superheroes", () -> errMessage);
+    }
+
+    @Test
+    void checkGroupNotProtectedThrows() {
+        String errMessage = "group protected";
+        for (String group : FreeIpaChecks.IPA_PROTECTED_GROUPS) {
+            Exception e = assertThrows(FreeIpaClientException.class, () ->
+                FreeIpaChecks.checkGroupNotProtected(group, () -> errMessage)
+            );
+            assertEquals(errMessage, e.getMessage());
+        }
+    }
+
+    @Test
+    void checkGroupNotUnmanagedPasses() throws FreeIpaClientException {
+        String errMessage = "group unmanaged";
+        FreeIpaChecks.checkGroupNotUnmanaged("superheroes", () -> errMessage);
+    }
+
+    @Test
+    void checkGroupNotUnmanagedThrows() {
+        String errMessage =  "group unmanaged";
+        for (String group : FreeIpaChecks.IPA_UNMANAGED_GROUPS) {
+            Exception e = assertThrows(FreeIpaClientException.class, () ->
+                FreeIpaChecks.checkGroupNotUnmanaged(group, () -> errMessage)
+            );
+            assertEquals(errMessage, e.getMessage());
+        }
+    }
+}

--- a/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/FreeIpaClientTest.java
+++ b/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/FreeIpaClientTest.java
@@ -1,0 +1,68 @@
+package com.sequenceiq.freeipa.client;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.googlecode.jsonrpc4j.JsonRpcHttpClient;
+
+class FreeIpaClientTest {
+
+    private FreeIpaClient underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new FreeIpaClient(
+                mock(JsonRpcHttpClient.class),
+                "apiVersion",
+                "apiAddress",
+                "hostname"
+        );
+    }
+
+    @Test
+    void deleteUserThrowsOnProtectedUser() {
+        assertThrows(FreeIpaClientException.class, () ->
+            underTest.deleteUser(FreeIpaChecks.IPA_PROTECTED_USERS.get(0))
+        );
+    }
+
+    @Test
+    void addUserThrowsOnProtectedUser() {
+        assertThrows(FreeIpaClientException.class, () ->
+                underTest.userAdd(FreeIpaChecks.IPA_PROTECTED_USERS.get(0), "first", "last")
+        );
+    }
+
+    @Test
+    void groupAddThrowsOnProtectedGroup() {
+        assertThrows(FreeIpaClientException.class, () ->
+                underTest.groupAdd(FreeIpaChecks.IPA_PROTECTED_GROUPS.get(0))
+        );
+    }
+
+    @Test
+    void deleteGroupThrowsOnProtectedGroup() {
+        assertThrows(FreeIpaClientException.class, () ->
+                underTest.deleteGroup(FreeIpaChecks.IPA_PROTECTED_GROUPS.get(0))
+        );
+    }
+
+    @Test
+    void groupAddMembersThrowsOnUnmanagedGroup() {
+        assertThrows(FreeIpaClientException.class, () ->
+                underTest.groupAddMembers(FreeIpaChecks.IPA_UNMANAGED_GROUPS.get(0), List.of("harry", "sally"))
+        );
+    }
+
+    @Test
+    void groupRemoveMembersThrowsOnUnmanagedGroup() {
+        assertThrows(FreeIpaClientException.class, () ->
+                underTest.groupAddMembers(FreeIpaChecks.IPA_UNMANAGED_GROUPS.get(0), List.of("harry", "sally"))
+        );
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncConstants.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncConstants.java
@@ -1,10 +1,12 @@
 package com.sequenceiq.freeipa.service.freeipa.user;
 
-public final class UserServiceConstants {
+public final class UserSyncConstants {
+
+    public static final String ADMINS_GROUP = "admins";
 
     public static final String CDP_USERSYNC_INTERNAL_GROUP = "cdp-usersync-internal";
 
-    private UserServiceConstants() {
+    private UserSyncConstants() {
 
         // private access
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/FmsGroup.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/FmsGroup.java
@@ -6,8 +6,9 @@ public class FmsGroup {
 
     private String name;
 
-    public void setName(String name) {
+    public FmsGroup withName(String name) {
         this.name = name;
+        return this;
     }
 
     public String getName() {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/FmsUser.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/FmsUser.java
@@ -14,24 +14,27 @@ public class FmsUser {
         return name;
     }
 
-    public void setName(String name) {
+    public FmsUser withName(String name) {
         this.name = name;
+        return this;
     }
 
     public String getFirstName() {
         return firstName;
     }
 
-    public void setFirstName(String firstName) {
+    public FmsUser withFirstName(String firstName) {
         this.firstName = firstName;
+        return this;
     }
 
     public String getLastName() {
         return lastName;
     }
 
-    public void setLastName(String lastName) {
+    public FmsUser withLastName(String lastName) {
         this.lastName = lastName;
+        return this;
     }
 
     @Override

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UmsUsersState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UmsUsersState.java
@@ -2,6 +2,7 @@ package com.sequenceiq.freeipa.service.freeipa.user.model;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -18,10 +19,14 @@ public class UmsUsersState {
 
     private final ImmutableSet<FmsUser> requestedWorkloadUsers;
 
-    public UmsUsersState(UsersState usersState, Map<String, WorkloadCredential> usersWorkloadCredentialMap, Set<FmsUser> requestedWorkloadUsers) {
+    private final ImmutableSet<FmsGroup> workloadAdministrationGroups;
+
+    private UmsUsersState(UsersState usersState, Map<String, WorkloadCredential> usersWorkloadCredentialMap, Set<FmsUser> requestedWorkloadUsers,
+            Collection<FmsGroup> workloadAdministrationGroups) {
         this.usersState = requireNonNull(usersState, "UsersState is null");
         this.usersWorkloadCredentialMap = ImmutableMap.copyOf(requireNonNull(usersWorkloadCredentialMap, "workload credential map is null"));
         this.requestedWorkloadUsers = ImmutableSet.copyOf(requireNonNull(requestedWorkloadUsers, "requested workload users is null"));
+        this.workloadAdministrationGroups = ImmutableSet.copyOf(requireNonNull(workloadAdministrationGroups, "workloadAdministrationGroups is null"));
     }
 
     public UsersState getUsersState() {
@@ -36,12 +41,18 @@ public class UmsUsersState {
         return requestedWorkloadUsers;
     }
 
+    public ImmutableSet<FmsGroup> getWorkloadAdministrationGroups() {
+        return workloadAdministrationGroups;
+    }
+
     public static class Builder {
         private UsersState usersState;
 
         private Map<String, WorkloadCredential> workloadCredentialMap = new HashMap<>();
 
         private Set<FmsUser> requestedWorkloadUsers = new HashSet<>();
+
+        private Collection<FmsGroup> workloadAdministrationGroups = Set.of();
 
         public Builder setUsersState(UsersState usersState) {
             this.usersState = usersState;
@@ -58,8 +69,13 @@ public class UmsUsersState {
             return this;
         }
 
+        public Builder setWorkloadAdministrationGroups(Collection<FmsGroup> workloadAdministrationGroups) {
+            this.workloadAdministrationGroups = workloadAdministrationGroups;
+            return this;
+        }
+
         public UmsUsersState build() {
-            return new UmsUsersState(usersState, workloadCredentialMap, requestedWorkloadUsers);
+            return new UmsUsersState(usersState, workloadCredentialMap, requestedWorkloadUsers, workloadAdministrationGroups);
         }
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/FreeIpaUsersStateProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/FreeIpaUsersStateProviderTest.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.freeipa.service.freeipa.user;
 
+import static com.sequenceiq.freeipa.client.FreeIpaChecks.IPA_PROTECTED_USERS;
+import static com.sequenceiq.freeipa.client.FreeIpaChecks.IPA_UNMANAGED_GROUPS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
@@ -42,12 +44,12 @@ class FreeIpaUsersStateProviderTest {
     @Test
     void testGetUserState() throws Exception {
         List<String> user1GroupNames = List.of("group1", "group2");
-        List<String> user2GroupNames = List.of("group2", "group3", FreeIpaUsersStateProvider.IPA_ONLY_GROUPS.get(0));
+        List<String> user2GroupNames = List.of("group2", "group3", IPA_UNMANAGED_GROUPS.get(0));
         List<String> ipaOnlyUserGroupNames = List.of("dont_include");
         Map<String, List<String>> users = Map.of(
                 "user1", user1GroupNames,
                 "user2", user2GroupNames,
-                FreeIpaUsersStateProvider.IPA_ONLY_USERS.get(0), ipaOnlyUserGroupNames
+                IPA_PROTECTED_USERS.get(0), ipaOnlyUserGroupNames
         );
 
         Set<com.sequenceiq.freeipa.client.model.User> usersFindAll = users.entrySet().stream()
@@ -55,7 +57,7 @@ class FreeIpaUsersStateProviderTest {
                 .collect(Collectors.toSet());
 
         Set<com.sequenceiq.freeipa.client.model.Group> groupsFindAll = Stream.of(user1GroupNames.stream(),
-                user2GroupNames.stream(), FreeIpaUsersStateProvider.IPA_ONLY_GROUPS.stream())
+                user2GroupNames.stream(), IPA_UNMANAGED_GROUPS.stream())
                 .flatMap(groupName -> groupName)
                 .map(this::createIpaGroup)
                 .collect(Collectors.toSet());
@@ -66,12 +68,12 @@ class FreeIpaUsersStateProviderTest {
         UsersState ipaState = underTest.getUsersState(freeIpaClient);
 
         Set<String> expectedUsers = users.keySet().stream()
-                .filter(user -> !FreeIpaUsersStateProvider.IPA_ONLY_USERS.contains(user))
+                .filter(user -> !IPA_PROTECTED_USERS.contains(user))
                 .collect(Collectors.toSet());
 
         Set<String> expectedGroups = expectedUsers.stream()
                 .flatMap(user -> users.get(user).stream())
-                .filter(group -> !FreeIpaUsersStateProvider.IPA_ONLY_GROUPS.contains(group))
+                .filter(group -> !IPA_UNMANAGED_GROUPS.contains(group))
                 .collect(Collectors.toSet());
 
         for (FmsUser fmsUser : ipaState.getUsers()) {
@@ -92,7 +94,7 @@ class FreeIpaUsersStateProviderTest {
         String username = "userNull";
         Set<com.sequenceiq.freeipa.client.model.User> usersFindAll = Set.of(createIpaUser(username, null));
 
-        Set<com.sequenceiq.freeipa.client.model.Group> groupsFindAll = FreeIpaUsersStateProvider.IPA_ONLY_GROUPS.stream()
+        Set<com.sequenceiq.freeipa.client.model.Group> groupsFindAll = IPA_UNMANAGED_GROUPS.stream()
                 .map(this::createIpaGroup)
                 .collect(Collectors.toSet());
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/model/UsersStateDifferenceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/model/UsersStateDifferenceTest.java
@@ -1,0 +1,224 @@
+package com.sequenceiq.freeipa.service.freeipa.user.model;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.sequenceiq.freeipa.client.FreeIpaChecks;
+import com.sequenceiq.freeipa.service.freeipa.user.UserSyncConstants;
+
+class UsersStateDifferenceTest {
+
+    @Test
+    void testCalculateUsersToAdd() {
+        FmsUser userUms = new FmsUser().withName("userUms");
+        FmsUser userProtected = new FmsUser().withName(FreeIpaChecks.IPA_PROTECTED_USERS.get(0));
+        FmsUser userBoth = new FmsUser().withName("userBoth");
+        FmsUser userIPA = new FmsUser().withName("userIPA");
+
+        UmsUsersState umsUsersState = new UmsUsersState.Builder()
+                .setUsersState(new UsersState.Builder()
+                        .addUser(userUms)
+                        .addUser(userProtected)
+                        .addUser(userBoth)
+                        .build())
+                .build();
+
+        UsersState ipaUsersState = new UsersState.Builder()
+                .addUser(userBoth)
+                .addUser(userIPA)
+                .build();
+
+        ImmutableSet<FmsUser> usersToAdd = UsersStateDifference.calculateUsersToAdd(umsUsersState, ipaUsersState);
+
+        // the user that exists only in the UMS will be added
+        assertTrue(usersToAdd.contains(userUms));
+        // protected users will be ignored
+        assertFalse(usersToAdd.contains(userProtected));
+        // users that exist in both or only in ipa will not be added
+        assertFalse(usersToAdd.contains(userBoth));
+        assertFalse(usersToAdd.contains(userIPA));
+    }
+
+    @Test
+    void testCalculateUsersToRemove() {
+        FmsUser userUms = new FmsUser().withName("userUms");
+        FmsUser userBoth = new FmsUser().withName("userBoth");
+        FmsUser userIPA = new FmsUser().withName("userIPA");
+        FmsUser userIPA2 = new FmsUser().withName("userIPA2");
+        FmsUser userProtected = new FmsUser().withName(FreeIpaChecks.IPA_PROTECTED_USERS.get(0));
+
+        UmsUsersState umsUsersState = new UmsUsersState.Builder()
+                .setUsersState(new UsersState.Builder()
+                        .addUser(userUms)
+                        .addMemberToGroup(UserSyncConstants.CDP_USERSYNC_INTERNAL_GROUP, userUms.getName())
+                        .addUser(userBoth)
+                        .addMemberToGroup(UserSyncConstants.CDP_USERSYNC_INTERNAL_GROUP, userBoth.getName())
+                        .build())
+                .build();
+
+        UsersState ipaUsersState = new UsersState.Builder()
+                .addUser(userBoth)
+                .addMemberToGroup(UserSyncConstants.CDP_USERSYNC_INTERNAL_GROUP, userBoth.getName())
+                .addUser(userIPA)
+                .addMemberToGroup(UserSyncConstants.CDP_USERSYNC_INTERNAL_GROUP, userIPA.getName())
+                .addUser(userIPA2)
+                .addUser(userProtected)
+                .addMemberToGroup(UserSyncConstants.CDP_USERSYNC_INTERNAL_GROUP, userProtected.getName())
+                .build();
+
+        ImmutableSet<String> usersToRemove = UsersStateDifference.calculateUsersToRemove(umsUsersState, ipaUsersState);
+
+        // the users that exists only in IPA that are members of the CDP_USERSYNC_INTERNAL_GROUP will be removed
+        assertTrue(usersToRemove.contains(userIPA.getName()));
+        // protected users will be ignored
+        assertFalse(usersToRemove.contains(userProtected.getName()));
+        // users that exist only in ums, exist in both ums and ipa, or are not members of CDP_USERSYNC_INTERNAL_GROUP will not be removed
+        assertFalse(usersToRemove.contains(userUms.getName()));
+        assertFalse(usersToRemove.contains(userBoth.getName()));
+        assertFalse(usersToRemove.contains(userIPA2.getName()));
+    }
+
+    @Test
+    void testCalculateGroupsToAdd() {
+        FmsGroup groupUms = new FmsGroup().withName("groupUms");
+        FmsGroup groupWag = new FmsGroup().withName("groupWag");
+        FmsGroup groupBoth = new FmsGroup().withName("groupBoth");
+        FmsGroup groupIPA = new FmsGroup().withName("groupIPA");
+        FmsGroup groupProtected = new FmsGroup().withName(FreeIpaChecks.IPA_PROTECTED_GROUPS.get(0));
+
+        UmsUsersState umsUsersState = new UmsUsersState.Builder()
+                .setUsersState(new UsersState.Builder()
+                        .addGroup(groupUms)
+                        .addGroup(groupBoth)
+                        .addGroup(groupProtected)
+                        .build())
+                .setWorkloadAdministrationGroups(Set.of(groupWag))
+                .build();
+
+        UsersState ipaUsersState = new UsersState.Builder()
+                .addGroup(groupBoth)
+                .addGroup(groupIPA)
+                .build();
+
+        ImmutableSet<FmsGroup> groupsToAdd = UsersStateDifference.calculateGroupsToAdd(umsUsersState, ipaUsersState);
+
+        // group that exists only in UMS will be added
+        assertTrue(groupsToAdd.contains(groupUms));
+        // protected groups will be ignored
+        assertFalse(groupsToAdd.contains(groupProtected));
+        // extra wags will not be added
+        assertFalse(groupsToAdd.contains(groupWag));
+        // groups that exist in both or only ipa will not be added
+        assertFalse(groupsToAdd.contains(groupBoth));
+        assertFalse(groupsToAdd.contains(groupIPA));
+    }
+
+    @Test
+    void testCalculateGroupsToRemove() {
+        FmsGroup groupUms = new FmsGroup().withName("groupUms");
+        FmsGroup groupWag = new FmsGroup().withName("groupWag");
+        FmsGroup groupBoth = new FmsGroup().withName("groupBoth");
+        FmsGroup groupIPA = new FmsGroup().withName("groupIPA");
+        FmsGroup groupProtected = new FmsGroup().withName(FreeIpaChecks.IPA_PROTECTED_GROUPS.get(0));
+
+        UmsUsersState umsUsersState = new UmsUsersState.Builder()
+                .setUsersState(new UsersState.Builder()
+                        .addGroup(groupUms)
+                        .addGroup(groupBoth)
+                        .build())
+                .setWorkloadAdministrationGroups(Set.of(groupWag))
+                .build();
+
+        UsersState ipaUsersState = new UsersState.Builder()
+                .addGroup(groupBoth)
+                .addGroup(groupIPA)
+                .addGroup(groupWag)
+                .addGroup(groupProtected)
+                .build();
+
+        ImmutableSet<FmsGroup> groupsToRemove = UsersStateDifference.calculateGroupsToRemove(umsUsersState, ipaUsersState);
+
+        // group that exists only in IPA will be removed
+        assertTrue(groupsToRemove.contains(groupIPA));
+        // group that exists in IPA will not be removed if the wag still exists in control plane
+        // even if the group is not calculated to be synced
+        assertFalse(groupsToRemove.contains(groupWag));
+        // protected groups will not be removed
+        assertFalse(groupsToRemove.contains(groupProtected));
+        // groups that exist in both or only ums will not be removed
+        assertFalse(groupsToRemove.contains(groupBoth));
+        assertFalse(groupsToRemove.contains(groupUms));
+    }
+
+    @Test
+    void testCalculateGroupMembershipsToAdd() {
+        String group = "group";
+        String unmanagedGroup = FreeIpaChecks.IPA_UNMANAGED_GROUPS.get(0);
+
+        String userUms = "userUms";
+        String userBoth = "userBoth";
+        String userIPA = "userIPA";
+
+        UmsUsersState umsUsersState = new UmsUsersState.Builder()
+                .setUsersState(new UsersState.Builder()
+                        .addMemberToGroup(group, userUms)
+                        .addMemberToGroup(group, userBoth)
+                        .addMemberToGroup(unmanagedGroup, userUms)
+                        .build())
+                .build();
+
+        UsersState ipaUsersState = new UsersState.Builder()
+                .addMemberToGroup(group, userBoth)
+                .addMemberToGroup(group, userIPA)
+                .build();
+
+        ImmutableMultimap<String, String> groupMembershipsToAdd = UsersStateDifference.calculateGroupMembershipToAdd(umsUsersState, ipaUsersState);
+
+        // group that exists only in UMS will be added
+        assertTrue(groupMembershipsToAdd.get(group).contains(userUms));
+        // unmanaged groups will be ignored
+        assertFalse(groupMembershipsToAdd.get(unmanagedGroup).contains(userUms));
+        // groups that exist in both or only ipa will not be added
+        assertFalse(groupMembershipsToAdd.get(group).contains(userBoth));
+        assertFalse(groupMembershipsToAdd.get(group).contains(userIPA));
+    }
+
+    @Test
+    void testCalculateGroupMembershipsToRemove() {
+        String group = "group";
+        String unmanagedGroup = FreeIpaChecks.IPA_UNMANAGED_GROUPS.get(0);
+
+        String userUms = "userUms";
+        String userBoth = "userBoth";
+        String userIPA = "userIPA";
+
+        UmsUsersState umsUsersState = new UmsUsersState.Builder()
+                .setUsersState(new UsersState.Builder()
+                        .addMemberToGroup(group, userUms)
+                        .addMemberToGroup(group, userBoth)
+                        .build())
+                .build();
+
+        UsersState ipaUsersState = new UsersState.Builder()
+                .addMemberToGroup(group, userBoth)
+                .addMemberToGroup(group, userIPA)
+                .addMemberToGroup(unmanagedGroup, userUms)
+                .build();
+
+        ImmutableMultimap<String, String> groupMembershipsToRemove = UsersStateDifference.calculateGroupMembershipToRemove(umsUsersState, ipaUsersState);
+
+        // group that exists only in IPA will be removed
+        assertTrue(groupMembershipsToRemove.get(group).contains(userIPA));
+        // unmanaged groups will be ignored
+        assertFalse(groupMembershipsToRemove.get(unmanagedGroup).contains(userUms));
+        // groups that exist in both or only ums will not be added
+        assertFalse(groupMembershipsToRemove.get(group).contains(userBoth));
+        assertFalse(groupMembershipsToRemove.get(group).contains(userUms));
+    }
+}


### PR DESCRIPTION
Groups that do not exist in the control plane at all can be safely removed
from IPA. The UmsUsersState has modified to include all WAGs so we can make
this determination.

Some protections were added to the FreeIPA client to prevent adding/removing
certain users that user sync should not touch. e.g., this prevents accidentally
removing the admin user or the admins group.

Added unit tests for new behavior
Tested manually by adding a group and running user sync
