### PR TITLE
CB-7826 - Improve CB repository readme with Contribution pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,5 +532,46 @@ For example: `https://tb-nt-local.tb-local.xcu2-8y8x.workload-dev.cloudera.com/c
 
 > Be aware of that this routing mechanism is based on cookies, so if you have problems to reach the CM UI directly especially when you reached any service through Knox previously then the deletion of cookies could solve your issues.
 
+
+## How to contribute
+
+I would like to start by the warm welcome if you would like to contribute to our project, making our - and from the point of contribution, it's yours also - goals closer. 
+
+We're happy for having your helpful intention to make this project greater than ever, but for this, I'd like to introduce you to some of our guidelines that you should follow for a successful contribution.
+
+When you would like to make a contribution you can do that by opening pull request against the desired version, but along with some very suggested guidelines not just for the sake of understandability but for having a properly combined request.
+
+
+### Appearance
+
+First of all, let's start with the appearance.
+As we speak (or writing) we don't enforce any formal requirements to the pull request message by any kind of tool, but we have a strongly recommended guidelines for that which would be the following:
+
+- if your commit message/jira description can fit into a Twitter message then probably, it is too short, and might not be clear what is the intention there
+- if it contains words like: fix or handle then probably you should consider some rewording, but of course, sometimes it is acceptable
+- if your commit fixes something obvious, e.g, a compile error, then of course you don’t need to write a long description about why it is a good idea to fix a compile error
+- compared to a 200-1000 lines of code change (which is the size of our average commit), adding a few more lines into the commit message/jira description is just a super small effort but would make a huge difference
+
+We were talking about what we should avoid, but let's see a few good examples, which helps the reviewer to understand the purpose of that commit:
+
+[https://github.com/hortonworks/cloudbreak/commit/56fdde5c6f48f48a378b505a170b3e3d83225c85](url)
+
+[https://github.com/hortonworks/cloudbreak/commit/d09b0074c45af209ccf34855dcf4c1f34c3ccebb](url)
+
+[https://github.com/hortonworks/cloudbreak/commit/c93b91fd6a08de7516ab763098f2dcd3abc149f0](url)
+
+[https://github.com/hortonworks/cloudbreak/commit/f50f5c8f38941db958eac27c663ae00ecba7b0f5](url)
+
+
+### Catching up
+
+When you're working on your precious change on your beloved branch and all of a sudden you face the issue of getting your branch drop behind from the desired/initial branch where you would like to open your future pull request, our way of catching up is [rebasing](https://git-scm.com/docs/git-rebase).
+
+If you're experiencing this quite common then the good practice would be fetching and rebasing the initial branch multiple times in a day because there are periods of times when dozens of changes are landing on different branches. I agree, sometimes (especially when someone is working on a huge change) continuously rebasing our branch could be could really be a pain in the bottom, but this practice ensures that we're submitting our commits in proper order and way.
+
+In addition please do not merge branches together if you can solve your problem with rebasing, and even if you think that your change would have no impact on the codebase or the actual collection of functionalities **- if you're not from our team or don't have written permission from one of our team members - please never ever push directly anything to the master branch normally and especially not by force.** 
+
+
+
 ## Additional info
 > * [Cloudbreak Service Provider Interface (SPI)](https://github.com/hortonworks/cloudbreak/blob/master/docs/spi.md)


### PR DESCRIPTION
Providing introductory content for the readme for those who would like to contribute to the Cloudbreak project.
The body contains some technical guidelines but in the majority, it points to the formal guidelines of opening a proper pull request.