### PR TITLE
Revert "CB-6370 Restore the validate ExternalDatabaseHostname test st…

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/InternalSdxDistroxTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/InternalSdxDistroxTest.java
@@ -1,21 +1,16 @@
 package com.sequenceiq.it.cloudbreak.testcase.e2e.sdx;
 
-import static com.sequenceiq.it.cloudbreak.assertion.distrox.DistroXExternalDatabaseAssertion.validateTemplateContainsExternalDatabaseHostname;
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
 
 import javax.inject.Inject;
 
 import org.testng.annotations.Test;
 
-import com.sequenceiq.distrox.api.v1.distrox.model.database.DistroXDatabaseAvailabilityType;
-import com.sequenceiq.it.TestParameter;
-import com.sequenceiq.it.cloudbreak.actor.Actor;
 import com.sequenceiq.it.cloudbreak.client.DistroXTestClient;
 import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
-import com.sequenceiq.it.cloudbreak.dto.distrox.externaldatabase.DistroXExternalDatabaseTestDto;
 import com.sequenceiq.it.cloudbreak.dto.distrox.image.DistroXImageTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
@@ -30,20 +25,15 @@ public class InternalSdxDistroxTest extends ImageValidatorE2ETest {
     @Inject
     private DistroXTestClient distroXTestClient;
 
-    @Inject
-    private TestParameter testParameter;
-
     @Test(dataProvider = TEST_CONTEXT)
     @Description(
             given = "a SDX internal request and a DistroX request",
             when = "a SDX internal create request is sent",
             then = "the SDX cluster and the corresponding DistroX cluster is created")
     public void testCreateInternalSdxAndDistrox(TestContext testContext) {
-        String externalDB = resourcePropertyProvider().getName();
-        String distrox = resourcePropertyProvider().getName();
         SdxDatabaseRequest sdxDatabaseRequest = new SdxDatabaseRequest();
         sdxDatabaseRequest.setAvailabilityType(SdxDatabaseAvailabilityType.NONE);
-
+        sdxDatabaseRequest.setCreate(false);
         testContext.given(SdxInternalTestDto.class)
                 .withDatabase(sdxDatabaseRequest)
                 .withTemplate(sdxTemplateName)
@@ -54,24 +44,19 @@ public class InternalSdxDistroxTest extends ImageValidatorE2ETest {
                 .await(SdxClusterStatusResponse.RUNNING)
                 .when(sdxTestClient.describeInternal())
                 .validate();
-        testContext
-                .given(externalDB, DistroXExternalDatabaseTestDto.class)
-                .withAvailabilityType(DistroXDatabaseAvailabilityType.NON_HA)
-                .given(distrox, DistroXTestDto.class)
+        testContext.given(DistroXTestDto.class)
                 .withTemplate(distroxTemplateName)
                 .withImageSettings(testContext
                         .given(DistroXImageTestDto.class)
                         .withImageCatalog(testContext.get(SdxInternalTestDto.class).getResponse().getStackV4Response().getImage().getCatalogName())
                         .withImageId(testContext.get(SdxInternalTestDto.class).getResponse().getStackV4Response().getImage().getId()))
-                .withExternalDatabase(externalDB)
-                .when(distroXTestClient.create(), key(distrox))
-                .await(STACK_AVAILABLE, key(distrox))
-                .then(validateTemplateContainsExternalDatabaseHostname(Actor.defaultUser(testParameter)))
-                .when(distroXTestClient.get(), key(distrox))
-                .then((tc, dto, client) -> {
-                    dto.getResponse();
-                    return dto;
+                .when(distroXTestClient.create())
+                .await(STACK_AVAILABLE)
+                .then((context, distrox, client) -> {
+                    distrox.getResponse();
+                    return distrox;
                 })
+                .when(distroXTestClient.get())
                 .validate();
     }
 


### PR DESCRIPTION
imagevalidators are running this test, thus we are generating lot of DBs thus lot of expense