### PR TITLE
CB-7403 better logging around FlowTriggers,Pollers 

### DIFF
--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxRepairRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxRepairRequest.java
@@ -23,4 +23,12 @@ public class SdxRepairRequest {
     public void setHostGroupNames(List<String> hostGroupNames) {
         this.hostGroupNames = hostGroupNames;
     }
+
+    @Override
+    public String toString() {
+        return "SdxRepairRequest{" +
+                "hostGroupName='" + hostGroupName + '\'' +
+                ", hostGroupNames=" + hostGroupNames +
+                '}';
+    }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/entity/SdxCluster.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/entity/SdxCluster.java
@@ -354,5 +354,21 @@ public class SdxCluster implements AccountIdAwareResource {
                 stackRequestToCloudbreak, deleted, created, createDatabase, databaseCrn, cloudStorageBaseLocation, cloudStorageFileSystemType,
                 databaseAvailabilityType, rangerRazEnabled);
     }
+
+    @Override
+    public String toString() {
+        return "SdxCluster{" +
+                "crn='" + crn + '\'' +
+                ", clusterName='" + clusterName + '\'' +
+                ", envName='" + envName + '\'' +
+                ", envCrn='" + envCrn + '\'' +
+                ", runtime='" + runtime + '\'' +
+                ", clusterShape=" + clusterShape +
+                ", createDatabase=" + createDatabase +
+                ", cloudStorageBaseLocation='" + cloudStorageBaseLocation + '\'' +
+                ", rangerRazEnabled=" + rangerRazEnabled +
+                '}';
+    }
+
     //CHECKSTYLE:ON
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxReactorFlowManager.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxReactorFlowManager.java
@@ -1,7 +1,7 @@
 package com.sequenceiq.datalake.flow;
 
-import static com.sequenceiq.datalake.flow.datalake.upgrade.DatalakeUpgradeEvent.DATALAKE_UPGRADE_EVENT;
 import static com.sequenceiq.datalake.flow.create.SdxCreateEvent.RDS_WAIT_EVENT;
+import static com.sequenceiq.datalake.flow.datalake.upgrade.DatalakeUpgradeEvent.DATALAKE_UPGRADE_EVENT;
 import static com.sequenceiq.datalake.flow.delete.SdxDeleteEvent.SDX_DELETE_EVENT;
 import static com.sequenceiq.datalake.flow.repair.SdxRepairEvent.SDX_REPAIR_EVENT;
 import static com.sequenceiq.datalake.flow.start.SdxStartEvent.SDX_START_EVENT;
@@ -13,6 +13,8 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.upgrade.UpgradeOptionV4Response;
@@ -21,6 +23,7 @@ import com.sequenceiq.cloudbreak.common.event.Acceptable;
 import com.sequenceiq.cloudbreak.exception.CloudbreakApiException;
 import com.sequenceiq.cloudbreak.exception.FlowNotAcceptedException;
 import com.sequenceiq.cloudbreak.exception.FlowsAlreadyRunningException;
+import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.flow.datalake.upgrade.event.DatalakeUpgradeStartEvent;
 import com.sequenceiq.datalake.flow.delete.event.SdxDeleteStartEvent;
 import com.sequenceiq.datalake.flow.repair.event.SdxRepairStartEvent;
@@ -43,53 +46,62 @@ public class SdxReactorFlowManager {
 
     private static final long WAIT_FOR_ACCEPT = 10L;
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxReactorFlowManager.class);
+
     @Inject
     private EventBus reactor;
 
     @Inject
     private ErrorHandlerAwareReactorEventFactory eventFactory;
 
