### PR TITLE
CB-6720 Fix a case-sensitivity bug in Ranger configs

### DIFF
--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerRoleConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerRoleConfigProviderTest.java
@@ -173,7 +173,7 @@ public class RangerRoleConfigProviderTest {
         assertEquals("ranger", serviceConfigs.get(1).getValue());
 
         assertEquals("ranger_database_type", serviceConfigs.get(2).getName());
-        assertEquals("PostgreSQL", serviceConfigs.get(2).getValue());
+        assertEquals("postgresql", serviceConfigs.get(2).getValue());
 
         assertEquals("ranger_database_user", serviceConfigs.get(3).getName());
         assertEquals("heyitsme", serviceConfigs.get(3).getValue());


### PR DESCRIPTION
This is a workaround fix for a CM bug which introduces case-sensitivity for ranger_database_type. Tested with unit-tests.