### PR TITLE
DISTX-478-Enable Autoscaling History

### DIFF
--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/v1/HistoryEndpoint.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/endpoint/v1/HistoryEndpoint.java
@@ -18,19 +18,13 @@ import com.sequenceiq.periscope.doc.ApiDescription.HistoryOpDescription;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 
-@Path("/v1/clusters/{clusterId}/history")
+@Path("/v1/clusters/{clusterCrn}/history")
 @Consumes(MediaType.APPLICATION_JSON)
-@Api(hidden = true, value = "/v1/history", description = HISTORY_DESCRIPTION, protocols = "http,https", consumes = MediaType.APPLICATION_JSON)
+@Api(value = "/v1/history", description = HISTORY_DESCRIPTION, protocols = "http,https", consumes = MediaType.APPLICATION_JSON)
 public interface HistoryEndpoint {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = HistoryOpDescription.HISTORY_GET_ALL, produces = MediaType.APPLICATION_JSON, notes = HistoryNotes.NOTES)
-    List<AutoscaleClusterHistoryResponse> getHistory(@PathParam("clusterId") Long clusterId);
-
-    @GET
-    @Path("{historyId}")
-    @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = HistoryOpDescription.HISTORY_GET, produces = MediaType.APPLICATION_JSON, notes = HistoryNotes.NOTES)
-    AutoscaleClusterHistoryResponse getHistoryById(@PathParam("clusterId") Long clusterId, @PathParam("historyId") Long historyId);
+    List<AutoscaleClusterHistoryResponse> getHistory(@PathParam("clusterCrn") String clusterCrn);
 }

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/AutoscaleClusterHistoryActivity.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/AutoscaleClusterHistoryActivity.java
@@ -1,0 +1,79 @@
+package com.sequenceiq.periscope.api.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.periscope.doc.ApiDescription;
+import io.swagger.annotations.ApiModelProperty;
+
+public class AutoscaleClusterHistoryActivity {
+
+    @ApiModelProperty(ApiDescription.HistoryJsonProperties.ALERTTYPE)
+    @JsonProperty("autoscalingType")
+    private AlertType alertType;
+
+    @ApiModelProperty(ApiDescription.HistoryJsonProperties.ADJUSTMENTTYPE)
+    private AdjustmentType adjustmentType;
+
+    @ApiModelProperty(ApiDescription.HistoryJsonProperties.ADJUSTMENT)
+    private int adjustment;
+
+    @ApiModelProperty(ApiDescription.HistoryJsonProperties.HOSTGROUP)
+    private String hostGroup;
+
+    @ApiModelProperty(ApiDescription.HistoryJsonProperties.ORIGINALNODECOUNT)
+    private int originalNodeCount;
+
+    @ApiModelProperty(ApiDescription.HistoryJsonProperties.PROPERTIES)
+    private Map<String, String> properties = new HashMap<>();
+
+    public String getAlertType() {
+        return Optional.ofNullable(alertType).map(AlertType::toString).orElse("");
+    }
+
+    public void setAlertType(AlertType alertType) {
+        this.alertType = alertType;
+    }
+
+    public AdjustmentType getAdjustmentType() {
+        return adjustmentType;
+    }
+
+    public void setAdjustmentType(AdjustmentType adjustmentType) {
+        this.adjustmentType = adjustmentType;
+    }
+
+    public int getAdjustment() {
+        return adjustment;
+    }
+
+    public void setAdjustment(int adjustment) {
+        this.adjustment = adjustment;
+    }
+
+    public String getHostGroup() {
+        return hostGroup;
+    }
+
+    public void setHostGroup(String hostGroup) {
+        this.hostGroup = hostGroup;
+    }
+
+    public int getOriginalNodeCount() {
+        return originalNodeCount;
+    }
+
+    public void setOriginalNodeCount(int originalNodeCount) {
+        this.originalNodeCount = originalNodeCount;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties;
+    }
+}

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/AutoscaleClusterHistoryResponse.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/AutoscaleClusterHistoryResponse.java
@@ -1,8 +1,6 @@
 package com.sequenceiq.periscope.api.model;
 
