### PR TITLE
CB-7804 Extend test failure report with spot info

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/Clue.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/Clue.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.it.cloudbreak.context;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.audits.responses.AuditEventV4Responses;
+
+public class Clue {
+
+    private final String name;
+
+    private final AuditEventV4Responses auditEvents;
+
+    private final Object response;
+
+    private final boolean hasSpotTermination;
+
+    public Clue(String name, AuditEventV4Responses auditEvents, Object response, boolean hasSpotTermination) {
+        this.name = name;
+        this.auditEvents = auditEvents;
+        this.response = response;
+        this.hasSpotTermination = hasSpotTermination;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public AuditEventV4Responses getAuditEvents() {
+        return auditEvents;
+    }
+
+    public Object getResponse() {
+        return response;
+    }
+
+    public boolean isHasSpotTermination() {
+        return hasSpotTermination;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/Investigable.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/Investigable.java
@@ -1,5 +1,5 @@
 package com.sequenceiq.it.cloudbreak.context;
 
 public interface Investigable {
-    String investigate();
+    Clue investigate();
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
@@ -15,13 +15,16 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.audits.responses.AuditEventV4Responses;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.SdxClient;
 import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
 import com.sequenceiq.it.cloudbreak.cloud.v4.CommonClusterManagerProperties;
+import com.sequenceiq.it.cloudbreak.context.Clue;
 import com.sequenceiq.it.cloudbreak.context.Investigable;
 import com.sequenceiq.it.cloudbreak.context.Purgable;
 import com.sequenceiq.it.cloudbreak.context.RunningParameter;
@@ -229,12 +232,19 @@ public class SdxTestDto extends AbstractSdxTestDto<SdxClusterRequest, SdxCluster
     }
 
     @Override
-    public String investigate() {
+    public Clue investigate() {
         if (getResponse() == null || getResponse().getCrn() == null) {
             return null;
         }
-        String crn = getResponse().getCrn();
 
-        return "SDX audit events: " + AuditUtil.getAuditEvents(getTestContext().getCloudbreakClient(), CloudbreakEventService.DATAHUB_RESOURCE_TYPE, null, crn);
+        AuditEventV4Responses auditEvents = AuditUtil.getAuditEvents(
+                getTestContext().getCloudbreakClient(),
+                CloudbreakEventService.DATAHUB_RESOURCE_TYPE,
+                null,
+                getResponse().getCrn());
+        boolean hasSpotTermination = getResponse().getStackV4Response().getInstanceGroups().stream()
+                .flatMap(ig -> ig.getMetadata().stream())
+                .anyMatch(metadata -> InstanceStatus.DELETED_BY_PROVIDER == metadata.getInstanceStatus());
+        return new Clue("SDX", auditEvents, getResponse(), hasSpotTermination);
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/AuditUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/AuditUtil.java
@@ -3,8 +3,6 @@ package com.sequenceiq.it.cloudbreak.util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.audits.AuditEventV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.audits.responses.AuditEventV4Responses;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
@@ -17,20 +15,8 @@ public class AuditUtil {
 
     }
 
-    private static String getAuditEvents(AuditEventV4Endpoint endpoint, String resourceType, Long id, String crn) {
-        AuditEventV4Responses events = endpoint.getAuditEvents(0L, resourceType, id, crn);
-        String json = null;
-        try {
-            json = new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(events);
-        } catch (JsonProcessingException e) {
-            return null;
-        }
-
-        return json;
-    }
-
-    public static String getAuditEvents(CloudbreakClient cloudbreakClient, String resourceType, Long id, String crn) {
+    public static AuditEventV4Responses getAuditEvents(CloudbreakClient cloudbreakClient, String resourceType, Long id, String crn) {
         AuditEventV4Endpoint endpoint = cloudbreakClient.getCloudbreakClient().auditV4Endpoint();
-        return getAuditEvents(endpoint, resourceType, id, crn);
+        return endpoint.getAuditEvents(0L, resourceType, id, crn);
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ErrorLogMessageProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ErrorLogMessageProvider.java
@@ -1,0 +1,69 @@
+package com.sequenceiq.it.cloudbreak.util;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.sequenceiq.it.cloudbreak.context.Clue;
+
+@Component
+public class ErrorLogMessageProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ErrorLogMessageProvider.class);
+
+    private static final ObjectWriter OBJECT_WRITER = new ObjectMapper().writerWithDefaultPrettyPrinter();
+
+    public String getMessage(Map<String, Exception> exceptionsDuringTest, List<Clue> clues) {
+        StringBuilder messageBuilder = new StringBuilder("All Exceptions that occurred during the test are logged after this message")
+                .append(System.lineSeparator());
+        exceptionsDuringTest.forEach((msg, ex) -> {
+            LOGGER.error("Exception during test: " + msg, ex);
+            messageBuilder.append(msg).append(": ")
+                    .append(ResponseUtil.getErrorMessage(ex))
+                    .append(System.lineSeparator());
+        });
+        addCluesToMessage(messageBuilder, clues);
+        return messageBuilder.toString().replace("%", "%%");
+    }
+
+    private void addCluesToMessage(StringBuilder builder, List<Clue> clues) {
+        if (clues.stream().anyMatch(Clue::isHasSpotTermination)) {
+            String spotTerminatedNames = clues.stream()
+                    .filter(Clue::isHasSpotTermination)
+                    .map(Clue::getName)
+                    .collect(Collectors.joining(", "));
+
+            LOGGER.warn("There were spot terminations in the following resources: {}", spotTerminatedNames);
+            builder.append("There were spot terminations in the following resources: ")
+                    .append(spotTerminatedNames)
+                    .append(System.lineSeparator());
+        }
+        builder.append("Responses:")
+                .append(System.lineSeparator());
+        clues.forEach(clue -> builder.append(clue.getName())
+                .append(" response: ")
+                .append(convertToString(clue.getResponse()))
+                .append(System.lineSeparator()));
+        builder.append("All audit events:")
+                .append(System.lineSeparator());
+        clues.forEach(clue -> builder.append(clue.getName())
+                .append(" audit events: ")
+                .append(convertToString(clue.getAuditEvents()))
+                .append(System.lineSeparator()));
+    }
+
+    private String convertToString(Object o) {
+        try {
+            return OBJECT_WRITER.writeValueAsString(o);
+        } catch (JsonProcessingException e) {
+            return "[ERROR] Failed to process json from " + o;
+        }
+    }
+}


### PR DESCRIPTION
Test failure reports will now contain if there were spot terminations, and also the relevant api responses to ease the troubleshooting.