### PR TITLE
DISTX-448 Enable Entitlements support in Periscope

### DIFF
--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/v1/AlertEndpoint.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/v1/AlertEndpoint.java
@@ -1,10 +1,8 @@
 package com.sequenceiq.periscope.api.endpoint.v1;
 
 import static com.sequenceiq.periscope.doc.ApiDescription.ALERT_DESCRIPTION;
-import static com.sequenceiq.periscope.doc.ApiDescription.AlertNotes.METRIC_BASED_NOTES;
-import static com.sequenceiq.periscope.doc.ApiDescription.AlertNotes.PROMETHEUS_BASED_NOTES;
+import static com.sequenceiq.periscope.doc.ApiDescription.AlertNotes.LOAD_BASED_NOTES;
 import static com.sequenceiq.periscope.doc.ApiDescription.AlertNotes.TIME_BASED_NOTES;
-import static com.sequenceiq.periscope.doc.ApiDescription.AlertOpDescription.PROMETHEUS_BASED_DEFINITIONS;
 
 import java.text.ParseException;
 import java.util.List;
@@ -20,11 +18,8 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import com.sequenceiq.periscope.api.model.AlertRuleDefinitionEntry;
-import com.sequenceiq.periscope.api.model.MetricAlertRequest;
-import com.sequenceiq.periscope.api.model.MetricAlertResponse;
-import com.sequenceiq.periscope.api.model.PrometheusAlertRequest;
-import com.sequenceiq.periscope.api.model.PrometheusAlertResponse;
+import com.sequenceiq.periscope.api.model.LoadAlertRequest;
+import com.sequenceiq.periscope.api.model.LoadAlertResponse;
 import com.sequenceiq.periscope.api.model.TimeAlertRequest;
 import com.sequenceiq.periscope.api.model.TimeAlertResponse;
 import com.sequenceiq.periscope.api.model.TimeAlertValidationRequest;
@@ -39,42 +34,16 @@ import io.swagger.annotations.ApiOperation;
 public interface AlertEndpoint {
 
     @POST
-    @Path("metric")
-    @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = AlertOpDescription.METRIC_BASED_POST, produces = MediaType.APPLICATION_JSON, notes = METRIC_BASED_NOTES)
-    MetricAlertResponse createMetricAlerts(@PathParam("clusterId") Long clusterId, @Valid MetricAlertRequest json);
-
-    @PUT
-    @Path("metric/{alertId}")
-    @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = AlertOpDescription.METRIC_BASED_PUT, produces = MediaType.APPLICATION_JSON, notes = METRIC_BASED_NOTES)
-    MetricAlertResponse updateMetricAlerts(@PathParam("clusterId") Long clusterId, @PathParam("alertId") Long alertId,
-            @Valid MetricAlertRequest json);
-
-    @GET
-    @Path("metric")
-    @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = AlertOpDescription.METRIC_BASED_GET, produces = MediaType.APPLICATION_JSON, notes = METRIC_BASED_NOTES)
-    List<MetricAlertResponse> getMetricAlerts(@PathParam("clusterId") Long clusterId);
-
-    @DELETE
-    @Path("metric/{alertId}")
-    @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = AlertOpDescription.METRIC_BASED_DELETE, produces = MediaType.APPLICATION_JSON, notes = METRIC_BASED_NOTES)
-    void deleteMetricAlarm(@PathParam("clusterId") Long clusterId, @PathParam("alertId") Long alertId);
-
-    @POST
     @Path("time")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = AlertOpDescription.TIME_BASED_POST, produces = MediaType.APPLICATION_JSON, notes = TIME_BASED_NOTES)
-    TimeAlertResponse createTimeAlert(@PathParam("clusterId") Long clusterId, @Valid TimeAlertRequest json) throws ParseException;
+    TimeAlertResponse createTimeAlert(@PathParam("clusterId") Long clusterId, @Valid TimeAlertRequest json);
 
     @PUT
     @Path("time/{alertId}")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = AlertOpDescription.TIME_BASED_PUT, produces = MediaType.APPLICATION_JSON, notes = TIME_BASED_NOTES)
-    TimeAlertResponse updateTimeAlert(@PathParam("clusterId") Long clusterId, @PathParam("alertId") Long alertId, @Valid TimeAlertRequest json)
-            throws ParseException;
+    TimeAlertResponse updateTimeAlert(@PathParam("clusterId") Long clusterId, @PathParam("alertId") Long alertId, @Valid TimeAlertRequest json);
 
     @GET
     @Path("time")
@@ -95,34 +64,26 @@ public interface AlertEndpoint {
     Boolean validateCronExpression(@PathParam("clusterId") Long clusterId, @Valid TimeAlertValidationRequest json) throws ParseException;
 
     @POST
-    @Path("prometheus")
+    @Path("load")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = AlertOpDescription.PROMETHEUS_BASED_POST, produces = MediaType.APPLICATION_JSON, notes = PROMETHEUS_BASED_NOTES)
-    PrometheusAlertResponse createPrometheusAlert(@PathParam("clusterId") Long clusterId, @Valid PrometheusAlertRequest json);
+    @ApiOperation(value = AlertOpDescription.LOAD_BASED_POST, produces = MediaType.APPLICATION_JSON, notes = LOAD_BASED_NOTES)
+    LoadAlertResponse createLoadAlert(@PathParam("clusterId") Long clusterId, @Valid LoadAlertRequest json);
 
     @PUT
-    @Path("prometheus/{alertId}")
+    @Path("load/{alertId}")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = AlertOpDescription.PROMETHEUS_BASED_PUT, produces = MediaType.APPLICATION_JSON, notes = PROMETHEUS_BASED_NOTES)
-    PrometheusAlertResponse updatePrometheusAlert(@PathParam("clusterId") Long clusterId, @PathParam("alertId") Long alertId,
-            @Valid PrometheusAlertRequest json);
+    @ApiOperation(value = AlertOpDescription.LOAD_BASED_PUT, produces = MediaType.APPLICATION_JSON, notes = LOAD_BASED_NOTES)
+    LoadAlertResponse updateLoadAlert(@PathParam("clusterId") Long clusterId, @PathParam("alertId") Long alertId, @Valid LoadAlertRequest json);
 
     @GET
-    @Path("prometheus")
+    @Path("load")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = AlertOpDescription.PROMETHEUS_BASED_GET, produces = MediaType.APPLICATION_JSON, notes = PROMETHEUS_BASED_NOTES)
-    List<PrometheusAlertResponse> getPrometheusAlerts(@PathParam("clusterId") Long clusterId);
+    @ApiOperation(value = AlertOpDescription.LOAD_BASED_GET, produces = MediaType.APPLICATION_JSON, notes = LOAD_BASED_NOTES)
+    List<LoadAlertResponse> getLoadAlerts(@PathParam("clusterId") Long clusterId);
 
     @DELETE
