### PR TITLE
CB-7576: Reduce the max nodes of FreeIPA to 3

### DIFF
--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -78,7 +78,7 @@ freeipa:
       initial-delay-millis: 60000
       fixed-delay-millis: 60000
   max:
-    instances: 4
+    instances: 3
     instance.groups: 1
   usersync:
     max-subjects-per-request: 10


### PR DESCRIPTION
When FreeIPA HA has 3 out of 4 failed instances, there were several
issues that occurred such as CB-6842, CB-7523, CDPSDX-1793, and
CDPSDX-1869. These issues do not occur when 2 out of 3 nodes have
failed. So the maximum number of instances of FreeIPA is being capped
at 3 nodes.

Closes #CB-7576