### PR TITLE
CB-7474 Updating SDXService to override sdx internal create when the …

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -265,6 +265,10 @@ public class SdxService implements ResourceIdProvider, ResourceBasedCrnProvider 
             stackRequest.getCluster().setRangerRazEnabled(sdxClusterRequest.isEnableRangerRaz());
             return stackRequest;
         } else {
+            // We have provided a --ranger-raz-enabled flag in the CLI, but it will
+            // get overwritten if you use a custom json (using --cli-json). To avoid
+            // this, we will set the raz enablement here as well. See CB-7474 for more details
+            internalStackV4Request.getCluster().setRangerRazEnabled(sdxClusterRequest.isEnableRangerRaz());
             return internalStackV4Request;
         }
     }


### PR DESCRIPTION
This fixes an issue where sdx internal create --ranger-raz-enabled=true, the raz flag is not respected.