-import java.util.HashMap;
-import java.util.Map;
-
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.periscope.doc.ApiDescription.HistoryJsonProperties;
 
 import io.swagger.annotations.ApiModel;
@@ -11,23 +9,8 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel
 public class AutoscaleClusterHistoryResponse implements Json {
 
-    @ApiModelProperty(HistoryJsonProperties.ID)
-    private long id;
-
-    @ApiModelProperty(HistoryJsonProperties.CLUSTERID)
-    private long clusterId;
-
     @ApiModelProperty(HistoryJsonProperties.CBSTACKCRN)
     private String stackCrn;
-
-    @ApiModelProperty(HistoryJsonProperties.ORIGINALNODECOUNT)
-    private int originalNodeCount;
-
-    @ApiModelProperty(HistoryJsonProperties.ADJUSTMENT)
-    private int adjustment;
-
-    @ApiModelProperty(HistoryJsonProperties.ADJUSTMENTTYPE)
-    private AdjustmentType adjustmentType;
 
     @ApiModelProperty(HistoryJsonProperties.SCALINGSTATUS)
     private ScalingStatus scalingStatus;
@@ -38,30 +21,9 @@ public class AutoscaleClusterHistoryResponse implements Json {
     @ApiModelProperty(HistoryJsonProperties.TIMESTAMP)
     private long timestamp;
 
-    @ApiModelProperty(HistoryJsonProperties.HOSTGROUP)
-    private String hostGroup;
-
-    @ApiModelProperty(HistoryJsonProperties.ALERTTYPE)
-    private AlertType alertType;
-
-    @ApiModelProperty(HistoryJsonProperties.PROPERTIES)
-    private Map<String, String> properties = new HashMap<>();
-
-    public long getId() {
-        return id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
-    }
-
-    public long getClusterId() {
-        return clusterId;
-    }
-
-    public void setClusterId(long clusterId) {
-        this.clusterId = clusterId;
-    }
+    @ApiModelProperty(HistoryJsonProperties.SCALINGACTIVITY)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private AutoscaleClusterHistoryActivity autoscaleClusterHistoryActivity;
 
     public String getStackCrn() {
         return stackCrn;
@@ -69,30 +31,6 @@ public class AutoscaleClusterHistoryResponse implements Json {
 
     public void setStackCrn(String stackCrn) {
         this.stackCrn = stackCrn;
-    }
-
-    public int getOriginalNodeCount() {
-        return originalNodeCount;
-    }
-
-    public void setOriginalNodeCount(int originalNodeCount) {
-        this.originalNodeCount = originalNodeCount;
-    }
-
-    public int getAdjustment() {
-        return adjustment;
-    }
-
-    public void setAdjustment(int adjustment) {
-        this.adjustment = adjustment;
-    }
-
-    public AdjustmentType getAdjustmentType() {
-        return adjustmentType;
-    }
-
-    public void setAdjustmentType(AdjustmentType adjustmentType) {
-        this.adjustmentType = adjustmentType;
     }
 
     public ScalingStatus getScalingStatus() {
@@ -119,27 +57,11 @@ public class AutoscaleClusterHistoryResponse implements Json {
         this.timestamp = timestamp;
     }
 
-    public String getHostGroup() {
-        return hostGroup;
+    public AutoscaleClusterHistoryActivity getAutoscaleClusterHistoryActivity() {
+        return autoscaleClusterHistoryActivity;
     }
 
-    public void setHostGroup(String hostGroup) {
-        this.hostGroup = hostGroup;
-    }
-
-    public AlertType getAlertType() {
-        return alertType;
-    }
-
-    public void setAlertType(AlertType alertType) {
-        this.alertType = alertType;
-    }
-
-    public Map<String, String> getProperties() {
-        return properties;
-    }
-
-    public void setProperties(Map<String, String> properties) {
-        this.properties = properties;
+    public void setAutoscaleClusterHistoryActivity(AutoscaleClusterHistoryActivity autoscaleClusterHistoryActivity) {
+        this.autoscaleClusterHistoryActivity = autoscaleClusterHistoryActivity;
     }
 }

--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/doc/ApiDescription.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/doc/ApiDescription.java
@@ -179,7 +179,7 @@ public class ApiDescription {
 
     public static class HistoryJsonProperties {
         public static final String ID = "Id of the history object";
-        public static final String CLUSTERID = "If of the cluster";
+        public static final String SCALINGACTIVITY = "Scaling Activity undertaken";
         public static final String CBSTACKCRN = "crn of the cloudbreak stack";
         public static final String ORIGINALNODECOUNT = "The node count before of the scaling";
         public static final String ADJUSTMENT = "Count of scaling";

--- a/autoscale/src/main/java/com/sequenceiq/periscope/controller/AutoScaleClusterCommonService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/controller/AutoScaleClusterCommonService.java
@@ -83,16 +83,19 @@ public class AutoScaleClusterCommonService {
     }
 
     public Cluster setAutoscaleState(Long clusterId, Boolean enableAutoScaling) {
-        Cluster cluster = clusterService.setAutoscaleState(clusterId, enableAutoScaling);
-        createHistoryAndNotification(cluster);
+        Cluster cluster = clusterService.findById(clusterId);
+        if (!cluster.isAutoscalingEnabled().equals(enableAutoScaling)) {
+            cluster = clusterService.setAutoscaleState(clusterId, enableAutoScaling);
+            createHistoryAndNotification(cluster);
+        }
         return cluster;
     }
 
     private void createHistoryAndNotification(Cluster cluster) {
         History history;
         history = cluster.isAutoscalingEnabled()
-                ? historyService.createEntry(ScalingStatus.ENABLED, "Autoscaling has been enabled for the cluster.", 0, cluster)
-                : historyService.createEntry(ScalingStatus.DISABLED, "Autoscaling has been disabled for the cluster.", 0, cluster);
+                ? historyService.createEntry(ScalingStatus.ENABLED, "Autoscaling has been enabled for the cluster.", cluster)
+                : historyService.createEntry(ScalingStatus.DISABLED, "Autoscaling has been disabled for the cluster.", cluster);
         notificationSender.send(cluster, history);
     }
 

--- a/autoscale/src/main/java/com/sequenceiq/periscope/controller/DistroXAutoScaleClusterV1Controller.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/controller/DistroXAutoScaleClusterV1Controller.java
@@ -117,7 +117,7 @@ public class DistroXAutoScaleClusterV1Controller implements DistroXAutoScaleClus
                 alertController.validateTimeAlertRequests(clusterId, autoscaleClusterRequest.getTimeAlertRequests());
                 alertController.createLoadAlerts(clusterId, autoscaleClusterRequest.getLoadAlertRequests());
                 alertController.createTimeAlerts(clusterId, autoscaleClusterRequest.getTimeAlertRequests());
-                clusterService.setAutoscaleState(clusterId, autoscaleClusterRequest.getEnableAutoscaling());
+                asClusterCommonService.setAutoscaleState(clusterId, autoscaleClusterRequest.getEnableAutoscaling());
             });
         } catch (TransactionService.TransactionExecutionException e) {
             throw e.getCause();

--- a/autoscale/src/main/java/com/sequenceiq/periscope/controller/EndpointConfig.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/controller/EndpointConfig.java
@@ -90,7 +90,7 @@ public class EndpointConfig extends ResourceConfig {
 
     private void registerEndpoints() {
         register(DistroXAutoScaleClusterV1Controller.class);
-        register(AlertController.class);
+        register(HistoryController.class);
         register(AuthorizationInfoController.class);
 
         register(io.swagger.jaxrs.listing.ApiListingResource.class);

--- a/autoscale/src/main/java/com/sequenceiq/periscope/controller/HistoryController.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/controller/HistoryController.java
@@ -2,33 +2,37 @@ package com.sequenceiq.periscope.controller;
 
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import javax.inject.Inject;
+
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.periscope.api.endpoint.v1.HistoryEndpoint;
 import com.sequenceiq.periscope.api.model.AutoscaleClusterHistoryResponse;
 import com.sequenceiq.periscope.converter.HistoryConverter;
-import com.sequenceiq.periscope.domain.History;
+import com.sequenceiq.periscope.service.AutoscaleRestRequestThreadLocalService;
+import com.sequenceiq.periscope.service.ClusterService;
 import com.sequenceiq.periscope.service.HistoryService;
+import com.sequenceiq.periscope.service.NotFoundException;
 
 @Component
 public class HistoryController implements HistoryEndpoint {
 
-    @Autowired
+    @Inject
     private HistoryService historyService;
 
-    @Autowired
+    @Inject
     private HistoryConverter historyConverter;
 
-    @Override
-    public List<AutoscaleClusterHistoryResponse> getHistory(Long clusterId) {
-        List<History> history = historyService.getHistory(clusterId);
-        return historyConverter.convertAllToJson(history);
-    }
+    @Inject
+    private AutoscaleRestRequestThreadLocalService restRequestThreadLocalService;
+
+    @Inject
+    private ClusterService clusterService;
 
     @Override
-    public AutoscaleClusterHistoryResponse getHistoryById(Long clusterId, Long historyId) {
-        History history = historyService.getHistory(clusterId, historyId);
-        return historyConverter.convert(history);
+    public List<AutoscaleClusterHistoryResponse> getHistory(String stackCrn) {
+        return clusterService.findOneByStackCrnAndWorkspaceId(stackCrn, restRequestThreadLocalService.getRequestedWorkspaceId())
+                .map(cluster -> historyConverter.convertAllToJson(historyService.getHistory(cluster.getId())))
+                .orElseThrow(NotFoundException.notFound("cluster", stackCrn));
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/converter/HistoryConverter.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/converter/HistoryConverter.java
@@ -1,28 +1,37 @@
 package com.sequenceiq.periscope.converter;
 
+import java.util.Set;
+
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.periscope.api.model.AutoscaleClusterHistoryActivity;
 import com.sequenceiq.periscope.api.model.AutoscaleClusterHistoryResponse;
+import com.sequenceiq.periscope.api.model.ScalingStatus;
 import com.sequenceiq.periscope.domain.History;
 
 @Component
 public class HistoryConverter extends AbstractConverter<AutoscaleClusterHistoryResponse, History> {
 
+    private Set<ScalingStatus> scalingActivityStatus = Set.of(ScalingStatus.SUCCESS, ScalingStatus.FAILED);
+
     @Override
     public AutoscaleClusterHistoryResponse convert(History source) {
         AutoscaleClusterHistoryResponse json = new AutoscaleClusterHistoryResponse();
-        json.setId(source.getId());
-        json.setAdjustment(source.getAdjustment());
-        json.setAdjustmentType(source.getAdjustmentType());
-        json.setAlertType(source.getAlertType());
         json.setStackCrn(source.getStackCrn());
-        json.setClusterId(source.getClusterId());
-        json.setHostGroup(source.getHostGroup());
-        json.setOriginalNodeCount(source.getOriginalNodeCount());
-        json.setProperties(source.getProperties());
         json.setScalingStatus(source.getScalingStatus());
         json.setTimestamp(source.getTimestamp());
         json.setStatusReason(source.getStatusReason());
+
+        if (scalingActivityStatus.contains(source.getScalingStatus())) {
+            AutoscaleClusterHistoryActivity scalingActivity = new AutoscaleClusterHistoryActivity();
+            scalingActivity.setHostGroup(source.getHostGroup());
+            scalingActivity.setOriginalNodeCount(source.getOriginalNodeCount());
+            scalingActivity.setProperties(source.getProperties());
+            scalingActivity.setAdjustment(source.getAdjustment());
+            scalingActivity.setAdjustmentType(source.getAdjustmentType());
+            scalingActivity.setAlertType(source.getAlertType());
+            json.setAutoscaleClusterHistoryActivity(scalingActivity);
+        }
         return json;
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/domain/History.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/domain/History.java
@@ -36,7 +36,7 @@ public class History {
 
     public static final String ALERT_STATE = "alertState";
 
-    public static final String ALERT_DESCRIPTION = "alertDescription";
+    public static final String ALERT_NAME = "alertName";
 
     public static final String TIME_ZONE = "timeZone";
 
@@ -90,17 +90,24 @@ public class History {
     public History() {
     }
 
-    public History(ScalingStatus status, String statusReason, int originalNodeCount) {
-        scalingStatus = status;
+    public History(ScalingStatus status, String statusReason, String stackCrn) {
+        this.scalingStatus = status;
+        this.statusReason = statusReason;
+        this.stackCrn = stackCrn;
+        this.timestamp = System.currentTimeMillis();
+    }
+
+    public History(ScalingStatus status, String statusReason, int originalNodeCount, int adjustment) {
+        this.scalingStatus = status;
         this.statusReason = statusReason;
         this.originalNodeCount = originalNodeCount;
-        timestamp = System.currentTimeMillis();
+        this.adjustment = adjustment;
+        this.timestamp = System.currentTimeMillis();
     }
 
     public History withScalingPolicy(ScalingPolicy policy) {
-        adjustment = policy.getScalingAdjustment();
-        adjustmentType = policy.getAdjustmentType();
-        hostGroup = policy.getHostGroup();
+        this.adjustmentType = policy.getAdjustmentType();
+        this.hostGroup = policy.getHostGroup();
         return this;
     }
 
@@ -122,8 +129,12 @@ public class History {
             properties.put(PERIOD, "" + pa.getPeriod());
             properties.put(ALERT_STATE, pa.getAlertState().name());
             properties.put(PARAMETERS, pa.getParameters().getValue());
+        } else if (alert instanceof  LoadAlert) {
+            LoadAlert la = (LoadAlert) alert;
+            properties.put(PARAMETERS, la.getLoadAlertConfiguration().toString());
+            alertType = AlertType.LOAD;
         }
-        properties.put(ALERT_DESCRIPTION, alert.getDescription());
+        properties.put(ALERT_NAME, alert.getName());
         return this;
     }
 

--- a/autoscale/src/main/java/com/sequenceiq/periscope/domain/LoadAlertConfiguration.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/domain/LoadAlertConfiguration.java
@@ -40,4 +40,13 @@ public class LoadAlertConfiguration {
     public void setCoolDownMinutes(Integer coolDownMinutes) {
         this.coolDownMinutes = coolDownMinutes;
     }
+
+    @Override
+    public String toString() {
+        return "LoadAlertConfiguration{" +
+                "minResourceValue=" + minResourceValue +
+                ", maxResourceValue=" + maxResourceValue +
+                ", coolDownMinutes=" + coolDownMinutes +
+                '}';
+    }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/repository/HistoryRepository.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/repository/HistoryRepository.java
@@ -11,8 +11,7 @@ import com.sequenceiq.periscope.domain.History;
 @EntityType(entityClass = History.class)
 public interface HistoryRepository extends CrudRepository<History, Long> {
 
-    List<History> findAllByCluster(@Param("id") Long id);
+    List<History> findFirst200ByClusterIdOrderByIdDesc(@Param("clusterId") Long clusterId);
 
     History findByCluster(@Param("clusterId") Long clusterId, @Param("historyId") Long historyId);
-
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/HistoryService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/HistoryService.java
@@ -17,29 +17,20 @@ public class HistoryService {
     @Autowired
     private HistoryRepository historyRepository;
 
-    @Autowired
-    private ClusterService clusterService;
-
-    public History createEntry(ScalingStatus scalingStatus, String statusReason, int originalNodeCount, ScalingPolicy scalingPolicy) {
-        History history = new History(scalingStatus, statusReason, originalNodeCount)
+    public History createEntry(ScalingStatus scalingStatus, String statusReason, int originalNodeCount, int adjustment, ScalingPolicy scalingPolicy) {
+        History history = new History(scalingStatus, statusReason, originalNodeCount, adjustment)
                 .withScalingPolicy(scalingPolicy)
                 .withAlert(scalingPolicy.getAlert())
-                .withCluster(scalingPolicy.getAlert().getCluster());
+                .withCluster(scalingPolicy.getCluster());
         return historyRepository.save(history);
     }
 
-    public History createEntry(ScalingStatus scalingStatus, String statusReason, int originalNodeCount, Cluster cluster) {
-        History history = new History(scalingStatus, statusReason, originalNodeCount)
-                .withCluster(cluster);
+    public History createEntry(ScalingStatus scalingStatus, String statusReason, Cluster cluster) {
+        History history = new History(scalingStatus, statusReason, cluster.getStackCrn()).withCluster(cluster);
         return historyRepository.save(history);
     }
 
-    public List<History> getHistory(long clusterId) {
-        clusterService.findById(clusterId);
-        return historyRepository.findAllByCluster(clusterId);
-    }
-
-    public History getHistory(long clusterId, long historyId) {
-        return historyRepository.findByCluster(clusterId, historyId);
+    public List<History> getHistory(Long clusterId) {
+        return historyRepository.findFirst200ByClusterIdOrderByIdDesc(clusterId);
     }
 }

--- a/autoscale/src/test/java/com/sequenceiq/periscope/controller/HistoryControllerTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/controller/HistoryControllerTest.java
@@ -1,0 +1,94 @@
+package com.sequenceiq.periscope.controller;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.sequenceiq.periscope.api.model.AutoscaleClusterHistoryResponse;
+import com.sequenceiq.periscope.converter.HistoryConverter;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.History;
+import com.sequenceiq.periscope.service.AutoscaleRestRequestThreadLocalService;
+import com.sequenceiq.periscope.service.ClusterService;
+import com.sequenceiq.periscope.service.HistoryService;
+import com.sequenceiq.periscope.service.NotFoundException;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HistoryControllerTest {
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    @InjectMocks
+    private HistoryController underTest;
+
+    @Mock
+    private HistoryService historyService;
+
+    @Mock
+    private HistoryConverter historyConverter;
+
+    @Mock
+    private ClusterService clusterService;
+
+    @Mock
+    private AutoscaleRestRequestThreadLocalService restRequestThreadLocalService;
+
+    private String testClusterCrn = "crn:cdp:iam:us-west-1:%s:cluster:mockuser@cloudera.com";
+
+    private Long workspaceId = 100L;
+
+    private Long clusterId = 100L;
+
+    private Cluster cluster = new Cluster();
+
+    @Before
+    public void setUp() {
+        cluster.setId(clusterId);
+    }
+
+    @Test
+    public void testGetHistoryWhenClusterNotFound() {
+        when(restRequestThreadLocalService.getRequestedWorkspaceId()).thenReturn(workspaceId);
+        when(clusterService.findOneByStackCrnAndWorkspaceId(testClusterCrn, workspaceId)).thenReturn(Optional.empty());
+
+        expectedException.expect(NotFoundException.class);
+        expectedException.expectMessage("cluster 'crn:cdp:iam:us-west-1:%s:cluster:mockuser@cloudera.com' not found.");
+
+        underTest.getHistory(testClusterCrn);
+    }
+
+    @Test
+    public void testGetHistoryWhenNoHistory() {
+        when(restRequestThreadLocalService.getRequestedWorkspaceId()).thenReturn(workspaceId);
+        when(clusterService.findOneByStackCrnAndWorkspaceId(testClusterCrn, workspaceId)).thenReturn(Optional.of(cluster));
+        when(historyService.getHistory(clusterId)).thenReturn(List.of());
+
+        List<AutoscaleClusterHistoryResponse> historyResponses = underTest.getHistory(testClusterCrn);
+        assertEquals("History Response size is 0", 0, historyResponses.size());
+    }
+
+    @Test
+    public void testGetHistoryWhenHistoryFound() {
+        List<History> mockHistoryResponses = List.of(new History(), new History());
+        when(restRequestThreadLocalService.getRequestedWorkspaceId()).thenReturn(workspaceId);
+        when(clusterService.findOneByStackCrnAndWorkspaceId(testClusterCrn, workspaceId)).thenReturn(Optional.of(cluster));
+        when(historyService.getHistory(clusterId)).thenReturn(mockHistoryResponses);
+        when(historyConverter.convertAllToJson(any(List.class))).thenCallRealMethod();
+
+        List<AutoscaleClusterHistoryResponse> historyResponses = underTest.getHistory(testClusterCrn);
+        assertEquals("History Response size is 2", 2, historyResponses.size());
+    }
+}


### PR DESCRIPTION
1. Enable Autoscaling History Endpoint to retrieve Autoscaling Events
2. Capture history events for autoscaling.
3. Downscaling should not validate node count since downscaling to 0 nodes for a hostgroup is supported.

Closes #DISTX-478
Closes #DISTX-413
Closed #DISTX-501