### PR TITLE
CB-7745 syncer shouldn't overwrite TERMINATED status

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cluster/ClusterV4RequestToClusterConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cluster/ClusterV4RequestToClusterConverter.java
@@ -133,7 +133,7 @@ public class ClusterV4RequestToClusterConverter extends AbstractConversionServic
         Set<ClusterComponent> components = new HashSet<>();
 
         ClouderaManagerV4Request clouderaManagerRequest = clusterRequest.getCm();
-        if (Objects.nonNull(clouderaManagerRequest) && !StackType.CDH.name().equals(cluster.getBlueprint().getStackType())) {
+        if (Objects.nonNull(clouderaManagerRequest) && cluster.getBlueprint() != null && !StackType.CDH.name().equals(cluster.getBlueprint().getStackType())) {
             throw new BadRequestException("Cannot process the provided Ambari blueprint with Cloudera Manager");
         }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapper.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapper.java
@@ -153,6 +153,7 @@ public class ClusterBootstrapper {
     }
 
     private void saveSaltComponent(Stack stack) {
+        LOGGER.info("Save salt component for stack: {}", stack.getName());
         ClusterComponent saltComponent = clusterComponentProvider.getComponent(stack.getCluster().getId(), ComponentType.SALT_STATE);
         if (saltComponent == null) {
             try {
@@ -204,9 +205,11 @@ public class ClusterBootstrapper {
     }
 
     private List<GatewayConfig> collectAndCheckGateways(Stack stack) {
+        LOGGER.info("Collect and check gateways for {}", stack.getName());
         List<GatewayConfig> allGatewayConfig = new ArrayList<>();
         for (InstanceMetaData gateway : stack.getGatewayInstanceMetadata()) {
             GatewayConfig gatewayConfig = gatewayConfigService.getGatewayConfig(stack, gateway, isKnoxEnabled(stack));
+            LOGGER.info("Add gateway config: {}", gatewayConfig);
             allGatewayConfig.add(gatewayConfig);
             PollingResult bootstrapApiPolling = hostBootstrapApiPollingService.pollWithAbsoluteTimeoutSingleFailure(
                     hostBootstrapApiCheckerTask, new HostBootstrapApiContext(stack, gatewayConfig, hostOrchestrator), POLL_INTERVAL, MAX_POLLING_ATTEMPTS);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/DecommissionHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/DecommissionHandler.java
@@ -147,8 +147,7 @@ public class DecommissionHandler implements EventHandler<DecommissionRequest> {
 
     private void updateInstanceStatuses(Collection<InstanceMetaData> instanceMetadatas, InstanceStatus instanceStatus, String statusReason) {
         for (InstanceMetaData instanceMetaData : instanceMetadatas) {
-            instanceMetaDataService.updateInstanceStatus(instanceMetaData, instanceStatus,
-                    statusReason);
+            instanceMetaDataService.updateInstanceStatus(instanceMetaData, instanceStatus, statusReason);
         }
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/orchestration/BootstrapMachineHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/orchestration/BootstrapMachineHandler.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.reactor.handler.orchestration;
 
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.common.event.Selectable;
@@ -17,6 +19,9 @@ import reactor.bus.EventBus;
 
 @Component
 public class BootstrapMachineHandler implements EventHandler<BootstrapMachinesRequest> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BootstrapMachineHandler.class);
+
     @Inject
     private EventBus eventBus;
 
@@ -34,8 +39,10 @@ public class BootstrapMachineHandler implements EventHandler<BootstrapMachinesRe
         Selectable response;
         try {
             if (request.isReBootstrap()) {
+                LOGGER.info("RE-Bootstrap machines");
                 clusterBootstrapper.reBootstrapMachines(request.getResourceId());
             } else {
+                LOGGER.info("Bootstrap machines");
                 clusterBootstrapper.bootstrapMachines(request.getResourceId());
             }
             response = new BootstrapMachinesSuccess(request.getResourceId());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/orchestration/HostMetadataSetupHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/orchestration/HostMetadataSetupHandler.java
@@ -5,19 +5,20 @@ import javax.inject.Inject;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.common.event.Selectable;
-import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.HostMetadataSetupFailed;
 import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.HostMetadataSetupRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.HostMetadataSetupSuccess;
-import com.sequenceiq.flow.reactor.api.handler.EventHandler;
 import com.sequenceiq.cloudbreak.service.stack.flow.HostMetadataSetup;
+import com.sequenceiq.flow.event.EventSelectorUtil;
+import com.sequenceiq.flow.reactor.api.handler.EventHandler;
 
 import reactor.bus.Event;
 import reactor.bus.EventBus;
 
 @Component
 public class HostMetadataSetupHandler implements EventHandler<HostMetadataSetupRequest> {
+
     @Inject
     private EventBus eventBus;
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceMetaDataRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceMetaDataRepository.java
@@ -8,6 +8,7 @@ import javax.transaction.Transactional;
 import javax.transaction.Transactional.TxType;
 
 import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -113,5 +114,11 @@ public interface InstanceMetaDataRepository extends CrudRepository<InstanceMetaD
             + "FROM InstanceMetaData i JOIN i.instanceGroup ig JOIN ig.stack s WHERE s.workspace.id= :id AND i.instanceStatus = 'SERVICES_UNHEALTHY' "
             + "GROUP BY s.id")
     Set<StackInstanceCount> countUnhealthyByWorkspaceId(@Param("id") Long workspaceId);
+
+    @Modifying
+    @Query("UPDATE InstanceMetaData SET instanceStatus = :newInstanceStatus, statusReason = :newStatusReason " +
+            "WHERE id = :id AND instanceStatus <> 'TERMINATED'")
+    int updateStatusIfNotTerminated(@Param("id") Long id, @Param("newInstanceStatus") InstanceStatus newInstanceStatus,
+            @Param("newStatusReason") String newStatusReason);
 
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/MetadataSetupService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/MetadataSetupService.java
@@ -12,6 +12,8 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceLifeCycle;
@@ -34,6 +36,8 @@ import com.sequenceiq.common.api.type.InstanceGroupType;
 
 @Service
 public class MetadataSetupService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MetadataSetupService.class);
 
     @Inject
     private ImageService imageService;
@@ -73,6 +77,7 @@ public class MetadataSetupService {
 
     public int saveInstanceMetaData(Stack stack, Iterable<CloudVmMetaDataStatus> cloudVmMetaDataStatusList, InstanceStatus status) {
         try {
+            LOGGER.info("Save instance metadata for stack: {}", stack.getName());
             int newInstances = 0;
             Set<InstanceMetaData> allInstanceMetadata = instanceMetaDataService.findNotTerminatedForStack(stack.getId());
             boolean primaryIgSelected = allInstanceMetadata.stream().anyMatch(imd -> imd.getInstanceMetadataType() == InstanceMetadataType.GATEWAY_PRIMARY);
@@ -114,13 +119,17 @@ public class MetadataSetupService {
                                 primaryIgSelected = true;
                                 instanceMetaDataEntry.setInstanceMetadataType(InstanceMetadataType.GATEWAY_PRIMARY);
                                 instanceMetaDataEntry.setServer(Boolean.TRUE);
+                                LOGGER.info("Primary gateway is not selected, let's select this instance: {}", instanceMetaDataEntry.getInstanceId());
                             } else {
+                                LOGGER.info("Primary gateway was selected");
                                 instanceMetaDataEntry.setInstanceMetadataType(InstanceMetadataType.GATEWAY);
                             }
                         } else {
+                            LOGGER.info("Instance is a core instance: {}", instanceMetaDataEntry.getInstanceId());
                             instanceMetaDataEntry.setInstanceMetadataType(InstanceMetadataType.CORE);
                         }
                     } else {
+                        LOGGER.info("Instance group is null, instance will be a core instance: {}", instanceMetaDataEntry.getInstanceId());
                         instanceMetaDataEntry.setInstanceMetadataType(InstanceMetadataType.CORE);
                     }
                 }


### PR DESCRIPTION
Sometimes in edge cases syncer put an instancemetadata from TERMINATED to some other status which is wrong. Example scenario:
1) stop master instance
2) call repair on master node
3) syncer try to call CM, but it is down and connection times out for several times
4) in the meantime repair was started, downscale was successful
5) after some retry to CM syncer starts to check if VMs are available or not
6) VM is down because dowscale was successful -> syncer puts master node to DELETED_IN_PROVIDER_SIDE

master instance status is TERMINATED at this point, but it will be  DELETED_IN_PROVIDER_SIDE which is wrong. It results there will be 2 primary gateway.

Solution: syncer should not update instance status from TERMINATED state