### PR TITLE
CB-7940 do not create reverse SSH tunnel on CORE type of instances

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/CcmParameters.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/CcmParameters.java
@@ -1,10 +1,14 @@
 package com.sequenceiq.cloudbreak.ccm.cloudinit;
 
+import static com.sequenceiq.common.api.type.InstanceGroupType.isGateway;
+
 import java.util.List;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import com.sequenceiq.common.api.type.InstanceGroupType;
 
 /**
  * Holds CCM cloud-init parameters, which encapsulate the user data required to configure an instance to
@@ -15,10 +19,12 @@ public interface CcmParameters {
     /**
      * Adds keys and values corresponding to the CCM parameters to the specified template model.
      *
-     * @param model the template model map
+     * @param type          instance group type, CCM is only enabled to GATEWAY type
+     * @param ccmParameters paramters for CCM
+     * @param model         the template model map
      */
-    static void addToTemplateModel(@Nullable CcmParameters ccmParameters, @Nonnull Map<String, Object> model) {
-        if (ccmParameters == null) {
+    static void addToTemplateModel(InstanceGroupType type, @Nullable CcmParameters ccmParameters, @Nonnull Map<String, Object> model) {
+        if (ccmParameters == null || !isGateway(type)) {
             model.put(CcmParameterConstants.CCM_ENABLED_KEY, Boolean.FALSE);
         } else {
             model.put(CcmParameterConstants.CCM_ENABLED_KEY, Boolean.TRUE);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/userdata/UserDataBuilder.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/userdata/UserDataBuilder.java
@@ -61,7 +61,7 @@ public class UserDataBuilder {
         model.put("customUserData", userDataBuilderParams.getCustomData());
         model.put("saltBootPassword", saltBootPassword);
         model.put("cbCert", cbCert);
-        CcmParameters.addToTemplateModel(ccmParameters, model);
+        CcmParameters.addToTemplateModel(type, ccmParameters, model);
         extendModelWithProxyParams(type, proxyConfig, model);
         return build(model);
     }

--- a/core/src/test/resources/azure-core-ccm-init.sh
+++ b/core/src/test/resources/azure-core-ccm-init.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+## logging
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+set -x
+
+export CLOUD_PLATFORM="AZURE"
+export START_LABEL=98
+export PLATFORM_DISK_PREFIX=sd
+export LAZY_FORMAT_DISK_LIMIT=12
+export IS_GATEWAY=false
+export TMP_SSH_KEY="#NOT_USER_ANYMORE_BUT_KEEP_FOR_BACKWARD_COMPATIBILITY"
+export SSH_USER=cloudbreak
+export SALT_BOOT_PASSWORD=pass
+export SALT_BOOT_SIGN_KEY=cHJpdi1rZXk=
+export CB_CERT=cert
+export IS_PROXY_ENABLED=false
+export IS_CCM_ENABLED=false
+
+date >> /tmp/time.txt
+
+/usr/bin/user-data-helper.sh "$@" &> /var/log/user-data.log
+
+chmod o-rwx /var/log/user-data.log
+chmod o-rwx /cdp/bin/*

--- a/core/src/test/resources/azure-gateway-ccm-init.sh
+++ b/core/src/test/resources/azure-gateway-ccm-init.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+## logging
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+set -x
+
+export CLOUD_PLATFORM="AZURE"
+export START_LABEL=98
+export PLATFORM_DISK_PREFIX=sd
+export LAZY_FORMAT_DISK_LIMIT=12
+export IS_GATEWAY=true
+export TMP_SSH_KEY="#NOT_USER_ANYMORE_BUT_KEEP_FOR_BACKWARD_COMPATIBILITY"
+export SSH_USER=cloudbreak
+export SALT_BOOT_PASSWORD=pass
+export SALT_BOOT_SIGN_KEY=cHJpdi1rZXk=
+export CB_CERT=cert
+export IS_PROXY_ENABLED=false
+export IS_CCM_ENABLED=true
+export CCM_HOST=ccm.cloudera.com
+export CCM_SSH_PORT=8990
+export CCM_PUBLIC_KEY="W2NjbS5jbG91ZGVyYS5jb21dOjg5OTAgcHViLWtleQ=="
+export CCM_TUNNEL_INITIATOR_ID="tunnel-id"
+export CCM_KEY_ID="key-id"
+export CCM_ENCIPHERED_PRIVATE_KEY="cHJpdmF0ZS1rZXk="
+export CCM_GATEWAY_PORT=9443
+export CCM_KNOX_PORT=8443
+
+date >> /tmp/time.txt
+
+/usr/bin/user-data-helper.sh "$@" &> /var/log/user-data.log
+
+chmod o-rwx /var/log/user-data.log
+chmod o-rwx /cdp/bin/*

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/userdata/UserDataBuilder.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/userdata/UserDataBuilder.java
@@ -18,6 +18,7 @@ import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
 import com.sequenceiq.cloudbreak.dto.ProxyConfig;
 import com.sequenceiq.cloudbreak.util.FreeMarkerTemplateUtils;
+import com.sequenceiq.common.api.type.InstanceGroupType;
 
 import freemarker.template.Configuration;
 import freemarker.template.TemplateException;
@@ -55,7 +56,7 @@ public class UserDataBuilder {
         model.put("customUserData", userDataBuilderParams.getCustomData());
         model.put("saltBootPassword", saltBootPassword);
         model.put("cbCert", cbCert);
-        CcmParameters.addToTemplateModel(ccmParameters, model);
+        CcmParameters.addToTemplateModel(InstanceGroupType.GATEWAY, ccmParameters, model);
         extendModelWithProxyParams(proxyConfig, model);
         return build(model);
     }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/userdata/UserDataBuilderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/userdata/UserDataBuilderTest.java
@@ -1,0 +1,98 @@
+package com.sequenceiq.freeipa.service.image.userdata;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.ui.freemarker.FreeMarkerConfigurationFactoryBean;
+
+import com.sequenceiq.cloudbreak.ccm.cloudinit.CcmParameters;
+import com.sequenceiq.cloudbreak.ccm.cloudinit.DefaultCcmParameters;
+import com.sequenceiq.cloudbreak.ccm.cloudinit.DefaultInstanceParameters;
+import com.sequenceiq.cloudbreak.ccm.cloudinit.DefaultServerParameters;
+import com.sequenceiq.cloudbreak.ccm.cloudinit.DefaultTunnelParameters;
+import com.sequenceiq.cloudbreak.ccm.endpoint.BaseServiceEndpoint;
+import com.sequenceiq.cloudbreak.ccm.endpoint.HostEndpoint;
+import com.sequenceiq.cloudbreak.ccm.endpoint.KnownServiceIdentifier;
+import com.sequenceiq.cloudbreak.cloud.PlatformParameters;
+import com.sequenceiq.cloudbreak.cloud.model.Platform;
+import com.sequenceiq.cloudbreak.cloud.model.ScriptParams;
+import com.sequenceiq.cloudbreak.util.FileReaderUtils;
+import com.sequenceiq.cloudbreak.util.FreeMarkerTemplateUtils;
+
+import freemarker.template.Configuration;
+import freemarker.template.TemplateException;
+
+@ExtendWith(MockitoExtension.class)
+public class UserDataBuilderTest {
+
+    @InjectMocks
+    private UserDataBuilder underTest;
+
+    @Spy
+    private FreeMarkerTemplateUtils freeMarkerTemplateUtils;
+
+    @BeforeEach
+    public void setup() throws IOException, TemplateException {
+        FreeMarkerConfigurationFactoryBean factoryBean = new FreeMarkerConfigurationFactoryBean();
+        factoryBean.setPreferFileSystemAccess(false);
+        factoryBean.setTemplateLoaderPath("classpath:/");
+        factoryBean.afterPropertiesSet();
+        Configuration configuration = factoryBean.getObject();
+        underTest.setFreemarkerConfiguration(configuration);
+
+        UserDataBuilderParams params = new UserDataBuilderParams();
+        params.setCustomData("date >> /tmp/time.txt");
+
+        ReflectionTestUtils.setField(underTest, "userDataBuilderParams", params);
+    }
+
+    @Test
+    @DisplayName("test if CCM parameters are passed the user data contains them")
+    public void testBuildUserDataWithCCMParams() throws IOException {
+        BaseServiceEndpoint serviceEndpoint = new BaseServiceEndpoint(new HostEndpoint("ccm.cloudera.com"));
+        DefaultServerParameters serverParameters = new DefaultServerParameters(serviceEndpoint, "pub-key", "mina-id");
+        DefaultInstanceParameters instanceParameters = new DefaultInstanceParameters("tunnel-id", "key-id", "private-key");
+        DefaultTunnelParameters nginxTunnel = new DefaultTunnelParameters(KnownServiceIdentifier.GATEWAY, 9443);
+        CcmParameters ccmParameters = new DefaultCcmParameters(serverParameters, instanceParameters, List.of(nginxTunnel));
+        PlatformParameters platformParameters = mock(PlatformParameters.class);
+        ScriptParams scriptParams = mock(ScriptParams.class);
+        when(scriptParams.getDiskPrefix()).thenReturn("sd");
+        when(scriptParams.getStartLabel()).thenReturn(98);
+        when(platformParameters.scriptParams()).thenReturn(scriptParams);
+
+        String userData = underTest.buildUserData(Platform.platform("AZURE"), "priv-key".getBytes(),
+                "cloudbreak", platformParameters, "pass", "cert", ccmParameters, null);
+
+        String expectedUserData = FileReaderUtils.readFileFromClasspath("azure-ccm-init.sh");
+        Assert.assertEquals(expectedUserData, userData);
+    }
+
+    @Test
+    @DisplayName("test if NO CCM parameters are passed the user data does not contain them")
+    public void testBuildUserDataWithoutCCMParams() throws IOException {
+        PlatformParameters platformParameters = mock(PlatformParameters.class);
+        ScriptParams scriptParams = mock(ScriptParams.class);
+        when(scriptParams.getDiskPrefix()).thenReturn("sd");
+        when(scriptParams.getStartLabel()).thenReturn(98);
+        when(platformParameters.scriptParams()).thenReturn(scriptParams);
+
+        String userData = underTest.buildUserData(Platform.platform("AZURE"), "priv-key".getBytes(),
+                "cloudbreak", platformParameters, "pass", "cert", null, null);
+
+        String expectedUserData = FileReaderUtils.readFileFromClasspath("azure-init.sh");
+        Assert.assertEquals(expectedUserData, userData);
+    }
+
+}

--- a/freeipa/src/test/resources/azure-ccm-init.sh
+++ b/freeipa/src/test/resources/azure-ccm-init.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+## logging
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+set -x
+
+export CLOUD_PLATFORM="AZURE"
+export START_LABEL=98
+export PLATFORM_DISK_PREFIX=sd
+export LAZY_FORMAT_DISK_LIMIT=12
+export IS_GATEWAY=true
+export TMP_SSH_KEY="dummy"
+export SSH_USER=cloudbreak
+export SALT_BOOT_PASSWORD=pass
+export SALT_BOOT_SIGN_KEY=cHJpdi1rZXk=
+export CB_CERT=cert
+export IS_PROXY_ENABLED=false
+export IS_CCM_ENABLED=true
+export CCM_HOST=ccm.cloudera.com
+export CCM_SSH_PORT=8990
+export CCM_PUBLIC_KEY="W2NjbS5jbG91ZGVyYS5jb21dOjg5OTAgcHViLWtleQ=="
+export CCM_TUNNEL_INITIATOR_ID="tunnel-id"
+export CCM_KEY_ID="key-id"
+export CCM_ENCIPHERED_PRIVATE_KEY="cHJpdmF0ZS1rZXk="
+export CCM_GATEWAY_PORT=9443
+
+date >> /tmp/time.txt
+
+/usr/bin/user-data-helper.sh "$@" &> /var/log/user-data.log
+
+chmod o-rwx /var/log/user-data.log
+chmod o-rwx /cdp/bin/*

--- a/freeipa/src/test/resources/azure-init.sh
+++ b/freeipa/src/test/resources/azure-init.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+## logging
+exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+set -x
+
+export CLOUD_PLATFORM="AZURE"
+export START_LABEL=98
+export PLATFORM_DISK_PREFIX=sd
+export LAZY_FORMAT_DISK_LIMIT=12
+export IS_GATEWAY=true
+export TMP_SSH_KEY="dummy"
+export SSH_USER=cloudbreak
+export SALT_BOOT_PASSWORD=pass
+export SALT_BOOT_SIGN_KEY=cHJpdi1rZXk=
+export CB_CERT=cert
+export IS_PROXY_ENABLED=false
+export IS_CCM_ENABLED=false
+
+date >> /tmp/time.txt
+
+/usr/bin/user-data-helper.sh "$@" &> /var/log/user-data.log
+
+chmod o-rwx /var/log/user-data.log
+chmod o-rwx /cdp/bin/*


### PR DESCRIPTION
Due to a missing filter we're configuring the reverse SSH tunnel
on every single instance. This is unnecessary as we're only
communicating with the master instance. With this change only the
instances with GATEWAY type will create the tunnel. FMS has only
1 type of instances.

See detailed description in the commit message.