### PR TITLE
CB-7162: FreeIPA AWS backup CLI command should use the regional endpoint

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaBackupConfigView.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaBackupConfigView.java
@@ -29,6 +29,8 @@ public class FreeIpaBackupConfigView {
 
     private final String proxyUrl;
 
+    private final String awsRegion;
+
     @SuppressWarnings("ExecutableStatementCount")
     private FreeIpaBackupConfigView(FreeIpaBackupConfigView.Builder builder) {
         enabled = builder.enabled;
@@ -39,6 +41,7 @@ public class FreeIpaBackupConfigView {
         platform = builder.platform;
         azureInstanceMsi = builder.azureInstanceMsi;
         proxyUrl = builder.proxyUrl;
+        awsRegion = builder.awsRegion;
     }
 
     public String getLocation() {
@@ -73,6 +76,10 @@ public class FreeIpaBackupConfigView {
         return proxyUrl;
     }
 
+    public String getAwsRegion() {
+        return awsRegion;
+    }
+
     @SuppressWarnings("ExecutableStatementCount")
     public Map<String, Object> toMap() {
         Map<String, Object> map = new HashMap<>();
@@ -84,6 +91,7 @@ public class FreeIpaBackupConfigView {
         map.put("platform", ObjectUtils.defaultIfNull(platform, EMPTY_CONFIG_DEFAULT));
         map.put("azure_instance_msi", ObjectUtils.defaultIfNull(azureInstanceMsi, EMPTY_CONFIG_DEFAULT));
         map.put("http_proxy", ObjectUtils.defaultIfNull(proxyUrl, EMPTY_CONFIG_DEFAULT));
+        map.put("aws_region", ObjectUtils.defaultIfNull(awsRegion, EMPTY_CONFIG_DEFAULT));
         return map;
     }
 
@@ -104,6 +112,8 @@ public class FreeIpaBackupConfigView {
         private String azureInstanceMsi;
 
         private String proxyUrl;
+
+        private String awsRegion;
 
         public FreeIpaBackupConfigView build() {
             return new FreeIpaBackupConfigView(this);
@@ -146,6 +156,11 @@ public class FreeIpaBackupConfigView {
 
         public Builder withProxyUrl(String proxyUrl) {
             this.proxyUrl = proxyUrl;
+            return this;
+        }
+
+        public Builder withAwsRegion(String awsRegion) {
+            this.awsRegion = awsRegion;
             return this;
         }
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaConfigService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaConfigService.java
@@ -90,7 +90,8 @@ public class FreeIpaConfigService {
                     .withLocation(backup.getStorageLocation());
             if (backup.getS3() != null) {
                 builder.withPlatform(CloudPlatform.AWS.name());
-                LOGGER.debug("Backups will be configured to use S3 output.");
+                builder.withAwsRegion(stack.getRegion());
+                LOGGER.debug("Backups will be configured to use S3 storage in {} region.", stack.getRegion());
             } else if (backup.getAdlsGen2() != null) {
                 builder.withPlatform(CloudPlatform.AZURE.name())
                         .withAzureInstanceMsi(backup.getAdlsGen2().getManagedIdentity());

--- a/freeipa/src/main/resources/freeipa-salt/pillar/freeipa/init.sls
+++ b/freeipa/src/main/resources/freeipa-salt/pillar/freeipa/init.sls
@@ -14,3 +14,4 @@ freeipa:
     location:
     azure_instance_msi:
     http_proxy:
+    aws_region:

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_backup
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_backup
@@ -33,6 +33,7 @@ config=( # set default values in config array
     [logfile]="/var/log/ipabackup.log"
     [backup_path]="/var/lib/ipa/backup"
     [http_proxy]=""
+    [aws_region]=""
 )
 
 set +x
@@ -132,7 +133,12 @@ doLog "DEBUG Uploading backup to ${BACKUP_LOCATION} on ${config[backup_platform]
 
 if [[ "${config[backup_platform]}" = "AWS" ]]; then
     doLog "INFO Syncing backups to AWS S3"
-    /usr/bin/aws s3 cp --recursive --sse AES256 --no-progress ${config[backup_path]}/${BACKUPDIR} ${BACKUP_LOCATION}/${BACKUPDIR} >> $LOGFILE 2>&1 || error_exit "Sync of backups to ${BACKUP_LOCATION} failed!"
+
+    REGION_OPTION=""
+    if [[ -n "${config[aws_region]}" ]]; then
+      REGION_OPTION="--region ${config[aws_region]}"
+    fi
+    /usr/bin/aws ${REGION_OPTION} s3 cp --recursive --sse AES256 --no-progress ${config[backup_path]}/${BACKUPDIR} ${BACKUP_LOCATION}/${BACKUPDIR} >> $LOGFILE 2>&1 || error_exit "Sync of backups to ${BACKUP_LOCATION} failed!"
     remove_local_backups
 elif [[ "${config[backup_platform]}" = "AZURE" ]]; then
     doLog "INFO Syncing backups to Azure Blog Storage"

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/settings.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/settings.sls
@@ -4,11 +4,13 @@
      {% set azure_instance_msi = salt['pillar.get']('freeipa:backup:azure_instance_msi') %}
      {% set http_proxy = salt['pillar.get']('freeipa:backup:http_proxy') %}
      {% set hostname = salt['grains.get']('fqdn') %}
+     {% set aws_region = salt['pillar.get']('freeipa:backup:aws_region') %}
 
      {% do freeipa.update({
          "backup_platform" : backup_platform,
          "backup_location" : backup_location,
          "hostname": hostname,
          "azure_instance_msi": azure_instance_msi,
-         "http_proxy": http_proxy
+         "http_proxy": http_proxy,
+         "aws_region": aws_region
      }) %}

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/templates/freeipa_backup.conf.j2
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/templates/freeipa_backup.conf.j2
@@ -3,3 +3,4 @@ backup_location={{freeipa.backup_location}}
 backup_platform={{freeipa.backup_platform}}
 azure_instance_msi={{freeipa.azure_instance_msi}}
 http_proxy={{freeipa.http_proxy}}
+aws_region={{freeipa.aws_region}}


### PR DESCRIPTION
This adds support to the AWS FreeIPA backup S3 uploader to set the region
to allow for the backup to use a regional endpoint.  It uses the region
defined for the stack.

This will result in upload url of s3.<region>.amazonaws.com instead of
s3.amazonaws.com as talked about in the documentation:
https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html

Closes #CB-7162