### PR TITLE
CB-4925 - Setting auth.mock.freeipadlebsencryption.enable=false by default

### DIFF
--- a/mock-caas/src/main/resources/application.yml
+++ b/mock-caas/src/main/resources/application.yml
@@ -18,4 +18,4 @@ auth:
     runtime.upgrade.enable: true
     sshpublickey.file: key.pub
     raz.enable: true
-    freeipadlebsencryption.enable: true
+    freeipadlebsencryption.enable: false


### PR DESCRIPTION
It's a possible trap for all developers who just want to setup an environment. For most devs encryption is not needed and they won't even know that it's enabled and slowing their work down. Who needs encryption, already knows this feature exists and can set the value to true in their dev env.