### PR TITLE
CB-7360 Speed up handling of encrypted EBS

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
@@ -53,6 +53,9 @@ public class EntitlementService {
     @VisibleForTesting
     static final String CDP_AZURE_SINGLE_RESOURCE_GROUP = "CDP_AZURE_SINGLE_RESOURCE_GROUP";
 
+    @VisibleForTesting
+    static final String CDP_CB_FAST_EBS_ENCRYPTION = "CDP_CB_FAST_EBS_ENCRYPTION";
+
     @Inject
     private GrpcUmsClient umsClient;
 
@@ -106,6 +109,10 @@ public class EntitlementService {
 
     public boolean azureSingleResourceGroupDeploymentEnabled(String actorCrn, String accountId) {
         return isEntitlementRegistered(actorCrn, accountId, CDP_AZURE_SINGLE_RESOURCE_GROUP);
+    }
+
+    public boolean fastEbsEncryptionEnabled(String actorCrn, String accountId) {
+        return isEntitlementRegistered(actorCrn, accountId, CDP_CB_FAST_EBS_ENCRYPTION);
     }
 
     public List<String> getEntitlements(String actorCrn, String accountId) {

--- a/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementServiceTest.java
+++ b/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementServiceTest.java
@@ -4,6 +4,7 @@ import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_AUTOMA
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_AZURE;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_AZURE_SINGLE_RESOURCE_GROUP;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_BASE_IMAGE;
+import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_CB_FAST_EBS_ENCRYPTION;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_CLOUD_STORAGE_VALIDATION;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_FMS_CLUSTER_PROXY;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_FREEIPA_DL_EBS_ENCRYPTION;
@@ -12,6 +13,7 @@ import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_FREEIP
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_RAZ;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_RUNTIME_UPGRADE;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CLOUDERA_INTERNAL_ACCOUNT;
+import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.LOCAL_DEV;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -95,10 +97,18 @@ class EntitlementServiceTest {
                 {"CDP_FREEIPA_DL_EBS_ENCRYPTION == true", CDP_FREEIPA_DL_EBS_ENCRYPTION,
                         (EntitlementCheckFunction) EntitlementService::freeIpaDlEbsEncryptionEnabled, true},
 
+                {"LOCAL_DEV == false", LOCAL_DEV, (EntitlementCheckFunction) EntitlementService::localDevelopment, false},
+                {"LOCAL_DEV == true", LOCAL_DEV, (EntitlementCheckFunction) EntitlementService::localDevelopment, true},
+
                 {"CDP_AZURE_SINGLE_RESOURCE_GROUP == false", CDP_AZURE_SINGLE_RESOURCE_GROUP,
                         (EntitlementCheckFunction) EntitlementService::azureSingleResourceGroupDeploymentEnabled, false},
                 {"CDP_AZURE_SINGLE_RESOURCE_GROUP == true", CDP_AZURE_SINGLE_RESOURCE_GROUP,
                         (EntitlementCheckFunction) EntitlementService::azureSingleResourceGroupDeploymentEnabled, true},
+
+                {"CDP_CB_FAST_EBS_ENCRYPTION == false", CDP_CB_FAST_EBS_ENCRYPTION,
+                        (EntitlementCheckFunction) EntitlementService::fastEbsEncryptionEnabled, false},
+                {"CDP_CB_FAST_EBS_ENCRYPTION == true", CDP_CB_FAST_EBS_ENCRYPTION,
+                        (EntitlementCheckFunction) EntitlementService::fastEbsEncryptionEnabled, true},
         };
     }
 

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/instance/AwsInstanceTemplate.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/instance/AwsInstanceTemplate.java
@@ -43,6 +43,24 @@ public class AwsInstanceTemplate extends InstanceTemplate {
      */
     public static final String EC2_SPOT_PERCENTAGE = "spotPercentage";
 
+    /**
+     * Key of the optional dynamic parameter denoting whether speed optimizations for the EBS encryption setup logic are enabled or not. This applies to both
+     * root & attached (data) volumes.
+     *
+     * <p>
+     *     Permitted values:
+     *     <ul>
+     *         <li>{@code Boolean.TRUE} instance, {@code "true"} (ignoring case): EBS encryption will be set up using the new fast logic.</li>
+     *         <li>{@code Boolean.FALSE} instance, {@code "false"} (or any other {@code String} not equal to {@code "true"} ignoring case), {@code null}:
+     *         EBS encryption provisioning will utilize the legacy slow logic.</li>
+     *     </ul>
+     * </p>
+     *
+     * @see #putParameter(String, Object)
+     * @see Boolean#parseBoolean(String)
+     */
+    public static final String FAST_EBS_ENCRYPTION_ENABLED = "fastEbsEncryption";
+
     public AwsInstanceTemplate(String flavor, String groupName, Long privateId, Collection<Volume> volumes, InstanceStatus status,
             Map<String, Object> parameters, Long templateId, String imageId) {
         super(flavor, groupName, privateId, volumes, status, parameters, templateId, imageId);

--- a/cloud-aws/build.gradle
+++ b/cloud-aws/build.gradle
@@ -19,12 +19,14 @@ dependencies {
   compile project(':template-manager-tag')
 
   // mockito juniper depends on ByteBuddy 1.9.7, but hibernate use older version
-  compile group: 'net.bytebuddy', name: 'byte-buddy', version: '1.9.12'
+  compile group: 'net.bytebuddy',                 name: 'byte-buddy',                     version: '1.9.12'
   compile group: 'org.slf4j',                     name: 'slf4j-api',                      version: slf4jApiVersion
   compile group: 'org.apache.commons',            name: 'commons-lang3',                  version: apacheCommonsLangVersion
   compile group: 'commons-io',                    name: 'commons-io',                     version: '2.4'
   compile group: 'commons-codec',                 name: 'commons-codec',                  version: commonsCodecVersion
-  compile (group: 'com.amazonaws',                name: 'aws-java-sdk',                   version: awsSdkVersion)      { exclude group: 'commons-logging' }
+  compile (group: 'com.amazonaws',                name: 'aws-java-sdk',                   version: awsSdkVersion) {
+      exclude group: 'commons-logging'
+  }
   compile group: 'org.freemarker',                name: 'freemarker',                     version: freemarkerVersion
   compile group: 'commons-net',                   name: 'commons-net',                    version: '3.6'
 
@@ -32,9 +34,10 @@ dependencies {
 
   testCompile group: 'org.springframework.boot',  name: 'spring-boot-starter-test',       version: springBootVersion
   testCompile group: 'org.springframework.boot',  name:'spring-boot-starter-freemarker',  version: springBootVersion
-  testCompile (group: 'org.mockito',             name: 'mockito-core',          version: mockitoVersion) {
+  testCompile (group: 'org.mockito',              name: 'mockito-core',                   version: mockitoVersion) {
       exclude group: 'org.hamcrest'
   }
-  testCompile (group: 'org.hamcrest', name: 'java-hamcrest', version: hamcrestVersion)
+  testCompile (group: 'org.hamcrest',             name: 'java-hamcrest',                  version: hamcrestVersion)
   testCompile group: 'org.assertj',               name: 'assertj-core',                   version: assertjVersion
+  testImplementation group: 'org.junit.jupiter',  name: 'junit-jupiter-migrationsupport', version: junitJupiterVersion
 }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilder.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilder.java
@@ -32,6 +32,7 @@ import freemarker.template.TemplateException;
 
 @Service("CloudFormationTemplateBuilder")
 public class CloudFormationTemplateBuilder {
+
     @Inject
     private Configuration freemarkerConfiguration;
 
@@ -58,12 +59,13 @@ public class CloudFormationTemplateBuilder {
                     group.getSecurity().getRules(),
                     group.getSecurity().getCloudSecurityIds(),
                     getSubnetIds(context.existingSubnetIds, subnetCounter, group, multigw),
-                    awsInstanceView.isKmsEnabled(),
+                    awsInstanceView.isKmsCustom(),
                     awsInstanceView.getKmsKey(),
                     encryptedAMI,
                     group.getSecurity().isUseNetworkCidrAsSourceForDefaultRules(),
                     getInstanceProfile(group),
-                    awsInstanceView.getOnDemandPercentage());
+                    awsInstanceView.getOnDemandPercentage(),
+                    awsInstanceView.isFastEbsEncryptionEnabled());
             awsGroupViews.add(groupView);
             if (group.getType() == InstanceGroupType.GATEWAY) {
                 awsGatewayGroupViews.add(groupView);
@@ -139,6 +141,7 @@ public class CloudFormationTemplateBuilder {
     }
 
     public static class ModelContext {
+
         private AuthenticatedContext ac;
 
         private CloudStack stack;
@@ -250,9 +253,11 @@ public class CloudFormationTemplateBuilder {
             this.encryptedAMIByGroupName.putAll(encryptedAMIByGroupName);
             return this;
         }
+
     }
 
     public static class RDSModelContext {
+
         private String template;
 
         private boolean hasPort;
@@ -282,4 +287,5 @@ public class CloudFormationTemplateBuilder {
         }
 
     }
+
 }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsGroupView.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsGroupView.java
@@ -50,9 +50,12 @@ public class AwsGroupView {
 
     private final int onDemandPercentage;
 
-    public AwsGroupView(Integer instanceCount, String type, String flavor, String groupName, Boolean ebsEncrypted, Integer rootVolumeSize,
-            Map<String, Long> volumeCounts, List<SecurityRule> rules, List<String> cloudSecurityIds, String subnetId, Boolean kmsKeyDefined,
-            String kmsKey, String encryptedAMI, boolean useNetworkCidrAsSourceForDefaultRules, String instanceProfile, int onDemandPercentage) {
+    private final Boolean fastEbsEncryptionEnabled;
+
+    public AwsGroupView(Integer instanceCount, String type, String flavor, String groupName, boolean ebsEncrypted, Integer rootVolumeSize,
+            Map<String, Long> volumeCounts, List<SecurityRule> rules, List<String> cloudSecurityIds, String subnetId, boolean kmsKeyDefined,
+            String kmsKey, String encryptedAMI, boolean useNetworkCidrAsSourceForDefaultRules, String instanceProfile, int onDemandPercentage,
+            boolean fastEbsEncryptionEnabled) {
         this.instanceCount = instanceCount;
         this.type = type;
         this.flavor = flavor;
@@ -72,6 +75,7 @@ public class AwsGroupView {
         this.instanceProfile = instanceProfile;
         hasInstanceProfile = instanceProfile != null;
         this.onDemandPercentage = onDemandPercentage;
+        this.fastEbsEncryptionEnabled = fastEbsEncryptionEnabled;
     }
 
     public static String getAutoScalingGroupName(String groupName) {
@@ -173,4 +177,9 @@ public class AwsGroupView {
     public int getOnDemandPercentage() {
         return onDemandPercentage;
     }
+
+    public Boolean getFastEbsEncryptionEnabled() {
+        return fastEbsEncryptionEnabled;
+    }
+
 }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsInstanceView.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsInstanceView.java
@@ -85,4 +85,15 @@ public class AwsInstanceView {
     public int getOnDemandPercentage() {
         return HUNDRED_PERCENT - Objects.requireNonNullElse(getSpotPercentage(), 0);
     }
+
+    public boolean isFastEbsEncryptionEnabled() {
+        Object fastEbsEncryption = instanceTemplate.getParameter(AwsInstanceTemplate.FAST_EBS_ENCRYPTION_ENABLED, Object.class);
+        if (fastEbsEncryption instanceof Boolean) {
+            return (Boolean) fastEbsEncryption;
+        } else if (fastEbsEncryption instanceof String) {
+            return Boolean.parseBoolean((String) fastEbsEncryption);
+        }
+        return false;
+    }
+
 }

--- a/cloud-aws/src/main/resources/templates/aws-cf-dbstack.ftl
+++ b/cloud-aws/src/main/resources/templates/aws-cf-dbstack.ftl
@@ -89,7 +89,7 @@
     "VPCSecurityGroupsParameter": {
         "Type": "List<AWS::EC2::SecurityGroup::Id>",
         "Description": "VPC security groups"
-    },
+    }
     <#else>
     "DBSecurityGroupNameParameter": {
         "Type": "String",

--- a/cloud-aws/src/main/resources/templates/aws-cf-stack-freeipa.ftl
+++ b/cloud-aws/src/main/resources/templates/aws-cf-stack-freeipa.ftl
@@ -144,12 +144,18 @@
             {
               "DeviceName" : { "Ref" : "RootDeviceName" },
               "Ebs" : {
+                <#if group.ebsEncrypted && group.fastEbsEncryptionEnabled>
+                "Encrypted" : "true",
+                  <#if group.kmsKeyDefined>
+                  "KmsKeyId" : "${group.kmsKey}",
+                  </#if>
+                </#if>
                 "VolumeSize" : "${group.rootVolumeSize}",
                 "VolumeType" : "gp2"
               }
             }
           ],
-          <#if group.ebsEncrypted == true>
+          <#if group.ebsEncrypted && !group.fastEbsEncryptionEnabled>
           "ImageId"        : "${group.encryptedAMI}",
           <#else>
           "ImageId"        : { "Ref" : "AMI" },

--- a/cloud-aws/src/main/resources/templates/aws-cf-stack.ftl
+++ b/cloud-aws/src/main/resources/templates/aws-cf-stack.ftl
@@ -328,6 +328,12 @@
             {
               "DeviceName" : { "Ref" : "RootDeviceName" },
               "Ebs" : {
+                <#if group.ebsEncrypted && group.fastEbsEncryptionEnabled>
+                "Encrypted" : "true",
+                  <#if group.kmsKeyDefined>
+                  "KmsKeyId" : "${group.kmsKey}",
+                  </#if>
+                </#if>
                 "VolumeSize" : "${group.rootVolumeSize}",
                 "VolumeType" : "gp2"
               }
@@ -344,7 +350,7 @@
               </#list>
             </#if>
           ],
-          <#if group.ebsEncrypted == true>
+          <#if group.ebsEncrypted && !group.fastEbsEncryptionEnabled>
           "ImageId"        : "${group.encryptedAMI}",
           <#else>
           "ImageId"        : { "Ref" : "AMI" },

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilderTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilderTest.java
@@ -4,11 +4,11 @@ import static com.sequenceiq.cloudbreak.cloud.aws.TestConstants.LATEST_AWS_CLOUD
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
+import static java.util.Map.entry;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -22,13 +22,12 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.ui.freemarker.FreeMarkerConfigurationFactoryBean;
 
@@ -60,13 +59,14 @@ import com.sequenceiq.cloudbreak.cloud.model.instance.AwsInstanceTemplate;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 import com.sequenceiq.cloudbreak.tag.CostTagging;
 import com.sequenceiq.cloudbreak.util.FreeMarkerTemplateUtils;
+import com.sequenceiq.common.api.type.EncryptionType;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.OutboundInternetTraffic;
 import com.sequenceiq.common.model.CloudIdentityType;
 
 import freemarker.template.Configuration;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class CloudFormationTemplateBuilderTest {
 
     private static final String USER_ID = "horton@hortonworks.com";
@@ -106,7 +106,7 @@ public class CloudFormationTemplateBuilderTest {
 
     private CloudInstance instance;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         FreeMarkerConfigurationFactoryBean factoryBean = new FreeMarkerConfigurationFactoryBean();
         factoryBean.setPreferFileSystemAccess(false);
@@ -136,7 +136,7 @@ public class CloudFormationTemplateBuilderTest {
     }
 
     @Test
-    public void buildTestInstanceGroupsAndRootVolumeSize() throws IOException {
+    public void buildTestInstanceGroupsAndRootVolumeSize() {
         //WHEN
         modelContext = new ModelContext()
                 .withAuthenticatedContext(authenticatedContext)
@@ -167,7 +167,7 @@ public class CloudFormationTemplateBuilderTest {
     @Test
     public void buildTestInstanceGroupsWhenRootVolumeSizeIsSuperLarge() throws IOException {
         //GIVEN
-        Integer rootVolumeSize = Integer.MAX_VALUE;
+        int rootVolumeSize = Integer.MAX_VALUE;
         Security security = getDefaultCloudStackSecurity();
         List<Group> groups = List.of(createDefaultGroup("master", InstanceGroupType.CORE, rootVolumeSize, security, Optional.empty()),
                 createDefaultGroup("gateway", InstanceGroupType.GATEWAY, rootVolumeSize, security, Optional.empty()));
@@ -187,17 +187,17 @@ public class CloudFormationTemplateBuilderTest {
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
 
         //THEN
-        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        Assertions.assertThat(JsonUtil.isValid(templateString)).overridingErrorMessage("Invalid JSON: " + templateString).isTrue();
         assertThat(templateString, containsString(Integer.toString(rootVolumeSize)));
         JsonNode firstBlockDeviceMapping = getJsonNode(JsonUtil.readTree(templateString), "BlockDeviceMappings").get(0);
         String volumeSize = getJsonNode(firstBlockDeviceMapping, "VolumeSize").textValue();
-        assertEquals(Integer.valueOf(volumeSize), rootVolumeSize);
+        Assertions.assertThat(Integer.valueOf(volumeSize)).isEqualTo(rootVolumeSize);
     }
 
     @Test
     public void buildTestInstanceGroupsWhenRootVolumeSizeIsSuperSmall() throws IOException {
         //GIVEN
-        Integer rootVolumeSize = Integer.MIN_VALUE;
+        int rootVolumeSize = Integer.MIN_VALUE;
         Security security = getDefaultCloudStackSecurity();
         List<Group> groups = List.of(createDefaultGroup("master", InstanceGroupType.CORE, rootVolumeSize, security, Optional.empty()),
                 createDefaultGroup("gateway", InstanceGroupType.GATEWAY, rootVolumeSize, security, Optional.empty()));
@@ -217,12 +217,11 @@ public class CloudFormationTemplateBuilderTest {
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
 
         //THEN
-        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        Assertions.assertThat(JsonUtil.isValid(templateString)).overridingErrorMessage("Invalid JSON: " + templateString).isTrue();
         assertThat(templateString, containsString(Integer.toString(rootVolumeSize)));
         JsonNode firstBlockDeviceMapping = getJsonNode(JsonUtil.readTree(templateString), "BlockDeviceMappings").get(0);
         String volumeSize = getJsonNode(firstBlockDeviceMapping, "VolumeSize").textValue();
-        assertEquals(Integer.valueOf(volumeSize), rootVolumeSize);
-
+        Assertions.assertThat(Integer.valueOf(volumeSize)).isEqualTo(rootVolumeSize);
     }
 
     @Test
@@ -242,7 +241,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withTemplate(awsCloudFormationTemplate);
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
-        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        Assertions.assertThat(JsonUtil.isValid(templateString)).overridingErrorMessage("Invalid JSON: " + templateString).isTrue();
         assertThat(templateString, containsString("InstanceProfile"));
         assertThat(templateString, containsString("VPCId"));
         assertThat(templateString, not(containsString("SubnetCIDR")));
@@ -271,7 +270,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withTemplate(awsCloudFormationTemplate);
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
-        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        Assertions.assertThat(JsonUtil.isValid(templateString)).overridingErrorMessage("Invalid JSON: " + templateString).isTrue();
         assertThat(templateString, containsString("InstanceProfile"));
         assertThat(templateString, containsString("VPCId"));
         assertThat(templateString, not(containsString("SubnetCIDR")));
@@ -300,7 +299,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withTemplate(awsCloudFormationTemplate);
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
-        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        Assertions.assertThat(JsonUtil.isValid(templateString)).overridingErrorMessage("Invalid JSON: " + templateString).isTrue();
         assertThat(templateString, containsString("InstanceProfile"));
         assertThat(templateString, containsString("VPCId"));
         assertThat(templateString, not(containsString("SubnetCIDR")));
@@ -328,7 +327,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withTemplate(awsCloudFormationTemplate);
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
-        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        Assertions.assertThat(JsonUtil.isValid(templateString)).overridingErrorMessage("Invalid JSON: " + templateString).isTrue();
         assertThat(templateString, not(containsString("InstanceProfile")));
         assertThat(templateString, containsString("VPCId"));
         assertThat(templateString, not(containsString("SubnetCIDR")));
@@ -357,7 +356,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withTemplate(awsCloudFormationTemplate);
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
-        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        Assertions.assertThat(JsonUtil.isValid(templateString)).overridingErrorMessage("Invalid JSON: " + templateString).isTrue();
         assertThat(templateString, containsString("InstanceProfile"));
         assertThat(templateString, containsString("VPCId"));
         assertThat(templateString, not(containsString("SubnetCIDR")));
@@ -393,7 +392,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withTemplate(awsCloudFormationTemplate);
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
-        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        Assertions.assertThat(JsonUtil.isValid(templateString)).overridingErrorMessage("Invalid JSON: " + templateString).isTrue();
         assertThat(templateString, containsString("InstanceProfile"));
         assertThat(templateString, containsString("VPCId"));
         assertThat(templateString, not(containsString("SubnetCIDR")));
@@ -425,7 +424,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withTemplate(awsCloudFormationTemplate);
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
-        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        Assertions.assertThat(JsonUtil.isValid(templateString)).overridingErrorMessage("Invalid JSON: " + templateString).isTrue();
         assertThat(templateString, containsString("InstanceProfile"));
         assertThat(templateString, containsString("VPCId"));
         assertThat(templateString, not(containsString("SubnetCIDR")));
@@ -454,7 +453,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withTemplate(awsCloudFormationTemplate);
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
-        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        Assertions.assertThat(JsonUtil.isValid(templateString)).overridingErrorMessage("Invalid JSON: " + templateString).isTrue();
         assertThat(templateString, containsString("InstanceProfile"));
         assertThat(templateString, containsString("VPCId"));
         assertThat(templateString, not(containsString("SubnetCIDR")));
@@ -482,7 +481,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withTemplate(awsCloudFormationTemplate);
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
-        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        Assertions.assertThat(JsonUtil.isValid(templateString)).overridingErrorMessage("Invalid JSON: " + templateString).isTrue();
         assertThat(templateString, not(containsString("InstanceProfile")));
         assertThat(templateString, containsString("VPCId"));
         assertThat(templateString, not(containsString("SubnetCIDR")));
@@ -511,7 +510,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withTemplate(awsCloudFormationTemplate);
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
-        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        Assertions.assertThat(JsonUtil.isValid(templateString)).overridingErrorMessage("Invalid JSON: " + templateString).isTrue();
         assertThat(templateString, containsString("InstanceProfile"));
         assertThat(templateString, containsString("VPCId"));
         assertThat(templateString, not(containsString("SubnetCIDR")));
@@ -540,7 +539,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withTemplate(awsCloudFormationTemplate);
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
-        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        Assertions.assertThat(JsonUtil.isValid(templateString)).overridingErrorMessage("Invalid JSON: " + templateString).isTrue();
         assertThat(templateString, containsString("InstanceProfile"));
         assertThat(templateString, containsString("VPCId"));
         assertThat(templateString, not(containsString("SubnetCIDR")));
@@ -569,7 +568,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withTemplate(awsCloudFormationTemplate);
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
-        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        Assertions.assertThat(JsonUtil.isValid(templateString)).overridingErrorMessage("Invalid JSON: " + templateString).isTrue();
         assertThat(templateString, containsString("InstanceProfile"));
         assertThat(templateString, containsString("VPCId"));
         assertThat(templateString, not(containsString("SubnetCIDR")));
@@ -597,7 +596,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withTemplate(awsCloudFormationTemplate);
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
-        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        Assertions.assertThat(JsonUtil.isValid(templateString)).overridingErrorMessage("Invalid JSON: " + templateString).isTrue();
         assertThat(templateString, not(containsString("InstanceProfile")));
         assertThat(templateString, containsString("VPCId"));
         assertThat(templateString, not(containsString("SubnetCIDR")));
@@ -626,7 +625,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withTemplate(awsCloudFormationTemplate);
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
-        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        Assertions.assertThat(JsonUtil.isValid(templateString)).overridingErrorMessage("Invalid JSON: " + templateString).isTrue();
         assertThat(templateString, containsString("InstanceProfile"));
         assertThat(templateString, not(containsString("VPCId")));
         assertThat(templateString, not(containsString("SubnetCIDR")));
@@ -655,7 +654,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withTemplate(awsCloudFormationTemplate);
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
-        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        Assertions.assertThat(JsonUtil.isValid(templateString)).overridingErrorMessage("Invalid JSON: " + templateString).isTrue();
         assertThat(templateString, containsString("InstanceProfile"));
         assertThat(templateString, not(containsString("VPCId")));
         assertThat(templateString, not(containsString("SubnetCIDR")));
@@ -684,7 +683,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withTemplate(awsCloudFormationTemplate);
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
-        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        Assertions.assertThat(JsonUtil.isValid(templateString)).overridingErrorMessage("Invalid JSON: " + templateString).isTrue();
         assertThat(templateString, containsString("InstanceProfile"));
         assertThat(templateString, not(containsString("VPCId")));
         assertThat(templateString, not(containsString("SubnetCIDR")));
@@ -713,7 +712,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withTemplate(awsCloudFormationTemplate);
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
-        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        Assertions.assertThat(JsonUtil.isValid(templateString)).overridingErrorMessage("Invalid JSON: " + templateString).isTrue();
         assertThat(templateString, not(containsString("InstanceProfile")));
         assertThat(templateString, not(containsString("VPCId")));
         assertThat(templateString, not(containsString("SubnetCIDR")));
@@ -747,7 +746,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withTemplate(awsCloudFormationTemplate);
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
-        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        Assertions.assertThat(JsonUtil.isValid(templateString)).overridingErrorMessage("Invalid JSON: " + templateString).isTrue();
         assertThat(templateString, containsString("VPCId"));
         assertThat(templateString, containsString("\"single-sg-id\""));
     }
@@ -776,7 +775,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withTemplate(awsCloudFormationTemplate);
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
-        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        Assertions.assertThat(JsonUtil.isValid(templateString)).overridingErrorMessage("Invalid JSON: " + templateString).isTrue();
         assertThat(templateString, containsString("VPCId"));
         assertThat(templateString, containsString("\"single-sg-id\""));
     }
@@ -803,7 +802,7 @@ public class CloudFormationTemplateBuilderTest {
                 .withTemplate(awsCloudFormationTemplate);
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
         //THEN
-        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        Assertions.assertThat(JsonUtil.isValid(templateString)).overridingErrorMessage("Invalid JSON: " + templateString).isTrue();
         assertThat(templateString, containsString("\"multi-sg-id1\",\"multi-sg-id2\""));
         assertThat(templateString, containsString("VPCId"));
     }
@@ -837,7 +836,7 @@ public class CloudFormationTemplateBuilderTest {
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
 
         //THEN
-        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        Assertions.assertThat(JsonUtil.isValid(templateString)).overridingErrorMessage("Invalid JSON: " + templateString).isTrue();
         assertThat(templateString, stringContainsInOrder("OnDemandPercentageAboveBaseCapacity", "40"));
     }
 
@@ -861,7 +860,7 @@ public class CloudFormationTemplateBuilderTest {
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
 
         //THEN
-        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        Assertions.assertThat(JsonUtil.isValid(templateString)).overridingErrorMessage("Invalid JSON: " + templateString).isTrue();
         assertThat(templateString, not(containsString("SecurityGroupEgress")));
     }
 
@@ -885,7 +884,7 @@ public class CloudFormationTemplateBuilderTest {
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
 
         //THEN
-        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        Assertions.assertThat(JsonUtil.isValid(templateString)).overridingErrorMessage("Invalid JSON: " + templateString).isTrue();
         assertThat(templateString, not(containsString("SecurityGroupEgress")));
     }
 
@@ -909,7 +908,7 @@ public class CloudFormationTemplateBuilderTest {
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
 
         //THEN
-        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        Assertions.assertThat(JsonUtil.isValid(templateString)).overridingErrorMessage("Invalid JSON: " + templateString).isTrue();
         assertThat(templateString, stringContainsInOrder("SecurityGroupEgress", "vpccidr1", "vpccidr2"));
     }
 
@@ -933,7 +932,7 @@ public class CloudFormationTemplateBuilderTest {
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
 
         //THEN
-        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        Assertions.assertThat(JsonUtil.isValid(templateString)).overridingErrorMessage("Invalid JSON: " + templateString).isTrue();
         assertThat(templateString, stringContainsInOrder("SecurityGroupEgress", "prefix1", "prefix2"));
     }
 
@@ -957,7 +956,7 @@ public class CloudFormationTemplateBuilderTest {
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
 
         //THEN
-        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        Assertions.assertThat(JsonUtil.isValid(templateString)).overridingErrorMessage("Invalid JSON: " + templateString).isTrue();
         assertThat(templateString, stringContainsInOrder("SecurityGroupEgress", "vpccidr1", "vpccidr2", "prefix1", "prefix2"));
     }
 
@@ -981,8 +980,147 @@ public class CloudFormationTemplateBuilderTest {
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
 
         //THEN
-        Assert.assertTrue("Invalid JSON: " + templateString, JsonUtil.isValid(templateString));
+        Assertions.assertThat(JsonUtil.isValid(templateString)).overridingErrorMessage("Invalid JSON: " + templateString).isTrue();
         assertThat(templateString, not(containsString("SecurityGroupEgress")));
+    }
+
+    @Test
+    public void buildTestNoEbsEncryption() {
+        //GIVEN
+        //WHEN
+        modelContext = new ModelContext()
+                .withAuthenticatedContext(authenticatedContext)
+                .withStack(cloudStack)
+                .withExistingVpc(true)
+                .withExistingIGW(true)
+                .withExistingSubnetCidr(singletonList(existingSubnetCidr))
+                .mapPublicIpOnLaunch(true)
+                .withEnableInstanceProfile(true)
+                .withInstanceProfileAvailable(true)
+                .withOutboundInternetTraffic(OutboundInternetTraffic.ENABLED)
+                .withTemplate(awsCloudFormationTemplate);
+        String templateString = cloudFormationTemplateBuilder.build(modelContext);
+        //THEN
+        Assertions.assertThat(templateString)
+                .matches(JsonUtil::isValid, "Invalid JSON: " + templateString)
+                .doesNotContain("\"Encrypted\"")
+                .contains("{ \"Ref\" : \"AMI\" }");
+    }
+
+    @Test
+    public void buildTestEbsEncryptionWithDefaultKey() {
+        //GIVEN
+        instance.getTemplate().putParameter(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, true);
+        instance.getTemplate().putParameter(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.DEFAULT.name());
+
+        //WHEN
+        modelContext = new ModelContext()
+                .withAuthenticatedContext(authenticatedContext)
+                .withStack(cloudStack)
+                .withExistingVpc(true)
+                .withExistingIGW(true)
+                .withExistingSubnetCidr(singletonList(existingSubnetCidr))
+                .mapPublicIpOnLaunch(true)
+                .withEnableInstanceProfile(true)
+                .withInstanceProfileAvailable(true)
+                .withOutboundInternetTraffic(OutboundInternetTraffic.ENABLED)
+                .withTemplate(awsCloudFormationTemplate)
+                .withEncryptedAMIByGroupName(Map.ofEntries(entry("master", "masterAMI"), entry("gateway", "gatewayAMI")));
+        String templateString = cloudFormationTemplateBuilder.build(modelContext);
+        //THEN
+        Assertions.assertThat(templateString)
+                .matches(JsonUtil::isValid, "Invalid JSON: " + templateString)
+                .doesNotContain("\"Encrypted\"")
+                .contains("\"masterAMI\"")
+                .contains("\"gatewayAMI\"")
+                .doesNotContain("{ \"Ref\" : \"AMI\" }");
+    }
+
+    @Test
+    public void buildTestEbsEncryptionWithCustomKey() {
+        //GIVEN
+        instance.getTemplate().putParameter(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, true);
+        instance.getTemplate().putParameter(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.CUSTOM.name());
+        instance.getTemplate().putParameter(InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, "customEncryptionKeyArn");
+
+        //WHEN
+        modelContext = new ModelContext()
+                .withAuthenticatedContext(authenticatedContext)
+                .withStack(cloudStack)
+                .withExistingVpc(true)
+                .withExistingIGW(true)
+                .withExistingSubnetCidr(singletonList(existingSubnetCidr))
+                .mapPublicIpOnLaunch(true)
+                .withEnableInstanceProfile(true)
+                .withInstanceProfileAvailable(true)
+                .withOutboundInternetTraffic(OutboundInternetTraffic.ENABLED)
+                .withTemplate(awsCloudFormationTemplate)
+                .withEncryptedAMIByGroupName(Map.ofEntries(entry("master", "masterAMI"), entry("gateway", "gatewayAMI")));
+        String templateString = cloudFormationTemplateBuilder.build(modelContext);
+        //THEN
+        Assertions.assertThat(templateString)
+                .matches(JsonUtil::isValid, "Invalid JSON: " + templateString)
+                .doesNotContain("\"Encrypted\"")
+                .contains("\"masterAMI\"")
+                .contains("\"gatewayAMI\"")
+                .doesNotContain("{ \"Ref\" : \"AMI\" }");
+    }
+
+    @Test
+    public void buildTestEbsEncryptionWithDefaultKeyAndFastEncryption() {
+        //GIVEN
+        instance.getTemplate().putParameter(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, true);
+        instance.getTemplate().putParameter(AwsInstanceTemplate.FAST_EBS_ENCRYPTION_ENABLED, true);
+        instance.getTemplate().putParameter(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.DEFAULT.name());
+
+        //WHEN
+        modelContext = new ModelContext()
+                .withAuthenticatedContext(authenticatedContext)
+                .withStack(cloudStack)
+                .withExistingVpc(true)
+                .withExistingIGW(true)
+                .withExistingSubnetCidr(singletonList(existingSubnetCidr))
+                .mapPublicIpOnLaunch(true)
+                .withEnableInstanceProfile(true)
+                .withInstanceProfileAvailable(true)
+                .withOutboundInternetTraffic(OutboundInternetTraffic.ENABLED)
+                .withTemplate(awsCloudFormationTemplate);
+        String templateString = cloudFormationTemplateBuilder.build(modelContext);
+        //THEN
+        Assertions.assertThat(templateString)
+                .matches(JsonUtil::isValid, "Invalid JSON: " + templateString)
+                .contains("\"Encrypted\"")
+                .contains("{ \"Ref\" : \"AMI\" }")
+                .doesNotContain("\"KmsKeyId\"");
+    }
+
+    @Test
+    public void buildTestEbsEncryptionWithCustomKeyAndFastEncryption() {
+        //GIVEN
+        instance.getTemplate().putParameter(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, true);
+        instance.getTemplate().putParameter(AwsInstanceTemplate.FAST_EBS_ENCRYPTION_ENABLED, true);
+        instance.getTemplate().putParameter(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.CUSTOM.name());
+        instance.getTemplate().putParameter(InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, "customEncryptionKeyArn");
+
+        //WHEN
+        modelContext = new ModelContext()
+                .withAuthenticatedContext(authenticatedContext)
+                .withStack(cloudStack)
+                .withExistingVpc(true)
+                .withExistingIGW(true)
+                .withExistingSubnetCidr(singletonList(existingSubnetCidr))
+                .mapPublicIpOnLaunch(true)
+                .withEnableInstanceProfile(true)
+                .withInstanceProfileAvailable(true)
+                .withOutboundInternetTraffic(OutboundInternetTraffic.ENABLED)
+                .withTemplate(awsCloudFormationTemplate);
+        String templateString = cloudFormationTemplateBuilder.build(modelContext);
+        //THEN
+        Assertions.assertThat(templateString)
+                .matches(JsonUtil::isValid, "Invalid JSON: " + templateString)
+                .contains("\"Encrypted\"")
+                .contains("{ \"Ref\" : \"AMI\" }")
+                .contains("\"KmsKeyId\" : \"customEncryptionKeyArn\"");
     }
 
     private CloudStack initCloudStackWithInstanceProfile() {

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/resource/AwsVolumeResourceBuilderTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/resource/AwsVolumeResourceBuilderTest.java
@@ -1,0 +1,401 @@
+package com.sequenceiq.cloudbreak.cloud.aws.resource;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.Map.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.FutureTask;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.core.task.AsyncTaskExecutor;
+
+import com.amazonaws.services.ec2.AmazonEC2Client;
+import com.amazonaws.services.ec2.model.CreateVolumeRequest;
+import com.amazonaws.services.ec2.model.CreateVolumeResult;
+import com.amazonaws.services.ec2.model.Tag;
+import com.amazonaws.services.ec2.model.TagSpecification;
+import com.sequenceiq.cloudbreak.cloud.aws.AwsClient;
+import com.sequenceiq.cloudbreak.cloud.aws.AwsPlatformParameters;
+import com.sequenceiq.cloudbreak.cloud.aws.AwsTaggingService;
+import com.sequenceiq.cloudbreak.cloud.aws.context.AwsContext;
+import com.sequenceiq.cloudbreak.cloud.aws.encryption.EncryptedSnapshotService;
+import com.sequenceiq.cloudbreak.cloud.aws.view.AwsCredentialView;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.Group;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
+import com.sequenceiq.cloudbreak.cloud.model.Location;
+import com.sequenceiq.cloudbreak.cloud.model.Region;
+import com.sequenceiq.cloudbreak.cloud.model.Volume;
+import com.sequenceiq.cloudbreak.cloud.model.VolumeSetAttributes;
+import com.sequenceiq.cloudbreak.cloud.model.instance.AwsInstanceTemplate;
+import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
+import com.sequenceiq.cloudbreak.service.Retry;
+import com.sequenceiq.common.api.type.CommonStatus;
+import com.sequenceiq.common.api.type.EncryptionType;
+import com.sequenceiq.common.api.type.InstanceGroupType;
+import com.sequenceiq.common.api.type.ResourceType;
+
+@ExtendWith(MockitoExtension.class)
+class AwsVolumeResourceBuilderTest {
+
+    private static final long PRIVATE_ID = 1234L;
+
+    private static final String FLAVOR = "medium";
+
+    private static final String GROUP_NAME = "master";
+
+    private static final long TEMPLATE_ID = 567L;
+
+    private static final String IMAGE_ID = "imageId";
+
+    private static final int ROOT_VOLUME_SIZE = 30;
+
+    private static final String INSTANCE_ID = "SOME_ID";
+
+    private static final String REGION_NAME = "region";
+
+    private static final String MOUNT_PREFIX = "/hadoop/volume_";
+
+    private static final int VOLUME_SIZE = 78;
+
+    private static final String TYPE_GP2 = AwsPlatformParameters.AwsDiskType.Gp2.value();
+
+    private static final String TYPE_EPHEMERAL = AwsPlatformParameters.AwsDiskType.Ephemeral.value();
+
+    private static final String VOLUME_SET_NAME = "volumeName";
+
+    private static final String VOLUME_ID = "volumeId";
+
+    private static final String AVAILABILITY_ZONE = "availabilityZone";
+
+    private static final Map<String, String> TAGS = Map.ofEntries(entry("key1", "value1"), entry("key2", "value2"));
+
+    private static final Collection<Tag> EC2_TAGS = List.of(new Tag("ec2_key", "ec2_value"));
+
+    private static final String SNAPSHOT_ID = "snapshotId";
+
+    private static final String ENCRYPTION_KEY_ARN = "encryptionKeyArn";
+
+    @Mock
+    private AsyncTaskExecutor intermediateBuilderExecutor;
+
+    @Mock
+    private PersistenceNotifier resourceNotifier;
+
+    @Mock
+    private AwsTaggingService awsTaggingService;
+
+    @Mock
+    private EncryptedSnapshotService encryptedSnapshotService;
+
+    @Mock
+    private AwsClient awsClient;
+
+    @Mock
+    private Retry retry;
+
+    @InjectMocks
+    private AwsVolumeResourceBuilder underTest;
+
+    @Mock
+    private AwsContext awsContext;
+
+    @Mock
+    private AuthenticatedContext authenticatedContext;
+
+    @Mock
+    private CloudStack cloudStack;
+
+    @Mock
+    private CloudContext cloudContext;
+
+    @Mock
+    private Location location;
+
+    @Mock
+    private Region region;
+
+    @Mock
+    private AmazonEC2Client amazonEC2Client;
+
+    @Captor
+    private ArgumentCaptor<CreateVolumeRequest> createVolumeRequestCaptor;
+
+    @BeforeEach
+    void setUp() {
+        when(authenticatedContext.getCloudContext()).thenReturn(cloudContext);
+        when(cloudContext.getLocation()).thenReturn(location);
+        when(location.getRegion()).thenReturn(region);
+        when(region.value()).thenReturn(REGION_NAME);
+        when(awsClient.createAccess(isA(AwsCredentialView.class), eq(REGION_NAME))).thenReturn(amazonEC2Client);
+        when(cloudStack.getTags()).thenReturn(TAGS);
+        when(awsTaggingService.prepareEc2Tags(authenticatedContext, TAGS)).thenReturn(EC2_TAGS);
+    }
+
+    @Test
+    void buildTestWhenNoVolumesAtAll() throws Exception {
+        Group group = createGroup(emptyList(), Map.of(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, false));
+
+        when(encryptedSnapshotService.isEncryptedVolumeRequested(group)).thenReturn(false);
+
+        List<CloudResource> result = underTest.build(awsContext, PRIVATE_ID, authenticatedContext, group, emptyList(), cloudStack);
+
+        assertThat(result).isEmpty();
+        verify(encryptedSnapshotService, never()).createSnapshotIfNeeded(authenticatedContext, cloudStack, group, resourceNotifier);
+    }
+
+    @Test
+    void buildTestWhenEphemeralVolumesOnly() throws Exception {
+        Group group = createGroup(List.of(createVolume(TYPE_EPHEMERAL)), Map.of(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, false));
+
+        when(encryptedSnapshotService.isEncryptedVolumeRequested(group)).thenReturn(false);
+
+        List<CloudResource> result = underTest.build(awsContext, PRIVATE_ID, authenticatedContext, group, List.of(createVolumeSet(emptyList())), cloudStack);
+
+        List<VolumeSetAttributes.Volume> volumes = verifyResultAndGetVolumes(result);
+        assertThat(volumes).isEmpty();
+        verify(encryptedSnapshotService, never()).createSnapshotIfNeeded(authenticatedContext, cloudStack, group, resourceNotifier);
+    }
+
+    @Test
+    void buildTestWhenAttachedVolumesOnlyAndNoEncryption() throws Exception {
+        Group group = createGroup(List.of(createVolume(TYPE_GP2)), Map.of(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, false));
+
+        when(encryptedSnapshotService.isEncryptedVolumeRequested(group)).thenReturn(false);
+        setUpTaskExecutors();
+        when(amazonEC2Client.createVolume(isA(CreateVolumeRequest.class))).thenReturn(createCreateVolumeResult());
+
+        List<CloudResource> result = underTest.build(awsContext, PRIVATE_ID, authenticatedContext, group,
+                List.of(createVolumeSet(List.of(createVolumeForVolumeSet(TYPE_GP2)))), cloudStack);
+
+        List<VolumeSetAttributes.Volume> volumes = verifyResultAndGetVolumes(result);
+        verifyVolumes(volumes, "/dev/xvdb");
+        verifyCreateVolumeRequest(null, false, null);
+        verify(encryptedSnapshotService, never()).createSnapshotIfNeeded(authenticatedContext, cloudStack, group, resourceNotifier);
+    }
+
+    @Test
+    void buildTestWhenEphemeralAndAttachedVolumesAndNoEncryption() throws Exception {
+        Group group = createGroup(List.of(createVolume(TYPE_EPHEMERAL), createVolume(TYPE_GP2)), Map.of(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, false));
+
+        when(encryptedSnapshotService.isEncryptedVolumeRequested(group)).thenReturn(false);
+        setUpTaskExecutors();
+        when(amazonEC2Client.createVolume(isA(CreateVolumeRequest.class))).thenReturn(createCreateVolumeResult());
+
+        List<CloudResource> result = underTest.build(awsContext, PRIVATE_ID, authenticatedContext, group,
+                List.of(createVolumeSet(List.of(createVolumeForVolumeSet(TYPE_GP2)))), cloudStack);
+
+        List<VolumeSetAttributes.Volume> volumes = verifyResultAndGetVolumes(result);
+        verifyVolumes(volumes, "/dev/xvdc");
+        verifyCreateVolumeRequest(null, false, null);
+        verify(encryptedSnapshotService, never()).createSnapshotIfNeeded(authenticatedContext, cloudStack, group, resourceNotifier);
+    }
+
+    @Test
+    @MockitoSettings(strictness = Strictness.LENIENT)
+    void buildTestWhenAttachedVolumesOnlyAndEncryptionWithDefaultKeyAndSnapshotError() {
+        Group group = createGroup(List.of(createVolume(TYPE_GP2)),
+                Map.ofEntries(entry(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, true),
+                        entry(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.DEFAULT.name()),
+                        entry(AwsInstanceTemplate.FAST_EBS_ENCRYPTION_ENABLED, false)));
+
+        when(encryptedSnapshotService.isEncryptedVolumeRequested(group)).thenReturn(true);
+        when(encryptedSnapshotService.createSnapshotIfNeeded(authenticatedContext, cloudStack, group, resourceNotifier)).thenReturn(Optional.empty());
+
+        CloudConnectorException exception = assertThrows(CloudConnectorException.class, () -> underTest.build(awsContext, PRIVATE_ID, authenticatedContext,
+                group, List.of(createVolumeSet(List.of(createVolumeForVolumeSet(TYPE_GP2)))), cloudStack));
+        assertThat(exception.getMessage()).contains("Failed to create EBS encrypted volume on stack:");
+    }
+
+    @Test
+    void buildTestWhenAttachedVolumesOnlyAndEncryptionWithDefaultKey() throws Exception {
+        Group group = createGroup(List.of(createVolume(TYPE_GP2)),
+                Map.ofEntries(entry(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, true),
+                        entry(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.DEFAULT.name()),
+                        entry(AwsInstanceTemplate.FAST_EBS_ENCRYPTION_ENABLED, false)));
+
+        when(encryptedSnapshotService.isEncryptedVolumeRequested(group)).thenReturn(true);
+        when(encryptedSnapshotService.createSnapshotIfNeeded(authenticatedContext, cloudStack, group, resourceNotifier)).thenReturn(Optional.of(SNAPSHOT_ID));
+        setUpTaskExecutors();
+        when(amazonEC2Client.createVolume(isA(CreateVolumeRequest.class))).thenReturn(createCreateVolumeResult());
+
+        List<CloudResource> result = underTest.build(awsContext, PRIVATE_ID, authenticatedContext, group,
+                List.of(createVolumeSet(List.of(createVolumeForVolumeSet(TYPE_GP2)))), cloudStack);
+
+        List<VolumeSetAttributes.Volume> volumes = verifyResultAndGetVolumes(result);
+        verifyVolumes(volumes, "/dev/xvdb");
+        verifyCreateVolumeRequest(SNAPSHOT_ID, null, null);
+    }
+
+    @Test
+    void buildTestWhenAttachedVolumesOnlyAndEncryptionWithCustomKey() throws Exception {
+        Group group = createGroup(List.of(createVolume(TYPE_GP2)),
+                Map.ofEntries(entry(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, true),
+                        entry(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.CUSTOM.name()),
+                        entry(InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, ENCRYPTION_KEY_ARN),
+                        entry(AwsInstanceTemplate.FAST_EBS_ENCRYPTION_ENABLED, false)));
+
+        when(encryptedSnapshotService.isEncryptedVolumeRequested(group)).thenReturn(true);
+        when(encryptedSnapshotService.createSnapshotIfNeeded(authenticatedContext, cloudStack, group, resourceNotifier)).thenReturn(Optional.of(SNAPSHOT_ID));
+        setUpTaskExecutors();
+        when(amazonEC2Client.createVolume(isA(CreateVolumeRequest.class))).thenReturn(createCreateVolumeResult());
+
+        List<CloudResource> result = underTest.build(awsContext, PRIVATE_ID, authenticatedContext, group,
+                List.of(createVolumeSet(List.of(createVolumeForVolumeSet(TYPE_GP2)))), cloudStack);
+
+        List<VolumeSetAttributes.Volume> volumes = verifyResultAndGetVolumes(result);
+        verifyVolumes(volumes, "/dev/xvdb");
+        verifyCreateVolumeRequest(SNAPSHOT_ID, null, null);
+    }
+
+    @Test
+    void buildTestWhenAttachedVolumesOnlyAndEncryptionWithDefaultKeyFast() throws Exception {
+        Group group = createGroup(List.of(createVolume(TYPE_GP2)),
+                Map.ofEntries(entry(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, true),
+                        entry(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.DEFAULT.name()),
+                        entry(AwsInstanceTemplate.FAST_EBS_ENCRYPTION_ENABLED, true)));
+
+        when(encryptedSnapshotService.isEncryptedVolumeRequested(group)).thenReturn(true);
+        setUpTaskExecutors();
+        when(amazonEC2Client.createVolume(isA(CreateVolumeRequest.class))).thenReturn(createCreateVolumeResult());
+
+        List<CloudResource> result = underTest.build(awsContext, PRIVATE_ID, authenticatedContext, group,
+                List.of(createVolumeSet(List.of(createVolumeForVolumeSet(TYPE_GP2)))), cloudStack);
+
+        List<VolumeSetAttributes.Volume> volumes = verifyResultAndGetVolumes(result);
+        verifyVolumes(volumes, "/dev/xvdb");
+        verifyCreateVolumeRequest(null, true, null);
+        verify(encryptedSnapshotService, never()).createSnapshotIfNeeded(authenticatedContext, cloudStack, group, resourceNotifier);
+    }
+
+    @Test
+    void buildTestWhenAttachedVolumesOnlyAndEncryptionWithCustomKeyFast() throws Exception {
+        Group group = createGroup(List.of(createVolume(TYPE_GP2)),
+                Map.ofEntries(entry(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, true),
+                        entry(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.CUSTOM.name()),
+                        entry(InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, ENCRYPTION_KEY_ARN),
+                        entry(AwsInstanceTemplate.FAST_EBS_ENCRYPTION_ENABLED, true)));
+
+        when(encryptedSnapshotService.isEncryptedVolumeRequested(group)).thenReturn(true);
+        setUpTaskExecutors();
+        when(amazonEC2Client.createVolume(isA(CreateVolumeRequest.class))).thenReturn(createCreateVolumeResult());
+
+        List<CloudResource> result = underTest.build(awsContext, PRIVATE_ID, authenticatedContext, group,
+                List.of(createVolumeSet(List.of(createVolumeForVolumeSet(TYPE_GP2)))), cloudStack);
+
+        List<VolumeSetAttributes.Volume> volumes = verifyResultAndGetVolumes(result);
+        verifyVolumes(volumes, "/dev/xvdb");
+        verifyCreateVolumeRequest(null, true, ENCRYPTION_KEY_ARN);
+        verify(encryptedSnapshotService, never()).createSnapshotIfNeeded(authenticatedContext, cloudStack, group, resourceNotifier);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setUpTaskExecutors() {
+        when(intermediateBuilderExecutor.submit(isA(Runnable.class))).thenAnswer(invocation -> {
+            FutureTask<Void> futureTask = new FutureTask<>(invocation.getArgument(0, Runnable.class), null);
+            futureTask.run();
+            return futureTask;
+        });
+        when(retry.testWith2SecDelayMax15Times(isA(Supplier.class))).thenAnswer(invocation -> invocation.getArgument(0, Supplier.class).get());
+    }
+
+    private Volume createVolume(String type) {
+        return new Volume(MOUNT_PREFIX + type, type, VOLUME_SIZE);
+    }
+
+    private Group createGroup(List<Volume> volumes, Map<String, Object> templateParameters) {
+        InstanceTemplate template = new InstanceTemplate(FLAVOR, GROUP_NAME, PRIVATE_ID, volumes, InstanceStatus.CREATE_REQUESTED, templateParameters,
+                TEMPLATE_ID, IMAGE_ID);
+        CloudInstance instance = new CloudInstance(INSTANCE_ID, template, null);
+        return new Group(GROUP_NAME, InstanceGroupType.GATEWAY, singletonList(instance), null, null, null, null, null, null, ROOT_VOLUME_SIZE, null);
+    }
+
+    private VolumeSetAttributes.Volume createVolumeForVolumeSet(String type) {
+        return new VolumeSetAttributes.Volume(null, null, VOLUME_SIZE, type);
+    }
+
+    private CloudResource createVolumeSet(List<VolumeSetAttributes.Volume> volumes) {
+        return CloudResource.builder()
+                .type(ResourceType.AWS_VOLUMESET)
+                .name(VOLUME_SET_NAME)
+                .status(CommonStatus.REQUESTED)
+                .params(Map.of(CloudResource.ATTRIBUTES, new VolumeSetAttributes.Builder()
+                        .withAvailabilityZone(AVAILABILITY_ZONE)
+                        .withVolumes(volumes)
+                        .build()))
+                .build();
+    }
+
+    private CreateVolumeResult createCreateVolumeResult() {
+        return new CreateVolumeResult().withVolume(new com.amazonaws.services.ec2.model.Volume().withVolumeId(VOLUME_ID));
+    }
+
+    private List<VolumeSetAttributes.Volume> verifyResultAndGetVolumes(List<CloudResource> result) {
+        assertThat(result).hasSize(1);
+        CloudResource cloudResource = result.get(0);
+        assertThat(cloudResource.getStatus()).isEqualTo(CommonStatus.CREATED);
+        VolumeSetAttributes volumeSet = cloudResource.getParameter(CloudResource.ATTRIBUTES, VolumeSetAttributes.class);
+        assertThat(volumeSet).isNotNull();
+        List<VolumeSetAttributes.Volume> volumes = volumeSet.getVolumes();
+        assertThat(volumes).isNotNull();
+        return volumes;
+    }
+
+    private void verifyVolumes(List<VolumeSetAttributes.Volume> volumes, String expectedDevice) {
+        assertThat(volumes).hasSize(1);
+        VolumeSetAttributes.Volume volume = volumes.get(0);
+        assertThat(volume).isNotNull();
+        assertThat(volume.getId()).isEqualTo(VOLUME_ID);
+        assertThat(volume.getType()).isEqualTo(TYPE_GP2);
+        assertThat(volume.getSize()).isEqualTo(VOLUME_SIZE);
+        assertThat(volume.getDevice()).isEqualTo(expectedDevice);
+    }
+
+    private void verifyCreateVolumeRequest(String expectedSnapshotId, Boolean expectedEncrypted, String expectedKmsKeyId) {
+        verify(amazonEC2Client).createVolume(createVolumeRequestCaptor.capture());
+        CreateVolumeRequest createVolumeRequest = createVolumeRequestCaptor.getValue();
+        assertThat(createVolumeRequest).isNotNull();
+        assertThat(createVolumeRequest.getAvailabilityZone()).isEqualTo(AVAILABILITY_ZONE);
+        assertThat(createVolumeRequest.getSize()).isEqualTo(VOLUME_SIZE);
+        assertThat(createVolumeRequest.getSnapshotId()).isEqualTo(expectedSnapshotId);
+        assertThat(createVolumeRequest.getVolumeType()).isEqualTo(TYPE_GP2);
+        assertThat(createVolumeRequest.getEncrypted()).isEqualTo(expectedEncrypted);
+        assertThat(createVolumeRequest.getKmsKeyId()).isEqualTo(expectedKmsKeyId);
+
+        List<TagSpecification> tagSpecifications = createVolumeRequest.getTagSpecifications();
+        assertThat(tagSpecifications).isNotNull();
+        assertThat(tagSpecifications).hasSize(1);
+        TagSpecification tagSpecification = tagSpecifications.get(0);
+        assertThat(tagSpecification).isNotNull();
+        assertThat(tagSpecification.getResourceType()).isEqualTo(com.amazonaws.services.ec2.model.ResourceType.Volume.toString());
+        assertThat(tagSpecification.getTags()).isEqualTo(EC2_TAGS);
+    }
+
+}

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsInstanceViewTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsInstanceViewTest.java
@@ -1,13 +1,12 @@
 package com.sequenceiq.cloudbreak.cloud.aws.view;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
@@ -16,18 +15,58 @@ import com.sequenceiq.common.api.type.EncryptionType;
 
 public class AwsInstanceViewTest {
 
+    private static final String IMAGE_ID = "imageId";
+
+    private static final String ENCRYPTION_KEY_ARN = "encryptionKeyArn";
+
     @Test
-    public void testTemplateParameters() {
+    public void testEncryptionParametersWhenDefaultKey() {
         Map<String, Object> map = new HashMap<>();
         map.put(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, true);
-        map.put(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.CUSTOM.name());
+        map.put(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.DEFAULT.name());
 
         InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
-                map, 0L, "imageId");
+                map, 0L, IMAGE_ID);
 
         AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
 
-        Assert.assertTrue(actual.isKmsCustom());
+        assertThat(actual.isKmsEnabled()).isTrue();
+        assertThat(actual.isKmsDefault()).isTrue();
+        assertThat(actual.isKmsCustom()).isFalse();
+        assertThat(actual.getKmsKey()).isNull();
+        assertThat(actual.isFastEbsEncryptionEnabled()).isFalse();
+    }
+
+    @Test
+    public void testEncryptionParametersWhenCustomKey() {
+        Map<String, Object> map = new HashMap<>();
+        map.put(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, true);
+        map.put(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.CUSTOM.name());
+        map.put(AwsInstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, ENCRYPTION_KEY_ARN);
+
+        InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
+                map, 0L, IMAGE_ID);
+
+        AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
+
+        assertThat(actual.isKmsEnabled()).isTrue();
+        assertThat(actual.isKmsDefault()).isFalse();
+        assertThat(actual.isKmsCustom()).isTrue();
+        assertThat(actual.getKmsKey()).isEqualTo(ENCRYPTION_KEY_ARN);
+        assertThat(actual.isFastEbsEncryptionEnabled()).isFalse();
+    }
+
+    @Test
+    public void testEncryptionParametersWhenFast() {
+        Map<String, Object> map = new HashMap<>();
+        map.put(AwsInstanceTemplate.FAST_EBS_ENCRYPTION_ENABLED, true);
+
+        InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
+                map, 0L, IMAGE_ID);
+
+        AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
+
+        assertThat(actual.isFastEbsEncryptionEnabled()).isTrue();
     }
 
     @Test
@@ -35,16 +74,17 @@ public class AwsInstanceViewTest {
         Map<String, Object> map = new HashMap<>();
         map.put(AwsInstanceTemplate.EC2_SPOT_PERCENTAGE, 30);
         InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
-                map, 0L, "imageId");
+                map, 0L, IMAGE_ID);
         AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
-        assertEquals(70, actual.getOnDemandPercentage());
+        assertThat(actual.getOnDemandPercentage()).isEqualTo(70);
     }
 
     @Test
     public void testOnDemandMissingPercentage() {
         InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
-                Map.of(), 0L, "imageId");
+                Map.of(), 0L, IMAGE_ID);
         AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
-        assertEquals(100, actual.getOnDemandPercentage());
+        assertThat(actual.getOnDemandPercentage()).isEqualTo(100);
     }
+
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/instance/DefaultInstanceGroupProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/instance/DefaultInstanceGroupProvider.java
@@ -49,6 +49,7 @@ public class DefaultInstanceGroupProvider {
             // FIXME Enable EBS encryption with appropriate KMS key
             template.setAttributes(new Json(Map.<String, Object>ofEntries(
                     entry(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, Boolean.TRUE),
+                    entry(AwsInstanceTemplate.FAST_EBS_ENCRYPTION_ENABLED, entitlementService.fastEbsEncryptionEnabled(INTERNAL_ACTOR_CRN, accountId)),
                     entry(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.DEFAULT.name()))));
         }
         return template;

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/instance/template/InstanceTemplateRequestToTemplateConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/instance/template/InstanceTemplateRequestToTemplateConverterTest.java
@@ -125,6 +125,24 @@ class InstanceTemplateRequestToTemplateConverterTest {
         Json attributes = result.getAttributes();
         assertThat(attributes).isNotNull();
         assertThat(attributes.<Object>getValue(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED)).isEqualTo(Boolean.TRUE);
+        assertThat(attributes.<Object>getValue(AwsInstanceTemplate.FAST_EBS_ENCRYPTION_ENABLED)).isEqualTo(Boolean.FALSE);
+        assertThat(attributes.<Object>getValue(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE)).isEqualTo(EncryptionType.DEFAULT.name());
+    }
+
+    @Test
+    void shouldSetVolumeEncryptionWhenAwsAndEntitledAndFastEncryption() {
+        InstanceTemplateRequest source = new InstanceTemplateRequest();
+        source.setInstanceType(INSTANCE_TYPE);
+
+        when(entitlementService.freeIpaDlEbsEncryptionEnabled(INTERNAL_ACTOR_CRN, ACCOUNT_ID)).thenReturn(true);
+        when(entitlementService.fastEbsEncryptionEnabled(INTERNAL_ACTOR_CRN, ACCOUNT_ID)).thenReturn(true);
+
+        Template result = underTest.convert(source, CLOUD_PLATFORM, ACCOUNT_ID);
+
+        Json attributes = result.getAttributes();
+        assertThat(attributes).isNotNull();
+        assertThat(attributes.<Object>getValue(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED)).isEqualTo(Boolean.TRUE);
+        assertThat(attributes.<Object>getValue(AwsInstanceTemplate.FAST_EBS_ENCRYPTION_ENABLED)).isEqualTo(Boolean.TRUE);
         assertThat(attributes.<Object>getValue(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE)).isEqualTo(EncryptionType.DEFAULT.name());
     }
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/instance/DefaultInstanceGroupProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/instance/DefaultInstanceGroupProviderTest.java
@@ -68,6 +68,22 @@ class DefaultInstanceGroupProviderTest {
         Json attributes = result.getAttributes();
         assertThat(attributes).isNotNull();
         assertThat(attributes.<Object>getValue(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED)).isEqualTo(Boolean.TRUE);
+        assertThat(attributes.<Object>getValue(AwsInstanceTemplate.FAST_EBS_ENCRYPTION_ENABLED)).isEqualTo(Boolean.FALSE);
+        assertThat(attributes.<Object>getValue(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE)).isEqualTo(EncryptionType.DEFAULT.name());
+    }
+
+    @Test
+    void createDefaultTemplateTestVolumeEncryptionAddedWhenAwsAndEntitledAndFastEncryption() {
+        when(entitlementService.freeIpaDlEbsEncryptionEnabled(INTERNAL_ACTOR_CRN, ACCOUNT_ID)).thenReturn(true);
+        when(entitlementService.fastEbsEncryptionEnabled(INTERNAL_ACTOR_CRN, ACCOUNT_ID)).thenReturn(true);
+
+        Template result = underTest.createDefaultTemplate(CloudPlatform.AWS, ACCOUNT_ID);
+
+        assertThat(result).isNotNull();
+        Json attributes = result.getAttributes();
+        assertThat(attributes).isNotNull();
+        assertThat(attributes.<Object>getValue(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED)).isEqualTo(Boolean.TRUE);
+        assertThat(attributes.<Object>getValue(AwsInstanceTemplate.FAST_EBS_ENCRYPTION_ENABLED)).isEqualTo(Boolean.TRUE);
         assertThat(attributes.<Object>getValue(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE)).isEqualTo(EncryptionType.DEFAULT.name());
     }
 

--- a/mock-caas/src/main/java/com/sequenceiq/caas/grpc/service/auth/MockUserManagementService.java
+++ b/mock-caas/src/main/java/com/sequenceiq/caas/grpc/service/auth/MockUserManagementService.java
@@ -196,6 +196,8 @@ public class MockUserManagementService extends UserManagementImplBase {
 
     private static final String CDP_AZURE_SINGLE_RESOURCE_GROUP = "CDP_AZURE_SINGLE_RESOURCE_GROUP";
 
+    private static final String CDP_CB_FAST_EBS_ENCRYPTION = "CDP_CB_FAST_EBS_ENCRYPTION";
+
     private static final String MOCK_RESOURCE = "mock_resource";
 
     private static final String SSH_PUBLIC_KEY_PATTERN = "^ssh-(rsa|ed25519)\\s+AAAA(B|C)3NzaC1.*(|\\n)";
@@ -253,6 +255,9 @@ public class MockUserManagementService extends UserManagementImplBase {
 
     @Value("${auth.mock.azure.single.resourcegroup.enable}")
     private boolean enableAzureSingleResourceGroupDeployment;
+
+    @Value("${auth.mock.fastebsencryption.enable}")
+    private boolean enableFastEbsEncryption;
 
     private String cbLicense;
 
@@ -515,6 +520,9 @@ public class MockUserManagementService extends UserManagementImplBase {
         }
         if (enableAzureSingleResourceGroupDeployment) {
             builder.addEntitlements(createEntitlement(CDP_AZURE_SINGLE_RESOURCE_GROUP));
+        }
+        if (enableFastEbsEncryption) {
+            builder.addEntitlements(createEntitlement(CDP_CB_FAST_EBS_ENCRYPTION));
         }
         responseObserver.onNext(
                 GetAccountResponse.newBuilder()

--- a/mock-caas/src/main/resources/application.yml
+++ b/mock-caas/src/main/resources/application.yml
@@ -20,5 +20,6 @@ auth:
     runtime.upgrade.enable: true
     sshpublickey.file: key.pub
     raz.enable: true
-    freeipadlebsencryption.enable: false
+    freeipadlebsencryption.enable: true
     azure.single.resourcegroup.enable: false
+    fastebsencryption.enable: true

--- a/mock-caas/src/test/java/com/sequenceiq/caas/grpc/service/auth/MockUserManagementServiceTest.java
+++ b/mock-caas/src/test/java/com/sequenceiq/caas/grpc/service/auth/MockUserManagementServiceTest.java
@@ -165,7 +165,8 @@ public class MockUserManagementServiceTest {
         assertThat(res.hasAccount()).isTrue();
         Account account = res.getAccount();
         List<String> entitlements = account.getEntitlementsList().stream().map(Entitlement::getEntitlementName).collect(Collectors.toList());
-        assertThat(entitlements).contains("CDP_AZURE", "CDP_AUTOMATIC_USERSYNC_POLLER", "CLOUDERA_INTERNAL_ACCOUNT", "LOCAL_DEV");
+        assertThat(entitlements).contains("CDP_AZURE", "CDP_AUTOMATIC_USERSYNC_POLLER", "CLOUDERA_INTERNAL_ACCOUNT", "DATAHUB_AZURE_AUTOSCALING",
+                "DATAHUB_AWS_AUTOSCALING", "LOCAL_DEV");
     }
 
     static Object[][] conditionalEntitlementDataProvider() {
@@ -176,6 +177,9 @@ public class MockUserManagementServiceTest {
 
                 {"enableFreeIpaHa false", "enableFreeIpaHa", false, "CDP_FREEIPA_HA", false},
                 {"enableFreeIpaHa true", "enableFreeIpaHa", true, "CDP_FREEIPA_HA", true},
+
+                {"enableFreeIpaHaRepair false", "enableFreeIpaHaRepair", false, "CDP_FREEIPA_HA_REPAIR", false},
+                {"enableFreeIpaHaRepair true", "enableFreeIpaHaRepair", true, "CDP_FREEIPA_HA_REPAIR", true},
 
                 {"enableCloudStorageValidation false", "enableCloudStorageValidation", false, "CDP_CLOUD_STORAGE_VALIDATION", false},
                 {"enableCloudStorageValidation true", "enableCloudStorageValidation", true, "CDP_CLOUD_STORAGE_VALIDATION", true},
@@ -188,6 +192,12 @@ public class MockUserManagementServiceTest {
 
                 {"enableFreeIpaDlEbsEncryption false", "enableFreeIpaDlEbsEncryption", false, "CDP_FREEIPA_DL_EBS_ENCRYPTION", false},
                 {"enableFreeIpaDlEbsEncryption true", "enableFreeIpaDlEbsEncryption", true, "CDP_FREEIPA_DL_EBS_ENCRYPTION", true},
+
+                {"enableAzureSingleResourceGroupDeployment false", "enableAzureSingleResourceGroupDeployment", false, "CDP_AZURE_SINGLE_RESOURCE_GROUP", false},
+                {"enableAzureSingleResourceGroupDeployment true", "enableAzureSingleResourceGroupDeployment", true, "CDP_AZURE_SINGLE_RESOURCE_GROUP", true},
+
+                {"enableFastEbsEncryption false", "enableFastEbsEncryption", false, "CDP_CB_FAST_EBS_ENCRYPTION", false},
+                {"enableFastEbsEncryption true", "enableFastEbsEncryption", true, "CDP_CB_FAST_EBS_ENCRYPTION", true},
         };
     }
 


### PR DESCRIPTION
This PR adds the ability to provision clusters with encrypted EBS in a fast way, avoiding unnecessary resource creations. Notes:
* Applies to FreeIPA & DL (#7833) as well as DH clusters.
* Affects root (always EBS) as well as EBS data / attached volumes.
* No change to service APIs; the flag controlling the fast logic is included as a new dynamic parameter in `InstanceTemplate`. The parameter key has been added to `AwsInstanceTemplate` introduced earlier in #8340.
* The fast logic is guarded by the new entitlement `CDP_CB_FAST_EBS_ENCRYPTION`. This entitlement gets checked by both FreeIPA and Cloudbreak / Core Svc; the absence of the entitlement grant will result in the legacy behavior.
* When testing with local CB, `mock-caas` defaults to presenting `CDP_FREEIPA_DL_EBS_ENCRYPTION` (#7833) and `CDP_CB_FAST_EBS_ENCRYPTION` always granted. The following VM argument shall be added to `MockCaasApplication` to disable these entitlements: `-Dauth.mock.freeipadlebsencryption.enable=false -Dauth.mock.fastebsencryption.enable=false`. The new defaults also revert the setting made in #8309.
* Unit tests have been added for all logic changes. These are all based on JUnit 5 and AssertJ, sometimes using `ParameterizedTest`s. Any existing tests have been ported to the above libraries.
