### PR TITLE
DISTX-494-Purge Old Periscope Cluster Data

### DIFF
--- a/autoscale/src/main/resources/schema/app/20200708120655_DISTX-494_Purge_Old_Cluster_Data.sql
+++ b/autoscale/src/main/resources/schema/app/20200708120655_DISTX-494_Purge_Old_Cluster_Data.sql
@@ -1,0 +1,22 @@
+-- // DISTX-494 Purge Old Cluster Data
+-- Migration SQL that makes the change goes here.
+-- Purge existing periscope cluster data, new cluster data would be auto-synced from CB.
+
+delete from failed_node;
+delete from history_properties;
+delete from history;
+delete from prometheusalert;
+delete from loadalert;
+delete from timealert;
+delete from metricalert;
+delete from scalingpolicy;
+delete from securityconfig;
+delete from cluster;
+delete from cluster_manager;
+delete from clusterpertain;
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+


### PR DESCRIPTION
1. Persicope old cluster data was not initialized with newly added columns like stacktype, cloudplatform..
2. Purging old data so that periscope auto-syncs new cluster data.
