### PR TITLE
CB-7443. Changes to make some improvements to the time it takes to scale

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/BackoffDelayStrategy.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/BackoffDelayStrategy.java
@@ -3,10 +3,16 @@ package com.sequenceiq.cloudbreak.cloud.aws.scheduler;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.amazonaws.waiters.PollingStrategy;
 import com.amazonaws.waiters.PollingStrategyContext;
 
 public class BackoffDelayStrategy implements PollingStrategy.DelayStrategy {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BackoffDelayStrategy.class);
+
     private static final int POLLING_INTERVAL = 5;
 
     private static final int MAX_POLLING_INTERVAL = 30;
@@ -19,6 +25,7 @@ public class BackoffDelayStrategy implements PollingStrategy.DelayStrategy {
     public void delayBeforeNextRetry(PollingStrategyContext pollingStrategyContext) throws InterruptedException {
         int requestAttempted = pollingStrategyContext.getRetriesAttempted();
         Double secondToWait = Math.min(POLLING_INTERVAL * Math.pow(2, requestAttempted) + RANDOM.nextInt(POLLING_INTERVAL), MAX_POLLING_INTERVAL);
+        LOGGER.info("Polling attempt: {}, Sleeping for: {}s", requestAttempted, secondToWait);
         Thread.sleep(secondToWait.longValue() * THOUSAND);
     }
 }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/CustomAmazonWaiterProvider.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/CustomAmazonWaiterProvider.java
@@ -63,7 +63,7 @@ public class CustomAmazonWaiterProvider {
                 })
                 .withDefaultPollingStrategy(new PollingStrategy(new MaxAttemptsRetryStrategy(DEFAULT_MAX_ATTEMPTS),
                         new FixedDelayStrategy(DEFAULT_DELAY_IN_SECONDS)))
