### PR TITLE
CB-7514 [opdb] Add Hue in the opdb blueprint 7.2.1

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-opdb-721.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-opdb-721.bp
@@ -155,7 +155,14 @@
               }
             ],
             "base": true
-          }
+          },
+          {
+              "refName": "hbase-HBASETHRIFTSERVER-BASE",
+              "roleType": "HBASETHRIFTSERVER",
+              "displayName": null,
+              "configs": [],
+              "base": true
+           }
         ]
       },
       {
@@ -215,6 +222,37 @@
             "base": true
           }
         ]
+      },
+      {
+        "refName": "hue",
+        "serviceType": "HUE",
+        "serviceConfigs": [
+          {
+            "name": "hue_service_safety_valve",
+            "value": "[desktop]\napp_blacklist=impala,security,filebrowser,rdbms,jobsub,pig,sqoop,zookeeper,metastore,spark,oozie,indexer,hive,documents,indexes,search",
+            "ref": null,
+            "variable": null,
+            "autoConfig": false
+          }
+        ],
+        "roleConfigGroups": [
+          {
+            "refName": "hue-HUE_SERVER-BASE",
+            "roleType": "HUE_SERVER",
+            "displayName": null,
+            "configs": [],
+            "base": true
+          },
+          {
+            "refName": "hue-HUE_LOAD_BALANCER-BASE",
+            "roleType": "HUE_LOAD_BALANCER",
+            "displayName": null,
+            "configs": [],
+            "base": true
+          }
+        ],
+        "displayName": null,
+        "roles": []
       }
     ],
     "hostTemplates": [
@@ -225,7 +263,9 @@
           "hbase-GATEWAY-BASE",
           "hdfs-GATEWAY-BASE",
           "knox-KNOX-GATEWAY-BASE",
-          "yarn-GATEWAY-BASE"
+          "yarn-GATEWAY-BASE",
+          "hue-HUE_SERVER-BASE",
+          "hue-HUE_LOAD_BALANCER-BASE"
         ]
       },
       {
@@ -247,6 +287,7 @@
         "cardinality": 1,
         "roleConfigGroupsRefNames": [
           "hbase-GATEWAY-BASE",
+          "hbase-HBASETHRIFTSERVER-BASE",
           "hdfs-GATEWAY-BASE",
           "hdfs-JOURNALNODE-BASE",
           "yarn-JOBHISTORY-BASE",


### PR DESCRIPTION
CB-7343 was used to track addition of Hue to 7.2.0 blueprint. This change applies the same addition to 7.2.1 blueprint.

Testing: Created cluster from custom blueprint and verified that Hue turns up.
Tried CRUD operations on a sample table from the Hue UI.