### PR TITLE
Workaround for CDPD-13636

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-720.bp
@@ -213,7 +213,7 @@
           },
           {
             "name": "hive_service_config_safety_valve",
-            "value": "<property><name>hive.server2.tez.sessions.per.default.queue</name><value>4</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property>"
+            "value": "<property><name>hive.server2.tez.sessions.per.default.queue</name><value>4</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property><property><name>hive.optimize.sort.dynamic.partition.threshold</name><value>0</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-720.bp
@@ -99,7 +99,7 @@
           },
           {
             "name": "hive_service_config_safety_valve",
-            "value": "<property><name>hive.server2.tez.sessions.per.default.queue</name><value>4</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property>"
+            "value": "<property><name>hive.server2.tez.sessions.per.default.queue</name><value>4</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property><property><name>hive.optimize.sort.dynamic.partition.threshold</name><value>0</value></property>"
           }
         ],
         "roleConfigGroups": [


### PR DESCRIPTION
Set hive.optimize.sort.dynamic.partition.threshold=0 as a workaround JIRA [CDPD-13636](https://jira.cloudera.com/browse/CDPD-13636)

For now this needs to be merged for CB 2.20 only.

Testing done:
I created custom template from DE & DE HA templates with tuned values in mow-dev. And launched clusters couple of times. There were no issues. Noticed changes were applied.