-    public FlowIdentifier triggerSdxCreation(Long sdxId) {
+    public FlowIdentifier triggerSdxCreation(SdxCluster cluster) {
+        LOGGER.info("Trigger Datalake creation for: {}", cluster);
         String selector = RDS_WAIT_EVENT.event();
         String userId = ThreadBasedUserCrnProvider.getUserCrn();
-        return notify(selector, new SdxEvent(selector, sdxId, userId));
+        return notify(selector, new SdxEvent(selector, cluster.getId(), userId));
     }
 
-    public FlowIdentifier triggerSdxDeletion(Long sdxId, boolean forced) {
+    public FlowIdentifier triggerSdxDeletion(SdxCluster cluster, boolean forced) {
+        LOGGER.info("Trigger Datalake deletion for: {} forced: ", cluster, forced);
         String selector = SDX_DELETE_EVENT.event();
         String userId = ThreadBasedUserCrnProvider.getUserCrn();
-        return notify(selector, new SdxDeleteStartEvent(selector, sdxId, userId, forced));
+        return notify(selector, new SdxDeleteStartEvent(selector, cluster.getId(), userId, forced));
     }
 
-    public FlowIdentifier triggerSdxRepairFlow(Long sdxId, SdxRepairRequest repairRequest) {
+    public FlowIdentifier triggerSdxRepairFlow(SdxCluster cluster, SdxRepairRequest repairRequest) {
+        LOGGER.info("Trigger Datalake repair for: {} with settings: {}", cluster, repairRequest);
         SdxRepairSettings settings = SdxRepairSettings.from(repairRequest);
         String selector = SDX_REPAIR_EVENT.event();
         String userId = ThreadBasedUserCrnProvider.getUserCrn();
-        return notify(selector, new SdxRepairStartEvent(selector, sdxId, userId, settings));
+        return notify(selector, new SdxRepairStartEvent(selector, cluster.getId(), userId, settings));
     }
 
-    public FlowIdentifier triggerDatalakeOsUpgradeFlow(Long sdxId, UpgradeOptionV4Response upgradeOption) {
+    public FlowIdentifier triggerDatalakeOsUpgradeFlow(SdxCluster cluster, UpgradeOptionV4Response upgradeOption) {
+        LOGGER.info("Trigger Datalake osUpgrade for: {} with settings: {}", cluster, upgradeOption);
         String selector = SDX_UPGRADE_EVENT.event();
         String userId = ThreadBasedUserCrnProvider.getUserCrn();
-        return notify(selector, new SdxUpgradeStartEvent(selector, sdxId, userId, upgradeOption));
+        return notify(selector, new SdxUpgradeStartEvent(selector, cluster.getId(), userId, upgradeOption));
     }
 
-    public FlowIdentifier triggerDatalakeRuntimeUpgradeFlow(Long sdxId, String imageId) {
+    public FlowIdentifier triggerDatalakeRuntimeUpgradeFlow(SdxCluster cluster, String imageId) {
+        LOGGER.info("Trigger Datalake runtimeUpgrade for: {} with imageId: {}", cluster, imageId);
         String selector = DATALAKE_UPGRADE_EVENT.event();
         String userId = ThreadBasedUserCrnProvider.getUserCrn();
-        return notify(selector, new DatalakeUpgradeStartEvent(selector, sdxId, userId, imageId));
+        return notify(selector, new DatalakeUpgradeStartEvent(selector, cluster.getId(), userId, imageId));
     }
 
-    public FlowIdentifier triggerSdxStartFlow(Long sdxId) {
+    public FlowIdentifier triggerSdxStartFlow(SdxCluster cluster) {
+        LOGGER.info("Trigger Datalake start for: {}", cluster);
         String selector = SDX_START_EVENT.event();
         String userId = ThreadBasedUserCrnProvider.getUserCrn();
-        return notify(selector, new SdxStartStartEvent(selector, sdxId, userId));
+        return notify(selector, new SdxStartStartEvent(selector, cluster.getId(), userId));
     }
 
-    public FlowIdentifier triggerSdxStopFlow(Long sdxId) {
+    public FlowIdentifier triggerSdxStopFlow(SdxCluster cluster) {
+        LOGGER.info("Trigger Datalake start for: {}", cluster);
         String selector = SDX_STOP_EVENT.event();
         String userId = ThreadBasedUserCrnProvider.getUserCrn();
-        return notify(selector, new SdxStartStopEvent(selector, sdxId, userId));
+        return notify(selector, new SdxStartStopEvent(selector, cluster.getId(), userId));
     }
 
     private FlowIdentifier notify(String selector, SdxEvent acceptable) {

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/create/handler/EnvWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/create/handler/EnvWaitHandler.java
@@ -54,14 +54,14 @@ public class EnvWaitHandler extends ExceptionCatcherEventHandler<EnvWaitRequest>
             response = new EnvWaitSuccessEvent(datalakeId, userId, detailedEnvironmentResponse);
             setEnvCreatedStatus(datalakeId);
         } catch (UserBreakException userBreakException) {
-            LOGGER.info("Env polling exited before timeout. Cause: ", userBreakException);
+            LOGGER.error("Env polling exited before timeout. Cause: ", userBreakException);
             response = new SdxCreateFailedEvent(datalakeId, userId, userBreakException);
         } catch (PollerStoppedException pollerStoppedException) {
-            LOGGER.info("Env poller stopped for sdx: {}", datalakeId, pollerStoppedException);
+            LOGGER.error("Env poller stopped for sdx: {}", datalakeId, pollerStoppedException);
             response = new SdxCreateFailedEvent(datalakeId, userId,
                     new PollerStoppedException("Env wait timed out after " + DURATION_IN_MINUTES_FOR_ENV_POLLING + " minutes"));
         } catch (PollerException exception) {
-            LOGGER.info("Env polling failed for sdx: {}", datalakeId, exception);
+            LOGGER.error("Env polling failed for sdx: {}", datalakeId, exception);
             response = new SdxCreateFailedEvent(datalakeId, userId, exception);
         } catch (Exception anotherException) {
             LOGGER.error("Something wrong happened in sdx creation wait phase", anotherException);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/create/handler/RdsWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/create/handler/RdsWaitHandler.java
@@ -81,14 +81,14 @@ public class RdsWaitHandler extends ExceptionCatcherEventHandler<RdsWaitRequest>
                 throw notFound("SDX cluster", sdxId).get();
             });
         } catch (UserBreakException userBreakException) {
-            LOGGER.info("Database polling exited before timeout. Cause: ", userBreakException);
+            LOGGER.error("Database polling exited before timeout. Cause: ", userBreakException);
             sendEvent(new SdxCreateFailedEvent(sdxId, userId, userBreakException), event);
         } catch (PollerStoppedException pollerStoppedException) {
-            LOGGER.info("Database poller stopped for sdx: {}", sdxId, pollerStoppedException);
+            LOGGER.error("Database poller stopped for sdx: {}", sdxId, pollerStoppedException);
             sendEvent(new SdxCreateFailedEvent(sdxId, userId,
                     new PollerStoppedException("Database creation timed out after " + DURATION_IN_MINUTES_FOR_DB_POLLING + " minutes")), event);
         } catch (PollerException exception) {
-            LOGGER.info("Database polling failed for sdx: {}", sdxId, exception);
+            LOGGER.error("Database polling failed for sdx: {}", sdxId, exception);
             sendEvent(new SdxCreateFailedEvent(sdxId, userId, exception), event);
         } catch (Exception anotherException) {
             LOGGER.error("Something wrong happened in sdx database creation wait phase", anotherException);
@@ -105,7 +105,7 @@ public class RdsWaitHandler extends ExceptionCatcherEventHandler<RdsWaitRequest>
         if (CloudPlatform.AWS.name().equalsIgnoreCase(env.getCloudPlatform())) {
             if (env.getNetwork().getSubnetMetas().size() < 2) {
                 message = String.format("Cannot create external database for sdx: %s, not enough subnets in the vpc", sdxId);
-                LOGGER.debug(message);
+                LOGGER.error(message);
                 throw new BadRequestException(message);
             }
             Map<String, Long> zones = env.getNetwork().getSubnetMetas().values().stream()
@@ -113,7 +113,7 @@ public class RdsWaitHandler extends ExceptionCatcherEventHandler<RdsWaitRequest>
             if (zones.size() < 2) {
                 message = String.format("Cannot create external database for sdx: %s, vpc subnets must cover at least two different availability zones",
                         sdxId);
-                LOGGER.debug(message);
+                LOGGER.error(message);
                 throw new BadRequestException(message);
             }
         }

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/create/handler/StackCreationHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/create/handler/StackCreationHandler.java
@@ -62,14 +62,14 @@ public class StackCreationHandler extends ExceptionCatcherEventHandler<StackCrea
             setStackCreatedStatus(sdxId);
             response = new StackCreationSuccessEvent(sdxId, userId);
         } catch (UserBreakException userBreakException) {
-            LOGGER.info("Polling exited before timeout for SDX: {}. Cause: ", sdxId, userBreakException);
+            LOGGER.error("Polling exited before timeout for SDX: {}. Cause: ", sdxId, userBreakException);
             response = new SdxCreateFailedEvent(sdxId, userId, userBreakException);
         } catch (PollerStoppedException pollerStoppedException) {
-            LOGGER.info("Poller stopped for SDX: {}", sdxId, pollerStoppedException);
+            LOGGER.error("Poller stopped for SDX: {}", sdxId, pollerStoppedException);
             response = new SdxCreateFailedEvent(sdxId, userId,
                     new PollerStoppedException("Datalake stack creation timed out after " + durationInMinutes + " minutes"));
         } catch (PollerException exception) {
-            LOGGER.info("Polling failed for stack: {}", sdxId, exception);
+            LOGGER.error("Polling failed for stack: {}", sdxId, exception);
             response = new SdxCreateFailedEvent(sdxId, userId, exception);
         } catch (Exception anotherException) {
             LOGGER.error("Something wrong happened in stack creation wait phase", anotherException);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/handler/DatalakeChangeImageWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/handler/DatalakeChangeImageWaitHandler.java
@@ -62,14 +62,14 @@ public class DatalakeChangeImageWaitHandler extends ExceptionCatcherEventHandler
                 response = new DatalakeUpgradeFailedEvent(sdxId, userId, new IllegalStateException(message));
             }
         } catch (UserBreakException userBreakException) {
-            LOGGER.info("Change image polling exited before timeout. Cause: ", userBreakException);
+            LOGGER.error("Change image polling exited before timeout. Cause: ", userBreakException);
             response = new DatalakeUpgradeFailedEvent(sdxId, userId, userBreakException);
         } catch (PollerStoppedException pollerStoppedException) {
-            LOGGER.info("Change image poller stopped for cluster: {}", sdxId);
+            LOGGER.error("Change image poller stopped for cluster: {}", sdxId);
             response = new DatalakeUpgradeFailedEvent(sdxId, userId,
                     new PollerStoppedException("Datalake repair timed out after " + DURATION_IN_MINUTES + " minutes"));
         } catch (PollerException exception) {
-            LOGGER.info("Change image polling failed for cluster: {}", sdxId);
+            LOGGER.error("Change image polling failed for cluster: {}", sdxId);
             response = new DatalakeUpgradeFailedEvent(sdxId, userId, exception);
         }
         sendEvent(response, event);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/handler/DatalakeUpgradeWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/handler/DatalakeUpgradeWaitHandler.java
@@ -53,14 +53,14 @@ public class DatalakeUpgradeWaitHandler extends ExceptionCatcherEventHandler<Dat
             upgradeService.waitCloudbreakFlow(sdxId, pollingConfig, "Stack Upgrade");
             response = new DatalakeImageChangeEvent(sdxId, userId, request.getImageId());
         } catch (UserBreakException userBreakException) {
-            LOGGER.info("Upgrade polling exited before timeout. Cause: ", userBreakException);
+            LOGGER.error("Upgrade polling exited before timeout. Cause: ", userBreakException);
             response = new DatalakeUpgradeFailedEvent(sdxId, userId, userBreakException);
         } catch (PollerStoppedException pollerStoppedException) {
-            LOGGER.info("Upgrade poller stopped for cluster: {}", sdxId);
+            LOGGER.error("Upgrade poller stopped for cluster: {}", sdxId);
             response = new DatalakeUpgradeFailedEvent(sdxId, userId,
                     new PollerStoppedException("Datalake upgrade timed out after " + DURATION_IN_MINUTES + " minutes"));
         } catch (PollerException exception) {
-            LOGGER.info("Upgrade polling failed for cluster: {}", sdxId);
+            LOGGER.error("Upgrade polling failed for cluster: {}", sdxId);
             response = new DatalakeUpgradeFailedEvent(sdxId, userId, exception);
         }
         sendEvent(response, event);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/delete/handler/RdsDeletionHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/delete/handler/RdsDeletionHandler.java
@@ -64,14 +64,14 @@ public class RdsDeletionHandler extends ExceptionCatcherEventHandler<RdsDeletion
             });
             response = new RdsDeletionSuccessEvent(sdxId, userId);
         } catch (UserBreakException userBreakException) {
-            LOGGER.info("Database polling exited before timeout. Cause: ", userBreakException);
+            LOGGER.error("Database polling exited before timeout. Cause: ", userBreakException);
             response = new SdxDeletionFailedEvent(sdxId, userId, userBreakException);
         } catch (PollerStoppedException pollerStoppedException) {
-            LOGGER.info("Database poller stopped for sdx: {}", sdxId, pollerStoppedException);
+            LOGGER.error("Database poller stopped for sdx: {}", sdxId, pollerStoppedException);
             response = new SdxDeletionFailedEvent(sdxId, userId,
                     new PollerStoppedException("Database deletion timed out after " + DURATION_IN_MINUTES_FOR_DB_POLLING + " minutes"));
         } catch (PollerException exception) {
-            LOGGER.info("Database polling failed for sdx: {}", sdxId, exception);
+            LOGGER.error("Database polling failed for sdx: {}", sdxId, exception);
             response = new SdxDeletionFailedEvent(sdxId, userId, exception);
         } catch (Exception anotherException) {
             LOGGER.error("Something wrong happened in sdx database deletion wait phase", anotherException);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/delete/handler/StackDeletionHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/delete/handler/StackDeletionHandler.java
@@ -56,14 +56,14 @@ public class StackDeletionHandler extends ExceptionCatcherEventHandler<StackDele
             provisionerService.waitCloudbreakClusterDeletion(sdxId, pollingConfig);
             response = new StackDeletionSuccessEvent(sdxId, userId, stackDeletionWaitRequest.isForced());
         } catch (UserBreakException userBreakException) {
-            LOGGER.info("Deletion polling exited before timeout. Cause: ", userBreakException);
+            LOGGER.error("Deletion polling exited before timeout. Cause: ", userBreakException);
             response = new SdxDeletionFailedEvent(sdxId, userId, userBreakException);
         } catch (PollerStoppedException pollerStoppedException) {
-            LOGGER.info("Deletion poller stopped for stack: {}", sdxId);
+            LOGGER.error("Deletion poller stopped for stack: {}", sdxId);
             response = new SdxDeletionFailedEvent(sdxId, userId,
                     new PollerStoppedException("Datalake stack deletion timed out after " + durationInMinutes + " minutes"));
         } catch (PollerException exception) {
-            LOGGER.info("Deletion polling failed for stack: {}", sdxId);
+            LOGGER.error("Deletion polling failed for stack: {}", sdxId);
             response = new SdxDeletionFailedEvent(sdxId, userId, exception);
         }
         sendEvent(response, event);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/repair/handler/SdxRepairWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/repair/handler/SdxRepairWaitHandler.java
