### PR TITLE
CB-7831: Connections to Solr are failing with a 500 on 7.2.1 clusters

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-sdx-721.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx-721.bp
@@ -167,6 +167,12 @@
         "roleConfigGroups": [
           {
             "base": true,
+            "configs": [
+              {
+                "name": "solr_https_port",
+                "value": "8985"
+              }
+            ],
             "refName": "solr-SOLR_SERVER-BASE",
             "roleType": "SOLR_SERVER"
           }


### PR DESCRIPTION
Manually tested the changed by spinning up a datalake with Runtime 7.2.1 and made sure that the "solr_https_port" is set to 8985 and also made sure that Solr HTTP service is reachable.