### PR TITLE
CDPD-12838:

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-720.bp
@@ -213,7 +213,7 @@
           },
           {
             "name": "hive_service_config_safety_valve",
-            "value": "<property><name>hive.server2.tez.sessions.per.default.queue</name><value>4</value></property>"
+            "value": "<property><name>hive.server2.tez.sessions.per.default.queue</name><value>4</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-720.bp
@@ -99,7 +99,7 @@
           },
           {
             "name": "hive_service_config_safety_valve",
-            "value": "<property><name>hive.server2.tez.sessions.per.default.queue</name><value>4</value></property>"
+            "value": "<property><name>hive.server2.tez.sessions.per.default.queue</name><value>4</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property>"
           }
         ],
         "roleConfigGroups": [


### PR DESCRIPTION
set hive.txn.acid.dir.cache.duration=0 in hive safety valve
until https://issues.apache.org/jira/browse/HIVE-23551 is fixed

Testing done:
I created custom template from 7.2.0 DE & DE HA templates with tuned hive config in mow-dev. And launched clusters couple of times. There were no issues. Noticed changes were applied.

Closes #CDPD-12838
