### PR TITLE
CDPCP-1561. Fix single user sync operation

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncAcceptor.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncAcceptor.java
@@ -11,6 +11,7 @@ import com.sequenceiq.freeipa.service.operation.OperationAcceptor;
 
 @Component
 public class UserSyncAcceptor extends OperationAcceptor {
+
     @Inject
     public UserSyncAcceptor(OperationRepository operationRepository) {
         super(operationRepository);
@@ -39,7 +40,7 @@ public class UserSyncAcceptor extends OperationAcceptor {
     @Override
     protected boolean doOperationsConflict(Operation operation, Operation other) {
         if (operation.getUserList().size() == 1) {
-            return true;
+            return false;
         } else if (!operation.getUserList().isEmpty()) {
             return super.doOperationsConflict(operation, other);
         } else {

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncAcceptorTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncAcceptorTest.java
@@ -1,0 +1,60 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import com.sequenceiq.freeipa.entity.Operation;
+import com.sequenceiq.freeipa.repository.OperationRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserSyncAcceptorTest {
+
+    @Mock
+    private OperationRepository operationRepository;
+
+    @InjectMocks
+    private UserSyncAcceptor userSyncAcceptor;
+
+    @Test
+    void testSingleUserAlwaysAcccepted() {
+        Operation syncOperation = mock(Operation.class);
+        when(syncOperation.getUserList()).thenReturn(List.of("userA"));
+        Operation runningSyncOperation = mock(Operation.class);
+        assertFalse(userSyncAcceptor.doOperationsConflict(syncOperation, runningSyncOperation));
+    }
+
+    @Test
+    void testUserSyncAcceptedWithDifferentEnvironment() {
+        Operation syncOperation = mock(Operation.class);
+        when(syncOperation.getUserList()).thenReturn(List.of("userA", "userB"));
+        when(syncOperation.getEnvironmentList()).thenReturn(List.of("envA"));
+
+        Operation runningSyncOperation = mock(Operation.class);
+        when(runningSyncOperation.getUserList()).thenReturn(List.of("userA"));
+        when(runningSyncOperation.getEnvironmentList()).thenReturn(List.of("envB"));
+
+        assertFalse(userSyncAcceptor.doOperationsConflict(syncOperation, runningSyncOperation));
+    }
+
+    @Test
+    void testSingleUserSyncRejectedOnUserAndEnvOverlap() {
+        Operation syncOperation = mock(Operation.class);
+        when(syncOperation.getUserList()).thenReturn(List.of("userA", "userB"));
+        when(syncOperation.getEnvironmentList()).thenReturn(List.of("envA"));
+
+        Operation runningSyncOperation = mock(Operation.class);
+        when(runningSyncOperation.getUserList()).thenReturn(List.of("userA"));
+        when(runningSyncOperation.getEnvironmentList()).thenReturn(List.of("envA"));
+
+        assertTrue(userSyncAcceptor.doOperationsConflict(syncOperation, runningSyncOperation));
+    }
+}


### PR DESCRIPTION
I noticed sync operations with a single user were still gettting rejected when there were other operations running. This is due to a bug in my earlier commit. Fixed now.