### PR TITLE
fix for DISTX-493

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-720.bp
@@ -18,6 +18,12 @@
       {
         "refName": "hdfs",
         "serviceType": "HDFS",
+        "serviceConfigs": [
+          {
+            "name": "hdfs_verify_ec_with_topology_enabled",
+            "value": false
+          }
+        ],
         "roleConfigGroups": [
           {
             "refName": "hdfs-NAMENODE-BASE",
@@ -31,6 +37,10 @@
               {
                 "name": "fs_trash_checkpoint_interval",
                 "value": "0"
+              },
+              {
+                "name": "erasure_coding_default_policy",
+                "value": " "
               }
             ]
           },
@@ -57,6 +67,10 @@
               {
                 "name": "dfs_client_use_trash",
                 "value": false
+              },
+              {
+                "name": "hdfs_client_env_safety_valve",
+                "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
               }
             ]
           }
@@ -122,6 +136,10 @@
               {
                 "name": "mapreduce_reduce_memory_mb",
                 "value": 4096
+              },
+              {
+                "name": "mapreduce_client_env_safety_valve",
+                "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
               }
             ]
           }
@@ -139,7 +157,13 @@
           {
             "refName": "spark_on_yarn-GATEWAY-BASE",
             "roleType": "GATEWAY",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                "name": "spark-conf/spark-defaults.conf_client_config_safety_valve",
+                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl"
+              }
+            ]
           }
         ]
       },
@@ -224,7 +248,7 @@
           },
           {
             "name": "hive_service_config_safety_valve",
-            "value": "<property><name>hive.server2.tez.sessions.per.default.queue</name><value>4</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property>"
+            "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-721.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-721.bp
@@ -18,6 +18,12 @@
       {
         "refName": "hdfs",
         "serviceType": "HDFS",
+        "serviceConfigs": [
+          {
+            "name": "hdfs_verify_ec_with_topology_enabled",
+            "value": false
+          }
+        ],
         "roleConfigGroups": [
           {
             "refName": "hdfs-NAMENODE-BASE",
@@ -31,6 +37,10 @@
               {
                 "name": "fs_trash_checkpoint_interval",
                 "value": "0"
+              },
+              {
+                "name": "erasure_coding_default_policy",
+                "value": " "
               }
             ]
           },
@@ -57,6 +67,10 @@
               {
                 "name": "dfs_client_use_trash",
                 "value": false
+              },
+              {
+                "name": "hdfs_client_env_safety_valve",
+                "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
               }
             ]
           }
@@ -122,6 +136,10 @@
               {
                 "name": "mapreduce_reduce_memory_mb",
                 "value": 4096
+              },
+              {
+                "name": "mapreduce_client_env_safety_valve",
+                "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
               }
             ]
           }
@@ -139,7 +157,13 @@
           {
             "refName": "spark_on_yarn-GATEWAY-BASE",
             "roleType": "GATEWAY",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                "name": "spark-conf/spark-defaults.conf_client_config_safety_valve",
+                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl"
+              }
+            ]
           }
         ]
       },
@@ -224,7 +248,7 @@
           },
           {
             "name": "hive_service_config_safety_valve",
-            "value": "<property><name>hive.server2.tez.sessions.per.default.queue</name><value>4</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property>"
+            "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-720.bp
@@ -20,6 +20,12 @@
         "serviceType": "HDFS",
         "serviceConfigs": [
           {
+            "name": "hdfs_verify_ec_with_topology_enabled",
+            "value": false
+          }
+        ],
+        "serviceConfigs": [
+          {
             "name": "redaction_policy_enabled",
             "value": "false"
           },
@@ -32,7 +38,21 @@
           {
             "refName": "hdfs-NAMENODE-BASE",
             "roleType": "NAMENODE",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                "name": "fs_trash_interval",
+                "value": "0"
+              },
+              {
+                "name": "fs_trash_checkpoint_interval",
+                "value": "0"
+              },
+              {
+                "name": "erasure_coding_default_policy",
+                "value": " "
+              }
+            ]
           },
           {
             "refName": "hdfs-FAILOVERCONTROLLER-BASE",
@@ -73,6 +93,10 @@
               {
                 "name": "dfs_client_use_trash",
                 "value": false
+              },
+              {
+                "name": "hdfs_client_env_safety_valve",
+                "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
               }
             ]
           }
