### PR TITLE
CB-7830: Fix NullPointerException when appversion is not present

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/util/ClusterProxyServiceAvailabilityChecker.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/util/ClusterProxyServiceAvailabilityChecker.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.freeipa.util;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.sequenceiq.cloudbreak.cloud.VersionComparator;
 import com.sequenceiq.cloudbreak.common.type.Versioned;
 import com.sequenceiq.freeipa.entity.Stack;
@@ -13,8 +15,12 @@ public class ClusterProxyServiceAvailabilityChecker {
     }
 
     public static boolean isDnsBasedServiceNameAvailable(Stack stack) {
-        Versioned currentVersion = () -> stack.getAppVersion();
-        return new VersionComparator().compare(currentVersion, DNS_BASED_SERVICE_NAME_AFTER_VERSION) > 0;
+        if (StringUtils.isNotBlank(stack.getAppVersion())) {
+            Versioned currentVersion = () -> stack.getAppVersion();
+            return new VersionComparator().compare(currentVersion, DNS_BASED_SERVICE_NAME_AFTER_VERSION) > 0;
+        } else {
+            return false;
+        }
     }
 
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/util/ClusterProxyServiceAvailabilityCheckerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/util/ClusterProxyServiceAvailabilityCheckerTest.java
@@ -49,4 +49,16 @@ public class ClusterProxyServiceAvailabilityCheckerTest {
         assertFalse(ClusterProxyServiceAvailabilityChecker.isDnsBasedServiceNameAvailable(stack));
     }
 
+    @Test
+    public void testAppVersionIsBlank() {
+        Stack stack = new Stack();
+        assertFalse(ClusterProxyServiceAvailabilityChecker.isDnsBasedServiceNameAvailable(stack));
+
+        stack.setAppVersion("");
+        assertFalse(ClusterProxyServiceAvailabilityChecker.isDnsBasedServiceNameAvailable(stack));
+
+        stack.setAppVersion(" ");
+        assertFalse(ClusterProxyServiceAvailabilityChecker.isDnsBasedServiceNameAvailable(stack));
+    }
+
 }


### PR DESCRIPTION
If the appversion is not filled out in the database, then a null
pointer exception will happen when
ClusterProxyServiceAvailabilityChecker is used.

Unit tests were added.

Closes #CB-7830