### PR TITLE
CB-7556. Anonyimize freeipa pwd by default (Dbus->Kibana)

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/telemetry/service/AccountTelemetryService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/telemetry/service/AccountTelemetryService.java
@@ -42,6 +42,10 @@ public class AccountTelemetryService {
 
     private static final String SSN_REPLACEMENT = "XXX-XX-XXXX";
 
+    private static final String FREEIPA_PWD_PATTERN = "FPW\\:\\s+[\\w|\\W].*";
+
+    private static final String FREEIPA_PWD_REPLACEMENT = "FPW: [REDACTED]";
+
     private final AccountTelemetryRepository accountTelemetryRepository;
 
     public AccountTelemetryService(AccountTelemetryRepository accountTelemetryRepository) {
@@ -129,9 +133,15 @@ public class AccountTelemetryService {
                 Base64.getEncoder().encodeToString(EMAIL_PATTERN.getBytes()));
         emailRule.setReplacement(EMAIL_REPLACEMENT);
 
+        AnonymizationRule freeIpaPwdRule = new AnonymizationRule();
+        freeIpaPwdRule.setValue(
+                Base64.getEncoder().encodeToString(FREEIPA_PWD_PATTERN.getBytes()));
+        freeIpaPwdRule.setReplacement(FREEIPA_PWD_REPLACEMENT);
+
         defaultRules.add(creditCardWithSepRule);
         defaultRules.add(ssnWithSepRule);
         defaultRules.add(emailRule);
+        defaultRules.add(freeIpaPwdRule);
 
         Features defaultFeatures = new Features();
         defaultFeatures.addClusterLogsCollection(false);

--- a/environment/src/test/java/com/sequenceiq/environment/telemetry/service/AccountTelemetryServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/telemetry/service/AccountTelemetryServiceTest.java
@@ -144,6 +144,7 @@ public class AccountTelemetryServiceTest {
             testPatternWithOutput(rule, "str myemail@email.com", "email");
             testPatternWithOutput(rule, "333-44-2222", "XXX-");
             testPatternWithOutput(rule, "card number: 1111-2222-3333-4444", "XXXX-");
+            testPatternWithOutput(rule, "- FPW: secret", "FPW");
         }
         assertThat(result.getFeatures().getClusterLogsCollection().isEnabled()).isEqualTo(false);
     }


### PR DESCRIPTION
seems like we should not log freeipa pwd in e2e test clusters (which appears in salt minion log) so adding a default anonymization rule for that

on long term, maybe we should create a static json that contains the default rules that is read at CB startup