### PR TITLE
CB-5738 Disable ClusterManagerHostHealthEvaluator

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/RemovableClusterMonitor.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/RemovableClusterMonitor.java
@@ -5,17 +5,16 @@ import java.util.List;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.periscope.api.model.ClusterState;
 import com.sequenceiq.periscope.domain.Cluster;
 import com.sequenceiq.periscope.monitor.evaluator.ClusterStateEvaluator;
 
-@Component("SuspendedClusterMonitor")
-@ConditionalOnProperty(prefix = "periscope.enabledAutoscaleMonitors.suspended-cluster-monitor", name = "enabled", havingValue = "true")
-public class SuspendedClusterMonitor extends ClusterMonitor {
+@Component("RemovableClusterMonitor")
+@ConditionalOnProperty(prefix = "periscope.enabledAutoscaleMonitors.removable-cluster-monitor", name = "enabled", havingValue = "true")
+public class RemovableClusterMonitor extends ClusterMonitor {
 
     @Override
     public String getIdentifier() {
-        return "suspended-cluster-monitor";
+        return "removable-cluster-monitor";
     }
 
     @Override
@@ -30,7 +29,6 @@ public class SuspendedClusterMonitor extends ClusterMonitor {
 
     @Override
     protected List<Cluster> getMonitored() {
-        //To monitor Suspended clusters and purge them in periscope when they are deleted in CB.
-        return getClusterService().findAllByStateAndNode(ClusterState.SUSPENDED, getPeriscopeNodeConfig().getId());
+        return getClusterService().findAllByPeriscopeNodeId(getPeriscopeNodeConfig().getId());
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/repository/ClusterRepository.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/repository/ClusterRepository.java
@@ -56,6 +56,8 @@ public interface ClusterRepository extends CrudRepository<Cluster, Long> {
 
     List<Cluster> findByStateAndPeriscopeNodeId(ClusterState state, String nodeId);
 
+    List<Cluster> findAllByPeriscopeNodeId(String nodeId);
+
     List<Cluster> findByStateAndAutoscalingEnabledAndPeriscopeNodeId(ClusterState state, boolean autoscalingEnabled, String nodeId);
 
     int countByStateAndAutoscalingEnabledAndPeriscopeNodeId(ClusterState state, boolean autoscalingEnabled, String nodeId);

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/ClusterService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/ClusterService.java
@@ -211,8 +211,8 @@ public class ClusterService implements ResourceBasedCrnProvider {
         return AuthorizationResourceType.DATAHUB;
     }
 
-    public String findStackCrnById(Long clusterId) {
-        return clusterRepository.findStackCrnById(clusterId);
+    public List<Cluster> findAllByPeriscopeNodeId(String nodeId) {
+        return clusterRepository.findAllByPeriscopeNodeId(nodeId);
     }
 
     public List<Cluster> findAllByStateAndNode(ClusterState state, String nodeId) {

--- a/autoscale/src/main/resources/application.yml
+++ b/autoscale/src/main/resources/application.yml
@@ -32,7 +32,6 @@ management:
 periscope:
   cert:
     dir: /certs/
-
   db:
     env:
       user: postgres
@@ -52,8 +51,8 @@ periscope:
     load-monitor:
       enabled: true
     cluster-manager-host-health-monitor:
-      enabled: true
-    suspended-cluster-monitor:
+      enabled: false
+    removable-cluster-monitor:
       enabled: true
     prometheus-monitor:
       enabled: false


### PR DESCRIPTION
1. Disable ClusterManagerHostHealthEvaluator.
2. Including autoscaling disabled clusters for removable check.

Closes CB-5738