### PR TITLE
CB-7744 passing in cloud paths to SDX.

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
@@ -27,6 +27,8 @@ public class CMRepositoryVersionUtil {
 
     public static final Versioned CLOUDERAMANAGER_VERSION_7_2_1 = () -> "7.2.1";
 
+    public static final Versioned CLOUDERAMANAGER_VERSION_7_2_2 = () -> "7.2.2";
+
     public static final Versioned CFM_VERSION_2_0_0_0 = () -> "2.0.0.0";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CMRepositoryVersionUtil.class);

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerCloudStorageServiceConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerCloudStorageServiceConfigProvider.java
@@ -1,18 +1,27 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.ranger;
 
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_2;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static com.sequenceiq.common.model.CloudStorageCdpService.HIVE_METASTORE_EXTERNAL_WAREHOUSE;
+import static com.sequenceiq.common.model.CloudStorageCdpService.HIVE_METASTORE_WAREHOUSE;
+import static com.sequenceiq.common.model.CloudStorageCdpService.HIVE_REPLICA_WAREHOUSE;
+import static com.sequenceiq.common.model.CloudStorageCdpService.RANGER_AUDIT;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateComponentConfigProvider;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.hdfs.HdfsRoleConfigProvider;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.hdfs.HdfsRoles;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 
 @Component
@@ -20,11 +29,47 @@ public class RangerCloudStorageServiceConfigProvider implements CmTemplateCompon
 
     private static final String RANGER_HDFS_AUDIT_URL = "ranger_plugin_hdfs_audit_url";
 
+    private static final String HIVE_METASTORE_DIR =  "hive.metastore.warehouse.dir";
+
+    private static final String HIVE_REPLICA_DIR = "hive.repl.replica.functions.root.dir";
+
+    private static final String HIVE_METASTORE_EXTERNAL_DIR = "hive.metastore.warehouse.external.dir";
+
+    private static final String CLOUD_STORAGE_PATHS = "cloud_storage_paths";
+
     @Override
     public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject templatePreparationObject) {
+
+        String cmVersion = templatePreparationObject.getProductDetailsView().getCm().getVersion();
+        if (CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited(cmVersion, CLOUDERAMANAGER_VERSION_7_2_2)
+                && templatePreparationObject.getCloudPlatform().equals(CloudPlatform.AZURE)) {
+
+            List<String> cloudPaths = new ArrayList<>();
+            ConfigUtils.getStorageLocationForServiceProperty(templatePreparationObject, HIVE_METASTORE_DIR)
+                    .ifPresent(location -> cloudPaths.add(HIVE_METASTORE_WAREHOUSE.name() + "=" + location.getValue()));
+
+            ConfigUtils.getStorageLocationForServiceProperty(templatePreparationObject, HIVE_REPLICA_DIR)
+                    .ifPresent(location -> cloudPaths.add(HIVE_REPLICA_WAREHOUSE.name() + "=" + location.getValue()));
+
+            ConfigUtils.getStorageLocationForServiceProperty(templatePreparationObject, HIVE_METASTORE_EXTERNAL_DIR)
+                    .ifPresent(location -> cloudPaths.add(HIVE_METASTORE_EXTERNAL_WAREHOUSE.name() + "=" + location.getValue()));
+
+            ConfigUtils.getStorageLocationForServiceProperty(templatePreparationObject, RANGER_HDFS_AUDIT_URL)
+                    .map(location -> cloudPaths.add(RANGER_AUDIT.name() + "=" + location.getValue()))
+                    .orElseGet(() -> cloudPaths.add(RANGER_AUDIT.name() + "=" + getDefaultRangerAuditUrl(templateProcessor, templatePreparationObject)));
+
+
+            String cloudPath = cloudPaths.stream().collect(Collectors.joining(","));
+            return List.of(getRangerAuditConfig(templateProcessor, templatePreparationObject), config(CLOUD_STORAGE_PATHS, cloudPath));
+        } else {
+            return List.of(getRangerAuditConfig(templateProcessor, templatePreparationObject));
+        }
+    }
+
+    private ApiClusterTemplateConfig getRangerAuditConfig(CmTemplateProcessor templateProcessor, TemplatePreparationObject templatePreparationObject) {
         return ConfigUtils.getStorageLocationForServiceProperty(templatePreparationObject, RANGER_HDFS_AUDIT_URL)
-                .map(location -> List.of(config(RANGER_HDFS_AUDIT_URL, location.getValue())))
-                .orElseGet(() -> List.of(config(RANGER_HDFS_AUDIT_URL, getDefaultRangerAuditUrl(templateProcessor, templatePreparationObject))));
+                .map(location -> config(RANGER_HDFS_AUDIT_URL, location.getValue()))
+                .orElseGet(() -> config(RANGER_HDFS_AUDIT_URL, getDefaultRangerAuditUrl(templateProcessor, templatePreparationObject)));
     }
 
     @Override

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerCloudStorageServiceConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerCloudStorageServiceConfigProviderTest.java
@@ -15,18 +15,22 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.hdfs.HdfsRoles;
-import com.sequenceiq.common.api.type.InstanceGroupType;
-import com.sequenceiq.common.api.filesystem.S3FileSystem;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.domain.StorageLocation;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject.Builder;
 import com.sequenceiq.cloudbreak.template.filesystem.StorageLocationView;
