### PR TITLE
CB-7923 MetricEvaluator should send alerts in batch

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/ScalingHandlerUtil.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/ScalingHandlerUtil.java
@@ -1,0 +1,106 @@
+package com.sequenceiq.periscope.monitor;
+
+import static java.lang.Math.ceil;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.sequenceiq.cloudbreak.client.CloudbreakClient;
+import com.sequenceiq.cloudbreak.service.Clock;
+import com.sequenceiq.periscope.domain.BaseAlert;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.ScalingPolicy;
+import com.sequenceiq.periscope.monitor.executor.LoggedExecutorService;
+import com.sequenceiq.periscope.service.ClusterService;
+import com.sequenceiq.periscope.service.RejectedThreadService;
+import com.sequenceiq.periscope.utils.ClusterUtils;
+import com.sequenceiq.periscope.utils.TimeUtil;
+
+@Component
+public class ScalingHandlerUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ScalingHandlerUtil.class);
+
+    @Inject
+    private ApplicationContext applicationContext;
+
+    @Inject
+    private RejectedThreadService rejectedThreadService;
+
+    @Inject
+    private CloudbreakClient cloudbreakClient;
+
+    @Inject
+    private ClusterService clusterService;
+
+    @Inject
+    private LoggedExecutorService loggedExecutorService;
+
+    @Inject
+    private Clock clock;
+
+    public void scaleIfNeed(Cluster cluster, BaseAlert alert) {
+        ScalingPolicy policy = alert.getScalingPolicy();
+        int totalNodes = Math.toIntExact(cloudbreakClient.autoscaleEndpoint().getHostMetadataCountForAutoscale(cluster.getStackId(), policy.getHostGroup()));
+        int desiredNodeCount = getDesiredNodeCount(cluster, policy, totalNodes);
+        if (totalNodes != desiredNodeCount) {
+            cluster.setLastScalingActivityCurrent();
+            clusterService.save(cluster);
+            scale(cluster, policy);
+        } else {
+            LOGGER.info("No scaling activity required for '{}' policy", policy.getName());
+        }
+    }
+
+    private void scale(Cluster cluster, ScalingPolicy policy) {
+        int totalNodes = Math.toIntExact(cloudbreakClient.autoscaleEndpoint().getHostMetadataCountForAutoscale(cluster.getStackId(), policy.getHostGroup()));
+        int desiredNodeCount = getDesiredNodeCount(cluster, policy, totalNodes);
+        Runnable scalingRequest = (Runnable) applicationContext.getBean("ScalingRequest", cluster, policy, totalNodes, desiredNodeCount);
+        loggedExecutorService.submit("ScalingHandler", scalingRequest);
+        rejectedThreadService.remove(cluster.getId());
+    }
+
+    public boolean isCooldownElapsed(Cluster cluster) {
+        long remainingTime = getRemainingCooldownTime(cluster);
+        if (remainingTime <= 0) {
+            return true;
+        }
+        LOGGER.info("Cluster cannot be scaled for {} min(s)",
+                ClusterUtils.TIME_FORMAT.format((double) remainingTime / TimeUtil.MIN_IN_MS));
+        return false;
+    }
+
+    private long getRemainingCooldownTime(Cluster cluster) {
+        long coolDown = cluster.getCoolDown();
+        long lastScalingActivity = cluster.getLastScalingActivity();
+        return lastScalingActivity == 0L ? 0L : (coolDown * TimeUtil.MIN_IN_MS) - (clock.getCurrentTime() - lastScalingActivity);
+    }
+
+    @VisibleForTesting
+    protected int getDesiredNodeCount(Cluster cluster, ScalingPolicy policy, int totalNodes) {
+        int scalingAdjustment = policy.getScalingAdjustment();
+        int desiredNodeCount;
+        switch (policy.getAdjustmentType()) {
+            case NODE_COUNT:
+                desiredNodeCount = totalNodes + scalingAdjustment;
+                break;
+            case PERCENTAGE:
+                desiredNodeCount = totalNodes
+                        + (int) (ceil(totalNodes * ((double) scalingAdjustment / ClusterUtils.MAX_CAPACITY)));
+                break;
+            case EXACT:
+                desiredNodeCount = policy.getScalingAdjustment();
+                break;
+            default:
+                desiredNodeCount = totalNodes;
+        }
+        int minSize = cluster.getMinSize();
+        int maxSize = cluster.getMaxSize();
+        return desiredNodeCount < minSize ? minSize : Math.min(desiredNodeCount, maxSize);
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/event/ScalingEvent.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/event/ScalingEvent.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.periscope.monitor.event;
 
+import java.util.List;
+
 import org.springframework.context.ApplicationEvent;
 
 import com.sequenceiq.periscope.domain.BaseAlert;
@@ -7,11 +9,15 @@ import com.sequenceiq.periscope.domain.BaseAlert;
 public class ScalingEvent extends ApplicationEvent {
 
     public ScalingEvent(BaseAlert alert) {
-        super(alert);
+        this(List.of(alert));
     }
 
-    public BaseAlert getAlert() {
-        return (BaseAlert) getSource();
+    public ScalingEvent(List<? extends BaseAlert> alerts) {
+        super(alerts);
+    }
+
+    public List<BaseAlert> getAlerts() {
+        return (List<BaseAlert>) getSource();
     }
 
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ScalingHandler.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ScalingHandler.java
@@ -1,105 +1,38 @@
 package com.sequenceiq.periscope.monitor.handler;
 
-import static java.lang.Math.ceil;
+import java.util.List;
 
 import javax.inject.Inject;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.client.CloudbreakClient;
-import com.sequenceiq.periscope.aspects.AmbariRequestLogging;
 import com.sequenceiq.periscope.domain.BaseAlert;
 import com.sequenceiq.periscope.domain.Cluster;
-import com.sequenceiq.periscope.domain.ScalingPolicy;
 import com.sequenceiq.periscope.log.MDCBuilder;
+import com.sequenceiq.periscope.monitor.ScalingHandlerUtil;
 import com.sequenceiq.periscope.monitor.event.ScalingEvent;
-import com.sequenceiq.periscope.monitor.executor.LoggedExecutorService;
 import com.sequenceiq.periscope.service.ClusterService;
-import com.sequenceiq.periscope.service.RejectedThreadService;
-import com.sequenceiq.periscope.utils.ClusterUtils;
-import com.sequenceiq.periscope.utils.TimeUtil;
 
 @Component
 public class ScalingHandler implements ApplicationListener<ScalingEvent> {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(ScalingHandler.class);
-
-    @Inject
-    private LoggedExecutorService loggedExecutorService;
 
     @Inject
     private ClusterService clusterService;
 
     @Inject
-    private ApplicationContext applicationContext;
-
-    @Inject
-    private RejectedThreadService rejectedThreadService;
-
-    @Inject
-    private AmbariRequestLogging ambariRequestLogging;
-
-    @Inject
-    private CloudbreakClient cloudbreakClient;
+    private ScalingHandlerUtil scalingHandlerUtil;
 
     @Override
     public void onApplicationEvent(ScalingEvent event) {
-        BaseAlert alert = event.getAlert();
-        Cluster cluster = clusterService.findById(alert.getCluster().getId());
+        List<BaseAlert> alerts = event.getAlerts();
+        Long clusterId = alerts.stream().findFirst().map(ma -> ma.getCluster().getId()).orElseThrow();
+        Cluster cluster = clusterService.findById(clusterId);
         MDCBuilder.buildMdcContext(cluster);
-        scale(cluster, alert.getScalingPolicy());
-    }
-
-    private void scale(Cluster cluster, ScalingPolicy policy) {
-        long remainingTime = getRemainingCooldownTime(cluster);
-        if (remainingTime <= 0) {
-            int totalNodes = Math.toIntExact(cloudbreakClient.autoscaleEndpoint().getHostMetadataCountForAutoscale(cluster.getStackId(), policy.getHostGroup()));
-            int desiredNodeCount = getDesiredNodeCount(cluster, policy, totalNodes);
-            if (totalNodes != desiredNodeCount) {
-                Runnable scalingRequest = (Runnable) applicationContext.getBean("ScalingRequest", cluster, policy, totalNodes, desiredNodeCount);
-                loggedExecutorService.submit("ScalingHandler", scalingRequest);
-                rejectedThreadService.remove(cluster.getId());
-                cluster.setLastScalingActivityCurrent();
-                clusterService.save(cluster);
-            } else {
-                LOGGER.info("No scaling activity required");
+        alerts.forEach(alert -> {
+            if (scalingHandlerUtil.isCooldownElapsed(cluster)) {
+                scalingHandlerUtil.scaleIfNeed(cluster, alert);
             }
-        } else {
-            LOGGER.info("Cluster cannot be scaled for {} min(s)",
-                    ClusterUtils.TIME_FORMAT.format((double) remainingTime / TimeUtil.MIN_IN_MS));
-        }
+        });
     }
-
-    private long getRemainingCooldownTime(Cluster cluster) {
-        long coolDown = cluster.getCoolDown();
-        long lastScalingActivity = cluster.getLastScalingActivity();
-        return lastScalingActivity == 0L ? 0L : (coolDown * TimeUtil.MIN_IN_MS) - (System.currentTimeMillis() - lastScalingActivity);
-    }
-
-    private int getDesiredNodeCount(Cluster cluster, ScalingPolicy policy, int totalNodes) {
-        int scalingAdjustment = policy.getScalingAdjustment();
-        int desiredNodeCount;
-        switch (policy.getAdjustmentType()) {
-            case NODE_COUNT:
-                desiredNodeCount = totalNodes + scalingAdjustment;
-                break;
-            case PERCENTAGE:
-                desiredNodeCount = totalNodes
-                        + (int) (ceil(totalNodes * ((double) scalingAdjustment / ClusterUtils.MAX_CAPACITY)));
-                break;
-            case EXACT:
-                desiredNodeCount = policy.getScalingAdjustment();
-                break;
-            default:
-                desiredNodeCount = totalNodes;
-        }
-        int minSize = cluster.getMinSize();
-        int maxSize = cluster.getMaxSize();
-        return desiredNodeCount < minSize ? minSize : desiredNodeCount > maxSize ? maxSize : desiredNodeCount;
-    }
-
 }

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/ScalingHandlerUtilTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/ScalingHandlerUtilTest.java
@@ -1,0 +1,208 @@
+package com.sequenceiq.periscope.monitor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.context.ApplicationContext;
+
+import com.sequenceiq.cloudbreak.api.endpoint.autoscale.AutoscaleEndpoint;
+import com.sequenceiq.cloudbreak.client.CloudbreakClient;
+import com.sequenceiq.cloudbreak.service.Clock;
+import com.sequenceiq.periscope.api.model.AdjustmentType;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.MetricAlert;
+import com.sequenceiq.periscope.domain.ScalingPolicy;
+import com.sequenceiq.periscope.monitor.executor.LoggedExecutorService;
+import com.sequenceiq.periscope.service.ClusterService;
+import com.sequenceiq.periscope.service.RejectedThreadService;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ScalingHandlerUtilTest {
+
+    @Mock
+    private ApplicationContext applicationContext;
+
+    @Mock
+    private RejectedThreadService rejectedThreadService;
+
+    @Mock
+    private CloudbreakClient cloudbreakClient;
+
+    @Mock
+    private AutoscaleEndpoint autoscaleEndpoint;
+
+    @Mock
+    private ClusterService clusterService;
+
+    @Mock
+    private LoggedExecutorService loggedExecutorService;
+
+    @Mock
+    private Clock clock;
+
+    @InjectMocks
+    private ScalingHandlerUtil underTest;
+
+    @Test
+    public void testIsCooldownElapsedWhenLastActivityIsZero() {
+        Cluster cluster = new Cluster();
+        cluster.setLastScalingActivity(0L);
+        boolean actual = underTest.isCooldownElapsed(cluster);
+        assertTrue(actual);
+    }
+
+    @Test
+    public void testIsCooldownElapsedWhenCoolDownLessThenZero() {
+        Cluster cluster = new Cluster();
+        cluster.setCoolDown(1);
+        cluster.setLastScalingActivity(1000L);
+
+        when(clock.getCurrentTime()).thenReturn(70000L);
+
+        boolean actual = underTest.isCooldownElapsed(cluster);
+        assertTrue(actual);
+    }
+
+    @Test
+    public void testIsCooldownElapsedWhenCoolDownMoreThenZero() {
+        Cluster cluster = new Cluster();
+        cluster.setCoolDown(1);
+        cluster.setLastScalingActivity(7000L);
+
+        when(clock.getCurrentTime()).thenReturn(1000L);
+
+        boolean actual = underTest.isCooldownElapsed(cluster);
+        assertFalse(actual);
+    }
+
+    @Test
+    public void testIsCooldownElapsedWhenCoolDownIsZero() {
+        Cluster cluster = new Cluster();
+        cluster.setCoolDown(1);
+        cluster.setLastScalingActivity(1000L);
+
+        when(clock.getCurrentTime()).thenReturn(61000L);
+
+        boolean actual = underTest.isCooldownElapsed(cluster);
+        assertTrue(actual);
+    }
+
+    @Test
+    public void testScaleIfNeedWhenTotalNodesEqualsToDesiredNodeCount() {
+        Cluster cluster = new Cluster();
+        cluster.setStackId(10L);
+        cluster.setMinSize(1);
+        ScalingPolicy policy = new ScalingPolicy();
+        policy.setAdjustmentType(AdjustmentType.EXACT);
+        policy.setScalingAdjustment(1);
+        policy.setHostGroup("hg");
+        MetricAlert alert = new MetricAlert();
+        alert.setScalingPolicy(policy);
+        when(cloudbreakClient.autoscaleEndpoint()).thenReturn(autoscaleEndpoint);
+        when(autoscaleEndpoint.getHostMetadataCountForAutoscale(10L, "hg")).thenReturn(1L);
+        underTest.scaleIfNeed(cluster, alert);
+        verify(clusterService, times(0)).save(cluster);
+    }
+
+    @Test
+    public void testScaleIfNeedWhenTotalNodesNotEqualsToDesiredNodeCount() {
+        Runnable runnable = mock(Runnable.class);
+
+        Cluster cluster = new Cluster();
+        cluster.setStackId(10L);
+        cluster.setMinSize(1);
+        ScalingPolicy policy = new ScalingPolicy();
+        policy.setAdjustmentType(AdjustmentType.EXACT);
+        policy.setScalingAdjustment(2);
+        policy.setHostGroup("hg");
+        MetricAlert alert = new MetricAlert();
+        alert.setScalingPolicy(policy);
+        when(cloudbreakClient.autoscaleEndpoint()).thenReturn(autoscaleEndpoint);
+        when(autoscaleEndpoint.getHostMetadataCountForAutoscale(10L, "hg")).thenReturn(1L);
+        when(applicationContext.getBean("ScalingRequest", cluster, policy, 1, 2)).thenReturn(runnable);
+        underTest.scaleIfNeed(cluster, alert);
+        verify(clusterService, times(1)).save(cluster);
+        verify(loggedExecutorService, times(1)).submit("ScalingHandler", runnable);
+    }
+
+    @Test
+    public void testGetDesiredCountWhenExact() {
+        Cluster cluster = new Cluster();
+        cluster.setStackId(10L);
+        cluster.setMinSize(1);
+        ScalingPolicy policy = new ScalingPolicy();
+        policy.setAdjustmentType(AdjustmentType.EXACT);
+        policy.setScalingAdjustment(1);
+
+        int actual = underTest.getDesiredNodeCount(cluster, policy, 1);
+
+        assertEquals(1, actual);
+    }
+
+    @Test
+    public void testGetDesiredCountWhenNodeCount() {
+        Cluster cluster = new Cluster();
+        cluster.setStackId(10L);
+        cluster.setMinSize(1);
+        ScalingPolicy policy = new ScalingPolicy();
+        policy.setAdjustmentType(AdjustmentType.NODE_COUNT);
+        policy.setScalingAdjustment(1);
+
+        int actual = underTest.getDesiredNodeCount(cluster, policy, 1);
+
+        assertEquals(2, actual);
+    }
+
+    @Test
+    public void testGetDesiredCountWhenPercentage() {
+        Cluster cluster = new Cluster();
+        cluster.setStackId(10L);
+        cluster.setMinSize(1);
+        ScalingPolicy policy = new ScalingPolicy();
+        policy.setAdjustmentType(AdjustmentType.NODE_COUNT);
+        policy.setScalingAdjustment(20);
+
+        int actual = underTest.getDesiredNodeCount(cluster, policy, 5);
+
+        assertEquals(25, actual);
+    }
+
+    @Test
+    public void testGetDesiredCountWhenMinSizeMoreThanDesiredCount() {
+        Cluster cluster = new Cluster();
+        cluster.setStackId(10L);
+        cluster.setMinSize(5);
+        ScalingPolicy policy = new ScalingPolicy();
+        policy.setAdjustmentType(AdjustmentType.EXACT);
+        policy.setScalingAdjustment(1);
+
+        int actual = underTest.getDesiredNodeCount(cluster, policy, 1);
+
+        assertEquals(5, actual);
+    }
+
+    @Test
+    public void testGetDesiredCountWhenMaxSizeLessThanDesiredCount() {
+        Cluster cluster = new Cluster();
+        cluster.setStackId(10L);
+        cluster.setMinSize(5);
+        cluster.setMaxSize(10);
+        ScalingPolicy policy = new ScalingPolicy();
+        policy.setAdjustmentType(AdjustmentType.EXACT);
+        policy.setScalingAdjustment(30);
+
+        int actual = underTest.getDesiredNodeCount(cluster, policy, 1);
+
+        assertEquals(10, actual);
+    }
+}

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/handler/ScalingHandlerTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/handler/ScalingHandlerTest.java
@@ -1,0 +1,52 @@
+package com.sequenceiq.periscope.monitor.handler;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.MetricAlert;
+import com.sequenceiq.periscope.domain.PeriscopeUser;
+import com.sequenceiq.periscope.monitor.ScalingHandlerUtil;
+import com.sequenceiq.periscope.monitor.event.ScalingEvent;
+import com.sequenceiq.periscope.service.ClusterService;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ScalingHandlerTest {
+
+    @InjectMocks
+    private ScalingHandler underTest;
+
+    @Mock
+    private ClusterService clusterService;
+
+    @Mock
+    private ScalingHandlerUtil scalingHandlerUtil;
+
+    @Test
+    public void testOnApplicationEventWhenHasTwoAlerts() {
+        Cluster cluster = new Cluster();
+        cluster.setUser(new PeriscopeUser());
+        cluster.setId(2L);
+        MetricAlert alert1 = new MetricAlert();
+        alert1.setCluster(cluster);
+        MetricAlert alert2 = new MetricAlert();
+        alert2.setCluster(cluster);
+        ScalingEvent event = new ScalingEvent(List.of(alert1, alert2));
+
+        when(scalingHandlerUtil.isCooldownElapsed(cluster)).thenReturn(true).thenReturn(false);
+        when(clusterService.findById(2L)).thenReturn(cluster);
+        underTest.onApplicationEvent(event);
+
+        verify(scalingHandlerUtil, times(1)).scaleIfNeed(cluster, alert1);
+        verify(scalingHandlerUtil, times(0)).scaleIfNeed(cluster, alert2);
+    }
+}


### PR DESCRIPTION
The periscope starts the alerts one by one. If the first alert finishes before then the last alert starts, the last alert will be skipped because the cooldown is calculated from the last activity field. So, we should send the alerts in batch and iterate after the cooldown check.

