### PR TITLE
CDPCP-808 Sync SSH keys to IPA

### DIFF
--- a/auth-connector/src/generated/main/grpc/com/cloudera/thunderhead/service/usermanagement/UserManagementGrpc.java
+++ b/auth-connector/src/generated/main/grpc/com/cloudera/thunderhead/service/usermanagement/UserManagementGrpc.java
@@ -513,6 +513,43 @@ public final class UserManagementGrpc {
      return getFindUsersByEmailMethod;
   }
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getFindUsersMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersResponse> METHOD_FIND_USERS = getFindUsersMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersResponse> getFindUsersMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersResponse> getFindUsersMethod() {
+    return getFindUsersMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersResponse> getFindUsersMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersResponse> getFindUsersMethod;
+    if ((getFindUsersMethod = UserManagementGrpc.getFindUsersMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getFindUsersMethod = UserManagementGrpc.getFindUsersMethod) == null) {
+          UserManagementGrpc.getFindUsersMethod = getFindUsersMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "usermanagement.UserManagement", "FindUsers"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("FindUsers"))
+                  .build();
+          }
+        }
+     }
+     return getFindUsersMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getCreateAccessKeyMethod()} instead. 
   public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateAccessKeyRequest,
       com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateAccessKeyResponse> METHOD_CREATE_ACCESS_KEY = getCreateAccessKeyMethodHelper();
