### PR TITLE
CB-7971 [IT] value of integrationtest.sshPublicKey is not honored

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/AbstractCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/AbstractCloudProvider.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -191,7 +192,11 @@ public abstract class AbstractCloudProvider implements CloudProvider {
 
     @Override
     public EnvironmentAuthenticationTestDto environmentAuthentication(EnvironmentAuthenticationTestDto environmentAuthenticationEntity) {
-        return environmentAuthenticationEntity.withPublicKey(DUMMY_SSH_KEY);
+        return environmentAuthenticationEntity.withPublicKey(
+                StringUtils.isNotEmpty(commonCloudProperties.getSshPublicKey())
+                        ? commonCloudProperties.getSshPublicKey()
+                        : DUMMY_SSH_KEY
+        );
     }
 
     @Override


### PR DESCRIPTION
Now you can specify your own sshPublicKey when starting an e2e test locally.

See detailed description in the commit message.