### PR TITLE
DISTX-494-PurgeExistingPeriscopeClusterData

### DIFF
--- a/autoscale/src/main/resources/schema/app/20200611115912_DISTX-494_Purge_existing_Periscope_Cluster_Data.sql
+++ b/autoscale/src/main/resources/schema/app/20200611115912_DISTX-494_Purge_existing_Periscope_Cluster_Data.sql
@@ -1,0 +1,22 @@
+-- // DISTX-494 Purge existing Periscope Cluster Data
+-- Migration SQL that makes the change goes here.
+-- Purge existing periscope cluster data, new cluster data would be auto-synced from CB.
+
+delete from failed_node;
+delete from history_properties;
+delete from history;
+delete from prometheusalert;
+delete from loadalert;
+delete from timealert;
+delete from metricalert;
+delete from scalingpolicy;
+delete from securityconfig;
+delete from cluster;
+delete from cluster_manager;
+delete from clusterpertain;
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+


### PR DESCRIPTION
Periscope database contains Cluster data where in each cluster creator is stored as a duplicate row in clusterpertain table. This mapping has been fixed to associate all clusters created by single user with a single entry in ClusterPertain.

Existing cluster table data needs to be purged to honour this new mapping.

Closes #DISTX-494