### PR TITLE
CB-6792 stop datalake delete when external db is provided but crn is …

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -18,6 +18,7 @@ import javax.inject.Inject;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.logging.log4j.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -474,6 +475,9 @@ public class SdxService implements ResourceIdProvider, ResourceBasedCrnProvider 
     }
 
     private void checkIfSdxIsDeletable(SdxCluster sdxCluster) {
+        if (sdxCluster.hasExternalDatabase() && Strings.isEmpty(sdxCluster.getDatabaseCrn())) {
+            throw new BadRequestException(String.format("Can not find external databese CRN for SDX: %s", sdxCluster.getClusterName()));
+        }
         Collection<StackViewV4Response> attachedDistroXClusters = distroxService.getAttachedDistroXClusters(sdxCluster.getEnvCrn());
         if (!attachedDistroXClusters.isEmpty()) {
             throw new BadRequestException(String.format("The following Data Hub cluster(s) must be terminated before SDX deletion [%s]",


### PR DESCRIPTION
…not yet available

**DELETE THIS TEMPLATE BEFORE SUBMITTING**

Describe the change you are making here!

Please include tests. Check out these examples:

- https://github.com/hortonworks/cloudbreak/blob/master/core/src/test/java/com/sequenceiq/cloudbreak/service/blueprint/BlueprintLoaderServiceTest.java#L62-L76

Please include a short description. Check out these examples:

- https://github.com/hortonworks/cloudbreak/commit/888b2e2a8887def28a24e26efcd6d9ca5863733a

If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:

Closes #xxx
Closes #xxx