### PR TITLE
CB-7073 azure storage assert should check only the clusters of the test

### DIFF
--- a/cloud-azure/build.gradle
+++ b/cloud-azure/build.gradle
@@ -29,7 +29,7 @@ dependencies {
   }
   compile (group: 'com.microsoft.azure',         name: 'azure-mgmt-datalake-store',  version: '1.22.0') { exclude group: 'org.slf4j' }
   compile (group: 'com.microsoft.azure',         name: 'azure-mgmt-sql',             version: azureSdkVersion) { exclude group: 'org.slf4j' }
-  compile group: 'com.microsoft.azure',         name: 'azure-storage',              version: '8.4.0'
+  compile group: 'com.microsoft.azure',         name: 'azure-storage',              version: azureStorageSdkVersion
   compile group: 'com.microsoft.azure',         name: 'adal4j',                     version: '1.6.4'
   compile group: 'org.apache.commons',                 name: 'commons-collections4', version: commonsCollections4Version
   compile (group: 'com.fasterxml.jackson.core', name: 'jackson-databind',           version: jacksonVersion) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,7 @@ org.gradle.caching=true
 springBootVersion=2.1.8.RELEASE
 awsSdkVersion=1.11.654
 azureSdkVersion=1.28.0
+azureStorageSdkVersion=8.4.0
 caffeineVersion=2.8.1
 eventBusVersion=2.0.7.RELEASE
 slf4jApiVersion=1.7.12

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -99,7 +99,7 @@ dependencies {
   compile (group: 'com.microsoft.azure',          name: 'azure',                          version: azureSdkVersion) { exclude group: 'org.slf4j' }
   compile group:  'com.google.apis',              name: 'google-api-services-compute',    version: 'v1-rev133-1.22.0'
   compile group: 'com.google.apis',               name: 'google-api-services-storage',    version: 'v1-rev94-1.22.0'
-  compile group: 'com.microsoft.azure',           name: 'azure-storage',                  version: '5.0.0'
+  compile group: 'com.microsoft.azure',           name: 'azure-storage',                  version: azureStorageSdkVersion
   compile group: 'com.microsoft.azure',           name: 'azure-data-lake-store-sdk',      version: '2.1.5'
   compile group:  'org.springframework.boot',     name: 'spring-boot-starter',            version: springBootVersion
   compile group:  'org.springframework.boot',     name: 'spring-boot-starter-test',       version: springBootVersion

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxRepairTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxRepairTests.java
@@ -13,11 +13,14 @@ import javax.inject.Inject;
 import org.testng.annotations.Test;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.describe.DescribeFreeIpaResponse;
+import com.sequenceiq.it.cloudbreak.client.FreeIPATestClient;
 import com.sequenceiq.it.cloudbreak.client.RecipeTestClient;
 import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
 import com.sequenceiq.it.cloudbreak.client.StackTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIPATestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
 import com.sequenceiq.it.cloudbreak.util.SdxUtil;
 import com.sequenceiq.it.cloudbreak.util.ssh.SshJUtil;
@@ -34,6 +37,9 @@ public class SdxRepairTests extends PreconditionSdxE2ETest {
 
     @Inject
     private StackTestClient stackTestClient;
+
+    @Inject
+    private FreeIPATestClient freeIPATestClient;
 
     @Inject
     private WaitUtil waitUtil;
@@ -106,6 +112,10 @@ public class SdxRepairTests extends PreconditionSdxE2ETest {
         List<String> actualIDBrokerVolumeIds = new ArrayList<>();
         List<String> expectedIDBrokerVolumeIds = new ArrayList<>();
 
+        DescribeFreeIpaResponse describeFreeIpaResponse = testContext.given(FreeIPATestDto.class)
+                .when(freeIPATestClient.describe())
+                .getResponse();
+
         testContext
                 .given(sdx, SdxTestDto.class).withCloudStorage()
                 .when(sdxTestClient.create(), key(sdx))
@@ -143,11 +153,13 @@ public class SdxRepairTests extends PreconditionSdxE2ETest {
                             new ArrayList<>(expectedIDBrokerVolumeIds));
                 })
                 .then((tc, testDto, client) -> {
-                    getCloudFunctionality(tc).cloudStorageListContainerDataLake(getBaseLocation(testDto));
+                    getCloudFunctionality(tc).cloudStorageListContainerDataLake(getBaseLocation(testDto),
+                            testDto.getResponse().getName(), testDto.getResponse().getStackCrn());
                     return testDto;
                 })
                 .then((tc, testDto, client) -> {
-                    getCloudFunctionality(tc).cloudStorageListContainerFreeIPA(getBaseLocation(testDto));
+                    getCloudFunctionality(tc).cloudStorageListContainerFreeIPA(getBaseLocation(testDto),
+                            describeFreeIpaResponse.getName(), describeFreeIpaResponse.getCrn());
                     return testDto;
                 })
                 .validate();
@@ -164,6 +176,10 @@ public class SdxRepairTests extends PreconditionSdxE2ETest {
 
         List<String> actualMasterVolumeIds = new ArrayList<>();
         List<String> expectedMasterVolumeIds = new ArrayList<>();
+
+        DescribeFreeIpaResponse describeFreeIpaResponse = testContext.given(FreeIPATestDto.class)
+                .when(freeIPATestClient.describe())
+                .getResponse();
 
         testContext
                 .given(sdx, SdxTestDto.class).withCloudStorage()
@@ -202,11 +218,13 @@ public class SdxRepairTests extends PreconditionSdxE2ETest {
                             new ArrayList<>(expectedMasterVolumeIds));
                 })
                 .then((tc, testDto, client) -> {
-                    getCloudFunctionality(tc).cloudStorageListContainerDataLake(getBaseLocation(testDto));
+                    getCloudFunctionality(tc).cloudStorageListContainerDataLake(getBaseLocation(testDto),
+                            testDto.getResponse().getName(), testDto.getResponse().getStackCrn());
                     return testDto;
                 })
                 .then((tc, testDto, client) -> {
-                    getCloudFunctionality(tc).cloudStorageListContainerFreeIPA(getBaseLocation(testDto));
+                    getCloudFunctionality(tc).cloudStorageListContainerFreeIPA(getBaseLocation(testDto),
+                            describeFreeIpaResponse.getName(), describeFreeIpaResponse.getCrn());
                     return testDto;
                 })
                 .validate();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/CloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/CloudFunctionality.java
