### PR TITLE
CB-7365 Extract magic string literals in AwsInstanceView

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/InstanceTemplate.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/InstanceTemplate.java
@@ -7,8 +7,42 @@ import java.util.Objects;
 
 import com.google.common.collect.ImmutableList;
 import com.sequenceiq.cloudbreak.cloud.model.generic.DynamicModel;
+import com.sequenceiq.common.api.type.EncryptionType;
 
 public class InstanceTemplate extends DynamicModel {
+
+    /**
+     * Key of the optional dynamic parameter denoting the type of encryption key to use for disk volume encryption. The exact interpretation of this setting
+     * is up to the target cloud provider.
+     *
+     * <p>
+     *     Permitted values are the names of enum constants in {@link EncryptionType}:
+     *     <ul>
+     *         <li>{@code "NONE"}, {@code null}: No encryption key. This setting essentially disables volume encryption.</li>
+     *         <li>{@code "DEFAULT"}: Use the default key. This is typically a cloud provider managed encryption key, but can also mean some customer-managed
+     *         key designated as the "default" in a cloud provider specific way.</li>
+     *         <li>{@code "CUSTOM"}: Use the customer-managed encryption key specified in {@link #VOLUME_ENCRYPTION_KEY_ID}.</li>
+     *     </ul>
+     * </p>
+     *
+     * @see #VOLUME_ENCRYPTION_KEY_ID
+     * @see #putParameter(String, Object)
+     * @see EncryptionType
+     */
+    public static final String VOLUME_ENCRYPTION_KEY_TYPE = "type";
+
+    /**
+     * Key of the dynamic parameter denoting the ID of the customer-managed encryption key to be used for disk volume encryption. Relevant and required only
+     * when {@link #VOLUME_ENCRYPTION_KEY_TYPE} equals {@code "CUSTOM"}. Its value will be ignored otherwise.
+     *
+     * <p>
+     *     When set, the value shall be a {@link String} containing the ID of the customer-managed encryption key in a cloud provider specific syntax.
+     * </p>
+     *
+     * @see #VOLUME_ENCRYPTION_KEY_TYPE
+     * @see #putParameter(String, Object)
+     */
+    public static final String VOLUME_ENCRYPTION_KEY_ID = "key";
 
     private final String flavor;
 

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/instance/AwsInstanceTemplate.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/instance/AwsInstanceTemplate.java
@@ -1,0 +1,51 @@
+package com.sequenceiq.cloudbreak.cloud.model.instance;
+
+import java.util.Collection;
+import java.util.Map;
+
+import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
+import com.sequenceiq.cloudbreak.cloud.model.Volume;
+
+public class AwsInstanceTemplate extends InstanceTemplate {
+
+    /**
+     * Key of the optional dynamic parameter denoting whether EBS encryption is enabled or not. This applies to both root & attached (data) volumes.
+     *
+     * <p>
+     *     Permitted values:
+     *     <ul>
+     *         <li>{@code Boolean.TRUE} instance, {@code "true"} (ignoring case): Encryption is enabled.</li>
+     *         <li>{@code Boolean.FALSE} instance, {@code "false"} (or any other {@code String} not equal to {@code "true"} ignoring case), {@code null}:
+     *         Encryption is disabled.</li>
+     *     </ul>
+     * </p>
+     *
+     * @see #putParameter(String, Object)
+     * @see Boolean#parseBoolean(String)
+     */
+    public static final String EBS_ENCRYPTION_ENABLED = "encrypted";
+
+    /**
+     * Key of the optional dynamic parameter denoting the percentage of EC2 instances to be allocated to spot instances. The remaining fraction of the total
+     * amount of EC2 instances will be running on on-demand instances.
+     *
+     * <p>
+     *     Permitted values:
+     *     <ul>
+     *         <li>{@code null}: Equivalent with a setting of 0 (i.e. 100% allocation to on-demand instances).</li>
+     *         <li>An {@link Integer} {@code i} in the range [0, 100], both inclusive: {@code i}% allocation to spot instances, (100 - {@code i})% allocation
+     *         to on-demand instances.</li>
+     *     </ul>
+     * </p>
+     *
+     * @see #putParameter(String, Object)
+     */
+    public static final String EC2_SPOT_PERCENTAGE = "spotPercentage";
+
+    public AwsInstanceTemplate(String flavor, String groupName, Long privateId, Collection<Volume> volumes, InstanceStatus status,
+            Map<String, Object> parameters, Long templateId, String imageId) {
+        super(flavor, groupName, privateId, volumes, status, parameters, templateId, imageId);
+    }
+
+}

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsInstanceView.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsInstanceView.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.Volume;
+import com.sequenceiq.cloudbreak.cloud.model.instance.AwsInstanceTemplate;
 import com.sequenceiq.common.api.type.EncryptionType;
 
 public class AwsInstanceView {
@@ -38,7 +39,7 @@ public class AwsInstanceView {
     }
 
     public boolean isEncryptedVolumes() {
-        Object ev = instanceTemplate.getParameter("encrypted", Object.class);
+        Object ev = instanceTemplate.getParameter(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, Object.class);
         if (ev instanceof Boolean) {
             return (Boolean) ev;
         } else if (ev instanceof String) {
@@ -48,7 +49,7 @@ public class AwsInstanceView {
     }
 
     public boolean isKmsEnabled() {
-        String type = instanceTemplate.getStringParameter("type");
+        String type = instanceTemplate.getStringParameter(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE);
         if (type != null) {
             EncryptionType ev = EncryptionType.valueOf(type);
             return ev != EncryptionType.NONE;
@@ -65,7 +66,7 @@ public class AwsInstanceView {
     }
 
     private boolean isTypeEqualsWith(EncryptionType encryptionType) {
-        String type = instanceTemplate.getStringParameter("type");
+        String type = instanceTemplate.getStringParameter(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE);
         if (type != null) {
             EncryptionType ev = EncryptionType.valueOf(type);
             return ev == encryptionType;
@@ -74,11 +75,11 @@ public class AwsInstanceView {
     }
 
     public String getKmsKey() {
-        return instanceTemplate.getStringParameter("key");
+        return instanceTemplate.getStringParameter(InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID);
     }
 
     public Integer getSpotPercentage() {
-        return instanceTemplate.getParameter("spotPercentage", Integer.class);
+        return instanceTemplate.getParameter(AwsInstanceTemplate.EC2_SPOT_PERCENTAGE, Integer.class);
     }
 
     public int getOnDemandPercentage() {

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilderTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilderTest.java
@@ -56,6 +56,7 @@ import com.sequenceiq.cloudbreak.cloud.model.Subnet;
 import com.sequenceiq.cloudbreak.cloud.model.Volume;
 import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudFileSystemView;
 import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudS3View;
+import com.sequenceiq.cloudbreak.cloud.model.instance.AwsInstanceTemplate;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 import com.sequenceiq.cloudbreak.tag.CostTagging;
 import com.sequenceiq.cloudbreak.util.FreeMarkerTemplateUtils;
@@ -814,7 +815,7 @@ public class CloudFormationTemplateBuilderTest {
         Security security = getDefaultCloudStackSecurity();
         groups.add(createDefaultGroup("master", InstanceGroupType.CORE, ROOT_VOLUME_SIZE, security, Optional.empty()));
         InstanceTemplate spotInstanceTemplate = createDefaultInstanceTemplate();
-        spotInstanceTemplate.putParameter("spotPercentage", 60);
+        spotInstanceTemplate.putParameter(AwsInstanceTemplate.EC2_SPOT_PERCENTAGE, 60);
         CloudInstance spotInstance = new CloudInstance("SOME_ID", spotInstanceTemplate, instanceAuthentication);
         groups.add(new Group("compute", InstanceGroupType.CORE, singletonList(spotInstance), security, spotInstance,
                 instanceAuthentication, instanceAuthentication.getLoginUserName(), "publickey", ROOT_VOLUME_SIZE, Optional.empty()));

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/encryption/EncryptedImageCopyServiceTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/encryption/EncryptedImageCopyServiceTest.java
@@ -51,6 +51,7 @@ import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.Location;
 import com.sequenceiq.cloudbreak.cloud.model.Region;
 import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudFileSystemView;
+import com.sequenceiq.cloudbreak.cloud.model.instance.AwsInstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.ResourceType;
@@ -99,7 +100,7 @@ public class EncryptedImageCopyServiceTest {
     @Test
     public void testCreateEncryptedImagesWhenNoEncryptionIsRequired() {
         InstanceTemplate temp = new InstanceTemplate("medium", "groupName", 0L, emptyList(), InstanceStatus.CREATE_REQUESTED,
-                Map.of("encrypted", false), 0L, "imageId");
+                Map.of(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, false), 0L, "imageId");
         CloudInstance instance = new CloudInstance("SOME_ID", temp, null);
         List<Group> groups = new ArrayList<>();
         groups.add(new Group("master", InstanceGroupType.GATEWAY, singletonList(instance), null, null, null, null, null, null, 30, identity));
@@ -115,7 +116,7 @@ public class EncryptedImageCopyServiceTest {
     public void testCreateEncryptedImagesWhenEveryGroupNeedToBeEncryptedWithTheDefaultKmsKey()
             throws InterruptedException, ExecutionException, TimeoutException {
         InstanceTemplate temp = new InstanceTemplate("medium", "groupName", 0L, emptyList(), InstanceStatus.CREATE_REQUESTED,
-                Map.of("encrypted", true), 0L, "imageId");
+                Map.of(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, true), 0L, "imageId");
         CloudInstance instance = new CloudInstance("SOME_ID", temp, null);
         List<Group> groups = new ArrayList<>();
         groups.add(new Group("master", InstanceGroupType.GATEWAY, singletonList(instance), null, null, null, null, null, null, 30, identity));
@@ -141,7 +142,8 @@ public class EncryptedImageCopyServiceTest {
     public void testCreateEncryptedImagesWhenEveryGroupNeedToBeEncryptedWithCustomKmsKey()
             throws InterruptedException, ExecutionException, TimeoutException {
         InstanceTemplate temp = new InstanceTemplate("medium", "groupName", 0L, emptyList(), InstanceStatus.CREATE_REQUESTED,
-                Map.of("encrypted", true, "key", "arn:aws:kms:eu-west-1:980678888888:key/7e9173f2-6ac8"), 0L, "imageId");
+                Map.of(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, true,
+                        InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, "arn:aws:kms:eu-west-1:980678888888:key/7e9173f2-6ac8"), 0L, "imageId");
         CloudInstance instance = new CloudInstance("SOME_ID", temp, null);
         List<Group> groups = new ArrayList<>();
         groups.add(new Group("master", InstanceGroupType.GATEWAY, singletonList(instance), null, null, null, null, null, null, 30, identity));
@@ -171,12 +173,14 @@ public class EncryptedImageCopyServiceTest {
         List<Group> groups = new ArrayList<>();
 
         InstanceTemplate temp = new InstanceTemplate("medium", "master", 0L, emptyList(), InstanceStatus.CREATE_REQUESTED,
-                Map.of("encrypted", true, "key", "arn:aws:kms:eu-west-1:980678888888:key/7e9173f2-6ac8"), 0L, "imageId");
+                Map.of(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, true,
+                        InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, "arn:aws:kms:eu-west-1:980678888888:key/7e9173f2-6ac8"), 0L, "imageId");
         CloudInstance instance = new CloudInstance("SOME_ID", temp, null);
         groups.add(new Group("master", InstanceGroupType.GATEWAY, singletonList(instance), null, null, null, null, null, null, 30, identity));
 
         InstanceTemplate temp2 = new InstanceTemplate("medium", "worker", 1L, emptyList(), InstanceStatus.CREATE_REQUESTED,
-                Map.of("encrypted", true, "key", "arn:aws:kms:eu-west-1:980678888888:key/almafa23-6ac8"), 1L, "imageId");
+                Map.of(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, true,
+                        InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, "arn:aws:kms:eu-west-1:980678888888:key/almafa23-6ac8"), 1L, "imageId");
         CloudInstance instance2 = new CloudInstance("SECOND_ID", temp2, null);
         groups.add(new Group("worker", InstanceGroupType.CORE, singletonList(instance2), null, null, null, null, null, null, 30, identity));
 
@@ -207,17 +211,19 @@ public class EncryptedImageCopyServiceTest {
         List<Group> groups = new ArrayList<>();
 
         InstanceTemplate temp = new InstanceTemplate("medium", "master", 0L, emptyList(), InstanceStatus.CREATE_REQUESTED,
-                Map.of("encrypted", true, "key", "arn:aws:kms:eu-west-1:980678888888:key/7e9173f2-6ac8"), 0L, "imageId");
+                Map.of(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, true,
+                        InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, "arn:aws:kms:eu-west-1:980678888888:key/7e9173f2-6ac8"), 0L, "imageId");
         CloudInstance instance = new CloudInstance("SOME_ID", temp, null);
         groups.add(new Group("master", InstanceGroupType.GATEWAY, singletonList(instance), null, null, null, null, null, null, 30, identity));
 
         InstanceTemplate temp2 = new InstanceTemplate("medium", "worker", 1L, emptyList(), InstanceStatus.CREATE_REQUESTED,
-                Map.of("encrypted", true, "key", "arn:aws:kms:eu-west-1:980678888888:key/almafa23-6ac8"), 1L, "imageId");
+                Map.of(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, true,
+                        InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, "arn:aws:kms:eu-west-1:980678888888:key/almafa23-6ac8"), 1L, "imageId");
         CloudInstance instance2 = new CloudInstance("SECOND_ID", temp2, null);
         groups.add(new Group("worker", InstanceGroupType.CORE, singletonList(instance2), null, null, null, null, null, null, 30, identity));
 
         InstanceTemplate unencryptedTemp = new InstanceTemplate("medium", "worker", 1L, emptyList(), InstanceStatus.CREATE_REQUESTED,
-                Map.of("encrypted", false), 1L, "imageId");
+                Map.of(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, false), 1L, "imageId");
         CloudInstance unencryptedInstance = new CloudInstance("UNENCRYPTED_ID", unencryptedTemp, null);
         groups.add(new Group("compute", InstanceGroupType.CORE, singletonList(unencryptedInstance), null, null, null, null, null, null, 30, identity));
 

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsInstanceViewTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsInstanceViewTest.java
@@ -11,14 +11,16 @@ import org.junit.Test;
 
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
+import com.sequenceiq.cloudbreak.cloud.model.instance.AwsInstanceTemplate;
+import com.sequenceiq.common.api.type.EncryptionType;
 
 public class AwsInstanceViewTest {
 
     @Test
     public void testTemplateParameters() {
         Map<String, Object> map = new HashMap<>();
-        map.put("encrypted", true);
-        map.put("type", "CUSTOM");
+        map.put(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, true);
+        map.put(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.CUSTOM.name());
 
         InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
                 map, 0L, "imageId");
@@ -31,7 +33,7 @@ public class AwsInstanceViewTest {
     @Test
     public void testOnDemand() {
         Map<String, Object> map = new HashMap<>();
-        map.put("spotPercentage", 30);
+        map.put(AwsInstanceTemplate.EC2_SPOT_PERCENTAGE, 30);
         InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
                 map, 0L, "imageId");
         AwsInstanceView actual = new AwsInstanceView(instanceTemplate);

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/service/GcpDiskEncryptionService.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/service/GcpDiskEncryptionService.java
@@ -42,6 +42,7 @@ import com.google.api.services.compute.model.Disk;
 import com.sequenceiq.cloudbreak.client.RestClientUtil;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.common.api.type.EncryptionType;
 
 @Service
 public class GcpDiskEncryptionService {
@@ -74,11 +75,12 @@ public class GcpDiskEncryptionService {
     }
 
     public boolean hasCustomEncryptionRequested(InstanceTemplate template) {
-        return "CUSTOM".equalsIgnoreCase(Optional.ofNullable(template.getStringParameter("type")).orElse("DEFAULT"));
+        return EncryptionType.CUSTOM.name().equalsIgnoreCase(
+                Optional.ofNullable(template.getStringParameter(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE)).orElse(EncryptionType.DEFAULT.name()));
     }
 
     public CustomerEncryptionKey createCustomerEncryptionKey(InstanceTemplate template) {
-        String key = Optional.ofNullable(template.getStringParameter("key")).orElse("");
+        String key = Optional.ofNullable(template.getStringParameter(InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID)).orElse("");
         String method = Optional.ofNullable(template.getStringParameter("keyEncryptionMethod")).orElse("RSA");
 
         switch (method) {

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilderTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilderTest.java
@@ -76,6 +76,7 @@ import com.sequenceiq.cloudbreak.cloud.model.SpiFileSystem;
 import com.sequenceiq.cloudbreak.cloud.model.Volume;
 import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudGcsView;
 import com.sequenceiq.common.api.type.CommonStatus;
+import com.sequenceiq.common.api.type.EncryptionType;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.ResourceType;
 import com.sequenceiq.common.model.CloudIdentityType;
@@ -293,13 +294,13 @@ public class GcpInstanceResourceBuilderTest {
 
     @Test
     public void testInstanceEncryptionWithDefault() throws Exception {
-        ImmutableMap<String, Object> params = ImmutableMap.of("type", "DEFAULT");
+        ImmutableMap<String, Object> params = ImmutableMap.of(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.DEFAULT.name());
         doTestDefaultDiskEncryption(params);
     }
 
     @Test
     public void testInstanceEncryptionWithEmptyType() throws Exception {
-        ImmutableMap<String, Object> params = ImmutableMap.of("type", "");
+        ImmutableMap<String, Object> params = ImmutableMap.of(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, "");
         doTestDefaultDiskEncryption(params);
     }
 
@@ -323,35 +324,39 @@ public class GcpInstanceResourceBuilderTest {
     @Test
     public void testInstanceEncryptionWithRawMethodEmptyKey() throws Exception {
         String encryptionKey = "";
-        ImmutableMap<String, Object> params = ImmutableMap.of("type", "CUSTOM", "keyEncryptionMethod", "RAW");
+        ImmutableMap<String, Object> params = ImmutableMap.of(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.CUSTOM.name(),
+                "keyEncryptionMethod", "RAW");
         doTestDiskEncryption(encryptionKey, params);
     }
 
     @Test
     public void testInstanceEncryptionWithRawMethod() throws Exception {
         String encryptionKey = "theKey";
-        ImmutableMap<String, Object> params = ImmutableMap.of("type", "CUSTOM", "keyEncryptionMethod", "RAW", "key", encryptionKey);
+        ImmutableMap<String, Object> params = ImmutableMap.of(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.CUSTOM.name(),
+                "keyEncryptionMethod", "RAW", InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, encryptionKey);
         doTestDiskEncryption(encryptionKey, params);
     }
 
     @Test
     public void testInstanceEncryptionWithEmptyMethod() throws Exception {
         String encryptionKey = "";
-        ImmutableMap<String, Object> params = ImmutableMap.of("type", "CUSTOM");
+        ImmutableMap<String, Object> params = ImmutableMap.of(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.CUSTOM.name());
         doTestDiskEncryption(encryptionKey, params);
     }
 
     @Test
     public void testInstanceEncryptionWithRsaMethodEmptyKey() throws Exception {
         String encryptionKey = "";
-        ImmutableMap<String, Object> params = ImmutableMap.of("type", "CUSTOM", "keyEncryptionMethod", "RSA");
+        ImmutableMap<String, Object> params = ImmutableMap.of(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.CUSTOM.name(),
+                "keyEncryptionMethod", "RSA");
         doTestDiskEncryption(encryptionKey, params);
     }
 
     @Test
     public void testInstanceEncryptionWithRsaMethod() throws Exception {
         String encryptionKey = "theKey";
-        ImmutableMap<String, Object> params = ImmutableMap.of("type", "CUSTOM", "keyEncryptionMethod", "RSA", "key", encryptionKey);
+        ImmutableMap<String, Object> params = ImmutableMap.of(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.CUSTOM.name(),
+                "keyEncryptionMethod", "RSA", InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, encryptionKey);
         doTestDiskEncryption(encryptionKey, params);
     }
 
@@ -392,7 +397,8 @@ public class GcpInstanceResourceBuilderTest {
     @Test
     public void testStartWithDefaultEncryption() throws Exception {
         InstanceAuthentication instanceAuthentication = new InstanceAuthentication("sshkey", "", "cloudbreak");
-        CloudInstance cloudInstance = newCloudInstance(Map.of("type", "DEFAULT"), instanceAuthentication);
+        CloudInstance cloudInstance = newCloudInstance(Map.of(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.DEFAULT.name()),
+                instanceAuthentication);
 
         doTestDefaultEncryption(cloudInstance);
     }
@@ -438,7 +444,8 @@ public class GcpInstanceResourceBuilderTest {
         CustomerEncryptionKey customerEncryptionKey = new CustomerEncryptionKey();
         customerEncryptionKey.setRawKey("HelloWorld==");
 
-        Map<String, Object> params = Map.of("type", "CUSTOM", "keyEncryptionMethod", "RAW", "key", "Hello World");
+        Map<String, Object> params = Map.of(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.CUSTOM.name(),
+                "keyEncryptionMethod", "RAW", InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, "Hello World");
         doTestCustomEncryption(params, customerEncryptionKey);
     }
 
@@ -489,7 +496,8 @@ public class GcpInstanceResourceBuilderTest {
         CustomerEncryptionKey customerEncryptionKey = new CustomerEncryptionKey();
         customerEncryptionKey.setRawKey("HelloWorld==");
 
-        Map<String, Object> params = Map.of("type", "CUSTOM", "keyEncryptionMethod", "RSA", "key", "Hello World");
+        Map<String, Object> params = Map.of(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.CUSTOM.name(),
+                "keyEncryptionMethod", "RSA", InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, "Hello World");
         doTestCustomEncryption(params, customerEncryptionKey);
     }
 
@@ -498,7 +506,9 @@ public class GcpInstanceResourceBuilderTest {
         CustomerEncryptionKey customerEncryptionKey = new CustomerEncryptionKey();
         customerEncryptionKey.setRawKey("HelloWorld==");
 
-        Map<String, Object> params = Map.of("type", "CUSTOM", "key", "Hello World");
+        Map<String, Object> params = Map.of(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.CUSTOM.name(),
+                InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, "Hello World");
         doTestCustomEncryption(params, customerEncryptionKey);
     }
+
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/template/AwsInstanceTemplateV4Parameters.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/template/AwsInstanceTemplateV4Parameters.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceTemplateV4ParameterBase;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
+import com.sequenceiq.cloudbreak.cloud.model.instance.AwsInstanceTemplate;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.doc.ModelDescriptions.TemplateModelDescription;
 import com.sequenceiq.common.api.type.EncryptionType;
@@ -49,10 +51,10 @@ public class AwsInstanceTemplateV4Parameters extends InstanceTemplateV4Parameter
     @Override
     public Map<String, Object> asMap() {
         Map<String, Object> map = super.asMap();
-        doIfNotNull(spot, sp -> putIfValueNotNull(map, "spotPercentage", sp.getPercentage()));
+        doIfNotNull(spot, sp -> putIfValueNotNull(map, AwsInstanceTemplate.EC2_SPOT_PERCENTAGE, sp.getPercentage()));
         if (encryption != null) {
-            putIfValueNotNull(map, "type", encryption.getType());
-            putIfValueNotNull(map, "encrypted", encryption.getType() != EncryptionType.NONE);
+            putIfValueNotNull(map, InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, encryption.getType());
+            putIfValueNotNull(map, AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, encryption.getType() != EncryptionType.NONE);
         }
         return map;
     }
@@ -68,21 +70,21 @@ public class AwsInstanceTemplateV4Parameters extends InstanceTemplateV4Parameter
     public Map<String, Object> asSecretMap() {
         Map<String, Object> secretMap = super.asSecretMap();
         if (encryption != null) {
-            secretMap.put("key", encryption.getKey());
+            secretMap.put(InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, encryption.getKey());
         }
         return secretMap;
     }
 
     @Override
     public void parse(Map<String, Object> parameters) {
-        Integer spotPercentage = getInt(parameters, "spotPercentage");
+        Integer spotPercentage = getInt(parameters, AwsInstanceTemplate.EC2_SPOT_PERCENTAGE);
         doIfNotNull(spotPercentage, sp -> {
             spot = new AwsInstanceTemplateV4SpotParameters();
             spot.setPercentage(sp);
         });
         AwsEncryptionV4Parameters encryption = new AwsEncryptionV4Parameters();
-        encryption.setKey(getParameterOrNull(parameters, "key"));
-        String type = getParameterOrNull(parameters, "type");
+        encryption.setKey(getParameterOrNull(parameters, InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID));
+        String type = getParameterOrNull(parameters, InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE);
         if (type != null) {
             encryption.setType(EncryptionType.valueOf(type));
         }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/template/GcpInstanceTemplateV4Parameters.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/template/GcpInstanceTemplateV4Parameters.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceTemplateV4ParameterBase;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.KeyEncryptionMethod;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.doc.ModelDescriptions.TemplateModelDescription;
 import com.sequenceiq.common.api.type.EncryptionType;
@@ -47,7 +48,7 @@ public class GcpInstanceTemplateV4Parameters extends InstanceTemplateV4Parameter
         Map<String, Object> map = super.asMap();
         if (encryption != null) {
             putIfValueNotNull(map, "keyEncryptionMethod", encryption.getKeyEncryptionMethod());
-            putIfValueNotNull(map, "type", encryption.getType());
+            putIfValueNotNull(map, InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, encryption.getType());
         }
         putIfValueNotNull(map, "preemptible", preemptible);
         return map;
@@ -64,7 +65,7 @@ public class GcpInstanceTemplateV4Parameters extends InstanceTemplateV4Parameter
     public Map<String, Object> asSecretMap() {
         Map<String, Object> secretMap = super.asSecretMap();
         if (encryption != null) {
-            secretMap.put("key", encryption.getKey());
+            secretMap.put(InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, encryption.getKey());
         }
         return secretMap;
     }
@@ -72,12 +73,12 @@ public class GcpInstanceTemplateV4Parameters extends InstanceTemplateV4Parameter
     @Override
     public void parse(Map<String, Object> parameters) {
         GcpEncryptionV4Parameters encryption = new GcpEncryptionV4Parameters();
-        encryption.setKey(getParameterOrNull(parameters, "key"));
+        encryption.setKey(getParameterOrNull(parameters, InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID));
         String keyEncryptionMethod = getParameterOrNull(parameters, "keyEncryptionMethod");
         if (keyEncryptionMethod != null) {
             encryption.setKeyEncryptionMethod(KeyEncryptionMethod.valueOf(keyEncryptionMethod));
         }
-        String type = getParameterOrNull(parameters, "type");
+        String type = getParameterOrNull(parameters, InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE);
         if (type != null) {
             encryption.setType(EncryptionType.valueOf(type));
             this.encryption = encryption;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
@@ -26,6 +26,7 @@ import com.sequenceiq.authorization.service.CommonPermissionCheckingUtils;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.InstanceGroupAdjustmentV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.StatusRequest;
+import com.sequenceiq.cloudbreak.cloud.model.instance.AwsInstanceTemplate;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
 import com.sequenceiq.cloudbreak.common.service.TransactionService.TransactionExecutionException;
@@ -161,7 +162,7 @@ public class StackOperationService {
                 .map(InstanceGroup::getTemplate)
                 .map(Template::getAttributes)
                 .map(Json::getMap)
-                .map(attributes -> attributes.getOrDefault("spotPercentage", 0))
+                .map(attributes -> attributes.getOrDefault(AwsInstanceTemplate.EC2_SPOT_PERCENTAGE, 0))
                 .map(spotPercentage -> Integer.parseInt(spotPercentage.toString()))
                 .anyMatch(spotPercentage -> spotPercentage != 0);
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/InstanceTemplateV4RequestToTemplateConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/InstanceTemplateV4RequestToTemplateConverterTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ResourceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.common.mappable.Mappable;
 import com.sequenceiq.cloudbreak.common.mappable.ProviderParameterCalculator;
@@ -174,10 +175,10 @@ public class InstanceTemplateV4RequestToTemplateConverterTest {
         assertNotNull(result.getAttributes());
         Map<String, Object> map = result.getAttributes().getMap();
         assertEquals("RAW", map.get("keyEncryptionMethod"));
-        assertEquals("CUSTOM", map.get("type"));
+        assertEquals(EncryptionType.CUSTOM.name(), map.get(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE));
 
         assertNotNull(result.getSecretAttributes());
-        assertEquals("myKey", new Json(result.getSecretAttributes()).getMap().get("key"));
+        assertEquals("myKey", new Json(result.getSecretAttributes()).getMap().get(InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID));
     }
 
     @Test
@@ -207,10 +208,10 @@ public class InstanceTemplateV4RequestToTemplateConverterTest {
 
         assertNotNull(result.getAttributes());
         Map<String, Object> map = result.getAttributes().getMap();
-        assertEquals("CUSTOM", map.get("type"));
+        assertEquals(EncryptionType.CUSTOM.name(), map.get(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE));
 
         assertNotNull(result.getSecretAttributes());
-        assertEquals("myKey", new Json(result.getSecretAttributes()).getMap().get("key"));
+        assertEquals("myKey", new Json(result.getSecretAttributes()).getMap().get(InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID));
     }
 
     private RootVolumeV4Request getRootVolume(Integer size) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverterTest.java
@@ -66,6 +66,7 @@ import com.sequenceiq.cloudbreak.service.image.ImageService;
 import com.sequenceiq.cloudbreak.service.securityrule.SecurityRuleService;
 import com.sequenceiq.cloudbreak.service.stack.DefaultRootVolumeSizeProvider;
 import com.sequenceiq.cloudbreak.template.filesystem.FileSystemConfigurationsViewProvider;
+import com.sequenceiq.common.api.type.EncryptionType;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureEnvironmentParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureResourceGroup;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.ResourceGroupUsage;
@@ -895,11 +896,11 @@ public class StackToCloudStackConverterTest {
     }
 
     @Test
-    public void testBuildInstanceTemplateWithEncryptionAttributes() throws Exception {
+    public void testBuildInstanceTemplateWithGcpEncryptionAttributes() throws Exception {
         Template template = new Template();
         template.setVolumeTemplates(Sets.newHashSet());
-        template.setAttributes(new Json(Map.of("keyEncryptionMethod", "RAW", "type", "CUSTOM")));
-        template.setSecretAttributes(new Json(Map.of("key", "myKey")).getValue());
+        template.setAttributes(new Json(Map.of("keyEncryptionMethod", "RAW", InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.CUSTOM.name())));
+        template.setSecretAttributes(new Json(Map.of(InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, "myKey")).getValue());
 
         InstanceTemplate instanceTemplate = underTest.buildInstanceTemplate(
                 template, "name", 0L, InstanceStatus.CREATE_REQUESTED, "instanceImageId");
@@ -907,7 +908,8 @@ public class StackToCloudStackConverterTest {
         Map<String, Object> parameters = instanceTemplate.getParameters();
         assertNotNull(parameters);
         assertEquals("RAW", parameters.get("keyEncryptionMethod"));
-        assertEquals("CUSTOM", parameters.get("type"));
-        assertEquals("myKey", parameters.get("key"));
+        assertEquals(EncryptionType.CUSTOM.name(), parameters.get(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE));
+        assertEquals("myKey", parameters.get(InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID));
     }
+
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationServiceTest.java
@@ -27,6 +27,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.InstanceGrou
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.StatusRequest;
+import com.sequenceiq.cloudbreak.cloud.model.instance.AwsInstanceTemplate;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
 import com.sequenceiq.cloudbreak.core.flow2.service.ReactorFlowManager;
@@ -169,7 +170,7 @@ public class StackOperationServiceTest {
 
     private InstanceGroup createInstanceGroup(Integer spotPercentage) {
         Template template = new Template();
-        template.setAttributes(new Json(spotPercentage != null ? Map.of("spotPercentage", spotPercentage) : Map.of()));
+        template.setAttributes(new Json(spotPercentage != null ? Map.of(AwsInstanceTemplate.EC2_SPOT_PERCENTAGE, spotPercentage) : Map.of()));
         InstanceGroup instanceGroup = new InstanceGroup();
         instanceGroup.setTemplate(template);
         return instanceGroup;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/instance/template/InstanceTemplateRequestToTemplateConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/instance/template/InstanceTemplateRequestToTemplateConverter.java
@@ -16,8 +16,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
+import com.sequenceiq.cloudbreak.cloud.model.instance.AwsInstanceTemplate;
 import com.sequenceiq.cloudbreak.common.converter.MissingResourceNameGenerator;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
@@ -35,15 +36,6 @@ import com.sequenceiq.freeipa.service.stack.instance.DefaultInstanceTypeProvider
 
 @Component
 public class InstanceTemplateRequestToTemplateConverter {
-
-    @VisibleForTesting
-    static final String ATTRIBUTE_VOLUME_ENCRYPTED = "encrypted";
-
-    @VisibleForTesting
-    static final String ATTRIBUTE_VOLUME_ENCRYPTION_TYPE = "type";
-
-    @VisibleForTesting
-    static final String ATTRIBUTE_SPOT_PERCENTAGE = "spotPercentage";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(InstanceTemplateRequestToTemplateConverter.class);
 
@@ -68,13 +60,13 @@ public class InstanceTemplateRequestToTemplateConverter {
         Map<String, Object> attributes = new HashMap<>();
         if (cloudPlatform == CloudPlatform.AWS && entitlementService.freeIpaDlEbsEncryptionEnabled(INTERNAL_ACTOR_CRN, accountId)) {
             // FIXME Enable EBS encryption with appropriate KMS key
-            attributes.put(ATTRIBUTE_VOLUME_ENCRYPTED, Boolean.TRUE);
-            attributes.put(ATTRIBUTE_VOLUME_ENCRYPTION_TYPE, EncryptionType.DEFAULT.name());
+            attributes.put(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, Boolean.TRUE);
+            attributes.put(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.DEFAULT.name());
         }
         Optional.ofNullable(source.getAws())
                 .map(AwsInstanceTemplateParameters::getSpot)
                 .map(AwsInstanceTemplateSpotParameters::getPercentage)
-                .ifPresent(spotPercentage -> attributes.put(ATTRIBUTE_SPOT_PERCENTAGE, spotPercentage));
+                .ifPresent(spotPercentage -> attributes.put(AwsInstanceTemplate.EC2_SPOT_PERCENTAGE, spotPercentage));
         template.setAttributes(new Json(attributes));
         return template;
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/instance/DefaultInstanceGroupProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/instance/DefaultInstanceGroupProvider.java
@@ -9,8 +9,9 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Service;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
+import com.sequenceiq.cloudbreak.cloud.model.instance.AwsInstanceTemplate;
 import com.sequenceiq.cloudbreak.common.converter.MissingResourceNameGenerator;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
@@ -22,12 +23,6 @@ import com.sequenceiq.freeipa.service.DefaultRootVolumeSizeProvider;
 
 @Service
 public class DefaultInstanceGroupProvider {
-
-    @VisibleForTesting
-    static final String ATTRIBUTE_VOLUME_ENCRYPTED = "encrypted";
-
-    @VisibleForTesting
-    static final String ATTRIBUTE_VOLUME_ENCRYPTION_TYPE = "type";
 
     @Inject
     private MissingResourceNameGenerator missingResourceNameGenerator;
@@ -53,8 +48,8 @@ public class DefaultInstanceGroupProvider {
         if (cloudPlatform == CloudPlatform.AWS && entitlementService.freeIpaDlEbsEncryptionEnabled(INTERNAL_ACTOR_CRN, accountId)) {
             // FIXME Enable EBS encryption with appropriate KMS key
             template.setAttributes(new Json(Map.<String, Object>ofEntries(
-                    entry(ATTRIBUTE_VOLUME_ENCRYPTED, Boolean.TRUE),
-                    entry(ATTRIBUTE_VOLUME_ENCRYPTION_TYPE, EncryptionType.DEFAULT.name()))));
+                    entry(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, Boolean.TRUE),
+                    entry(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.DEFAULT.name()))));
         }
         return template;
     }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/instance/template/InstanceTemplateRequestToTemplateConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/instance/template/InstanceTemplateRequestToTemplateConverterTest.java
@@ -1,9 +1,6 @@
 package com.sequenceiq.freeipa.converter.instance.template;
 
 import static com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient.INTERNAL_ACTOR_CRN;
-import static com.sequenceiq.freeipa.converter.instance.template.InstanceTemplateRequestToTemplateConverter.ATTRIBUTE_SPOT_PERCENTAGE;
-import static com.sequenceiq.freeipa.converter.instance.template.InstanceTemplateRequestToTemplateConverter.ATTRIBUTE_VOLUME_ENCRYPTED;
-import static com.sequenceiq.freeipa.converter.instance.template.InstanceTemplateRequestToTemplateConverter.ATTRIBUTE_VOLUME_ENCRYPTION_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -14,6 +11,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
+import com.sequenceiq.cloudbreak.cloud.model.instance.AwsInstanceTemplate;
 import com.sequenceiq.cloudbreak.common.converter.MissingResourceNameGenerator;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
@@ -83,7 +82,7 @@ class InstanceTemplateRequestToTemplateConverterTest {
 
         Json attributes = result.getAttributes();
         assertThat(attributes).isNotNull();
-        assertThat(attributes.<Object>getValue(ATTRIBUTE_SPOT_PERCENTAGE)).isEqualTo(SPOT_PERCENTAGE);
+        assertThat(attributes.<Object>getValue(AwsInstanceTemplate.EC2_SPOT_PERCENTAGE)).isEqualTo(SPOT_PERCENTAGE);
     }
 
     @Test
@@ -95,8 +94,8 @@ class InstanceTemplateRequestToTemplateConverterTest {
 
         Json attributes = result.getAttributes();
         assertThat(attributes).isNotNull();
-        assertThat(attributes.<Object>getValue(ATTRIBUTE_VOLUME_ENCRYPTED)).isNull();
-        assertThat(attributes.<Object>getValue(ATTRIBUTE_VOLUME_ENCRYPTION_TYPE)).isNull();
+        assertThat(attributes.<Object>getValue(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED)).isNull();
+        assertThat(attributes.<Object>getValue(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE)).isNull();
     }
 
     @Test
@@ -110,8 +109,8 @@ class InstanceTemplateRequestToTemplateConverterTest {
 
         Json attributes = result.getAttributes();
         assertThat(attributes).isNotNull();
-        assertThat(attributes.<Object>getValue(ATTRIBUTE_VOLUME_ENCRYPTED)).isNull();
-        assertThat(attributes.<Object>getValue(ATTRIBUTE_VOLUME_ENCRYPTION_TYPE)).isNull();
+        assertThat(attributes.<Object>getValue(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED)).isNull();
+        assertThat(attributes.<Object>getValue(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE)).isNull();
     }
 
     @Test
@@ -125,8 +124,8 @@ class InstanceTemplateRequestToTemplateConverterTest {
 
         Json attributes = result.getAttributes();
         assertThat(attributes).isNotNull();
-        assertThat(attributes.<Object>getValue(ATTRIBUTE_VOLUME_ENCRYPTED)).isEqualTo(Boolean.TRUE);
-        assertThat(attributes.<Object>getValue(ATTRIBUTE_VOLUME_ENCRYPTION_TYPE)).isEqualTo(EncryptionType.DEFAULT.name());
+        assertThat(attributes.<Object>getValue(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED)).isEqualTo(Boolean.TRUE);
+        assertThat(attributes.<Object>getValue(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE)).isEqualTo(EncryptionType.DEFAULT.name());
     }
 
     @Test
@@ -141,9 +140,9 @@ class InstanceTemplateRequestToTemplateConverterTest {
 
         Json attributes = result.getAttributes();
         assertThat(attributes).isNotNull();
-        assertThat(attributes.<Object>getValue(ATTRIBUTE_VOLUME_ENCRYPTED)).isEqualTo(Boolean.TRUE);
-        assertThat(attributes.<Object>getValue(ATTRIBUTE_VOLUME_ENCRYPTION_TYPE)).isEqualTo(EncryptionType.DEFAULT.name());
-        assertThat(attributes.<Object>getValue(ATTRIBUTE_SPOT_PERCENTAGE)).isEqualTo(SPOT_PERCENTAGE);
+        assertThat(attributes.<Object>getValue(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED)).isEqualTo(Boolean.TRUE);
+        assertThat(attributes.<Object>getValue(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE)).isEqualTo(EncryptionType.DEFAULT.name());
+        assertThat(attributes.<Object>getValue(AwsInstanceTemplate.EC2_SPOT_PERCENTAGE)).isEqualTo(SPOT_PERCENTAGE);
     }
 
     private AwsInstanceTemplateParameters createAwsInstanceTemplateParameters(int spotPercentage) {

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/instance/DefaultInstanceGroupProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/instance/DefaultInstanceGroupProviderTest.java
@@ -1,8 +1,6 @@
 package com.sequenceiq.freeipa.service.stack.instance;
 
 import static com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient.INTERNAL_ACTOR_CRN;
-import static com.sequenceiq.freeipa.service.stack.instance.DefaultInstanceGroupProvider.ATTRIBUTE_VOLUME_ENCRYPTED;
-import static com.sequenceiq.freeipa.service.stack.instance.DefaultInstanceGroupProvider.ATTRIBUTE_VOLUME_ENCRYPTION_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -13,6 +11,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
+import com.sequenceiq.cloudbreak.cloud.model.instance.AwsInstanceTemplate;
 import com.sequenceiq.cloudbreak.common.converter.MissingResourceNameGenerator;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
@@ -67,8 +67,8 @@ class DefaultInstanceGroupProviderTest {
         assertThat(result).isNotNull();
         Json attributes = result.getAttributes();
         assertThat(attributes).isNotNull();
-        assertThat(attributes.<Object>getValue(ATTRIBUTE_VOLUME_ENCRYPTED)).isEqualTo(Boolean.TRUE);
-        assertThat(attributes.<Object>getValue(ATTRIBUTE_VOLUME_ENCRYPTION_TYPE)).isEqualTo(EncryptionType.DEFAULT.name());
+        assertThat(attributes.<Object>getValue(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED)).isEqualTo(Boolean.TRUE);
+        assertThat(attributes.<Object>getValue(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE)).isEqualTo(EncryptionType.DEFAULT.name());
     }
 
 }


### PR DESCRIPTION
* Extract AWS magic strings as constants in the new class `AwsInstanceTemplate` in `cloud-api`
  * The similar magic strings used for Azure & GCP encryption scenarios have not been touched. The only exceptions are the strings `"type"` and `"key"` that are common to AWS & GCP (and might be used later for Azure as well for customer-managed encryption keys); these have been added as constants to the superclass `InstanceTemplate`.
* Replace raw strings (`"NONE"`, `"DEFAULT"`, `"CUSTOM"`) with `EncryptionType` enum constant names
