### PR TITLE
CB-6967 Use DatabaseStack as resource connector parameter instead of DBInstanceIdentifier and implement Azure status lookup

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/ResourceConnector.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/ResourceConnector.java
@@ -122,28 +122,28 @@ public interface ResourceConnector<R> {
      * Starts the database server. The caller does not need to wait/block until
      * database server gets started.
      * @param authenticatedContext the authenticated context which holds the client object
-     * @param dbInstanceIdentifier the database server instance identifier
+     * @param stack contains the full description of infrastructure
      * @throws Exception in case of any error
      */
-    void startDatabaseServer(AuthenticatedContext authenticatedContext, String dbInstanceIdentifier) throws Exception;
+    void startDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack) throws Exception;
 
     /**
      * Stops the database server. The caller does not need to wait/block until
      * database server gets stopped.
      * @param authenticatedContext the authenticated context which holds the client object
-     * @param dbInstanceIdentifier the database server instance identifier
+     * @param stack contains the full description of infrastructure
      * @throws Exception in case of any error
      */
-    void stopDatabaseServer(AuthenticatedContext authenticatedContext, String dbInstanceIdentifier) throws Exception;
+    void stopDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack) throws Exception;
 
     /**
      *
      * @param authenticatedContext the authenticated context which holds the client object
-     * @param dbInstanceIdentifier the server instance identifier
+     * @param stack contains the full description of infrastructure
      * @return The status of the given database server instance
      * @throws Exception in case of any error
      */
