### PR TITLE
CB-5469 datalake shutdown hangs where idbroker node is missing

### DIFF
--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -347,7 +347,7 @@ cb:
     yarn.resource.name.length: 63
 
     salt.new.service.retry: 180
-    salt.new.service.leave.retry: 10
+    salt.new.service.leave.retry: 5
     salt.new.service.retry.onerror: 20
     salt.recipe.execution.retry: 180
 


### PR DESCRIPTION
cloudbreak tries to remove node from domain, however the node is missing and salt command is running for 5 minutes and repeats for 10 times without success. Datalake will mark the deletion with failure (because of time out after 60 minutes), but after a while cloudbreak is finishing with the datalake stack deletion (redbeams remains as it was).
I decreased the repeat time to 5 (~25 minutes).

closing cb-5469