### PR TITLE
CB-7132: Fix FreeIPA provisioning when using CCM

### DIFF
--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ClusterServiceConfig.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ClusterServiceConfig.java
@@ -21,42 +21,20 @@ public class ClusterServiceConfig {
     private ClientCertificate clientCertificate;
 
     @JsonProperty
-    private Boolean tlsStrictCheck;
-
-    @JsonProperty
-    private Boolean useTunnel;
-
-    @JsonProperty
-    private List<Tunnel> tunnels;
-
-    @JsonProperty
-    private String accountId;
-
-    @JsonProperty
     private ClusterServiceHealthCheck healthCheck;
 
     @JsonCreator
     public ClusterServiceConfig(String serviceName, List<String> endpoints, List<ClusterServiceCredential> credentials, ClientCertificate clientCertificate,
-                                Boolean tlsStrictCheck, Boolean useTunnel, List<Tunnel> tunnels, String accountId, ClusterServiceHealthCheck healthCheck) {
+                                ClusterServiceHealthCheck healthCheck) {
         this.name = serviceName;
         this.endpoints = endpoints;
         this.credentials = credentials;
         this.clientCertificate = clientCertificate;
-        this.tlsStrictCheck = tlsStrictCheck;
-        this.useTunnel = useTunnel;
-        this.tunnels = tunnels;
-        this.accountId = accountId;
         this.healthCheck = healthCheck;
     }
 
-    public ClusterServiceConfig(String serviceName, List<String> endpoints, List<ClusterServiceCredential> credentials, ClientCertificate clientCertificate,
-            Boolean tlsStrictCheck) {
-        this(serviceName, endpoints, credentials, clientCertificate, tlsStrictCheck, null);
-    }
-
-    public ClusterServiceConfig(String serviceName, List<String> endpoints, List<ClusterServiceCredential> credentials, ClientCertificate clientCertificate,
-                                Boolean tlsStrictCheck, ClusterServiceHealthCheck healthCheck) {
-        this(serviceName, endpoints, credentials, clientCertificate, tlsStrictCheck, false, List.of(), null, healthCheck);
+    public ClusterServiceConfig(String serviceName, List<String> endpoints, List<ClusterServiceCredential> credentials, ClientCertificate clientCertificate) {
+        this(serviceName, endpoints, credentials, clientCertificate, null);
     }
 
     //CHECKSTYLE:OFF: CyclomaticComplexity
@@ -75,17 +53,13 @@ public class ClusterServiceConfig {
                 Objects.equals(endpoints, that.endpoints) &&
                 Objects.equals(credentials, that.credentials) &&
                 Objects.equals(clientCertificate, that.clientCertificate) &&
-                Objects.equals(tlsStrictCheck, that.tlsStrictCheck) &&
-                Objects.equals(useTunnel, that.useTunnel) &&
-                Objects.equals(tunnels, that.tunnels) &&
-                Objects.equals(accountId, that.accountId) &&
-                Objects.equals(healthCheck,that.healthCheck);
+                Objects.equals(healthCheck, that.healthCheck);
     }
     //CHECKSTYLE:ON
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, endpoints, credentials, clientCertificate, tlsStrictCheck, useTunnel, tunnels, accountId, healthCheck);
+        return Objects.hash(name, endpoints, credentials, clientCertificate, healthCheck);
     }
 
     @Override
