### PR TITLE
CB-6619-Optimize-CB-ClusterSync

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/cm/ClouderaManagerClusterCreationEvaluator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/cm/ClouderaManagerClusterCreationEvaluator.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.periscope.monitor.evaluator.cm;
 
-import static com.sequenceiq.periscope.api.model.ClusterState.PENDING;
 import static com.sequenceiq.periscope.api.model.ClusterState.RUNNING;
 
 import javax.annotation.Nonnull;
@@ -27,7 +26,6 @@ import com.sequenceiq.periscope.api.model.ScalingStatus;
 import com.sequenceiq.periscope.aspects.RequestLogging;
 import com.sequenceiq.periscope.domain.Cluster;
 import com.sequenceiq.periscope.domain.ClusterManager;
-import com.sequenceiq.periscope.domain.ClusterPertain;
 import com.sequenceiq.periscope.domain.History;
 import com.sequenceiq.periscope.domain.SecurityConfig;
 import com.sequenceiq.periscope.model.MonitoredStack;
@@ -128,8 +126,7 @@ public class ClouderaManagerClusterCreationEvaluator extends ClusterCreationEval
 
     private void createCluster(AutoscaleStackV4Response stack, MonitoredStack monitoredStack) {
         LOGGER.debug("Creating cluster for Cloudera Manager host: {}", monitoredStack.getClusterManager().getHost());
-        Cluster cluster = clusterService.create(monitoredStack, PENDING,
-                new ClusterPertain(stack.getTenant(), stack.getWorkspaceId(), stack.getUserId(), stack.getUserCrn()));
+        Cluster cluster = clusterService.create(stack);
         MDCBuilder.buildMdcContext(cluster);
         History history = historyService.createEntry(ScalingStatus.ENABLED, "Autoscaling has been enabled for the cluster.", 0, cluster);
 
@@ -148,7 +145,7 @@ public class ClouderaManagerClusterCreationEvaluator extends ClusterCreationEval
     }
 
     private MonitoredStack createMonitoredStack(AutoscaleStackV4Response stack, Long clusterId) {
-        String host = stack.getAmbariServerIp();
+        String host = stack.getClusterManagerIp();
         String gatewayPort = String.valueOf(stack.getGatewayPort());
         SecurityConfig securityConfig = null;
         if (clusterId != null) {

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/CloudbreakCommunicator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/CloudbreakCommunicator.java
@@ -10,11 +10,13 @@ import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.response.ClusterProxyConfiguration;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.AutoscaleStackV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackStatusV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 import com.sequenceiq.cloudbreak.client.CloudbreakInternalCrnClient;
 import com.sequenceiq.periscope.aspects.RequestLogging;
 import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.service.AutoscaleRestRequestThreadLocalService;
 
 @Service
 public class CloudbreakCommunicator {
@@ -23,10 +25,23 @@ public class CloudbreakCommunicator {
     private CloudbreakInternalCrnClient cloudbreakInternalCrnClient;
 
     @Inject
+    private AutoscaleRestRequestThreadLocalService restRequestThreadLocalService;
+
+    @Inject
     private RequestLogging requestLogging;
 
     public StackV4Response getByCrn(String stackCrn) {
         return cloudbreakInternalCrnClient.withInternalCrn().autoscaleEndpoint().get(stackCrn);
+    }
+
+    public AutoscaleStackV4Response getAutoscaleClusterByCrn(String stackCrn) {
+        return cloudbreakInternalCrnClient.withUserCrn(restRequestThreadLocalService.getCloudbreakUser().getUserCrn())
+                .autoscaleEndpoint().getAutoscaleClusterByCrn(stackCrn);
+    }
+
+    public AutoscaleStackV4Response getAutoscaleClusterByName(String stackName) {
+        return cloudbreakInternalCrnClient.withUserCrn(restRequestThreadLocalService.getCloudbreakUser().getUserCrn())
+                .autoscaleEndpoint().getAutoscaleClusterByName(stackName);
     }
 
     public StackStatusV4Response getStackStatusByCrn(String stackCrn) {

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/ha/LeaderElectionService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/ha/LeaderElectionService.java
@@ -36,7 +36,6 @@ import com.sequenceiq.periscope.repository.ClusterRepository;
 import com.sequenceiq.periscope.repository.PeriscopeNodeRepository;
 import com.sequenceiq.periscope.service.DateTimeService;
 import com.sequenceiq.periscope.service.PeriscopeMetricService;
-import com.sequenceiq.periscope.service.StackCollectorService;
 import com.sequenceiq.periscope.utils.TimeUtil;
 
 @Service
@@ -70,9 +69,6 @@ public class LeaderElectionService {
     private TransactionService transactionService;
 
     @Inject
-    private StackCollectorService stackCollectorService;
-
-    @Inject
     private DateTimeService dateTimeService;
 
     @Inject
@@ -85,18 +81,6 @@ public class LeaderElectionService {
     @PostConstruct
     public void init() {
         timer = timerFactory.get();
-        if (!periscopeNodeConfig.isNodeIdSpecified()) {
-            timer.schedule(new TimerTask() {
-                @Override
-                public void run() {
-                    try {
-                        stackCollectorService.collectStackDetails();
-                    } catch (RuntimeException e) {
-                        LOGGER.error("Error happend during fetching stacks", e);
-                    }
-                }
-            }, 0L, STACK_COLLECTOR_PERIOD);
-        }
     }
 
     @Scheduled(initialDelay = 35000L, fixedDelay = 30000L)
@@ -126,7 +110,6 @@ public class LeaderElectionService {
                     @Override
                     public void run() {
                         try {
-                            stackCollectorService.collectStackDetails();
                             long limit = clock.getCurrentTimeMillis() - heartbeatThresholdRate;
                             List<PeriscopeNode> activeNodes = periscopeNodeRepository.findAllByLastUpdatedIsGreaterThan(limit);
                             reallocateOrphanClusters(activeNodes);

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/security/SecurityConfigService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/security/SecurityConfigService.java
@@ -42,13 +42,18 @@ public class SecurityConfigService {
         SecurityConfig securityConfig = securityConfigRepository.findByClusterId(clusterId);
         if (securityConfig == null) {
             LOGGER.info("SecurityConfig not found by : {}", clusterId);
-            String stackCrn = clusterRepository.findStackCrnById(clusterId);
-            securityConfig = getRemoteSecurityConfig(stackCrn);
-            Optional<Cluster> cluster = clusterRepository.findById(clusterId);
-            if (cluster.isPresent()) {
-                securityConfig.setCluster(cluster.get());
-                securityConfigRepository.save(securityConfig);
-            }
+            securityConfig = syncSecurityConfigForCluster(clusterId);
+        }
+        return securityConfig;
+    }
+
+    public SecurityConfig syncSecurityConfigForCluster(Long clusterId) {
+        String stackCrn = clusterRepository.findStackCrnById(clusterId);
+        SecurityConfig securityConfig = getRemoteSecurityConfig(stackCrn);
+        Optional<Cluster> cluster = clusterRepository.findById(clusterId);
+        if (cluster.isPresent()) {
+            securityConfig.setCluster(cluster.get());
+            securityConfigRepository.save(securityConfig);
         }
         return securityConfig;
     }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/security/TlsHttpClientConfigurationService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/security/TlsHttpClientConfigurationService.java
@@ -35,7 +35,7 @@ public class TlsHttpClientConfigurationService {
         Optional<String> clusterProxyUrl = clusterProxyConfigurationService.getClusterProxyUrl();
         HttpClientConfig httpClientConfig =
                 new HttpClientConfig(host, tlsConfiguration.getServerCert(), tlsConfiguration.getClientCert(), tlsConfiguration.getClientKey());
-        if (clusterProxyUrl.isPresent() && tunnel.useClusterProxy()) {
+        if (clusterProxyUrl.isPresent()) {
             httpClientConfig.withClusterProxy(clusterProxyUrl.get(), stackCrn);
         }
         return httpClientConfig;

--- a/autoscale/src/test/java/com/sequenceiq/periscope/controller/AutoscaleClusterCommonServiceTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/controller/AutoscaleClusterCommonServiceTest.java
@@ -1,0 +1,131 @@
+package com.sequenceiq.periscope.controller;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.AutoscaleStackV4Response;
+import com.sequenceiq.common.api.type.Tunnel;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.model.NameOrCrn;
+import com.sequenceiq.periscope.monitor.handler.CloudbreakCommunicator;
+import com.sequenceiq.periscope.service.AutoscaleRestRequestThreadLocalService;
+import com.sequenceiq.periscope.service.ClusterService;
+import com.sequenceiq.periscope.service.NotFoundException;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AutoscaleClusterCommonServiceTest {
+
+    private static final String TEST_CLUSTER_NAME = "testcluster";
+
+    private static final String TEST_CLUSTER_CRN = "crn:cdp:datahub:us-west-1:autoscale:cluster:f7563fc1-e8ff-486a-9260-4e54ccabbaa0";
+
+    @InjectMocks
+    private AutoScaleClusterCommonService underTest;
+
+    @Mock
+    private ClusterService clusterService;
+
+    @Mock
+    private CloudbreakCommunicator cloudbreakCommunicator;
+
+    @Mock
+    private AutoscaleRestRequestThreadLocalService restRequestThreadLocalService;
+
+    private Long workspaceId = 10L;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testGetClusterByCRNWhenPresentInDB() {
+        when(restRequestThreadLocalService.getRequestedWorkspaceId()).thenReturn(workspaceId);
+        when(clusterService.findOneByStackCrnAndWorkspaceId(TEST_CLUSTER_CRN, workspaceId)).thenReturn(getACluster());
+
+        underTest.getClusterByCrnOrName(NameOrCrn.ofCrn(TEST_CLUSTER_CRN));
+        verify(cloudbreakCommunicator, never()).getAutoscaleClusterByCrn(TEST_CLUSTER_CRN);
+        verify(clusterService, never()).create(any(AutoscaleStackV4Response.class));
+    }
+
+    @Test
+    public void testGetClusterByNameWhenPresentInDB() {
+        when(restRequestThreadLocalService.getRequestedWorkspaceId()).thenReturn(workspaceId);
+        when(clusterService.findOneByStackNameAndWorkspaceId(TEST_CLUSTER_NAME, workspaceId)).thenReturn(getACluster());
+
+        underTest.getClusterByCrnOrName(NameOrCrn.ofName(TEST_CLUSTER_NAME));
+        verify(cloudbreakCommunicator, never()).getAutoscaleClusterByName(TEST_CLUSTER_NAME);
+        verify(clusterService, never()).create(any(AutoscaleStackV4Response.class));
+    }
+
+    @Test
+    public void testGetClusterByCRNWhenNotPresentInDBThenCBSyncByCrn() {
+        AutoscaleStackV4Response autoscaleStackV4Response = mock(AutoscaleStackV4Response.class);
+        when(restRequestThreadLocalService.getRequestedWorkspaceId()).thenReturn(workspaceId);
+        when(clusterService.findOneByStackCrnAndWorkspaceId(TEST_CLUSTER_CRN, workspaceId)).thenReturn(Optional.empty());
+        when(cloudbreakCommunicator.getAutoscaleClusterByCrn(TEST_CLUSTER_CRN)).thenReturn(autoscaleStackV4Response);
+        when(autoscaleStackV4Response.getStackType()).thenReturn(StackType.WORKLOAD);
+        when(clusterService.create(autoscaleStackV4Response)).thenReturn(getACluster().get());
+
+        Cluster cluster = underTest.getClusterByCrnOrName(NameOrCrn.ofCrn(TEST_CLUSTER_CRN));
+        assertEquals("Cluster Name should match", TEST_CLUSTER_NAME, cluster.getStackName());
+        assertEquals("Cluster CRN should match", TEST_CLUSTER_CRN, cluster.getStackCrn());
+    }
+
+    @Test
+    public void testGetClusterByNameWhenNotPresentInDBThenCBSyncByName() {
+        AutoscaleStackV4Response autoscaleStackV4Response = mock(AutoscaleStackV4Response.class);
+        when(restRequestThreadLocalService.getRequestedWorkspaceId()).thenReturn(workspaceId);
+        when(clusterService.findOneByStackNameAndWorkspaceId(TEST_CLUSTER_NAME, workspaceId)).thenReturn(Optional.empty());
+        when(cloudbreakCommunicator.getAutoscaleClusterByName(TEST_CLUSTER_NAME)).thenReturn(autoscaleStackV4Response);
+        when(autoscaleStackV4Response.getStackType()).thenReturn(StackType.WORKLOAD);
+        when(clusterService.create(autoscaleStackV4Response)).thenReturn(getACluster().get());
+
+        Cluster cluster = underTest.getClusterByCrnOrName(NameOrCrn.ofName(TEST_CLUSTER_NAME));
+        assertEquals("Cluster Name should match", TEST_CLUSTER_NAME, cluster.getStackName());
+        assertEquals("Cluster CRN should match", TEST_CLUSTER_CRN, cluster.getStackCrn());
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void testGetClusterByNameWhenNotFound() {
+        when(restRequestThreadLocalService.getRequestedWorkspaceId()).thenReturn(workspaceId);
+        when(clusterService.findOneByStackNameAndWorkspaceId(TEST_CLUSTER_NAME, workspaceId)).thenReturn(Optional.empty());
+        when(cloudbreakCommunicator.getAutoscaleClusterByName(TEST_CLUSTER_NAME)).thenThrow(NotFoundException.class);
+
+        underTest.getClusterByCrnOrName(NameOrCrn.ofName(TEST_CLUSTER_NAME));
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void testGetClusterByCrnWhenNotFound() {
+        when(restRequestThreadLocalService.getRequestedWorkspaceId()).thenReturn(workspaceId);
+        when(clusterService.findOneByStackCrnAndWorkspaceId(TEST_CLUSTER_CRN, workspaceId)).thenReturn(Optional.empty());
+        when(cloudbreakCommunicator.getAutoscaleClusterByCrn(TEST_CLUSTER_CRN)).thenThrow(NotFoundException.class);
+
+        underTest.getClusterByCrnOrName(NameOrCrn.ofCrn(TEST_CLUSTER_CRN));
+    }
+
+    private Optional<Cluster> getACluster() {
+        Cluster cluster = new Cluster();
+        cluster.setStackCrn(TEST_CLUSTER_CRN);
+        cluster.setStackName(TEST_CLUSTER_NAME);
+        cluster.setCloudPlatform("AWS");
+        cluster.setTunnel(Tunnel.CLUSTER_PROXY);
+        cluster.setStackType(StackType.WORKLOAD);
+        return Optional.of(cluster);
+    }
+}

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/cm/ClouderaManagerClusterCreationEvaluatorTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/cm/ClouderaManagerClusterCreationEvaluatorTest.java
@@ -3,8 +3,6 @@ package com.sequenceiq.periscope.monitor.evaluator.cm;
 import static com.sequenceiq.periscope.api.model.ClusterState.PENDING;
 import static com.sequenceiq.periscope.api.model.ClusterState.RUNNING;
 import static com.sequenceiq.periscope.api.model.ClusterState.SUSPENDED;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -42,7 +40,6 @@ import com.sequenceiq.periscope.domain.Cluster;
 import com.sequenceiq.periscope.domain.ClusterPertain;
 import com.sequenceiq.periscope.domain.History;
 import com.sequenceiq.periscope.domain.SecurityConfig;
-import com.sequenceiq.periscope.model.MonitoredStack;
 import com.sequenceiq.periscope.monitor.context.EvaluatorContext;
 import com.sequenceiq.periscope.notification.HttpNotificationSender;
 import com.sequenceiq.periscope.service.ClusterService;
@@ -173,18 +170,14 @@ public class ClouderaManagerClusterCreationEvaluatorTest {
         setUpMocks(null, false, stack, history);
 
         Cluster cluster = getCluster(null);
-        when(clusterService.create(any(), any(), any())).thenReturn(cluster);
+        when(clusterService.create(any())).thenReturn(cluster);
         when(historyService.createEntry(any(), anyString(), anyInt(), eq(cluster))).thenReturn(history);
 
         underTest.execute();
 
         verify(clusterService).findOneByStackId(STACK_ID);
         verify(clusterService).validateClusterUniqueness(any());
-        verify(clusterService).create(any(MonitoredStack.class), eq(PENDING), captor.capture());
-        ClusterPertain clusterPertain = captor.getValue();
-        assertThat(clusterPertain.getTenant(), is("TENANT"));
-        assertThat(clusterPertain.getWorkspaceId(), is(10L));
-        assertThat(clusterPertain.getUserId(), is("USER_ID"));
+        verify(clusterService).create(any(AutoscaleStackV4Response.class));
     }
 
     private void setUpMocks(Cluster cluster, boolean healthy, StackV4Response stackV4Response, History history) {
@@ -213,7 +206,7 @@ public class ClouderaManagerClusterCreationEvaluatorTest {
         AutoscaleStackV4Response stack = new AutoscaleStackV4Response();
         stack.setStackId(STACK_ID);
         stack.setStackCrn(STACK_CRN);
-        stack.setAmbariServerIp("0.0.0.0");
+        stack.setClusterManagerIp("0.0.0.0");
         stack.setGatewayPort(8080);
         stack.setTenant("TENANT");
         stack.setWorkspaceId(10L);

--- a/autoscale/src/test/java/com/sequenceiq/periscope/service/ha/LeaderElectionServiceTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/service/ha/LeaderElectionServiceTest.java
@@ -39,7 +39,6 @@ import com.sequenceiq.periscope.repository.ClusterRepository;
 import com.sequenceiq.periscope.repository.PeriscopeNodeRepository;
 import com.sequenceiq.periscope.service.DateTimeService;
 import com.sequenceiq.periscope.service.PeriscopeMetricService;
-import com.sequenceiq.periscope.service.StackCollectorService;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LeaderElectionServiceTest {
@@ -64,9 +63,6 @@ public class LeaderElectionServiceTest {
 
     @Mock
     private TransactionService transactionService;
-
-    @Mock
-    private StackCollectorService stackCollectorService;
 
     @Mock
     private Timer timer;

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/autoscales/AutoscaleV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/autoscales/AutoscaleV4Endpoint.java
@@ -24,6 +24,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.response.Certificate
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.response.ClusterProxyConfiguration;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses.AutoscaleRecommendationV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.UpdateClusterV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.AutoscaleStackV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackStatusV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 import com.sequenceiq.cloudbreak.doc.ControllerDescription;
@@ -58,6 +59,20 @@ public interface AutoscaleV4Endpoint {
     @Produces(APPLICATION_JSON)
     @ApiOperation(value = StackOpDescription.GET_ALL, produces = APPLICATION_JSON, notes = Notes.STACK_NOTES, nickname = "getAllStackForAutoscale")
     AutoscaleStackV4Responses getAllForAutoscale();
+
+    @GET
+    @Path("/autoscale_cluster/crn/{crn}")
+    @Produces(APPLICATION_JSON)
+    @ApiOperation(value = StackOpDescription.GET_AUTOSCALE_BY_CRN, produces = APPLICATION_JSON,
+            notes = Notes.STACK_NOTES, nickname = "getAutoscaleClusterByCrn")
+    AutoscaleStackV4Response getAutoscaleClusterByCrn(@PathParam("crn") String crn);
+
+    @GET
+    @Path("/autoscale_cluster/name/{name}")
+    @Produces(APPLICATION_JSON)
+    @ApiOperation(value = StackOpDescription.GET_AUTOSCALE_BY_NAME, produces = APPLICATION_JSON,
+            notes = Notes.STACK_NOTES, nickname = "getAutoscaleClusterByName")
+    AutoscaleStackV4Response getAutoscaleClusterByName(@PathParam("name") String name);
 
     @GET
     @Path("/stack/crn/{crn}")

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/AutoscaleStackV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/AutoscaleStackV4Response.java
@@ -43,7 +43,7 @@ public class AutoscaleStackV4Response {
     private Integer gatewayPort;
 
     @ApiModelProperty(StackModelDescription.SERVER_IP)
-    private String ambariServerIp;
+    private String clusterManagerIp;
 
     @ApiModelProperty(StackModelDescription.USERNAME)
     private String userNamePath;
@@ -131,12 +131,12 @@ public class AutoscaleStackV4Response {
         this.gatewayPort = gatewayPort;
     }
 
-    public String getAmbariServerIp() {
-        return ambariServerIp;
+    public String getClusterManagerIp() {
+        return clusterManagerIp;
     }
 
-    public void setAmbariServerIp(String ambariServerIp) {
-        this.ambariServerIp = ambariServerIp;
+    public void setClusterManagerIp(String clusterManagerIp) {
+        this.clusterManagerIp = clusterManagerIp;
     }
 
     public String getUserNamePath() {

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
@@ -18,12 +18,13 @@ public class OperationDescriptions {
         public static final String GET_STATUS_BY_NAME = "retrieve stack status by stack name";
         public static final String PUT_BY_ID = "update stack by id";
         public static final String PUT_BY_NAME = "update stack by name";
-        public static final String GET_BY_AMBARI_ADDRESS = "retrieve stack by ambari address";
         public static final String GET_STACK_CERT = "retrieves the TLS certificate used by the gateway";
         public static final String GET_ALL = "retrieve all stacks";
         public static final String LIST_BY_WORKSPACE = "list stacks for the given workspace and environment name";
         public static final String GET_BY_NAME_IN_WORKSPACE = "get stack by name in workspace";
         public static final String GET_BY_CRN_IN_WORKSPACE = "get stack by crn in workspace";
+        public static final String GET_AUTOSCALE_BY_NAME = "get autoscale stack by name in workspace";
+        public static final String GET_AUTOSCALE_BY_CRN = "get autoscale stack by crn in workspace";
         public static final String CREATE_IN_WORKSPACE = "create stack in workspace";
         public static final String DELETE_BY_NAME_IN_WORKSPACE = "delete stack by name in workspace";
         public static final String SYNC_BY_NAME_IN_WORKSPACE = "syncs the stack by name in workspace";

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/AutoscaleV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/AutoscaleV4Controller.java
@@ -98,6 +98,20 @@ public class AutoscaleV4Controller implements AutoscaleV4Endpoint {
     }
 
     @Override
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.DATAHUB_READ)
+    public AutoscaleStackV4Response getAutoscaleClusterByCrn(String crn) {
+        Stack stack = stackService.getByCrnInWorkspace(crn, restRequestThreadLocalService.getRequestedWorkspaceId());
+        return converterUtil.convert(stack, AutoscaleStackV4Response.class);
+    }
+
+    @Override
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.DATAHUB_READ)
+    public AutoscaleStackV4Response getAutoscaleClusterByName(String name) {
+        Stack stack = stackService.getByNameInWorkspace(name, restRequestThreadLocalService.getRequestedWorkspaceId());
+        return converterUtil.convert(stack, AutoscaleStackV4Response.class);
+    }
+
+    @Override
     @DisableCheckPermissions
     @PreAuthorize("hasRole('AUTOSCALE')")
     public AutoscaleStackV4Responses getAllForAutoscale() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/stack/AutoscaleStackToAutoscaleStackResponseJsonConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/stack/AutoscaleStackToAutoscaleStackResponseJsonConverter.java
@@ -34,7 +34,7 @@ public class AutoscaleStackToAutoscaleStackResponseJsonConverter extends Abstrac
 
         if (source.getClusterStatus() != null) {
             String gatewayIp = gatewayConfigService.getPrimaryGatewayIp(source);
-            result.setAmbariServerIp(gatewayIp);
+            result.setClusterManagerIp(gatewayIp);
             result.setUserNamePath(source.getCloudbreakAmbariUser().getSecret());
             result.setPasswordPath(source.getCloudbreakAmbariPassword().getSecret());
             result.setClusterStatus(source.getClusterStatus());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackToAutoscaleStackV4ResponseConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackToAutoscaleStackV4ResponseConverter.java
@@ -1,20 +1,14 @@
 package com.sequenceiq.cloudbreak.converter.v4.stacks;
 
-import javax.inject.Inject;
-
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.AutoscaleStackV4Response;
 import com.sequenceiq.cloudbreak.converter.AbstractConversionServiceAwareConverter;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
-import com.sequenceiq.cloudbreak.service.GatewayConfigService;
 
 @Component
 public class StackToAutoscaleStackV4ResponseConverter extends AbstractConversionServiceAwareConverter<Stack, AutoscaleStackV4Response> {
-
-    @Inject
-    private GatewayConfigService gatewayConfigService;
 
     @Override
     public AutoscaleStackV4Response convert(Stack source) {
@@ -29,11 +23,13 @@ public class StackToAutoscaleStackV4ResponseConverter extends AbstractConversion
         result.setStatus(source.getStatus());
         result.setStackCrn(source.getResourceCrn());
         result.setTunnel(source.getTunnel());
+        result.setCloudPlatform(source.getCloudPlatform());
+        result.setUserCrn(source.getCreator().getUserCrn());
+        result.setStackType(source.getType());
 
         if (source.getCluster() != null) {
             Cluster cluster = source.getCluster();
-            String gatewayIp = gatewayConfigService.getPrimaryGatewayIp(source);
-            result.setAmbariServerIp(gatewayIp);
+            result.setClusterManagerIp(cluster.getClusterManagerIp());
             result.setUserNamePath(cluster.getCloudbreakAmbariUserSecret());
             result.setPasswordPath(cluster.getCloudbreakAmbariPasswordSecret());
             result.setClusterStatus(cluster.getStatus());


### PR DESCRIPTION
1. Introducing CB-Periscope Cluster Sync on-demand instead of polling all CB Clusters every 30 seconds to avoid unnecessary CB DB Load and  periscope processing already synced clusters.
2. Persicope CM Communication is defaulted to use cluster-proxy which is the recommended mechanism for all Cluster Communication since CM IP would not be reachable in all scenarios.

This was tested on private stack for periscope-cb cluster sync and autoscaling scaleup\scaledown actions.

Closes #CB-6619