### PR TITLE
DISTX-471 Periscope Entitlement Service Integration

### DIFF
--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/validator/DistroXAutoscaleRequestValidator.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/validator/DistroXAutoscaleRequestValidator.java
@@ -35,6 +35,13 @@ public class DistroXAutoscaleRequestValidator
         Set<String> distinctLoadBasedHostGroups = new HashSet<>();
         Set<AdjustmentType> distinctLoadBasedAdjustmentTypes = new HashSet<>();
 
+        if (request.getLoadAlertRequests().size() > 1) {
+            String message = String.format("LoadBased autoscaling currently supports a single HostGroup in a Cluster.");
+            com.sequenceiq.cloudbreak.validation.ValidatorUtil.addConstraintViolation(context, message, "loadAlertRequests")
+                    .disableDefaultConstraintViolation();
+            return false;
+        }
+
         Set<String> duplicateHostGroups =
                 request.getLoadAlertRequests().stream()
                         .map(loadAlertRequest -> loadAlertRequest.getScalingPolicy())

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/client/AutoscaleUserCrnClient.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/client/AutoscaleUserCrnClient.java
@@ -12,6 +12,7 @@ import com.sequenceiq.periscope.api.AutoscaleApi;
 import com.sequenceiq.periscope.api.endpoint.v1.AlertEndpoint;
 import com.sequenceiq.periscope.api.endpoint.v1.AutoScaleClusterV1Endpoint;
 import com.sequenceiq.periscope.api.endpoint.v1.ConfigurationEndpoint;
+import com.sequenceiq.periscope.api.endpoint.v1.DistroXAutoScaleClusterV1Endpoint;
 import com.sequenceiq.periscope.api.endpoint.v1.HistoryEndpoint;
 import com.sequenceiq.periscope.api.endpoint.v1.PolicyEndpoint;
 
