### PR TITLE
CB-7534: Fix downscale when deleting host without a hostname

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/handler/RemoveHostsHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/handler/RemoveHostsHandler.java
@@ -67,19 +67,21 @@ public class RemoveHostsHandler implements EventHandler<RemoveHostsFromOrchestra
         Set<String> hostNames = request.getHosts();
         Selectable result;
         try {
-            Stack stack = stackService.getByIdWithListsInTransaction(request.getResourceId());
-            PollingResult orchestratorRemovalPollingResult =
-                    removeHostsFromOrchestrator(stack, new ArrayList<>(hostNames));
-            if (!PollingResult.isSuccess(orchestratorRemovalPollingResult)) {
-                LOGGER.warn("Can not remove hosts from orchestrator: {}", hostNames);
+            if (!hostNames.isEmpty()) {
+                Stack stack = stackService.getByIdWithListsInTransaction(request.getResourceId());
+                PollingResult orchestratorRemovalPollingResult =
+                        removeHostsFromOrchestrator(stack, new ArrayList<>(hostNames));
+                if (!PollingResult.isSuccess(orchestratorRemovalPollingResult)) {
+                    LOGGER.warn("Can not remove hosts from orchestrator: {}", hostNames);
+                }
+                // rebootstrap to update the minion's multi-master configuration
+                List<String> remainingInstanceIds = stack.getNotDeletedInstanceMetaDataList().stream()
+                        .filter(metadata -> Objects.nonNull(metadata.getDiscoveryFQDN()))
+                        .filter(metadata -> !hostNames.contains(metadata.getDiscoveryFQDN()))
+                        .map(InstanceMetaData::getInstanceId)
+                        .collect(Collectors.toList());
+                bootstrapService.bootstrap(stack.getId(), remainingInstanceIds);
             }
-            // rebootstrap to update the minion's multi-master configuration
-            List<String> remainingInstanceIds = stack.getNotDeletedInstanceMetaDataList().stream()
-                    .filter(metadata -> Objects.nonNull(metadata.getDiscoveryFQDN()))
-                    .filter(metadata -> !hostNames.contains(metadata.getDiscoveryFQDN()))
-                    .map(InstanceMetaData::getInstanceId)
-                    .collect(Collectors.toList());
-            bootstrapService.bootstrap(stack.getId(), remainingInstanceIds);
             result = new RemoveHostsFromOrchestrationSuccess(request.getResourceId());
         } catch (Exception e) {
             LOGGER.error("Failed to remove hosts from orchestration", e);

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/freeipa/downscale/handler/RemoveHostsHandlerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/freeipa/downscale/handler/RemoveHostsHandlerTest.java
@@ -90,4 +90,13 @@ class RemoveHostsHandlerTest {
         verify(eventBus, times(1)).notify(eq("DOWNSCALEFAILUREEVENT"), ArgumentMatchers.<Event>any());
     }
 
+    @Test
+    void testSendsSuccessMessageWhenNoHostnamesAreProvided() throws Exception {
+        CleanupEvent cleanupEvent =
+                new CleanupEvent(STACK_ID, USERS, Set.of(), ROLES, IPS, STATES_TO_SKIP, ACCOUNT_ID, OPERATION_ID, CLUSTER_NAME, ENVIRONMENT_CRN);
+        RemoveHostsFromOrchestrationRequest request = new RemoveHostsFromOrchestrationRequest(cleanupEvent);
+        underTest.accept(new Event<>(request));
+        verify(eventBus, times(1)).notify(eq("REMOVEHOSTSFROMORCHESTRATIONSUCCESS"), ArgumentMatchers.<Event>any());
+    }
+
 }


### PR DESCRIPTION
When an upscale operation fails before the hostname is collected, the
subsequent repair operation used to fail because the hostnames to
remove from the orchestrater was empty. This was fixed.

A unit test was added and it was tested manually on a local deployment
of cloudbreak.

Closes #CB-7534