### PR TITLE
CB-7048: Change FreeIPA ASDL backup location from older .blob. to .dfs

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/AdlsGen2BackupConfigGenerator.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/AdlsGen2BackupConfigGenerator.java
@@ -16,9 +16,7 @@ public class AdlsGen2BackupConfigGenerator extends CloudBackupConfigGenerator<Ad
 
     private static final String[] ADLS_GEN2_SCHEME_PREFIXES = {"abfs://", "abfss://"};
 
-    private static final String AZURE_DFS_DOMAIN_SUFFIX = ".dfs.core.windows.net";
-
-    private static final String AZURE_BLOB_STORAGE_SUFFIX = "blob.core.windows.net";
+    private static final String AZURE_DFS_DOMAIN_SUFFIX = "dfs.core.windows.net";
 
     private static final String AZURE_BLOB_STORAGE_SCHEMA = "https://";
 
@@ -27,7 +25,7 @@ public class AdlsGen2BackupConfigGenerator extends CloudBackupConfigGenerator<Ad
             String clusterName, String clusterId) {
         AdlsGen2BackupConfig adlsGen2BackupConfig = generateBackupConfig(location);
         String logFolder = resolveBackupFolder(adlsGen2BackupConfig, clusterType, clusterName, clusterId);
-        String hostPart = String.format("%s.%s", adlsGen2BackupConfig.getAccount(), AZURE_BLOB_STORAGE_SUFFIX);
+        String hostPart = String.format("%s.%s", adlsGen2BackupConfig.getAccount(), AZURE_DFS_DOMAIN_SUFFIX);
         String generatedLocation = String.format("%s%s", AZURE_BLOB_STORAGE_SCHEMA,
                 Paths.get(hostPart, adlsGen2BackupConfig.getFileSystem(), logFolder));
         LOGGER.info("The following ADLS Gen2 base folder location is generated: {} (from {})",
@@ -44,7 +42,7 @@ public class AdlsGen2BackupConfigGenerator extends CloudBackupConfigGenerator<Ad
             if (locationSplit.length < 2) {
                 return new AdlsGen2BackupConfig(folderPrefix, storageWithSuffix[0], null);
             } else {
-                String[] splitByDomain = locationSplit[1].split(AZURE_DFS_DOMAIN_SUFFIX);
+                String[] splitByDomain = locationSplit[1].split("." + AZURE_DFS_DOMAIN_SUFFIX);
                 String account = splitByDomain[0];
                 if (splitByDomain.length > 1) {
                     String folderPrefixAfterDomain = splitByDomain[1];

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/AdlsGen2BackupConfigGeneratorTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/AdlsGen2BackupConfigGeneratorTest.java
@@ -19,7 +19,7 @@ public class AdlsGen2BackupConfigGeneratorTest {
                 FluentClusterType.FREEIPA.value(),
                 "mycluster",
                 "12345");
-        assertEquals("https://someaccount.blob.core.windows.net/mycontainer/cluster-backups/freeipa/mycluster_12345", location);
+        assertEquals("https://someaccount.dfs.core.windows.net/mycontainer/cluster-backups/freeipa/mycluster_12345", location);
     }
 
     @Test
@@ -30,7 +30,7 @@ public class AdlsGen2BackupConfigGeneratorTest {
                 FluentClusterType.FREEIPA.value(),
                 "mycluster",
                 "12345");
-        assertEquals("https://someaccount.blob.core.windows.net/mycontainer/someplace/cluster-backups/freeipa/mycluster_12345", location);
+        assertEquals("https://someaccount.dfs.core.windows.net/mycontainer/someplace/cluster-backups/freeipa/mycluster_12345", location);
     }
 
     @Test
@@ -41,7 +41,7 @@ public class AdlsGen2BackupConfigGeneratorTest {
                 FluentClusterType.FREEIPA.value(),
                 "mycluster",
                 "12345");
-        assertEquals("https://someaccount.blob.core.windows.net/mycontainer/cluster-backups/freeipa/mycluster_12345", location);
+        assertEquals("https://someaccount.dfs.core.windows.net/mycontainer/cluster-backups/freeipa/mycluster_12345", location);
     }
 
     @Test
@@ -52,7 +52,7 @@ public class AdlsGen2BackupConfigGeneratorTest {
                 FluentClusterType.FREEIPA.value(),
                 "mycluster",
                 "12345");
-        assertEquals("https://someaccount.blob.core.windows.net/mycontainer/cluster-backups/freeipa/mycluster_12345", location);
+        assertEquals("https://someaccount.dfs.core.windows.net/mycontainer/cluster-backups/freeipa/mycluster_12345", location);
     }
 
     @Test
@@ -63,6 +63,6 @@ public class AdlsGen2BackupConfigGeneratorTest {
                 FluentClusterType.FREEIPA.value(),
                 "mycluster",
                 "12345");
-        assertEquals("https://someaccount.blob.core.windows.net/mycontainer/someplace/deeper/cluster-backups/freeipa/mycluster_12345", location);
+        assertEquals("https://someaccount.dfs.core.windows.net/mycontainer/someplace/deeper/cluster-backups/freeipa/mycluster_12345", location);
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/CloudBackupFolderResolverServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/CloudBackupFolderResolverServiceTest.java
@@ -44,7 +44,7 @@ public class CloudBackupFolderResolverServiceTest {
         underTest.updateStorageLocation(backup, FluentClusterType.FREEIPA.value(), "mycluster",
                 "crn:cdp:cloudbreak:us-west-1:someone:stack:12345");
         // THEN
-        assertEquals("https://someaccount.blob.core.windows.net/mycontainer/cluster-backups/freeipa/mycluster_12345", backup.getStorageLocation());
+        assertEquals("https://someaccount.dfs.core.windows.net/mycontainer/cluster-backups/freeipa/mycluster_12345", backup.getStorageLocation());
     }
 
     @Test
@@ -58,7 +58,7 @@ public class CloudBackupFolderResolverServiceTest {
         underTest.updateStorageLocation(backup, FluentClusterType.FREEIPA.value(), "mycluster",
                 "crn:cdp:cloudbreak:us-west-1:someone:stack:12345");
         // THEN
-        assertEquals("https://someaccount.blob.core.windows.net/mycontainer/cluster-backups/freeipa/mycluster_12345", backup.getStorageLocation());
+        assertEquals("https://someaccount.dfs.core.windows.net/mycontainer/cluster-backups/freeipa/mycluster_12345", backup.getStorageLocation());
     }
 
     @Test


### PR DESCRIPTION
This changes the backup location for FreeIPA backups to the older blob.core.windows.net to the same location that is used by telemetry (dfs.core.windows.net)  so we have the same dns url to be used with things like Private Link.

Closes #CB-7048