@@ -53,14 +53,14 @@ public class SdxRepairWaitHandler extends ExceptionCatcherEventHandler<SdxRepair
             repairService.waitCloudbreakClusterRepair(sdxId, pollingConfig);
             response = new SdxRepairSuccessEvent(sdxId, userId);
         } catch (UserBreakException userBreakException) {
-            LOGGER.info("Repair polling exited before timeout. Cause: ", userBreakException);
+            LOGGER.error("Repair polling exited before timeout. Cause: ", userBreakException);
             response = new SdxRepairFailedEvent(sdxId, userId, userBreakException);
         } catch (PollerStoppedException pollerStoppedException) {
-            LOGGER.info("Repair poller stopped for stack: {}", sdxId);
+            LOGGER.error("Repair poller stopped for stack: {}", sdxId);
             response = new SdxRepairFailedEvent(sdxId, userId,
                     new PollerStoppedException("Datalake repair timed out after " + DURATION_IN_MINUTES + " minutes"));
         } catch (PollerException exception) {
-            LOGGER.info("Repair polling failed for stack: {}", sdxId);
+            LOGGER.error("Repair polling failed for stack: {}", sdxId);
             response = new SdxRepairFailedEvent(sdxId, userId, exception);
         }
         sendEvent(response, event);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/start/handler/RdsStartHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/start/handler/RdsStartHandler.java
