### PR TITLE
CB-7707: Add CDP_FREEIPA_HA_REPAIR entitlement check

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
@@ -27,6 +27,9 @@ public class EntitlementService {
     static final String CDP_FREEIPA_HA = "CDP_FREEIPA_HA";
 
     @VisibleForTesting
+    static final String CDP_FREEIPA_HA_REPAIR = "CDP_FREEIPA_HA_REPAIR";
+
+    @VisibleForTesting
     static final String CLOUDERA_INTERNAL_ACCOUNT = "CLOUDERA_INTERNAL_ACCOUNT";
 
     @VisibleForTesting
@@ -67,6 +70,10 @@ public class EntitlementService {
 
     public boolean freeIpaHaEnabled(String actorCrn, String accountID) {
         return isEntitlementRegistered(actorCrn, accountID, CDP_FREEIPA_HA);
+    }
+
+    public boolean freeIpaHaRepairEnabled(String actorCrn, String accountID) {
+        return isEntitlementRegistered(actorCrn, accountID, CDP_FREEIPA_HA_REPAIR);
     }
 
     public boolean internalTenant(String actorCrn, String accountId) {

--- a/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementServiceTest.java
+++ b/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementServiceTest.java
@@ -8,6 +8,7 @@ import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_CLOUD_
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_FMS_CLUSTER_PROXY;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_FREEIPA_DL_EBS_ENCRYPTION;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_FREEIPA_HA;
+import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_FREEIPA_HA_REPAIR;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_RAZ;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_RUNTIME_UPGRADE;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CLOUDERA_INTERNAL_ACCOUNT;
@@ -68,6 +69,9 @@ class EntitlementServiceTest {
 
                 {"CDP_FREEIPA_HA == false", CDP_FREEIPA_HA, (EntitlementCheckFunction) EntitlementService::freeIpaHaEnabled, false},
                 {"CDP_FREEIPA_HA == true", CDP_FREEIPA_HA, (EntitlementCheckFunction) EntitlementService::freeIpaHaEnabled, true},
+
+                {"CDP_FREEIPA_HA_REPAIR == false", CDP_FREEIPA_HA_REPAIR, (EntitlementCheckFunction) EntitlementService::freeIpaHaRepairEnabled, false},
+                {"CDP_FREEIPA_HA_REPAIR == true", CDP_FREEIPA_HA_REPAIR, (EntitlementCheckFunction) EntitlementService::freeIpaHaRepairEnabled, true},
 
                 {"CLOUDERA_INTERNAL_ACCOUNT == false", CLOUDERA_INTERNAL_ACCOUNT, (EntitlementCheckFunction) EntitlementService::internalTenant, false},
                 {"CLOUDERA_INTERNAL_ACCOUNT == true", CLOUDERA_INTERNAL_ACCOUNT, (EntitlementCheckFunction) EntitlementService::internalTenant, true},

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/RepairInstancesService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/RepairInstancesService.java
@@ -80,8 +80,8 @@ public class RepairInstancesService {
             Collection<InstanceMetaData> instancesToRepair) {
         LOGGER.debug("Validating repair for account {} and stack ID {}. Remaining good instances [{}]. Remaining bad instances [{}]. Instances to repair [{}].",
                 accountId, stack.getId(), remainingGoodInstances, remainingBadInstances, instancesToRepair);
-        if (!entitlementService.freeIpaHaEnabled(INTERNAL_ACTOR_CRN, accountId)) {
-            throw new BadRequestException("The FreeIPA HA capability is disabled.");
+        if (!entitlementService.freeIpaHaRepairEnabled(INTERNAL_ACTOR_CRN, accountId)) {
+            throw new BadRequestException("The FreeIPA HA Repair capability is disabled.");
         }
         if (instancesToRepair.isEmpty()) {
             throw new NotFoundException("No unhealthy instances to repair.  Maybe use the force option.");

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/RepairInstancesServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/RepairInstancesServiceTest.java
@@ -129,7 +129,7 @@ class RepairInstancesServiceTest {
                 .thenReturn(createHealthDetails(InstanceStatus.CREATED, InstanceStatus.UNREACHABLE));
         when(operationService.startOperation(any(), any(), any(), any())).thenReturn(createOperation());
         when(operationToOperationStatusConverter.convert(any())).thenReturn(operationStatus);
-        when(entitlementService.freeIpaHaEnabled(any(), any())).thenReturn(Boolean.TRUE);
+        when(entitlementService.freeIpaHaRepairEnabled(any(), any())).thenReturn(Boolean.TRUE);
         when(stackUpdater.updateStackStatus(anyLong(), any(), any())).thenReturn(stack);
 
         RepairInstancesRequest request = new RepairInstancesRequest();
@@ -154,7 +154,7 @@ class RepairInstancesServiceTest {
         when(stackService.getByEnvironmentCrnAndAccountIdWithLists(ENVIRONMENT_ID1, ACCOUNT_ID)).thenReturn(stack);
         when(healthDetailsService.getHealthDetails(ENVIRONMENT_ID1, ACCOUNT_ID))
                 .thenReturn(createHealthDetails(InstanceStatus.CREATED, InstanceStatus.CREATED));
-        when(entitlementService.freeIpaHaEnabled(any(), any())).thenReturn(Boolean.TRUE);
+        when(entitlementService.freeIpaHaRepairEnabled(any(), any())).thenReturn(Boolean.TRUE);
 
         RepairInstancesRequest request = new RepairInstancesRequest();
         request.setForceRepair(false);
@@ -172,7 +172,7 @@ class RepairInstancesServiceTest {
         when(stackService.getByEnvironmentCrnAndAccountIdWithLists(ENVIRONMENT_ID1, ACCOUNT_ID)).thenReturn(stack);
         when(operationService.startOperation(any(), any(), any(), any())).thenReturn(createOperation());
         when(operationToOperationStatusConverter.convert(any())).thenReturn(operationStatus);
-        when(entitlementService.freeIpaHaEnabled(any(), any())).thenReturn(Boolean.TRUE);
+        when(entitlementService.freeIpaHaRepairEnabled(any(), any())).thenReturn(Boolean.TRUE);
         when(stackUpdater.updateStackStatus(anyLong(), any(), any())).thenReturn(stack);
 
         RepairInstancesRequest request = new RepairInstancesRequest();
@@ -200,7 +200,7 @@ class RepairInstancesServiceTest {
                 .thenReturn(createHealthDetails(InstanceStatus.CREATED, InstanceStatus.UNREACHABLE));
         when(operationService.startOperation(any(), any(), any(), any())).thenReturn(createOperation());
         when(operationToOperationStatusConverter.convert(any())).thenReturn(operationStatus);
-        when(entitlementService.freeIpaHaEnabled(any(), any())).thenReturn(Boolean.TRUE);
+        when(entitlementService.freeIpaHaRepairEnabled(any(), any())).thenReturn(Boolean.TRUE);
         when(stackUpdater.updateStackStatus(anyLong(), any(), any())).thenReturn(stack);
 
         RepairInstancesRequest request = new RepairInstancesRequest();
@@ -268,7 +268,7 @@ class RepairInstancesServiceTest {
         when(stackService.getByEnvironmentCrnAndAccountIdWithLists(ENVIRONMENT_ID1, ACCOUNT_ID)).thenReturn(stack);
         when(operationService.startOperation(any(), any(), any(), any())).thenReturn(createOperation());
         when(operationToOperationStatusConverter.convert(any())).thenReturn(operationStatus);
-        when(entitlementService.freeIpaHaEnabled(any(), any())).thenReturn(Boolean.TRUE);
+        when(entitlementService.freeIpaHaRepairEnabled(any(), any())).thenReturn(Boolean.TRUE);
         when(stackUpdater.updateStackStatus(anyLong(), any(), any())).thenReturn(stack);
 
         RepairInstancesRequest request = new RepairInstancesRequest();

--- a/mock-caas/src/main/java/com/sequenceiq/caas/grpc/service/auth/MockUserManagementService.java
+++ b/mock-caas/src/main/java/com/sequenceiq/caas/grpc/service/auth/MockUserManagementService.java
@@ -180,6 +180,8 @@ public class MockUserManagementService extends UserManagementImplBase {
 
     private static final String CDP_FREEIPA_HA = "CDP_FREEIPA_HA";
 
+    private static final String CDP_FREEIPA_HA_REPAIR = "CDP_FREEIPA_HA_REPAIR";
+
     private static final String CDP_CLOUD_STORAGE_VALIDATION = "CDP_CLOUD_STORAGE_VALIDATION";
 
     private static final String CDP_RUNTIME_UPGRADE = "CDP_RUNTIME_UPGRADE";
@@ -233,6 +235,9 @@ public class MockUserManagementService extends UserManagementImplBase {
 
     @Value("${auth.mock.freeipa.ha.enable}")
     private boolean enableFreeIpaHa;
+
+    @Value("${auth.mock.freeipa.ha.repair.enable}")
+    private boolean enableFreeIpaHaRepair;
 
     @Value("${auth.mock.cloudstoragevalidation.enable}")
     private boolean enableCloudStorageValidation;
@@ -492,6 +497,9 @@ public class MockUserManagementService extends UserManagementImplBase {
         }
         if (enableFreeIpaHa) {
             builder.addEntitlements(createEntitlement(CDP_FREEIPA_HA));
+        }
+        if (enableFreeIpaHaRepair) {
+            builder.addEntitlements(createEntitlement(CDP_FREEIPA_HA_REPAIR));
         }
         if (enableCloudStorageValidation) {
             builder.addEntitlements(createEntitlement(CDP_CLOUD_STORAGE_VALIDATION));

--- a/mock-caas/src/main/resources/application.yml
+++ b/mock-caas/src/main/resources/application.yml
@@ -13,7 +13,9 @@ auth:
     baseimage.enable: true
     event-generation:
       expiration-minutes: 10
-    freeipa.ha.enable: true
+    freeipa.ha:
+      enable: true
+      repair.enable: true
     cloudstoragevalidation.enable: true
     runtime.upgrade.enable: true
     sshpublickey.file: key.pub


### PR DESCRIPTION
Check the CDP_FREEIPA_HA_REPAIR entitlement when repairing FreeIPA HA.

This was tested manually with a local deployment of cloudbreak.

Closes #CB-7707