### PR TITLE
CB-7089: Prevent FreeIPA backup script parallel runs

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_backup
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_backup
@@ -100,7 +100,7 @@ error_exit()
 {
     doLog "ERROR $1"
     doStatus "ERROR $1"
-    exit 1
+	  exit 1
 }
 
 remove_local_backups() {


### PR DESCRIPTION
Pull of CB-7089 into master.

Original PR for 2.20 was #8078

CB-7089: Prevent FreeIPA backup script parallel runs

This adds locks to the backup scripts so that only one backup
job can run at any one time on a host.