### PR TITLE
CB-7405: Add a force uninstall and force-join option to FreeIPA replica install

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_replica_install.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_replica_install.sh
@@ -5,6 +5,8 @@ set -e
 FQDN=$(hostname -f)
 IPADDR=$(hostname -i)
 
+ipa-server-install --unattended --uninstall
+
 ipa-replica-install \
           --server $FREEIPA_TO_REPLICATE \
           --setup-ca \
@@ -20,6 +22,7 @@ ipa-replica-install \
           --mkhomedir \
           --ip-address $IPADDR \
           --auto-forwarders \
+          --force-join \
 {%- if not salt['pillar.get']('freeipa:dnssecValidationEnabled') %}
           --no-dnssec-validation \
 {%- endif %}


### PR DESCRIPTION
This does an ipa-server-uninstall to clean up any possible bad server install
components in case of a retry of the replica install.  As well it adds a
--force-join option to the replica install in case the client has already
been installed and registered on the main server.  This effectively makes
the replica install idempotent.

Closes #CB-7405