### PR TITLE
CB-7902 add /hive2 and /cliservice to support PowerBI driver to conne…

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/clouderamanager-ssl-user-facing.conf
+++ b/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/clouderamanager-ssl-user-facing.conf
@@ -28,6 +28,11 @@ server {
         rewrite ^([/](?!clouderamanager/).*$) /clouderamanager$1;
     }
 
+{%- if 'HIVESERVER2' in salt['pillar.get']('gateway:location') %}
+    rewrite ^/cliservice(.*)$ /{{ salt['pillar.get']('gateway:path') }}/cdp-proxy-api/hive$1;
+    rewrite ^/hive2(.*)$ /{{ salt['pillar.get']('gateway:path') }}/cdp-proxy-api/hive$1;
+{%- endif %}
+
     # If hadoop-jwt cookie not set and favicon is requested return 403.
     if ($cookie_hadoop-jwt !~ .+) {
         rewrite ^/favicon.ico$ /favicon.403;
@@ -47,6 +52,7 @@ server {
         proxy_set_header   Connection $connection_upgrade;
         proxy_set_header   Referer {{ protocol }}://$host/$1;
     }
+
     location ~ .*/ {
         proxy_pass         https://knox;
         proxy_connect_timeout       300;


### PR DESCRIPTION
…ct through Nginx

PowerBI drivers use 2 default hard-coded paths to contact HiveServer2: /cliservice and /hive2.
CDW forwards all these paths to the corresponding Hive install through Nginx, because the
cluster name is encoded in the hostname. Knox encodes the endpoint information in the HTTP path
and it is not possible to override it in PowerBI drivers.
A proxy_pass through nginx will result in Knox rejecting /cliservice or /hive2 and it does not
work out of the box.

See detailed description in the commit message.