### PR TITLE
DISTX-488 [opdb] Disable Erasure Coding for OpDB templates

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-opdb-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-opdb-720.bp
@@ -28,11 +28,27 @@
       {
         "refName": "hdfs",
         "serviceType": "HDFS",
+	    "serviceConfigs": [
+          {
+            "name": "hdfs_verify_ec_with_topology_enabled",
+            "value": false
+          },
+          {
+            "name": "service_health_suppression_hdfs_verify_ec_with_topology",
+            "value": true
+          }
+        ],
         "roleConfigGroups": [
           {
             "refName": "hdfs-NAMENODE-BASE",
             "roleType": "NAMENODE",
-            "base": true
+            "base": true,
+	        "configs": [
+              {
+                "name": "erasure_coding_default_policy",
+                "value": " "
+              }
+            ]
           },
           {
             "refName": "hdfs-SECONDARYNAMENODE-BASE",

--- a/core/src/main/resources/defaults/blueprints/cdp-opdb-721.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-opdb-721.bp
@@ -28,11 +28,27 @@
       {
         "refName": "hdfs",
         "serviceType": "HDFS",
+        "serviceConfigs": [
+          {
+            "name": "hdfs_verify_ec_with_topology_enabled",
+            "value": false
+          },
+          {
+            "name": "service_health_suppression_hdfs_verify_ec_with_topology",
+            "value": true
+          }
+        ],
         "roleConfigGroups": [
           {
             "refName": "hdfs-NAMENODE-BASE",
             "roleType": "NAMENODE",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                "name": "erasure_coding_default_policy",
+                "value": " "
+              }
+            ]
           },
           {
             "refName": "hdfs-SECONDARYNAMENODE-BASE",


### PR DESCRIPTION
Disable Erasure Coding for opdb templates. 7.2.0 enables EC by default. However, since HDFS is used as temporary storage on public cloud clusters, EC and corresponding health checks need to be disabled.

Testing: Made the changes to a custom blueprint and created a cluster with the blueprint. Verified that the EC test fail message is not shown up.