### PR TITLE
CB-7217 Add necessary salt stack changes to invoke the database backup restore scripts.

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/pillar/postgresql/disaster_recovery.sls
+++ b/orchestrator-salt/src/main/resources/salt/pillar/postgresql/disaster_recovery.sls
@@ -1,0 +1,3 @@
+disaster_recovery:
+  object_storage_url:
+

--- a/orchestrator-salt/src/main/resources/salt/pillar/top.sls
+++ b/orchestrator-salt/src/main/resources/salt/pillar/top.sls
@@ -66,6 +66,7 @@ base:
     - gateway.ldap
     - gateway.settings
     - monitoring.init
+    - postgresql.disaster_recovery
 
   'roles:knox_gateway':
     - match: grain

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/.pgpass
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/.pgpass
@@ -1,0 +1,3 @@
+{{ pillar['postgres']['remote_db_url'] }}:{{ pillar['postgres']['remote_db_port'] }}:hive:{{ pillar['postgres']['remote_admin'] }}:{{ pillar['postgres']['remote_admin_pw'] }}
+{{ pillar['postgres']['remote_db_url'] }}:{{ pillar['postgres']['remote_db_port'] }}:ranger:{{ pillar['postgres']['remote_admin'] }}:{{ pillar['postgres']['remote_admin_pw'] }}
+{{ pillar['postgres']['remote_db_url'] }}:{{ pillar['postgres']['remote_db_port'] }}:postgres:{{ pillar['postgres']['remote_admin'] }}:{{ pillar['postgres']['remote_admin_pw'] }}

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/backup.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/backup.sls
@@ -1,0 +1,16 @@
+{% set configure_remote_db = salt['pillar.get']('postgres:configure_remote_db', 'None') %}
+
+{% if 'None' != configure_remote_db %}
+
+include:
+  - postgresql.disaster_recovery
+
+backup_postgresql_db:
+  cmd.run:
+    - name: /opt/salt/scripts/backup_db.sh {{salt['pillar.get']('platform')}} {{salt['pillar.get']('disaster_recovery:object_storage_url')}} {{salt['pillar.get']('postgres:remote_db_url')}} {{salt['pillar.get']('postgres:remote_db_port')}} {{salt['pillar.get']('postgres:remote_admin')}}
+    - require:
+        - sls: postgresql.disaster_recovery
+
+{%- else %}
+{# Intentionally left blank, we're not handling backup of non-remote (embedded) DBs #}
+{% endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/init.sls
@@ -1,0 +1,27 @@
+/opt/salt/scripts/backup_db.sh:
+  file.managed:
+    - makedirs: True
+    - mode: 750
+    - source: salt://postgresql/disaster_recovery/scripts/backup_db.sh
+    - template: jinja
+
+/opt/salt/scripts/restore_db.sh:
+  file.managed:
+    - makedirs: True
+    - mode: 750
+    - source: salt://postgresql/disaster_recovery/scripts/restore_db.sh
+    - template: jinja
+
+/opt/salt/postgresql/.pgpass:
+  file.managed:
+    - makedirs: True
+    - mode: 600
+    - source: salt://postgresql/disaster_recovery/.pgpass
+    - template: jinja
+
+set_pgpass_file:
+  environ.setenv:
+    - name: PGPASSFILE
+    - value: /opt/salt/postgresql/.pgpass
+    - require:
+      - file: /opt/salt/postgresql/.pgpass

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/restore.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/restore.sls
@@ -1,0 +1,16 @@
+{% set configure_remote_db = salt['pillar.get']('postgres:configure_remote_db', 'None') %}
+
+{% if 'None' != configure_remote_db %}
+
+include:
+  - postgresql.disaster_recovery
+
+restore_postgresql_db:
+  cmd.run:
+    - name: /opt/salt/scripts/restore_db.sh {{salt['pillar.get']('platform')}} {{salt['pillar.get']('disaster_recovery:object_storage_url')}} {{salt['pillar.get']('postgres:remote_db_url')}} {{salt['pillar.get']('postgres:remote_db_port')}} {{salt['pillar.get']('postgres:remote_admin')}}
+    - require:
+        - sls: postgresql.disaster_recovery
+
+{%- else %}
+{# Intentionally left blank, we're not handling backup of non-remote (embedded) DBs #}
+{% endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
@@ -13,14 +13,14 @@ if [ $# -ne 5 ]; then
   echo "Invalid inputs provided"
   echo "Script accepts 5 inputs:"
   echo "  1. Cloud Provider (azure | aws)"
-  echo "  2. Object Storage Service url to retrieve backups."
+  echo "  2. Object Storage Service url to place backups."
   echo "  3. PostgreSQL host name."
   echo "  4. PostgreSQL port."
   echo "  5. PostgreSQL user name."
   exit 1
 fi
 
-CLOUD_PROVIDER="$1"
+CLOUD_PROVIDER=$(echo "$1" | tr '[:upper:]' '[:lower:]')
 BACKUP_LOCATION=$(echo "$2" | sed 's/\/\+$//g') # Clear trailng '/' (if present) for later path joining.
 HOST="$3"
 PORT="$4"
@@ -31,7 +31,7 @@ LOGFILE=/var/log/dl_postgres_backup.log
 echo "Logs at ${LOGFILE}"
 
 doLog() {
-  type_of_msg=$(echo $* | cut -d" " -f1)
+  type_of_msg=$(echo "$@" | cut -d" " -f1)
   msg=$(echo "$*" | cut -d" " -f2-)
   [[ $type_of_msg == INFO ]] && type_of_msg="INFO " # one space for aligning
   [[ $type_of_msg == WARN ]] && type_of_msg="WARN " # as well

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/restore_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/restore_db.sh
@@ -19,7 +19,7 @@ if [ $# -ne 5 ]; then
   exit 1
 fi
 
-CLOUD_PROVIDER="$1"
+CLOUD_PROVIDER=$(echo "$1" | tr '[:upper:]' '[:lower:]')
 CLOUD_LOCATION=$(echo "$2" | sed 's/\/\+$//g') # Clear trailng '/' (if present) for later path joining.
 HOST="$3"
 PORT="$4"
@@ -31,7 +31,7 @@ echo "Logs at ${LOGFILE}"
 BACKUPS_DIR="/var/tmp/postgres_restore_staging"
 
 doLog() {
-  type_of_msg=$(echo $* | cut -d" " -f1)
+  type_of_msg=$(echo "$@" | cut -d" " -f1)
   msg=$(echo "$*" | cut -d" " -f2-)
   [[ $type_of_msg == INFO ]] && type_of_msg="INFO " # one space for aligning
   [[ $type_of_msg == WARN ]] && type_of_msg="WARN " # as well


### PR DESCRIPTION
 Invoke PostgreSQL backup and restore salt scripts.
* Add Salt States for:
  * Copying scripts to master node
  * Copying .pgpass for credentials
  * Running backup and restore scripts
* Move PostgreSQL scripts to `disaster_recovery` directory.
* Add Pillar value for backup location

Closes CB-7217