### PR TITLE
CDPCP-1941. Sync Azure OID Mappings as part of user sync

### DIFF
--- a/auth-connector/src/generated/main/grpc/com/cloudera/thunderhead/service/usermanagement/UserManagementGrpc.java
+++ b/auth-connector/src/generated/main/grpc/com/cloudera/thunderhead/service/usermanagement/UserManagementGrpc.java
@@ -3287,6 +3287,154 @@ public final class UserManagementGrpc {
      }
      return getSetWorkloadPasswordPolicyMethod;
   }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getAssignCloudIdentityMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityResponse> METHOD_ASSIGN_CLOUD_IDENTITY = getAssignCloudIdentityMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityResponse> getAssignCloudIdentityMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityResponse> getAssignCloudIdentityMethod() {
+    return getAssignCloudIdentityMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityResponse> getAssignCloudIdentityMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityResponse> getAssignCloudIdentityMethod;
+    if ((getAssignCloudIdentityMethod = UserManagementGrpc.getAssignCloudIdentityMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getAssignCloudIdentityMethod = UserManagementGrpc.getAssignCloudIdentityMethod) == null) {
+          UserManagementGrpc.getAssignCloudIdentityMethod = getAssignCloudIdentityMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "usermanagement.UserManagement", "AssignCloudIdentity"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("AssignCloudIdentity"))
+                  .build();
+          }
+        }
+     }
+     return getAssignCloudIdentityMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getUnassignCloudIdentityMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignCloudIdentityRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignCloudIdentityResponse> METHOD_UNASSIGN_CLOUD_IDENTITY = getUnassignCloudIdentityMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignCloudIdentityRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignCloudIdentityResponse> getUnassignCloudIdentityMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignCloudIdentityRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignCloudIdentityResponse> getUnassignCloudIdentityMethod() {
+    return getUnassignCloudIdentityMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignCloudIdentityRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignCloudIdentityResponse> getUnassignCloudIdentityMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignCloudIdentityRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignCloudIdentityResponse> getUnassignCloudIdentityMethod;
+    if ((getUnassignCloudIdentityMethod = UserManagementGrpc.getUnassignCloudIdentityMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getUnassignCloudIdentityMethod = UserManagementGrpc.getUnassignCloudIdentityMethod) == null) {
+          UserManagementGrpc.getUnassignCloudIdentityMethod = getUnassignCloudIdentityMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignCloudIdentityRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignCloudIdentityResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "usermanagement.UserManagement", "UnassignCloudIdentity"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignCloudIdentityRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignCloudIdentityResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("UnassignCloudIdentity"))
+                  .build();
+          }
+        }
+     }
+     return getUnassignCloudIdentityMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getAssignServicePrincipalCloudIdentityMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignServicePrincipalCloudIdentityRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignServicePrincipalCloudIdentityResponse> METHOD_ASSIGN_SERVICE_PRINCIPAL_CLOUD_IDENTITY = getAssignServicePrincipalCloudIdentityMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignServicePrincipalCloudIdentityRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignServicePrincipalCloudIdentityResponse> getAssignServicePrincipalCloudIdentityMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignServicePrincipalCloudIdentityRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignServicePrincipalCloudIdentityResponse> getAssignServicePrincipalCloudIdentityMethod() {
+    return getAssignServicePrincipalCloudIdentityMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignServicePrincipalCloudIdentityRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignServicePrincipalCloudIdentityResponse> getAssignServicePrincipalCloudIdentityMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignServicePrincipalCloudIdentityRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignServicePrincipalCloudIdentityResponse> getAssignServicePrincipalCloudIdentityMethod;
+    if ((getAssignServicePrincipalCloudIdentityMethod = UserManagementGrpc.getAssignServicePrincipalCloudIdentityMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getAssignServicePrincipalCloudIdentityMethod = UserManagementGrpc.getAssignServicePrincipalCloudIdentityMethod) == null) {
+          UserManagementGrpc.getAssignServicePrincipalCloudIdentityMethod = getAssignServicePrincipalCloudIdentityMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignServicePrincipalCloudIdentityRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignServicePrincipalCloudIdentityResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "usermanagement.UserManagement", "AssignServicePrincipalCloudIdentity"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignServicePrincipalCloudIdentityRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignServicePrincipalCloudIdentityResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("AssignServicePrincipalCloudIdentity"))
+                  .build();
+          }
+        }
+     }
+     return getAssignServicePrincipalCloudIdentityMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getUnassignServicePrincipalCloudIdentityMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityResponse> METHOD_UNASSIGN_SERVICE_PRINCIPAL_CLOUD_IDENTITY = getUnassignServicePrincipalCloudIdentityMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityResponse> getUnassignServicePrincipalCloudIdentityMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityResponse> getUnassignServicePrincipalCloudIdentityMethod() {
+    return getUnassignServicePrincipalCloudIdentityMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityResponse> getUnassignServicePrincipalCloudIdentityMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityResponse> getUnassignServicePrincipalCloudIdentityMethod;
+    if ((getUnassignServicePrincipalCloudIdentityMethod = UserManagementGrpc.getUnassignServicePrincipalCloudIdentityMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getUnassignServicePrincipalCloudIdentityMethod = UserManagementGrpc.getUnassignServicePrincipalCloudIdentityMethod) == null) {
+          UserManagementGrpc.getUnassignServicePrincipalCloudIdentityMethod = getUnassignServicePrincipalCloudIdentityMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "usermanagement.UserManagement", "UnassignServicePrincipalCloudIdentity"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("UnassignServicePrincipalCloudIdentity"))
+                  .build();
+          }
+        }
+     }
+     return getUnassignServicePrincipalCloudIdentityMethod;
+  }
 
   /**
    * Creates a new async stub that supports all call types for the service
@@ -4235,6 +4383,46 @@ public final class UserManagementGrpc {
       asyncUnimplementedUnaryCall(getSetWorkloadPasswordPolicyMethodHelper(), responseObserver);
     }
 
+    /**
+     * <pre>
+     * Assign a cloud identity to an actor or group.
+     * </pre>
+     */
+    public void assignCloudIdentity(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getAssignCloudIdentityMethodHelper(), responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Unassign a cloud identity from an actor or group.
+     * </pre>
+     */
+    public void unassignCloudIdentity(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignCloudIdentityRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignCloudIdentityResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getUnassignCloudIdentityMethodHelper(), responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Assign a cloud identity to a service principal or service principal category.
+     * </pre>
+     */
+    public void assignServicePrincipalCloudIdentity(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignServicePrincipalCloudIdentityRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignServicePrincipalCloudIdentityResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getAssignServicePrincipalCloudIdentityMethodHelper(), responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Unassign a cloud identity from a service principal or service principal category.
+     * </pre>
+     */
+    public void unassignServicePrincipalCloudIdentity(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getUnassignServicePrincipalCloudIdentityMethodHelper(), responseObserver);
+    }
+
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
@@ -4853,6 +5041,34 @@ public final class UserManagementGrpc {
                 com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyRequest,
                 com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyResponse>(
                   this, METHODID_SET_WORKLOAD_PASSWORD_POLICY)))
+          .addMethod(
+            getAssignCloudIdentityMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityResponse>(
+                  this, METHODID_ASSIGN_CLOUD_IDENTITY)))
+          .addMethod(
+            getUnassignCloudIdentityMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignCloudIdentityRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignCloudIdentityResponse>(
+                  this, METHODID_UNASSIGN_CLOUD_IDENTITY)))
+          .addMethod(
+            getAssignServicePrincipalCloudIdentityMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignServicePrincipalCloudIdentityRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignServicePrincipalCloudIdentityResponse>(
+                  this, METHODID_ASSIGN_SERVICE_PRINCIPAL_CLOUD_IDENTITY)))
+          .addMethod(
+            getUnassignServicePrincipalCloudIdentityMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityResponse>(
+                  this, METHODID_UNASSIGN_SERVICE_PRINCIPAL_CLOUD_IDENTITY)))
           .build();
     }
   }
