### PR TITLE
DISTX-451 Oozie: Add s3a and adls to the supported filesystems

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-720.bp
@@ -370,6 +370,12 @@
           {
             "refName": "oozie-OOZIE_SERVER-BASE",
             "roleType": "OOZIE_SERVER",
+            "configs": [
+              {
+                "name": "oozie_config_safety_valve",
+                "value": "<property><name>oozie.service.HadoopAccessorService.nameNode.whitelist</name><value></value></property>"
+              }
+            ],
             "base": true
           }
         ]

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-721.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-721.bp
@@ -370,6 +370,12 @@
           {
             "refName": "oozie-OOZIE_SERVER-BASE",
             "roleType": "OOZIE_SERVER",
+            "configs": [
+              {
+                "name": "oozie_config_safety_valve",
+                "value": "<property><name>oozie.service.HadoopAccessorService.nameNode.whitelist</name><value></value></property>"
+              }
+            ],
             "base": true
           }
         ]

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-720.bp
@@ -207,6 +207,12 @@
           {
             "refName": "oozie-OOZIE_SERVER-BASE",
             "roleType": "OOZIE_SERVER",
+            "configs": [
+              {
+                "name": "oozie_config_safety_valve",
+                "value": "<property><name>oozie.service.HadoopAccessorService.nameNode.whitelist</name><value></value></property>"
+              }
+            ],
             "base": true
           }
         ]

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-721.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-721.bp
@@ -207,6 +207,12 @@
           {
             "refName": "oozie-OOZIE_SERVER-BASE",
             "roleType": "OOZIE_SERVER",
+            "configs": [
+              {
+                "name": "oozie_config_safety_valve",
+                "value": "<property><name>oozie.service.HadoopAccessorService.nameNode.whitelist</name><value></value></property>"
+              }
+            ],
             "base": true
           }
         ]


### PR DESCRIPTION
1. CDPD-12283 added s3a and adls as a supported filesystem for CDPD oozie in **7.2.0**.
2. Still, it does not work because only the namenode of the cluster is whitelisted by default in oozie.
3. Oozie team thinks that it is bad to whitelist everything.
4. CDP-PC datahub clusters need to work with any s3a or adls filesystem.
5. So removing the whitelisting by overriding it with an empty value.
6. Tested this in a cluster. I was getting the below error which went away after the safety valve setting.

```
{"errorMessage":"E0307: Runtime error [Could not check whether file [s3a://gk1priv-cdp-bucket/oozie/hive/workflow.xml] exists on HDFS. Error message: E0901: NameNode [gk1priv-cdp-bucket] not allowed, not in Oozie's whitelist. Allowed values are: [knox-ry7x7s-dw-master5.knox-bb3.svbr-nqvp.int.cldr.work:8020]]","httpStatusCode":400}
```