### PR TITLE
CB-6996 - Streaming GA requirements: Ranger pluging cfg.provider, blueprints, proxy settings

### DIFF
--- a/core/src/main/resources/defaults/clustertemplates/aws/aws-streaming-720.json
+++ b/core/src/main/resources/defaults/clustertemplates/aws/aws-streaming-720.json
@@ -3,8 +3,6 @@
   "description": "",
   "type": "STREAMING",
   "cloudPlatform": "AWS",
-  "featureState": "PREVIEW",
-
   "distroXTemplate": {
     "cluster": {
       "blueprintName": "7.2.0 - Streams Messaging Heavy Duty: Apache Kafka, Schema Registry, Streams Messaging Manager"
@@ -88,7 +86,7 @@
             {
               "count": 1,
               "size": 1000,
-              "type": "st1"
+              "type": "gp2"
             }
           ],
           "rootVolume": {

--- a/core/src/main/resources/defaults/clustertemplates/aws/aws-streaming-small-720.json
+++ b/core/src/main/resources/defaults/clustertemplates/aws/aws-streaming-small-720.json
@@ -3,10 +3,12 @@
   "description": "",
   "type": "STREAMING",
   "cloudPlatform": "AWS",
-  "featureState": "PREVIEW",
   "distroXTemplate": {
     "cluster": {
       "blueprintName": "7.2.0 - Streams Messaging Light Duty: Apache Kafka, Schema Registry, Streams Messaging Manager"
+    },
+    "externalDatabase": {
+      "availabilityType": "NON_HA"
     },
     "instanceGroups": [
       {
@@ -35,7 +37,7 @@
           "attachedVolumes": [
             {
               "count": 1,
-              "size": 500,
+              "size": 1000,
               "type": "st1"
             }
           ],

--- a/core/src/main/resources/defaults/clustertemplates/azure/azure-streaming-720.json
+++ b/core/src/main/resources/defaults/clustertemplates/azure/azure-streaming-720.json
@@ -3,7 +3,6 @@
   "description": "",
   "type": "STREAMING",
   "cloudPlatform": "AZURE",
-  "featureState": "PREVIEW",
   "distroXTemplate": {
     "cluster": {
       "blueprintName": "7.2.0 - Streams Messaging Heavy Duty: Apache Kafka, Schema Registry, Streams Messaging Manager"
@@ -78,8 +77,8 @@
           "instanceType": "Standard_D8_v3",
           "attachedVolumes": [
             {
-              "count": 1,
-              "size": 1000,
+              "count": 2,
+              "size": 500,
               "type": "StandardSSD_LRS"
             }
           ]

--- a/core/src/main/resources/defaults/clustertemplates/azure/azure-streaming-small-720.json
+++ b/core/src/main/resources/defaults/clustertemplates/azure/azure-streaming-small-720.json
@@ -3,10 +3,12 @@
   "description": "",
   "type": "STREAMING",
   "cloudPlatform": "AZURE",
-  "featureState": "PREVIEW",
   "distroXTemplate": {
     "cluster": {
       "blueprintName": "7.2.0 - Streams Messaging Light Duty: Apache Kafka, Schema Registry, Streams Messaging Manager"
+    },
+    "externalDatabase": {
+      "availabilityType": "NON_HA"
     },
     "instanceGroups": [
       {
@@ -32,8 +34,8 @@
           "attachedVolumes": [
             {
               "count": 1,
-              "size": 500,
-              "type": "StandardSSD_LRS"
+              "size": 1000,
+              "type": "Standard_LRS"
             }
           ]
         },

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -661,6 +661,10 @@
                 {% for hostloc in salt['pillar.get']('gateway:location')['SCHEMA_REGISTRY_SERVER'] -%}
                 <url>{{ protocol }}://{{ hostloc }}:{{ ports['SCHEMA-REGISTRY'] }}</url>
                 {%- endfor %}
+                <param>
+                    <name>replayBufferSize</name>
+                    <value>512</value>
+                </param>
             </service>
         {%- endif %}
      {%- endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
@@ -427,6 +427,10 @@
         {% for hostloc in salt['pillar.get']('gateway:location')['SCHEMA_REGISTRY_SERVER'] -%}
         <url>{{ protocol }}://{{ hostloc }}:{{ ports['SCHEMA-REGISTRY'] }}</url>
         {%- endfor %}
+        <param>
+            <name>replayBufferSize</name>
+            <value>512</value>
+        </param>
     </service>
     {%- endif %}
     {%- endif %}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaDatahubConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaDatahubConfigProvider.java
@@ -19,9 +19,9 @@ import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 @Component
 public class KafkaDatahubConfigProvider implements CmTemplateComponentConfigProvider {
 
-    static final String RANGER_PLUGIN_KAFKA_SERVICE_NAME = "ranger_plugin_kafka_service_name";
+    public static final String RANGER_PLUGIN_KAFKA_SERVICE_NAME = "ranger_plugin_kafka_service_name";
 
-    static final String GENERATED_RANGER_SERVICE_NAME = "{{GENERATED_RANGER_SERVICE_NAME}}";
+    public static final String GENERATED_RANGER_SERVICE_NAME = "{{GENERATED_RANGER_SERVICE_NAME}}";
 
     static final String PRODUCER_METRICS_ENABLE = "producer.metrics.enable";
 

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/smm/StreamsMessagingManagerServiceConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/smm/StreamsMessagingManagerServiceConfigProviderTest.java
@@ -34,7 +34,7 @@ public class StreamsMessagingManagerServiceConfigProviderTest {
 
     @Test
     public void testGetStreamsMessagingManagerServerConfigs() {
-        String inputJson = getBlueprintText("input/cdp-streaming.bp");
+        String inputJson = getBlueprintText("input/cdp-streaming.bp").replace("__CDH_VERSION__", "7.2.0");
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
         TemplatePreparationObject preparationObject = getTemplatePreparationObject(null, false, cmTemplateProcessor);
 

--- a/template-manager-cmtemplate/src/test/resources/input/cdp-streaming.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/cdp-streaming.bp
@@ -1,5 +1,5 @@
 {
-    "cdhVersion": "7.2.0",
+    "cdhVersion": "__CDH_VERSION__",
     "displayName": "CDP - STREAMING",
     "cmVersion": "7.x.0",
     "repositories": [


### PR DESCRIPTION
This PR contains the remaining requirements for GA 7.2.0 streaming clusters.
- Config provider for Schema Registry Ranger repo
- Custom Knox proxy setting for SCHEMA_REGISTRY:  replayBufferSize=512
- Final blueprints and cluster definitions

Testing:
- Tested manual cluster installation for all combinations (AWS / Azure, Light Duty / Heavy Duty)
- Wrote new unit tests for config providers

Closes:
CB-6996
CB-7153
CB-7208