@@ -1,5 +1,13 @@
 package com.sequenceiq.datalake.flow.start.handler;
 
+import static com.sequenceiq.datalake.service.sdx.database.DatabaseService.DURATION_IN_MINUTES_FOR_DB_POLLING;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
 import com.dyngr.exception.PollerException;
 import com.dyngr.exception.PollerStoppedException;
 import com.dyngr.exception.UserBreakException;
@@ -9,17 +17,10 @@ import com.sequenceiq.datalake.flow.start.event.RdsStartSuccessEvent;
 import com.sequenceiq.datalake.flow.start.event.RdsWaitingToStartRequest;
 import com.sequenceiq.datalake.flow.start.event.SdxStartFailedEvent;
 import com.sequenceiq.datalake.repository.SdxClusterRepository;
+import com.sequenceiq.datalake.service.pause.DatabasePauseSupportService;
 import com.sequenceiq.datalake.service.sdx.database.DatabaseService;
 import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
-import com.sequenceiq.datalake.service.pause.DatabasePauseSupportService;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
-
-import javax.inject.Inject;
-
-import static com.sequenceiq.datalake.service.sdx.database.DatabaseService.DURATION_IN_MINUTES_FOR_DB_POLLING;
 
 @Component
 public class RdsStartHandler extends ExceptionCatcherEventHandler<RdsWaitingToStartRequest> {
@@ -69,14 +70,14 @@ public class RdsStartHandler extends ExceptionCatcherEventHandler<RdsWaitingToSt
             });
             response = new RdsStartSuccessEvent(sdxId, userId);
         } catch (UserBreakException userBreakException) {
-            LOGGER.info("Database polling exited before timeout. Cause: ", userBreakException);
+            LOGGER.error("Database polling exited before timeout. Cause: ", userBreakException);
             response = new SdxStartFailedEvent(sdxId, userId, userBreakException);
         } catch (PollerStoppedException pollerStoppedException) {
-            LOGGER.info("Database poller stopped for sdx: {}", sdxId, pollerStoppedException);
+            LOGGER.error("Database poller stopped for sdx: {}", sdxId, pollerStoppedException);
             response = new SdxStartFailedEvent(sdxId, userId,
                     new PollerStoppedException("Database start timed out after " + DURATION_IN_MINUTES_FOR_DB_POLLING + " minutes"));
         } catch (PollerException exception) {
-            LOGGER.info("Database polling failed for sdx: {}", sdxId, exception);
+            LOGGER.error("Database polling failed for sdx: {}", sdxId, exception);
             response = new SdxStartFailedEvent(sdxId, userId, exception);
         } catch (Exception anotherException) {
             LOGGER.error("Something wrong happened in sdx database start wait phase", anotherException);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/start/handler/SdxStartWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/start/handler/SdxStartWaitHandler.java
@@ -53,14 +53,14 @@ public class SdxStartWaitHandler extends ExceptionCatcherEventHandler<SdxStartWa
             sdxStartService.waitCloudbreakCluster(sdxId, pollingConfig);
             response = new SdxStartSuccessEvent(sdxId, userId);
         } catch (UserBreakException userBreakException) {
-            LOGGER.info("Start polling exited before timeout. Cause: ", userBreakException);
+            LOGGER.error("Start polling exited before timeout. Cause: ", userBreakException);
             response = new SdxStartFailedEvent(sdxId, userId, userBreakException);
         } catch (PollerStoppedException pollerStoppedException) {
-            LOGGER.info("Start poller stopped for stack: {}", sdxId);
+            LOGGER.error("Start poller stopped for stack: {}", sdxId);
             response = new SdxStartFailedEvent(sdxId, userId,
                     new PollerStoppedException("Datalake start timed out after " + DURATION_IN_MINUTES + " minutes"));
         } catch (PollerException exception) {
-            LOGGER.info("Start polling failed for stack: {}", sdxId);
+            LOGGER.error("Start polling failed for stack: {}", sdxId);
             response = new SdxStartFailedEvent(sdxId, userId, exception);
         }
         sendEvent(response, event);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/stop/handler/RdsStopHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/stop/handler/RdsStopHandler.java
