### PR TITLE
CB-7803 Disable retry of failed test cases on spot instances

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/spot/SpotRetryUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/spot/SpotRetryUtil.java
@@ -3,6 +3,7 @@ package com.sequenceiq.it.cloudbreak.util.spot;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.testng.ITestNGMethod;
 
@@ -13,12 +14,16 @@ public class SpotRetryUtil {
 
     private final SpotUtil spotUtil;
 
-    public SpotRetryUtil(SpotUtil spotUtil) {
+    private final boolean retryEnabled;
+
+    public SpotRetryUtil(SpotUtil spotUtil, @Value("${integrationtest.spot.retryEnabled:false}") boolean retryEnabled) {
         this.spotUtil = spotUtil;
+        this.retryEnabled = retryEnabled;
     }
 
     public boolean willRetry(ITestNGMethod testMethod) {
-        return spotUtil.shouldUseSpotInstancesForTest(testMethod.getConstructorOrMethod().getMethod())
+        return retryEnabled
+                && spotUtil.shouldUseSpotInstancesForTest(testMethod.getConstructorOrMethod().getMethod())
                 && RETRIED_TEST_METHODS.add(testMethod);
     }
 

--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -73,6 +73,7 @@ integrationtest:
   spot:
     enabledCloudPlatforms:
       - AWS
+    retryEnabled: false
 
   # aws parameters
   aws:

--- a/integration-test/src/test/java/com/sequenceiq/it/cloudbreak/util/spot/SpotRetryUtilTest.java
+++ b/integration-test/src/test/java/com/sequenceiq/it/cloudbreak/util/spot/SpotRetryUtilTest.java
@@ -1,0 +1,70 @@
+package com.sequenceiq.it.cloudbreak.util.spot;
+
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.lang.reflect.Method;
+
+import org.mockito.Mockito;
+import org.testng.ITestNGMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.testng.internal.ConstructorOrMethod;
+
+public class SpotRetryUtilTest {
+
+    private Method method;
+
+    private SpotUtil spotUtil;
+
+    private ITestNGMethod testMethod;
+
+    private SpotRetryUtil underTest;
+
+    @BeforeMethod
+    public void setUp() throws NoSuchMethodException {
+        ConstructorOrMethod constructorOrMethod = Mockito.mock(ConstructorOrMethod.class);
+        method = ExampleTest.class.getDeclaredMethod("exampleMethod");
+        when(constructorOrMethod.getMethod()).thenReturn(method);
+        testMethod = Mockito.mock(ITestNGMethod.class);
+        when(testMethod.getConstructorOrMethod()).thenReturn(constructorOrMethod);
+
+        spotUtil = Mockito.mock(SpotUtil.class);
+        underTest = new SpotRetryUtil(spotUtil, true);
+    }
+
+    @Test
+    void shouldRetryOnFirstTryButNotOnSecondWhenShouldUseSpotInstances() {
+        when(spotUtil.shouldUseSpotInstancesForTest(method)).thenReturn(true);
+
+        // first try - is not retried, and it will retry
+        assertFalse(underTest.isRetried(testMethod));
+        assertTrue(underTest.willRetry(testMethod));
+
+        // second try - retried, and it will not retry
+        assertTrue(underTest.isRetried(testMethod));
+        assertFalse(underTest.willRetry(testMethod));
+    }
+
+    @Test
+    void shouldNotRetryWhenShouldUseSpotInstancesIsFalse() {
+        when(spotUtil.shouldUseSpotInstancesForTest(method)).thenReturn(false);
+
+        boolean result = underTest.willRetry(testMethod);
+        assertFalse(result);
+    }
+
+    @Test
+    void shouldNotRetryWhenRetryEnabledIsFalse() {
+        underTest = new SpotRetryUtil(spotUtil, true);
+
+        boolean result = underTest.willRetry(testMethod);
+        assertFalse(result);
+    }
+
+    private static class ExampleTest {
+        private void exampleMethod() {
+        }
+    }
+}


### PR DESCRIPTION
This change is already on master, but we need it for 2.25 too