### PR TITLE
CB-6359 Speedup hosts decommission

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterDecomissionService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterDecomissionService.java
@@ -25,6 +25,8 @@ public interface ClusterDecomissionService {
 
     void deleteHostFromCluster(InstanceMetaData data);
 
+    void deleteUnusedCredentialsFromCluster();
+
     void restartStaleServices() throws CloudbreakException;
 
     Map<String, Map<String, String>> getStatusOfComponentsForHost(String host);

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterDecomissionService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterDecomissionService.java
@@ -102,6 +102,11 @@ public class ClouderaManagerClusterDecomissionService implements ClusterDecomiss
     }
 
     @Override
+    public void deleteUnusedCredentialsFromCluster() {
+        clouderaManagerDecomissioner.deleteUnusedCredentialsFromCluster(stack, client);
+    }
+
+    @Override
     public void restartStaleServices() throws CloudbreakException {
         try {
             applicationContext.getBean(ClouderaManagerModificationService.class, stack, clientConfig)

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerDecomissioner.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerDecomissioner.java
@@ -258,17 +258,16 @@ public class ClouderaManagerDecomissioner {
         LOGGER.debug("Deleting host: [{}]", data.getDiscoveryFQDN());
         deleteRolesFromHost(stack, data, client);
         deleteHostFromClouderaManager(stack, data, client);
-        deleteUnusedCredentialsFromCluster(stack, data, client);
     }
 
-    private void deleteUnusedCredentialsFromCluster(Stack stack, InstanceMetaData data, ApiClient client) {
+    public void deleteUnusedCredentialsFromCluster(Stack stack, ApiClient client) {
         LOGGER.debug("Deleting unused credentials");
         ClouderaManagerResourceApi clouderaManagerResourceApi = clouderaManagerApiFactory.getClouderaManagerResourceApi(client);
         try {
             ApiCommand command = clouderaManagerResourceApi.deleteCredentialsCommand("unused");
             clouderaManagerPollingServiceProvider.startPollingCmKerberosJob(stack, client, command.getId());
         } catch (ApiException e) {
-            LOGGER.error("Failed to delete credentials of host: {}", data.getDiscoveryFQDN(), e);
+            LOGGER.error("Failed to delete unused credentials", e);
             throw new CloudbreakServiceException(e.getMessage(), e);
         }
     }


### PR DESCRIPTION
1. For autoscaling feature, we need fast scale up and scale down for better user experience and competitive edge.
2. Right now we decommission CM hosts one by one, which is slow and the decommission flow stops on the first failure.
3. The patch kicks off decommission in parallel and also it moved the delete unused credentials to post CM host deletion.
4. For a 10 node cluster just on the CM side, we reduce the host removal time from 8 mins to 3.5 mins, also we made it a constant instead of being linear.
5. The error reporting pattern of consolidating exceptions of parallel decommissions is similar to Azure host decommission.

./gradlew build && tested in private stack

1. Before : <img width="1443" alt="Screen Shot 2020-07-16 at 5 37 46 PM" src="https://user-images.githubusercontent.com/18580046/87997778-f1e83700-caaa-11ea-92ee-e34b6b662354.png">
2. After : <img width="1394" alt="Screen Shot 2020-07-20 at 4 48 05 PM" src="https://user-images.githubusercontent.com/18580046/87997783-f4e32780-caaa-11ea-86e2-89df32695da8.png">