### PR TITLE
CB-7758. Add proxy support to fluentd plugin installations.

### DIFF
--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/init.sls
@@ -93,6 +93,10 @@ install_fluentd_plugins:
     - user: "{{ fluent.user }}"
     - group: "{{ fluent.group }}"
     - mode: '0750'
+{%- if fluent.proxyFullUrl %}
+    - env:
+      - https_proxy: {{ fluent.proxyFullUrl }}
+{% endif %}
 
 check_fluentd_plugins:
    cmd.run:

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
@@ -127,14 +127,17 @@
     {% set proxy_auth = True %}
     {% set proxy_user = salt['pillar.get']('proxy:user') %}
     {% set proxy_password = salt['pillar.get']('proxy:password') %}
+    {% set proxy_full_url =  proxy_protocol + "://" + proxy_user + ":"+ proxy_password + "@" + proxy_host + ":" + proxy_port %}
   {% else %}
     {% set proxy_auth = False %}
+    {% set proxy_full_url = proxy_url %}
   {% endif %}
 {% else %}
   {% set proxy_url = None %}
   {% set proxy_user = None %}
   {% set proxy_password = None %}
   {% set proxy_auth = False %}
+  {% set proxy_full_url = None %}
 {% endif %}
 
 {% do fluent.update({
@@ -185,5 +188,6 @@
     "proxyUrl": proxy_url,
     "proxyAuth": proxy_auth,
     "proxyUser": proxy_user,
-    "proxyPassword": proxy_password
+    "proxyPassword": proxy_password,
+    "proxyFullUrl": proxy_full_url
 }) %}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/check_fluent_plugins.sh.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/check_fluent_plugins.sh.j2
@@ -18,6 +18,10 @@ function install_plugin() {
      install_command="${install_command} -v ${version}"
      /opt/td-agent/embedded/bin/fluent-gem uninstall "${plugin}"
   fi
+
+  if [[ -n "${https_proxy}" ]]; then
+     install_command="${install_command} --http-proxy ${https_proxy}"
+  fi
   echo "Run install command: ${install_command}"
   command_result=$(${install_command})
   echo "Install ${plugin} command output: ${command_result}"


### PR DESCRIPTION
in case of old images with newer CB, for limited network, it should be possible to use proxy for gem/curl based installs