### PR TITLE
CB-7933 Do not fail on sdx status update in Create and Delete action failurehandler

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/exception/NotFoundException.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/exception/NotFoundException.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.common.exception;
 
 import java.util.function.Supplier;
 
+//TODO: there is another NotFoundException in com.sequenceiq.cloudbreak.exception package, we should to remove one of them
 public class NotFoundException extends RuntimeException {
 
     public NotFoundException(String message) {
@@ -18,5 +19,9 @@ public class NotFoundException extends RuntimeException {
 
     public static Supplier<NotFoundException> notFound(String what, Long which) {
         return () -> new NotFoundException(String.format("%s '%d' not found.", what, which));
+    }
+
+    public static NotFoundException notFoundException(String what, String which) {
+        return new NotFoundException(String.format("%s '%s' not found.", what, which));
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/create/SdxCreateActions.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/create/SdxCreateActions.java
@@ -17,6 +17,7 @@ import org.springframework.statemachine.StateContext;
 import org.springframework.statemachine.action.Action;
 
 import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.datalake.entity.DatalakeStatusEnum;
 import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.flow.SdxContext;
@@ -190,9 +191,13 @@ public class SdxCreateActions {
                 if (exception.getMessage() != null) {
                     statusReason = exception.getMessage();
                 }
-                SdxCluster sdxCluster = sdxStatusService.setStatusForDatalakeAndNotify(DatalakeStatusEnum.PROVISIONING_FAILED,
-                        statusReason, payload.getResourceId());
-                metricService.incrementMetricCounter(MetricType.SDX_CREATION_FAILED, sdxCluster);
+                try {
+                    SdxCluster sdxCluster = sdxStatusService.setStatusForDatalakeAndNotify(DatalakeStatusEnum.PROVISIONING_FAILED,
+                            statusReason, payload.getResourceId());
+                    metricService.incrementMetricCounter(MetricType.SDX_CREATION_FAILED, sdxCluster);
+                } catch (NotFoundException notFoundException) {
+                    LOGGER.info("Can not set status to SDX_CREATION_FAILED because data lake was not found");
+                }
                 sendEvent(context, SDX_CREATE_FAILED_HANDLED_EVENT.event(), payload);
             }
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/delete/handler/RdsDeletionHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/delete/handler/RdsDeletionHandler.java
@@ -14,6 +14,7 @@ import com.dyngr.exception.PollerStoppedException;
 import com.dyngr.exception.UserBreakException;
 import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.logger.MDCUtils;
 import com.sequenceiq.datalake.entity.DatalakeStatusEnum;
 import com.sequenceiq.datalake.entity.SdxCluster;
@@ -86,7 +87,11 @@ public class RdsDeletionHandler extends ExceptionCatcherEventHandler<RdsDeletion
     }
 
     private void setDeletedStatus(SdxCluster cluster) {
-        sdxStatusService.setStatusForDatalakeAndNotify(DatalakeStatusEnum.DELETED, "Datalake External RDS deleted", cluster);
+        try {
+            sdxStatusService.setStatusForDatalakeAndNotify(DatalakeStatusEnum.DELETED, "Datalake External RDS deleted", cluster);
+        } catch (NotFoundException notFoundException) {
+            LOGGER.info("Can not set status to DELETED because data lake was not found");
+        }
         grpcUmsClient.notifyResourceDeleted(cluster.getCrn(), MDCUtils.getRequestId());
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/status/SdxStatusService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/status/SdxStatusService.java
@@ -1,6 +1,6 @@
 package com.sequenceiq.datalake.service.sdx.status;
 
-import static com.sequenceiq.cloudbreak.exception.NotFoundException.notFoundException;
+import static com.sequenceiq.cloudbreak.common.exception.NotFoundException.notFoundException;
 import static com.sequenceiq.datalake.entity.DatalakeStatusEnum.DELETED;
 
 import java.util.Collection;
@@ -15,10 +15,10 @@ import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
-import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.common.service.Clock;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
 import com.sequenceiq.cloudbreak.event.ResourceEvent;
+import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.datalake.entity.DatalakeStatusEnum;
 import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.entity.SdxStatusEntity;

--- a/flow/src/main/java/com/sequenceiq/flow/core/AbstractAction.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/AbstractAction.java
@@ -18,6 +18,7 @@ import org.springframework.util.CollectionUtils;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.common.event.Payload;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.metrics.MetricService;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.flow.reactor.ErrorHandlerAwareReactorEventFactory;
@@ -107,6 +108,7 @@ public abstract class AbstractAction<S extends FlowState, E extends FlowEvent, C
                     sendEvent(flowParameters, failureEvent.event(), getFailurePayload(payload, Optional.ofNullable(flowContext), ex), Map.of());
                 } else {
                     LOGGER.error("Missing error handling for " + getClass().getName());
+                    throw new CloudbreakServiceException("Missing error handling for " + getClass().getName());
                 }
             }
         });


### PR DESCRIPTION
On prod I realized lot of flows are running and most of them are very old. These flows stuck, in SdxCreateActions and SdxDeleteActions the failure handlers could throw exception if sdx cluster is terminated at status save. This problem now handled and I introduced some improvement 
