### PR TITLE
CB-7356 Adding new Ranger cloud paths for data and logs.

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerCloudStorageServiceConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerCloudStorageServiceConfigProvider.java
@@ -1,18 +1,22 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.ranger;
 
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_1;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
 import org.springframework.stereotype.Component;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateComponentConfigProvider;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.hdfs.HdfsRoleConfigProvider;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.hdfs.HdfsRoles;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 
 @Component
@@ -20,11 +24,30 @@ public class RangerCloudStorageServiceConfigProvider implements CmTemplateCompon
 
     private static final String RANGER_HDFS_AUDIT_URL = "ranger_plugin_hdfs_audit_url";
 
+    private static final String RANGER_DATA_URL = "cloud_data_location_url";
+
+    private static final String RANGER_LOG_URL = "cloud_log_location_url";
+
     @Override
     public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject templatePreparationObject) {
-        return ConfigUtils.getStorageLocationForServiceProperty(templatePreparationObject, RANGER_HDFS_AUDIT_URL)
-                .map(location -> List.of(config(RANGER_HDFS_AUDIT_URL, location.getValue())))
-                .orElseGet(() -> List.of(config(RANGER_HDFS_AUDIT_URL, getDefaultRangerAuditUrl(templateProcessor, templatePreparationObject))));
+        List<ApiClusterTemplateConfig> rangerConfigs = new ArrayList<>();
+
+        ConfigUtils.getStorageLocationForServiceProperty(templatePreparationObject, RANGER_HDFS_AUDIT_URL)
+                .map(location -> rangerConfigs.add(config(RANGER_HDFS_AUDIT_URL, location.getValue())))
+                .orElseGet(() -> rangerConfigs.add(config(RANGER_HDFS_AUDIT_URL, getDefaultRangerAuditUrl(templateProcessor, templatePreparationObject))));
+
+        String cmVersion = templatePreparationObject.getProductDetailsView().getCm().getVersion();
+        //TODO: CB-7709 fix this properly
+        if (CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited(cmVersion, CLOUDERAMANAGER_VERSION_7_2_1)
+                && CloudPlatform.AZURE == templatePreparationObject.getCloudPlatform()
+                && templatePreparationObject.getGeneralClusterConfigs().isEnableRangerRaz()) {
+            //CB-7356 hack, we need to clean this up, see CB-7709.
+            String rangerAuditPath =  rangerConfigs.get(0).getValue();
+            String baseDataPath = rangerAuditPath.split("ranger/audit")[0];
+
+            rangerConfigs.add(config(RANGER_DATA_URL, baseDataPath));
+        }
+        return rangerConfigs;
     }
 
     @Override

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerCloudStorageServiceConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerCloudStorageServiceConfigProviderTest.java
@@ -15,18 +15,22 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.hdfs.HdfsRoles;
-import com.sequenceiq.common.api.type.InstanceGroupType;
-import com.sequenceiq.common.api.filesystem.S3FileSystem;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.domain.StorageLocation;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject.Builder;
 import com.sequenceiq.cloudbreak.template.filesystem.StorageLocationView;
+import com.sequenceiq.cloudbreak.template.filesystem.adlsgen2.AdlsGen2FileSystemConfigurationsView;
 import com.sequenceiq.cloudbreak.template.filesystem.s3.S3FileSystemConfigurationsView;
 import com.sequenceiq.cloudbreak.template.model.GeneralClusterConfigs;
 import com.sequenceiq.cloudbreak.template.views.BlueprintView;
 import com.sequenceiq.cloudbreak.template.views.HostgroupView;
