### PR TITLE
CDPCP-2435. Add user sync failed state

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/UserSyncState.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/UserSyncState.java
@@ -3,5 +3,6 @@ package com.sequenceiq.freeipa.api.v1.freeipa.user.model;
 public enum UserSyncState {
     UP_TO_DATE,
     STALE,
-    SYNC_IN_PROGRESS
+    SYNC_IN_PROGRESS,
+    SYNC_FAILED
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/EnvironmentUserSyncStateCalculator.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/EnvironmentUserSyncStateCalculator.java
@@ -77,9 +77,11 @@ public class EnvironmentUserSyncStateCalculator {
                 throw createExceptionForUnexpectedOperationStatus(envCrnString, userSyncStatus);
             case TIMEDOUT:
                 LOGGER.warn("UserSyncStatus.lastStartedFullSync '{}' is timed out for environment '{}'", lastSync.getOperationId(), envCrnString);
-                state  = UserSyncState.STALE;
+                state  = UserSyncState.SYNC_FAILED;
                 break;
             case FAILED:
+                state  = UserSyncState.SYNC_FAILED;
+                break;
             default:
                 state  = UserSyncState.STALE;
                 break;
@@ -93,9 +95,11 @@ public class EnvironmentUserSyncStateCalculator {
             UmsEventGenerationIds currentEventGenerationIds = umsEventGenerationIdsProvider.getEventGenerationIds(accountId, MDCUtils.getRequestId());
             if (eventGenerationIdsChecker.isInSync(userSyncStatus, currentEventGenerationIds)) {
                 return UserSyncState.UP_TO_DATE;
+            } else {
+                return UserSyncState.STALE;
             }
         }
-        return UserSyncState.STALE;
+        return UserSyncState.SYNC_FAILED;
     }
 
     private IllegalStateException createExceptionForUnexpectedOperationStatus(String envCrnString, UserSyncStatus userSyncStatus) {

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/EnvironmentUserSyncStateCalculatorTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/EnvironmentUserSyncStateCalculatorTest.java
@@ -83,7 +83,7 @@ class EnvironmentUserSyncStateCalculatorTest {
 
         EnvironmentUserSyncState result = underTest.internalCalculateEnvironmentUserSyncState(ACCOUNT_ID, ENVIRONMENT_CRN, userSyncStatus);
 
-        assertEquals(UserSyncState.STALE, result.getState());
+        assertEquals(UserSyncState.SYNC_FAILED, result.getState());
         assertEquals(lastSync.getOperationId(), result.getLastUserSyncOperationId());
     }
 
@@ -97,7 +97,7 @@ class EnvironmentUserSyncStateCalculatorTest {
 
         EnvironmentUserSyncState result = underTest.internalCalculateEnvironmentUserSyncState(ACCOUNT_ID, ENVIRONMENT_CRN, userSyncStatus);
 
-        assertEquals(UserSyncState.STALE, result.getState());
+        assertEquals(UserSyncState.SYNC_FAILED, result.getState());
         assertEquals(lastSync.getOperationId(), result.getLastUserSyncOperationId());
     }
 
@@ -134,7 +134,7 @@ class EnvironmentUserSyncStateCalculatorTest {
 
         EnvironmentUserSyncState result = underTest.internalCalculateEnvironmentUserSyncState(ACCOUNT_ID, ENVIRONMENT_CRN, userSyncStatus);
 
-        assertEquals(UserSyncState.STALE, result.getState());
+        assertEquals(UserSyncState.SYNC_FAILED, result.getState());
         assertEquals(lastSync.getOperationId(), result.getLastUserSyncOperationId());
     }
 


### PR DESCRIPTION
The environment sync state is calculated from the last started
user sync operation. This commit adds a SYNC_FAILED state and
updates the state calculations to explicitly call out when the
sync failed instead of just marking the environment STALE.
