### PR TITLE
DISTX-475-NotMandatoryCoolDownMins

### DIFF
--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/LoadAlertConfigurationRequest.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/LoadAlertConfigurationRequest.java
@@ -33,7 +33,6 @@ public class LoadAlertConfigurationRequest implements Json {
     @Min(value = 2)
     @Max(value = 180)
     @Digits(fraction = 0, integer = 3)
-    @NotNull
     private @Valid Integer coolDownMinutes;
 
     public Integer getMinResourceValue() {

--- a/autoscale/src/main/java/com/sequenceiq/periscope/domain/LoadAlertConfiguration.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/domain/LoadAlertConfiguration.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.periscope.domain;
 
+import static com.sequenceiq.periscope.monitor.evaluator.ScalingConstants.DEFAULT_LOAD_BASED_AUTOSCALING_COOLDOWN_MINS;
+
 import java.util.concurrent.TimeUnit;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -10,7 +12,7 @@ public class LoadAlertConfiguration {
 
     private Integer maxResourceValue;
 
-    private Integer coolDownMinutes;
+    private Integer coolDownMinutes = DEFAULT_LOAD_BASED_AUTOSCALING_COOLDOWN_MINS;
 
     public Integer getMinResourceValue() {
         return minResourceValue;
@@ -38,7 +40,9 @@ public class LoadAlertConfiguration {
     }
 
     public void setCoolDownMinutes(Integer coolDownMinutes) {
-        this.coolDownMinutes = coolDownMinutes;
+        if (null != coolDownMinutes) {
+            this.coolDownMinutes = coolDownMinutes;
+        }
     }
 
     @Override

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ScalingConstants.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ScalingConstants.java
@@ -14,7 +14,7 @@ public class ScalingConstants {
 
     public static final int DEFAULT_MAX_SCALE_UP_STEP_SIZE = 50;
 
-    public static final Long UNINITIALIZED_WORKSPACE_ID = -1L;
+    public static final int DEFAULT_LOAD_BASED_AUTOSCALING_COOLDOWN_MINS = 2;
 
     private ScalingConstants() {
     }


### PR DESCRIPTION
LoadAlertConfigurationRequest::coolDownMinutes is made not mandatory and initialized with default value of 2 mins.
.