### PR TITLE
CB-5908 - Fix datamart instance types on Azure

### DIFF
--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -180,7 +180,7 @@ cb:
         Standard_D16_v3,
         Standard_D32_v3,
         Standard_E8_v3,
-        Standard_E16_v3
+        Standard_E16_v3,
         Standard_E32_v3,
         Standard_F8s_v2,
         Standard_F16s_v2,

--- a/core/src/main/resources/defaults/clustertemplates/azure/azure-datamart-702.json
+++ b/core/src/main/resources/defaults/clustertemplates/azure/azure-datamart-702.json
@@ -25,7 +25,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
+          "instanceType": "Standard_E8_v3",
           "rootVolume": {
             "size": 50
           }
@@ -51,7 +51,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
+          "instanceType": "Standard_E16_v3",
           "rootVolume": {
             "size": 50
           }
@@ -77,7 +77,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
+          "instanceType": "Standard_E16_v3",
           "rootVolume": {
             "size": 50
           }

--- a/core/src/main/resources/defaults/clustertemplates/azure/azure-datamart-720.json
+++ b/core/src/main/resources/defaults/clustertemplates/azure/azure-datamart-720.json
@@ -25,7 +25,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
+          "instanceType": "Standard_E8_v3",
           "rootVolume": {
             "size": 50
           }
@@ -51,7 +51,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
+          "instanceType": "Standard_E16_v3",
           "rootVolume": {
             "size": 50
           }
@@ -77,7 +77,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
+          "instanceType": "Standard_E16_v3",
           "rootVolume": {
             "size": 50
           }


### PR DESCRIPTION
Fix instance types in datamart template on Azure:

Master:  D16_v3 -> E8_v3
Impala coordinator and executors:  D8_v3 -> E16_v3

Use less expensive instance type for master (but same memory size)
Increase size of coordinator and executor instances to match sizes used by Datamart on AWS and DWX