### PR TITLE
CDPCP-2566. Do not try to start metering application on DataLake cluster (every 5 sec)

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/metering/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/metering/init.sls
@@ -7,8 +7,6 @@
 {% set metering_rmp_repo_url = 'https://cloudera-service-delivery-cache.s3.amazonaws.com/thunderhead-metering-heartbeat-application/clients/'%}
 {% set metering_rpm_location = metering_rmp_repo_url + metering_package_name + '-' + metering_package_version + '.x86_64.rpm' %}
 
-{% if metering.enabled %}
-
 {%- if os == "RedHat" or os == "CentOS" %}
 
 {% if metering.is_systemd %}
@@ -46,6 +44,7 @@ stop_metering_heartbeat_application:
       - group
       - mode
 
+{% if metering.enabled %}
 /etc/metering/generate_heartbeats.ini:
   file.managed:
     - source: salt://metering/template/generate_heartbeats.ini.j2
@@ -53,6 +52,7 @@ stop_metering_heartbeat_application:
     - user: "root"
     - group: "root"
     - mode: 640
+{% endif %}
 
 /etc/systemd/system/metering-heartbeat-application.service:
   file.managed:
@@ -62,6 +62,7 @@ stop_metering_heartbeat_application:
     - group: "root"
     - mode: 640
 
+{% if metering.enabled %}
 start_metering_heartbeat_application:
   service.running:
     - enable: True

--- a/orchestrator-salt/src/main/resources/salt/salt/metering/template/metering-heartbeat-application.service.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/metering/template/metering-heartbeat-application.service.j2
@@ -6,10 +6,12 @@ After=td-agent.service
 
 [Service]
 Type=simple
-Restart=always
 ExecStart=/opt/metering-heartbeat --configFile /etc/metering/generate_heartbeats.ini
 PIDFile=/var/run/heartbeat_producer.pid
+{% if metering.enabled %}
 RestartSec=5
+Restart=always
 
 [Install]
 WantedBy=multi-user.target
+{% endif %}


### PR DESCRIPTION
metering application is burned on both datahub and datalake image, by default it tries to restart itself, but on datalake cluster we are not configuring that in the right way (generate_heartbeats.ini) and we do not even need metering application there yet. 
(only needed for DataHub)

solution:
- rewrite service descriptor on datalake cluster -> it wont restart the service and won't be started at startup (after salt highstate)