### PR TITLE
Fix Flink blueprint and AWS template naming

### DIFF
--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -289,7 +289,7 @@ cb:
         7.2.1 - Flow Management Light Duty with Apache NiFi, Apache NiFi Registry=cdp-flow-management-small-721;
         7.2.1 - Flow Management Heavy Duty with Apache NiFi, Apache NiFi Registry=cdp-flow-management-721;
         7.2.1 - Data Discovery and Exploration=cdp-dde-721;
-        7.2.1 - Streaming Analytics with Apache Flink=cdp-flink-ha-721;
+        7.2.1 - Streaming Analytics Light Duty with Apache Flink=cdp-flink-light-721;
 
   clustertemplate.defaults:
   template.defaults: minviable-gcp,minviable-azure-managed-disks,minviable-aws

--- a/core/src/main/resources/defaults/blueprints/cdp-flink-light-721.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-flink-light-721.bp
@@ -1,5 +1,5 @@
 {
-  "description": "7.2.1 - Streaming Analytics with Apache Flink",
+  "description": "7.2.1 - Streaming Analytics Light Duty with Apache Flink",
   "blueprint": {
     "cdhVersion": "7.2.1",
     "displayName": "streaming-analytics",

--- a/core/src/main/resources/defaults/clustertemplates/aws/aws-flink-light-721.json
+++ b/core/src/main/resources/defaults/clustertemplates/aws/aws-flink-light-721.json
@@ -1,12 +1,12 @@
 {
-  "name": "7.2.1 - Streaming Analytics with Apache Flink for AWS",
+  "name": "7.2.1 - Streaming Analytics Light Duty for AWS",
   "description": "",
   "type": "STREAMING",
   "featureState": "PREVIEW",
   "cloudPlatform": "AWS",
 	"distroXTemplate": {
 			"cluster": {
-				"blueprintName": "7.2.1 - Streaming Analytics with Apache Flink"
+				"blueprintName": "7.2.1 - Streaming Analytics Light Duty with Apache Flink"
 			},
 			"instanceGroups": [{
 					"name": "worker",


### PR DESCRIPTION
Remove Apache Flink from AWS template name + include Light Duty in naming

cc @doktoric @mbalassi 