### PR TITLE
CB-8002 Freeipa termination waitcycle does not detect 404 - logging i…

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/ExceptionChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/ExceptionChecker.java
@@ -1,11 +1,17 @@
 package com.sequenceiq.it.cloudbreak.util.wait.service;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.sequenceiq.it.cloudbreak.exception.TestFailException;
 
 public abstract class ExceptionChecker<T> implements StatusChecker<T> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExceptionChecker.class);
+
     @Override
     public void handleException(Exception e) {
+        LOGGER.error("Failing with exception", e);
         throw new TestFailException(e.getMessage());
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitService.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitService.java
@@ -49,6 +49,7 @@ public class WaitService<T> {
             sleep(interval);
             attempts++;
             timeout = timeoutChecker.checkTimeout();
+            LOGGER.info("Checking if wait can exit.");
             exit = statusChecker.exitWaiting(t);
         }
         if (timeout) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaAwait.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaAwait.java
@@ -46,7 +46,7 @@ public class FreeIpaAwait implements Await<FreeIpaTestDto, Status> {
             }
         } catch (Exception e) {
             if (runningParameter.isLogError()) {
-                LOGGER.error("await [{}] is failed for statuses {}: {}, name: {}", entity, desiredStatus, ResponseUtil.getErrorMessage(e),
+                LOGGER.error("await [{}] is failed for statuses {}: {}, name: {}", entity, desiredStatus, e,
                         entity.getName());
                 Log.await(null, String.format("[%s] is failed for statuses %s: %s, name: %s",
                         entity, desiredStatus, ResponseUtil.getErrorMessage(e), entity.getName()));


### PR DESCRIPTION
…mprovement

The 404 during delete was handled in FreeIpaAwait instead of FreeIpaTerminationChecker and triggered a TestFailedException, seems to be a sporadic error. I could not understand the root cause so improved logging to be able to catch the type of exception and stack trace when TestFailedException is thrown.

See detailed description in the commit message.