-                .withExecutorService(WaiterExecutorServiceFactory.buildExecutorServiceForWaiter("AmazonRDSWaiters")).build();
+                .withExecutorService(WaiterExecutorServiceFactory.buildExecutorServiceForWaiter("AmazonASInstanceInServiceWaiters")).build();
     }
 
     public Waiter<DescribeScalingActivitiesRequest> getAutoscalingActivitiesWaiter(AmazonAutoScalingClient asClient, Date timeBeforeASUpdate) {

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/SlowStartCancellablePollingStrategy.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/SlowStartCancellablePollingStrategy.java
@@ -1,0 +1,16 @@
+package com.sequenceiq.cloudbreak.cloud.aws.scheduler;
+
+import com.amazonaws.waiters.PollingStrategy;
+
+public class SlowStartCancellablePollingStrategy {
+
+    private static final int DEFAULT_MAX_ATTEMPTS = 1000;
+
+    private SlowStartCancellablePollingStrategy() {
+    }
+
+    public static PollingStrategy getExpectedRuntimeCancellablePollingStrategy(CancellationCheck cancellationCheck, int expectedRuntimeSeconds) {
+        return new PollingStrategy(new MaxAttempCancellablePetryStrategy(DEFAULT_MAX_ATTEMPTS, cancellationCheck),
+                new SlowStartDelayStrategy(expectedRuntimeSeconds));
+    }
+}

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/SlowStartDelayStrategy.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/SlowStartDelayStrategy.java
@@ -34,6 +34,7 @@ public class SlowStartDelayStrategy implements PollingStrategy.DelayStrategy {
     private final int expectedRuntimeSeconds;
 
     private final long msToWaitRequest0;
+
     private final long msToWaitRequest1;
 
     public SlowStartDelayStrategy(int expectedRuntimeSeconds) {

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/SlowStartDelayStrategy.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/SlowStartDelayStrategy.java
@@ -1,0 +1,70 @@
+package com.sequenceiq.cloudbreak.cloud.aws.scheduler;
+
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.amazonaws.waiters.PollingStrategy;
+import com.amazonaws.waiters.PollingStrategyContext;
+
+/**
+ * A polling strategy which is less aggressive early, and gets more aggressive once the
+ * provided expectedRuntime is reached.
+ */
+public class SlowStartDelayStrategy implements PollingStrategy.DelayStrategy {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SlowStartDelayStrategy.class);
+
+    private static final Random RANDOM = ThreadLocalRandom.current();
+
+    private static final int MAX_POLLING_INTERVAL_SECONDS = 60;
+
+    private static final int STABLE_POLLING_INTERVAL_SECONDS_MAX = 5;
+
+    private static final int STABLE_POLLING_INTERVAL_SECONDS_MIN = 1;
+
+    private static final double FIRST_POLL_RATIO = 0.75;
+
+    private static final double SECOND_POLL_RATIO = 0.2;
+
+    private static final double THOUSAND = 1000.0;
+
+    private final int expectedRuntimeSeconds;
+
+    private final long msToWaitRequest0;
+    private final long msToWaitRequest1;
+
+    public SlowStartDelayStrategy(int expectedRuntimeSeconds) {
+        this.expectedRuntimeSeconds = expectedRuntimeSeconds;
+        msToWaitRequest0 = (long) (THOUSAND * Math.min(
+                Math.max(FIRST_POLL_RATIO * expectedRuntimeSeconds, STABLE_POLLING_INTERVAL_SECONDS_MIN),
+                MAX_POLLING_INTERVAL_SECONDS));
+        msToWaitRequest1 = (long) (THOUSAND * Math.min(
+                Math.max(SECOND_POLL_RATIO * expectedRuntimeSeconds, STABLE_POLLING_INTERVAL_SECONDS_MIN),
+                MAX_POLLING_INTERVAL_SECONDS));
+    }
+
+    @Override
+    public void delayBeforeNextRetry(PollingStrategyContext pollingStrategyContext) throws InterruptedException {
+        int requestNumber = pollingStrategyContext.getRetriesAttempted();
+
+        // Start polling at 75% of minExpectedRuntime.
+        // Next at 20% of minExpectedRuntime
+        // After this random between min and max
+
+        long msToWait;
+        if (requestNumber == 0) {
+            msToWait = msToWaitRequest0;
+        } else if (requestNumber == 1) {
+            msToWait = msToWaitRequest1;
+        } else {
+            msToWait = (long) (THOUSAND * Math.max(STABLE_POLLING_INTERVAL_SECONDS_MIN,
+                    RANDOM.nextInt(STABLE_POLLING_INTERVAL_SECONDS_MAX)));
+        }
+        LOGGER.info("Polling attempt: {}, Sleeping for: {}ms for request: {}. ExpectedRuntime={}s",
+                requestNumber, msToWait, pollingStrategyContext.getOriginalRequest(), expectedRuntimeSeconds);
+        Thread.sleep(msToWait);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterBuilderService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterBuilderService.java
@@ -173,7 +173,7 @@ public class ClusterBuilderService {
                 proxyConfig.orElse(null),
                 template);
         clusterService.save(cluster);
-        recipeEngine.executePostInstallRecipes(stack);
+        recipeEngine.executePostInstallRecipes(stack, hostGroupService.getRecipesByCluster(cluster.getId()));
         Set<InstanceMetaData> instanceMetaDatas = instanceMetaDataByHostGroup.values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
         clusterCreationSuccessHandler.handleClusterCreationSuccess(instanceMetaDatas, stack.getCluster());
         if (StackType.DATALAKE == stack.getType()) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterUpscaleService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterUpscaleService.java
@@ -126,7 +126,7 @@ public class ClusterUpscaleService {
     public void executePostRecipesOnNewHosts(Long stackId) throws CloudbreakException {
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
         LOGGER.debug("Start executing post recipes");
-        recipeEngine.executePostInstallRecipes(stack);
+        recipeEngine.executePostInstallRecipes(stack, hostGroupService.getRecipesByCluster(stack.getCluster().getId()));
     }
 
     public Map<String, String> gatherInstalledComponents(Long stackId, String hostname) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/BootstrapNewNodesHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/BootstrapNewNodesHandler.java
@@ -1,13 +1,18 @@
 package com.sequenceiq.cloudbreak.reactor;
 
+import java.time.Duration;
+import java.time.Instant;
+
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterBootstrapper;
-import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.BootstrapNewNodesRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.BootstrapNewNodesResult;
+import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.EventHandler;
 
 import reactor.bus.Event;
@@ -15,6 +20,9 @@ import reactor.bus.EventBus;
 
 @Component
 public class BootstrapNewNodesHandler implements EventHandler<BootstrapNewNodesRequest> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BootstrapNewNodesHandler.class);
+
     @Inject
     private EventBus eventBus;
 
@@ -28,6 +36,9 @@ public class BootstrapNewNodesHandler implements EventHandler<BootstrapNewNodesR
 
     @Override
     public void accept(Event<BootstrapNewNodesRequest> event) {
+        int numHosts = event.getData().getHostNames() == null ? -1 : event.getData().getUpscaleCandidateAddresses().size();
+        LOGGER.debug("BootstrapNewNodes for #hosts: {}", numHosts);
+        Instant start = Instant.now();
         BootstrapNewNodesRequest request = event.getData();
         BootstrapNewNodesResult result;
         try {
@@ -35,6 +46,8 @@ public class BootstrapNewNodesHandler implements EventHandler<BootstrapNewNodesR
             result = new BootstrapNewNodesResult(request);
         } catch (Exception e) {
             result = new BootstrapNewNodesResult(e.getMessage(), e, request);
+        } finally {
+            LOGGER.debug("BootstrapNewNodesHandler finished in {}ms", Duration.between(start, Instant.now()).toMillis());
         }
         eventBus.notify(result.selector(), new Event<>(event.getHeaders(), result));
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/CleanupFreeIpaHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/CleanupFreeIpaHandler.java
@@ -2,6 +2,9 @@ package com.sequenceiq.cloudbreak.reactor.handler.cluster;
 
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.provision.ClusterCreationEvent.CLEANUP_FREEIPA_FINISHED_EVENT;
 
+import java.time.Duration;
+import java.time.Instant;
+
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
@@ -40,6 +43,7 @@ public class CleanupFreeIpaHandler implements EventHandler<CleanupFreeIpaEvent> 
 
     @Override
     public void accept(Event<CleanupFreeIpaEvent> cleanupFreeIpaEvent) {
+        Instant start = Instant.now();
         CleanupFreeIpaEvent event = cleanupFreeIpaEvent.getData();
         try {
             LOGGER.debug("Handle cleanup request for hosts: {} and IPs: {}", event.getHostNames(), event.getIps());
@@ -59,6 +63,8 @@ public class CleanupFreeIpaHandler implements EventHandler<CleanupFreeIpaEvent> 
                     event.getIps(), event.isRecover());
             Event<StackEvent> responseEvent = new Event<>(cleanupFreeIpaEvent.getHeaders(), response);
             eventBus.notify(CLEANUP_FREEIPA_FINISHED_EVENT.event(), responseEvent);
+            LOGGER.debug("CleanupFreeIPA for #hosts={} finished in {}ms", event.getHostNames() == null ? "NA" : event.getHostNames().size(),
+                    Duration.between(start, Instant.now()).toMillis());
         }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/InstallClusterHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/InstallClusterHandler.java
@@ -1,5 +1,8 @@
 package com.sequenceiq.cloudbreak.reactor.handler.cluster;
 
+import java.time.Duration;
+import java.time.Instant;
+
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
@@ -37,6 +40,8 @@ public class InstallClusterHandler implements EventHandler<InstallClusterRequest
 
     @Override
     public void accept(Event<InstallClusterRequest> event) {
+        LOGGER.debug("InstallClusterHandler for {}", event.getData().getResourceId());
+        Instant start = Instant.now();
         Long stackId = event.getData().getResourceId();
         Selectable response;
         try {
@@ -45,6 +50,8 @@ public class InstallClusterHandler implements EventHandler<InstallClusterRequest
         } catch (RuntimeException | ClusterClientInitException | CloudbreakException e) {
             LOGGER.error("Build cluster failed", e);
             response = new InstallClusterFailed(stackId, e);
+        } finally {
+            LOGGER.debug("InstallClusterHandler for {} finished in {}ms", event.getData().getResourceId(), Duration.between(start, Instant.now()).toMillis());
         }
         eventBus.notify(response.selector(), new Event<>(event.getHeaders(), response));
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/UpscaleClusterHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/UpscaleClusterHandler.java
@@ -1,7 +1,12 @@
 package com.sequenceiq.cloudbreak.reactor.handler.cluster;
 
+import java.time.Duration;
+import java.time.Instant;
+
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.core.cluster.ClusterUpscaleService;
@@ -15,6 +20,9 @@ import reactor.bus.EventBus;
 
 @Component
 public class UpscaleClusterHandler implements EventHandler<UpscaleClusterRequest> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UpscaleClusterHandler.class);
+
     @Inject
     private EventBus eventBus;
 
@@ -28,6 +36,8 @@ public class UpscaleClusterHandler implements EventHandler<UpscaleClusterRequest
 
     @Override
     public void accept(Event<UpscaleClusterRequest> event) {
+        LOGGER.debug("UpscaleClusterHandler for {}", event.getData().getResourceId());
+        Instant start = Instant.now();
         UpscaleClusterRequest request = event.getData();
         UpscaleClusterResult result;
         try {
@@ -36,6 +46,8 @@ public class UpscaleClusterHandler implements EventHandler<UpscaleClusterRequest
             result = new UpscaleClusterResult(request);
         } catch (Exception e) {
             result = new UpscaleClusterResult(e.getMessage(), e, request);
+        } finally {
+            LOGGER.debug("UpscaleClusterHandler for {} finished in {}ms", event.getData().getResourceId(), Duration.between(start, Instant.now()).toMillis());
         }
         eventBus.notify(result.selector(), new Event<>(event.getHeaders(), result));
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/UpscaleClusterManagerHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/UpscaleClusterManagerHandler.java
@@ -1,7 +1,12 @@
 package com.sequenceiq.cloudbreak.reactor.handler.cluster;
 
+import java.time.Duration;
+import java.time.Instant;
+
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.core.cluster.ClusterUpscaleService;
@@ -16,6 +21,8 @@ import reactor.bus.EventBus;
 @Component
 public class UpscaleClusterManagerHandler implements EventHandler<UpscaleClusterManagerRequest> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(UpscaleClusterManagerHandler.class);
+
     @Inject
     private EventBus eventBus;
 
@@ -29,6 +36,8 @@ public class UpscaleClusterManagerHandler implements EventHandler<UpscaleCluster
 
     @Override
     public void accept(Event<UpscaleClusterManagerRequest> event) {
+        LOGGER.debug("UpscaleClusterManagerHandler for {}", event.getData().getResourceId());
+        Instant start = Instant.now();
         UpscaleClusterManagerRequest request = event.getData();
         UpscaleClusterManagerResult result;
         try {
@@ -37,6 +46,8 @@ public class UpscaleClusterManagerHandler implements EventHandler<UpscaleCluster
             result = new UpscaleClusterManagerResult(request);
         } catch (Exception e) {
             result = new UpscaleClusterManagerResult(e.getMessage(), e, request);
+        } finally {
+            LOGGER.debug("UpscaleClusterManagerHandler finished for {} in {}ms", request.getResourceId(), Duration.between(start, Instant.now()).toMillis());
         }
         eventBus.notify(result.selector(), new Event<>(event.getHeaders(), result));
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/ssh/SshKeyService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/ssh/SshKeyService.java
@@ -27,7 +27,7 @@ public class SshKeyService {
 
     private static final String ADD_SSH_PUBLICKEY_STATE = "ssh.add_ssh_publickey";
 
-    private static final int SSH_KEY_OPERATION_RETRY_COUNT = 10;
+    private static final int SSH_KEY_OPERATION_RETRY_COUNT = 20;
 
     @Inject
     private HostOrchestrator hostOrchestrator;

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -417,9 +417,9 @@ cb:
     openstack.resource.name.length: 120
     yarn.resource.name.length: 63
 
-    salt.new.service.retry: 180
+    salt.new.service.retry: 360
     salt.new.service.leave.retry: 5
-    salt.new.service.retry.onerror: 20
+    salt.new.service.retry.onerror: 40
     salt.recipe.execution.retry: 180
 
   address.resolving.timeout: 60000

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
@@ -91,7 +91,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 public class
 SaltOrchestrator implements HostOrchestrator {
 
-    private static final int SLEEP_TIME = 10000;
+    private static final int SLEEP_TIME = 5000;
 
     private static final int SLEEP_TIME_IN_SEC = SLEEP_TIME / 1000;
 
@@ -135,10 +135,10 @@ SaltOrchestrator implements HostOrchestrator {
     @Value("${cb.max.salt.recipe.execution.retry.forced:2}")
     private int maxRetryRecipeForced;
 
-    @Value("${cb.max.salt.database.dr.retry:60}")
+    @Value("${cb.max.salt.database.dr.retry:120}")
     private int maxDatabaseDrRetry;
 
-    @Value("${cb.max.salt.database.dr.retry.onerror:5}")
+    @Value("${cb.max.salt.database.dr.retry.onerror:10}")
     private int maxDatabaseDrRetryOnError;
 
     @Inject

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/runner/SaltRunner.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/runner/SaltRunner.java
@@ -15,7 +15,7 @@ import com.sequenceiq.cloudbreak.orchestrator.state.ExitCriteriaModel;
 @Component
 public class SaltRunner {
 
-    private static final int SLEEP_TIME = 10000;
+    private static final int SLEEP_TIME = 5000;
 
     @Value("${cb.max.salt.new.service.retry.onerror}")
     private int maxRetryOnError;

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/init.sls
@@ -2,6 +2,7 @@
 {%- from 'cloudera/manager/settings.sls' import cloudera_manager with context %}
 {%- set manager_server_fqdn = salt['pillar.get']('hosts')[metadata.server_address]['fqdn'] %}
 
+{%- if not "prewarmed_v1" in grains.get('roles', []) -%}
 install-cloudera-manager-agent:
   pkg.installed:
     - failhard: True
@@ -10,6 +11,7 @@ install-cloudera-manager-agent:
       - cloudera-manager-agent
     - unless:
       - rpm -q cloudera-manager-daemons cloudera-manager-agent
+{%- endif %}
 
 {% if cloudera_manager.settings.cloudera_scm_sudo_access == True %}
 
@@ -23,11 +25,13 @@ install-cloudera-manager-agent:
 
 {% endif %}
 
+{%- if not "prewarmed_v1" in grains.get('roles', []) -%}
 {%- if not salt['pkg.version']('python-psycopg2') and not salt['pkg.version']('python2-psycopg2') %}
 install-psycopg2:
   cmd.run:
     - name: pip install psycopg2==2.7.5 --ignore-installed
     - unless: pip list --no-index | grep -E 'psycopg2.*2.7.5'
+{%- endif %}
 {%- endif %}
 
 replace_server_host:

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/start.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/start.sls
@@ -22,9 +22,11 @@ update_frontend_url_of_cm:
 restart_cm_after_fronted_url_change:
   service.running:
     - name: cloudera-scm-server
+{%- if not "prewarmed_v1" in grains.get('roles', []) -%}
 {% if "ipa_member" in grains.get('roles', []) %}
     - require:
         - pkg: ipa_packages_install
+{% endif %}
 {% endif %}
     - watch:
       - file: update_frontend_url_of_cm
@@ -34,7 +36,9 @@ start_server:
   service.running:
     - enable: True
     - name: cloudera-scm-server
+{%- if not "prewarmed_v1" in grains.get('roles', []) -%}
 {% if "ipa_member" in grains.get('roles', []) %}
     - require:
         - pkg: ipa_packages_install
+{% endif %}
 {% endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/kerberos/common.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/kerberos/common.sls
@@ -1,9 +1,11 @@
+{%- if not "prewarmed_v1" in grains.get('roles', []) -%}
 haveged:
   pkg.installed:
     - unless:
       - rpm -q haveged
   service.running:
     - enable: True
+{% endif %}
 
 {% if grains['os_family'] == 'Suse' %}
 install_kerberos:
@@ -17,6 +19,7 @@ install_kerberos:
       - krb5-kdc
       - krb5-admin-server
 {% else %}
+{%- if not "prewarmed_v1" in grains.get('roles', []) -%}
 install_kerberos:
   pkg.installed:
     - pkgs:
@@ -25,6 +28,7 @@ install_kerberos:
       - krb5-workstation
     - unless:
       - rpm -q krb5-server krb5-libs krb5-workstation
+{% endif %}
 {% endif %}
 
 {% if grains['os_family'] == 'Suse' %}

--- a/orchestrator-salt/src/main/resources/salt/salt/metering/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/metering/init.sls
@@ -11,10 +11,12 @@
 
 {% if metering.is_systemd %}
 
+{%- if not "prewarmed_v1" in grains.get('roles', []) -%}
 install_metering_rpm_manually:
   cmd.run:
     - name: "rpm -i {{ metering_rpm_location }}"
     - onlyif: "! rpm -q {{ metering_package_name }}"
+{% endif %}
 
 stop_metering_heartbeat_application_if_needed:
   service.dead:

--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/ipa.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/ipa.sls
@@ -1,6 +1,7 @@
 {%- from 'sssd/settings.sls' import ipa with context %}
 {%- from 'metadata/settings.sls' import metadata with context %}
 
+{%- if not "prewarmed_v1" in grains.get('roles', []) -%}
 ipa_packages_install:
   pkg.installed:
     - refresh: False
@@ -11,6 +12,7 @@ ipa_packages_install:
         - openldap-clients
     - unless:
       - rpm -q ipa-client openldap openldap-clients
+{% endif %}
 
 /opt/salt/scripts/join_ipa.sh:
   file.managed:


### PR DESCRIPTION
up nodes.
- Generally lowers polling intervals
- Adds a SlowStart poller which, for operations which are expected to
take time, polls at a slower interval earlier, and then gets more
aggressive.
- PostCM and PostClusterInstall recipes only executed if they exist.
- Protected various expensive commands during highState via prewarmed
checks via the 'roles' grain.

See detailed description in the commit message.