+import com.sequenceiq.cloudbreak.template.filesystem.adlsgen2.AdlsGen2FileSystemConfigurationsView;
 import com.sequenceiq.cloudbreak.template.filesystem.s3.S3FileSystemConfigurationsView;
 import com.sequenceiq.cloudbreak.template.model.GeneralClusterConfigs;
 import com.sequenceiq.cloudbreak.template.views.BlueprintView;
 import com.sequenceiq.cloudbreak.template.views.HostgroupView;
+import com.sequenceiq.common.api.filesystem.AdlsGen2FileSystem;
+import com.sequenceiq.common.api.filesystem.S3FileSystem;
+import com.sequenceiq.common.api.type.InstanceGroupType;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RangerCloudStorageServiceConfigProviderTest {
@@ -34,10 +38,12 @@ public class RangerCloudStorageServiceConfigProviderTest {
     private final RangerCloudStorageServiceConfigProvider underTest = new RangerCloudStorageServiceConfigProvider();
 
     @Test
-    public void testGetRangerCloudStorageServiceConfigs() {
+    public void testGetRangerAWSCloudStorageServiceConfigs() {
         CmTemplateProcessor templateProcessor = mock(CmTemplateProcessor.class);
-        TemplatePreparationObject preparationObject = getTemplatePreparationObject(true)
+        TemplatePreparationObject preparationObject = getTemplatePreparationObjectForAWS(true)
                 .withBlueprintView(mock(BlueprintView.class))
+                .withCloudPlatform(CloudPlatform.AWS)
+                .withProductDetails(new ClouderaManagerRepo().withVersion("7.2.1"), List.of())
                 .build();
 
         List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(templateProcessor, preparationObject);
@@ -48,6 +54,42 @@ public class RangerCloudStorageServiceConfigProviderTest {
     }
 
     @Test
+    public void testGetRangerAzureCloudStorageServiceConfigs() {
+        CmTemplateProcessor templateProcessor = mock(CmTemplateProcessor.class);
+        TemplatePreparationObject preparationObject = getTemplatePreparationObjectForAzure(true)
+                .withBlueprintView(mock(BlueprintView.class))
+                .withCloudPlatform(CloudPlatform.AZURE)
+                .withProductDetails(new ClouderaManagerRepo().withVersion("7.2.2"), List.of())
+                .build();
+
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(templateProcessor, preparationObject);
+
+        assertEquals(2, serviceConfigs.size());
+        assertEquals("ranger_plugin_hdfs_audit_url", serviceConfigs.get(0).getName());
+        assertEquals("abfs://data@your-san.dfs.core.windows.net/ranger/audit/", serviceConfigs.get(0).getValue());
+        assertEquals("cloud_storage_paths", serviceConfigs.get(1).getName());
+        assertEquals("HIVE_METASTORE_WAREHOUSE=abfs://data@your-san.dfs.core.windows.net/warehouse/tablespace/managed/hive," +
+                "HIVE_REPLICA_WAREHOUSE=abfs://data@your-san.dfs.core.windows.net/hive_replica_functions_dir," +
+                "HIVE_METASTORE_EXTERNAL_WAREHOUSE=abfs://data@your-san.dfs.core.windows.net/warehouse/tablespace/external/hive," +
+                "RANGER_AUDIT=abfs://data@your-san.dfs.core.windows.net/ranger/audit/", serviceConfigs.get(1).getValue());
+    }
+
+    @Test
+    public void testGetRangerAzure720CloudStorageServiceConfigs() {
+        CmTemplateProcessor templateProcessor = mock(CmTemplateProcessor.class);
+        TemplatePreparationObject preparationObject = getTemplatePreparationObjectForAzure(false)
+                .withBlueprintView(mock(BlueprintView.class))
+                .withProductDetails(new ClouderaManagerRepo().withVersion("7.2.0"), List.of())
+                .build();
+
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(templateProcessor, preparationObject);
+
+        assertEquals(1, serviceConfigs.size());
+        assertEquals("ranger_plugin_hdfs_audit_url", serviceConfigs.get(0).getName());
+        assertEquals("abfs://data@your-san.dfs.core.windows.net/ranger/audit/", serviceConfigs.get(0).getValue());
+    }
+
+    @Test
     public void defaultRangerHdfsAuditUrlWithNamenodeHA() {
         CmTemplateProcessor templateProcessor = mock(CmTemplateProcessor.class);
         BlueprintView blueprintView = mock(BlueprintView.class);
@@ -55,8 +97,9 @@ public class RangerCloudStorageServiceConfigProviderTest {
         when(templateProcessor.getHostGroupsWithComponent(HdfsRoles.NAMENODE)).thenReturn(Set.of("master"));
         when(templateProcessor.getRoleConfig(HdfsRoles.HDFS, HdfsRoles.NAMENODE, "dfs_federation_namenode_nameservice"))
                 .thenReturn(Optional.of(config("dfs_federation_namenode_nameservice", "ns")));
-        TemplatePreparationObject preparationObject = getTemplatePreparationObject(false)
+        TemplatePreparationObject preparationObject = getTemplatePreparationObjectForAWS(false)
                 .withBlueprintView(blueprintView)
+                .withProductDetails(new ClouderaManagerRepo().withVersion("7.2.0"), List.of())
                 .build();
 
         List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(templateProcessor, preparationObject);
@@ -72,8 +115,9 @@ public class RangerCloudStorageServiceConfigProviderTest {
         BlueprintView blueprintView = mock(BlueprintView.class);
         when(blueprintView.getProcessor()).thenReturn(templateProcessor);
         when(templateProcessor.getHostGroupsWithComponent(HdfsRoles.NAMENODE)).thenReturn(Set.of("gateway"));
-        TemplatePreparationObject preparationObject = getTemplatePreparationObject(false)
+        TemplatePreparationObject preparationObject = getTemplatePreparationObjectForAWS(false)
                 .withBlueprintView(blueprintView)
+                .withProductDetails(new ClouderaManagerRepo().withVersion("7.2.0"), List.of())
                 .build();
 
         List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(templateProcessor, preparationObject);
@@ -83,7 +127,37 @@ public class RangerCloudStorageServiceConfigProviderTest {
         assertEquals("hdfs://g", serviceConfigs.get(0).getValue());
     }
 
-    private TemplatePreparationObject.Builder getTemplatePreparationObject(boolean includeLocations) {
+    private TemplatePreparationObject.Builder getTemplatePreparationObjectForAzure(boolean above721) {
+        HostgroupView gateway = new HostgroupView("gateway", 1, InstanceGroupType.GATEWAY, Set.of("g"));
+        HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.CORE, Set.of("m1", "m2"));
+        HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, Set.of("w1", "w2", "w3"));
+
+        List<StorageLocationView> locations = new ArrayList<>();
+
+        locations.add(new StorageLocationView(getRangerAuditCloudStorageDirAzure()));
+        if (above721) {
+            locations.add(new StorageLocationView(buildStorageLocation("hive.metastore.warehouse.dir",
+                    "abfs://data@your-san.dfs.core.windows.net/warehouse/tablespace/managed/hive")));
+            locations.add(new StorageLocationView(buildStorageLocation("hive.repl.replica.functions.root.dir",
+                    "abfs://data@your-san.dfs.core.windows.net/hive_replica_functions_dir")));
+            locations.add(new StorageLocationView(buildStorageLocation("hive.metastore.warehouse.external.dir",
+                    "abfs://data@your-san.dfs.core.windows.net/warehouse/tablespace/external/hive")));
+            locations.add(new StorageLocationView(buildStorageLocation("ranger_plugin_hdfs_audit_url",
+                    "abfs://data@your-san.dfs.core.windows.net/ranger/audit")));
+        }
+        AdlsGen2FileSystemConfigurationsView fileSystemConfigurationsView =
+                new AdlsGen2FileSystemConfigurationsView(new AdlsGen2FileSystem(), locations, false);
+
+        GeneralClusterConfigs generalClusterConfigs =  new GeneralClusterConfigs();
+        generalClusterConfigs.setPrimaryGatewayInstanceDiscoveryFQDN(Optional.of("fqdn"));
+
+        return Builder.builder()
+                .withFileSystemConfigurationView(fileSystemConfigurationsView)
+                .withHostgroupViews(Set.of(gateway, master, worker))
+                .withGeneralClusterConfigs(generalClusterConfigs);
+    }
+
+    private TemplatePreparationObject.Builder getTemplatePreparationObjectForAWS(boolean includeLocations) {
         HostgroupView gateway = new HostgroupView("gateway", 1, InstanceGroupType.GATEWAY, Set.of("g"));
         HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.CORE, Set.of("m1", "m2"));
         HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, Set.of("w1", "w2", "w3"));
@@ -109,6 +183,20 @@ public class RangerCloudStorageServiceConfigProviderTest {
         StorageLocation rangerAuditLogLocation = new StorageLocation();
         rangerAuditLogLocation.setProperty("ranger_plugin_hdfs_audit_url");
         rangerAuditLogLocation.setValue("s3a://bucket/ranger/auditlogs");
+        return rangerAuditLogLocation;
+    }
+
+    protected StorageLocation getRangerAuditCloudStorageDirAzure() {
+        StorageLocation rangerAuditLogLocation = new StorageLocation();
+        rangerAuditLogLocation.setProperty("ranger_plugin_hdfs_audit_url");
+        rangerAuditLogLocation.setValue("abfs://data@your-san.dfs.core.windows.net/ranger/audit/");
+        return rangerAuditLogLocation;
+    }
+
+    protected StorageLocation buildStorageLocation(String property, String value) {
+        StorageLocation rangerAuditLogLocation = new StorageLocation();
+        rangerAuditLogLocation.setProperty(property);
+        rangerAuditLogLocation.setValue(value);
         return rangerAuditLogLocation;
     }
 }


### PR DESCRIPTION
This adds in passing in the cloud paths to Ranger during CM template
construction for SDX.  This is only on 7.2.2 and Azure for now.