### PR TITLE
CB-7089: Prevent FreeIPA backup script parallel runs

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/backups.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/backups.sls
@@ -5,7 +5,6 @@
     - group: root
     - mode: 750
 
-{% if salt['pillar.get']('freeipa:backup:enabled') %}
 /etc/freeipa_backup.conf:
   file.managed:
     - source: salt://freeipa/templates/freeipa_backup.conf.j2
@@ -13,6 +12,17 @@
     - user: root
     - group: root
     - mode: 640
+
+{% if salt['pillar.get']('freeipa:backup:enabled') %}
+{% if salt['pillar.get']('freeipa:backup:initial_full_enabled') %}
+freeipa_initial_full_backup:
+  cmd.run:
+    - name: /usr/local/bin/freeipa_backup -t FULL -f "{{salt['grains.get']('fqdn')}}/full" && echo $(date +%Y-%m-%d:%H:%M:%S) >> /var/log/freeipa_initial_backup-executed
+    - unless: test -f /var/log/freeipa_initial_backup-executed
+    - require:
+        - file: /usr/local/bin/freeipa_backup
+        - file: /etc/freeipa_backup.conf
+{% endif %}
 
 {% if salt['pillar.get']('freeipa:backup:monthly_full_enabled') %}
 /etc/cron.monthly/freeipa_backup_monthly:
@@ -32,15 +42,5 @@
     - user: root
     - group: root
     - mode: 750
-{% endif %}
-
-{% if salt['pillar.get']('freeipa:backup:initial_full_enabled') %}
-freeipa_initial_full_backup:
-  cmd.run:
-    - name: /usr/local/bin/freeipa_backup -t FULL -f "{{salt['grains.get']('fqdn')}}/full" && echo $(date +%Y-%m-%d:%H:%M:%S) >> /var/log/freeipa_initial_backup-executed
-    - unless: test -f /var/log/freeipa_initial_backup-executed
-    - require:
-        - file: /usr/local/bin/freeipa_backup
-        - file: /etc/freeipa_backup.conf
 {% endif %}
 {% endif %}

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_backup
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_backup
@@ -1,10 +1,28 @@
 #!/bin/bash
-# Name: freeipa_backup.sh
+# Name: freeipa_backup
 # Description: Backup FreeIPA and Upload backup to provided Cloud Location
 ################################################################
 set -x
 
 CONFIG_FILE=/etc/freeipa_backup.conf
+
+LOCKFILE="/var/lock/`basename $0`"
+LOCKFD=99
+
+# PRIVATE
+_lock()             { flock -$1 $LOCKFD; }
+_no_more_locking()  { _lock u; _lock xn && rm -f $LOCKFILE; }
+_prepare_locking()  { eval "exec $LOCKFD>\"$LOCKFILE\""; trap _no_more_locking EXIT; }
+
+# ON START
+_prepare_locking
+
+# PUBLIC
+exlock_now()        { _lock xn; }  # obtain an exclusive lock immediately or fail
+exlock()            { _lock x; }   # obtain an exclusive lock
+shlock()            { _lock s; }   # obtain a shared lock
+unlock()            { _lock u; }   # drop a lock
+
 
 # Config Defaults
 typeset -A config # init array
@@ -86,7 +104,7 @@ doLog(){
 error_exit()
 {
     doLog "ERROR $1"
-	exit 1
+	  exit 1
 }
 
 remove_local_backups() {
@@ -95,6 +113,8 @@ remove_local_backups() {
 }
 
 doLog "INFO Running ${TYPE} IPA backup."
+
+exlock_now || error_exit "A backup seems to be currently running. Lock file is at ${LOCKFILE}"
 
 set +x
 if [[ -n "${config[http_proxy]}" ]]; then


### PR DESCRIPTION
This adds locks to the backup scripts so that only one backup
job can run at any one time on a host.

As well it reorders the deployment of the corn jobs until after the
running of the initial backup.

Closes #CB-7089
