### PR TITLE
CB-7783: Fix the backup/restore script to remove trailing "/"

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
@@ -21,7 +21,7 @@ if [ $# -ne 5 ]; then
 fi
 
 CLOUD_PROVIDER=$(echo "$1" | tr '[:upper:]' '[:lower:]')
-BACKUP_LOCATION=$(echo "$2" | sed 's/\/\+$//g') # Clear trailng '/' (if present) for later path joining.
+BACKUP_LOCATION=$(echo "$2" | sed 's/[/]$//g') # Clear trailng '/' (if present) for later path joining.
 HOST="$3"
 PORT="$4"
 USERNAME="$5"

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/restore_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/restore_db.sh
@@ -20,7 +20,7 @@ if [ $# -ne 5 ]; then
 fi
 
 CLOUD_PROVIDER=$(echo "$1" | tr '[:upper:]' '[:lower:]')
-CLOUD_LOCATION=$(echo "$2" | sed 's/\/\+$//g') # Clear trailng '/' (if present) for later path joining.
+BACKUP_LOCATION=$(echo "$2" | sed 's/[/]$//g') # Clear trailng '/' (if present) for later path joining.
 HOST="$3"
 PORT="$4"
 USERNAME="$5"


### PR DESCRIPTION
Database backup/restore scripts have issue handling the backup location that has a trailing "/". Scripts have a logic of removing it upfront and the rest of the script assumes that there is no trailing "/". The logic that should remove the trailing "/" is not actually removing as a result there two "//" in the path creating issues.

I fixed the code that removes the trailing slash.

