### PR TITLE
Fix permission check for internal actors

### DIFF
--- a/authorization-common/src/main/java/com/sequenceiq/authorization/service/PermissionCheckService.java
+++ b/authorization-common/src/main/java/com/sequenceiq/authorization/service/PermissionCheckService.java
@@ -54,7 +54,7 @@ public class PermissionCheckService {
 
         if (commonPermissionCheckingUtils.isAuthorizationDisabled(proceedingJoinPoint) ||
                 InternalCrnBuilder.isInternalCrn(ThreadBasedUserCrnProvider.getUserCrn())) {
-            commonPermissionCheckingUtils.proceed(proceedingJoinPoint, methodSignature, startTime);
+            return commonPermissionCheckingUtils.proceed(proceedingJoinPoint, methodSignature, startTime);
         }
 
         Optional<Class<?>> authorizationClass = commonPermissionCheckingUtils.getAuthorizationClass(proceedingJoinPoint);


### PR DESCRIPTION
The PermissionCheckerService will double proceed when called with an
internal actor. This is fixed by returning the results of the first
proceed call.
