### PR TITLE
DISTX-421 Separate endpoint for autoscale recommendation

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/autoscales/AutoscaleV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/autoscales/AutoscaleV4Endpoint.java
@@ -118,4 +118,10 @@ public interface AutoscaleV4Endpoint {
     @Path("/stack/crn/{crn}/recommendation")
     @Produces(MediaType.APPLICATION_JSON)
     AutoscaleRecommendationV4Response getRecommendation(@PathParam("crn") String clusterCrn);
+
+    @GET
+    @Path("recommendation")
+    @Produces(MediaType.APPLICATION_JSON)
+    AutoscaleRecommendationV4Response getRecommendation(@QueryParam("workspaceId") @Valid Long workspaceId,
+                                                        @QueryParam("blueprintName") @NotEmpty String blueprintName);
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/AutoscaleV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/AutoscaleV4Controller.java
@@ -176,4 +176,12 @@ public class AutoscaleV4Controller implements AutoscaleV4Endpoint {
 
         return converterUtil.convert(autoscaleRecommendation, AutoscaleRecommendationV4Response.class);
     }
+
+    @Override
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.DATAHUB_READ)
+    public AutoscaleRecommendationV4Response getRecommendation(Long workspaceId, String blueprintName) {
+        AutoscaleRecommendation autoscaleRecommendation = blueprintService.getAutoscaleRecommendation(workspaceId, blueprintName);
+
+        return converterUtil.convert(autoscaleRecommendation, AutoscaleRecommendationV4Response.class);
+    }
 }


### PR DESCRIPTION
1. Autoscale needs a recommendation endpoint for UI.
2. This API is similar to the one exposed recently for the periscope, so no further testing is done.