### PR TITLE
DISTX-445 Indent and sort DE templates for checking parity

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-702.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-702.bp
@@ -5,13 +5,24 @@
     "displayName": "dataengineering",
     "services": [
       {
-        "refName": "zookeeper",
-        "serviceType": "ZOOKEEPER",
+        "refName": "das",
+        "serviceType": "DAS",
         "roleConfigGroups": [
           {
-            "refName": "zookeeper-SERVER-BASE",
-            "roleType": "SERVER",
+            "refName": "das-DAS_EVENT_PROCESSOR",
+            "roleType": "DAS_EVENT_PROCESSOR",
             "base": true
+          },
+          {
+            "refName": "das-DAS_WEBAPP",
+            "roleType": "DAS_WEBAPP",
+            "base": true,
+            "configs": [
+              {
+                "name": "data_analytics_studio_admin_users",
+                "value": "*"
+              }
+            ]
           }
         ]
       },
@@ -20,23 +31,8 @@
         "serviceType": "HDFS",
         "roleConfigGroups": [
           {
-            "refName": "hdfs-NAMENODE-BASE",
-            "roleType": "NAMENODE",
-            "base": true,
-	    "configs": [
-              {
-                "name": "fs_trash_interval",
-                "value": "0"
-              },
-	      {
-	        "name": "fs_trash_checkpoint_interval",
-	        "value": "0"
-              }
-            ]
-          },
-          {
-            "refName": "hdfs-SECONDARYNAMENODE-BASE",
-            "roleType": "SECONDARYNAMENODE",
+            "refName": "hdfs-BALANCER-BASE",
+            "roleType": "BALANCER",
             "base": true
           },
           {
@@ -45,124 +41,23 @@
             "base": true
           },
           {
-            "refName": "hdfs-BALANCER-BASE",
-            "roleType": "BALANCER",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "yarn",
-        "serviceType": "YARN",
-        "serviceConfigs": [
-          {
-            "name": "yarn_admin_acl",
-            "value": "yarn,hive,hdfs"
-          }
-        ],
-        "roleConfigGroups": [
-          {
-            "refName": "yarn-RESOURCEMANAGER-BASE",
-            "roleType": "RESOURCEMANAGER",
+            "refName": "hdfs-NAMENODE-BASE",
+            "roleType": "NAMENODE",
             "base": true,
             "configs": [
-            	{
-	   		        "name": "resourcemanager_config_safety_valve",
-	   		        "value": "<property><name>yarn.scheduler.configuration.store.class</name><value>file</value></property>"
-	   	   	    },
               {
-                "name": "yarn_resourcemanager_scheduler_class",
-                "value": "org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler"
+                "name": "fs_trash_interval",
+                "value": "0"
               },
               {
-                "name": "yarn_scheduler_capacity_resource_calculator",
-                "value": "org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator"
-              },
-              {
-                "name": "resourcemanager_capacity_scheduler_configuration",
-                "value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property><property><name>yarn.scheduler.capacity.per-node-heartbeat.maximum-offswitch-assignments</name><value>4</value></property></configuration>"
+                "name": "fs_trash_checkpoint_interval",
+                "value": "0"
               }
             ]
           },
           {
-            "refName": "yarn-NODEMANAGER-WORKER",
-            "roleType": "NODEMANAGER",
-            "base": false
-          },
-          {
-            "refName": "yarn-NODEMANAGER-COMPUTE",
-            "roleType": "NODEMANAGER",
-            "base": false
-          },
-          {
-            "refName": "yarn-JOBHISTORY-BASE",
-            "roleType": "JOBHISTORY",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "spark_on_yarn",
-        "serviceType": "SPARK_ON_YARN",
-        "roleConfigGroups": [
-          {
-            "refName": "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
-            "roleType": "SPARK_YARN_HISTORY_SERVER",
-            "base": true
-          },
-          {
-            "refName": "spark_on_yarn-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "tez",
-        "serviceType": "TEZ",
-        "serviceConfigs": [
-          {
-            "name": "yarn_service",
-            "ref": "yarn"
-          },
-          {
-            "name": "tez.am.container.reuse.non-local-fallback.enabled",
-            "value": "true"
-          },
-          {
-            "name": "tez.am.container.reuse.locality.delay-allocation-millis",
-            "value": "0"
-          },
-	  {
-            "name": "tez.am.launch.cmd-opts",
-            "value": "-XX:+PrintGCDetails -verbose:gc -XX:+UseNUMA -XX:+UseG1GC -XX:+ResizeTLAB"
-	  },
-	  {
-            "name": "tez.task.launch.cmd-opts",
-	    "value": "-XX:+PrintGCDetails -verbose:gc -XX:+UseNUMA -XX:+UseG1GC -XX:+ResizeTLAB"
-	  }
-	],
-        "roleConfigGroups": [
-          {
-            "refName": "tez-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "hms",
-        "serviceType": "HIVE",
-        "displayName": "Hive Metastore",
-        "roleConfigGroups": [
-          {
-            "refName": "hms-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "base": true
-          },
-          {
-            "refName": "hms-HIVEMETASTORE-BASE",
-            "roleType": "HIVEMETASTORE",
+            "refName": "hdfs-SECONDARYNAMENODE-BASE",
+            "roleType": "SECONDARYNAMENODE",
             "base": true
           }
         ]
@@ -205,10 +100,27 @@
             "base": true,
             "configs": [
               {
-                 "name": "hive_server2_transport_mode",
-                 "value": "http"
+                "name": "hive_server2_transport_mode",
+                "value": "http"
               }
             ]
+          }
+        ]
+      },
+      {
+        "refName": "hms",
+        "serviceType": "HIVE",
+        "displayName": "Hive Metastore",
+        "roleConfigGroups": [
+          {
+            "refName": "hms-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          },
+          {
+            "refName": "hms-HIVEMETASTORE-BASE",
+            "roleType": "HIVEMETASTORE",
+            "base": true
           }
         ]
       },
@@ -223,13 +135,13 @@
         ],
         "roleConfigGroups": [
           {
-            "refName": "hue-HUE_SERVER-BASE",
-            "roleType": "HUE_SERVER",
+            "refName": "hue-HUE_LOAD_BALANCER-BASE",
+            "roleType": "HUE_LOAD_BALANCER",
             "base": true
           },
           {
-            "refName": "hue-HUE_LOAD_BALANCER-BASE",
-            "roleType": "HUE_LOAD_BALANCER",
+            "refName": "hue-HUE_SERVER-BASE",
+            "roleType": "HUE_SERVER",
             "base": true
           }
         ]
@@ -247,6 +159,116 @@
             "refName": "livy-LIVY_SERVER-BASE",
             "roleType": "LIVY_SERVER",
             "base": true
+          }
+        ]
+      },
+      {
+        "refName": "oozie",
+        "serviceType": "OOZIE",
+        "roleConfigGroups": [
+          {
+            "refName": "oozie-OOZIE_SERVER-BASE",
+            "roleType": "OOZIE_SERVER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "spark_on_yarn",
+        "serviceType": "SPARK_ON_YARN",
+        "roleConfigGroups": [
+          {
+            "refName": "spark_on_yarn-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          },
+          {
+            "refName": "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+            "roleType": "SPARK_YARN_HISTORY_SERVER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "tez",
+        "serviceType": "TEZ",
+        "serviceConfigs": [
+          {
+            "name": "yarn_service",
+            "ref": "yarn"
+          },
+          {
+            "name": "tez.am.container.reuse.non-local-fallback.enabled",
+            "value": "true"
+          },
+          {
+            "name": "tez.am.container.reuse.locality.delay-allocation-millis",
+            "value": "0"
+          },
+          {
+            "name": "tez.am.launch.cmd-opts",
+            "value": "-XX:+PrintGCDetails -verbose:gc -XX:+UseNUMA -XX:+UseG1GC -XX:+ResizeTLAB"
+          },
+          {
+            "name": "tez.task.launch.cmd-opts",
+            "value": "-XX:+PrintGCDetails -verbose:gc -XX:+UseNUMA -XX:+UseG1GC -XX:+ResizeTLAB"
+          }
+        ],
+        "roleConfigGroups": [
+          {
+            "refName": "tez-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "yarn",
+        "serviceType": "YARN",
+        "serviceConfigs": [
+          {
+            "name": "yarn_admin_acl",
+            "value": "yarn,hive,hdfs"
+          }
+        ],
+        "roleConfigGroups": [
+          {
+            "refName": "yarn-JOBHISTORY-BASE",
+            "roleType": "JOBHISTORY",
+            "base": true
+          },
+          {
+            "refName": "yarn-NODEMANAGER-COMPUTE",
+            "roleType": "NODEMANAGER",
+            "base": false
+          },
+          {
+            "refName": "yarn-NODEMANAGER-WORKER",
+            "roleType": "NODEMANAGER",
+            "base": false
+          },
+          {
+            "refName": "yarn-RESOURCEMANAGER-BASE",
+            "roleType": "RESOURCEMANAGER",
+            "base": true,
+            "configs": [
+              {
+                "name": "resourcemanager_config_safety_valve",
+                "value": "<property><name>yarn.scheduler.configuration.store.class</name><value>file</value></property>"
+              },
+              {
+                "name": "yarn_resourcemanager_scheduler_class",
+                "value": "org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler"
+              },
+              {
+                "name": "yarn_scheduler_capacity_resource_calculator",
+                "value": "org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator"
+              },
+              {
+                "name": "resourcemanager_capacity_scheduler_configuration",
+                "value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property><property><name>yarn.scheduler.capacity.per-node-heartbeat.maximum-offswitch-assignments</name><value>4</value></property></configuration>"
+              }
+            ]
           }
         ]
       },
@@ -276,34 +298,12 @@
         ]
       },
       {
-        "refName": "das",
-        "serviceType": "DAS",
+        "refName": "zookeeper",
+        "serviceType": "ZOOKEEPER",
         "roleConfigGroups": [
           {
-            "refName": "das-DAS_WEBAPP",
-            "roleType": "DAS_WEBAPP",
-            "base": true,
-            "configs": [
-              {
-                "name": "data_analytics_studio_admin_users",
-                "value": "*"
-              }
-            ]
-          },
-          {
-            "refName": "das-DAS_EVENT_PROCESSOR",
-            "roleType": "DAS_EVENT_PROCESSOR",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "oozie",
-        "serviceType": "OOZIE",
-        "roleConfigGroups": [
-          {
-            "refName": "oozie-OOZIE_SERVER-BASE",
-            "roleType": "OOZIE_SERVER",
+            "refName": "zookeeper-SERVER-BASE",
+            "roleType": "SERVER",
             "base": true
           }
         ]
@@ -311,52 +311,13 @@
     ],
     "hostTemplates": [
       {
-        "refName": "master",
-        "cardinality": 1,
-        "roleConfigGroupsRefNames": [
-          "hdfs-BALANCER-BASE",
-          "hdfs-NAMENODE-BASE",
-          "hdfs-SECONDARYNAMENODE-BASE",
-          "hms-GATEWAY-BASE",
-          "hms-HIVEMETASTORE-BASE",
-          "hive_on_tez-HIVESERVER2-BASE",
-          "hive_on_tez-GATEWAY-BASE",
-          "hue-HUE_LOAD_BALANCER-BASE",
-          "hue-HUE_SERVER-BASE",
-          "tez-GATEWAY-BASE",
-          "spark_on_yarn-GATEWAY-BASE",
-          "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
-          "livy-LIVY_SERVER-BASE",
-          "zeppelin-ZEPPELIN_SERVER-BASE",
-          "oozie-OOZIE_SERVER-BASE",
-          "yarn-JOBHISTORY-BASE",
-          "yarn-RESOURCEMANAGER-BASE",
-          "zookeeper-SERVER-BASE",
-          "das-DAS_WEBAPP",
-          "das-DAS_EVENT_PROCESSOR"
-        ]
-      },
-      {
-        "refName": "worker",
-        "cardinality": 3,
-        "roleConfigGroupsRefNames": [
-          "hdfs-DATANODE-BASE",
-          "hms-GATEWAY-BASE",
-          "hive_on_tez-GATEWAY-BASE",
-          "tez-GATEWAY-BASE",
-          "spark_on_yarn-GATEWAY-BASE",
-          "livy-GATEWAY-BASE",
-          "yarn-NODEMANAGER-WORKER"
-        ]
-      },
-      {
         "refName": "compute",
         "cardinality": 0,
         "roleConfigGroupsRefNames": [
-          "hms-GATEWAY-BASE",
           "hive_on_tez-GATEWAY-BASE",
-          "tez-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
           "yarn-NODEMANAGER-COMPUTE"
         ]
       },
@@ -364,11 +325,50 @@
         "refName": "gateway",
         "cardinality": 0,
         "roleConfigGroupsRefNames": [
-          "hms-GATEWAY-BASE",
           "hive_on_tez-GATEWAY-BASE",
-          "tez-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
+          "livy-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
-          "livy-GATEWAY-BASE"
+          "tez-GATEWAY-BASE"
+        ]
+      },
+      {
+        "refName": "master",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "das-DAS_EVENT_PROCESSOR",
+          "das-DAS_WEBAPP",
+          "hdfs-BALANCER-BASE",
+          "hdfs-NAMENODE-BASE",
+          "hdfs-SECONDARYNAMENODE-BASE",
+          "hive_on_tez-GATEWAY-BASE",
+          "hive_on_tez-HIVESERVER2-BASE",
+          "hms-GATEWAY-BASE",
+          "hms-HIVEMETASTORE-BASE",
+          "hue-HUE_LOAD_BALANCER-BASE",
+          "hue-HUE_SERVER-BASE",
+          "livy-LIVY_SERVER-BASE",
+          "oozie-OOZIE_SERVER-BASE",
+          "spark_on_yarn-GATEWAY-BASE",
+          "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+          "tez-GATEWAY-BASE",
+          "yarn-JOBHISTORY-BASE",
+          "yarn-RESOURCEMANAGER-BASE",
+          "zeppelin-ZEPPELIN_SERVER-BASE",
+          "zookeeper-SERVER-BASE"
+        ]
+      },
+      {
+        "refName": "worker",
+        "cardinality": 3,
+        "roleConfigGroupsRefNames": [
+          "hdfs-DATANODE-BASE",
+          "hive_on_tez-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
+          "livy-GATEWAY-BASE",
+          "spark_on_yarn-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
+          "yarn-NODEMANAGER-WORKER"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-710.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-710.bp
@@ -5,13 +5,24 @@
     "displayName": "dataengineering",
     "services": [
       {
-        "refName": "zookeeper",
-        "serviceType": "ZOOKEEPER",
+        "refName": "das",
+        "serviceType": "DAS",
         "roleConfigGroups": [
           {
-            "refName": "zookeeper-SERVER-BASE",
-            "roleType": "SERVER",
+            "refName": "das-DAS_EVENT_PROCESSOR",
+            "roleType": "DAS_EVENT_PROCESSOR",
             "base": true
+          },
+          {
+            "refName": "das-DAS_WEBAPP",
+            "roleType": "DAS_WEBAPP",
+            "base": true,
+            "configs": [
+              {
+                "name": "data_analytics_studio_admin_users",
+                "value": "*"
+              }
+            ]
           }
         ]
       },
@@ -20,23 +31,8 @@
         "serviceType": "HDFS",
         "roleConfigGroups": [
           {
-            "refName": "hdfs-NAMENODE-BASE",
-            "roleType": "NAMENODE",
-            "base": true,
-	    "configs": [
-              {
-                "name": "fs_trash_interval",
-                "value": "0"
-              },
-	      {
-	        "name": "fs_trash_checkpoint_interval",
-	        "value": "0"
-              }
-            ]
-          },
-          {
-            "refName": "hdfs-SECONDARYNAMENODE-BASE",
-            "roleType": "SECONDARYNAMENODE",
+            "refName": "hdfs-BALANCER-BASE",
+            "roleType": "BALANCER",
             "base": true
           },
           {
@@ -45,143 +41,23 @@
             "base": true
           },
           {
-            "refName": "hdfs-BALANCER-BASE",
-            "roleType": "BALANCER",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "yarn",
-        "serviceType": "YARN",
-        "serviceConfigs": [
-          {
-            "name": "yarn_admin_acl",
-            "value": "yarn,hive,hdfs"
-          },
-          {
-            "name": "yarn_log_aggregation_IFile_remote_app_log_dir",
-            "value": ""
-          }
-        ],
-        "roleConfigGroups": [
-          {
-            "refName": "yarn-RESOURCEMANAGER-BASE",
-            "roleType": "RESOURCEMANAGER",
+            "refName": "hdfs-NAMENODE-BASE",
+            "roleType": "NAMENODE",
             "base": true,
             "configs": [
-            	{
-	   		        "name": "resourcemanager_config_safety_valve",
-	   		        "value": "<property><name>yarn.scheduler.configuration.store.class</name><value>file</value></property>"
-	   	   	    },
               {
-                "name": "yarn_resourcemanager_scheduler_class",
-                "value": "org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler"
+                "name": "fs_trash_interval",
+                "value": "0"
               },
               {
-                "name": "yarn_scheduler_capacity_resource_calculator",
-                "value": "org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator"
-              },
-              {
-                "name": "resourcemanager_capacity_scheduler_configuration",
-                "value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property></configuration>"
+                "name": "fs_trash_checkpoint_interval",
+                "value": "0"
               }
             ]
           },
           {
-            "refName": "yarn-NODEMANAGER-WORKER",
-            "roleType": "NODEMANAGER",
-            "base": false
-          },
-          {
-            "refName": "yarn-NODEMANAGER-COMPUTE",
-            "roleType": "NODEMANAGER",
-            "base": false
-          },
-          {
-            "refName": "yarn-JOBHISTORY-BASE",
-            "roleType": "JOBHISTORY",
-            "base": true
-          },
-          {
-            "refName": "yarn-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "base": true,
-            "configs": [
-              {
-                "name": "mapreduce_map_memory_mb",
-                "value": 4096
-              },
-              {
-                "name": "mapreduce_reduce_memory_mb",
-                "value": 4096
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "refName": "spark_on_yarn",
-        "serviceType": "SPARK_ON_YARN",
-        "roleConfigGroups": [
-          {
-            "refName": "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
-            "roleType": "SPARK_YARN_HISTORY_SERVER",
-            "base": true
-          },
-          {
-            "refName": "spark_on_yarn-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "tez",
-        "serviceType": "TEZ",
-        "serviceConfigs": [
-          {
-            "name": "yarn_service",
-            "ref": "yarn"
-          },
-          {
-            "name": "tez.am.container.reuse.non-local-fallback.enabled",
-            "value": "true"
-          },
-          {
-            "name": "tez.am.container.reuse.locality.delay-allocation-millis",
-            "value": "0"
-          },
-	  {
-            "name": "tez.am.launch.cmd-opts",
-            "value": "-XX:+PrintGCDetails -verbose:gc -XX:+UseNUMA -XX:+UseG1GC -XX:+ResizeTLAB"
-	  },
-	  {
-            "name": "tez.task.launch.cmd-opts",
-	    "value": "-XX:+PrintGCDetails -verbose:gc -XX:+UseNUMA -XX:+UseG1GC -XX:+ResizeTLAB"
-	  }
-	],
-        "roleConfigGroups": [
-          {
-            "refName": "tez-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "hms",
-        "serviceType": "HIVE",
-        "displayName": "Hive Metastore",
-        "roleConfigGroups": [
-          {
-            "refName": "hms-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "base": true
-          },
-          {
-            "refName": "hms-HIVEMETASTORE-BASE",
-            "roleType": "HIVEMETASTORE",
+            "refName": "hdfs-SECONDARYNAMENODE-BASE",
+            "roleType": "SECONDARYNAMENODE",
             "base": true
           }
         ]
@@ -232,18 +108,35 @@
             "base": true,
             "configs": [
               {
-                 "name": "hive_server2_transport_mode",
-                 "value": "http"
+                "name": "hive_server2_transport_mode",
+                "value": "http"
               },
               {
-                 "name": "hiveserver2_mv_files_thread",
-                 "value": 20
+                "name": "hiveserver2_mv_files_thread",
+                "value": 20
               },
               {
-                 "name": "hiveserver2_load_dynamic_partitions_thread_count",
-                 "value": 20
+                "name": "hiveserver2_load_dynamic_partitions_thread_count",
+                "value": 20
               }
             ]
+          }
+        ]
+      },
+      {
+        "refName": "hms",
+        "serviceType": "HIVE",
+        "displayName": "Hive Metastore",
+        "roleConfigGroups": [
+          {
+            "refName": "hms-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          },
+          {
+            "refName": "hms-HIVEMETASTORE-BASE",
+            "roleType": "HIVEMETASTORE",
+            "base": true
           }
         ]
       },
@@ -258,13 +151,13 @@
         ],
         "roleConfigGroups": [
           {
-            "refName": "hue-HUE_SERVER-BASE",
-            "roleType": "HUE_SERVER",
+            "refName": "hue-HUE_LOAD_BALANCER-BASE",
+            "roleType": "HUE_LOAD_BALANCER",
             "base": true
           },
           {
-            "refName": "hue-HUE_LOAD_BALANCER-BASE",
-            "roleType": "HUE_LOAD_BALANCER",
+            "refName": "hue-HUE_SERVER-BASE",
+            "roleType": "HUE_SERVER",
             "base": true
           }
         ]
@@ -282,6 +175,135 @@
             "refName": "livy-LIVY_SERVER-BASE",
             "roleType": "LIVY_SERVER",
             "base": true
+          }
+        ]
+      },
+      {
+        "refName": "oozie",
+        "serviceType": "OOZIE",
+        "roleConfigGroups": [
+          {
+            "refName": "oozie-OOZIE_SERVER-BASE",
+            "roleType": "OOZIE_SERVER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "spark_on_yarn",
+        "serviceType": "SPARK_ON_YARN",
+        "roleConfigGroups": [
+          {
+            "refName": "spark_on_yarn-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          },
+          {
+            "refName": "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+            "roleType": "SPARK_YARN_HISTORY_SERVER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "tez",
+        "serviceType": "TEZ",
+        "serviceConfigs": [
+          {
+            "name": "yarn_service",
+            "ref": "yarn"
+          },
+          {
+            "name": "tez.am.container.reuse.non-local-fallback.enabled",
+            "value": "true"
+          },
+          {
+            "name": "tez.am.container.reuse.locality.delay-allocation-millis",
+            "value": "0"
+          },
+          {
+            "name": "tez.am.launch.cmd-opts",
+            "value": "-XX:+PrintGCDetails -verbose:gc -XX:+UseNUMA -XX:+UseG1GC -XX:+ResizeTLAB"
+          },
+          {
+            "name": "tez.task.launch.cmd-opts",
+            "value": "-XX:+PrintGCDetails -verbose:gc -XX:+UseNUMA -XX:+UseG1GC -XX:+ResizeTLAB"
+          }
+        ],
+        "roleConfigGroups": [
+          {
+            "refName": "tez-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "yarn",
+        "serviceType": "YARN",
+        "serviceConfigs": [
+          {
+            "name": "yarn_admin_acl",
+            "value": "yarn,hive,hdfs"
+          },
+          {
+            "name": "yarn_log_aggregation_IFile_remote_app_log_dir",
+            "value": ""
+          }
+        ],
+        "roleConfigGroups": [
+          {
+            "refName": "yarn-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true,
+            "configs": [
+              {
+                "name": "mapreduce_map_memory_mb",
+                "value": 4096
+              },
+              {
+                "name": "mapreduce_reduce_memory_mb",
+                "value": 4096
+              }
+            ]
+          },
+          {
+            "refName": "yarn-JOBHISTORY-BASE",
+            "roleType": "JOBHISTORY",
+            "base": true
+          },
+          {
+            "refName": "yarn-NODEMANAGER-COMPUTE",
+            "roleType": "NODEMANAGER",
+            "base": false
+          },
+          {
+            "refName": "yarn-NODEMANAGER-WORKER",
+            "roleType": "NODEMANAGER",
+            "base": false
+          },
+          {
+            "refName": "yarn-RESOURCEMANAGER-BASE",
+            "roleType": "RESOURCEMANAGER",
+            "base": true,
+            "configs": [
+              {
+                "name": "resourcemanager_config_safety_valve",
+                "value": "<property><name>yarn.scheduler.configuration.store.class</name><value>file</value></property>"
+              },
+              {
+                "name": "yarn_resourcemanager_scheduler_class",
+                "value": "org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler"
+              },
+              {
+                "name": "yarn_scheduler_capacity_resource_calculator",
+                "value": "org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator"
+              },
+              {
+                "name": "resourcemanager_capacity_scheduler_configuration",
+                "value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property></configuration>"
+              }
+            ]
           }
         ]
       },
@@ -311,34 +333,12 @@
         ]
       },
       {
-        "refName": "das",
-        "serviceType": "DAS",
+        "refName": "zookeeper",
+        "serviceType": "ZOOKEEPER",
         "roleConfigGroups": [
           {
-            "refName": "das-DAS_WEBAPP",
-            "roleType": "DAS_WEBAPP",
-            "base": true,
-            "configs": [
-              {
-                "name": "data_analytics_studio_admin_users",
-                "value": "*"
-              }
-            ]
-          },
-          {
-            "refName": "das-DAS_EVENT_PROCESSOR",
-            "roleType": "DAS_EVENT_PROCESSOR",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "oozie",
-        "serviceType": "OOZIE",
-        "roleConfigGroups": [
-          {
-            "refName": "oozie-OOZIE_SERVER-BASE",
-            "roleType": "OOZIE_SERVER",
+            "refName": "zookeeper-SERVER-BASE",
+            "roleType": "SERVER",
             "base": true
           }
         ]
@@ -346,30 +346,54 @@
     ],
     "hostTemplates": [
       {
+        "refName": "compute",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "hive_on_tez-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
+          "spark_on_yarn-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
+          "yarn-GATEWAY-BASE",
+          "yarn-NODEMANAGER-COMPUTE"
+        ]
+      },
+      {
+        "refName": "gateway",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "hive_on_tez-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
+          "livy-GATEWAY-BASE",
+          "spark_on_yarn-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
+          "yarn-GATEWAY-BASE"
+        ]
+      },
+      {
         "refName": "master",
         "cardinality": 1,
         "roleConfigGroupsRefNames": [
+          "das-DAS_EVENT_PROCESSOR",
+          "das-DAS_WEBAPP",
           "hdfs-BALANCER-BASE",
           "hdfs-NAMENODE-BASE",
           "hdfs-SECONDARYNAMENODE-BASE",
+          "hive_on_tez-GATEWAY-BASE",
+          "hive_on_tez-HIVESERVER2-BASE",
           "hms-GATEWAY-BASE",
           "hms-HIVEMETASTORE-BASE",
-          "hive_on_tez-HIVESERVER2-BASE",
-          "hive_on_tez-GATEWAY-BASE",
           "hue-HUE_LOAD_BALANCER-BASE",
           "hue-HUE_SERVER-BASE",
-          "tez-GATEWAY-BASE",
+          "livy-LIVY_SERVER-BASE",
+          "oozie-OOZIE_SERVER-BASE",
           "spark_on_yarn-GATEWAY-BASE",
           "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
-          "livy-LIVY_SERVER-BASE",
-          "zeppelin-ZEPPELIN_SERVER-BASE",
-          "oozie-OOZIE_SERVER-BASE",
+          "tez-GATEWAY-BASE",
+          "yarn-GATEWAY-BASE",
           "yarn-JOBHISTORY-BASE",
           "yarn-RESOURCEMANAGER-BASE",
-          "zookeeper-SERVER-BASE",
-          "das-DAS_WEBAPP",
-          "das-DAS_EVENT_PROCESSOR",
-          "yarn-GATEWAY-BASE"
+          "zeppelin-ZEPPELIN_SERVER-BASE",
+          "zookeeper-SERVER-BASE"
         ]
       },
       {
@@ -377,37 +401,13 @@
         "cardinality": 3,
         "roleConfigGroupsRefNames": [
           "hdfs-DATANODE-BASE",
-          "hms-GATEWAY-BASE",
           "hive_on_tez-GATEWAY-BASE",
-          "tez-GATEWAY-BASE",
-          "spark_on_yarn-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
           "livy-GATEWAY-BASE",
-          "yarn-NODEMANAGER-WORKER",
-          "yarn-GATEWAY-BASE"
-        ]
-      },
-      {
-        "refName": "compute",
-        "cardinality": 0,
-        "roleConfigGroupsRefNames": [
-          "hms-GATEWAY-BASE",
-          "hive_on_tez-GATEWAY-BASE",
-          "tez-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
-          "yarn-NODEMANAGER-COMPUTE",
-          "yarn-GATEWAY-BASE"
-        ]
-      },
-      {
-        "refName": "gateway",
-        "cardinality": 0,
-        "roleConfigGroupsRefNames": [
-          "hms-GATEWAY-BASE",
-          "hive_on_tez-GATEWAY-BASE",
           "tez-GATEWAY-BASE",
-          "spark_on_yarn-GATEWAY-BASE",
-          "livy-GATEWAY-BASE",
-          "yarn-GATEWAY-BASE"
+          "yarn-GATEWAY-BASE",
+          "yarn-NODEMANAGER-WORKER"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-720.bp
@@ -5,13 +5,24 @@
     "displayName": "dataengineering",
     "services": [
       {
-        "refName": "zookeeper",
-        "serviceType": "ZOOKEEPER",
+        "refName": "das",
+        "serviceType": "DAS",
         "roleConfigGroups": [
           {
-            "refName": "zookeeper-SERVER-BASE",
-            "roleType": "SERVER",
+            "refName": "das-DAS_EVENT_PROCESSOR",
+            "roleType": "DAS_EVENT_PROCESSOR",
             "base": true
+          },
+          {
+            "refName": "das-DAS_WEBAPP",
+            "roleType": "DAS_WEBAPP",
+            "base": true,
+            "configs": [
+              {
+                "name": "data_analytics_studio_admin_users",
+                "value": "*"
+              }
+            ]
           }
         ]
       },
@@ -19,6 +30,16 @@
         "refName": "hdfs",
         "serviceType": "HDFS",
         "roleConfigGroups": [
+          {
+            "refName": "hdfs-BALANCER-BASE",
+            "roleType": "BALANCER",
+            "base": true
+          },
+          {
+            "refName": "hdfs-DATANODE-BASE",
+            "roleType": "DATANODE",
+            "base": true
+          },
           {
             "refName": "hdfs-NAMENODE-BASE",
             "roleType": "NAMENODE",
@@ -37,147 +58,6 @@
           {
             "refName": "hdfs-SECONDARYNAMENODE-BASE",
             "roleType": "SECONDARYNAMENODE",
-            "base": true
-          },
-          {
-            "refName": "hdfs-DATANODE-BASE",
-            "roleType": "DATANODE",
-            "base": true
-          },
-          {
-            "refName": "hdfs-BALANCER-BASE",
-            "roleType": "BALANCER",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "yarn",
-        "serviceType": "YARN",
-        "serviceConfigs": [
-          {
-            "name": "yarn_admin_acl",
-            "value": "yarn,hive,hdfs"
-          }
-        ],
-        "roleConfigGroups": [
-          {
-            "refName": "yarn-RESOURCEMANAGER-BASE",
-            "roleType": "RESOURCEMANAGER",
-            "base": true,
-            "configs": [
-              {
-                "name": "resourcemanager_config_safety_valve",
-                "value": "<property><name>yarn.scheduler.configuration.store.class</name><value>zk</value></property>"
-              },
-              {
-                "name": "yarn_resourcemanager_scheduler_class",
-                "value": "org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler"
-              },
-              {
-                "name": "yarn_scheduler_capacity_resource_calculator",
-                "value": "org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator"
-              },
-              {
-                "name": "resourcemanager_capacity_scheduler_configuration",
-                "value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property></configuration>"
-              }
-            ]
-          },
-          {
-            "refName": "yarn-NODEMANAGER-WORKER",
-            "roleType": "NODEMANAGER",
-            "base": false
-          },
-          {
-            "refName": "yarn-NODEMANAGER-COMPUTE",
-            "roleType": "NODEMANAGER",
-            "base": false
-          },
-          {
-            "refName": "yarn-JOBHISTORY-BASE",
-            "roleType": "JOBHISTORY",
-            "base": true
-          },
-          {
-            "refName": "yarn-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "base": true,
-            "configs": [
-              {
-                "name": "mapreduce_map_memory_mb",
-                "value": 4096
-              },
-              {
-                "name": "mapreduce_reduce_memory_mb",
-                "value": 4096
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "refName": "spark_on_yarn",
-        "serviceType": "SPARK_ON_YARN",
-        "roleConfigGroups": [
-          {
-            "refName": "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
-            "roleType": "SPARK_YARN_HISTORY_SERVER",
-            "base": true
-          },
-          {
-            "refName": "spark_on_yarn-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "tez",
-        "serviceType": "TEZ",
-        "serviceConfigs": [
-          {
-            "name": "yarn_service",
-            "ref": "yarn"
-          },
-          {
-            "name": "tez.am.container.reuse.non-local-fallback.enabled",
-            "value": "true"
-          },
-          {
-            "name": "tez.am.container.reuse.locality.delay-allocation-millis",
-            "value": "0"
-          },
-          {
-            "name": "tez.am.launch.cmd-opts",
-            "value": "-XX:+PrintGCDetails -verbose:gc -XX:+UseNUMA -XX:+UseG1GC -XX:+ResizeTLAB"
-          },
-          {
-            "name": "tez.task.launch.cmd-opts",
-            "value": "-XX:+PrintGCDetails -verbose:gc -XX:+UseNUMA -XX:+UseG1GC -XX:+ResizeTLAB"
-          }
-        ],
-        "roleConfigGroups": [
-          {
-            "refName": "tez-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "hms",
-        "serviceType": "HIVE",
-        "displayName": "Hive Metastore",
-        "roleConfigGroups": [
-          {
-            "refName": "hms-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "base": true
-          },
-          {
-            "refName": "hms-HIVEMETASTORE-BASE",
-            "roleType": "HIVEMETASTORE",
             "base": true
           }
         ]
@@ -244,6 +124,23 @@
         ]
       },
       {
+        "refName": "hms",
+        "serviceType": "HIVE",
+        "displayName": "Hive Metastore",
+        "roleConfigGroups": [
+          {
+            "refName": "hms-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          },
+          {
+            "refName": "hms-HIVEMETASTORE-BASE",
+            "roleType": "HIVEMETASTORE",
+            "base": true
+          }
+        ]
+      },
+      {
         "refName": "hue",
         "serviceType": "HUE",
         "serviceConfigs": [
@@ -254,13 +151,13 @@
         ],
         "roleConfigGroups": [
           {
-            "refName": "hue-HUE_SERVER-BASE",
-            "roleType": "HUE_SERVER",
+            "refName": "hue-HUE_LOAD_BALANCER-BASE",
+            "roleType": "HUE_LOAD_BALANCER",
             "base": true
           },
           {
-            "refName": "hue-HUE_LOAD_BALANCER-BASE",
-            "roleType": "HUE_LOAD_BALANCER",
+            "refName": "hue-HUE_SERVER-BASE",
+            "roleType": "HUE_SERVER",
             "base": true
           }
         ]
@@ -278,6 +175,153 @@
             "refName": "livy-LIVY_SERVER-BASE",
             "roleType": "LIVY_SERVER",
             "base": true
+          }
+        ]
+      },
+      {
+        "refName": "oozie",
+        "serviceType": "OOZIE",
+        "roleConfigGroups": [
+          {
+            "refName": "oozie-OOZIE_SERVER-BASE",
+            "roleType": "OOZIE_SERVER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "queuemanager",
+        "serviceType": "QUEUEMANAGER",
+        "serviceConfigs": [
+          {
+            "name": "kerberos.auth.enabled",
+            "value": "true"
+          }
+        ],
+        "roleConfigGroups": [
+          {
+            "refName": "yarn-QUEUEMANAGER_STORE-BASE",
+            "roleType": "QUEUEMANAGER_STORE",
+            "base": true
+          },
+          {
+            "refName": "yarn-QUEUEMANAGER_WEBAPP-BASE",
+            "roleType": "QUEUEMANAGER_WEBAPP",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "spark_on_yarn",
+        "serviceType": "SPARK_ON_YARN",
+        "roleConfigGroups": [
+          {
+            "refName": "spark_on_yarn-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          },
+          {
+            "refName": "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+            "roleType": "SPARK_YARN_HISTORY_SERVER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "tez",
+        "serviceType": "TEZ",
+        "serviceConfigs": [
+          {
+            "name": "yarn_service",
+            "ref": "yarn"
+          },
+          {
+            "name": "tez.am.container.reuse.non-local-fallback.enabled",
+            "value": "true"
+          },
+          {
+            "name": "tez.am.container.reuse.locality.delay-allocation-millis",
+            "value": "0"
+          },
+          {
+            "name": "tez.am.launch.cmd-opts",
+            "value": "-XX:+PrintGCDetails -verbose:gc -XX:+UseNUMA -XX:+UseG1GC -XX:+ResizeTLAB"
+          },
+          {
+            "name": "tez.task.launch.cmd-opts",
+            "value": "-XX:+PrintGCDetails -verbose:gc -XX:+UseNUMA -XX:+UseG1GC -XX:+ResizeTLAB"
+          }
+        ],
+        "roleConfigGroups": [
+          {
+            "refName": "tez-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "yarn",
+        "serviceType": "YARN",
+        "serviceConfigs": [
+          {
+            "name": "yarn_admin_acl",
+            "value": "yarn,hive,hdfs"
+          }
+        ],
+        "roleConfigGroups": [
+          {
+            "refName": "yarn-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true,
+            "configs": [
+              {
+                "name": "mapreduce_map_memory_mb",
+                "value": 4096
+              },
+              {
+                "name": "mapreduce_reduce_memory_mb",
+                "value": 4096
+              }
+            ]
+          },
+          {
+            "refName": "yarn-JOBHISTORY-BASE",
+            "roleType": "JOBHISTORY",
+            "base": true
+          },
+          {
+            "refName": "yarn-NODEMANAGER-COMPUTE",
+            "roleType": "NODEMANAGER",
+            "base": false
+          },
+          {
+            "refName": "yarn-NODEMANAGER-WORKER",
+            "roleType": "NODEMANAGER",
+            "base": false
+          },
+          {
+            "refName": "yarn-RESOURCEMANAGER-BASE",
+            "roleType": "RESOURCEMANAGER",
+            "base": true,
+            "configs": [
+              {
+                "name": "resourcemanager_config_safety_valve",
+                "value": "<property><name>yarn.scheduler.configuration.store.class</name><value>zk</value></property>"
+              },
+              {
+                "name": "yarn_resourcemanager_scheduler_class",
+                "value": "org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler"
+              },
+              {
+                "name": "yarn_scheduler_capacity_resource_calculator",
+                "value": "org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator"
+              },
+              {
+                "name": "resourcemanager_capacity_scheduler_configuration",
+                "value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property></configuration>"
+              }
+            ]
           }
         ]
       },
@@ -307,56 +351,12 @@
         ]
       },
       {
-        "refName": "das",
-        "serviceType": "DAS",
+        "refName": "zookeeper",
+        "serviceType": "ZOOKEEPER",
         "roleConfigGroups": [
           {
-            "refName": "das-DAS_WEBAPP",
-            "roleType": "DAS_WEBAPP",
-            "base": true,
-            "configs": [
-              {
-                "name": "data_analytics_studio_admin_users",
-                "value": "*"
-              }
-            ]
-          },
-          {
-            "refName": "das-DAS_EVENT_PROCESSOR",
-            "roleType": "DAS_EVENT_PROCESSOR",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "oozie",
-        "serviceType": "OOZIE",
-        "roleConfigGroups": [
-          {
-            "refName": "oozie-OOZIE_SERVER-BASE",
-            "roleType": "OOZIE_SERVER",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "queuemanager",
-        "serviceType": "QUEUEMANAGER",
-        "serviceConfigs": [
-          {
-            "name": "kerberos.auth.enabled",
-            "value": "true"
-          }
-        ],
-        "roleConfigGroups": [
-          {
-            "refName": "yarn-QUEUEMANAGER_WEBAPP-BASE",
-            "roleType": "QUEUEMANAGER_WEBAPP",
-            "base": true
-          },
-          {
-            "refName": "yarn-QUEUEMANAGER_STORE-BASE",
-            "roleType": "QUEUEMANAGER_STORE",
+            "refName": "zookeeper-SERVER-BASE",
+            "roleType": "SERVER",
             "base": true
           }
         ]
@@ -364,32 +364,56 @@
     ],
     "hostTemplates": [
       {
+        "refName": "compute",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "hive_on_tez-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
+          "spark_on_yarn-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
+          "yarn-GATEWAY-BASE",
+          "yarn-NODEMANAGER-COMPUTE"
+        ]
+      },
+      {
+        "refName": "gateway",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "hive_on_tez-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
+          "livy-GATEWAY-BASE",
+          "spark_on_yarn-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
+          "yarn-GATEWAY-BASE"
+        ]
+      },
+      {
         "refName": "master",
         "cardinality": 1,
         "roleConfigGroupsRefNames": [
+          "das-DAS_EVENT_PROCESSOR",
+          "das-DAS_WEBAPP",
           "hdfs-BALANCER-BASE",
           "hdfs-NAMENODE-BASE",
           "hdfs-SECONDARYNAMENODE-BASE",
+          "hive_on_tez-GATEWAY-BASE",
+          "hive_on_tez-HIVESERVER2-BASE",
           "hms-GATEWAY-BASE",
           "hms-HIVEMETASTORE-BASE",
-          "hive_on_tez-HIVESERVER2-BASE",
-          "hive_on_tez-GATEWAY-BASE",
           "hue-HUE_LOAD_BALANCER-BASE",
           "hue-HUE_SERVER-BASE",
-          "tez-GATEWAY-BASE",
+          "livy-LIVY_SERVER-BASE",
+          "oozie-OOZIE_SERVER-BASE",
           "spark_on_yarn-GATEWAY-BASE",
           "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
-          "livy-LIVY_SERVER-BASE",
-          "zeppelin-ZEPPELIN_SERVER-BASE",
-          "oozie-OOZIE_SERVER-BASE",
+          "tez-GATEWAY-BASE",
+          "yarn-GATEWAY-BASE",
           "yarn-JOBHISTORY-BASE",
-          "yarn-RESOURCEMANAGER-BASE",
-          "zookeeper-SERVER-BASE",
-          "das-DAS_WEBAPP",
-          "das-DAS_EVENT_PROCESSOR",
-          "yarn-QUEUEMANAGER_WEBAPP-BASE",
           "yarn-QUEUEMANAGER_STORE-BASE",
-          "yarn-GATEWAY-BASE"
+          "yarn-QUEUEMANAGER_WEBAPP-BASE",
+          "yarn-RESOURCEMANAGER-BASE",
+          "zeppelin-ZEPPELIN_SERVER-BASE",
+          "zookeeper-SERVER-BASE"
         ]
       },
       {
@@ -397,37 +421,13 @@
         "cardinality": 3,
         "roleConfigGroupsRefNames": [
           "hdfs-DATANODE-BASE",
-          "hms-GATEWAY-BASE",
           "hive_on_tez-GATEWAY-BASE",
-          "tez-GATEWAY-BASE",
-          "spark_on_yarn-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
           "livy-GATEWAY-BASE",
-          "yarn-NODEMANAGER-WORKER",
-          "yarn-GATEWAY-BASE"
-        ]
-      },
-      {
-        "refName": "compute",
-        "cardinality": 0,
-        "roleConfigGroupsRefNames": [
-          "hms-GATEWAY-BASE",
-          "hive_on_tez-GATEWAY-BASE",
-          "tez-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
-          "yarn-NODEMANAGER-COMPUTE",
-          "yarn-GATEWAY-BASE"
-        ]
-      },
-      {
-        "refName": "gateway",
-        "cardinality": 0,
-        "roleConfigGroupsRefNames": [
-          "hms-GATEWAY-BASE",
-          "hive_on_tez-GATEWAY-BASE",
           "tez-GATEWAY-BASE",
-          "spark_on_yarn-GATEWAY-BASE",
-          "livy-GATEWAY-BASE",
-          "yarn-GATEWAY-BASE"
+          "yarn-GATEWAY-BASE",
+          "yarn-NODEMANAGER-WORKER"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-702.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-702.bp
@@ -5,13 +5,24 @@
     "displayName": "dataengineering ha",
     "services": [
       {
-        "refName": "zookeeper",
-        "serviceType": "ZOOKEEPER",
+        "refName": "das",
+        "serviceType": "DAS",
         "roleConfigGroups": [
           {
-            "refName": "zookeeper-SERVER-BASE",
-            "roleType": "SERVER",
+            "refName": "das-DAS_EVENT_PROCESSOR",
+            "roleType": "DAS_EVENT_PROCESSOR",
             "base": true
+          },
+          {
+            "refName": "das-DAS_WEBAPP",
+            "roleType": "DAS_WEBAPP",
+            "base": true,
+            "configs": [
+              {
+                "name": "data_analytics_studio_admin_users",
+                "value": "*"
+              }
+            ]
           }
         ]
       },
@@ -30,8 +41,13 @@
         ],
         "roleConfigGroups": [
           {
-            "refName": "hdfs-NAMENODE-BASE",
-            "roleType": "NAMENODE",
+            "refName": "hdfs-BALANCER-BASE",
+            "roleType": "BALANCER",
+            "base": true
+          },
+          {
+            "refName": "hdfs-DATANODE-BASE",
+            "roleType": "DATANODE",
             "base": true
           },
           {
@@ -45,8 +61,8 @@
             "base": true
           },
           {
-            "refName": "hdfs-DATANODE-BASE",
-            "roleType": "DATANODE",
+            "refName": "hdfs-NAMENODE-BASE",
+            "roleType": "NAMENODE",
             "base": true
           },
           {
@@ -58,28 +74,6 @@
                 "value": "/should_not_be_required_in_HA_setup"
               }
             ],
-            "base": true
-          },
-          {
-            "refName": "hdfs-BALANCER-BASE",
-            "roleType": "BALANCER",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "hms",
-        "serviceType": "HIVE",
-        "displayName": "Hive Metastore",
-        "roleConfigGroups": [
-          {
-            "refName": "hms-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "base": true
-          },
-          {
-            "refName": "hms-HIVEMETASTORE-BASE",
-            "roleType": "HIVEMETASTORE",
             "base": true
           }
         ]
@@ -108,6 +102,23 @@
         ]
       },
       {
+        "refName": "hms",
+        "serviceType": "HIVE",
+        "displayName": "Hive Metastore",
+        "roleConfigGroups": [
+          {
+            "refName": "hms-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          },
+          {
+            "refName": "hms-HIVEMETASTORE-BASE",
+            "roleType": "HIVEMETASTORE",
+            "base": true
+          }
+        ]
+      },
+      {
         "refName": "hue",
         "serviceType": "HUE",
         "serviceConfigs": [
@@ -118,16 +129,27 @@
         ],
         "roleConfigGroups": [
           {
-            "refName": "hue-HUE_SERVER-BASE",
-            "roleType": "HUE_SERVER",
-            "base": true
-          },
-          {
             "refName": "hue-HUE_LOAD_BALANCER-BASE",
             "roleType": "HUE_LOAD_BALANCER",
             "base": true
+          },
+          {
+            "refName": "hue-HUE_SERVER-BASE",
+            "roleType": "HUE_SERVER",
+            "base": true
           }
         ]
+      },
+      {
+        "refName": "knox",
+        "roleConfigGroups": [
+          {
+            "base": true,
+            "refName": "knox-KNOX_GATEWAY-BASE",
+            "roleType": "KNOX_GATEWAY"
+          }
+        ],
+        "serviceType": "KNOX"
       },
       {
         "refName": "livy",
@@ -157,67 +179,17 @@
         ]
       },
       {
-        "refName": "yarn",
-        "serviceType": "YARN",
-        "serviceConfigs": [
-          {
-            "name": "yarn_admin_acl",
-            "value": "yarn,hive,hdfs"
-          }
-        ],
-        "roleConfigGroups": [
-          {
-            "refName": "yarn-RESOURCEMANAGER-BASE",
-            "roleType": "RESOURCEMANAGER",
-            "base": true,
-            "configs": [
-              {
-                "name": "resourcemanager_config_safety_valve",
-                "value": "<property><name>yarn.scheduler.configuration.store.class</name><value>file</value></property>"
-              },
-              {
-                "name": "yarn_resourcemanager_scheduler_class",
-                "value": "org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler"
-              },
-              {
-                "name": "yarn_scheduler_capacity_resource_calculator",
-                "value": "org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator"
-              },
-              {
-                "name": "resourcemanager_capacity_scheduler_configuration",
-                "value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property><property><name>yarn.scheduler.capacity.per-node-heartbeat.maximum-offswitch-assignments</name><value>4</value></property></configuration>"
-              }
-            ]
-          },
-          {
-            "refName": "yarn-NODEMANAGER-WORKER",
-            "roleType": "NODEMANAGER",
-            "base": false
-          },
-          {
-            "refName": "yarn-NODEMANAGER-COMPUTE",
-            "roleType": "NODEMANAGER",
-            "base": false
-          },
-          {
-            "refName": "yarn-JOBHISTORY-BASE",
-            "roleType": "JOBHISTORY",
-            "base": true
-          }
-        ]
-      },
-      {
         "refName": "spark_on_yarn",
         "serviceType": "SPARK_ON_YARN",
         "roleConfigGroups": [
           {
-            "refName": "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
-            "roleType": "SPARK_YARN_HISTORY_SERVER",
+            "refName": "spark_on_yarn-GATEWAY-BASE",
+            "roleType": "GATEWAY",
             "base": true
           },
           {
-            "refName": "spark_on_yarn-GATEWAY-BASE",
-            "roleType": "GATEWAY",
+            "refName": "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+            "roleType": "SPARK_YARN_HISTORY_SERVER",
             "base": true
           }
         ]
@@ -256,37 +228,54 @@
         ]
       },
       {
-        "refName": "das",
-        "serviceType": "DAS",
+        "refName": "yarn",
+        "serviceType": "YARN",
+        "serviceConfigs": [
+          {
+            "name": "yarn_admin_acl",
+            "value": "yarn,hive,hdfs"
+          }
+        ],
         "roleConfigGroups": [
           {
-            "refName": "das-DAS_WEBAPP",
-            "roleType": "DAS_WEBAPP",
+            "refName": "yarn-JOBHISTORY-BASE",
+            "roleType": "JOBHISTORY",
+            "base": true
+          },
+          {
+            "refName": "yarn-NODEMANAGER-COMPUTE",
+            "roleType": "NODEMANAGER",
+            "base": false
+          },
+          {
+            "refName": "yarn-NODEMANAGER-WORKER",
+            "roleType": "NODEMANAGER",
+            "base": false
+          },
+          {
+            "refName": "yarn-RESOURCEMANAGER-BASE",
+            "roleType": "RESOURCEMANAGER",
             "base": true,
             "configs": [
               {
-                "name": "data_analytics_studio_admin_users",
-                "value": "*"
+                "name": "resourcemanager_config_safety_valve",
+                "value": "<property><name>yarn.scheduler.configuration.store.class</name><value>file</value></property>"
+              },
+              {
+                "name": "yarn_resourcemanager_scheduler_class",
+                "value": "org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler"
+              },
+              {
+                "name": "yarn_scheduler_capacity_resource_calculator",
+                "value": "org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator"
+              },
+              {
+                "name": "resourcemanager_capacity_scheduler_configuration",
+                "value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property><property><name>yarn.scheduler.capacity.per-node-heartbeat.maximum-offswitch-assignments</name><value>4</value></property></configuration>"
               }
             ]
-          },
-          {
-            "refName": "das-DAS_EVENT_PROCESSOR",
-            "roleType": "DAS_EVENT_PROCESSOR",
-            "base": true
           }
         ]
-      },
-      {
-        "refName": "knox",
-        "roleConfigGroups": [
-          {
-            "base": true,
-            "refName": "knox-KNOX_GATEWAY-BASE",
-            "roleType": "KNOX_GATEWAY"
-          }
-        ],
-        "serviceType": "KNOX"
       },
       {
         "refName": "zeppelin",
@@ -312,9 +301,32 @@
             "base": true
           }
         ]
+      },
+      {
+        "refName": "zookeeper",
+        "serviceType": "ZOOKEEPER",
+        "roleConfigGroups": [
+          {
+            "refName": "zookeeper-SERVER-BASE",
+            "roleType": "SERVER",
+            "base": true
+          }
+        ]
       }
     ],
     "hostTemplates": [
+      {
+        "refName": "compute",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "hive-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
+          "livy-GATEWAY-BASE",
+          "spark_on_yarn-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
+          "yarn-NODEMANAGER-COMPUTE"
+        ]
+      },
       {
         "refName": "gateway",
         "cardinality": 0,
@@ -327,10 +339,34 @@
         ]
       },
       {
+        "refName": "manager",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "das-DAS_EVENT_PROCESSOR",
+          "das-DAS_WEBAPP",
+          "hdfs-BALANCER-BASE",
+          "hdfs-JOURNALNODE-BASE",
+          "hive-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
+          "hue-HUE_LOAD_BALANCER-BASE",
+          "knox-KNOX_GATEWAY-BASE",
+          "livy-GATEWAY-BASE",
+          "livy-LIVY_SERVER-BASE",
+          "oozie-OOZIE_SERVER-BASE",
+          "spark_on_yarn-GATEWAY-BASE",
+          "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+          "tez-GATEWAY-BASE",
+          "yarn-JOBHISTORY-BASE",
+          "zeppelin-ZEPPELIN_SERVER-BASE",
+          "zookeeper-SERVER-BASE"
+        ]
+      },
+      {
         "refName": "master",
         "cardinality": 2,
         "roleConfigGroupsRefNames": [
           "hdfs-FAILOVERCONTROLLER-BASE",
+          "hdfs-JOURNALNODE-BASE",
           "hdfs-NAMENODE-BASE",
           "hive-GATEWAY-BASE",
           "hive-HIVESERVER2-BASE",
@@ -342,30 +378,6 @@
           "spark_on_yarn-GATEWAY-BASE",
           "tez-GATEWAY-BASE",
           "yarn-RESOURCEMANAGER-BASE",
-          "hdfs-JOURNALNODE-BASE",
-          "zookeeper-SERVER-BASE"
-        ]
-      },
-      {
-        "refName": "manager",
-        "cardinality": 1,
-        "roleConfigGroupsRefNames": [
-          "hdfs-BALANCER-BASE",
-          "hive-GATEWAY-BASE",
-          "hms-GATEWAY-BASE",
-          "hue-HUE_LOAD_BALANCER-BASE",
-          "livy-GATEWAY-BASE",
-          "livy-LIVY_SERVER-BASE",
-          "spark_on_yarn-GATEWAY-BASE",
-          "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
-          "tez-GATEWAY-BASE",
-          "yarn-JOBHISTORY-BASE",
-          "oozie-OOZIE_SERVER-BASE",
-          "zeppelin-ZEPPELIN_SERVER-BASE",
-          "das-DAS_EVENT_PROCESSOR",
-          "das-DAS_WEBAPP",
-          "knox-KNOX_GATEWAY-BASE",
-          "hdfs-JOURNALNODE-BASE",
           "zookeeper-SERVER-BASE"
         ]
       },
@@ -380,18 +392,6 @@
           "spark_on_yarn-GATEWAY-BASE",
           "tez-GATEWAY-BASE",
           "yarn-NODEMANAGER-WORKER"
-        ]
-      },
-      {
-        "refName": "compute",
-        "cardinality": 0,
-        "roleConfigGroupsRefNames": [
-          "hive-GATEWAY-BASE",
-          "hms-GATEWAY-BASE",
-          "livy-GATEWAY-BASE",
-          "spark_on_yarn-GATEWAY-BASE",
-          "tez-GATEWAY-BASE",
-          "yarn-NODEMANAGER-COMPUTE"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-710.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-710.bp
@@ -5,13 +5,24 @@
     "displayName": "dataengineering ha",
     "services": [
       {
-        "refName": "zookeeper",
-        "serviceType": "ZOOKEEPER",
+        "refName": "das",
+        "serviceType": "DAS",
         "roleConfigGroups": [
           {
-            "refName": "zookeeper-SERVER-BASE",
-            "roleType": "SERVER",
+            "refName": "das-DAS_EVENT_PROCESSOR",
+            "roleType": "DAS_EVENT_PROCESSOR",
             "base": true
+          },
+          {
+            "refName": "das-DAS_WEBAPP",
+            "roleType": "DAS_WEBAPP",
+            "base": true,
+            "configs": [
+              {
+                "name": "data_analytics_studio_admin_users",
+                "value": "*"
+              }
+            ]
           }
         ]
       },
@@ -30,8 +41,13 @@
         ],
         "roleConfigGroups": [
           {
-            "refName": "hdfs-NAMENODE-BASE",
-            "roleType": "NAMENODE",
+            "refName": "hdfs-BALANCER-BASE",
+            "roleType": "BALANCER",
+            "base": true
+          },
+          {
+            "refName": "hdfs-DATANODE-BASE",
+            "roleType": "DATANODE",
             "base": true
           },
           {
@@ -45,8 +61,8 @@
             "base": true
           },
           {
-            "refName": "hdfs-DATANODE-BASE",
-            "roleType": "DATANODE",
+            "refName": "hdfs-NAMENODE-BASE",
+            "roleType": "NAMENODE",
             "base": true
           },
           {
@@ -58,28 +74,6 @@
                 "value": "/should_not_be_required_in_HA_setup"
               }
             ],
-            "base": true
-          },
-          {
-            "refName": "hdfs-BALANCER-BASE",
-            "roleType": "BALANCER",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "hms",
-        "serviceType": "HIVE",
-        "displayName": "Hive Metastore",
-        "roleConfigGroups": [
-          {
-            "refName": "hms-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "base": true
-          },
-          {
-            "refName": "hms-HIVEMETASTORE-BASE",
-            "roleType": "HIVEMETASTORE",
             "base": true
           }
         ]
@@ -118,14 +112,31 @@
                 "value": "http"
               },
               {
-                 "name": "hiveserver2_mv_files_thread",
-                 "value": 20
+                "name": "hiveserver2_mv_files_thread",
+                "value": 20
               },
               {
-                 "name": "hiveserver2_load_dynamic_partitions_thread_count",
-                 "value": 20
+                "name": "hiveserver2_load_dynamic_partitions_thread_count",
+                "value": 20
               }
             ]
+          }
+        ]
+      },
+      {
+        "refName": "hms",
+        "serviceType": "HIVE",
+        "displayName": "Hive Metastore",
+        "roleConfigGroups": [
+          {
+            "refName": "hms-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          },
+          {
+            "refName": "hms-HIVEMETASTORE-BASE",
+            "roleType": "HIVEMETASTORE",
+            "base": true
           }
         ]
       },
@@ -140,16 +151,27 @@
         ],
         "roleConfigGroups": [
           {
-            "refName": "hue-HUE_SERVER-BASE",
-            "roleType": "HUE_SERVER",
-            "base": true
-          },
-          {
             "refName": "hue-HUE_LOAD_BALANCER-BASE",
             "roleType": "HUE_LOAD_BALANCER",
             "base": true
+          },
+          {
+            "refName": "hue-HUE_SERVER-BASE",
+            "roleType": "HUE_SERVER",
+            "base": true
           }
         ]
+      },
+      {
+        "refName": "knox",
+        "roleConfigGroups": [
+          {
+            "base": true,
+            "refName": "knox-KNOX_GATEWAY-BASE",
+            "roleType": "KNOX_GATEWAY"
+          }
+        ],
+        "serviceType": "KNOX"
       },
       {
         "refName": "livy",
@@ -179,86 +201,17 @@
         ]
       },
       {
-        "refName": "yarn",
-        "serviceType": "YARN",
-        "serviceConfigs": [
-          {
-            "name": "yarn_admin_acl",
-            "value": "yarn,hive,hdfs"
-          },
-          {
-            "name": "yarn_log_aggregation_IFile_remote_app_log_dir",
-            "value": ""
-          }
-        ],
-        "roleConfigGroups": [
-          {
-            "refName": "yarn-RESOURCEMANAGER-BASE",
-            "roleType": "RESOURCEMANAGER",
-            "base": true,
-            "configs": [
-              {
-                "name": "resourcemanager_config_safety_valve",
-                "value": "<property><name>yarn.scheduler.configuration.store.class</name><value>file</value></property>"
-              },
-              {
-                "name": "yarn_resourcemanager_scheduler_class",
-                "value": "org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler"
-              },
-              {
-                "name": "yarn_scheduler_capacity_resource_calculator",
-                "value": "org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator"
-              },
-              {
-                "name": "resourcemanager_capacity_scheduler_configuration",
-                "value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property></configuration>"
-              }
-            ]
-          },
-          {
-            "refName": "yarn-NODEMANAGER-WORKER",
-            "roleType": "NODEMANAGER",
-            "base": false
-          },
-          {
-            "refName": "yarn-NODEMANAGER-COMPUTE",
-            "roleType": "NODEMANAGER",
-            "base": false
-          },
-          {
-            "refName": "yarn-JOBHISTORY-BASE",
-            "roleType": "JOBHISTORY",
-            "base": true
-          },
-          {
-            "refName": "yarn-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "base": true,
-            "configs": [
-              {
-                "name": "mapreduce_map_memory_mb",
-                "value": 4096
-              },
-              {
-                "name": "mapreduce_reduce_memory_mb",
-                "value": 4096
-              }
-            ]
-          }
-        ]
-      },
-      {
         "refName": "spark_on_yarn",
         "serviceType": "SPARK_ON_YARN",
         "roleConfigGroups": [
           {
-            "refName": "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
-            "roleType": "SPARK_YARN_HISTORY_SERVER",
+            "refName": "spark_on_yarn-GATEWAY-BASE",
+            "roleType": "GATEWAY",
             "base": true
           },
           {
-            "refName": "spark_on_yarn-GATEWAY-BASE",
-            "roleType": "GATEWAY",
+            "refName": "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+            "roleType": "SPARK_YARN_HISTORY_SERVER",
             "base": true
           }
         ]
@@ -297,37 +250,73 @@
         ]
       },
       {
-        "refName": "das",
-        "serviceType": "DAS",
+        "refName": "yarn",
+        "serviceType": "YARN",
+        "serviceConfigs": [
+          {
+            "name": "yarn_admin_acl",
+            "value": "yarn,hive,hdfs"
+          },
+          {
+            "name": "yarn_log_aggregation_IFile_remote_app_log_dir",
+            "value": ""
+          }
+        ],
         "roleConfigGroups": [
           {
-            "refName": "das-DAS_WEBAPP",
-            "roleType": "DAS_WEBAPP",
+            "refName": "yarn-GATEWAY-BASE",
+            "roleType": "GATEWAY",
             "base": true,
             "configs": [
               {
-                "name": "data_analytics_studio_admin_users",
-                "value": "*"
+                "name": "mapreduce_map_memory_mb",
+                "value": 4096
+              },
+              {
+                "name": "mapreduce_reduce_memory_mb",
+                "value": 4096
               }
             ]
           },
           {
-            "refName": "das-DAS_EVENT_PROCESSOR",
-            "roleType": "DAS_EVENT_PROCESSOR",
+            "refName": "yarn-JOBHISTORY-BASE",
+            "roleType": "JOBHISTORY",
             "base": true
+          },
+          {
+            "refName": "yarn-NODEMANAGER-COMPUTE",
+            "roleType": "NODEMANAGER",
+            "base": false
+          },
+          {
+            "refName": "yarn-NODEMANAGER-WORKER",
+            "roleType": "NODEMANAGER",
+            "base": false
+          },
+          {
+            "refName": "yarn-RESOURCEMANAGER-BASE",
+            "roleType": "RESOURCEMANAGER",
+            "base": true,
+            "configs": [
+              {
+                "name": "resourcemanager_config_safety_valve",
+                "value": "<property><name>yarn.scheduler.configuration.store.class</name><value>file</value></property>"
+              },
+              {
+                "name": "yarn_resourcemanager_scheduler_class",
+                "value": "org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler"
+              },
+              {
+                "name": "yarn_scheduler_capacity_resource_calculator",
+                "value": "org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator"
+              },
+              {
+                "name": "resourcemanager_capacity_scheduler_configuration",
+                "value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property></configuration>"
+              }
+            ]
           }
         ]
-      },
-      {
-        "refName": "knox",
-        "roleConfigGroups": [
-          {
-            "base": true,
-            "refName": "knox-KNOX_GATEWAY-BASE",
-            "roleType": "KNOX_GATEWAY"
-          }
-        ],
-        "serviceType": "KNOX"
       },
       {
         "refName": "zeppelin",
@@ -353,9 +342,33 @@
             "base": true
           }
         ]
+      },
+      {
+        "refName": "zookeeper",
+        "serviceType": "ZOOKEEPER",
+        "roleConfigGroups": [
+          {
+            "refName": "zookeeper-SERVER-BASE",
+            "roleType": "SERVER",
+            "base": true
+          }
+        ]
       }
     ],
     "hostTemplates": [
+      {
+        "refName": "compute",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "hive-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
+          "livy-GATEWAY-BASE",
+          "spark_on_yarn-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
+          "yarn-GATEWAY-BASE",
+          "yarn-NODEMANAGER-COMPUTE"
+        ]
+      },
       {
         "refName": "gateway",
         "cardinality": 0,
@@ -369,10 +382,35 @@
         ]
       },
       {
+        "refName": "manager",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "das-DAS_EVENT_PROCESSOR",
+          "das-DAS_WEBAPP",
+          "hdfs-BALANCER-BASE",
+          "hdfs-JOURNALNODE-BASE",
+          "hive-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
+          "hue-HUE_LOAD_BALANCER-BASE",
+          "knox-KNOX_GATEWAY-BASE",
+          "livy-GATEWAY-BASE",
+          "livy-LIVY_SERVER-BASE",
+          "oozie-OOZIE_SERVER-BASE",
+          "spark_on_yarn-GATEWAY-BASE",
+          "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+          "tez-GATEWAY-BASE",
+          "yarn-GATEWAY-BASE",
+          "yarn-JOBHISTORY-BASE",
+          "zeppelin-ZEPPELIN_SERVER-BASE",
+          "zookeeper-SERVER-BASE"
+        ]
+      },
+      {
         "refName": "master",
         "cardinality": 2,
         "roleConfigGroupsRefNames": [
           "hdfs-FAILOVERCONTROLLER-BASE",
+          "hdfs-JOURNALNODE-BASE",
           "hdfs-NAMENODE-BASE",
           "hive-GATEWAY-BASE",
           "hive-HIVESERVER2-BASE",
@@ -383,34 +421,9 @@
           "livy-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
           "tez-GATEWAY-BASE",
+          "yarn-GATEWAY-BASE",
           "yarn-RESOURCEMANAGER-BASE",
-          "hdfs-JOURNALNODE-BASE",
-          "zookeeper-SERVER-BASE",
-          "yarn-GATEWAY-BASE"
-        ]
-      },
-      {
-        "refName": "manager",
-        "cardinality": 1,
-        "roleConfigGroupsRefNames": [
-          "hdfs-BALANCER-BASE",
-          "hive-GATEWAY-BASE",
-          "hms-GATEWAY-BASE",
-          "hue-HUE_LOAD_BALANCER-BASE",
-          "livy-GATEWAY-BASE",
-          "livy-LIVY_SERVER-BASE",
-          "spark_on_yarn-GATEWAY-BASE",
-          "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
-          "tez-GATEWAY-BASE",
-          "yarn-JOBHISTORY-BASE",
-          "oozie-OOZIE_SERVER-BASE",
-          "zeppelin-ZEPPELIN_SERVER-BASE",
-          "das-DAS_EVENT_PROCESSOR",
-          "das-DAS_WEBAPP",
-          "knox-KNOX_GATEWAY-BASE",
-          "hdfs-JOURNALNODE-BASE",
-          "zookeeper-SERVER-BASE",
-          "yarn-GATEWAY-BASE"
+          "zookeeper-SERVER-BASE"
         ]
       },
       {
@@ -423,21 +436,8 @@
           "livy-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
           "tez-GATEWAY-BASE",
-          "yarn-NODEMANAGER-WORKER",
-          "yarn-GATEWAY-BASE"
-        ]
-      },
-      {
-        "refName": "compute",
-        "cardinality": 0,
-        "roleConfigGroupsRefNames": [
-          "hive-GATEWAY-BASE",
-          "hms-GATEWAY-BASE",
-          "livy-GATEWAY-BASE",
-          "spark_on_yarn-GATEWAY-BASE",
-          "tez-GATEWAY-BASE",
-          "yarn-NODEMANAGER-COMPUTE",
-          "yarn-GATEWAY-BASE"
+          "yarn-GATEWAY-BASE",
+          "yarn-NODEMANAGER-WORKER"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-720.bp
@@ -5,13 +5,24 @@
     "displayName": "dataengineering ha",
     "services": [
       {
-        "refName": "zookeeper",
-        "serviceType": "ZOOKEEPER",
+        "refName": "das",
+        "serviceType": "DAS",
         "roleConfigGroups": [
           {
-            "refName": "zookeeper-SERVER-BASE",
-            "roleType": "SERVER",
+            "refName": "das-DAS_EVENT_PROCESSOR",
+            "roleType": "DAS_EVENT_PROCESSOR",
             "base": true
+          },
+          {
+            "refName": "das-DAS_WEBAPP",
+            "roleType": "DAS_WEBAPP",
+            "base": true,
+            "configs": [
+              {
+                "name": "data_analytics_studio_admin_users",
+                "value": "*"
+              }
+            ]
           }
         ]
       },
@@ -30,8 +41,13 @@
         ],
         "roleConfigGroups": [
           {
-            "refName": "hdfs-NAMENODE-BASE",
-            "roleType": "NAMENODE",
+            "refName": "hdfs-BALANCER-BASE",
+            "roleType": "BALANCER",
+            "base": true
+          },
+          {
+            "refName": "hdfs-DATANODE-BASE",
+            "roleType": "DATANODE",
             "base": true
           },
           {
@@ -45,8 +61,8 @@
             "base": true
           },
           {
-            "refName": "hdfs-DATANODE-BASE",
-            "roleType": "DATANODE",
+            "refName": "hdfs-NAMENODE-BASE",
+            "roleType": "NAMENODE",
             "base": true
           },
           {
@@ -58,28 +74,6 @@
                 "value": "/should_not_be_required_in_HA_setup"
               }
             ],
-            "base": true
-          },
-          {
-            "refName": "hdfs-BALANCER-BASE",
-            "roleType": "BALANCER",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "hms",
-        "serviceType": "HIVE",
-        "displayName": "Hive Metastore",
-        "roleConfigGroups": [
-          {
-            "refName": "hms-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "base": true
-          },
-          {
-            "refName": "hms-HIVEMETASTORE-BASE",
-            "roleType": "HIVEMETASTORE",
             "base": true
           }
         ]
@@ -130,6 +124,23 @@
         ]
       },
       {
+        "refName": "hms",
+        "serviceType": "HIVE",
+        "displayName": "Hive Metastore",
+        "roleConfigGroups": [
+          {
+            "refName": "hms-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          },
+          {
+            "refName": "hms-HIVEMETASTORE-BASE",
+            "roleType": "HIVEMETASTORE",
+            "base": true
+          }
+        ]
+      },
+      {
         "refName": "hue",
         "serviceType": "HUE",
         "serviceConfigs": [
@@ -140,16 +151,27 @@
         ],
         "roleConfigGroups": [
           {
-            "refName": "hue-HUE_SERVER-BASE",
-            "roleType": "HUE_SERVER",
-            "base": true
-          },
-          {
             "refName": "hue-HUE_LOAD_BALANCER-BASE",
             "roleType": "HUE_LOAD_BALANCER",
             "base": true
+          },
+          {
+            "refName": "hue-HUE_SERVER-BASE",
+            "roleType": "HUE_SERVER",
+            "base": true
           }
         ]
+      },
+      {
+        "refName": "knox",
+        "roleConfigGroups": [
+          {
+            "base": true,
+            "refName": "knox-KNOX_GATEWAY-BASE",
+            "roleType": "KNOX_GATEWAY"
+          }
+        ],
+        "serviceType": "KNOX"
       },
       {
         "refName": "livy",
@@ -179,67 +201,24 @@
         ]
       },
       {
-        "refName": "yarn",
-        "serviceType": "YARN",
+        "refName": "queuemanager",
+        "serviceType": "QUEUEMANAGER",
         "serviceConfigs": [
           {
-            "name": "yarn_admin_acl",
-            "value": "yarn,hive,hdfs"
+            "name": "kerberos.auth.enabled",
+            "value": "true"
           }
         ],
         "roleConfigGroups": [
           {
-            "refName": "yarn-RESOURCEMANAGER-BASE",
-            "roleType": "RESOURCEMANAGER",
-            "base": true,
-            "configs": [
-              {
-                "name": "resourcemanager_config_safety_valve",
-                "value": "<property><name>yarn.scheduler.configuration.store.class</name><value>zk</value></property>"
-              },
-              {
-                "name": "yarn_resourcemanager_scheduler_class",
-                "value": "org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler"
-              },
-              {
-                "name": "yarn_scheduler_capacity_resource_calculator",
-                "value": "org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator"
-              },
-              {
-                "name": "resourcemanager_capacity_scheduler_configuration",
-                "value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property></configuration>"
-              }
-            ]
-          },
-          {
-            "refName": "yarn-NODEMANAGER-WORKER",
-            "roleType": "NODEMANAGER",
-            "base": false
-          },
-          {
-            "refName": "yarn-NODEMANAGER-COMPUTE",
-            "roleType": "NODEMANAGER",
-            "base": false
-          },
-          {
-            "refName": "yarn-JOBHISTORY-BASE",
-            "roleType": "JOBHISTORY",
+            "refName": "yarn-QUEUEMANAGER_STORE-BASE",
+            "roleType": "QUEUEMANAGER_STORE",
             "base": true
           },
           {
-            "refName": "yarn-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "base": true,
-            "configs": [
-              {
-                "name": "mapreduce_map_memory_mb",
-                "value": 4096
-              },
-              {
-                "name": "mapreduce_reduce_memory_mb",
-                "value": 4096
-              }
-            ]
+            "refName": "yarn-QUEUEMANAGER_WEBAPP-BASE",
+            "roleType": "QUEUEMANAGER_WEBAPP",
+            "base": true
           }
         ]
       },
@@ -248,13 +227,13 @@
         "serviceType": "SPARK_ON_YARN",
         "roleConfigGroups": [
           {
-            "refName": "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
-            "roleType": "SPARK_YARN_HISTORY_SERVER",
+            "refName": "spark_on_yarn-GATEWAY-BASE",
+            "roleType": "GATEWAY",
             "base": true
           },
           {
-            "refName": "spark_on_yarn-GATEWAY-BASE",
-            "roleType": "GATEWAY",
+            "refName": "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+            "roleType": "SPARK_YARN_HISTORY_SERVER",
             "base": true
           }
         ]
@@ -293,37 +272,69 @@
         ]
       },
       {
-        "refName": "das",
-        "serviceType": "DAS",
+        "refName": "yarn",
+        "serviceType": "YARN",
+        "serviceConfigs": [
+          {
+            "name": "yarn_admin_acl",
+            "value": "yarn,hive,hdfs"
+          }
+        ],
         "roleConfigGroups": [
           {
-            "refName": "das-DAS_WEBAPP",
-            "roleType": "DAS_WEBAPP",
+            "refName": "yarn-GATEWAY-BASE",
+            "roleType": "GATEWAY",
             "base": true,
             "configs": [
               {
-                "name": "data_analytics_studio_admin_users",
-                "value": "*"
+                "name": "mapreduce_map_memory_mb",
+                "value": 4096
+              },
+              {
+                "name": "mapreduce_reduce_memory_mb",
+                "value": 4096
               }
             ]
           },
           {
-            "refName": "das-DAS_EVENT_PROCESSOR",
-            "roleType": "DAS_EVENT_PROCESSOR",
+            "refName": "yarn-JOBHISTORY-BASE",
+            "roleType": "JOBHISTORY",
             "base": true
+          },
+          {
+            "refName": "yarn-NODEMANAGER-COMPUTE",
+            "roleType": "NODEMANAGER",
+            "base": false
+          },
+          {
+            "refName": "yarn-NODEMANAGER-WORKER",
+            "roleType": "NODEMANAGER",
+            "base": false
+          },
+          {
+            "refName": "yarn-RESOURCEMANAGER-BASE",
+            "roleType": "RESOURCEMANAGER",
+            "base": true,
+            "configs": [
+              {
+                "name": "resourcemanager_config_safety_valve",
+                "value": "<property><name>yarn.scheduler.configuration.store.class</name><value>zk</value></property>"
+              },
+              {
+                "name": "yarn_resourcemanager_scheduler_class",
+                "value": "org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler"
+              },
+              {
+                "name": "yarn_scheduler_capacity_resource_calculator",
+                "value": "org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator"
+              },
+              {
+                "name": "resourcemanager_capacity_scheduler_configuration",
+                "value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property></configuration>"
+              }
+            ]
           }
         ]
-      },
-      {
-        "refName": "knox",
-        "roleConfigGroups": [
-          {
-            "base": true,
-            "refName": "knox-KNOX_GATEWAY-BASE",
-            "roleType": "KNOX_GATEWAY"
-          }
-        ],
-        "serviceType": "KNOX"
       },
       {
         "refName": "zeppelin",
@@ -351,29 +362,31 @@
         ]
       },
       {
-        "refName": "queuemanager",
-        "serviceType": "QUEUEMANAGER",
-        "serviceConfigs": [
-          {
-            "name": "kerberos.auth.enabled",
-            "value": "true"
-          }
-        ],
+        "refName": "zookeeper",
+        "serviceType": "ZOOKEEPER",
         "roleConfigGroups": [
           {
-            "refName": "yarn-QUEUEMANAGER_WEBAPP-BASE",
-            "roleType": "QUEUEMANAGER_WEBAPP",
-            "base": true
-          },
-          {
-            "refName": "yarn-QUEUEMANAGER_STORE-BASE",
-            "roleType": "QUEUEMANAGER_STORE",
+            "refName": "zookeeper-SERVER-BASE",
+            "roleType": "SERVER",
             "base": true
           }
         ]
       }
     ],
     "hostTemplates": [
+      {
+        "refName": "compute",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "hive-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
+          "livy-GATEWAY-BASE",
+          "spark_on_yarn-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
+          "yarn-GATEWAY-BASE",
+          "yarn-NODEMANAGER-COMPUTE"
+        ]
+      },
       {
         "refName": "gateway",
         "cardinality": 0,
@@ -387,10 +400,37 @@
         ]
       },
       {
+        "refName": "manager",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "das-DAS_EVENT_PROCESSOR",
+          "das-DAS_WEBAPP",
+          "hdfs-BALANCER-BASE",
+          "hdfs-JOURNALNODE-BASE",
+          "hive-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
+          "hue-HUE_LOAD_BALANCER-BASE",
+          "knox-KNOX_GATEWAY-BASE",
+          "livy-GATEWAY-BASE",
+          "livy-LIVY_SERVER-BASE",
+          "oozie-OOZIE_SERVER-BASE",
+          "spark_on_yarn-GATEWAY-BASE",
+          "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+          "tez-GATEWAY-BASE",
+          "yarn-GATEWAY-BASE",
+          "yarn-JOBHISTORY-BASE",
+          "yarn-QUEUEMANAGER_STORE-BASE",
+          "yarn-QUEUEMANAGER_WEBAPP-BASE",
+          "zeppelin-ZEPPELIN_SERVER-BASE",
+          "zookeeper-SERVER-BASE"
+        ]
+      },
+      {
         "refName": "master",
         "cardinality": 2,
         "roleConfigGroupsRefNames": [
           "hdfs-FAILOVERCONTROLLER-BASE",
+          "hdfs-JOURNALNODE-BASE",
           "hdfs-NAMENODE-BASE",
           "hive-GATEWAY-BASE",
           "hive-HIVESERVER2-BASE",
@@ -401,36 +441,9 @@
           "livy-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
           "tez-GATEWAY-BASE",
+          "yarn-GATEWAY-BASE",
           "yarn-RESOURCEMANAGER-BASE",
-          "hdfs-JOURNALNODE-BASE",
-          "zookeeper-SERVER-BASE",
-          "yarn-GATEWAY-BASE"
-        ]
-      },
-      {
-        "refName": "manager",
-        "cardinality": 1,
-        "roleConfigGroupsRefNames": [
-          "hdfs-BALANCER-BASE",
-          "hive-GATEWAY-BASE",
-          "hms-GATEWAY-BASE",
-          "hue-HUE_LOAD_BALANCER-BASE",
-          "livy-GATEWAY-BASE",
-          "livy-LIVY_SERVER-BASE",
-          "spark_on_yarn-GATEWAY-BASE",
-          "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
-          "tez-GATEWAY-BASE",
-          "yarn-JOBHISTORY-BASE",
-          "oozie-OOZIE_SERVER-BASE",
-          "zeppelin-ZEPPELIN_SERVER-BASE",
-          "das-DAS_EVENT_PROCESSOR",
-          "das-DAS_WEBAPP",
-          "knox-KNOX_GATEWAY-BASE",
-          "hdfs-JOURNALNODE-BASE",
-          "zookeeper-SERVER-BASE",
-          "yarn-QUEUEMANAGER_WEBAPP-BASE",
-          "yarn-QUEUEMANAGER_STORE-BASE",
-          "yarn-GATEWAY-BASE"
+          "zookeeper-SERVER-BASE"
         ]
       },
       {
@@ -443,21 +456,8 @@
           "livy-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
           "tez-GATEWAY-BASE",
-          "yarn-NODEMANAGER-WORKER",
-          "yarn-GATEWAY-BASE"
-        ]
-      },
-      {
-        "refName": "compute",
-        "cardinality": 0,
-        "roleConfigGroupsRefNames": [
-          "hive-GATEWAY-BASE",
-          "hms-GATEWAY-BASE",
-          "livy-GATEWAY-BASE",
-          "spark_on_yarn-GATEWAY-BASE",
-          "tez-GATEWAY-BASE",
-          "yarn-NODEMANAGER-COMPUTE",
-          "yarn-GATEWAY-BASE"
+          "yarn-GATEWAY-BASE",
+          "yarn-NODEMANAGER-WORKER"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-710.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-710.bp
@@ -9,6 +9,16 @@
         "serviceType": "HDFS",
         "roleConfigGroups": [
           {
+            "refName": "hdfs-BALANCER-BASE",
+            "roleType": "BALANCER",
+            "base": true
+          },
+          {
+            "refName": "hdfs-DATANODE-BASE",
+            "roleType": "DATANODE",
+            "base": true
+          },
+          {
             "refName": "hdfs-NAMENODE-BASE",
             "roleType": "NAMENODE",
             "base": true,
@@ -27,15 +37,38 @@
             "refName": "hdfs-SECONDARYNAMENODE-BASE",
             "roleType": "SECONDARYNAMENODE",
             "base": true
-          },
+          }
+        ]
+      },
+      {
+        "refName": "hms",
+        "serviceType": "HIVE",
+        "displayName": "Hive Metastore",
+        "roleConfigGroups": [
           {
-            "refName": "hdfs-DATANODE-BASE",
-            "roleType": "DATANODE",
+            "refName": "hms-GATEWAY-BASE",
+            "roleType": "GATEWAY",
             "base": true
           },
           {
-            "refName": "hdfs-BALANCER-BASE",
-            "roleType": "BALANCER",
+            "refName": "hms-HIVEMETASTORE-BASE",
+            "roleType": "HIVEMETASTORE",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "spark3_on_yarn",
+        "serviceType": "SPARK3_ON_YARN",
+        "roleConfigGroups": [
+          {
+            "refName": "spark3_on_yarn-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          },
+          {
+            "refName": "spark3_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+            "roleType": "SPARK3_YARN_HISTORY_SERVER",
             "base": true
           }
         ]
@@ -50,6 +83,21 @@
           }
         ],
         "roleConfigGroups": [
+          {
+            "refName": "yarn-JOBHISTORY-BASE",
+            "roleType": "JOBHISTORY",
+            "base": true
+          },
+          {
+            "refName": "yarn-NODEMANAGER-COMPUTE",
+            "roleType": "NODEMANAGER",
+            "base": false
+          },
+          {
+            "refName": "yarn-NODEMANAGER-WORKER",
+            "roleType": "NODEMANAGER",
+            "base": false
+          },
           {
             "refName": "yarn-RESOURCEMANAGER-BASE",
             "roleType": "RESOURCEMANAGER",
@@ -72,59 +120,20 @@
                 "value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property><property><name>yarn.scheduler.capacity.per-node-heartbeat.maximum-offswitch-assignments</name><value>4</value></property></configuration>"
               }
             ]
-          },
-          {
-            "refName": "yarn-NODEMANAGER-WORKER",
-            "roleType": "NODEMANAGER",
-            "base": false
-          },
-          {
-            "refName": "yarn-NODEMANAGER-COMPUTE",
-            "roleType": "NODEMANAGER",
-            "base": false
-          },
-          {
-            "refName": "yarn-JOBHISTORY-BASE",
-            "roleType": "JOBHISTORY",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "spark3_on_yarn",
-        "serviceType": "SPARK3_ON_YARN",
-        "roleConfigGroups": [
-          {
-            "refName": "spark3_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
-            "roleType": "SPARK3_YARN_HISTORY_SERVER",
-            "base": true
-          },
-          {
-            "refName": "spark3_on_yarn-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "hms",
-        "serviceType": "HIVE",
-        "displayName": "Hive Metastore",
-        "roleConfigGroups": [
-          {
-            "refName": "hms-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "base": true
-          },
-          {
-            "refName": "hms-HIVEMETASTORE-BASE",
-            "roleType": "HIVEMETASTORE",
-            "base": true
           }
         ]
       }
     ],
     "hostTemplates": [
+      {
+        "refName": "compute",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "hms-GATEWAY-BASE",
+          "spark3_on_yarn-GATEWAY-BASE",
+          "yarn-NODEMANAGER-COMPUTE"
+        ]
+      },
       {
         "refName": "master",
         "cardinality": 1,
@@ -148,15 +157,6 @@
           "hms-GATEWAY-BASE",
           "spark3_on_yarn-GATEWAY-BASE",
           "yarn-NODEMANAGER-WORKER"
-        ]
-      },
-      {
-        "refName": "compute",
-        "cardinality": 0,
-        "roleConfigGroupsRefNames": [
-          "hms-GATEWAY-BASE",
-          "spark3_on_yarn-GATEWAY-BASE",
-          "yarn-NODEMANAGER-COMPUTE"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-720.bp
@@ -9,6 +9,16 @@
         "serviceType": "HDFS",
         "roleConfigGroups": [
           {
+            "refName": "hdfs-BALANCER-BASE",
+            "roleType": "BALANCER",
+            "base": true
+          },
+          {
+            "refName": "hdfs-DATANODE-BASE",
+            "roleType": "DATANODE",
+            "base": true
+          },
+          {
             "refName": "hdfs-NAMENODE-BASE",
             "roleType": "NAMENODE",
             "base": true,
@@ -26,82 +36,6 @@
           {
             "refName": "hdfs-SECONDARYNAMENODE-BASE",
             "roleType": "SECONDARYNAMENODE",
-            "base": true
-          },
-          {
-            "refName": "hdfs-DATANODE-BASE",
-            "roleType": "DATANODE",
-            "base": true
-          },
-          {
-            "refName": "hdfs-BALANCER-BASE",
-            "roleType": "BALANCER",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "yarn",
-        "serviceType": "YARN",
-        "serviceConfigs": [
-          {
-            "name": "yarn_admin_acl",
-            "value": "yarn,hdfs"
-          }
-        ],
-        "roleConfigGroups": [
-          {
-            "refName": "yarn-RESOURCEMANAGER-BASE",
-            "roleType": "RESOURCEMANAGER",
-            "base": true,
-            "configs": [
-              {
-                "name": "resourcemanager_config_safety_valve",
-                "value": "<property><name>yarn.scheduler.configuration.store.class</name><value>zk</value></property>"
-              },
-              {
-                "name": "yarn_resourcemanager_scheduler_class",
-                "value": "org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler"
-              },
-              {
-                "name": "yarn_scheduler_capacity_resource_calculator",
-                "value": "org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator"
-              },
-              {
-                "name": "resourcemanager_capacity_scheduler_configuration",
-                "value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property><property><name>yarn.scheduler.capacity.per-node-heartbeat.maximum-offswitch-assignments</name><value>4</value></property></configuration>"
-              }
-            ]
-          },
-          {
-            "refName": "yarn-NODEMANAGER-WORKER",
-            "roleType": "NODEMANAGER",
-            "base": false
-          },
-          {
-            "refName": "yarn-NODEMANAGER-COMPUTE",
-            "roleType": "NODEMANAGER",
-            "base": false
-          },
-          {
-            "refName": "yarn-JOBHISTORY-BASE",
-            "roleType": "JOBHISTORY",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "spark3_on_yarn",
-        "serviceType": "SPARK3_ON_YARN",
-        "roleConfigGroups": [
-          {
-            "refName": "spark3_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
-            "roleType": "SPARK3_YARN_HISTORY_SERVER",
-            "base": true
-          },
-          {
-            "refName": "spark3_on_yarn-GATEWAY-BASE",
-            "roleType": "GATEWAY",
             "base": true
           }
         ]
@@ -134,19 +68,94 @@
         ],
         "roleConfigGroups": [
           {
-            "refName": "yarn-QUEUEMANAGER_WEBAPP-BASE",
-            "roleType": "QUEUEMANAGER_WEBAPP",
-            "base": true
-          },
-          {
             "refName": "yarn-QUEUEMANAGER_STORE-BASE",
             "roleType": "QUEUEMANAGER_STORE",
             "base": true
+          },
+          {
+            "refName": "yarn-QUEUEMANAGER_WEBAPP-BASE",
+            "roleType": "QUEUEMANAGER_WEBAPP",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "spark3_on_yarn",
+        "serviceType": "SPARK3_ON_YARN",
+        "roleConfigGroups": [
+          {
+            "refName": "spark3_on_yarn-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          },
+          {
+            "refName": "spark3_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+            "roleType": "SPARK3_YARN_HISTORY_SERVER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "yarn",
+        "serviceType": "YARN",
+        "serviceConfigs": [
+          {
+            "name": "yarn_admin_acl",
+            "value": "yarn,hdfs"
+          }
+        ],
+        "roleConfigGroups": [
+          {
+            "refName": "yarn-JOBHISTORY-BASE",
+            "roleType": "JOBHISTORY",
+            "base": true
+          },
+          {
+            "refName": "yarn-NODEMANAGER-COMPUTE",
+            "roleType": "NODEMANAGER",
+            "base": false
+          },
+          {
+            "refName": "yarn-NODEMANAGER-WORKER",
+            "roleType": "NODEMANAGER",
+            "base": false
+          },
+          {
+            "refName": "yarn-RESOURCEMANAGER-BASE",
+            "roleType": "RESOURCEMANAGER",
+            "base": true,
+            "configs": [
+              {
+                "name": "resourcemanager_config_safety_valve",
+                "value": "<property><name>yarn.scheduler.configuration.store.class</name><value>zk</value></property>"
+              },
+              {
+                "name": "yarn_resourcemanager_scheduler_class",
+                "value": "org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler"
+              },
+              {
+                "name": "yarn_scheduler_capacity_resource_calculator",
+                "value": "org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator"
+              },
+              {
+                "name": "resourcemanager_capacity_scheduler_configuration",
+                "value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property><property><name>yarn.scheduler.capacity.per-node-heartbeat.maximum-offswitch-assignments</name><value>4</value></property></configuration>"
+              }
+            ]
           }
         ]
       }
     ],
     "hostTemplates": [
+      {
+        "refName": "compute",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "hms-GATEWAY-BASE",
+          "spark3_on_yarn-GATEWAY-BASE",
+          "yarn-NODEMANAGER-COMPUTE"
+        ]
+      },
       {
         "refName": "master",
         "cardinality": 1,
@@ -159,9 +168,9 @@
           "spark3_on_yarn-GATEWAY-BASE",
           "spark3_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
           "yarn-JOBHISTORY-BASE",
-          "yarn-RESOURCEMANAGER-BASE",
+          "yarn-QUEUEMANAGER_STORE-BASE",
           "yarn-QUEUEMANAGER_WEBAPP-BASE",
-          "yarn-QUEUEMANAGER_STORE-BASE"
+          "yarn-RESOURCEMANAGER-BASE"
         ]
       },
       {
@@ -172,15 +181,6 @@
           "hms-GATEWAY-BASE",
           "spark3_on_yarn-GATEWAY-BASE",
           "yarn-NODEMANAGER-WORKER"
-        ]
-      },
-      {
-        "refName": "compute",
-        "cardinality": 0,
-        "roleConfigGroupsRefNames": [
-          "hms-GATEWAY-BASE",
-          "spark3_on_yarn-GATEWAY-BASE",
-          "yarn-NODEMANAGER-COMPUTE"
         ]
       }
     ]


### PR DESCRIPTION
1. CB-6547 identified a parity between normal template and HA templates.
2. There is not much difference between the templates but when one exists it takes a lot of time to figure out the parity.
3. To ease parity identification, as a first step sorting and indenting the DE templates.
4. To ease code review, this change does not contain any other modification than sort order and indentation.
5. The algorithm is `jq  '.blueprint.services|=sort_by(.refName)|.blueprint.services[].roleConfigGroups|=sort_by(.refName)|.blueprint.hostTemplates|=sort_by(.refName)|.blueprint.hostTemplates[].roleConfigGroupsRefNames|=sort'`.
6. Spot checked the difference between non ha and ha for couple of versions.