@@ -110,7 +134,7 @@
           },
           {
             "name": "hive_service_config_safety_valve",
-            "value": "<property><name>hive.server2.tez.sessions.per.default.queue</name><value>4</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property>"
+            "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -249,6 +273,10 @@
               {
                 "name": "mapreduce_reduce_memory_mb",
                 "value": 4096
+              },
+              {
+                "name": "mapreduce_client_env_safety_valve",
+                "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
               }
             ]
           }
@@ -266,7 +294,13 @@
           {
             "refName": "spark_on_yarn-GATEWAY-BASE",
             "roleType": "GATEWAY",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                "name": "spark-conf/spark-defaults.conf_client_config_safety_valve",
+                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl"
+              }
+            ]
           }
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-720.bp
@@ -20,18 +20,16 @@
         "serviceType": "HDFS",
         "serviceConfigs": [
           {
-            "name": "hdfs_verify_ec_with_topology_enabled",
-            "value": false
-          }
-        ],
-        "serviceConfigs": [
-          {
             "name": "redaction_policy_enabled",
             "value": "false"
           },
           {
             "name": "zookeeper_service",
             "ref": "zookeeper"
+          },
+          {
+            "name": "hdfs_verify_ec_with_topology_enabled",
+            "value": false
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-721.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-721.bp
@@ -20,6 +20,12 @@
         "serviceType": "HDFS",
         "serviceConfigs": [
           {
+            "name": "hdfs_verify_ec_with_topology_enabled",
+            "value": false
+          }
+        ],
+        "serviceConfigs": [
+          {
             "name": "redaction_policy_enabled",
             "value": "false"
           },
@@ -32,7 +38,21 @@
           {
             "refName": "hdfs-NAMENODE-BASE",
             "roleType": "NAMENODE",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                "name": "fs_trash_interval",
+                "value": "0"
+              },
+              {
+                "name": "fs_trash_checkpoint_interval",
+                "value": "0"
+              },
+              {
+                "name": "erasure_coding_default_policy",
+                "value": " "
+              }
+            ]
           },
           {
             "refName": "hdfs-FAILOVERCONTROLLER-BASE",
@@ -73,6 +93,10 @@
               {
                 "name": "dfs_client_use_trash",
                 "value": false
+              },
+              {
+                "name": "hdfs_client_env_safety_valve",
+                "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
               }
             ]
           }
@@ -110,7 +134,7 @@
           },
           {
             "name": "hive_service_config_safety_valve",
-            "value": "<property><name>hive.server2.tez.sessions.per.default.queue</name><value>4</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property>"
+            "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -249,6 +273,10 @@
               {
                 "name": "mapreduce_reduce_memory_mb",
                 "value": 4096
+              },
+              {
+                "name": "mapreduce_client_env_safety_valve",
+                "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
               }
             ]
           }