@@ -1,5 +1,13 @@
 package com.sequenceiq.datalake.flow.stop.handler;
 
+import static com.sequenceiq.datalake.service.sdx.database.DatabaseService.DURATION_IN_MINUTES_FOR_DB_POLLING;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
 import com.dyngr.exception.PollerException;
 import com.dyngr.exception.PollerStoppedException;
 import com.dyngr.exception.UserBreakException;
@@ -9,17 +17,10 @@ import com.sequenceiq.datalake.flow.stop.event.RdsStopSuccessEvent;
 import com.sequenceiq.datalake.flow.stop.event.RdsWaitingToStopRequest;
 import com.sequenceiq.datalake.flow.stop.event.SdxStopFailedEvent;
 import com.sequenceiq.datalake.repository.SdxClusterRepository;
+import com.sequenceiq.datalake.service.pause.DatabasePauseSupportService;
 import com.sequenceiq.datalake.service.sdx.database.DatabaseService;
 import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
-import com.sequenceiq.datalake.service.pause.DatabasePauseSupportService;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
-
-import javax.inject.Inject;
-
-import static com.sequenceiq.datalake.service.sdx.database.DatabaseService.DURATION_IN_MINUTES_FOR_DB_POLLING;
 
 @Component
 public class RdsStopHandler extends ExceptionCatcherEventHandler<RdsWaitingToStopRequest> {
@@ -69,14 +70,14 @@ public class RdsStopHandler extends ExceptionCatcherEventHandler<RdsWaitingToSto
             });
             response = new RdsStopSuccessEvent(sdxId, userId);
         } catch (UserBreakException userBreakException) {
-            LOGGER.info("Database polling exited before timeout. Cause: ", userBreakException);
+            LOGGER.error("Database polling exited before timeout. Cause: ", userBreakException);
             response = new SdxStopFailedEvent(sdxId, userId, userBreakException);
         } catch (PollerStoppedException pollerStoppedException) {
-            LOGGER.info("Database poller stopped for sdx: {}", sdxId, pollerStoppedException);
+            LOGGER.error("Database poller stopped for sdx: {}", sdxId, pollerStoppedException);
             response = new SdxStopFailedEvent(sdxId, userId,
                     new PollerStoppedException("Database stop timed out after " + DURATION_IN_MINUTES_FOR_DB_POLLING + " minutes"));
         } catch (PollerException exception) {
-            LOGGER.info("Database polling failed for sdx: {}", sdxId, exception);
+            LOGGER.error("Database polling failed for sdx: {}", sdxId, exception);
             response = new SdxStopFailedEvent(sdxId, userId, exception);
         } catch (Exception anotherException) {
             LOGGER.error("Something wrong happened in sdx database stop wait phase", anotherException);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/stop/handler/SdxStopAllDatahubHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/stop/handler/SdxStopAllDatahubHandler.java
@@ -48,14 +48,14 @@ public class SdxStopAllDatahubHandler extends ExceptionCatcherEventHandler<SdxSt
             sdxStopService.stopAllDatahub(sdxId);
             response = new SdxEvent(SdxStopEvent.SDX_STOP_IN_PROGRESS_EVENT.event(), sdxId, userId);
         } catch (UserBreakException userBreakException) {
-            LOGGER.info("Polling exited before timeout. Cause ", userBreakException);
+            LOGGER.error("Polling exited before timeout. Cause ", userBreakException);
             response = new SdxStopFailedEvent(sdxId, userId, userBreakException);
         } catch (PollerStoppedException pollerStoppedException) {
-            LOGGER.info("Poller stopped for stack: " + sdxId, pollerStoppedException);
+            LOGGER.error("Poller stopped for stack: " + sdxId, pollerStoppedException);
             response = new SdxStopFailedEvent(sdxId, userId,
                     new PollerStoppedException("Datalake start timed out after " + DURATION_IN_MINUTES + " minutes", pollerStoppedException));
         } catch (PollerException exception) {
-            LOGGER.info("Polling failed for stack: {}", sdxId);
+            LOGGER.error("Polling failed for stack: {}", sdxId);
             response = new SdxStopFailedEvent(sdxId, userId, exception);
         }
         sendEvent(response, event);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/stop/handler/SdxStopWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/stop/handler/SdxStopWaitHandler.java
@@ -48,14 +48,14 @@ public class SdxStopWaitHandler extends ExceptionCatcherEventHandler<SdxStopWait
             sdxStopService.waitCloudbreakCluster(sdxId, pollingConfig);
             response = new SdxStopSuccessEvent(sdxId, userId);
         } catch (UserBreakException userBreakException) {
-            LOGGER.info("Stop polling exited before timeout. Cause: ", userBreakException);
+            LOGGER.error("Stop polling exited before timeout. Cause: ", userBreakException);
             response = new SdxStopFailedEvent(sdxId, userId, userBreakException);
         } catch (PollerStoppedException pollerStoppedException) {
-            LOGGER.info("Stop poller stopped for stack: {}", sdxId);
+            LOGGER.error("Stop poller stopped for stack: {}", sdxId);
             response = new SdxStopFailedEvent(sdxId, userId,
                     new PollerStoppedException("Datalake stop timed out after " + DURATION_IN_MINUTES + " minutes"));
         } catch (PollerException exception) {
-            LOGGER.info("Stop polling failed for stack: {}", sdxId);
+            LOGGER.error("Stop polling failed for stack: {}", sdxId);
             response = new SdxStopFailedEvent(sdxId, userId, exception);
         }
         sendEvent(response, event);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/sync/handler/SdxSyncHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/sync/handler/SdxSyncHandler.java
