### PR TITLE
CB-7767: Fix 2 FMS to use correct cluster proxy service names for ...

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactory.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactory.java
@@ -35,7 +35,7 @@ import com.sequenceiq.freeipa.service.TlsSecurityService;
 import com.sequenceiq.freeipa.service.config.FreeIpaDomainUtils;
 import com.sequenceiq.freeipa.service.stack.ClusterProxyService;
 import com.sequenceiq.freeipa.service.stack.StackService;
-import com.sequenceiq.freeipa.util.BalancedDnsAvailabilityChecker;
+import com.sequenceiq.freeipa.util.ClusterProxyServiceAvailabilityChecker;
 
 @Service
 public class FreeIpaClientFactory {
@@ -96,7 +96,7 @@ public class FreeIpaClientFactory {
     }
 
     private boolean useLegacyClusterProxyRegistration(Stack stack) {
-        return !BalancedDnsAvailabilityChecker.isBalancedDnsAvailable(stack);
+        return !ClusterProxyServiceAvailabilityChecker.isDnsBasedServiceNameAvailable(stack);
     }
 
     private FreeIpaClient getFreeIpaClient(Stack stack, boolean withPing, boolean forceCheckUnreachable, Optional<String> freeIpaFqdn)


### PR DESCRIPTION
...clusters created with CB prior to 2.21.

The first fix for CB-7767 only addressed clusters that were created
with cloudbreak 2.19 and prior. This specifically fixes it for 2.20.

Fix FreeIPA management service to use the the "freeipa" service name
for clusters that were created before CB 2.21.

NOTE: I have not yet tested this. We identified an issue with what was believed to be a CB 2.20 cluster and found this. I am testing this now.

Closes #CB-7767