### PR TITLE
CB-7715 Set cluster DNS entries TTL to 30 sec

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
@@ -352,6 +352,7 @@ public class ClusterHostServiceRunner {
             sssdConnfig.put("domain", kerberosConfig.getDomain());
             sssdConnfig.put("password", kerberosConfig.getPassword());
             sssdConnfig.put("server", kerberosConfig.getUrl());
+            sssdConnfig.put("dns_ttl", kerberosDetailService.getDnsTtl());
             // enumeration has performance impacts so it's only enabled if Ranger is installed on the cluster
             // otherwise the usersync does not work with nss
             boolean enumerate = !CollectionUtils.isEmpty(serviceLocations.get("RANGER_ADMIN"))

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -114,6 +114,8 @@ cb:
   freeipa:
     url: http://localhost:8090
     contextPath: /freeipa
+    dns:
+      ttl: 30
   sdx:
     url: http://localhost:8086
     contextPath: /dl

--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/ipa.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/ipa.sls
@@ -55,7 +55,7 @@ removing_dns_entries:
 
 add_dns_record:
   cmd.run:
-    - name: echo $PW | kinit {{salt['pillar.get']('sssd-ipa:principal')}} && ipa dnsrecord-add {{salt['pillar.get']('sssd-ipa:domain')}}. $(hostname) --a-rec=$(hostname -i) --a-create-reverse && echo $(date +%Y-%m-%d:%H:%M:%S) >> /var/log/dnsrecord-add-executed
+    - name: echo $PW | kinit {{salt['pillar.get']('sssd-ipa:principal')}} && ipa dnsrecord-add {{salt['pillar.get']('sssd-ipa:domain')}}. $(hostname) --a-rec=$(hostname -i) --a-create-reverse --ttl {{salt['pillar.get']('sssd-ipa:dns_ttl')}} && echo $(date +%Y-%m-%d:%H:%M:%S) >> /var/log/dnsrecord-add-executed
     - unless: test -f /var/log/dnsrecord-add-executed || { echo $PW | kinit {{salt['pillar.get']('sssd-ipa:principal')}} && ipa dnsrecord-find {{salt['pillar.get']('sssd-ipa:domain')}} --a-rec=$(hostname -i); }
     - env:
         - PW: "{{salt['pillar.get']('sssd-ipa:password')}}"

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/kerberos/KerberosDetailService.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/kerberos/KerberosDetailService.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 
 import javax.annotation.Nonnull;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -20,6 +21,9 @@ import com.sequenceiq.cloudbreak.type.KerberosType;
 
 @Service
 public class KerberosDetailService {
+
+    @Value("${cb.freeipa.dns.ttl}")
+    private int dnsTtl;
 
     private final Gson gson = new Gson();
 
@@ -112,5 +116,9 @@ public class KerberosDetailService {
 
         return supportedOnCloudPlatform
                 && kerberosConfigOptional.isPresent() && isIpaJoinable(kerberosConfigOptional.get());
+    }
+
+    public int getDnsTtl() {
+        return dnsTtl;
     }
 }

--- a/template-manager-recipe/src/test/java/com/sequenceiq/cloudbreak/recipe/moduletest/CentralRecipeContext.java
+++ b/template-manager-recipe/src/test/java/com/sequenceiq/cloudbreak/recipe/moduletest/CentralRecipeContext.java
@@ -11,6 +11,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.vault.core.VaultTemplate;
 
 import com.sequenceiq.cloudbreak.common.metrics.MetricService;
@@ -23,6 +24,9 @@ import com.sequenceiq.cloudbreak.service.secret.SecretEngine;
 import com.sequenceiq.cloudbreak.service.secret.service.SecretService;
 
 @ContextConfiguration
+@TestPropertySource(properties = {
+        "cb.freeipa.dns.ttl=30"
+})
 public class CentralRecipeContext {
 
     @Inject


### PR DESCRIPTION
During upgrade/repair it's possible that unbound would return the old IP as the TTL in FreeIPA by default is 1200 sec (unbound honors this value)
Unfortunately FreeIPA doesn't support setting default TTL for DNS zones. See:
https://www.redhat.com/archives/freeipa-users/2013-October/msg00122.html

This leaves us with 2 option:
- add DNS record with TTL (this is the current implementation)
- create a plugin which enables LDAP level editing for DNS zones

After some investigation we are going with 30 sec as:
- it is a very short period, won't cause any disruption
- 0 is an invalid value for TTL
- many DNS servers don't honor values under 30, which could cause they would fall back to their default value