### PR TITLE
CB-7346. FluentD - get rid of s3 getObject requirement.

### DIFF
--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/output.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/output.conf.j2
@@ -7,9 +7,10 @@
     @type s3
     s3_bucket {{fluent.s3LogArchiveBucketName}}
     path "{{fluent.logFolderName}}/{{fluent.serviceLogPathSuffix}}"
-    s3_object_key_format %{path}-%{index}.%{file_extension}
+    s3_object_key_format %{path}-%{hex_random}.%{file_extension}
     auto_create_bucket false
     check_apikey_on_start false
+    check_object false
 
     <buffer tag,time>
       @type file
@@ -17,7 +18,7 @@
       timekey {{fluent.partitionIntervalMin}}m
       timekey_wait 0s
       total_limit_size  2048MB
-      chunk_limit_size  60m
+      chunk_limit_size  16m
       flush_at_shutdown true
       overflow_action drop_oldest_chunk
       disable_chunk_backup  true
@@ -33,8 +34,9 @@
     @type s3
     s3_bucket {{fluent.s3LogArchiveBucketName}}
     path "{{fluent.logFolderName}}/{{fluent.cmCommandLogPathSuffix}}"
-    s3_object_key_format %{path}-%{index}.%{file_extension}
+    s3_object_key_format %{path}-%{hex_random}.%{file_extension}
     auto_create_bucket false
+    check_object false
     check_apikey_on_start false
 
     <buffer tag,time>
@@ -43,7 +45,7 @@
       timekey {{fluent.partitionIntervalMin}}m
       timekey_wait 0s
       total_limit_size  1024MB
-      chunk_limit_size  60m
+      chunk_limit_size  16m
       flush_at_shutdown true
       overflow_action drop_oldest_chunk
       disable_chunk_backup  true


### PR DESCRIPTION
config changes to avoid usage of getObject calls

if object is not checked, we cannot know any number index of the files, that is needed also for multi part uploads

if no index in the filename -> uploaded files are overwritten. solutions for these:
- use a hex random in every buffer (4 digit - that is not unique, but the chance is really low you will generate the same random in the same minute for 2 different file - also it creates the same filename with the right minute timestamp if the log is grows larger than 16MB in the same minute -> there is a `uuid_flush` as well which is unique, but that's a long string, hex random looks better)
- decrease chunk limit from 60MB (default: 256MB) to 16MB in order to - most likely - avoid multi part uploads (so we do not need AbortMultipartUpload policy) - although because of the 5 minute intervals, 256 MB should be good enough, that's better to keep the value lower if we will increase interval (like -  if we make it configurable, we should keep that value low)