### PR TITLE
CB-7246 - Prevent favicon.ico requests for unauthenticated UIs

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/clouderamanager-ssl-user-facing.conf
+++ b/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/clouderamanager-ssl-user-facing.conf
@@ -28,6 +28,14 @@ server {
         rewrite ^([/](?!clouderamanager/).*$) /clouderamanager$1;
     }
 
+    # If hadoop-jwt cookie not set and favicon is requested return 403.
+    if ($cookie_hadoop-jwt !~ .+) {
+        rewrite ^/favicon.ico$ /favicon.403;
+    }
+    location ~ ^/favicon.403$ {
+        return 403;
+    }
+
     location ~ .*/clouderamanager/(.*) {
         proxy_pass         {{ protocol }}://clouderamanager/$1$is_args$args;
         proxy_redirect     http:// https://;


### PR DESCRIPTION
### Describe the change you are making here!

The changes are to nginx component. 
With this change unauthenticated favicon.ico requests (automatic requests by browser) to UIs will be denied (with 403 response). Favicon requests will only be allowed when the UI is authenticated i.e. hadoop-jwt cookie is present. This only affects requests going in via Knox and does not affect CM requests. 

**Why is this change needed**
More details can be found in [CB-7246](jira.cloudera.com/browse/CB-7246). In a nutshell this is what is happening (in Chrome browser):

1. Request is made to a UI page (Atlas, CM, Ranger etc.) from CP.
2. In case where there is no authentication KnoxSSO flow is triggered.
3. Before the previous KnoxSSO flow is completed Chrome requests favicon.ico at the root of the server (this is the nginx host).
4. This favicon.ico request rewrite the originalURL parameter in Pac4j cookie causing the UI page to land on favicon icon.
5. This only happens the first time later requests work as expected.

**What the patch does:**
This patch looks for hadoop-jwt cookie in the request, if the cookie is found there is no change to the request flow. If hadoop-jwt cookie is not found and the request is for favicon.ico then the request is blocked by the nginx and 403 response code is returned.

**Side effects:**
So far local testing has not uncovered any side effects. After successful authentication all UIs (Ranger, Atlas, CM etc.) will display their favicons like they used to.

This screenshot demonstrates the initial favicon.ico request is denied but after the UI is authenticated a new request is issues and favicon is displayed properly.

![image](https://user-images.githubusercontent.com/380997/85762358-a5931c80-b6e1-11ea-836b-327043f99e60.png)

### Please include a short description. Check out these examples:
Prevent unauthenticated favicon.ico requests by browsers. 