@@ -36,6 +37,10 @@ public class AutoscaleUserCrnClient extends AbstractUserCrnServiceClient<Autosca
 
         public AlertEndpoint alertEndpoint() {
             return getEndpoint(AlertEndpoint.class);
+        }
+
+        public DistroXAutoScaleClusterV1Endpoint distroXAutoScaleClusterV1Endpoint() {
+            return getEndpoint(DistroXAutoScaleClusterV1Endpoint.class);
         }
 
         public AutoScaleClusterV1Endpoint clusterEndpoint() {

--- a/autoscale-api/src/test/java/com/sequenceiq/periscope/api/endpoint/validator/DistroXAutoscaleRequestValidatorTest.java
+++ b/autoscale-api/src/test/java/com/sequenceiq/periscope/api/endpoint/validator/DistroXAutoscaleRequestValidatorTest.java
@@ -53,7 +53,7 @@ public class DistroXAutoscaleRequestValidatorTest {
 
     @Test
     public void testIsValidWhenValidLoadAlertsThenTrue() {
-        List<String> loadHostGroups = Arrays.asList("compute2", "hdfs1", "hdfs3");
+        List<String> loadHostGroups = Arrays.asList("compute2");
 
         boolean underTestValid = underTest
                 .isValid(getTestRequest(List.of(), loadHostGroups, Optional.empty()), validatorContext);

--- a/autoscale/build.gradle
+++ b/autoscale/build.gradle
@@ -164,6 +164,7 @@ dependencies {
     testCompile group: 'org.powermock',             name: 'powermock-api-mockito2'
     testCompile group: 'org.ow2.asm',               name: 'asm'
     testCompile group: 'com.openpojo',              name: 'openpojo'
+    testCompile group: "com.h2database",            name: "h2",     version: h2databaseVersion
 
     compile project(':core-api')
     compile project(':autoscale-api')

--- a/autoscale/src/main/java/com/sequenceiq/periscope/PeriscopeApplication.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/PeriscopeApplication.java
@@ -5,7 +5,7 @@ import static com.sequenceiq.periscope.VersionedApplication.versionedApplication
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.actuate.autoconfigure.metrics.web.servlet.WebMvcMetricsAutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.context.annotation.ComponentScan;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 
@@ -14,8 +14,8 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 @Configuration
 @EnableAutoConfiguration(exclude = WebMvcMetricsAutoConfiguration.class)
 @EnableSwagger2
-@ComponentScan(basePackages = {"com.sequenceiq"})
 @EnableAspectJAutoProxy(proxyTargetClass = true)
+@SpringBootApplication(scanBasePackages = "com.sequenceiq", exclude = WebMvcMetricsAutoConfiguration.class)
 public class PeriscopeApplication {
 
     public static void main(String[] args) {

--- a/autoscale/src/main/java/com/sequenceiq/periscope/cache/AccountEntitlementCache.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/cache/AccountEntitlementCache.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.periscope.cache;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cache.common.AbstractCacheDefinition;
+
+@Component
+public class AccountEntitlementCache extends AbstractCacheDefinition {
+
+    public static final String INSTANCE_CONFIG_CACHE = "accountEntitlementCache";
+
+    private static final long MAX_ENTRIES = 500L;
+
+    private static final int TTL_IN_MINUTES = 5;
+
+    @Override
+    protected String getName() {
+        return INSTANCE_CONFIG_CACHE;
+    }
+
+    @Override
+    protected long getMaxEntries() {
+        return MAX_ENTRIES;
+    }
+
+    @Override
+    protected long getTimeToLiveSeconds() {
+        return TimeUnit.MINUTES.toSeconds(TTL_IN_MINUTES);
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/config/DatabaseConfig.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/config/DatabaseConfig.java
@@ -15,6 +15,7 @@ import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
@@ -33,6 +34,7 @@ import com.zaxxer.hikari.HikariDataSource;
 
 @Configuration
 @EnableTransactionManagement
+@ConditionalOnProperty(name = "periscope.db.enabled", havingValue = "true", matchIfMissing = true)
 public class DatabaseConfig {
 
     @Value("${periscope.db.env.user:postgres}")

--- a/autoscale/src/main/java/com/sequenceiq/periscope/controller/AlertController.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/controller/AlertController.java
@@ -11,13 +11,13 @@ import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.ws.rs.BadRequestException;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.authorization.annotation.AuthorizationResource;
 import com.sequenceiq.authorization.annotation.CheckPermissionByAccount;
 import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.periscope.api.endpoint.v1.AlertEndpoint;
 import com.sequenceiq.periscope.api.model.AlertType;
 import com.sequenceiq.periscope.api.model.LoadAlertRequest;
@@ -37,15 +37,13 @@ import com.sequenceiq.periscope.service.AlertService;
 import com.sequenceiq.periscope.service.AutoscaleRestRequestThreadLocalService;
 import com.sequenceiq.periscope.service.ClusterService;
 import com.sequenceiq.periscope.service.DateService;
+import com.sequenceiq.periscope.service.EntitlementValidationService;
 import com.sequenceiq.periscope.service.NotFoundException;
 import com.sequenceiq.periscope.service.configuration.ClusterProxyConfigurationService;
 
 @Controller
 @AuthorizationResource
 public class AlertController implements AlertEndpoint {
-
-    @Value("${periscope.enabledPlatforms:}")
-    private Set<String> supportedCloudPlatforms;
 
     @Inject
     private AlertService alertService;
@@ -73,6 +71,9 @@ public class AlertController implements AlertEndpoint {
 
     @Inject
     private ClusterProxyConfigurationService clusterProxyConfigurationService;
+
+    @Inject
+    private EntitlementValidationService entitlementValidationService;
 
     @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.DATAHUB_WRITE)
@@ -170,9 +171,12 @@ public class AlertController implements AlertEndpoint {
                 .orElseThrow(NotFoundException.notFound("cluster", clusterId));
     }
 
-    private void validateCloudPlatform(Cluster cluster) {
-        if (!supportedCloudPlatforms.contains(cluster.getCloudPlatform())) {
-            throw new BadRequestException(String.format("Autoscaling for CloudPlatform '%s' is not supported, Cluster '%s'",
+    private void validateAccountEntitlement(Cluster cluster) {
+        if (!entitlementValidationService.autoscalingEntitlementEnabled(
+                ThreadBasedUserCrnProvider.getUserCrn(),
+                ThreadBasedUserCrnProvider.getAccountId(),
+                cluster.getCloudPlatform())) {
+            throw new BadRequestException(String.format("Autoscaling is not enabled for CloudPlatform '%s', Cluster '%s' in this Account",
                     cluster.getCloudPlatform(), cluster.getStackCrn()));
         }
     }
@@ -180,7 +184,7 @@ public class AlertController implements AlertEndpoint {
     private void validateTimeAlert(Long clusterId, Optional<Long> alertId, TimeAlertRequest json) {
         Cluster cluster = getClusterForWorkspace(clusterId);
         alertId.ifPresentOrElse(updateAlert -> validateAlertForUpdate(cluster, updateAlert, AlertType.TIME),
-                () -> validateCloudPlatform(cluster));
+                () -> validateAccountEntitlement(cluster));
         try {
             dateService.validateTimeZone(json.getTimeZone());
             dateService.getCronExpression(json.getCron());
@@ -193,7 +197,7 @@ public class AlertController implements AlertEndpoint {
         Cluster cluster = getClusterForWorkspace(clusterId);
         alertId.ifPresentOrElse(updateAlert -> validateAlertForUpdate(cluster, updateAlert, AlertType.LOAD),
                 () -> {
-                    validateCloudPlatform(cluster);
+                    validateAccountEntitlement(cluster);
                     String requestHostGroup = json.getScalingPolicy().getHostGroup();
                     cluster.getLoadAlerts().stream().map(LoadAlert::getScalingPolicy).map(ScalingPolicy::getHostGroup)
                             .filter(hostGroup -> hostGroup.equalsIgnoreCase(requestHostGroup)).findAny()

--- a/autoscale/src/main/java/com/sequenceiq/periscope/controller/EndpointConfig.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/controller/EndpointConfig.java
@@ -88,7 +88,6 @@ public class EndpointConfig extends ResourceConfig {
     }
 
     private void registerEndpoints() {
-        register(AlertController.class);
         register(DistroXAutoScaleClusterV1Controller.class);
 
         register(io.swagger.jaxrs.listing.ApiListingResource.class);

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/SuspendedClusterMonitor.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/SuspendedClusterMonitor.java
@@ -1,0 +1,36 @@
+package com.sequenceiq.periscope.monitor;
+
+import java.util.List;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.periscope.api.model.ClusterState;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.monitor.evaluator.ClusterStateEvaluator;
+
+@Component("SuspendedClusterMonitor")
+@ConditionalOnProperty(prefix = "periscope.enabledAutoscaleMonitors.suspended-cluster-monitor", name = "enabled", havingValue = "true")
+public class SuspendedClusterMonitor extends ClusterMonitor {
+
+    @Override
+    public String getIdentifier() {
+        return "suspended-cluster-monitor";
+    }
+
+    @Override
+    public String getTriggerExpression() {
+        return MonitorUpdateRate.EVERY_MIN_RATE_CRON;
+    }
+
+    @Override
+    public Class<?> getEvaluatorType(Cluster cluster) {
+        return ClusterStateEvaluator.class;
+    }
+
+    @Override
+    protected List<Cluster> getMonitored() {
+        //To monitor Suspended clusters and purge them in periscope when they are deleted in CB.
+        return getClusterService().findAllByStateAndNode(ClusterState.SUSPENDED, getPeriscopeNodeConfig().getId());
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ClusterStateEvaluator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ClusterStateEvaluator.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.periscope.monitor.evaluator;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.periscope.monitor.context.ClusterIdEvaluatorContext;
+import com.sequenceiq.periscope.monitor.context.EvaluatorContext;
+import com.sequenceiq.periscope.monitor.event.UpdateFailedEvent;
+
+@Component("ClusterStateEvaluator")
+@Scope("prototype")
+public class ClusterStateEvaluator extends EvaluatorExecutor {
+
+    private static final String EVALUATOR_NAME = ClusterStateEvaluator.class.getName();
+
+    @Inject
+    private EventPublisher eventPublisher;
+
+    private long clusterId;
+
+    @Override
+    public void setContext(EvaluatorContext context) {
+        clusterId = (long) context.getData();
+    }
+
+    @Override
+    @Nonnull
+    public EvaluatorContext getContext() {
+        return new ClusterIdEvaluatorContext(clusterId);
+    }
+
+    @Override
+    public String getName() {
+        return EVALUATOR_NAME;
+    }
+
+    @Override
+    public void execute() {
+        eventPublisher.publishEvent(new UpdateFailedEvent(clusterId));
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/UpdateFailedHandler.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/UpdateFailedHandler.java
@@ -109,7 +109,9 @@ public class UpdateFailedHandler implements ApplicationListener<UpdateFailedEven
     }
 
     private void suspendCluster(Cluster cluster) {
-        clusterService.setState(cluster, ClusterState.SUSPENDED);
+        if (!cluster.getState().equals(ClusterState.SUSPENDED)) {
+            clusterService.setState(cluster, ClusterState.SUSPENDED);
+        }
     }
 
     private void reportClusterManagerServerFailure(Cluster cluster, StackV4Response stackResponse) {

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/EntitlementValidationService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/EntitlementValidationService.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.periscope.service;
+
+import java.util.Map;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+
+@Service
+public class EntitlementValidationService {
+
+    private static final String ALLOWED = "ALLOWED_PLATFORM";
+
+    private static final Map<String, String> PLATFORM_ENTITLEMENTS = Map.of(
+            "AWS", "DATAHUB_AWS_AUTOSCALING",
+            "AZURE", "DATAHUB_AZURE_AUTOSCALING",
+            "YARN", ALLOWED);
+
+    @Value("${periscope.entitlementCheckEnabled:true}")
+    private Boolean entitlementCheckEnabled;
+
+    @Inject
+    private EntitlementService entitlementService;
+
+    @Cacheable(cacheNames = "accountEntitlementCache", key = "{#accountId,#cloudPlatform}")
+    public boolean autoscalingEntitlementEnabled(String userCrn, String accountId, String cloudPlatform) {
+        boolean entitled;
+        Optional<String> platformEntitlement = Optional.ofNullable(PLATFORM_ENTITLEMENTS.get(cloudPlatform));
+        if (!entitlementCheckEnabled || platformEntitlement.map(entitlement -> ALLOWED.equals(entitlement)).orElse(false)) {
+            entitled = true;
+        } else if (platformEntitlement.isEmpty()) {
+            entitled = false;
+        } else {
+            entitled = entitlementService.getEntitlements(userCrn, accountId)
+                    .stream().anyMatch(e -> e.equalsIgnoreCase(platformEntitlement.get()));
+        }
+        return entitled;
+    }
+}

--- a/autoscale/src/main/resources/application-test.yml
+++ b/autoscale/src/main/resources/application-test.yml
@@ -34,16 +34,17 @@ periscope:
     dir: /certs/
 
   db:
-    env:
-      user: postgres
-      pass:
-      db: periscopedb
-      schema: public
-      cert.file: database.crt
-      ssl: false
-    port.5432.tcp:
-      addr: localhost
-      port: 5432
+    enabled: false
+#    env:
+#      user: postgres
+#      pass:
+#      db: periscopedb
+#      schema: public
+#      cert.file: database.crt
+#      ssl: false
+#    port.5432.tcp:
+#      addr: localhost
+#      port: 5432
   cloudbreak.url: http://localhost:9091
   entitlementCheckEnabled: false
   enabledAutoscaleMonitors:
@@ -53,14 +54,15 @@ periscope:
       enabled: true
     cluster-manager-host-health-monitor:
       enabled: true
-    suspended-cluster-monitor:
-      enabled: true
     prometheus-monitor:
       enabled: false
 
 cb:
   server:
     contextPath: "/cb"
+  schema:
+    migration:
+      auto: false
 
 rest:
   debug: false
@@ -77,25 +79,17 @@ spring:
     template-loader-path: classpath:/
     prefer-file-system-access: false
   datasource:
-      maxActive: 30
+    maxActive: 30
+  profiles: test
 
 secret:
   application: as/shared
   engine: "com.sequenceiq.cloudbreak.service.secret.vault.VaultKvV2Engine"
 
 vault:
-  addr: localhost
-  port: 8200
-  ssl.enabled: false
-  kv.engine.v2.path: secret
-  config.enabled: true
-  auth:
-    type: "token"
-    kubernetes:
-      service.account.token.path: /var/run/secrets/kubernetes.io/serviceaccount/token
-      mount.path: "dps-dev"
-      login.role: "autoscale.default"
+  config.enabled: false
 
 altus:
   ums:
     host: localhost
+

--- a/autoscale/src/test/java/com/sequenceiq/periscope/endpointtests/DistroXAutoScaleClusterV1EndpointTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/endpointtests/DistroXAutoScaleClusterV1EndpointTest.java
@@ -1,0 +1,384 @@
+package com.sequenceiq.periscope.endpointtests;
+
+import static com.sequenceiq.periscope.api.model.AdjustmentType.LOAD_BASED;
+import static com.sequenceiq.periscope.api.model.AdjustmentType.NODE_COUNT;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.AssertionErrors.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import javax.inject.Inject;
+import javax.ws.rs.BadRequestException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
+import com.sequenceiq.authorization.service.UmsAccountAuthorizationService;
+import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
+import com.sequenceiq.cloudbreak.auth.altus.UmsClient;
+import com.sequenceiq.periscope.api.endpoint.v1.DistroXAutoScaleClusterV1Endpoint;
+import com.sequenceiq.periscope.api.model.AutoscaleClusterState;
+import com.sequenceiq.periscope.api.model.DistroXAutoscaleClusterRequest;
+import com.sequenceiq.periscope.api.model.DistroXAutoscaleClusterResponse;
+import com.sequenceiq.periscope.api.model.LoadAlertConfigurationRequest;
+import com.sequenceiq.periscope.api.model.LoadAlertRequest;
+import com.sequenceiq.periscope.api.model.LoadAlertResponse;
+import com.sequenceiq.periscope.api.model.ScalingPolicyRequest;
+import com.sequenceiq.periscope.api.model.TimeAlertRequest;
+import com.sequenceiq.periscope.api.model.TimeAlertResponse;
+import com.sequenceiq.periscope.client.AutoscaleUserCrnClientBuilder;
+import com.sequenceiq.periscope.testcontext.EndpointTestContext;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.ClusterPertain;
+import com.sequenceiq.periscope.repository.ClusterRepository;
+import com.sequenceiq.periscope.repository.LoadAlertRepository;
+import com.sequenceiq.periscope.repository.TimeAlertRepository;
+import com.sequenceiq.periscope.service.configuration.ClusterProxyConfigurationService;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = EndpointTestContext.class)
+@ActiveProfiles("test")
+public class DistroXAutoScaleClusterV1EndpointTest {
+
+    private static final String SERVICE_ADDRESS = "http://localhost:%d/as";
+
+    private static final Long TEST_USER_ID = 100L;
+
+    private static final Long TEST_WORKSPACE_ID = 100L;
+
+    private static final Integer MIN_RESOURCE_COUNT = 4;
+
+    private static final Integer MAX_RESOURCE_COUNT = 15;
+
+    private static final Integer COOL_DOWN_MINUTES = 5;
+
+    private static final String TEST_SCHEDULE_CRON = "1 0 1 1 1 1";
+
+    private static final String TEST_SCHEDULE_TIMEZONE = "GMT";
+
+    private static final Integer TEST_SCHEDULE_NODE_COUNT = 10;
+
+    private static final String TEST_ACCOUNT_ID = "accid";
+
+    private static final String TEST_CLUSTER_NAME = "testCluster";
+
+    private static final String TEST_USER_CRN = String.format("crn:cdp:iam:us-west-1:%s:user:mockuser@cloudera.com", TEST_ACCOUNT_ID);
+
+    private static final String TEST_CLUSTER_CRN = String.format("crn:cdp:iam:us-west-1:%s:cluster:mockuser@cloudera.com", TEST_ACCOUNT_ID);
+
+    @LocalServerPort
+    private int port;
+
+    @MockBean
+    private UmsAccountAuthorizationService umsAccountAuthorizationService;
+
+    @MockBean
+    private ClusterProxyConfigurationService clusterProxyConfigurationService;
+
+    @MockBean(name = "grpcUmsClient")
+    private GrpcUmsClient grpcUmsClient;
+
+    @MockBean(name = "umsClient")
+    private UmsClient umsClient;
+
+    @Inject
+    private ClusterRepository clusterRepository;
+
+    @Inject
+    private LoadAlertRepository loadAlertRepository;
+
+    @Inject
+    private TimeAlertRepository timeAlertRepository;
+
+    private DistroXAutoScaleClusterV1Endpoint distroXAutoScaleClusterV1Endpoint;
+
+    @Before
+    public void setup() {
+        distroXAutoScaleClusterV1Endpoint = new AutoscaleUserCrnClientBuilder(String.format(SERVICE_ADDRESS, port))
+                .build().withCrn(TEST_USER_CRN).distroXAutoScaleClusterV1Endpoint();
+
+        Cluster testCluster = new Cluster();
+        testCluster.setStackCrn(TEST_CLUSTER_CRN);
+        testCluster.setStackName(TEST_CLUSTER_NAME);
+        testCluster.setCloudPlatform("AWS");
+
+        ClusterPertain clusterPertain = new ClusterPertain();
+        clusterPertain.setTenant("test-tenant");
+        clusterPertain.setWorkspaceId(TEST_WORKSPACE_ID);
+        clusterPertain.setUserId(TEST_USER_ID.toString());
+        clusterPertain.setUserCrn(TEST_USER_CRN);
+        testCluster.setClusterPertain(clusterPertain);
+
+        UserManagementProto.User user = UserManagementProto.User.newBuilder()
+                .setCrn(TEST_USER_CRN).setEmail("dummyuser@cloudera.com").setUserId(TEST_USER_ID.toString()).build();
+        clusterRepository.save(testCluster);
+
+        when(grpcUmsClient.getUserDetails(anyString(), anyString(), any())).thenReturn(user);
+        when(umsAccountAuthorizationService.hasRightOfUser(anyString(), anyString())).thenReturn(true);
+        when(clusterProxyConfigurationService.getClusterProxyUrl()).thenReturn(Optional.of("http://clusterproxy"));
+    }
+
+    @After
+    public void tearDown() {
+        clusterRepository.deleteAll();
+        loadAlertRepository.deleteAll();
+        timeAlertRepository.deleteAll();
+    }
+
+    @Test
+    public void testUpdateAutoscaleConfigByClusterCrnForEnableDisableAutoscaling() {
+        DistroXAutoscaleClusterRequest distroXAutoscaleClusterRequest = new DistroXAutoscaleClusterRequest();
+        distroXAutoscaleClusterRequest.setEnableAutoscaling(true);
+
+        distroXAutoScaleClusterV1Endpoint
+                .updateAutoscaleConfigByClusterCrn(TEST_CLUSTER_CRN, distroXAutoscaleClusterRequest);
+
+        DistroXAutoscaleClusterResponse xAutoscaleClusterResponse = distroXAutoScaleClusterV1Endpoint.getClusterByCrn(TEST_CLUSTER_CRN);
+        assertTrue("Autoscaling should be enabled", xAutoscaleClusterResponse.isAutoscalingEnabled());
+
+        distroXAutoscaleClusterRequest.setEnableAutoscaling(false);
+        distroXAutoScaleClusterV1Endpoint
+                .updateAutoscaleConfigByClusterCrn(TEST_CLUSTER_CRN, distroXAutoscaleClusterRequest);
+        xAutoscaleClusterResponse = distroXAutoScaleClusterV1Endpoint.getClusterByCrn(TEST_CLUSTER_CRN);
+        assertFalse("Autoscaling should be disabled", xAutoscaleClusterResponse.isAutoscalingEnabled());
+    }
+
+    @Test
+    public void testEnableAutoscaleForClusterCrn() {
+        distroXAutoScaleClusterV1Endpoint.enableAutoscaleForClusterCrn(TEST_CLUSTER_CRN, AutoscaleClusterState.enable());
+        DistroXAutoscaleClusterResponse xAutoscaleClusterResponse = distroXAutoScaleClusterV1Endpoint.getClusterByCrn(TEST_CLUSTER_CRN);
+        assertTrue("Autoscaling should be enabled", xAutoscaleClusterResponse.isAutoscalingEnabled());
+
+        distroXAutoScaleClusterV1Endpoint.enableAutoscaleForClusterCrn(TEST_CLUSTER_CRN, AutoscaleClusterState.disable());
+        xAutoscaleClusterResponse = distroXAutoScaleClusterV1Endpoint.getClusterByCrn(TEST_CLUSTER_CRN);
+        assertFalse("Autoscaling should be disabled", xAutoscaleClusterResponse.isAutoscalingEnabled());
+
+        distroXAutoScaleClusterV1Endpoint.enableAutoscaleForClusterCrn(TEST_CLUSTER_CRN, AutoscaleClusterState.enable());
+        xAutoscaleClusterResponse = distroXAutoScaleClusterV1Endpoint.getClusterByCrn(TEST_CLUSTER_CRN);
+        assertTrue("Autoscaling should be enabled", xAutoscaleClusterResponse.isAutoscalingEnabled());
+    }
+
+    @Test
+    public void testEnableAutoscaleForClusterName() {
+        distroXAutoScaleClusterV1Endpoint.enableAutoscaleForClusterName(TEST_CLUSTER_NAME, AutoscaleClusterState.enable());
+        DistroXAutoscaleClusterResponse xAutoscaleClusterResponse = distroXAutoScaleClusterV1Endpoint.getClusterByName(TEST_CLUSTER_NAME);
+        assertTrue("Autoscaling should be enabled", xAutoscaleClusterResponse.isAutoscalingEnabled());
+
+        distroXAutoScaleClusterV1Endpoint.enableAutoscaleForClusterName(TEST_CLUSTER_NAME, AutoscaleClusterState.disable());
+        xAutoscaleClusterResponse = distroXAutoScaleClusterV1Endpoint.getClusterByName(TEST_CLUSTER_NAME);
+        assertFalse("Autoscaling should be disabled", xAutoscaleClusterResponse.isAutoscalingEnabled());
+    }
+
+    @Test
+    public void testUpdateAutoscaleConfigByClusterCrnForLoadAlerts() {
+        List<LoadAlertRequest> loadAlertRequests = getLoadAlertRequests(1, List.of("compute"));
+
+        DistroXAutoscaleClusterRequest distroXAutoscaleClusterRequest = new DistroXAutoscaleClusterRequest();
+        distroXAutoscaleClusterRequest.setLoadAlertRequests(loadAlertRequests);
+        distroXAutoscaleClusterRequest.setEnableAutoscaling(true);
+
+        distroXAutoScaleClusterV1Endpoint
+                .updateAutoscaleConfigByClusterCrn(TEST_CLUSTER_CRN, distroXAutoscaleClusterRequest);
+        DistroXAutoscaleClusterResponse xAutoscaleClusterResponse =
+                distroXAutoScaleClusterV1Endpoint.getClusterByCrn(TEST_CLUSTER_CRN);
+
+        assertEquals("Retrieved Alerts Size Should Match", 1, xAutoscaleClusterResponse.getLoadAlerts().size());
+        assertTrue("Autoscaling should be enabled", xAutoscaleClusterResponse.isAutoscalingEnabled());
+        xAutoscaleClusterResponse.getLoadAlerts().stream().forEach(this::validateLoadAlertResponse);
+    }
+
+    @Test
+    public void testUpdateAutoscaleConfigByClusterNameForLoadAlerts() {
+        List<LoadAlertRequest> loadAlertRequests = getLoadAlertRequests(1, List.of("compute"));
+
+        DistroXAutoscaleClusterRequest distroXAutoscaleClusterRequest = new DistroXAutoscaleClusterRequest();
+        distroXAutoscaleClusterRequest.setLoadAlertRequests(loadAlertRequests);
+        distroXAutoscaleClusterRequest.setEnableAutoscaling(true);
+
+        distroXAutoScaleClusterV1Endpoint.updateAutoscaleConfigByClusterName(TEST_CLUSTER_NAME, distroXAutoscaleClusterRequest);
+        DistroXAutoscaleClusterResponse xAutoscaleClusterResponse =
+                distroXAutoScaleClusterV1Endpoint.getClusterByName(TEST_CLUSTER_NAME);
+
+        assertEquals("Retrieved Alerts Size Should Match", 1, xAutoscaleClusterResponse.getLoadAlerts().size());
+        assertTrue("Autoscaling should be enabled", xAutoscaleClusterResponse.isAutoscalingEnabled());
+        xAutoscaleClusterResponse.getLoadAlerts().stream().forEach(this::validateLoadAlertResponse);
+    }
+
+    @Test
+    public void testDeleteAlertByClusterCrnForLoadAlerts() {
+        List<LoadAlertRequest> loadAlertRequests = getLoadAlertRequests(1, List.of("compute"));
+
+        DistroXAutoscaleClusterRequest distroXAutoscaleClusterRequest = new DistroXAutoscaleClusterRequest();
+        distroXAutoscaleClusterRequest.setLoadAlertRequests(loadAlertRequests);
+        distroXAutoscaleClusterRequest.setEnableAutoscaling(true);
+
+        distroXAutoScaleClusterV1Endpoint.updateAutoscaleConfigByClusterCrn(TEST_CLUSTER_CRN, distroXAutoscaleClusterRequest);
+        DistroXAutoscaleClusterResponse xAutoscaleClusterResponse =
+                distroXAutoScaleClusterV1Endpoint.getClusterByCrn(TEST_CLUSTER_CRN);
+
+        assertEquals("Retrieved Alerts Size Should Match", 1, xAutoscaleClusterResponse.getLoadAlerts().size());
+        distroXAutoScaleClusterV1Endpoint.deleteAlertsForClusterCrn(TEST_CLUSTER_CRN);
+        xAutoscaleClusterResponse = distroXAutoScaleClusterV1Endpoint.getClusterByCrn(TEST_CLUSTER_CRN);
+        assertEquals("Retrieved Alerts Size Should Match", 0, xAutoscaleClusterResponse.getLoadAlerts().size());
+    }
+
+    @Test
+    public void testUpdateAutoscaleConfigByClusterCrnForTimeAlerts() {
+        List<TimeAlertRequest> timeAlertRequests = getTimeAlertRequests(2, List.of("compute", "compute"));
+
+        DistroXAutoscaleClusterRequest distroXAutoscaleClusterRequest = new DistroXAutoscaleClusterRequest();
+        distroXAutoscaleClusterRequest.setTimeAlertRequests(timeAlertRequests);
+        distroXAutoscaleClusterRequest.setEnableAutoscaling(true);
+
+        distroXAutoScaleClusterV1Endpoint.updateAutoscaleConfigByClusterCrn(TEST_CLUSTER_CRN, distroXAutoscaleClusterRequest);
+        DistroXAutoscaleClusterResponse xAutoscaleClusterResponse =
+                distroXAutoScaleClusterV1Endpoint.getClusterByCrn(TEST_CLUSTER_CRN);
+
+        assertEquals("Retrieved Alerts Size Should Match", 2, xAutoscaleClusterResponse.getTimeAlerts().size());
+        assertTrue("Autoscaling should be enabled", xAutoscaleClusterResponse.isAutoscalingEnabled());
+        xAutoscaleClusterResponse.getTimeAlerts().stream().forEach(this::validateTimeAlertResponse);
+    }
+
+    @Test
+    public void testUpdateAutoscaleConfigByClusterNameForTimeAlerts() {
+        List<TimeAlertRequest> timeAlertRequests = getTimeAlertRequests(2, List.of("compute", "compute"));
+
+        DistroXAutoscaleClusterRequest distroXAutoscaleClusterRequest = new DistroXAutoscaleClusterRequest();
+        distroXAutoscaleClusterRequest.setTimeAlertRequests(timeAlertRequests);
+        distroXAutoscaleClusterRequest.setEnableAutoscaling(true);
+
+        distroXAutoScaleClusterV1Endpoint.updateAutoscaleConfigByClusterName(TEST_CLUSTER_NAME, distroXAutoscaleClusterRequest);
+        DistroXAutoscaleClusterResponse xAutoscaleClusterResponse =
+                distroXAutoScaleClusterV1Endpoint.getClusterByName(TEST_CLUSTER_NAME);
+
+        assertEquals("Retrieved Alerts Size Should Match", 2, xAutoscaleClusterResponse.getTimeAlerts().size());
+        assertTrue("Autoscaling should be enabled", xAutoscaleClusterResponse.isAutoscalingEnabled());
+        xAutoscaleClusterResponse.getTimeAlerts().stream().forEach(this::validateTimeAlertResponse);
+    }
+
+    @Test
+    public void testDeleteAlertByClusterNameForTimeAlerts() {
+        List<TimeAlertRequest> timeAlertRequests = getTimeAlertRequests(2, List.of("compute", "compute"));
+
+        DistroXAutoscaleClusterRequest distroXAutoscaleClusterRequest = new DistroXAutoscaleClusterRequest();
+        distroXAutoscaleClusterRequest.setTimeAlertRequests(timeAlertRequests);
+        distroXAutoscaleClusterRequest.setEnableAutoscaling(true);
+
+        distroXAutoScaleClusterV1Endpoint.updateAutoscaleConfigByClusterName(TEST_CLUSTER_NAME, distroXAutoscaleClusterRequest);
+        DistroXAutoscaleClusterResponse xAutoscaleClusterResponse =
+                distroXAutoScaleClusterV1Endpoint.getClusterByName(TEST_CLUSTER_NAME);
+        assertEquals("Retrieved Alerts Size Should Match", 2, xAutoscaleClusterResponse.getTimeAlerts().size());
+
+
+        distroXAutoScaleClusterV1Endpoint.deleteAlertsForClusterName(TEST_CLUSTER_NAME);
+        xAutoscaleClusterResponse = distroXAutoScaleClusterV1Endpoint.getClusterByName(TEST_CLUSTER_NAME);
+        assertEquals("Retrieved Alerts Size Should Match", 0, xAutoscaleClusterResponse.getTimeAlerts().size());
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testUpdateAutoscaleConfigWhenMultipleAlertTypes() {
+        List<TimeAlertRequest> timeAlertRequests = getTimeAlertRequests(2, List.of("compute", "compute"));
+        List<LoadAlertRequest> loadAlertRequests = getLoadAlertRequests(2, List.of("group1", "group2"));
+
+        DistroXAutoscaleClusterRequest distroXAutoscaleClusterRequest = new DistroXAutoscaleClusterRequest();
+        distroXAutoscaleClusterRequest.setTimeAlertRequests(timeAlertRequests);
+        distroXAutoscaleClusterRequest.setLoadAlertRequests(loadAlertRequests);
+        distroXAutoscaleClusterRequest.setEnableAutoscaling(true);
+
+        distroXAutoScaleClusterV1Endpoint
+                .updateAutoscaleConfigByClusterName(TEST_CLUSTER_NAME, distroXAutoscaleClusterRequest);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testUpdateAutoscaleConfigByClusterCrnForMultipleLoadAlerts() {
+        List<LoadAlertRequest> loadAlertRequests = getLoadAlertRequests(2, List.of("compute", "compute"));
+        DistroXAutoscaleClusterRequest distroXAutoscaleClusterRequest = new DistroXAutoscaleClusterRequest();
+        distroXAutoscaleClusterRequest.setLoadAlertRequests(loadAlertRequests);
+        distroXAutoscaleClusterRequest.setEnableAutoscaling(true);
+
+        distroXAutoScaleClusterV1Endpoint
+                .updateAutoscaleConfigByClusterCrn(TEST_CLUSTER_CRN, distroXAutoscaleClusterRequest);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testUpdateAutoscaleConfigByClusterCrnForMultipleLoadAlertsAndHostGroups() {
+        List<LoadAlertRequest> loadAlertRequests = getLoadAlertRequests(2, List.of("group1", "group2"));
+        DistroXAutoscaleClusterRequest distroXAutoscaleClusterRequest = new DistroXAutoscaleClusterRequest();
+        distroXAutoscaleClusterRequest.setLoadAlertRequests(loadAlertRequests);
+        distroXAutoscaleClusterRequest.setEnableAutoscaling(true);
+
+        distroXAutoScaleClusterV1Endpoint
+                .updateAutoscaleConfigByClusterCrn(TEST_CLUSTER_CRN, distroXAutoscaleClusterRequest);
+    }
+
+    private void validateLoadAlertResponse(LoadAlertResponse alertResponse) {
+        assertEquals("Retrieved HostGroup Should Match", "compute", alertResponse.getScalingPolicy().getHostGroup());
+        assertEquals("Retrieved AdjustmentType Should Match", LOAD_BASED, alertResponse.getScalingPolicy().getAdjustmentType());
+        assertEquals("Retrieved MinResourceValue Should Match", MIN_RESOURCE_COUNT, alertResponse.getLoadAlertConfiguration().getMinResourceValue());
+        assertEquals("Retrieved MaxResourceValue Should Match", MAX_RESOURCE_COUNT, alertResponse.getLoadAlertConfiguration().getMaxResourceValue());
+        assertEquals("Retrieved CoolDownMins Should Match", COOL_DOWN_MINUTES, alertResponse.getLoadAlertConfiguration().getCoolDownMinutes());
+    }
+
+    private void validateTimeAlertResponse(TimeAlertResponse alertResponse) {
+        assertEquals("Retrieved HostGroup Should Match", "compute", alertResponse.getScalingPolicy().getHostGroup());
+        assertEquals("Retrieved AdjustmentType Should Match", NODE_COUNT, alertResponse.getScalingPolicy().getAdjustmentType());
+        assertEquals("Retrieved Adjustment Should Match", TEST_SCHEDULE_NODE_COUNT, alertResponse.getScalingPolicy().getScalingAdjustment());
+        assertEquals("Retrieved Cron Should Match", TEST_SCHEDULE_CRON, alertResponse.getCron());
+        assertEquals("Retrieved TimeZone Should Match", TEST_SCHEDULE_TIMEZONE, alertResponse.getTimeZone());
+    }
+
+    private List<LoadAlertRequest> getLoadAlertRequests(Integer loadAlertRequestCount, List<String> computeGroups) {
+        List<LoadAlertRequest> loadRequests = new ArrayList();
+        IntStream.range(0, loadAlertRequestCount).forEach(loop -> {
+            LoadAlertRequest loadAlertRequest = new LoadAlertRequest();
+            loadAlertRequest.setAlertName("testalert");
+            LoadAlertConfigurationRequest loadAlertConfiguration = new LoadAlertConfigurationRequest();
+            loadAlertConfiguration.setMinResourceValue(MIN_RESOURCE_COUNT);
+            loadAlertConfiguration.setMaxResourceValue(MAX_RESOURCE_COUNT);
+            loadAlertConfiguration.setCoolDownMinutes(COOL_DOWN_MINUTES);
+
+            ScalingPolicyRequest scalingPolicyRequest = new ScalingPolicyRequest();
+            scalingPolicyRequest.setAdjustmentType(LOAD_BASED);
+            scalingPolicyRequest.setHostGroup(computeGroups.get(loop));
+
+            loadAlertRequest.setScalingPolicy(scalingPolicyRequest);
+            loadAlertRequest.setLoadAlertConfiguration(loadAlertConfiguration);
+            loadRequests.add(loadAlertRequest);
+        });
+        return loadRequests;
+    }
+
+    private List<TimeAlertRequest> getTimeAlertRequests(Integer timeAlertRequestCount, List<String> computeGroups) {
+        List<TimeAlertRequest> timeAlertRequests = new ArrayList();
+        IntStream.range(0, timeAlertRequestCount).forEach(loop -> {
+            TimeAlertRequest timeAlertRequest = new TimeAlertRequest();
+            timeAlertRequest.setAlertName("testalert");
+            timeAlertRequest.setTimeZone(TEST_SCHEDULE_TIMEZONE);
+            timeAlertRequest.setCron(TEST_SCHEDULE_CRON);
+
+            ScalingPolicyRequest scalingPolicyRequest = new ScalingPolicyRequest();
+            scalingPolicyRequest.setAdjustmentType(NODE_COUNT);
+            scalingPolicyRequest.setScalingAdjustment(TEST_SCHEDULE_NODE_COUNT);
+            scalingPolicyRequest.setHostGroup(computeGroups.get(loop));
+
+            timeAlertRequest.setScalingPolicy(scalingPolicyRequest);
+            timeAlertRequests.add(timeAlertRequest);
+        });
+        return timeAlertRequests;
+    }
+}

--- a/autoscale/src/test/java/com/sequenceiq/periscope/modul/rejected/RejectedThreadContext.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/modul/rejected/RejectedThreadContext.java
@@ -13,6 +13,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolExecutorFactoryBean;
@@ -59,6 +60,7 @@ public class RejectedThreadContext {
     @MockBean({Clock.class, ClusterService.class, CloudbreakClientConfiguration.class,
             MetricUtils.class, InternalCrnBuilder.class, FailedNodeRepository.class})
     @EnableAsync
+    @Profile("dev")
     public static class SpringConfig implements AsyncConfigurer {
 
         @Inject

--- a/autoscale/src/test/java/com/sequenceiq/periscope/modul/rejected/StackCollectorContext.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/modul/rejected/StackCollectorContext.java
@@ -13,6 +13,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Profile;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -60,6 +61,7 @@ public class StackCollectorContext {
     @MockBean({ClusterService.class, CloudbreakClientConfiguration.class, TlsSecurityService.class, SecurityConfigService.class,
             HistoryService.class, HttpNotificationSender.class, MetricUtils.class, Clock.class, ClouderaManagerApiFactory.class, SecretService.class})
     @EnableAsync
+    @Profile("dev")
     public static class StackCollectorSpringConfig implements AsyncConfigurer {
 
         @Inject

--- a/autoscale/src/test/java/com/sequenceiq/periscope/service/EntitlementValidationServiceTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/service/EntitlementValidationServiceTest.java
@@ -1,0 +1,88 @@
+package com.sequenceiq.periscope.service;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.powermock.reflect.Whitebox;
+
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EntitlementValidationServiceTest {
+
+    private static final String TEST_ACCOUNT_ID = "accid";
+
+    private static final String TEST_USER_CRN = String.format("crn:cdp:iam:us-west-1:%s:user:mockuser@cloudera.com", TEST_ACCOUNT_ID);
+
+    @InjectMocks
+    private EntitlementValidationService underTest;
+
+    @Mock
+    private EntitlementService entitlementService;
+
+    @Before
+    public void setUp() {
+        Whitebox.setInternalState(underTest, "entitlementCheckEnabled", true);
+    }
+
+    @Test
+    public void testWhenEntitlementCheckDisabledThenEntitled() {
+        Whitebox.setInternalState(underTest, "entitlementCheckEnabled", false);
+        boolean entitled = underTest.autoscalingEntitlementEnabled(TEST_USER_CRN, TEST_ACCOUNT_ID, "AWS");
+        assertTrue("entitled should be true when entitlementCheckDisabled", entitled);
+    }
+
+    @Test
+    public void testWhenAWSAndEntitled() {
+        when(entitlementService.getEntitlements(anyString(), anyString())).thenReturn(List.of("DATAHUB_AWS_AUTOSCALING"));
+
+        boolean entitled = underTest.autoscalingEntitlementEnabled(TEST_USER_CRN, TEST_ACCOUNT_ID, "AWS");
+        assertTrue("isEntitled should be true when entitlement found", entitled);
+    }
+
+    @Test
+    public void testWhenAWSAndNotEntitled() {
+        when(entitlementService.getEntitlements(anyString(), anyString())).thenReturn(List.of("DATAHUB_AZURE_AUTOSCALING"));
+
+        boolean entitled = underTest.autoscalingEntitlementEnabled(TEST_USER_CRN, TEST_ACCOUNT_ID, "AWS");
+        assertFalse("isEntitled should be false when entitlement is not found", entitled);
+    }
+
+    @Test
+    public void testWhenAzureAndEntitled() {
+        when(entitlementService.getEntitlements(anyString(), anyString())).thenReturn(List.of("DATAHUB_AWS_AUTOSCALING", "DATAHUB_AZURE_AUTOSCALING"));
+
+        boolean entitled = underTest.autoscalingEntitlementEnabled(TEST_USER_CRN, TEST_ACCOUNT_ID, "AZURE");
+        assertTrue("isEntitled should be true when entitlement found", entitled);
+    }
+
+    @Test
+    public void testWhenAzureAndNotEntitled() {
+        when(entitlementService.getEntitlements(anyString(), anyString())).thenReturn(List.of());
+
+        boolean entitled = underTest.autoscalingEntitlementEnabled(TEST_USER_CRN, TEST_ACCOUNT_ID, "AZURE");
+        assertFalse("isEntitled should be false when entitlement is not found", entitled);
+    }
+
+    @Test
+    public void testWhenYarnAndAlwaysAllowed() {
+        boolean entitled = underTest.autoscalingEntitlementEnabled(TEST_USER_CRN, TEST_ACCOUNT_ID, "YARN");
+        assertTrue("isEntitled should be true when entitlement always allowed", entitled);
+    }
+
+    @Test
+    public void testWhenGCPAndNotEntitled() {
+        boolean entitled = underTest.autoscalingEntitlementEnabled(TEST_USER_CRN, TEST_ACCOUNT_ID, "GCP");
+        assertFalse("isEntitled should be false when entitlement is not defined", entitled);
+    }
+}

--- a/autoscale/src/test/java/com/sequenceiq/periscope/testcontext/EndpointTestContext.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/testcontext/EndpointTestContext.java
@@ -1,0 +1,16 @@
+package com.sequenceiq.periscope.testcontext;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Profile;
+
+import com.sequenceiq.cloudbreak.service.secret.service.SecretService;
+
+@TestConfiguration
+@EntityScan(basePackages = {"com.sequenceiq.periscope"})
+@Profile("test")
+public class EndpointTestContext {
+    @MockBean
+    private SecretService secretService;
+}


### PR DESCRIPTION
1. Introduce Entitlement Validations
2. Introduce SuspendedClusterMonitor which monitors suspended clusters and purges them if they are deleted in CB
3. Disable AlertEndpoint
4. Introduce DistroXAutoscaleEndpointTests which runs endpoint tests against embedded tomcat and embedded db.

Closes #DISTX-471