### PR TITLE
CB-7391: Fix FreeIPA instance group database table's node count

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/instance/InstanceGroupRequestToInstanceGroupConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/instance/InstanceGroupRequestToInstanceGroupConverter.java
@@ -8,7 +8,6 @@ import javax.inject.Inject;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
-import com.sequenceiq.cloudbreak.common.mappable.ProviderParameterCalculator;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupRequest;
 import com.sequenceiq.freeipa.converter.instance.template.InstanceTemplateRequestToTemplateConverter;
 import com.sequenceiq.freeipa.entity.InstanceGroup;
@@ -17,9 +16,6 @@ import com.sequenceiq.freeipa.service.stack.instance.DefaultInstanceGroupProvide
 
 @Component
 public class InstanceGroupRequestToInstanceGroupConverter {
-
-    @Inject
-    private ProviderParameterCalculator providerParameterCalculator;
 
     @Inject
     private InstanceTemplateRequestToTemplateConverter templateConverter;
@@ -42,6 +38,7 @@ public class InstanceGroupRequestToInstanceGroupConverter {
         if (source.getNodeCount() > 0) {
             addInstanceMetadatas(source, instanceGroup);
         }
+        instanceGroup.setNodeCount(source.getNodeCount());
         return instanceGroup;
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/InstanceGroup.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/InstanceGroup.java
@@ -58,6 +58,8 @@ public class InstanceGroup implements Comparable<InstanceGroup> {
     @Column(columnDefinition = "TEXT")
     private Json attributes;
 
+    private Integer nodeCount;
+
     public String getGroupName() {
         return groupName;
     }
@@ -75,7 +77,11 @@ public class InstanceGroup implements Comparable<InstanceGroup> {
     }
 
     public int getNodeCount() {
-        return getNotTerminatedInstanceMetaDataSet().size();
+        return nodeCount;
+    }
+
+    public void setNodeCount(Integer nodeCount) {
+        this.nodeCount = nodeCount;
     }
 
     public Stack getStack() {

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/instance/InstanceGroupRequestToInstanceGroupConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/instance/InstanceGroupRequestToInstanceGroupConverterTest.java
@@ -1,0 +1,75 @@
+package com.sequenceiq.freeipa.converter.instance;
+
+import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.MOCK;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupType;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.security.SecurityGroupRequest;
+import com.sequenceiq.freeipa.converter.instance.template.InstanceTemplateRequestToTemplateConverter;
+import com.sequenceiq.freeipa.entity.InstanceGroup;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
+import com.sequenceiq.freeipa.entity.SecurityGroup;
+import com.sequenceiq.freeipa.entity.Template;
+import com.sequenceiq.freeipa.service.stack.instance.DefaultInstanceGroupProvider;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InstanceGroupRequestToInstanceGroupConverterTest {
+
+    private static final String ACCOUNT_ID = "account_id";
+
+    private static final String CLOUD_PLATFORM = "MOCK";
+
+    private static final String NAME = "NAME";
+
+    @InjectMocks
+    private InstanceGroupRequestToInstanceGroupConverter underTest;
+
+    @Mock
+    private InstanceTemplateRequestToTemplateConverter templateConverter;
+
+    @Mock
+    private SecurityGroupRequestToSecurityGroupConverter securityGroupConverter;
+
+    @Mock
+    private DefaultInstanceGroupProvider defaultInstanceGroupProvider;
+
+    @Test
+    public void testConvertWithNullTemplate() {
+        int nodeCount = 2;
+        InstanceGroupRequest request = new InstanceGroupRequest();
+        request.setName(NAME);
+        request.setType(InstanceGroupType.MASTER);
+        request.setNodeCount(nodeCount);
+
+        Template template = mock(Template.class);
+        SecurityGroupRequest securityGroupRequest = mock(SecurityGroupRequest.class);
+        SecurityGroup securityGroup = mock(SecurityGroup.class);
+        request.setSecurityGroup(securityGroupRequest);
+
+        // GIVEN
+        given(defaultInstanceGroupProvider.createDefaultTemplate(eq(MOCK), eq(ACCOUNT_ID))).willReturn(template);
+        given(securityGroupConverter.convert(eq(securityGroupRequest))).willReturn(securityGroup);
+        // WHEN
+        InstanceGroup result = underTest.convert(request, ACCOUNT_ID, CLOUD_PLATFORM);
+        // THEN
+        assertEquals(NAME, result.getGroupName());
+        assertEquals(InstanceGroupType.MASTER, result.getInstanceGroupType());
+        assertEquals(securityGroup, result.getSecurityGroup());
+        assertEquals(nodeCount, result.getNodeCount());
+        assertEquals(nodeCount, result.getInstanceMetaData().size());
+        for (InstanceMetaData instanceMetaData : result.getInstanceMetaData()) {
+            assertEquals(result, instanceMetaData.getInstanceGroup());
+        }
+    }
+
+}


### PR DESCRIPTION
I am targeting this for 2.23 so that when FreeIPA basic HA is enabled, the database will contain the information needed in order for the repair to work when full HA is available.

The FreeIPA instance group database table's node count was set to
null. This sets the value for newly provisioned FreeIPA clusters.

This was tested using the unit tests and also by checking the database
table values when provisioning a cluster.

Closes #CB-7391