### PR TITLE
DISTX-428 Add a recommendation for manager host group to be one of the right places for hosting CM service.

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/CloudResourceAdvisor.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/CloudResourceAdvisor.java
@@ -195,7 +195,8 @@ public class CloudResourceAdvisor {
     private boolean fallbackGatewayFilter(String hostGroupName) {
         String lowerName = hostGroupName.toLowerCase();
         return lowerName.contains("master")
-                || lowerName.contains("services");
+                || lowerName.contains("services")
+                || lowerName.contains("manager");
     }
 
     private ResizeRecommendation recommendResize(BlueprintTextProcessor blueprintTextProcessor) {


### PR DESCRIPTION


1. The built-in DE HA template uses the manager host group for hosting CM.
2. Usually, workflow for folks to create HA template is to copy from the built-in.
3. Since the recommendation of 1 host, plus the name of the host group to be manager or services does not match the default template, the CM gets automatically placed in the compute host group whose default size is 0.
4. To prevent users from shooting themselves in the foot, adding manager as a recommended host group.

./gradlew build