### PR TITLE
CB-6879: Redundant full backup created on Azure FreeIPA HA hosts

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/backups.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/backups.sls
@@ -15,6 +15,11 @@
     - mode: 640
 
 {% if salt['pillar.get']('freeipa:backup:monthly_full_enabled') %}
+freeipa_backoff_monthly_full:
+  cmd.run:
+    - name: /sbin/anacron -u cron.monthly
+    - onlyif: test ! -s /var/spool/anacron/cron.monthly
+
 /etc/cron.monthly/freeipa_backup_monthly:
   file.managed:
     - source: salt://freeipa/templates/freeipa_backup_monthly.j2


### PR DESCRIPTION
This prevents the monthly backup from running, when enabled, until the next month after the initial install.  This is the first step to fixing CB-6717 across multiple FreeIPA HA nodes.

Closes #CB-6879