-    ExternalDatabaseStatus getDatabaseServerStatus(AuthenticatedContext authenticatedContext, String dbInstanceIdentifier) throws Exception;
+    ExternalDatabaseStatus getDatabaseServerStatus(AuthenticatedContext authenticatedContext, DatabaseStack stack) throws Exception;
 
     /**
      * Update of infrastructure on Cloud platform. (e.g change Security groups). It does not need to wait/block until the infrastructure update is

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsStartService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsStartService.java
@@ -8,6 +8,7 @@ import com.sequenceiq.cloudbreak.cloud.aws.task.AwsPollTaskFactory;
 import com.sequenceiq.cloudbreak.cloud.aws.view.AwsCredentialView;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.cloudbreak.cloud.task.PollTask;
 import org.springframework.stereotype.Service;
 
@@ -29,10 +30,12 @@ public class AwsRdsStartService {
     @Inject
     private AwsBackoffSyncPollingScheduler<Boolean> awsBackoffSyncPollingScheduler;
 
-    public void start(AuthenticatedContext ac, String dbInstanceIdentifier) throws ExecutionException, TimeoutException, InterruptedException {
+    public void start(AuthenticatedContext ac, DatabaseStack dbStack) throws ExecutionException, TimeoutException, InterruptedException {
         AwsCredentialView credentialView = new AwsCredentialView(ac.getCloudCredential());
         String regionName = ac.getCloudContext().getLocation().getRegion().value();
         AmazonRDS rdsClient = awsClient.createRdsClient(credentialView, regionName);
+
+        String dbInstanceIdentifier = dbStack.getDatabaseServer().getServerId();
 
         StartDBInstanceRequest startDBInstanceRequest = new StartDBInstanceRequest();
         startDBInstanceRequest.setDBInstanceIdentifier(dbInstanceIdentifier);

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsStatusLookupService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsStatusLookupService.java
@@ -8,6 +8,7 @@ import com.sequenceiq.cloudbreak.cloud.aws.AwsClient;
 import com.sequenceiq.cloudbreak.cloud.aws.view.AwsCredentialView;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.cloudbreak.cloud.model.ExternalDatabaseStatus;
 import org.springframework.stereotype.Service;
 
@@ -19,10 +20,12 @@ public class AwsRdsStatusLookupService {
     @Inject
     private AwsClient awsClient;
 
-    public ExternalDatabaseStatus getStatus(AuthenticatedContext ac, String dbInstanceIdentifier) {
+    public ExternalDatabaseStatus getStatus(AuthenticatedContext ac, DatabaseStack dbStack) {
         AwsCredentialView credentialView = new AwsCredentialView(ac.getCloudCredential());
         String regionName = ac.getCloudContext().getLocation().getRegion().value();
         AmazonRDS rdsClient = awsClient.createRdsClient(credentialView, regionName);
+
+        String dbInstanceIdentifier = dbStack.getDatabaseServer().getServerId();
 
         DescribeDBInstancesRequest describeDBInstancesRequest = new DescribeDBInstancesRequest().withDBInstanceIdentifier(dbInstanceIdentifier);
         DescribeDBInstancesResult describeDBInstancesResult;

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsStopService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsStopService.java
@@ -8,6 +8,7 @@ import com.sequenceiq.cloudbreak.cloud.aws.task.AwsPollTaskFactory;
 import com.sequenceiq.cloudbreak.cloud.aws.view.AwsCredentialView;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.cloudbreak.cloud.task.PollTask;
 import org.springframework.stereotype.Service;
 
@@ -29,10 +30,12 @@ public class AwsRdsStopService {
     @Inject
     private AwsBackoffSyncPollingScheduler<Boolean> awsBackoffSyncPollingScheduler;
 
-    public void stop(AuthenticatedContext ac, String dbInstanceIdentifier) throws ExecutionException, TimeoutException, InterruptedException {
+    public void stop(AuthenticatedContext ac, DatabaseStack dbStack) throws ExecutionException, TimeoutException, InterruptedException {
         AwsCredentialView credentialView = new AwsCredentialView(ac.getCloudCredential());
         String regionName = ac.getCloudContext().getLocation().getRegion().value();
         AmazonRDS rdsClient = awsClient.createRdsClient(credentialView, regionName);
+
+        String dbInstanceIdentifier = dbStack.getDatabaseServer().getServerId();
 
         StopDBInstanceRequest stopDBInstanceRequest = new StopDBInstanceRequest();
         stopDBInstanceRequest.setDBInstanceIdentifier(dbInstanceIdentifier);

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnector.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnector.java
@@ -121,18 +121,18 @@ public class AwsResourceConnector implements ResourceConnector<Object> {
     }
 
     @Override
-    public void startDatabaseServer(AuthenticatedContext ac, String dbInstanceIdentifier) throws Exception {
-        awsRdsStartService.start(ac, dbInstanceIdentifier);
+    public void startDatabaseServer(AuthenticatedContext ac, DatabaseStack stack) throws Exception {
+        awsRdsStartService.start(ac, stack);
     }
 
     @Override
-    public void stopDatabaseServer(AuthenticatedContext ac, String dbInstanceIdentifier) throws Exception {
-        awsRdsStopService.stop(ac, dbInstanceIdentifier);
+    public void stopDatabaseServer(AuthenticatedContext ac, DatabaseStack stack) throws Exception {
+        awsRdsStopService.stop(ac, stack);
     }
 
     @Override
-    public ExternalDatabaseStatus getDatabaseServerStatus(AuthenticatedContext authenticatedContext, String dbInstanceIdentifier) throws Exception {
-        return awsRdsStatusLookupService.getStatus(authenticatedContext, dbInstanceIdentifier);
+    public ExternalDatabaseStatus getDatabaseServerStatus(AuthenticatedContext authenticatedContext, DatabaseStack stack) throws Exception {
+        return awsRdsStatusLookupService.getStatus(authenticatedContext, stack);
     }
 
     @Override

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsStopServiceTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsStopServiceTest.java
@@ -10,6 +10,8 @@ import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseServer;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.cloudbreak.cloud.model.Location;
 import com.sequenceiq.cloudbreak.cloud.model.Region;
 import com.sequenceiq.cloudbreak.cloud.task.PollTask;
@@ -68,6 +70,12 @@ public class AwsRdsStopServiceTest {
     @Mock
     private PollTask<Boolean> task;
 
+    @Mock
+    private DatabaseStack dbStack;
+
+    @Mock
+    private DatabaseServer databaseServer;
+
     @InjectMocks
     private AwsRdsStopService victim;
 
@@ -81,6 +89,8 @@ public class AwsRdsStopServiceTest {
         when(location.getRegion()).thenReturn(region);
         when(region.value()).thenReturn(REGION);
         when(awsClient.createRdsClient(any(AwsCredentialView.class), eq(REGION))).thenReturn(amazonRDS);
+        when(dbStack.getDatabaseServer()).thenReturn(databaseServer);
+        when(databaseServer.getServerId()).thenReturn(DB_INSTANCE_IDENTIFIER);
     }
 
     @Test
@@ -89,7 +99,7 @@ public class AwsRdsStopServiceTest {
         when(amazonRDS.stopDBInstance(stopDBInstanceRequestArgumentCaptor.capture())).thenReturn(null);
         when(awsPollTaskFactory.newRdbStatusCheckerTask(authenticatedContext, DB_INSTANCE_IDENTIFIER, SUCCESS_STATUS, amazonRDS)).thenReturn(task);
 
-        victim.stop(authenticatedContext, DB_INSTANCE_IDENTIFIER);
+        victim.stop(authenticatedContext, dbStack);
 
         assertEquals(DB_INSTANCE_IDENTIFIER, stopDBInstanceRequestArgumentCaptor.getValue().getDBInstanceIdentifier());
         verify(awsBackoffSyncPollingScheduler).schedule(task);
@@ -101,7 +111,7 @@ public class AwsRdsStopServiceTest {
 
         when(amazonRDS.stopDBInstance(stopDBInstanceRequestArgumentCaptor.capture())).thenThrow(new RuntimeException());
 
-        victim.stop(authenticatedContext, DB_INSTANCE_IDENTIFIER);
+        victim.stop(authenticatedContext, dbStack);
     }
 
     @Test(expected = CloudConnectorException.class)
@@ -111,6 +121,6 @@ public class AwsRdsStopServiceTest {
         when(awsPollTaskFactory.newRdbStatusCheckerTask(authenticatedContext, DB_INSTANCE_IDENTIFIER, SUCCESS_STATUS, amazonRDS)).thenReturn(task);
         doThrow(RuntimeException.class).when(awsBackoffSyncPollingScheduler).schedule(task);
 
-        victim.stop(authenticatedContext, DB_INSTANCE_IDENTIFIER);
+        victim.stop(authenticatedContext, dbStack);
     }
 }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
@@ -164,18 +164,18 @@ public class AzureResourceConnector implements ResourceConnector<Map<String, Map
     }
 
     @Override
-    public void startDatabaseServer(AuthenticatedContext authenticatedContext, String dbInstanceIdentifier) {
+    public void startDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack) {
         throw new UnsupportedOperationException("Database server start operation is not supported for " + getClass().getName());
     }
 
     @Override
-    public void stopDatabaseServer(AuthenticatedContext authenticatedContext, String dbInstanceIdentifier) {
+    public void stopDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack) {
         throw new UnsupportedOperationException("Database server stop operation is not supported for " + getClass().getName());
     }
 
     @Override
-    public ExternalDatabaseStatus getDatabaseServerStatus(AuthenticatedContext authenticatedContext, String dbInstanceIdentifier) throws Exception {
-        throw new UnsupportedOperationException("Database server status lookup is not supported for " + getClass().getName());
+    public ExternalDatabaseStatus getDatabaseServerStatus(AuthenticatedContext authenticatedContext, DatabaseStack stack) throws Exception {
+        return azureDatabaseResourceService.getDatabaseServerStatus(authenticatedContext, stack);
     }
 
     @Override

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/AzureDatabaseResourceService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/AzureDatabaseResourceService.java
@@ -6,6 +6,8 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
+import com.microsoft.azure.management.resources.ResourceGroup;
+import com.sequenceiq.cloudbreak.cloud.model.ExternalDatabaseStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -140,6 +142,23 @@ public class AzureDatabaseResourceService {
                 .type(ResourceType.AZURE_RESOURCE_GROUP)
                 .name(resourceGroupName)
                 .build(), ResourceStatus.DELETED));
+    }
+
+    public ExternalDatabaseStatus getDatabaseServerStatus(AuthenticatedContext ac, DatabaseStack stack) {
+        CloudContext cloudContext = ac.getCloudContext();
+        AzureClient client = ac.getParameter(AzureClient.class);
+        String resourceGroupName = azureUtils.getResourceGroupName(cloudContext, stack);
+
+        try {
+            ResourceGroup resourceGroup = client.getResourceGroup(resourceGroupName);
+            if (resourceGroup == null) {
+                return ExternalDatabaseStatus.DELETED;
+            }
+            return ExternalDatabaseStatus.STARTED;
+        } catch (Exception e) {
+            LOGGER.error(e.getMessage());
+            throw new CloudConnectorException(e);
+        }
     }
 }
 

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/AzureDatabaseResourceServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/AzureDatabaseResourceServiceTest.java
@@ -1,0 +1,75 @@
+package com.sequenceiq.cloudbreak.cloud.azure.connector.resource;
+
+import com.microsoft.azure.management.resources.ResourceGroup;
+import com.sequenceiq.cloudbreak.cloud.azure.AzureTemplateBuilder;
+import com.sequenceiq.cloudbreak.cloud.azure.AzureUtils;
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
+import com.sequenceiq.cloudbreak.cloud.model.ExternalDatabaseStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class AzureDatabaseResourceServiceTest {
+
+    private static final String RESOURCE_GROUP_NAME = "resource group name";
+
+    @Mock
+    private AzureTemplateBuilder azureTemplateBuilder;
+
+    @Mock
+    private AzureUtils azureUtils;
+
+    @Mock
+    private AuthenticatedContext ac;
+
+    @Mock
+    private DatabaseStack databaseStack;
+
+    @Mock
+    private CloudContext cloudContext;
+
+    @Mock
+    private AzureClient client;
+
+    @Mock
+    private ResourceGroup resourceGroup;
+
+    @InjectMocks
+    private AzureDatabaseResourceService victim;
+
+    @BeforeEach
+    public void initTests() {
+        when(ac.getCloudContext()).thenReturn(cloudContext);
+        when(ac.getParameter(AzureClient.class)).thenReturn(client);
+        when(azureUtils.getResourceGroupName(cloudContext, databaseStack)).thenReturn(RESOURCE_GROUP_NAME);
+    }
+
+    @Test
+    public void shouldReturnDeletedStatusInCaseOfMissingResourceGroup() {
+        when(client.getResourceGroup(RESOURCE_GROUP_NAME)).thenReturn(null);
+
+        ExternalDatabaseStatus actual = victim.getDatabaseServerStatus(ac, databaseStack);
+
+        assertEquals(ExternalDatabaseStatus.DELETED, actual);
+    }
+
+    @Test
+    public void shouldReturnStartedStatusInCaseOfExistingResourceGroup() {
+        when(client.getResourceGroup(RESOURCE_GROUP_NAME)).thenReturn(resourceGroup);
+
+        ExternalDatabaseStatus actual = victim.getDatabaseServerStatus(ac, databaseStack);
+
+        assertEquals(ExternalDatabaseStatus.STARTED, actual);
+    }
+}

--- a/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockResourceConnector.java
+++ b/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockResourceConnector.java
@@ -193,17 +193,17 @@ public class MockResourceConnector implements ResourceConnector<Object> {
     }
 
     @Override
-    public void startDatabaseServer(AuthenticatedContext authenticatedContext, String dbInstanceIdentifier) {
+    public void startDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack) {
         throw new UnsupportedOperationException("Database server start operation is not supported for " + getClass().getName());
     }
 
     @Override
-    public void stopDatabaseServer(AuthenticatedContext authenticatedContext, String dbInstanceIdentifier) {
+    public void stopDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack) {
         throw new UnsupportedOperationException("Database server stop operation is not supported for " + getClass().getName());
     }
 
     @Override
-    public ExternalDatabaseStatus getDatabaseServerStatus(AuthenticatedContext authenticatedContext, String dbInstanceIdentifier) throws Exception {
+    public ExternalDatabaseStatus getDatabaseServerStatus(AuthenticatedContext authenticatedContext, DatabaseStack stack) throws Exception {
         throw new UnsupportedOperationException("Database server status lookup is not supported for " + getClass().getName());
     }
 }

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/heat/OpenStackResourceConnector.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/heat/OpenStackResourceConnector.java
@@ -127,17 +127,17 @@ public class OpenStackResourceConnector implements ResourceConnector<Object> {
     }
 
     @Override
-    public void startDatabaseServer(AuthenticatedContext authenticatedContext, String dbInstanceIdentifier) {
+    public void startDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack) {
         throw new UnsupportedOperationException("Database server start operation is not supported for " + getClass().getName());
     }
 
     @Override
-    public void stopDatabaseServer(AuthenticatedContext authenticatedContext, String dbInstanceIdentifier) {
+    public void stopDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack) {
         throw new UnsupportedOperationException("Database server stop operation is not supported for " + getClass().getName());
     }
 
     @Override
-    public ExternalDatabaseStatus getDatabaseServerStatus(AuthenticatedContext authenticatedContext, String dbInstanceIdentifier) throws Exception {
+    public ExternalDatabaseStatus getDatabaseServerStatus(AuthenticatedContext authenticatedContext, DatabaseStack stack) throws Exception {
         throw new UnsupportedOperationException("Database server status lookup is not supported for " + getClass().getName());
     }
 

--- a/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/task/PollPermanentExternalDatabaseStateTask.java
+++ b/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/task/PollPermanentExternalDatabaseStateTask.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.cloud.task;
 import com.sequenceiq.cloudbreak.cloud.ResourceConnector;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.cloudbreak.cloud.model.ExternalDatabaseStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,22 +18,22 @@ public class PollPermanentExternalDatabaseStateTask extends AbstractPollTask<Ext
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PollPermanentExternalDatabaseStateTask.class);
 
-    private String dbInstanceIdentifier;
+    private DatabaseStack dbStack;
 
     private ResourceConnector resourceConnector;
 
     public PollPermanentExternalDatabaseStateTask(AuthenticatedContext authenticatedContext,
-            String dbInstanceIdentifier, ResourceConnector resourceConnector) {
+            DatabaseStack dbStack, ResourceConnector resourceConnector) {
         super(authenticatedContext);
-        this.dbInstanceIdentifier = dbInstanceIdentifier;
+        this.dbStack = dbStack;
         this.resourceConnector = resourceConnector;
     }
 
     @Override
     protected ExternalDatabaseStatus doCall() {
-        LOGGER.debug("Checking '{}' RDB instance status is in permanent status group.", dbInstanceIdentifier);
+        LOGGER.debug("Checking '{}' RDB instance status is in permanent status group.", dbStack);
         try {
-            return resourceConnector.getDatabaseServerStatus(getAuthenticatedContext(), dbInstanceIdentifier);
+            return resourceConnector.getDatabaseServerStatus(getAuthenticatedContext(), dbStack);
         } catch (Exception ex) {
             throw new CloudConnectorException(ex.getMessage(), ex);
         }

--- a/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/task/PollTaskFactory.java
+++ b/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/task/PollTaskFactory.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
@@ -36,9 +37,9 @@ public class PollTaskFactory {
     }
 
     public PollTask<ExternalDatabaseStatus> newPollPermanentExternalDatabaseStateTask(AuthenticatedContext authenticatedContext,
-            String dbInstanceIdentifier) {
+            DatabaseStack dbStack) {
         CloudConnector<Object> connector = cloudPlatformConnectors.get(authenticatedContext.getCloudContext().getPlatformVariant());
-        return createPollTask(PollPermanentExternalDatabaseStateTask.NAME, authenticatedContext, dbInstanceIdentifier, connector.resources());
+        return createPollTask(PollPermanentExternalDatabaseStateTask.NAME, authenticatedContext, dbStack, connector.resources());
     }
 
     @SuppressWarnings("unchecked")

--- a/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/AbstractResourceConnector.java
+++ b/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/AbstractResourceConnector.java
@@ -110,17 +110,17 @@ public abstract class AbstractResourceConnector implements ResourceConnector<Lis
     }
 
     @Override
-    public void startDatabaseServer(AuthenticatedContext authenticatedContext, String dbInstanceIdentifier) {
+    public void startDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack) {
         throw new UnsupportedOperationException("Database server start operation is not supported for " + getClass().getName());
     }
 
     @Override
-    public void stopDatabaseServer(AuthenticatedContext authenticatedContext, String dbInstanceIdentifier) {
+    public void stopDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack) {
         throw new UnsupportedOperationException("Database server stop operation is not supported for " + getClass().getName());
     }
 
     @Override
-    public ExternalDatabaseStatus getDatabaseServerStatus(AuthenticatedContext authenticatedContext, String dbInstanceIdentifier) throws Exception {
+    public ExternalDatabaseStatus getDatabaseServerStatus(AuthenticatedContext authenticatedContext, DatabaseStack stack) throws Exception {
         throw new UnsupportedOperationException("Database server status lookup is not supported for " + getClass().getName());
     }
 

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnResourceConnector.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnResourceConnector.java
@@ -230,17 +230,17 @@ public class YarnResourceConnector implements ResourceConnector<Object> {
     }
 
     @Override
-    public void startDatabaseServer(AuthenticatedContext authenticatedContext, String dbInstanceIdentifier) {
+    public void startDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack) {
         throw new UnsupportedOperationException("Database server start operation is not supported for " + getClass().getName());
     }
 
     @Override
-    public void stopDatabaseServer(AuthenticatedContext authenticatedContext, String dbInstanceIdentifier) {
+    public void stopDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack) {
         throw new UnsupportedOperationException("Database server stop operation is not supported for " + getClass().getName());
     }
 
     @Override
-    public ExternalDatabaseStatus getDatabaseServerStatus(AuthenticatedContext authenticatedContext, String dbInstanceIdentifier) throws Exception {
+    public ExternalDatabaseStatus getDatabaseServerStatus(AuthenticatedContext authenticatedContext, DatabaseStack stack) throws Exception {
         throw new UnsupportedOperationException("Database server status lookup is not supported for " + getClass().getName());
     }
 

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/start/RedbeamsStartContext.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/start/RedbeamsStartContext.java
@@ -2,6 +2,7 @@ package com.sequenceiq.redbeams.flow.redbeams.start;
 
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.flow.core.CommonContext;
 import com.sequenceiq.flow.core.FlowParameters;
 
@@ -11,20 +12,16 @@ public class RedbeamsStartContext extends CommonContext {
 
     private final CloudCredential cloudCredential;
 
-    private final String dbInstanceIdentifier;
-
-    private final String dbVendorDisplayName;
+    private final DatabaseStack databaseStack;
 
     public RedbeamsStartContext(FlowParameters flowParameters,
                                 CloudContext cloudContext,
                                 CloudCredential cloudCredential,
-                                String dbInstanceIdentifier,
-                                String dbVendorDisplayName) {
+                                DatabaseStack databaseStack) {
         super(flowParameters);
         this.cloudContext = cloudContext;
         this.cloudCredential = cloudCredential;
-        this.dbInstanceIdentifier = dbInstanceIdentifier;
-        this.dbVendorDisplayName = dbVendorDisplayName;
+        this.databaseStack = databaseStack;
     }
 
     public CloudContext getCloudContext() {
@@ -35,11 +32,7 @@ public class RedbeamsStartContext extends CommonContext {
         return cloudCredential;
     }
 
-    public String getDbInstanceIdentifier() {
-        return dbInstanceIdentifier;
-    }
-
-    public String getDbVendorDisplayName() {
-        return dbVendorDisplayName;
+    public DatabaseStack getDatabaseStack() {
+        return databaseStack;
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/start/actions/StartDatabaseServerAction.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/start/actions/StartDatabaseServerAction.java
@@ -29,6 +29,6 @@ public class StartDatabaseServerAction extends AbstractRedbeamsStartAction<Redbe
     @Override
     protected Selectable createRequest(RedbeamsStartContext context) {
         return new StartDatabaseServerRequest(context.getCloudContext(), context.getCloudCredential(),
-            context.getDbInstanceIdentifier());
+            context.getDatabaseStack());
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/start/actions/StartDatabaseServerFinishedAction.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/start/actions/StartDatabaseServerFinishedAction.java
@@ -2,13 +2,13 @@ package com.sequenceiq.redbeams.flow.redbeams.start.actions;
 
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.redbeams.api.model.common.DetailedDBStackStatus;
+import com.sequenceiq.redbeams.domain.stack.DBStack;
 import com.sequenceiq.redbeams.flow.redbeams.common.RedbeamsEvent;
 import com.sequenceiq.redbeams.flow.redbeams.start.RedbeamsStartContext;
 import com.sequenceiq.redbeams.flow.redbeams.start.RedbeamsStartEvent;
 import com.sequenceiq.redbeams.flow.redbeams.start.event.StartDatabaseServerSuccess;
 import com.sequenceiq.redbeams.metrics.MetricType;
 import com.sequenceiq.redbeams.metrics.RedbeamsMetricService;
-import com.sequenceiq.redbeams.metrics.RedbeamsMetricTag;
 import com.sequenceiq.redbeams.service.stack.DBStackStatusUpdater;
 import org.springframework.stereotype.Component;
 
@@ -30,13 +30,12 @@ public class StartDatabaseServerFinishedAction extends AbstractRedbeamsStartActi
 
     @Override
     protected void prepareExecution(StartDatabaseServerSuccess payload, Map<Object, Object> variables) {
-        dbStackStatusUpdater.updateStatus(payload.getResourceId(), DetailedDBStackStatus.STARTED);
+        DBStack dbStack = dbStackStatusUpdater.updateStatus(payload.getResourceId(), DetailedDBStackStatus.STARTED);
+        metricService.incrementMetricCounter(MetricType.DB_START_FINISHED, dbStack);
     }
 
     @Override
     protected Selectable createRequest(RedbeamsStartContext context) {
-        metricService.incrementMetricCounter(MetricType.DB_START_FINISHED, RedbeamsMetricTag.DATABASE_VENDOR.name(), context.getDbVendorDisplayName());
-
         return new RedbeamsEvent(RedbeamsStartEvent.REDBEAMS_START_FINISHED_EVENT.name(), 0L);
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/start/event/StartDatabaseServerRequest.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/start/event/StartDatabaseServerRequest.java
@@ -2,6 +2,7 @@ package com.sequenceiq.redbeams.flow.redbeams.start.event;
 
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.redbeams.flow.redbeams.common.RedbeamsEvent;
 
 /**
@@ -13,13 +14,13 @@ public class StartDatabaseServerRequest extends RedbeamsEvent {
 
     private final CloudCredential cloudCredential;
 
-    private final String dbInstanceIdentifier;
+    private final DatabaseStack dbStack;
 
-    public StartDatabaseServerRequest(CloudContext cloudContext, CloudCredential cloudCredential, String dbInstanceIdentifier) {
+    public StartDatabaseServerRequest(CloudContext cloudContext, CloudCredential cloudCredential, DatabaseStack dbStack) {
         super(cloudContext != null ? cloudContext.getId() : null);
         this.cloudContext = cloudContext;
         this.cloudCredential = cloudCredential;
-        this.dbInstanceIdentifier = dbInstanceIdentifier;
+        this.dbStack = dbStack;
     }
 
     public CloudContext getCloudContext() {
@@ -30,15 +31,15 @@ public class StartDatabaseServerRequest extends RedbeamsEvent {
         return cloudCredential;
     }
 
-    public String getDbInstanceIdentifier() {
-        return dbInstanceIdentifier;
+    public DatabaseStack getDbStack() {
+        return dbStack;
     }
 
     public String toString() {
         return "StartDatabaseServerRequest{"
                 + "cloudContext=" + cloudContext
                 + ", cloudCredential=" + cloudCredential
-                + ", dbInstanceIdentifier=" + dbInstanceIdentifier
+                + ", dbStack=" + dbStack
                 + '}';
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/start/handler/StartDatabaseServerHandler.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/start/handler/StartDatabaseServerHandler.java
@@ -57,20 +57,20 @@ public class StartDatabaseServerHandler implements EventHandler<StartDatabaseSer
             CloudConnector<Object> connector = cloudPlatformConnectors.get(cloudContext.getPlatformVariant());
             AuthenticatedContext ac = connector.authentication().authenticate(cloudContext, request.getCloudCredential());
 
-            ExternalDatabaseStatus status = connector.resources().getDatabaseServerStatus(ac, request.getDbInstanceIdentifier());
+            ExternalDatabaseStatus status = connector.resources().getDatabaseServerStatus(ac, request.getDbStack());
             if (status != null && status.isTransient()) {
-                LOGGER.debug("Database server '{}' is in '{}' status. Start waiting for a permanent status.", request.getDbInstanceIdentifier(), status);
+                LOGGER.debug("Database server '{}' is in '{}' status. Start waiting for a permanent status.", request.getDbStack(), status);
 
-                PollTask<ExternalDatabaseStatus> task = statusCheckFactory.newPollPermanentExternalDatabaseStateTask(ac, request.getDbInstanceIdentifier());
+                PollTask<ExternalDatabaseStatus> task = statusCheckFactory.newPollPermanentExternalDatabaseStateTask(ac, request.getDbStack());
                 status = externalDatabaseStatusPollingScheduler.schedule(task);
             }
 
             if (status != STARTED) {
                 LOGGER.debug("Database server '{}' is in '{}' status. Calling for '{}' status.",
-                        request.getDbInstanceIdentifier(), status, STARTED);
-                connector.resources().startDatabaseServer(ac, request.getDbInstanceIdentifier());
+                        request.getDbStack(), status, STARTED);
+                connector.resources().startDatabaseServer(ac, request.getDbStack());
             } else {
-                LOGGER.debug("Database server '{}' is already in '{}' status.", request.getDbInstanceIdentifier(), STARTED);
+                LOGGER.debug("Database server '{}' is already in '{}' status.", request.getDbStack(), STARTED);
             }
 
             RedbeamsEvent success = new StartDatabaseServerSuccess(request.getResourceId());

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/stop/RedbeamsStopContext.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/stop/RedbeamsStopContext.java
@@ -2,6 +2,7 @@ package com.sequenceiq.redbeams.flow.redbeams.stop;
 
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.flow.core.CommonContext;
 import com.sequenceiq.flow.core.FlowParameters;
 
@@ -11,20 +12,16 @@ public class RedbeamsStopContext extends CommonContext {
 
     private final CloudCredential cloudCredential;
 
-    private final String dbInstanceIdentifier;
-
-    private final String dbVendorDisplayName;
+    private final DatabaseStack databaseStack;
 
     public RedbeamsStopContext(FlowParameters flowParameters,
-                                CloudContext cloudContext,
-                                CloudCredential cloudCredential,
-                                String dbInstanceIdentifier,
-                                String dbVendorDisplayName) {
+            CloudContext cloudContext,
+            CloudCredential cloudCredential,
+            DatabaseStack databaseStack) {
         super(flowParameters);
         this.cloudContext = cloudContext;
         this.cloudCredential = cloudCredential;
-        this.dbInstanceIdentifier = dbInstanceIdentifier;
-        this.dbVendorDisplayName = dbVendorDisplayName;
+        this.databaseStack = databaseStack;
     }
 
     public CloudContext getCloudContext() {
@@ -35,11 +32,7 @@ public class RedbeamsStopContext extends CommonContext {
         return cloudCredential;
     }
 
-    public String getDbInstanceIdentifier() {
-        return dbInstanceIdentifier;
-    }
-
-    public String getDbVendorDisplayName() {
-        return dbVendorDisplayName;
+    public DatabaseStack getDatabaseStack() {
+        return databaseStack;
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/stop/actions/AbstractRedbeamsStopAction.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/stop/actions/AbstractRedbeamsStopAction.java
@@ -2,12 +2,14 @@ package com.sequenceiq.redbeams.flow.redbeams.stop.actions;
 
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.cloudbreak.cloud.model.Location;
 import com.sequenceiq.cloudbreak.common.event.Payload;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.flow.core.AbstractAction;
 import com.sequenceiq.flow.core.FlowParameters;
 import com.sequenceiq.redbeams.converter.cloud.CredentialToCloudCredentialConverter;
+import com.sequenceiq.redbeams.converter.spi.DBStackToDatabaseStackConverter;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
 import com.sequenceiq.redbeams.dto.Credential;
 import com.sequenceiq.redbeams.flow.redbeams.common.RedbeamsFailureEvent;
@@ -30,8 +32,6 @@ import static com.sequenceiq.cloudbreak.cloud.model.Region.region;
 public abstract class AbstractRedbeamsStopAction<P extends Payload>
         extends AbstractAction<RedbeamsStopState, RedbeamsStopEvent, RedbeamsStopContext, P> {
 
-    private static final String UNKOWN_VENDOR_DISPLAY_NAME = "UNKNOWN";
-
     @Inject
     private DBStackService dbStackService;
 
@@ -40,6 +40,9 @@ public abstract class AbstractRedbeamsStopAction<P extends Payload>
 
     @Inject
     private CredentialToCloudCredentialConverter credentialConverter;
+
+    @Inject
+    private DBStackToDatabaseStackConverter databaseStackConverter;
 
     protected AbstractRedbeamsStopAction(Class<P> payloadClass) {
         super(payloadClass);
@@ -56,36 +59,20 @@ public abstract class AbstractRedbeamsStopAction<P extends Payload>
     }
 
     @Override
-    protected RedbeamsStopContext createFlowContext(
-            FlowParameters flowParameters,
-            StateContext<RedbeamsStopState, RedbeamsStopEvent> stateContext,
-            P payload) {
-        Optional<DBStack> optionalDBStack = dbStackService.findById(payload.getResourceId());
+    protected RedbeamsStopContext createFlowContext(FlowParameters flowParameters,
+            StateContext<RedbeamsStopState, RedbeamsStopEvent> stateContext, P payload) {
+        DBStack dbStack = dbStackService.getById(payload.getResourceId());
+        MDCBuilder.buildMdcContext(dbStack);
+        Location location = location(region(dbStack.getRegion()), availabilityZone(dbStack.getAvailabilityZone()));
+        String userName = dbStack.getOwnerCrn().getUserId();
+        String accountId = dbStack.getOwnerCrn().getAccountId();
+        CloudContext cloudContext = new CloudContext(dbStack.getId(), dbStack.getName(), dbStack.getCloudPlatform(), dbStack.getPlatformVariant(),
+                location, userName, accountId);
+        Credential credential = credentialService.getCredentialByEnvCrn(dbStack.getEnvironmentId());
+        CloudCredential cloudCredential = credentialConverter.convert(credential);
+        DatabaseStack databaseStack = databaseStackConverter.convert(dbStack);
 
-        CloudContext cloudContext = null;
-        CloudCredential cloudCredential = null;
-        String dbInstanceIdentifier = null;
-        String dbVendorDisplayName = UNKOWN_VENDOR_DISPLAY_NAME;
-
-        if (optionalDBStack.isPresent()) {
-            DBStack dbStack = optionalDBStack.get();
-            MDCBuilder.buildMdcContext(dbStack);
-            Location location = location(region(dbStack.getRegion()), availabilityZone(dbStack.getAvailabilityZone()));
-            String userName = dbStack.getOwnerCrn().getUserId();
-            String accountId = dbStack.getOwnerCrn().getAccountId();
-            cloudContext = new CloudContext(dbStack.getId(), dbStack.getName(), dbStack.getCloudPlatform(), dbStack.getPlatformVariant(),
-                    location, userName, accountId);
-            Credential credential = credentialService.getCredentialByEnvCrn(dbStack.getEnvironmentId());
-            cloudCredential = credentialConverter.convert(credential);
-
-            if (dbStack.getDatabaseServer() != null) {
-                dbInstanceIdentifier = dbStack.getDatabaseServer().getName();
-                if (dbStack.getDatabaseServer().getDatabaseVendor() != null) {
-                    dbVendorDisplayName = dbStack.getDatabaseServer().getDatabaseVendor().displayName();
-                }
-            }
-        }
-        return new RedbeamsStopContext(flowParameters, cloudContext, cloudCredential, dbInstanceIdentifier, dbVendorDisplayName);
+        return new RedbeamsStopContext(flowParameters, cloudContext, cloudCredential, databaseStack);
     }
 
     @Override

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/stop/actions/StopDatabaseServerAction.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/stop/actions/StopDatabaseServerAction.java
@@ -29,6 +29,6 @@ public class StopDatabaseServerAction extends AbstractRedbeamsStopAction<Redbeam
     @Override
     protected Selectable createRequest(RedbeamsStopContext context) {
         return new StopDatabaseServerRequest(context.getCloudContext(), context.getCloudCredential(),
-                context.getDbInstanceIdentifier());
+                context.getDatabaseStack());
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/stop/actions/StopDatabaseServerFinishedAction.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/stop/actions/StopDatabaseServerFinishedAction.java
@@ -2,13 +2,13 @@ package com.sequenceiq.redbeams.flow.redbeams.stop.actions;
 
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.redbeams.api.model.common.DetailedDBStackStatus;
+import com.sequenceiq.redbeams.domain.stack.DBStack;
 import com.sequenceiq.redbeams.flow.redbeams.common.RedbeamsEvent;
 import com.sequenceiq.redbeams.flow.redbeams.stop.RedbeamsStopContext;
 import com.sequenceiq.redbeams.flow.redbeams.stop.RedbeamsStopEvent;
 import com.sequenceiq.redbeams.flow.redbeams.stop.event.StopDatabaseServerSuccess;
 import com.sequenceiq.redbeams.metrics.MetricType;
 import com.sequenceiq.redbeams.metrics.RedbeamsMetricService;
-import com.sequenceiq.redbeams.metrics.RedbeamsMetricTag;
 import com.sequenceiq.redbeams.service.stack.DBStackStatusUpdater;
 import org.springframework.stereotype.Component;
 
@@ -30,13 +30,12 @@ public class StopDatabaseServerFinishedAction extends AbstractRedbeamsStopAction
 
     @Override
     protected void prepareExecution(StopDatabaseServerSuccess payload, Map<Object, Object> variables) {
-        dbStackStatusUpdater.updateStatus(payload.getResourceId(), DetailedDBStackStatus.STOPPED);
+        DBStack dbStack = dbStackStatusUpdater.updateStatus(payload.getResourceId(), DetailedDBStackStatus.STOPPED);
+        metricService.incrementMetricCounter(MetricType.DB_STOP_FINISHED, dbStack);
     }
 
     @Override
     protected Selectable createRequest(RedbeamsStopContext context) {
-        metricService.incrementMetricCounter(MetricType.DB_STOP_FINISHED, RedbeamsMetricTag.DATABASE_VENDOR.name(), context.getDbVendorDisplayName());
-
         return new RedbeamsEvent(RedbeamsStopEvent.REDBEAMS_STOP_FINISHED_EVENT.name(), 0L);
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/stop/event/StopDatabaseServerRequest.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/stop/event/StopDatabaseServerRequest.java
@@ -2,6 +2,7 @@ package com.sequenceiq.redbeams.flow.redbeams.stop.event;
 
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.redbeams.flow.redbeams.common.RedbeamsEvent;
 
 /**
@@ -13,13 +14,13 @@ public class StopDatabaseServerRequest extends RedbeamsEvent {
 
     private final CloudCredential cloudCredential;
 
-    private final String dbInstanceIdentifier;
+    private final DatabaseStack dbStack;
 
-    public StopDatabaseServerRequest(CloudContext cloudContext, CloudCredential cloudCredential, String dbInstanceIdentifier) {
+    public StopDatabaseServerRequest(CloudContext cloudContext, CloudCredential cloudCredential, DatabaseStack dbStack) {
         super(cloudContext != null ? cloudContext.getId() : null);
         this.cloudContext = cloudContext;
         this.cloudCredential = cloudCredential;
-        this.dbInstanceIdentifier = dbInstanceIdentifier;
+        this.dbStack = dbStack;
     }
 
     public CloudContext getCloudContext() {
@@ -30,15 +31,15 @@ public class StopDatabaseServerRequest extends RedbeamsEvent {
         return cloudCredential;
     }
 
-    public String getDbInstanceIdentifier() {
-        return dbInstanceIdentifier;
+    public DatabaseStack getDbStack() {
+        return dbStack;
     }
 
     public String toString() {
         return "StopDatabaseServerRequest{"
                 + "cloudContext=" + cloudContext
                 + ", cloudCredential=" + cloudCredential
-                + ", dbInstanceIdentifier=" + dbInstanceIdentifier
+                + ", dbStack=" + dbStack
                 + '}';
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/stop/handler/StopDatabaseServerHandler.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/stop/handler/StopDatabaseServerHandler.java
@@ -61,19 +61,19 @@ public class StopDatabaseServerHandler implements EventHandler<StopDatabaseServe
             CloudConnector<Object> connector = cloudPlatformConnectors.get(cloudContext.getPlatformVariant());
             AuthenticatedContext ac = connector.authentication().authenticate(cloudContext, request.getCloudCredential());
 
-            ExternalDatabaseStatus status = connector.resources().getDatabaseServerStatus(ac, request.getDbInstanceIdentifier());
+            ExternalDatabaseStatus status = connector.resources().getDatabaseServerStatus(ac, request.getDbStack());
             if (status != null && status.isTransient()) {
-                LOGGER.debug("Database server '{}' is in '{}' status. Start waiting for a permanent status.", request.getDbInstanceIdentifier(), status);
+                LOGGER.debug("Database server '{}' is in '{}' status. Start waiting for a permanent status.", request.getDbStack(), status);
 
-                PollTask<ExternalDatabaseStatus> task = statusCheckFactory.newPollPermanentExternalDatabaseStateTask(ac, request.getDbInstanceIdentifier());
+                PollTask<ExternalDatabaseStatus> task = statusCheckFactory.newPollPermanentExternalDatabaseStateTask(ac, request.getDbStack());
                 status = externalDatabaseStatusPollingScheduler.schedule(task);
             }
 
             if (status != STOPPED) {
-                LOGGER.debug("Database server '{}' is in '{}' status. Calling for '{}' status.", request.getDbInstanceIdentifier(), status, STOPPED);
-                connector.resources().stopDatabaseServer(ac, request.getDbInstanceIdentifier());
+                LOGGER.debug("Database server '{}' is in '{}' status. Calling for '{}' status.", request.getDbStack(), status, STOPPED);
+                connector.resources().stopDatabaseServer(ac, request.getDbStack());
             } else {
-                LOGGER.debug("Database server '{}' is already in '{}' status.", request.getDbInstanceIdentifier(), STOPPED);
+                LOGGER.debug("Database server '{}' is already in '{}' status.", request.getDbStack(), STOPPED);
             }
 
             RedbeamsEvent success = new StopDatabaseServerSuccess(request.getResourceId());

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/sync/DBStackJobService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/sync/DBStackJobService.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
 
-import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
 import com.sequenceiq.statuschecker.service.JobService;
 
@@ -26,16 +25,14 @@ public class DBStackJobService {
     }
 
     public void schedule(DBStack dbStack) {
-        if (dbStack.getCloudPlatform().equalsIgnoreCase(CloudPlatform.AWS.name()) && autoSyncConfig.isEnabled()) {
+        if (autoSyncConfig.isEnabled()) {
             jobService.schedule(new DBStackJobAdapter(dbStack));
             LOGGER.info("{} is scheduled for auto sync", dbStack.getName());
         }
     }
 
     public void unschedule(DBStack dbStack) {
-        if (dbStack.getCloudPlatform().equalsIgnoreCase(CloudPlatform.AWS.name())) {
-            jobService.unschedule(new DBStackJobAdapter(dbStack).getLocalId());
-            LOGGER.info("{} is unscheduled, it will not auto sync anymore", dbStack.getName());
-        }
+        jobService.unschedule(new DBStackJobAdapter(dbStack).getLocalId());
+        LOGGER.info("{} is unscheduled, it will not auto sync anymore", dbStack.getName());
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/sync/DBStackStatusSyncService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/sync/DBStackStatusSyncService.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.redbeams.sync;
 
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
+import com.sequenceiq.redbeams.converter.spi.DBStackToDatabaseStackConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -42,6 +44,9 @@ public class DBStackStatusSyncService {
 
     @Inject
     private CloudPlatformConnectors cloudPlatformConnectors;
+
+    @Inject
+    private DBStackToDatabaseStackConverter databaseStackConverter;
 
     @Inject
     private DBStackStatusUpdater dbStackStatusUpdater;
@@ -106,8 +111,9 @@ public class DBStackStatusSyncService {
 
             CloudConnector<Object> connector = cloudPlatformConnectors.get(cloudContext.getPlatformVariant());
             AuthenticatedContext ac = connector.authentication().authenticate(cloudContext, cloudCredential);
+            DatabaseStack databaseStack = databaseStackConverter.convert(dbStack);
 
-            return ofNullable(connector.resources().getDatabaseServerStatus(ac, dbStack.getDatabaseServer().getName()));
+            return ofNullable(connector.resources().getDatabaseServerStatus(ac, databaseStack));
         } catch (Exception ex) {
             LOGGER.error(":::Auto sync::: External DB status lookup failed.", ex);
             return empty();

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/start/actions/StartDatabaseServerActionTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/start/actions/StartDatabaseServerActionTest.java
@@ -2,6 +2,7 @@ package com.sequenceiq.redbeams.flow.redbeams.start.actions;
 
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.flow.core.FlowParameters;
 import com.sequenceiq.redbeams.api.model.common.DetailedDBStackStatus;
 import com.sequenceiq.redbeams.flow.redbeams.common.RedbeamsEvent;
@@ -22,10 +23,6 @@ public class StartDatabaseServerActionTest {
 
     private static final long RESOURCE_ID = 123L;
 
-    private static final String DB_INSTANCE_IDENTIFIER = "dbInstanceIdentifier";
-
-    private static final String DB_VENDOR_DISPLAY_NAME = "dbVendorDisplayName";
-
     @Mock
     private DBStackStatusUpdater dbStackStatusUpdater;
 
@@ -37,6 +34,9 @@ public class StartDatabaseServerActionTest {
 
     @Mock
     private FlowParameters flowParameters;
+
+    @Mock
+    private DatabaseStack dbStack;
 
     @InjectMocks
     private StartDatabaseServerAction victim;
@@ -52,12 +52,12 @@ public class StartDatabaseServerActionTest {
 
     @Test
     public void createRequestShouldReturnStartDatabaseServerRequest() {
-        RedbeamsStartContext context = new RedbeamsStartContext(flowParameters, cloudContext, cloudCredential, DB_INSTANCE_IDENTIFIER, DB_VENDOR_DISPLAY_NAME);
+        RedbeamsStartContext context = new RedbeamsStartContext(flowParameters, cloudContext, cloudCredential, dbStack);
 
         StartDatabaseServerRequest startDatabaseServerRequest = (StartDatabaseServerRequest) victim.createRequest(context);
 
         assertEquals(cloudContext, startDatabaseServerRequest.getCloudContext());
         assertEquals(cloudCredential, startDatabaseServerRequest.getCloudCredential());
-        assertEquals(DB_INSTANCE_IDENTIFIER, startDatabaseServerRequest.getDbInstanceIdentifier());
+        assertEquals(dbStack, startDatabaseServerRequest.getDbStack());
     }
 }

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/start/actions/StartDatabaseServerFailedActionTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/start/actions/StartDatabaseServerFailedActionTest.java
@@ -2,13 +2,14 @@ package com.sequenceiq.redbeams.flow.redbeams.start.actions;
 
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.flow.core.Flow;
 import com.sequenceiq.flow.core.FlowParameters;
 import com.sequenceiq.flow.core.FlowRegister;
 import com.sequenceiq.redbeams.api.model.common.DetailedDBStackStatus;
 import com.sequenceiq.redbeams.converter.cloud.CredentialToCloudCredentialConverter;
+import com.sequenceiq.redbeams.converter.spi.DBStackToDatabaseStackConverter;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
-import com.sequenceiq.redbeams.domain.stack.DatabaseServer;
 import com.sequenceiq.redbeams.dto.Credential;
 import com.sequenceiq.redbeams.flow.redbeams.common.RedbeamsEvent;
 import com.sequenceiq.redbeams.flow.redbeams.common.RedbeamsFailureEvent;
@@ -26,8 +27,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.statemachine.StateContext;
-
-import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verify;
@@ -57,8 +56,6 @@ public class StartDatabaseServerFailedActionTest {
     private static final String DB_STACK_AZ = "dbStackAz";
 
     private static final String DB_STACK_ENV_ID = "dbStackEnvId";
-
-    private static final String DB_SERVER_NAME = "dbServerName";
 
     @Mock
     private DBStackService dbStackService;
@@ -106,7 +103,10 @@ public class StartDatabaseServerFailedActionTest {
     private CloudCredential cloudCredential;
 
     @Mock
-    private DatabaseServer databaseServer;
+    private DBStackToDatabaseStackConverter databaseStackConverter;
+
+    @Mock
+    private DatabaseStack databaseStack;
 
     @InjectMocks
     private StartDatabaseServerFailedAction victim;
@@ -139,7 +139,7 @@ public class StartDatabaseServerFailedActionTest {
         when(runningFlows.get(FLOW_ID)).thenReturn(flow);
         when(payload.getException()).thenReturn(exception);
         when(payload.getResourceId()).thenReturn(RESOURCE_ID);
-        when(dbStackService.findById(RESOURCE_ID)).thenReturn(Optional.of(dbStack));
+        when(dbStackService.getById(RESOURCE_ID)).thenReturn(dbStack);
         when(dbStack.getOwnerCrn()).thenReturn(ownerCrn);
         when(dbStack.getId()).thenReturn(DB_STACK_ID);
         when(dbStack.getName()).thenReturn(DB_STACK_NAME);
@@ -148,12 +148,11 @@ public class StartDatabaseServerFailedActionTest {
         when(dbStack.getRegion()).thenReturn(DB_STACK_REGION);
         when(dbStack.getAvailabilityZone()).thenReturn(DB_STACK_AZ);
         when(dbStack.getEnvironmentId()).thenReturn(DB_STACK_ENV_ID);
-        when(dbStack.getDatabaseServer()).thenReturn(databaseServer);
         when(ownerCrn.getUserId()).thenReturn(USER_NAME);
         when(ownerCrn.getAccountId()).thenReturn(ACCOUNT_ID);
         when(credentialService.getCredentialByEnvCrn(DB_STACK_ENV_ID)).thenReturn(credential);
         when(credentialConverter.convert(credential)).thenReturn(cloudCredential);
-        when(databaseServer.getName()).thenReturn(DB_SERVER_NAME);
+        when(databaseStackConverter.convert(dbStack)).thenReturn(databaseStack);
 
         RedbeamsStartContext redbeamsStartContext = victim.createFlowContext(flowParameters, stateContext, payload);
 
@@ -170,7 +169,7 @@ public class StartDatabaseServerFailedActionTest {
         assertEquals(ACCOUNT_ID, redbeamsStartContext.getCloudContext().getAccountId());
         assertEquals(flowParameters, redbeamsStartContext.getFlowParameters());
         assertEquals(cloudCredential, redbeamsStartContext.getCloudCredential());
-        assertEquals(DB_SERVER_NAME, redbeamsStartContext.getDbInstanceIdentifier());
+        assertEquals(databaseStack, redbeamsStartContext.getDatabaseStack());
     }
 
     @Test

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/start/actions/StartDatabaseServerFinishedActionTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/start/actions/StartDatabaseServerFinishedActionTest.java
@@ -2,15 +2,16 @@ package com.sequenceiq.redbeams.flow.redbeams.start.actions;
 
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.flow.core.FlowParameters;
 import com.sequenceiq.redbeams.api.model.common.DetailedDBStackStatus;
+import com.sequenceiq.redbeams.domain.stack.DBStack;
 import com.sequenceiq.redbeams.flow.redbeams.common.RedbeamsEvent;
 import com.sequenceiq.redbeams.flow.redbeams.start.RedbeamsStartContext;
 import com.sequenceiq.redbeams.flow.redbeams.start.RedbeamsStartEvent;
 import com.sequenceiq.redbeams.flow.redbeams.start.event.StartDatabaseServerSuccess;
 import com.sequenceiq.redbeams.metrics.MetricType;
 import com.sequenceiq.redbeams.metrics.RedbeamsMetricService;
-import com.sequenceiq.redbeams.metrics.RedbeamsMetricTag;
 import com.sequenceiq.redbeams.service.stack.DBStackStatusUpdater;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,15 +21,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class StartDatabaseServerFinishedActionTest {
 
     private static final long RESOURCE_ID = 123L;
-
-    private static final String DB_INSTANCE_IDENTIFIER = "dbInstanceIdentifier";
-
-    private static final String DB_VENDOR_DISPLAY_NAME = "dbVendorDisplayName";
 
     @Mock
     private DBStackStatusUpdater dbStackStatusUpdater;
@@ -45,25 +43,33 @@ public class StartDatabaseServerFinishedActionTest {
     @Mock
     private CloudCredential cloudCredential;
 
+    @Mock
+    private DBStack dbStack;
+
+    @Mock
+    private DatabaseStack databaseStack;
+
     @InjectMocks
     private StartDatabaseServerFinishedAction victim;
 
     @Test
     public void shouldUpdateStatusOnPrepare() {
+        when(dbStackStatusUpdater.updateStatus(RESOURCE_ID, DetailedDBStackStatus.STARTED)).thenReturn(dbStack);
+
         StartDatabaseServerSuccess event = new StartDatabaseServerSuccess(RESOURCE_ID);
 
         victim.prepareExecution(event, null);
 
         verify(dbStackStatusUpdater).updateStatus(RESOURCE_ID, DetailedDBStackStatus.STARTED);
+        verify(metricService).incrementMetricCounter(MetricType.DB_START_FINISHED, dbStack);
     }
 
     @Test
     public void shouldIncrementMetricOnCreateRequest() {
-        RedbeamsStartContext context = new RedbeamsStartContext(flowParameters, cloudContext, cloudCredential, DB_INSTANCE_IDENTIFIER, DB_VENDOR_DISPLAY_NAME);
+        RedbeamsStartContext context = new RedbeamsStartContext(flowParameters, cloudContext, cloudCredential, databaseStack);
 
         RedbeamsEvent redbeamsEvent = (RedbeamsEvent) victim.createRequest(context);
 
-        verify(metricService).incrementMetricCounter(MetricType.DB_START_FINISHED, RedbeamsMetricTag.DATABASE_VENDOR.name(), DB_VENDOR_DISPLAY_NAME);
         assertEquals(RedbeamsStartEvent.REDBEAMS_START_FINISHED_EVENT.name(), redbeamsEvent.selector());
     }
 }

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/stop/actions/StopDatabaseServerActionTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/stop/actions/StopDatabaseServerActionTest.java
@@ -2,6 +2,7 @@ package com.sequenceiq.redbeams.flow.redbeams.stop.actions;
 
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.flow.core.FlowParameters;
 import com.sequenceiq.redbeams.api.model.common.DetailedDBStackStatus;
 import com.sequenceiq.redbeams.flow.redbeams.common.RedbeamsEvent;
@@ -22,10 +23,6 @@ public class StopDatabaseServerActionTest {
 
     private static final long RESOURCE_ID = 123L;
 
-    private static final String DB_INSTANCE_IDENTIFIER = "dbInstanceIdentifier";
-
-    private static final String DB_VENDOR_DISPLAY_NAME = "dbVendorDisplayName";
-
     @Mock
     private DBStackStatusUpdater dbStackStatusUpdater;
 
@@ -37,6 +34,9 @@ public class StopDatabaseServerActionTest {
 
     @Mock
     private FlowParameters flowParameters;
+
+    @Mock
+    private DatabaseStack databaseStack;
 
     @InjectMocks
     private StopDatabaseServerAction victim;
@@ -52,12 +52,11 @@ public class StopDatabaseServerActionTest {
 
     @Test
     public void createRequestShouldReturnStopDatabaseServerRequest() {
-        RedbeamsStopContext context = new RedbeamsStopContext(flowParameters, cloudContext, cloudCredential, DB_INSTANCE_IDENTIFIER, DB_VENDOR_DISPLAY_NAME);
+        RedbeamsStopContext context = new RedbeamsStopContext(flowParameters, cloudContext, cloudCredential, databaseStack);
 
         StopDatabaseServerRequest stopDatabaseServerRequest = (StopDatabaseServerRequest) victim.createRequest(context);
 
         assertEquals(cloudContext, stopDatabaseServerRequest.getCloudContext());
         assertEquals(cloudCredential, stopDatabaseServerRequest.getCloudCredential());
-        assertEquals(DB_INSTANCE_IDENTIFIER, stopDatabaseServerRequest.getDbInstanceIdentifier());
     }
 }

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/stop/actions/StopDatabaseServerFinishedActionTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/stop/actions/StopDatabaseServerFinishedActionTest.java
@@ -2,15 +2,16 @@ package com.sequenceiq.redbeams.flow.redbeams.stop.actions;
 
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.flow.core.FlowParameters;
 import com.sequenceiq.redbeams.api.model.common.DetailedDBStackStatus;
+import com.sequenceiq.redbeams.domain.stack.DBStack;
 import com.sequenceiq.redbeams.flow.redbeams.common.RedbeamsEvent;
 import com.sequenceiq.redbeams.flow.redbeams.stop.RedbeamsStopContext;
 import com.sequenceiq.redbeams.flow.redbeams.stop.RedbeamsStopEvent;
 import com.sequenceiq.redbeams.flow.redbeams.stop.event.StopDatabaseServerSuccess;
 import com.sequenceiq.redbeams.metrics.MetricType;
 import com.sequenceiq.redbeams.metrics.RedbeamsMetricService;
-import com.sequenceiq.redbeams.metrics.RedbeamsMetricTag;
 import com.sequenceiq.redbeams.service.stack.DBStackStatusUpdater;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,15 +21,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class StopDatabaseServerFinishedActionTest {
 
     private static final long RESOURCE_ID = 123L;
-
-    private static final String DB_INSTANCE_IDENTIFIER = "dbInstanceIdentifier";
-
-    private static final String DB_VENDOR_DISPLAY_NAME = "dbVendorDisplayName";
 
     @Mock
     private DBStackStatusUpdater dbStackStatusUpdater;
@@ -45,6 +43,12 @@ public class StopDatabaseServerFinishedActionTest {
     @Mock
     private CloudCredential cloudCredential;
 
+    @Mock
+    private DatabaseStack databaseStack;
+
+    @Mock
+    private DBStack dbStack;
+
     @InjectMocks
     private StopDatabaseServerFinishedAction victim;
 
@@ -52,18 +56,19 @@ public class StopDatabaseServerFinishedActionTest {
     public void shouldUpdateStatusOnPrepare() {
         StopDatabaseServerSuccess event = new StopDatabaseServerSuccess(RESOURCE_ID);
 
+        when(dbStackStatusUpdater.updateStatus(RESOURCE_ID, DetailedDBStackStatus.STOPPED)).thenReturn(dbStack);
+
         victim.prepareExecution(event, null);
 
-        verify(dbStackStatusUpdater).updateStatus(RESOURCE_ID, DetailedDBStackStatus.STOPPED);
+        verify(metricService).incrementMetricCounter(MetricType.DB_STOP_FINISHED, dbStack);
     }
 
     @Test
     public void shouldIncrementMetricOnCreateRequest() {
-        RedbeamsStopContext context = new RedbeamsStopContext(flowParameters, cloudContext, cloudCredential, DB_INSTANCE_IDENTIFIER, DB_VENDOR_DISPLAY_NAME);
+        RedbeamsStopContext context = new RedbeamsStopContext(flowParameters, cloudContext, cloudCredential, databaseStack);
 
         RedbeamsEvent redbeamsEvent = (RedbeamsEvent) victim.createRequest(context);
 
-        verify(metricService).incrementMetricCounter(MetricType.DB_STOP_FINISHED, RedbeamsMetricTag.DATABASE_VENDOR.name(), DB_VENDOR_DISPLAY_NAME);
         assertEquals(RedbeamsStopEvent.REDBEAMS_STOP_FINISHED_EVENT.name(), redbeamsEvent.selector());
     }
 }

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/sync/DBStackJobServiceTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/sync/DBStackJobServiceTest.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.redbeams.sync;
 
-import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
 import com.sequenceiq.statuschecker.service.JobService;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,8 +33,6 @@ public class DBStackJobServiceTest {
     @BeforeEach
     public void initTests() {
         initMocks(this);
-
-        when(dbStack.getCloudPlatform()).thenReturn(CloudPlatform.AWS.name());
     }
 
     @Test
@@ -61,31 +58,11 @@ public class DBStackJobServiceTest {
     }
 
     @Test
-    public void shouldNotScheduleJobInCaseOfNonAws() {
-        when(autoSyncConfig.isEnabled()).thenReturn(true);
-        when(dbStack.getCloudPlatform()).thenReturn(CloudPlatform.AZURE.name());
-
-        victim.schedule(dbStack);
-
-        verifyZeroInteractions(jobService);
-    }
-
-    @Test
     public void shouldUnscheduleJob() {
         when(dbStack.getId()).thenReturn(DB_STACK_ID);
 
         victim.unschedule(dbStack);
 
         verify(jobService).unschedule(String.valueOf(DB_STACK_ID));
-    }
-
-    @Test
-    public void shouldNotUnscheduleJobInCaseOfNonAws() {
-        when(dbStack.getId()).thenReturn(DB_STACK_ID);
-        when(dbStack.getCloudPlatform()).thenReturn(CloudPlatform.AZURE.name());
-
-        victim.unschedule(dbStack);
-
-        verifyZeroInteractions(jobService);
     }
 }


### PR DESCRIPTION
CB-6967 Use DatabaseStack as resource connector parameter instead of DBInstanceIdentifier and implement Azure status lookup