@@ -266,7 +294,13 @@
           {
             "refName": "spark_on_yarn-GATEWAY-BASE",
             "roleType": "GATEWAY",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                "name": "spark-conf/spark-defaults.conf_client_config_safety_valve",
+                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl"
+              }
+            ]
           }
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-721.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-721.bp
@@ -20,18 +20,16 @@
         "serviceType": "HDFS",
         "serviceConfigs": [
           {
-            "name": "hdfs_verify_ec_with_topology_enabled",
-            "value": false
-          }
-        ],
-        "serviceConfigs": [
-          {
             "name": "redaction_policy_enabled",
             "value": "false"
           },
           {
             "name": "zookeeper_service",
             "ref": "zookeeper"
+          },
+          {
+            "name": "hdfs_verify_ec_with_topology_enabled",
+            "value": false
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-720.bp
@@ -237,7 +237,7 @@
           "spark3_on_yarn-GATEWAY-BASE",
           "yarn-NODEMANAGER-WORKER",
           "zookeeper-SERVER-BASE",
-          "yarn-GATEWAY-BASE
+          "yarn-GATEWAY-BASE"
         ]
       },
       {
@@ -248,7 +248,7 @@
           "hms-GATEWAY-BASE",
           "spark3_on_yarn-GATEWAY-BASE",
           "yarn-NODEMANAGER-COMPUTE",
-          "yarn-GATEWAY-BASE
+          "yarn-GATEWAY-BASE"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-720.bp
@@ -18,6 +18,12 @@
       {
         "refName": "hdfs",
         "serviceType": "HDFS",
+        "serviceConfigs": [
+          {
+            "name": "hdfs_verify_ec_with_topology_enabled",
+            "value": false
+          }
+        ],
         "roleConfigGroups": [
           {
             "refName": "hdfs-NAMENODE-BASE",
@@ -31,6 +37,10 @@
               {
                 "name": "fs_trash_checkpoint_interval",
                 "value": "0"
+              },
+              {
+                "name": "erasure_coding_default_policy",
+                "value": " "
               }
             ]
           },
@@ -57,6 +67,10 @@
               {
                 "name": "dfs_client_use_trash",
                 "value": false
+              },
+              {
+                "name": "hdfs_client_env_safety_valve",
+                "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
               }
             ]
           }
@@ -109,6 +123,25 @@
             "refName": "yarn-JOBHISTORY-BASE",
             "roleType": "JOBHISTORY",
             "base": true
+          },
+          {
+            "refName": "yarn-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true,
+            "configs": [
+              {
+                "name": "mapreduce_map_memory_mb",
+                "value": 4096
+              },
+              {
+                "name": "mapreduce_reduce_memory_mb",
+                "value": 4096
+              },
+              {
+                "name": "mapreduce_client_env_safety_valve",
+                "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
+              }
+            ]
           }
         ]
       },
@@ -124,7 +157,13 @@
           {
             "refName": "spark3_on_yarn-GATEWAY-BASE",
             "roleType": "GATEWAY",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                "name": "spark3-conf/spark-defaults.conf_client_config_safety_valve",
+                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl"
+              }
+            ]
           }
         ]
       },
@@ -184,7 +223,8 @@
           "yarn-JOBHISTORY-BASE",
           "yarn-RESOURCEMANAGER-BASE",
           "yarn-QUEUEMANAGER_WEBAPP-BASE",
-          "yarn-QUEUEMANAGER_STORE-BASE"
+          "yarn-QUEUEMANAGER_STORE-BASE",
+          "yarn-GATEWAY-BASE"
         ]
       },
       {
@@ -196,7 +236,8 @@
           "hms-GATEWAY-BASE",
           "spark3_on_yarn-GATEWAY-BASE",
           "yarn-NODEMANAGER-WORKER",
-          "zookeeper-SERVER-BASE"
+          "zookeeper-SERVER-BASE",
+          "yarn-GATEWAY-BASE
         ]
       },
       {
@@ -206,7 +247,8 @@
           "hdfs-GATEWAY-BASE",
           "hms-GATEWAY-BASE",
           "spark3_on_yarn-GATEWAY-BASE",
-          "yarn-NODEMANAGER-COMPUTE"
+          "yarn-NODEMANAGER-COMPUTE",
+          "yarn-GATEWAY-BASE
         ]
       }
     ]

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-721.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-721.bp
@@ -224,7 +224,7 @@
           "yarn-RESOURCEMANAGER-BASE",
           "yarn-QUEUEMANAGER_WEBAPP-BASE",
           "yarn-QUEUEMANAGER_STORE-BASE",
