### PR TITLE
CB-7901 Enable Solr backup location override java opt on datalake

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-sdx-721.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx-721.bp
@@ -171,6 +171,10 @@
               {
                 "name": "solr_https_port",
                 "value": "8985"
+              },
+              {
+                "name": "solr_java_opts",
+                "value": "{{JAVA_GC_ARGS}} -Dsolr.hdfs.allow.location.override=true"
               }
             ],
             "refName": "solr-SOLR_SERVER-BASE",


### PR DESCRIPTION
Adds the "-Dsolr.hdfs.allow.location.override=true" to the Solr java opts on
the 7.2.1 datalake. This option is used with some recent Solr change to allow
the datalake disaster recovery service to export Solr backups to cloud storage.
See also CDPSDX-1707 and CDPSDX-2121.