-    @Path("prometheus/{alertId}")
+    @Path("load/{alertId}")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = AlertOpDescription.PROMETHEUS_BASED_DELETE, produces = MediaType.APPLICATION_JSON, notes = PROMETHEUS_BASED_NOTES)
-    void deletePrometheusAlarm(@PathParam("clusterId") Long clusterId, @PathParam("alertId") Long alertId);
-
-    @GET
-    @Path("prometheus/definitions")
-    @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = AlertOpDescription.METRIC_BASED_DEFINITIONS, produces = MediaType.APPLICATION_JSON, notes = PROMETHEUS_BASED_DEFINITIONS)
-    List<AlertRuleDefinitionEntry> getPrometheusDefinitions(@PathParam("clusterId") Long clusterId);
-
+    @ApiOperation(value = AlertOpDescription.LOAD_BASED_DELETE, produces = MediaType.APPLICATION_JSON, notes = LOAD_BASED_NOTES)
+    void deleteLoadAlert(@PathParam("clusterId") Long clusterId, @PathParam("alertId") Long alertId);
 }

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/v1/DistroXAutoScaleClusterV1Endpoint.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/v1/DistroXAutoScaleClusterV1Endpoint.java
@@ -1,0 +1,87 @@
+package com.sequenceiq.periscope.api.endpoint.v1;
+
+import static com.sequenceiq.periscope.doc.ApiDescription.CLUSTERS_DESCRIPTION;
+
+import java.util.List;
+
+import javax.validation.Valid;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import com.sequenceiq.periscope.api.endpoint.validator.ValidDistroXAutoscaleRequest;
+import com.sequenceiq.periscope.api.model.AutoscaleClusterState;
+import com.sequenceiq.periscope.api.model.DistroXAutoscaleClusterRequest;
+import com.sequenceiq.periscope.api.model.DistroXAutoscaleClusterResponse;
+import com.sequenceiq.periscope.doc.ApiDescription;
+import com.sequenceiq.periscope.doc.ApiDescription.ClusterOpDescription;
+import com.sequenceiq.periscope.doc.ApiDescription.DistroXClusterNotes;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
+@Path("/v1/distrox")
+@Consumes(MediaType.APPLICATION_JSON)
+@Api(value = "/v1/distrox", description = CLUSTERS_DESCRIPTION, protocols = "http,https", consumes = MediaType.APPLICATION_JSON)
+public interface DistroXAutoScaleClusterV1Endpoint {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = ClusterOpDescription.CLUSTER_GET_ALL, produces = MediaType.APPLICATION_JSON, notes = DistroXClusterNotes.NOTES)
+    List<DistroXAutoscaleClusterResponse> getClusters();
+
+    @GET
+    @Path("crn/{crn}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = ClusterOpDescription.CLUSTER_GET, produces = MediaType.APPLICATION_JSON, notes = DistroXClusterNotes.NOTES)
+    DistroXAutoscaleClusterResponse getClusterByCrn(@PathParam("crn") String clusterCrn);
+
+    @GET
+    @Path("name/{name}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = ClusterOpDescription.CLUSTER_GET, produces = MediaType.APPLICATION_JSON, notes = DistroXClusterNotes.NOTES)
+    DistroXAutoscaleClusterResponse getClusterByName(@PathParam("name") String clusterName);
+
+    @POST
+    @Path("crn/{crn}/autoscaleconfig")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = ClusterOpDescription.CLUSTER_UPDATE_AUTOSCALE_CONFIG, produces = MediaType.APPLICATION_JSON, notes = DistroXClusterNotes.NOTES)
+    DistroXAutoscaleClusterResponse updateAutoscaleConfigByClusterCrn(@PathParam("crn") String clusterCrn,
+            @ValidDistroXAutoscaleRequest @Valid DistroXAutoscaleClusterRequest autoscaleClusterRequest);
+
+    @POST
+    @Path("name/{name}/autoscaleconfig")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = ClusterOpDescription.CLUSTER_UPDATE_AUTOSCALE_CONFIG, produces = MediaType.APPLICATION_JSON, notes = DistroXClusterNotes.NOTES)
+    DistroXAutoscaleClusterResponse updateAutoscaleConfigByClusterName(@PathParam("name") String clusterName,
+            @ValidDistroXAutoscaleRequest @Valid DistroXAutoscaleClusterRequest autoscaleClusterRequest);
+
+    @DELETE
+    @Path("name/{name}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = ClusterOpDescription.CLUSTER_DELETE_ALERTS, produces = MediaType.APPLICATION_JSON, notes = DistroXClusterNotes.NOTES)
+    void deleteAlertsForClusterName(@PathParam("name") String clusterName);
+
+    @DELETE
+    @Path("crn/{crn}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = ClusterOpDescription.CLUSTER_DELETE_ALERTS, produces = MediaType.APPLICATION_JSON, notes = DistroXClusterNotes.NOTES)
+    void deleteAlertsForClusterCrn(@PathParam("crn") String clusterCrn);
+
+    @POST
+    @Path("name/{name}/autoscale")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = ClusterOpDescription.CLUSTER_SET_AUTOSCALE_STATE, produces = MediaType.APPLICATION_JSON, notes = ApiDescription.ClusterNotes.NOTES)
+    DistroXAutoscaleClusterResponse enableAutoscaleForClusterName(@PathParam("name") String clusterName, AutoscaleClusterState autoscaleState);
+
+    @POST
+    @Path("crn/{crn}/autoscale")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = ClusterOpDescription.CLUSTER_SET_AUTOSCALE_STATE, produces = MediaType.APPLICATION_JSON, notes = ApiDescription.ClusterNotes.NOTES)
+    DistroXAutoscaleClusterResponse enableAutoscaleForClusterCrn(@PathParam("crn") String clusterCrn, AutoscaleClusterState autoscaleState);
+}

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/validator/DistroXAutoscaleRequestValidator.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/validator/DistroXAutoscaleRequestValidator.java
@@ -1,0 +1,67 @@
+package com.sequenceiq.periscope.api.endpoint.validator;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+import com.sequenceiq.periscope.api.model.AdjustmentType;
+import com.sequenceiq.periscope.api.model.DistroXAutoscaleClusterRequest;
+
+public class DistroXAutoscaleRequestValidator
+        implements ConstraintValidator<ValidDistroXAutoscaleRequest, DistroXAutoscaleClusterRequest> {
+
+    @Override
+    public boolean isValid(DistroXAutoscaleClusterRequest request, ConstraintValidatorContext context) {
+
+        if (!request.getLoadAlertRequests().isEmpty() &&
+                !request.getTimeAlertRequests().isEmpty()) {
+            String message = String.format("Cluster can be configured with only one type of autoscaling policies.");
+            com.sequenceiq.cloudbreak.validation.ValidatorUtil.addConstraintViolation(context, message, "autoscalingPolicy")
+                    .disableDefaultConstraintViolation();
+            return false;
+        }
+
+        if (!request.getLoadAlertRequests().isEmpty()) {
+            return isValidLoadAlertRequests(request, context);
+        }
+
+        return true;
+    }
+
+    private Boolean isValidLoadAlertRequests(DistroXAutoscaleClusterRequest request, ConstraintValidatorContext context) {
+        Set<String> distinctLoadBasedHostGroups = new HashSet<>();
+        Set<AdjustmentType> distinctLoadBasedAdjustmentTypes = new HashSet<>();
+
+        Set<String> duplicateHostGroups =
+                request.getLoadAlertRequests().stream()
+                        .map(loadAlertRequest -> loadAlertRequest.getScalingPolicy())
+                        .map(scalingPolicyRequest -> {
+                            distinctLoadBasedAdjustmentTypes.add(scalingPolicyRequest.getAdjustmentType());
+                            return scalingPolicyRequest;
+                        })
+                        .map(scalingPolicyRequest -> scalingPolicyRequest.getHostGroup())
+                        .filter(n -> !distinctLoadBasedHostGroups.add(n))
+                        .collect(Collectors.toSet());
+
+        if (distinctLoadBasedAdjustmentTypes.size() > 1 || !distinctLoadBasedAdjustmentTypes.contains(AdjustmentType.LOAD_BASED)) {
+            String message = String.format("LoadBased Autoscale policy does not support AdjustmentType of type %s.",
+                    distinctLoadBasedAdjustmentTypes.toString());
+            com.sequenceiq.cloudbreak.validation.ValidatorUtil.addConstraintViolation(context, message, "adjustmentType")
+                    .disableDefaultConstraintViolation();
+            return false;
+        }
+
+        if (duplicateHostGroups.size() > 0) {
+            String message = String.format("Hostgroup(s) %s configured with multiple LoadBased Autoscaling policies.",
+                    duplicateHostGroups.toString());
+            com.sequenceiq.cloudbreak.validation.ValidatorUtil.addConstraintViolation(context, message, "hostGroup")
+                    .disableDefaultConstraintViolation();
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/validator/DistroXAutoscaleRequestValidator.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/validator/DistroXAutoscaleRequestValidator.java
@@ -35,6 +35,13 @@ public class DistroXAutoscaleRequestValidator
         Set<String> distinctLoadBasedHostGroups = new HashSet<>();
         Set<AdjustmentType> distinctLoadBasedAdjustmentTypes = new HashSet<>();
 
+        if (request.getLoadAlertRequests().size() > 1) {
+            String message = String.format("LoadBased autoscaling currently supports a single HostGroup in a Cluster.");
+            com.sequenceiq.cloudbreak.validation.ValidatorUtil.addConstraintViolation(context, message, "loadAlertRequests")
+                    .disableDefaultConstraintViolation();
+            return false;
+        }
+
         Set<String> duplicateHostGroups =
                 request.getLoadAlertRequests().stream()
                         .map(loadAlertRequest -> loadAlertRequest.getScalingPolicy())

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/validator/LoadAlertConfigurationRequestValidator.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/validator/LoadAlertConfigurationRequestValidator.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.periscope.api.endpoint.validator;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+import com.sequenceiq.cloudbreak.validation.ValidatorUtil;
+import com.sequenceiq.periscope.api.model.LoadAlertConfigurationRequest;
+
+public class LoadAlertConfigurationRequestValidator implements ConstraintValidator<ValidLoadAlertConfiguration, LoadAlertConfigurationRequest> {
+
+    @Override
+    public void initialize(ValidLoadAlertConfiguration constraintAnnotation) {
+    }
+
+    @Override
+    public boolean isValid(LoadAlertConfigurationRequest request, ConstraintValidatorContext context) {
+        boolean validRequest = true;
+        if (request.getMinResourceValue() >= request.getMaxResourceValue()) {
+            validRequest = false;
+            String message = "The specified loadAlertConfiguration is not valid because the minResourceValue " +
+                    " must be less than maxResourceValue.";
+            ValidatorUtil.addConstraintViolation(context, message, "minResourceValue")
+                    .disableDefaultConstraintViolation();
+        }
+        return validRequest;
+    }
+
+}

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/validator/ValidDistroXAutoscaleRequest.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/validator/ValidDistroXAutoscaleRequest.java
@@ -1,0 +1,22 @@
+package com.sequenceiq.periscope.api.endpoint.validator;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Documented
+@Constraint(validatedBy = DistroXAutoscaleRequestValidator.class)
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidDistroXAutoscaleRequest {
+    String message() default "DistroXAutoscaleRequest validation error";
+
+    Class<?>[] groups() default { };
+
+    Class<? extends Payload>[] payload() default { };
+}

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/validator/ValidLoadAlertConfiguration.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/validator/ValidLoadAlertConfiguration.java
@@ -1,0 +1,22 @@
+package com.sequenceiq.periscope.api.endpoint.validator;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Documented
+@Constraint(validatedBy = LoadAlertConfigurationRequestValidator.class)
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidLoadAlertConfiguration {
+    String message() default "LoadAlertConfiguration validation error";
+
+    Class<?>[] groups() default { };
+
+    Class<? extends Payload>[] payload() default { };
+}

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/AbstractAlertJson.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/AbstractAlertJson.java
@@ -1,7 +1,9 @@
 package com.sequenceiq.periscope.api.model;
 
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Pattern;
 
+import javax.validation.constraints.Size;
 import com.sequenceiq.periscope.doc.ApiDescription.BaseAlertJsonProperties;
 
 import io.swagger.annotations.ApiModelProperty;
@@ -10,10 +12,13 @@ public abstract class AbstractAlertJson implements Json {
 
     @Pattern(regexp = "(^[a-zA-Z][-a-zA-Z0-9]*$)",
             message = "The name can only contain alphanumeric characters and hyphens and has start with an alphanumeric character")
+    @NotEmpty
+    @Size(max = 250)
     @ApiModelProperty(BaseAlertJsonProperties.ALERTNAME)
     private String alertName;
 
     @ApiModelProperty(BaseAlertJsonProperties.DESCRIPTION)
+    @Size(max = 250)
     private String description;
 
     public String getAlertName() {

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/AdjustmentType.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/AdjustmentType.java
@@ -3,5 +3,6 @@ package com.sequenceiq.periscope.api.model;
 public enum AdjustmentType {
     NODE_COUNT,
     PERCENTAGE,
-    EXACT
+    EXACT,
+    LOAD_BASED
 }

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/AlertType.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/AlertType.java
@@ -1,5 +1,5 @@
 package com.sequenceiq.periscope.api.model;
 
 public enum AlertType {
-    METRIC, TIME, PROMETHEUS
+    METRIC, TIME, PROMETHEUS, LOAD
 }

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/AutoscaleClusterResponse.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/AutoscaleClusterResponse.java
@@ -28,6 +28,9 @@ public class AutoscaleClusterResponse extends ClusterBaseJson {
     @ApiModelProperty(ClusterJsonsProperties.PROMETHEUS_ALERTS)
     private List<PrometheusAlertResponse> prometheusAlerts;
 
+    @ApiModelProperty(ClusterJsonsProperties.LOAD_ALERTS)
+    private List<LoadAlertResponse> loadAlerts;
+
     @ApiModelProperty(ClusterJsonsProperties.SCALING_CONFIGURATION)
     private ScalingConfigurationRequest scalingConfiguration;
 
@@ -87,6 +90,14 @@ public class AutoscaleClusterResponse extends ClusterBaseJson {
 
     public void setPrometheusAlerts(List<PrometheusAlertResponse> prometheusAlerts) {
         this.prometheusAlerts = prometheusAlerts;
+    }
+
+    public List<LoadAlertResponse> getLoadAlerts() {
+        return loadAlerts;
+    }
+
+    public void setLoadAlerts(List<LoadAlertResponse> loadAlerts) {
+        this.loadAlerts = loadAlerts;
     }
 
     public ScalingConfigurationRequest getScalingConfiguration() {

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/AutoscaleClusterState.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/AutoscaleClusterState.java
@@ -5,7 +5,7 @@ import com.sequenceiq.periscope.doc.ApiDescription.ClusterAutoscaleState;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
-@ApiModel
+@ApiModel("AutoscaleState")
 public class AutoscaleClusterState {
 
     @ApiModelProperty(ClusterAutoscaleState.ENABLE_AUTOSCALING)

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/AutoscalingModeType.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/AutoscalingModeType.java
@@ -1,0 +1,6 @@
+package com.sequenceiq.periscope.api.model;
+
+public enum AutoscalingModeType {
+    TIME_BASED,
+    LOAD_BASED
+}

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/ClusterBaseJson.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/ClusterBaseJson.java
@@ -17,11 +17,19 @@ public class ClusterBaseJson implements Json {
     @ApiModelProperty(ClusterJsonsProperties.USERNAME)
     private String user;
 
+    @ApiModelProperty(ClusterJsonsProperties.STACK_NAME)
+    private String stackName;
+
     @NotNull
     @ApiModelProperty(ClusterJsonsProperties.STACK_CRN)
     private String stackCrn;
 
     public ClusterBaseJson() {
+    }
+
+    public ClusterBaseJson(String stackCrn, String stackName) {
+        this.stackCrn = stackCrn;
+        this.stackName = stackName;
     }
 
     public ClusterBaseJson(String host, String port, String user, String stackCrn) {
@@ -63,4 +71,11 @@ public class ClusterBaseJson implements Json {
         this.stackCrn = stackCrn;
     }
 
+    public String getStackName() {
+        return stackName;
+    }
+
+    public void setStackName(String stackName) {
+        this.stackName = stackName;
+    }
 }

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/DistroXAutoscaleClusterRequest.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/DistroXAutoscaleClusterRequest.java
@@ -1,0 +1,50 @@
+package com.sequenceiq.periscope.api.model;
+
+import java.util.List;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+import com.sequenceiq.periscope.doc.ApiDescription.ClusterJsonsProperties;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+public class DistroXAutoscaleClusterRequest implements Json {
+    @ApiModelProperty(ClusterJsonsProperties.ENABLE_AUTOSCALING)
+    private @NotNull Boolean enableAutoscaling;
+
+    @ApiModelProperty(ClusterJsonsProperties.TIME_ALERTS)
+    private List<@Valid TimeAlertRequest> timeAlertRequests;
+
+    @ApiModelProperty(ClusterJsonsProperties.LOAD_ALERTS)
+    private List<@Valid LoadAlertRequest> loadAlertRequests;
+
+    public DistroXAutoscaleClusterRequest() {
+    }
+
+    public void setEnableAutoscaling(Boolean enableAutoscaling) {
+        this.enableAutoscaling = enableAutoscaling;
+    }
+
+    public List<TimeAlertRequest> getTimeAlertRequests() {
+        return timeAlertRequests != null ? timeAlertRequests : List.of();
+    }
+
+    public void setTimeAlertRequests(List<TimeAlertRequest> timeAlertRequests) {
+        this.timeAlertRequests = timeAlertRequests;
+    }
+
+    public Boolean getEnableAutoscaling() {
+        return enableAutoscaling;
+    }
+
+    public List<LoadAlertRequest> getLoadAlertRequests() {
+        return loadAlertRequests != null ? loadAlertRequests : List.of();
+    }
+
+    public void setLoadAlertRequests(List<LoadAlertRequest> loadAlertRequests) {
+        this.loadAlertRequests = loadAlertRequests;
+    }
+}

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/DistroXAutoscaleClusterResponse.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/DistroXAutoscaleClusterResponse.java
@@ -1,0 +1,112 @@
+package com.sequenceiq.periscope.api.model;
+
+import java.util.List;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.periscope.doc.ApiDescription.ClusterJsonsProperties;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+public class DistroXAutoscaleClusterResponse implements Json {
+    @ApiModelProperty(ClusterJsonsProperties.ID)
+    private long id;
+
+    @ApiModelProperty(ClusterJsonsProperties.STACK_NAME)
+    private String stackName;
+
+    @ApiModelProperty(ClusterJsonsProperties.STACK_CRN)
+    private String stackCrn;
+
+    @ApiModelProperty(ClusterJsonsProperties.STATE)
+    private ClusterState state;
+
+    @ApiModelProperty(ClusterJsonsProperties.STACK_TYPE)
+    private StackType stackType;
+
+    @ApiModelProperty(ClusterJsonsProperties.AUTOSCALING_ENABLED)
+    private Boolean autoscalingEnabled;
+
+    @ApiModelProperty(ClusterJsonsProperties.TIME_ALERTS)
+    private List<TimeAlertResponse> timeAlerts;
+
+    @ApiModelProperty(ClusterJsonsProperties.LOAD_ALERTS)
+    private List<LoadAlertResponse> loadAlerts;
+
+    public DistroXAutoscaleClusterResponse() {
+    }
+
+    public DistroXAutoscaleClusterResponse(String stackCrn, String stackName,
+            boolean autoscalingEnabled, long id, ClusterState state) {
+        this.stackCrn = stackCrn;
+        this.stackName = stackName;
+        this.id = id;
+        this.state = state;
+        this.autoscalingEnabled = autoscalingEnabled;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public ClusterState getState() {
+        return state;
+    }
+
+    public void setState(ClusterState state) {
+        this.state = state;
+    }
+
+    public StackType getStackType() {
+        return stackType;
+    }
+
+    public void setStackType(StackType stackType) {
+        this.stackType = stackType;
+    }
+
+    public boolean isAutoscalingEnabled() {
+        return autoscalingEnabled;
+    }
+
+    public void setAutoscalingEnabled(boolean autoscalingEnabled) {
+        this.autoscalingEnabled = autoscalingEnabled;
+    }
+
+    public List<TimeAlertResponse> getTimeAlerts() {
+        return timeAlerts;
+    }
+
+    public void setTimeAlerts(List<TimeAlertResponse> timeAlerts) {
+        this.timeAlerts = timeAlerts;
+    }
+
+    public List<LoadAlertResponse> getLoadAlerts() {
+        return loadAlerts;
+    }
+
+    public void setLoadAlerts(List<LoadAlertResponse> loadAlerts) {
+        this.loadAlerts = loadAlerts;
+    }
+
+    public String getStackName() {
+        return stackName;
+    }
+
+    public void setStackName(String stackName) {
+        this.stackName = stackName;
+    }
+
+    public String getStackCrn() {
+        return stackCrn;
+    }
+
+    public void setStackCrn(String stackCrn) {
+        this.stackCrn = stackCrn;
+    }
+}

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/LoadAlertConfigurationRequest.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/LoadAlertConfigurationRequest.java
@@ -1,0 +1,62 @@
+package com.sequenceiq.periscope.api.model;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Digits;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+import com.sequenceiq.periscope.api.endpoint.validator.ValidLoadAlertConfiguration;
+import com.sequenceiq.periscope.doc.ApiDescription.LoadAlertJsonProperties;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@ValidLoadAlertConfiguration
+public class LoadAlertConfigurationRequest implements Json {
+    @ApiModelProperty(LoadAlertJsonProperties.LOAD_ALERT_CONFIGURATION_MIN_RESOUCE_VALUE)
+    @Min(value = 0)
+    @Max(value = 200)
+    @Digits(fraction = 0, integer = 3)
+    @NotNull
+    private @Valid Integer minResourceValue;
+
+    @ApiModelProperty(LoadAlertJsonProperties.LOAD_ALERT_CONFIGURATION_MAX_RESOUCE_VALUE)
+    @Min(value = 0)
+    @Max(value = 200)
+    @Digits(fraction = 0, integer = 3)
+    @NotNull
+    private @Valid Integer maxResourceValue;
+
+    @ApiModelProperty(LoadAlertJsonProperties.LOAD_ALERT_CONFIGURATION_COOL_DOWN_MINS_VALUE)
+    @Min(value = 2)
+    @Max(value = 180)
+    @Digits(fraction = 0, integer = 3)
+    @NotNull
+    private @Valid Integer coolDownMinutes;
+
+    public Integer getMinResourceValue() {
+        return minResourceValue;
+    }
+
+    public void setMinResourceValue(Integer minResourceValue) {
+        this.minResourceValue = minResourceValue;
+    }
+
+    public Integer getMaxResourceValue() {
+        return maxResourceValue;
+    }
+
+    public void setMaxResourceValue(Integer maxResourceValue) {
+        this.maxResourceValue = maxResourceValue;
+    }
+
+    public Integer getCoolDownMinutes() {
+        return coolDownMinutes;
+    }
+
+    public void setCoolDownMinutes(Integer coolDownMinutes) {
+        this.coolDownMinutes = coolDownMinutes;
+    }
+}

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/LoadAlertConfigurationResponse.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/LoadAlertConfigurationResponse.java
@@ -1,0 +1,43 @@
+package com.sequenceiq.periscope.api.model;
+
+import com.sequenceiq.periscope.doc.ApiDescription.LoadAlertJsonProperties;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+public class LoadAlertConfigurationResponse implements Json {
+
+    @ApiModelProperty(LoadAlertJsonProperties.LOAD_ALERT_CONFIGURATION_MIN_RESOUCE_VALUE)
+    private Integer minResourceValue;
+
+    @ApiModelProperty(LoadAlertJsonProperties.LOAD_ALERT_CONFIGURATION_MAX_RESOUCE_VALUE)
+    private Integer maxResourceValue;
+
+    @ApiModelProperty(LoadAlertJsonProperties.LOAD_ALERT_CONFIGURATION_COOL_DOWN_MINS_VALUE)
+    private Integer coolDownMinutes;
+
+    public Integer getMinResourceValue() {
+        return minResourceValue;
+    }
+
+    public void setMinResourceValue(Integer minResourceValue) {
+        this.minResourceValue = minResourceValue;
+    }
+
+    public Integer getMaxResourceValue() {
+        return maxResourceValue;
+    }
+
+    public void setMaxResourceValue(Integer maxResourceValue) {
+        this.maxResourceValue = maxResourceValue;
+    }
+
+    public Integer getCoolDownMinutes() {
+        return coolDownMinutes;
+    }
+
+    public void setCoolDownMinutes(Integer coolDownMinutes) {
+        this.coolDownMinutes = coolDownMinutes;
+    }
+}

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/LoadAlertRequest.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/LoadAlertRequest.java
@@ -1,0 +1,36 @@
+package com.sequenceiq.periscope.api.model;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+import com.sequenceiq.periscope.doc.ApiDescription.BaseAlertJsonProperties;
+import com.sequenceiq.periscope.doc.ApiDescription.LoadAlertJsonProperties;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+public class LoadAlertRequest extends AbstractAlertJson {
+
+    @ApiModelProperty(LoadAlertJsonProperties.LOAD_ALERT_CONFIGURATION)
+    private @Valid @NotNull LoadAlertConfigurationRequest loadAlertConfiguration;
+
+    @ApiModelProperty(BaseAlertJsonProperties.SCALINGPOLICYID)
+    private @Valid @NotNull ScalingPolicyRequest scalingPolicy;
+
+    public ScalingPolicyRequest getScalingPolicy() {
+        return scalingPolicy;
+    }
+
+    public void setScalingPolicy(ScalingPolicyRequest scalingPolicy) {
+        this.scalingPolicy = scalingPolicy;
+    }
+
+    public LoadAlertConfigurationRequest getLoadAlertConfiguration() {
+        return loadAlertConfiguration;
+    }
+
+    public void setLoadAlertConfiguration(LoadAlertConfigurationRequest loadAlertConfiguration) {
+        this.loadAlertConfiguration = loadAlertConfiguration;
+    }
+}

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/LoadAlertResponse.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/LoadAlertResponse.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.periscope.api.model;
+
+import com.sequenceiq.periscope.doc.ApiDescription.BaseAlertJsonProperties;
+import com.sequenceiq.periscope.doc.ApiDescription.LoadAlertJsonProperties;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+public class LoadAlertResponse extends AbstractAlertJson {
+
+    @ApiModelProperty(BaseAlertJsonProperties.ID)
+    private Long id;
+
+    @ApiModelProperty(BaseAlertJsonProperties.SCALINGPOLICYID)
+    private ScalingPolicyResponse scalingPolicy;
+
+    @ApiModelProperty(LoadAlertJsonProperties.LOAD_ALERT_CONFIGURATION)
+    private LoadAlertConfigurationResponse loadAlertConfiguration;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public ScalingPolicyResponse getScalingPolicy() {
+        return scalingPolicy;
+    }
+
+    public void setScalingPolicy(ScalingPolicyResponse scalingPolicy) {
+        this.scalingPolicy = scalingPolicy;
+    }
+
+    public LoadAlertConfigurationResponse getLoadAlertConfiguration() {
+        return loadAlertConfiguration;
+    }
+
+    public void setLoadAlertConfiguration(LoadAlertConfigurationResponse loadAlertConfiguration) {
+        this.loadAlertConfiguration = loadAlertConfiguration;
+    }
+}

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/ScalingPolicyBase.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/ScalingPolicyBase.java
@@ -1,6 +1,9 @@
 package com.sequenceiq.periscope.api.model;
 
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
 
 import com.sequenceiq.periscope.api.endpoint.validator.ValidScalingPolicy;
 import com.sequenceiq.periscope.doc.ApiDescription.ScalingPolicyJsonProperties;
@@ -16,6 +19,7 @@ public class ScalingPolicyBase implements Json {
     private String name;
 
     @ApiModelProperty(ScalingPolicyJsonProperties.ADJUSTMENTTYPE)
+    @NotNull
     private AdjustmentType adjustmentType;
 
     @ApiModelProperty(ScalingPolicyJsonProperties.SCALINGADJUSTMENT)
@@ -25,6 +29,10 @@ public class ScalingPolicyBase implements Json {
     private long alertId;
 
     @ApiModelProperty(ScalingPolicyJsonProperties.HOSTGROUP)
+    @NotEmpty
+    @Size(max = 250)
+    @Pattern(regexp = "(^[a-zA-Z][-a-zA-Z0-9]*$)",
+            message = "The hostGroup can only contain alphanumeric characters and hyphens and has to start with an alphanumeric character")
     private String hostGroup;
 
     public long getAlertId() {

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/TimeAlertRequest.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/TimeAlertRequest.java
@@ -1,6 +1,9 @@
 package com.sequenceiq.periscope.api.model;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 import com.sequenceiq.periscope.doc.ApiDescription.BaseAlertJsonProperties;
 import com.sequenceiq.periscope.doc.ApiDescription.TimeAlertJsonProperties;
@@ -12,12 +15,16 @@ import io.swagger.annotations.ApiModelProperty;
 public class TimeAlertRequest extends AbstractAlertJson {
 
     @ApiModelProperty(TimeAlertJsonProperties.TIMEZONE)
+    @Size(max = 50)
     private String timeZone;
 
     @ApiModelProperty(TimeAlertJsonProperties.CRON)
+    @NotEmpty
+    @Size(max = 100)
     private String cron;
 
     @Valid
+    @NotNull
     @ApiModelProperty(BaseAlertJsonProperties.SCALINGPOLICYID)
     private ScalingPolicyRequest scalingPolicy;
 

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/TimeAlertResponse.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/TimeAlertResponse.java
@@ -19,10 +19,7 @@ public class TimeAlertResponse extends AbstractAlertJson {
     private String cron;
 
     @ApiModelProperty(BaseAlertJsonProperties.SCALINGPOLICYID)
-    private Long scalingPolicyId;
-
-    @ApiModelProperty(BaseAlertJsonProperties.SCALINGPOLICYID)
-    private ScalingPolicyRequest scalingPolicy;
+    private ScalingPolicyResponse scalingPolicy;
 
     public String getTimeZone() {
         return timeZone;
@@ -48,19 +45,11 @@ public class TimeAlertResponse extends AbstractAlertJson {
         this.id = id;
     }
 
-    public Long getScalingPolicyId() {
-        return scalingPolicyId;
-    }
-
-    public void setScalingPolicyId(Long scalingPolicyId) {
-        this.scalingPolicyId = scalingPolicyId;
-    }
-
-    public ScalingPolicyRequest getScalingPolicy() {
+    public ScalingPolicyResponse getScalingPolicy() {
         return scalingPolicy;
     }
 
-    public void setScalingPolicy(ScalingPolicyRequest scalingPolicy) {
+    public void setScalingPolicy(ScalingPolicyResponse scalingPolicy) {
         this.scalingPolicy = scalingPolicy;
     }
 }

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/client/AutoscaleUserCrnClient.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/client/AutoscaleUserCrnClient.java
@@ -12,6 +12,7 @@ import com.sequenceiq.periscope.api.AutoscaleApi;
 import com.sequenceiq.periscope.api.endpoint.v1.AlertEndpoint;
 import com.sequenceiq.periscope.api.endpoint.v1.AutoScaleClusterV1Endpoint;
 import com.sequenceiq.periscope.api.endpoint.v1.ConfigurationEndpoint;
+import com.sequenceiq.periscope.api.endpoint.v1.DistroXAutoScaleClusterV1Endpoint;
 import com.sequenceiq.periscope.api.endpoint.v1.HistoryEndpoint;
 import com.sequenceiq.periscope.api.endpoint.v1.PolicyEndpoint;
 
@@ -36,6 +37,10 @@ public class AutoscaleUserCrnClient extends AbstractUserCrnServiceClient<Autosca
 
         public AlertEndpoint alertEndpoint() {
             return getEndpoint(AlertEndpoint.class);
+        }
+
+        public DistroXAutoScaleClusterV1Endpoint distroXAutoScaleClusterV1Endpoint() {
+            return getEndpoint(DistroXAutoScaleClusterV1Endpoint.class);
         }
 
         public AutoScaleClusterV1Endpoint clusterEndpoint() {

--- a/autoscale-api/src/test/java/com/sequenceiq/periscope/api/endpoint/validator/DistroXAutoscaleRequestValidatorTest.java
+++ b/autoscale-api/src/test/java/com/sequenceiq/periscope/api/endpoint/validator/DistroXAutoscaleRequestValidatorTest.java
@@ -1,0 +1,131 @@
+package com.sequenceiq.periscope.api.endpoint.validator;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.ConstraintValidatorContext.ConstraintViolationBuilder;
+import javax.validation.ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.sequenceiq.periscope.api.model.AdjustmentType;
+import com.sequenceiq.periscope.api.model.DistroXAutoscaleClusterRequest;
+import com.sequenceiq.periscope.api.model.LoadAlertRequest;
+import com.sequenceiq.periscope.api.model.ScalingPolicyRequest;
+import com.sequenceiq.periscope.api.model.TimeAlertRequest;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DistroXAutoscaleRequestValidatorTest {
+
+    private DistroXAutoscaleRequestValidator underTest = new DistroXAutoscaleRequestValidator();
+
+    private ConstraintViolationBuilder constraintViolationBuilder;
+
+    private NodeBuilderCustomizableContext nodeBuilderCustomizableContext;
+
+    private ConstraintValidatorContext validatorContext;
+
+    @Before
+    public void setupMocks() {
+        constraintViolationBuilder = mock(ConstraintValidatorContext.ConstraintViolationBuilder.class);
+        nodeBuilderCustomizableContext =
+                mock(ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext.class);
+        validatorContext = mock(ConstraintValidatorContext.class);
+
+        when(validatorContext.buildConstraintViolationWithTemplate(any())).thenReturn(constraintViolationBuilder);
+        when(constraintViolationBuilder.addPropertyNode(any())).thenReturn(nodeBuilderCustomizableContext);
+        when(nodeBuilderCustomizableContext.addConstraintViolation()).thenReturn(validatorContext);
+        doNothing().when(validatorContext).disableDefaultConstraintViolation();
+    }
+
+    @Test
+    public void testIsValidWhenValidLoadAlertsThenTrue() {
+        List<String> loadHostGroups = Arrays.asList("compute2", "hdfs1", "hdfs3");
+
+        boolean underTestValid = underTest
+                .isValid(getTestRequest(List.of(), loadHostGroups, Optional.empty()), validatorContext);
+        assertTrue("Valid Load Alert Autoscale Policy", underTestValid);
+    }
+
+    @Test
+    public void testIsValidWhenValidTimeAlertsThenTrue() {
+        List<String> timeHostGroups = Arrays.asList("compute2", "hdfs1", "hdfs3");
+
+        boolean underTestValid = underTest
+                .isValid(getTestRequest(timeHostGroups, List.of(), Optional.empty()), validatorContext);
+        assertTrue("Valid Time Alert Autoscale Policy", underTestValid);
+    }
+
+    @Test
+    public void testIsValidWhenBothAlertsThenFalse() {
+        List<String> timeHostGroups = Arrays.asList("hdfs1", "compute1", "hdfs3");
+        List<String> loadHostGroups = Arrays.asList("compute2", "hdfs1", "hdfs3");
+
+        boolean underTestValid = underTest
+                .isValid(getTestRequest(timeHostGroups, loadHostGroups, Optional.empty()), validatorContext);
+        assertFalse("Cluster can be configured with only one type of autoscale policy", underTestValid);
+    }
+
+    @Test
+    public void testIsValidWhenDuplicateLoadAlertHostGroupThenFalse() {
+        List<String> loadHostGroups = Arrays.asList("compute2", "compute2", "hdfs3");
+
+        boolean underTestValid = underTest
+                .isValid(getTestRequest(List.of(), loadHostGroups, Optional.empty()), validatorContext);
+        assertFalse("Cluster can be configured with only one type of autoscale policy", underTestValid);
+    }
+
+    @Test
+    public void testIsValidWhenLoadAlertWithInvalidAdjustmentTypeThenFalse() {
+        List<String> loadHostGroups = Arrays.asList("compute2", "compute2", "hdfs3");
+
+        boolean underTestValid = underTest
+                .isValid(getTestRequest(List.of(), loadHostGroups, Optional.of(AdjustmentType.NODE_COUNT)), validatorContext);
+        assertFalse("Cluster can be configured with only one type of autoscale policy", underTestValid);
+    }
+
+    private DistroXAutoscaleClusterRequest getTestRequest(List<String> timeHostGroups,
+            List<String> loadHostGroups, Optional<AdjustmentType> testAdjustmentType) {
+        DistroXAutoscaleClusterRequest testRequest = new DistroXAutoscaleClusterRequest();
+        List<TimeAlertRequest> timeAlertRequests = new ArrayList<>();
+        List<LoadAlertRequest> loadAlertRequests = new ArrayList<>();
+
+        if (timeHostGroups != null) {
+            for (String hostGroup : timeHostGroups) {
+                TimeAlertRequest request = new TimeAlertRequest();
+                ScalingPolicyRequest scalingPolicyRequest = new ScalingPolicyRequest();
+                scalingPolicyRequest.setHostGroup(hostGroup);
+                scalingPolicyRequest.setAdjustmentType(testAdjustmentType.orElse(AdjustmentType.NODE_COUNT));
+                request.setScalingPolicy(scalingPolicyRequest);
+                timeAlertRequests.add(request);
+            }
+            testRequest.setTimeAlertRequests(timeAlertRequests);
+        }
+
+        if (loadHostGroups != null) {
+            for (String hostGroup : loadHostGroups) {
+                LoadAlertRequest request = new LoadAlertRequest();
+                ScalingPolicyRequest scalingPolicyRequest = new ScalingPolicyRequest();
+                scalingPolicyRequest.setHostGroup(hostGroup);
+                scalingPolicyRequest.setAdjustmentType(testAdjustmentType.orElse(AdjustmentType.LOAD_BASED));
+                request.setScalingPolicy(scalingPolicyRequest);
+                loadAlertRequests.add(request);
+            }
+            testRequest.setLoadAlertRequests(loadAlertRequests);
+        }
+        return testRequest;
+    }
+}

--- a/autoscale-api/src/test/java/com/sequenceiq/periscope/api/endpoint/validator/DistroXAutoscaleRequestValidatorTest.java
+++ b/autoscale-api/src/test/java/com/sequenceiq/periscope/api/endpoint/validator/DistroXAutoscaleRequestValidatorTest.java
@@ -53,7 +53,7 @@ public class DistroXAutoscaleRequestValidatorTest {
 
     @Test
     public void testIsValidWhenValidLoadAlertsThenTrue() {
-        List<String> loadHostGroups = Arrays.asList("compute2", "hdfs1", "hdfs3");
+        List<String> loadHostGroups = Arrays.asList("compute2");
 
         boolean underTestValid = underTest
                 .isValid(getTestRequest(List.of(), loadHostGroups, Optional.empty()), validatorContext);

--- a/autoscale/build.gradle
+++ b/autoscale/build.gradle
@@ -164,8 +164,8 @@ dependencies {
     testCompile group: 'org.powermock',             name: 'powermock-api-mockito2'
     testCompile group: 'org.ow2.asm',               name: 'asm'
     testCompile group: 'com.openpojo',              name: 'openpojo'
+    testCompile group: "com.h2database",            name: "h2",     version: h2databaseVersion
 
-    compile project(':core-api')
     compile project(':autoscale-api')
     compile project(':common')
     compile project(':workspace')

--- a/autoscale/src/main/java/com/sequenceiq/periscope/PeriscopeApplication.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/PeriscopeApplication.java
@@ -5,7 +5,7 @@ import static com.sequenceiq.periscope.VersionedApplication.versionedApplication
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.actuate.autoconfigure.metrics.web.servlet.WebMvcMetricsAutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.context.annotation.ComponentScan;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 
@@ -14,8 +14,8 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 @Configuration
 @EnableAutoConfiguration(exclude = WebMvcMetricsAutoConfiguration.class)
 @EnableSwagger2
-@ComponentScan(basePackages = {"com.sequenceiq"})
 @EnableAspectJAutoProxy(proxyTargetClass = true)
+@SpringBootApplication(scanBasePackages = "com.sequenceiq", exclude = WebMvcMetricsAutoConfiguration.class)
 public class PeriscopeApplication {
 
     public static void main(String[] args) {

--- a/autoscale/src/main/java/com/sequenceiq/periscope/aspects/RequestLogging.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/aspects/RequestLogging.java
@@ -11,10 +11,10 @@ public class RequestLogging {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RequestLogging.class);
 
-    public <T> T logging(Supplier<T> callback, String requestName) {
+    public <T> T logResponseTime(Supplier<T> callback, String requestName) {
         long start = System.currentTimeMillis();
-        T o = callback.get();
-        LOGGER.debug("Ambari '{}' finished in {} ms", requestName, System.currentTimeMillis() - start);
-        return o;
+        T response = callback.get();
+        LOGGER.info("Request '{}' finished in '{}' ms.", requestName, System.currentTimeMillis() - start);
+        return response;
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/cache/AccountEntitlementCache.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/cache/AccountEntitlementCache.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.periscope.cache;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cache.common.AbstractCacheDefinition;
+
+@Component
+public class AccountEntitlementCache extends AbstractCacheDefinition {
+
+    public static final String INSTANCE_CONFIG_CACHE = "accountEntitlementCache";
+
+    private static final long MAX_ENTRIES = 500L;
+
+    private static final int TTL_IN_MINUTES = 5;
+
+    @Override
+    protected String getName() {
+        return INSTANCE_CONFIG_CACHE;
+    }
+
+    @Override
+    protected long getMaxEntries() {
+        return MAX_ENTRIES;
+    }
+
+    @Override
+    protected long getTimeToLiveSeconds() {
+        return TimeUnit.MINUTES.toSeconds(TTL_IN_MINUTES);
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/cache/InstanceConfigCache.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/cache/InstanceConfigCache.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.periscope.cache;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cache.common.AbstractCacheDefinition;
+
+@Component
+public class InstanceConfigCache extends AbstractCacheDefinition {
+
+    public static final String INSTANCE_CONFIG_CACHE = "instanceConfigCache";
+
+    private static final long MAX_ENTRIES = 5000L;
+
+    private static final int TTL_IN_MINUTES = 30;
+
+    @Override
+    protected String getName() {
+        return INSTANCE_CONFIG_CACHE;
+    }
+
+    @Override
+    protected long getMaxEntries() {
+        return MAX_ENTRIES;
+    }
+
+    @Override
+    protected long getTimeToLiveSeconds() {
+        return TimeUnit.MINUTES.toSeconds(TTL_IN_MINUTES);
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/config/DatabaseConfig.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/config/DatabaseConfig.java
@@ -15,6 +15,7 @@ import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
@@ -33,6 +34,7 @@ import com.zaxxer.hikari.HikariDataSource;
 
 @Configuration
 @EnableTransactionManagement
+@ConditionalOnProperty(name = "periscope.db.enabled", havingValue = "true", matchIfMissing = true)
 public class DatabaseConfig {
 
     @Value("${periscope.db.env.user:postgres}")

--- a/autoscale/src/main/java/com/sequenceiq/periscope/config/SecurityConfig.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/config/SecurityConfig.java
@@ -97,6 +97,7 @@ public class SecurityConfig {
                     .authorizeRequests()
                     .antMatchers(API_ROOT_CONTEXT + "/v1/clusters/**").authenticated()
                     .antMatchers(API_ROOT_CONTEXT + "/v2/clusters/**").authenticated()
+                    .antMatchers(API_ROOT_CONTEXT + "/v1/distrox/**").authenticated()
                     .antMatchers(API_ROOT_CONTEXT + "/swagger.json").permitAll()
                     .antMatchers(API_ROOT_CONTEXT + "/api-docs/**").permitAll()
                     .antMatchers(API_ROOT_CONTEXT + "/**").denyAll()

--- a/autoscale/src/main/java/com/sequenceiq/periscope/controller/AlertController.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/controller/AlertController.java
@@ -3,45 +3,52 @@ package com.sequenceiq.periscope.controller;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
+import javax.validation.Valid;
+import javax.ws.rs.BadRequestException;
 
-import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Controller;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.sequenceiq.authorization.annotation.AuthorizationResource;
+import com.sequenceiq.authorization.annotation.CheckPermissionByAccount;
+import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
 import com.sequenceiq.periscope.api.endpoint.v1.AlertEndpoint;
-import com.sequenceiq.periscope.api.model.AlertRuleDefinitionEntry;
-import com.sequenceiq.periscope.api.model.MetricAlertRequest;
-import com.sequenceiq.periscope.api.model.MetricAlertResponse;
-import com.sequenceiq.periscope.api.model.PrometheusAlertRequest;
-import com.sequenceiq.periscope.api.model.PrometheusAlertResponse;
+import com.sequenceiq.periscope.api.model.AlertType;
+import com.sequenceiq.periscope.api.model.LoadAlertRequest;
+import com.sequenceiq.periscope.api.model.LoadAlertResponse;
 import com.sequenceiq.periscope.api.model.TimeAlertRequest;
 import com.sequenceiq.periscope.api.model.TimeAlertResponse;
 import com.sequenceiq.periscope.api.model.TimeAlertValidationRequest;
-import com.sequenceiq.periscope.converter.MetricAlertRequestConverter;
-import com.sequenceiq.periscope.converter.MetricAlertResponseConverter;
-import com.sequenceiq.periscope.converter.PrometheusAlertRequestConverter;
-import com.sequenceiq.periscope.converter.PrometheusAlertResponseConverter;
+import com.sequenceiq.periscope.converter.LoadAlertRequestConverter;
+import com.sequenceiq.periscope.converter.LoadAlertResponseConverter;
 import com.sequenceiq.periscope.converter.TimeAlertRequestConverter;
 import com.sequenceiq.periscope.converter.TimeAlertResponseConverter;
-import com.sequenceiq.periscope.domain.MetricAlert;
-import com.sequenceiq.periscope.domain.PrometheusAlert;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.LoadAlert;
+import com.sequenceiq.periscope.domain.ScalingPolicy;
 import com.sequenceiq.periscope.domain.TimeAlert;
 import com.sequenceiq.periscope.service.AlertService;
+import com.sequenceiq.periscope.service.AutoscaleRestRequestThreadLocalService;
+import com.sequenceiq.periscope.service.ClusterService;
 import com.sequenceiq.periscope.service.DateService;
+import com.sequenceiq.periscope.service.NotFoundException;
+import com.sequenceiq.periscope.service.configuration.ClusterProxyConfigurationService;
 
-@Component
+@Controller
+@AuthorizationResource
 public class AlertController implements AlertEndpoint {
+
+    @Value("${periscope.enabledPlatforms:}")
+    private Set<String> supportedCloudPlatforms;
 
     @Inject
     private AlertService alertService;
-
-    @Inject
-    private MetricAlertRequestConverter metricAlertRequestConverter;
-
-    @Inject
-    private MetricAlertResponseConverter metricAlertResponseConverter;
 
     @Inject
     private TimeAlertRequestConverter timeAlertRequestConverter;
@@ -50,112 +57,184 @@ public class AlertController implements AlertEndpoint {
     private TimeAlertResponseConverter timeAlertResponseConverter;
 
     @Inject
-    private PrometheusAlertRequestConverter prometheusAlertRequestConverter;
+    private LoadAlertRequestConverter loadAlertRequestConverter;
 
     @Inject
-    private PrometheusAlertResponseConverter prometheusAlertResponseConverter;
+    private LoadAlertResponseConverter loadAlertResponseConverter;
 
     @Inject
     private DateService dateService;
 
-    @Override
-    public MetricAlertResponse createMetricAlerts(Long clusterId, MetricAlertRequest json) {
-        MetricAlert metricAlert = metricAlertRequestConverter.convert(json);
-        return createMetricAlarmResponse(alertService.createMetricAlert(clusterId, metricAlert));
-    }
+    @Inject
+    private ClusterService clusterService;
+
+    @Inject
+    private AutoscaleRestRequestThreadLocalService restRequestThreadLocalService;
+
+    @Inject
+    private ClusterProxyConfigurationService clusterProxyConfigurationService;
 
     @Override
-    public MetricAlertResponse updateMetricAlerts(Long clusterId, Long alertId, MetricAlertRequest json) {
-        MetricAlert metricAlert = metricAlertRequestConverter.convert(json);
-        return createMetricAlarmResponse(alertService.updateMetricAlert(clusterId, alertId, metricAlert));
-    }
-
-    @Override
-    public List<MetricAlertResponse> getMetricAlerts(Long clusterId) {
-        return createAlarmsResponse(alertService.getMetricAlerts(clusterId));
-    }
-
-    @Override
-    public void deleteMetricAlarm(Long clusterId, Long alertId) {
-        alertService.deleteMetricAlert(clusterId, alertId);
-    }
-
-    @Override
-    public TimeAlertResponse createTimeAlert(Long clusterId, TimeAlertRequest json) throws ParseException {
-        TimeAlert timeAlert = validateTimeAlert(json);
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.DATAHUB_WRITE)
+    public TimeAlertResponse createTimeAlert(Long clusterId, TimeAlertRequest json) {
+        validateTimeAlert(clusterId, Optional.empty(), json);
+        TimeAlert timeAlert = timeAlertRequestConverter.convert(json);
         return createTimeAlertResponse(alertService.createTimeAlert(clusterId, timeAlert));
     }
 
     @Override
-    public TimeAlertResponse updateTimeAlert(Long clusterId, Long alertId, TimeAlertRequest json)
-            throws ParseException {
-        TimeAlert timeAlert = validateTimeAlert(json);
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.DATAHUB_WRITE)
+    public TimeAlertResponse updateTimeAlert(Long clusterId, Long alertId, TimeAlertRequest json) {
+        validateTimeAlert(clusterId, Optional.of(alertId), json);
+        TimeAlert timeAlert = timeAlertRequestConverter.convert(json);
         return createTimeAlertResponse(alertService.updateTimeAlert(clusterId, alertId, timeAlert));
     }
 
     @Override
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.DATAHUB_READ)
     public List<TimeAlertResponse> getTimeAlerts(Long clusterId) {
-        Set<TimeAlert> timeAlerts = alertService.getTimeAlerts(clusterId);
+        Set<TimeAlert> timeAlerts = getClusterForWorkspace(clusterId).getTimeAlerts();
         return createTimeAlertsResponse(timeAlerts);
     }
 
     @Override
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.DATAHUB_WRITE)
     public void deleteTimeAlert(Long clusterId, Long alertId) {
+        validateAlertForUpdate(getClusterForWorkspace(clusterId), alertId, AlertType.TIME);
         alertService.deleteTimeAlert(clusterId, alertId);
     }
 
     @Override
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.DATAHUB_READ)
     public Boolean validateCronExpression(Long clusterId, TimeAlertValidationRequest json) throws ParseException {
         dateService.getCronExpression(json.getCronExpression());
         return true;
     }
 
     @Override
-    public PrometheusAlertResponse createPrometheusAlert(Long clusterId, PrometheusAlertRequest json) {
-        PrometheusAlert prometheusAlert = prometheusAlertRequestConverter.convert(json);
-        return createPrometheusAlertResponse(alertService.createPrometheusAlert(clusterId, prometheusAlert));
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.DATAHUB_WRITE)
+    public LoadAlertResponse createLoadAlert(Long clusterId, @Valid LoadAlertRequest json) {
+        validateLoadAlert(clusterId, Optional.empty(), json);
+        LoadAlert loadAlert = loadAlertRequestConverter.convert(json);
+        return createLoadAlertResponse(alertService.createLoadAlert(clusterId, loadAlert));
     }
 
     @Override
-    public PrometheusAlertResponse updatePrometheusAlert(Long clusterId, Long alertId, PrometheusAlertRequest json) {
-        PrometheusAlert prometheusAlert = prometheusAlertRequestConverter.convert(json);
-        return createPrometheusAlertResponse(alertService.updatePrometheusAlert(clusterId, alertId, prometheusAlert));
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.DATAHUB_WRITE)
+    public LoadAlertResponse updateLoadAlert(Long clusterId, Long alertId, @Valid LoadAlertRequest json) {
+        validateLoadAlert(clusterId, Optional.of(alertId), json);
+        LoadAlert loadAlert = loadAlertRequestConverter.convert(json);
+        return createLoadAlertResponse(alertService.updateLoadAlert(clusterId, alertId, loadAlert));
     }
 
     @Override
-    public List<PrometheusAlertResponse> getPrometheusAlerts(Long clusterId) {
-        return alertService.getPrometheusAlerts(clusterId).stream()
-                .map(this::createPrometheusAlertResponse).collect(Collectors.toList());
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.DATAHUB_READ)
+    public List<LoadAlertResponse> getLoadAlerts(Long clusterId) {
+        return getClusterForWorkspace(clusterId).getLoadAlerts().stream()
+                .map(this::createLoadAlertResponse).collect(Collectors.toList());
     }
 
     @Override
-    public void deletePrometheusAlarm(Long clusterId, Long alertId) {
-        alertService.deletePrometheusAlert(clusterId, alertId);
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.DATAHUB_WRITE)
+    public void deleteLoadAlert(Long clusterId, Long alertId) {
+        validateAlertForUpdate(getClusterForWorkspace(clusterId), alertId, AlertType.LOAD);
+        alertService.deleteLoadAlert(clusterId, alertId);
     }
 
-    @Override
-    public List<AlertRuleDefinitionEntry> getPrometheusDefinitions(Long clusterId) {
-        return alertService.getPrometheusAlertDefinitions();
+    public void createLoadAlerts(Long clusterId, List<LoadAlertRequest> loadAlerts) {
+        for (LoadAlertRequest loadAlert : loadAlerts) {
+            createLoadAlert(clusterId, loadAlert);
+        }
     }
 
-    private TimeAlert validateTimeAlert(TimeAlertRequest json) throws ParseException {
-        TimeAlert alert = timeAlertRequestConverter.convert(json);
-        dateService.getCronExpression(alert.getCron());
-        return alert;
+    public void createTimeAlerts(Long clusterId, List<TimeAlertRequest> timeAlerts) {
+        for (TimeAlertRequest timeAlert : timeAlerts) {
+            createTimeAlert(clusterId, timeAlert);
+        }
     }
 
-    private List<MetricAlertResponse> createAlarmsResponse(Set<MetricAlert> alerts) {
-        List<MetricAlert> metricAlerts = new ArrayList<>(alerts);
-        return metricAlertResponseConverter.convertAllToJson(metricAlerts);
+    public void validateLoadAlertRequests(Long clusterId, List<LoadAlertRequest> loadAlertRequests) {
+        for (LoadAlertRequest loadAlertRequest : loadAlertRequests) {
+            validateLoadAlert(clusterId, Optional.empty(), loadAlertRequest);
+        }
+    }
+
+    public void validateTimeAlertRequests(Long clusterId, List<TimeAlertRequest> timeAlertRequests) {
+        for (TimeAlertRequest timeAlertRequest : timeAlertRequests) {
+            validateTimeAlert(clusterId, Optional.empty(), timeAlertRequest);
+        }
+    }
+
+    private Cluster getClusterForWorkspace(Long clusterId) {
+        return clusterService.findOneByClusterIdAndWorkspaceId(clusterId, restRequestThreadLocalService.getRequestedWorkspaceId())
+                .orElseThrow(NotFoundException.notFound("cluster", clusterId));
+    }
+
+    private void validateCloudPlatform(Cluster cluster) {
+        if (!supportedCloudPlatforms.contains(cluster.getCloudPlatform())) {
+            throw new BadRequestException(String.format("Autoscaling for CloudPlatform '%s' is not supported, Cluster '%s'",
+                    cluster.getCloudPlatform(), cluster.getStackCrn()));
+        }
+    }
+
+    private void validateTimeAlert(Long clusterId, Optional<Long> alertId, TimeAlertRequest json) {
+        Cluster cluster = getClusterForWorkspace(clusterId);
+        alertId.ifPresentOrElse(updateAlert -> validateAlertForUpdate(cluster, updateAlert, AlertType.TIME),
+                () -> validateCloudPlatform(cluster));
+        try {
+            dateService.validateTimeZone(json.getTimeZone());
+            dateService.getCronExpression(json.getCron());
+        } catch (ParseException parseException) {
+            throw new BadRequestException(parseException.getMessage(), parseException);
+        }
+    }
+
+    private void validateLoadAlert(Long clusterId, Optional<Long> alertId, LoadAlertRequest json) {
+        Cluster cluster = getClusterForWorkspace(clusterId);
+        alertId.ifPresentOrElse(updateAlert -> validateAlertForUpdate(cluster, updateAlert, AlertType.LOAD),
+                () -> {
+                    validateCloudPlatform(cluster);
+                    String requestHostGroup = json.getScalingPolicy().getHostGroup();
+                    cluster.getLoadAlerts().stream().map(LoadAlert::getScalingPolicy).map(ScalingPolicy::getHostGroup)
+                            .filter(hostGroup -> hostGroup.equalsIgnoreCase(requestHostGroup)).findAny()
+                            .ifPresent(hostGroup -> {
+                                throw new BadRequestException(String.format("LoadAlert is already defined for Cluster '%s', HostGroup '%s'",
+                                        cluster.getStackCrn(), requestHostGroup));
+                            });
+                    clusterProxyConfigurationService.getClusterProxyUrl()
+                            .orElseThrow(() ->  new BadRequestException(String.format("ClusterProxy Not Configured for Cluster '{}', " +
+                                    " Load Alert cannot be configured.", cluster.getStackCrn())));
+                });
+    }
+
+    private void validateAlertForUpdate(Cluster cluster, Long alertId, AlertType alertType) {
+        Optional alert;
+        switch (alertType) {
+            case LOAD:
+                alert = cluster.getLoadAlerts().stream().map(LoadAlert::getId)
+                        .filter(loadAlertId -> loadAlertId.equals(alertId))
+                        .findAny();
+                break;
+            case TIME:
+                alert = cluster.getTimeAlerts().stream().map(TimeAlert::getId)
+                        .filter(timeAlertId -> timeAlertId.equals(alertId))
+                        .findAny();
+                break;
+
+            default:
+                //Prometheus and Metrics Alerts not supported.
+                throw new BadRequestException(String.format("Unsupported AlertType '%s'", alertType));
+        }
+
+        if (alert.isEmpty()) {
+            throw new NotFoundException(
+                    String.format("Could not find '%s' alert with id: '%s', for cluster: '%s'", alertType, alertId, cluster.getStackCrn()));
+        }
     }
 
     private List<TimeAlertResponse> createTimeAlertsResponse(Set<TimeAlert> alarms) {
-        List<TimeAlert> metricAlarms = new ArrayList<>(alarms);
-        return createTimeAlertsResponse(metricAlarms);
-    }
-
-    private MetricAlertResponse createMetricAlarmResponse(MetricAlert alert) {
-        return metricAlertResponseConverter.convert(alert);
+        List<TimeAlert> timeAlerts = new ArrayList<>(alarms);
+        return createTimeAlertsResponse(timeAlerts);
     }
 
     private TimeAlertResponse createTimeAlertResponse(TimeAlert alarm) {
@@ -166,7 +245,12 @@ public class AlertController implements AlertEndpoint {
         return timeAlertResponseConverter.convertAllToJson(alarms);
     }
 
-    private PrometheusAlertResponse createPrometheusAlertResponse(PrometheusAlert alarm) {
-        return prometheusAlertResponseConverter.convert(alarm);
+    private LoadAlertResponse createLoadAlertResponse(LoadAlert loadAlert) {
+        return loadAlertResponseConverter.convert(loadAlert);
+    }
+
+    @VisibleForTesting
+    protected void setDateService(DateService dateService) {
+        this.dateService = dateService;
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/controller/AutoScaleClusterCommonService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/controller/AutoScaleClusterCommonService.java
@@ -7,26 +7,25 @@ import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.periscope.api.model.AutoscaleClusterResponse;
 import com.sequenceiq.periscope.api.model.AutoscaleClusterState;
 import com.sequenceiq.periscope.api.model.ScalingStatus;
 import com.sequenceiq.periscope.api.model.StateJson;
-import com.sequenceiq.periscope.converter.ClusterConverter;
 import com.sequenceiq.periscope.domain.Cluster;
 import com.sequenceiq.periscope.domain.History;
+import com.sequenceiq.periscope.model.NameOrCrn;
 import com.sequenceiq.periscope.notification.HttpNotificationSender;
 import com.sequenceiq.periscope.service.AutoscaleRestRequestThreadLocalService;
 import com.sequenceiq.periscope.service.ClusterService;
 import com.sequenceiq.periscope.service.HistoryService;
+import com.sequenceiq.periscope.service.NotFoundException;
 
 @Component
 public class AutoScaleClusterCommonService {
     private static final Logger LOGGER = LoggerFactory.getLogger(AutoScaleClusterCommonService.class);
-
-    @Inject
-    private ClusterConverter clusterConverter;
 
     @Inject
     private ClusterService clusterService;
@@ -40,33 +39,54 @@ public class AutoScaleClusterCommonService {
     @Inject
     private AutoscaleRestRequestThreadLocalService restRequestThreadLocalService;
 
-    public List<AutoscaleClusterResponse> getClusters() {
-        List<Cluster> clusters = clusterService.findAllByUser(restRequestThreadLocalService.getCloudbreakUser());
-        return clusterConverter.convertAllToJson(clusters);
+    public List<Cluster> getClusters() {
+        return clusterService.findAllByUser(restRequestThreadLocalService.getCloudbreakUser());
     }
 
-    public AutoscaleClusterResponse getCluster(Long clusterId) {
-        return createClusterJsonResponse(clusterService.findById(clusterId));
+    public List<Cluster> getDistroXClusters() {
+        return clusterService.findDistroXByWorkspace(restRequestThreadLocalService.getRequestedWorkspaceId());
+    }
+
+    public Cluster getCluster(Long clusterId) {
+        return clusterService.findById(clusterId);
+    }
+
+    @Retryable(value = NotFoundException.class, maxAttempts = 10, backoff = @Backoff(delay = 5000))
+    public Cluster getClusterByStackCrn(String stackCrn) {
+        return getClusterByCrnOrName(NameOrCrn.ofCrn(stackCrn));
+    }
+
+    @Retryable(value = NotFoundException.class, maxAttempts = 10, backoff = @Backoff(delay = 5000))
+    public Cluster getClusterByStackName(String stackName) {
+        return getClusterByCrnOrName(NameOrCrn.ofName(stackName));
+    }
+
+    protected Cluster getClusterByCrnOrName(NameOrCrn nameOrCrn) {
+        return nameOrCrn.hasName() ?
+                clusterService.findOneByStackNameAndWorkspaceId(nameOrCrn.getName(), restRequestThreadLocalService.getRequestedWorkspaceId())
+                        .orElseThrow(NotFoundException.notFound("cluster", nameOrCrn.getName())) :
+                clusterService.findOneByStackCrnAndWorkspaceId(nameOrCrn.getCrn(), restRequestThreadLocalService.getRequestedWorkspaceId())
+                        .orElseThrow(NotFoundException.notFound("cluster", nameOrCrn.getCrn()));
     }
 
     public void deleteCluster(Long clusterId) {
         clusterService.removeById(clusterId);
     }
 
-    public AutoscaleClusterResponse setState(Long clusterId, StateJson stateJson) {
+    public Cluster setState(Long clusterId, StateJson stateJson) {
         Cluster cluster = clusterService.setState(clusterId, stateJson.getState());
         createHistoryAndNotification(cluster);
-        return createClusterJsonResponse(cluster);
+        return cluster;
     }
 
-    public AutoscaleClusterResponse setAutoscaleState(Long clusterId, AutoscaleClusterState autoscaleState) {
-        Cluster cluster = clusterService.setAutoscaleState(clusterId, autoscaleState.isEnableAutoscaling());
+    public Cluster setAutoscaleState(Long clusterId, AutoscaleClusterState autoscaleState) {
+        return setAutoscaleState(clusterId, autoscaleState.isEnableAutoscaling());
+    }
+
+    public Cluster setAutoscaleState(Long clusterId, Boolean enableAutoScaling) {
+        Cluster cluster = clusterService.setAutoscaleState(clusterId, enableAutoScaling);
         createHistoryAndNotification(cluster);
-        return createClusterJsonResponse(cluster);
-    }
-
-    private AutoscaleClusterResponse createClusterJsonResponse(Cluster cluster) {
-        return clusterConverter.convert(cluster);
+        return cluster;
     }
 
     private void createHistoryAndNotification(Cluster cluster) {
@@ -75,5 +95,15 @@ public class AutoScaleClusterCommonService {
                 ? historyService.createEntry(ScalingStatus.ENABLED, "Autoscaling has been enabled for the cluster.", 0, cluster)
                 : historyService.createEntry(ScalingStatus.DISABLED, "Autoscaling has been disabled for the cluster.", 0, cluster);
         notificationSender.send(cluster, history);
+    }
+
+    public void deleteAlertsForClusterCrn(String stackCrn) {
+        Cluster cluster = getClusterByCrnOrName(NameOrCrn.ofCrn(stackCrn));
+        clusterService.deleteAlertsForCluster(cluster.getId());
+    }
+
+    public void deleteAlertsForClusterName(String stackName) {
+        Cluster cluster = getClusterByCrnOrName(NameOrCrn.ofName(stackName));
+        clusterService.deleteAlertsForCluster(cluster.getId());
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/controller/AutoScaleClusterV1Controller.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/controller/AutoScaleClusterV1Controller.java
@@ -10,6 +10,8 @@ import com.sequenceiq.periscope.api.endpoint.v1.AutoScaleClusterV1Endpoint;
 import com.sequenceiq.periscope.api.model.AutoscaleClusterResponse;
 import com.sequenceiq.periscope.api.model.AutoscaleClusterState;
 import com.sequenceiq.periscope.api.model.StateJson;
+import com.sequenceiq.periscope.converter.ClusterConverter;
+import com.sequenceiq.periscope.domain.Cluster;
 
 @Component
 public class AutoScaleClusterV1Controller implements AutoScaleClusterV1Endpoint {
@@ -17,14 +19,17 @@ public class AutoScaleClusterV1Controller implements AutoScaleClusterV1Endpoint 
     @Inject
     private AutoScaleClusterCommonService autoScaleClusterCommonService;
 
+    @Inject
+    private ClusterConverter clusterConverter;
+
     @Override
     public List<AutoscaleClusterResponse> getClusters() {
-        return autoScaleClusterCommonService.getClusters();
+        return clusterConverter.convertAllToJson(autoScaleClusterCommonService.getClusters());
     }
 
     @Override
     public AutoscaleClusterResponse getCluster(Long clusterId) {
-        return autoScaleClusterCommonService.getCluster(clusterId);
+        return createClusterJsonResponse(autoScaleClusterCommonService.getCluster(clusterId));
     }
 
     @Override
@@ -34,11 +39,16 @@ public class AutoScaleClusterV1Controller implements AutoScaleClusterV1Endpoint 
 
     @Override
     public AutoscaleClusterResponse setState(Long clusterId, StateJson stateJson) {
-        return autoScaleClusterCommonService.setState(clusterId, stateJson);
+        return createClusterJsonResponse(autoScaleClusterCommonService.setState(clusterId, stateJson));
     }
 
     @Override
     public AutoscaleClusterResponse setAutoscaleState(Long clusterId, AutoscaleClusterState autoscaleState) {
-        return autoScaleClusterCommonService.setAutoscaleState(clusterId, autoscaleState);
+        return createClusterJsonResponse(autoScaleClusterCommonService.setAutoscaleState(clusterId, autoscaleState));
     }
+
+    private AutoscaleClusterResponse createClusterJsonResponse(Cluster cluster) {
+        return clusterConverter.convert(cluster);
+    }
+
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/controller/AutoScaleClusterV2Controller.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/controller/AutoScaleClusterV2Controller.java
@@ -10,6 +10,7 @@ import com.sequenceiq.periscope.api.endpoint.v2.AutoScaleClusterV2Endpoint;
 import com.sequenceiq.periscope.api.model.AutoscaleClusterResponse;
 import com.sequenceiq.periscope.api.model.AutoscaleClusterState;
 import com.sequenceiq.periscope.api.model.StateJson;
+import com.sequenceiq.periscope.converter.ClusterConverter;
 import com.sequenceiq.periscope.domain.Cluster;
 import com.sequenceiq.periscope.service.ClusterService;
 
@@ -24,10 +25,14 @@ public class AutoScaleClusterV2Controller implements AutoScaleClusterV2Endpoint 
     @Inject
     private ClusterService clusterService;
 
+    @Inject
+    private ClusterConverter clusterConverter;
+
     @Override
     public AutoscaleClusterResponse getByCloudbreakCluster(Long stackId) {
         Cluster cluster = clusterService.findOneByStackId(stackId);
-        return autoScaleClusterCommonService.getCluster(cluster.getId());
+        return createClusterJsonResponse(
+                autoScaleClusterCommonService.getCluster(cluster.getId()));
     }
 
     @Override
@@ -39,25 +44,33 @@ public class AutoScaleClusterV2Controller implements AutoScaleClusterV2Endpoint 
     @Override
     public AutoscaleClusterResponse runByCloudbreakCluster(Long stackId) {
         Cluster cluster = clusterService.findOneByStackId(stackId);
-        return autoScaleClusterCommonService.setState(cluster.getId(), StateJson.running());
+        return createClusterJsonResponse(
+                autoScaleClusterCommonService.setState(cluster.getId(), StateJson.running()));
     }
 
     @Override
     public AutoscaleClusterResponse suspendByCloudbreakCluster(Long stackId) {
         Cluster cluster = clusterService.findOneByStackId(stackId);
-        return autoScaleClusterCommonService.setState(cluster.getId(), StateJson.suspended());
+        return createClusterJsonResponse(
+                autoScaleClusterCommonService.setState(cluster.getId(), StateJson.suspended()));
     }
 
     @Override
     public AutoscaleClusterResponse enableAutoscaleStateByCloudbreakCluster(Long stackId) {
         Cluster cluster = clusterService.findOneByStackId(stackId);
-        return autoScaleClusterCommonService.setAutoscaleState(cluster.getId(), AutoscaleClusterState.enable());
+        return createClusterJsonResponse(
+                autoScaleClusterCommonService.setAutoscaleState(cluster.getId(), AutoscaleClusterState.enable()));
     }
 
     @Override
     public AutoscaleClusterResponse disableAutoscaleStateByCloudbreakCluster(Long stackId) {
         Cluster cluster = clusterService.findOneByStackId(stackId);
-        return autoScaleClusterCommonService.setAutoscaleState(cluster.getId(), AutoscaleClusterState.disable());
+        return createClusterJsonResponse(
+                autoScaleClusterCommonService.setAutoscaleState(cluster.getId(), AutoscaleClusterState.disable()));
+    }
+
+    private AutoscaleClusterResponse createClusterJsonResponse(Cluster cluster) {
+        return clusterConverter.convert(cluster);
     }
 
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/controller/DistroXAutoScaleClusterV1Controller.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/controller/DistroXAutoScaleClusterV1Controller.java
@@ -1,0 +1,128 @@
+package com.sequenceiq.periscope.controller;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Controller;
+
+import com.sequenceiq.authorization.annotation.AuthorizationResource;
+import com.sequenceiq.authorization.annotation.CheckPermissionByAccount;
+import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
+import com.sequenceiq.cloudbreak.common.service.TransactionService;
+import com.sequenceiq.periscope.api.endpoint.v1.DistroXAutoScaleClusterV1Endpoint;
+import com.sequenceiq.periscope.api.model.AutoscaleClusterState;
+import com.sequenceiq.periscope.api.model.DistroXAutoscaleClusterRequest;
+import com.sequenceiq.periscope.api.model.DistroXAutoscaleClusterResponse;
+import com.sequenceiq.periscope.converter.DistroXAutoscaleClusterResponseConverter;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.service.ClusterService;
+
+@Controller
+@AuthorizationResource
+public class DistroXAutoScaleClusterV1Controller implements DistroXAutoScaleClusterV1Endpoint {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DistroXAutoScaleClusterV1Controller.class);
+
+    @Inject
+    private AutoScaleClusterCommonService asClusterCommonService;
+
+    @Inject
+    private ClusterService clusterService;
+
+    @Inject
+    private AlertController alertController;
+
+    @Inject
+    private TransactionService transactionService;
+
+    @Inject
+    private DistroXAutoscaleClusterResponseConverter distroXAutoscaleClusterResponseConverter;
+
+    @Override
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.DATAHUB_READ)
+    public List<DistroXAutoscaleClusterResponse> getClusters() {
+        return distroXAutoscaleClusterResponseConverter.convertAllToJson(asClusterCommonService.getDistroXClusters());
+    }
+
+    @Override
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.DATAHUB_READ)
+    public DistroXAutoscaleClusterResponse getClusterByCrn(String clusterCrn) {
+        return createClusterJsonResponse(
+                asClusterCommonService.getClusterByStackCrn(clusterCrn));
+    }
+
+    @Override
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.DATAHUB_READ)
+    public DistroXAutoscaleClusterResponse getClusterByName(String clusterName) {
+        return createClusterJsonResponse(
+                asClusterCommonService.getClusterByStackName(clusterName));
+    }
+
+    @Override
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.DATAHUB_WRITE)
+    public DistroXAutoscaleClusterResponse enableAutoscaleForClusterCrn(String clusterCrn, AutoscaleClusterState autoscaleState) {
+        Cluster cluster = asClusterCommonService.getClusterByStackCrn(clusterCrn);
+        return createClusterJsonResponse(asClusterCommonService.setAutoscaleState(cluster.getId(), autoscaleState));
+    }
+
+    @Override
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.DATAHUB_WRITE)
+    public DistroXAutoscaleClusterResponse enableAutoscaleForClusterName(String clusterName, AutoscaleClusterState autoscaleState) {
+        Cluster cluster = asClusterCommonService.getClusterByStackName(clusterName);
+        return createClusterJsonResponse(asClusterCommonService.setAutoscaleState(cluster.getId(), autoscaleState));
+    }
+
+    @Override
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.DATAHUB_WRITE)
+    public void deleteAlertsForClusterName(String clusterName) {
+        asClusterCommonService.deleteAlertsForClusterName(clusterName);
+    }
+
+    @Override
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.DATAHUB_WRITE)
+    public void deleteAlertsForClusterCrn(String clusterCrn) {
+        asClusterCommonService.deleteAlertsForClusterCrn(clusterCrn);
+    }
+
+    @Override
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.DATAHUB_WRITE)
+    public DistroXAutoscaleClusterResponse updateAutoscaleConfigByClusterCrn(String clusterCrn,
+            DistroXAutoscaleClusterRequest autoscaleClusterRequest) {
+        Cluster cluster = asClusterCommonService.getClusterByStackCrn(clusterCrn);
+        return updateClusterAutoScaleConfig(cluster.getId(), autoscaleClusterRequest);
+    }
+
+    @Override
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.DATAHUB_WRITE)
+    public DistroXAutoscaleClusterResponse updateAutoscaleConfigByClusterName(String clusterName,
+            DistroXAutoscaleClusterRequest autoscaleClusterRequest) {
+        Cluster cluster = asClusterCommonService.getClusterByStackName(clusterName);
+        return updateClusterAutoScaleConfig(cluster.getId(), autoscaleClusterRequest);
+    }
+
+    private DistroXAutoscaleClusterResponse createClusterJsonResponse(Cluster cluster) {
+        return distroXAutoscaleClusterResponseConverter.convert(cluster);
+    }
+
+    private DistroXAutoscaleClusterResponse updateClusterAutoScaleConfig(Long clusterId,
+            DistroXAutoscaleClusterRequest autoscaleClusterRequest) {
+
+        try {
+            transactionService.required(() -> {
+                clusterService.deleteAlertsForCluster(clusterId);
+                alertController.validateLoadAlertRequests(clusterId, autoscaleClusterRequest.getLoadAlertRequests());
+                alertController.validateTimeAlertRequests(clusterId, autoscaleClusterRequest.getTimeAlertRequests());
+                alertController.createLoadAlerts(clusterId, autoscaleClusterRequest.getLoadAlertRequests());
+                alertController.createTimeAlerts(clusterId, autoscaleClusterRequest.getTimeAlertRequests());
+                clusterService.setAutoscaleState(clusterId, autoscaleClusterRequest.getEnableAutoscaling());
+            });
+        } catch (TransactionService.TransactionExecutionException e) {
+            throw e.getCause();
+        }
+
+        return createClusterJsonResponse(clusterService.findById(clusterId));
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/controller/EndpointConfig.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/controller/EndpointConfig.java
@@ -89,6 +89,7 @@ public class EndpointConfig extends ResourceConfig {
 
     private void registerEndpoints() {
         register(AlertController.class);
+        register(DistroXAutoScaleClusterV1Controller.class);
 
         register(io.swagger.jaxrs.listing.ApiListingResource.class);
         register(io.swagger.jaxrs.listing.SwaggerSerializers.class);

--- a/autoscale/src/main/java/com/sequenceiq/periscope/controller/EndpointConfig.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/controller/EndpointConfig.java
@@ -88,7 +88,6 @@ public class EndpointConfig extends ResourceConfig {
     }
 
     private void registerEndpoints() {
-        register(AlertController.class);
         register(DistroXAutoScaleClusterV1Controller.class);
 
         register(io.swagger.jaxrs.listing.ApiListingResource.class);

--- a/autoscale/src/main/java/com/sequenceiq/periscope/converter/ClusterConverter.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/converter/ClusterConverter.java
@@ -7,13 +7,14 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.service.secret.service.SecretService;
 import com.sequenceiq.periscope.api.model.AutoscaleClusterResponse;
+import com.sequenceiq.periscope.api.model.LoadAlertResponse;
 import com.sequenceiq.periscope.api.model.MetricAlertResponse;
 import com.sequenceiq.periscope.api.model.PrometheusAlertResponse;
 import com.sequenceiq.periscope.api.model.ScalingConfigurationRequest;
 import com.sequenceiq.periscope.api.model.TimeAlertResponse;
 import com.sequenceiq.periscope.domain.Cluster;
-import com.sequenceiq.cloudbreak.service.secret.service.SecretService;
 
 @Component
 public class ClusterConverter extends AbstractConverter<AutoscaleClusterResponse, Cluster> {
@@ -26,6 +27,9 @@ public class ClusterConverter extends AbstractConverter<AutoscaleClusterResponse
 
     @Inject
     private PrometheusAlertResponseConverter prometheusAlertResponseConverter;
+
+    @Inject
+    private LoadAlertResponseConverter loadAlertResponseConverter;
 
     @Inject
     private SecretService secretService;
@@ -59,6 +63,11 @@ public class ClusterConverter extends AbstractConverter<AutoscaleClusterResponse
             json.setPrometheusAlerts(prometheusAlertRequests);
         }
 
+        if (!source.getLoadAlerts().isEmpty()) {
+            List<LoadAlertResponse> loadAlertRequests =
+                    loadAlertResponseConverter.convertAllToJson(new ArrayList<>(source.getLoadAlerts()));
+            json.setLoadAlerts(loadAlertRequests);
+        }
         ScalingConfigurationRequest scalingConfig = new ScalingConfigurationRequest(source.getMinSize(), source.getMaxSize(), source.getCoolDown());
         json.setScalingConfiguration(scalingConfig);
 

--- a/autoscale/src/main/java/com/sequenceiq/periscope/converter/DistroXAutoscaleClusterResponseConverter.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/converter/DistroXAutoscaleClusterResponseConverter.java
@@ -1,0 +1,45 @@
+package com.sequenceiq.periscope.converter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.periscope.api.model.DistroXAutoscaleClusterResponse;
+import com.sequenceiq.periscope.api.model.LoadAlertResponse;
+import com.sequenceiq.periscope.api.model.TimeAlertResponse;
+import com.sequenceiq.periscope.domain.Cluster;
+
+@Component
+public class DistroXAutoscaleClusterResponseConverter extends AbstractConverter<DistroXAutoscaleClusterResponse, Cluster> {
+
+    @Inject
+    private TimeAlertResponseConverter timeAlertResponseConverter;
+
+    @Inject
+    private LoadAlertResponseConverter loadAlertResponseConverter;
+
+    @Override
+    public DistroXAutoscaleClusterResponse convert(Cluster source) {
+        DistroXAutoscaleClusterResponse json = new DistroXAutoscaleClusterResponse(
+                source.getStackCrn(),
+                source.getStackName(),
+                source.isAutoscalingEnabled(),
+                source.getId(),
+                source.getState());
+
+        json.setStackType(source.getStackType());
+
+        List<TimeAlertResponse> timeAlertRequests =
+                timeAlertResponseConverter.convertAllToJson(new ArrayList<>(source.getTimeAlerts()));
+        json.setTimeAlerts(timeAlertRequests);
+
+        List<LoadAlertResponse> loadAlertRequests =
+                loadAlertResponseConverter.convertAllToJson(new ArrayList<>(source.getLoadAlerts()));
+        json.setLoadAlerts(loadAlertRequests);
+
+        return json;
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/converter/LoadAlertConfigurationRequestConverter.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/converter/LoadAlertConfigurationRequestConverter.java
@@ -1,0 +1,19 @@
+package com.sequenceiq.periscope.converter;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.periscope.api.model.LoadAlertConfigurationRequest;
+import com.sequenceiq.periscope.domain.LoadAlertConfiguration;
+
+@Component
+public class LoadAlertConfigurationRequestConverter extends AbstractConverter<LoadAlertConfigurationRequest, LoadAlertConfiguration> {
+
+    @Override
+    public LoadAlertConfiguration convert(LoadAlertConfigurationRequest source) {
+        LoadAlertConfiguration loadAlertConfiguration = new LoadAlertConfiguration();
+        loadAlertConfiguration.setMaxResourceValue(source.getMaxResourceValue());
+        loadAlertConfiguration.setMinResourceValue(source.getMinResourceValue());
+        loadAlertConfiguration.setCoolDownMinutes(source.getCoolDownMinutes());
+        return loadAlertConfiguration;
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/converter/LoadAlertConfigurationResponseConverter.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/converter/LoadAlertConfigurationResponseConverter.java
@@ -1,0 +1,19 @@
+package com.sequenceiq.periscope.converter;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.periscope.api.model.LoadAlertConfigurationResponse;
+import com.sequenceiq.periscope.domain.LoadAlertConfiguration;
+
+@Component
+public class LoadAlertConfigurationResponseConverter extends AbstractConverter<LoadAlertConfigurationResponse, LoadAlertConfiguration> {
+
+    @Override
+    public LoadAlertConfigurationResponse convert(LoadAlertConfiguration source) {
+        LoadAlertConfigurationResponse json = new LoadAlertConfigurationResponse();
+        json.setMaxResourceValue(source.getMaxResourceValue());
+        json.setMinResourceValue(source.getMinResourceValue());
+        json.setCoolDownMinutes(source.getCoolDownMinutes());
+        return json;
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/converter/LoadAlertRequestConverter.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/converter/LoadAlertRequestConverter.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.periscope.converter;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.periscope.api.model.LoadAlertRequest;
+import com.sequenceiq.periscope.domain.LoadAlert;
+
+@Component
+public class LoadAlertRequestConverter extends AbstractConverter<LoadAlertRequest, LoadAlert> {
+
+    @Inject
+    private ScalingPolicyRequestConverter scalingPolicyRequestConverter;
+
+    @Inject
+    private LoadAlertConfigurationRequestConverter loadAlertConfigurationRequestConverter;
+
+    @Override
+    public LoadAlert convert(LoadAlertRequest source) {
+        LoadAlert alert = new LoadAlert();
+        alert.setName(source.getAlertName());
+        alert.setDescription(source.getDescription());
+
+        if (source.getScalingPolicy() != null) {
+            alert.setScalingPolicy(scalingPolicyRequestConverter.convert(source.getScalingPolicy()));
+        }
+
+        if (source.getLoadAlertConfiguration() != null) {
+            alert.setLoadAlertConfiguration(
+                    loadAlertConfigurationRequestConverter.convert(source.getLoadAlertConfiguration()));
+        }
+        return alert;
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/converter/LoadAlertResponseConverter.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/converter/LoadAlertResponseConverter.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.periscope.converter;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.periscope.api.model.LoadAlertResponse;
+import com.sequenceiq.periscope.domain.LoadAlert;
+
+@Component
+public class LoadAlertResponseConverter extends AbstractConverter<LoadAlertResponse, LoadAlert> {
+
+    @Inject
+    private ScalingPolicyResponseConverter scalingPolicyResponseConverter;
+
+    @Inject
+    private LoadAlertConfigurationResponseConverter loadAlertConfigurationResponseConverter;
+
+    @Override
+    public LoadAlertResponse convert(LoadAlert source) {
+        LoadAlertResponse json = new LoadAlertResponse();
+        json.setId(source.getId());
+        json.setAlertName(source.getName());
+        json.setDescription(source.getDescription());
+        if (source.getLoadAlertConfiguration() != null) {
+            json.setLoadAlertConfiguration(
+                    loadAlertConfigurationResponseConverter.convert(source.getLoadAlertConfiguration()));
+        }
+        if (source.getScalingPolicy() != null) {
+            json.setScalingPolicy(scalingPolicyResponseConverter.convert(source.getScalingPolicy()));
+        }
+        return json;
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/converter/TimeAlertRequestConverter.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/converter/TimeAlertRequestConverter.java
@@ -38,5 +38,4 @@ public class TimeAlertRequestConverter extends AbstractConverter<TimeAlertReques
         }
         return json;
     }
-
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/converter/TimeAlertResponseConverter.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/converter/TimeAlertResponseConverter.java
@@ -11,20 +11,7 @@ import com.sequenceiq.periscope.domain.TimeAlert;
 public class TimeAlertResponseConverter extends AbstractConverter<TimeAlertResponse, TimeAlert> {
 
     @Inject
-    private ScalingPolicyRequestConverter scalingPolicyRequestConverter;
-
-    @Override
-    public TimeAlert convert(TimeAlertResponse source) {
-        TimeAlert alarm = new TimeAlert();
-        alarm.setName(source.getAlertName());
-        alarm.setDescription(source.getDescription());
-        alarm.setCron(source.getCron());
-        alarm.setTimeZone(source.getTimeZone());
-        if (source.getScalingPolicy() != null) {
-            alarm.setScalingPolicy(scalingPolicyRequestConverter.convert(source.getScalingPolicy()));
-        }
-        return alarm;
-    }
+    private ScalingPolicyResponseConverter scalingPolicyResponseConverter;
 
     @Override
     public TimeAlertResponse convert(TimeAlert source) {
@@ -34,9 +21,8 @@ public class TimeAlertResponseConverter extends AbstractConverter<TimeAlertRespo
         json.setCron(source.getCron());
         json.setTimeZone(source.getTimeZone());
         json.setDescription(source.getDescription());
-        json.setScalingPolicyId(source.getScalingPolicyId());
         if (source.getScalingPolicy() != null) {
-            json.setScalingPolicy(scalingPolicyRequestConverter.convert(source.getScalingPolicy()));
+            json.setScalingPolicy(scalingPolicyResponseConverter.convert(source.getScalingPolicy()));
         }
         return json;
     }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/converter/db/LoadAlertConfigAttributeConverter.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/converter/db/LoadAlertConfigAttributeConverter.java
@@ -1,0 +1,36 @@
+package com.sequenceiq.periscope.converter.db;
+
+import javax.persistence.AttributeConverter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sequenceiq.periscope.domain.LoadAlertConfiguration;
+
+public class LoadAlertConfigAttributeConverter implements AttributeConverter<LoadAlertConfiguration, String> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(LoadAlertConfigAttributeConverter.class);
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(LoadAlertConfiguration loadAlertConfiguration) {
+        try {
+            return objectMapper.writeValueAsString(loadAlertConfiguration);
+        } catch (Exception ex) {
+            LOGGER.error("Error generating Load Alert Configuration Json", ex);
+        }
+        return null;
+    }
+
+    @Override
+    public LoadAlertConfiguration convertToEntityAttribute(String dbConfig) {
+        LoadAlertConfiguration loadAlertConfiguration = null;
+        try {
+            loadAlertConfiguration = objectMapper.readValue(dbConfig, LoadAlertConfiguration.class);
+        } catch (Exception ex) {
+            LOGGER.error("Error Read Load Alert Configuration", ex);
+        }
+        return loadAlertConfiguration;
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/converter/db/StackTypeAttributeConverter.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/converter/db/StackTypeAttributeConverter.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.periscope.converter.db;
+
+import javax.persistence.AttributeConverter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+
+public class StackTypeAttributeConverter implements AttributeConverter<StackType, String> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(StackTypeAttributeConverter.class);
+
+    @Override
+    public String convertToDatabaseColumn(StackType attribute) {
+        return attribute.name();
+    }
+
+    @Override
+    public StackType convertToEntityAttribute(String dbData) {
+        try {
+            return StackType.valueOf(dbData);
+        } catch (Exception e) {
+            LOGGER.info("The StackType value is not backward compatible: {}", dbData);
+        }
+        return StackType.DATALAKE;
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/domain/BaseAlert.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/domain/BaseAlert.java
@@ -75,5 +75,4 @@ public abstract class BaseAlert implements Clustered {
     public void setCluster(Cluster cluster) {
         this.cluster = cluster;
     }
-
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/domain/Cluster.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/domain/Cluster.java
@@ -18,20 +18,17 @@ import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.SequenceGenerator;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.converter.TunnelConverter;
 import com.sequenceiq.common.api.type.Tunnel;
 import com.sequenceiq.periscope.api.model.ClusterState;
+import com.sequenceiq.periscope.converter.db.StackTypeAttributeConverter;
 import com.sequenceiq.periscope.model.MonitoredStack;
 import com.sequenceiq.periscope.monitor.Monitored;
+import com.sequenceiq.periscope.monitor.evaluator.ScalingConstants;
 
 @Entity
 public class Cluster implements Monitored, Clustered {
-
-    private static final int DEFAULT_MIN_SIZE = 2;
-
-    private static final int DEFAULT_MAX_SIZE = 100;
-
-    private static final int DEFAULT_COOLDOWN = 30;
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO, generator = "cluster_generator")
@@ -51,32 +48,45 @@ public class Cluster implements Monitored, Clustered {
     @Enumerated(EnumType.STRING)
     private ClusterState state = ClusterState.PENDING;
 
-    @OneToMany(mappedBy = "cluster", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "cluster", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private Set<MetricAlert> metricAlerts = new HashSet<>();
 
     @OneToMany(mappedBy = "cluster", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     private Set<TimeAlert> timeAlerts = new HashSet<>();
 
     @OneToMany(mappedBy = "cluster", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    private Set<LoadAlert> loadAlerts = new HashSet<>();
+
+    @OneToMany(mappedBy = "cluster", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private Set<PrometheusAlert> prometheusAlerts = new HashSet<>();
 
     @Column(name = "min_size")
-    private int minSize = DEFAULT_MIN_SIZE;
+    private Integer minSize = ScalingConstants.DEFAULT_CLUSTER_MIN_SIZE;
 
     @Column(name = "max_size")
-    private int maxSize = DEFAULT_MAX_SIZE;
+    private Integer maxSize = ScalingConstants.DEFAULT_CLUSTER_MAX_SIZE;
 
     @Column(name = "cooldown")
-    private int coolDown = DEFAULT_COOLDOWN;
+    private Integer coolDown = ScalingConstants.DEFAULT_CLUSTER_COOLDOWN_MINS;
 
     @Column(name = "cb_stack_crn")
     private String stackCrn;
+
+    @Column(name = "cb_stack_name")
+    private String stackName;
+
+    @Column(name = "cloud_platform")
+    private String cloudPlatform;
+
+    @Column(name = "cb_stack_type")
+    @Convert(converter = StackTypeAttributeConverter.class)
+    private StackType stackType = StackType.TEMPLATE;
 
     @Column(name = "last_scaling_activity")
     private volatile long lastScalingActivity;
 
     @Column(name = "autoscaling_enabled")
-    private boolean autoscalingEnabled;
+    private Boolean autoscalingEnabled = false;
 
     private String periscopeNodeId;
 
@@ -177,27 +187,27 @@ public class Cluster implements Monitored, Clustered {
         this.timeAlerts = timeAlerts;
     }
 
-    public int getMinSize() {
+    public Integer getMinSize() {
         return minSize;
     }
 
-    public void setMinSize(int minSize) {
+    public void setMinSize(Integer minSize) {
         this.minSize = minSize;
     }
 
-    public int getMaxSize() {
+    public Integer getMaxSize() {
         return maxSize;
     }
 
-    public void setMaxSize(int maxSize) {
+    public void setMaxSize(Integer maxSize) {
         this.maxSize = maxSize;
     }
 
-    public int getCoolDown() {
+    public Integer getCoolDown() {
         return coolDown;
     }
 
-    public void setCoolDown(int coolDown) {
+    public void setCoolDown(Integer coolDown) {
         this.coolDown = coolDown;
     }
 
@@ -241,6 +251,10 @@ public class Cluster implements Monitored, Clustered {
         timeAlerts.add(alert);
     }
 
+    public void addLoadAlert(LoadAlert alert) {
+        loadAlerts.add(alert);
+    }
+
     public Set<PrometheusAlert> getPrometheusAlerts() {
         return prometheusAlerts;
     }
@@ -253,11 +267,11 @@ public class Cluster implements Monitored, Clustered {
         prometheusAlerts.add(alert);
     }
 
-    public boolean isAutoscalingEnabled() {
+    public Boolean isAutoscalingEnabled() {
         return autoscalingEnabled;
     }
 
-    public void setAutoscalingEnabled(boolean autoscalingEnabled) {
+    public void setAutoscalingEnabled(Boolean autoscalingEnabled) {
         this.autoscalingEnabled = autoscalingEnabled;
     }
 
@@ -271,6 +285,22 @@ public class Cluster implements Monitored, Clustered {
 
     public long getLastEvaluated() {
         return lastEvaluated;
+    }
+
+    public String getStackName() {
+        return stackName;
+    }
+
+    public void setStackName(String stackName) {
+        this.stackName = stackName;
+    }
+
+    public StackType getStackType() {
+        return stackType;
+    }
+
+    public void setStackType(StackType stackType) {
+        this.stackType = stackType;
     }
 
     @Override
@@ -289,6 +319,26 @@ public class Cluster implements Monitored, Clustered {
 
     public void setTunnel(Tunnel tunnel) {
         this.tunnel = tunnel;
+    }
+
+    public Set<LoadAlert> getLoadAlerts() {
+        return loadAlerts;
+    }
+
+    public void setLoadAlerts(Set<LoadAlert> loadAlerts) {
+        this.loadAlerts = loadAlerts;
+    }
+
+    public String getCloudPlatform() {
+        return cloudPlatform;
+    }
+
+    public void setCloudPlatform(String cloudPlatform) {
+        this.cloudPlatform = cloudPlatform;
+    }
+
+    public Boolean getAutoscalingEnabled() {
+        return autoscalingEnabled;
     }
 }
 

--- a/autoscale/src/main/java/com/sequenceiq/periscope/domain/ClusterPertain.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/domain/ClusterPertain.java
@@ -20,13 +20,16 @@ public class ClusterPertain {
 
     private String userId;
 
+    private String userCrn;
+
     public ClusterPertain() {
     }
 
-    public ClusterPertain(String tenant, Long workspaceId, String userId) {
+    public ClusterPertain(String tenant, Long workspaceId, String userId, String userCrn) {
         this.tenant = tenant;
         this.workspaceId = workspaceId;
         this.userId = userId;
+        this.userCrn = userCrn;
     }
 
     public Long getId() {
@@ -59,5 +62,13 @@ public class ClusterPertain {
 
     public void setUserId(String userId) {
         this.userId = userId;
+    }
+
+    public String getUserCrn() {
+        return userCrn;
+    }
+
+    public void setUserCrn(String userCrn) {
+        this.userCrn = userCrn;
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/domain/LoadAlert.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/domain/LoadAlert.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.periscope.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+
+import com.sequenceiq.periscope.converter.db.LoadAlertConfigAttributeConverter;
+
+@Entity
+@DiscriminatorValue("LOAD")
+@NamedQueries({
+        @NamedQuery(name = "LoadAlert.findByCluster", query = "SELECT c FROM LoadAlert c WHERE c.cluster.id= :clusterId AND c.id= :alertId"),
+        @NamedQuery(name = "LoadAlert.findAllByCluster", query = "SELECT c FROM LoadAlert c WHERE c.cluster.id= :clusterId")
+})
+public class LoadAlert extends BaseAlert {
+
+    @ManyToOne
+    private Cluster cluster;
+
+    @Convert(converter = LoadAlertConfigAttributeConverter.class)
+    @Column(name = "load_alert_config")
+    private LoadAlertConfiguration loadAlertConfiguration;
+
+    @Override
+    public Cluster getCluster() {
+        return cluster;
+    }
+
+    public void setCluster(Cluster cluster) {
+        this.cluster = cluster;
+    }
+
+    public LoadAlertConfiguration getLoadAlertConfiguration() {
+        return loadAlertConfiguration;
+    }
+
+    public void setLoadAlertConfiguration(LoadAlertConfiguration loadAlertConfiguration) {
+        this.loadAlertConfiguration = loadAlertConfiguration;
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/domain/LoadAlertConfiguration.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/domain/LoadAlertConfiguration.java
@@ -1,0 +1,43 @@
+package com.sequenceiq.periscope.domain;
+
+import java.util.concurrent.TimeUnit;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public class LoadAlertConfiguration {
+
+    private Integer minResourceValue;
+
+    private Integer maxResourceValue;
+
+    private Integer coolDownMinutes;
+
+    public Integer getMinResourceValue() {
+        return minResourceValue;
+    }
+
+    public void setMinResourceValue(Integer minResourceValue) {
+        this.minResourceValue = minResourceValue;
+    }
+
+    public Integer getMaxResourceValue() {
+        return maxResourceValue;
+    }
+
+    public void setMaxResourceValue(Integer maxResourceValue) {
+        this.maxResourceValue = maxResourceValue;
+    }
+
+    public Integer getCoolDownMinutes() {
+        return coolDownMinutes;
+    }
+
+    @JsonIgnore
+    public Long getCoolDownMillis() {
+        return TimeUnit.MILLISECONDS.convert(coolDownMinutes, TimeUnit.MINUTES);
+    }
+
+    public void setCoolDownMinutes(Integer coolDownMinutes) {
+        this.coolDownMinutes = coolDownMinutes;
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/filter/CloudbreakUserConfiguratorFilter.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/filter/CloudbreakUserConfiguratorFilter.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.periscope.filter;
 
+import static com.sequenceiq.periscope.monitor.evaluator.ScalingConstants.UNINITIALIZED_WORKSPACE_ID;
+
 import java.io.IOException;
 
 import javax.servlet.FilterChain;
@@ -11,7 +13,9 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.sequenceiq.cloudbreak.auth.security.authentication.AuthenticatedUserService;
 import com.sequenceiq.cloudbreak.common.user.CloudbreakUser;
+import com.sequenceiq.periscope.domain.ClusterPertain;
 import com.sequenceiq.periscope.service.AutoscaleRestRequestThreadLocalService;
+import com.sequenceiq.periscope.service.ClusterPertainService;
 
 public class CloudbreakUserConfiguratorFilter extends OncePerRequestFilter {
 
@@ -19,16 +23,26 @@ public class CloudbreakUserConfiguratorFilter extends OncePerRequestFilter {
 
     private final AuthenticatedUserService authenticatedUserService;
 
+    private final ClusterPertainService clusterPertainService;
+
     public CloudbreakUserConfiguratorFilter(AutoscaleRestRequestThreadLocalService restRequestThreadLocalService,
-            AuthenticatedUserService authenticatedUserService) {
+            AuthenticatedUserService authenticatedUserService, ClusterPertainService clusterPertainService) {
         this.restRequestThreadLocalService = restRequestThreadLocalService;
         this.authenticatedUserService = authenticatedUserService;
+        this.clusterPertainService = clusterPertainService;
     }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         CloudbreakUser cloudbreakUser = authenticatedUserService.getCbUser();
-        restRequestThreadLocalService.setCloudbreakUser(cloudbreakUser);
+        Long workspaceId = UNINITIALIZED_WORKSPACE_ID;
+        if (cloudbreakUser != null) {
+            workspaceId = clusterPertainService.getClusterPertain(cloudbreakUser.getUserCrn())
+                    .map(ClusterPertain::getWorkspaceId)
+                    .orElse(UNINITIALIZED_WORKSPACE_ID);
+        }
+
+        restRequestThreadLocalService.setCloudbreakUser(cloudbreakUser, workspaceId);
         filterChain.doFilter(request, response);
         restRequestThreadLocalService.removeCloudbreakUser();
     }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/filter/FilterConfiguration.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/filter/FilterConfiguration.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Configuration;
 
 import com.sequenceiq.cloudbreak.auth.security.authentication.AuthenticatedUserService;
 import com.sequenceiq.periscope.service.AutoscaleRestRequestThreadLocalService;
+import com.sequenceiq.periscope.service.ClusterPertainService;
 
 @Configuration
 public class FilterConfiguration {
@@ -18,10 +19,14 @@ public class FilterConfiguration {
     @Inject
     private AutoscaleRestRequestThreadLocalService restRequestThreadLocalService;
 
+    @Inject
+    private ClusterPertainService clusterPertainService;
+
     @Bean
     public FilterRegistrationBean<CloudbreakUserConfiguratorFilter> identityUserConfiguratorFilterRegistrationBean() {
         FilterRegistrationBean<CloudbreakUserConfiguratorFilter> registrationBean = new FilterRegistrationBean<>();
-        CloudbreakUserConfiguratorFilter filter = new CloudbreakUserConfiguratorFilter(restRequestThreadLocalService, authenticatedUserService);
+        CloudbreakUserConfiguratorFilter filter =
+                new CloudbreakUserConfiguratorFilter(restRequestThreadLocalService, authenticatedUserService, clusterPertainService);
         registrationBean.setFilter(filter);
         registrationBean.setOrder(Integer.MAX_VALUE);
         return registrationBean;

--- a/autoscale/src/main/java/com/sequenceiq/periscope/model/InstanceConfig.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/model/InstanceConfig.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.periscope.model;
+
+public class InstanceConfig {
+
+    private String instanceName;
+
+    private Integer coreCPU;
+
+    private Long memoryInMb;
+
+    private Boolean defaultValueUsed = false;
+
+    public InstanceConfig(String instanceName) {
+        this.instanceName = instanceName;
+    }
+
+    public String getInstanceName() {
+        return instanceName;
+    }
+
+    public Integer getCoreCPU() {
+        return coreCPU;
+    }
+
+    public void setCoreCPU(Integer coreCPU) {
+        this.coreCPU = coreCPU;
+    }
+
+    public Long getMemoryInMb() {
+        return memoryInMb;
+    }
+
+    public void setMemoryInMb(Long memoryInMb) {
+        this.memoryInMb = memoryInMb;
+    }
+
+    public void setDefaultValueUsed(Boolean toBeCached) {
+        defaultValueUsed = toBeCached;
+    }
+
+    public Boolean getDefaultValueUsed() {
+        return defaultValueUsed;
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/model/MonitoredStack.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/model/MonitoredStack.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.periscope.model;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.common.api.type.Tunnel;
 import com.sequenceiq.periscope.domain.ClusterManager;
 import com.sequenceiq.periscope.domain.SecurityConfig;
@@ -10,18 +11,29 @@ public final class MonitoredStack {
 
     private final String stackCrn;
 
+    private final String stackName;
+
+    private final StackType stackType;
+
+    private final String cloudPlatform;
+
     private final Long stackId;
 
     private final SecurityConfig securityConfig;
 
     private final Tunnel tunnel;
 
-    public MonitoredStack(ClusterManager clusterManager, String stackCrn, Long stackId, SecurityConfig securityConfig, Tunnel tunnel) {
+    @SuppressWarnings("checkstyle:ExecutableStatementCount")
+    public MonitoredStack(ClusterManager clusterManager, String stackName, String stackCrn, String cloudPlatform,
+            StackType stackType, Long stackId, SecurityConfig securityConfig, Tunnel tunnel) {
         this.clusterManager = clusterManager;
-        this.stackCrn = stackCrn;
-        this.stackId = stackId;
         this.securityConfig = securityConfig;
         this.tunnel = tunnel;
+        this.stackId = stackId;
+        this.stackName = stackName;
+        this.stackCrn = stackCrn;
+        this.cloudPlatform = cloudPlatform;
+        this.stackType = stackType;
     }
 
     public ClusterManager getClusterManager() {
@@ -30,6 +42,18 @@ public final class MonitoredStack {
 
     public String getStackCrn() {
         return stackCrn;
+    }
+
+    public String getStackName() {
+        return stackName;
+    }
+
+    public StackType getStackType() {
+        return stackType;
+    }
+
+    public String getCloudPlatform() {
+        return cloudPlatform;
     }
 
     public Long getStackId() {

--- a/autoscale/src/main/java/com/sequenceiq/periscope/model/NameOrCrn.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/model/NameOrCrn.java
@@ -1,0 +1,96 @@
+package com.sequenceiq.periscope.model;
+
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
+import java.util.Objects;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.google.common.annotations.VisibleForTesting;
+
+public class NameOrCrn {
+
+    private static final String NAME_MUST_BE_PROVIDED_EXCEPTION_MESSAGE = "Name must be provided.";
+
+    private static final String CRN_MUST_BE_PROVIDED_EXCEPTION_MESSAGE = "Crn must be provided.";
+
+    @VisibleForTesting
+    final String name;
+
+    @VisibleForTesting
+    final String crn;
+
+    private NameOrCrn(String name, String crn) {
+        this.name = name;
+        this.crn = crn;
+    }
+
+    public static NameOrCrn ofName(String name) {
+        if (StringUtils.isEmpty(name)) {
+            throw new IllegalArgumentException(NAME_MUST_BE_PROVIDED_EXCEPTION_MESSAGE);
+        }
+        return new NameOrCrn(name, null);
+    }
+
+    public static NameOrCrn ofCrn(String crn) {
+        if (StringUtils.isEmpty(crn)) {
+            throw new IllegalArgumentException(CRN_MUST_BE_PROVIDED_EXCEPTION_MESSAGE);
+        }
+        return new NameOrCrn(null, crn);
+    }
+
+    public String getName() {
+        if (StringUtils.isEmpty(name)) {
+            throw new IllegalArgumentException("Request to get name when crn was provided on " + this);
+        }
+        return name;
+    }
+
+    public String getCrn() {
+        if (StringUtils.isEmpty(crn)) {
+            throw new IllegalArgumentException("Request to get crn when name was provided on " + this);
+        }
+        return crn;
+    }
+
+    public boolean hasName() {
+        return isNotEmpty(name);
+    }
+
+    public boolean hasCrn() {
+        return isNotEmpty(crn);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder toString = new StringBuilder();
+        toString.append("[NameOrCrn");
+        if (isNotEmpty(name)) {
+            toString.append(" of name: '");
+            toString.append(name);
+        } else {
+            toString.append(" of crn: '");
+            toString.append(crn);
+        }
+        toString.append("']");
+        return toString.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        NameOrCrn nameOrCrn = (NameOrCrn) o;
+        return Objects.equals(name, nameOrCrn.name) &&
+                Objects.equals(crn, nameOrCrn.crn);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, crn);
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/model/yarn/YarnScalingServiceV1Request.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/model/yarn/YarnScalingServiceV1Request.java
@@ -1,0 +1,77 @@
+package com.sequenceiq.periscope.model.yarn;
+
+import java.util.List;
+
+public class YarnScalingServiceV1Request {
+
+    private List<HostGroupInstanceType> instanceTypes;
+
+    public List<HostGroupInstanceType> getInstanceTypes() {
+        return instanceTypes;
+    }
+
+    public void setInstanceTypes(List<HostGroupInstanceType> instanceTypes) {
+        this.instanceTypes = instanceTypes;
+    }
+
+    public static class HostGroupInstanceType {
+        private String modelName;
+
+        private Capacity capacity;
+
+        public HostGroupInstanceType() {
+        }
+
+        public HostGroupInstanceType(String modelName, Integer memMB, Integer vcore) {
+            this.modelName = modelName;
+            this.capacity = new Capacity(memMB, vcore);
+        }
+
+        public String getModelName() {
+            return modelName;
+        }
+
+        public void setModelName(String modelName) {
+            this.modelName = modelName;
+        }
+
+        public Capacity getCapacity() {
+            return capacity;
+        }
+
+        public void setCapacity(Capacity capacity) {
+            this.capacity = capacity;
+        }
+
+        public static class Capacity {
+            private Integer memMB;
+
+            private Integer vcore;
+
+            Capacity() {
+            }
+
+            Capacity(Integer memMB, Integer vcore) {
+                this.memMB = memMB;
+                this.vcore = vcore;
+            }
+
+            public Integer getMemMB() {
+                return memMB;
+            }
+
+            public void setMemMB(Integer memMB) {
+                this.memMB = memMB;
+            }
+
+            public Integer getVcore() {
+                return vcore;
+            }
+
+            public void setVcore(Integer vcore) {
+                this.vcore = vcore;
+            }
+        }
+    }
+}
+

--- a/autoscale/src/main/java/com/sequenceiq/periscope/model/yarn/YarnScalingServiceV1Response.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/model/yarn/YarnScalingServiceV1Response.java
@@ -1,0 +1,210 @@
+package com.sequenceiq.periscope.model.yarn;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import com.sequenceiq.periscope.model.yarn.YarnScalingServiceV1Request.HostGroupInstanceType;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public class YarnScalingServiceV1Response {
+
+    private static final String YARN_RESPONSE_NM_CANDIDATES_KEY = "newNMCandidates";
+
+    private static final String YARN_RESPONSE_DECOMMISSION_CANDIDATES_KEY = "candidates";
+
+    private String apiVersion;
+
+    private String consideredResourceTypes;
+
+    @JsonIgnore
+    private Map<String, List<HostGroupInstanceType>> nodeInstanceTypeList;
+
+    private Map<String, NewNodeManagerCandidates> newNMCandidates;
+
+    private Map<String, List<DecommissionCandidate>> decommissionCandidates;
+
+    public String getApiVersion() {
+        return apiVersion;
+    }
+
+    public void setApiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
+    }
+
+    public String getConsideredResourceTypes() {
+        return consideredResourceTypes;
+    }
+
+    public void setConsideredResourceTypes(String consideredResourceTypes) {
+        this.consideredResourceTypes = consideredResourceTypes;
+    }
+
+    public Map<String, NewNodeManagerCandidates> getNewNMCandidates() {
+        return newNMCandidates == null ? Map.of() : newNMCandidates;
+    }
+
+    public void setNewNMCandidates(Map<String, NewNodeManagerCandidates> newNMCandidates) {
+        this.newNMCandidates = newNMCandidates;
+    }
+
+    public Map<String, List<DecommissionCandidate>> getDecommissionCandidates() {
+        return decommissionCandidates == null ? Map.of() : decommissionCandidates;
+    }
+
+    public void setDecommissionCandidates(Map<String, List<DecommissionCandidate>> decommissionCandidates) {
+        this.decommissionCandidates = decommissionCandidates;
+    }
+
+    public Map<String, List<HostGroupInstanceType>> getNodeInstanceTypeList() {
+        return nodeInstanceTypeList == null ? Map.of() : nodeInstanceTypeList;
+    }
+
+    public void setNodeInstanceTypeList(Map<String, List<HostGroupInstanceType>> nodeInstanceTypeList) {
+        this.nodeInstanceTypeList = nodeInstanceTypeList;
+    }
+
+    public Optional<NewNodeManagerCandidates> getScaleUpCandidates() {
+        return Optional.ofNullable(getNewNMCandidates().get(YARN_RESPONSE_NM_CANDIDATES_KEY));
+    }
+
+    public Optional<List<DecommissionCandidate>> getScaleDownCandidates() {
+        return Optional.ofNullable(getDecommissionCandidates().get(YARN_RESPONSE_DECOMMISSION_CANDIDATES_KEY));
+    }
+
+    @Override
+    public String toString() {
+        return "YarnScalingServiceV1Response{" +
+                "apiVersion='" + apiVersion + '\'' +
+                ", newNMCandidates=" + newNMCandidates +
+                ", decommissionCandidates=" + decommissionCandidates +
+                '}';
+    }
+
+    public static class DecommissionCandidate {
+
+        private Integer amCount;
+
+        private Integer runningAppCount;
+
+        private Integer decommissionTimeout;
+
+        private String nodeId;
+
+        private String nodeState;
+
+        public Integer getAmCount() {
+            return amCount;
+        }
+
+        public void setAmCount(Integer amCount) {
+            this.amCount = amCount;
+        }
+
+        public Integer getRunningAppCount() {
+            return runningAppCount;
+        }
+
+        public void setRunningAppCount(Integer runningAppCount) {
+            this.runningAppCount = runningAppCount;
+        }
+
+        public Integer getDecommissionTimeout() {
+            return decommissionTimeout;
+        }
+
+        public void setDecommissionTimeout(Integer decommissionTimeout) {
+            this.decommissionTimeout = decommissionTimeout;
+        }
+
+        public String getNodeId() {
+            return nodeId;
+        }
+
+        public void setNodeId(String nodeId) {
+            this.nodeId = nodeId;
+        }
+
+        public String getNodeState() {
+            return nodeState;
+        }
+
+        public void setNodeState(String nodeState) {
+            this.nodeState = nodeState;
+        }
+
+        @Override
+        public String toString() {
+            return "DecommissionCandidate{" +
+                    "amCount=" + amCount +
+                    ", runningAppCount=" + runningAppCount +
+                    ", decommissionTimeout=" + decommissionTimeout +
+                    ", nodeId='" + nodeId + '\'' +
+                    ", nodeState='" + nodeState + '\'' +
+                    '}';
+        }
+    }
+
+    public static class NewNodeManagerCandidates {
+
+        @JsonIgnore
+        private String recommendActionTime;
+
+        private List<Candidate> candidates = new ArrayList<>(1);
+
+        public String getRecommendActionTime() {
+            return recommendActionTime;
+        }
+
+        public void setRecommendActionTime(String recommendActionTime) {
+            this.recommendActionTime = recommendActionTime;
+        }
+
+        public List<Candidate> getCandidates() {
+            return candidates;
+        }
+
+        public void setCandidates(List<Candidate> candidates) {
+            this.candidates = candidates;
+        }
+
+        @Override
+        public String toString() {
+            return "NewNodeManagerCandidates{" +
+                    "Candidates=" + candidates +
+                    '}';
+        }
+
+        public static class Candidate {
+            private String modelName;
+
+            private Integer count;
+
+            public String getModelName() {
+                return modelName;
+            }
+
+            public void setModelName(String modelName) {
+                this.modelName = modelName;
+            }
+
+            public Integer getCount() {
+                return count;
+            }
+
+            public void setCount(Integer count) {
+                this.count = count;
+            }
+
+            @Override
+            public String toString() {
+                return "Candidate{" +
+                        "modelName='" + modelName + '\'' +
+                        ", count=" + count +
+                        '}';
+            }
+        }
+    }
+}
+

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/LoadMonitor.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/LoadMonitor.java
@@ -1,0 +1,39 @@
+package com.sequenceiq.periscope.monitor;
+
+import java.util.List;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.periscope.api.model.ClusterState;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.monitor.evaluator.EvaluatorExecutor;
+import com.sequenceiq.periscope.monitor.evaluator.load.YarnLoadEvaluator;
+
+@Component
+@ConditionalOnProperty(prefix = "periscope.enabledAutoscaleMonitors.load-monitor", name = "enabled", havingValue = "true")
+public class LoadMonitor extends ClusterMonitor {
+
+    @Override
+    public String getIdentifier() {
+        return "load-monitor";
+    }
+
+    @Override
+    public String getTriggerExpression() {
+        return MonitorUpdateRate.EVERY_TWO_MIN_RATE_CRON;
+    }
+
+    @Override
+    public Class<? extends EvaluatorExecutor> getEvaluatorType(Cluster cluster) {
+        return YarnLoadEvaluator.class;
+    }
+
+    @Override
+    protected List<Cluster> getMonitored() {
+        List<Long> clusterIds = getClusterService().findLoadAlertClustersForNode(StackType.WORKLOAD,
+                ClusterState.RUNNING, true, getPeriscopeNodeConfig().getId());
+        return clusterIds.isEmpty() ? List.of() : getClusterService().findClustersByClusterIds(clusterIds);
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/MonitorUpdateRate.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/MonitorUpdateRate.java
@@ -8,11 +8,6 @@ public final class MonitorUpdateRate {
     public static final String APP_REPORT_UPDATE_RATE_CRON = "0 0/2 * * * ?";
 
     /**
-     * Every 20 seconds.
-     */
-    public static final String YARN_UPDATE_RATE_CRON = "0/20 * * * * ?";
-
-    /**
      * Every 30 seconds.
      */
     public static final String METRIC_UPDATE_RATE_CRON = "0/30 * * * * ?";
@@ -36,6 +31,16 @@ public final class MonitorUpdateRate {
      * Every minutes.
      */
     public static final String EVERY_MIN_RATE_CRON = "0 * * * * ?";
+
+    /**
+     * Every 2 minutes.
+     */
+    public static final String EVERY_TWO_MIN_RATE_CRON = "0 0/2 * * * ?";
+
+    /**
+     * Every 5 minutes.
+     */
+    public static final String EVERY_FIVE_MIN_RATE_CRON = "0 0/5 * * * ?";
 
     /**
      * Every minutes.

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/SuspendedClusterMonitor.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/SuspendedClusterMonitor.java
@@ -1,0 +1,36 @@
+package com.sequenceiq.periscope.monitor;
+
+import java.util.List;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.periscope.api.model.ClusterState;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.monitor.evaluator.ClusterStateEvaluator;
+
+@Component("SuspendedClusterMonitor")
+@ConditionalOnProperty(prefix = "periscope.enabledAutoscaleMonitors.suspended-cluster-monitor", name = "enabled", havingValue = "true")
+public class SuspendedClusterMonitor extends ClusterMonitor {
+
+    @Override
+    public String getIdentifier() {
+        return "suspended-cluster-monitor";
+    }
+
+    @Override
+    public String getTriggerExpression() {
+        return MonitorUpdateRate.EVERY_MIN_RATE_CRON;
+    }
+
+    @Override
+    public Class<?> getEvaluatorType(Cluster cluster) {
+        return ClusterStateEvaluator.class;
+    }
+
+    @Override
+    protected List<Cluster> getMonitored() {
+        //To monitor Suspended clusters and purge them in periscope when they are deleted in CB.
+        return getClusterService().findAllByStateAndNode(ClusterState.SUSPENDED, getPeriscopeNodeConfig().getId());
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/client/YarnMetricsClient.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/client/YarnMetricsClient.java
@@ -1,0 +1,84 @@
+package com.sequenceiq.periscope.monitor.client;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.cloudbreak.client.RestClientUtil;
+import com.sequenceiq.periscope.aspects.RequestLogging;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.model.InstanceConfig;
+import com.sequenceiq.periscope.model.TlsConfiguration;
+import com.sequenceiq.periscope.model.yarn.YarnScalingServiceV1Request;
+import com.sequenceiq.periscope.model.yarn.YarnScalingServiceV1Request.HostGroupInstanceType;
+import com.sequenceiq.periscope.model.yarn.YarnScalingServiceV1Response;
+import com.sequenceiq.periscope.service.configuration.ClusterProxyConfigurationService;
+import com.sequenceiq.periscope.service.security.TlsSecurityService;
+
+@Component
+public class YarnMetricsClient {
+    private static final Logger LOGGER = LoggerFactory.getLogger(YarnMetricsClient.class);
+
+    private static final String YARN_API_URL = "%s/proxy/%s/resourcemanager/v1/cluster/scaling";
+
+    private static final String HEADER_ACTOR_CRN = "x-cdp-actor-crn";
+
+    private static final String PARAM_UPSCALE_FACTOR_NODE_RESOURCE_TYPE = "upscaling-factor-in-node-resource-types";
+
+    private static final String DEFAULT_UPSCALE_RESOURCE_TYPE = "memory-mb";
+
+    @Inject
+    private TlsSecurityService tlsSecurityService;
+
+    @Inject
+    private ClusterProxyConfigurationService clusterProxyConfigurationService;
+
+    @Inject
+    private RequestLogging requestLogging;
+
+    @Inject
+    private YarnServiceConfigClient yarnServiceConfigClient;
+
+    @Retryable(value = Exception.class, maxAttempts = 5, backoff = @Backoff(delay = 5000))
+    public YarnScalingServiceV1Response getYarnMetricsForCluster(Cluster cluster, StackV4Response stackV4Response,
+            String hostGroup) throws Exception {
+        TlsConfiguration tlsConfig = tlsSecurityService.getTls(cluster.getId());
+        String clusterProxyUrl = clusterProxyConfigurationService.getClusterProxyUrl()
+                .orElseThrow(() ->  new RuntimeException(String.format("ClusterProxy Not Configured for Cluster {}, " +
+                        " cannot query YARN Metrics.", cluster.getStackCrn())));
+
+        Client restClient = RestClientUtil.createClient(tlsConfig.getServerCert(),
+                tlsConfig.getClientCert(), tlsConfig.getClientKey(), true);
+        String yarnApiUrl = String.format(YARN_API_URL, clusterProxyUrl, cluster.getStackCrn());
+
+        InstanceConfig instanceConfig = yarnServiceConfigClient.getInstanceConfigFromCM(cluster, stackV4Response, hostGroup);
+        YarnScalingServiceV1Request yarnScalingServiceV1Request = new YarnScalingServiceV1Request();
+        yarnScalingServiceV1Request.setInstanceTypes(List.of(
+                new HostGroupInstanceType(instanceConfig.getInstanceName(),
+                        instanceConfig.getMemoryInMb().intValue(), instanceConfig.getCoreCPU())));
+
+        String clusterCreatorCrn = cluster.getClusterPertain().getUserCrn();
+        YarnScalingServiceV1Response yarnResponse = requestLogging.logResponseTime(() -> {
+            return restClient.target(yarnApiUrl)
+                    .queryParam(PARAM_UPSCALE_FACTOR_NODE_RESOURCE_TYPE, DEFAULT_UPSCALE_RESOURCE_TYPE)
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_VALUE)
+                    .header(HEADER_ACTOR_CRN, clusterCreatorCrn)
+                    .post(Entity.json(yarnScalingServiceV1Request), YarnScalingServiceV1Response.class);
+        }, String.format("YarnScalingAPI query for cluster crn '%s'", cluster.getStackCrn()));
+
+        LOGGER.info("YarnScalingAPI response for cluster crn '{}',  response '{}'", cluster.getStackCrn(), yarnResponse);
+        return yarnResponse;
+    }
+
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/client/YarnServiceConfigClient.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/client/YarnServiceConfigClient.java
@@ -1,0 +1,63 @@
+package com.sequenceiq.periscope.monitor.client;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+
+import com.cloudera.api.swagger.model.ApiConfig;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.model.InstanceConfig;
+import com.sequenceiq.periscope.monitor.handler.ClouderaManagerCommunicator;
+import com.sequenceiq.periscope.utils.StackResponseUtils;
+
+@Component
+public class YarnServiceConfigClient {
+
+    private static final String YARN_SERVICE = "yarn";
+
+    private static final String NODEMANAGER_ROLE = "NODEMANAGER";
+
+    private static final String YARN_NODEMANAGER_VCORES = "yarn_nodemanager_resource_cpu_vcores";
+
+    private static final String YARN_NODEMANAGER_MEMORY = "yarn_nodemanager_resource_memory_mb";
+
+    @Inject
+    private StackResponseUtils stackResponseUtils;
+
+    @Inject
+    private ClouderaManagerCommunicator clouderaManagerCommunicator;
+
+    @Cacheable(cacheNames = "instanceConfigCache", unless = "#result.getDefaultValueUsed() == true", key = "#cluster.id + #hostGroup")
+    public InstanceConfig getInstanceConfigFromCM(Cluster cluster, StackV4Response stackV4Response, String hostGroup)
+            throws Exception {
+        String nodeManagerRoleConfigName = stackResponseUtils
+                .getRoleConfigNameForHostGroup(stackV4Response, hostGroup, YARN_SERVICE, NODEMANAGER_ROLE);
+
+        Map<String, ApiConfig> roleConfigProperties = clouderaManagerCommunicator.getRoleConfigPropertiesFromCM(cluster, YARN_SERVICE,
+                nodeManagerRoleConfigName, Set.of(YARN_NODEMANAGER_VCORES, YARN_NODEMANAGER_MEMORY));
+
+        ApiConfig apiConfigVCores = roleConfigProperties.get(YARN_NODEMANAGER_VCORES);
+        ApiConfig apiConfigMemory = roleConfigProperties.get(YARN_NODEMANAGER_MEMORY);
+
+        InstanceConfig instanceConfig = new InstanceConfig(hostGroup);
+        String hostVCores = Optional.ofNullable(apiConfigVCores.getValue()).orElseGet(() -> {
+            instanceConfig.setDefaultValueUsed(true);
+            return apiConfigVCores.getDefault();
+        });
+
+        String hostMemory = Optional.ofNullable(apiConfigMemory.getValue()).orElseGet(() -> {
+            instanceConfig.setDefaultValueUsed(true);
+            return apiConfigMemory.getDefault();
+        });
+
+        instanceConfig.setCoreCPU(Integer.valueOf(hostVCores));
+        instanceConfig.setMemoryInMb(Long.valueOf(hostMemory));
+        return instanceConfig;
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ClusterStateEvaluator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ClusterStateEvaluator.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.periscope.monitor.evaluator;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.periscope.monitor.context.ClusterIdEvaluatorContext;
+import com.sequenceiq.periscope.monitor.context.EvaluatorContext;
+import com.sequenceiq.periscope.monitor.event.UpdateFailedEvent;
+
+@Component("ClusterStateEvaluator")
+@Scope("prototype")
+public class ClusterStateEvaluator extends EvaluatorExecutor {
+
+    private static final String EVALUATOR_NAME = ClusterStateEvaluator.class.getName();
+
+    @Inject
+    private EventPublisher eventPublisher;
+
+    private long clusterId;
+
+    @Override
+    public void setContext(EvaluatorContext context) {
+        clusterId = (long) context.getData();
+    }
+
+    @Override
+    @Nonnull
+    public EvaluatorContext getContext() {
+        return new ClusterIdEvaluatorContext(clusterId);
+    }
+
+    @Override
+    public String getName() {
+        return EVALUATOR_NAME;
+    }
+
+    @Override
+    public void execute() {
+        eventPublisher.publishEvent(new UpdateFailedEvent(clusterId));
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/EvaluatorExecutor.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/EvaluatorExecutor.java
@@ -3,10 +3,18 @@ package com.sequenceiq.periscope.monitor.evaluator;
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.sequenceiq.periscope.monitor.context.EvaluatorContext;
+import com.sequenceiq.periscope.monitor.evaluator.load.YarnLoadEvaluator;
 import com.sequenceiq.periscope.monitor.executor.ExecutorServiceWithRegistry;
+import com.sequenceiq.periscope.utils.ClusterUtils;
+import com.sequenceiq.periscope.utils.TimeUtil;
 
 public abstract class EvaluatorExecutor implements Runnable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(YarnLoadEvaluator.class);
 
     @Inject
     private ExecutorServiceWithRegistry executorServiceWithRegistry;
@@ -30,4 +38,16 @@ public abstract class EvaluatorExecutor implements Runnable {
 
     protected abstract void execute();
 
+    protected boolean isCoolDownTimeElapsed(String clusterCrn, long expectedCoolDownMillis, long lastClusterScalingActivity) {
+        long remainingTime = ClusterUtils.getRemainingCooldownTime(
+                expectedCoolDownMillis, lastClusterScalingActivity);
+
+        if (remainingTime <= 0) {
+            return true;
+        } else {
+            LOGGER.debug("Cluster {} cannot be scaled for {} min(s)", clusterCrn,
+                    ClusterUtils.TIME_FORMAT.format((double) remainingTime / TimeUtil.MIN_IN_MS));
+        }
+        return false;
+    }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ScalingConstants.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ScalingConstants.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.periscope.monitor.evaluator;
+
+public class ScalingConstants {
+
+    public static final int DEFAULT_CLUSTER_MIN_SIZE = 2;
+
+    public static final int DEFAULT_CLUSTER_MAX_SIZE = 200;
+
+    public static final int DEFAULT_CLUSTER_COOLDOWN_MINS = 5;
+
+    public static final int DEFAULT_HOSTGROUP_MIN_SIZE = 0;
+
+    public static final int DEFAULT_HOSTGROUP_MAX_SIZE = 200;
+
+    public static final int DEFAULT_MAX_SCALE_UP_STEP_SIZE = 50;
+
+    public static final Long UNINITIALIZED_WORKSPACE_ID = -1L;
+
+    private ScalingConstants() {
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/cm/ClouderaManagerClusterCreationEvaluator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/cm/ClouderaManagerClusterCreationEvaluator.java
@@ -17,6 +17,7 @@ import com.cloudera.api.swagger.ClouderaManagerResourceApi;
 import com.cloudera.api.swagger.client.ApiClient;
 import com.cloudera.api.swagger.client.ApiException;
 import com.cloudera.api.swagger.model.ApiVersionInfo;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ClusterManagerVariant;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.AutoscaleStackV4Response;
 import com.sequenceiq.cloudbreak.client.HttpClientConfig;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiClientProvider;
@@ -27,7 +28,6 @@ import com.sequenceiq.periscope.api.model.ScalingStatus;
 import com.sequenceiq.periscope.aspects.RequestLogging;
 import com.sequenceiq.periscope.domain.Cluster;
 import com.sequenceiq.periscope.domain.ClusterManager;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ClusterManagerVariant;
 import com.sequenceiq.periscope.domain.ClusterPertain;
 import com.sequenceiq.periscope.domain.History;
 import com.sequenceiq.periscope.domain.SecurityConfig;
@@ -130,10 +130,11 @@ public class ClouderaManagerClusterCreationEvaluator extends ClusterCreationEval
 
     private void createCluster(AutoscaleStackV4Response stack, MonitoredStack monitoredStack) {
         LOGGER.debug("Creating cluster for Cloudera Manager host: {}", monitoredStack.getClusterManager().getHost());
-        Cluster cluster = clusterService.create(monitoredStack, RUNNING,
-                new ClusterPertain(stack.getTenant(), stack.getWorkspaceId(), stack.getUserId()));
+        Cluster cluster = clusterService.create(monitoredStack, PENDING,
+                new ClusterPertain(stack.getTenant(), stack.getWorkspaceId(), stack.getUserId(), stack.getUserCrn()));
         MDCBuilder.buildMdcContext(cluster);
         History history = historyService.createEntry(ScalingStatus.ENABLED, "Autoscaling has been enabled for the cluster.", 0, cluster);
+
         notificationSender.send(cluster, history);
     }
 
@@ -156,7 +157,8 @@ public class ClouderaManagerClusterCreationEvaluator extends ClusterCreationEval
         }
         ClusterManager clusterManager =
                 new ClusterManager(host, gatewayPort, stack.getUserNamePath(), stack.getPasswordPath(), ClusterManagerVariant.CLOUDERA_MANAGER);
-        return new MonitoredStack(clusterManager, stack.getStackCrn(), stack.getStackId(), securityConfig, stack.getTunnel());
+        return new MonitoredStack(clusterManager, stack.getName(), stack.getStackCrn(), stack.getCloudPlatform(), stack.getStackType(),
+                stack.getStackId(), securityConfig, stack.getTunnel());
     }
 
     private void cmHealthCheck(MonitoredStack monitoredStack) {
@@ -169,7 +171,7 @@ public class ClouderaManagerClusterCreationEvaluator extends ClusterCreationEval
             String pass = secretService.get(cm.getPass());
             ApiClient client = clouderaManagerApiClientProvider.getClient(Integer.valueOf(cm.getPort()), user, pass, httpClientConfig);
             ClouderaManagerResourceApi resourceApi = clouderaManagerApiFactory.getClouderaManagerResourceApi(client);
-            Boolean healthCheckResult = requestLogging.logging(() -> {
+            Boolean healthCheckResult = requestLogging.logResponseTime(() -> {
                 try {
                     ApiVersionInfo version = resourceApi.getVersion();
                     return StringUtils.isNotEmpty(version.getVersion());

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/load/YarnLoadEvaluator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/load/YarnLoadEvaluator.java
@@ -1,0 +1,172 @@
+package com.sequenceiq.periscope.monitor.evaluator.load;
+
+import static com.sequenceiq.periscope.monitor.evaluator.ScalingConstants.DEFAULT_MAX_SCALE_UP_STEP_SIZE;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.LoadAlert;
+import com.sequenceiq.periscope.domain.LoadAlertConfiguration;
+import com.sequenceiq.periscope.model.yarn.YarnScalingServiceV1Response;
+import com.sequenceiq.periscope.model.yarn.YarnScalingServiceV1Response.DecommissionCandidate;
+import com.sequenceiq.periscope.model.yarn.YarnScalingServiceV1Response.NewNodeManagerCandidates;
+import com.sequenceiq.periscope.monitor.client.YarnMetricsClient;
+import com.sequenceiq.periscope.monitor.context.ClusterIdEvaluatorContext;
+import com.sequenceiq.periscope.monitor.context.EvaluatorContext;
+import com.sequenceiq.periscope.monitor.evaluator.EvaluatorExecutor;
+import com.sequenceiq.periscope.monitor.evaluator.EventPublisher;
+import com.sequenceiq.periscope.monitor.event.ScalingEvent;
+import com.sequenceiq.periscope.monitor.event.UpdateFailedEvent;
+import com.sequenceiq.periscope.monitor.handler.CloudbreakCommunicator;
+import com.sequenceiq.periscope.repository.LoadAlertRepository;
+import com.sequenceiq.periscope.service.ClusterService;
+import com.sequenceiq.periscope.utils.StackResponseUtils;
+
+@Component("YarnLoadEvaluator")
+@Scope("prototype")
+public class YarnLoadEvaluator extends EvaluatorExecutor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(YarnLoadEvaluator.class);
+
+    private static final String EVALUATOR_NAME = YarnLoadEvaluator.class.getName();
+
+    @Inject
+    private ClusterService clusterService;
+
+    @Inject
+    private LoadAlertRepository alertRepository;
+
+    @Inject
+    private EventPublisher eventPublisher;
+
+    @Inject
+    private YarnMetricsClient yarnMetricsClient;
+
+    @Inject
+    private StackResponseUtils stackResponseUtils;
+
+    @Inject
+    private CloudbreakCommunicator cloudbreakCommunicator;
+
+    private long clusterId;
+
+    private Cluster cluster;
+
+    private LoadAlert loadAlert;
+
+    private LoadAlertConfiguration loadAlertConfiguration;
+
+    private String policyHostGroup;
+
+    @Nonnull
+    @Override
+    public EvaluatorContext getContext() {
+        return new ClusterIdEvaluatorContext(clusterId);
+    }
+
+    @Override
+    public void setContext(EvaluatorContext context) {
+        clusterId = (long) context.getData();
+    }
+
+    @Override
+    public String getName() {
+        return EVALUATOR_NAME;
+    }
+
+    @Override
+    protected void execute() {
+        long start = System.currentTimeMillis();
+        String stackCrn = "NotInitialized";
+        try {
+            MDCBuilder.buildMdcContext(cluster);
+            cluster = clusterService.findById(clusterId);
+            stackCrn = cluster.getStackCrn();
+            loadAlert = cluster.getLoadAlerts().stream().findFirst().get();
+            loadAlertConfiguration = loadAlert.getLoadAlertConfiguration();
+            policyHostGroup = loadAlert.getScalingPolicy().getHostGroup();
+
+            if (isCoolDownTimeElapsed(cluster.getStackCrn(), loadAlertConfiguration.getCoolDownMillis(),
+                    cluster.getLastScalingActivity())) {
+                pollYarnMetricsAndScaleCluster();
+            }
+        } catch (Exception ex) {
+            LOGGER.info("Failed to process load alert for Cluster {}, exception {}", stackCrn, ex);
+            eventPublisher.publishEvent(new UpdateFailedEvent(clusterId));
+        } finally {
+            LOGGER.debug("Finished loadEvaluator for cluster {} in {} ms", stackCrn, System.currentTimeMillis() - start);
+        }
+    }
+
+    protected void pollYarnMetricsAndScaleCluster() throws Exception {
+        StackV4Response stackV4Response = cloudbreakCommunicator.getByCrn(cluster.getStackCrn());
+        Map<String, String> hostFqdnsToInstanceId = stackResponseUtils.getCloudInstanceIdsForHostGroup(stackV4Response, policyHostGroup);
+        Set<String> hostGroupFqdns = hostFqdnsToInstanceId.keySet();
+
+        YarnScalingServiceV1Response yarnResponse = yarnMetricsClient.getYarnMetricsForCluster(cluster, stackV4Response, policyHostGroup);
+        int existingHostGroupSize = hostFqdnsToInstanceId.size();
+
+        int configMaxNodeCount = loadAlertConfiguration.getMaxResourceValue() - existingHostGroupSize;
+        int configMinNodeCount = hostGroupFqdns.size() - loadAlertConfiguration.getMinResourceValue();
+
+        int allowedUpScale = configMaxNodeCount < 0 ? 0 : configMaxNodeCount;
+        int yarnRecommendedScaleUpCount = yarnResponse.getScaleUpCandidates()
+                .map(NewNodeManagerCandidates::getCandidates).orElse(List.of()).stream()
+                .filter(candidate -> candidate.getModelName().equalsIgnoreCase(policyHostGroup))
+                .findFirst()
+                .map(NewNodeManagerCandidates.Candidate::getCount)
+                .map(scaleUpCount -> IntStream.of(scaleUpCount, allowedUpScale, DEFAULT_MAX_SCALE_UP_STEP_SIZE).min().getAsInt())
+                .orElse(0);
+
+        int allowedDownScale = configMinNodeCount > 0 ? configMinNodeCount : 0;
+        List<String> yarnDecommissionHosts = yarnResponse.getScaleDownCandidates().orElse(List.of()).stream()
+                .sorted(Comparator.comparingInt(DecommissionCandidate::getAmCount))
+                .map(DecommissionCandidate::getNodeId)
+                .map(nodeFqdn -> nodeFqdn.split(":")[0])
+                .filter(s -> hostGroupFqdns.contains(s))
+                .map(nodeFqdn -> hostFqdnsToInstanceId.get(nodeFqdn))
+                .limit(allowedDownScale)
+                .collect(Collectors.toList());
+
+        int targetScaleUpCount = configMinNodeCount < 0 ? Math.max(-1 * configMinNodeCount, yarnRecommendedScaleUpCount) : yarnRecommendedScaleUpCount;
+        int targetScaleDownCount = configMaxNodeCount < 0 ? Math.max(-1 * configMaxNodeCount, yarnDecommissionHosts.size()) : yarnDecommissionHosts.size();
+
+        if (targetScaleUpCount > 0) {
+
+            ScalingEvent scalingEvent = new ScalingEvent(loadAlert);
+            scalingEvent.setHostGroupNodeCount(Optional.of(existingHostGroupSize));
+            scalingEvent.setScalingNodeCount(Optional.of(targetScaleUpCount));
+            eventPublisher.publishEvent(scalingEvent);
+            LOGGER.info("ScaleUp NodeCount '{}' for Cluster '{}', HostGroup '{}'", targetScaleUpCount, cluster.getStackCrn(), policyHostGroup);
+        } else if (targetScaleDownCount > 0) {
+
+            ScalingEvent scalingEvent = new ScalingEvent(loadAlert);
+            scalingEvent.setHostGroupNodeCount(Optional.of(existingHostGroupSize));
+            targetScaleDownCount = -1 * targetScaleDownCount;
+            if (!yarnDecommissionHosts.isEmpty()) {
+                scalingEvent.setDecommissionNodeIds(yarnDecommissionHosts);
+            } else {
+                scalingEvent.setScalingNodeCount(Optional.of(targetScaleDownCount));
+            }
+            eventPublisher.publishEvent(scalingEvent);
+            LOGGER.info("ScaleDown NodeCount '{}' for Cluster '{}', HostGroup '{}', NodeIds '{}'", targetScaleDownCount,
+                    cluster.getStackCrn(), policyHostGroup, yarnDecommissionHosts);
+        }
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/event/ScalingEvent.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/event/ScalingEvent.java
@@ -1,10 +1,21 @@
 package com.sequenceiq.periscope.monitor.event;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.context.ApplicationEvent;
 
 import com.sequenceiq.periscope.domain.BaseAlert;
 
 public class ScalingEvent extends ApplicationEvent {
+
+    private static final long serialVersionUID = 1587121489597L;
+
+    private List<String> decommissionNodeIds;
+
+    private transient Optional<Integer> scalingNodeCount = Optional.empty();
+
+    private transient Optional<Integer> hostGroupNodeCount = Optional.empty();
 
     public ScalingEvent(BaseAlert alert) {
         super(alert);
@@ -14,4 +25,27 @@ public class ScalingEvent extends ApplicationEvent {
         return (BaseAlert) getSource();
     }
 
+    public List<String> getDecommissionNodeIds() {
+        return decommissionNodeIds != null ? decommissionNodeIds : List.of();
+    }
+
+    public void setDecommissionNodeIds(List<String> decommissionNodeIds) {
+        this.decommissionNodeIds = decommissionNodeIds;
+    }
+
+    public Optional<Integer> getScalingNodeCount() {
+        return scalingNodeCount;
+    }
+
+    public void setScalingNodeCount(Optional<Integer> scalingNodeCount) {
+        this.scalingNodeCount = scalingNodeCount;
+    }
+
+    public Optional<Integer> getHostGroupNodeCount() {
+        return hostGroupNodeCount;
+    }
+
+    public void setHostGroupNodeCount(Optional<Integer> hostGroupNodeCount) {
+        this.hostGroupNodeCount = hostGroupNodeCount;
+    }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/CloudbreakCommunicator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/CloudbreakCommunicator.java
@@ -1,11 +1,16 @@
 package com.sequenceiq.periscope.monitor.handler;
 
+import java.util.List;
+import java.util.Optional;
+
 import javax.inject.Inject;
 
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 import com.sequenceiq.cloudbreak.client.CloudbreakInternalCrnClient;
+import com.sequenceiq.periscope.aspects.RequestLogging;
+import com.sequenceiq.periscope.domain.Cluster;
 
 @Service
 public class CloudbreakCommunicator {
@@ -13,8 +18,21 @@ public class CloudbreakCommunicator {
     @Inject
     private CloudbreakInternalCrnClient cloudbreakInternalCrnClient;
 
+    @Inject
+    private RequestLogging requestLogging;
+
     public StackV4Response getByCrn(String stackCrn) {
         return cloudbreakInternalCrnClient.withInternalCrn().autoscaleEndpoint().get(stackCrn);
     }
 
+    public void decommissionInstancesForCluster(Cluster cluster, List<String> decommissionNodeIds) {
+        requestLogging.logResponseTime(() -> {
+            cloudbreakInternalCrnClient.withUserCrn(cluster.getClusterPertain().getUserCrn()).autoscaleEndpoint()
+                    .decommissionInstancesForClusterCrn(cluster.getStackCrn(),
+                            cluster.getClusterPertain().getWorkspaceId(),
+                            decommissionNodeIds, false);
+            return Optional.empty();
+        }, String.format("DecommissionInstancesForCluster query for cluster crn %s, NodeIds %s",
+                cluster.getStackCrn(), decommissionNodeIds));
+    }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ClouderaManagerCommunicator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ClouderaManagerCommunicator.java
@@ -1,0 +1,82 @@
+package com.sequenceiq.periscope.monitor.handler;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.cloudera.api.swagger.RoleConfigGroupsResourceApi;
+import com.cloudera.api.swagger.client.ApiClient;
+import com.cloudera.api.swagger.model.ApiConfig;
+import com.sequenceiq.cloudbreak.client.HttpClientConfig;
+import com.sequenceiq.cloudbreak.cm.DataView;
+import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiClientProvider;
+import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
+import com.sequenceiq.cloudbreak.service.secret.service.SecretService;
+import com.sequenceiq.periscope.aspects.RequestLogging;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.ClusterManager;
+import com.sequenceiq.periscope.service.ClusterService;
+import com.sequenceiq.periscope.service.security.TlsHttpClientConfigurationService;
+
+@Service
+public class ClouderaManagerCommunicator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerCommunicator.class);
+
+    @Inject
+    private TlsHttpClientConfigurationService tlsHttpClientConfigurationService;
+
+    @Inject
+    private SecretService secretService;
+
+    @Inject
+    private ClusterService clusterService;
+
+    @Inject
+    private RequestLogging requestLogging;
+
+    @Inject
+    private ClouderaManagerApiFactory clouderaManagerApiFactory;
+
+    @Inject
+    private ClouderaManagerApiClientProvider clouderaManagerApiClientProvider;
+
+    public Map<String, ApiConfig> getRoleConfigPropertiesFromCM(Cluster cluster, String serviceName,
+            String roleGroupRef, Set roleConfigPropertyNames) {
+        LOGGER.debug("Retrieving roleConfigProperties for cluster '{}', service '{}', roleGroupRef '{}'",
+                cluster.getStackCrn(), serviceName, roleGroupRef);
+
+        HttpClientConfig httpClientConfig = tlsHttpClientConfigurationService.buildTLSClientConfig(cluster.getStackCrn(),
+                cluster.getClusterManager().getHost(), cluster.getTunnel());
+        ClusterManager cm = cluster.getClusterManager();
+        String user = secretService.get(cm.getUser());
+        String pass = secretService.get(cm.getPass());
+
+        Map<String, ApiConfig> roleConfigProperties = requestLogging.logResponseTime(() -> {
+            try {
+                ApiClient client = clouderaManagerApiClientProvider.getClient(Integer.valueOf(cm.getPort()), user, pass, httpClientConfig);
+                RoleConfigGroupsResourceApi roleConfigGroupsResourceApi = clouderaManagerApiFactory.getRoleConfigGroupsResourceApi(client);
+
+                return roleConfigGroupsResourceApi
+                        .readConfig(cluster.getStackName(), roleGroupRef, serviceName, DataView.FULL.name())
+                        .getItems().stream()
+                        .filter(apiConfig -> roleConfigPropertyNames.contains(apiConfig.getName()))
+                        .collect(Collectors.toMap(ApiConfig::getName, apiConfig -> apiConfig));
+            } catch (Exception ex) {
+                throw new RuntimeException(ex);
+            }
+        }, String.format("getRoleConfigPropertiesFromCM for cluster crn '%s'", cluster.getStackCrn()));
+
+        LOGGER.debug("Retrieved roleConfigPropertyValues for cluster '{}', service '{}', roleGroupRef '{}', roleConfigProperties '{}",
+                cluster.getStackCrn(), serviceName, roleGroupRef,
+                roleConfigProperties.values().stream().map(apiConfig -> String.format("ApiConfig Name '%s, Value '%s', Default '%s",
+                        apiConfig.getName(), apiConfig.getValue(), apiConfig.getDefault())).collect(Collectors.toSet()));
+        return roleConfigProperties;
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ScalingHandler.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ScalingHandler.java
@@ -13,16 +13,17 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.periscope.domain.BaseAlert;
 import com.sequenceiq.periscope.domain.Cluster;
 import com.sequenceiq.periscope.domain.ScalingPolicy;
-import com.sequenceiq.periscope.monitor.evaluator.cm.ClouderaManagerTotalHostsEvaluator;
+import com.sequenceiq.periscope.monitor.evaluator.ScalingConstants;
 import com.sequenceiq.periscope.monitor.event.ScalingEvent;
 import com.sequenceiq.periscope.service.ClusterService;
 import com.sequenceiq.periscope.service.RejectedThreadService;
 import com.sequenceiq.periscope.utils.ClusterUtils;
-import com.sequenceiq.periscope.utils.TimeUtil;
+import com.sequenceiq.periscope.utils.StackResponseUtils;
 
 @Component
 public class ScalingHandler implements ApplicationListener<ScalingEvent> {
@@ -43,62 +44,67 @@ public class ScalingHandler implements ApplicationListener<ScalingEvent> {
     private RejectedThreadService rejectedThreadService;
 
     @Inject
-    private ClouderaManagerTotalHostsEvaluator totalHostsEvaluatorService;
+    private StackResponseUtils stackResponseUtils;
+
+    @Inject
+    private CloudbreakCommunicator cloudbreakCommunicator;
 
     @Override
     public void onApplicationEvent(ScalingEvent event) {
         BaseAlert alert = event.getAlert();
         Cluster cluster = clusterService.findById(alert.getCluster().getId());
         MDCBuilder.buildMdcContext(cluster);
-        scale(cluster, alert.getScalingPolicy());
-    }
+        ScalingPolicy policy = alert.getScalingPolicy();
 
-    private void scale(Cluster cluster, ScalingPolicy policy) {
-        long remainingTime = getRemainingCooldownTime(cluster);
-        if (remainingTime <= 0) {
-            int totalNodes = totalHostsEvaluatorService.getTotalHosts(cluster);
-            int desiredNodeCount = getDesiredNodeCount(cluster, policy, totalNodes);
-            if (totalNodes != desiredNodeCount) {
-                Runnable scalingRequest = (Runnable) applicationContext.getBean("ScalingRequest", cluster, policy, totalNodes, desiredNodeCount);
-                executorService.submit(scalingRequest);
-                rejectedThreadService.remove(cluster.getId());
-                cluster.setLastScalingActivityCurrent();
-                clusterService.save(cluster);
-            } else {
-                LOGGER.debug("No scaling activity required");
-            }
+        int hostGroupNodeCount = getHostGroupNodeCount(event, cluster, policy);
+        int desiredNodeCount = getDesiredNodeCount(event, hostGroupNodeCount);
+        if (hostGroupNodeCount != desiredNodeCount) {
+            Runnable scalingRequest = (Runnable) applicationContext.getBean("ScalingRequest", cluster, policy,
+                    hostGroupNodeCount, desiredNodeCount, event.getDecommissionNodeIds());
+
+            executorService.submit(scalingRequest);
+            rejectedThreadService.remove(cluster.getId());
+            cluster.setLastScalingActivityCurrent();
+            clusterService.save(cluster);
         } else {
-            LOGGER.debug("Cluster cannot be scaled for {} min(s)",
-                    ClusterUtils.TIME_FORMAT.format((double) remainingTime / TimeUtil.MIN_IN_MS));
+            LOGGER.debug("No scaling activity required for cluster crn {}", cluster.getStackCrn());
         }
     }
 
-    private long getRemainingCooldownTime(Cluster cluster) {
-        long coolDown = cluster.getCoolDown();
-        long lastScalingActivity = cluster.getLastScalingActivity();
-        return lastScalingActivity == 0L ? 0L : (coolDown * TimeUtil.MIN_IN_MS) - (System.currentTimeMillis() - lastScalingActivity);
-    }
-
-    private int getDesiredNodeCount(Cluster cluster, ScalingPolicy policy, int totalNodes) {
+    private int getDesiredNodeCount(ScalingEvent event, int hostGroupNodeCount) {
+        ScalingPolicy policy = event.getAlert().getScalingPolicy();
         int scalingAdjustment = policy.getScalingAdjustment();
-        int desiredNodeCount;
+        int desiredHostGroupNodeCount;
         switch (policy.getAdjustmentType()) {
             case NODE_COUNT:
-                desiredNodeCount = totalNodes + scalingAdjustment;
+                desiredHostGroupNodeCount = hostGroupNodeCount + scalingAdjustment;
                 break;
             case PERCENTAGE:
-                desiredNodeCount = totalNodes
-                        + (int) (ceil(totalNodes * ((double) scalingAdjustment / ClusterUtils.MAX_CAPACITY)));
+                desiredHostGroupNodeCount = hostGroupNodeCount
+                        + (int) (ceil(hostGroupNodeCount * ((double) scalingAdjustment / ClusterUtils.MAX_CAPACITY)));
                 break;
             case EXACT:
-                desiredNodeCount = policy.getScalingAdjustment();
+                desiredHostGroupNodeCount = policy.getScalingAdjustment();
+                break;
+            case LOAD_BASED:
+                desiredHostGroupNodeCount = hostGroupNodeCount + event.getScalingNodeCount()
+                        .orElseGet(() -> {
+                            return -1 * event.getDecommissionNodeIds().size();
+                        });
                 break;
             default:
-                desiredNodeCount = totalNodes;
+                desiredHostGroupNodeCount = hostGroupNodeCount;
         }
-        int minSize = cluster.getMinSize();
-        int maxSize = cluster.getMaxSize();
-        return desiredNodeCount < minSize ? minSize : desiredNodeCount > maxSize ? maxSize : desiredNodeCount;
+        int minSize = ScalingConstants.DEFAULT_HOSTGROUP_MIN_SIZE;
+        int maxSize = ScalingConstants.DEFAULT_HOSTGROUP_MAX_SIZE;
+
+        return desiredHostGroupNodeCount < minSize ? minSize : desiredHostGroupNodeCount > maxSize ? maxSize : desiredHostGroupNodeCount;
     }
 
+    private Integer getHostGroupNodeCount(ScalingEvent event, Cluster cluster, ScalingPolicy policy) {
+        return event.getHostGroupNodeCount().orElseGet(() -> {
+            StackV4Response stackV4Response = cloudbreakCommunicator.getByCrn(cluster.getStackCrn());
+            return stackResponseUtils.getNodeCountForHostGroup(stackV4Response, policy.getHostGroup());
+        });
+    }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/repository/ClusterPertainRepository.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/repository/ClusterPertainRepository.java
@@ -1,0 +1,14 @@
+package com.sequenceiq.periscope.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
+import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
+import com.sequenceiq.periscope.domain.ClusterPertain;
+
+@EntityType(entityClass = ClusterPertain.class)
+public interface ClusterPertainRepository extends CrudRepository<ClusterPertain, Long> {
+    Optional<ClusterPertain> findByUserCrn(@Param("userCrn") String userCrn);
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/repository/ClusterRepository.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/repository/ClusterRepository.java
@@ -1,12 +1,14 @@
 package com.sequenceiq.periscope.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
 import com.sequenceiq.periscope.api.model.ClusterState;
 import com.sequenceiq.periscope.domain.Cluster;
@@ -16,14 +18,41 @@ public interface ClusterRepository extends CrudRepository<Cluster, Long> {
 
     Cluster findByStackId(@Param("stackId") Long stackId);
 
+    @Query(" SELECT c FROM Cluster c LEFT JOIN FETCH c.clusterPertain " +
+            " WHERE c.stackCrn = :stackCrn and c.clusterPertain.workspaceId = :workspaceId")
+    Optional<Cluster> findByStackCrnAndWorkspaceId(@Param("stackCrn") String stackCrn, @Param("workspaceId") Long workspaceId);
+
+    @Query(" SELECT c FROM Cluster c LEFT JOIN FETCH c.clusterPertain " +
+            " WHERE c.stackName = :stackName and c.clusterPertain.workspaceId = :workspaceId")
+    Optional<Cluster> findByStackNameAndWorkspaceId(@Param("stackName") String stackName, @Param("workspaceId") Long workspaceId);
+
+    @Query(" SELECT c FROM Cluster c LEFT JOIN FETCH c.clusterPertain " +
+            " WHERE c.id = :clusterId and c.clusterPertain.workspaceId = :workspaceId")
+    Optional<Cluster> findByClusterIdAndWorkspaceId(@Param("clusterId") Long clusterId, @Param("workspaceId") Long workspaceId);
+
     @Query("SELECT c.stackCrn FROM Cluster c WHERE c.id = :id")
     String findStackCrnById(@Param("id") Long id);
 
     @Query("SELECT c.id FROM Cluster c WHERE c.stackCrn = :stackCrn")
     Long findIdStackCrn(@Param("stackCrn") String stackCrn);
 
+    @Query("SELECT c FROM Cluster c WHERE c.id IN :clusterIds")
+    List<Cluster> findClustersByClusterIds(@Param("clusterIds") List<Long> clusterIds);
+
     @Query("SELECT c FROM Cluster c LEFT JOIN FETCH c.clusterPertain WHERE c.clusterPertain.userId = :userId")
     List<Cluster> findByUserId(@Param("userId") String userId);
+
+    @Query("SELECT c FROM Cluster c LEFT JOIN FETCH c.clusterPertain WHERE c.clusterPertain.workspaceId = :workspaceId and c.stackType = :stackType")
+    List<Cluster> findByWorkspaceIdAndStackType(@Param("workspaceId") Long workspaceId, @Param("stackType") StackType stackType);
+
+    @Query("SELECT distinct c.id FROM Cluster c JOIN c.loadAlerts loadalert WHERE c.stackType = :stackType " +
+            " and c.autoscalingEnabled = :autoScalingEnabled" +
+            " and c.state = :clusterState  " +
+            " and (:periscopeNodeId IS NULL or c.periscopeNodeId = :periscopeNodeId) ")
+    List<Long> findByLoadAlertAndStackTypeAndClusterStateAndAutoscaling(@Param("stackType") StackType stackType,
+            @Param("clusterState") ClusterState clusterState,
+            @Param("autoScalingEnabled") Boolean autoScalingEnabled,
+            @Param("periscopeNodeId") String periscopeNodeId);
 
     List<Cluster> findByStateAndPeriscopeNodeId(ClusterState state, String nodeId);
 
@@ -36,5 +65,4 @@ public interface ClusterRepository extends CrudRepository<Cluster, Long> {
     @Modifying
     @Query("UPDATE Cluster c SET c.periscopeNodeId = NULL WHERE c.periscopeNodeId = :periscopeNodeId")
     void deallocateClustersOfNode(@Param("periscopeNodeId") String periscopeNodeId);
-
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/repository/LoadAlertRepository.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/repository/LoadAlertRepository.java
@@ -1,0 +1,13 @@
+package com.sequenceiq.periscope.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
+import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
+import com.sequenceiq.periscope.domain.LoadAlert;
+
+@EntityType(entityClass = LoadAlert.class)
+public interface LoadAlertRepository extends CrudRepository<LoadAlert, Long> {
+
+    LoadAlert findByCluster(@Param("alertId") Long alertId, @Param("clusterId") Long clusterId);
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/AlertService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/AlertService.java
@@ -14,9 +14,11 @@ import com.sequenceiq.periscope.api.model.AlertRuleDefinitionEntry;
 import com.sequenceiq.periscope.aspects.RequestLogging;
 import com.sequenceiq.periscope.domain.BaseAlert;
 import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.LoadAlert;
 import com.sequenceiq.periscope.domain.MetricAlert;
 import com.sequenceiq.periscope.domain.PrometheusAlert;
 import com.sequenceiq.periscope.domain.TimeAlert;
+import com.sequenceiq.periscope.repository.LoadAlertRepository;
 import com.sequenceiq.periscope.repository.MetricAlertRepository;
 import com.sequenceiq.periscope.repository.PrometheusAlertRepository;
 import com.sequenceiq.periscope.repository.TimeAlertRepository;
@@ -39,6 +41,9 @@ public class AlertService {
 
     @Inject
     private TimeAlertRepository timeAlertRepository;
+
+    @Inject
+    private LoadAlertRepository loadAlertRepository;
 
     @Inject
     private PrometheusAlertRepository prometheusAlertRepository;
@@ -114,12 +119,18 @@ public class AlertService {
         return timeAlertRepository.findByCluster(alertId, clusterId);
     }
 
-    public TimeAlert updateTimeAlert(Long clusterId, Long alertId, TimeAlert timeAlert) {
+    public TimeAlert updateTimeAlert(Long clusterId, Long alertId, TimeAlert timeAlertForUpdate) {
         TimeAlert alert = timeAlertRepository.findByCluster(alertId, clusterId);
-        alert.setDescription(timeAlert.getDescription());
-        alert.setCron(timeAlert.getCron());
-        alert.setTimeZone(timeAlert.getTimeZone());
-        alert.setName(timeAlert.getName());
+        alert.setDescription(timeAlertForUpdate.getDescription());
+        alert.setCron(timeAlertForUpdate.getCron());
+        alert.setTimeZone(timeAlertForUpdate.getTimeZone());
+        alert.setName(timeAlertForUpdate.getName());
+        if (timeAlertForUpdate.getScalingPolicy() != null) {
+            alert.getScalingPolicy().setName(timeAlertForUpdate.getScalingPolicy().getName());
+            alert.getScalingPolicy().setAdjustmentType(timeAlertForUpdate.getScalingPolicy().getAdjustmentType());
+            alert.getScalingPolicy().setScalingAdjustment(timeAlertForUpdate.getScalingPolicy().getScalingAdjustment());
+            alert.getScalingPolicy().setHostGroup(timeAlertForUpdate.getScalingPolicy().getHostGroup());
+        }
         return timeAlertRepository.save(alert);
     }
 
@@ -156,6 +167,11 @@ public class AlertService {
         } catch (RuntimeException ignored) {
             LOGGER.info("Could not found Prometheus alert with id: '{}', for cluster: '{}'!", alertId, clusterId);
         }
+        try {
+            return findLoadAlertByCluster(clusterId, alertId);
+        } catch (RuntimeException ignored) {
+            LOGGER.info("Could not found Load alert with id: '{}', for cluster: '{}'!", alertId, clusterId);
+        }
 
         throw new NotFoundException(String.format("Could not found alert with id: '%s', for cluster: '%s'!", alertId, clusterId));
     }
@@ -169,6 +185,8 @@ public class AlertService {
             res = timeAlertRepository.save((TimeAlert) alert);
         } else if (alert instanceof PrometheusAlert) {
             res = prometheusAlertRepository.save((PrometheusAlert) alert);
+        } else if (alert instanceof LoadAlert) {
+            res = loadAlertRepository.save((LoadAlert) alert);
         }
         return res;
     }
@@ -224,5 +242,57 @@ public class AlertService {
 
     public Set<PrometheusAlert> getPrometheusAlerts(Long clusterId) {
         return prometheusAlertRepository.findAllByCluster(clusterId);
+    }
+
+    public LoadAlert createLoadAlert(Long clusterId, LoadAlert loadAlert) {
+        Cluster cluster = clusterService.findById(clusterId);
+        loadAlert.setCluster(cluster);
+        loadAlert = (LoadAlert) save(loadAlert);
+        cluster.addLoadAlert(loadAlert);
+        clusterService.save(cluster);
+        return loadAlert;
+    }
+
+    public LoadAlert updateLoadAlert(Long clusterId, Long alertId, LoadAlert loadAlertForUpdate) {
+        LoadAlert alert = loadAlertRepository.findByCluster(alertId, clusterId);
+        alert.setName(loadAlertForUpdate.getName());
+        alert.setDescription(loadAlertForUpdate.getDescription());
+        if (loadAlertForUpdate.getLoadAlertConfiguration() != null) {
+            alert.setLoadAlertConfiguration(loadAlertForUpdate.getLoadAlertConfiguration());
+        }
+        if (loadAlertForUpdate.getScalingPolicy() != null) {
+            alert.getScalingPolicy().setName(loadAlertForUpdate.getScalingPolicy().getName());
+            alert.getScalingPolicy().setAdjustmentType(loadAlertForUpdate.getScalingPolicy().getAdjustmentType());
+            alert.getScalingPolicy().setScalingAdjustment(loadAlertForUpdate.getScalingPolicy().getScalingAdjustment());
+            alert.getScalingPolicy().setHostGroup(loadAlertForUpdate.getScalingPolicy().getHostGroup());
+        }
+        return loadAlertRepository.save(alert);
+    }
+
+    public LoadAlert findLoadAlertByCluster(Long clusterId, Long alertId) {
+        return loadAlertRepository.findByCluster(alertId, clusterId);
+    }
+
+    public void deleteLoadAlert(Long clusterId, Long alertId) {
+        LoadAlert loadAlert = loadAlertRepository.findByCluster(alertId, clusterId);
+        Cluster cluster = clusterService.findById(clusterId);
+        cluster.setLoadAlerts(removeLoadAlert(cluster, alertId));
+        loadAlertRepository.delete(loadAlert);
+        clusterService.save(cluster);
+    }
+
+    public Set<LoadAlert> removeLoadAlert(Cluster cluster, Long alertId) {
+        return cluster.getLoadAlerts().stream().filter(a -> !a.getId().equals(alertId)).collect(Collectors.toSet());
+    }
+
+    public Set<LoadAlert> getLoadAlertsForClusterHostGroup(Long clusterId, String hostGroup) {
+        Cluster cluster = clusterService.findById(clusterId);
+        return cluster.getLoadAlerts().stream()
+                .filter(a -> a.getScalingPolicy().getHostGroup().equals(hostGroup)).collect(Collectors.toSet());
+    }
+
+    public Set<LoadAlert> getLoadAlerts(Long clusterId) {
+        Cluster cluster = clusterService.findById(clusterId);
+        return cluster.getLoadAlerts();
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/AutoscaleRestRequestThreadLocalService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/AutoscaleRestRequestThreadLocalService.java
@@ -7,10 +7,13 @@ import com.sequenceiq.cloudbreak.common.user.CloudbreakUser;
 @Service("RestRequestThreadLocalService")
 public class AutoscaleRestRequestThreadLocalService {
 
+    private static final ThreadLocal<Long> REQUESTED_WORKSPACE_ID = new ThreadLocal<>();
+
     private static final ThreadLocal<CloudbreakUser> CLOUDBREAK_USER = new ThreadLocal<>();
 
-    public void setCloudbreakUser(CloudbreakUser cloudbreakUser) {
+    public void setCloudbreakUser(CloudbreakUser cloudbreakUser, Long workspaceId) {
         CLOUDBREAK_USER.set(cloudbreakUser);
+        REQUESTED_WORKSPACE_ID.set(workspaceId);
     }
 
     public CloudbreakUser getCloudbreakUser() {
@@ -19,6 +22,12 @@ public class AutoscaleRestRequestThreadLocalService {
 
     public void removeCloudbreakUser() {
         CLOUDBREAK_USER.remove();
+        REQUESTED_WORKSPACE_ID.remove();
     }
+
+    public Long getRequestedWorkspaceId() {
+        return REQUESTED_WORKSPACE_ID.get();
+    }
+
 }
 

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/ClusterPertainService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/ClusterPertainService.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.periscope.service;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.periscope.domain.ClusterPertain;
+import com.sequenceiq.periscope.repository.ClusterPertainRepository;
+
+@Service
+public class ClusterPertainService {
+
+    @Inject
+    private ClusterPertainRepository clusterPertainRepository;
+
+    public Optional<ClusterPertain> getClusterPertain(String clusterUserCrn) {
+        return clusterPertainRepository.findByUserCrn(clusterUserCrn);
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/ClusterService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/ClusterService.java
@@ -7,6 +7,7 @@ import static org.springframework.util.StringUtils.isEmpty;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.StreamSupport;
 
 import javax.annotation.PostConstruct;
@@ -17,6 +18,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.authorization.resource.AuthorizationResourceType;
+import com.sequenceiq.authorization.service.ResourceBasedCrnProvider;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.common.user.CloudbreakUser;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.periscope.api.model.ClusterState;
@@ -33,7 +37,7 @@ import com.sequenceiq.periscope.repository.SecurityConfigRepository;
 import com.sequenceiq.periscope.service.ha.PeriscopeNodeConfig;
 
 @Service
-public class ClusterService {
+public class ClusterService implements ResourceBasedCrnProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ClusterService.class);
 
@@ -66,10 +70,15 @@ public class ClusterService {
 
     public Cluster create(Cluster cluster, ClusterPertain clusterPertain, MonitoredStack stack, ClusterState clusterState) {
         cluster.setClusterPertain(clusterPertain);
+        cluster.setStackName(stack.getStackName());
         cluster.setClusterManager(stack.getClusterManager());
         cluster.setStackCrn(stack.getStackCrn());
         cluster.setStackId(stack.getStackId());
+        cluster.setStackType(stack.getStackType());
         cluster.setTunnel(stack.getTunnel());
+        if (stack.getCloudPlatform() != null) {
+            cluster.setCloudPlatform(stack.getCloudPlatform().toUpperCase());
+        }
         if (clusterState != null) {
             cluster.setState(clusterState);
         }
@@ -92,6 +101,7 @@ public class ClusterService {
         ClusterState newState = clusterState != null ? clusterState : cluster.getState();
         cluster.setState(newState);
         cluster.setAutoscalingEnabled(enableAutoscaling);
+        cluster.setStackName(stack.getStackName());
         cluster.update(stack);
         SecurityConfig sSecConf = stack.getSecurityConfig();
         if (sSecConf != null) {
@@ -117,8 +127,24 @@ public class ClusterService {
         return clusterRepository.findByUserId(user.getUserId());
     }
 
+    public List<Cluster> findDistroXByWorkspace(Long workspaceId) {
+        return clusterRepository.findByWorkspaceIdAndStackType(workspaceId, StackType.WORKLOAD);
+    }
+
     public Cluster findOneByStackId(Long stackId) {
         return clusterRepository.findByStackId(stackId);
+    }
+
+    public Optional<Cluster> findOneByStackCrnAndWorkspaceId(String stackCrn, Long workspaceId) {
+        return  clusterRepository.findByStackCrnAndWorkspaceId(stackCrn, workspaceId);
+    }
+
+    public Optional<Cluster> findOneByStackNameAndWorkspaceId(String stackName, Long workspaceId) {
+        return  clusterRepository.findByStackNameAndWorkspaceId(stackName, workspaceId);
+    }
+
+    public Optional<Cluster> findOneByClusterIdAndWorkspaceId(Long clusterId, Long workspaceId) {
+        return  clusterRepository.findByClusterIdAndWorkspaceId(clusterId, workspaceId);
     }
 
     public Cluster save(Cluster cluster) {
@@ -170,7 +196,7 @@ public class ClusterService {
         return cluster;
     }
 
-    public Cluster setAutoscaleState(Long clusterId, boolean enableAutoscaling) {
+    public Cluster setAutoscaleState(Long clusterId, Boolean enableAutoscaling) {
         Cluster cluster = findById(clusterId);
         MDCBuilder.buildMdcContext(cluster);
         cluster.setAutoscalingEnabled(enableAutoscaling);
@@ -180,12 +206,30 @@ public class ClusterService {
         return cluster;
     }
 
+    @Override
+    public AuthorizationResourceType getResourceType() {
+        return AuthorizationResourceType.DATAHUB;
+    }
+
+    public String findStackCrnById(Long clusterId) {
+        return clusterRepository.findStackCrnById(clusterId);
+    }
+
     public List<Cluster> findAllByStateAndNode(ClusterState state, String nodeId) {
         return clusterRepository.findByStateAndPeriscopeNodeId(state, nodeId);
     }
 
     public List<Cluster> findAllForNode(ClusterState state, boolean autoscalingEnabled, String nodeId) {
         return clusterRepository.findByStateAndAutoscalingEnabledAndPeriscopeNodeId(state, autoscalingEnabled, nodeId);
+    }
+
+    public List<Cluster> findClustersByClusterIds(List<Long> clusterIds) {
+        return clusterRepository.findClustersByClusterIds(clusterIds);
+    }
+
+    public List<Long> findLoadAlertClustersForNode(StackType stackType, ClusterState state,
+            boolean autoscalingEnabled, String nodeId) {
+        return clusterRepository.findByLoadAlertAndStackTypeAndClusterStateAndAutoscaling(stackType, state, autoscalingEnabled, nodeId);
     }
 
     public void validateClusterUniqueness(MonitoredStack stack) {
@@ -216,5 +260,12 @@ public class ClusterService {
                 clusterRepository.countByStateAndAutoscalingEnabledAndPeriscopeNodeId(RUNNING, true, periscopeNodeConfig.getId()));
         metricService.submit(MetricType.CLUSTER_STATE_SUSPENDED,
                 clusterRepository.countByStateAndAutoscalingEnabledAndPeriscopeNodeId(SUSPENDED, true, periscopeNodeConfig.getId()));
+    }
+
+    public void deleteAlertsForCluster(Long clusterId) {
+        Cluster cluster = findById(clusterId);
+        cluster.getLoadAlerts().clear();
+        cluster.getTimeAlerts().clear();
+        save(cluster);
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/EntitlementValidationService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/EntitlementValidationService.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.periscope.service;
+
+import java.util.Map;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+
+@Service
+public class EntitlementValidationService {
+
+    private static final String ALLOWED = "ALLOWED_PLATFORM";
+
+    private static final Map<String, String> PLATFORM_ENTITLEMENTS = Map.of(
+            "AWS", "CDP_AWS_AUTOSCALING",
+            "AZURE", "CDP_AZURE_AUTOSCALING",
+            "YARN", ALLOWED);
+
+    @Value("${periscope.entitlementCheckEnabled:true}")
+    private Boolean entitlementCheckEnabled;
+
+    @Inject
+    private EntitlementService entitlementService;
+
+    @Cacheable(cacheNames = "accountEntitlementCache", key = "{#accountId,#cloudPlatform}")
+    public boolean autoscalingEntitlementEnabled(String userCrn, String accountId, String cloudPlatform) {
+        boolean entitled;
+        Optional<String> platformEntitlement = Optional.ofNullable(PLATFORM_ENTITLEMENTS.get(cloudPlatform));
+        if (!entitlementCheckEnabled || platformEntitlement.map(entitlement -> ALLOWED.equals(entitlement)).orElse(false)) {
+            entitled = true;
+        } else if (platformEntitlement.isEmpty()) {
+            entitled = false;
+        } else {
+            entitled = entitlementService.getEntitlements(userCrn, accountId)
+                    .stream().anyMatch(e -> e.equalsIgnoreCase(platformEntitlement.get()));
+        }
+        return entitled;
+    }
+}

--- a/autoscale/src/main/resources/application-test.yml
+++ b/autoscale/src/main/resources/application-test.yml
@@ -34,16 +34,17 @@ periscope:
     dir: /certs/
 
   db:
-    env:
-      user: postgres
-      pass:
-      db: periscopedb
-      schema: public
-      cert.file: database.crt
-      ssl: false
-    port.5432.tcp:
-      addr: localhost
-      port: 5432
+    enabled: false
+#    env:
+#      user: postgres
+#      pass:
+#      db: periscopedb
+#      schema: public
+#      cert.file: database.crt
+#      ssl: false
+#    port.5432.tcp:
+#      addr: localhost
+#      port: 5432
   cloudbreak.url: http://localhost:9091
   entitlementCheckEnabled: false
   enabledAutoscaleMonitors:
@@ -53,14 +54,15 @@ periscope:
       enabled: true
     cluster-manager-host-health-monitor:
       enabled: true
-    suspended-cluster-monitor:
-      enabled: true
     prometheus-monitor:
       enabled: false
 
 cb:
   server:
     contextPath: "/cb"
+  schema:
+    migration:
+      auto: false
 
 rest:
   debug: false
@@ -77,25 +79,17 @@ spring:
     template-loader-path: classpath:/
     prefer-file-system-access: false
   datasource:
-      maxActive: 30
+    maxActive: 30
+  profiles: test
 
 secret:
   application: as/shared
   engine: "com.sequenceiq.cloudbreak.service.secret.vault.VaultKvV2Engine"
 
 vault:
-  addr: localhost
-  port: 8200
-  ssl.enabled: false
-  kv.engine.v2.path: secret
-  config.enabled: true
-  auth:
-    type: "token"
-    kubernetes:
-      service.account.token.path: /var/run/secrets/kubernetes.io/serviceaccount/token
-      mount.path: "dps-dev"
-      login.role: "autoscale.default"
+  config.enabled: false
 
 altus:
   ums:
     host: localhost
+

--- a/autoscale/src/main/resources/schema/app/20200311042200_CB-5734_add_loadbased_alert_type.sql
+++ b/autoscale/src/main/resources/schema/app/20200311042200_CB-5734_add_loadbased_alert_type.sql
@@ -1,0 +1,19 @@
+-- // cb-5734-add-loadbased-alert-type
+-- Migration SQL that makes the change goes here.
+
+CREATE TABLE IF NOT EXISTS loadalert (
+    id bigint NOT NULL,
+    description character varying(255),
+    name character varying(255),
+    load_alert_config character varying(1024),
+    scalingpolicy_id bigint,
+    cluster_id bigint,
+    CONSTRAINT loadalert_pkey PRIMARY KEY (id),
+    CONSTRAINT fk_loadalert_cluster_id FOREIGN KEY (cluster_id) REFERENCES cluster(id),
+    CONSTRAINT fk_loadalert_scalingpolicy_id FOREIGN KEY (scalingpolicy_id) REFERENCES scalingpolicy(id)
+);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+DROP TABLE IF EXISTS loadalert;

--- a/autoscale/src/main/resources/schema/app/20200318083430_CB-5734_cluster_table_enhancements.sql
+++ b/autoscale/src/main/resources/schema/app/20200318083430_CB-5734_cluster_table_enhancements.sql
@@ -1,0 +1,22 @@
+-- // CB-5734_cluster_table_enhancements
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE cluster ADD COLUMN IF NOT EXISTS cb_stack_name VARCHAR(255);
+
+ALTER TABLE cluster ADD COLUMN IF NOT EXISTS cb_stack_type VARCHAR(255);
+
+ALTER TABLE cluster ADD COLUMN IF NOT EXISTS cloud_platform VARCHAR(255);
+
+CREATE INDEX IF NOT EXISTS idx_cluster_cb_stack_type ON cluster (cb_stack_type);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+DROP INDEX IF EXISTS idx_cluster_cb_stack_type;
+
+ALTER TABLE cluster DROP COLUMN IF EXISTS cb_stack_name;
+
+ALTER TABLE cluster DROP COLUMN IF EXISTS cb_stack_type;
+
+ALTER TABLE cluster DROP COLUMN IF EXISTS cloud_platform;
+

--- a/autoscale/src/main/resources/schema/app/20200414121801_CB-5736_cluster_creator_crn_retrieval.sql
+++ b/autoscale/src/main/resources/schema/app/20200414121801_CB-5736_cluster_creator_crn_retrieval.sql
@@ -1,0 +1,10 @@
+-- // CB-5736 cluster creator crn retrieval
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE clusterpertain ADD COLUMN IF NOT EXISTS usercrn VARCHAR(512);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+
+ALTER TABLE clusterpertain DROP COLUMN IF EXISTS usercrn;

--- a/autoscale/src/test/java/com/sequenceiq/periscope/component/MetricTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/component/MetricTest.java
@@ -393,7 +393,7 @@ public class MetricTest {
     }
 
     private ClusterPertain getClusterPertain() {
-        return new ClusterPertain("tenant", 1L, "user");
+        return new ClusterPertain("tenant", 1L, "user", "userCrn");
     }
 
     private Cluster getACluster(ClusterState clusterState) {

--- a/autoscale/src/test/java/com/sequenceiq/periscope/controller/AlertControllerTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/controller/AlertControllerTest.java
@@ -1,0 +1,256 @@
+package com.sequenceiq.periscope.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.Set;
+
+import javax.ws.rs.BadRequestException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.powermock.reflect.Whitebox;
+
+import com.sequenceiq.common.api.type.Tunnel;
+import com.sequenceiq.periscope.api.model.LoadAlertConfigurationRequest;
+import com.sequenceiq.periscope.api.model.LoadAlertRequest;
+import com.sequenceiq.periscope.api.model.ScalingPolicyRequest;
+import com.sequenceiq.periscope.api.model.TimeAlertRequest;
+import com.sequenceiq.periscope.converter.LoadAlertConfigurationRequestConverter;
+import com.sequenceiq.periscope.converter.LoadAlertRequestConverter;
+import com.sequenceiq.periscope.converter.LoadAlertResponseConverter;
+import com.sequenceiq.periscope.converter.ScalingPolicyRequestConverter;
+import com.sequenceiq.periscope.converter.TimeAlertRequestConverter;
+import com.sequenceiq.periscope.converter.TimeAlertResponseConverter;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.LoadAlert;
+import com.sequenceiq.periscope.domain.LoadAlertConfiguration;
+import com.sequenceiq.periscope.domain.ScalingPolicy;
+import com.sequenceiq.periscope.domain.TimeAlert;
+import com.sequenceiq.periscope.service.AlertService;
+import com.sequenceiq.periscope.service.AutoscaleRestRequestThreadLocalService;
+import com.sequenceiq.periscope.service.ClusterService;
+import com.sequenceiq.periscope.service.DateService;
+import com.sequenceiq.periscope.service.NotFoundException;
+import com.sequenceiq.periscope.service.configuration.ClusterProxyConfigurationService;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AlertControllerTest {
+
+    @InjectMocks
+    private AlertController underTest;
+
+    @Mock
+    private AlertService alertService;
+
+    @Mock
+    private ClusterService clusterService;
+
+    @Mock
+    private LoadAlertRequestConverter loadAlertRequestConverter;
+
+    @Mock
+    private LoadAlertResponseConverter loadAlertResponseConverter;
+
+    @Mock
+    private ScalingPolicyRequestConverter scalingPolicyRequestConverter;
+
+    @Mock
+    private LoadAlertConfigurationRequestConverter loadAlertConfigurationRequestConverter;
+
+    @Mock
+    private TimeAlertRequestConverter timeAlertRequestConverter;
+
+    @Mock
+    private TimeAlertResponseConverter timeAlertResponseConverter;
+
+    @Mock
+    private AutoscaleRestRequestThreadLocalService restRequestThreadLocalService;
+
+    @Mock
+    private ClusterProxyConfigurationService clusterProxyConfigurationService;
+
+    private DateService dateService = new DateService();
+
+    private Long clusterId = 10L;
+
+    private Long workspaceId = 10L;
+
+    private Long alertId = 20L;
+
+    @Before
+    public void setup() {
+        Whitebox.setInternalState(underTest, "supportedCloudPlatforms", Set.of("AWS", "AZURE"));
+        underTest.setDateService(dateService);
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void testLoadAlertUpdateNotFound() {
+        LoadAlertRequest request = getALoadAlertRequest();
+
+        Optional<Cluster> aCluster = getACluster();
+        when(restRequestThreadLocalService.getRequestedWorkspaceId()).thenReturn(workspaceId);
+        when(clusterService.findOneByClusterIdAndWorkspaceId(clusterId, workspaceId)).thenReturn(aCluster);
+
+        underTest.updateLoadAlert(clusterId, alertId, request);
+    }
+
+    @Test
+    public void testLoadAlertUpdate() {
+        LoadAlertRequest request = getALoadAlertRequest();
+        LoadAlert alert = getALoadAlert();
+
+        Optional<Cluster> aCluster = getACluster();
+        aCluster.get().setLoadAlerts(Set.of(alert));
+        when(restRequestThreadLocalService.getRequestedWorkspaceId()).thenReturn(workspaceId);
+        when(clusterService.findOneByClusterIdAndWorkspaceId(clusterId, workspaceId)).thenReturn(aCluster);
+        when(loadAlertRequestConverter.convert(request)).thenReturn(alert);
+
+        underTest.updateLoadAlert(clusterId, alertId, request);
+        verify(alertService).updateLoadAlert(anyLong(), anyLong(), any(LoadAlert.class));
+    }
+
+    @Test
+    public void testLoadAlertCreate() {
+        LoadAlertRequest request = getALoadAlertRequest();
+
+        Optional<Cluster> aCluster = getACluster();
+        when(loadAlertRequestConverter.convert(request)).thenReturn(getALoadAlert());
+        when(restRequestThreadLocalService.getRequestedWorkspaceId()).thenReturn(workspaceId);
+        when(clusterService.findOneByClusterIdAndWorkspaceId(clusterId, workspaceId)).thenReturn(aCluster);
+        when(clusterProxyConfigurationService.getClusterProxyUrl()).thenReturn(Optional.of("http://clusterproxy"));
+
+        underTest.createLoadAlert(clusterId, request);
+        verify(alertService).createLoadAlert(anyLong(), any(LoadAlert.class));
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testLoadAlertCreateWhenClusterProxyNotRegistered() {
+        LoadAlertRequest request = getALoadAlertRequest();
+
+        Optional<Cluster> aCluster = getACluster();
+        when(restRequestThreadLocalService.getRequestedWorkspaceId()).thenReturn(workspaceId);
+        when(clusterService.findOneByClusterIdAndWorkspaceId(clusterId, workspaceId)).thenReturn(aCluster);
+        when(clusterProxyConfigurationService.getClusterProxyUrl()).thenReturn(Optional.empty());
+
+        underTest.createLoadAlert(clusterId, request);
+        verify(alertService).createLoadAlert(anyLong(), any(LoadAlert.class));
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testInvalidCloudPlatform() {
+        LoadAlertRequest request = getALoadAlertRequest();
+        Optional<Cluster> aCluster = getACluster();
+        aCluster.get().setCloudPlatform("Yarn");
+
+        when(restRequestThreadLocalService.getRequestedWorkspaceId()).thenReturn(workspaceId);
+        when(clusterService.findOneByClusterIdAndWorkspaceId(clusterId, workspaceId)).thenReturn(aCluster);
+
+        underTest.createLoadAlert(clusterId, request);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testLoadAlertCreateDuplicate() {
+        LoadAlertRequest request = getALoadAlertRequest();
+
+        Optional<Cluster> aCluster = getACluster();
+        aCluster.get().setLoadAlerts(Set.of(getALoadAlert()));
+
+        when(restRequestThreadLocalService.getRequestedWorkspaceId()).thenReturn(workspaceId);
+        when(clusterService.findOneByClusterIdAndWorkspaceId(clusterId, workspaceId)).thenReturn(aCluster);
+
+        underTest.createLoadAlert(clusterId, request);
+    }
+
+    @Test
+    public void testTimeAlertCreate() {
+        TimeAlertRequest request = new TimeAlertRequest();
+        request.setCron("1 0 1 1 1 1");
+        request.setTimeZone("GMT");
+        ScalingPolicyRequest scalingPolicy = new ScalingPolicyRequest();
+        scalingPolicy.setHostGroup("compute");
+        request.setScalingPolicy(scalingPolicy);
+
+        Optional<Cluster> aCluster = getACluster();
+
+        when(restRequestThreadLocalService.getRequestedWorkspaceId()).thenReturn(workspaceId);
+        when(clusterService.findOneByClusterIdAndWorkspaceId(clusterId, workspaceId)).thenReturn(aCluster);
+        when(timeAlertRequestConverter.convert(request)).thenReturn(new TimeAlert());
+
+        underTest.createTimeAlert(clusterId, request);
+        verify(alertService).createTimeAlert(anyLong(), any(TimeAlert.class));
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void testTimeAlertUpdateNotFound() {
+        TimeAlertRequest request = new TimeAlertRequest();
+
+        Optional<Cluster> aCluster = getACluster();
+        when(restRequestThreadLocalService.getRequestedWorkspaceId()).thenReturn(workspaceId);
+        when(clusterService.findOneByClusterIdAndWorkspaceId(clusterId, workspaceId)).thenReturn(aCluster);
+        underTest.updateTimeAlert(clusterId, alertId, request);
+    }
+
+    @Test
+    public void testTimeAlertUpdate() {
+        TimeAlertRequest request = new TimeAlertRequest();
+        request.setCron("1 0 1 1 1 1");
+        request.setTimeZone("GMT");
+        ScalingPolicyRequest scalingPolicy = new ScalingPolicyRequest();
+        scalingPolicy.setHostGroup("compute");
+        request.setScalingPolicy(scalingPolicy);
+        TimeAlert alert = new TimeAlert();
+        alert.setId(alertId);
+
+        Optional<Cluster> aCluster = getACluster();
+        aCluster.get().setTimeAlerts(Set.of(alert));
+        when(restRequestThreadLocalService.getRequestedWorkspaceId()).thenReturn(workspaceId);
+        when(clusterService.findOneByClusterIdAndWorkspaceId(clusterId, workspaceId)).thenReturn(aCluster);
+        when(timeAlertRequestConverter.convert(request)).thenReturn(alert);
+
+        underTest.updateTimeAlert(clusterId, alertId, request);
+        verify(alertService).updateTimeAlert(anyLong(), anyLong(), any(TimeAlert.class));
+    }
+
+    private LoadAlert getALoadAlert() {
+        LoadAlert alert = new LoadAlert();
+        alert.setId(alertId);
+        LoadAlertConfiguration testConfiguration = new LoadAlertConfiguration();
+        testConfiguration.setMaxResourceValue(200);
+        testConfiguration.setMinResourceValue(0);
+        alert.setLoadAlertConfiguration(testConfiguration);
+
+        ScalingPolicy scalingPolicy = new ScalingPolicy();
+        scalingPolicy.setHostGroup("compute");
+        alert.setScalingPolicy(scalingPolicy);
+        return alert;
+    }
+
+    private LoadAlertRequest getALoadAlertRequest() {
+        LoadAlertRequest loadAlertRequest = new LoadAlertRequest();
+        LoadAlertConfigurationRequest testConfiguration = new LoadAlertConfigurationRequest();
+        testConfiguration.setMaxResourceValue(200);
+        testConfiguration.setMinResourceValue(0);
+        loadAlertRequest.setLoadAlertConfiguration(testConfiguration);
+        ScalingPolicyRequest scalingPolicy = new ScalingPolicyRequest();
+        scalingPolicy.setHostGroup("compute");
+        loadAlertRequest.setScalingPolicy(scalingPolicy);
+        return loadAlertRequest;
+    }
+
+    private Optional<Cluster> getACluster() {
+        Cluster cluster = new Cluster();
+        cluster.setCloudPlatform("AWS");
+        cluster.setTunnel(Tunnel.CLUSTER_PROXY);
+        return Optional.of(cluster);
+    }
+}

--- a/autoscale/src/test/java/com/sequenceiq/periscope/converter/LoadAlertRequestConverterTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/converter/LoadAlertRequestConverterTest.java
@@ -1,0 +1,63 @@
+package com.sequenceiq.periscope.converter;
+
+import static com.sequenceiq.periscope.api.model.AdjustmentType.LOAD_BASED;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.sequenceiq.periscope.api.model.LoadAlertRequest;
+import com.sequenceiq.periscope.api.model.ScalingPolicyRequest;
+import com.sequenceiq.periscope.domain.LoadAlert;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LoadAlertRequestConverterTest {
+
+    @Mock
+    ScalingPolicyRequestConverter scalingPolicyRequestConverter;
+
+    @InjectMocks
+    private LoadAlertRequestConverter underTest = new LoadAlertRequestConverter();
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testConvertLoadAlertRequestToLoadAlert() {
+        LoadAlertRequest req = new LoadAlertRequest();
+        req.setAlertName("loadalert");
+        req.setDescription("loadalertdesc");
+
+        ScalingPolicyRequest scalingPolicyRequest = getScalingPolicyRequest();
+        req.setScalingPolicy(scalingPolicyRequest);
+
+        when(scalingPolicyRequestConverter.convert(any(ScalingPolicyRequest.class))).thenCallRealMethod();
+
+        LoadAlert loadAlert = underTest.convert(req);
+        assertEquals("LoadAlert Name should match", loadAlert.getName(), "loadalert");
+        assertEquals("LoadAlert Desc should match", loadAlert.getDescription(), "loadalertdesc");
+        assertEquals("LoadAlert Hostgroup should match",
+                loadAlert.getScalingPolicy().getHostGroup(), "compute");
+        assertEquals("LoadAlert Adjustment Type should match",
+                loadAlert.getScalingPolicy().getAdjustmentType(), LOAD_BASED);
+        assertEquals("LoadAlert Adjustment should match",
+                loadAlert.getScalingPolicy().getScalingAdjustment(), 10);
+    }
+
+    private ScalingPolicyRequest getScalingPolicyRequest() {
+        ScalingPolicyRequest scalingPolicyRequest = new ScalingPolicyRequest();
+        scalingPolicyRequest.setAdjustmentType(LOAD_BASED);
+        scalingPolicyRequest.setHostGroup("compute");
+        scalingPolicyRequest.setScalingAdjustment(10);
+        return scalingPolicyRequest;
+    }
+}

--- a/autoscale/src/test/java/com/sequenceiq/periscope/converter/LoadAlertResponseConverterTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/converter/LoadAlertResponseConverterTest.java
@@ -1,0 +1,65 @@
+package com.sequenceiq.periscope.converter;
+
+import static com.sequenceiq.periscope.api.model.AdjustmentType.NODE_COUNT;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.sequenceiq.periscope.api.model.LoadAlertResponse;
+import com.sequenceiq.periscope.domain.LoadAlert;
+import com.sequenceiq.periscope.domain.ScalingPolicy;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LoadAlertResponseConverterTest {
+
+    @Mock
+    ScalingPolicyResponseConverter scalingPolicyResponseConverter;
+
+    @InjectMocks
+    private LoadAlertResponseConverter underTest = new LoadAlertResponseConverter();
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testConvertLoadAlertToLoadAlertResponse() {
+        LoadAlert req = new LoadAlert();
+        req.setName("loadalert");
+        req.setDescription("loadalertdesc");
+        req.setId(10L);
+
+        ScalingPolicy scalingPolicy = getScalingPolicy();
+        req.setScalingPolicy(scalingPolicy);
+
+        when(scalingPolicyResponseConverter.convert(any(ScalingPolicy.class))).thenCallRealMethod();
+
+        LoadAlertResponse loadAlertResponse = underTest.convert(req);
+        assertEquals("LoadAlert Name should match", loadAlertResponse.getAlertName(), "loadalert");
+        assertEquals("LoadAlert Desc should match", loadAlertResponse.getDescription(), "loadalertdesc");
+        assertEquals("LoadAlert Hostgroup should match",
+                loadAlertResponse.getScalingPolicy().getHostGroup(), "compute");
+        assertEquals("LoadAlert Adjustment Type should match",
+                loadAlertResponse.getScalingPolicy().getAdjustmentType(), NODE_COUNT);
+        assertEquals("LoadAlert Adjustment should match",
+                loadAlertResponse.getScalingPolicy().getScalingAdjustment(), 10);
+    }
+
+    private ScalingPolicy getScalingPolicy() {
+        ScalingPolicy scalingPolicy = new ScalingPolicy();
+        scalingPolicy.setName("loadalertpolicy");
+        scalingPolicy.setAdjustmentType(NODE_COUNT);
+        scalingPolicy.setHostGroup("compute");
+        scalingPolicy.setScalingAdjustment(10);
+        return scalingPolicy;
+    }
+}

--- a/autoscale/src/test/java/com/sequenceiq/periscope/converter/TimeAlertRequestConverterTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/converter/TimeAlertRequestConverterTest.java
@@ -1,0 +1,68 @@
+package com.sequenceiq.periscope.converter;
+
+import static com.sequenceiq.periscope.api.model.AdjustmentType.NODE_COUNT;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.sequenceiq.periscope.api.model.ScalingPolicyRequest;
+import com.sequenceiq.periscope.api.model.TimeAlertRequest;
+import com.sequenceiq.periscope.domain.TimeAlert;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TimeAlertRequestConverterTest {
+
+    @Mock
+    ScalingPolicyRequestConverter scalingPolicyRequestConverter;
+
+    @InjectMocks
+    private TimeAlertRequestConverter underTest = new TimeAlertRequestConverter();
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testConvertTimeAlertRequestToTimeAlert() {
+        TimeAlertRequest req = new TimeAlertRequest();
+        req.setAlertName("timealert");
+        req.setDescription("timealertdesc");
+        req.setTimeZone("GMT - 5");
+        req.setCron("0   23  */2 *   *");
+
+        ScalingPolicyRequest scalingPolicyRequest = getScalingPolicyRequest();
+        req.setScalingPolicy(scalingPolicyRequest);
+
+        when(scalingPolicyRequestConverter.convert(any(ScalingPolicyRequest.class))).thenCallRealMethod();
+
+        TimeAlert timeAlert = underTest.convert(req);
+        assertEquals("TimeAlert Name should match", timeAlert.getName(), "timealert");
+        assertEquals("TimeAlert Desc should match", timeAlert.getDescription(), "timealertdesc");
+        assertEquals("TimeAlert Cron should match", timeAlert.getCron(), "0   23  */2 *   *");
+        assertEquals("TimeAlert Timezone should match", timeAlert.getTimeZone(), "GMT - 5");
+
+        assertEquals("TimeAlert Hostgroup should match",
+                timeAlert.getScalingPolicy().getHostGroup(), "compute");
+        assertEquals("TimeAlert Adjustment Type should match",
+                timeAlert.getScalingPolicy().getAdjustmentType(), NODE_COUNT);
+        assertEquals("TimeAlert Adjustment should match",
+                timeAlert.getScalingPolicy().getScalingAdjustment(), 10);
+    }
+
+    private ScalingPolicyRequest getScalingPolicyRequest() {
+        ScalingPolicyRequest scalingPolicyRequest = new ScalingPolicyRequest();
+        scalingPolicyRequest.setAdjustmentType(NODE_COUNT);
+        scalingPolicyRequest.setHostGroup("compute");
+        scalingPolicyRequest.setScalingAdjustment(10);
+        return scalingPolicyRequest;
+    }
+}

--- a/autoscale/src/test/java/com/sequenceiq/periscope/converter/TimeAlertResponseConverterTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/converter/TimeAlertResponseConverterTest.java
@@ -1,0 +1,70 @@
+package com.sequenceiq.periscope.converter;
+
+import static com.sequenceiq.periscope.api.model.AdjustmentType.NODE_COUNT;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.sequenceiq.periscope.api.model.TimeAlertResponse;
+import com.sequenceiq.periscope.domain.ScalingPolicy;
+import com.sequenceiq.periscope.domain.TimeAlert;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TimeAlertResponseConverterTest {
+
+    @Mock
+    ScalingPolicyResponseConverter scalingPolicyResponseConverter;
+
+    @InjectMocks
+    private TimeAlertResponseConverter underTest = new TimeAlertResponseConverter();
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testConvertTimeAlertToTimeAlertResponse() {
+        TimeAlert timeAlert = new TimeAlert();
+        timeAlert.setName("timealert");
+        timeAlert.setDescription("timealertdesc");
+        timeAlert.setCron("0   23  */2 *   *");
+        timeAlert.setTimeZone("GMT");
+        timeAlert.setId(20L);
+
+        ScalingPolicy scalingPolicy = getScalingPolicy();
+        timeAlert.setScalingPolicy(scalingPolicy);
+
+        when(scalingPolicyResponseConverter.convert(any(ScalingPolicy.class))).thenCallRealMethod();
+
+        TimeAlertResponse timeAlertResponse = underTest.convert(timeAlert);
+        assertEquals("TimeAlert Name should match", timeAlertResponse.getAlertName(), "timealert");
+        assertEquals("TimeAlert Desc should match", timeAlertResponse.getDescription(), "timealertdesc");
+        assertEquals("TimeAlert Cron should match", timeAlertResponse.getCron(), "0   23  */2 *   *");
+        assertEquals("TimeAlert Timezone should match", timeAlertResponse.getTimeZone(), "GMT");
+
+        assertEquals("TimeAlert Hostgroup should match",
+                timeAlertResponse.getScalingPolicy().getHostGroup(), "compute");
+        assertEquals("TimeAlert Adjustment Type should match",
+                timeAlertResponse.getScalingPolicy().getAdjustmentType(), NODE_COUNT);
+        assertEquals("TimeAlert Adjustment should match",
+                timeAlertResponse.getScalingPolicy().getScalingAdjustment(), 10);
+    }
+
+    private ScalingPolicy getScalingPolicy() {
+        ScalingPolicy scalingPolicy = new ScalingPolicy();
+        scalingPolicy.setName("loadalertpolicy");
+        scalingPolicy.setAdjustmentType(NODE_COUNT);
+        scalingPolicy.setHostGroup("compute");
+        scalingPolicy.setScalingAdjustment(10);
+        return scalingPolicy;
+    }
+}

--- a/autoscale/src/test/java/com/sequenceiq/periscope/endpointtests/DistroXAutoScaleClusterV1EndpointTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/endpointtests/DistroXAutoScaleClusterV1EndpointTest.java
@@ -1,0 +1,384 @@
+package com.sequenceiq.periscope.endpointtests;
+
+import static com.sequenceiq.periscope.api.model.AdjustmentType.LOAD_BASED;
+import static com.sequenceiq.periscope.api.model.AdjustmentType.NODE_COUNT;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.AssertionErrors.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import javax.inject.Inject;
+import javax.ws.rs.BadRequestException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
+import com.sequenceiq.authorization.service.UmsAccountAuthorizationService;
+import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
+import com.sequenceiq.cloudbreak.auth.altus.UmsClient;
+import com.sequenceiq.periscope.api.endpoint.v1.DistroXAutoScaleClusterV1Endpoint;
+import com.sequenceiq.periscope.api.model.AutoscaleClusterState;
+import com.sequenceiq.periscope.api.model.DistroXAutoscaleClusterRequest;
+import com.sequenceiq.periscope.api.model.DistroXAutoscaleClusterResponse;
+import com.sequenceiq.periscope.api.model.LoadAlertConfigurationRequest;
+import com.sequenceiq.periscope.api.model.LoadAlertRequest;
+import com.sequenceiq.periscope.api.model.LoadAlertResponse;
+import com.sequenceiq.periscope.api.model.ScalingPolicyRequest;
+import com.sequenceiq.periscope.api.model.TimeAlertRequest;
+import com.sequenceiq.periscope.api.model.TimeAlertResponse;
+import com.sequenceiq.periscope.client.AutoscaleUserCrnClientBuilder;
+import com.sequenceiq.periscope.testcontext.EndpointTestContext;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.ClusterPertain;
+import com.sequenceiq.periscope.repository.ClusterRepository;
+import com.sequenceiq.periscope.repository.LoadAlertRepository;
+import com.sequenceiq.periscope.repository.TimeAlertRepository;
+import com.sequenceiq.periscope.service.configuration.ClusterProxyConfigurationService;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = EndpointTestContext.class)
+@ActiveProfiles("test")
+public class DistroXAutoScaleClusterV1EndpointTest {
+
+    private static final String SERVICE_ADDRESS = "http://localhost:%d/as";
+
+    private static final Long TEST_USER_ID = 100L;
+
+    private static final Long TEST_WORKSPACE_ID = 100L;
+
+    private static final Integer MIN_RESOURCE_COUNT = 4;
+
+    private static final Integer MAX_RESOURCE_COUNT = 15;
+
+    private static final Integer COOL_DOWN_MINUTES = 5;
+
+    private static final String TEST_SCHEDULE_CRON = "1 0 1 1 1 1";
+
+    private static final String TEST_SCHEDULE_TIMEZONE = "GMT";
+
+    private static final Integer TEST_SCHEDULE_NODE_COUNT = 10;
+
+    private static final String TEST_ACCOUNT_ID = "accid";
+
+    private static final String TEST_CLUSTER_NAME = "testCluster";
+
+    private static final String TEST_USER_CRN = String.format("crn:cdp:iam:us-west-1:%s:user:mockuser@cloudera.com", TEST_ACCOUNT_ID);
+
+    private static final String TEST_CLUSTER_CRN = String.format("crn:cdp:iam:us-west-1:%s:cluster:mockuser@cloudera.com", TEST_ACCOUNT_ID);
+
+    @LocalServerPort
+    private int port;
+
+    @MockBean
+    private UmsAccountAuthorizationService umsAccountAuthorizationService;
+
+    @MockBean
+    private ClusterProxyConfigurationService clusterProxyConfigurationService;
+
+    @MockBean(name = "grpcUmsClient")
+    private GrpcUmsClient grpcUmsClient;
+
+    @MockBean(name = "umsClient")
+    private UmsClient umsClient;
+
+    @Inject
+    private ClusterRepository clusterRepository;
+
+    @Inject
+    private LoadAlertRepository loadAlertRepository;
+
+    @Inject
+    private TimeAlertRepository timeAlertRepository;
+
+    private DistroXAutoScaleClusterV1Endpoint distroXAutoScaleClusterV1Endpoint;
+
+    @Before
+    public void setup() {
+        distroXAutoScaleClusterV1Endpoint = new AutoscaleUserCrnClientBuilder(String.format(SERVICE_ADDRESS, port))
+                .build().withCrn(TEST_USER_CRN).distroXAutoScaleClusterV1Endpoint();
+
+        Cluster testCluster = new Cluster();
+        testCluster.setStackCrn(TEST_CLUSTER_CRN);
+        testCluster.setStackName(TEST_CLUSTER_NAME);
+        testCluster.setCloudPlatform("AWS");
+
+        ClusterPertain clusterPertain = new ClusterPertain();
+        clusterPertain.setTenant("test-tenant");
+        clusterPertain.setWorkspaceId(TEST_WORKSPACE_ID);
+        clusterPertain.setUserId(TEST_USER_ID.toString());
+        clusterPertain.setUserCrn(TEST_USER_CRN);
+        testCluster.setClusterPertain(clusterPertain);
+
+        UserManagementProto.User user = UserManagementProto.User.newBuilder()
+                .setCrn(TEST_USER_CRN).setEmail("dummyuser@cloudera.com").setUserId(TEST_USER_ID.toString()).build();
+        clusterRepository.save(testCluster);
+
+        when(grpcUmsClient.getUserDetails(anyString(), anyString(), any())).thenReturn(user);
+        when(umsAccountAuthorizationService.hasRightOfUser(anyString(), anyString())).thenReturn(true);
+        when(clusterProxyConfigurationService.getClusterProxyUrl()).thenReturn(Optional.of("http://clusterproxy"));
+    }
+
+    @After
+    public void tearDown() {
+        clusterRepository.deleteAll();
+        loadAlertRepository.deleteAll();
+        timeAlertRepository.deleteAll();
+    }
+
+    @Test
+    public void testUpdateAutoscaleConfigByClusterCrnForEnableDisableAutoscaling() {
+        DistroXAutoscaleClusterRequest distroXAutoscaleClusterRequest = new DistroXAutoscaleClusterRequest();
+        distroXAutoscaleClusterRequest.setEnableAutoscaling(true);
+
+        distroXAutoScaleClusterV1Endpoint
+                .updateAutoscaleConfigByClusterCrn(TEST_CLUSTER_CRN, distroXAutoscaleClusterRequest);
+
+        DistroXAutoscaleClusterResponse xAutoscaleClusterResponse = distroXAutoScaleClusterV1Endpoint.getClusterByCrn(TEST_CLUSTER_CRN);
+        assertTrue("Autoscaling should be enabled", xAutoscaleClusterResponse.isAutoscalingEnabled());
+
+        distroXAutoscaleClusterRequest.setEnableAutoscaling(false);
+        distroXAutoScaleClusterV1Endpoint
+                .updateAutoscaleConfigByClusterCrn(TEST_CLUSTER_CRN, distroXAutoscaleClusterRequest);
+        xAutoscaleClusterResponse = distroXAutoScaleClusterV1Endpoint.getClusterByCrn(TEST_CLUSTER_CRN);
+        assertFalse("Autoscaling should be disabled", xAutoscaleClusterResponse.isAutoscalingEnabled());
+    }
+
+    @Test
+    public void testEnableAutoscaleForClusterCrn() {
+        distroXAutoScaleClusterV1Endpoint.enableAutoscaleForClusterCrn(TEST_CLUSTER_CRN, AutoscaleClusterState.enable());
+        DistroXAutoscaleClusterResponse xAutoscaleClusterResponse = distroXAutoScaleClusterV1Endpoint.getClusterByCrn(TEST_CLUSTER_CRN);
+        assertTrue("Autoscaling should be enabled", xAutoscaleClusterResponse.isAutoscalingEnabled());
+
+        distroXAutoScaleClusterV1Endpoint.enableAutoscaleForClusterCrn(TEST_CLUSTER_CRN, AutoscaleClusterState.disable());
+        xAutoscaleClusterResponse = distroXAutoScaleClusterV1Endpoint.getClusterByCrn(TEST_CLUSTER_CRN);
+        assertFalse("Autoscaling should be disabled", xAutoscaleClusterResponse.isAutoscalingEnabled());
+
+        distroXAutoScaleClusterV1Endpoint.enableAutoscaleForClusterCrn(TEST_CLUSTER_CRN, AutoscaleClusterState.enable());
+        xAutoscaleClusterResponse = distroXAutoScaleClusterV1Endpoint.getClusterByCrn(TEST_CLUSTER_CRN);
+        assertTrue("Autoscaling should be enabled", xAutoscaleClusterResponse.isAutoscalingEnabled());
+    }
+
+    @Test
+    public void testEnableAutoscaleForClusterName() {
+        distroXAutoScaleClusterV1Endpoint.enableAutoscaleForClusterName(TEST_CLUSTER_NAME, AutoscaleClusterState.enable());
+        DistroXAutoscaleClusterResponse xAutoscaleClusterResponse = distroXAutoScaleClusterV1Endpoint.getClusterByName(TEST_CLUSTER_NAME);
+        assertTrue("Autoscaling should be enabled", xAutoscaleClusterResponse.isAutoscalingEnabled());
+
+        distroXAutoScaleClusterV1Endpoint.enableAutoscaleForClusterName(TEST_CLUSTER_NAME, AutoscaleClusterState.disable());
+        xAutoscaleClusterResponse = distroXAutoScaleClusterV1Endpoint.getClusterByName(TEST_CLUSTER_NAME);
+        assertFalse("Autoscaling should be disabled", xAutoscaleClusterResponse.isAutoscalingEnabled());
+    }
+
+    @Test
+    public void testUpdateAutoscaleConfigByClusterCrnForLoadAlerts() {
+        List<LoadAlertRequest> loadAlertRequests = getLoadAlertRequests(1, List.of("compute"));
+
+        DistroXAutoscaleClusterRequest distroXAutoscaleClusterRequest = new DistroXAutoscaleClusterRequest();
+        distroXAutoscaleClusterRequest.setLoadAlertRequests(loadAlertRequests);
+        distroXAutoscaleClusterRequest.setEnableAutoscaling(true);
+
+        distroXAutoScaleClusterV1Endpoint
+                .updateAutoscaleConfigByClusterCrn(TEST_CLUSTER_CRN, distroXAutoscaleClusterRequest);
+        DistroXAutoscaleClusterResponse xAutoscaleClusterResponse =
+                distroXAutoScaleClusterV1Endpoint.getClusterByCrn(TEST_CLUSTER_CRN);
+
+        assertEquals("Retrieved Alerts Size Should Match", 1, xAutoscaleClusterResponse.getLoadAlerts().size());
+        assertTrue("Autoscaling should be enabled", xAutoscaleClusterResponse.isAutoscalingEnabled());
+        xAutoscaleClusterResponse.getLoadAlerts().stream().forEach(this::validateLoadAlertResponse);
+    }
+
+    @Test
+    public void testUpdateAutoscaleConfigByClusterNameForLoadAlerts() {
+        List<LoadAlertRequest> loadAlertRequests = getLoadAlertRequests(1, List.of("compute"));
+
+        DistroXAutoscaleClusterRequest distroXAutoscaleClusterRequest = new DistroXAutoscaleClusterRequest();
+        distroXAutoscaleClusterRequest.setLoadAlertRequests(loadAlertRequests);
+        distroXAutoscaleClusterRequest.setEnableAutoscaling(true);
+
+        distroXAutoScaleClusterV1Endpoint.updateAutoscaleConfigByClusterName(TEST_CLUSTER_NAME, distroXAutoscaleClusterRequest);
+        DistroXAutoscaleClusterResponse xAutoscaleClusterResponse =
+                distroXAutoScaleClusterV1Endpoint.getClusterByName(TEST_CLUSTER_NAME);
+
+        assertEquals("Retrieved Alerts Size Should Match", 1, xAutoscaleClusterResponse.getLoadAlerts().size());
+        assertTrue("Autoscaling should be enabled", xAutoscaleClusterResponse.isAutoscalingEnabled());
+        xAutoscaleClusterResponse.getLoadAlerts().stream().forEach(this::validateLoadAlertResponse);
+    }
+
+    @Test
+    public void testDeleteAlertByClusterCrnForLoadAlerts() {
+        List<LoadAlertRequest> loadAlertRequests = getLoadAlertRequests(1, List.of("compute"));
+
+        DistroXAutoscaleClusterRequest distroXAutoscaleClusterRequest = new DistroXAutoscaleClusterRequest();
+        distroXAutoscaleClusterRequest.setLoadAlertRequests(loadAlertRequests);
+        distroXAutoscaleClusterRequest.setEnableAutoscaling(true);
+
+        distroXAutoScaleClusterV1Endpoint.updateAutoscaleConfigByClusterCrn(TEST_CLUSTER_CRN, distroXAutoscaleClusterRequest);
+        DistroXAutoscaleClusterResponse xAutoscaleClusterResponse =
+                distroXAutoScaleClusterV1Endpoint.getClusterByCrn(TEST_CLUSTER_CRN);
+
+        assertEquals("Retrieved Alerts Size Should Match", 1, xAutoscaleClusterResponse.getLoadAlerts().size());
+        distroXAutoScaleClusterV1Endpoint.deleteAlertsForClusterCrn(TEST_CLUSTER_CRN);
+        xAutoscaleClusterResponse = distroXAutoScaleClusterV1Endpoint.getClusterByCrn(TEST_CLUSTER_CRN);
+        assertEquals("Retrieved Alerts Size Should Match", 0, xAutoscaleClusterResponse.getLoadAlerts().size());
+    }
+
+    @Test
+    public void testUpdateAutoscaleConfigByClusterCrnForTimeAlerts() {
+        List<TimeAlertRequest> timeAlertRequests = getTimeAlertRequests(2, List.of("compute", "compute"));
+
+        DistroXAutoscaleClusterRequest distroXAutoscaleClusterRequest = new DistroXAutoscaleClusterRequest();
+        distroXAutoscaleClusterRequest.setTimeAlertRequests(timeAlertRequests);
+        distroXAutoscaleClusterRequest.setEnableAutoscaling(true);
+
+        distroXAutoScaleClusterV1Endpoint.updateAutoscaleConfigByClusterCrn(TEST_CLUSTER_CRN, distroXAutoscaleClusterRequest);
+        DistroXAutoscaleClusterResponse xAutoscaleClusterResponse =
+                distroXAutoScaleClusterV1Endpoint.getClusterByCrn(TEST_CLUSTER_CRN);
+
+        assertEquals("Retrieved Alerts Size Should Match", 2, xAutoscaleClusterResponse.getTimeAlerts().size());
+        assertTrue("Autoscaling should be enabled", xAutoscaleClusterResponse.isAutoscalingEnabled());
+        xAutoscaleClusterResponse.getTimeAlerts().stream().forEach(this::validateTimeAlertResponse);
+    }
+
+    @Test
+    public void testUpdateAutoscaleConfigByClusterNameForTimeAlerts() {
+        List<TimeAlertRequest> timeAlertRequests = getTimeAlertRequests(2, List.of("compute", "compute"));
+
+        DistroXAutoscaleClusterRequest distroXAutoscaleClusterRequest = new DistroXAutoscaleClusterRequest();
+        distroXAutoscaleClusterRequest.setTimeAlertRequests(timeAlertRequests);
+        distroXAutoscaleClusterRequest.setEnableAutoscaling(true);
+
+        distroXAutoScaleClusterV1Endpoint.updateAutoscaleConfigByClusterName(TEST_CLUSTER_NAME, distroXAutoscaleClusterRequest);
+        DistroXAutoscaleClusterResponse xAutoscaleClusterResponse =
+                distroXAutoScaleClusterV1Endpoint.getClusterByName(TEST_CLUSTER_NAME);
+
+        assertEquals("Retrieved Alerts Size Should Match", 2, xAutoscaleClusterResponse.getTimeAlerts().size());
+        assertTrue("Autoscaling should be enabled", xAutoscaleClusterResponse.isAutoscalingEnabled());
+        xAutoscaleClusterResponse.getTimeAlerts().stream().forEach(this::validateTimeAlertResponse);
+    }
+
+    @Test
+    public void testDeleteAlertByClusterNameForTimeAlerts() {
+        List<TimeAlertRequest> timeAlertRequests = getTimeAlertRequests(2, List.of("compute", "compute"));
+
+        DistroXAutoscaleClusterRequest distroXAutoscaleClusterRequest = new DistroXAutoscaleClusterRequest();
+        distroXAutoscaleClusterRequest.setTimeAlertRequests(timeAlertRequests);
+        distroXAutoscaleClusterRequest.setEnableAutoscaling(true);
+
+        distroXAutoScaleClusterV1Endpoint.updateAutoscaleConfigByClusterName(TEST_CLUSTER_NAME, distroXAutoscaleClusterRequest);
+        DistroXAutoscaleClusterResponse xAutoscaleClusterResponse =
+                distroXAutoScaleClusterV1Endpoint.getClusterByName(TEST_CLUSTER_NAME);
+        assertEquals("Retrieved Alerts Size Should Match", 2, xAutoscaleClusterResponse.getTimeAlerts().size());
+
+
+        distroXAutoScaleClusterV1Endpoint.deleteAlertsForClusterName(TEST_CLUSTER_NAME);
+        xAutoscaleClusterResponse = distroXAutoScaleClusterV1Endpoint.getClusterByName(TEST_CLUSTER_NAME);
+        assertEquals("Retrieved Alerts Size Should Match", 0, xAutoscaleClusterResponse.getTimeAlerts().size());
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testUpdateAutoscaleConfigWhenMultipleAlertTypes() {
+        List<TimeAlertRequest> timeAlertRequests = getTimeAlertRequests(2, List.of("compute", "compute"));
+        List<LoadAlertRequest> loadAlertRequests = getLoadAlertRequests(2, List.of("group1", "group2"));
+
+        DistroXAutoscaleClusterRequest distroXAutoscaleClusterRequest = new DistroXAutoscaleClusterRequest();
+        distroXAutoscaleClusterRequest.setTimeAlertRequests(timeAlertRequests);
+        distroXAutoscaleClusterRequest.setLoadAlertRequests(loadAlertRequests);
+        distroXAutoscaleClusterRequest.setEnableAutoscaling(true);
+
+        distroXAutoScaleClusterV1Endpoint
+                .updateAutoscaleConfigByClusterName(TEST_CLUSTER_NAME, distroXAutoscaleClusterRequest);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testUpdateAutoscaleConfigByClusterCrnForMultipleLoadAlerts() {
+        List<LoadAlertRequest> loadAlertRequests = getLoadAlertRequests(2, List.of("compute", "compute"));
+        DistroXAutoscaleClusterRequest distroXAutoscaleClusterRequest = new DistroXAutoscaleClusterRequest();
+        distroXAutoscaleClusterRequest.setLoadAlertRequests(loadAlertRequests);
+        distroXAutoscaleClusterRequest.setEnableAutoscaling(true);
+
+        distroXAutoScaleClusterV1Endpoint
+                .updateAutoscaleConfigByClusterCrn(TEST_CLUSTER_CRN, distroXAutoscaleClusterRequest);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testUpdateAutoscaleConfigByClusterCrnForMultipleLoadAlertsAndHostGroups() {
+        List<LoadAlertRequest> loadAlertRequests = getLoadAlertRequests(2, List.of("group1", "group2"));
+        DistroXAutoscaleClusterRequest distroXAutoscaleClusterRequest = new DistroXAutoscaleClusterRequest();
+        distroXAutoscaleClusterRequest.setLoadAlertRequests(loadAlertRequests);
+        distroXAutoscaleClusterRequest.setEnableAutoscaling(true);
+
+        distroXAutoScaleClusterV1Endpoint
+                .updateAutoscaleConfigByClusterCrn(TEST_CLUSTER_CRN, distroXAutoscaleClusterRequest);
+    }
+
+    private void validateLoadAlertResponse(LoadAlertResponse alertResponse) {
+        assertEquals("Retrieved HostGroup Should Match", "compute", alertResponse.getScalingPolicy().getHostGroup());
+        assertEquals("Retrieved AdjustmentType Should Match", LOAD_BASED, alertResponse.getScalingPolicy().getAdjustmentType());
+        assertEquals("Retrieved MinResourceValue Should Match", MIN_RESOURCE_COUNT, alertResponse.getLoadAlertConfiguration().getMinResourceValue());
+        assertEquals("Retrieved MaxResourceValue Should Match", MAX_RESOURCE_COUNT, alertResponse.getLoadAlertConfiguration().getMaxResourceValue());
+        assertEquals("Retrieved CoolDownMins Should Match", COOL_DOWN_MINUTES, alertResponse.getLoadAlertConfiguration().getCoolDownMinutes());
+    }
+
+    private void validateTimeAlertResponse(TimeAlertResponse alertResponse) {
+        assertEquals("Retrieved HostGroup Should Match", "compute", alertResponse.getScalingPolicy().getHostGroup());
+        assertEquals("Retrieved AdjustmentType Should Match", NODE_COUNT, alertResponse.getScalingPolicy().getAdjustmentType());
+        assertEquals("Retrieved Adjustment Should Match", TEST_SCHEDULE_NODE_COUNT, alertResponse.getScalingPolicy().getScalingAdjustment());
+        assertEquals("Retrieved Cron Should Match", TEST_SCHEDULE_CRON, alertResponse.getCron());
+        assertEquals("Retrieved TimeZone Should Match", TEST_SCHEDULE_TIMEZONE, alertResponse.getTimeZone());
+    }
+
+    private List<LoadAlertRequest> getLoadAlertRequests(Integer loadAlertRequestCount, List<String> computeGroups) {
+        List<LoadAlertRequest> loadRequests = new ArrayList();
+        IntStream.range(0, loadAlertRequestCount).forEach(loop -> {
+            LoadAlertRequest loadAlertRequest = new LoadAlertRequest();
+            loadAlertRequest.setAlertName("testalert");
+            LoadAlertConfigurationRequest loadAlertConfiguration = new LoadAlertConfigurationRequest();
+            loadAlertConfiguration.setMinResourceValue(MIN_RESOURCE_COUNT);
+            loadAlertConfiguration.setMaxResourceValue(MAX_RESOURCE_COUNT);
+            loadAlertConfiguration.setCoolDownMinutes(COOL_DOWN_MINUTES);
+
+            ScalingPolicyRequest scalingPolicyRequest = new ScalingPolicyRequest();
+            scalingPolicyRequest.setAdjustmentType(LOAD_BASED);
+            scalingPolicyRequest.setHostGroup(computeGroups.get(loop));
+
+            loadAlertRequest.setScalingPolicy(scalingPolicyRequest);
+            loadAlertRequest.setLoadAlertConfiguration(loadAlertConfiguration);
+            loadRequests.add(loadAlertRequest);
+        });
+        return loadRequests;
+    }
+
+    private List<TimeAlertRequest> getTimeAlertRequests(Integer timeAlertRequestCount, List<String> computeGroups) {
+        List<TimeAlertRequest> timeAlertRequests = new ArrayList();
+        IntStream.range(0, timeAlertRequestCount).forEach(loop -> {
+            TimeAlertRequest timeAlertRequest = new TimeAlertRequest();
+            timeAlertRequest.setAlertName("testalert");
+            timeAlertRequest.setTimeZone(TEST_SCHEDULE_TIMEZONE);
+            timeAlertRequest.setCron(TEST_SCHEDULE_CRON);
+
+            ScalingPolicyRequest scalingPolicyRequest = new ScalingPolicyRequest();
+            scalingPolicyRequest.setAdjustmentType(NODE_COUNT);
+            scalingPolicyRequest.setScalingAdjustment(TEST_SCHEDULE_NODE_COUNT);
+            scalingPolicyRequest.setHostGroup(computeGroups.get(loop));
+
+            timeAlertRequest.setScalingPolicy(scalingPolicyRequest);
+            timeAlertRequests.add(timeAlertRequest);
+        });
+        return timeAlertRequests;
+    }
+}

--- a/autoscale/src/test/java/com/sequenceiq/periscope/modul/rejected/RejectedThreadContext.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/modul/rejected/RejectedThreadContext.java
@@ -13,6 +13,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolExecutorFactoryBean;
@@ -59,6 +60,7 @@ public class RejectedThreadContext {
     @MockBean({Clock.class, ClusterService.class, CloudbreakClientConfiguration.class,
             MetricUtils.class, InternalCrnBuilder.class, FailedNodeRepository.class})
     @EnableAsync
+    @Profile("dev")
     public static class SpringConfig implements AsyncConfigurer {
 
         @Inject

--- a/autoscale/src/test/java/com/sequenceiq/periscope/modul/rejected/StackCollectorContext.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/modul/rejected/StackCollectorContext.java
@@ -13,6 +13,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Profile;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -60,6 +61,7 @@ public class StackCollectorContext {
     @MockBean({ClusterService.class, CloudbreakClientConfiguration.class, TlsSecurityService.class, SecurityConfigService.class,
             HistoryService.class, HttpNotificationSender.class, MetricUtils.class, Clock.class, ClouderaManagerApiFactory.class, SecretService.class})
     @EnableAsync
+    @Profile("dev")
     public static class StackCollectorSpringConfig implements AsyncConfigurer {
 
         @Inject

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/cm/ClouderaManagerClusterCreationEvaluatorTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/cm/ClouderaManagerClusterCreationEvaluatorTest.java
@@ -180,7 +180,7 @@ public class ClouderaManagerClusterCreationEvaluatorTest {
 
         verify(clusterService).findOneByStackId(STACK_ID);
         verify(clusterService).validateClusterUniqueness(any());
-        verify(clusterService).create(any(MonitoredStack.class), eq(RUNNING), captor.capture());
+        verify(clusterService).create(any(MonitoredStack.class), eq(PENDING), captor.capture());
         ClusterPertain clusterPertain = captor.getValue();
         assertThat(clusterPertain.getTenant(), is("TENANT"));
         assertThat(clusterPertain.getWorkspaceId(), is(10L));
@@ -199,7 +199,7 @@ public class ClouderaManagerClusterCreationEvaluatorTest {
         when(evaluatorContext.getData()).thenReturn(stack);
         when(securityConfigService.getSecurityConfig(anyLong())).thenReturn(new SecurityConfig());
         when(clusterService.findOneByStackId(anyLong())).thenReturn(cluster);
-        when(requestLogging.logging(any(), any())).thenReturn(healthy);
+        when(requestLogging.logResponseTime(any(), any())).thenReturn(healthy);
         if (cluster != null) {
             when(historyService.createEntry(any(), anyString(), anyInt(), any(Cluster.class))).thenReturn(history);
         }

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/load/YarnLoadEvaluatorTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/load/YarnLoadEvaluatorTest.java
@@ -1,0 +1,270 @@
+package com.sequenceiq.periscope.monitor.evaluator.load;
+
+import static com.sequenceiq.periscope.monitor.evaluator.ScalingConstants.DEFAULT_MAX_SCALE_UP_STEP_SIZE;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.junit.Before;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
+import com.sequenceiq.periscope.api.model.AdjustmentType;
+import com.sequenceiq.periscope.api.model.ClusterState;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.LoadAlert;
+import com.sequenceiq.periscope.domain.LoadAlertConfiguration;
+import com.sequenceiq.periscope.domain.ScalingPolicy;
+import com.sequenceiq.periscope.model.yarn.YarnScalingServiceV1Response;
+import com.sequenceiq.periscope.model.yarn.YarnScalingServiceV1Response.DecommissionCandidate;
+import com.sequenceiq.periscope.model.yarn.YarnScalingServiceV1Response.NewNodeManagerCandidates;
+import com.sequenceiq.periscope.monitor.client.YarnMetricsClient;
+import com.sequenceiq.periscope.monitor.context.ClusterIdEvaluatorContext;
+import com.sequenceiq.periscope.monitor.evaluator.EventPublisher;
+import com.sequenceiq.periscope.monitor.event.ScalingEvent;
+import com.sequenceiq.periscope.monitor.event.UpdateFailedEvent;
+import com.sequenceiq.periscope.monitor.executor.ExecutorServiceWithRegistry;
+import com.sequenceiq.periscope.monitor.handler.CloudbreakCommunicator;
+import com.sequenceiq.periscope.service.ClusterService;
+import com.sequenceiq.periscope.utils.MockStackResponseGenerator;
+import com.sequenceiq.periscope.utils.StackResponseUtils;
+
+@ExtendWith(MockitoExtension.class)
+public class YarnLoadEvaluatorTest {
+
+    private static final long AUTOSCALE_CLUSTER_ID = 101L;
+
+    private static final String CLOUDBREAK_STACK_CRN = "someCrn";
+
+    private static final int TEST_HOSTGROUP_MIN_SIZE = 3;
+
+    private static final int TEST_HOSTGROUP_MAX_SIZE = 200;
+
+    @InjectMocks
+    private YarnLoadEvaluator underTest;
+
+    @Mock
+    private ClusterService clusterService;
+
+    @Mock
+    private ExecutorServiceWithRegistry executorServiceWithRegistry;
+
+    @Mock
+    private CloudbreakCommunicator cloudbreakCommunicator;
+
+    @Mock
+    private StackResponseUtils stackResponseUtils;
+
+    @Mock
+    private EventPublisher eventPublisher;
+
+    @Mock
+    private YarnMetricsClient yarnMetricsClient;
+
+    private String fqdnBase = "test_fqdn";
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testRunCallsFinished() {
+        underTest.setContext(new ClusterIdEvaluatorContext(AUTOSCALE_CLUSTER_ID));
+        when(clusterService.findById(anyLong())).thenThrow(new RuntimeException("exception from the test"));
+
+        underTest.run();
+        verify(executorServiceWithRegistry).finished(underTest, AUTOSCALE_CLUSTER_ID);
+        verify(eventPublisher).publishEvent(any(UpdateFailedEvent.class));
+    }
+
+    @Test
+    public void testExecuteBeforeCoolDownPeriod() {
+        Cluster cluster = getARunningCluster();
+        cluster.setLastScalingActivity(Instant.now()
+                .minus(2, ChronoUnit.MINUTES).toEpochMilli());
+        when(clusterService.findById(anyLong())).thenReturn(cluster);
+        underTest.setContext(new ClusterIdEvaluatorContext(AUTOSCALE_CLUSTER_ID));
+        underTest.execute();
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    public static Stream<Arguments> dataUpScaling() {
+        return Stream.of(
+                            //TestCase,CurrentHostGroupCount,YarnRecommendedUpScaleCount,ExpectedUpScaleCount
+                Arguments.of("SCALE_UP_ALLOWED",  3,  5, 5),
+                Arguments.of("SCALE_UP_ALLOWED_AT_LIMIT", TEST_HOSTGROUP_MAX_SIZE - 10, 10, 10),
+                Arguments.of("SCALE_UP_BEYOND_MAX_LIMIT", TEST_HOSTGROUP_MAX_SIZE - 10, 20, 10),
+                Arguments.of("SCALE_UP_BEYOND_STEP_LIMIT", 10, 500, DEFAULT_MAX_SCALE_UP_STEP_SIZE),
+                Arguments.of("SCALE_UP_NOT_ALLOWED", TEST_HOSTGROUP_MAX_SIZE + 2, 10, 0),
+                Arguments.of("SCALE_UP_FORCED", 0, 0, 3),
+                Arguments.of("SCALE_UP_FORCED", 1, 0, 2),
+                Arguments.of("SCALE_UP_WHEN_HOST_SIZE_BELOW_MIN", 1, 10, 10)
+        );
+    }
+
+    @ParameterizedTest(name = "{0}: With currentHostGroupCount={1}, yarnRecommendedUpScaleCount ={2}, expectedUpScaleCount={3} ")
+    @MethodSource("dataUpScaling")
+    public void testLoadBasedUpScaling(String testType, int currentHostGroupCount,
+            int yarnRecommendedUpScaleCount, int expectedUpScaleCount)  throws Exception {
+        testUpScaleBasedOnYarnResponse(currentHostGroupCount, yarnRecommendedUpScaleCount, expectedUpScaleCount);
+    }
+
+    public static Stream<Arguments> dataDownScaling() {
+        return Stream.of(
+                            //TestCase,CurrentHostGroupCount,YarnRecommendedDecommissionCount,ExpectedDecommissionCount
+                Arguments.of("DOWN_SCALE_ALLOWED",  7,  5, 7 - TEST_HOSTGROUP_MIN_SIZE),
+                Arguments.of("DOWN_SCALE_FORCED",  TEST_HOSTGROUP_MAX_SIZE + 20,  0, -20),
+                Arguments.of("DOWN_SCALE_BEYOND_MAX_LIMIT",  TEST_HOSTGROUP_MAX_SIZE + 20,  5, 5),
+                Arguments.of("DOWN_SCALE_AT_YARN_LIMIT",  TEST_HOSTGROUP_MAX_SIZE + 20,  10, 10),
+                Arguments.of("DOWN_SCALE_ALLOWED_MIN_LIMIT", 10, 10, 10 - TEST_HOSTGROUP_MIN_SIZE),
+                Arguments.of("DOWN_SCALE_ALLOWED_AT_MIN_LIMIT", 20, 20 - TEST_HOSTGROUP_MIN_SIZE, 20 - TEST_HOSTGROUP_MIN_SIZE),
+                Arguments.of("DOWN_SCALE_BEYOND_MIN_LIMIT", 10,  52, 10 - TEST_HOSTGROUP_MIN_SIZE),
+                Arguments.of("DOWN_SCALE_NOT_ALLOWED", 0, 5, 0)
+        );
+    }
+
+    @ParameterizedTest(name = "{0}: With currentHostGroupCount={1}, yarnRecommendedDecommissionCount ={2}, expectedDecommissionCount={3} ")
+    @MethodSource("dataDownScaling")
+    public void testLoadBasedDownScaling(String testType, int currentHostGroupCount,
+            int yarnRecommendedDecommissionCount, int expectedDecommissionCount)  throws Exception {
+        boolean forcedDownScale = testType.contains("FORCED") ? true : false;
+        testDownScaleBasedOnYarnResponse(currentHostGroupCount, yarnRecommendedDecommissionCount, expectedDecommissionCount, forcedDownScale);
+    }
+
+    private void testDownScaleBasedOnYarnResponse(int currentHostGroupCount, int yarnDecommissionCount,
+            int expectedDownScaleCount, boolean forcedDownScale) throws Exception {
+        boolean scalingEventExpected = expectedDownScaleCount != 0 ? true : false;
+        Optional<ScalingEvent> scalingEvent = captureScalingEvent(currentHostGroupCount, 0, yarnDecommissionCount, scalingEventExpected);
+
+        if (scalingEventExpected) {
+            int actualDownScaleCount = forcedDownScale ? scalingEvent.get().getScalingNodeCount().get() :
+                    scalingEvent.get().getDecommissionNodeIds().size();
+            assertEquals("ScaleDown Node Count should match.", expectedDownScaleCount, actualDownScaleCount);
+        }
+    }
+
+    private void testUpScaleBasedOnYarnResponse(int currentHostGroupCount, int yarnUpScaleCount, int expectedUpscaleCount) throws Exception {
+        boolean scalingEventExpected = expectedUpscaleCount != 0 ? true : false;
+
+        Optional<ScalingEvent> scalingEvent = captureScalingEvent(currentHostGroupCount, yarnUpScaleCount, 0, scalingEventExpected);
+        if (scalingEventExpected) {
+            assertEquals("ScaleUp Node Count should match.", expectedUpscaleCount,
+                    scalingEvent.get().getScalingNodeCount().get().intValue());
+        }
+    }
+
+    private Optional<ScalingEvent> captureScalingEvent(int currentHostGroupCount, int yarnUpScaleCount,
+            int yarnDownScaleCount, boolean scalingEventExpected) throws Exception {
+        MockitoAnnotations.initMocks(this);
+        Cluster cluster = getARunningCluster();
+        String hostGroup = "compute";
+        StackV4Response stackV4Response = getMockStackV4Response(hostGroup, currentHostGroupCount);
+
+        YarnScalingServiceV1Response upScale = getMockYarnScalingResponse(hostGroup, yarnUpScaleCount, yarnDownScaleCount);
+
+        when(clusterService.findById(anyLong())).thenReturn(cluster);
+        when(cloudbreakCommunicator.getByCrn(anyString())).thenReturn(stackV4Response);
+        when(stackResponseUtils.getCloudInstanceIdsForHostGroup(any(), any())).thenCallRealMethod();
+        when(yarnMetricsClient.getYarnMetricsForCluster(any(Cluster.class), any(StackV4Response.class), anyString()))
+                .thenReturn(upScale);
+
+        underTest.setContext(new ClusterIdEvaluatorContext(AUTOSCALE_CLUSTER_ID));
+        underTest.execute();
+
+        Optional scalingEventCaptured = Optional.empty();
+        if (scalingEventExpected) {
+            ArgumentCaptor<ScalingEvent> captor = ArgumentCaptor.forClass(ScalingEvent.class);
+            verify(eventPublisher).publishEvent(captor.capture());
+            scalingEventCaptured = Optional.of(captor.getValue());
+        }
+        return scalingEventCaptured;
+    }
+
+    private YarnScalingServiceV1Response getMockYarnScalingResponse(String instanceType, int upScaleCount, int downScaleCount) {
+        NewNodeManagerCandidates.Candidate candidate = new NewNodeManagerCandidates.Candidate();
+        candidate.setCount(upScaleCount);
+        candidate.setModelName(instanceType);
+        NewNodeManagerCandidates candidates = new NewNodeManagerCandidates();
+        candidates.setCandidates(List.of(candidate));
+
+        YarnScalingServiceV1Response yarnScalingReponse = new YarnScalingServiceV1Response();
+        if (upScaleCount > 0) {
+            yarnScalingReponse.setNewNMCandidates(Map.of("newNMCandidates", candidates));
+        }
+
+        List decommissionCandidates = new ArrayList();
+        for (int i = 1; i <= downScaleCount; i++) {
+            DecommissionCandidate decommissionCandidate = new DecommissionCandidate();
+            decommissionCandidate.setAmCount(2);
+            decommissionCandidate.setNodeId(fqdnBase + i + ":8042");
+            decommissionCandidates.add(decommissionCandidate);
+        }
+        yarnScalingReponse.setDecommissionCandidates(Map.of("candidates", decommissionCandidates));
+        return yarnScalingReponse;
+    }
+
+    private StackV4Response getMockStackV4Response(String hostGroup, int currentHostGroupCount) {
+        Set hostGroups = Set.of(hostGroup, "master1", "worker1");
+
+        Set fqdnToInstanceIds = new HashSet();
+        for (int i = 1; i <= currentHostGroupCount; i++) {
+            InstanceMetaDataV4Response metadata1 = new InstanceMetaDataV4Response();
+            metadata1.setDiscoveryFQDN(fqdnBase + i);
+            metadata1.setInstanceId("test_instanceid" + i);
+            fqdnToInstanceIds.add(metadata1);
+        }
+
+        return MockStackResponseGenerator.getMockStackV4Response("test-crn",
+                hostGroups, fqdnToInstanceIds);
+    }
+
+    private Cluster getARunningCluster() {
+        Cluster cluster = new Cluster();
+        cluster.setId(AUTOSCALE_CLUSTER_ID);
+        cluster.setStackCrn(CLOUDBREAK_STACK_CRN);
+        cluster.setState(ClusterState.RUNNING);
+
+        ScalingPolicy scalingPolicy = new ScalingPolicy();
+        scalingPolicy.setAdjustmentType(AdjustmentType.LOAD_BASED);
+        scalingPolicy.setHostGroup("compute");
+
+        LoadAlertConfiguration alertConfiguration = new LoadAlertConfiguration();
+        alertConfiguration.setCoolDownMinutes(10);
+        alertConfiguration.setMaxResourceValue(TEST_HOSTGROUP_MAX_SIZE);
+        alertConfiguration.setMinResourceValue(TEST_HOSTGROUP_MIN_SIZE);
+
+        LoadAlert loadAlert = new LoadAlert();
+        loadAlert.setScalingPolicy(scalingPolicy);
+        loadAlert.setLoadAlertConfiguration(alertConfiguration);
+
+        cluster.setLoadAlerts(Set.of(loadAlert));
+        cluster.setLastScalingActivity(Instant.now()
+                .minus(45, ChronoUnit.MINUTES).toEpochMilli());
+        return cluster;
+    }
+}

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/handler/ScalingHandlerTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/handler/ScalingHandlerTest.java
@@ -1,0 +1,235 @@
+package com.sequenceiq.periscope.monitor.handler;
+
+import static com.sequenceiq.periscope.api.model.AdjustmentType.EXACT;
+import static com.sequenceiq.periscope.api.model.AdjustmentType.LOAD_BASED;
+import static com.sequenceiq.periscope.api.model.AdjustmentType.NODE_COUNT;
+import static com.sequenceiq.periscope.api.model.AdjustmentType.PERCENTAGE;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.stream.Stream;
+
+import org.junit.Before;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.periscope.api.model.AdjustmentType;
+import com.sequenceiq.periscope.api.model.ClusterState;
+import com.sequenceiq.periscope.domain.BaseAlert;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.LoadAlert;
+import com.sequenceiq.periscope.domain.ScalingPolicy;
+import com.sequenceiq.periscope.domain.TimeAlert;
+import com.sequenceiq.periscope.monitor.event.ScalingEvent;
+import com.sequenceiq.periscope.service.ClusterService;
+import com.sequenceiq.periscope.service.RejectedThreadService;
+import com.sequenceiq.periscope.utils.StackResponseUtils;
+
+@ExtendWith(MockitoExtension.class)
+public class ScalingHandlerTest {
+
+    private static final long AUTOSCALE_CLUSTER_ID = 101L;
+
+    private static final String CLOUDBREAK_STACK_CRN = "someCrn";
+
+    private static final Integer TEST_HOSTGROUP_MAX_SIZE = 200;
+
+    private static final Integer TEST_HOSTGROUP_MIN_SIZE = 0;
+
+    @InjectMocks
+    private ScalingHandler underTest;
+
+    @Mock
+    private ClusterService clusterService;
+
+    @Mock
+    private CloudbreakCommunicator cloudbreakCommunicator;
+
+    @Mock
+    private StackResponseUtils stackResponseUtils;
+
+    @Mock
+    private RejectedThreadService rejectedThreadService;
+
+    @Mock
+    private ExecutorService executorService;
+
+    @Mock
+    private ApplicationContext applicationContext;
+
+    private ScalingPolicy scalingPolicyMock = mock(ScalingPolicy.class);
+
+    private ScalingEvent scalingEventMock = mock(ScalingEvent.class);
+
+    private Runnable runnableMock = mock(Runnable.class);
+
+    private StackV4Response stackV4ResponseMock = mock(StackV4Response.class);
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testOnApplicationEventWhenLoadAlertDecommissionNodes() {
+        LoadAlert loadAlertMock = mock(LoadAlert.class);
+        Cluster cluster = getARunningCluster();
+
+        int hostGroupNodeCount = 10;
+        List nodeIds = List.of("nodeId1", "nodeId2", "nodeId3");
+        int expectedNodeCount = hostGroupNodeCount - nodeIds.size();
+
+        when(scalingEventMock.getAlert()).thenReturn(loadAlertMock);
+        when(loadAlertMock.getCluster()).thenReturn(cluster);
+        when(loadAlertMock.getScalingPolicy()).thenReturn(scalingPolicyMock);
+        when(clusterService.findById(anyLong())).thenReturn(cluster);
+        when(scalingPolicyMock.getAdjustmentType()).thenReturn(LOAD_BASED);
+        when(scalingEventMock.getHostGroupNodeCount()).thenReturn(Optional.of(hostGroupNodeCount));
+        when(scalingEventMock.getDecommissionNodeIds()).thenReturn(nodeIds);
+        when(applicationContext.getBean("ScalingRequest", cluster, scalingPolicyMock,
+                hostGroupNodeCount, expectedNodeCount, nodeIds)).thenReturn(runnableMock);
+
+        underTest.onApplicationEvent(scalingEventMock);
+
+        verify(rejectedThreadService).remove(AUTOSCALE_CLUSTER_ID);
+        verify(clusterService).save(cluster);
+        verify(executorService).submit(runnableMock);
+    }
+
+    @Test
+    public void testOnApplicationEventWhenNoScaling() {
+        Cluster cluster = getARunningCluster();
+        String testHostGroup = "compute";
+        TimeAlert timeAlertMock = mock(TimeAlert.class);
+
+        when(clusterService.findById(anyLong())).thenReturn(cluster);
+        when(timeAlertMock.getCluster()).thenReturn(cluster);
+        when(timeAlertMock.getScalingPolicy()).thenReturn(scalingPolicyMock);
+
+        when(scalingPolicyMock.getAdjustmentType()).thenReturn(EXACT);
+        when(scalingPolicyMock.getHostGroup()).thenReturn(testHostGroup);
+        when(scalingPolicyMock.getScalingAdjustment()).thenReturn(2);
+
+        when(cloudbreakCommunicator.getByCrn(anyString())).thenReturn(stackV4ResponseMock);
+        when(stackResponseUtils.getNodeCountForHostGroup(stackV4ResponseMock, testHostGroup))
+                .thenReturn(2);
+
+        underTest.onApplicationEvent(new ScalingEvent(timeAlertMock));
+
+        verify(clusterService, never()).save(cluster);
+        verify(applicationContext, never()).getBean("ScalingRequest");
+    }
+
+    public static Stream<Arguments> dataLoadScaling() {
+        return Stream.of(
+                //TestCase, AdjustmentType, CurrentHostGroupCount,ScalingAdjustment,ExpectedScalingCount
+                Arguments.of("LOAD_SCALEUP_WITHIN_MAX_LIMIT",  2,  5, 7),
+                Arguments.of("LOAD_SCALEUP_WITHIN_MAX_LIMIT", 10, 40, 50),
+                Arguments.of("LOAD_SCALEUP_WITHIN_MAX_LIMIT", 10, 15, 25),
+                Arguments.of("LOAD_SCALEUP_WITHIN_MAX_LIMIT", 10, 40, 50),
+                Arguments.of("LOAD_SCALEUP_BEYOND_MAX_LIMIT",  4, 202, TEST_HOSTGROUP_MAX_SIZE)
+        );
+    }
+
+    @ParameterizedTest(name = "{0}: With currentHostGroupCount={1}, scalingAdjustment ={2}, expectedScalingCount={3} ")
+    @MethodSource("dataLoadScaling")
+    public void testLoadBasedScaling(String testType, int currentHostGroupCount,
+            int scalingAdjustment, int expectedScalingCount) {
+        LoadAlert loadAlertMock = mock(LoadAlert.class);
+        validateClusterScaling(loadAlertMock, LOAD_BASED, currentHostGroupCount, scalingAdjustment, expectedScalingCount);
+    }
+
+    public static Stream<Arguments> dataTmeScaling() {
+        return Stream.of(
+                            //TestCase, AdjustmentType, CurrentHostGroupCount,ScalingAdjustment,ExpectedScalingCount
+                Arguments.of("TIME_SCALEUP_NODE_COUNT_WITHIN_MAX_LIMIT", NODE_COUNT, 2, 25, 27),
+                Arguments.of("TIME_SCALEUP_NODE_COUNT_AT_MAX_LIMIT", NODE_COUNT, 2, 198, TEST_HOSTGROUP_MAX_SIZE),
+                Arguments.of("TIME_SCALEUP_NODE_COUNT_BEYOND_MAX_LIMIT", NODE_COUNT, 2,  1000, TEST_HOSTGROUP_MAX_SIZE),
+
+                Arguments.of("TIME_SCALEUP_PERCENTAGE_WITHIN_MAX_LIMIT", PERCENTAGE, 2, 50, 3),
+                Arguments.of("TIME_SCALEUP_PERCENTAGE_WITHIN_MAX_LIMIT", PERCENTAGE, 2, 100, 4),
+                Arguments.of("TIME_SCALEUP_PERCENTAGE_BEYOND_MAX_LIMIT", PERCENTAGE, 101, 1000, TEST_HOSTGROUP_MAX_SIZE),
+
+                Arguments.of("TIME_SCALEUP_EXACT_WITHIN_MAX_LIMIT", EXACT,  2, 10, 10),
+                Arguments.of("TIME_SCALEUP_EXACT_WITHIN_MAX_LIMIT", EXACT, 12, 24, 24),
+                Arguments.of("TIME_SCALEUP_EXACT_BEYOND_MAX_LIMIT", EXACT, 40, 1000, TEST_HOSTGROUP_MAX_SIZE),
+
+                Arguments.of("TIME_SCALEDOWN_NODE_COUNT_BEYOND_MIN_LIMIT", NODE_COUNT, 2, -12, TEST_HOSTGROUP_MIN_SIZE),
+                Arguments.of("TIME_SCALEDOWN_PERCENTAGE_BEYOND_MIN_LIMIT", PERCENTAGE, 2, -100, TEST_HOSTGROUP_MIN_SIZE),
+                Arguments.of("TIME_SCALEDOWN_EXACT_BEYOND_MIN_LIMIT", EXACT, 2, 0, TEST_HOSTGROUP_MIN_SIZE),
+
+                Arguments.of("TIME_SCALEDOWN_NODE_COUNT_WITHIN_MIN_LIMIT", NODE_COUNT, 10, -2, 8),
+                Arguments.of("TIME_SCALEDOWN_PERCENTAGE_WITHIN_MIN_LIMIT", PERCENTAGE, 10, -50, 5),
+                Arguments.of("TIME_SCALEDOWN_EXACT_WITHIN_MIN_LIMIT", EXACT, 10, 6, 6)
+                );
+    }
+
+    @ParameterizedTest(name = "{0}: With AdjustmentType{1}, currentHostGroupCount={2}, scalingAdjustment ={3}, expectedScalingCount={4} ")
+    @MethodSource("dataTmeScaling")
+    public void testTimeBasedScaling(String testType, AdjustmentType adjustmentType, int currentHostGroupCount,
+            int scalingAdjustment, int expectedScalingCount) {
+        TimeAlert timeAlertMock = mock(TimeAlert.class);
+        validateClusterScaling(timeAlertMock, adjustmentType, currentHostGroupCount, scalingAdjustment, expectedScalingCount);
+    }
+
+    private void validateClusterScaling(BaseAlert baseAlertMock, AdjustmentType adjustmentType,
+            int currentHostGroupCount, int scalingAdjument, int expectedScaleUpCount) {
+        MockitoAnnotations.initMocks(this);
+        Cluster cluster = getARunningCluster();
+        String testHostGroup = "compute";
+
+        when(scalingEventMock.getAlert()).thenReturn(baseAlertMock);
+        if (LOAD_BASED.equals(adjustmentType)) {
+            when(scalingEventMock.getHostGroupNodeCount()).thenReturn(Optional.of(currentHostGroupCount));
+            when(scalingEventMock.getScalingNodeCount()).thenReturn(Optional.of(scalingAdjument));
+        } else {
+            when(cloudbreakCommunicator.getByCrn(anyString())).thenReturn(stackV4ResponseMock);
+            when(stackResponseUtils.getNodeCountForHostGroup(stackV4ResponseMock, testHostGroup))
+                    .thenReturn(currentHostGroupCount);
+        }
+        when(clusterService.findById(anyLong())).thenReturn(cluster);
+        when(baseAlertMock.getCluster()).thenReturn(cluster);
+        when(baseAlertMock.getScalingPolicy()).thenReturn(scalingPolicyMock);
+
+        when(scalingPolicyMock.getAdjustmentType()).thenReturn(adjustmentType);
+        when(scalingPolicyMock.getHostGroup()).thenReturn(testHostGroup);
+        when(scalingPolicyMock.getScalingAdjustment()).thenReturn(scalingAdjument);
+        when(scalingEventMock.getDecommissionNodeIds()).thenCallRealMethod();
+        when(applicationContext.getBean("ScalingRequest", cluster, scalingPolicyMock,
+                currentHostGroupCount, expectedScaleUpCount, List.of())).thenReturn(runnableMock);
+
+        underTest.onApplicationEvent(scalingEventMock);
+
+        verify(rejectedThreadService).remove(AUTOSCALE_CLUSTER_ID);
+        verify(clusterService).save(cluster);
+        verify(executorService).submit(runnableMock);
+    }
+
+    private Cluster getARunningCluster() {
+        Cluster cluster = new Cluster();
+        cluster.setId(AUTOSCALE_CLUSTER_ID);
+        cluster.setStackCrn(CLOUDBREAK_STACK_CRN);
+        cluster.setState(ClusterState.RUNNING);
+        cluster.setLastScalingActivity(Instant.now()
+                .minus(45, ChronoUnit.MINUTES).toEpochMilli());
+        return cluster;
+    }
+}

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/handler/UpdateFailedHandlerTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/handler/UpdateFailedHandlerTest.java
@@ -67,7 +67,7 @@ public class UpdateFailedHandlerTest {
     public void testOnApplicationEventWhenStatusDelete() {
         Cluster cluster = getARunningCluster();
         when(clusterService.findById(anyLong())).thenReturn(cluster);
-        when(cloudbreakCommunicator.getByCrn(anyString())).thenReturn(getStackResponse(Status.DELETE_IN_PROGRESS, Status.DELETE_IN_PROGRESS));
+        when(cloudbreakCommunicator.getByCrn(anyString())).thenReturn(getStackResponse(Status.DELETE_COMPLETED, Status.DELETE_COMPLETED));
 
         underTest.onApplicationEvent(new UpdateFailedEvent(AUTOSCALE_CLUSTER_ID));
 

--- a/autoscale/src/test/java/com/sequenceiq/periscope/service/AlertServiceTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/service/AlertServiceTest.java
@@ -1,0 +1,185 @@
+package com.sequenceiq.periscope.service;
+
+import static com.sequenceiq.periscope.api.model.AdjustmentType.NODE_COUNT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.springframework.test.util.AssertionErrors.assertNotNull;
+
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.LoadAlert;
+import com.sequenceiq.periscope.domain.ScalingPolicy;
+import com.sequenceiq.periscope.domain.TimeAlert;
+import com.sequenceiq.periscope.repository.LoadAlertRepository;
+import com.sequenceiq.periscope.repository.TimeAlertRepository;
+
+public class AlertServiceTest {
+
+    @InjectMocks
+    AlertService underTest;
+
+    @Mock
+    ClusterService clusterService;
+
+    @Mock
+    LoadAlertRepository loadAlertRepository;
+
+    @Mock
+    TimeAlertRepository timeAlertRepository;
+
+    @Mock
+    Cluster mockCluster;
+
+    @Mock
+    LoadAlert mockLoadAlert;
+
+    @Mock
+    TimeAlert mockTimeAlert;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testCreateLoadAlert() {
+        Long clusterId = 10L;
+        LoadAlert testAlert = getLoadAlert();
+        when(clusterService.findById(clusterId)).thenReturn(mockCluster);
+        when(clusterService.save(mockCluster)).thenReturn(mockCluster);
+        when(loadAlertRepository.save(testAlert)).thenReturn(mockLoadAlert);
+
+        LoadAlert response = underTest.createLoadAlert(clusterId, testAlert);
+
+        assertNotNull("LoadAlert should not be null", response);
+        assertNotNull("LoadAlert' cluster should not be null", testAlert.getCluster());
+        verify(loadAlertRepository).save(any(LoadAlert.class));
+        verify(clusterService).findById(clusterId);
+        verify(clusterService).save(mockCluster);
+    }
+
+    @Test
+    public void testUpdateLoadAlert() {
+        Long clusterId = 10L;
+        Long alertId = 20L;
+        LoadAlert testAlert = getLoadAlert();
+
+        when(loadAlertRepository.findByCluster(alertId, clusterId)).thenReturn(mockLoadAlert);
+        when(mockLoadAlert.getScalingPolicy()).thenReturn(new ScalingPolicy());
+        when(loadAlertRepository.save(mockLoadAlert)).thenReturn(mockLoadAlert);
+
+        LoadAlert response = underTest.updateLoadAlert(clusterId, alertId, testAlert);
+        assertNotNull("LoadAlert should not be null", response);
+
+        verify(mockLoadAlert).setName(anyString());
+        verify(mockLoadAlert).setDescription(anyString());
+        verify(mockLoadAlert, times(4)).getScalingPolicy();
+        verify(loadAlertRepository).save(mockLoadAlert);
+    }
+
+    @Test
+    public void testDeleteLoadAlert() {
+        Long clusterId = 10L;
+        Long alertId = 20L;
+
+        when(loadAlertRepository.findByCluster(alertId, clusterId)).thenReturn(mockLoadAlert);
+        when(clusterService.findById(clusterId)).thenReturn(mockCluster);
+
+        underTest.deleteLoadAlert(clusterId, alertId);
+
+        verify(mockCluster).setLoadAlerts(any(Set.class));
+        verify(loadAlertRepository).delete(mockLoadAlert);
+        verify(clusterService).save(mockCluster);
+    }
+
+    @Test
+    public void testCreateTimeAlert() {
+        Long clusterId = 10L;
+        TimeAlert testAlert = getTimeAlert();
+        when(clusterService.findById(clusterId)).thenReturn(mockCluster);
+        when(clusterService.save(mockCluster)).thenReturn(mockCluster);
+        when(timeAlertRepository.save(testAlert)).thenReturn(mockTimeAlert);
+
+        TimeAlert response = underTest.createTimeAlert(clusterId, testAlert);
+
+        assertNotNull("TestAlert should not be null", response);
+        assertNotNull("TestAlert' cluster should not be null", testAlert.getCluster());
+        verify(timeAlertRepository).save(any(TimeAlert.class));
+        verify(clusterService).findById(clusterId);
+        verify(clusterService).save(mockCluster);
+        verify(mockCluster).addTimeAlert(mockTimeAlert);
+    }
+
+    @Test
+    public void testUpdateTimeAlert() {
+        Long clusterId = 10L;
+        Long alertId = 20L;
+        TimeAlert testAlert = getTimeAlert();
+
+        when(timeAlertRepository.findByCluster(alertId, clusterId)).thenReturn(mockTimeAlert);
+        when(mockTimeAlert.getScalingPolicy()).thenReturn(new ScalingPolicy());
+        when(timeAlertRepository.save(mockTimeAlert)).thenReturn(mockTimeAlert);
+
+        TimeAlert response = underTest.updateTimeAlert(clusterId, alertId, testAlert);
+        assertNotNull("TimeAlert should not be null", response);
+
+        verify(mockTimeAlert).setName(anyString());
+        verify(mockTimeAlert).setDescription(anyString());
+        verify(mockTimeAlert).setCron(anyString());
+        verify(mockTimeAlert).setTimeZone(anyString());
+        verify(mockTimeAlert, times(4)).getScalingPolicy();
+        verify(timeAlertRepository).save(mockTimeAlert);
+    }
+
+    @Test
+    public void testDeleteTimeAlert() {
+        Long clusterId = 10L;
+        Long alertId = 20L;
+
+        when(timeAlertRepository.findByCluster(alertId, clusterId)).thenReturn(mockTimeAlert);
+        when(clusterService.findById(clusterId)).thenReturn(mockCluster);
+
+        underTest.deleteTimeAlert(clusterId, alertId);
+
+        verify(mockCluster).setTimeAlerts(any(Set.class));
+        verify(timeAlertRepository).delete(mockTimeAlert);
+        verify(clusterService).save(mockCluster);
+    }
+
+    private ScalingPolicy getScalingPolicy() {
+        ScalingPolicy scalingPolicy = new ScalingPolicy();
+        scalingPolicy.setName("loadalertpolicy");
+        scalingPolicy.setAdjustmentType(NODE_COUNT);
+        scalingPolicy.setHostGroup("compute");
+        scalingPolicy.setScalingAdjustment(10);
+        return scalingPolicy;
+    }
+
+    private LoadAlert getLoadAlert() {
+        LoadAlert testAlert = new LoadAlert();
+        testAlert.setName("test");
+        testAlert.setDescription("test desc");
+        testAlert.setScalingPolicy(getScalingPolicy());
+        return testAlert;
+    }
+
+    private TimeAlert getTimeAlert() {
+        TimeAlert testAlert = new TimeAlert();
+        testAlert.setName("test");
+        testAlert.setDescription("test desc");
+        testAlert.setCron("cron string");
+        testAlert.setTimeZone("GMT");
+        testAlert.setScalingPolicy(getScalingPolicy());
+        return testAlert;
+    }
+}

--- a/autoscale/src/test/java/com/sequenceiq/periscope/service/EntitlementValidationServiceTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/service/EntitlementValidationServiceTest.java
@@ -1,0 +1,88 @@
+package com.sequenceiq.periscope.service;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.powermock.reflect.Whitebox;
+
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EntitlementValidationServiceTest {
+
+    private static final String TEST_ACCOUNT_ID = "accid";
+
+    private static final String TEST_USER_CRN = String.format("crn:cdp:iam:us-west-1:%s:user:mockuser@cloudera.com", TEST_ACCOUNT_ID);
+
+    @InjectMocks
+    private EntitlementValidationService underTest;
+
+    @Mock
+    private EntitlementService entitlementService;
+
+    @Before
+    public void setUp() {
+        Whitebox.setInternalState(underTest, "entitlementCheckEnabled", true);
+    }
+
+    @Test
+    public void testWhenEntitlementCheckDisabledThenEntitled() {
+        Whitebox.setInternalState(underTest, "entitlementCheckEnabled", false);
+        boolean entitled = underTest.autoscalingEntitlementEnabled(TEST_USER_CRN, TEST_ACCOUNT_ID, "AWS");
+        assertTrue("entitled should be true when entitlementCheckDisabled", entitled);
+    }
+
+    @Test
+    public void testWhenAWSAndEntitled() {
+        when(entitlementService.getEntitlements(anyString(), anyString())).thenReturn(List.of("CDP_AWS_AUTOSCALING"));
+
+        boolean entitled = underTest.autoscalingEntitlementEnabled(TEST_USER_CRN, TEST_ACCOUNT_ID, "AWS");
+        assertTrue("isEntitled should be true when entitlement found", entitled);
+    }
+
+    @Test
+    public void testWhenAWSAndNotEntitled() {
+        when(entitlementService.getEntitlements(anyString(), anyString())).thenReturn(List.of("CDP_AZURE_AUTOSCALING"));
+
+        boolean entitled = underTest.autoscalingEntitlementEnabled(TEST_USER_CRN, TEST_ACCOUNT_ID, "AWS");
+        assertFalse("isEntitled should be false when entitlement is not found", entitled);
+    }
+
+    @Test
+    public void testWhenAzureAndEntitled() {
+        when(entitlementService.getEntitlements(anyString(), anyString())).thenReturn(List.of("CDP_AWS_AUTOSCALING", "CDP_AZURE_AUTOSCALING"));
+
+        boolean entitled = underTest.autoscalingEntitlementEnabled(TEST_USER_CRN, TEST_ACCOUNT_ID, "AZURE");
+        assertTrue("isEntitled should be true when entitlement found", entitled);
+    }
+
+    @Test
+    public void testWhenAzureAndNotEntitled() {
+        when(entitlementService.getEntitlements(anyString(), anyString())).thenReturn(List.of());
+
+        boolean entitled = underTest.autoscalingEntitlementEnabled(TEST_USER_CRN, TEST_ACCOUNT_ID, "AZURE");
+        assertFalse("isEntitled should be false when entitlement is not found", entitled);
+    }
+
+    @Test
+    public void testWhenYarnAndAlwaysAllowed() {
+        boolean entitled = underTest.autoscalingEntitlementEnabled(TEST_USER_CRN, TEST_ACCOUNT_ID, "YARN");
+        assertTrue("isEntitled should be true when entitlement always allowed", entitled);
+    }
+
+    @Test
+    public void testWhenGCPAndNotEntitled() {
+        boolean entitled = underTest.autoscalingEntitlementEnabled(TEST_USER_CRN, TEST_ACCOUNT_ID, "GCP");
+        assertFalse("isEntitled should be false when entitlement is not defined", entitled);
+    }
+}

--- a/autoscale/src/test/java/com/sequenceiq/periscope/testcontext/EndpointTestContext.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/testcontext/EndpointTestContext.java
@@ -1,0 +1,16 @@
+package com.sequenceiq.periscope.testcontext;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Profile;
+
+import com.sequenceiq.cloudbreak.service.secret.service.SecretService;
+
+@TestConfiguration
+@EntityScan(basePackages = {"com.sequenceiq.periscope"})
+@Profile("test")
+public class EndpointTestContext {
+    @MockBean
+    private SecretService secretService;
+}

--- a/autoscale/src/test/java/com/sequenceiq/periscope/utils/ModelTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/utils/ModelTest.java
@@ -19,7 +19,7 @@ import com.openpojo.validation.test.impl.SetterTester;
 
 public class ModelTest {
 
-    private static final int EXPECTED_CLASS_COUNT = 15;
+    private static final int EXPECTED_CLASS_COUNT = 17;
 
     private static final String DOMAIN_PACKAGE = "com.sequenceiq.periscope.domain";
 

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/autoscales/AutoscaleV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/autoscales/AutoscaleV4Endpoint.java
@@ -10,7 +10,6 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -18,7 +17,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 
 import com.cloudera.cdp.shaded.javax.ws.rs.core.MediaType;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.AmbariAddressV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.UpdateStackV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.response.AuthorizeForAutoscaleV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.response.AutoscaleStackV4Responses;
@@ -47,13 +45,6 @@ public interface AutoscaleV4Endpoint {
     @Produces(APPLICATION_JSON)
     @ApiOperation(value = StackOpDescription.PUT_BY_ID, produces = APPLICATION_JSON, notes = Notes.STACK_NOTES, nickname = "putStackForAutoscale")
     void putStack(@PathParam("crn") String crn, @PathParam("userId") String userId, @Valid UpdateStackV4Request updateRequest);
-
-    @POST
-    @Path("ambari")
-    @Produces(APPLICATION_JSON)
-    @ApiOperation(value = StackOpDescription.GET_BY_AMBARI_ADDRESS, produces = APPLICATION_JSON, notes = Notes.STACK_NOTES,
-            nickname = "getStackForAmbariForAutoscale")
-    StackV4Response getStackForAmbari(@Valid AmbariAddressV4Request json);
 
     @PUT
     @Path("/stack/crn/{crn}/{userId}/cluster")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/AutoscaleV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/AutoscaleV4Controller.java
@@ -21,7 +21,6 @@ import com.sequenceiq.authorization.annotation.CheckPermissionByAccount;
 import com.sequenceiq.authorization.annotation.DisableCheckPermissions;
 import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.AutoscaleV4Endpoint;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.AmbariAddressV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.UpdateStackV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.response.AuthorizeForAutoscaleV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.response.AutoscaleStackV4Responses;
@@ -78,12 +77,6 @@ public class AutoscaleV4Controller implements AutoscaleV4Endpoint {
     @CheckPermissionByAccount(action = AuthorizationResourceAction.DATAHUB_WRITE)
     public void putCluster(String crn, String userId, @Valid UpdateClusterV4Request updateRequest) {
         clusterCommonService.put(crn, updateRequest);
-    }
-
-    @Override
-    @CheckPermissionByAccount(action = AuthorizationResourceAction.DATAHUB_READ)
-    public StackV4Response getStackForAmbari(@Valid AmbariAddressV4Request json) {
-        return stackCommonService.getStackForAmbari(json);
     }
 
     @Override


### PR DESCRIPTION
1. Introduce Entitlement Validations
2. Introduce SuspendedClusterMonitor which monitors suspended clusters and purges them if they are deleted in CB
3. Disable AlertEndpoint
4. Introduce DistroXAutoscaleEndpointTests which runs endpoint tests against embedded tomcat and embedded db.