### PR TITLE
CB-7578: Run backup and restore against an embedded PostgreSQL database.

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/.pgpass
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/.pgpass
@@ -1,3 +1,6 @@
+{% set configure_remote_db = salt['pillar.get']('postgres:configure_remote_db', 'None') %}
+{% if 'None' != configure_remote_db %}
 {{ pillar['postgres']['remote_db_url'] }}:{{ pillar['postgres']['remote_db_port'] }}:hive:{{ pillar['postgres']['remote_admin'] }}:{{ pillar['postgres']['remote_admin_pw'] }}
 {{ pillar['postgres']['remote_db_url'] }}:{{ pillar['postgres']['remote_db_port'] }}:ranger:{{ pillar['postgres']['remote_admin'] }}:{{ pillar['postgres']['remote_admin_pw'] }}
 {{ pillar['postgres']['remote_db_url'] }}:{{ pillar['postgres']['remote_db_port'] }}:postgres:{{ pillar['postgres']['remote_admin'] }}:{{ pillar['postgres']['remote_admin_pw'] }}
+{% endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/backup.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/backup.sls
@@ -1,16 +1,21 @@
 {% set configure_remote_db = salt['pillar.get']('postgres:configure_remote_db', 'None') %}
 
-{% if 'None' != configure_remote_db %}
 
 include:
   - postgresql.disaster_recovery
 
+{% if 'None' != configure_remote_db %}
 backup_postgresql_db:
   cmd.run:
     - name: /opt/salt/scripts/backup_db.sh {{salt['pillar.get']('platform')}} {{salt['pillar.get']('disaster_recovery:object_storage_url')}} {{salt['pillar.get']('postgres:remote_db_url')}} {{salt['pillar.get']('postgres:remote_db_port')}} {{salt['pillar.get']('postgres:remote_admin')}}
     - require:
-        - sls: postgresql.disaster_recovery
+      - sls: postgresql.disaster_recovery
 
 {%- else %}
-{# Intentionally left blank, we're not handling backup of non-remote (embedded) DBs #}
+backup_postgresql_db:
+  cmd.run:
+    - name: /opt/salt/scripts/backup_db.sh {{salt['pillar.get']('platform')}} {{salt['pillar.get']('disaster_recovery:object_storage_url')}} "" "" "" "/var/lib/pgsql"
+    - runas: postgres
+    - require:
+      - sls: postgresql.disaster_recovery
 {% endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/restore.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/restore.sls
@@ -1,10 +1,9 @@
 {% set configure_remote_db = salt['pillar.get']('postgres:configure_remote_db', 'None') %}
 
-{% if 'None' != configure_remote_db %}
-
 include:
   - postgresql.disaster_recovery
 
+{% if 'None' != configure_remote_db %}
 restore_postgresql_db:
   cmd.run:
     - name: /opt/salt/scripts/restore_db.sh {{salt['pillar.get']('platform')}} {{salt['pillar.get']('disaster_recovery:object_storage_url')}} {{salt['pillar.get']('postgres:remote_db_url')}} {{salt['pillar.get']('postgres:remote_db_port')}} {{salt['pillar.get']('postgres:remote_admin')}}
@@ -12,5 +11,10 @@ restore_postgresql_db:
         - sls: postgresql.disaster_recovery
 
 {%- else %}
-{# Intentionally left blank, we're not handling backup of non-remote (embedded) DBs #}
+restore_postgresql_db:
+  cmd.run:
+    - name: /opt/salt/scripts/restore_db.sh {{salt['pillar.get']('platform')}} {{salt['pillar.get']('disaster_recovery:object_storage_url')}} "" "" "" "/var/lib/pgsql"
+    - runas: postgres
+    - require:
+        - sls: postgresql.disaster_recovery
 {% endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
@@ -9,7 +9,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ $# -ne 5 ]; then
+if [[ $# -ne 5 && $# -ne 6 ]]; then
   echo "Invalid inputs provided"
   echo "Script accepts 5 inputs:"
   echo "  1. Cloud Provider (azure | aws)"
@@ -17,6 +17,7 @@ if [ $# -ne 5 ]; then
   echo "  3. PostgreSQL host name."
   echo "  4. PostgreSQL port."
   echo "  5. PostgreSQL user name."
+  echo "  6. (optional) Log file location"
   exit 1
 fi
 
@@ -26,8 +27,7 @@ HOST="$3"
 PORT="$4"
 USERNAME="$5"
 
-LOGFILE=/var/log/dl_postgres_backup.log
-
+LOGFILE=${6:-/var/log/}/dl_postgres_backup.log
 echo "Logs at ${LOGFILE}"
 
 doLog() {

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/restore_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/restore_db.sh
@@ -8,7 +8,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ $# -ne 5 ]; then
+if [[ $# -ne 5 && $# -ne 6 ]]; then
   echo "Invalid inputs provided"
   echo "Script accepts 5 inputs:"
   echo "  1. Cloud Provider (azure | aws)"
@@ -16,6 +16,7 @@ if [ $# -ne 5 ]; then
   echo "  3. PostgreSQL host name."
   echo "  4. PostgreSQL port."
   echo "  5. PostgreSQL user name."
+  echo "  6. (optional) Log file location"
   exit 1
 fi
 
@@ -25,7 +26,7 @@ HOST="$3"
 PORT="$4"
 USERNAME="$5"
 
-LOGFILE=/var/log/dl_postgres_restore.log
+LOGFILE=${6:-/var/log/}/dl_postgres_backup.log
 echo "Logs at ${LOGFILE}"
 
 BACKUPS_DIR="/var/tmp/postgres_restore_staging"
@@ -75,6 +76,7 @@ run_aws_restore () {
   rm -rfv "$BACKUPS_DIR" > >(tee -a $LOGFILE) 2> >(tee -a $LOGFILE >&2)
 }
 
+doLog "INFO Initiating restore"
 if [[ "$CLOUD_PROVIDER" == "azure" ]]; then
   run_azure_restore
 elif [[ "$CLOUD_PROVIDER" == "aws" ]]; then


### PR DESCRIPTION
Closes [CB-7578](https://jira.cloudera.com/browse/CB-7578).

* Make the `.pgpass` file empty if we're using an embedded db
* Pass empty string parameters `""` to the backup and restore script for host url, port, and username
* `psql` cli tools will default to `localhost:5432` and `postgres` as the host, port, and user if none are provided -- this matches up with the embedded db case.
* Provide a configurable location for log output.

The embedded PostgreSQL DB listens at `localhost:5432` and allows connections from the `postgres` system user without credentials.
The normal `/var/logs` directory is not accessible to the `postgres` user without further changes to the system. It was easier to provide configurable logging location.

Tested by copying the salt states over to a Data Lake master node, and running the backup and restore salt commands. 
Performed once against a master node running an external database, and once using an embedded database.