@@ -13,9 +13,9 @@ public interface CloudFunctionality {
 
     void cloudStorageListContainer(String baseLocation);
 
-    void cloudStorageListContainerFreeIPA(String baseLocation);
+    void cloudStorageListContainerFreeIPA(String baseLocation, String clusterName, String crn);
 
-    void cloudStorageListContainerDataLake(String baseLocation);
+    void cloudStorageListContainerDataLake(String baseLocation, String clusterName, String crn);
 
     void cloudStorageDeleteContainer(String baseLocation);
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/AwsCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/AwsCloudFunctionality.java
@@ -49,12 +49,12 @@ public class AwsCloudFunctionality implements CloudFunctionality {
     }
 
     @Override
-    public void cloudStorageListContainerFreeIPA(String baseLocation) {
+    public void cloudStorageListContainerFreeIPA(String baseLocation, String clusterName, String crn) {
         amazonS3Util.listFreeIPAObject(baseLocation);
     }
 
     @Override
-    public void cloudStorageListContainerDataLake(String baseLocation) {
+    public void cloudStorageListContainerDataLake(String baseLocation, String clusterName, String crn) {
         amazonS3Util.listDataLakeObject(baseLocation);
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/AzureCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/AzureCloudFunctionality.java
@@ -45,13 +45,13 @@ public class AzureCloudFunctionality implements CloudFunctionality {
     }
 
     @Override
-    public void cloudStorageListContainerFreeIPA(String baseLocation) {
-        azureCloudBlobUtil.listFreeIPAFoldersInAContaier(baseLocation);
+    public void cloudStorageListContainerFreeIPA(String baseLocation, String clusterName, String crn) {
+        azureCloudBlobUtil.listFreeIPAFoldersInAContaier(baseLocation, clusterName, crn);
     }
 
     @Override
-    public void cloudStorageListContainerDataLake(String baseLocation) {
-        azureCloudBlobUtil.listDataLakeFoldersInAContaier(baseLocation);
+    public void cloudStorageListContainerDataLake(String baseLocation, String clusterName, String crn) {
+        azureCloudBlobUtil.listDataLakeFoldersInAContaier(baseLocation, clusterName, crn);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurecloudblob/AzureCloudBlobUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurecloudblob/AzureCloudBlobUtil.java
@@ -7,6 +7,7 @@ import javax.inject.Inject;
 import org.springframework.stereotype.Component;
 
 import com.microsoft.azure.storage.StorageException;
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.it.cloudbreak.SdxClient;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
@@ -40,11 +41,13 @@ public class AzureCloudBlobUtil {
         azureCloudBlobClientActions.listAllFolders(baseLocation);
     }
 
-    public void listDataLakeFoldersInAContaier(String baseLocation) {
-        azureCloudBlobClientActions.listSelectedDirectory(baseLocation, "datalake", false);
+    public void listDataLakeFoldersInAContaier(String baseLocation, String clusterName, String crn) {
+        azureCloudBlobClientActions.listSelectedDirectory(baseLocation,
+                "datalake/" + clusterName + "_" + Crn.fromString(crn).getResource(), false);
     }
 
-    public void listFreeIPAFoldersInAContaier(String baseLocation) {
-        azureCloudBlobClientActions.listSelectedDirectory(baseLocation, "freeipa", false);
+    public void listFreeIPAFoldersInAContaier(String baseLocation, String clusterName, String crn) {
+        azureCloudBlobClientActions.listSelectedDirectory(baseLocation,
+                "freeipa/" + clusterName + "_" + Crn.fromString(crn).getResource(), false);
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpCloudFunctionality.java
@@ -36,12 +36,12 @@ public class GcpCloudFunctionality implements CloudFunctionality {
     }
 
     @Override
-    public void cloudStorageListContainerFreeIPA(String baseLocation) {
+    public void cloudStorageListContainerFreeIPA(String baseLocation, String clusterName, String crn) {
         throw new NotImplementedException(GCP_IMPLEMENTATION_MISSING);
     }
 
     @Override
-    public void cloudStorageListContainerDataLake(String baseLocation) {
+    public void cloudStorageListContainerDataLake(String baseLocation, String clusterName, String crn) {
         throw new NotImplementedException(GCP_IMPLEMENTATION_MISSING);
     }
 


### PR DESCRIPTION
I noticed that azure storage assert in e2e tests is checking all blobs in the given container which is time consuming and unnecessary, so I changed to check only the cluster and freeipa of the given test