### PR TITLE
Fix Data Engineering templates post merge

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-710.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-710.bp
@@ -9,16 +9,6 @@
         "serviceType": "HDFS",
         "roleConfigGroups": [
           {
-            "refName": "hdfs-BALANCER-BASE",
-            "roleType": "BALANCER",
-            "base": true
-          },
-          {
-            "refName": "hdfs-DATANODE-BASE",
-            "roleType": "DATANODE",
-            "base": true
-          },
-          {
             "refName": "hdfs-NAMENODE-BASE",
             "roleType": "NAMENODE",
             "base": true,
@@ -37,38 +27,15 @@
             "refName": "hdfs-SECONDARYNAMENODE-BASE",
             "roleType": "SECONDARYNAMENODE",
             "base": true
-          }
-        ]
-      },
-      {
-        "refName": "hms",
-        "serviceType": "HIVE",
-        "displayName": "Hive Metastore",
-        "roleConfigGroups": [
+          },
           {
-            "refName": "hms-GATEWAY-BASE",
-            "roleType": "GATEWAY",
+            "refName": "hdfs-DATANODE-BASE",
+            "roleType": "DATANODE",
             "base": true
           },
           {
-            "refName": "hms-HIVEMETASTORE-BASE",
-            "roleType": "HIVEMETASTORE",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "spark3_on_yarn",
-        "serviceType": "SPARK3_ON_YARN",
-        "roleConfigGroups": [
-          {
-            "refName": "spark3_on_yarn-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "base": true
-          },
-          {
-            "refName": "spark3_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
-            "roleType": "SPARK3_YARN_HISTORY_SERVER",
+            "refName": "hdfs-BALANCER-BASE",
+            "roleType": "BALANCER",
             "base": true
           },
           {
@@ -95,21 +62,6 @@
         ],
         "roleConfigGroups": [
           {
-            "refName": "yarn-JOBHISTORY-BASE",
-            "roleType": "JOBHISTORY",
-            "base": true
-          },
-          {
-            "refName": "yarn-NODEMANAGER-COMPUTE",
-            "roleType": "NODEMANAGER",
-            "base": false
-          },
-          {
-            "refName": "yarn-NODEMANAGER-WORKER",
-            "roleType": "NODEMANAGER",
-            "base": false
-          },
-          {
             "refName": "yarn-RESOURCEMANAGER-BASE",
             "roleType": "RESOURCEMANAGER",
             "base": true,
@@ -131,20 +83,59 @@
                 "value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property><property><name>yarn.scheduler.capacity.per-node-heartbeat.maximum-offswitch-assignments</name><value>4</value></property></configuration>"
               }
             ]
+          },
+          {
+            "refName": "yarn-NODEMANAGER-WORKER",
+            "roleType": "NODEMANAGER",
+            "base": false
+          },
+          {
+            "refName": "yarn-NODEMANAGER-COMPUTE",
+            "roleType": "NODEMANAGER",
+            "base": false
+          },
+          {
+            "refName": "yarn-JOBHISTORY-BASE",
+            "roleType": "JOBHISTORY",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "spark3_on_yarn",
+        "serviceType": "SPARK3_ON_YARN",
+        "roleConfigGroups": [
+          {
+            "refName": "spark3_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+            "roleType": "SPARK3_YARN_HISTORY_SERVER",
+            "base": true
+          },
+          {
+            "refName": "spark3_on_yarn-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "hms",
+        "serviceType": "HIVE",
+        "displayName": "Hive Metastore",
+        "roleConfigGroups": [
+          {
+            "refName": "hms-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          },
+          {
+            "refName": "hms-HIVEMETASTORE-BASE",
+            "roleType": "HIVEMETASTORE",
+            "base": true
           }
         ]
       }
     ],
     "hostTemplates": [
-      {
-        "refName": "compute",
-        "cardinality": 0,
-        "roleConfigGroupsRefNames": [
-          "hms-GATEWAY-BASE",
-          "spark3_on_yarn-GATEWAY-BASE",
-          "yarn-NODEMANAGER-COMPUTE"
-        ]
-      },
       {
         "refName": "master",
         "cardinality": 1,
@@ -170,6 +161,16 @@
           "hms-GATEWAY-BASE",
           "spark3_on_yarn-GATEWAY-BASE",
           "yarn-NODEMANAGER-WORKER"
+        ]
+      },
+      {
+        "refName": "compute",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "hdfs-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
+          "spark3_on_yarn-GATEWAY-BASE",
+          "yarn-NODEMANAGER-COMPUTE"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-720.bp
@@ -9,16 +9,6 @@
         "serviceType": "HDFS",
         "roleConfigGroups": [
           {
-            "refName": "hdfs-BALANCER-BASE",
-            "roleType": "BALANCER",
-            "base": true
-          },
-          {
-            "refName": "hdfs-DATANODE-BASE",
-            "roleType": "DATANODE",
-            "base": true
-          },
-          {
             "refName": "hdfs-NAMENODE-BASE",
             "roleType": "NAMENODE",
             "base": true,
@@ -37,22 +27,15 @@
             "refName": "hdfs-SECONDARYNAMENODE-BASE",
             "roleType": "SECONDARYNAMENODE",
             "base": true
-          }
-        ]
-      },
-      {
-        "refName": "hms",
-        "serviceType": "HIVE",
-        "displayName": "Hive Metastore",
-        "roleConfigGroups": [
+          },
           {
-            "refName": "hms-GATEWAY-BASE",
-            "roleType": "GATEWAY",
+            "refName": "hdfs-DATANODE-BASE",
+            "roleType": "DATANODE",
             "base": true
           },
           {
-            "refName": "hms-HIVEMETASTORE-BASE",
-            "roleType": "HIVEMETASTORE",
+            "refName": "hdfs-BALANCER-BASE",
+            "roleType": "BALANCER",
             "base": true
           },
           {
@@ -69,44 +52,6 @@
         ]
       },
       {
-        "refName": "queuemanager",
-        "serviceType": "QUEUEMANAGER",
-        "serviceConfigs": [
-          {
-            "name": "kerberos.auth.enabled",
-            "value": "true"
-          }
-        ],
-        "roleConfigGroups": [
-          {
-            "refName": "yarn-QUEUEMANAGER_STORE-BASE",
-            "roleType": "QUEUEMANAGER_STORE",
-            "base": true
-          },
-          {
-            "refName": "yarn-QUEUEMANAGER_WEBAPP-BASE",
-            "roleType": "QUEUEMANAGER_WEBAPP",
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "spark3_on_yarn",
-        "serviceType": "SPARK3_ON_YARN",
-        "roleConfigGroups": [
-          {
-            "refName": "spark3_on_yarn-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "base": true
-          },
-          {
-            "refName": "spark3_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
-            "roleType": "SPARK3_YARN_HISTORY_SERVER",
-            "base": true
-          }
-        ]
-      },
-      {
         "refName": "yarn",
         "serviceType": "YARN",
         "serviceConfigs": [
@@ -116,21 +61,6 @@
           }
         ],
         "roleConfigGroups": [
-          {
-            "refName": "yarn-JOBHISTORY-BASE",
-            "roleType": "JOBHISTORY",
-            "base": true
-          },
-          {
-            "refName": "yarn-NODEMANAGER-COMPUTE",
-            "roleType": "NODEMANAGER",
-            "base": false
-          },
-          {
-            "refName": "yarn-NODEMANAGER-WORKER",
-            "roleType": "NODEMANAGER",
-            "base": false
-          },
           {
             "refName": "yarn-RESOURCEMANAGER-BASE",
             "roleType": "RESOURCEMANAGER",
@@ -153,20 +83,81 @@
                 "value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property><property><name>yarn.scheduler.capacity.per-node-heartbeat.maximum-offswitch-assignments</name><value>4</value></property></configuration>"
               }
             ]
+          },
+          {
+            "refName": "yarn-NODEMANAGER-WORKER",
+            "roleType": "NODEMANAGER",
+            "base": false
+          },
+          {
+            "refName": "yarn-NODEMANAGER-COMPUTE",
+            "roleType": "NODEMANAGER",
+            "base": false
+          },
+          {
+            "refName": "yarn-JOBHISTORY-BASE",
+            "roleType": "JOBHISTORY",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "spark3_on_yarn",
+        "serviceType": "SPARK3_ON_YARN",
+        "roleConfigGroups": [
+          {
+            "refName": "spark3_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+            "roleType": "SPARK3_YARN_HISTORY_SERVER",
+            "base": true
+          },
+          {
+            "refName": "spark3_on_yarn-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "hms",
+        "serviceType": "HIVE",
+        "displayName": "Hive Metastore",
+        "roleConfigGroups": [
+          {
+            "refName": "hms-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true
+          },
+          {
+            "refName": "hms-HIVEMETASTORE-BASE",
+            "roleType": "HIVEMETASTORE",
+            "base": true
+          }
+        ]
+      },
+      {
+        "refName": "queuemanager",
+        "serviceType": "QUEUEMANAGER",
+        "serviceConfigs": [
+          {
+            "name": "kerberos.auth.enabled",
+            "value": "true"
+          }
+        ],
+        "roleConfigGroups": [
+          {
+            "refName": "yarn-QUEUEMANAGER_WEBAPP-BASE",
+            "roleType": "QUEUEMANAGER_WEBAPP",
+            "base": true
+          },
+          {
+            "refName": "yarn-QUEUEMANAGER_STORE-BASE",
+            "roleType": "QUEUEMANAGER_STORE",
+            "base": true
           }
         ]
       }
     ],
     "hostTemplates": [
-      {
-        "refName": "compute",
-        "cardinality": 0,
-        "roleConfigGroupsRefNames": [
-          "hms-GATEWAY-BASE",
-          "spark3_on_yarn-GATEWAY-BASE",
-          "yarn-NODEMANAGER-COMPUTE"
-        ]
-      },
       {
         "refName": "master",
         "cardinality": 1,
@@ -180,9 +171,9 @@
           "spark3_on_yarn-GATEWAY-BASE",
           "spark3_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
           "yarn-JOBHISTORY-BASE",
-          "yarn-QUEUEMANAGER_STORE-BASE",
+          "yarn-RESOURCEMANAGER-BASE",
           "yarn-QUEUEMANAGER_WEBAPP-BASE",
-          "yarn-RESOURCEMANAGER-BASE"
+          "yarn-QUEUEMANAGER_STORE-BASE"
         ]
       },
       {
@@ -194,6 +185,16 @@
           "hms-GATEWAY-BASE",
           "spark3_on_yarn-GATEWAY-BASE",
           "yarn-NODEMANAGER-WORKER"
+        ]
+      },
+      {
+        "refName": "compute",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "hdfs-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
+          "spark3_on_yarn-GATEWAY-BASE",
+          "yarn-NODEMANAGER-COMPUTE"
         ]
       }
     ]


### PR DESCRIPTION
There's also some conflicts in the 711 templates. However - afaik - those are not used and should just be deleted. Will create a jira and second PR to remove those.