@@ -94,10 +68,6 @@ public class ClusterServiceConfig {
                 + ", endpoints=" + endpoints
                 + ", credentials=" + credentials
                 + ", clientCertificate=" + clientCertificate
-                + ", tlsStrictCheck=" + tlsStrictCheck
-                + ", useTunnel=" + useTunnel
-                + ", tunnels=" + tunnels
-                + ", accountId=" + accountId
                 + ", healthCheck=" + healthCheck
                 + '}';
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/clusterproxy/ClusterProxyService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/clusterproxy/ClusterProxyService.java
@@ -154,7 +154,7 @@ public class ClusterProxyService {
 
         List<ClusterServiceCredential> credentials = asList(new ClusterServiceCredential(cloudbreakUser, cloudbreakPasswordVaultPath),
                 new ClusterServiceCredential(dpUser, dpPasswordVaultPath, true));
-        return new ClusterServiceConfig(serviceName, singletonList(clusterManagerUrl), credentials, clientCertificate, null);
+        return new ClusterServiceConfig(serviceName, singletonList(clusterManagerUrl), credentials, clientCertificate);
     }
 
     private ClientCertificate clientCertificates(Stack stack) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactory.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactory.java
@@ -17,6 +17,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import com.googlecode.jsonrpc4j.JsonRpcClient.RequestListener;
+import com.sequenceiq.cloudbreak.ccm.endpoint.ServiceFamilies;
 import com.sequenceiq.cloudbreak.client.HttpClientConfig;
 import com.sequenceiq.cloudbreak.clusterproxy.ClusterProxyConfiguration;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
@@ -204,8 +205,8 @@ public class FreeIpaClientFactory {
         HttpClientConfig httpClientConfig = tlsSecurityService.buildTLSClientConfig(
                 stack, instanceMetaData.getPublicIpWrapper(), instanceMetaData);
         FreeIpa freeIpa = freeIpaService.findByStack(stack);
-        return new FreeIpaClientBuilder(ADMIN_USER, freeIpa.getAdminPassword(), httpClientConfig, stack.getGatewayport(),
-                instanceMetaData.getDiscoveryFQDN());
+        int gatewayPort = Optional.ofNullable(stack.getGatewayport()).orElse(ServiceFamilies.GATEWAY.getDefaultPort());
+        return new FreeIpaClientBuilder(ADMIN_USER, freeIpa.getAdminPassword(), httpClientConfig, gatewayPort, instanceMetaData.getDiscoveryFQDN());
     }
 
     private FreeIpaClientException createFreeIpaStateIsInvalidException(Status stackStatus) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/polling/clusterproxy/ServiceEndpointHealthListenerTask.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/polling/clusterproxy/ServiceEndpointHealthListenerTask.java
@@ -23,7 +23,7 @@ public class ServiceEndpointHealthListenerTask implements StatusCheckerTask<Serv
     public boolean checkStatus(ServiceEndpointHealthPollerObject serviceEndpointHealthPollerObject) {
         boolean healthy = false;
         String clusterIdentifer = serviceEndpointHealthPollerObject.getClusterIdentifier();
-        LOGGER.debug("Check cluter proxy endpoint health for {}.", clusterIdentifer);
+        LOGGER.debug("Check cluster proxy endpoint health for {}.", clusterIdentifer);
         try {
             ClusterProxyRegistrationClient client = serviceEndpointHealthPollerObject.getClient();
             ReadConfigResponse response = client.readConfig(clusterIdentifer);
@@ -37,7 +37,7 @@ public class ServiceEndpointHealthListenerTask implements StatusCheckerTask<Serv
                 healthy = stillWaitingForHealthyCount == 0;
             }
         } catch (Exception e) {
-            LOGGER.debug("Failed to check cluter proxy endpoint health for {}, error: {}", clusterIdentifer, e.getMessage());
+            LOGGER.debug("Failed to check cluster proxy endpoint health for {}, error: {}", clusterIdentifer, e.getMessage());
         }
         return healthy;
     }


### PR DESCRIPTION
FreeIPA provisioning using CCM was fixed. When provisioning, cluster
proxy registration occurred with bootstrapping information followed by
additional connections. The second registration used gateway
config's port which had been updated to refer to cluster proxy's port.
This was fixed so that it always refers to NGINX.

The FreeIPA client builder was fixed so that very old clusters which
were provisioned before the stack's port was saved will still work.

Reregistering FreeIPA with cluster proxy was fixed so that it works
with CCM clusters which were originally provisioned prior to
cloudbreak 2.21.0. Previously the gateway's configuration was not
included in the reregistration with cluster proxy.

The accountId, tunnels, useTunnel, and tlsStrictCheck were cleaned up
from the cluster service configuration. These properties were supposed
to be in the registration request, not in both places. This was
confusing because the values were different in the two locations and
log statements logged the wrong one.

Old Cluster Proxy Configuration Registration Request:
{
  "accountId": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
  "clusterCrn": "crn:cdp:freeipa:XXXXXXXXXX",
  "services": [
    {
      "serviceName": "freeipa",
      "endpoints": [
        "https://XXXXXXXXXX:9443
      ],
      "credentials": [],
      "clientCertificate": {
        "keyRef": "XXXXXXXXXX"
        "certificateRef": "XXXXXXXXXX"
      },
      "tlsStrictCheck": false,
      "useTunnel": false,
      "tunnels": [],
    }
  ],
  "useTunnel": true,
  "tunnels": [
    {
      "key": "XXXXXXXXXX",
      "serviceType": "GATEWAY",
      "host": "XXXXXXXXXX',
      "port": 10080,
      "minaSshdServiceId": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
    }
  ]
}

New Cluster Proxy Configuration Registration Request:
{
  "accountId": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
  "clusterCrn": "crn:cdp:freeipa:XXXXXXXXXX",
  "services": [
    {
      "serviceName": "freeipa",
      "endpoints": [
        "https://XXXXXXXXXX:9443
      ],
      "credentials": [],
      "clientCertificate": {
        "keyRef": "XXXXXXXXXX"
        "certificateRef": "XXXXXXXXXX"
      }
    }
  ],
  "useTunnel": true,
  "tunnels": [
    {
      "key": "XXXXXXXXXX",
      "serviceType": "GATEWAY",
      "host": "XXXXXXXXXX',
      "port": 9443,
      "minaSshdServiceId": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
    }
  ]
}

This was tested by provisioning a cluster using direct mode and
cluster proxy mode with a local cloudbreak. CCM mode was not tested
locally because it requires the entire control plane which cannot be
deployed locally.

Closes #CB-7132