-          "yarn-GATEWAY-BASE
+          "yarn-GATEWAY-BASE"
         ]
       },
       {
@@ -237,7 +237,7 @@
           "spark3_on_yarn-GATEWAY-BASE",
           "yarn-NODEMANAGER-WORKER",
           "zookeeper-SERVER-BASE",
-          "yarn-GATEWAY-BASE
+          "yarn-GATEWAY-BASE"
         ]
       },
       {
@@ -248,7 +248,7 @@
           "hms-GATEWAY-BASE",
           "spark3_on_yarn-GATEWAY-BASE",
           "yarn-NODEMANAGER-COMPUTE",
-          "yarn-GATEWAY-BASE
+          "yarn-GATEWAY-BASE"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-721.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-721.bp
@@ -18,6 +18,12 @@
       {
         "refName": "hdfs",
         "serviceType": "HDFS",
+        "serviceConfigs": [
+          {
+            "name": "hdfs_verify_ec_with_topology_enabled",
+            "value": false
+          }
+        ],
         "roleConfigGroups": [
           {
             "refName": "hdfs-NAMENODE-BASE",
@@ -31,6 +37,10 @@
               {
                 "name": "fs_trash_checkpoint_interval",
                 "value": "0"
+              },
+              {
+                "name": "erasure_coding_default_policy",
+                "value": " "
               }
             ]
           },
@@ -57,6 +67,10 @@
               {
                 "name": "dfs_client_use_trash",
                 "value": false
+              },
+              {
+                "name": "hdfs_client_env_safety_valve",
+                "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
               }
             ]
           }
@@ -109,6 +123,25 @@
             "refName": "yarn-JOBHISTORY-BASE",
             "roleType": "JOBHISTORY",
             "base": true
+          },
+          {
+            "refName": "yarn-GATEWAY-BASE",
+            "roleType": "GATEWAY",
+            "base": true,
+            "configs": [
+              {
+                "name": "mapreduce_map_memory_mb",
+                "value": 4096
+              },
+              {
+                "name": "mapreduce_reduce_memory_mb",
+                "value": 4096
+              },
+              {
+                "name": "mapreduce_client_env_safety_valve",
+                "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
+              }
+            ]
           }
         ]
       },
@@ -124,7 +157,13 @@
           {
             "refName": "spark3_on_yarn-GATEWAY-BASE",
             "roleType": "GATEWAY",
-            "base": true
+            "base": true,
+            "configs": [
+              { 
+                "name": "spark3-conf/spark-defaults.conf_client_config_safety_valve",
+                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl"
+              }
+            ]
           }
         ]
       },
@@ -184,7 +223,8 @@
           "yarn-JOBHISTORY-BASE",
           "yarn-RESOURCEMANAGER-BASE",
           "yarn-QUEUEMANAGER_WEBAPP-BASE",
-          "yarn-QUEUEMANAGER_STORE-BASE"
+          "yarn-QUEUEMANAGER_STORE-BASE",
+          "yarn-GATEWAY-BASE
         ]
       },
       {
@@ -196,7 +236,8 @@
           "hms-GATEWAY-BASE",
           "spark3_on_yarn-GATEWAY-BASE",
           "yarn-NODEMANAGER-WORKER",
-          "zookeeper-SERVER-BASE"
+          "zookeeper-SERVER-BASE",
+          "yarn-GATEWAY-BASE
         ]
       },
       {
@@ -206,7 +247,8 @@
           "hdfs-GATEWAY-BASE",
           "hms-GATEWAY-BASE",
           "spark3_on_yarn-GATEWAY-BASE",
-          "yarn-NODEMANAGER-COMPUTE"
+          "yarn-NODEMANAGER-COMPUTE",
+          "yarn-GATEWAY-BASE
         ]
       }
     ]


### PR DESCRIPTION
[DISTX-493](https://jira.cloudera.com/browse/DISTX-493)
1. Disabled erasure encoding
2. Enabled S3AFileSystem to use openssl for hive & spark
3. Removed hive.server2.tez.sessions.per.default.queue=4 from hive safety valve

Testing done:

- I created custom template from DE, DE Spark3 templates with tuned values in mow-dev. And launched clusters couple of times. There were no issues. Noticed changes were applied.
- For openssl related changes verified via async profiler output that openssl & wildfly related are being used.

Closes #DISTX-493