### PR TITLE
COMPX-3063. Add mapred user as YARN admin

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-721.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-721.bp
@@ -82,7 +82,7 @@
         "serviceConfigs": [
           {
             "name": "yarn_admin_acl",
-            "value": "yarn,hive,hdfs"
+            "value": "yarn,hive,hdfs,mapred"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-721.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-721.bp
@@ -223,7 +223,7 @@
         "serviceConfigs": [
           {
             "name": "yarn_admin_acl",
-            "value": "yarn,hive,hdfs"
+            "value": "yarn,hive,hdfs,mapred"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-721.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-721.bp
@@ -82,7 +82,7 @@
         "serviceConfigs": [
           {
             "name": "yarn_admin_acl",
-            "value": "yarn,hdfs"
+            "value": "yarn,hdfs,mapred"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/cdp-flink-ha-721.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-flink-ha-721.bp
@@ -104,7 +104,7 @@
         "serviceConfigs": [
           {
             "name": "yarn_admin_acl",
-            "value": "yarn,hdfs,flink"
+            "value": "yarn,hdfs,flink,mapred"
           }
         ],
         "roleConfigGroups": [

--- a/integration-test/src/main/resources/blueprint/clouderamanager.bp
+++ b/integration-test/src/main/resources/blueprint/clouderamanager.bp
@@ -57,7 +57,7 @@
         "serviceConfigs": [
           {
             "name": "yarn_admin_acl",
-            "value": "yarn,hive,hdfs"
+            "value": "yarn,hive,hdfs,mapred"
           }
         ],
         "roleConfigGroups": [

--- a/template-manager-cmtemplate/src/test/resources/input/de-ha.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/de-ha.bp
@@ -193,7 +193,7 @@
         "serviceConfigs": [
           {
             "name": "yarn_admin_acl",
-            "value": "yarn,hive,hdfs"
+            "value": "yarn,hive,hdfs,mapred"
           },
           {
             "name": "yarn_log_aggregation_IFile_remote_app_log_dir",


### PR DESCRIPTION
YARN UI2 fetches logs from MR HistoryServer LogsServlet which runs as mapred
user. Currently, mapred user accesses the RM and NM to get job details and job
logs details respectively. This requires mapred user to have access on viewing
all the jobs.

This change got pushed into master in PR https://github.com/hortonworks/cloudbreak/pull/8487.