### PR TITLE
CB-7110. Persist anonymization rules on cluster side (freeipa/datalake/datahub)

### DIFF
--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/doc/TelemetryModelDescription.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/doc/TelemetryModelDescription.java
@@ -7,6 +7,7 @@ public class TelemetryModelDescription {
     public static final String TELEMETRY_WORKLOAD_ANALYTICS_ATTRIBUTES = "Workload analytics (telemetry) attributes.";
     public static final String TELEMETRY_FLUENT_ATTRIBUTES = "Telemetry fluent settings (overrides).";
     public static final String TELEMETRY_FEATURES = "Telemetry features settings";
+    public static final String TELEMETRY_RULES = "Telemetry anonymization rules (persistent on cluster level) that are applied on shipped logs.";
     public static final String TELEMETRY_METERING = "Telemetry metering feature setting";
     public static final String TELEMETRY_LOGGING_S3_ATTRIBUTES = "telemetry - logging s3 attributes";
     public static final String TELEMETRY_LOGGING_ADLS_GEN_2_ATTRIBUTES = "telemetry - logging adls gen2 attributes";

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/Telemetry.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/Telemetry.java
@@ -2,6 +2,7 @@ package com.sequenceiq.common.api.telemetry.model;
 
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -27,6 +28,9 @@ public class Telemetry implements Serializable {
 
     @JsonProperty("fluentAttributes")
     private Map<String, Object> fluentAttributes = new HashMap<>();
+
+    @JsonProperty("rules")
+    private List<AnonymizationRule> rules;
 
     public Logging getLogging() {
         return logging;
@@ -66,6 +70,14 @@ public class Telemetry implements Serializable {
 
     public void setFluentAttributes(Map<String, Object> fluentAttributes) {
         this.fluentAttributes = fluentAttributes;
+    }
+
+    public List<AnonymizationRule> getRules() {
+        return rules;
+    }
+
+    public void setRules(List<AnonymizationRule> rules) {
+        this.rules = rules;
     }
 
     @JsonIgnore

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/response/TelemetryResponse.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/response/TelemetryResponse.java
@@ -1,8 +1,11 @@
 package com.sequenceiq.common.api.telemetry.response;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.sequenceiq.common.api.telemetry.base.TelemetryBase;
 import com.sequenceiq.common.api.telemetry.doc.TelemetryModelDescription;
+import com.sequenceiq.common.api.telemetry.model.AnonymizationRule;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -19,6 +22,9 @@ public class TelemetryResponse extends TelemetryBase {
 
     @ApiModelProperty(TelemetryModelDescription.TELEMETRY_FEATURES)
     private FeaturesResponse features;
+
+    @ApiModelProperty(TelemetryModelDescription.TELEMETRY_RULES)
+    private List<AnonymizationRule> rules;
 
     public LoggingResponse getLogging() {
         return logging;
@@ -42,5 +48,13 @@ public class TelemetryResponse extends TelemetryBase {
 
     public void setFeatures(FeaturesResponse features) {
         this.features = features;
+    }
+
+    public List<AnonymizationRule> getRules() {
+        return rules;
+    }
+
+    public void setRules(List<AnonymizationRule> rules) {
+        this.rules = rules;
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigService.java
@@ -49,12 +49,6 @@ public class FluentConfigService {
 
     public FluentConfigView createFluentConfigs(TelemetryClusterDetails clusterDetails,
             boolean databusEnabled, boolean meteringEnabled, Telemetry telemetry) {
-        return createFluentConfigs(clusterDetails, databusEnabled, meteringEnabled, telemetry, null);
-    }
-
-    public FluentConfigView createFluentConfigs(TelemetryClusterDetails clusterDetails,
-            boolean databusEnabled, boolean meteringEnabled, Telemetry telemetry,
-            List<AnonymizationRule> anonymizationRules) {
         final FluentConfigView.Builder builder = new FluentConfigView.Builder();
         boolean enabled = false;
         if (telemetry != null) {
@@ -66,7 +60,7 @@ public class FluentConfigService {
             enabled = determineAndSetLogging(builder, telemetry, databusEnabled, meteringEnabled);
             if (telemetry.isClusterLogsCollectionEnabled()) {
                 LOGGER.debug("Set anonymization rules (only for cluster log collection)");
-                builder.withAnonymizationRules(decodeRules(anonymizationRules));
+                builder.withAnonymizationRules(decodeRules(telemetry.getRules()));
             }
         }
         if (!enabled) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
@@ -74,6 +74,7 @@ public class TelemetryConverter {
             response.setLogging(loggingResponse);
             response.setWorkloadAnalytics(waResponse);
             response.setFluentAttributes(telemetry.getFluentAttributes());
+            response.setRules(telemetry.getRules());
             createFeaturesResponseFromSource(response, telemetry.getFeatures());
         }
         return response;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecorator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecorator.java
@@ -3,7 +3,6 @@ package com.sequenceiq.cloudbreak.core.bootstrap.service.host.decorator;
 import static com.sequenceiq.cloudbreak.telemetry.TelemetryClusterDetails.CLUSTER_CRN_KEY;
 import static java.util.Collections.singletonMap;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -15,10 +14,9 @@ import com.sequenceiq.cloudbreak.auth.altus.model.AltusCredential;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
 import com.sequenceiq.cloudbreak.service.altus.AltusMachineUserService;
-import com.sequenceiq.cloudbreak.service.environment.telemetry.AccountTelemetryClientService;
+import com.sequenceiq.cloudbreak.telemetry.TelemetryClusterDetails;
 import com.sequenceiq.cloudbreak.telemetry.databus.DatabusConfigService;
 import com.sequenceiq.cloudbreak.telemetry.databus.DatabusConfigView;
-import com.sequenceiq.cloudbreak.telemetry.TelemetryClusterDetails;
 import com.sequenceiq.cloudbreak.telemetry.fluent.FluentClusterType;
 import com.sequenceiq.cloudbreak.telemetry.fluent.FluentConfigService;
 import com.sequenceiq.cloudbreak.telemetry.fluent.FluentConfigView;
@@ -28,7 +26,6 @@ import com.sequenceiq.cloudbreak.telemetry.monitoring.MonitoringAuthConfig;
 import com.sequenceiq.cloudbreak.telemetry.monitoring.MonitoringClusterType;
 import com.sequenceiq.cloudbreak.telemetry.monitoring.MonitoringConfigService;
 import com.sequenceiq.cloudbreak.telemetry.monitoring.MonitoringConfigView;
-import com.sequenceiq.common.api.telemetry.model.AnonymizationRule;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
 
 /**
@@ -79,21 +76,17 @@ public class TelemetryDecorator {
 
     private final AltusMachineUserService altusMachineUserService;
 
-    private final AccountTelemetryClientService accountTelemetryClientService;
-
     public TelemetryDecorator(DatabusConfigService databusConfigService,
             FluentConfigService fluentConfigService,
             MeteringConfigService meteringConfigService,
             MonitoringConfigService monitoringConfigService,
             AltusMachineUserService altusMachineUserService,
-            AccountTelemetryClientService accountTelemetryClientService,
             @Value("${info.app.version:}") String version) {
         this.databusConfigService = databusConfigService;
         this.fluentConfigService = fluentConfigService;
         this.meteringConfigService = meteringConfigService;
         this.monitoringConfigService = monitoringConfigService;
         this.altusMachineUserService = altusMachineUserService;
-        this.accountTelemetryClientService = accountTelemetryClientService;
         this.version = version;
     }
 
@@ -126,9 +119,8 @@ public class TelemetryDecorator {
                 .withPlatform(stack.getCloudPlatform())
                 .withVersion(version)
                 .build();
-        List<AnonymizationRule> rules = accountTelemetryClientService.getAnonymizationRules();
         FluentConfigView fluentConfigView = fluentConfigService.createFluentConfigs(clusterDetails,
-                databusConfigView.isEnabled(), meteringEnabled, telemetry, rules);
+                databusConfigView.isEnabled(), meteringEnabled, telemetry);
         if (fluentConfigView.isEnabled()) {
             Map<String, Object> fluentConfig = fluentConfigView.toMap();
             servicePillar.put("fluent",

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
@@ -84,6 +84,7 @@ import com.sequenceiq.cloudbreak.service.datalake.DatalakeResourcesService;
 import com.sequenceiq.cloudbreak.service.decorator.StackResponseDecorator;
 import com.sequenceiq.cloudbreak.service.environment.credential.OpenSshPublicKeyValidator;
 import com.sequenceiq.cloudbreak.service.environment.tag.AccountTagClientService;
+import com.sequenceiq.cloudbreak.service.environment.telemetry.AccountTelemetryClientService;
 import com.sequenceiq.cloudbreak.service.image.ImageService;
 import com.sequenceiq.cloudbreak.service.image.StatedImage;
 import com.sequenceiq.cloudbreak.service.orchestrator.OrchestratorService;
@@ -188,6 +189,9 @@ public class StackService implements ResourceIdProvider {
 
     @Inject
     private AccountTagClientService accountTagClientService;
+
+    @Inject
+    private AccountTelemetryClientService accountTelemetryClientService;
 
     @Inject
     private ResourceService resourceService;
@@ -729,6 +733,9 @@ public class StackService implements ResourceIdProvider {
                             ? FluentClusterType.DATALAKE : FluentClusterType.DATAHUB;
                     try {
                         Telemetry telemetry = component.getAttributes().get(Telemetry.class);
+                        if (telemetry != null) {
+                            telemetry.setRules(accountTelemetryClientService.getAnonymizationRules());
+                        }
                         cloudStorageFolderResolverService.updateStorageLocation(telemetry,
                                 fluentClusterType.value(),
                                 stack.getCluster().getName(), stack.getResourceCrn());

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecoratorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecoratorTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
@@ -27,10 +26,9 @@ import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
 import com.sequenceiq.cloudbreak.service.altus.AltusMachineUserService;
-import com.sequenceiq.cloudbreak.service.environment.telemetry.AccountTelemetryClientService;
+import com.sequenceiq.cloudbreak.telemetry.TelemetryClusterDetails;
 import com.sequenceiq.cloudbreak.telemetry.databus.DatabusConfigService;
 import com.sequenceiq.cloudbreak.telemetry.databus.DatabusConfigView;
-import com.sequenceiq.cloudbreak.telemetry.TelemetryClusterDetails;
 import com.sequenceiq.cloudbreak.telemetry.fluent.FluentConfigService;
 import com.sequenceiq.cloudbreak.telemetry.fluent.FluentConfigView;
 import com.sequenceiq.cloudbreak.telemetry.metering.MeteringConfigService;
@@ -59,9 +57,6 @@ public class TelemetryDecoratorTest {
     @Mock
     private AltusMachineUserService altusMachineUserService;
 
-    @Mock
-    private AccountTelemetryClientService accountTelemetryClientService;
-
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
@@ -69,8 +64,7 @@ public class TelemetryDecoratorTest {
         given(altusMachineUserService.generateDatabusMachineUserForFluent(any(Stack.class), any(Telemetry.class)))
                 .willReturn(Optional.of(altusCredential));
         underTest = new TelemetryDecorator(databusConfigService, fluentConfigService,
-                meteringConfigService, monitoringConfigService, altusMachineUserService,
-                accountTelemetryClientService, "1.0.0");
+                meteringConfigService, monitoringConfigService, altusMachineUserService, "1.0.0");
     }
 
     @Test
@@ -101,7 +95,7 @@ public class TelemetryDecoratorTest {
         assertEquals(results.get("platform"), CloudPlatform.AWS.name());
         assertEquals(results.get("user"), "root");
         verify(fluentConfigService, times(1)).createFluentConfigs(any(TelemetryClusterDetails.class),
-                anyBoolean(), anyBoolean(), any(Telemetry.class), anyList());
+                anyBoolean(), anyBoolean(), any(Telemetry.class));
         verify(meteringConfigService, times(1)).createMeteringConfigs(anyBoolean(), anyString(), anyString(), anyString(),
                 anyString());
     }
@@ -257,7 +251,7 @@ public class TelemetryDecoratorTest {
         given(databusConfigService.createDatabusConfigs(anyString(), any(), isNull(), isNull()))
                 .willReturn(databusConfigView);
         given(fluentConfigService.createFluentConfigs(any(TelemetryClusterDetails.class),
-                anyBoolean(), anyBoolean(), any(Telemetry.class), anyList()))
+                anyBoolean(), anyBoolean(), any(Telemetry.class)))
                 .willReturn(fluentConfigView);
         given(meteringConfigService.createMeteringConfigs(anyBoolean(), anyString(), anyString(), anyString(),
                 anyString())).willReturn(meteringConfigView);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverter.java
@@ -59,6 +59,7 @@ public class TelemetryConverter {
             response.setFluentAttributes(telemetry.getFluentAttributes());
             response.setLogging(createLoggingResponseFromSource(telemetry.getLogging()));
             response.setFeatures(createFeaturesResponseFromSource(telemetry.getFeatures()));
+            response.setRules(telemetry.getRules());
         }
         return response;
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaInstallService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaInstallService.java
@@ -33,12 +33,10 @@ import com.sequenceiq.cloudbreak.telemetry.databus.DatabusConfigView;
 import com.sequenceiq.cloudbreak.telemetry.fluent.FluentClusterType;
 import com.sequenceiq.cloudbreak.telemetry.fluent.FluentConfigService;
 import com.sequenceiq.cloudbreak.telemetry.fluent.FluentConfigView;
-import com.sequenceiq.common.api.telemetry.model.AnonymizationRule;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
 import com.sequenceiq.freeipa.entity.InstanceMetaData;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.orchestrator.StackBasedExitCriteriaModel;
-import com.sequenceiq.freeipa.service.AccountTelemetryService;
 import com.sequenceiq.freeipa.service.AltusMachineUserService;
 import com.sequenceiq.freeipa.service.GatewayConfigService;
 import com.sequenceiq.freeipa.service.freeipa.config.FreeIpaConfigService;
@@ -71,9 +69,6 @@ public class FreeIpaInstallService {
 
     @Inject
     private DatabusConfigService databusConfigService;
-
-    @Inject
-    private AccountTelemetryService accountTelemetryService;
 
     @Inject
     private AltusMachineUserService altusMachineUserService;
@@ -139,9 +134,8 @@ public class FreeIpaInstallService {
                     .withPlatform(stack.getCloudPlatform())
                     .withVersion(version)
                     .build();
-            List<AnonymizationRule> rules = accountTelemetryService.getAnonymizationRules();
             FluentConfigView fluentConfigView = fluentConfigService.createFluentConfigs(clusterDetails,
-                    databusEnabled, false, telemetry, rules);
+                    databusEnabled, false, telemetry);
             servicePillarConfig.put("fluent", new SaltPillarProperties("/fluent/init.sls", Collections.singletonMap("fluent", fluentConfigView.toMap())));
             if (databusEnabled) {
                 Optional<AltusCredential> credential = altusMachineUserService.createMachineUserWithAccessKeys(stack, telemetry);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaCreationService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaCreationService.java
@@ -40,6 +40,7 @@ import com.sequenceiq.freeipa.entity.SecurityConfig;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.flow.chain.FlowChainTriggers;
 import com.sequenceiq.freeipa.flow.stack.StackEvent;
+import com.sequenceiq.freeipa.service.AccountTelemetryService;
 import com.sequenceiq.freeipa.service.CredentialService;
 import com.sequenceiq.freeipa.service.SecurityConfigService;
 import com.sequenceiq.freeipa.service.TlsSecurityService;
@@ -106,6 +107,9 @@ public class FreeIpaCreationService {
     @Inject
     private SecurityConfigService securityConfigService;
 
+    @Inject
+    private AccountTelemetryService accountTelemetryService;
+
     @Value("${info.app.version:}")
     private String appVersion;
 
@@ -116,8 +120,10 @@ public class FreeIpaCreationService {
         Stack stack = stackConverter.convert(request, accountId, userFuture, userCrn, credential.getCloudPlatform());
         stack.setAppVersion(appVersion);
         GetPlatformTemplateRequest getPlatformTemplateRequest = templateService.triggerGetTemplate(stack, credential);
-
         Telemetry telemetry = stack.getTelemetry();
+        if (telemetry != null) {
+            telemetry.setRules(accountTelemetryService.getAnonymizationRules());
+        }
         cloudStorageFolderResolverService.updateStorageLocation(telemetry,
                 FluentClusterType.FREEIPA.value(), stack.getName(), stack.getResourceCrn());
 


### PR DESCRIPTION
why?
to see what anonymization rules were used for the cluster during deployment, even after the rules changed

manual testing is in progress (freeipa looks good)