@@ -84,14 +84,14 @@ public class SdxSyncHandler extends ExceptionCatcherEventHandler<SdxSyncWaitRequ
             updateSdxStatus(sdxCluster, stackV4Response);
             response = new SdxSyncSuccessEvent(sdxId, userId);
         } catch (UserBreakException userBreakException) {
-            LOGGER.info("Sync polling exited before timeout. Cause: ", userBreakException);
+            LOGGER.error("Sync polling exited before timeout. Cause: ", userBreakException);
             response = new SdxSyncFailedEvent(sdxId, userId, userBreakException);
         } catch (PollerStoppedException pollerStoppedException) {
-            LOGGER.info("Sync poller stopped for stack: {}", sdxId);
+            LOGGER.error("Sync poller stopped for stack: {}", sdxId);
             response = new SdxSyncFailedEvent(sdxId, userId,
                     new PollerStoppedException("Datalake sync timed out after " + DURATION_IN_MINUTES + " minutes"));
         } catch (PollerException exception) {
-            LOGGER.info("Sync polling failed for stack: {}", sdxId);
+            LOGGER.error("Sync polling failed for stack: {}", sdxId);
             response = new SdxSyncFailedEvent(sdxId, userId, exception);
         }
         sendEvent(response, event);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/upgrade/handler/SdxChangeImageWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/upgrade/handler/SdxChangeImageWaitHandler.java
@@ -62,14 +62,14 @@ public class SdxChangeImageWaitHandler extends ExceptionCatcherEventHandler<SdxC
                 response = new SdxUpgradeFailedEvent(sdxId, userId, new IllegalStateException(message));
             }
         } catch (UserBreakException userBreakException) {
-            LOGGER.info("Change image polling exited before timeout. Cause: ", userBreakException);
+            LOGGER.error("Change image polling exited before timeout. Cause: ", userBreakException);
             response = new SdxUpgradeFailedEvent(sdxId, userId, userBreakException);
         } catch (PollerStoppedException pollerStoppedException) {
-            LOGGER.info("Change image poller stopped for cluster: {}", sdxId);
+            LOGGER.error("Change image poller stopped for cluster: {}", sdxId);
             response = new SdxUpgradeFailedEvent(sdxId, userId,
                     new PollerStoppedException("Datalake repair timed out after " + DURATION_IN_MINUTES + " minutes"));
         } catch (PollerException exception) {
-            LOGGER.info("Change image polling failed for cluster: {}", sdxId);
+            LOGGER.error("Change image polling failed for cluster: {}", sdxId);
             response = new SdxUpgradeFailedEvent(sdxId, userId, exception);
         }
         sendEvent(response, event);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/upgrade/handler/SdxUpgradeWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/upgrade/handler/SdxUpgradeWaitHandler.java
@@ -53,14 +53,14 @@ public class SdxUpgradeWaitHandler extends ExceptionCatcherEventHandler<SdxUpgra
             upgradeService.waitCloudbreakFlow(sdxId, pollingConfig, "Upgrade");
             response = new SdxUpgradeSuccessEvent(sdxId, userId);
         } catch (UserBreakException userBreakException) {
-            LOGGER.info("Upgrade polling exited before timeout. Cause: ", userBreakException);
+            LOGGER.error("Upgrade polling exited before timeout. Cause: ", userBreakException);
             response = new SdxUpgradeFailedEvent(sdxId, userId, userBreakException);
         } catch (PollerStoppedException pollerStoppedException) {
-            LOGGER.info("Upgrade poller stopped for cluster: {}", sdxId);
+            LOGGER.error("Upgrade poller stopped for cluster: {}", sdxId);
             response = new SdxUpgradeFailedEvent(sdxId, userId,
                     new PollerStoppedException("Datalake repair timed out after " + DURATION_IN_MINUTES + " minutes"));
         } catch (PollerException exception) {
-            LOGGER.info("Upgrade polling failed for cluster: {}", sdxId);
+            LOGGER.error("Upgrade polling failed for cluster: {}", sdxId);
             response = new SdxUpgradeFailedEvent(sdxId, userId, exception);
         }
         sendEvent(response, event);

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/FreeipaService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/FreeipaService.java
@@ -22,7 +22,7 @@ public class FreeipaService {
         try {
             return freeIpaV1Endpoint.describe(envCrn);
         } catch (NotFoundException e) {
-            LOGGER.info("Could not find freeipa with envCrn: " + envCrn);
+            LOGGER.error("Could not find freeipa with envCrn: " + envCrn, e);
         }
         return null;
     }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/registry/RetryingServiceAddressResolver.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/registry/RetryingServiceAddressResolver.java
@@ -58,7 +58,7 @@ public class RetryingServiceAddressResolver implements ServiceAddressResolver {
                 LOGGER.debug("Unsuccessful address resolving: {}, retrying in {}millis", e.getMessage(), SLEEPTIME);
                 Thread.sleep(SLEEPTIME);
             } catch (InterruptedException ie) {
-                LOGGER.info("Interrupted exception occurred: {}", ie.getMessage());
+                LOGGER.error("Interrupted exception occurred: {}", ie.getMessage());
             }
         }
     }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/ProvisionerService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/ProvisionerService.java
