### PR TITLE
CB-7506: Update example logging IAM policy to block FreeIPA backup access

### DIFF
--- a/cloud-aws/src/main/resources/definitions/cdp/aws-cdp-log-policy.json
+++ b/cloud-aws/src/main/resources/definitions/cdp/aws-cdp-log-policy.json
@@ -17,6 +17,14 @@
         "s3:PutObject"
       ],
       "Resource": "arn:aws:s3:::${LOGS_LOCATION_BASE}/*"
+    },
+    {
+      "Effect": "Deny",
+      "Action": "s3:GetObject",
+      "Resource": [
+        "arn:aws:s3:::${LOGS_LOCATION_BASE}/cluster-backups",
+        "arn:aws:s3:::${LOGS_LOCATION_BASE}/cluster-backups/*"
+      ]
     }
   ]
 }


### PR DESCRIPTION
This changes the example logging policy so that the FreeIPA backups can
not be read.  It only allows writing to that location.

Closes #CB-7506