### PR TITLE
CB-7641 changing minimum CM version for Raz to 7.2.1

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -439,10 +439,10 @@ public class SdxService implements ResourceIdProvider, ResourceBasedCrnProvider 
                 validationBuilder.error("Provisioning Ranger Raz is not enabled for this account.");
             }
             if (!AZURE.name().equalsIgnoreCase(environment.getCloudPlatform())) {
-                validationBuilder.error("Provisioning Ranger Raz is only valid for Microsft Azure.");
+                validationBuilder.error("Provisioning Ranger Raz is only valid for Microsoft Azure.");
             }
             if (!isRazSupported(sdxClusterRequest.getRuntime())) {
-                validationBuilder.error("Provisioning Ranger Raz is only valid for CM version > 7.2.0 and not " + sdxClusterRequest.getRuntime());
+                validationBuilder.error("Provisioning Ranger Raz is only valid for CM version > 7.2.1 and not " + sdxClusterRequest.getRuntime());
             }
         }
         ValidationResult validationResult = validationBuilder.build();
@@ -452,14 +452,14 @@ public class SdxService implements ResourceIdProvider, ResourceBasedCrnProvider 
     }
 
     /**
-     * Ranger Raz is only on 7.2.0 and later.  If runtime is empty, then sdx-internal call was used.
+     * Ranger Raz is only on 7.2.1 and later.  If runtime is empty, then sdx-internal call was used.
      */
     private boolean isRazSupported(String runtime) {
         if (StringUtils.isEmpty(runtime)) {
             return true;
         }
         Comparator<Versioned> versionComparator = new VersionComparator();
-        return versionComparator.compare(() -> runtime, () -> "7.2.0") > -1;
+        return versionComparator.compare(() -> runtime, () -> "7.2.1") > -1;
     }
 
     private boolean isCloudStorageConfigured(SdxClusterRequest clusterRequest) {

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxServiceTest.java
@@ -502,7 +502,7 @@ class SdxServiceTest {
         when(cdpConfigService.getConfigForKey(any())).thenReturn(JsonUtil.readValue(lightDutyJson, StackV4Request.class));
         when(sdxReactorFlowManager.triggerSdxCreation(any())).thenReturn(new FlowIdentifier(FlowType.FLOW, "FLOW_ID"));
         SdxClusterRequest sdxClusterRequest = new SdxClusterRequest();
-        sdxClusterRequest.setRuntime("7.2.0");
+        sdxClusterRequest.setRuntime("7.2.1");
         sdxClusterRequest.setClusterShape(LIGHT_DUTY);
         Map<String, String> tags = new HashMap<>();
         tags.put("mytag", "tagecske");
@@ -531,7 +531,7 @@ class SdxServiceTest {
     @Test
     void testSdxCreateRazEnabledNoEntitlement() throws IOException {
         SdxClusterRequest sdxClusterRequest = new SdxClusterRequest();
-        sdxClusterRequest.setRuntime("7.2.0");
+        sdxClusterRequest.setRuntime("7.2.1");
         sdxClusterRequest.setClusterShape(LIGHT_DUTY);
         Map<String, String> tags = new HashMap<>();
         tags.put("mytag", "tagecske");
@@ -550,7 +550,7 @@ class SdxServiceTest {
     @Test
     void testSdxCreateRazEnabledNotAzure() throws IOException {
         SdxClusterRequest sdxClusterRequest = new SdxClusterRequest();
-        sdxClusterRequest.setRuntime("7.2.0");
+        sdxClusterRequest.setRuntime("7.2.1");
         sdxClusterRequest.setClusterShape(LIGHT_DUTY);
         Map<String, String> tags = new HashMap<>();
         tags.put("mytag", "tagecske");
@@ -563,13 +563,13 @@ class SdxServiceTest {
         when(entitlementService.razEnabled(anyString(), anyString())).thenReturn(true);
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
                 () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
-        assertEquals("1. Provisioning Ranger Raz is only valid for Microsft Azure.", badRequestException.getMessage());
+        assertEquals("1. Provisioning Ranger Raz is only valid for Microsoft Azure.", badRequestException.getMessage());
     }
 
     @Test
     void testSdxCreateRazEnabledNoEntitlmentAndNotAzure() throws IOException {
         SdxClusterRequest sdxClusterRequest = new SdxClusterRequest();
-        sdxClusterRequest.setRuntime("7.2.0");
+        sdxClusterRequest.setRuntime("7.2.1");
         sdxClusterRequest.setClusterShape(LIGHT_DUTY);
         Map<String, String> tags = new HashMap<>();
         tags.put("mytag", "tagecske");
@@ -583,7 +583,7 @@ class SdxServiceTest {
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
                 () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
         assertEquals("1. Provisioning Ranger Raz is not enabled for this account.\n" +
-                "2. Provisioning Ranger Raz is only valid for Microsft Azure.", badRequestException.getMessage());
+                "2. Provisioning Ranger Raz is only valid for Microsoft Azure.", badRequestException.getMessage());
     }
 
     @Test
@@ -602,7 +602,26 @@ class SdxServiceTest {
         when(entitlementService.razEnabled(anyString(), anyString())).thenReturn(true);
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
                 () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
-        assertEquals("1. Provisioning Ranger Raz is only valid for CM version > 7.2.0 and not 7.1.0", badRequestException.getMessage());
+        assertEquals("1. Provisioning Ranger Raz is only valid for CM version > 7.2.1 and not 7.1.0", badRequestException.getMessage());
+    }
+
+    @Test
+    void testSdxCreateRazEnabled720Runtime() {
+        SdxClusterRequest sdxClusterRequest = new SdxClusterRequest();
+        sdxClusterRequest.setRuntime("7.2.0");
+        sdxClusterRequest.setClusterShape(LIGHT_DUTY);
+        Map<String, String> tags = new HashMap<>();
+        tags.put("mytag", "tagecske");
+        sdxClusterRequest.addTags(tags);
+        sdxClusterRequest.setEnvironment("envir");
+        when(sdxClusterRepository.findByAccountIdAndEnvNameAndDeletedIsNull(anyString(), anyString())).thenReturn(new ArrayList<>());
+        long id = 10L;
+        mockEnvironmentCall(sdxClusterRequest, CloudPlatform.AZURE);
+        sdxClusterRequest.setEnableRangerRaz(true);
+        when(entitlementService.razEnabled(anyString(), anyString())).thenReturn(true);
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
+        assertEquals("1. Provisioning Ranger Raz is only valid for CM version > 7.2.1 and not 7.2.0", badRequestException.getMessage());
     }
 
     private void setSpot(SdxClusterRequest sdxClusterRequest) {

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
@@ -70,7 +70,7 @@ public class CMRepositoryVersionUtil {
 
     public static boolean isRazConfigurationSupported(String version) {
         LOGGER.info("ClouderaManagerRepo is compared for Raz Ranger support");
-        return isVersionNewerOrEqualThanLimited(version, CLOUDERAMANAGER_VERSION_7_2_0);
+        return isVersionNewerOrEqualThanLimited(version, CLOUDERAMANAGER_VERSION_7_2_1);
     }
 
     public static boolean isVersionNewerOrEqualThanLimited(Versioned currentVersion, Versioned limitedAPIVersion) {

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/RangerRazConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/RangerRazConfigProviderTest.java
@@ -73,10 +73,31 @@ class RangerRazConfigProviderTest {
     }
 
     @Test
-    @DisplayName("CM 7.2.0 is used and Raz is requested, Raz service needs to be added to the template")
+    @DisplayName("CM 7.2.0 is used and Raz is requested, no additional service needs to be added to the template")
     void getAdditionalServicesWhenRazIsEnabledWithCm720() {
         ClouderaManagerRepo cmRepo = new ClouderaManagerRepo();
         cmRepo.setVersion("7.2.0");
+        GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
+        generalClusterConfigs.setEnableRangerRaz(true);
+        HostgroupView master = new HostgroupView("master", 0, InstanceGroupType.GATEWAY, List.of());
+        HostgroupView idbroker = new HostgroupView("idbroker", 0, InstanceGroupType.CORE, List.of());
+        TemplatePreparationObject preparationObject = Builder.builder()
+                .withStackType(StackType.DATALAKE)
+                .withCloudPlatform(CloudPlatform.AZURE)
+                .withProductDetails(cmRepo, List.of())
+                .withGeneralClusterConfigs(generalClusterConfigs)
+                .withHostgroupViews(Set.of(master, idbroker))
+                .build();
+        Map<String, ApiClusterTemplateService> additionalServices = configProvider.getAdditionalServices(cmTemplateProcessor, preparationObject);
+
+        assertEquals(0, additionalServices.size());
+    }
+
+    @Test
+    @DisplayName("CM 7.2.1 is used and Raz is requested, Raz service needs to be added to the template")
+    void getAdditionalServicesWhenRazIsEnabledWithCm721() {
+        ClouderaManagerRepo cmRepo = new ClouderaManagerRepo();
+        cmRepo.setVersion("7.2.1");
         GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
         generalClusterConfigs.setEnableRangerRaz(true);
         HostgroupView master = new HostgroupView("master", 0, InstanceGroupType.GATEWAY, List.of());


### PR DESCRIPTION
Bunch of raz fixes went into 7.2.1, so raz should only be enabled past that.