### PR TITLE
CB-7626. Update Azure storage plugin version for VM nodes (support write only mode)

### DIFF
--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
@@ -83,7 +83,7 @@
 {% set partition_interval = salt['pillar.get']('fluent:partitionIntervalMin') %}
 {% set cloudera_public_gem_repo = 'https://repository.cloudera.com/cloudera/api/gems/cloudera-gems/' %}
 {% set cloudera_azure_plugin_version = '1.0.1' %}
-{% set cloudera_azure_gen2_plugin_version = '0.2.7' %}
+{% set cloudera_azure_gen2_plugin_version = '0.3.1' %}
 {% set cloudera_databus_plugin_version = '1.0.4' %}
 {% set redaction_plugin_version = '0.1.2' %}
 {% set platform = salt['pillar.get']('fluent:platform') %}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/output.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/output.conf.j2
@@ -7,7 +7,7 @@
     @type s3
     s3_bucket {{fluent.s3LogArchiveBucketName}}
     path "{{fluent.logFolderName}}/{{fluent.serviceLogPathSuffix}}"
-    s3_object_key_format %{path}-%{hex_random}.%{file_extension}
+    s3_object_key_format %{path}-%{hms_slice}.%{file_extension}
     auto_create_bucket false
     check_apikey_on_start false
     check_object false
@@ -34,7 +34,7 @@
     @type s3
     s3_bucket {{fluent.s3LogArchiveBucketName}}
     path "{{fluent.logFolderName}}/{{fluent.cmCommandLogPathSuffix}}"
-    s3_object_key_format %{path}-%{hex_random}.%{file_extension}
+    s3_object_key_format %{path}-%{hms_slice}.%{file_extension}
     auto_create_bucket false
     check_object false
     check_apikey_on_start false
@@ -76,11 +76,12 @@
 {% endif %}
     store_as                 gzip
     path                     "{{fluent.logFolderName}}/{{fluent.serviceLogPathSuffix}}"
-    azure_object_key_format  %{path}-%{index}.%{file_extension}
+    azure_object_key_format  %{path}-%{upload_timestamp}-%{index}.%{file_extension}
     auto_create_container    true
     enable_retry             true
     failsafe_container_check true
     startup_fail_on_error    false
+    write_only               true
 
     <buffer tag,time>
       @type file
@@ -88,7 +89,7 @@
       timekey {{fluent.partitionIntervalMin}}m
       timekey_wait 0s
       total_limit_size  2048MB
-      chunk_limit_size  60m
+      chunk_limit_size  4m
       flush_at_shutdown true
       overflow_action   drop_oldest_chunk
       disable_chunk_backup  true
@@ -118,11 +119,12 @@
 {% endif %}
     store_as                 gzip
     path                     "{{fluent.logFolderName}}/{{fluent.cmCommandLogPathSuffix}}"
-    azure_object_key_format  %{path}-%{index}.%{file_extension}
+    azure_object_key_format  %{path}-%{upload_timestamp}-%{index}.%{file_extension}
     auto_create_container    true
     enable_retry             true
     failsafe_container_check true
     startup_fail_on_error    false
+    write_only               true
 
     <buffer tag,time>
       @type file
@@ -130,7 +132,7 @@
       timekey {{fluent.partitionIntervalMin}}m
       timekey_wait 0s
       total_limit_size  1024MB
-      chunk_limit_size  60m
+      chunk_limit_size  4m
       flush_at_shutdown true
       overflow_action   drop_oldest_chunk
       disable_chunk_backup  true


### PR DESCRIPTION
- added write_only option for azure plugin
- use upload timestamp instead of index in the filename (format: 'HHSSmmff')
- set buffer chunk size to 4MB (as you need to upload in multiple parts per abfs blocks, the block size is 4MB, and as during upload knowing the position is required we cannot continue the uploading if for some reason the app is stopped and we cannot gather the blob properties through a head operation)

edit: also add an update to s3 path to use hms_slice instead of hex random

edit2: it's possible freeipa backup will need read anyway, if that's the case, maybe this fix is not a must