### PR TITLE
CB-7706 Verify tags on cloud provider side

### DIFF
--- a/common-model/src/main/java/com/sequenceiq/common/api/tag/response/MapToTaggedResponseAdapter.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/tag/response/MapToTaggedResponseAdapter.java
@@ -1,0 +1,17 @@
+package com.sequenceiq.common.api.tag.response;
+
+import java.util.Map;
+
+public class MapToTaggedResponseAdapter implements TaggedResponse {
+
+    private final Map<String, String> tags;
+
+    public MapToTaggedResponseAdapter(Map<String, String> tags) {
+        this.tags = tags;
+    }
+
+    @Override
+    public String getTagValue(String key) {
+        return tags.get(key);
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/util/CloudProviderSideTagAssertion.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/util/CloudProviderSideTagAssertion.java
@@ -1,0 +1,90 @@
+package com.sequenceiq.it.cloudbreak.assertion.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
+import com.sequenceiq.common.api.tag.response.MapToTaggedResponseAdapter;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceMetaDataResponse;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.describe.DescribeFreeIpaResponse;
+import com.sequenceiq.it.cloudbreak.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.EnvironmentClient;
+import com.sequenceiq.it.cloudbreak.FreeIpaClient;
+import com.sequenceiq.it.cloudbreak.SdxClient;
+import com.sequenceiq.it.cloudbreak.assertion.Assertion;
+import com.sequenceiq.it.cloudbreak.cloud.v4.CloudProviderProxy;
+import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.util.TagsUtil;
+
+@Service
+public class CloudProviderSideTagAssertion {
+
+    private final CloudProviderProxy cloudProviderProxy;
+
+    private final TagsUtil tagsUtil;
+
+    public CloudProviderSideTagAssertion(CloudProviderProxy cloudProviderProxy, TagsUtil tagsUtil) {
+        this.cloudProviderProxy = cloudProviderProxy;
+        this.tagsUtil = tagsUtil;
+    }
+
+    public Assertion<EnvironmentTestDto, EnvironmentClient> verifyEnvironmentTags(Map<String, String> customTags) {
+        return (testContext, testDto, client) -> {
+            String envCrn = testDto.getResponse().getCrn();
+            DescribeFreeIpaResponse freeIpaResponse = testContext.getMicroserviceClient(FreeIpaClient.class)
+                    .getFreeIpaClient()
+                    .getFreeIpaV1Endpoint()
+                    .describe(envCrn);
+
+            List<String> instanceIds = freeIpaResponse.getInstanceGroups().stream()
+                    .flatMap(ig -> ig.getMetaData().stream())
+                    .map(InstanceMetaDataResponse::getInstanceId)
+                    .collect(Collectors.toList());
+
+            verifyTags(instanceIds, customTags);
+
+            return testDto;
+        };
+    }
+
+    public Assertion<SdxInternalTestDto, SdxClient> verifyInternalSdxTags(Map<String, String> customTags) {
+        return (testContext, testDto, client) -> {
+            List<String> instanceIds = testDto.getResponse().getStackV4Response().getInstanceGroups().stream()
+                    .flatMap(ig -> ig.getMetadata().stream())
+                    .map(InstanceMetaDataV4Response::getInstanceId)
+                    .collect(Collectors.toList());
+
+            verifyTags(instanceIds, customTags);
+
+            return testDto;
+        };
+    }
+
+    public Assertion<DistroXTestDto, CloudbreakClient> verifyDistroxTags(Map<String, String> customTags) {
+        return (testContext, testDto, client) -> {
+            List<String> instanceIds = testDto.getResponse().getInstanceGroups().stream()
+                    .flatMap(ig -> ig.getMetadata().stream())
+                    .map(InstanceMetaDataV4Response::getInstanceId)
+                    .collect(Collectors.toList());
+
+            verifyTags(instanceIds, customTags);
+
+            return testDto;
+        };
+    }
+
+    private void verifyTags(List<String> instanceIds, Map<String, String> customTags) {
+        Map<String, Map<String, String>> tagsByInstanceId = cloudProviderProxy.getCloudFunctionality().listTagsByInstanceId(instanceIds);
+        tagsByInstanceId.forEach((id, tags) -> {
+            tagsUtil.verifyTags(new MapToTaggedResponseAdapter(tags));
+            customTags.forEach((key, value) -> assertThat(tags.get(key)).isEqualTo(value));
+        });
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/MeasuredTestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/MeasuredTestContext.java
@@ -242,7 +242,7 @@ public class MeasuredTestContext extends MockedTestContext {
     }
 
     @Override
-    public <U extends MicroserviceClient> U getMicroserviceClient(Class<? extends MicroserviceClient> msClientClass) {
+    public <U extends MicroserviceClient> U getMicroserviceClient(Class<U> msClientClass) {
         return wrappedTestContext.getMicroserviceClient(msClientClass);
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
@@ -637,7 +637,7 @@ public abstract class TestContext implements ApplicationContextAware {
         return getSdxClient(getActingUserAccessKey());
     }
 
-    public <U extends MicroserviceClient> U getMicroserviceClient(Class<? extends MicroserviceClient> msClientClass) {
+    public <U extends MicroserviceClient> U getMicroserviceClient(Class<U> msClientClass) {
         return getMicroserviceClient(msClientClass, getActingUserAccessKey());
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/database/RedbeamsDatabaseTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/database/RedbeamsDatabaseTestDto.java
@@ -29,7 +29,7 @@ public class RedbeamsDatabaseTestDto extends DeletableRedbeamsTestDto<DatabaseV4
         if (testContext == null) {
             throw new IllegalStateException("Cannot create valid instance, test context is not available");
         }
-        String environmentCrn = ((RedbeamsClient) testContext.getMicroserviceClient(RedbeamsClient.class)).getEnvironmentCrn();
+        String environmentCrn = testContext.getMicroserviceClient(RedbeamsClient.class).getEnvironmentCrn();
         return withName(getResourcePropertyProvider().getName(getCloudPlatform()))
                 .withDescription(getResourcePropertyProvider().getDescription("database"))
                 .withConnectionUserName("user")

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDto.java
@@ -250,6 +250,11 @@ public class DistroXTestDto extends DistroXTestDtoBase<DistroXTestDto> implement
         return this;
     }
 
+    public DistroXTestDto addTags(Map<String, String> tags) {
+        getRequest().initAndGetTags().getUserDefined().putAll(tags);
+        return this;
+    }
+
     @Override
     public Clue investigate() {
         if (getResponse() == null || getResponse().getId() == null) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
@@ -9,6 +9,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -234,6 +235,11 @@ public class EnvironmentTestDto
     public EnvironmentTestDto withParentEnvironment() {
         CloudbreakTestDto parentEnvDto = getTestContext().given(EnvironmentTestDto.class);
         return withParentEnvironment(parentEnvDto);
+    }
+
+    public EnvironmentTestDto addTags(Map<String, String> tags) {
+        getRequest().getTags().putAll(tags);
+        return this;
     }
 
     private EnvironmentTestDto withParentEnvironment(CloudbreakTestDto parentEnvDto) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxInternalTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxInternalTestDto.java
@@ -18,8 +18,8 @@ import javax.inject.Inject;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.audits.responses.AuditEventV4Responses;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.customdomain.CustomDomainSettingsV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.image.ImageSettingsV4Request;
@@ -132,6 +132,11 @@ public class SdxInternalTestDto extends AbstractSdxTestDto<SdxInternalClusterReq
 
     public SdxInternalTestDto withStackRequest(StackV4Request stackV4Request) {
         getRequest().setStackV4Request(stackV4Request);
+        return this;
+    }
+
+    public SdxInternalTestDto addTags(Map<String, String> tags) {
+        getRequest().getStackV4Request().initAndGetTags().getUserDefined().putAll(tags);
         return this;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/CloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/CloudFunctionality.java
@@ -1,9 +1,12 @@
 package com.sequenceiq.it.cloudbreak.util;
 
 import java.util.List;
+import java.util.Map;
 
 public interface CloudFunctionality {
     List<String> listInstanceVolumeIds(List<String> instanceIds);
+
+    Map<String, Map<String, String>> listTagsByInstanceId(List<String> instanceIds);
 
     void deleteInstances(List<String> instanceIds);
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/AwsCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/AwsCloudFunctionality.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.it.cloudbreak.util.aws;
 
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 
@@ -26,6 +27,11 @@ public class AwsCloudFunctionality implements CloudFunctionality {
     @Override
     public List<String> listInstanceVolumeIds(List<String> instanceIds) {
         return amazonEC2Util.listInstanceVolumeIds(instanceIds);
+    }
+
+    @Override
+    public Map<String, Map<String, String>> listTagsByInstanceId(List<String> instanceIds) {
+        return amazonEC2Util.listTagsByInstanceId(instanceIds);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazonec2/AmazonEC2Util.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazonec2/AmazonEC2Util.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.it.cloudbreak.util.aws.amazonec2;
 
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 
@@ -18,6 +19,10 @@ public class AmazonEC2Util {
 
     public List<String> listInstanceVolumeIds(List<String> instanceIds) {
         return ec2ClientActions.getInstanceVolumeIds(instanceIds);
+    }
+
+    public Map<String, Map<String, String>> listTagsByInstanceId(List<String> instanceIds) {
+        return ec2ClientActions.listTagsByInstanceId(instanceIds);
     }
 
     public void deleteHostGroupInstances(List<String> instanceIds) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazonec2/action/EC2ClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazonec2/action/EC2ClientActions.java
@@ -25,6 +25,7 @@ import com.amazonaws.services.ec2.model.InstanceState;
 import com.amazonaws.services.ec2.model.Reservation;
 import com.amazonaws.services.ec2.model.StopInstancesRequest;
 import com.amazonaws.services.ec2.model.StopInstancesResult;
+import com.amazonaws.services.ec2.model.Tag;
 import com.amazonaws.services.ec2.model.TerminateInstancesRequest;
 import com.amazonaws.services.ec2.model.TerminateInstancesResult;
 import com.amazonaws.services.lambda.model.EC2UnexpectedException;
@@ -157,5 +158,18 @@ public class EC2ClientActions extends EC2Client {
                 LOGGER.error("EC2 Instance {} stop has not been successful, because of EC2UnexpectedException: {}", instanceId, e);
             }
         }
+    }
+
+    public Map<String, Map<String, String>> listTagsByInstanceId(List<String> instanceIds) {
+        DescribeInstancesRequest describeInstancesRequest = new DescribeInstancesRequest().withInstanceIds(instanceIds);
+        DescribeInstancesResult describeInstancesResult = buildEC2Client().describeInstances(describeInstancesRequest);
+        return describeInstancesResult.getReservations().stream()
+                .flatMap(reservation -> reservation.getInstances().stream())
+                .collect(Collectors.toMap(Instance::getInstanceId, this::getTagsForInstance));
+    }
+
+    private Map<String, String> getTagsForInstance(Instance instance) {
+        return instance.getTags().stream()
+                .collect(Collectors.toMap(Tag::getKey, Tag::getValue));
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/AzureCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/AzureCloudFunctionality.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.it.cloudbreak.util.azure;
 
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 
@@ -22,6 +23,11 @@ public class AzureCloudFunctionality implements CloudFunctionality {
     @Override
     public List<String> listInstanceVolumeIds(List<String> instanceIds) {
         return azureClientActions.listInstanceVolumeIds(instanceIds);
+    }
+
+    @Override
+    public Map<String, Map<String, String>> listTagsByInstanceId(List<String> instanceIds) {
+        return azureClientActions.listTagsByInstanceId(instanceIds);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurevm/action/AzureClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurevm/action/AzureClientActions.java
@@ -2,6 +2,7 @@ package com.sequenceiq.it.cloudbreak.util.azure.azurevm.action;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -98,5 +99,11 @@ public class AzureClientActions {
 
     public void setAzure(Azure azure) {
         this.azure = azure;
+    }
+
+    public Map<String, Map<String, String>> listTagsByInstanceId(List<String> instanceIds) {
+        return instanceIds.stream()
+                .map(id -> azure.virtualMachines().getByResourceGroup(getResourceGroupName(id), id))
+                .collect(Collectors.toMap(VirtualMachine::id, VirtualMachine::tags));
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpCloudFunctionality.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.it.cloudbreak.util.gcp;
 
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang3.NotImplementedException;
 
@@ -12,6 +13,11 @@ public class GcpCloudFunctionality implements CloudFunctionality {
 
     @Override
     public List<String> listInstanceVolumeIds(List<String> instanceIds) {
+        throw new NotImplementedException(GCP_IMPLEMENTATION_MISSING);
+    }
+
+    @Override
+    public Map<String, Map<String, String>> listTagsByInstanceId(List<String> instanceIds) {
         throw new NotImplementedException(GCP_IMPLEMENTATION_MISSING);
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/util/TagsUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/util/TagsUtil.java
@@ -64,7 +64,7 @@ public class TagsUtil {
         return tag;
     }
 
-    private void verifyTags(TaggedResponse response) {
+    public void verifyTags(TaggedResponse response) {
         SoftAssert softAssert = new SoftAssert();
         softAssert.assertNotNull(response.getTagValue(TEST_NAME_TAG), MISSING_TEST_NAME_TAG_MESSAGE);
         DEFAULT_TAGS.forEach(tag -> softAssert.assertNotNull(response.getTagValue(tag), String.format(MISSING_DEFAULT_TAG, tag)));


### PR DESCRIPTION
Extend tag verification so that it does not jut verify tags on CB side, but actually query the cloud provider that resources have the needed tags. Supported cloud providers are Aws and Azure.