### PR TITLE
CB-7861 Proxy config internal call fix

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/proxy/v1/controller/ProxyController.java
+++ b/environment/src/main/java/com/sequenceiq/environment/proxy/v1/controller/ProxyController.java
@@ -16,6 +16,8 @@ import com.sequenceiq.authorization.annotation.CheckPermissionByAccount;
 import com.sequenceiq.authorization.annotation.ResourceCrn;
 import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.security.internal.InternalReady;
+import com.sequenceiq.cloudbreak.auth.security.internal.TenantAwareParam;
 import com.sequenceiq.cloudbreak.event.ResourceEvent;
 import com.sequenceiq.environment.api.v1.proxy.endpoint.ProxyEndpoint;
 import com.sequenceiq.environment.api.v1.proxy.model.request.ProxyRequest;
@@ -30,6 +32,7 @@ import com.sequenceiq.notification.NotificationController;
 
 @Controller
 @AuthorizationResource
+@InternalReady
 @Transactional(TxType.NEVER)
 public class ProxyController extends NotificationController implements ProxyEndpoint {
 
@@ -69,7 +72,7 @@ public class ProxyController extends NotificationController implements ProxyEndp
 
     @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.ENVIRONMENT_READ)
-    public ProxyResponse getByEnvironmentCrn(@ResourceCrn String environmentCrn) {
+    public ProxyResponse getByEnvironmentCrn(@ResourceCrn @TenantAwareParam String environmentCrn) {
         String accountId = ThreadBasedUserCrnProvider.getAccountId();
         ProxyConfig proxyConfig = proxyConfigService.getByEnvironmentCrnAndAccountId(environmentCrn, accountId);
         return proxyConfigToProxyResponseConverter.convert(proxyConfig);


### PR DESCRIPTION
Somehow annotations (responsible to make account id usage possible with internal actor) were accidentally removed