### PR TITLE
CB-6730. List instance groups even if all metadata are terminated.

### DIFF
--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/instance/InstanceGroup.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/instance/InstanceGroup.java
@@ -105,6 +105,12 @@ public class InstanceGroup implements ProvisionEntity, Comparable<InstanceGroup>
         this.stack = stack;
     }
 
+    public InstanceGroup replaceInstanceMetadata(Set<InstanceMetaData> instanceMetaData) {
+        this.instanceMetaData.clear();
+        Optional.ofNullable(instanceMetaData).ifPresent(this.instanceMetaData::addAll);
+        return this;
+    }
+
     public Set<InstanceMetaData> getNotTerminatedInstanceMetaDataSet() {
         return instanceMetaData.stream()
                 .filter(metaData -> !metaData.isTerminated())

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceGroupRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceGroupRepository.java
@@ -32,8 +32,4 @@ public interface InstanceGroupRepository extends CrudRepository<InstanceGroup, L
             "FROM InstanceMetaData i " +
             "WHERE i.instanceGroup.stack.id= :stackId AND i.discoveryFQDN= :hostName AND i.instanceStatus <> 'TERMINATED'")
     Optional<InstanceGroup> findInstanceGroupInStackByHostName(@Param("stackId") Long stackId, @Param("hostName") String hostName);
-
-    @Query("SELECT i FROM InstanceGroup i LEFT JOIN FETCH i.instanceMetaData im "
-            + "WHERE i.stack.id = :stackId AND (im IS NULL OR im.instanceStatus <> 'TERMINATED')")
-    Set<InstanceGroup> findNotTerminatedByStackId(@Param("stackId") Long stackId);
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/InstanceGroupService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/InstanceGroupService.java
@@ -36,7 +36,13 @@ public class InstanceGroupService {
     }
 
     public Set<InstanceGroup> findNotTerminatedByStackId(Long stackId) {
-        return repository.findNotTerminatedByStackId(stackId);
+        Set<InstanceGroup> instanceGroups = repository.findByStackId(stackId);
+        instanceGroups.forEach(
+                ig -> {
+                    ig.replaceInstanceMetadata(ig.getNotTerminatedInstanceMetaDataSet());
+                }
+        );
+        return instanceGroups;
     }
 
     public Set<InstanceGroup> saveAll(Set<InstanceGroup> instanceGroups, Workspace workspace) {


### PR DESCRIPTION
### Problem
- on resize, if you have downscaled all the nodes for an instance groups you cannot get back the instance group itself with 0 instance metadata (if ALL terminated)

### Changes
- removed left join fetch query
- get instance groups by stack and filter in java on the non-terminated instance metadata

### Why like this?
- condition (not terminated) should go into the right side of the join -> BUT you cannot include any with/on-clause if you are using fetch
- without using fetch, we end up to using many queries (around 8)
- with the actual (removed) query, we still load stack anyway in the objects, so it contains all instance groups/instance metadata -> in terms of space/load query only the instance group with all metadata should not cause larger heap space
