### PR TITLE
CB-6364: Create CB core api and flow which updates salt config

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
@@ -245,6 +245,9 @@ public enum ResourceEvent {
 
     CLUSTER_SALT_UPDATE_FAILED("cluster.salt.update.failed"),
     CLUSTER_SALT_UPDATE_FINISHED("cluster.salt.update.finished"),
+    CLUSTER_PILLAR_CONFIG_UPDATE_FAILED("cluster.pillar.config.update.failed"),
+    CLUSTER_PILLAR_CONFIG_UPDATE_FINISHED("cluster.pillar.config.update.finished"),
+    CLUSTER_PILLAR_CONFIG_UPDATE_STARTED("cluster.pillar.config.update.started"),
     CLUSTER_STOPPING("cluster.stopping"),
     CLUSTER_STOPPED("cluster.stopped"),
     CLUSTER_STOP_FAILED("cluster.stop.failed"),

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -209,6 +209,10 @@ cluster.upgrade.start.upgrade=Calling upgrade on Runtime
 cluster.salt.update.failed=Failed to update salt states
 cluster.salt.update.finished=Salt successfully updated
 
+cluster.pillar.config.update.started=Update of cluster configuration started. 
+cluster.pillar.config.update.finished=Cluster configuration successfully updated.
+cluster.pillar.config.update.failed=Failed to update cluster configuration,
+
 resource.blueprint.created=Blueprint created.
 resource.blueprint.deleted=Blueprint deleted.
 resource.sdx.created=Datalake cluster created.

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks;
 
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.ClusterOpDescription.PUT_BY_STACK_ID;
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.ClusterOpDescription.SET_MAINTENANCE_MODE_BY_NAME;
+import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.ClusterOpDescription.UPDATE_PILLAR_CONFIG;
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.ClusterOpDescription.UPDATE_SALT;
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescription.CHECK_FOR_UPGRADE_CLUSTER_IN_WORKSPACE;
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescription.CHECK_IMAGE_IN_WORKSPACE;
@@ -272,6 +273,12 @@ public interface StackV4Endpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = UPDATE_SALT, nickname = "updateSaltByName")
     FlowIdentifier updateSaltByName(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name);
+
+    @PUT
+    @Path("{name}/pillar_config_update")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = UPDATE_PILLAR_CONFIG, nickname = "updatePillarConfigurationByName")
+    FlowIdentifier updatePillarConfigurationByName(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name);
 
     @POST
     @Path("{name}/database_backup")

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
@@ -54,6 +54,7 @@ public class OperationDescriptions {
         public static final String SET_MAINTENANCE_MODE_BY_NAME = "set maintenance mode for the cluster by name";
         public static final String SET_MAINTENANCE_MODE_BY_CRN = "set maintenance mode for the cluster by crn";
         public static final String UPDATE_SALT = "Update salt states on cluster";
+        public static final String UPDATE_PILLAR_CONFIG = "Update salt pillar configuration on cluster";
     }
 
     public static class ClusterTemplateOpDescription {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
@@ -196,6 +196,11 @@ public class StackV4Controller extends NotificationController implements StackV4
     }
 
     @Override
+    public FlowIdentifier updatePillarConfigurationByName(Long workspaceId, String name) {
+        return stackOperations.updatePillarConfiguration(NameOrCrn.ofName(name), workspaceId);
+    }
+
+    @Override
     public BackupV4Response backupDatabaseByName(Long workspaceId, String name, String backupLocation, String backupId) {
         FlowIdentifier flowIdentifier =
             stackOperations.backupClusterDatabase(NameOrCrn.ofName(name), workspaceId, backupLocation, backupId);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
@@ -223,6 +223,20 @@ public class ClusterHostServiceRunner {
         }
     }
 
