### PR TITLE
CB-7306 setting HDFS replication to 1 and suppressing health check.

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hdfs/HdfsConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hdfs/HdfsConfigProvider.java
@@ -1,14 +1,20 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.hdfs;
 
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_0;
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateComponentConfigProvider;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.s3guard.S3GuardConfigProvider;
@@ -28,8 +34,20 @@ public class HdfsConfigProvider implements CmTemplateComponentConfigProvider {
 
         s3GuardConfigProvider.getServiceConfigs(templatePreparationObject, hdfsCoreSiteSafetyValveValue);
 
-        return hdfsCoreSiteSafetyValveValue.toString().isEmpty() ? List.of()
-                : List.of(config(CORE_SITE_SAFETY_VALVE, hdfsCoreSiteSafetyValveValue.toString()));
+        List<ApiClusterTemplateConfig> list = new ArrayList<>();
+        if (StringUtils.isNotEmpty(hdfsCoreSiteSafetyValveValue.toString())) {
+            list.add(config(CORE_SITE_SAFETY_VALVE, hdfsCoreSiteSafetyValveValue.toString()));
+        }
+        if (templatePreparationObject.getProductDetailsView() != null &&
+                templatePreparationObject.getProductDetailsView().getCm() != null &&
+                templatePreparationObject.getProductDetailsView().getCm().getVersion() != null) {
+            String cmVersion = templatePreparationObject.getProductDetailsView().getCm().getVersion();
+            if (templatePreparationObject.getStackType() == StackType.DATALAKE && isVersionNewerOrEqualThanLimited(cmVersion, CLOUDERAMANAGER_VERSION_7_2_0)) {
+                list.add(config("dfs_replication", "1"));
+                list.add(config("service_health_suppression_hdfs_verify_ec_with_topology", "true"));
+            }
+        }
+        return Collections.unmodifiableList(list);
     }
 
     @Override


### PR DESCRIPTION
This fixes an red error warning in CM about HDFS health and suppresses a  yellow warning error.  This needs to go into 2.20 and 2.21.