### PR TITLE
Missing error handling for RedbeamsTerminationActions$4

### DIFF
--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/start/actions/StartDatabaseServerFailedAction.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/start/actions/StartDatabaseServerFailedAction.java
@@ -1,5 +1,15 @@
 package com.sequenceiq.redbeams.flow.redbeams.start.actions;
 
+import java.util.Map;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.statemachine.StateContext;
+import org.springframework.stereotype.Component;
+
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.flow.core.Flow;
 import com.sequenceiq.flow.core.FlowParameters;
@@ -13,13 +23,6 @@ import com.sequenceiq.redbeams.flow.redbeams.start.RedbeamsStartState;
 import com.sequenceiq.redbeams.metrics.MetricType;
 import com.sequenceiq.redbeams.metrics.RedbeamsMetricService;
 import com.sequenceiq.redbeams.service.stack.DBStackStatusUpdater;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.statemachine.StateContext;
-import org.springframework.stereotype.Component;
-
-import javax.inject.Inject;
-import java.util.Map;
 
 @Component("REDBEAMS_START_FAILED_STATE")
 public class StartDatabaseServerFailedAction extends AbstractRedbeamsStartAction<RedbeamsFailureEvent> {
@@ -42,7 +45,7 @@ public class StartDatabaseServerFailedAction extends AbstractRedbeamsStartAction
         LOGGER.info("Error during database server start flow:", failureException);
 
         String errorReason = failureException == null ? "Unknown error" : failureException.getMessage();
-        DBStack dbStack = dbStackStatusUpdater.updateStatus(payload.getResourceId(), DetailedDBStackStatus.START_FAILED, errorReason);
+        Optional<DBStack> dbStack = dbStackStatusUpdater.updateStatus(payload.getResourceId(), DetailedDBStackStatus.START_FAILED, errorReason);
         metricService.incrementMetricCounter(MetricType.DB_START_FAILED, dbStack);
     }
 

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/start/actions/StartDatabaseServerFinishedAction.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/start/actions/StartDatabaseServerFinishedAction.java
@@ -1,5 +1,12 @@
 package com.sequenceiq.redbeams.flow.redbeams.start.actions;
 
+import java.util.Map;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.redbeams.api.model.common.DetailedDBStackStatus;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
@@ -10,10 +17,6 @@ import com.sequenceiq.redbeams.flow.redbeams.start.event.StartDatabaseServerSucc
 import com.sequenceiq.redbeams.metrics.MetricType;
 import com.sequenceiq.redbeams.metrics.RedbeamsMetricService;
 import com.sequenceiq.redbeams.service.stack.DBStackStatusUpdater;
