### PR TITLE
CDPCP-2294. Fix NullPointer in user sync

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncService.java
@@ -381,7 +381,8 @@ public class UserSyncService {
                 LOGGER.debug("adding users [{}] to group [{}]", users, group);
                 try {
                     RPCResponse<Group> groupAddMemberResponse = freeIpaClient.groupAddMembers(group, users);
-                    if (groupAddMemberResponse.getResult().getMemberUser().containsAll(users)) {
+                    List<String> members = Optional.ofNullable(groupAddMemberResponse.getResult().getMemberUser()).orElse(List.of());
+                    if (members.containsAll(users)) {
                         LOGGER.debug("Successfully added users {} to {}", users, groupAddMemberResponse.getResult());
                     } else {
                         // TODO specialize RPCResponse completed/failed objects
@@ -405,7 +406,8 @@ public class UserSyncService {
                 LOGGER.debug("removing users {} from group {}", users, group);
                 try {
                     RPCResponse<Group> groupRemoveMembersResponse = freeIpaClient.groupRemoveMembers(group, users);
-                    if (Collections.disjoint(groupRemoveMembersResponse.getResult().getMemberUser(), users)) {
+                    List<String> members = Optional.ofNullable(groupRemoveMembersResponse.getResult().getMemberUser()).orElse(List.of());
+                    if (Collections.disjoint(members, users)) {
                         LOGGER.debug("Successfully removed users {} from {}", users, groupRemoveMembersResponse.getResult());
                     } else {
                         // TODO specialize RPCResponse completed/failed objects


### PR DESCRIPTION
User sync changes in CDPCP-808 introduced a potential null pointer
exception when removing all users from a group. FreeIPA will return
null for the Group member_user field. The new check for whether the
group member removal works did not null-check this field.

The UserSyncService is updated to not fail when this field is null.
