### PR TITLE
CB-7673: Fix NPE when rebooting or repairing FreeIPA without FQDN

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaHealthDetailsService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaHealthDetailsService.java
@@ -2,6 +2,7 @@ package com.sequenceiq.freeipa.service.stack;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -104,6 +105,7 @@ public class FreeIpaHealthDetailsService {
 
     private Map<String, String> getNameIdMap(Stack stack) {
         return stack.getInstanceGroups().stream().flatMap(ig -> ig.getInstanceMetaData().stream())
+                .filter(im -> Objects.nonNull(im.getDiscoveryFQDN()) && Objects.nonNull(im.getInstanceId()))
                 .collect(Collectors.toMap(InstanceMetaData::getDiscoveryFQDN, InstanceMetaData::getInstanceId));
     }
 


### PR DESCRIPTION
If an instance of FreeIPA does not have an assigned FQDN, then the
reboot and repair operation which are not forced can throw a null
pointer exception.

This was tested with a local deployment of cloudbreak.

Closes #CB-7673