+import com.sequenceiq.common.api.filesystem.AdlsGen2FileSystem;
+import com.sequenceiq.common.api.filesystem.S3FileSystem;
+import com.sequenceiq.common.api.type.InstanceGroupType;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RangerCloudStorageServiceConfigProviderTest {
@@ -34,10 +38,11 @@ public class RangerCloudStorageServiceConfigProviderTest {
     private final RangerCloudStorageServiceConfigProvider underTest = new RangerCloudStorageServiceConfigProvider();
 
     @Test
-    public void testGetRangerCloudStorageServiceConfigs() {
+    public void testGetRangerAWSCloudStorageServiceConfigs() {
         CmTemplateProcessor templateProcessor = mock(CmTemplateProcessor.class);
-        TemplatePreparationObject preparationObject = getTemplatePreparationObject(true)
+        TemplatePreparationObject preparationObject = getTemplatePreparationObjectForAWS(true)
                 .withBlueprintView(mock(BlueprintView.class))
+                .withProductDetails(new ClouderaManagerRepo().withVersion("7.2.1"), List.of())
                 .build();
 
         List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(templateProcessor, preparationObject);
@@ -48,6 +53,61 @@ public class RangerCloudStorageServiceConfigProviderTest {
     }
 
     @Test
+    public void testGetRangerAzureCloudStorageServiceConfigs() {
+        CmTemplateProcessor templateProcessor = mock(CmTemplateProcessor.class);
+        GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
+        generalClusterConfigs.setEnableRangerRaz(true);
+        TemplatePreparationObject preparationObject = getTemplatePreparationObjectForAzure(true)
+                .withBlueprintView(mock(BlueprintView.class))
+                .withCloudPlatform(CloudPlatform.AZURE)
+                .withGeneralClusterConfigs(generalClusterConfigs)
+                .withProductDetails(new ClouderaManagerRepo().withVersion("7.2.1"), List.of())
+                .build();
+
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(templateProcessor, preparationObject);
+
+        assertEquals(2, serviceConfigs.size());
+        assertEquals("ranger_plugin_hdfs_audit_url", serviceConfigs.get(0).getName());
+        assertEquals("abfs://data@your-san.dfs.core.windows.net/ranger/audit/", serviceConfigs.get(0).getValue());
+        assertEquals("cloud_data_location_url", serviceConfigs.get(1).getName());
+        assertEquals("abfs://data@your-san.dfs.core.windows.net/", serviceConfigs.get(1).getValue());
+    }
+
+    @Test
+    public void testGetRangerAzureCloudStorageServiceConfigsNoRaz() {
+        CmTemplateProcessor templateProcessor = mock(CmTemplateProcessor.class);
+        GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
+        generalClusterConfigs.setEnableRangerRaz(false);
+        TemplatePreparationObject preparationObject = getTemplatePreparationObjectForAzure(true)
+                .withBlueprintView(mock(BlueprintView.class))
+                .withCloudPlatform(CloudPlatform.AZURE)
+                .withGeneralClusterConfigs(generalClusterConfigs)
+                .withProductDetails(new ClouderaManagerRepo().withVersion("7.2.1"), List.of())
+                .build();
+
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(templateProcessor, preparationObject);
+
+        assertEquals(1, serviceConfigs.size());
+        assertEquals("ranger_plugin_hdfs_audit_url", serviceConfigs.get(0).getName());
+        assertEquals("abfs://data@your-san.dfs.core.windows.net/ranger/audit/", serviceConfigs.get(0).getValue());
+    }
+
+    @Test
+    public void testGetRangerAzure720CloudStorageServiceConfigs() {
+        CmTemplateProcessor templateProcessor = mock(CmTemplateProcessor.class);
+        TemplatePreparationObject preparationObject = getTemplatePreparationObjectForAzure(false)
+                .withBlueprintView(mock(BlueprintView.class))
+                .withProductDetails(new ClouderaManagerRepo().withVersion("7.2.0"), List.of())
+                .build();
+
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(templateProcessor, preparationObject);
+
+        assertEquals(1, serviceConfigs.size());
+        assertEquals("ranger_plugin_hdfs_audit_url", serviceConfigs.get(0).getName());
+        assertEquals("abfs://data@your-san.dfs.core.windows.net/ranger/audit/", serviceConfigs.get(0).getValue());
+    }
+
+    @Test
     public void defaultRangerHdfsAuditUrlWithNamenodeHA() {
         CmTemplateProcessor templateProcessor = mock(CmTemplateProcessor.class);
         BlueprintView blueprintView = mock(BlueprintView.class);
@@ -55,8 +115,9 @@ public class RangerCloudStorageServiceConfigProviderTest {
         when(templateProcessor.getHostGroupsWithComponent(HdfsRoles.NAMENODE)).thenReturn(Set.of("master"));
         when(templateProcessor.getRoleConfig(HdfsRoles.HDFS, HdfsRoles.NAMENODE, "dfs_federation_namenode_nameservice"))
                 .thenReturn(Optional.of(config("dfs_federation_namenode_nameservice", "ns")));
-        TemplatePreparationObject preparationObject = getTemplatePreparationObject(false)
+        TemplatePreparationObject preparationObject = getTemplatePreparationObjectForAWS(false)
                 .withBlueprintView(blueprintView)
+                .withProductDetails(new ClouderaManagerRepo().withVersion("7.2.0"), List.of())
                 .build();
 
         List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(templateProcessor, preparationObject);
@@ -72,8 +133,9 @@ public class RangerCloudStorageServiceConfigProviderTest {
         BlueprintView blueprintView = mock(BlueprintView.class);
         when(blueprintView.getProcessor()).thenReturn(templateProcessor);
         when(templateProcessor.getHostGroupsWithComponent(HdfsRoles.NAMENODE)).thenReturn(Set.of("gateway"));
-        TemplatePreparationObject preparationObject = getTemplatePreparationObject(false)
+        TemplatePreparationObject preparationObject = getTemplatePreparationObjectForAWS(false)
                 .withBlueprintView(blueprintView)
+                .withProductDetails(new ClouderaManagerRepo().withVersion("7.2.0"), List.of())
                 .build();
 
         List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(templateProcessor, preparationObject);
@@ -83,7 +145,30 @@ public class RangerCloudStorageServiceConfigProviderTest {
         assertEquals("hdfs://g", serviceConfigs.get(0).getValue());
     }
 
-    private TemplatePreparationObject.Builder getTemplatePreparationObject(boolean includeLocations) {
+    private TemplatePreparationObject.Builder getTemplatePreparationObjectForAzure(boolean above721) {
+        HostgroupView gateway = new HostgroupView("gateway", 1, InstanceGroupType.GATEWAY, Set.of("g"));
+        HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.CORE, Set.of("m1", "m2"));
+        HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, Set.of("w1", "w2", "w3"));
+
+        List<StorageLocationView> locations = new ArrayList<>();
+
+        locations.add(new StorageLocationView(getRangerAuditCloudStorageDirAzure()));
+        if (above721) {
+            locations.add(new StorageLocationView(getRangerDataCloudStorageDir()));
+        }
+        AdlsGen2FileSystemConfigurationsView fileSystemConfigurationsView =
+                new AdlsGen2FileSystemConfigurationsView(new AdlsGen2FileSystem(), locations, false);
+
+        GeneralClusterConfigs generalClusterConfigs =  new GeneralClusterConfigs();
+        generalClusterConfigs.setPrimaryGatewayInstanceDiscoveryFQDN(Optional.of("fqdn"));
+
+        return Builder.builder()
+                .withFileSystemConfigurationView(fileSystemConfigurationsView)
+                .withHostgroupViews(Set.of(gateway, master, worker))
+                .withGeneralClusterConfigs(generalClusterConfigs);
+    }
+
+    private TemplatePreparationObject.Builder getTemplatePreparationObjectForAWS(boolean includeLocations) {
         HostgroupView gateway = new HostgroupView("gateway", 1, InstanceGroupType.GATEWAY, Set.of("g"));
         HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.CORE, Set.of("m1", "m2"));
         HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, Set.of("w1", "w2", "w3"));
@@ -109,6 +194,20 @@ public class RangerCloudStorageServiceConfigProviderTest {
         StorageLocation rangerAuditLogLocation = new StorageLocation();
         rangerAuditLogLocation.setProperty("ranger_plugin_hdfs_audit_url");
         rangerAuditLogLocation.setValue("s3a://bucket/ranger/auditlogs");
+        return rangerAuditLogLocation;
+    }
+
+    protected StorageLocation getRangerAuditCloudStorageDirAzure() {
+        StorageLocation rangerAuditLogLocation = new StorageLocation();
+        rangerAuditLogLocation.setProperty("ranger_plugin_hdfs_audit_url");
+        rangerAuditLogLocation.setValue("abfs://data@your-san.dfs.core.windows.net/ranger/audit/");
+        return rangerAuditLogLocation;
+    }
+
+    protected StorageLocation getRangerDataCloudStorageDir() {
+        StorageLocation rangerAuditLogLocation = new StorageLocation();
+        rangerAuditLogLocation.setProperty("cloud_data_location_url");
+        rangerAuditLogLocation.setValue("abfs://data@your-san.dfs.core.windows.net/");
         return rangerAuditLogLocation;
     }
 }


### PR DESCRIPTION
This adds in 2 new cloud storage paths for Ranger for data and logs for CM > 7.2.1 and only for ALDSv2.