@@ -3414,12 +3451,22 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
-     * Find users.
+     * Find users by Email.
      * </pre>
      */
     public void findUsersByEmail(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersByEmailRequest request,
         io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersByEmailResponse> responseObserver) {
       asyncUnimplementedUnaryCall(getFindUsersByEmailMethodHelper(), responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Find users.
+     * </pre>
+     */
+    public void findUsers(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getFindUsersMethodHelper(), responseObserver);
     }
 
     /**
@@ -4282,6 +4329,13 @@ public final class UserManagementGrpc {
                 com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersByEmailResponse>(
                   this, METHODID_FIND_USERS_BY_EMAIL)))
           .addMethod(
+            getFindUsersMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersResponse>(
+                  this, METHODID_FIND_USERS)))
+          .addMethod(
             getCreateAccessKeyMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
@@ -4969,13 +5023,24 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
-     * Find users.
+     * Find users by Email.
      * </pre>
      */
     public void findUsersByEmail(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersByEmailRequest request,
         io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersByEmailResponse> responseObserver) {
       asyncUnaryCall(
           getChannel().newCall(getFindUsersByEmailMethodHelper(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Find users.
+     * </pre>
+     */
+    public void findUsers(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getFindUsersMethodHelper(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -5973,12 +6038,22 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
-     * Find users.
+     * Find users by Email.
      * </pre>
      */
     public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersByEmailResponse findUsersByEmail(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersByEmailRequest request) {
       return blockingUnaryCall(
           getChannel(), getFindUsersByEmailMethodHelper(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * Find users.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersResponse findUsers(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getFindUsersMethodHelper(), getCallOptions(), request);
     }
 
     /**
@@ -6914,13 +6989,24 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
-     * Find users.
+     * Find users by Email.
      * </pre>
      */
     public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersByEmailResponse> findUsersByEmail(
         com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersByEmailRequest request) {
       return futureUnaryCall(
           getChannel().newCall(getFindUsersByEmailMethodHelper(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
+     * Find users.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersResponse> findUsers(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getFindUsersMethodHelper(), getCallOptions()), request);
     }
 
     /**
@@ -7777,80 +7863,81 @@ public final class UserManagementGrpc {
   private static final int METHODID_GET_USER = 10;
   private static final int METHODID_LIST_USERS = 11;
   private static final int METHODID_FIND_USERS_BY_EMAIL = 12;
-  private static final int METHODID_CREATE_ACCESS_KEY = 13;
-  private static final int METHODID_UPDATE_ACCESS_KEY = 14;
-  private static final int METHODID_DELETE_ACCESS_KEY = 15;
-  private static final int METHODID_GET_ACCESS_KEY = 16;
-  private static final int METHODID_LIST_ACCESS_KEYS = 17;
-  private static final int METHODID_GET_VERSION = 18;
-  private static final int METHODID_GET_ACCOUNT = 19;
-  private static final int METHODID_LIST_ACCOUNTS = 20;
-  private static final int METHODID_GET_RIGHTS = 21;
-  private static final int METHODID_CHECK_RIGHTS = 22;
-  private static final int METHODID_CREATE_ACCOUNT = 23;
-  private static final int METHODID_CREATE_TRIAL_ACCOUNT = 24;
-  private static final int METHODID_GRANT_ENTITLEMENT = 25;
-  private static final int METHODID_REVOKE_ENTITLEMENT = 26;
-  private static final int METHODID_ASSIGN_ROLE = 27;
-  private static final int METHODID_UNASSIGN_ROLE = 28;
-  private static final int METHODID_LIST_ASSIGNED_ROLES = 29;
-  private static final int METHODID_ASSIGN_RESOURCE_ROLE = 30;
-  private static final int METHODID_UNASSIGN_RESOURCE_ROLE = 31;
-  private static final int METHODID_LIST_ASSIGNED_RESOURCE_ROLES = 32;
-  private static final int METHODID_LIST_ROLES = 33;
-  private static final int METHODID_LIST_RESOURCE_ROLES = 34;
-  private static final int METHODID_LIST_RESOURCE_ASSIGNEES = 35;
-  private static final int METHODID_UPDATE_CLOUDERA_MANAGER_LICENSE_KEY = 36;
-  private static final int METHODID_INITIATE_SUPPORT_CASE = 37;
-  private static final int METHODID_NOTIFY_RESOURCE_DELETED = 38;
-  private static final int METHODID_CREATE_MACHINE_USER = 39;
-  private static final int METHODID_LIST_MACHINE_USERS = 40;
-  private static final int METHODID_DELETE_MACHINE_USER = 41;
-  private static final int METHODID_LIST_RESOURCE_ROLE_ASSIGNMENTS = 42;
-  private static final int METHODID_SET_ACCOUNT_MESSAGES = 43;
-  private static final int METHODID_ACCEPT_TERMS = 44;
-  private static final int METHODID_CLEAR_ACCEPTED_TERMS = 45;
-  private static final int METHODID_DESCRIBE_TERMS = 46;
-  private static final int METHODID_LIST_TERMS = 47;
-  private static final int METHODID_LIST_ENTITLEMENTS = 48;
-  private static final int METHODID_SET_TERMS_ACCEPTANCE_EXPIRY = 49;
-  private static final int METHODID_CONFIRM_AZURE_SUBSCRIPTION_VERIFIED = 50;
-  private static final int METHODID_INSERT_AZURE_SUBSCRIPTION = 51;
-  private static final int METHODID_CREATE_GROUP = 52;
-  private static final int METHODID_DELETE_GROUP = 53;
-  private static final int METHODID_LIST_GROUPS = 54;
-  private static final int METHODID_UPDATE_GROUP = 55;
-  private static final int METHODID_ADD_MEMBER_TO_GROUP = 56;
-  private static final int METHODID_REMOVE_MEMBER_FROM_GROUP = 57;
-  private static final int METHODID_LIST_GROUP_MEMBERS = 58;
-  private static final int METHODID_LIST_GROUPS_FOR_MEMBER = 59;
-  private static final int METHODID_LIST_WORKLOAD_ADMINISTRATION_GROUPS_FOR_MEMBER = 60;
-  private static final int METHODID_CREATE_CLUSTER_SSH_PRIVATE_KEY = 61;
-  private static final int METHODID_GET_CLUSTER_SSH_PRIVATE_KEY = 62;
-  private static final int METHODID_GET_ASSIGNEE_AUTHORIZATION_INFORMATION = 63;
-  private static final int METHODID_CREATE_IDENTITY_PROVIDER_CONNECTOR = 64;
-  private static final int METHODID_LIST_IDENTITY_PROVIDER_CONNECTORS = 65;
-  private static final int METHODID_DELETE_IDENTITY_PROVIDER_CONNECTOR = 66;
-  private static final int METHODID_DESCRIBE_IDENTITY_PROVIDER_CONNECTOR = 67;
-  private static final int METHODID_UPDATE_IDENTITY_PROVIDER_CONNECTOR = 68;
-  private static final int METHODID_SET_CLOUDERA_SSOLOGIN_ENABLED = 69;
-  private static final int METHODID_GET_ID_PMETADATA_FOR_WORKLOAD_SSO = 70;
-  private static final int METHODID_PROCESS_WORKLOAD_SSOAUTHN_REQ = 71;
-  private static final int METHODID_SET_WORKLOAD_SUBDOMAIN = 72;
-  private static final int METHODID_CREATE_WORKLOAD_MACHINE_USER = 73;
-  private static final int METHODID_DELETE_WORKLOAD_MACHINE_USER = 74;
-  private static final int METHODID_GET_WORKLOAD_ADMINISTRATION_GROUP_NAME = 75;
-  private static final int METHODID_SET_WORKLOAD_ADMINISTRATION_GROUP_NAME = 76;
-  private static final int METHODID_DELETE_WORKLOAD_ADMINISTRATION_GROUP_NAME = 77;
-  private static final int METHODID_LIST_WORKLOAD_ADMINISTRATION_GROUPS = 78;
-  private static final int METHODID_SET_ACTOR_WORKLOAD_CREDENTIALS = 79;
-  private static final int METHODID_GET_ACTOR_WORKLOAD_CREDENTIALS = 80;
-  private static final int METHODID_GET_EVENT_GENERATION_IDS = 81;
-  private static final int METHODID_ADD_ACTOR_SSH_PUBLIC_KEY = 82;
-  private static final int METHODID_LIST_ACTOR_SSH_PUBLIC_KEYS = 83;
-  private static final int METHODID_DESCRIBE_ACTOR_SSH_PUBLIC_KEY = 84;
-  private static final int METHODID_DELETE_ACTOR_SSH_PUBLIC_KEY = 85;
-  private static final int METHODID_SET_WORKLOAD_PASSWORD_POLICY = 86;
+  private static final int METHODID_FIND_USERS = 13;
+  private static final int METHODID_CREATE_ACCESS_KEY = 14;
+  private static final int METHODID_UPDATE_ACCESS_KEY = 15;
+  private static final int METHODID_DELETE_ACCESS_KEY = 16;
+  private static final int METHODID_GET_ACCESS_KEY = 17;
+  private static final int METHODID_LIST_ACCESS_KEYS = 18;
+  private static final int METHODID_GET_VERSION = 19;
+  private static final int METHODID_GET_ACCOUNT = 20;
+  private static final int METHODID_LIST_ACCOUNTS = 21;
+  private static final int METHODID_GET_RIGHTS = 22;
+  private static final int METHODID_CHECK_RIGHTS = 23;
+  private static final int METHODID_CREATE_ACCOUNT = 24;
+  private static final int METHODID_CREATE_TRIAL_ACCOUNT = 25;
+  private static final int METHODID_GRANT_ENTITLEMENT = 26;
+  private static final int METHODID_REVOKE_ENTITLEMENT = 27;
+  private static final int METHODID_ASSIGN_ROLE = 28;
+  private static final int METHODID_UNASSIGN_ROLE = 29;
+  private static final int METHODID_LIST_ASSIGNED_ROLES = 30;
+  private static final int METHODID_ASSIGN_RESOURCE_ROLE = 31;
+  private static final int METHODID_UNASSIGN_RESOURCE_ROLE = 32;
+  private static final int METHODID_LIST_ASSIGNED_RESOURCE_ROLES = 33;
+  private static final int METHODID_LIST_ROLES = 34;
+  private static final int METHODID_LIST_RESOURCE_ROLES = 35;
+  private static final int METHODID_LIST_RESOURCE_ASSIGNEES = 36;
+  private static final int METHODID_UPDATE_CLOUDERA_MANAGER_LICENSE_KEY = 37;
+  private static final int METHODID_INITIATE_SUPPORT_CASE = 38;
+  private static final int METHODID_NOTIFY_RESOURCE_DELETED = 39;
+  private static final int METHODID_CREATE_MACHINE_USER = 40;
+  private static final int METHODID_LIST_MACHINE_USERS = 41;
+  private static final int METHODID_DELETE_MACHINE_USER = 42;
+  private static final int METHODID_LIST_RESOURCE_ROLE_ASSIGNMENTS = 43;
+  private static final int METHODID_SET_ACCOUNT_MESSAGES = 44;
+  private static final int METHODID_ACCEPT_TERMS = 45;
+  private static final int METHODID_CLEAR_ACCEPTED_TERMS = 46;
+  private static final int METHODID_DESCRIBE_TERMS = 47;
+  private static final int METHODID_LIST_TERMS = 48;
+  private static final int METHODID_LIST_ENTITLEMENTS = 49;
+  private static final int METHODID_SET_TERMS_ACCEPTANCE_EXPIRY = 50;
+  private static final int METHODID_CONFIRM_AZURE_SUBSCRIPTION_VERIFIED = 51;
+  private static final int METHODID_INSERT_AZURE_SUBSCRIPTION = 52;
+  private static final int METHODID_CREATE_GROUP = 53;
+  private static final int METHODID_DELETE_GROUP = 54;
+  private static final int METHODID_LIST_GROUPS = 55;
+  private static final int METHODID_UPDATE_GROUP = 56;
+  private static final int METHODID_ADD_MEMBER_TO_GROUP = 57;
+  private static final int METHODID_REMOVE_MEMBER_FROM_GROUP = 58;
+  private static final int METHODID_LIST_GROUP_MEMBERS = 59;
+  private static final int METHODID_LIST_GROUPS_FOR_MEMBER = 60;
+  private static final int METHODID_LIST_WORKLOAD_ADMINISTRATION_GROUPS_FOR_MEMBER = 61;
+  private static final int METHODID_CREATE_CLUSTER_SSH_PRIVATE_KEY = 62;
+  private static final int METHODID_GET_CLUSTER_SSH_PRIVATE_KEY = 63;
+  private static final int METHODID_GET_ASSIGNEE_AUTHORIZATION_INFORMATION = 64;
+  private static final int METHODID_CREATE_IDENTITY_PROVIDER_CONNECTOR = 65;
+  private static final int METHODID_LIST_IDENTITY_PROVIDER_CONNECTORS = 66;
+  private static final int METHODID_DELETE_IDENTITY_PROVIDER_CONNECTOR = 67;
+  private static final int METHODID_DESCRIBE_IDENTITY_PROVIDER_CONNECTOR = 68;
+  private static final int METHODID_UPDATE_IDENTITY_PROVIDER_CONNECTOR = 69;
+  private static final int METHODID_SET_CLOUDERA_SSOLOGIN_ENABLED = 70;
+  private static final int METHODID_GET_ID_PMETADATA_FOR_WORKLOAD_SSO = 71;
+  private static final int METHODID_PROCESS_WORKLOAD_SSOAUTHN_REQ = 72;
+  private static final int METHODID_SET_WORKLOAD_SUBDOMAIN = 73;
+  private static final int METHODID_CREATE_WORKLOAD_MACHINE_USER = 74;
+  private static final int METHODID_DELETE_WORKLOAD_MACHINE_USER = 75;
+  private static final int METHODID_GET_WORKLOAD_ADMINISTRATION_GROUP_NAME = 76;
+  private static final int METHODID_SET_WORKLOAD_ADMINISTRATION_GROUP_NAME = 77;
+  private static final int METHODID_DELETE_WORKLOAD_ADMINISTRATION_GROUP_NAME = 78;
+  private static final int METHODID_LIST_WORKLOAD_ADMINISTRATION_GROUPS = 79;
+  private static final int METHODID_SET_ACTOR_WORKLOAD_CREDENTIALS = 80;
+  private static final int METHODID_GET_ACTOR_WORKLOAD_CREDENTIALS = 81;
+  private static final int METHODID_GET_EVENT_GENERATION_IDS = 82;
+  private static final int METHODID_ADD_ACTOR_SSH_PUBLIC_KEY = 83;
+  private static final int METHODID_LIST_ACTOR_SSH_PUBLIC_KEYS = 84;
+  private static final int METHODID_DESCRIBE_ACTOR_SSH_PUBLIC_KEY = 85;
+  private static final int METHODID_DELETE_ACTOR_SSH_PUBLIC_KEY = 86;
+  private static final int METHODID_SET_WORKLOAD_PASSWORD_POLICY = 87;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -7920,6 +8007,10 @@ public final class UserManagementGrpc {
         case METHODID_FIND_USERS_BY_EMAIL:
           serviceImpl.findUsersByEmail((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersByEmailRequest) request,
               (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersByEmailResponse>) responseObserver);
+          break;
+        case METHODID_FIND_USERS:
+          serviceImpl.findUsers((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.FindUsersResponse>) responseObserver);
           break;
         case METHODID_CREATE_ACCESS_KEY:
           serviceImpl.createAccessKey((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateAccessKeyRequest) request,
@@ -8291,6 +8382,7 @@ public final class UserManagementGrpc {
               .addMethod(getGetUserMethodHelper())
               .addMethod(getListUsersMethodHelper())
               .addMethod(getFindUsersByEmailMethodHelper())
+              .addMethod(getFindUsersMethodHelper())
               .addMethod(getCreateAccessKeyMethodHelper())
               .addMethod(getUpdateAccessKeyMethodHelper())
               .addMethod(getDeleteAccessKeyMethodHelper())

--- a/auth-connector/src/main/proto/usermanagement.proto
+++ b/auth-connector/src/main/proto/usermanagement.proto
@@ -73,9 +73,14 @@ service UserManagement {
   rpc ListUsers (ListUsersRequest)
     returns (ListUsersResponse) {}
 
-  // Find users.
+  // Find users by Email.
   rpc FindUsersByEmail (FindUsersByEmailRequest)
     returns (FindUsersByEmailResponse) {}
+
+  // Find users.
+  rpc FindUsers (FindUsersRequest)
+    returns (FindUsersResponse) {
+  }
 
   // Creates a new access key.
   rpc CreateAccessKey (CreateAccessKeyRequest)
@@ -402,6 +407,16 @@ service UserManagement {
   returns (SetWorkloadPasswordPolicyResponse) {}
 }
 
+// The state of the actor.
+message ActorState {
+  enum Value {
+    // Active indicates that the actor can authenticate in to CDP.
+    ACTIVE = 0;
+    // Deleting indicates that the actor can no longer authenticate in to CDP.
+    DELETING = 1;
+  }
+}
+
 // An User is the Altus identity corresponding to an external SFDC contact. Users
 // can interactively login, be assigned roles to, and can be designated account
 // administrators.
@@ -438,6 +453,12 @@ message User {
   // if a user is deleted the workload username it used becomes available to new
   // users in the account.
   string workloadUsername = 14;
+  // The state of the user.
+  ActorState.Value state = 15;
+  // The date when the user record can safely be removed from storage.
+  // In ms from the Java epoch of 1970-01-01T00:00:00Z.
+  // The value is only meaningful when the 'state' is DELETING.
+  uint64 safeDeleteDateMs = 16;
 }
 
 // A MachineUser is an internal Altus identity, used by applications to call
@@ -466,6 +487,12 @@ message MachineUser {
   // determine the existence of an internal machine user. We simply prevent them
   // from shooting themselves in the foot by modifying one.
   bool internal = 6;
+  // The state of the machine user.
+  ActorState.Value state = 7;
+  // The date when the user record can safely be removed from storage.
+  // In ms from the Java epoch of 1970-01-01T00:00:00Z.
+  // The value is only meaningful when the 'state' is DELETING.
+  uint64 safeDeleteDateMs = 8;
 }
 
 // A Group is a Altus resource that contains a collection of Actors. Groups
@@ -645,8 +672,8 @@ message InteractiveLogin3rdPartyRequest {
   // This may be an empty string.
   string lastName = 6;
   // Optional. The InResponseTo field, which is included in the AuthnResponse by
-  // the IdP during an SP-initiated login. For an IdP-initiated login this will
-  // be an empty string.
+  // the IdP during an SP-initiated login. For an IdP-initiated or for non-SAML
+  // logins this will be an empty string.
   string inResponseTo = 7;
   // Optional. The IP address that the request was made from.
   string sourceIpAddress = 8;
@@ -790,6 +817,8 @@ message ListUsersRequest {
   string accountId = 4;
   // The list is optional. The default is to return all users.
   repeated string userIdOrCrn = 5;
+  // Whether to include deleted users.
+  bool includeDeleted = 6;
   // See the PageToken comment in paging.proto on paging usage.
   int32 pageSize = 2;
   paging.PageToken pageToken = 3;
@@ -835,6 +864,31 @@ message FindUsersByEmailRequest {
 }
 
 message FindUsersByEmailResponse {
+  // The users.
+  repeated User user = 1;
+  // See the PageToken comment in paging.proto on paging usage.
+  paging.PageToken nextPageToken = 2;
+}
+
+message SearchByEmail {
+  string email = 1;
+}
+
+message SearchByWorkloadUsername {
+  string workloadUsername = 1;
+}
+
+message FindUsersRequest {
+  oneof search_by {
+    SearchByEmail searchByEmail = 1;
+    SearchByWorkloadUsername searchByWorkloadUsername = 2;
+  }
+  // See the PageToken comment in paging.proto on paging usage.
+  int32 pageSize = 3;
+  paging.PageToken pageToken = 4;
+}
+
+message FindUsersResponse {
   // The users.
   repeated User user = 1;
   // See the PageToken comment in paging.proto on paging usage.
@@ -1529,6 +1583,8 @@ message ListMachineUsersRequest {
   // when listing by name or CRN. For those calls, internal machine users are
   // always returned.
   bool includeInternal = 5;
+  // Whether to include deleted machine users.
+  bool includeDeleted = 6;
   // See the PageToken comment in paging.proto on paging usage.
   int32 pageSize = 3;
   paging.PageToken pageToken = 4;
@@ -1873,6 +1929,90 @@ message SamlProviderDetails {
   string metadata = 1;
 }
 
+// LDAP connection attributes used to create a LDAP identity provider connector.
+message LdapProviderDetails {
+  // LDAP server URL.
+  // Required. We support only scheme, host and port
+  // Any other attribute supplied as part of the URI would be stripped away for security
+  // eg. ldaps://ldap.example.org:663
+  string url = 1;
+  // Admin connection DN.
+  // Optional. Default: Anonymous bind when allowed
+  // If not provided, or if supplied an empty string would result in anonymous bind when allowed.
+  // e.g. uid=myapp,ou=users,dc=example,dc=org
+  string bindDn = 2;
+  // Optional. Required if bind is not anonymous
+  // This value would be stored in Vault KV store on usermanagement/<ConnectorCrn>:bindPassword
+  // Password for bindDN.
+  string bindPassword = 3 [(options.FieldExtension.sensitive) = true];
+  // Property of the LDAP user object to use when binding to verify the password.
+  // e.g. name, email
+  string userBindProperty = 4;
+  // The base DN from which to search for users by username.
+  // e.g. ou=users,dc=example,dc=org
+  string userSearchBase = 5;
+  // LDAP search filter with which to find a user by username
+  // Use the literal {{username}} to have the given username interpolated in for the LDAP search.
+  // e.g. (uid={{username}})
+  string userSearchFilter = 6;
+  // The property of user object to use in {{dn}} interpolation of groupSearchFilter.
+  string groupDnProperty = 7;
+  // The base DN from which to search for groups.
+  // If defined, groupSearchFilter must also be defined for the search to work.
+  string groupSearchBase = 8;
+  // LDAP search filter for groups.
+  // Place literal {{dn}} in the filter to have it replaced by the property defined with groupDnProperty of the found user object.
+  // {{username}} is also available and will be replaced with the uid of the found user.
+  string groupSearchFilter = 9;
+
+  // https://nodejs.org/dist/latest-v12.x/docs/api/tls.html#tls_tls_createsecurecontext_options
+  // Optionally override the trusted CA certificates. Default is to trust the well-known CAs configured in system truststore.
+  // System truststore is completely replaced when CAs are explicitly specified using this option.
+  // The value can be a string or an Array of strings. Any string can contain multiple PEM CAs concatenated together.
+  // The peer's certificate must be chainable to a CA trusted by the server for the connection to be authenticated.
+  // When using certificates that are not chainable to a well-known CA, the certificate's CA must be explicitly specified
+  // as a trusted or the connection will fail to authenticate. If the peer uses a certificate that doesn't match or chain
+  // to one of the default CAs configured in system truststore, use this option to provide a CA certificate that the peer's
+  // certificate can match or chain to. For self-signed certificates, the certificate is its own CA, and must be provided.
+  // For PEM encoded certificates, supported types are "TRUSTED CERTIFICATE", "X509 CERTIFICATE", and "CERTIFICATE".
+  // If the user is setup with a referral, we must provide certificates which can verify connection to every server
+  repeated string tlsCaCertificates = 10;
+
+  // All LDAP servers are slightly different in their own way. Information required to create a UMS user might be stored under
+  // a different attribute. Following properties would help in mapping attributes from a given LDAP server.
+
+  // Mapping user's LDAP entry into idpUserId attribute of UMS
+  string usernameMappingAttribute = 20;
+  // Mapping user's LDAP entry into email attribute of UMS
+  string emailMappingAttribute = 21;
+  // Mapping user's LDAP entry into firstName attribute of UMS
+  string firstNameMappingAttribute = 22;
+  // Mapping user's LDAP entry into lastName attribute of UMS
+  string lastNameMappingAttribute = 23;
+  // Mapping group's LDAP entry into group attribute of UMS
+  string groupNameMappingAttribute = 24;
+}
+
+// Local connection attributes used to create a local identity provider connector.
+// This was created to support first-time user onboarding and scenarios when an account
+// ended up getting locked because of a misconfigured/unreachable identity provider
+// This should only be used to configure other (real) IdP connectors
+message LocalProviderDetails {
+  // Username of the only user who can log-in using this identity provider
+  // This field must be admin
+  string username = 1;
+  // Password of this user
+  string password = 2 [(options.FieldExtension.sensitive) = true];
+  // Email address of this user
+  // This is a required field for interactive login. However, we would not ever want to use this
+  // address or expect it to be valid.
+  string email = 3;
+  // This may be an empty string.
+  string firstName = 4;
+  // This may be an empty string.
+  string lastName = 5;
+}
+
 message CreateIdentityProviderConnectorRequest {
   // Account id for which external identity provider connector is created.
   string accountId = 1;
@@ -1881,6 +2021,10 @@ message CreateIdentityProviderConnectorRequest {
   oneof providerDetails_oneof {
     // Covers SAML provider attributes.
     SamlProviderDetails samlDetails = 3;
+    // Covers LDAP connection attributes
+    LdapProviderDetails ldapDetails = 5;
+    // Covers Local connection attributes
+    LocalProviderDetails localDetails = 6;
   }
   // Whether to sync groups on login or not. This flag is reversed as the default
   // behavior before this flag was introduced was to sync group on login and the
@@ -1898,6 +2042,98 @@ message SamlProviderInfo {
   repeated SamlCert certs = 2;
 }
 
+// Information about an LDAP identity provider connector. Certain fields may
+// be switched for ListIdentityProviderConnectors, see below for details.
+message LdapProviderInfo {
+  // LDAP server URL.
+  // Required. We support only scheme, host and port
+  // Any other attribute supplied as part of the URI would be stripped away for security
+  // eg. ldaps://ldap.example.org:663
+  string url = 1;
+  // Admin connection DN.
+  // Optional. Default: Anonymous bind when allowed
+  // If not provided, or if supplied an empty string would result in anonymous bind when allowed.
+  // e.g. uid=myapp,ou=users,dc=example,dc=org
+  string bindDn = 2;
+  // Optional. Required if bind is not anonymous
+  // This value points to the path in Vault KV store where the actual value of bindPassword is stored.
+  // It is formatted as path/to/secret/on/vault:key, where `path/to/secret/on/vault` is the path in Vault
+  // where the password is stored. This, when using Vault KV store is a key-value map. `key` is the actual
+  // key name inside this map.
+  // To enable login via LDAP, console auth service should must have required permissions to read this value.
+  string bindPasswordRef = 3;
+  // Property of the LDAP user object to use when binding to verify the password.
+  // e.g. name, email
+  string userBindProperty = 4;
+  // The base DN from which to search for users by username.
+  // e.g. ou=users,dc=example,dc=org
+  string userSearchBase = 5;
+  // LDAP search filter with which to find a user by username
+  // Use the literal {{username}} to have the given username interpolated in for the LDAP search.
+  // e.g. (uid={{username}})
+  string userSearchFilter = 6;
+  // The property of user object to use in {{dn}} interpolation of groupSearchFilter.
+  string groupDnProperty = 7;
+  // The base DN from which to search for groups.
+  // If defined, groupSearchFilter must also be defined for the search to work.
+  string groupSearchBase = 8;
+  // LDAP search filter for groups.
+  // Place literal {{dn}} in the filter to have it replaced by the property defined with groupDnProperty of the found user object.
+  // {{username}} is also available and will be replaced with the uid of the found user.
+  string groupSearchFilter = 9;
+
+  // https://nodejs.org/dist/latest-v12.x/docs/api/tls.html#tls_tls_createsecurecontext_options
+  // Optionally override the trusted CA certificates. Default is to trust the well-known CAs configured in system truststore.
+  // System truststore is completely replaced when CAs are explicitly specified using this option.
+  // The value can be a string or an Array of strings. Any string can contain multiple PEM CAs concatenated together.
+  // The peer's certificate must be chainable to a CA trusted by the server for the connection to be authenticated.
+  // When using certificates that are not chainable to a well-known CA, the certificate's CA must be explicitly specified
+  // as a trusted or the connection will fail to authenticate. If the peer uses a certificate that doesn't match or chain
+  // to one of the default CAs configured in system truststore, use this option to provide a CA certificate that the peer's
+  // certificate can match or chain to. For self-signed certificates, the certificate is its own CA, and must be provided.
+  // For PEM encoded certificates, supported types are "TRUSTED CERTIFICATE", "X509 CERTIFICATE", and "CERTIFICATE".
+  // If the user is setup with a referral, we must provide certificates which can verify connection to every server
+  repeated string tlsCaCertificates = 10;
+
+  // All LDAP servers are slightly different in their own way. Information required to create a UMS user might be stored under
+  // a different attribute. Following properties would help in mapping attributes from a given LDAP server.
+
+  // Mapping LDAP entry into idpUserId attribute of UMS
+  string usernameMappingAttribute = 20;
+  // Mapping LDAP entry into email attribute of UMS
+  string emailMappingAttribute = 21;
+  // Mapping LDAP entry into firstName attribute of UMS
+  string firstNameMappingAttribute = 22;
+  // Mapping LDAP entry into lastName attribute of UMS
+  string lastNameMappingAttribute = 23;
+  // Mapping group's LDAP entry into group attribute of UMS
+  string groupNameMappingAttribute = 24;
+}
+
+// Local connection attributes used to create a local identity provider connector.
+// This was created to support first-time user onboarding and scenarios when an account
+// ended up getting locked because of a misconfigured/unreachable identity provider
+// This should only be used to configure other (real) IdP connectors
+message LocalProviderInfo {
+  // Username of the only user who can log-in using this identity provider
+  // This field must be admin
+  string username = 1;
+  // This value points to the path in Vault KV store where the value of user's password hash is stored.
+  // It is formatted as path/to/secret/on/vault:key, where `path/to/secret/on/vault` is the path in Vault
+  // where the password is stored. This, when using Vault KV store is a key-value map. `key` is the actual
+  // key name inside this map.
+  // To enable login via Local, console auth service should must have required permissions to read this value.
+  string passwordHashRef = 2;
+  // Email address of this user
+  // This is a required field for interactive login. However, we would not ever want to use this
+  // address or expect it to be valid.
+  string email = 3;
+  // This may be an empty string.
+  string firstName = 4;
+  // This may be an empty string.
+  string lastName = 5;
+}
+
 message IdentityProviderConnector {
   // Name of the identity provider connector.
   string identityProviderConnectorName = 1;
@@ -1908,6 +2144,10 @@ message IdentityProviderConnector {
   oneof providerDetails_oneof {
     // Covers SAML provider attributes.
     SamlProviderInfo samlDetails = 4;
+    // Covers LDAP connection attributes
+    LdapProviderInfo ldapDetails = 7;
+    // Covers Local connection attributes
+    LocalProviderInfo localDetails = 8;
   }
   // Identity provider connector id.
   string identityProviderConnectorId = 5;
@@ -1994,11 +2234,108 @@ message SamlIdpDetails {
   repeated SamlCert certs = 2;
 }
 
+// The IdP connector details for a LDAP typed connector. Used only for
+// dynamo db storage
+message LdapIdpDetails {
+  // LDAP server URL.
+  // Required. We support only scheme, host and port
+  // Any other attribute supplied as part of the URI would be stripped away for security
+  // eg. ldaps://ldap.example.org:663
+  string url = 1;
+  // Admin connection DN.
+  // Optional. Default: Anonymous bind when allowed
+  // If not provided, or if supplied an empty string would result in anonymous bind when allowed.
+  // e.g. uid=myapp,ou=users,dc=example,dc=org
+  string bindDn = 2;
+  // Optional. Required if bind is not anonymous
+  // This value points to the path in Vault KV store where the actual value of bindPassword is stored.
+  // It is formatted as path/to/secret/on/vault:key, where `path/to/secret/on/vault` is the path in Vault
+  // where the password is stored. This, when using Vault KV store is a key-value map. `key` is the actual
+  // key name inside this map.
+  // To enable login via LDAP, console auth service should must have required permissions to read this value.
+  string bindPasswordRef = 3;
+  // Property of the LDAP user object to use when binding to verify the password.
+  // e.g. name, email
+  string userBindProperty = 4;
+  // The base DN from which to search for users by username.
+  // e.g. ou=users,dc=example,dc=org
+  string userSearchBase = 5;
+  // LDAP search filter with which to find a user by username
+  // Use the literal {{username}} to have the given username interpolated in for the LDAP search.
+  // e.g. (uid={{username}})
+  string userSearchFilter = 6;
+  // The property of user object to use in {{dn}} interpolation of groupSearchFilter.
+  string groupDnProperty = 7;
+  // The base DN from which to search for groups.
+  // If defined, groupSearchFilter must also be defined for the search to work.
+  string groupSearchBase = 8;
+  // LDAP search filter for groups.
+  // Place literal {{dn}} in the filter to have it replaced by the property defined with groupDnProperty of the found user object.
+  // {{username}} is also available and will be replaced with the uid of the found user.
+  string groupSearchFilter = 9;
+
+  // https://nodejs.org/dist/latest-v12.x/docs/api/tls.html#tls_tls_createsecurecontext_options
+  // Optionally override the trusted CA certificates. Default is to trust the well-known CAs configured in system truststore.
+  // System truststore is completely replaced when CAs are explicitly specified using this option.
+  // The value can be a string or an Array of strings. Any string can contain multiple PEM CAs concatenated together.
+  // The peer's certificate must be chainable to a CA trusted by the server for the connection to be authenticated.
+  // When using certificates that are not chainable to a well-known CA, the certificate's CA must be explicitly specified
+  // as a trusted or the connection will fail to authenticate. If the peer uses a certificate that doesn't match or chain
+  // to one of the default CAs configured in system truststore, use this option to provide a CA certificate that the peer's
+  // certificate can match or chain to. For self-signed certificates, the certificate is its own CA, and must be provided.
+  // For PEM encoded certificates, supported types are "TRUSTED CERTIFICATE", "X509 CERTIFICATE", and "CERTIFICATE".
+  // If the user is setup with a referral, we must provide certificates which can verify connection to every server
+  repeated string tlsCaCertificates = 10;
+
+  // All LDAP servers are slightly different in their own way. Information required to create a UMS user might be stored under
+  // a different attribute. Following properties would help in mapping attributes from a given LDAP server.
+
+  // Mapping LDAP entry into idpUserId attribute of UMS
+  string usernameMappingAttribute = 20;
+  // Mapping LDAP entry into email attribute of UMS
+  string emailMappingAttribute = 21;
+  // Mapping LDAP entry into firstName attribute of UMS
+  string firstNameMappingAttribute = 22;
+  // Mapping LDAP entry into lastName attribute of UMS
+  string lastNameMappingAttribute = 23;
+  // Mapping group's LDAP entry into group attribute of UMS
+  string groupNameMappingAttribute = 24;
+}
+
+// Local connection attributes used to create a local identity provider connector.
+// This was created to support first-time user onboarding and scenarios when an account
+// ended up getting locked because of a misconfigured/unreachable identity provider
+// This should only be used to configure other (real) IdP connectors
+// Used only for DynamoDB storage
+message LocalIdpDetails {
+  // Username of the only user who can log-in using this identity provider
+  // This field must be admin
+  string username = 1;
+  // This value points to the path in Vault KV store where the value of user's password hash is stored.
+  // It is formatted as path/to/secret/on/vault:key, where `path/to/secret/on/vault` is the path in Vault
+  // where the password is stored. This, when using Vault KV store is a key-value map. `key` is the actual
+  // key name inside this map.
+  // To enable login via Local, console auth service should must have required permissions to read this value.
+  string passwordHashRef = 2;
+  // Email address of this user
+  // This is a required field for interactive login. However, we would not ever want to use this
+  // address or expect it to be valid.
+  string email = 3;
+  // This may be an empty string.
+  string firstName = 4;
+  // This may be an empty string.
+  string lastName = 5;
+}
+
 // An object used to serialize the IdP connector details to the dynamo db table.
 message IdpDetails {
   oneof details {
     // The SAML IdP connector details.
     SamlIdpDetails saml = 1;
+    // The LDAP IdP connector details.
+    LdapIdpDetails ldap = 2;
+    // The Local IdP connector details.
+    LocalIdpDetails local = 3;
   }
 }
 
@@ -2022,6 +2359,10 @@ message UpdateIdentityProviderConnectorRequest {
   oneof providerDetails_oneof {
     // Covers SAML provider attributes.
     SamlProviderDetails samlDetails = 3;
+    // Covers LDAP connection attributes
+    LdapProviderDetails ldapDetails = 5;
+    // Covers Local connection attributes
+    LocalProviderDetails localDetails = 6;
   }
   // Whether to sync groups on login or not. This flag is reversed as the default
   // behavior before this flag was introduced was to sync group on login and the
@@ -2294,6 +2635,8 @@ message GetActorWorkloadCredentialsResponse {
   repeated ActorKerberosKey kerberosKeys = 2;
   // The workload username for the actor.
   string workloadUsername = 4;
+  // A list of Ssh public keys for the actor.
+  repeated SshPublicKey sshPublicKey = 5;
 }
 
 message GetEventGenerationIdsRequest {

--- a/common/src/main/java/com/sequenceiq/cloudbreak/auth/altus/Crn.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/auth/altus/Crn.java
@@ -316,6 +316,7 @@ public class Crn {
         IMAGE_CATALOG("imageCatalog"),
         KERBEROS("kerberos"),
         RECIPE("recipe"),
+        PUBLIC_KEY("publicKey"),
         FREEIPA("freeipa"),
         DATALAKE("datalake"),
         ACCOUNT_TAG("accountTag"),

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientExceptionUtil.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientExceptionUtil.java
@@ -87,6 +87,10 @@ public class FreeIpaClientExceptionUtil {
         return isExceptionWithErrorCode(e, Set.of(FreeIpaErrorCodes.DUPLICATE_ENTRY));
     }
 
+    public static boolean isEmptyModlistException(FreeIpaClientException e) {
+        return isExceptionWithErrorCode(e, Set.of(FreeIpaErrorCodes.EMPTY_MODLIST));
+    }
+
     public static boolean isExceptionWithErrorCode(FreeIpaClientException e, Set<FreeIpaErrorCodes> errorCodes) {
         return Stream.of(getAncestorCauseBeforeFreeIpaClientExceptions(e))
                 .filter(JsonRpcClientException.class::isInstance)

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/user/handler/SetPasswordHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/user/handler/SetPasswordHandler.java
@@ -2,33 +2,29 @@ package com.sequenceiq.freeipa.flow.freeipa.user.handler;
 
 import javax.inject.Inject;
 
-import com.sequenceiq.cloudbreak.auth.altus.Crn;
-import com.sequenceiq.cloudbreak.auth.security.InternalCrnBuilder;
-import com.sequenceiq.cloudbreak.logger.MDCUtils;
-import com.sequenceiq.freeipa.client.FreeIpaCapabilities;
-import com.sequenceiq.freeipa.client.FreeIpaClientException;
-import com.sequenceiq.freeipa.service.freeipa.user.UmsCredentialProvider;
-import com.sequenceiq.freeipa.service.freeipa.user.kerberos.KrbKeySetEncoder;
-import com.sequenceiq.freeipa.service.freeipa.user.model.WorkloadCredential;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.cloudbreak.auth.security.InternalCrnBuilder;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.cloudbreak.logger.MDCUtils;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.EventHandler;
+import com.sequenceiq.freeipa.client.FreeIpaCapabilities;
 import com.sequenceiq.freeipa.client.FreeIpaClient;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.flow.freeipa.user.event.SetPasswordRequest;
 import com.sequenceiq.freeipa.flow.freeipa.user.event.SetPasswordResult;
 import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
+import com.sequenceiq.freeipa.service.freeipa.WorkloadCredentialService;
+import com.sequenceiq.freeipa.service.freeipa.user.UmsCredentialProvider;
+import com.sequenceiq.freeipa.service.freeipa.user.model.WorkloadCredential;
 import com.sequenceiq.freeipa.service.stack.StackService;
 
 import reactor.bus.Event;
-
-import java.io.IOException;
-import java.time.Instant;
-import java.util.Optional;
 
 @Component
 public class SetPasswordHandler implements EventHandler<SetPasswordRequest> {
@@ -46,17 +42,12 @@ public class SetPasswordHandler implements EventHandler<SetPasswordRequest> {
     @Inject
     private UmsCredentialProvider umsCredentialProvider;
 
+    @Inject
+    private WorkloadCredentialService workloadCredentialService;
+
     @Override
     public String selector() {
         return EventSelectorUtil.selector(SetPasswordRequest.class);
-    }
-
-    private void setPasswordHashFromUms(FreeIpaClient freeIpaClient, String username, String userCrn,
-                                        Optional<Instant> passwordExpirationInstant) throws IOException, FreeIpaClientException {
-        WorkloadCredential workloadCredential = umsCredentialProvider.getCredentials(userCrn, MDCUtils.getRequestId());
-        String ansEncodedKrbPrincipalKey = KrbKeySetEncoder.getASNEncodedKrbPrincipalKey(workloadCredential.getKeys());
-        freeIpaClient.userSetPasswordHash(username, workloadCredential.getHashedPassword(), ansEncodedKrbPrincipalKey,
-                passwordExpirationInstant);
     }
 
     @Override
@@ -69,10 +60,17 @@ public class SetPasswordHandler implements EventHandler<SetPasswordRequest> {
 
             FreeIpaClient freeIpaClient = freeIpaClientFactory.getFreeIpaClientForStack(stack);
             if (FreeIpaCapabilities.hasSetPasswordHashSupport(freeIpaClient.getConfig())) {
-                LOGGER.info("IPA has password hash support, credentials information from UMS will be used.");
-                setPasswordHashFromUms(freeIpaClient, request.getUsername(), request.getUserCrn(), request.getExpirationInstant());
+                WorkloadCredential workloadCredential = umsCredentialProvider.getCredentials(request.getUserCrn(), MDCUtils.getRequestId());
+
+                LOGGER.info("IPA has password hash support. Credentials information from UMS will be used.");
+                workloadCredentialService.setWorkloadCredential(freeIpaClient, request.getUsername(), workloadCredential);
+                if (StringUtils.isBlank(workloadCredential.getHashedPassword())) {
+                    LOGGER.info("IPA has password hash support but user does not have a password set in UMS; using the provided password directly.");
+                    freeIpaClient.userSetPasswordWithExpiration(
+                            request.getUsername(), request.getPassword(), request.getExpirationInstant());
+                }
             } else {
-                LOGGER.info("IPA does not have password hash support, using the provided password directly.");
+                LOGGER.info("IPA does not have password hash support; using the provided password directly.");
                 freeIpaClient.userSetPasswordWithExpiration(
                         request.getUsername(), request.getPassword(), request.getExpirationInstant());
             }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/WorkloadCredentialService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/WorkloadCredentialService.java
@@ -1,0 +1,62 @@
+package com.sequenceiq.freeipa.service.freeipa;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
+import com.sequenceiq.freeipa.client.FreeIpaClient;
+import com.sequenceiq.freeipa.client.FreeIpaClientException;
+import com.sequenceiq.freeipa.client.FreeIpaClientExceptionUtil;
+import com.sequenceiq.freeipa.service.freeipa.user.kerberos.KrbKeySetEncoder;
+import com.sequenceiq.freeipa.service.freeipa.user.model.WorkloadCredential;
+
+@Service
+public class WorkloadCredentialService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(WorkloadCredentialService.class);
+
+    public void setWorkloadCredential(FreeIpaClient freeIpaClient, String username, WorkloadCredential workloadCredential)
+            throws IOException, FreeIpaClientException {
+        LOGGER.debug("Setting workload credentials for user '{}'", username);
+
+        try {
+            String ansEncodedKrbPrincipalKey = KrbKeySetEncoder.getASNEncodedKrbPrincipalKey(workloadCredential.getKeys());
+            freeIpaClient.userSetWorkloadCredentials(username,
+                    workloadCredential.getHashedPassword(), ansEncodedKrbPrincipalKey, workloadCredential.getExpirationDate(),
+                    workloadCredential.getSshPublicKeys().stream().map(UserManagementProto.SshPublicKey::getPublicKey).collect(Collectors.toList()));
+        } catch (FreeIpaClientException e) {
+            if (FreeIpaClientExceptionUtil.isEmptyModlistException(e)) {
+                LOGGER.debug("Workload credentials for user '{}' already set.", username);
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    public void setWorkloadCredentials(FreeIpaClient freeIpaClient, Map<String, WorkloadCredential> workloadCredentials,
+            BiConsumer<String, String> warnings) throws FreeIpaClientException {
+        for (Map.Entry<String, WorkloadCredential> entry : workloadCredentials.entrySet()) {
+            try {
+                setWorkloadCredential(freeIpaClient, entry.getKey(), entry.getValue());
+            } catch (IOException e) {
+                recordWarning(entry.getKey(), e, warnings);
+            } catch (FreeIpaClientException e) {
+                recordWarning(entry.getKey(), e, warnings);
+                if (e.isClientUnusable()) {
+                    LOGGER.warn("Client is not usable for further usage");
+                    throw e;
+                }
+            }
+        }
+    }
+
+    private void recordWarning(String username, Exception e, BiConsumer<String, String> warnings) {
+        LOGGER.warn("Failed to set workload credentials for user '{}'", username, e);
+        warnings.accept(username, "Failed to set workload credentials:" + e.getMessage());
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UmsCredentialProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UmsCredentialProvider.java
@@ -1,15 +1,17 @@
 package com.sequenceiq.freeipa.service.freeipa.user;
 
-import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetActorWorkloadCredentialsResponse;
-import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
-import com.sequenceiq.freeipa.service.freeipa.user.model.WorkloadCredential;
-import org.springframework.stereotype.Component;
+import static com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient.INTERNAL_ACTOR_CRN;
 
-import javax.inject.Inject;
 import java.time.Instant;
 import java.util.Optional;
 
-import static com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient.INTERNAL_ACTOR_CRN;
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetActorWorkloadCredentialsResponse;
+import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
+import com.sequenceiq.freeipa.service.freeipa.user.model.WorkloadCredential;
 
 @Component
 public class UmsCredentialProvider {
@@ -20,9 +22,10 @@ public class UmsCredentialProvider {
     public WorkloadCredential getCredentials(String userCrn, Optional<String> requestId) {
         GetActorWorkloadCredentialsResponse response =
                 grpcUmsClient.getActorWorkloadCredentials(INTERNAL_ACTOR_CRN, userCrn, requestId);
+
         long expirationDate = response.getPasswordHashExpirationDate();
         Optional<Instant> expirationInstant = expirationDate == 0 ?
                 Optional.empty() : Optional.of(Instant.ofEpochMilli(expirationDate));
-        return new WorkloadCredential(response.getPasswordHash(), response.getKerberosKeysList(), expirationInstant);
+        return new WorkloadCredential(response.getPasswordHash(), response.getKerberosKeysList(), expirationInstant, response.getSshPublicKeyList());
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/SyncStatusDetail.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/SyncStatusDetail.java
@@ -2,6 +2,8 @@ package com.sequenceiq.freeipa.service.freeipa.user.model;
 
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizationStatus;
 
 public class SyncStatusDetail {
@@ -12,10 +14,13 @@ public class SyncStatusDetail {
 
     private String details;
 
-    public SyncStatusDetail(String environmentCrn, SynchronizationStatus status, String details) {
+    private ImmutableMultimap<String, String> warnings;
+
+    public SyncStatusDetail(String environmentCrn, SynchronizationStatus status, String details, Multimap<String, String> warnings) {
         this.environmentCrn = requireNonNull(environmentCrn);
         this.status = requireNonNull(status);
         this.details = requireNonNull(details);
+        this.warnings = ImmutableMultimap.copyOf(requireNonNull(warnings));
     }
 
     public String getEnvironmentCrn() {
@@ -30,11 +35,15 @@ public class SyncStatusDetail {
         return details;
     }
 
-    public static SyncStatusDetail fail(String environmentCrn, String failureMessage) {
-        return new SyncStatusDetail(environmentCrn, SynchronizationStatus.FAILED, failureMessage);
+    public ImmutableMultimap<String, String> getWarnings() {
+        return warnings;
     }
 
-    public static SyncStatusDetail succeed(String environmentCrn, String details) {
-        return new SyncStatusDetail(environmentCrn, SynchronizationStatus.COMPLETED, details);
+    public static SyncStatusDetail fail(String environmentCrn, String failureMessage, Multimap<String, String> warnings) {
+        return new SyncStatusDetail(environmentCrn, SynchronizationStatus.FAILED, failureMessage, warnings);
+    }
+
+    public static SyncStatusDetail succeed(String environmentCrn) {
+        return new SyncStatusDetail(environmentCrn, SynchronizationStatus.COMPLETED, "sync completed successfully", ImmutableMultimap.of());
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/WorkloadCredential.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/WorkloadCredential.java
@@ -1,10 +1,12 @@
 package com.sequenceiq.freeipa.service.freeipa.user.model;
 
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ActorKerberosKey;
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SshPublicKey;
 import com.google.common.collect.ImmutableList;
 
 public class WorkloadCredential {
@@ -15,10 +17,14 @@ public class WorkloadCredential {
 
     private final Optional<Instant> expirationDate;
 
-    public WorkloadCredential(String hashedPassword, List<ActorKerberosKey> keys, Optional<Instant> expirationDate) {
+    private final ImmutableList<SshPublicKey> sshPublicKeys;
+
+    public WorkloadCredential(String hashedPassword, Collection<ActorKerberosKey> keys, Optional<Instant> expirationDate,
+            Collection<SshPublicKey> sshPublicKeys) {
         this.hashedPassword = hashedPassword;
         this.keys = ImmutableList.copyOf(keys);
         this.expirationDate = expirationDate;
+        this.sshPublicKeys = ImmutableList.copyOf(sshPublicKeys);
     }
 
     public String getHashedPassword() {
@@ -31,5 +37,9 @@ public class WorkloadCredential {
 
     public Optional<Instant> getExpirationDate() {
         return expirationDate;
+    }
+
+    public ImmutableList<SshPublicKey> getSshPublicKeys() {
+        return sshPublicKeys;
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/WorkloadCredentialServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/WorkloadCredentialServiceTest.java
@@ -1,0 +1,75 @@
+package com.sequenceiq.freeipa.service.freeipa;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
+import com.sequenceiq.freeipa.client.FreeIpaClient;
+import com.sequenceiq.freeipa.service.freeipa.user.kerberos.KrbKeySetEncoder;
+import com.sequenceiq.freeipa.service.freeipa.user.model.WorkloadCredential;
+
+class WorkloadCredentialServiceTest {
+
+    private WorkloadCredentialService underTest = new WorkloadCredentialService();
+
+    @Test
+    void setWorkloadCredential() throws Exception {
+        FreeIpaClient freeIpaClient = mock(FreeIpaClient.class);
+        String username = "username";
+        WorkloadCredential workloadCredential = new WorkloadCredential("hashedpassword",
+                List.of(),
+                Optional.of(Instant.now()),
+                List.of(UserManagementProto.SshPublicKey.newBuilder().setPublicKey("fakepublickey").build(),
+                        UserManagementProto.SshPublicKey.newBuilder().setPublicKey("anotherfakepublickey").build()));
+
+        underTest.setWorkloadCredential(freeIpaClient, username, workloadCredential);
+
+        ArgumentCaptor<List<String>> captor = ArgumentCaptor.forClass(List.class);
+        verify(freeIpaClient).userSetWorkloadCredentials(
+                eq(username),
+                eq(workloadCredential.getHashedPassword()),
+                eq(KrbKeySetEncoder.getASNEncodedKrbPrincipalKey(workloadCredential.getKeys())),
+                eq(workloadCredential.getExpirationDate()),
+                captor.capture());
+        assertTrue(captor.getValue().containsAll(List.of("fakepublickey", "anotherfakepublickey")));
+    }
+
+    @Test
+    void setWorkloadCredentials() throws Exception {
+        FreeIpaClient freeIpaClient = mock(FreeIpaClient.class);
+        Map<String, WorkloadCredential> workloadCredentialMap = Map.of(
+                "user1", mock(WorkloadCredential.class),
+                "user2", mock(WorkloadCredential.class),
+                "user3", mock(WorkloadCredential.class),
+                "user4", mock(WorkloadCredential.class));
+
+        WorkloadCredentialService spyUnderTest = spy(underTest);
+        doNothing().when(spyUnderTest).setWorkloadCredential(any(FreeIpaClient.class), anyString(), any(WorkloadCredential.class));
+        BiConsumer<String, String> warnings = mock(BiConsumer.class);
+
+        spyUnderTest.setWorkloadCredentials(freeIpaClient, workloadCredentialMap, warnings);
+
+
+        verify(spyUnderTest).setWorkloadCredentials(freeIpaClient, workloadCredentialMap, warnings);
+        for (Map.Entry<String, WorkloadCredential> entry : workloadCredentialMap.entrySet()) {
+            verify(spyUnderTest).setWorkloadCredential(freeIpaClient, entry.getKey(), entry.getValue());
+        }
+        verifyNoMoreInteractions(spyUnderTest);
+    }
+}

--- a/mock-caas/src/main/resources/application.yml
+++ b/mock-caas/src/main/resources/application.yml
@@ -16,3 +16,4 @@ auth:
     freeipa.ha.enable: true
     cloudstoragevalidation.enable: true
     runtime.upgrade.enable: true
+    sshpublickey.file: key.pub


### PR DESCRIPTION
Ssh public keys are retrieved for each user as part of the UMS
GetActorWorkloadCredentials API. The user sync code to set workload
passwords in FreeIPA has been refactored to sync both the hashed
password and the public keys.

FreeIPA may return an 4202 error code during the user-mod call that can
be safely ignored. This error indicates that the mod list is empty and
may occur if the user does not have a hashed password set in the UMS and
does not have any ssh public keys. Exception handling in the user sync
code has been improved to also ignore similar exceptions for user and
group addition and removal as well as group membership changes.
Non-ignorable exceptions are now propagated to the sync operation status.
Environments with these exceptions are now put in the "failure" list
instead of the "success" list.