### PR TITLE
DISTX-442 Associate Cluster Retrieval with workspace.

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/controller/AutoScaleClusterCommonService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/controller/AutoScaleClusterCommonService.java
@@ -44,7 +44,7 @@ public class AutoScaleClusterCommonService {
     }
 
     public List<Cluster> getDistroXClusters() {
-        return clusterService.findDistroXByUser(restRequestThreadLocalService.getCloudbreakUser());
+        return clusterService.findDistroXByWorkspace(restRequestThreadLocalService.getRequestedWorkspaceId());
     }
 
     public Cluster getCluster(Long clusterId) {
@@ -63,9 +63,9 @@ public class AutoScaleClusterCommonService {
 
     protected Cluster getClusterByCrnOrName(NameOrCrn nameOrCrn) {
         return nameOrCrn.hasName() ?
-                clusterService.findOneByStackNameAndUserId(nameOrCrn.getName(), restRequestThreadLocalService.getCloudbreakUser())
+                clusterService.findOneByStackNameAndWorkspaceId(nameOrCrn.getName(), restRequestThreadLocalService.getRequestedWorkspaceId())
                         .orElseThrow(NotFoundException.notFound("cluster", nameOrCrn.getName())) :
-                clusterService.findOneByStackCrnAndUserId(nameOrCrn.getCrn(), restRequestThreadLocalService.getCloudbreakUser())
+                clusterService.findOneByStackCrnAndWorkspaceId(nameOrCrn.getCrn(), restRequestThreadLocalService.getRequestedWorkspaceId())
                         .orElseThrow(NotFoundException.notFound("cluster", nameOrCrn.getCrn()));
     }
 

--- a/autoscale/src/main/java/com/sequenceiq/periscope/filter/CloudbreakUserConfiguratorFilter.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/filter/CloudbreakUserConfiguratorFilter.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.periscope.filter;
 
+import static com.sequenceiq.periscope.monitor.evaluator.ScalingConstants.UNINITIALIZED_WORKSPACE_ID;
+
 import java.io.IOException;
 
 import javax.servlet.FilterChain;
@@ -11,7 +13,9 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.sequenceiq.cloudbreak.auth.security.authentication.AuthenticatedUserService;
 import com.sequenceiq.cloudbreak.common.user.CloudbreakUser;
+import com.sequenceiq.periscope.domain.ClusterPertain;
 import com.sequenceiq.periscope.service.AutoscaleRestRequestThreadLocalService;
+import com.sequenceiq.periscope.service.ClusterPertainService;
 
 public class CloudbreakUserConfiguratorFilter extends OncePerRequestFilter {
 
@@ -19,16 +23,26 @@ public class CloudbreakUserConfiguratorFilter extends OncePerRequestFilter {
 
     private final AuthenticatedUserService authenticatedUserService;
 
+    private final ClusterPertainService clusterPertainService;
+
     public CloudbreakUserConfiguratorFilter(AutoscaleRestRequestThreadLocalService restRequestThreadLocalService,
-            AuthenticatedUserService authenticatedUserService) {
+            AuthenticatedUserService authenticatedUserService, ClusterPertainService clusterPertainService) {
         this.restRequestThreadLocalService = restRequestThreadLocalService;
         this.authenticatedUserService = authenticatedUserService;
+        this.clusterPertainService = clusterPertainService;
     }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         CloudbreakUser cloudbreakUser = authenticatedUserService.getCbUser();
-        restRequestThreadLocalService.setCloudbreakUser(cloudbreakUser);
+        Long workspaceId = UNINITIALIZED_WORKSPACE_ID;
+        if (cloudbreakUser != null) {
+            workspaceId = clusterPertainService.getClusterPertain(cloudbreakUser.getUserCrn())
+                    .map(ClusterPertain::getWorkspaceId)
+                    .orElse(UNINITIALIZED_WORKSPACE_ID);
+        }
+
+        restRequestThreadLocalService.setCloudbreakUser(cloudbreakUser, workspaceId);
         filterChain.doFilter(request, response);
         restRequestThreadLocalService.removeCloudbreakUser();
     }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/filter/FilterConfiguration.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/filter/FilterConfiguration.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Configuration;
 
 import com.sequenceiq.cloudbreak.auth.security.authentication.AuthenticatedUserService;
 import com.sequenceiq.periscope.service.AutoscaleRestRequestThreadLocalService;
+import com.sequenceiq.periscope.service.ClusterPertainService;
 
 @Configuration
 public class FilterConfiguration {
@@ -18,10 +19,14 @@ public class FilterConfiguration {
     @Inject
     private AutoscaleRestRequestThreadLocalService restRequestThreadLocalService;
 
+    @Inject
+    private ClusterPertainService clusterPertainService;
+
     @Bean
     public FilterRegistrationBean<CloudbreakUserConfiguratorFilter> identityUserConfiguratorFilterRegistrationBean() {
         FilterRegistrationBean<CloudbreakUserConfiguratorFilter> registrationBean = new FilterRegistrationBean<>();
-        CloudbreakUserConfiguratorFilter filter = new CloudbreakUserConfiguratorFilter(restRequestThreadLocalService, authenticatedUserService);
+        CloudbreakUserConfiguratorFilter filter =
+                new CloudbreakUserConfiguratorFilter(restRequestThreadLocalService, authenticatedUserService, clusterPertainService);
         registrationBean.setFilter(filter);
         registrationBean.setOrder(Integer.MAX_VALUE);
         return registrationBean;

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ScalingConstants.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ScalingConstants.java
@@ -14,6 +14,8 @@ public class ScalingConstants {
 
     public static final int DEFAULT_MAX_SCALE_UP_STEP_SIZE = 50;
 
+    public static final Long UNINITIALIZED_WORKSPACE_ID = -1L;
+
     private ScalingConstants() {
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/repository/ClusterPertainRepository.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/repository/ClusterPertainRepository.java
@@ -1,0 +1,14 @@
+package com.sequenceiq.periscope.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
+import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
+import com.sequenceiq.periscope.domain.ClusterPertain;
+
+@EntityType(entityClass = ClusterPertain.class)
+public interface ClusterPertainRepository extends CrudRepository<ClusterPertain, Long> {
+    Optional<ClusterPertain> findByUserCrn(@Param("userCrn") String userCrn);
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/repository/ClusterRepository.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/repository/ClusterRepository.java
@@ -19,12 +19,16 @@ public interface ClusterRepository extends CrudRepository<Cluster, Long> {
     Cluster findByStackId(@Param("stackId") Long stackId);
 
     @Query(" SELECT c FROM Cluster c LEFT JOIN FETCH c.clusterPertain " +
-            " WHERE c.stackCrn = :stackCrn and c.clusterPertain.userId = :userId")
-    Optional<Cluster> findByStackCrnAndUserId(@Param("stackCrn") String stackCrn, @Param("userId") String userId);
+            " WHERE c.stackCrn = :stackCrn and c.clusterPertain.workspaceId = :workspaceId")
+    Optional<Cluster> findByStackCrnAndWorkspaceId(@Param("stackCrn") String stackCrn, @Param("workspaceId") Long workspaceId);
 
     @Query(" SELECT c FROM Cluster c LEFT JOIN FETCH c.clusterPertain " +
-            " WHERE c.stackName = :stackName and c.clusterPertain.userId = :userId")
-    Optional<Cluster> findByStackNameAndUserId(@Param("stackName") String stackName, @Param("userId") String userId);
+            " WHERE c.stackName = :stackName and c.clusterPertain.workspaceId = :workspaceId")
+    Optional<Cluster> findByStackNameAndWorkspaceId(@Param("stackName") String stackName, @Param("workspaceId") Long workspaceId);
+
+    @Query(" SELECT c FROM Cluster c LEFT JOIN FETCH c.clusterPertain " +
+            " WHERE c.id = :clusterId and c.clusterPertain.workspaceId = :workspaceId")
+    Optional<Cluster> findByClusterIdAndWorkspaceId(@Param("clusterId") Long clusterId, @Param("workspaceId") Long workspaceId);
 
     @Query("SELECT c.stackCrn FROM Cluster c WHERE c.id = :id")
     String findStackCrnById(@Param("id") Long id);
@@ -38,8 +42,8 @@ public interface ClusterRepository extends CrudRepository<Cluster, Long> {
     @Query("SELECT c FROM Cluster c LEFT JOIN FETCH c.clusterPertain WHERE c.clusterPertain.userId = :userId")
     List<Cluster> findByUserId(@Param("userId") String userId);
 
-    @Query("SELECT c FROM Cluster c LEFT JOIN FETCH c.clusterPertain WHERE c.clusterPertain.userId = :userId and c.stackType = :stackType")
-    List<Cluster> findByUserIdAndStackType(@Param("userId") String userId, @Param("stackType") StackType stackType);
+    @Query("SELECT c FROM Cluster c LEFT JOIN FETCH c.clusterPertain WHERE c.clusterPertain.workspaceId = :workspaceId and c.stackType = :stackType")
+    List<Cluster> findByWorkspaceIdAndStackType(@Param("workspaceId") Long workspaceId, @Param("stackType") StackType stackType);
 
     @Query("SELECT distinct c.id FROM Cluster c JOIN c.loadAlerts loadalert WHERE c.stackType = :stackType " +
             " and c.autoscalingEnabled = :autoScalingEnabled" +

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/AutoscaleRestRequestThreadLocalService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/AutoscaleRestRequestThreadLocalService.java
@@ -7,10 +7,13 @@ import com.sequenceiq.cloudbreak.common.user.CloudbreakUser;
 @Service("RestRequestThreadLocalService")
 public class AutoscaleRestRequestThreadLocalService {
 
+    private static final ThreadLocal<Long> REQUESTED_WORKSPACE_ID = new ThreadLocal<>();
+
     private static final ThreadLocal<CloudbreakUser> CLOUDBREAK_USER = new ThreadLocal<>();
 
-    public void setCloudbreakUser(CloudbreakUser cloudbreakUser) {
+    public void setCloudbreakUser(CloudbreakUser cloudbreakUser, Long workspaceId) {
         CLOUDBREAK_USER.set(cloudbreakUser);
+        REQUESTED_WORKSPACE_ID.set(workspaceId);
     }
 
     public CloudbreakUser getCloudbreakUser() {
@@ -19,6 +22,12 @@ public class AutoscaleRestRequestThreadLocalService {
 
     public void removeCloudbreakUser() {
         CLOUDBREAK_USER.remove();
+        REQUESTED_WORKSPACE_ID.remove();
     }
+
+    public Long getRequestedWorkspaceId() {
+        return REQUESTED_WORKSPACE_ID.get();
+    }
+
 }
 

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/ClusterPertainService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/ClusterPertainService.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.periscope.service;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.periscope.domain.ClusterPertain;
+import com.sequenceiq.periscope.repository.ClusterPertainRepository;
+
+@Service
+public class ClusterPertainService {
+
+    @Inject
+    private ClusterPertainRepository clusterPertainRepository;
+
+    public Optional<ClusterPertain> getClusterPertain(String clusterUserCrn) {
+        return clusterPertainRepository.findByUserCrn(clusterUserCrn);
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/ClusterService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/ClusterService.java
@@ -127,20 +127,24 @@ public class ClusterService implements ResourceBasedCrnProvider {
         return clusterRepository.findByUserId(user.getUserId());
     }
 
-    public List<Cluster> findDistroXByUser(CloudbreakUser user) {
-        return clusterRepository.findByUserIdAndStackType(user.getUserId(), StackType.WORKLOAD);
+    public List<Cluster> findDistroXByWorkspace(Long workspaceId) {
+        return clusterRepository.findByWorkspaceIdAndStackType(workspaceId, StackType.WORKLOAD);
     }
 
     public Cluster findOneByStackId(Long stackId) {
         return clusterRepository.findByStackId(stackId);
     }
 
-    public Optional<Cluster> findOneByStackCrnAndUserId(String stackCrn, CloudbreakUser cloudbreakUser) {
-        return  clusterRepository.findByStackCrnAndUserId(stackCrn, cloudbreakUser.getUserId());
+    public Optional<Cluster> findOneByStackCrnAndWorkspaceId(String stackCrn, Long workspaceId) {
+        return  clusterRepository.findByStackCrnAndWorkspaceId(stackCrn, workspaceId);
     }
 
-    public Optional<Cluster> findOneByStackNameAndUserId(String stackName, CloudbreakUser cloudbreakUser) {
-        return  clusterRepository.findByStackNameAndUserId(stackName, cloudbreakUser.getUserId());
+    public Optional<Cluster> findOneByStackNameAndWorkspaceId(String stackName, Long workspaceId) {
+        return  clusterRepository.findByStackNameAndWorkspaceId(stackName, workspaceId);
+    }
+
+    public Optional<Cluster> findOneByClusterIdAndWorkspaceId(Long clusterId, Long workspaceId) {
+        return  clusterRepository.findByClusterIdAndWorkspaceId(clusterId, workspaceId);
     }
 
     public Cluster save(Cluster cluster) {


### PR DESCRIPTION
With UMS Authorization, all authorized users with DataHub permission can configure cluster autoscaling. Hence Cluster RetrievalByName,ID, CRN is associated with workspace (CB currently associates each tenant with a workspace). Also clusterNames are unique within a tenant and hence workspace.
Even though Cluster Retrieval ByCRN, ByID doesn't require workspace association, it is associated for additional security incase of leaked CRN or guessed clusterId.