@@ -64,7 +64,7 @@ public class ProvisionerService {
 
     private AttemptResult<StackV4Response> sdxCreationFailed(String statusReason) {
         String errorMessage = "Data Lake creation failed: " + statusReason;
-        LOGGER.info(errorMessage);
+        LOGGER.error(errorMessage);
         return AttemptResults.breakFor(errorMessage);
     }
 
@@ -216,15 +216,15 @@ public class ProvisionerService {
                                 return AttemptResults.finishWith(stackV4Response);
                             } else {
                                 if (Status.CREATE_FAILED.equals(stackV4Response.getStatus())) {
-                                    LOGGER.info("Stack creation failed {}", stackV4Response.getName());
+                                    LOGGER.error("Stack creation failed {}", stackV4Response.getName());
                                     return sdxCreationFailed(stackV4Response.getStatusReason());
                                 } else if (Status.CREATE_FAILED.equals(stackV4Response.getCluster().getStatus())) {
-                                    LOGGER.info("Cluster creation failed {}", stackV4Response.getCluster().getName());
+                                    LOGGER.error("Cluster creation failed {}", stackV4Response.getCluster().getName());
                                     return sdxCreationFailed(stackV4Response.getCluster().getStatusReason());
                                 } else {
                                     String message = sdxStatusService.getShortStatusMessage(stackV4Response);
                                     if (FINISHED.equals(flowState)) {
-                                        LOGGER.warn("Cluster creation flow finished but stack or cluster is not available! {}", message);
+                                        LOGGER.error("Cluster creation flow finished but stack or cluster is not available! {}", message);
                                         return sdxCreationFailed(message);
                                     } else {
                                         LOGGER.info("Cluster creation polling will continue, {}", message);

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxRepairService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxRepairService.java
@@ -69,13 +69,13 @@ public class SdxRepairService {
     public FlowIdentifier triggerRepairByCrn(String userCrn, String clusterCrn, SdxRepairRequest clusterRepairRequest) {
         SdxCluster cluster = sdxService.getByCrn(userCrn, clusterCrn);
         MDCBuilder.buildMdcContext(cluster);
-        return sdxReactorFlowManager.triggerSdxRepairFlow(cluster.getId(), clusterRepairRequest);
+        return sdxReactorFlowManager.triggerSdxRepairFlow(cluster, clusterRepairRequest);
     }
 
     public FlowIdentifier triggerRepairByName(String userCrn, String clusterName, SdxRepairRequest clusterRepairRequest) {
         SdxCluster cluster = sdxService.getSdxByNameInAccount(userCrn, clusterName);
         MDCBuilder.buildMdcContext(cluster);
-        return sdxReactorFlowManager.triggerSdxRepairFlow(cluster.getId(), clusterRepairRequest);
+        return sdxReactorFlowManager.triggerSdxRepairFlow(cluster, clusterRepairRequest);
     }
 
     public void startSdxRepair(Long id, SdxRepairSettings repairRequest) {

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -235,8 +235,7 @@ public class SdxService implements ResourceIdProvider, ResourceBasedCrnProvider 
             throw new TransactionRuntimeExecutionException(e);
         }
 
-        LOGGER.info("trigger SDX creation: {}", savedSdxCluster);
-        FlowIdentifier flowIdentifier = sdxReactorFlowManager.triggerSdxCreation(savedSdxCluster.getId());
+        FlowIdentifier flowIdentifier = sdxReactorFlowManager.triggerSdxCreation(savedSdxCluster);
 
         return Pair.of(savedSdxCluster, flowIdentifier);
     }
@@ -541,9 +540,8 @@ public class SdxService implements ResourceIdProvider, ResourceBasedCrnProvider 
         MDCBuilder.buildMdcContext(sdxCluster);
         sdxClusterRepository.save(sdxCluster);
         sdxStatusService.setStatusForDatalakeAndNotify(DatalakeStatusEnum.DELETE_REQUESTED, "Datalake deletion requested", sdxCluster);
-        FlowIdentifier flowIdentifier = sdxReactorFlowManager.triggerSdxDeletion(sdxCluster.getId(), forced);
+        FlowIdentifier flowIdentifier = sdxReactorFlowManager.triggerSdxDeletion(sdxCluster, forced);
         flowCancelService.cancelRunningFlows(sdxCluster.getId());
-        LOGGER.info("SDX delete triggered: {}", sdxCluster.getClusterName());
         return flowIdentifier;
     }
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxUpgradeService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxUpgradeService.java
@@ -95,7 +95,7 @@ public class SdxUpgradeService {
 
     private SdxUpgradeResponse triggerUpgrade(UpgradeOptionV4Response upgradeOption, SdxCluster cluster) {
         MDCBuilder.buildMdcContext(cluster);
-        FlowIdentifier flowIdentifier = sdxReactorFlowManager.triggerDatalakeOsUpgradeFlow(cluster.getId(), upgradeOption);
+        FlowIdentifier flowIdentifier = sdxReactorFlowManager.triggerDatalakeOsUpgradeFlow(cluster, upgradeOption);
         String imageId = upgradeOption.getUpgrade().getImageId();
         String message = getMessage(imageId);
         return new SdxUpgradeResponse(message, flowIdentifier);

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/start/SdxStartService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/start/SdxStartService.java
@@ -69,7 +69,7 @@ public class SdxStartService {
     public FlowIdentifier triggerStartIfClusterNotRunning(SdxCluster cluster) {
         MDCBuilder.buildMdcContext(cluster);
         checkFreeipaRunning(cluster.getEnvCrn());
-        return sdxReactorFlowManager.triggerSdxStartFlow(cluster.getId());
+        return sdxReactorFlowManager.triggerSdxStartFlow(cluster);
     }
 
     public void start(Long sdxId) {

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/stop/SdxStopService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/stop/SdxStopService.java
@@ -73,7 +73,7 @@ public class SdxStopService {
     public FlowIdentifier triggerStopIfClusterNotStopped(SdxCluster cluster) {
         MDCBuilder.buildMdcContext(cluster);
         checkFreeipaRunning(cluster.getEnvCrn());
-        return sdxReactorFlowManager.triggerSdxStopFlow(cluster.getId());
+        return sdxReactorFlowManager.triggerSdxStopFlow(cluster);
     }
 
     public void stop(Long sdxId) {
@@ -84,14 +84,14 @@ public class SdxStopService {
             sdxStatusService.setStatusForDatalakeAndNotify(DatalakeStatusEnum.STOP_IN_PROGRESS, "Datalake stop in progress", sdxCluster);
             cloudbreakFlowService.saveLastCloudbreakFlowChainId(sdxCluster, flowIdentifier);
         } catch (NotFoundException e) {
-            LOGGER.info("Can not find stack on cloudbreak side {}", sdxCluster.getClusterName());
+            LOGGER.error("Can not find stack on cloudbreak side {}", sdxCluster.getClusterName());
         } catch (ClientErrorException e) {
             String errorMessage = webApplicationExceptionMessageExtractor.getErrorMessage(e);
-            LOGGER.info("Can not stop stack {} from cloudbreak: {}", sdxCluster.getStackId(), errorMessage, e);
+            LOGGER.error("Can not stop stack {} from cloudbreak: {}", sdxCluster.getStackId(), errorMessage, e);
             throw new RuntimeException("Can not stop stack, client error happened on Cloudbreak side: " + errorMessage);
         } catch (WebApplicationException e) {
             String errorMessage = webApplicationExceptionMessageExtractor.getErrorMessage(e);
-            LOGGER.info("Can not stop stack {} from cloudbreak: {}", sdxCluster.getStackId(), errorMessage, e);
+            LOGGER.error("Can not stop stack {} from cloudbreak: {}", sdxCluster.getStackId(), errorMessage, e);
             throw new RuntimeException("Can not stop stack, web application error happened on Cloudbreak side: " + errorMessage);
         }
     }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/SdxRuntimeUpgradeService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/SdxRuntimeUpgradeService.java
@@ -100,7 +100,7 @@ public class SdxRuntimeUpgradeService {
 
     private FlowIdentifier triggerDatalakeUpgradeFlow(String imageId, SdxCluster cluster) {
         MDCBuilder.buildMdcContext(cluster);
-        return sdxReactorFlowManager.triggerDatalakeRuntimeUpgradeFlow(cluster.getId(), imageId);
+        return sdxReactorFlowManager.triggerDatalakeRuntimeUpgradeFlow(cluster, imageId);
     }
 
     private String getMessage(String imageId) {

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxServiceTest.java
@@ -10,7 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
@@ -49,8 +48,8 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.InstanceGroupV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Response;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
-import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.common.service.Clock;
@@ -255,7 +254,7 @@ class SdxServiceTest {
         assertEquals("0.0.0.0/0", gateway.getSecurityGroup().getSecurityRules().get(1).getSubnet());
         assertEquals("22", gateway.getSecurityGroup().getSecurityRules().get(1).getPorts().get(0));
 
-        verify(sdxReactorFlowManager).triggerSdxCreation(id);
+        verify(sdxReactorFlowManager).triggerSdxCreation(createdSdxCluster);
     }
 
     @Test
@@ -446,10 +445,10 @@ class SdxServiceTest {
     void testDeleteSdxWhenNameIsProvidedShouldInitiateSdxDeletionFlow() {
         SdxCluster sdxCluster = getSdxClusterForDeletionTest();
         when(sdxClusterRepository.findByAccountIdAndClusterNameAndDeletedIsNull(anyString(), anyString())).thenReturn(Optional.of(sdxCluster));
-        when(sdxReactorFlowManager.triggerSdxDeletion(anyLong(), anyBoolean())).thenReturn(new FlowIdentifier(FlowType.FLOW, "FLOW_ID"));
+        when(sdxReactorFlowManager.triggerSdxDeletion(any(SdxCluster.class), anyBoolean())).thenReturn(new FlowIdentifier(FlowType.FLOW, "FLOW_ID"));
         mockCBCallForDistroXClusters(Sets.newHashSet());
         underTest.deleteSdx(USER_CRN, "sdx-cluster-name", true);
-        verify(sdxReactorFlowManager, times(1)).triggerSdxDeletion(SDX_ID, true);
+        verify(sdxReactorFlowManager, times(1)).triggerSdxDeletion(sdxCluster, true);
         final ArgumentCaptor<SdxCluster> captor = ArgumentCaptor.forClass(SdxCluster.class);
         verify(sdxClusterRepository, times(1)).save(captor.capture());
         verify(sdxStatusService, times(1))

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/start/SdxStartServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/start/SdxStartServiceTest.java
@@ -89,7 +89,7 @@ public class SdxStartServiceTest {
 
         underTest.triggerStartIfClusterNotRunning(sdxCluster);
 
-        verify(sdxReactorFlowManager).triggerSdxStartFlow(CLUSTER_ID);
+        verify(sdxReactorFlowManager).triggerSdxStartFlow(sdxCluster);
     }
 
     @Test
@@ -98,7 +98,7 @@ public class SdxStartServiceTest {
 
         underTest.triggerStartIfClusterNotRunning(sdxCluster);
 
-        verify(sdxReactorFlowManager).triggerSdxStartFlow(CLUSTER_ID);
+        verify(sdxReactorFlowManager).triggerSdxStartFlow(sdxCluster);
     }
 
     @Test

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/stop/SdxStopServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/stop/SdxStopServiceTest.java
@@ -86,7 +86,7 @@ public class SdxStopServiceTest {
 
         underTest.triggerStopIfClusterNotStopped(sdxCluster);
 
-        verify(sdxReactorFlowManager).triggerSdxStopFlow(CLUSTER_ID);
+        verify(sdxReactorFlowManager).triggerSdxStopFlow(sdxCluster);
     }
 
     @Test

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/upgrade/SdxRuntimeUpgradeServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/upgrade/SdxRuntimeUpgradeServiceTest.java
@@ -198,8 +198,8 @@ public class SdxRuntimeUpgradeServiceTest {
 
         underTest.triggerRuntimeUpgradeByCrn(USER_CRN, STACK_CRN, sdxUpgradeRequest);
 
-        verify(sdxReactorFlowManager, times(1)).triggerDatalakeRuntimeUpgradeFlow(1L, IMAGE_ID_LAST);
-        verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(1L, IMAGE_ID);
+        verify(sdxReactorFlowManager, times(1)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID_LAST);
+        verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID);
     }
 
     @Test
@@ -222,8 +222,8 @@ public class SdxRuntimeUpgradeServiceTest {
 
         underTest.triggerRuntimeUpgradeByCrn(USER_CRN, STACK_CRN, null);
 
-        verify(sdxReactorFlowManager, times(1)).triggerDatalakeRuntimeUpgradeFlow(1L, IMAGE_ID_LAST);
-        verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(1L, IMAGE_ID);
+        verify(sdxReactorFlowManager, times(1)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID_LAST);
+        verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID);
     }
 
     @Test
@@ -249,8 +249,8 @@ public class SdxRuntimeUpgradeServiceTest {
 
         underTest.triggerRuntimeUpgradeByCrn(USER_CRN, STACK_CRN, null);
 
-        verify(sdxReactorFlowManager, times(1)).triggerDatalakeRuntimeUpgradeFlow(1L, IMAGE_ID_LAST);
-        verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(1L, IMAGE_ID);
+        verify(sdxReactorFlowManager, times(1)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID_LAST);
+        verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID);
     }
 
     @Test


### PR DESCRIPTION
+ Cluster details and overall log levels

I'm not sure why we always logged on INFO level once a poller exited abruptly.

Maybe @sodre90 knows?