### PR TITLE
CB-8015 inherit the user data fields from original image during runti…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageService.java
@@ -106,11 +106,11 @@ public class ImageService {
         componentConfigProviderService.store(components);
     }
 
-    public void updateComponentsByStackId(Stack stack, StatedImage targetImage)
+    public void updateComponentsByStackId(Stack stack, StatedImage targetImage, Map<InstanceGroupType, String> userData)
             throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
         String imageName = determineImageName(stack.cloudPlatform(), stack.getRegion(), targetImage.getImage());
         Set<Component> components = componentConfigProviderService.getComponentsByStackId(stack.getId());
-        Set<Component> targetComponents = getComponents(stack, Map.of(), targetImage.getImage(), imageName,
+        Set<Component> targetComponents = getComponents(stack, userData, targetImage.getImage(), imageName,
                 targetImage.getImageCatalogUrl(),
                 targetImage.getImageCatalogName(),
                 targetImage.getImage().getUuid());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/UpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/UpgradeService.java
@@ -169,7 +169,7 @@ public class UpgradeService {
             StatedImage currentStatedImage =
                     imageCatalogService.getImage(currentImage.getImageCatalogUrl(), currentImage.getImageCatalogName(), currentImage.getImageId());
             StatedImage targetStatedImage = imageCatalogService.getImage(currentImage.getImageCatalogUrl(), currentImage.getImageCatalogName(), imageId);
-            imageService.updateComponentsByStackId(stack, targetStatedImage);
+            imageService.updateComponentsByStackId(stack, targetStatedImage, currentImage.getUserdata());
             return Pair.of(currentStatedImage, targetStatedImage);
 
         } catch (CloudbreakImageNotFoundException | CloudbreakImageCatalogException e) {


### PR DESCRIPTION
…me upgrade

During runtime upgrade we replace the original image in the components table
with a new one that we are upgrading to. This new image should have the same
user data fields as the original one otherwise the last change-image step will fail.