-import org.springframework.stereotype.Component;
-
-import javax.inject.Inject;
-import java.util.Map;
 
 @Component("REDBEAMS_START_FINISHED_STATE")
 public class StartDatabaseServerFinishedAction extends AbstractRedbeamsStartAction<StartDatabaseServerSuccess> {
@@ -30,7 +33,7 @@ public class StartDatabaseServerFinishedAction extends AbstractRedbeamsStartActi
 
     @Override
     protected void prepareExecution(StartDatabaseServerSuccess payload, Map<Object, Object> variables) {
-        DBStack dbStack = dbStackStatusUpdater.updateStatus(payload.getResourceId(), DetailedDBStackStatus.STARTED);
+        Optional<DBStack> dbStack = dbStackStatusUpdater.updateStatus(payload.getResourceId(), DetailedDBStackStatus.STARTED);
         metricService.incrementMetricCounter(MetricType.DB_START_FINISHED, dbStack);
     }
 

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/stop/actions/StopDatabaseServerFailedAction.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/stop/actions/StopDatabaseServerFailedAction.java
@@ -1,5 +1,15 @@
 package com.sequenceiq.redbeams.flow.redbeams.stop.actions;
 
+import java.util.Map;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.statemachine.StateContext;
+import org.springframework.stereotype.Component;
+
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.flow.core.Flow;
 import com.sequenceiq.flow.core.FlowParameters;
@@ -13,13 +23,6 @@ import com.sequenceiq.redbeams.flow.redbeams.stop.RedbeamsStopState;
 import com.sequenceiq.redbeams.metrics.MetricType;
 import com.sequenceiq.redbeams.metrics.RedbeamsMetricService;
 import com.sequenceiq.redbeams.service.stack.DBStackStatusUpdater;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.statemachine.StateContext;
-import org.springframework.stereotype.Component;
-
-import javax.inject.Inject;
-import java.util.Map;
 
 @Component("REDBEAMS_STOP_FAILED_STATE")
 public class StopDatabaseServerFailedAction extends AbstractRedbeamsStopAction<RedbeamsFailureEvent> {
@@ -42,7 +45,7 @@ public class StopDatabaseServerFailedAction extends AbstractRedbeamsStopAction<R
         LOGGER.info("Error during database server stop flow:", failureException);
 
         String errorReason = failureException == null ? "Unknown error" : failureException.getMessage();
-        DBStack dbStack = dbStackStatusUpdater.updateStatus(payload.getResourceId(), DetailedDBStackStatus.STOP_FAILED, errorReason);
+        Optional<DBStack> dbStack = dbStackStatusUpdater.updateStatus(payload.getResourceId(), DetailedDBStackStatus.STOP_FAILED, errorReason);
         metricService.incrementMetricCounter(MetricType.DB_STOP_FAILED, dbStack);
     }
 

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/stop/actions/StopDatabaseServerFinishedAction.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/stop/actions/StopDatabaseServerFinishedAction.java
@@ -1,5 +1,12 @@
 package com.sequenceiq.redbeams.flow.redbeams.stop.actions;
 
+import java.util.Map;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.redbeams.api.model.common.DetailedDBStackStatus;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
@@ -10,10 +17,6 @@ import com.sequenceiq.redbeams.flow.redbeams.stop.event.StopDatabaseServerSucces
 import com.sequenceiq.redbeams.metrics.MetricType;
 import com.sequenceiq.redbeams.metrics.RedbeamsMetricService;
 import com.sequenceiq.redbeams.service.stack.DBStackStatusUpdater;
-import org.springframework.stereotype.Component;
-
-import javax.inject.Inject;
-import java.util.Map;
 
 @Component("REDBEAMS_STOP_FINISHED_STATE")
 public class StopDatabaseServerFinishedAction extends AbstractRedbeamsStopAction<StopDatabaseServerSuccess> {
@@ -30,7 +33,7 @@ public class StopDatabaseServerFinishedAction extends AbstractRedbeamsStopAction
 
     @Override
     protected void prepareExecution(StopDatabaseServerSuccess payload, Map<Object, Object> variables) {
-        DBStack dbStack = dbStackStatusUpdater.updateStatus(payload.getResourceId(), DetailedDBStackStatus.STOPPED);
+        Optional<DBStack> dbStack = dbStackStatusUpdater.updateStatus(payload.getResourceId(), DetailedDBStackStatus.STOPPED);
         metricService.incrementMetricCounter(MetricType.DB_STOP_FINISHED, dbStack);
     }
 

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/termination/action/RedbeamsTerminationActions.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/termination/action/RedbeamsTerminationActions.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.redbeams.flow.redbeams.termination.action;
 
 import java.util.Map;
+import java.util.Optional;
 
 import javax.inject.Inject;
 
@@ -102,8 +103,8 @@ public class RedbeamsTerminationActions {
             protected Selectable createRequest(RedbeamsContext context) {
                 // Delete the DB stack here instead of deregistration so that we can keep track of its status
                 // through the termination
-                metricService.incrementMetricCounter(MetricType.DB_TERMINATION_FINISHED, context.getDBStack());
-                dbStackService.delete(context.getDBStack());
+                metricService.incrementMetricCounter(MetricType.DB_TERMINATION_FINISHED, Optional.of(context.getDBStack()));
+                dbStackService.delete(context.getDBStack().getId());
 
                 return new RedbeamsEvent(RedbeamsTerminationEvent.REDBEAMS_TERMINATION_FINISHED_EVENT.name(), 0L);
             }
@@ -128,7 +129,7 @@ public class RedbeamsTerminationActions {
                 } else {
                     // StackCreationActions / StackCreationService only update status if stack isn't mid-deletion
                     String errorReason = failureException == null ? "Unknown error" : failureException.getMessage();
-                    DBStack dbStack = dbStackStatusUpdater.updateStatus(payload.getResourceId(), DetailedDBStackStatus.DELETE_FAILED, errorReason);
+                    Optional<DBStack> dbStack = dbStackStatusUpdater.updateStatus(payload.getResourceId(), DetailedDBStackStatus.DELETE_FAILED, errorReason);
                     metricService.incrementMetricCounter(MetricType.DB_TERMINATION_FAILED, dbStack);
                 }
 

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/metrics/RedbeamsMetricService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/metrics/RedbeamsMetricService.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.redbeams.metrics;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.common.metrics.AbstractMetricService;
@@ -15,9 +17,11 @@ public class RedbeamsMetricService extends AbstractMetricService {
         return METRIC_PREFIX;
     }
 
-    public void incrementMetricCounter(MetricType metricType, DBStack dbStack) {
-        String dbVendorName = dbStack != null ? dbStack.getDatabaseServer()
-                != null ? dbStack.getDatabaseServer().getDatabaseVendor().displayName() : "UNKNOWN" : "UNKNOWN";
+    public void incrementMetricCounter(MetricType metricType, Optional<DBStack> dbStack) {
+        String dbVendorName = dbStack
+                .filter(db -> db.getDatabaseServer() != null)
+                .map(db -> db.getDatabaseServer().getDatabaseVendor().displayName())
+                .orElse("UNKNOWN");
         incrementMetricCounter(metricType,
                 RedbeamsMetricTag.DATABASE_VENDOR.name(), dbVendorName);
     }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/DBStackService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/DBStackService.java
@@ -67,4 +67,10 @@ public class DBStackService {
     public void delete(DBStack dbStack) {
         dbStackRepository.delete(dbStack);
     }
+
+    @Transactional
+    public void delete(Long dbStackId) {
+        dbStackRepository.deleteById(dbStackId);
+    }
+
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/RedbeamsStartService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/RedbeamsStartService.java
@@ -1,15 +1,16 @@
 package com.sequenceiq.redbeams.service.stack;
 
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
 import com.sequenceiq.redbeams.api.model.common.DetailedDBStackStatus;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
 import com.sequenceiq.redbeams.flow.RedbeamsFlowManager;
 import com.sequenceiq.redbeams.flow.redbeams.common.RedbeamsEvent;
 import com.sequenceiq.redbeams.flow.redbeams.start.RedbeamsStartEvent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Service;
-
-import javax.inject.Inject;
 
 @Service
 public class RedbeamsStartService {
@@ -36,7 +37,7 @@ public class RedbeamsStartService {
             return;
         }
 
-        dbStack = dbStackStatusUpdater.updateStatus(dbStack.getId(), DetailedDBStackStatus.START_REQUESTED);
+        dbStackStatusUpdater.updateStatus(dbStack.getId(), DetailedDBStackStatus.START_REQUESTED);
 
         flowManager.notify(RedbeamsStartEvent.REDBEAMS_START_EVENT.selector(),
                 new RedbeamsEvent(RedbeamsStartEvent.REDBEAMS_START_EVENT.selector(), dbStack.getId()));

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/RedbeamsStopService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/RedbeamsStopService.java
@@ -1,15 +1,16 @@
 package com.sequenceiq.redbeams.service.stack;
 
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
 import com.sequenceiq.redbeams.api.model.common.DetailedDBStackStatus;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
 import com.sequenceiq.redbeams.flow.RedbeamsFlowManager;
 import com.sequenceiq.redbeams.flow.redbeams.common.RedbeamsEvent;
 import com.sequenceiq.redbeams.flow.redbeams.stop.RedbeamsStopEvent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Service;
-
-import javax.inject.Inject;
 
 @Service
 public class RedbeamsStopService {
@@ -36,7 +37,7 @@ public class RedbeamsStopService {
             return;
         }
 
-        dbStack = dbStackStatusUpdater.updateStatus(dbStack.getId(), DetailedDBStackStatus.STOP_REQUESTED);
+        dbStackStatusUpdater.updateStatus(dbStack.getId(), DetailedDBStackStatus.STOP_REQUESTED);
 
         flowManager.notify(RedbeamsStopEvent.REDBEAMS_STOP_EVENT.selector(),
                 new RedbeamsEvent(RedbeamsStopEvent.REDBEAMS_STOP_EVENT.selector(), dbStack.getId()));

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/RedbeamsTerminationService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/RedbeamsTerminationService.java
@@ -67,7 +67,7 @@ public class RedbeamsTerminationService {
             return server;
         }
 
-        dbStack = dbStackStatusUpdater.updateStatus(dbStack.getId(), DetailedDBStackStatus.DELETE_REQUESTED);
+        dbStackStatusUpdater.updateStatus(dbStack.getId(), DetailedDBStackStatus.DELETE_REQUESTED);
         // re-fetch to see new status
         server = databaseServerConfigService.getByCrn(crn);
 

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/start/actions/StartDatabaseServerFailedActionTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/start/actions/StartDatabaseServerFailedActionTest.java
@@ -1,5 +1,18 @@
 package com.sequenceiq.redbeams.flow.redbeams.start.actions;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.statemachine.StateContext;
+
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
@@ -21,16 +34,6 @@ import com.sequenceiq.redbeams.metrics.RedbeamsMetricService;
 import com.sequenceiq.redbeams.service.CredentialService;
 import com.sequenceiq.redbeams.service.stack.DBStackService;
 import com.sequenceiq.redbeams.service.stack.DBStackStatusUpdater;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.statemachine.StateContext;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class StartDatabaseServerFailedActionTest {
@@ -114,23 +117,23 @@ public class StartDatabaseServerFailedActionTest {
     @Test
     public void shouldUpdateStatusAndIncrementMetricOnPrepare() {
         RedbeamsFailureEvent event = new RedbeamsFailureEvent(RESOURCE_ID, exception);
-
-        when(dbStackStatusUpdater.updateStatus(RESOURCE_ID, DetailedDBStackStatus.START_FAILED, null)).thenReturn(dbStack);
+        Optional<DBStack> dbStackOptional = Optional.of(dbStack);
+        when(dbStackStatusUpdater.updateStatus(RESOURCE_ID, DetailedDBStackStatus.START_FAILED, null)).thenReturn(dbStackOptional);
 
         victim.prepareExecution(event, null);
 
-        verify(metricService).incrementMetricCounter(MetricType.DB_START_FAILED, dbStack);
+        verify(metricService).incrementMetricCounter(MetricType.DB_START_FAILED, dbStackOptional);
     }
 
     @Test
     public void shouldUpdateStatusWithUknownErrorAndIncrementMetricOnPrepare() {
         RedbeamsFailureEvent event = new RedbeamsFailureEvent(RESOURCE_ID, null);
-
-        when(dbStackStatusUpdater.updateStatus(RESOURCE_ID, DetailedDBStackStatus.START_FAILED, "Unknown error")).thenReturn(dbStack);
+        Optional<DBStack> dbStackOptional = Optional.of(dbStack);
+        when(dbStackStatusUpdater.updateStatus(RESOURCE_ID, DetailedDBStackStatus.START_FAILED, "Unknown error")).thenReturn(dbStackOptional);
 
         victim.prepareExecution(event, null);
 
-        verify(metricService).incrementMetricCounter(MetricType.DB_START_FAILED, dbStack);
+        verify(metricService).incrementMetricCounter(MetricType.DB_START_FAILED, dbStackOptional);
     }
 
     @Test

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/start/actions/StartDatabaseServerFinishedActionTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/start/actions/StartDatabaseServerFinishedActionTest.java
@@ -1,5 +1,17 @@
 package com.sequenceiq.redbeams.flow.redbeams.start.actions;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
@@ -13,15 +25,6 @@ import com.sequenceiq.redbeams.flow.redbeams.start.event.StartDatabaseServerSucc
 import com.sequenceiq.redbeams.metrics.MetricType;
 import com.sequenceiq.redbeams.metrics.RedbeamsMetricService;
 import com.sequenceiq.redbeams.service.stack.DBStackStatusUpdater;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class StartDatabaseServerFinishedActionTest {
@@ -54,14 +57,15 @@ public class StartDatabaseServerFinishedActionTest {
 
     @Test
     public void shouldUpdateStatusOnPrepare() {
-        when(dbStackStatusUpdater.updateStatus(RESOURCE_ID, DetailedDBStackStatus.STARTED)).thenReturn(dbStack);
+        Optional<DBStack> dbStackOptional = Optional.of(dbStack);
+        when(dbStackStatusUpdater.updateStatus(RESOURCE_ID, DetailedDBStackStatus.STARTED)).thenReturn(dbStackOptional);
 
         StartDatabaseServerSuccess event = new StartDatabaseServerSuccess(RESOURCE_ID);
 
         victim.prepareExecution(event, null);
 
         verify(dbStackStatusUpdater).updateStatus(RESOURCE_ID, DetailedDBStackStatus.STARTED);
-        verify(metricService).incrementMetricCounter(MetricType.DB_START_FINISHED, dbStack);
+        verify(metricService).incrementMetricCounter(MetricType.DB_START_FINISHED, dbStackOptional);
     }
 
     @Test

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/stop/actions/StopDatabaseServerFailedActionTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/stop/actions/StopDatabaseServerFailedActionTest.java
@@ -1,5 +1,18 @@
 package com.sequenceiq.redbeams.flow.redbeams.stop.actions;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.statemachine.StateContext;
+
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
@@ -21,16 +34,6 @@ import com.sequenceiq.redbeams.metrics.RedbeamsMetricService;
 import com.sequenceiq.redbeams.service.CredentialService;
 import com.sequenceiq.redbeams.service.stack.DBStackService;
 import com.sequenceiq.redbeams.service.stack.DBStackStatusUpdater;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.statemachine.StateContext;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class StopDatabaseServerFailedActionTest {
@@ -114,23 +117,23 @@ public class StopDatabaseServerFailedActionTest {
     @Test
     public void shouldUpdateStatusAndIncrementMetricOnPrepare() {
         RedbeamsFailureEvent event = new RedbeamsFailureEvent(RESOURCE_ID, exception);
-
-        when(dbStackStatusUpdater.updateStatus(RESOURCE_ID, DetailedDBStackStatus.STOP_FAILED, null)).thenReturn(dbStack);
+        Optional<DBStack> dbStackOptional = Optional.of(dbStack);
+        when(dbStackStatusUpdater.updateStatus(RESOURCE_ID, DetailedDBStackStatus.STOP_FAILED, null)).thenReturn(dbStackOptional);
 
         victim.prepareExecution(event, null);
 
-        verify(metricService).incrementMetricCounter(MetricType.DB_STOP_FAILED, dbStack);
+        verify(metricService).incrementMetricCounter(MetricType.DB_STOP_FAILED, dbStackOptional);
     }
 
     @Test
     public void shouldUpdateStatusWithUknownErrorAndIncrementMetricOnPrepare() {
         RedbeamsFailureEvent event = new RedbeamsFailureEvent(RESOURCE_ID, null);
-
-        when(dbStackStatusUpdater.updateStatus(RESOURCE_ID, DetailedDBStackStatus.STOP_FAILED, "Unknown error")).thenReturn(dbStack);
+        Optional<DBStack> dbStackOptional = Optional.of(dbStack);
+        when(dbStackStatusUpdater.updateStatus(RESOURCE_ID, DetailedDBStackStatus.STOP_FAILED, "Unknown error")).thenReturn(Optional.of(dbStack));
 
         victim.prepareExecution(event, null);
 
-        verify(metricService).incrementMetricCounter(MetricType.DB_STOP_FAILED, dbStack);
+        verify(metricService).incrementMetricCounter(MetricType.DB_STOP_FAILED, dbStackOptional);
     }
 
     @Test

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/stop/actions/StopDatabaseServerFinishedActionTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/flow/redbeams/stop/actions/StopDatabaseServerFinishedActionTest.java
@@ -1,5 +1,17 @@
 package com.sequenceiq.redbeams.flow.redbeams.stop.actions;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
@@ -13,15 +25,6 @@ import com.sequenceiq.redbeams.flow.redbeams.stop.event.StopDatabaseServerSucces
 import com.sequenceiq.redbeams.metrics.MetricType;
 import com.sequenceiq.redbeams.metrics.RedbeamsMetricService;
 import com.sequenceiq.redbeams.service.stack.DBStackStatusUpdater;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class StopDatabaseServerFinishedActionTest {
@@ -55,12 +58,12 @@ public class StopDatabaseServerFinishedActionTest {
     @Test
     public void shouldUpdateStatusOnPrepare() {
         StopDatabaseServerSuccess event = new StopDatabaseServerSuccess(RESOURCE_ID);
-
-        when(dbStackStatusUpdater.updateStatus(RESOURCE_ID, DetailedDBStackStatus.STOPPED)).thenReturn(dbStack);
+        Optional<DBStack> dbStackOptional = Optional.of(dbStack);
+        when(dbStackStatusUpdater.updateStatus(RESOURCE_ID, DetailedDBStackStatus.STOPPED)).thenReturn(dbStackOptional);
 
         victim.prepareExecution(event, null);
 
-        verify(metricService).incrementMetricCounter(MetricType.DB_STOP_FINISHED, dbStack);
+        verify(metricService).incrementMetricCounter(MetricType.DB_STOP_FINISHED, dbStackOptional);
     }
 
     @Test

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/service/stack/RedbeamsStartServiceTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/service/stack/RedbeamsStartServiceTest.java
@@ -1,12 +1,13 @@
 package com.sequenceiq.redbeams.service.stack;
 
-import com.sequenceiq.cloudbreak.auth.altus.Crn;
-import com.sequenceiq.redbeams.api.model.common.DetailedDBStackStatus;
-import com.sequenceiq.redbeams.api.model.common.Status;
-import com.sequenceiq.redbeams.domain.stack.DBStack;
-import com.sequenceiq.redbeams.flow.RedbeamsFlowManager;
-import com.sequenceiq.redbeams.flow.redbeams.common.RedbeamsEvent;
-import com.sequenceiq.redbeams.flow.redbeams.start.RedbeamsStartEvent;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,11 +16,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.redbeams.api.model.common.DetailedDBStackStatus;
+import com.sequenceiq.redbeams.api.model.common.Status;
+import com.sequenceiq.redbeams.domain.stack.DBStack;
+import com.sequenceiq.redbeams.flow.RedbeamsFlowManager;
+import com.sequenceiq.redbeams.flow.redbeams.common.RedbeamsEvent;
+import com.sequenceiq.redbeams.flow.redbeams.start.RedbeamsStartEvent;
 
 @ExtendWith(MockitoExtension.class)
 public class RedbeamsStartServiceTest {
@@ -57,7 +60,7 @@ public class RedbeamsStartServiceTest {
     public void shouldSetStartRequestedStatusAndNotifyTheFlowManager() {
         when(dbStack.getId()).thenReturn(1L);
         when(dbStack.getStatus()).thenReturn(Status.STOPPED);
-        when(dbStackStatusUpdater.updateStatus(dbStack.getId(), DetailedDBStackStatus.START_REQUESTED)).thenReturn(dbStack);
+        when(dbStackStatusUpdater.updateStatus(dbStack.getId(), DetailedDBStackStatus.START_REQUESTED)).thenReturn(Optional.of(dbStack));
         ArgumentCaptor<RedbeamsEvent> redbeamsEventArgumentCaptor = ArgumentCaptor.forClass(RedbeamsEvent.class);
 
         victim.startDatabaseServer(CRN_STRING);

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/service/stack/RedbeamsStopServiceTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/service/stack/RedbeamsStopServiceTest.java
@@ -1,12 +1,13 @@
 package com.sequenceiq.redbeams.service.stack;
 
-import com.sequenceiq.cloudbreak.auth.altus.Crn;
-import com.sequenceiq.redbeams.api.model.common.DetailedDBStackStatus;
-import com.sequenceiq.redbeams.api.model.common.Status;
-import com.sequenceiq.redbeams.domain.stack.DBStack;
-import com.sequenceiq.redbeams.flow.RedbeamsFlowManager;
-import com.sequenceiq.redbeams.flow.redbeams.common.RedbeamsEvent;
-import com.sequenceiq.redbeams.flow.redbeams.stop.RedbeamsStopEvent;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,11 +16,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.redbeams.api.model.common.DetailedDBStackStatus;
+import com.sequenceiq.redbeams.api.model.common.Status;
+import com.sequenceiq.redbeams.domain.stack.DBStack;
+import com.sequenceiq.redbeams.flow.RedbeamsFlowManager;
+import com.sequenceiq.redbeams.flow.redbeams.common.RedbeamsEvent;
+import com.sequenceiq.redbeams.flow.redbeams.stop.RedbeamsStopEvent;
 
 @ExtendWith(MockitoExtension.class)
 public class RedbeamsStopServiceTest {
@@ -56,7 +59,8 @@ public class RedbeamsStopServiceTest {
     public void shouldSetStopRequestedStatusAndNotifyTheFlowManager() {
         when(dbStack.getId()).thenReturn(1L);
         when(dbStack.getStatus()).thenReturn(Status.AVAILABLE);
-        when(dbStackStatusUpdater.updateStatus(dbStack.getId(), DetailedDBStackStatus.STOP_REQUESTED)).thenReturn(dbStack);
+        Optional<DBStack> dbStackOptional = Optional.of(dbStack);
+        when(dbStackStatusUpdater.updateStatus(dbStack.getId(), DetailedDBStackStatus.STOP_REQUESTED)).thenReturn(dbStackOptional);
         ArgumentCaptor<RedbeamsEvent> redbeamsEventArgumentCaptor = ArgumentCaptor.forClass(RedbeamsEvent.class);
 
         victim.stopDatabaseServer(CRN_STRING);

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/service/stack/RedbeamsTerminationServiceTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/service/stack/RedbeamsTerminationServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
 import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -172,7 +173,7 @@ class RedbeamsTerminationServiceTest {
     private void mockTerminationByCrn(String crn, DBStack dbStack, DatabaseServerConfig server) {
         doReturn(dbStack).when(dbStackService).getByCrn(crn);
         doReturn(server).when(databaseServerConfigService).getByCrn(crn);
-        doReturn(dbStack).when(dbStackStatusUpdater).updateStatus(dbStack.getId(), DetailedDBStackStatus.DELETE_REQUESTED);
+        doReturn(Optional.of(dbStack)).when(dbStackStatusUpdater).updateStatus(dbStack.getId(), DetailedDBStackStatus.DELETE_REQUESTED);
     }
 
     private void verifyTermination(long id) {


### PR DESCRIPTION
Problem: termination went failed because of an OptimisticLockException at delete of DBStack. Nevertheless the entry was deleted and the status could not be set during the failure handling (NPE), leading to another failure. This commit fixes setting the status and tries to fix the OptimisticLockException as well.

See detailed description in the commit message.