+    public void updateClusterConfigs(@Nonnull Stack stack, @Nonnull Cluster cluster, List<String> candidateAddresses) {
+        try {
+            Set<Node> nodes = stackUtil.collectReachableNodes(stack);
+            GatewayConfig primaryGatewayConfig = gatewayConfigService.getPrimaryGatewayConfig(stack);
+            List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
+            SaltConfig saltConfig = createSaltConfig(stack, cluster, primaryGatewayConfig, gatewayConfigs, nodes);
+            ExitCriteriaModel exitCriteriaModel = clusterDeletionBasedModel(stack.getId(), cluster.getId());
+            hostOrchestrator.initSaltConfig(gatewayConfigs, nodes, saltConfig, exitCriteriaModel);
+            hostOrchestrator.runService(gatewayConfigs, nodes, saltConfig, exitCriteriaModel);
+        } catch (CloudbreakOrchestratorException | IOException e) {
+            throw new CloudbreakServiceException(e.getMessage(), e);
+        }
+    }
+
     public Map<String, String> addClusterServices(Long stackId, String hostGroupName, Integer scalingAdjustment) {
         Map<String, String> candidates;
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/CloudbreakFlowInformation.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/CloudbreakFlowInformation.java
@@ -24,6 +24,7 @@ import com.sequenceiq.cloudbreak.core.flow2.cluster.termination.ClusterTerminati
 import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.ClusterUpgradeFlowConfig;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.upscale.ClusterUpscaleFlowConfig;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.userpasswd.ClusterCredentialChangeFlowConfig;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.PillarConfigUpdateFlowConfig;
 import com.sequenceiq.cloudbreak.core.flow2.externaldatabase.terminate.config.ExternalDatabaseTerminationEvent;
 import com.sequenceiq.cloudbreak.core.flow2.externaldatabase.terminate.config.ExternalDatabaseTerminationFlowConfig;
 import com.sequenceiq.cloudbreak.core.flow2.stack.downscale.StackDownscaleConfig;
@@ -63,7 +64,7 @@ public class CloudbreakFlowInformation implements ApplicationFlowInformation {
             ClusterStartFlowConfig.class, ClusterStopFlowConfig.class,
             ClusterUpscaleFlowConfig.class, ClusterDownscaleFlowConfig.class,
             ClusterUpgradeFlowConfig.class, ClusterResetFlowConfig.class, ChangePrimaryGatewayFlowConfig.class,
-            ClusterCertificateRenewFlowConfig.class, DatabaseBackupFlowConfig.class, DatabaseRestoreFlowConfig.class
+            ClusterCertificateRenewFlowConfig.class, DatabaseBackupFlowConfig.class, DatabaseRestoreFlowConfig.class, PillarConfigUpdateFlowConfig.class
     );
 
     @Inject

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/config/update/PillarConfigUpdateActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/config/update/PillarConfigUpdateActions.java
@@ -1,0 +1,85 @@
+package com.sequenceiq.cloudbreak.core.flow2.cluster.config.update;
+
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.PillarConfigurationUpdateEvent.PILLAR_CONFIG_UPDATE_FINALIZE_EVENT;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.AbstractClusterAction;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.ClusterViewContext;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.event.PillarConfigUpdateRequest;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.event.PillarConfigUpdateSuccess;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.provision.ClusterCreationEvent;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.provision.ClusterCreationState;
+import com.sequenceiq.cloudbreak.core.flow2.stack.AbstractStackFailureAction;
+import com.sequenceiq.cloudbreak.core.flow2.stack.StackFailureContext;
+import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+import com.sequenceiq.cloudbreak.reactor.api.event.StackFailureEvent;
+import java.util.Map;
+import javax.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.statemachine.action.Action;
+
+@Configuration
+public class PillarConfigUpdateActions {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PillarConfigUpdateActions.class);
+
+    @Inject
+    private PillarConfigUpdateService pillarConfigUpdateService;
+
+    @Bean(name = "PILLAR_CONFIG_UPDATE_START_STATE")
+    public Action<?, ?> configUpdateStartAction() {
+        return new AbstractClusterAction<>(StackEvent.class) {
+            @Override
+            protected void doExecute(ClusterViewContext context, StackEvent payload,
+                Map<Object, Object> variables) {
+                sendEvent(context);
+            }
+
+            @Override
+            protected Selectable createRequest(ClusterViewContext context) {
+                return new PillarConfigUpdateRequest(context.getStack().getId());
+            }
+        };
+    }
+
+    @Bean(name = "PILLAR_CONFIG_UPDATE_FINISHED_STATE")
+    public Action<?, ?> configUpdateFinishedAction() {
+        return new AbstractClusterAction<>(PillarConfigUpdateSuccess.class) {
+            @Override
+            protected void doExecute(ClusterViewContext context, PillarConfigUpdateSuccess payload,
+                Map<Object, Object> variables) {
+                pillarConfigUpdateService.configUpdateFinished(context.getStack());
+                sendEvent(context);
+            }
+
+            @Override
+            protected Selectable createRequest(ClusterViewContext context) {
+                return new StackEvent(PILLAR_CONFIG_UPDATE_FINALIZE_EVENT.event(), context.getStackId());
+            }
+        };
+    }
+
+    @Bean(name = "PILLAR_CONFIG_UPDATE_FAILED_STATE")
+    public Action<?, ?> configUpdateFailedAction() {
+        return new AbstractStackFailureAction<ClusterCreationState, ClusterCreationEvent>() {
+            @Override
+            protected void doExecute(StackFailureContext context, StackFailureEvent payload,
+                Map<Object, Object> variables) {
+                LOGGER.warn("Pillar configuration update failed.", payload.getException());
+                pillarConfigUpdateService
+                    .handleConfigUpdateFailure(context.getStackView(), payload.getException());
+                sendEvent(context);
+            }
+
+            @Override
+            protected Selectable createRequest(StackFailureContext context) {
+                return new StackEvent(PillarConfigurationUpdateEvent.PILLAR_CONFIG_UPDATE_FAILURE_HANDLED_EVENT
+                    .event(),
+                    context.getStackView().getId());
+            }
+        };
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/config/update/PillarConfigUpdateFlowConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/config/update/PillarConfigUpdateFlowConfig.java
@@ -1,0 +1,66 @@
+package com.sequenceiq.cloudbreak.core.flow2.cluster.config.update;
+
+
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.PillarConfigurationUpdateEvent.PILLAR_CONFIG_UPDATE_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.PillarConfigurationUpdateEvent.PILLAR_CONFIG_UPDATE_FAILED_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.PillarConfigurationUpdateEvent.PILLAR_CONFIG_UPDATE_FAILURE_HANDLED_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.PillarConfigurationUpdateEvent.PILLAR_CONFIG_UPDATE_FINALIZE_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.PillarConfigurationUpdateEvent.PILLAR_CONFIG_UPDATE_FINISHED_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.PillarConfigUpdateState.PILLAR_CONFIG_UPDATE_FAILED_STATE;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.PillarConfigUpdateState.PILLAR_CONFIG_UPDATE_FINISHED_STATE;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.PillarConfigUpdateState.PILLAR_CONFIG_UPDATE_START_STATE;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.PillarConfigUpdateState.FINAL_STATE;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.PillarConfigUpdateState.INIT_STATE;
+
+import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
+import com.sequenceiq.flow.core.config.AbstractFlowConfiguration.Transition.Builder;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PillarConfigUpdateFlowConfig extends
+    AbstractFlowConfiguration<PillarConfigUpdateState, PillarConfigurationUpdateEvent> {
+
+    private static final List<Transition<PillarConfigUpdateState, PillarConfigurationUpdateEvent>> TRANSITIONS =
+        new Builder<PillarConfigUpdateState, PillarConfigurationUpdateEvent>()
+            .defaultFailureEvent(PILLAR_CONFIG_UPDATE_FAILED_EVENT)
+            .from(INIT_STATE).to(PILLAR_CONFIG_UPDATE_START_STATE).event(PILLAR_CONFIG_UPDATE_EVENT)
+            .noFailureEvent()
+            .from(PILLAR_CONFIG_UPDATE_START_STATE).to(PILLAR_CONFIG_UPDATE_FINISHED_STATE)
+            .event(PILLAR_CONFIG_UPDATE_FINISHED_EVENT).failureEvent(
+            PILLAR_CONFIG_UPDATE_FAILED_EVENT)
+            .from(PILLAR_CONFIG_UPDATE_FINISHED_STATE).to(FINAL_STATE).event(
+            PILLAR_CONFIG_UPDATE_FINALIZE_EVENT)
+            .noFailureEvent()
+            .build();
+
+    public PillarConfigUpdateFlowConfig() {
+        super(PillarConfigUpdateState.class, PillarConfigurationUpdateEvent.class);
+    }
+
+    @Override
+    protected List<Transition<PillarConfigUpdateState, PillarConfigurationUpdateEvent>> getTransitions() {
+        return TRANSITIONS;
+    }
+
+    @Override
+    protected FlowEdgeConfig<PillarConfigUpdateState, PillarConfigurationUpdateEvent> getEdgeConfig() {
+        return new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, PILLAR_CONFIG_UPDATE_FAILED_STATE,
+            PILLAR_CONFIG_UPDATE_FAILURE_HANDLED_EVENT);
+    }
+
+    @Override
+    public PillarConfigurationUpdateEvent[] getEvents() {
+        return PillarConfigurationUpdateEvent.values();
+    }
+
+    @Override
+    public PillarConfigurationUpdateEvent[] getInitEvents() {
+        return new PillarConfigurationUpdateEvent[]{PILLAR_CONFIG_UPDATE_EVENT};
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Pillar configuration update";
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/config/update/PillarConfigUpdateService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/config/update/PillarConfigUpdateService.java
@@ -1,0 +1,98 @@
+package com.sequenceiq.cloudbreak.core.flow2.cluster.config.update;
+
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.AVAILABLE;
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.UPDATE_FAILED;
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.UPDATE_IN_PROGRESS;
+import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_PILLAR_CONFIG_UPDATE_FAILED;
+import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_PILLAR_CONFIG_UPDATE_FINISHED;
+import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_PILLAR_CONFIG_UPDATE_STARTED;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
+import com.sequenceiq.cloudbreak.common.service.TransactionService;
+import com.sequenceiq.cloudbreak.common.service.TransactionService.TransactionExecutionException;
+import com.sequenceiq.cloudbreak.common.service.TransactionService.TransactionRuntimeExecutionException;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.host.ClusterHostServiceRunner;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.provision.ClusterCreationService;
+import com.sequenceiq.cloudbreak.core.flow2.stack.CloudbreakFlowMessageService;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.view.StackView;
+import com.sequenceiq.cloudbreak.service.StackUpdater;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+import java.util.List;
+import javax.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PillarConfigUpdateService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PillarConfigUpdateService.class);
+
+    @Inject
+    private StackUpdater stackUpdater;
+
+    @Inject
+    private CloudbreakFlowMessageService flowMessageService;
+
+    @Inject
+    private ClusterService clusterService;
+
+    @Inject
+    private TransactionService transactionService;
+
+    @Inject
+    private ClusterCreationService clusterCreationService;
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private ClusterHostServiceRunner clusterHostServiceRunner;
+
+    public void doConfigUpdate(Long stackId) {
+        stackUpdater.updateStackStatus(stackId, DetailedStackStatus.BOOTSTRAPPING_MACHINES);
+        flowMessageService
+            .fireEventAndLog(stackId, UPDATE_IN_PROGRESS.name(),
+                CLUSTER_PILLAR_CONFIG_UPDATE_STARTED);
+        Stack stack = stackService.getByIdWithClusterInTransaction(stackId);
+        clusterHostServiceRunner.updateClusterConfigs(stack, stack.getCluster(), List.of());
+    }
+
+    public void configUpdateFinished(StackView stackView) {
+        try {
+            transactionService.required(() -> {
+                clusterService.updateClusterStatusByStackId(stackView.getId(), AVAILABLE);
+                stackUpdater.updateStackStatus(stackView.getId(), DetailedStackStatus.AVAILABLE,
+                    "Config update finished.");
+            });
+            flowMessageService.fireEventAndLog(stackView.getId(), AVAILABLE.name(),
+                CLUSTER_PILLAR_CONFIG_UPDATE_FINISHED);
+        } catch (TransactionExecutionException e) {
+            throw new TransactionRuntimeExecutionException(e);
+        }
+    }
+
+    public void handleConfigUpdateFailure(StackView stackView, Exception exception) {
+        try {
+            if (stackView.getClusterView() != null) {
+                String errorMessage = clusterCreationService
+                    .getErrorMessageFromException(exception);
+                transactionService.required(() -> {
+                    clusterService
+                        .updateClusterStatusByStackId(stackView.getId(), UPDATE_FAILED,
+                            errorMessage);
+                    stackUpdater
+                        .updateStackStatus(stackView.getId(), DetailedStackStatus.AVAILABLE);
+                });
+                flowMessageService.fireEventAndLog(stackView.getId(), UPDATE_FAILED.name(),
+                    CLUSTER_PILLAR_CONFIG_UPDATE_FAILED, errorMessage);
+            } else {
+                LOGGER.info("Cluster was null. Flow action was not required.");
+            }
+        } catch (TransactionExecutionException e) {
+            LOGGER.warn("Error setting status for Pillar configuration update failure", e);
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/config/update/PillarConfigUpdateState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/config/update/PillarConfigUpdateState.java
@@ -1,0 +1,11 @@
+package com.sequenceiq.cloudbreak.core.flow2.cluster.config.update;
+
+import com.sequenceiq.flow.core.FlowState;
+
+public enum PillarConfigUpdateState implements FlowState {
+    INIT_STATE,
+    PILLAR_CONFIG_UPDATE_START_STATE,
+    PILLAR_CONFIG_UPDATE_FINISHED_STATE,
+    FINAL_STATE,
+    PILLAR_CONFIG_UPDATE_FAILED_STATE;
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/config/update/PillarConfigurationUpdateEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/config/update/PillarConfigurationUpdateEvent.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.cloudbreak.core.flow2.cluster.config.update;
+
+import com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.event.PillarConfigUpdateFailed;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.event.PillarConfigUpdateSuccess;
+import com.sequenceiq.flow.core.FlowEvent;
+import com.sequenceiq.flow.event.EventSelectorUtil;
+
+public enum PillarConfigurationUpdateEvent implements FlowEvent {
+    PILLAR_CONFIG_UPDATE_EVENT("PILLAR_CONFIG_UPDATE_TRIGGER_EVENT"),
+    PILLAR_CONFIG_UPDATE_FINISHED_EVENT(EventSelectorUtil.selector(PillarConfigUpdateSuccess.class)),
+    PILLAR_CONFIG_UPDATE_FAILED_EVENT(EventSelectorUtil.selector(PillarConfigUpdateFailed.class)),
+    PILLAR_CONFIG_UPDATE_FINALIZE_EVENT("PILLAR_CONFIG_UPDATE_FINALIZE"),
+    PILLAR_CONFIG_UPDATE_FAILURE_HANDLED_EVENT("PILLAR_CONFIG_UPDATE_FAIL_HANDLED");
+
+    private final String event;
+
+    PillarConfigurationUpdateEvent(String event) {
+        this.event = event;
+    }
+
+    @Override
+    public String event() {
+        return event;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/config/update/event/PillarConfigUpdateFailed.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/config/update/event/PillarConfigUpdateFailed.java
@@ -1,0 +1,10 @@
+package com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.event;
+
+import com.sequenceiq.cloudbreak.reactor.api.event.StackFailureEvent;
+
+public class PillarConfigUpdateFailed extends StackFailureEvent {
+
+    public PillarConfigUpdateFailed(Long stackId, Exception ex) {
+        super(stackId, ex);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/config/update/event/PillarConfigUpdateRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/config/update/event/PillarConfigUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.event;
+
+import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+
+public class PillarConfigUpdateRequest extends StackEvent {
+
+    public PillarConfigUpdateRequest(Long stackId) {
+        super(stackId);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/config/update/event/PillarConfigUpdateSuccess.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/config/update/event/PillarConfigUpdateSuccess.java
@@ -1,0 +1,10 @@
+package com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.event;
+
+import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+
+public class PillarConfigUpdateSuccess extends StackEvent {
+
+    public PillarConfigUpdateSuccess(Long stackId) {
+        super(stackId);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/config/update/handler/PillarConfigUpdateHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/config/update/handler/PillarConfigUpdateHandler.java
@@ -1,0 +1,46 @@
+package com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.handler;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.PillarConfigUpdateService;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.event.PillarConfigUpdateFailed;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.event.PillarConfigUpdateRequest;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.event.PillarConfigUpdateSuccess;
+import com.sequenceiq.flow.event.EventSelectorUtil;
+import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import javax.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PillarConfigUpdateHandler extends ExceptionCatcherEventHandler<PillarConfigUpdateRequest> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PillarConfigUpdateHandler.class);
+
+    @Inject
+    private PillarConfigUpdateService pillarConfigUpdateService;
+
+    @Override
+    public String selector() {
+        return EventSelectorUtil.selector(PillarConfigUpdateRequest.class);
+    }
+
+    @Override
+    protected Selectable defaultFailureEvent(Long resourceId, Exception e) {
+        return new PillarConfigUpdateFailed(resourceId, e);
+    }
+
+    @Override
+    protected void doAccept(HandlerEvent event) {
+        PillarConfigUpdateRequest request = event.getData();
+        Selectable response;
+        try {
+            pillarConfigUpdateService.doConfigUpdate(request.getResourceId());
+            response = new PillarConfigUpdateSuccess(request.getResourceId());
+        } catch (Exception e) {
+            LOGGER.warn("Pillar configuration update failed.", e);
+            response = new PillarConfigUpdateFailed(request.getResourceId(), e);
+        }
+        sendEvent(response, event);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
@@ -7,6 +7,7 @@ import static com.sequenceiq.cloudbreak.core.flow2.cluster.provision.ClusterCrea
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.salt.update.SaltUpdateEvent.SALT_UPDATE_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.start.ClusterStartEvent.CLUSTER_START_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.sync.ClusterSyncEvent.CLUSTER_SYNC_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.PillarConfigurationUpdateEvent.PILLAR_CONFIG_UPDATE_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.upscale.ClusterUpscaleEvent.CLUSTER_UPSCALE_TRIGGER_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.userpasswd.ClusterCredentialChangeEvent.CLUSTER_CREDENTIALCHANGE_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.downscale.StackDownscaleEvent.STACK_DOWNSCALE_EVENT;
@@ -265,6 +266,11 @@ public class ReactorFlowManager {
 
     public FlowIdentifier triggerSaltUpdate(Long stackId) {
         String selector = SALT_UPDATE_EVENT.event();
+        return reactorNotifier.notify(stackId, selector, new StackEvent(selector, stackId));
+    }
+
+    public FlowIdentifier triggerPillarConfigurationUpdate(Long stackId) {
+        String selector = PILLAR_CONFIG_UPDATE_EVENT.event();
         return reactorNotifier.notify(stackId, selector, new StackEvent(selector, stackId));
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/ClusterCommonService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/ClusterCommonService.java
@@ -258,4 +258,17 @@ public class ClusterCommonService {
         Stack stack = stackService.getByNameOrCrnInWorkspace(nameOrCrn, workspaceId);
         return clusterOperationService.updateSalt(stack);
     }
+
+    public FlowIdentifier updatePillarConfiguration(NameOrCrn nameOrCrn, Long workspaceId) {
+        Stack stack = stackService.getByNameOrCrnInWorkspace(nameOrCrn, workspaceId);
+        MDCBuilder.buildMdcContext(stack);
+        if (!stack.isAvailable()) {
+            throw new BadRequestException(String.format(
+                "Stack '%s' is currently in '%s' state. Updates to the Pillar Configuration can "
+                    + "only be made when the underlying stack is 'AVAILABLE'.",
+                stack.getName(),
+                stack.getStatus()));
+        }
+        return clusterOperationService.updatePillarConfiguration(stack);
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/ClusterOperationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/ClusterOperationService.java
@@ -498,4 +498,8 @@ public class ClusterOperationService {
     public FlowIdentifier updateSalt(Stack stack) {
         return flowManager.triggerSaltUpdate(stack.getId());
     }
+
+    public FlowIdentifier updatePillarConfiguration(Stack stack) {
+        return flowManager.triggerPillarConfigurationUpdate(stack.getId());
+    }
 }

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
@@ -229,6 +229,11 @@ public class StackOperations implements ResourceBasedCrnProvider {
         return clusterCommonService.updateSalt(nameOrCrn, workspaceId);
     }
 
+    public FlowIdentifier updatePillarConfiguration(@NotNull NameOrCrn nameOrCrn, Long workspaceId) {
+        LOGGER.debug("Starting pillar configuration update: " + nameOrCrn);
+        return clusterCommonService.updatePillarConfiguration(nameOrCrn, workspaceId);
+    }
+
     public UpgradeV4Response checkForClusterUpgrade(@NotNull NameOrCrn nameOrCrn, Long workspaceId, UpgradeV4Request request) {
         if (nameOrCrn.hasName()) {
             String stackName = nameOrCrn.getName();

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
@@ -122,6 +122,7 @@ public class ReactorFlowManagerTest {
         underTest.triggerClusterCertificationRenewal(STACK_ID);
         underTest.triggerDatalakeClusterUpgrade(STACK_ID, null, null);
         underTest.triggerSaltUpdate(STACK_ID);
+        underTest.triggerPillarConfigurationUpdate(STACK_ID);
         underTest.triggerDatalakeDatabaseBackup(STACK_ID, null, null);
         underTest.triggerDatalakeDatabaseRestore(STACK_ID, null, null);
 


### PR DESCRIPTION
This commit adds support for a flow and API call that updates
the salt config on a cluster and then runs the high state to
apply the config.  Primarily this is to allow for the DNS
server IPs to be updated when they change with a FreeIPA node
change.  Since those IPs are pulled from the FreeIPA service
dynamically when a salt config is created it was felt that a
general salt config update flow and API call would allow for
any change the affects the salt config to be updated and
configured on a cluster.

Closes #CB-6364