### PR TITLE
CB-7601: Modify the FreeIPA backup script to work write only.

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_backup
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_backup
@@ -177,7 +177,7 @@ elif [[ "${config[backup_platform]}" = "AZURE" ]]; then
     doLog "INFO Syncing backups to Azure Blog Storage"
     /bin/keyctl new_session >> $LOGFILE 2>&1 || error_exit "Unable to setup keyring session"
     /usr/local/bin/azcopy login --identity --identity-resource-id "${config[azure_instance_msi]}" >> $LOGFILE 2>&1 || error_exit "Unable to login to Azure!"
-    /usr/local/bin/azcopy copy ${config[backup_path]}/${BACKUPDIR} ${BACKUP_LOCATION} --recursive=true >> $LOGFILE 2>&1 || error_exit "Sync of backups to ${BACKUP_LOCATION} failed!"
+    /usr/local/bin/azcopy copy ${config[backup_path]}/${BACKUPDIR} ${BACKUP_LOCATION} --recursive=true --check-length=false >> $LOGFILE 2>&1 || error_exit "Sync of backups to ${BACKUP_LOCATION} failed!"
     remove_local_backups
 fi
 


### PR DESCRIPTION
This modifies the FreeIPA backup script to be write-only
by taking out the file length check that does a read
of the file in order to verify the upload.

Closes #CB-7601