### PR TITLE
CB-8060 Make FreeIPA install retryable

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_install.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_install.sh
@@ -5,6 +5,8 @@ set -e
 FQDN=$(hostname -f)
 IPADDR=$(hostname -i)
 
+ipa-server-install --unattended --uninstall
+
 ipa-server-install \
           --realm $REALM \
           --domain $DOMAIN \


### PR DESCRIPTION
If FreeIPA installation fails it couldn't be rerun as it would fail
with `FreeIPA already installed`.
In this commit uninstall is added prior install as the installation
script shouldn't run if there was a successful installation.
Only when FreeIPA isn't installed, or the installation failed would
run. This is ensured with the state and not in the script.