### PR TITLE
Cb-7808 Flow events are missing from Structuctured events

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/common/StackType.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/common/StackType.java
@@ -1,15 +1,20 @@
 package com.sequenceiq.cloudbreak.api.endpoint.v4.common;
 
 import static com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService.DATAHUB_RESOURCE_TYPE;
+import static com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService.LEGACY_RESOURCE_TYPE;
 
 public enum  StackType {
     WORKLOAD,
     DATALAKE,
-    TEMPLATE;
+    TEMPLATE,
+    LEGACY;
 
     public String getResourceType() {
         if (WORKLOAD.equals(this)) {
             return DATAHUB_RESOURCE_TYPE;
+        }
+        if (LEGACY.equals(this)) {
+            return LEGACY_RESOURCE_TYPE;
         }
         return name().toLowerCase();
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/decorator/responseprovider/StackResponseEventProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/decorator/responseprovider/StackResponseEventProvider.java
@@ -1,12 +1,16 @@
 package com.sequenceiq.cloudbreak.service.decorator.responseprovider;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.events.responses.CloudbreakEventV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.StackResponseEntries;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
@@ -15,15 +19,32 @@ import com.sequenceiq.cloudbreak.facade.CloudbreakEventsFacade;
 
 @Component
 public class StackResponseEventProvider implements ResponseProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StackResponseEventProvider.class);
+
     @Inject
     private CloudbreakEventsFacade cloudbreakEventsFacade;
 
     @Override
     public StackV4Response providerEntriesToStackResponse(Stack stack, StackV4Response stackResponse) {
+        List<CloudbreakEventV4Response> events = new ArrayList<>();
         List<CloudbreakEventV4Response> cloudbreakEvents = cloudbreakEventsFacade
                 .retrieveEventsByStack(stack.getId(), stack.getType(), PageRequest.of(0, Integer.MAX_VALUE)).getContent();
-        stackResponse.setCloudbreakEvents(cloudbreakEvents);
+        events.addAll(cloudbreakEvents);
+        events.addAll(getLegacyStackType(stack));
+        stackResponse.setCloudbreakEvents(events);
         return stackResponse;
+    }
+
+    private List<CloudbreakEventV4Response> getLegacyStackType(Stack stack) {
+        List<CloudbreakEventV4Response> events = cloudbreakEventsFacade
+                .retrieveEventsByStack(stack.getId(), StackType.LEGACY, PageRequest.of(0, Integer.MAX_VALUE)).getContent();
+        if (events.isEmpty()) {
+            LOGGER.info("Cannot find any legacy events for stack: {}, crn: {}", stack.getId(), stack.getResourceCrn());
+        } else {
+            LOGGER.info("{} legacy events for stack: {}, crn: {}", events.size(), stack.getId(), stack.getResourceCrn());
+        }
+        return events;
     }
 
     @Override

--- a/core/src/main/resources/schema/app/20200708143948_CB-7808_set_from_datahub,_datalake_stack_type_to_stacks_in_structured_events.sql
+++ b/core/src/main/resources/schema/app/20200708143948_CB-7808_set_from_datahub,_datalake_stack_type_to_stacks_in_structured_events.sql
@@ -1,0 +1,9 @@
+-- // CB-7808 set from datahub, datalake stack type to stacks in structured events
+-- Migration SQL that makes the change goes here.
+
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+update structuredevent set resourcetype = 'stacks' where resourcetype = 'datahub' OR resourcetype = 'datalake';

--- a/structuredevent-model/src/main/java/com/sequenceiq/cloudbreak/structuredevent/event/CloudbreakEventService.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/cloudbreak/structuredevent/event/CloudbreakEventService.java
@@ -14,6 +14,8 @@ public interface CloudbreakEventService {
 
     String DATALAKE_RESOURCE_TYPE = "datalake";
 
+    String LEGACY_RESOURCE_TYPE = "stacks";
+
     void fireCloudbreakEvent(Long entityId, String eventType, ResourceEvent resourceEvent);
 
     void fireCloudbreakEvent(Long entityId, String eventType, ResourceEvent resourceEvent, Collection<String> eventMessageArgs);


### PR DESCRIPTION
We filtered the structured events to datalake and datahub only but before 2.25 the CB stored as stacks. The legacy resource type added

