### PR TITLE
DISTX-399 Introduce Periscope DataHub Autoscaling (Part 1)

### DIFF
--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/v1/AutoScaleClusterV1Endpoint.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/v1/AutoScaleClusterV1Endpoint.java
@@ -24,7 +24,7 @@ import io.swagger.annotations.ApiOperation;
 
 @Path("/v1/clusters")
 @Consumes(MediaType.APPLICATION_JSON)
-@Api(value = "/v1/clusters", description = CLUSTERS_DESCRIPTION, protocols = "http,https", consumes = MediaType.APPLICATION_JSON)
+@Api(hidden = true, value = "/v1/clusters", description = CLUSTERS_DESCRIPTION, protocols = "http,https", consumes = MediaType.APPLICATION_JSON)
 public interface AutoScaleClusterV1Endpoint {
 
     @GET

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/v1/ConfigurationEndpoint.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/v1/ConfigurationEndpoint.java
@@ -20,7 +20,7 @@ import io.swagger.annotations.ApiOperation;
 
 @Path("/v1/clusters/{clusterId}/configurations")
 @Consumes(MediaType.APPLICATION_JSON)
-@Api(value = "/v1/configurations", description = CONFIGURATION_DESCRIPTION, protocols = "http,https", consumes = MediaType.APPLICATION_JSON)
+@Api(hidden = true, value = "/v1/configurations", description = CONFIGURATION_DESCRIPTION, protocols = "http,https", consumes = MediaType.APPLICATION_JSON)
 public interface ConfigurationEndpoint {
 
     @POST

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/v1/HistoryEndpoint.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/v1/HistoryEndpoint.java
@@ -20,7 +20,7 @@ import io.swagger.annotations.ApiOperation;
 
 @Path("/v1/clusters/{clusterId}/history")
 @Consumes(MediaType.APPLICATION_JSON)
-@Api(value = "/v1/history", description = HISTORY_DESCRIPTION, protocols = "http,https", consumes = MediaType.APPLICATION_JSON)
+@Api(hidden = true, value = "/v1/history", description = HISTORY_DESCRIPTION, protocols = "http,https", consumes = MediaType.APPLICATION_JSON)
 public interface HistoryEndpoint {
 
     @GET

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/v1/PolicyEndpoint.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/v1/PolicyEndpoint.java
@@ -25,7 +25,7 @@ import io.swagger.annotations.ApiOperation;
 
 @Path("/v1/clusters/{clusterId}/policies")
 @Consumes(MediaType.APPLICATION_JSON)
-@Api(value = "/v1/policies", description = POLICIES_DESCRIPTION, protocols = "http,https", consumes = MediaType.APPLICATION_JSON)
+@Api(hidden = true, value = "/v1/policies", description = POLICIES_DESCRIPTION, protocols = "http,https", consumes = MediaType.APPLICATION_JSON)
 public interface PolicyEndpoint {
 
     @POST

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/v2/AutoScaleClusterV2Endpoint.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/v2/AutoScaleClusterV2Endpoint.java
@@ -20,7 +20,7 @@ import io.swagger.annotations.ApiOperation;
 
 @Path("/v2/clusters")
 @Consumes(MediaType.APPLICATION_JSON)
-@Api(value = "/v2/clusters", description = CLUSTERS_DESCRIPTION, protocols = "http,https", consumes = MediaType.APPLICATION_JSON)
+@Api(hidden = true, value = "/v2/clusters", description = CLUSTERS_DESCRIPTION, protocols = "http,https", consumes = MediaType.APPLICATION_JSON)
 public interface AutoScaleClusterV2Endpoint {
 
     @GET

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/doc/ApiDescription.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/doc/ApiDescription.java
@@ -15,11 +15,16 @@ public class ApiDescription {
         public static final String METRIC_BASED_DELETE = "delete alert which metric based";
         public static final String METRIC_BASED_DEFINITIONS = "retrieve alert definitions";
 
-        public static final String TIME_BASED_POST = "create alert which time based";
-        public static final String TIME_BASED_PUT = "modify alert which time based";
-        public static final String TIME_BASED_GET = "retrieve alert which time based";
-        public static final String TIME_BASED_DELETE = "delete alert which time based";
+        public static final String TIME_BASED_POST = "create alert which are time based";
+        public static final String TIME_BASED_PUT = "modify alert which are time based";
+        public static final String TIME_BASED_GET = "retrieve alert which are time based";
+        public static final String TIME_BASED_DELETE = "delete alert which are time based";
         public static final String TIME_BASED_CRON = "cron expression validation";
+
+        public static final String LOAD_BASED_POST = "create alert which is load based";
+        public static final String LOAD_BASED_PUT = "modify alert which is load based";
+        public static final String LOAD_BASED_GET = "retrieve alert which is load based";
+        public static final String LOAD_BASED_DELETE = "delete alert which is load based";
 
         public static final String PROMETHEUS_BASED_POST = "create alert which prometheus based";
         public static final String PROMETHEUS_BASED_PUT = "modify alert which prometheus based";
@@ -29,13 +34,14 @@ public class ApiDescription {
     }
 
     public static class AlertNotes {
-        public static final String TIME_BASED_NOTES = "Auto-scaling supports two Alert types: metric and time based. "
+        public static final String TIME_BASED_NOTES = "Auto-scaling supports two Alert types: load and time based. "
                 + "Time based alerts are based on cron expressions and allow alerts to be triggered based on time.";
         public static final String METRIC_BASED_NOTES = "Auto-scaling supports two Alert types: metric and time based. "
                 + "Metric based alerts are using the default (or custom) Ambari metrics. These metrics have a default Threshold value configured in Ambari - "
                 + "nevertheless these thresholds can be configured, changed or altered in Ambari. In order to change the default threshold for a metric "
                 + "please go to Ambari UI and select the Alerts tab and the metric. The values can be changed in the Threshold section. ";
         public static final String PROMETHEUS_BASED_NOTES = "Prometheus based alerts are using Prometheus under the hood. ";
+        public static final String LOAD_BASED_NOTES = "Load based alerts are based on the load observed in the cluster ";
     }
 
     public static class ConfigurationOpDescription {
@@ -82,11 +88,17 @@ public class ApiDescription {
         public static final String CLUSTER_GET_ALL = "retrieve all cluster";
         public static final String CLUSTER_DELETE = "delete cluster";
         public static final String CLUSTER_SET_STATE = "set cluster state";
-        public static final String CLUSTER_SET_AUTOSCALE_STATE = "set cluster's autoscale feature state";
+        public static final String CLUSTER_SET_AUTOSCALE_STATE = "enable or disable cluster's autoscale feature";
+        public static final String CLUSTER_UPDATE_AUTOSCALE_CONFIG = "update cluster's autoscale config";
+        public static final String CLUSTER_DELETE_ALERTS = "delete a cluster's alerts";
     }
 
     public static class ClusterNotes {
         public static final String NOTES = "Ambari cluster.";
+    }
+
+    public static class DistroXClusterNotes {
+        public static final String NOTES = "DataHub cluster.";
     }
 
     public static class ClusterJsonsProperties {
@@ -99,10 +111,13 @@ public class ApiDescription {
         public static final String ENABLE_AUTOSCALING = "Enable or Disable the Autoscaling feature set on the underlying Periscope cluster";
         public static final String AUTOSCALING_ENABLED = "Indicate that the Autoscaling feature set is Enabled or Disabled";
         public static final String ID = "Id of the cluster";
+        public static final String STACK_NAME = "Name of stack in Cloudbreak";
+        public static final String STACK_TYPE = "Type of stack in Cloudbreak";
         public static final String STATE = "State of the cluster";
         public static final String METRIC_ALERTS = "Metric based alerts of the cluster";
         public static final String TIME_ALERTS = "Time based alerts of the cluster";
         public static final String PROMETHEUS_ALERTS = "Prometheus based alerts of the cluster";
+        public static final String LOAD_ALERTS = "Load based alerts of the cluster";
         public static final String SCALING_CONFIGURATION = "Scaling configuration for the cluster";
     }
 
@@ -146,6 +161,13 @@ public class ApiDescription {
         public static final String THRESHOLD = "Threshold of the alert in percent";
         public static final String ALERTSTATE = "State of the alert";
         public static final String ALERTOPERATOR = "Operator of the alert's query.";
+    }
+
+    public static class LoadAlertJsonProperties {
+        public static final String LOAD_ALERT_CONFIGURATION_MIN_RESOUCE_VALUE = "The lower bound for the resource";
+        public static final String LOAD_ALERT_CONFIGURATION_MAX_RESOUCE_VALUE = "The upper bound for the resource";
+        public static final String LOAD_ALERT_CONFIGURATION_COOL_DOWN_MINS_VALUE = "CoolDown between successive cluster autoscaling actions.";
+        public static final String LOAD_ALERT_CONFIGURATION = "Configuration of Load Alert";
     }
 
     public static class BaseAlertJsonProperties {

--- a/autoscale/build.gradle
+++ b/autoscale/build.gradle
@@ -171,6 +171,7 @@ dependencies {
     compile project(':workspace')
     compile project(':secret-engine')
     compile project(':client-cm')
+    compile project(':authorization-common')
 }
 
 task buildInfo(type: BuildInfoTask, dependsOn: processResources) {

--- a/autoscale/src/main/java/com/sequenceiq/periscope/controller/EndpointConfig.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/controller/EndpointConfig.java
@@ -89,11 +89,6 @@ public class EndpointConfig extends ResourceConfig {
 
     private void registerEndpoints() {
         register(AlertController.class);
-        register(AutoScaleClusterV1Controller.class);
-        register(AutoScaleClusterV2Controller.class);
-        register(ConfigurationController.class);
-        register(HistoryController.class);
-        register(PolicyController.class);
 
         register(io.swagger.jaxrs.listing.ApiListingResource.class);
         register(io.swagger.jaxrs.listing.SwaggerSerializers.class);

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/ClusterManagerHostHealthMonitor.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/ClusterManagerHostHealthMonitor.java
@@ -2,13 +2,15 @@ package com.sequenceiq.periscope.monitor;
 
 import java.util.List;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.periscope.api.model.ClusterState;
 import com.sequenceiq.periscope.domain.Cluster;
 import com.sequenceiq.periscope.monitor.evaluator.ClusterManagerHostHealthEvaluator;
 
-@Component
+@Component("ClusterManagerHostHealthMonitor")
+@ConditionalOnProperty(prefix = "periscope.enabledAutoscaleMonitors.cluster-manager-host-health-monitor", name = "enabled", havingValue = "true")
 public class ClusterManagerHostHealthMonitor extends ClusterMonitor {
 
     @Override

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/PrometheusMonitor.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/PrometheusMonitor.java
@@ -1,8 +1,13 @@
 package com.sequenceiq.periscope.monitor;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
 import com.sequenceiq.periscope.domain.Cluster;
 import com.sequenceiq.periscope.monitor.evaluator.PrometheusEvaluator;
 
+@Component
+@ConditionalOnProperty(prefix = "periscope.enabledAutoscaleMonitors.prometheus-monitor", name = "enabled", havingValue = "true")
 public class PrometheusMonitor extends ClusterMonitor {
 
     @Override

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/TimeMonitor.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/TimeMonitor.java
@@ -1,11 +1,13 @@
 package com.sequenceiq.periscope.monitor;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.periscope.domain.Cluster;
 import com.sequenceiq.periscope.monitor.evaluator.CronTimeEvaluator;
 
 @Component
+@ConditionalOnProperty(prefix = "periscope.enabledAutoscaleMonitors.time-monitor", name = "enabled", havingValue = "true")
 public class TimeMonitor extends ClusterMonitor {
 
     @Override

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/CronTimeEvaluator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/CronTimeEvaluator.java
@@ -81,7 +81,7 @@ public class CronTimeEvaluator extends EvaluatorExecutor {
         Cluster cluster = clusterService.findById(clusterId);
         MDCBuilder.buildMdcContext(cluster);
         publishIfNeeded(alertRepository.findAllByCluster(clusterId));
-        LOGGER.debug("Finished cronTimeEvaluator for cluster {} in {} ms", clusterId, System.currentTimeMillis() - start);
+        LOGGER.debug("Finished cronTimeEvaluator for cluster {} in {} ms", cluster.getStackCrn(), System.currentTimeMillis() - start);
     }
 
     private void publishIfNeeded(List<TimeAlert> alerts) {

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/DateService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/DateService.java
@@ -68,4 +68,14 @@ public final class DateService {
             throw new ParseException(ex.getMessage(), 0);
         }
     }
+
+    public void validateTimeZone(String timeZone) throws ParseException {
+        try {
+            if (timeZone != null) {
+                ZoneId.of(timeZone);
+            }
+        } catch (Exception ex) {
+            throw new ParseException(ex.getMessage(), 0);
+        }
+    }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/utils/ClusterUtils.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/utils/ClusterUtils.java
@@ -2,12 +2,22 @@ package com.sequenceiq.periscope.utils;
 
 import java.text.DecimalFormat;
 
-public final class ClusterUtils {
+public class ClusterUtils {
 
     public static final DecimalFormat TIME_FORMAT = new DecimalFormat("##.##");
 
     public static final int MAX_CAPACITY = 100;
 
+    public static final long  MEGABYTE = 1024L * 1024L;
+
     private ClusterUtils() {
+    }
+
+    public static long getRemainingCooldownTime(long coolDownMs, long lastScalingActivity) {
+        return lastScalingActivity == 0L ? 0L : coolDownMs - (System.currentTimeMillis() - lastScalingActivity);
+    }
+
+    public static long memoryBytesToMB(long memoryInBytes) {
+        return memoryInBytes / MEGABYTE;
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/utils/StackResponseUtils.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/utils/StackResponseUtils.java
@@ -1,13 +1,22 @@
 package com.sequenceiq.periscope.utils;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
+import com.cloudera.api.swagger.model.ApiClusterTemplate;
+import com.cloudera.api.swagger.model.ApiClusterTemplateHostTemplate;
+import com.cloudera.api.swagger.model.ApiClusterTemplateRoleConfigGroup;
+import com.cloudera.api.swagger.model.ApiClusterTemplateService;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceMetadataType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
+import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 
 @Service
 public class StackResponseUtils {
@@ -17,5 +26,50 @@ public class StackResponseUtils {
                 im -> im.getInstanceType() == InstanceMetadataType.GATEWAY_PRIMARY
                         && im.getInstanceStatus() != InstanceStatus.TERMINATED
         ).findFirst();
+    }
+
+    public Map<String, String> getCloudInstanceIdsForHostGroup(StackV4Response stackResponse, String hostGroup) {
+        return stackResponse.getInstanceGroups().stream()
+                .filter(instanceGroupV4Response -> instanceGroupV4Response.getName().equalsIgnoreCase(hostGroup))
+                .flatMap(instanceGroupV4Response -> instanceGroupV4Response.getMetadata().stream())
+                .filter(instanceMetaData -> instanceMetaData.getDiscoveryFQDN() != null)
+                .collect(Collectors.toMap(InstanceMetaDataV4Response::getDiscoveryFQDN,
+                        InstanceMetaDataV4Response::getInstanceId));
+    }
+
+    public Integer getNodeCountForHostGroup(StackV4Response stackResponse, String hostGroup) {
+        return stackResponse.getInstanceGroups().stream()
+                .filter(instanceGroupV4Response -> instanceGroupV4Response.getName().equalsIgnoreCase(hostGroup))
+                .flatMap(instanceGroupV4Response -> instanceGroupV4Response.getMetadata().stream())
+                .map(InstanceMetaDataV4Response::getDiscoveryFQDN)
+                .collect(Collectors.counting())
+                .intValue();
+    }
+
+    public String getRoleConfigNameForHostGroup(StackV4Response stackResponse, String hostGroupName, String serviceType, String roleType)
+            throws Exception {
+        String template = stackResponse.getCluster().getBlueprint().getBlueprint();
+        ApiClusterTemplate cmTemplate = JsonUtil.readValue(template, ApiClusterTemplate.class);
+
+        Set<String> hostGroupRoleConfigNames = cmTemplate.getHostTemplates().stream()
+                .filter(clusterTemplate -> clusterTemplate.getRefName().equalsIgnoreCase(hostGroupName))
+                .findFirst().map(ApiClusterTemplateHostTemplate::getRoleConfigGroupsRefNames).orElse(List.of())
+                .stream()
+                .collect(Collectors.toSet());
+
+        String roleReferenceName = cmTemplate.getServices().stream()
+                .filter(s -> s.getServiceType().equalsIgnoreCase(serviceType))
+                .findFirst()
+                .map(ApiClusterTemplateService::getRoleConfigGroups).orElse(List.of())
+                .stream()
+                .filter(rcg -> rcg.getRoleType().equalsIgnoreCase(roleType))
+                .filter(rcg -> hostGroupRoleConfigNames.contains(rcg.getRefName()))
+                .map(ApiClusterTemplateRoleConfigGroup::getRefName)
+                .findFirst()
+                .orElseThrow(
+                        () -> new Exception(String.format("Unable to retrieve RoleConfigGroupRefName for Service '%s', RoleType '%s'," +
+                                " HostGroup '%s', Cluster '%s'", serviceType, roleType, hostGroupName, stackResponse.getCrn())));
+
+        return roleReferenceName;
     }
 }

--- a/autoscale/src/main/resources/application.yml
+++ b/autoscale/src/main/resources/application.yml
@@ -9,7 +9,7 @@ management:
     web:
       base-path: "/"
       exposure:
-        include: info,health,prometheus
+        include: info,health,prometheus,metrics
       path-mapping:
         prometheus: metrics
   endpoint:
@@ -32,6 +32,7 @@ management:
 periscope:
   cert:
     dir: /certs/
+
   db:
     env:
       user: postgres
@@ -44,6 +45,16 @@ periscope:
       addr: localhost
       port: 5432
   cloudbreak.url: http://localhost:9091
+  enabledPlatforms: AWS
+  enabledAutoscaleMonitors:
+    time-monitor:
+      enabled: true
+    load-monitor:
+      enabled: true
+    cluster-manager-host-health-monitor:
+      enabled: true
+    prometheus-monitor:
+      enabled: false
 
 cb:
   server:

--- a/autoscale/src/main/resources/swagger/auto-scaling-introduction
+++ b/autoscale/src/main/resources/swagger/auto-scaling-introduction
@@ -1,3 +1,1 @@
-The auto-scaling capabilities is based on Ambari Metrics - and Ambari Alerts. Based on the Blueprint used and the running services, Cloudbreak can access all the available metrics from the subsystem and define alerts based on this information.
-
-Beside the default Ambari Metrics, Cloudbreak includes two custom metrics: Pending YARN containers and Pending applications. These two custom metrics works with the YARN subsystem in order to bring application level QoS to the cluster.
+The auto-scaling capabilities is based on Cluster Load Metrics and Time Alerts. Based on the Cluster Template used and the running services, Autoscale Service can access all the available metrics from the subsystem and define alerts based on this information.

--- a/autoscale/src/test/java/com/sequenceiq/periscope/service/DateServiceTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/service/DateServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
+import java.text.ParseException;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
@@ -121,6 +122,16 @@ public class DateServiceTest {
         when(dateTimeService.getZonedDateTime(currentZonedTime.toInstant(), timeZone)).thenReturn(currentZonedTime);
         TimeAlert timeAlert = createTimeAlert(timeZone);
         assertTrue(underTest.isTrigger(timeAlert, monitorUpdateRate));
+    }
+
+    @Test
+    public void testValidateTimeZoneWhenValid() throws Exception {
+        underTest.validateTimeZone("GMT");
+    }
+
+    @Test(expected = ParseException.class)
+    public void testValidateTimeZoneWhenInvalid() throws Exception {
+        underTest.validateTimeZone("GMTzen");
     }
 
     private TimeAlert createTimeAlert(String timeZone) {

--- a/autoscale/src/test/java/com/sequenceiq/periscope/utils/ClusterUtilsTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/utils/ClusterUtilsTest.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.periscope.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import org.junit.Test;
+
+public class ClusterUtilsTest {
+
+    @Test
+    public void testGetRemainingCoolDownWhenNoScalingDone() {
+        long remainingTime =
+                ClusterUtils.getRemainingCooldownTime(30 * TimeUtil.MIN_IN_MS, 0);
+        assertEquals("Remaining Time should be 0 when no scaling", 0, remainingTime);
+    }
+
+    @Test
+    public void testGetRemainingCoolDownAfterCoolDownTimeThenGreaterThanZero() {
+        long remainingTime =
+                ClusterUtils.getRemainingCooldownTime(30 * TimeUtil.MIN_IN_MS, Instant.now().minus(35, ChronoUnit.MINUTES).toEpochMilli());
+        assertTrue("Remaining Time should be negative when cool down period elapsed.", remainingTime <= 0);
+    }
+
+    @Test
+    public void testGetRemainingCoolDownBeforeCoolDownTimeThenLesserThanZero() {
+        long remainingTime =
+                ClusterUtils.getRemainingCooldownTime(30 * TimeUtil.MIN_IN_MS, Instant.now().minus(20, ChronoUnit.MINUTES).toEpochMilli());
+        assertTrue("Remaining Time should be positive when cool down period not elapsed.", remainingTime > 0);
+    }
+}

--- a/autoscale/src/test/java/com/sequenceiq/periscope/utils/MockStackResponseGenerator.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/utils/MockStackResponseGenerator.java
@@ -1,0 +1,47 @@
+package com.sequenceiq.periscope.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.template.InstanceTemplateV4Response;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+
+public class MockStackResponseGenerator {
+    private MockStackResponseGenerator() {
+    }
+
+    public static StackV4Response getMockStackV4Response(String clusterCrn, Set<String> hostGroups,
+            Set<InstanceMetaDataV4Response> instanceMetaDataV4Responses) {
+        StackV4Response mockReponse = new StackV4Response();
+
+        List<InstanceGroupV4Response> instanceGroupV4Responses = new ArrayList<>();
+        hostGroups.stream().forEach(hostGroup -> {
+            instanceGroupV4Responses.add(instanceGroup(hostGroup, awsTemplate(),
+                    instanceMetaDataV4Responses));
+        });
+
+        mockReponse.setCrn(clusterCrn);
+        mockReponse.setInstanceGroups(instanceGroupV4Responses);
+        mockReponse.setCloudPlatform(CloudPlatform.AWS);
+        return mockReponse;
+    }
+
+    public static InstanceTemplateV4Response awsTemplate() {
+        InstanceTemplateV4Response awsTemplate = new InstanceTemplateV4Response();
+        awsTemplate.setCloudPlatform(CloudPlatform.AWS);
+        return awsTemplate;
+    }
+
+    public static InstanceGroupV4Response instanceGroup(String hostGroupName, InstanceTemplateV4Response template,
+            Set<InstanceMetaDataV4Response> instanceMetaDataV4Responses) {
+        InstanceGroupV4Response instanceGroup = new InstanceGroupV4Response();
+        instanceGroup.setTemplate(template);
+        instanceGroup.setName(hostGroupName);
+        instanceGroup.setMetadata(instanceMetaDataV4Responses);
+        return instanceGroup;
+    }
+}

--- a/autoscale/src/test/java/com/sequenceiq/periscope/utils/StackResponseUtilsTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/utils/StackResponseUtilsTest.java
@@ -1,0 +1,116 @@
+package com.sequenceiq.periscope.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.blueprint.responses.BlueprintV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.cluster.ClusterV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
+import com.sequenceiq.cloudbreak.util.FileReaderUtils;
+
+public class StackResponseUtilsTest {
+
+    private StackResponseUtils underTest = new StackResponseUtils();
+
+    @Test
+    public void testGetCloudInstanceIdsForHostGroup() {
+        String hostGroup = "compute";
+
+        Map<String, String> instanceIdsForHostGroups = underTest
+                .getCloudInstanceIdsForHostGroup(getMockStackV4Response(hostGroup), hostGroup);
+
+        assertEquals("Retrieved Instance Ids size should match", instanceIdsForHostGroups.size(), 3);
+        assertEquals("Retrieved Instance Id should match",
+                instanceIdsForHostGroups.get("test_fqdn1"), "test_instanceid1");
+        assertEquals("Retrieved Instance Id should match",
+                instanceIdsForHostGroups.get("test_fqdn2"), "test_instanceid2");
+        assertEquals("Retrieved Instance Id should match",
+                instanceIdsForHostGroups.get("test_fqdn3"), "test_instanceid3");
+    }
+
+    @Test
+    public void testGetNodeCountForHostGroup() {
+        String hostGroup = "compute";
+
+        Integer nodeCountForHostGroup = underTest
+                .getNodeCountForHostGroup(getMockStackV4Response(hostGroup), hostGroup);
+        assertEquals("Retrieved HostGroup Instance Count should match.", Integer.valueOf(3), nodeCountForHostGroup);
+    }
+
+    @Test
+    public void testGetRoleConfigNameForHostGroup() throws Exception {
+        validateGetRoleConfigNameForHostGroup("YARN", "NODEMANAGER",
+                "compute", "yarn-NODEMANAGER-COMPUTE");
+
+        validateGetRoleConfigNameForHostGroup("YARN", "NODEMANAGER",
+                "worker", "yarn-NODEMANAGER-WORKER");
+
+        validateGetRoleConfigNameForHostGroup("YARN", "NODEMANAGER",
+                "randomHostGroup", "random-NODEMANAGER-BASE");
+    }
+
+    @Test
+    public void testGetRoleConfigNameForHostGroupWhenInvalidHostGroup() {
+        Exception exception = assertThrows(Exception.class, () ->
+                validateGetRoleConfigNameForHostGroup("YARN", "NODEMANAGER",
+                "compute1", ""));
+        assertTrue(exception.getMessage().contains("Unable to retrieve RoleConfigGroupRefName for Service 'YARN'"));
+        assertTrue(exception.getMessage().contains("compute1"));
+    }
+
+    @Test
+    public void testGetRoleConfigNameForHostGroupWhenHostGroupWithoutNodeManager() {
+        Exception exception = assertThrows(Exception.class, () ->
+                validateGetRoleConfigNameForHostGroup("YARN", "NODEMANAGER",
+                        "gateway", ""));
+        assertTrue(exception.getMessage().contains("Unable to retrieve RoleConfigGroupRefName for Service 'YARN'"));
+        assertTrue(exception.getMessage().contains("gateway"));
+    }
+
+    private void validateGetRoleConfigNameForHostGroup(String testService, String testRole,
+            String testHostGroup, String expectedRoleConfigName) throws Exception {
+        StackV4Response mockStackResponse = mock(StackV4Response.class);
+        ClusterV4Response mockCluster = mock(ClusterV4Response.class);
+        BlueprintV4Response mockBluePrint = mock(BlueprintV4Response.class);
+
+        when(mockStackResponse.getCluster()).thenReturn(mockCluster);
+        when(mockCluster.getBlueprint()).thenReturn(mockBluePrint);
+        when(mockBluePrint.getBlueprint()).thenReturn(getTestBP());
+        String hostGroupRolename = underTest.getRoleConfigNameForHostGroup(mockStackResponse, testHostGroup, testService, testRole);
+        assertEquals("RoleConfigName in template should match for HostGroup", expectedRoleConfigName, hostGroupRolename);
+    }
+
+    private StackV4Response getMockStackV4Response(String hostGroup) {
+        Set hostGroupInstanceType = Set.of("compute1", "master1", "worker1", hostGroup);
+
+        InstanceMetaDataV4Response metadata1 = new InstanceMetaDataV4Response();
+        metadata1.setDiscoveryFQDN("test_fqdn1");
+        metadata1.setInstanceId("test_instanceid1");
+
+        InstanceMetaDataV4Response metadata2 = new InstanceMetaDataV4Response();
+        metadata2.setDiscoveryFQDN("test_fqdn2");
+        metadata2.setInstanceId("test_instanceid2");
+
+        InstanceMetaDataV4Response metadata3 = new InstanceMetaDataV4Response();
+        metadata3.setDiscoveryFQDN("test_fqdn3");
+        metadata3.setInstanceId("test_instanceid3");
+
+        return MockStackResponseGenerator.getMockStackV4Response("test-crn",
+                hostGroupInstanceType,
+                Set.of(metadata1, metadata2, metadata3));
+    }
+
+    private String getTestBP() throws IOException {
+        return FileReaderUtils.readFileFromClasspath("/dataengineering-test.json");
+    }
+}

--- a/autoscale/src/test/resources/dataengineering-test.json
+++ b/autoscale/src/test/resources/dataengineering-test.json
@@ -1,0 +1,444 @@
+{
+    "cdhVersion": "7.2.0",
+    "displayName": "dataengineering",
+    "services": [
+      {
+        "refName": "zookeeper",
+        "serviceType": "ZOOKEEPER",
+        "roleConfigGroups": [
+          {
+            "refName": "zookeeper-SERVER-BASE",
+            "roleType": "SERVER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "hdfs",
+        "serviceType": "HDFS",
+        "roleConfigGroups": [
+          {
+            "refName": "hdfs-NAMENODE-BASE",
+            "roleType": "NAMENODE",
+            "base": true,
+            "configs": [
+              {
+                "name": "fs_trash_interval",
+                "value": "0"
+              },
+              {
+                "name": "fs_trash_checkpoint_interval",
+                "value": "0"
+              }
+            ]
+          },
+          {
+            "refName": "hdfs-SECONDARYNAMENODE-BASE",
+            "roleType": "SECONDARYNAMENODE",
+            "base": true
+          },
+          {
+            "refName": "hdfs-DATANODE-BASE",
+            "roleType": "DATANODE",
+            "base": true
+          },
+          {
+            "refName": "hdfs-BALANCER-BASE",
+            "roleType": "BALANCER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "yarn",
+        "serviceType": "YARN",
+        "serviceConfigs": [
+          {
+            "name": "yarn_admin_acl",
+            "value": "yarn,hive,hdfs"
+          }
+        ],
+        "roleConfigGroups": [
+          {
+            "refName": "yarn-RESOURCEMANAGER-BASE",
+            "roleType": "RESOURCEMANAGER",
+            "base": true,
+            "configs": [
+              {
+                "name": "resourcemanager_config_safety_valve",
+                "value": "<property><name>yarn.scheduler.configuration.store.class</name><value>zk</value></property>"
+              },
+              {
+                "name": "yarn_resourcemanager_scheduler_class",
+                "value": "org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler"
+              },
+              {
+                "name": "yarn_scheduler_capacity_resource_calculator",
+                "value": "org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator"
+              },
+              {
+                "name": "resourcemanager_capacity_scheduler_configuration",
+                "value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property></configuration>"
+              }
+            ]
+          },
+          {
+            "refName": "yarn-NODEMANAGER-WORKER",
+            "roleType": "NODEMANAGER",
+            "base": false
+          },
+          {
+            "refName": "yarn-NODEMANAGER-COMPUTE",
+            "roleType": "NODEMANAGER",
+            "base": false
+          },
+          {
+            "refName": "random-NODEMANAGER-BASE",
+            "roleType": "NODEMANAGER",
+            "base": false
+          },
+          {
+            "refName": "yarn-JOBHISTORY-BASE",
+            "roleType": "JOBHISTORY",
+            "base": true
+          },
+          {
+            "refName": "yarn-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true,
+            "configs": [
+              {
+                "name": "mapreduce_map_memory_mb",
+                "value": 4096
+              },
+              {
+                "name": "mapreduce_reduce_memory_mb",
+                "value": 4096
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "refName": "spark_on_yarn",
+        "serviceType": "SPARK_ON_YARN",
+        "roleConfigGroups": [
+          {
+            "refName": "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+            "roleType": "SPARK_YARN_HISTORY_SERVER",
+            "base": true
+          },
+          {
+            "refName": "spark_on_yarn-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "tez",
+        "serviceType": "TEZ",
+        "serviceConfigs": [
+          {
+            "name": "yarn_service",
+            "ref": "yarn"
+          },
+          {
+            "name": "tez.am.container.reuse.non-local-fallback.enabled",
+            "value": "true"
+          },
+          {
+            "name": "tez.am.container.reuse.locality.delay-allocation-millis",
+            "value": "0"
+          },
+          {
+            "name": "tez.am.launch.cmd-opts",
+            "value": "-XX:+PrintGCDetails -verbose:gc -XX:+UseNUMA -XX:+UseG1GC -XX:+ResizeTLAB"
+          },
+          {
+            "name": "tez.task.launch.cmd-opts",
+            "value": "-XX:+PrintGCDetails -verbose:gc -XX:+UseNUMA -XX:+UseG1GC -XX:+ResizeTLAB"
+          }
+        ],
+        "roleConfigGroups": [
+          {
+            "refName": "tez-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "hms",
+        "serviceType": "HIVE",
+        "displayName": "Hive Metastore",
+        "roleConfigGroups": [
+          {
+            "refName": "hms-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          },
+          {
+            "refName": "hms-HIVEMETASTORE-BASE",
+            "roleType": "HIVEMETASTORE",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "hive_on_tez",
+        "serviceType": "HIVE_ON_TEZ",
+        "displayName": "Hive",
+        "serviceConfigs": [
+          {
+            "name": "hms_connector",
+            "ref": "hms"
+          },
+          {
+            "name": "tez_service",
+            "ref": "tez"
+          },
+          {
+            "name": "zookeeper_service",
+            "ref": "zookeeper"
+          },
+          {
+            "name": "mapreduce_yarn_service",
+            "ref": "yarn"
+          },
+          {
+            "name": "tez_container_size",
+            "value": "4096"
+          },
+          {
+            "name": "tez_auto_reducer_parallelism",
+            "value": "false"
+          },
+          {
+            "name": "hive_service_config_safety_valve",
+            "value": "<property><name>hive.server2.tez.sessions.per.default.queue</name><value>4</value></property>"
+          }
+        ],
+        "roleConfigGroups": [
+          {
+            "refName": "hive_on_tez-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          },
+          {
+            "refName": "hive_on_tez-HIVESERVER2-BASE",
+            "roleType": "HIVESERVER2",
+            "base": true,
+            "configs": [
+              {
+                "name": "hive_server2_transport_mode",
+                "value": "http"
+              },
+              {
+                "name": "hiveserver2_mv_files_thread",
+                "value": 20
+              },
+              {
+                "name": "hiveserver2_load_dynamic_partitions_thread_count",
+                "value": 20
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "refName": "hue",
+        "serviceType": "HUE",
+        "serviceConfigs": [
+          {
+            "name": "hue_service_safety_valve",
+            "value": "[desktop]\napp_blacklist=spark,zookeeper,hbase,impala,search,sqoop,security,pig"
+          }
+        ],
+        "roleConfigGroups": [
+          {
+            "refName": "hue-HUE_SERVER-BASE",
+            "roleType": "HUE_SERVER",
+            "base": true
+          },
+          {
+            "refName": "hue-HUE_LOAD_BALANCER-BASE",
+            "roleType": "HUE_LOAD_BALANCER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "livy",
+        "serviceType": "LIVY",
+        "roleConfigGroups": [
+          {
+            "refName": "livy-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          },
+          {
+            "refName": "livy-LIVY_SERVER-BASE",
+            "roleType": "LIVY_SERVER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "zeppelin",
+        "serviceType": "ZEPPELIN",
+        "serviceConfigs": [
+          {
+            "name": "yarn_service",
+            "ref": "yarn"
+          },
+          {
+            "name": "hdfs_service",
+            "ref": "hdfs"
+          },
+          {
+            "name": "spark_on_yarn_service",
+            "ref": "spark_on_yarn"
+          }
+        ],
+        "roleConfigGroups": [
+          {
+            "refName": "zeppelin-ZEPPELIN_SERVER-BASE",
+            "roleType": "ZEPPELIN_SERVER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "das",
+        "serviceType": "DAS",
+        "roleConfigGroups": [
+          {
+            "refName": "das-DAS_WEBAPP",
+            "roleType": "DAS_WEBAPP",
+            "base": true,
+            "configs": [
+              {
+                "name": "data_analytics_studio_admin_users",
+                "value": "*"
+              }
+            ]
+          },
+          {
+            "refName": "das-DAS_EVENT_PROCESSOR",
+            "roleType": "DAS_EVENT_PROCESSOR",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "oozie",
+        "serviceType": "OOZIE",
+        "roleConfigGroups": [
+          {
+            "refName": "oozie-OOZIE_SERVER-BASE",
+            "roleType": "OOZIE_SERVER",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "queuemanager",
+        "serviceType": "QUEUEMANAGER",
+        "serviceConfigs": [
+          {
+            "name": "kerberos.auth.enabled",
+            "value": "true"
+          }
+        ],
+        "roleConfigGroups": [
+          {
+            "refName": "yarn-QUEUEMANAGER_WEBAPP-BASE",
+            "roleType": "QUEUEMANAGER_WEBAPP",
+            "base": true
+          },
+          {
+            "refName": "yarn-QUEUEMANAGER_STORE-BASE",
+            "roleType": "QUEUEMANAGER_STORE",
+            "base": true
+          }
+        ]
+      }
+    ],
+    "hostTemplates": [
+      {
+        "refName": "master",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "hdfs-BALANCER-BASE",
+          "hdfs-NAMENODE-BASE",
+          "hdfs-SECONDARYNAMENODE-BASE",
+          "hms-GATEWAY-BASE",
+          "hms-HIVEMETASTORE-BASE",
+          "hive_on_tez-HIVESERVER2-BASE",
+          "hive_on_tez-GATEWAY-BASE",
+          "hue-HUE_LOAD_BALANCER-BASE",
+          "hue-HUE_SERVER-BASE",
+          "tez-GATEWAY-BASE",
+          "spark_on_yarn-GATEWAY-BASE",
+          "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+          "livy-LIVY_SERVER-BASE",
+          "zeppelin-ZEPPELIN_SERVER-BASE",
+          "oozie-OOZIE_SERVER-BASE",
+          "yarn-JOBHISTORY-BASE",
+          "yarn-RESOURCEMANAGER-BASE",
+          "zookeeper-SERVER-BASE",
+          "das-DAS_WEBAPP",
+          "das-DAS_EVENT_PROCESSOR",
+          "yarn-QUEUEMANAGER_WEBAPP-BASE",
+          "yarn-QUEUEMANAGER_STORE-BASE",
+          "yarn-GATEWAY-BASE"
+        ]
+      },
+      {
+        "refName": "worker",
+        "cardinality": 3,
+        "roleConfigGroupsRefNames": [
+          "hdfs-DATANODE-BASE",
+          "hms-GATEWAY-BASE",
+          "hive_on_tez-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
+          "spark_on_yarn-GATEWAY-BASE",
+          "livy-GATEWAY-BASE",
+          "yarn-NODEMANAGER-WORKER",
+          "yarn-GATEWAY-BASE"
+        ]
+      },
+      {
+        "refName": "compute",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "hms-GATEWAY-BASE",
+          "hive_on_tez-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
+          "spark_on_yarn-GATEWAY-BASE",
+          "yarn-NODEMANAGER-COMPUTE",
+          "yarn-GATEWAY-BASE"
+        ]
+      },
+      {
+        "refName": "gateway",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "hms-GATEWAY-BASE",
+          "hive_on_tez-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
+          "spark_on_yarn-GATEWAY-BASE",
+          "livy-GATEWAY-BASE",
+          "yarn-GATEWAY-BASE"
+        ]
+      },
+      {
+        "refName": "randomHostGroup",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "random-NODEMANAGER-BASE"
+        ]
+      }
+    ]
+  }

--- a/client-cm/src/main/java/com/sequenceiq/cloudbreak/cm/client/retry/ClouderaManagerApiFactory.java
+++ b/client-cm/src/main/java/com/sequenceiq/cloudbreak/cm/client/retry/ClouderaManagerApiFactory.java
@@ -22,6 +22,7 @@ import com.cloudera.api.swagger.MgmtServiceResourceApi;
 import com.cloudera.api.swagger.ParcelResourceApi;
 import com.cloudera.api.swagger.ParcelsResourceApi;
 import com.cloudera.api.swagger.RoleCommandsResourceApi;
+import com.cloudera.api.swagger.RoleConfigGroupsResourceApi;
 import com.cloudera.api.swagger.RolesResourceApi;
 import com.cloudera.api.swagger.ServicesResourceApi;
 import com.cloudera.api.swagger.ToolsResourceApi;
@@ -54,6 +55,9 @@ public class ClouderaManagerApiFactory {
 
     @Inject
     private Function<ApiClient, RolesResourceApi> rolesResourceApiFactory;
+
+    @Inject
+    private Function<ApiClient, RoleConfigGroupsResourceApi> roleConfigGroupsResourceApiFactory;
 
     @Inject
     private Function<ApiClient, RoleCommandsResourceApi> roleCommandsResourceApiFactory;
@@ -121,6 +125,10 @@ public class ClouderaManagerApiFactory {
 
     public RolesResourceApi getRolesResourceApi(ApiClient apiClient) {
         return rolesResourceApiFactory.apply(apiClient);
+    }
+
+    public RoleConfigGroupsResourceApi getRoleConfigGroupsResourceApi(ApiClient apiClient) {
+        return roleConfigGroupsResourceApiFactory.apply(apiClient);
     }
 
     public RoleCommandsResourceApi getRoleCommandsResourceApi(ApiClient apiClient) {

--- a/client-cm/src/main/java/com/sequenceiq/cloudbreak/cm/client/retry/CmClientConfig.java
+++ b/client-cm/src/main/java/com/sequenceiq/cloudbreak/cm/client/retry/CmClientConfig.java
@@ -22,6 +22,7 @@ import com.cloudera.api.swagger.MgmtServiceResourceApi;
 import com.cloudera.api.swagger.ParcelResourceApi;
 import com.cloudera.api.swagger.ParcelsResourceApi;
 import com.cloudera.api.swagger.RoleCommandsResourceApi;
+import com.cloudera.api.swagger.RoleConfigGroupsResourceApi;
 import com.cloudera.api.swagger.RolesResourceApi;
 import com.cloudera.api.swagger.ServicesResourceApi;
 import com.cloudera.api.swagger.ToolsResourceApi;
@@ -70,6 +71,11 @@ public class CmClientConfig {
     @Bean
     public Function<ApiClient, RolesResourceApi> rolesResourceApiFactory() {
         return this::rolesResourceApi;
+    }
+
+    @Bean
+    public Function<ApiClient, RoleConfigGroupsResourceApi> roleConfigGroupsResourceApiFactory() {
+        return this::roleConfigGroupsResourceApi;
     }
 
     @Bean
@@ -180,6 +186,12 @@ public class CmClientConfig {
     @Scope(value = "prototype")
     public RolesResourceApi rolesResourceApi(ApiClient apiClient) {
         return new RolesResourceApi(apiClient);
+    }
+
+    @Bean
+    @Scope(value = "prototype")
+    public RoleConfigGroupsResourceApi roleConfigGroupsResourceApi(ApiClient apiClient) {
+        return new RoleConfigGroupsResourceApi(apiClient);
     }
 
     @Bean

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/autoscales/AutoscaleV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/autoscales/AutoscaleV4Endpoint.java
@@ -2,14 +2,20 @@ package com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
+import java.util.List;
+
 import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 
 import com.cloudera.cdp.shaded.javax.ws.rs.core.MediaType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.AmbariAddressV4Request;
@@ -42,18 +48,18 @@ public interface AutoscaleV4Endpoint {
     @ApiOperation(value = StackOpDescription.PUT_BY_ID, produces = APPLICATION_JSON, notes = Notes.STACK_NOTES, nickname = "putStackForAutoscale")
     void putStack(@PathParam("crn") String crn, @PathParam("userId") String userId, @Valid UpdateStackV4Request updateRequest);
 
-    @PUT
-    @Path("/stack/crn/{crn}/{userId}/cluster")
-    @Produces(APPLICATION_JSON)
-    @ApiOperation(value = StackOpDescription.PUT_BY_ID, produces = APPLICATION_JSON, notes = Notes.STACK_NOTES, nickname = "putClusterForAutoscale")
-    void putCluster(@PathParam("crn") String crn, @PathParam("userId") String userId, @Valid UpdateClusterV4Request updateRequest);
-
     @POST
     @Path("ambari")
     @Produces(APPLICATION_JSON)
     @ApiOperation(value = StackOpDescription.GET_BY_AMBARI_ADDRESS, produces = APPLICATION_JSON, notes = Notes.STACK_NOTES,
             nickname = "getStackForAmbariForAutoscale")
     StackV4Response getStackForAmbari(@Valid AmbariAddressV4Request json);
+
+    @PUT
+    @Path("/stack/crn/{crn}/{userId}/cluster")
+    @Produces(APPLICATION_JSON)
+    @ApiOperation(value = StackOpDescription.PUT_BY_ID, produces = APPLICATION_JSON, notes = Notes.STACK_NOTES, nickname = "putClusterForAutoscale")
+    void putCluster(@PathParam("crn") String crn, @PathParam("userId") String userId, @Valid UpdateClusterV4Request updateRequest);
 
     @GET
     @Path("stack/all")
@@ -85,6 +91,16 @@ public interface AutoscaleV4Endpoint {
     @ApiOperation(value = StackOpDescription.GET_STACK_CERT, produces = APPLICATION_JSON, notes = Notes.STACK_NOTES,
             nickname = "getCertificateStackForAutoscale")
     CertificateV4Response getCertificate(@PathParam("crn") String crn);
+
+    @DELETE
+    @Path("/stack/crn/{crn}/instances")
+    @Produces(APPLICATION_JSON)
+    @ApiOperation(value = StackOpDescription.DELETE_MULTIPLE_INSTANCES_BY_ID_IN_WORKSPACE, produces = APPLICATION_JSON,
+            notes = Notes.STACK_NOTES, nickname = "decommissionInstancesForClusterCrn")
+    void decommissionInstancesForClusterCrn(@PathParam("crn") String clusterCrn,
+            @QueryParam("workspaceId") @Valid Long workspaceId,
+            @QueryParam("instanceId") @NotEmpty List<String> instanceIds,
+            @QueryParam("forced") @DefaultValue("false") Boolean forced);
 
     @GET
     @Path("clusterproxy")

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/AutoscaleStackV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/AutoscaleStackV4Response.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response;
 import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.doc.ModelDescriptions.ClusterModelDescription;
 import com.sequenceiq.cloudbreak.doc.ModelDescriptions.StackModelDescription;
@@ -25,6 +26,9 @@ public class AutoscaleStackV4Response {
 
     @ApiModelProperty(StackModelDescription.USER_ID)
     private String userId;
+
+    @ApiModelProperty(StackModelDescription.USER_CRN)
+    private String userCrn;
 
     @ApiModelProperty(StackModelDescription.STACK_ID)
     private Long stackId;
@@ -61,6 +65,12 @@ public class AutoscaleStackV4Response {
 
     @ApiModelProperty(StackModelDescription.CRN)
     private String stackCrn;
+
+    @ApiModelProperty(StackModelDescription.CLOUD_PLATFORM)
+    private String cloudPlatform;
+
+    @ApiModelProperty(StackModelDescription.TYPE)
+    private StackType stackType;
 
     @ApiModelProperty(StackModelDescription.TUNNEL)
     private Tunnel tunnel;
@@ -183,5 +193,29 @@ public class AutoscaleStackV4Response {
 
     public void setTunnel(Tunnel tunnel) {
         this.tunnel = tunnel;
+    }
+
+    public StackType getStackType() {
+        return stackType;
+    }
+
+    public void setStackType(StackType stackType) {
+        this.stackType = stackType;
+    }
+
+    public String getUserCrn() {
+        return userCrn;
+    }
+
+    public void setUserCrn(String userCrn) {
+        this.userCrn = userCrn;
+    }
+
+    public String getCloudPlatform() {
+        return cloudPlatform;
+    }
+
+    public void setCloudPlatform(String cloudPlatform) {
+        this.cloudPlatform = cloudPlatform;
     }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/client/CloudbreakInternalCrnClient.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/client/CloudbreakInternalCrnClient.java
@@ -16,4 +16,8 @@ public class CloudbreakInternalCrnClient {
     public CloudbreakServiceCrnEndpoints withInternalCrn() {
         return client.withCrn(internalCrnBuilder.getInternalCrnForServiceAsString());
     }
+
+    public CloudbreakServiceCrnEndpoints withUserCrn(String userCrn) {
+        return client.withCrn(userCrn);
+    }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
@@ -125,8 +125,10 @@ public class ModelDescriptions {
     public static class StackModelDescription {
         public static final String TENANANT = "name of the tenant";
         public static final String CRN = "the unique crn of the resource";
+        public static final String TYPE = "the typeof the resource";
         public static final String WORKSPACE_ID = "id of the workspace";
         public static final String USER_ID = "id of the user";
+        public static final String USER_CRN = "crn of the user";
         public static final String STACK_ID = "id of the stack";
         public static final String CUSTOM = "AmbariKerberosDescriptor parameters as a json";
         public static final String ENTRIES = "Entries parameters as a json";

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/projection/AutoscaleStack.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/projection/AutoscaleStack.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.domain.projection;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceMetadataType;
 import com.sequenceiq.cloudbreak.service.secret.domain.Secret;
@@ -42,9 +43,15 @@ public interface AutoscaleStack {
 
     String getUserId();
 
+    String getUserCrn();
+
     String getClusterManagerVariant();
 
     String getCrn();
+
+    String getCloudPlatform();
+
+    StackType getType();
 
     Tunnel getTunnel();
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/stack/AutoscaleStackToAutoscaleStackResponseJsonConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/stack/AutoscaleStackToAutoscaleStackResponseJsonConverter.java
@@ -21,12 +21,15 @@ public class AutoscaleStackToAutoscaleStackResponseJsonConverter extends Abstrac
         result.setTenant(source.getTenantName());
         result.setWorkspaceId(source.getWorkspaceId());
         result.setUserId(source.getUserId());
+        result.setUserCrn(source.getUserCrn());
         result.setStackId(source.getId());
         result.setName(source.getName());
         result.setGatewayPort(source.getGatewayPort());
         result.setCreated(source.getCreated());
         result.setStatus(source.getStackStatus());
         result.setStackCrn(source.getCrn());
+        result.setCloudPlatform(source.getCloudPlatform());
+        result.setStackType(source.getType());
         result.setTunnel(source.getTunnel());
 
         if (source.getClusterStatus() != null) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/config/generator/OfflineStateGenerator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/config/generator/OfflineStateGenerator.java
@@ -394,7 +394,7 @@ public class OfflineStateGenerator {
         }
 
         @Override
-        public Set<AutoscaleStack> findAliveOnesWithAmbari() {
+        public Set<AutoscaleStack> findAliveOnesWithClusterManager() {
             return null;
         }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
@@ -157,9 +157,12 @@ public interface StackRepository extends WorkspaceResourceRepository<Stack, Long
             + "w.id as workspaceId, "
             + "t.name as tenantName, "
             + "u.userId as userId, "
+            + "u.userCrn as userCrn, "
             + "s.resourceCrn as crn, "
             + "c.variant as clusterManagerVariant, "
-            + "s.tunnel as tunnel "
+            + "s.tunnel as tunnel, "
+            + "s.cloudPlatform as cloudPlatform, "
+            + "s.type as type "
             + "FROM Stack s "
             + "LEFT JOIN s.cluster c "
             + "LEFT JOIN s.stackStatus ss "
@@ -172,10 +175,9 @@ public interface StackRepository extends WorkspaceResourceRepository<Stack, Long
             + "WHERE ig.instanceGroupType = 'GATEWAY' "
             + "AND im.instanceMetadataType = 'GATEWAY_PRIMARY' "
             + "AND s.terminated = null "
-            + "AND c.clusterManagerIp IS NOT NULL "
-            + "AND c.status = 'AVAILABLE' "
+            + "AND c.status in ('AVAILABLE', 'REQUESTED', 'UPDATE_IN_PROGRESS') "
             + "AND (s.type is not 'TEMPLATE' OR s.type is null)")
-    Set<AutoscaleStack> findAliveOnesWithAmbari();
+    Set<AutoscaleStack> findAliveOnesWithClusterManager();
 
     @Query("SELECT s.id as id, s.name as name FROM Stack s WHERE s.network = :network")
     Set<StackIdView> findByNetwork(@Param("network") Network network);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/StackCommonService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/StackCommonService.java
@@ -11,7 +11,6 @@ import javax.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.AmbariAddressV4Request;
@@ -254,7 +253,6 @@ public class StackCommonService {
         return response;
     }
 
-    @PreAuthorize("hasRole('AUTOSCALE')")
     public CertificateV4Response getCertificate(String crn) {
         Stack stack = stackService.findByCrn(crn);
         return tlsSecurityService.getCertificates(stack.getId());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
@@ -23,7 +23,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 import com.google.common.base.Strings;
@@ -97,7 +96,6 @@ import com.sequenceiq.cloudbreak.tag.CostTagging;
 import com.sequenceiq.cloudbreak.tag.request.CDPTagGenerationRequest;
 import com.sequenceiq.cloudbreak.telemetry.fluent.FluentClusterType;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.CloudStorageFolderResolverService;
-import com.sequenceiq.cloudbreak.workspace.model.Tenant;
 import com.sequenceiq.cloudbreak.workspace.model.User;
 import com.sequenceiq.cloudbreak.workspace.model.Workspace;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
@@ -261,22 +259,10 @@ public class StackService implements ResourceIdProvider {
         return foundStack.orElseThrow(() -> new NotFoundException(String.format(STACK_NOT_FOUND_BY_NAME_OR_CRN_EXCEPTION_MESSAGE, nameOrCrn)));
     }
 
-    @PreAuthorize("hasRole('AUTOSCALE')")
-    public Long getWorkspaceId(String crn) {
-        return stackRepository.findWorkspaceIdByCrn(crn);
-    }
-
-    @PreAuthorize("hasRole('AUTOSCALE')")
-    public Tenant getTenant(String crn) {
-        Workspace workspace = stackRepository.findWorkspaceByCrn(crn).orElseThrow(notFound("workspace", crn));
-        return workspace.getTenant();
-    }
-
-    @PreAuthorize("hasRole('AUTOSCALE')")
     public Set<AutoscaleStackV4Response> getAllForAutoscale() {
         try {
             return transactionService.required(() -> {
-                Set<AutoscaleStack> aliveOnes = stackRepository.findAliveOnesWithAmbari();
+                Set<AutoscaleStack> aliveOnes = stackRepository.findAliveOnesWithClusterManager();
                 Set<AutoscaleStack> aliveNotUnderDeletion = Optional.ofNullable(aliveOnes).orElse(Set.of()).stream()
                         .filter(stack -> !DELETE_IN_PROGRESS.equals(stack.getStackStatus()))
                         .collect(Collectors.toSet());

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/StackServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/StackServiceTest.java
@@ -224,7 +224,7 @@ public class StackServiceTest {
             Supplier<AutoscaleStackV4Response> callback = invocation.getArgument(0);
             return callback.get();
         });
-        when(stackRepository.findAliveOnesWithAmbari()).thenReturn(null);
+        when(stackRepository.findAliveOnesWithClusterManager()).thenReturn(null);
         ArgumentCaptor<Set> aliveStackCaptor = ArgumentCaptor.forClass(Set.class);
         when(converterUtil.convertAllAsSet(aliveStackCaptor.capture(), eq(AutoscaleStackV4Response.class))).thenReturn(Set.of());
 
@@ -245,7 +245,7 @@ public class StackServiceTest {
 
         AutoscaleStack stack = mock(AutoscaleStack.class);
         when(stack.getStackStatus()).thenReturn(Status.AVAILABLE);
-        when(stackRepository.findAliveOnesWithAmbari()).thenReturn(Set.of(stack));
+        when(stackRepository.findAliveOnesWithClusterManager()).thenReturn(Set.of(stack));
 
         ArgumentCaptor<Set> aliveStackCaptor = ArgumentCaptor.forClass(Set.class);
         AutoscaleStackV4Response autoscaleStackResponse = new AutoscaleStackV4Response();
@@ -272,7 +272,7 @@ public class StackServiceTest {
 
         AutoscaleStack deleteInProgressStack = mock(AutoscaleStack.class);
         when(deleteInProgressStack.getStackStatus()).thenReturn(Status.AVAILABLE);
-        when(stackRepository.findAliveOnesWithAmbari()).thenReturn(Set.of(availableStack, deleteInProgressStack));
+        when(stackRepository.findAliveOnesWithClusterManager()).thenReturn(Set.of(availableStack, deleteInProgressStack));
 
         ArgumentCaptor<Set> aliveStackCaptor = ArgumentCaptor.forClass(Set.class);
         AutoscaleStackV4Response autoscaleStackResponse = new AutoscaleStackV4Response();


### PR DESCRIPTION
DISTX-399 Introduce Periscope DataHub Autoscaling (Part 1).

1. All AutoscaleV4Endpoint endpoints are authorized by UMS Authorization or hasRole for internal-crn and all authorization checks moved to AutoscaleV4Controller.
2. Disabling unused endpoint registration and in swagger-spec for swagger-spec based cdp-cli integration.
3. Disabled unused monitors from running.
4. Support for retrieving additional parameters Cluster Creator's User CRN, Stack Type, CloudPlatform during cluster sync.
5. Existing scaling interaction between Periscope and CB was based on Cluster Creator's UserId, this has been enhanced to use Cluster Creator's UserCRN, since CB requires valid Knox UserCRN while scaling up cluster.

Some methods in PR appear unused because DISTX-399-Feature-Branch-Datahub-AutoScaling has full feature change and am merging the changes in smaller PRs for easier review.