### PR TITLE
CDPCP-2566. Do not try to start metering application on DataLake cluster (every 5 sec)

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/metering/template/metering-heartbeat-application.service.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/metering/template/metering-heartbeat-application.service.j2
@@ -6,10 +6,12 @@ After=td-agent.service
 
 [Service]
 Type=simple
-Restart=always
 ExecStart=/opt/metering-heartbeat --configFile /etc/metering/generate_heartbeats.ini
 PIDFile=/var/run/heartbeat_producer.pid
+{% if metering.enabled %}
 RestartSec=5
+Restart=always
 
 [Install]
 WantedBy=multi-user.target
+{% endif %}


### PR DESCRIPTION
as patch was reverted because of a command issue (missing echo):
- if metering is not enabled make sure the service is dead
- fix os/systed error messages - > fix missing echo from the wrong commands
+ add the metering configuration file for watch list for the service