### PR TITLE
CB-7667: Fix failed FreeIPA repair flows to not run chained flows

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/repair/changeprimarygw/action/ChangePrimaryGatewayActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/repair/changeprimarygw/action/ChangePrimaryGatewayActions.java
@@ -21,8 +21,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.statemachine.StateContext;
 import org.springframework.statemachine.action.Action;
 
+import com.sequenceiq.flow.core.Flow;
+import com.sequenceiq.flow.core.FlowParameters;
 import com.sequenceiq.flow.core.PayloadConverter;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.FailureDetails;
@@ -31,7 +34,9 @@ import com.sequenceiq.freeipa.entity.InstanceMetaData;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.flow.freeipa.provision.event.clusterproxy.ClusterProxyUpdateRegistrationRequest;
 import com.sequenceiq.freeipa.flow.freeipa.repair.changeprimarygw.ChangePrimaryGatewayContext;
+import com.sequenceiq.freeipa.flow.freeipa.repair.changeprimarygw.ChangePrimaryGatewayFlowEvent;
 import com.sequenceiq.freeipa.flow.freeipa.repair.changeprimarygw.ChangePrimaryGatewayService;
+import com.sequenceiq.freeipa.flow.freeipa.repair.changeprimarygw.ChangePrimaryGatewayState;
 import com.sequenceiq.freeipa.flow.freeipa.repair.changeprimarygw.event.ChangePrimaryGatewayEvent;
 import com.sequenceiq.freeipa.flow.freeipa.repair.changeprimarygw.event.ChangePrimaryGatewayFailureEvent;
 import com.sequenceiq.freeipa.flow.freeipa.repair.changeprimarygw.event.selection.ChangePrimaryGatewaySelectionRequest;
@@ -163,6 +168,14 @@ public class ChangePrimaryGatewayActions {
 
             @Inject
             private OperationService operationService;
+
+            @Override
+            protected ChangePrimaryGatewayContext createFlowContext(FlowParameters flowParameters,
+                    StateContext<ChangePrimaryGatewayState, ChangePrimaryGatewayFlowEvent> stateContext, ChangePrimaryGatewayFailureEvent payload) {
+                Flow flow = getFlow(flowParameters.getFlowId());
+                flow.setFlowFailed(payload.getException());
+                return super.createFlowContext(flowParameters, stateContext, payload);
+            }
 
             @Override
             protected Object getFailurePayload(ChangePrimaryGatewayFailureEvent payload, Optional<ChangePrimaryGatewayContext> flowContext, Exception ex) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/action/FreeIpaUpscaleActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/action/FreeIpaUpscaleActions.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.statemachine.StateContext;
 import org.springframework.statemachine.action.Action;
 
 import com.sequenceiq.cloudbreak.cloud.event.instance.CollectMetadataRequest;
@@ -43,6 +44,8 @@ import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.transform.ResourceLists;
 import com.sequenceiq.cloudbreak.service.OperationException;
 import com.sequenceiq.common.api.type.CommonResourceType;
+import com.sequenceiq.flow.core.Flow;
+import com.sequenceiq.flow.core.FlowParameters;
 import com.sequenceiq.flow.core.PayloadConverter;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.FailureDetails;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SuccessDetails;
@@ -63,6 +66,7 @@ import com.sequenceiq.freeipa.flow.freeipa.provision.event.postinstall.PostInsta
 import com.sequenceiq.freeipa.flow.freeipa.provision.event.services.InstallFreeIpaServicesRequest;
 import com.sequenceiq.freeipa.flow.freeipa.provision.event.services.InstallFreeIpaServicesSuccess;
 import com.sequenceiq.freeipa.flow.freeipa.upscale.UpscaleFlowEvent;
+import com.sequenceiq.freeipa.flow.freeipa.upscale.UpscaleState;
 import com.sequenceiq.freeipa.flow.freeipa.upscale.event.UpscaleEvent;
 import com.sequenceiq.freeipa.flow.freeipa.upscale.event.UpscaleFailureEvent;
 import com.sequenceiq.freeipa.flow.freeipa.upscale.failure.BootstrapMachinesFailedToUpscaleFailureEventConverter;
@@ -454,6 +458,14 @@ public class FreeIpaUpscaleActions {
 
             @Inject
             private OperationService operationService;
+
+            @Override
+            protected StackContext createFlowContext(FlowParameters flowParameters, StateContext<UpscaleState, UpscaleFlowEvent> stateContext,
+                    UpscaleFailureEvent payload) {
+                Flow flow = getFlow(flowParameters.getFlowId());
+                flow.setFlowFailed(payload.getException());
+                return super.createFlowContext(flowParameters, stateContext, payload);
+            }
 
             @Override
             protected Object getFailurePayload(UpscaleFailureEvent payload, Optional<StackContext> flowContext, Exception ex) {


### PR DESCRIPTION
The chained FreeIPA repair flow was fixed so that if one of the flows
fails, subsequent chained flows do not run.

This was tested manually on a local deployment of cloudbreak by
injecting failures in each of the chained flows for FreeIPA repair and
ensuring that subsequent flows are not executed.

Closes #CB-7667