### PR TITLE
CB-8018 update the SDX runtime version after upgrade

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/cluster/clouderamanager/ClouderaManagerProductV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/cluster/clouderamanager/ClouderaManagerProductV4Response.java
@@ -1,13 +1,14 @@
 package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.cluster.clouderamanager;
 
 import java.util.List;
+import java.util.StringJoiner;
 
 import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.sequenceiq.common.model.JsonEntity;
 import com.sequenceiq.cloudbreak.doc.ModelDescriptions;
+import com.sequenceiq.common.model.JsonEntity;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -80,5 +81,15 @@ public class ClouderaManagerProductV4Response implements JsonEntity {
     public ClouderaManagerProductV4Response withCsd(List<String> csd) {
         this.csd = csd;
         return this;
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", ClouderaManagerProductV4Response.class.getSimpleName() + "[", "]")
+                .add("name='" + name + "'")
+                .add("version='" + version + "'")
+                .add("parcel='" + parcel + "'")
+                .add("csd=" + csd)
+                .toString();
     }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/cluster/clouderamanager/ClouderaManagerV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/cluster/clouderamanager/ClouderaManagerV4Response.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.cluster.clouderamanager;
 
 import java.util.List;
+import java.util.StringJoiner;
 
 import javax.validation.Valid;
 
@@ -66,5 +67,14 @@ public class ClouderaManagerV4Response implements JsonEntity {
     public ClouderaManagerV4Response withTlsEnabled(Boolean enabled) {
         setEnableAutoTls(enabled);
         return this;
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", ClouderaManagerV4Response.class.getSimpleName() + "[", "]")
+                .add("repository=" + repository)
+                .add("products=" + products)
+                .add("enableAutoTls=" + enableAutoTls)
+                .toString();
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/DatalakeUpgradeActions.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/DatalakeUpgradeActions.java
@@ -141,6 +141,7 @@ public class DatalakeUpgradeActions {
             @Override
             protected void doExecute(SdxContext context, DatalakeUpgradeSuccessEvent payload, Map<Object, Object> variables) throws Exception {
                 LOGGER.info("Sdx upgrade was finalized with sdx id: {}", payload.getResourceId());
+                sdxUpgradeService.updateRuntimeVersionFromCloudbreak(payload.getResourceId());
                 sdxStatusService.setStatusForDatalakeAndNotify(
                         DatalakeStatusEnum.RUNNING,
                         ResourceEvent.DATALAKE_UPGRADE_FINISHED,

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxUpgradeServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxUpgradeServiceTest.java
@@ -1,0 +1,161 @@
+package com.sequenceiq.datalake.service.sdx;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.StackV4Endpoint;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.cluster.ClusterV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.cluster.clouderamanager.ClouderaManagerProductV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.cluster.clouderamanager.ClouderaManagerV4Response;
+import com.sequenceiq.datalake.entity.SdxCluster;
+import com.sequenceiq.datalake.repository.SdxClusterRepository;
+import com.sequenceiq.sdx.api.model.SdxClusterShape;
+
+@ExtendWith(MockitoExtension.class)
+public class SdxUpgradeServiceTest {
+
+    @InjectMocks
+    private SdxUpgradeService underTest;
+
+    @Mock
+    private SdxService sdxService;
+
+    @Mock
+    private StackV4Endpoint stackV4Endpoint;
+
+    @Mock
+    private SdxClusterRepository sdxClusterRepository;
+
+    @Captor
+    private ArgumentCaptor<SdxCluster> sdxClusterArgumentCaptor;
+
+    private SdxCluster sdxCluster;
+
+    @BeforeEach
+    public void setUp() {
+        sdxCluster = getValidSdxCluster();
+    }
+
+    @Test
+    @DisplayName("Test if the runtime is properly updated")
+    public void testUpdateRuntimeVersionFromCloudbreak() {
+        when(sdxService.getById(1L)).thenReturn(sdxCluster);
+        when(stackV4Endpoint.get(0L, "test-sdx-cluster", Set.of())).thenReturn(getStackV4Response());
+
+        underTest.updateRuntimeVersionFromCloudbreak(1L);
+
+        verify(sdxClusterRepository, times(1)).save(sdxClusterArgumentCaptor.capture());
+        assertEquals("7.2.1", sdxClusterArgumentCaptor.getValue().getRuntime());
+    }
+
+    @Test
+    @DisplayName("Test if the runtime cannot be updated when there is no CDH product installed")
+    public void testUpdateRuntimeVersionFromCloudbreakWithoutCDH() {
+        when(sdxService.getById(1L)).thenReturn(sdxCluster);
+        StackV4Response stackV4Response = getStackV4Response();
+        ClouderaManagerProductV4Response spark3 = new ClouderaManagerProductV4Response();
+        spark3.setName("SPARK3");
+        spark3.setVersion("3.0.0.2.99.7110.0-18-1.p0.3525631");
+        stackV4Response.getCluster().getCm().setProducts(List.of(spark3));
+        when(stackV4Endpoint.get(0L, "test-sdx-cluster", Set.of())).thenReturn(stackV4Response);
+
+        underTest.updateRuntimeVersionFromCloudbreak(1L);
+
+        verify(sdxClusterRepository, times(0)).save(any());
+    }
+
+    @Test
+    @DisplayName("Test if the runtime cannot be updated when there is no CM installed")
+    public void testUpdateRuntimeVersionFromCloudbreakWithoutCM() {
+        when(sdxService.getById(1L)).thenReturn(sdxCluster);
+        StackV4Response stackV4Response = getStackV4Response();
+        stackV4Response.getCluster().setCm(null);
+        when(stackV4Endpoint.get(0L, "test-sdx-cluster", Set.of())).thenReturn(stackV4Response);
+
+        underTest.updateRuntimeVersionFromCloudbreak(1L);
+
+        verify(sdxClusterRepository, times(0)).save(any());
+    }
+
+    @Test
+    @DisplayName("Test if the runtime cannot be updated when there is no cluster")
+    public void testUpdateRuntimeVersionFromCloudbreakWithoutCluster() {
+        when(sdxService.getById(1L)).thenReturn(sdxCluster);
+        StackV4Response stackV4Response = getStackV4Response();
+        stackV4Response.setCluster(null);
+        when(stackV4Endpoint.get(0L, "test-sdx-cluster", Set.of())).thenReturn(stackV4Response);
+
+        underTest.updateRuntimeVersionFromCloudbreak(1L);
+
+        verify(sdxClusterRepository, times(0)).save(any());
+    }
+
+    @Test
+    @DisplayName("Test if the runtime cannot be updated when there is no CDP version specified")
+    public void testUpdateRuntimeVersionFromCloudbreakWithoutCDHVersion() {
+        when(sdxService.getById(1L)).thenReturn(sdxCluster);
+        StackV4Response stackV4Response = getStackV4Response();
+        ClouderaManagerProductV4Response cdp = new ClouderaManagerProductV4Response();
+        cdp.setName("CDH");
+        stackV4Response.getCluster().getCm().setProducts(List.of(cdp));
+        when(stackV4Endpoint.get(0L, "test-sdx-cluster", Set.of())).thenReturn(stackV4Response);
+
+        underTest.updateRuntimeVersionFromCloudbreak(1L);
+
+        verify(sdxClusterRepository, times(0)).save(any());
+    }
+
+    private StackV4Response getStackV4Response() {
+        ClouderaManagerProductV4Response cdp = new ClouderaManagerProductV4Response();
+        cdp.setName("CDH");
+        cdp.setVersion("7.2.1-1.cdh7.2.0.p0.3758356");
+
+        ClouderaManagerProductV4Response cfm = new ClouderaManagerProductV4Response();
+        cfm.setName("CFM");
+        cfm.setVersion("2.0.0.0");
+
+        ClouderaManagerProductV4Response spark3 = new ClouderaManagerProductV4Response();
+        spark3.setName("SPARK3");
+        spark3.setVersion("3.0.0.2.99.7110.0-18-1.p0.3525631");
+
+        ClouderaManagerV4Response cm = new ClouderaManagerV4Response();
+        cm.setProducts(List.of(cdp, cfm, spark3));
+
+        ClusterV4Response clusterV4Response = new ClusterV4Response();
+        clusterV4Response.setCm(cm);
+
+        StackV4Response stackV4Response = new StackV4Response();
+        stackV4Response.setName("test-sdx-cluster");
+        stackV4Response.setCluster(clusterV4Response);
+
+        return stackV4Response;
+    }
+
+    private SdxCluster getValidSdxCluster() {
+        SdxCluster sdxCluster = new SdxCluster();
+        sdxCluster.setClusterName("test-sdx-cluster");
+        sdxCluster.setClusterShape(SdxClusterShape.LIGHT_DUTY);
+        sdxCluster.setEnvName("test-env");
+        sdxCluster.setCrn("crn:sdxcluster");
+        sdxCluster.setRuntime("7.2.0");
+        sdxCluster.setId(1L);
+        return sdxCluster;
+    }
+}


### PR DESCRIPTION
During upgrade we might change the runtime version. For example
we can upgrade from 7.2.0 to 7.2.1. This version is used on the
UI to offer Data Hubs to create. If it's not updated then the
UI will offer the old runtime version of 7.2.0 which might not
be compatible with the upgraded version of 7.2.1.
