### PR TITLE
CDPCP-1941. Allow setting ranger azure cloud id configs in FMS

### DIFF
--- a/freeipa/build.gradle
+++ b/freeipa/build.gradle
@@ -50,6 +50,7 @@ dependencies {
   implementation     group: 'io.opentracing.contrib',    name: 'opentracing-jaxrs2',                   version: opentracingJaxrs2Version
   implementation     group: 'io.opentracing.contrib',    name: 'opentracing-jdbc',                     version: opentracingJdbcVersion
 
+  implementation     group: 'com.cloudera.api.swagger',    name: 'cloudera-manager-api-swagger',       version: cmClientVersion
 
   implementation     group: 'org.apache.kerby',          name: 'kerb-util',                            version: '2.0.0'
   
@@ -98,7 +99,9 @@ dependencies {
   implementation project(':notification-sender')
   implementation project(':environment-api')
   implementation project(':environment-common')
+  implementation project(':datalake-api')
   implementation project(':cluster-proxy')
+  implementation project(':client-cm')
   implementation project(':status-checker')
   implementation project(':template-manager-tag')
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/SdxApiConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/SdxApiConfig.java
@@ -1,0 +1,30 @@
+package com.sequenceiq.freeipa.configuration;
+
+import com.sequenceiq.sdx.client.internal.SdxApiClientParams;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@Configuration
+public class SdxApiConfig {
+    @Value("${rest.debug:false}")
+    private boolean restDebug;
+
+    @Value("${cert.validation:true}")
+    private boolean certificateValidation;
+
+    @Value("${cert.ignorePreValidation:false}")
+    private boolean ignorePreValidation;
+
+    @Inject
+    @Named("sdxServerUrl")
+    private String sdxServerUrl;
+
+    @Bean
+    public SdxApiClientParams sdxApiClientParams() {
+        return new SdxApiClientParams(restDebug, certificateValidation, ignorePreValidation, sdxServerUrl);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/ServiceEndpointConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/ServiceEndpointConfig.java
@@ -30,6 +30,15 @@ public class ServiceEndpointConfig {
     @Value("${freeipa.environment.contextPath}")
     private String environmentRootContextPath;
 
+    @Value("${freeipa.sdx.url:}")
+    private String sdxServiceUrl;
+
+    @Value("${freeipa.sdx.serviceId:}")
+    private String sdxServiceId;
+
+    @Value("${freeipa.sdx.server.contextPath:/dl}")
+    private String sdxRootContextPath;
+
     @Bean
     public ServiceAddressResolver serviceAddressResolver() {
         return new RetryingServiceAddressResolver(new DNSServiceAddressResolver(), resolvingTimeout);
@@ -44,5 +53,10 @@ public class ServiceEndpointConfig {
     @Bean
     public String environmentServiceUrl() throws ServiceAddressResolvingException {
         return serviceAddressResolver().resolveUrl(environmentServiceUrl + environmentRootContextPath, "", null);
+    }
+
+    @Bean
+    public String sdxServerUrl() throws ServiceAddressResolvingException {
+        return serviceAddressResolver().resolveUrl(sdxServiceUrl + sdxRootContextPath, "http", sdxServiceId);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/CloudIdentityRangerSyncService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/CloudIdentityRangerSyncService.java
@@ -1,0 +1,43 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import com.cloudera.api.swagger.client.ApiException;
+import com.sequenceiq.sdx.api.endpoint.SdxEndpoint;
+import com.sequenceiq.sdx.api.model.SdxClusterResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class CloudIdentityRangerSyncService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CloudIdentityRangerSyncService.class);
+
+    @Inject
+    private ClouderaManagerRangerUtil clouderaManagerRangerUtil;
+
+    @Inject
+    private SdxEndpoint sdxEndpoint;
+
+    public void updateAzureCloudIdentityMapping(String environmentCrn,
+                                                Map<String, String> azureUserMapping,
+                                                Map<String, String> azureGroupMapping) {
+        LOGGER.info("Updating Azure cloud id mappings for environment = {}", environmentCrn);
+        List<SdxClusterResponse> responses = sdxEndpoint.getByEnvCrn(environmentCrn);
+        if (responses.isEmpty()) {
+            LOGGER.info("Environment has no datalake clusters to sync");
+        }
+        responses.forEach(sdxClusterResponse -> {
+            String stackCrn = sdxClusterResponse.getStackCrn();
+            LOGGER.info("Updating azure cloud id mappings for datalake stack crn = {}, environment = {}", stackCrn, environmentCrn);
+            try {
+                clouderaManagerRangerUtil.updateAzureCloudIdentityMapping(stackCrn, azureUserMapping, azureGroupMapping);
+            } catch (ApiException e) {
+                throw new RuntimeException("Encountered api exception", e);
+            }
+        });
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/ClouderaManagerProxiedClientFactory.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/ClouderaManagerProxiedClientFactory.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import com.cloudera.api.swagger.client.ApiClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+public class ClouderaManagerProxiedClientFactory {
+
+    private static final String API_VERSION_32 = "v32";
+
+    private static final int CM_READ_TIMEOUT_MS =  60 * 1000;
+
+    private static final int CM_CONNECT_TIMEOUT_MS = 20 * 1000;
+
+    @Value("${clusterProxy.url:}")
+    private String clusterProxyUrl;
+
+    private String getClusterProxyCloderaManagerBasePath(String clusterCrn) {
+        return String.format("%s/proxy/%s/cloudera-manager/api/%s", clusterProxyUrl, clusterCrn, API_VERSION_32);
+    }
+
+    public ApiClient getProxiedClouderaManagerClient(String clouderaManagerStackCrn) {
+        ApiClient apiClient = new ApiClient();
+        apiClient.setBasePath(getClusterProxyCloderaManagerBasePath(clouderaManagerStackCrn));
+        apiClient.setConnectTimeout(CM_READ_TIMEOUT_MS);
+        apiClient.getHttpClient().setReadTimeout(CM_CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        return apiClient;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/ClouderaManagerRangerUtil.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/ClouderaManagerRangerUtil.java
@@ -1,0 +1,85 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import com.cloudera.api.swagger.ClustersResourceApi;
+import com.cloudera.api.swagger.RolesResourceApi;
+import com.cloudera.api.swagger.client.ApiClient;
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.model.ApiClusterList;
+import com.cloudera.api.swagger.model.ApiConfig;
+import com.cloudera.api.swagger.model.ApiConfigList;
+import com.cloudera.api.swagger.model.ApiRole;
+import com.google.common.base.Joiner;
+import com.google.common.base.Joiner.MapJoiner;
+import com.google.common.collect.Iterables;
+import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class ClouderaManagerRangerUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerRangerUtil.class);
+
+    private static final String RANGER_SERVICE_NAME = "ranger";
+
+    private static final String RANGER_USER_SYNC_ROLE_TYPE = "RANGER_USERSYNC";
+
+    private static final String AZURE_USER_MAPPING = "ranger_usersync_azure_user_mapping";
+
+    private static final String AZURE_GROUP_MAPPING = "ranger_usersync_azure_group_mapping";
+
+    private static final MapJoiner CLOUD_IDENTITY_CONFIG_MAP_JOINER =
+            Joiner.on(";").withKeyValueSeparator("=");
+
+    @Inject
+    private ClouderaManagerProxiedClientFactory clouderaManagerProxiedClientFactory;
+
+    @Inject
+    private ClouderaManagerApiFactory clouderaManagerApiFactory;
+
+    private String getClusterName(ApiClient client) throws ApiException {
+        ClustersResourceApi clustersResource = clouderaManagerApiFactory.getClustersResourceApi(client);
+        ApiClusterList clusterList = clustersResource.readClusters(null, null);
+        return Iterables.getOnlyElement(clusterList.getItems()).getName();
+    }
+
+    private String getRangerUserSyncRoleName(ApiClient client, String clusterName) throws ApiException {
+        RolesResourceApi rolesResourceApi = clouderaManagerApiFactory.getRolesResourceApi(client);
+        List<ApiRole> apiRoleList =  rolesResourceApi.readRoles(clusterName, RANGER_SERVICE_NAME, null, null)
+                .getItems()
+                .stream()
+                .filter(apiRole -> apiRole.getType().equals(RANGER_USER_SYNC_ROLE_TYPE))
+                .collect(Collectors.toList());
+        return Iterables.getOnlyElement(apiRoleList).getName();
+    }
+
+    private ApiConfig newCloudIdentityConfig(String configName, Map<String, String> configValues) {
+        ApiConfig config = new ApiConfig();
+        config.setName(configName);
+        config.setValue(CLOUD_IDENTITY_CONFIG_MAP_JOINER.join(configValues));
+        return config;
+    }
+
+    public void updateAzureCloudIdentityMapping(String clouderaManagerStackCrn,
+                                                Map<String, String> azureUserMapping,
+                                                Map<String, String> azureGroupMapping) throws ApiException {
+        // NOTE: The necessary configs changed here are only available in CM7.2-1
+        ApiClient client = clouderaManagerProxiedClientFactory.getProxiedClouderaManagerClient(clouderaManagerStackCrn);
+        String clusterName = getClusterName(client);
+        String rangerUserSyncRoleName = getRangerUserSyncRoleName(client, clusterName);
+        RolesResourceApi rolesResourceApi = clouderaManagerApiFactory.getRolesResourceApi(client);
+        ApiConfigList configList = new ApiConfigList();
+        configList.addItemsItem(newCloudIdentityConfig(AZURE_USER_MAPPING, azureUserMapping));
+        configList.addItemsItem(newCloudIdentityConfig(AZURE_GROUP_MAPPING, azureGroupMapping));
+        rolesResourceApi.updateRoleConfig(clusterName, rangerUserSyncRoleName, RANGER_SERVICE_NAME,
+                "Updating Azure Cloud Identity Mapping through Cloudbreak",
+                configList);
+        // TODO : The ranger role needs to be refreshed
+    }
+}

--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -62,6 +62,9 @@ freeipa:
   environment:
     url: http://localhost:8088
     contextPath: /environmentservice
+  sdx:
+    url: http://localhost:8086
+    contextPath: /dl
   intermediate.threadpool:
     core.size: 100
     capacity.size: 4000
@@ -241,4 +244,3 @@ clusterProxy:
   healthyStatusCode: 400
   maxAttempts: 10
   maxFailure: 1
-


### PR DESCRIPTION
This introduces a service component (CloudIdentityRangerSyncService) that
user sync will call in order to set azure cloud identity configurations
(oid mappings) into the datalake instance for a specified environment.

This is an initial implementation/poc. In future commits we'll need to
hook this up to user sync service, trigger CM role refresh, better
exception handling and error propagation, etc.

Also note that the necessary CM configs will be made available in
CM 7.2.1, I've tested my changes against a manually patched CM node.
    
Testing Done

```
String envCrn = "crn:cdp:environments:us-west-1:cloudera:environment:c2874f4b-6ac1-4d2e-b28d-c243d5ac60b0";
var azureUserMapping = Map.of("K1","V1","K2","V2");
var azureGroupMapping = Map.of("K3","V3");
cloudIdentityRangerSyncService.updateAzureCloudIdentityMapping(envCrn, azureUserMapping, azureGroupMapping);
```

Verified correct CM Configs were set

```
{
  "items": [
    ...,
    {
      "name": "ranger_usersync_azure_group_mapping",
      "value": "K3=V3",
      "sensitive": false
    },
    {
      "name": "ranger_usersync_azure_user_mapping",
      "value": "K2=V2;K1=V1",
      "sensitive": false
    },
    ...
  ]
}
```
