### PR TITLE
CB-7794 Node decommissioning fails in CCM enabled cluster due to auto…

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/AbstractClouderaManagerCommandCheckerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/AbstractClouderaManagerCommandCheckerTask.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.cm.polling.task;
 
 import java.net.ConnectException;
 import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -97,7 +98,9 @@ public abstract class AbstractClouderaManagerCommandCheckerTask<T extends Cloude
     }
 
     private boolean isToleratedError(ApiException e) {
-        return e.getCode() == HttpStatus.INTERNAL_SERVER_ERROR.value() || e.getCause() instanceof SocketException;
+        return e.getCode() == HttpStatus.INTERNAL_SERVER_ERROR.value()
+                || e.getCause() instanceof SocketException
+                || e.getCause() instanceof SocketTimeoutException;
     }
 
     protected boolean doStatusCheck(T pollerObject, CommandsResourceApi commandsResourceApi) throws ApiException {

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/polling/task/AbstractClouderaManagerCommandCheckerTaskTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/polling/task/AbstractClouderaManagerCommandCheckerTaskTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 import java.math.BigDecimal;
 import java.net.ConnectException;
 import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.util.Collections;
 import java.util.List;
 
@@ -108,10 +109,12 @@ public class AbstractClouderaManagerCommandCheckerTaskTest {
         Stack stack = new Stack();
         BigDecimal id = new BigDecimal(ID);
         ClouderaManagerPollerObject pollerObject = new ClouderaManagerPollerObject(stack, apiClient, id);
+        SocketTimeoutException socketTimeoutException = new SocketTimeoutException("timeout");
+        ApiException apiException0 = new ApiException(socketTimeoutException);
         SocketException socketException = new SocketException("Network is unreachable (connect failed)");
-        ApiException apiException = new ApiException(socketException);
+        ApiException apiException1 = new ApiException(socketException);
         when(commandsResourceApi.readCommand(id))
-                .thenAnswer(new ExceptionThrowingApiCommandAnswer(apiException, apiException, apiException, apiException, apiException));
+                .thenAnswer(new ExceptionThrowingApiCommandAnswer(apiException0, apiException1, apiException1, apiException1, apiException1));
 
         for (int i = 0; i < FIVE; i++) {
             boolean inProgress = underTest.checkStatus(pollerObject);


### PR DESCRIPTION
…ssh connection restarts

1. CDPAM-677 shows reverse tunnel autossh connection may restart due to multiple reasons.
2. This causes few API calls to the CM failing intermittently during cluster scale down. It is known that CB makes a lot of CM API calls during scale down from CDPAM-665.
3. ClouderaManagerApiFactory is used so that all those calls are retried per retry policy.
4. In the case of SocketTimeoutException, the retry logic is skipped, because SocketTimeException and SocketException are in the different class hierarchy.
5. Added toleration rule for SocketTimeoutException as well with a unit test.

./gradlew build