### PR TITLE
CB-7860: Return operation ID with FreeIPA reboot

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
@@ -83,7 +83,7 @@ public interface FreeIpaV1Endpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = FreeIpaOperationDescriptions.REBOOT, produces = MediaType.APPLICATION_JSON, notes = FreeIpaNotes.FREEIPA_NOTES,
             nickname = "rebootV1")
-    void rebootInstances(@Valid RebootInstancesRequest request);
+    OperationStatus rebootInstances(@Valid RebootInstancesRequest request);
 
     @POST
     @Path("repair")

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/operation/model/OperationType.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/operation/model/OperationType.java
@@ -6,6 +6,7 @@ public enum OperationType {
     USER_SYNC,
     SET_PASSWORD,
     CLEANUP,
+    REBOOT,
     REPAIR,
     DOWNSCALE,
     UPSCALE;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaV1Controller.java
@@ -190,9 +190,9 @@ public class FreeIpaV1Controller implements FreeIpaV1Endpoint {
 
     @Override
     @CheckPermissionByResourceObject
-    public void rebootInstances(@ResourceObject @Valid RebootInstancesRequest request) {
+    public OperationStatus rebootInstances(@ResourceObject @Valid RebootInstancesRequest request) {
         String accountId = crnService.getCurrentAccountId();
-        repairInstancesService.rebootInstances(accountId, request);
+        return repairInstancesService.rebootInstances(accountId, request);
     }
 
     @Override

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/RebootInstanceEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/RebootInstanceEvent.java
@@ -1,0 +1,18 @@
+package com.sequenceiq.freeipa.flow.instance.reboot;
+
+import java.util.List;
+
+import com.sequenceiq.freeipa.flow.instance.InstanceEvent;
+
+public class RebootInstanceEvent extends InstanceEvent {
+    private final String operationId;
+
+    public RebootInstanceEvent(String selector, Long resourceId, List<String> instanceIds, String operationId) {
+        super(selector, resourceId, instanceIds);
+        this.operationId = operationId;
+    }
+
+    public String getOperationId() {
+        return operationId;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/RebootOperationAcceptor.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/RebootOperationAcceptor.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.freeipa.flow.instance.reboot;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationType;
+import com.sequenceiq.freeipa.repository.OperationRepository;
+import com.sequenceiq.freeipa.service.operation.OperationAcceptor;
+
+@Component
+public class RebootOperationAcceptor extends OperationAcceptor {
+
+    @Inject
+    public RebootOperationAcceptor(OperationRepository operationRepository) {
+        super(operationRepository);
+    }
+
+    @Override
+    protected OperationType selector() {
+        return OperationType.REBOOT;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/action/AbstractRebootAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/action/AbstractRebootAction.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.freeipa.flow.instance.reboot.action;
 
+import java.util.Map;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -10,11 +12,21 @@ import com.sequenceiq.freeipa.flow.instance.reboot.RebootState;
 import com.sequenceiq.freeipa.flow.stack.AbstractStackAction;
 
 public abstract class AbstractRebootAction<P extends Payload>
-        extends AbstractStackAction<RebootState, RebootEvent, RebootContext, P>  {
+        extends AbstractStackAction<RebootState, RebootEvent, RebootContext, P> {
+
+    protected static final String OPERATION_ID = "OPERATION_ID";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractRebootAction.class);
 
     protected AbstractRebootAction(Class<P> payloadClass) {
         super(payloadClass);
+    }
+
+    protected void setOperationId(Map<Object, Object> variables, String operationId) {
+        variables.put(OPERATION_ID, operationId);
+    }
+
+    protected String getOperationId(Map<Object, Object> variables) {
+        return (String) variables.get(OPERATION_ID);
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/RepairInstancesServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/RepairInstancesServiceTest.java
@@ -95,6 +95,7 @@ class RepairInstancesServiceTest {
     public static void init() {
         stack1 = new Stack();
         stack1.setResourceCrn(ENVIRONMENT_ID1);
+        stack1.setEnvironmentCrn(ENVIRONMENT_ID1);
         InstanceGroup instanceGroup = new InstanceGroup();
         stack1.getInstanceGroups().add(instanceGroup);
         instanceGroup.setInstanceGroupType(InstanceGroupType.MASTER);
@@ -105,6 +106,7 @@ class RepairInstancesServiceTest {
 
         stack2 = new Stack();
         stack2.setResourceCrn(ENVIRONMENT_ID2);
+        stack2.setEnvironmentCrn(ENVIRONMENT_ID2);
         instanceGroup = new InstanceGroup();
         stack2.getInstanceGroups().add(instanceGroup);
         instanceGroup.setInstanceGroupType(InstanceGroupType.MASTER);
@@ -302,11 +304,14 @@ class RepairInstancesServiceTest {
 
     @Test
     public void testBasicSuccessReboot() throws Exception {
+        OperationStatus operationStatus = new OperationStatus();
         Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(stack1);
         Mockito.when(healthDetailsService.getHealthDetails(any(), any())).thenReturn(getMockDetails1());
+        Mockito.when(operationService.startOperation(any(), any(), any(), any())).thenReturn(createOperation());
+        Mockito.when(operationToOperationStatusConverter.convert(any())).thenReturn(operationStatus);
         RebootInstancesRequest rebootInstancesRequest = new RebootInstancesRequest();
         rebootInstancesRequest.setEnvironmentCrn(ENVIRONMENT_ID1);
-        underTest.rebootInstances(ACCOUNT_ID, rebootInstancesRequest);
+        assertEquals(operationStatus, underTest.rebootInstances(ACCOUNT_ID, rebootInstancesRequest));
 
         ArgumentCaptor<InstanceEvent> terminationEventArgumentCaptor = ArgumentCaptor.forClass(InstanceEvent.class);
         verify(flowManager, times(1)).notify(eq(REBOOT_EVENT.event()), terminationEventArgumentCaptor.capture());
@@ -314,12 +319,15 @@ class RepairInstancesServiceTest {
 
     @Test
     public void testInstancesSuccessReboot() throws Exception {
+        OperationStatus operationStatus = new OperationStatus();
         Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(stack1);
         Mockito.when(healthDetailsService.getHealthDetails(any(), any())).thenReturn(getMockDetails1());
+        Mockito.when(operationService.startOperation(any(), any(), any(), any())).thenReturn(createOperation());
+        Mockito.when(operationToOperationStatusConverter.convert(any())).thenReturn(operationStatus);
         RebootInstancesRequest rebootInstancesRequest = new RebootInstancesRequest();
         rebootInstancesRequest.setEnvironmentCrn(ENVIRONMENT_ID1);
         rebootInstancesRequest.setInstanceIds(Arrays.asList("instance_1"));
-        underTest.rebootInstances(ACCOUNT_ID, rebootInstancesRequest);
+        assertEquals(operationStatus, underTest.rebootInstances(ACCOUNT_ID, rebootInstancesRequest));
 
         ArgumentCaptor<InstanceEvent> terminationEventArgumentCaptor = ArgumentCaptor.forClass(InstanceEvent.class);
         verify(flowManager, times(1)).notify(eq(REBOOT_EVENT.event()), terminationEventArgumentCaptor.capture());
@@ -340,12 +348,15 @@ class RepairInstancesServiceTest {
 
     @Test
     public void testForceInstancesSuccessReboot() throws Exception {
+        OperationStatus operationStatus = new OperationStatus();
         Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(stack1);
+        Mockito.when(operationService.startOperation(any(), any(), any(), any())).thenReturn(createOperation());
+        Mockito.when(operationToOperationStatusConverter.convert(any())).thenReturn(operationStatus);
         RebootInstancesRequest rebootInstancesRequest = new RebootInstancesRequest();
         rebootInstancesRequest.setEnvironmentCrn(ENVIRONMENT_ID1);
         rebootInstancesRequest.setInstanceIds(Arrays.asList("instance_1"));
         rebootInstancesRequest.setForceReboot(true);
-        underTest.rebootInstances(ACCOUNT_ID, rebootInstancesRequest);
+        assertEquals(operationStatus, underTest.rebootInstances(ACCOUNT_ID, rebootInstancesRequest));
 
         ArgumentCaptor<InstanceEvent> terminationEventArgumentCaptor = ArgumentCaptor.forClass(InstanceEvent.class);
         verify(flowManager, times(1)).notify(eq(REBOOT_EVENT.event()), terminationEventArgumentCaptor.capture());
@@ -368,22 +379,28 @@ class RepairInstancesServiceTest {
 
     @Test
     public void testNonForceMultiInstanceReboot() throws Exception {
+        OperationStatus operationStatus = new OperationStatus();
         Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(stack2);
         Mockito.when(healthDetailsService.getHealthDetails(any(), any())).thenReturn(getMockDetails2());
+        Mockito.when(operationService.startOperation(any(), any(), any(), any())).thenReturn(createOperation());
+        Mockito.when(operationToOperationStatusConverter.convert(any())).thenReturn(operationStatus);
         RebootInstancesRequest rebootInstancesRequest = new RebootInstancesRequest();
         rebootInstancesRequest.setEnvironmentCrn(ENVIRONMENT_ID2);
-        underTest.rebootInstances(ACCOUNT_ID, rebootInstancesRequest);
+        assertEquals(operationStatus, underTest.rebootInstances(ACCOUNT_ID, rebootInstancesRequest));
         ArgumentCaptor<InstanceEvent> terminationEventArgumentCaptor = ArgumentCaptor.forClass(InstanceEvent.class);
         verify(flowManager, times(1)).notify(eq(REBOOT_EVENT.event()), terminationEventArgumentCaptor.capture());
     }
 
     @Test
     public void testForceMultiInstanceReboot() throws Exception {
+        OperationStatus operationStatus = new OperationStatus();
         Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(stack2);
+        Mockito.when(operationService.startOperation(any(), any(), any(), any())).thenReturn(createOperation());
+        Mockito.when(operationToOperationStatusConverter.convert(any())).thenReturn(operationStatus);
         RebootInstancesRequest rebootInstancesRequest = new RebootInstancesRequest();
         rebootInstancesRequest.setEnvironmentCrn(ENVIRONMENT_ID2);
         rebootInstancesRequest.setForceReboot(true);
-        underTest.rebootInstances(ACCOUNT_ID, rebootInstancesRequest);
+        assertEquals(operationStatus, underTest.rebootInstances(ACCOUNT_ID, rebootInstancesRequest));
         ArgumentCaptor<InstanceEvent> terminationEventArgumentCaptor = ArgumentCaptor.forClass(InstanceEvent.class);
         verify(flowManager, times(1)).notify(eq(REBOOT_EVENT.event()), terminationEventArgumentCaptor.capture());
     }


### PR DESCRIPTION
The reboot API in FreeIPA Management Service was updated to return an
operation ID instead of void. This makes the reboot API consistent
with the repair API and it allows the client to know when the reboot
operation is complete.

This tested by with unit tests and manually checking the return
value in a local deployment of cloudbreak.

NOTE: This does not wait for the reboot flow to ensure the nodes have come back online, which will be handled by a separate pull request.

Closes #CB-7860