### PR TITLE
CB-7063 tests could be skipped if developer find it flaky

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/MeasuredTestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/MeasuredTestContext.java
@@ -263,7 +263,7 @@ public class MeasuredTestContext extends MockedTestContext {
     }
 
     @Override
-    public void handleExceptionsDuringTest(boolean silently) {
+    public void handleExceptionsDuringTest(TestErrorLog silently) {
         wrappedTestContext.handleExceptionsDuringTest(silently);
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestErrorLog.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestErrorLog.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.it.cloudbreak.context;
+
+import org.slf4j.Logger;
+import org.testng.SkipException;
+
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.it.cloudbreak.log.Log;
+
+public enum TestErrorLog {
+    IGNORE(false, null),
+    FAIL(true, true),
+    SKIP(true, false);
+
+    private Boolean report;
+
+    private Boolean fail;
+
+    TestErrorLog(Boolean report, Boolean fail) {
+        this.report = report;
+        this.fail = fail;
+    }
+
+    void report(Logger logger, String message) {
+        if (report) {
+            Log.validateError(logger, message);
+            if (fail) {
+                throw new TestFailException(message);
+            } else {
+                throw new SkipException(message);
+            }
+        }
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractTestDto.java
@@ -23,6 +23,7 @@ import com.sequenceiq.it.cloudbreak.assertion.Assertion;
 import com.sequenceiq.it.cloudbreak.cloud.v4.CloudProvider;
 import com.sequenceiq.it.cloudbreak.context.RunningParameter;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.context.TestErrorLog;
 import com.sequenceiq.it.cloudbreak.finder.Attribute;
 import com.sequenceiq.it.cloudbreak.finder.Finder;
 
@@ -249,7 +250,11 @@ public abstract class AbstractTestDto<R, S, T extends CloudbreakTestDto, U exten
     }
 
     public void validate() {
-        testContext.handleExceptionsDuringTest(false);
+        testContext.handleExceptionsDuringTest(TestErrorLog.FAIL);
+    }
+
+    public void skipWhenFailure() {
+        testContext.handleExceptionsDuringTest(TestErrorLog.SKIP);
     }
 
     public ResourcePropertyProvider getResourcePropertyProvider() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/mock/HttpMock.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/mock/HttpMock.java
@@ -24,6 +24,7 @@ import com.sequenceiq.it.cloudbreak.cloud.v4.CloudProvider;
 import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
 import com.sequenceiq.it.cloudbreak.context.RunningParameter;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.context.TestErrorLog;
 import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
 import com.sequenceiq.it.cloudbreak.dto.mock.answer.RequestData;
 import com.sequenceiq.it.cloudbreak.mock.DefaultModel;
@@ -188,7 +189,7 @@ public class HttpMock implements CloudbreakTestDto {
     }
 
     public void validate() {
-        testContext.handleExceptionsDuringTest(false);
+        testContext.handleExceptionsDuringTest(TestErrorLog.FAIL);
     }
 
     public DefaultModel getModel() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/log/Log.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/log/Log.java
@@ -90,6 +90,10 @@ public class Log<T extends CloudbreakTestDto> {
         log(logger, "Await", message);
     }
 
+    public static void validateError(Logger logger, String message) {
+        log(logger, "Validate", message);
+    }
+
     public static void log(String message) {
         Reporter.log(message);
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxRepairTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxRepairTests.java
@@ -91,7 +91,7 @@ public class SdxRepairTests extends PreconditionSdxE2ETest {
                     return testDto;
                 })
                 .then((tc, testDto, client) -> compareVolumeIdsAfterRepair(testDto, actualVolumeIds, expectedVolumeIds))
-                .validate();
+                .skipWhenFailure();
     }
 
     @Test(dataProvider = TEST_CONTEXT)
@@ -150,7 +150,7 @@ public class SdxRepairTests extends PreconditionSdxE2ETest {
                     getCloudFunctionality(tc).cloudStorageListContainerFreeIPA(getBaseLocation(testDto));
                     return testDto;
                 })
-                .validate();
+                .skipWhenFailure();
     }
 
     @Test(dataProvider = TEST_CONTEXT)


### PR DESCRIPTION
when tests are could not be fixed, instead of removing or skipping the whole test ,developer can use skipWhenFail() or validate() at the end of the test code. skipWhenFail() let the test run as usual do all the reporting, but skip if exceptions were collected during the run.
If the test or functionality fixed skipWhenFail() easily may swap with validate().