### PR TITLE
CB-6948: Force disable DNSSEC for Azure environments.

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaConfigView.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaConfigView.java
@@ -35,11 +35,14 @@ public class FreeIpaConfigView {
 
     private final FreeIpaBackupConfigView backup;
 
+    private final boolean dnssecValidationEnabled;
+
     @SuppressWarnings("ExecutableStatementCount")
     private FreeIpaConfigView(Builder builder) {
         this.realm = builder.realm;
         this.domain = builder.domain;
         this.password = builder.password;
+        this.dnssecValidationEnabled = builder.dnssecValidationEnabled;
         this.reverseZones = builder.reverseZones;
         this.adminUser = builder.adminUser;
         this.freeipaToReplicate = builder.freeipaToReplicate;
@@ -57,6 +60,10 @@ public class FreeIpaConfigView {
 
     public String getPassword() {
         return password;
+    }
+
+    public boolean isDnssecValidationEnabled() {
+        return dnssecValidationEnabled;
     }
 
     public String getReverseZones() {
@@ -85,6 +92,7 @@ public class FreeIpaConfigView {
         map.put("realm", ObjectUtils.defaultIfNull(this.realm, EMPTY_CONFIG_DEFAULT));
         map.put("domain", ObjectUtils.defaultIfNull(this.domain, EMPTY_CONFIG_DEFAULT));
         map.put("password", ObjectUtils.defaultIfNull(this.password, EMPTY_CONFIG_DEFAULT));
+        map.put("dnssecValidationEnabled", this.dnssecValidationEnabled);
         map.put("reverseZones", ObjectUtils.defaultIfNull(this.reverseZones, EMPTY_CONFIG_DEFAULT));
         map.put("admin_user", ObjectUtils.defaultIfNull(this.adminUser, EMPTY_CONFIG_DEFAULT));
         map.put("freeipa_to_replicate", ObjectUtils.defaultIfNull(this.freeipaToReplicate, EMPTY_CONFIG_DEFAULT));
@@ -113,6 +121,8 @@ public class FreeIpaConfigView {
 
         private Set<Object> hosts;
 
+        private boolean dnssecValidationEnabled;
+
         private FreeIpaBackupConfigView backup;
 
         public FreeIpaConfigView build() {
@@ -131,6 +141,11 @@ public class FreeIpaConfigView {
 
         public Builder withPassword(String password) {
             this.password = password;
+            return this;
+        }
+
+        public Builder withDnssecValidationEnabled(boolean dnssecEnabled) {
+            this.dnssecValidationEnabled = dnssecEnabled;
             return this;
         }
 

--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -56,6 +56,9 @@ freeipa:
   platform.default.instanceType:
     AWS: m5.large
     AZURE: Standard_D3_v2
+  platform.dnssec.validation:
+    AWS: true
+    AZURE: false
   environment:
     url: http://localhost:8088
     contextPath: /environmentservice
@@ -88,6 +91,7 @@ freeipa:
     threadpool:
       core.size: 100
       capacity.size: 4000
+
 
 info:
   app:

--- a/freeipa/src/main/resources/freeipa-salt/pillar/freeipa/init.sls
+++ b/freeipa/src/main/resources/freeipa-salt/pillar/freeipa/init.sls
@@ -1,6 +1,7 @@
 freeipa:
   domain: testdomain
   password: pwpwpw
+  dnssecValidationEnabled: true
   realm: testrealm
   admin_user: admin
   freeipa_to_replicate:

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_install.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_install.sh
@@ -21,6 +21,9 @@ ipa-server-install \
           --mkhomedir \
           --ip-address $IPADDR \
           --auto-forwarders \
+{%- if not salt['pillar.get']('freeipa:dnssecValidationEnabled') %}
+          --no-dnssec-validation \
+{%- endif %}
           --unattended
 
 set +e

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_replica_install.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_replica_install.sh
@@ -20,6 +20,9 @@ ipa-replica-install \
           --mkhomedir \
           --ip-address $IPADDR \
           --auto-forwarders \
+{%- if not salt['pillar.get']('freeipa:dnssecValidationEnabled') %}
+          --no-dnssec-validation \
+{%- endif %}
           --unattended
 
 set +e

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaConfigServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaConfigServiceTest.java
@@ -5,16 +5,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.Map;
-import java.util.Set;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
-
 import com.google.common.collect.ImmutableSet;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
@@ -30,6 +20,15 @@ import com.sequenceiq.freeipa.service.freeipa.FreeIpaService;
 import com.sequenceiq.freeipa.service.freeipa.backup.cloud.S3BackupConfigGenerator;
 import com.sequenceiq.freeipa.service.freeipa.dns.ReverseDnsZoneCalculator;
 import com.sequenceiq.freeipa.service.stack.NetworkService;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.core.env.Environment;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FreeIpaConfigServiceTest {
@@ -69,6 +68,9 @@ public class FreeIpaConfigServiceTest {
     @Mock
     private FreeIpaClientFactory freeIpaClientFactory;
 
+    @Mock
+    private Environment environment;
+
     @InjectMocks
     private FreeIpaConfigService freeIpaConfigService;
 
@@ -89,6 +91,7 @@ public class FreeIpaConfigServiceTest {
         when(freeIpaClientFactory.getAdminUser()).thenReturn(ADMIN);
         when(networkService.getFilteredSubnetWithCidr(any())).thenReturn(SUBNET_WITH_CIDR);
         when(reverseDnsZoneCalculator.reverseDnsZoneForCidrs(any())).thenReturn(REVERSE_ZONE);
+        when(environment.getProperty("freeipa.platform.dnssec.validation.AWS", "true")).thenReturn("true");
         GatewayConfig gatewayConfig = mock(GatewayConfig.class);
         when(gatewayConfig.getHostname()).thenReturn(HOSTNAME);
         when(gatewayConfigService.getPrimaryGatewayConfig(any())).thenReturn(gatewayConfig);


### PR DESCRIPTION
This forces the dnssec.validation of the FreeIPA DNS server to be
disabled for Azure deployments. It allows for the config to set the
DNSSEC validation based on the Cloud Platform deployment that the stack
is being deployed to.

This uses the freeipa.platform.dnssec.validation.<PLATFORM> config property
to set this on a per Cloud Platform basis.

Closes #CB-6948