### PR TITLE
CB-7929 OS upgrade should work with non-auto joinable master

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/SaltBootstrapFingerprintVersionChecker.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/SaltBootstrapFingerprintVersionChecker.java
@@ -1,0 +1,47 @@
+package com.sequenceiq.cloudbreak.core.bootstrap.service;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.VersionComparator;
+import com.sequenceiq.cloudbreak.cloud.model.Image;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.common.type.Versioned;
+import com.sequenceiq.cloudbreak.core.flow2.stack.image.update.PackageVersionChecker;
+
+@Component
+public class SaltBootstrapFingerprintVersionChecker {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SaltBootstrapFingerprintVersionChecker.class);
+
+    private static final Versioned MIN_VERSION = () -> "0.13.2";
+
+    public boolean isFingerprintingSupported(Json image) {
+        if (image == null) {
+            LOGGER.info("Image is null, couldn't verify salt-bootstrap version");
+            return false;
+        } else {
+            try {
+                Image instanceImage = image.get(Image.class);
+                Map<String, String> packageVersions = instanceImage.getPackageVersions();
+                if (packageVersions != null) {
+                    String saltBootstrapVersion = packageVersions.getOrDefault(PackageVersionChecker.SALT_BOOTSTRAP, "0.0.0");
+                    Versioned currentVersion = () -> StringUtils.substringBefore(saltBootstrapVersion, "-");
+                    LOGGER.debug("Saltboot version in image: {}", currentVersion.getVersion());
+                    return -1 < new VersionComparator().compare(currentVersion, MIN_VERSION);
+                } else {
+                    LOGGER.info("PackageVersions is null in image {} {}", instanceImage.getImageId(), instanceImage.getImageName());
+                    return false;
+                }
+            } catch (IOException e) {
+                LOGGER.warn("Couldn't parse image", e);
+                return false;
+            }
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/image/update/PackageVersionChecker.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/image/update/PackageVersionChecker.java
@@ -30,9 +30,9 @@ import com.sequenceiq.cloudbreak.service.image.StatedImage;
 
 @Component
 public class PackageVersionChecker {
-    private static final Logger LOGGER = LoggerFactory.getLogger(PackageVersionChecker.class);
+    public static final String SALT_BOOTSTRAP = "salt-bootstrap";
 
-    private static final String SALT_BOOTSTRAP = "salt-bootstrap";
+    private static final Logger LOGGER = LoggerFactory.getLogger(PackageVersionChecker.class);
 
     @Inject
     private InstanceMetadataUpdater instanceMetadataUpdater;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/ClusterCommonService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/ClusterCommonService.java
@@ -256,6 +256,7 @@ public class ClusterCommonService {
 
     public FlowIdentifier updateSalt(NameOrCrn nameOrCrn, Long workspaceId) {
         Stack stack = stackService.getByNameOrCrnInWorkspace(nameOrCrn, workspaceId);
+        MDCBuilder.buildMdcContext(stack);
         return clusterOperationService.updateSalt(stack);
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/SaltBootstrapFingerprintVersionCheckerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/SaltBootstrapFingerprintVersionCheckerTest.java
@@ -1,0 +1,61 @@
+package com.sequenceiq.cloudbreak.core.bootstrap.service;
+
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.cloud.model.Image;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.core.flow2.stack.image.update.PackageVersionChecker;
+
+class SaltBootstrapFingerprintVersionCheckerTest {
+
+    private SaltBootstrapFingerprintVersionChecker underTest = new SaltBootstrapFingerprintVersionChecker();
+
+    @Test
+    public void testFingerPrintSupported() {
+        assertTrue(underTest.isFingerprintingSupported(getJsonImage("0.13.2")));
+        assertTrue(underTest.isFingerprintingSupported(getJsonImage("0.13.2-134")));
+        assertTrue(underTest.isFingerprintingSupported(getJsonImage("0.13.3")));
+        assertTrue(underTest.isFingerprintingSupported(getJsonImage("0.13.3-3245")));
+        assertTrue(underTest.isFingerprintingSupported(getJsonImage("0.14")));
+        assertTrue(underTest.isFingerprintingSupported(getJsonImage("0.14.0")));
+        assertTrue(underTest.isFingerprintingSupported(getJsonImage("1.0.0")));
+    }
+
+    @Test
+    public void testFingerPrintNotSupported() {
+        assertFalse(underTest.isFingerprintingSupported(getJsonImage("0.13.1")));
+        assertFalse(underTest.isFingerprintingSupported(getJsonImage("0.13.0")));
+        assertFalse(underTest.isFingerprintingSupported(getJsonImage("0.13.1.1")));
+        assertFalse(underTest.isFingerprintingSupported(getJsonImage("0.13.1-134")));
+        assertFalse(underTest.isFingerprintingSupported(getJsonImage("0.12.3")));
+        assertFalse(underTest.isFingerprintingSupported(getJsonImage("0.12.3-3245")));
+    }
+
+    @Test
+    public void testNullImage() {
+        assertFalse(underTest.isFingerprintingSupported(null));
+    }
+
+    @Test
+    public void testNoPackageVersionMap() {
+        Image image = new Image(null, null, null, null, null, null, null, null);
+        assertFalse(underTest.isFingerprintingSupported(new Json(image)));
+    }
+
+    @Test
+    public void testNoPackageVersionForSb() {
+        Image image = new Image(null, null, null, null, null, null, null, Map.of());
+        assertFalse(underTest.isFingerprintingSupported(new Json(image)));
+    }
+
+    protected Json getJsonImage(String version) {
+        Image image = new Image(null, null, null, null, null, null, null, Map.of(PackageVersionChecker.SALT_BOOTSTRAP, version));
+        return new Json(image);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/BootstrapService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/BootstrapService.java
@@ -78,6 +78,7 @@ public class BootstrapService {
 
         ImageEntity image = imageService.getByStack(stack);
         params.setOs(image.getOs());
+        params.setSaltBootstrapFpSupported(true);
         try {
             byte[] stateConfigZip = getStateConfigZip();
             hostOrchestrator.bootstrapNewNodes(gatewayConfigs, allNodes, allNodes,

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/model/BootstrapParams.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/model/BootstrapParams.java
@@ -5,6 +5,8 @@ public class BootstrapParams {
 
     private String os;
 
+    private boolean saltBootstrapFpSupported;
+
     public String getCloud() {
         return cloud;
     }
@@ -19,5 +21,22 @@ public class BootstrapParams {
 
     public void setOs(String os) {
         this.os = os;
+    }
+
+    public boolean isSaltBootstrapFpSupported() {
+        return saltBootstrapFpSupported;
+    }
+
+    public void setSaltBootstrapFpSupported(boolean saltBootstrapFpSupported) {
+        this.saltBootstrapFpSupported = saltBootstrapFpSupported;
+    }
+
+    @Override
+    public String toString() {
+        return "BootstrapParams{" +
+                "cloud='" + cloud + '\'' +
+                ", os='" + os + '\'' +
+                ", saltBootstrapFpSupported=" + saltBootstrapFpSupported +
+                '}';
     }
 }

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/domain/FingerprintsResponse.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/domain/FingerprintsResponse.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 public class FingerprintsResponse {
 
-    private List<Fingerprint> fingerprints;
+    private List<Fingerprint> fingerprints = List.of();
 
     private String errorText;
 

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/domain/Minion.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/domain/Minion.java
@@ -79,4 +79,17 @@ public class Minion {
     public String getId() {
         return hostName + '.' + domain;
     }
+
+    @Override
+    public String toString() {
+        return "Minion{" +
+                "address='" + address + '\'' +
+                ", server='" + server + '\'' +
+                ", servers=" + servers +
+                ", hostGroup='" + hostGroup + '\'' +
+                ", domain='" + domain + '\'' +
+                ", hostName='" + hostName + '\'' +
+                ", id='" + getId() + '\'' +
+                '}';
+    }
 }

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/SaltBootstrap.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/SaltBootstrap.java
@@ -26,6 +26,10 @@ import com.sequenceiq.cloudbreak.orchestrator.salt.domain.Os;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.SaltAction;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.SaltAuth;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.SaltMaster;
+import com.sequenceiq.cloudbreak.orchestrator.salt.poller.join.AcceptAllFpMatcher;
+import com.sequenceiq.cloudbreak.orchestrator.salt.poller.join.DummyFingerprintCollector;
+import com.sequenceiq.cloudbreak.orchestrator.salt.poller.join.EqualMinionFpMatcher;
+import com.sequenceiq.cloudbreak.orchestrator.salt.poller.join.FingerprintFromSbCollector;
 import com.sequenceiq.cloudbreak.orchestrator.salt.poller.join.MinionAcceptor;
 import com.sequenceiq.cloudbreak.orchestrator.salt.states.SaltStates;
 
@@ -99,7 +103,9 @@ public class SaltBootstrap implements OrchestratorBootstrap {
     }
 
     protected MinionAcceptor createMinionAcceptor(SaltAction saltAction) {
-        return new MinionAcceptor(sc, saltAction.getMinions());
+        return params.isSaltBootstrapFpSupported() ?
+                new MinionAcceptor(sc, saltAction.getMinions(), new EqualMinionFpMatcher(), new FingerprintFromSbCollector())
+                : new MinionAcceptor(sc, saltAction.getMinions(), new AcceptAllFpMatcher(), new DummyFingerprintCollector());
     }
 
     private SaltAction createBootstrap() {

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/join/AcceptAllFpMatcher.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/join/AcceptAllFpMatcher.java
@@ -1,0 +1,18 @@
+package com.sequenceiq.cloudbreak.orchestrator.salt.poller.join;
+
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AcceptAllFpMatcher implements MinionFingerprintMatcher {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AcceptAllFpMatcher.class);
+
+    @Override
+    public List<String> collectMinionsWithMatchingFp(Map<String, String> fingerprintsFromMaster, Map<String, String> fingerprintByMinion) {
+        LOGGER.info("Accept all keys: {}", fingerprintsFromMaster.keySet());
+        return List.copyOf(fingerprintsFromMaster.keySet());
+    }
+}

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/join/DummyFingerprintCollector.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/join/DummyFingerprintCollector.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.cloudbreak.orchestrator.salt.poller.join;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.orchestrator.salt.client.SaltConnector;
+import com.sequenceiq.cloudbreak.orchestrator.salt.domain.FingerprintsResponse;
+import com.sequenceiq.cloudbreak.orchestrator.salt.domain.Minion;
+
+public class DummyFingerprintCollector implements FingerprintCollector {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DummyFingerprintCollector.class);
+
+    @Override
+    public FingerprintsResponse collectFingerprintFromMinions(SaltConnector sc, List<Minion> minionsToAccept) {
+        LOGGER.info("Return empty 'FingerprintsResponse'");
+        return new FingerprintsResponse();
+    }
+}

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/join/EqualMinionFpMatcher.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/join/EqualMinionFpMatcher.java
@@ -1,0 +1,30 @@
+package com.sequenceiq.cloudbreak.orchestrator.salt.poller.join;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class EqualMinionFpMatcher implements MinionFingerprintMatcher {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EqualMinionFpMatcher.class);
+
+    public List<String> collectMinionsWithMatchingFp(Map<String, String> fingerprintsFromMaster, Map<String, String> fingerprintByMinion) {
+        LOGGER.info("Matching fingerprints from master: {} and from minions: {}", fingerprintsFromMaster, fingerprintByMinion);
+        return fingerprintsFromMaster.entrySet().stream()
+                .filter(entry -> isFingerPrintMatches(fingerprintByMinion, entry))
+                .map(Entry::getKey)
+                .collect(Collectors.toList());
+    }
+
+    private boolean isFingerPrintMatches(Map<String, String> fingerprintByMinion, Map.Entry<String, String> fingerPrintFromMasterByMinion) {
+        String minionId = fingerPrintFromMasterByMinion.getKey();
+        String fingerprintOnMinion = fingerprintByMinion.get(minionId);
+        LOGGER.debug("Minion ID: [{}] Fingerprint on master: [{}] Fingerprint on minion: [{}]",
+                minionId, fingerPrintFromMasterByMinion.getValue(), fingerprintOnMinion);
+        return fingerPrintFromMasterByMinion.getValue().equals(fingerprintOnMinion);
+    }
+}

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/join/FingerprintCollector.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/join/FingerprintCollector.java
@@ -1,55 +1,14 @@
 package com.sequenceiq.cloudbreak.orchestrator.salt.poller.join;
 
 import java.util.List;
-import java.util.stream.Collectors;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpStatus;
 
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
 import com.sequenceiq.cloudbreak.orchestrator.salt.client.SaltConnector;
-import com.sequenceiq.cloudbreak.orchestrator.salt.domain.Fingerprint;
-import com.sequenceiq.cloudbreak.orchestrator.salt.domain.FingerprintRequest;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.FingerprintsResponse;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.Minion;
 
-public class FingerprintCollector {
+public interface FingerprintCollector {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(FingerprintCollector.class);
+    FingerprintsResponse collectFingerprintFromMinions(SaltConnector sc, List<Minion> minionsToAccept) throws CloudbreakOrchestratorFailedException;
 
-    public FingerprintsResponse collectFingerprintFromMinions(SaltConnector sc, List<Minion> minionsToAccept) throws CloudbreakOrchestratorFailedException {
-        FingerprintsResponse fingerprintsResponse;
-        try {
-            fingerprintsResponse = sc.collectFingerPrints(new FingerprintRequest(minionsToAccept));
-        } catch (Exception e) {
-            LOGGER.error("Couldn't collect fingerprints for minions: {}", minionsToAccept, e);
-            throw new CloudbreakOrchestratorFailedException("Couldn't collect fingerprints for minions", e);
-        }
-        validateFingerprintResponse(minionsToAccept, fingerprintsResponse);
-        return fingerprintsResponse;
-    }
-
-    private void validateFingerprintResponse(List<Minion> minionsToAccept, FingerprintsResponse response) throws CloudbreakOrchestratorFailedException {
-        validateHttpStatus(response, minionsToAccept);
-        validateAllMinionsCollected(minionsToAccept, response);
-    }
-
-    private void validateAllMinionsCollected(List<Minion> minionsToAccept, FingerprintsResponse response) throws CloudbreakOrchestratorFailedException {
-        List<String> collectedMinionAddress = response.getFingerprints().stream().map(Fingerprint::getAddress).collect(Collectors.toList());
-        boolean allFingerprintCollected = minionsToAccept.stream().allMatch(minion -> collectedMinionAddress.contains(minion.getAddress()));
-        if (!allFingerprintCollected) {
-            LOGGER.error("Not all minions' fingerprint has been collected. Minions to collect: [{}] Response: [{}]", minionsToAccept, response);
-            throw new CloudbreakOrchestratorFailedException("Not all minions' fingerprint has been collected.");
-        }
-    }
-
-    private void validateHttpStatus(FingerprintsResponse response, List<Minion> minionsToAccept) throws CloudbreakOrchestratorFailedException {
-        if (HttpStatus.OK.value() != response.getStatusCode()) {
-            LOGGER.error("There was an error during collection of fingerprints from minions. Response: [{}] Minions: [{}]", response, minionsToAccept);
-            throw new CloudbreakOrchestratorFailedException(
-                    String.format("Couldn't collect fingerprints for minions. Statuscode: [%s] Status reason: [%s]",
-                            response.getStatusCode(), response.getErrorText()));
-        }
-    }
 }

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/join/FingerprintFromSbCollector.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/join/FingerprintFromSbCollector.java
@@ -1,0 +1,55 @@
+package com.sequenceiq.cloudbreak.orchestrator.salt.poller.join;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.orchestrator.salt.client.SaltConnector;
+import com.sequenceiq.cloudbreak.orchestrator.salt.domain.Fingerprint;
+import com.sequenceiq.cloudbreak.orchestrator.salt.domain.FingerprintRequest;
+import com.sequenceiq.cloudbreak.orchestrator.salt.domain.FingerprintsResponse;
+import com.sequenceiq.cloudbreak.orchestrator.salt.domain.Minion;
+
+public class FingerprintFromSbCollector implements FingerprintCollector {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FingerprintFromSbCollector.class);
+
+    public FingerprintsResponse collectFingerprintFromMinions(SaltConnector sc, List<Minion> minionsToAccept) throws CloudbreakOrchestratorFailedException {
+        FingerprintsResponse fingerprintsResponse;
+        try {
+            fingerprintsResponse = sc.collectFingerPrints(new FingerprintRequest(minionsToAccept));
+        } catch (Exception e) {
+            LOGGER.error("Couldn't collect fingerprints for minions: {}", minionsToAccept, e);
+            throw new CloudbreakOrchestratorFailedException("Couldn't collect fingerprints for minions", e);
+        }
+        validateFingerprintResponse(minionsToAccept, fingerprintsResponse);
+        return fingerprintsResponse;
+    }
+
+    private void validateFingerprintResponse(List<Minion> minionsToAccept, FingerprintsResponse response) throws CloudbreakOrchestratorFailedException {
+        validateHttpStatus(response, minionsToAccept);
+        validateAllMinionsCollected(minionsToAccept, response);
+    }
+
+    private void validateAllMinionsCollected(List<Minion> minionsToAccept, FingerprintsResponse response) throws CloudbreakOrchestratorFailedException {
+        List<String> collectedMinionAddress = response.getFingerprints().stream().map(Fingerprint::getAddress).collect(Collectors.toList());
+        boolean allFingerprintCollected = minionsToAccept.stream().allMatch(minion -> collectedMinionAddress.contains(minion.getAddress()));
+        if (!allFingerprintCollected) {
+            LOGGER.error("Not all minions' fingerprint has been collected. Minions to collect: [{}] Response: [{}]", minionsToAccept, response);
+            throw new CloudbreakOrchestratorFailedException("Not all minions' fingerprint has been collected.");
+        }
+    }
+
+    private void validateHttpStatus(FingerprintsResponse response, List<Minion> minionsToAccept) throws CloudbreakOrchestratorFailedException {
+        if (HttpStatus.OK.value() != response.getStatusCode()) {
+            LOGGER.error("There was an error during collection of fingerprints from minions. Response: [{}] Minions: [{}]", response, minionsToAccept);
+            throw new CloudbreakOrchestratorFailedException(
+                    String.format("Couldn't collect fingerprints for minions. Statuscode: [%s] Status reason: [%s]",
+                            response.getStatusCode(), response.getErrorText()));
+        }
+    }
+}

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/join/MinionFingerprintMatcher.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/join/MinionFingerprintMatcher.java
@@ -1,0 +1,8 @@
+package com.sequenceiq.cloudbreak.orchestrator.salt.poller.join;
+
+import java.util.List;
+import java.util.Map;
+
+public interface MinionFingerprintMatcher {
+    List<String> collectMinionsWithMatchingFp(Map<String, String> fingerprintsFromMaster, Map<String, String> fingerprintByMinion);
+}

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/join/FingerprintFromSbCollectorTest.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/join/FingerprintFromSbCollectorTest.java
@@ -18,9 +18,9 @@ import com.sequenceiq.cloudbreak.orchestrator.salt.domain.FingerprintRequest;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.FingerprintsResponse;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.Minion;
 
-class FingerprintCollectorTest {
+class FingerprintFromSbCollectorTest {
 
-    private FingerprintCollector underTest = new FingerprintCollector();
+    private FingerprintFromSbCollector underTest = new FingerprintFromSbCollector();
 
     private SaltConnector sc = mock(SaltConnector.class);
 


### PR DESCRIPTION
When a cluster is started with old salt-bootstrap it will have auto join in salt master configuration. Every minion will be able to join.
During cluster upgrade we replace the master first. Master will not have the auto join configured
but we can't collect the fingerprints from the old salt-bootstrap.

In this change we will check if every instance has a new salt-bootstrap (greater or equal to 0.13.2).
If any instance has old one, we will replace the FingerprintCollector with a dummy implementation which won't collect the fingerprints as it would fail anyway.
The fingerprint matching has been refactored into a separate class. If there is an old salt-bootstrap between the instances we will use `AcceptAllFpMatcher`.
It will return with all fingerprints are matching, so every minion will be accepted.

If salt-bootstrap supports fingerprint collection everything would work as expected, with collecting and matching fingerprints to validate minions.