### PR TITLE
CB-8021 Replace DnsV1Endpoint#deleteDnsRecordsByFqdn call with cleanu…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/DecommissionHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/DecommissionHandler.java
@@ -127,7 +127,7 @@ public class DecommissionHandler implements EventHandler<DecommissionRequest> {
             boolean forced = request.getDetails() != null && request.getDetails().isForced();
             hostOrchestrator.stopClusterManagerAgent(gatewayConfig, decommissionedNodes, clusterDeletionBasedModel(stack.getId(), cluster.getId()),
                     kerberosDetailService.isAdJoinable(kerberosConfig), kerberosDetailService.isIpaJoinable(kerberosConfig), forced);
-            cleanUpFreeIpa(stack, hostsToRemove, forced);
+            cleanUpFreeIpa(stack, hostsToRemove);
             List<InstanceMetaData> decommisionedInstances = decommissionedHostNames.stream()
                     .map(hostsToRemove::get)
                     .filter(Objects::nonNull)
@@ -152,10 +152,10 @@ public class DecommissionHandler implements EventHandler<DecommissionRequest> {
         }
     }
 
-    private void cleanUpFreeIpa(Stack stack, Map<String, InstanceMetaData> hostsToRemove, boolean forced) {
+    private void cleanUpFreeIpa(Stack stack, Map<String, InstanceMetaData> hostsToRemove) {
         try {
             Set<String> ips = hostsToRemove.values().stream().map(InstanceMetaData::getPrivateIp).filter(StringUtils::isNotBlank).collect(Collectors.toSet());
-            freeIpaCleanupService.cleanup(stack, true, false, hostsToRemove.keySet(), ips);
+            freeIpaCleanupService.cleanupOnScale(stack, hostsToRemove.keySet(), ips);
         } catch (FreeIpaOperationFailedException | CloudbreakServiceException e) {
             LOGGER.warn("FreeIPA cleanup has failed during decommission, ignoring error", e);
         }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/CleanupFreeIpaHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/CleanupFreeIpaHandler.java
@@ -44,7 +44,13 @@ public class CleanupFreeIpaHandler implements EventHandler<CleanupFreeIpaEvent> 
         try {
             LOGGER.debug("Handle cleanup request for hosts: {} and IPs: {}", event.getHostNames(), event.getIps());
             Stack stack = stackService.get(event.getResourceId());
-            freeIpaCleanupService.cleanup(stack, true, event.isRecover(), event.getHostNames(), event.getIps());
+            if (event.isRecover()) {
+                LOGGER.debug("Invoke cleanup on recover");
+                freeIpaCleanupService.cleanupOnRecover(stack, event.getHostNames(), event.getIps());
+            } else {
+                LOGGER.debug("Invoke cleanup on scale");
+                freeIpaCleanupService.cleanupOnScale(stack, event.getHostNames(), event.getIps());
+            }
             LOGGER.debug("Cleanup finished for hosts: {} and IPs: {}", event.getHostNames(), event.getIps());
         } catch (Exception e) {
             LOGGER.error("FreeIPA cleanup failed for hosts {} and IPs: {}", event.getHostNames(), event.getIps(), e);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/freeipa/InstanceMetadataProcessor.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/freeipa/InstanceMetadataProcessor.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.cloudbreak.service.freeipa;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+
+@Component
+public class InstanceMetadataProcessor {
+
+    public Set<String> extractIps(Stack stack) {
+        return extractIps(stack.getInstanceMetaDataAsList());
+    }
+
+    public Set<String> extractIps(Collection<InstanceMetaData> instanceMetaData) {
+        return collectDataFromInstanceMetaDataList(instanceMetaData, InstanceMetaData::getPrivateIp);
+    }
+
+    public Set<String> extractFqdn(Stack stack) {
+        return extractFqdn(stack.getInstanceMetaDataAsList());
+    }
+
+    public Set<String> extractFqdn(Collection<InstanceMetaData> instanceMetaData) {
+        return collectDataFromInstanceMetaDataList(instanceMetaData, InstanceMetaData::getDiscoveryFQDN);
+    }
+
+    private Set<String> collectDataFromInstanceMetaDataList(Collection<InstanceMetaData> instanceMetaData,
+            Function<InstanceMetaData, String> instanceMetaDataStringFunction) {
+        return instanceMetaData.stream().map(instanceMetaDataStringFunction).filter(StringUtils::isNotBlank)
+                .collect(Collectors.toSet());
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/TerminationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/TerminationService.java
@@ -70,7 +70,7 @@ public class TerminationService {
     public void finalizeTermination(Long stackId, boolean force) {
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
         Date now = new Date();
-        cleanupFreeIpa(force, stack);
+        cleanupFreeIpa(stack);
         String terminatedName = stack.getName() + DELIMITER + now.getTime();
         if (stack.getType() == StackType.DATALAKE) {
             datalakeResourcesService.deleteWithDependenciesByStackId(stack.getId());
@@ -97,9 +97,9 @@ public class TerminationService {
         }
     }
 
-    private void cleanupFreeIpa(Boolean forcedTermination, Stack stack) {
+    private void cleanupFreeIpa(Stack stack) {
         try {
-            freeIpaCleanupService.cleanup(stack, false, false, null, null);
+            freeIpaCleanupService.cleanup(stack);
         } catch (Exception e) {
             LOGGER.warn("FreeIPA cleanup has failed during termination finalization, ignoring error", e);
         }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/CleanupFreeIpaHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/CleanupFreeIpaHandlerTest.java
@@ -1,0 +1,99 @@
+package com.sequenceiq.cloudbreak.reactor.handler.cluster;
+
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.provision.ClusterCreationEvent.CLEANUP_FREEIPA_FINISHED_EVENT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.reactor.api.event.stack.CleanupFreeIpaEvent;
+import com.sequenceiq.cloudbreak.service.freeipa.FreeIpaCleanupService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+
+import reactor.bus.Event;
+import reactor.bus.EventBus;
+
+@ExtendWith(MockitoExtension.class)
+class CleanupFreeIpaHandlerTest {
+
+    @Mock
+    private EventBus eventBus;
+
+    @Mock
+    private FreeIpaCleanupService freeIpaCleanupService;
+
+    @Mock
+    private StackService stackService;
+
+    @InjectMocks
+    private CleanupFreeIpaHandler underTest;
+
+    @Test
+    public void testRecover() {
+        Event<CleanupFreeIpaEvent> cleanupFreeIpaEvent = mock(Event.class);
+        Set<String> hostNames = Set.of("asdfg");
+        Set<String> ips = Set.of("1.1.1.1");
+        when(cleanupFreeIpaEvent.getData()).thenReturn(new CleanupFreeIpaEvent(1L, hostNames, ips, true));
+        Stack stack = new Stack();
+        when(stackService.get(1L)).thenReturn(stack);
+
+        underTest.accept(cleanupFreeIpaEvent);
+
+        verify(freeIpaCleanupService).cleanupOnRecover(stack, hostNames, ips);
+        verify(freeIpaCleanupService, never()).cleanupOnScale(any(Stack.class), anySet(), anySet());
+        verify(eventBus).notify(eq(CLEANUP_FREEIPA_FINISHED_EVENT.event()), any(Event.class));
+    }
+
+    @Test
+    public void testNotRecover() {
+        Event<CleanupFreeIpaEvent> cleanupFreeIpaEvent = mock(Event.class);
+        Set<String> hostNames = Set.of("asdfg");
+        Set<String> ips = Set.of("1.1.1.1");
+        when(cleanupFreeIpaEvent.getData()).thenReturn(new CleanupFreeIpaEvent(1L, hostNames, ips, false));
+        Stack stack = new Stack();
+        when(stackService.get(1L)).thenReturn(stack);
+
+        underTest.accept(cleanupFreeIpaEvent);
+
+        verify(freeIpaCleanupService).cleanupOnScale(stack, hostNames, ips);
+        verify(freeIpaCleanupService, never()).cleanupOnRecover(any(Stack.class), anySet(), anySet());
+        verify(eventBus).notify(eq(CLEANUP_FREEIPA_FINISHED_EVENT.event()), any(Event.class));
+    }
+
+    @Test
+    public void testEventSentOnErrorNotRecover() {
+        Event<CleanupFreeIpaEvent> cleanupFreeIpaEvent = mock(Event.class);
+        when(cleanupFreeIpaEvent.getData()).thenReturn(new CleanupFreeIpaEvent(1L, Set.of(), Set.of(), false));
+        when(stackService.get(1L)).thenReturn(new Stack());
+        doThrow(new RuntimeException()).when(freeIpaCleanupService).cleanupOnScale(any(Stack.class), anySet(), anySet());
+
+        underTest.accept(cleanupFreeIpaEvent);
+
+        verify(eventBus).notify(eq(CLEANUP_FREEIPA_FINISHED_EVENT.event()), any(Event.class));
+    }
+
+    @Test
+    public void testEventSentOnErrorRecover() {
+        Event<CleanupFreeIpaEvent> cleanupFreeIpaEvent = mock(Event.class);
+        when(cleanupFreeIpaEvent.getData()).thenReturn(new CleanupFreeIpaEvent(1L, Set.of(), Set.of(), true));
+        when(stackService.get(1L)).thenReturn(new Stack());
+        doThrow(new RuntimeException()).when(freeIpaCleanupService).cleanupOnRecover(any(Stack.class), anySet(), anySet());
+
+        underTest.accept(cleanupFreeIpaEvent);
+
+        verify(eventBus).notify(eq(CLEANUP_FREEIPA_FINISHED_EVENT.event()), any(Event.class));
+    }
+}


### PR DESCRIPTION
…p in CB

In case of downscale the above mentioned endpoint was invoked.
This is not an async call, which could result in timout.
This commit moves this call to cleanup, which has polling already.
Also some simple refactor is introduced to cleanup code.

See detailed description in the commit message.