### PR TITLE
CB-7024 Salt change: deprecated expr_form to tgt_type to support Salt 3000+

### DIFF
--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/client/SaltConnector.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/client/SaltConnector.java
@@ -147,7 +147,7 @@ public class SaltConnector implements Closeable {
                 .param("client", clientType.getType());
         if (target != null) {
             form = form.param("tgt", target.getTarget())
-                    .param("expr_form", target.getType());
+                    .param("tgt_type", target.getType());
         }
         if ("state.show_sls".equals(fun)) {
             form.param("full_return",  "True");

--- a/orchestrator-salt/src/main/resources/salt/salt/metadata/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/metadata/settings.sls
@@ -1,5 +1,5 @@
 {% set server_address = [] %}
-{%- for host, host_ips in salt['mine.get']('G@roles:manager_server', 'network.ipaddrs', expr_form = 'compound').items() %}
+{%- for host, host_ips in salt['mine.get']('G@roles:manager_server', 'network.ipaddrs', tgt_type = 'compound').items() %}
   {%- for ip, args in pillar.get('hosts', {}).items() %}
     {% if ip in host_ips %}
       {% do server_address.append(ip) %}


### PR DESCRIPTION
Old images with 2017.7.5 and 2017.7.7 will continue to work as both param is present. 
```
Changed in version 2017.7.0: The expr_form argument has been renamed to tgt_type, earlier releases must use expr_form.
```
https://docs.saltstack.com/en/latest/topics/releases/2017.7.0.html#expr-form-deprecation