### PR TITLE
CB-7479: Update the service name for DEX

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/auth/altus/Crn.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/auth/altus/Crn.java
@@ -159,7 +159,12 @@ public class Crn {
         FREEIPA("freeipa", NON_ADMIN_SERVICE),
         DATAHUB("datahub", NON_ADMIN_SERVICE),
         DATALAKE("datalake", NON_ADMIN_SERVICE),
+        /**
+         * @deprecated {@link #DEX} was replaced by {@link #DE} and is kept here for backward compatibility.
+         */
+        @Deprecated
         DEX("dex", NON_ADMIN_SERVICE),
+        DE("de", NON_ADMIN_SERVICE),
         ACCOUNTTAG("accounttag", NON_ADMIN_SERVICE),
         ACCOUNTTELEMETRY("accounttelemetry", NON_ADMIN_SERVICE),
         ML("ml", NON_ADMIN_SERVICE);


### PR DESCRIPTION
Update the CRN service name for DEX to match with the thunderhead
service name (defined in Crn.java in the thunderhead repo).

Refer: https://github.infra.cloudera.com/thunderhead/thunderhead/blob/master/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java
