### PR TITLE
CB-7792 Introduce Group.getReferenceInstanceTemplate()

### DIFF
--- a/cloud-api/build.gradle
+++ b/cloud-api/build.gradle
@@ -17,18 +17,19 @@ dependencies {
   compile project(":common")
   compile project(':common-model')
 
-  compile group: 'io.swagger', name: 'swagger-annotations', version: swaggerVersion
+  compile            group: 'io.swagger',                 name: 'swagger-annotations',   version: swaggerVersion
 
-  testCompile(group: 'junit', name: 'junit', version: junitVersion) {
-    exclude group: 'org.hamcrest'
+  testCompile(       group: 'junit',                      name: 'junit',                 version: junitVersion) {
+    exclude          group: 'org.hamcrest'
   }
-  testCompile(group: 'org.mockito', name: 'mockito-core', version: mockitoVersion) {
-    exclude group: 'org.hamcrest'
+  testCompile(       group: 'org.mockito',                name: 'mockito-core',          version: mockitoVersion) {
+    exclude          group: 'org.hamcrest'
   }
-  testCompile (group: 'org.hamcrest', name: 'java-hamcrest', version: hamcrestVersion)
+  testCompile (      group: 'org.hamcrest',               name: 'java-hamcrest',         version: hamcrestVersion)
+  testImplementation group: 'org.assertj',                name: 'assertj-core',          version: assertjVersion
 
-  runtime group: 'org.glassfish.jersey.core', name: 'jersey-common', version: jerseyCoreVersion
-  compile(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion) {
+  runtime            group: 'org.glassfish.jersey.core',  name: 'jersey-common',         version: jerseyCoreVersion
+  compile(           group: 'com.fasterxml.jackson.core', name: 'jackson-databind',      version: jacksonVersion) {
     force = true
   }
 

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/Group.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/Group.java
@@ -70,6 +70,10 @@ public class Group extends DynamicModel {
         return instances.get(0);
     }
 
+    public InstanceTemplate getReferenceInstanceTemplate() {
+        return getReferenceInstanceConfiguration().getTemplate();
+    }
+
     public String getName() {
         return name;
     }

--- a/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/model/GroupTest.java
+++ b/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/model/GroupTest.java
@@ -1,0 +1,151 @@
+package com.sequenceiq.cloudbreak.cloud.model;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.mockito.Mockito.mock;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.common.api.type.InstanceGroupType;
+
+@ExtendWith(MockitoExtension.class)
+class GroupTest {
+
+    private static final String GROUP_NAME = "myGroup";
+
+    private static final String LOGIN_USER_NAME = "i_wanna_be_root";
+
+    private static final String PUBLIC_KEY = "ssh-rsa yaddayaddayadda";
+
+    private static final int ROOT_VOLUME_SIZE = 123;
+
+    private static final String INSTANCE_ID = "machine-6789";
+
+    @Mock
+    private Security security;
+
+    @Mock
+    private InstanceAuthentication instanceAuthentication;
+
+    @Test
+    void constructorTestWhenInstancesIsNull() {
+        assertThatNullPointerException().isThrownBy(() -> createGroup(null, createCloudInstance()));
+    }
+
+    @Test
+    void constructorTestWhenInstancesContainingNull() {
+        ArrayList<CloudInstance> instances = new ArrayList<>();
+        instances.add(createCloudInstance());
+        instances.add(null);
+        instances.add(createCloudInstance());
+        assertThatNullPointerException().isThrownBy(() -> createGroup(instances, createCloudInstance()));
+    }
+
+    @Test
+    void getReferenceInstanceConfigurationTestWhenNoInstancesAndSkeletonIsNull() {
+        Group group = createGroup(emptyList(), null);
+
+        assertThatExceptionOfType(RuntimeException.class).isThrownBy(group::getReferenceInstanceConfiguration)
+                .withMessage("There is no skeleton and instance available for Group -> name:" + GROUP_NAME);
+    }
+
+    @Test
+    void getReferenceInstanceConfigurationTestWhenNoInstancesAndValidSkeleton() {
+        CloudInstance cloudInstance = createCloudInstance();
+        Group group = createGroup(emptyList(), cloudInstance);
+
+        CloudInstance result = group.getReferenceInstanceConfiguration();
+        assertThat(result).isSameAs(cloudInstance);
+    }
+
+    @Test
+    void getReferenceInstanceConfigurationTestWhenSingleInstanceAndSkeletonIsNull() {
+        CloudInstance cloudInstance = createCloudInstance();
+        Group group = createGroup(List.of(cloudInstance), null);
+
+        CloudInstance result = group.getReferenceInstanceConfiguration();
+        assertThat(result).isSameAs(cloudInstance);
+    }
+
+    @Test
+    void getReferenceInstanceConfigurationTestWhenSingleInstanceAndValidSkeleton() {
+        CloudInstance cloudInstance = createCloudInstance();
+        Group group = createGroup(List.of(cloudInstance), createCloudInstance());
+
+        CloudInstance result = group.getReferenceInstanceConfiguration();
+        assertThat(result).isSameAs(cloudInstance);
+    }
+
+    @Test
+    void getReferenceInstanceConfigurationTestWhenMultipleInstances() {
+        CloudInstance cloudInstanceFirst = createCloudInstance();
+        Group group = createGroup(List.of(cloudInstanceFirst, createCloudInstance()), null);
+
+        CloudInstance result = group.getReferenceInstanceConfiguration();
+        assertThat(result).isSameAs(cloudInstanceFirst);
+    }
+
+    @Test
+    void getReferenceInstanceTemplateTestWhenNoInstancesAndSkeletonIsNull() {
+        Group group = createGroup(emptyList(), null);
+
+        assertThatExceptionOfType(RuntimeException.class).isThrownBy(group::getReferenceInstanceTemplate)
+                .withMessage("There is no skeleton and instance available for Group -> name:" + GROUP_NAME);
+    }
+
+    @Test
+    void getReferenceInstanceTemplateTestWhenNoInstancesAndValidSkeleton() {
+        CloudInstance cloudInstance = createCloudInstance();
+        Group group = createGroup(emptyList(), cloudInstance);
+
+        InstanceTemplate result = group.getReferenceInstanceTemplate();
+        assertThat(result).isSameAs(cloudInstance.getTemplate());
+    }
+
+    @Test
+    void getReferenceInstanceTemplateTestWhenSingleInstanceAndSkeletonIsNull() {
+        CloudInstance cloudInstance = createCloudInstance();
+        Group group = createGroup(List.of(cloudInstance), null);
+
+        InstanceTemplate result = group.getReferenceInstanceTemplate();
+        assertThat(result).isSameAs(cloudInstance.getTemplate());
+    }
+
+    @Test
+    void getReferenceInstanceTemplateTestWhenSingleInstanceAndValidSkeleton() {
+        CloudInstance cloudInstance = createCloudInstance();
+        Group group = createGroup(List.of(cloudInstance), createCloudInstance());
+
+        InstanceTemplate result = group.getReferenceInstanceTemplate();
+        assertThat(result).isSameAs(cloudInstance.getTemplate());
+    }
+
+    @Test
+    void getReferenceInstanceTemplateTestWhenMultipleInstances() {
+        CloudInstance cloudInstanceFirst = createCloudInstance();
+        Group group = createGroup(List.of(cloudInstanceFirst, createCloudInstance()), null);
+
+        InstanceTemplate result = group.getReferenceInstanceTemplate();
+        assertThat(result).isSameAs(cloudInstanceFirst.getTemplate());
+    }
+
+    private Group createGroup(Collection<CloudInstance> instances, CloudInstance skeleton) {
+        return new Group(GROUP_NAME, InstanceGroupType.GATEWAY, instances, security, skeleton, instanceAuthentication, LOGIN_USER_NAME, PUBLIC_KEY,
+                ROOT_VOLUME_SIZE, Optional.empty());
+    }
+
+    private CloudInstance createCloudInstance() {
+        return new CloudInstance(INSTANCE_ID, mock(InstanceTemplate.class), instanceAuthentication);
+    }
+
+}

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsSetup.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsSetup.java
@@ -141,7 +141,7 @@ public class AwsSetup implements Setup {
             for (Group group : stack.getGroups()) {
                 if (group.getInstances() != null
                         && !group.getInstances().isEmpty()
-                        && new AwsInstanceView(group.getReferenceInstanceConfiguration().getTemplate()).getSpotPercentage() != null) {
+                        && new AwsInstanceView(group.getReferenceInstanceTemplate()).getSpotPercentage() != null) {
                     throw new CloudConnectorException(String.format("Spot instances are not supported on this AMI: %s", stack.getImage()));
                 }
             }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilder.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilder.java
@@ -46,7 +46,7 @@ public class CloudFormationTemplateBuilder {
         int subnetCounter = 0;
         boolean multigw = context.stack.getGroups().stream().filter(g -> g.getType() == InstanceGroupType.GATEWAY).count() > 1;
         for (Group group : context.stack.getGroups()) {
-            AwsInstanceView awsInstanceView = new AwsInstanceView(group.getReferenceInstanceConfiguration().getTemplate());
+            AwsInstanceView awsInstanceView = new AwsInstanceView(group.getReferenceInstanceTemplate());
             String encryptedAMI = context.encryptedAMIByGroupName.get(group.getName());
             AwsGroupView groupView = new AwsGroupView(
                     group.getInstancesSize(),

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/encryption/EncryptedImageCopyService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/encryption/EncryptedImageCopyService.java
@@ -39,7 +39,6 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource.Builder;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
-import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
 import com.sequenceiq.common.api.type.ResourceType;
 
@@ -93,8 +92,7 @@ public class EncryptedImageCopyService {
         Map<String, EncryptedImageConfig> configByGroupName = new HashMap<>();
         for (Group group : cloudStack.getGroups()) {
             if (isEncryptedVolumeRequested(group) && !isFastEbsEncryptionEnabled(group)) {
-                InstanceTemplate instanceTemplate = group.getReferenceInstanceConfiguration().getTemplate();
-                AwsInstanceView awsInstanceView = new AwsInstanceView(instanceTemplate);
+                AwsInstanceView awsInstanceView = new AwsInstanceView(group.getReferenceInstanceTemplate());
                 Optional<String> actualKmsKey = Optional.ofNullable(awsInstanceView.getKmsKey());
 
                 Optional<EncryptedImageConfig> existingEncryptedImageConfig = configByGroupName.values()
@@ -111,11 +109,11 @@ public class EncryptedImageCopyService {
     }
 
     private boolean isEncryptedVolumeRequested(Group group) {
-        return new AwsInstanceView(group.getReferenceInstanceConfiguration().getTemplate()).isEncryptedVolumes();
+        return new AwsInstanceView(group.getReferenceInstanceTemplate()).isEncryptedVolumes();
     }
 
     private boolean isFastEbsEncryptionEnabled(Group group) {
-        return new AwsInstanceView(group.getReferenceInstanceConfiguration().getTemplate()).isFastEbsEncryptionEnabled();
+        return new AwsInstanceView(group.getReferenceInstanceTemplate()).isFastEbsEncryptionEnabled();
     }
 
     private EncryptedImageConfig createEncryptedImageFromAMI(AmazonEC2Client client, AwsInstanceView awsInstanceView, String selectedAMIName,

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/encryption/EncryptedSnapshotService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/encryption/EncryptedSnapshotService.java
@@ -43,7 +43,6 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource.Builder;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
-import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
 import com.sequenceiq.common.api.type.ResourceType;
 
@@ -69,13 +68,12 @@ public class EncryptedSnapshotService {
     private AwsTaggingService awsTaggingService;
 
     public boolean isEncryptedVolumeRequested(Group group) {
-        return new AwsInstanceView(group.getReferenceInstanceConfiguration().getTemplate()).isEncryptedVolumes();
+        return new AwsInstanceView(group.getReferenceInstanceTemplate()).isEncryptedVolumes();
     }
 
     public Optional<String> createSnapshotIfNeeded(AuthenticatedContext ac, CloudStack cloudStack, Group group, PersistenceNotifier resourceNotifier) {
-        InstanceTemplate instanceTemplate = group.getReferenceInstanceConfiguration().getTemplate();
         String regionName = ac.getCloudContext().getLocation().getRegion().value();
-        AwsInstanceView awsInstanceView = new AwsInstanceView(instanceTemplate);
+        AwsInstanceView awsInstanceView = new AwsInstanceView(group.getReferenceInstanceTemplate());
         AwsCredentialView awsCredentialView = new AwsCredentialView(ac.getCloudCredential());
 
         AmazonEC2Client client = awsClient.createAccess(awsCredentialView, regionName);

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtils.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtils.java
@@ -222,7 +222,7 @@ public class AzureUtils {
 
     public void validateStorageType(CloudStack stack) {
         for (Group group : stack.getGroups()) {
-            InstanceTemplate template = group.getReferenceInstanceConfiguration().getTemplate();
+            InstanceTemplate template = group.getReferenceInstanceTemplate();
             if (!template.getVolumes().isEmpty()) {
                 String volumeType = template.getVolumes().get(0).getType();
                 String flavor = template.getFlavor();

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureVolumeResourceBuilder.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureVolumeResourceBuilder.java
@@ -34,7 +34,6 @@ import com.sequenceiq.cloudbreak.cloud.azure.context.AzureContext;
 import com.sequenceiq.cloudbreak.cloud.azure.service.AzureResourceNameService;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
-import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource.Builder;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
@@ -95,8 +94,7 @@ public class AzureVolumeResourceBuilder extends AbstractAzureComputeBuilder {
         return () -> {
             AzureResourceNameService resourceNameService = getResourceNameService();
 
-            CloudInstance instance = group.getReferenceInstanceConfiguration();
-            InstanceTemplate template = instance.getTemplate();
+            InstanceTemplate template = group.getReferenceInstanceTemplate();
             String groupName = group.getName();
             CloudContext cloudContext = auth.getCloudContext();
             String stackName = cloudContext.getName();

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureVolumeResourceBuilderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureVolumeResourceBuilderTest.java
@@ -30,7 +30,6 @@ import com.sequenceiq.cloudbreak.cloud.azure.context.AzureContext;
 import com.sequenceiq.cloudbreak.cloud.azure.service.AzureResourceNameService;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
-import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
@@ -57,9 +56,6 @@ public class AzureVolumeResourceBuilderTest {
 
     @Mock
     private Image image;
-
-    @Mock
-    private CloudInstance cloudInstance;
 
     @Mock
     private InstanceTemplate instanceTemplate;
@@ -97,8 +93,7 @@ public class AzureVolumeResourceBuilderTest {
         CloudResource cloudResource2 = mock(CloudResource.class);
         when(context.getComputeResources(PRIVATE_ID)).thenReturn(List.of(cloudResource1, cloudResource2));
         when(context.getStringParameter(PlatformParametersConsts.RESOURCE_CRN_PARAMETER)).thenReturn(STACK_CRN);
-        when(group.getReferenceInstanceConfiguration()).thenReturn(cloudInstance);
-        when(cloudInstance.getTemplate()).thenReturn(instanceTemplate);
+        when(group.getReferenceInstanceTemplate()).thenReturn(instanceTemplate);
         when(instanceTemplate.getVolumes()).thenReturn(List.of(volumeTemplate));
         when(auth.getCloudContext()).thenReturn(cloudContext);
         when(auth.getParameter(AzureClient.class)).thenReturn(azureClient);

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpAttachedDiskResourceBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpAttachedDiskResourceBuilder.java
@@ -32,7 +32,6 @@ import com.sequenceiq.cloudbreak.cloud.gcp.context.GcpContext;
 import com.sequenceiq.cloudbreak.cloud.gcp.service.GcpDiskEncryptionService;
 import com.sequenceiq.cloudbreak.cloud.gcp.service.GcpResourceNameService;
 import com.sequenceiq.cloudbreak.cloud.gcp.util.GcpStackUtil;
-import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource.Builder;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
@@ -78,8 +77,7 @@ public class GcpAttachedDiskResourceBuilder extends AbstractGcpComputeBuilder {
     }
 
     private CloudResource createAttachedDiskSet(GcpContext context, long privateId, AuthenticatedContext auth, Group group) {
-        CloudInstance instance = group.getReferenceInstanceConfiguration();
-        InstanceTemplate template = instance.getTemplate();
+        InstanceTemplate template = group.getReferenceInstanceTemplate();
         GcpResourceNameService resourceNameService = getResourceNameService();
         String groupName = group.getName();
         CloudContext cloudContext = auth.getCloudContext();
@@ -110,8 +108,7 @@ public class GcpAttachedDiskResourceBuilder extends AbstractGcpComputeBuilder {
     @Override
     public List<CloudResource> build(GcpContext context, long privateId, AuthenticatedContext auth, Group group,
             List<CloudResource> resources, CloudStack cloudStack) throws Exception {
-        CloudInstance instance = group.getReferenceInstanceConfiguration();
-        InstanceTemplate template = instance.getTemplate();
+        InstanceTemplate template = group.getReferenceInstanceTemplate();
 
         List<String> operations = new ArrayList<>();
         List<String> syncedOperations = Collections.synchronizedList(operations);

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpDiskResourceBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpDiskResourceBuilder.java
@@ -52,7 +52,7 @@ public class GcpDiskResourceBuilder extends AbstractGcpComputeBuilder {
         disk.setName(buildableResources.get(0).getName());
         disk.setKind(GcpDiskType.HDD.getUrl(projectId, location.getAvailabilityZone()));
 
-        InstanceTemplate template = group.getReferenceInstanceConfiguration().getTemplate();
+        InstanceTemplate template = group.getReferenceInstanceTemplate();
         gcpDiskEncryptionService.addEncryptionKeyToDisk(template, disk);
 
         Map<String, String> customTags = new HashMap<>();

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilder.java
@@ -104,7 +104,7 @@ public class GcpInstanceResourceBuilder extends AbstractGcpComputeBuilder {
     @Override
     public List<CloudResource> build(GcpContext context, long privateId, AuthenticatedContext auth, Group group, List<CloudResource> buildableResource,
             CloudStack cloudStack) throws Exception {
-        InstanceTemplate template = group.getReferenceInstanceConfiguration().getTemplate();
+        InstanceTemplate template = group.getReferenceInstanceTemplate();
         String projectId = context.getProjectId();
         Location location = context.getLocation();
         Compute compute = context.getCompute();

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/common/OpenStackFlavorVerifier.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/common/OpenStackFlavorVerifier.java
@@ -28,7 +28,7 @@ public class OpenStackFlavorVerifier {
         }
         Set<String> notFoundFlavors = new HashSet<>();
         for (Group instanceGroup : instanceGroups) {
-            String instanceType = instanceGroup.getReferenceInstanceConfiguration().getTemplate().getFlavor();
+            String instanceType = instanceGroup.getReferenceInstanceTemplate().getFlavor();
             boolean found = false;
             for (Flavor flavor : flavors) {
                 if (flavor.getName().equalsIgnoreCase(instanceType)) {

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnResourceConnector.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnResourceConnector.java
@@ -137,7 +137,7 @@ public class YarnResourceConnector implements ResourceConnector<Object> {
                 stack.getLoginUserName(), stack.getPublicKey()));
         component.setArtifact(artifact);
         component.setDependencies(new ArrayList<>());
-        InstanceTemplate instanceTemplate = group.getReferenceInstanceConfiguration().getTemplate();
+        InstanceTemplate instanceTemplate = group.getReferenceInstanceTemplate();
         Resource resource = new Resource();
         resource.setCpus(instanceTemplate.getParameter(PlatformParametersConsts.CUSTOM_INSTANCETYPE_CPUS, Integer.class));
         resource.setMemory(instanceTemplate.getParameter(PlatformParametersConsts.CUSTOM_INSTANCETYPE_MEMORY, Integer.class));

--- a/cloud-yarn/src/test/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnResourceConnectorTest.java
+++ b/cloud-yarn/src/test/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnResourceConnectorTest.java
@@ -211,7 +211,7 @@ public class YarnResourceConnectorTest {
     }
 
     private void assertResource(Group group, YarnComponent yarnComponent) {
-        InstanceTemplate instanceTemplate = group.getReferenceInstanceConfiguration().getTemplate();
+        InstanceTemplate instanceTemplate = group.getReferenceInstanceTemplate();
         Integer cpuParam = instanceTemplate.getParameter(PlatformParametersConsts.CUSTOM_INSTANCETYPE_CPUS, Integer.class);
         assertEquals(cpuParam, Integer.valueOf(yarnComponent.getResource().getCpus()));
         Integer memoryParam = instanceTemplate.getParameter(PlatformParametersConsts.CUSTOM_INSTANCETYPE_MEMORY, Integer.class);


### PR DESCRIPTION
* Add a new convenience method `getReferenceInstanceTemplate()` to `Group` (`cloud-api`) returning `getReferenceInstanceConfiguration().getTemplate()`.
* Replace all occurrences of the expression `getReferenceInstanceConfiguration().getTemplate()` in various classes with invocations of `getReferenceInstanceTemplate()`.
  * Eliminate some superfluous local variables in said classes as part of the refactoring.