@@ -5882,6 +6098,50 @@ public final class UserManagementGrpc {
       asyncUnaryCall(
           getChannel().newCall(getSetWorkloadPasswordPolicyMethodHelper(), getCallOptions()), request, responseObserver);
     }
+
+    /**
+     * <pre>
+     * Assign a cloud identity to an actor or group.
+     * </pre>
+     */
+    public void assignCloudIdentity(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getAssignCloudIdentityMethodHelper(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Unassign a cloud identity from an actor or group.
+     * </pre>
+     */
+    public void unassignCloudIdentity(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignCloudIdentityRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignCloudIdentityResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getUnassignCloudIdentityMethodHelper(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Assign a cloud identity to a service principal or service principal category.
+     * </pre>
+     */
+    public void assignServicePrincipalCloudIdentity(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignServicePrincipalCloudIdentityRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignServicePrincipalCloudIdentityResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getAssignServicePrincipalCloudIdentityMethodHelper(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Unassign a cloud identity from a service principal or service principal category.
+     * </pre>
+     */
+    public void unassignServicePrincipalCloudIdentity(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getUnassignServicePrincipalCloudIdentityMethodHelper(), getCallOptions()), request, responseObserver);
+    }
   }
 
   /**
@@ -6820,6 +7080,46 @@ public final class UserManagementGrpc {
     public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyResponse setWorkloadPasswordPolicy(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyRequest request) {
       return blockingUnaryCall(
           getChannel(), getSetWorkloadPasswordPolicyMethodHelper(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * Assign a cloud identity to an actor or group.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityResponse assignCloudIdentity(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getAssignCloudIdentityMethodHelper(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * Unassign a cloud identity from an actor or group.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignCloudIdentityResponse unassignCloudIdentity(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignCloudIdentityRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getUnassignCloudIdentityMethodHelper(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * Assign a cloud identity to a service principal or service principal category.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignServicePrincipalCloudIdentityResponse assignServicePrincipalCloudIdentity(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignServicePrincipalCloudIdentityRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getAssignServicePrincipalCloudIdentityMethodHelper(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * Unassign a cloud identity from a service principal or service principal category.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityResponse unassignServicePrincipalCloudIdentity(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getUnassignServicePrincipalCloudIdentityMethodHelper(), getCallOptions(), request);
     }
   }
 
@@ -7848,6 +8148,50 @@ public final class UserManagementGrpc {
       return futureUnaryCall(
           getChannel().newCall(getSetWorkloadPasswordPolicyMethodHelper(), getCallOptions()), request);
     }
+
+    /**
+     * <pre>
+     * Assign a cloud identity to an actor or group.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityResponse> assignCloudIdentity(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getAssignCloudIdentityMethodHelper(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
+     * Unassign a cloud identity from an actor or group.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignCloudIdentityResponse> unassignCloudIdentity(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignCloudIdentityRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getUnassignCloudIdentityMethodHelper(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
+     * Assign a cloud identity to a service principal or service principal category.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignServicePrincipalCloudIdentityResponse> assignServicePrincipalCloudIdentity(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignServicePrincipalCloudIdentityRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getAssignServicePrincipalCloudIdentityMethodHelper(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
+     * Unassign a cloud identity from a service principal or service principal category.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityResponse> unassignServicePrincipalCloudIdentity(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getUnassignServicePrincipalCloudIdentityMethodHelper(), getCallOptions()), request);
+    }
   }
 
   private static final int METHODID_INTERACTIVE_LOGIN = 0;
@@ -7938,6 +8282,10 @@ public final class UserManagementGrpc {
   private static final int METHODID_DESCRIBE_ACTOR_SSH_PUBLIC_KEY = 85;
   private static final int METHODID_DELETE_ACTOR_SSH_PUBLIC_KEY = 86;
   private static final int METHODID_SET_WORKLOAD_PASSWORD_POLICY = 87;
+  private static final int METHODID_ASSIGN_CLOUD_IDENTITY = 88;
+  private static final int METHODID_UNASSIGN_CLOUD_IDENTITY = 89;
+  private static final int METHODID_ASSIGN_SERVICE_PRINCIPAL_CLOUD_IDENTITY = 90;
+  private static final int METHODID_UNASSIGN_SERVICE_PRINCIPAL_CLOUD_IDENTITY = 91;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -8308,6 +8656,22 @@ public final class UserManagementGrpc {
           serviceImpl.setWorkloadPasswordPolicy((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyRequest) request,
               (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyResponse>) responseObserver);
           break;
+        case METHODID_ASSIGN_CLOUD_IDENTITY:
+          serviceImpl.assignCloudIdentity((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityResponse>) responseObserver);
+          break;
+        case METHODID_UNASSIGN_CLOUD_IDENTITY:
+          serviceImpl.unassignCloudIdentity((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignCloudIdentityRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignCloudIdentityResponse>) responseObserver);
+          break;
+        case METHODID_ASSIGN_SERVICE_PRINCIPAL_CLOUD_IDENTITY:
+          serviceImpl.assignServicePrincipalCloudIdentity((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignServicePrincipalCloudIdentityRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignServicePrincipalCloudIdentityResponse>) responseObserver);
+          break;
+        case METHODID_UNASSIGN_SERVICE_PRINCIPAL_CLOUD_IDENTITY:
+          serviceImpl.unassignServicePrincipalCloudIdentity((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityResponse>) responseObserver);
+          break;
         default:
           throw new AssertionError();
       }
@@ -8457,6 +8821,10 @@ public final class UserManagementGrpc {
               .addMethod(getDescribeActorSshPublicKeyMethodHelper())
               .addMethod(getDeleteActorSshPublicKeyMethodHelper())
               .addMethod(getSetWorkloadPasswordPolicyMethodHelper())
+              .addMethod(getAssignCloudIdentityMethodHelper())
+              .addMethod(getUnassignCloudIdentityMethodHelper())
+              .addMethod(getAssignServicePrincipalCloudIdentityMethodHelper())
+              .addMethod(getUnassignServicePrincipalCloudIdentityMethodHelper())
               .build();
         }
       }

--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
@@ -56,6 +56,9 @@ public class EntitlementService {
     @VisibleForTesting
     static final String CDP_CB_FAST_EBS_ENCRYPTION = "CDP_CB_FAST_EBS_ENCRYPTION";
 
+    @VisibleForTesting
+    static final String CDP_CLOUD_IDENTITY_MAPPING = "CDP_CLOUD_IDENTITY_MAPPING";
+
     @Inject
     private GrpcUmsClient umsClient;
 
@@ -113,6 +116,10 @@ public class EntitlementService {
 
     public boolean fastEbsEncryptionEnabled(String actorCrn, String accountId) {
         return isEntitlementRegistered(actorCrn, accountId, CDP_CB_FAST_EBS_ENCRYPTION);
+    }
+
+    public boolean cloudIdentityMappingEnabled(String actorCrn, String accountId) {
+        return isEntitlementRegistered(actorCrn, accountId, CDP_CLOUD_IDENTITY_MAPPING);
     }
 
     public List<String> getEntitlements(String actorCrn, String accountId) {

--- a/auth-connector/src/main/proto/usermanagement.proto
+++ b/auth-connector/src/main/proto/usermanagement.proto
@@ -404,7 +404,23 @@ service UserManagement {
 
   // Sets the workload password policy for an account.
   rpc SetWorkloadPasswordPolicy (SetWorkloadPasswordPolicyRequest)
-  returns (SetWorkloadPasswordPolicyResponse) {}
+    returns (SetWorkloadPasswordPolicyResponse) {}
+
+  // Assign a cloud identity to an actor or group.
+  rpc AssignCloudIdentity (AssignCloudIdentityRequest)
+    returns (AssignCloudIdentityResponse) {}
+
+  // Unassign a cloud identity from an actor or group.
+  rpc UnassignCloudIdentity (UnassignCloudIdentityRequest)
+    returns (UnassignCloudIdentityResponse) {}
+
+  // Assign a cloud identity to a service principal or service principal category.
+  rpc AssignServicePrincipalCloudIdentity (AssignServicePrincipalCloudIdentityRequest)
+    returns (AssignServicePrincipalCloudIdentityResponse) {}
+
+  // Unassign a cloud identity from a service principal or service principal category.
+  rpc UnassignServicePrincipalCloudIdentity (UnassignServicePrincipalCloudIdentityRequest)
+    returns (UnassignServicePrincipalCloudIdentityResponse) {}
 }
 
 // The state of the actor.
@@ -459,6 +475,8 @@ message User {
   // In ms from the Java epoch of 1970-01-01T00:00:00Z.
   // The value is only meaningful when the 'state' is DELETING.
   uint64 safeDeleteDateMs = 16;
+  // A list of cloud identities for the user.
+  repeated CloudIdentity cloudIdentities = 17;
 }
 
 // A MachineUser is an internal Altus identity, used by applications to call
@@ -493,6 +511,8 @@ message MachineUser {
   // In ms from the Java epoch of 1970-01-01T00:00:00Z.
   // The value is only meaningful when the 'state' is DELETING.
   uint64 safeDeleteDateMs = 8;
+  // A list of cloud identities for the machine user.
+  repeated CloudIdentity cloudIdentities = 9;
 }
 
 // A Group is a Altus resource that contains a collection of Actors. Groups
@@ -512,6 +532,8 @@ message Group {
   // relevant for federated users as we don't get group membership through
   // cloudera-sso.
   bool syncMembershipOnUserLogin = 5;
+  // A list of cloud identities for the group.
+  repeated CloudIdentity cloudIdentities = 6;
 }
 
 message AccessKeyUsage {
@@ -2581,6 +2603,52 @@ message SshPublicKeyStorage {
   string description = 3;
 }
 
+// A namespace for cloud identities. All cloud identities exist within a cloud
+// identity domain. At most one cloud identity may be assigned to a given entity
+// within a given domain. The modeling of a cloud identity domain is cloud
+// provider-specific. The following object is used to represent a cloud identity
+// domain in dynamo.
+message CloudIdentityDomainStorage {
+  oneof domain {
+    AzureCloudIdentityDomainStorage azureCloudIdentityDomain = 1;
+  }
+}
+
+// Object used to represent an Azure cloud identity domain in dynamo.
+message AzureCloudIdentityDomainStorage {
+  // A unique identifier for an Azure AD instance.
+  string azureAdIdentifier = 1;
+}
+
+// An identifier for a cloud identity that is unique within the enclosing
+// domain. The modeling of a cloud identity name is cloud provider-specific.
+// The following object is used to represent a cloud identity name in dynamo.
+message CloudIdentityNameStorage {
+  oneof name {
+    AzureCloudIdentityNameStorage azureCloudIdentityName = 1;
+  }
+}
+
+// Object used to represent an Azure cloud identity name in dynamo.
+message AzureCloudIdentityNameStorage {
+  // The Azure object ID (OID).
+  string objectId = 1;
+}
+
+// Object used to represent a cloud identity in dynamo.
+message CloudIdentityStorage {
+  // The domain in which the cloud identity exists.
+  CloudIdentityDomainStorage cloudIdentityDomain = 1;
+  // The unique name of the cloud identity within the domain.
+  CloudIdentityNameStorage cloudIdentityName = 2;
+}
+
+// Object used to store a list of cloud identities in dynamo.
+message CloudIdentitiesStorage {
+  // A list of assigned cloud identities.
+  repeated CloudIdentityStorage cloudIdentities = 1;
+}
+
 // This is used to serialize all the Actor dynamoDB related information that is
 // not indexed.
 message ActorDetails {
@@ -2594,6 +2662,15 @@ message ActorDetails {
   repeated StoredKerberosKey kerberosKeys = 2;
   // A list of ssh public keys for the actor.
   repeated SshPublicKeyStorage sshPublicKeys = 3;
+  // Cloud identities assigned to the actor.
+  CloudIdentitiesStorage cloudIdentities = 5;
+}
+
+// This is used to serialize all the Group dynamoDB related information that is
+// not indexed.
+message GroupDetails {
+  // Cloud identities assigned to the group.
+  CloudIdentitiesStorage cloudIdentities = 1;
 }
 
 message SetActorWorkloadCredentialsRequest {
@@ -2747,4 +2824,99 @@ message SetWorkloadPasswordPolicyRequest {
 }
 
 message SetWorkloadPasswordPolicyResponse {
+}
+
+// A namespace for cloud identities. All cloud identities exist within a cloud
+// identity domain. At most one cloud identity may be assigned to a given entity
+// within a given domain. The modeling of a cloud identity domain is cloud
+// provider-specific. The following object is used to represent a cloud identity
+// domain in the wire protocol.
+message CloudIdentityDomain {
+  oneof domain {
+    AzureCloudIdentityDomain azureCloudIdentityDomain = 1;
+  }
+}
+
+// Object used to represent an Azure cloud identity domain in the wire protocol.
+message AzureCloudIdentityDomain {
+  // A unique identifier for an Azure AD instance.
+  string azureAdIdentifier = 1;
+}
+
+// An identifier for a cloud identity that is unique within the enclosing
+// domain. The modeling of a cloud identity name is cloud provider-specific.
+// The following object is used to represent a cloud identity name in the
+// wire protocol.
+message CloudIdentityName {
+  oneof name {
+    AzureCloudIdentityName azureCloudIdentityName = 1;
+  }
+}
+
+// Object used to represent an Azure cloud identity name in the wire protocol.
+message AzureCloudIdentityName {
+  // The Azure object ID (OID).
+  string objectId = 1;
+}
+
+// Object used to represent a cloud identity in the wire protocol.
+message CloudIdentity {
+  // The domain in which the cloud identity exists.
+  CloudIdentityDomain cloudIdentityDomain = 1;
+  // The unique name of the cloud identity within the domain.
+  CloudIdentityName cloudIdentityName = 2;
+}
+
+message AssignCloudIdentityRequest {
+  // The actor or group to which the cloud identity is to be assigned.
+  Assignee assignee = 1;
+  // The cloud identity to assign.
+  CloudIdentity cloudIdentity = 2;
+}
+
+message AssignCloudIdentityResponse {
+}
+
+message UnassignCloudIdentityRequest {
+  // The actor or group from which the cloud identity is to be unassigned.
+  Assignee assignee = 1;
+  // The domain in which the cloud identity to unassign exists. Since there
+  // can be at most one identity assigned to the actor or group within a given
+  // domain, this fully identifies the identity to unassign.
+  CloudIdentityDomain cloudIdentityDomain = 2;
+}
+
+message UnassignCloudIdentityResponse {
+}
+
+message AssignServicePrincipalCloudIdentityRequest {
+  // The account id in which the service principal or service principal category
+  // exists.
+  string accountId = 1;
+  // The service principal or service principal category to which the cloud
+  // identity is to be assigned. Note that the UMS guarantees that there are
+  // no name collisions between service principals and categories.
+  string servicePrincipalOrCategory = 2;
+  // The cloud identity to assign.
+  CloudIdentity cloudIdentity = 3;
+}
+
+message AssignServicePrincipalCloudIdentityResponse {
+}
+
+message UnassignServicePrincipalCloudIdentityRequest {
+  // The account id in which the service principal or service principal category
+  // exists.
+  string accountId = 1;
+  // The service principal or service principal category from which the cloud
+  // identity is to be unassigned. Note that the UMS guarantees that there are
+  // no name collisions between service principals and categories.
+  string servicePrincipalOrCategory = 2;
+  // The domain in which the cloud identity to unassign exists. Since there can
+  // be at most one identity assigned to the service principal within a given
+  // domain, this fully identifies the identity to unassign.
+  CloudIdentityDomain cloudIdentityDomain = 3;
+}
+
+message UnassignServicePrincipalCloudIdentityResponse {
 }

--- a/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementServiceTest.java
+++ b/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementServiceTest.java
@@ -5,6 +5,7 @@ import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_AZURE;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_AZURE_SINGLE_RESOURCE_GROUP;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_BASE_IMAGE;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_CB_FAST_EBS_ENCRYPTION;
+import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_CLOUD_IDENTITY_MAPPING;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_CLOUD_STORAGE_VALIDATION;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_FMS_CLUSTER_PROXY;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_FREEIPA_DL_EBS_ENCRYPTION;
@@ -109,6 +110,11 @@ class EntitlementServiceTest {
                         (EntitlementCheckFunction) EntitlementService::fastEbsEncryptionEnabled, false},
                 {"CDP_CB_FAST_EBS_ENCRYPTION == true", CDP_CB_FAST_EBS_ENCRYPTION,
                         (EntitlementCheckFunction) EntitlementService::fastEbsEncryptionEnabled, true},
+
+                {"CDP_CLOUD_IDENTITY_MAPPING == false", CDP_CLOUD_IDENTITY_MAPPING,
+                        (EntitlementCheckFunction) EntitlementService::cloudIdentityMappingEnabled, false},
+                {"CDP_CLOUD_IDENTITY_MAPPING == true", CDP_CLOUD_IDENTITY_MAPPING,
+                        (EntitlementCheckFunction) EntitlementService::cloudIdentityMappingEnabled, true},
         };
     }
 

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxEndpoint.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxEndpoint.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Set;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
@@ -15,6 +16,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import com.sequenceiq.sdx.api.model.SetRangerCloudIdentityMappingRequest;
 import org.springframework.validation.annotation.Validated;
 
 import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
@@ -196,4 +198,11 @@ public interface SdxEndpoint {
     @ApiOperation(value = "Get the status of datalake database restore operation", produces = MediaType.APPLICATION_JSON, nickname = "restoreDatabaseStatus")
     SdxDatabaseRestoreStatusResponse getRestoreDatabaseStatusByName(@PathParam("name") String name,
             @QueryParam("operationId") String operationId);
+
+    @POST
+    @Path("/envcrn/{envCrn}/ranger_cloud_identity_mapping")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "set ranger cloud identity mapping", produces = MediaType.APPLICATION_JSON, nickname = "setRangerCloudIdentityMapping")
+    void setRangerCloudIdentityMapping(@PathParam("envCrn") @ValidCrn String envCrn, @NotNull @Valid SetRangerCloudIdentityMappingRequest request);
+
 }

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SetRangerCloudIdentityMappingRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SetRangerCloudIdentityMappingRequest.java
@@ -1,0 +1,45 @@
+package com.sequenceiq.sdx.api.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.constraints.NotNull;
+import java.util.Map;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SetRangerCloudIdentityMappingRequest {
+
+    @ApiModelProperty
+    @NotNull
+    private Map<String, String> azureUserMapping;
+
+    @ApiModelProperty
+    @NotNull
+    private Map<String, String> azureGroupMapping;
+
+    public Map<String, String> getAzureUserMapping() {
+        return azureUserMapping;
+    }
+
+    public void setAzureUserMapping(Map<String, String> azureUserMapping) {
+        this.azureUserMapping = azureUserMapping;
+    }
+
+    public Map<String, String> getAzureGroupMapping() {
+        return azureGroupMapping;
+    }
+
+    public void setAzureGroupMapping(Map<String, String> azureGroupMapping) {
+        this.azureGroupMapping = azureGroupMapping;
+    }
+
+    @Override
+    public String toString() {
+        return "SetRangerCloudIdentityMappingRequest{" +
+                "azureUserMapping=" + azureUserMapping +
+                ", azureGroupMapping=" + azureGroupMapping +
+                '}';
+    }
+}

--- a/datalake/build.gradle
+++ b/datalake/build.gradle
@@ -31,6 +31,7 @@ dependencies {
   compile project(':status-checker')
 
   implementation     project(":freeipa-api")
+  implementation     project(':client-cm')
 
   implementation     group: 'com.squareup.okhttp3',      name: 'okhttp',                          version: okhttpVersion
   implementation     group: 'com.google.code.gson',      name: 'gson',                            version: '2.6.2'
@@ -60,6 +61,8 @@ dependencies {
   implementation     group: 'io.opentracing.contrib',    name: 'opentracing-jaxrs2',                       version: opentracingJaxrs2Version
   implementation     group: 'io.opentracing.contrib',    name: 'opentracing-jdbc',                         version: opentracingJdbcVersion
   implementation     group: 'org.springframework.boot',  name: 'spring-boot-starter-quartz',               version: springBootVersion
+
+  implementation     group: 'com.cloudera.api.swagger',    name: 'cloudera-manager-api-swagger',       version: cmClientVersion
 
   testImplementation group: 'org.springframework.boot',  name: 'spring-boot-starter-test',        version: springBootVersion
   testImplementation group: 'org.mockito',               name: 'mockito-core',                   version: mockitoVersion

--- a/datalake/src/main/java/com/sequenceiq/datalake/cm/ClouderaManagerProxiedClientFactory.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/cm/ClouderaManagerProxiedClientFactory.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.datalake.cm;
+
+import com.cloudera.api.swagger.client.ApiClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+// TODO Use ClouderaManagerApiClientProvider in client-cm instad of relying on this class
+@Component
+public class ClouderaManagerProxiedClientFactory {
+
+    private static final String API_VERSION_31 = "v31";
+
+    private static final int CM_READ_TIMEOUT_MS =  60 * 1000;
+
+    private static final int CM_CONNECT_TIMEOUT_MS = 60 * 1000;
+
+    @Value("${clusterProxy.url:}")
+    private String clusterProxyUrl;
+
+    private String getClusterProxyCloderaManagerBasePath(String clusterCrn) {
+        return String.format("%s/proxy/%s/cloudera-manager/api/%s", clusterProxyUrl, clusterCrn, API_VERSION_31);
+    }
+
+    public ApiClient getProxiedClouderaManagerClient(String clouderaManagerStackCrn) {
+        ApiClient apiClient = new ApiClient();
+        apiClient.setBasePath(getClusterProxyCloderaManagerBasePath(clouderaManagerStackCrn));
+        apiClient.setConnectTimeout(CM_READ_TIMEOUT_MS);
+        apiClient.getHttpClient().setReadTimeout(CM_CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        return apiClient;
+    }
+
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/cm/ClouderaManagerRangerUtil.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/cm/ClouderaManagerRangerUtil.java
@@ -1,0 +1,124 @@
+package com.sequenceiq.datalake.cm;
+
+import com.cloudera.api.swagger.ClustersResourceApi;
+import com.cloudera.api.swagger.RoleCommandsResourceApi;
+import com.cloudera.api.swagger.RolesResourceApi;
+import com.cloudera.api.swagger.client.ApiClient;
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.model.ApiBulkCommandList;
+import com.cloudera.api.swagger.model.ApiClusterList;
+import com.cloudera.api.swagger.model.ApiCommand;
+import com.cloudera.api.swagger.model.ApiConfig;
+import com.cloudera.api.swagger.model.ApiConfigList;
+import com.cloudera.api.swagger.model.ApiRole;
+import com.cloudera.api.swagger.model.ApiRoleNameList;
+import com.google.common.base.Joiner;
+import com.google.common.base.Joiner.MapJoiner;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Iterables;
+
+import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
+import com.sequenceiq.datalake.controller.exception.RangerCloudIdentitySyncException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class ClouderaManagerRangerUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerRangerUtil.class);
+
+    private static final String RANGER_SERVICE_NAME = "ranger";
+
+    private static final String RANGER_USER_SYNC_ROLE_TYPE = "RANGER_USERSYNC";
+
+    private static final String AZURE_USER_MAPPING = "ranger_usersync_azure_user_mapping";
+
+    private static final String AZURE_GROUP_MAPPING = "ranger_usersync_azure_group_mapping";
+
+    private static final MapJoiner CLOUD_IDENTITY_CONFIG_MAP_JOINER =
+            Joiner.on(";").withKeyValueSeparator("=");
+
+    @Inject
+    private ClouderaManagerProxiedClientFactory clouderaManagerProxiedClientFactory;
+
+    @Inject
+    private ClouderaManagerApiFactory clouderaManagerApiFactory;
+
+    private String getClusterName(ApiClient client) throws ApiException {
+        ClustersResourceApi clustersResource = clouderaManagerApiFactory.getClustersResourceApi(client);
+        ApiClusterList clusterList = clustersResource.readClusters(null, null);
+        return Iterables.getOnlyElement(clusterList.getItems()).getName();
+    }
+
+    private String getRangerUserSyncRoleName(ApiClient client, String clusterName) throws ApiException {
+        RolesResourceApi rolesResourceApi = clouderaManagerApiFactory.getRolesResourceApi(client);
+        List<ApiRole> apiRoleList =  rolesResourceApi.readRoles(clusterName, RANGER_SERVICE_NAME, null, null)
+                .getItems()
+                .stream()
+                .filter(apiRole -> RANGER_USER_SYNC_ROLE_TYPE.equals(apiRole.getType()))
+                .collect(Collectors.toList());
+        return Iterables.getOnlyElement(apiRoleList).getName();
+    }
+
+    private ApiConfig newCloudIdentityConfig(String configName, Map<String, String> configValues) {
+        // NOTE: We sort the configs first. This isn't really necessary but is more consistent.
+        ImmutableSortedMap<String, String> configValuesSorted = ImmutableSortedMap.copyOf(configValues);
+        ApiConfig config = new ApiConfig();
+        config.setName(configName);
+        config.setValue(CLOUD_IDENTITY_CONFIG_MAP_JOINER.join(configValuesSorted));
+        return config;
+    }
+
+    private void triggerRoleRefresh(ApiClient client, String clusterName, String serviceName, String roleName) {
+        LOGGER.info("Attempting to trigger role refresh on clusterName = {}, serviceName = {}, roleName = {}", clusterName, serviceName, roleName);
+        ApiRoleNameList roleNameList = new ApiRoleNameList();
+        roleNameList.addItemsItem(roleName);
+        RoleCommandsResourceApi roleCommandsResourceApi = clouderaManagerApiFactory.getRoleCommandsResourceApi(client);
+        try {
+            ApiBulkCommandList bulkResponse = roleCommandsResourceApi.refreshCommand(clusterName, serviceName, roleNameList);
+            ApiCommand response = Iterables.getOnlyElement(bulkResponse.getItems());
+            LOGGER.info("ApiCommand response for role refresh = {}", response);
+            if (response != null && (response.getActive() || response.getSuccess())) {
+                LOGGER.info("Successfully triggered role refresh");
+            } else {
+                LOGGER.debug("Failed to trigger role refresh");
+                throw new RangerCloudIdentitySyncException("Role refresh was not successfully trigerred");
+            }
+        } catch (ApiException e) {
+            LOGGER.error("Encountered ApiException on role refresh", e);
+            throw new RangerCloudIdentitySyncException("Encountered ApiException on role refresh", e);
+        }
+    }
+
+    private boolean isCloudIdMappingSupported(RolesResourceApi rolesResourceApi, String clusterName, String rangerUserSyncRole) throws ApiException {
+        ApiConfigList configList = rolesResourceApi.readRoleConfig(clusterName, rangerUserSyncRole, RANGER_SERVICE_NAME, "full");
+        return configList.getItems().stream().map(ApiConfig::getName).anyMatch(configName -> configName.equals(AZURE_USER_MAPPING));
+    }
+
+    public void setAzureCloudIdentityMapping(String stackCrn, Map<String, String> azureUserMapping, Map<String, String> azureGroupMapping) throws ApiException {
+        // NOTE: The necessary configs changed here are only available in CM7.2-1
+        // TODO Skip setting role and trigerring refresh if the configs haven't changed
+        ApiClient client = clouderaManagerProxiedClientFactory.getProxiedClouderaManagerClient(stackCrn);
+        String clusterName = getClusterName(client);
+        String rangerUserSyncRoleName = getRangerUserSyncRoleName(client, clusterName);
+        RolesResourceApi rolesResourceApi = clouderaManagerApiFactory.getRolesResourceApi(client);
+        if (!isCloudIdMappingSupported(rolesResourceApi, clusterName, rangerUserSyncRoleName)) {
+            LOGGER.info("This version of CM does not support cloud identity mapping. Skipping.");
+        } else {
+            ApiConfigList configList = new ApiConfigList();
+            configList.addItemsItem(newCloudIdentityConfig(AZURE_USER_MAPPING, azureUserMapping));
+            configList.addItemsItem(newCloudIdentityConfig(AZURE_GROUP_MAPPING, azureGroupMapping));
+            rolesResourceApi.updateRoleConfig(clusterName, rangerUserSyncRoleName, RANGER_SERVICE_NAME,
+                    "Updating Azure Cloud Identity Mapping through Cloudbreak",
+                    configList);
+            triggerRoleRefresh(client, clusterName, RANGER_SERVICE_NAME, rangerUserSyncRoleName);
+        }
+    }
+
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/cm/RangerCloudIdentityService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/cm/RangerCloudIdentityService.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.datalake.cm;
+
+import com.cloudera.api.swagger.client.ApiException;
+import com.sequenceiq.datalake.controller.exception.RangerCloudIdentitySyncException;
+import com.sequenceiq.datalake.entity.SdxCluster;
+import com.sequenceiq.datalake.service.sdx.SdxService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+public class RangerCloudIdentityService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RangerCloudIdentityService.class);
+
+    @Inject
+    private ClouderaManagerRangerUtil clouderaManagerRangerUtil;
+
+    @Inject
+    private SdxService sdxService;
+
+    private void setAzureCloudIdentityMapping(SdxCluster sdxCluster, Map<String, String> azureUserMapping, Map<String, String> azureGroupMapping) {
+        String stackCrn = sdxCluster.getStackCrn();
+        LOGGER.info("Updating azure cloud id mappings for datalake stack crn = {}", stackCrn);
+        try {
+            clouderaManagerRangerUtil.setAzureCloudIdentityMapping(stackCrn, azureUserMapping, azureGroupMapping);
+        } catch (ApiException e) {
+            LOGGER.error("Encountered api exception", e);
+            throw new RangerCloudIdentitySyncException("Encountered api exception", e);
+        }
+    }
+
+    public void setAzureCloudIdentityMapping(String environmentCrn, Map<String, String> azureUserMapping, Map<String, String> azureGroupMapping) {
+        List<SdxCluster> sdxClusters = sdxService.listSdxByEnvCrn(environmentCrn);
+        List<String> sdxClusterCrns = sdxClusters.stream().map(SdxCluster::getCrn).collect(Collectors.toList());
+        LOGGER.info("Setting Azure cloud id mappings for datalake clusters = {}, environment = {}", sdxClusterCrns, environmentCrn);
+        sdxClusters.forEach(sdxCluster -> setAzureCloudIdentityMapping(sdxCluster, azureUserMapping, azureGroupMapping));
+    }
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/exception/RangerCloudIdentitySyncException.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/exception/RangerCloudIdentitySyncException.java
@@ -1,0 +1,12 @@
+package com.sequenceiq.datalake.controller.exception;
+
+public class RangerCloudIdentitySyncException extends RuntimeException {
+
+    public RangerCloudIdentitySyncException(String errorMessage) {
+        super(errorMessage);
+    }
+
+    public RangerCloudIdentitySyncException(String errorMessage, Throwable err) {
+        super(errorMessage, err);
+    }
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
@@ -7,6 +7,9 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.validation.Valid;
 
+import com.sequenceiq.authorization.annotation.InternalOnly;
+import com.sequenceiq.datalake.cm.RangerCloudIdentityService;
+import com.sequenceiq.sdx.api.model.SetRangerCloudIdentityMappingRequest;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Controller;
 
@@ -75,6 +78,9 @@ public class SdxController implements SdxEndpoint {
 
     @Inject
     private SdxDatabaseDrService sdxDatabaseDrService;
+
+    @Inject
+    private RangerCloudIdentityService rangerCloudIdentityService;
 
     @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.CREATE_DATALAKE)
@@ -277,4 +283,10 @@ public class SdxController implements SdxEndpoint {
         String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
         SdxCluster sdxCluster = sdxService.getSdxByNameInAccount(userCrn, name);
         return sdxDatabaseDrService.getDatabaseRestoreStatus(sdxCluster, operationId);    }
+
+    @Override
+    @InternalOnly
+    public void setRangerCloudIdentityMapping(String envCrn, SetRangerCloudIdentityMappingRequest request) {
+        rangerCloudIdentityService.setAzureCloudIdentityMapping(envCrn, request.getAzureUserMapping(), request.getAzureGroupMapping());
+    }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -513,6 +513,12 @@ public class SdxService implements ResourceIdProvider, ResourceBasedCrnProvider 
         return sdxClusterRepository.findByAccountIdAndEnvCrnAndDeletedIsNull(accountIdFromCrn, envCrn);
     }
 
+    public List<SdxCluster> listSdxByEnvCrn(String envCrn) {
+        LOGGER.debug("Listing SDX clusters by environment crn {}", envCrn);
+        String accountIdFromCrn = getAccountIdFromCrn(envCrn);
+        return sdxClusterRepository.findByAccountIdAndEnvCrnAndDeletedIsNull(accountIdFromCrn, envCrn);
+    }
+
     public List<SdxCluster> listSdx(String userCrn, String envName) {
         String accountIdFromCrn = getAccountIdFromCrn(userCrn);
         if (envName != null) {

--- a/datalake/src/main/resources/application.yml
+++ b/datalake/src/main/resources/application.yml
@@ -99,3 +99,6 @@ cb:
 
 notification:
   urls: http://localhost:3000/notifications
+
+clusterProxy:
+  url: http://localhost:10180/cluster-proxy

--- a/datalake/src/test/java/com/sequenceiq/datalake/cm/ClouderaManagerRangerUtilTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/cm/ClouderaManagerRangerUtilTest.java
@@ -1,0 +1,154 @@
+package com.sequenceiq.datalake.cm;
+
+import com.cloudera.api.swagger.ClustersResourceApi;
+import com.cloudera.api.swagger.RoleCommandsResourceApi;
+import com.cloudera.api.swagger.RolesResourceApi;
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.model.ApiBulkCommandList;
+import com.cloudera.api.swagger.model.ApiCluster;
+import com.cloudera.api.swagger.model.ApiClusterList;
+import com.cloudera.api.swagger.model.ApiCommand;
+import com.cloudera.api.swagger.model.ApiConfig;
+import com.cloudera.api.swagger.model.ApiConfigList;
+import com.cloudera.api.swagger.model.ApiRole;
+import com.cloudera.api.swagger.model.ApiRoleList;
+import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
+import com.sequenceiq.datalake.controller.exception.RangerCloudIdentitySyncException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ClouderaManagerRangerUtilTest {
+
+    private static final String CLUSTER = "cluster";
+
+    private static final String RANGER_USER_SYNC_ROLE = "ranger_user_sync_role";
+
+    @Mock
+    private ClouderaManagerProxiedClientFactory clouderaManagerProxiedClientFactory;
+
+    @Mock
+    private ClouderaManagerApiFactory clouderaManagerApiFactory;
+
+    @Mock
+    private ClustersResourceApi clustersResourceApi;
+
+    @Mock
+    private RolesResourceApi rolesResourceApi;
+
+    @Mock
+    private RoleCommandsResourceApi roleCommandsResourceApi;
+
+    @InjectMocks
+    private ClouderaManagerRangerUtil underTest;
+
+    private void setupCluster() throws ApiException {
+        ApiCluster apiCluster = new ApiCluster();
+        apiCluster.setName(CLUSTER);
+        ApiClusterList apiClusterList = new ApiClusterList();
+        apiClusterList.addItemsItem(apiCluster);
+        when(clustersResourceApi.readClusters(null, null)).thenReturn(apiClusterList);
+    }
+
+    private void setupRangerUserSyncRole() throws ApiException {
+        ApiRole apiRole = new ApiRole();
+        apiRole.setType("RANGER_USERSYNC");
+        apiRole.setName(RANGER_USER_SYNC_ROLE);
+        ApiRoleList roleList = new ApiRoleList();
+        roleList.addItemsItem(apiRole);
+        when(rolesResourceApi.readRoles(eq(CLUSTER), any(), any(), any())).thenReturn(roleList);
+    }
+
+    private void setupRangerUserSyncRoleConig(boolean supportsCloudIdentityConfig) throws ApiException {
+        ApiConfigList apiConfigList = new ApiConfigList();
+        if (supportsCloudIdentityConfig) {
+            ApiConfig apiConfig = new ApiConfig();
+            apiConfig.setName("ranger_usersync_azure_user_mapping");
+            apiConfigList.addItemsItem(apiConfig);
+        } else {
+            apiConfigList.setItems(List.of());
+        }
+        when(rolesResourceApi.readRoleConfig(eq(CLUSTER), eq(RANGER_USER_SYNC_ROLE), anyString(), eq("full"))).thenReturn(apiConfigList);
+    }
+
+    private void setupRoleRefreshResponse(boolean success) throws ApiException {
+        ApiCommand response = new ApiCommand();
+        response.setActive(Boolean.FALSE);
+        response.setSuccess(success);
+        ApiBulkCommandList apiBulkCommandList = new ApiBulkCommandList();
+        apiBulkCommandList.addItemsItem(response);
+        when(roleCommandsResourceApi.refreshCommand(eq(CLUSTER), anyString(), any())).thenReturn(apiBulkCommandList);
+    }
+
+    @Test
+    public void testSetAzureCloudIdentityMapping() throws ApiException {
+        when(clouderaManagerApiFactory.getClustersResourceApi(any())).thenReturn(clustersResourceApi);
+        when(clouderaManagerApiFactory.getRolesResourceApi(any())).thenReturn(rolesResourceApi);
+        when(clouderaManagerApiFactory.getRoleCommandsResourceApi(any())).thenReturn(roleCommandsResourceApi);
+        setupCluster();
+        setupRangerUserSyncRole();
+        setupRangerUserSyncRoleConig(true);
+        setupRoleRefreshResponse(true);
+
+        underTest.setAzureCloudIdentityMapping("stackCrn", Map.of("user01", "val01", "user02", "val02"), Map.of("group01", "val"));
+
+        ArgumentCaptor<ApiConfigList> apiConfigListCaptor = ArgumentCaptor.forClass(ApiConfigList.class);
+        verify(rolesResourceApi, times(1)).updateRoleConfig(eq(CLUSTER), eq(RANGER_USER_SYNC_ROLE), anyString(), anyString(), apiConfigListCaptor.capture());
+
+        ApiConfig expectedAzureUserMappingConfig = new ApiConfig();
+        expectedAzureUserMappingConfig.setName("ranger_usersync_azure_user_mapping");
+        expectedAzureUserMappingConfig.setValue("user01=val01;user02=val02");
+        ApiConfig expectedAzureGroupMappingConfig = new ApiConfig();
+        expectedAzureGroupMappingConfig.setName("ranger_usersync_azure_group_mapping");
+        expectedAzureGroupMappingConfig.setValue("group01=val");
+
+        ApiConfigList apiConfigList = apiConfigListCaptor.getValue();
+        assertThat(apiConfigList.getItems(), hasItems(expectedAzureUserMappingConfig, expectedAzureGroupMappingConfig));
+    }
+
+    @Test
+    public void testSetAzureCloudIdentityMappingUnsuccessfulRefresh() throws ApiException {
+        when(clouderaManagerApiFactory.getClustersResourceApi(any())).thenReturn(clustersResourceApi);
+        when(clouderaManagerApiFactory.getRolesResourceApi(any())).thenReturn(rolesResourceApi);
+        when(clouderaManagerApiFactory.getRoleCommandsResourceApi(any())).thenReturn(roleCommandsResourceApi);
+        setupCluster();
+        setupRangerUserSyncRole();
+        setupRangerUserSyncRoleConig(true);
+        setupRoleRefreshResponse(false);
+
+        assertThrows(RangerCloudIdentitySyncException.class, () -> underTest.setAzureCloudIdentityMapping("stackCrn",
+                Map.of("user01", "val01", "user02", "val02"), Map.of("group01", "val")));
+    }
+
+    @Test
+    public void testSetAzureCloudIdentityMappingUnsupported() throws ApiException {
+        when(clouderaManagerApiFactory.getClustersResourceApi(any())).thenReturn(clustersResourceApi);
+        when(clouderaManagerApiFactory.getRolesResourceApi(any())).thenReturn(rolesResourceApi);
+        setupCluster();
+        setupRangerUserSyncRole();
+        setupRangerUserSyncRoleConig(false);
+
+        underTest.setAzureCloudIdentityMapping("stackCrn", Map.of("user01", "val01", "user02", "val02"), Map.of("group01", "val"));
+
+        verify(rolesResourceApi, never()).updateRoleConfig(any(), any(), any(), any(), any());
+    }
+
+}

--- a/datalake/src/test/java/com/sequenceiq/datalake/cm/RangerCloudIdentityServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/cm/RangerCloudIdentityServiceTest.java
@@ -1,0 +1,45 @@
+package com.sequenceiq.datalake.cm;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.cloudera.api.swagger.client.ApiException;
+import com.sequenceiq.datalake.entity.SdxCluster;
+import com.sequenceiq.datalake.service.sdx.SdxService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+@ExtendWith(MockitoExtension.class)
+class RangerCloudIdentityServiceTest {
+
+    @Mock
+    private ClouderaManagerRangerUtil clouderaManagerRangerUtil;
+
+    @Mock
+    private SdxService sdxService;
+
+    @InjectMocks
+    private RangerCloudIdentityService underTest;
+
+    @Test
+    public void testSetAzureCloudIdentityMapping() throws ApiException {
+        SdxCluster cluster = mock(SdxCluster.class);
+        when(cluster.getStackCrn()).thenReturn("stack-crn");
+        when(sdxService.listSdxByEnvCrn(anyString())).thenReturn(List.of(cluster));
+        Map<String, String> userMapping = Map.of("user", "val1");
+        Map<String, String> groupMapping = Map.of("group", "val2");
+        underTest.setAzureCloudIdentityMapping("env-crn", userMapping, groupMapping);
+        verify(clouderaManagerRangerUtil, times(1)).setAzureCloudIdentityMapping(eq("stack-crn"), eq(userMapping), eq(groupMapping));
+    }
+
+}

--- a/freeipa/build.gradle
+++ b/freeipa/build.gradle
@@ -50,7 +50,6 @@ dependencies {
   implementation     group: 'io.opentracing.contrib',    name: 'opentracing-jaxrs2',                   version: opentracingJaxrs2Version
   implementation     group: 'io.opentracing.contrib',    name: 'opentracing-jdbc',                     version: opentracingJdbcVersion
 
-
   implementation     group: 'org.apache.kerby',          name: 'kerb-util',                            version: '2.0.0'
   
   implementation     group: 'com.github.briandilley.jsonrpc4j', name: 'jsonrpc4j',                     version: '1.5.3'
@@ -98,6 +97,7 @@ dependencies {
   implementation project(':notification-sender')
   implementation project(':environment-api')
   implementation project(':environment-common')
+  implementation project(':datalake-api')
   implementation project(':cluster-proxy')
   implementation project(':status-checker')
   implementation project(':template-manager-tag')

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/SdxApiConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/SdxApiConfig.java
@@ -1,0 +1,30 @@
+package com.sequenceiq.freeipa.configuration;
+
+import com.sequenceiq.sdx.client.internal.SdxApiClientParams;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@Configuration
+public class SdxApiConfig {
+    @Value("${rest.debug:false}")
+    private boolean restDebug;
+
+    @Value("${cert.validation:true}")
+    private boolean certificateValidation;
+
+    @Value("${cert.ignorePreValidation:false}")
+    private boolean ignorePreValidation;
+
+    @Inject
+    @Named("sdxServerUrl")
+    private String sdxServerUrl;
+
+    @Bean
+    public SdxApiClientParams sdxApiClientParams() {
+        return new SdxApiClientParams(restDebug, certificateValidation, ignorePreValidation, sdxServerUrl);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/ServiceEndpointConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/ServiceEndpointConfig.java
@@ -30,6 +30,15 @@ public class ServiceEndpointConfig {
     @Value("${freeipa.environment.contextPath}")
     private String environmentRootContextPath;
 
+    @Value("${freeipa.sdx.url:}")
+    private String sdxServiceUrl;
+
+    @Value("${freeipa.sdx.serviceId:}")
+    private String sdxServiceId;
+
+    @Value("${freeipa.sdx.server.contextPath:/dl}")
+    private String sdxRootContextPath;
+
     @Bean
     public ServiceAddressResolver serviceAddressResolver() {
         return new RetryingServiceAddressResolver(new DNSServiceAddressResolver(), resolvingTimeout);
@@ -44,5 +53,10 @@ public class ServiceEndpointConfig {
     @Bean
     public String environmentServiceUrl() throws ServiceAddressResolvingException {
         return serviceAddressResolver().resolveUrl(environmentServiceUrl + environmentRootContextPath, "", null);
+    }
+
+    @Bean
+    public String sdxServerUrl() throws ServiceAddressResolvingException {
+        return serviceAddressResolver().resolveUrl(sdxServiceUrl + sdxRootContextPath, "http", sdxServiceId);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/CloudIdentitySyncService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/CloudIdentitySyncService.java
@@ -1,0 +1,103 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CloudIdentity;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.freeipa.user.model.FmsUser;
+import com.sequenceiq.freeipa.service.freeipa.user.model.UmsUsersState;
+import com.sequenceiq.sdx.api.endpoint.SdxEndpoint;
+import com.sequenceiq.sdx.api.model.SetRangerCloudIdentityMappingRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+
+@Service
+public class CloudIdentitySyncService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CloudIdentitySyncService.class);
+
+    @Inject
+    private SdxEndpoint sdxEndpoint;
+
+    public void syncCloudIdentites(Stack stack, UmsUsersState umsUsersState, BiConsumer<String, String> warnings) {
+        LOGGER.info("Syncing cloud identities for stack = {}", stack);
+        if (CloudPlatform.AZURE.equalsIgnoreCase(stack.getCloudPlatform())) {
+            LOGGER.info("Syncing Azure Object IDs for stack = {}", stack);
+            syncAzureObjectIds(stack, umsUsersState, warnings);
+        }
+    }
+
+    private void syncAzureObjectIds(Stack stack, UmsUsersState umsUsersState, BiConsumer<String, String> warnings) {
+        String envCrn = stack.getEnvironmentCrn();
+        LOGGER.info("Syncing Azure Object IDs for environment {}", envCrn);
+
+        try {
+            Map<String, List<CloudIdentity>> userCloudIdentites = getUserCloudIdentitiesToSync(umsUsersState);
+
+            Map<String, String> userToAzureObjectIdMap = getAzureObjectIdMap(userCloudIdentites);
+            Map<String, String> groupToAzureObjectIdMap = getAzureObjectIdMap(umsUsersState.getGroupToCloudIdentityMap());
+
+            SetRangerCloudIdentityMappingRequest setRangerCloudIdentityMappingRequest = new SetRangerCloudIdentityMappingRequest();
+            setRangerCloudIdentityMappingRequest.setAzureUserMapping(userToAzureObjectIdMap);
+            setRangerCloudIdentityMappingRequest.setAzureGroupMapping(groupToAzureObjectIdMap);
+            // TODO The SDX endpoint currently sets the config and triggers refresh. The SDX endpoint should also be updated
+            //      to allow polling the status of the refresh.
+            LOGGER.debug("Setting ranger cloud identity mapping: {}", setRangerCloudIdentityMappingRequest);
+            sdxEndpoint.setRangerCloudIdentityMapping(envCrn, setRangerCloudIdentityMappingRequest);
+        } catch (Exception e) {
+            LOGGER.warn("Failed to set cloud identity mapping for environment {}", envCrn, e);
+            warnings.accept(envCrn, "Failed to set cloud identity mapping");
+        }
+    }
+
+    private Map<String, String> getAzureObjectIdMap(Map<String, List<CloudIdentity>> cloudIdentityMapping) {
+        LOGGER.debug("Exracting Azure Object ID mapping from {}", cloudIdentityMapping);
+        ImmutableMap.Builder<String, String> azureObjectIdMap = ImmutableMap.builder();
+        cloudIdentityMapping.forEach((key, cloudIdentities) -> {
+            Optional<String> azureObjectId = getOptionalAzureObjectId(cloudIdentities);
+            if (azureObjectId.isPresent()) {
+                azureObjectIdMap.put(key, azureObjectId.get());
+            }
+        });
+        return azureObjectIdMap.build();
+    }
+
+    private Optional<String> getOptionalAzureObjectId(List<CloudIdentity> cloudIdentities) {
+        List<CloudIdentity> azureCloudIdentities = cloudIdentities.stream()
+                .filter(cloudIdentity -> cloudIdentity.getCloudIdentityDomain().hasAzureCloudIdentityDomain())
+                .collect(Collectors.toList());
+        if (azureCloudIdentities.isEmpty()) {
+            return Optional.empty();
+        } else if (azureCloudIdentities.size() > 1) {
+            throw new IllegalStateException(String.format("List contains multiple azure cloud identities = %s", cloudIdentities));
+        } else {
+            String azureObjectId = Iterables.getOnlyElement(azureCloudIdentities).getCloudIdentityName().getAzureCloudIdentityName().getObjectId();
+            return Optional.of(azureObjectId);
+        }
+    }
+
+    private Map<String, List<CloudIdentity>> getUserCloudIdentitiesToSync(UmsUsersState umsUsersState) {
+        Map<String, List<CloudIdentity>> allUserCloudIdentites = umsUsersState.getUserToCloudIdentityMap();
+        Set<String> userFilter = usersWithEnvironmentAccess(umsUsersState);
+        return allUserCloudIdentites.entrySet().stream()
+                .filter(entry -> userFilter.contains(entry.getKey()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private Set<String> usersWithEnvironmentAccess(UmsUsersState umsUsersState) {
+        return umsUsersState.getUsersState().getUsers().stream()
+                .map(FmsUser::getName)
+                .collect(Collectors.toSet());
+    }
+
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UmsUsersState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UmsUsersState.java
@@ -5,9 +5,11 @@ import static java.util.Objects.requireNonNull;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CloudIdentity;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
@@ -21,12 +23,19 @@ public class UmsUsersState {
 
     private final ImmutableSet<FmsGroup> workloadAdministrationGroups;
 
+    private final ImmutableMap<String, List<CloudIdentity>> userToCloudIdentityMap;
+
+    private final ImmutableMap<String, List<CloudIdentity>> groupToCloudIdentityMap;
+
     private UmsUsersState(UsersState usersState, Map<String, WorkloadCredential> usersWorkloadCredentialMap, Set<FmsUser> requestedWorkloadUsers,
-            Collection<FmsGroup> workloadAdministrationGroups) {
+            Collection<FmsGroup> workloadAdministrationGroups, Map<String, List<CloudIdentity>> userToCloudIdentityMap,
+            Map<String, List<CloudIdentity>> groupToCloudIdentityMap) {
         this.usersState = requireNonNull(usersState, "UsersState is null");
         this.usersWorkloadCredentialMap = ImmutableMap.copyOf(requireNonNull(usersWorkloadCredentialMap, "workload credential map is null"));
         this.requestedWorkloadUsers = ImmutableSet.copyOf(requireNonNull(requestedWorkloadUsers, "requested workload users is null"));
         this.workloadAdministrationGroups = ImmutableSet.copyOf(requireNonNull(workloadAdministrationGroups, "workloadAdministrationGroups is null"));
+        this.userToCloudIdentityMap = ImmutableMap.copyOf(requireNonNull(userToCloudIdentityMap, "userToCloudIdentityMap is null"));
+        this.groupToCloudIdentityMap = ImmutableMap.copyOf(requireNonNull(groupToCloudIdentityMap, "groupToCloudIdentityMap is null"));
     }
 
     public UsersState getUsersState() {
@@ -45,6 +54,14 @@ public class UmsUsersState {
         return workloadAdministrationGroups;
     }
 
+    public ImmutableMap<String, List<CloudIdentity>> getUserToCloudIdentityMap() {
+        return userToCloudIdentityMap;
+    }
+
+    public ImmutableMap<String, List<CloudIdentity>> getGroupToCloudIdentityMap() {
+        return groupToCloudIdentityMap;
+    }
+
     public static class Builder {
         private UsersState usersState;
 
@@ -53,6 +70,10 @@ public class UmsUsersState {
         private Set<FmsUser> requestedWorkloadUsers = new HashSet<>();
 
         private Collection<FmsGroup> workloadAdministrationGroups = Set.of();
+
+        private Map<String, List<CloudIdentity>> userToCloudIdentityMap = new HashMap<>();
+
+        private Map<String, List<CloudIdentity>> groupToCloudIdentityMap = new HashMap<>();
 
         public Builder setUsersState(UsersState usersState) {
             this.usersState = usersState;
@@ -74,8 +95,19 @@ public class UmsUsersState {
             return this;
         }
 
+        public Builder addUserCloudIdentities(String user, List<CloudIdentity> cloudIdentities) {
+            userToCloudIdentityMap.put(user, cloudIdentities);
+            return this;
+        }
+
+        public Builder addGroupCloudIdentities(String group, List<CloudIdentity> cloudIdentities) {
+            groupToCloudIdentityMap.put(group, cloudIdentities);
+            return this;
+        }
+
         public UmsUsersState build() {
-            return new UmsUsersState(usersState, workloadCredentialMap, requestedWorkloadUsers, workloadAdministrationGroups);
+            return new UmsUsersState(usersState, workloadCredentialMap, requestedWorkloadUsers, workloadAdministrationGroups, userToCloudIdentityMap,
+                    groupToCloudIdentityMap);
         }
     }
 }

--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -60,6 +60,9 @@ freeipa:
   environment:
     url: http://localhost:8088
     contextPath: /environmentservice
+  sdx:
+    url: http://localhost:8086
+    contextPath: /dl
   intermediate.threadpool:
     core.size: 100
     capacity.size: 4000
@@ -244,4 +247,3 @@ clusterProxy:
   healthyStatusCode: 400
   maxAttempts: 10
   maxFailure: 1
-

--- a/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
+++ b/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
@@ -198,6 +198,8 @@ public class MockUserManagementService extends UserManagementImplBase {
 
     private static final String CDP_CB_FAST_EBS_ENCRYPTION = "CDP_CB_FAST_EBS_ENCRYPTION";
 
+    private static final String CDP_CLOUD_IDENTITY_MAPPING = "CDP_CLOUD_IDENTITY_MAPPING";
+
     private static final String MOCK_RESOURCE = "mock_resource";
 
     private static final String SSH_PUBLIC_KEY_PATTERN = "^ssh-(rsa|ed25519)\\s+AAAA(B|C)3NzaC1.*(|\\n)";
@@ -258,6 +260,9 @@ public class MockUserManagementService extends UserManagementImplBase {
 
     @Value("${auth.mock.fastebsencryption.enable}")
     private boolean enableFastEbsEncryption;
+
+    @Value("${auth.mock.cloudidentitymappinng.enable}")
+    private boolean enableCloudIdentityMappinng;
 
     private String cbLicense;
 
@@ -523,6 +528,9 @@ public class MockUserManagementService extends UserManagementImplBase {
         }
         if (enableFastEbsEncryption) {
             builder.addEntitlements(createEntitlement(CDP_CB_FAST_EBS_ENCRYPTION));
+        }
+        if (enableCloudIdentityMappinng) {
+            builder.addEntitlements(createEntitlement(CDP_CLOUD_IDENTITY_MAPPING));
         }
         responseObserver.onNext(
                 GetAccountResponse.newBuilder()

--- a/mock-thunderhead/src/main/resources/application.yml
+++ b/mock-thunderhead/src/main/resources/application.yml
@@ -23,3 +23,4 @@ auth:
     freeipadlebsencryption.enable: true
     azure.single.resourcegroup.enable: false
     fastebsencryption.enable: true
+    cloudidentitymappinng.enable: true


### PR DESCRIPTION
Azure cloud identity information (Azure OID mapping) are now synced from
UMS into all appropriate datalake instances. At high level the
implementation is:

- SDX service has a new endpoint that allows setting azure ranger
configs (azure user and group mappings). The SDX service will make the
necessary CM api call (through cluster proxy) to set the config and
trigger a role refresh.

- The FMS user sync service will pull the Azure Object IDs (cloud
identity mapping) from UMS and call the new SDX endpoint to set the
configs.

Follow on work items include:
- Poll the status of the refresh after triggering it
- Individual user level and group level sync of OIDs
- Moving some of the CM logic into cluster-cm and client-cm