### PR TITLE
CB-7876 Save deletable TestContext resource names for API Cleanup

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/IntegrationTestApp.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/IntegrationTestApp.java
@@ -1,9 +1,16 @@
 package com.sequenceiq.it;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -34,6 +41,7 @@ import org.uncommons.reportng.JUnitXMLReporter;
 import com.google.common.collect.ImmutableMap;
 import com.sequenceiq.it.cloudbreak.cloud.v4.aws.AwsProperties;
 import com.sequenceiq.it.cloudbreak.listener.ReportListener;
+import com.sequenceiq.it.cloudbreak.listener.TestInvocationListener;
 import com.sequenceiq.it.cloudbreak.listener.ThreadLocalTestListener;
 import com.sequenceiq.it.cloudbreak.search.CustomHTMLReporter;
 import com.sequenceiq.it.config.ITProps;
@@ -112,6 +120,7 @@ public class IntegrationTestApp implements CommandLineRunner {
         testng.addListener(new CustomHTMLReporter());
         testng.addListener(new JUnitXMLReporter());
         testng.addListener(new ReportListener());
+        testng.addListener(new TestInvocationListener());
         setupSuites(testng);
         if (!CLEANUP_COMMAND.equals(itCommand)) {
             testng.run();
@@ -131,7 +140,7 @@ public class IntegrationTestApp implements CommandLineRunner {
             case "suiteurls":
                 List<String> suitePathes = itProps.getSuiteFiles();
                 testng.setXmlSuites(loadSuites(suitePathes));
-
+                removeOldResourceFiles();
                 break;
             case CLEANUP_COMMAND:
                 cleanupUtil.cleanupDistroxes();
@@ -184,5 +193,31 @@ public class IntegrationTestApp implements CommandLineRunner {
             result = YAML_PARSER;
         }
         return result;
+    }
+
+    /**
+     * Removes all the collected E2E test resources' files from the test folder (defined by 'outputDirectory') if there is any present.
+     */
+    private void removeOldResourceFiles() {
+        File folder = new File(outputDirectory);
+        Path folderPath = Path.of(folder.getPath()).normalize().toAbsolutePath();
+
+        File[] foundResourceFiles = Optional.ofNullable(folder.listFiles((file, path) -> path.contains("resource_names_"))).orElse(new File[0]);
+        if (foundResourceFiles.length > 0) {
+            Arrays.stream(foundResourceFiles).forEach(file -> {
+                try {
+                    FileTime creationTime = Files.readAttributes(Path.of(file.getName()), BasicFileAttributes.class).creationTime();
+                    if (file.delete()) {
+                        LOG.info("Old resource file: {} (creation time: {}) have been found and deleted at: {}.", file.getName(), creationTime, folderPath);
+                    } else {
+                        LOG.info("Old resource file: {} (creation time: {}) have NOT been deleted at: {}.", file.getName(), creationTime, folderPath);
+                    }
+                } catch (IOException e) {
+                    LOG.info("{} resource file get creation time throws exception: {}", file.getName(), e.getMessage(), e);
+                } catch (Exception e) {
+                    LOG.info("{} resource file cleanup has been failed, because of: {}", e.getMessage(), e);
+                }
+            });
+        }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
@@ -55,9 +55,9 @@ import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
 import com.sequenceiq.it.cloudbreak.finder.Attribute;
 import com.sequenceiq.it.cloudbreak.finder.Capture;
 import com.sequenceiq.it.cloudbreak.finder.Finder;
-import com.sequenceiq.it.cloudbreak.util.ErrorLogMessageProvider;
 import com.sequenceiq.it.cloudbreak.log.Log;
 import com.sequenceiq.it.cloudbreak.mock.DefaultModel;
+import com.sequenceiq.it.cloudbreak.util.ErrorLogMessageProvider;
 import com.sequenceiq.it.cloudbreak.util.ResponseUtil;
 import com.sequenceiq.it.cloudbreak.util.wait.FlowUtil;
 import com.sequenceiq.it.cloudbreak.util.wait.service.WaitService;
@@ -939,7 +939,7 @@ public abstract class TestContext implements ApplicationContextAware {
             try {
                 testDto.cleanUp(this, getCloudbreakClient(getActingUserAccessKey()));
             } catch (Exception e) {
-                LOGGER.error("Was not able to cleanup resource [{}]., {}", testDto.getName(), ResponseUtil.getErrorMessage(e), e);
+                LOGGER.error("Cleaning up of {} resource is failing, because of: {}", testDto.getName(), e.getMessage(), e);
             }
         }
         shutdown();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractTestDto.java
@@ -85,6 +85,10 @@ public abstract class AbstractTestDto<R, S, T extends CloudbreakTestDto, U exten
         this.name = name;
     }
 
+    public String getResourceNameType() {
+        return null;
+    }
+
     public R getRequest() {
         return request;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/CloudbreakTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/CloudbreakTestDto.java
@@ -24,6 +24,8 @@ public interface CloudbreakTestDto extends Orderable {
 
     String getName();
 
+    String getResourceNameType();
+
     CloudPlatform getCloudPlatform();
 
     default void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/blueprint/BlueprintTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/blueprint/BlueprintTestDto.java
@@ -16,7 +16,10 @@ import com.sequenceiq.it.cloudbreak.context.TestContext;
 
 @Prototype
 public class BlueprintTestDto extends AbstractCloudbreakTestDto<BlueprintV4Request, BlueprintV4Response, BlueprintTestDto> {
+
     public static final String BLUEPRINT = "BLUEPRINT";
+
+    private static final String BLUEPRINT_RESOURCE_NAME = "blueprintName";
 
     private Collection<BlueprintV4ViewResponse> viewResponses;
 
@@ -43,6 +46,11 @@ public class BlueprintTestDto extends AbstractCloudbreakTestDto<BlueprintV4Reque
         getRequest().setName(name);
         setName(name);
         return this;
+    }
+
+    @Override
+    public String getResourceNameType() {
+        return BLUEPRINT_RESOURCE_NAME;
     }
 
     public String getDescription() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/credential/CredentialTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/credential/CredentialTestDto.java
@@ -25,6 +25,8 @@ public class CredentialTestDto extends DeletableEnvironmentTestDto<CredentialReq
 
     public static final String CREDENTIAL = "CREDENTIAL";
 
+    private static final String CREDENTIAL_RESOURCE_NAME = "credentialName";
+
     @Inject
     private CredentialTestClient credentialTestClient;
 
@@ -47,6 +49,11 @@ public class CredentialTestDto extends DeletableEnvironmentTestDto<CredentialReq
         getRequest().setName(name);
         setName(name);
         return this;
+    }
+
+    @Override
+    public String getResourceNameType() {
+        return CREDENTIAL_RESOURCE_NAME;
     }
 
     public CredentialTestDto withDescription(String description) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/database/RedbeamsDatabaseTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/database/RedbeamsDatabaseTestDto.java
@@ -19,6 +19,8 @@ public class RedbeamsDatabaseTestDto extends DeletableRedbeamsTestDto<DatabaseV4
 
     public static final String DATABASE = "DATABASE";
 
+    private static final String REDBEAMS_RESOURCE_NAME = "redbeamsName";
+
     public RedbeamsDatabaseTestDto(TestContext testContext) {
         super(new DatabaseV4Request(), testContext);
     }
@@ -48,6 +50,11 @@ public class RedbeamsDatabaseTestDto extends DeletableRedbeamsTestDto<DatabaseV4
         getRequest().setName(name);
         setName(name);
         return this;
+    }
+
+    @Override
+    public String getResourceNameType() {
+        return REDBEAMS_RESOURCE_NAME;
     }
 
     public RedbeamsDatabaseTestDto withDescription(String description) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDtoBase.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDtoBase.java
@@ -26,6 +26,8 @@ import com.sequenceiq.sdx.api.model.SdxInternalClusterRequest;
 
 public class DistroXTestDtoBase<T extends DistroXTestDtoBase> extends AbstractCloudbreakTestDto<DistroXV1Request, StackV4Response, T> {
 
+    private static final String DISTROX_RESOURCE_NAME = "distroxName";
+
     protected DistroXTestDtoBase(DistroXV1Request request, TestContext testContext) {
         super(request, testContext);
     }
@@ -68,6 +70,11 @@ public class DistroXTestDtoBase<T extends DistroXTestDtoBase> extends AbstractCl
         getRequest().setName(name);
         setName(name);
         return this;
+    }
+
+    @Override
+    public String getResourceNameType() {
+        return DISTROX_RESOURCE_NAME;
     }
 
     public DistroXTestDtoBase<T> withCluster() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/image/DistroXImageTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/image/DistroXImageTestDto.java
@@ -12,6 +12,9 @@ import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
 
 @Prototype
 public class DistroXImageTestDto extends AbstractCloudbreakTestDto<DistroXImageV1Request, Response, DistroXImageTestDto> {
+
+    private static final String DISTROXIMAGE_RESOURCE_NAME = "distroxImageName";
+
     private static final String DEFAULT_SETTING_NAME = "test-image-setting" + '-' + UUID.randomUUID().toString().replaceAll("-", "");
 
     public DistroXImageTestDto(TestContext testContext) {
@@ -41,6 +44,11 @@ public class DistroXImageTestDto extends AbstractCloudbreakTestDto<DistroXImageV
     public DistroXImageTestDto withName(String name) {
         setName(name);
         return this;
+    }
+
+    @Override
+    public String getResourceNameType() {
+        return DISTROXIMAGE_RESOURCE_NAME;
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
@@ -51,6 +51,8 @@ public class EnvironmentTestDto
 
     public static final String ENVIRONMENT = "ENVIRONMENT";
 
+    private static final String ENVIRONMENT_RESOURCE_NAME = "environmentName";
+
     private static final int ORDER = 600;
 
     @Inject
@@ -120,6 +122,11 @@ public class EnvironmentTestDto
         getRequest().setName(name);
         setName(name);
         return this;
+    }
+
+    @Override
+    public String getResourceNameType() {
+        return ENVIRONMENT_RESOURCE_NAME;
     }
 
     public EnvironmentTestDto withIdBrokerMappingSource(IdBrokerMappingSource idBrokerMappingSource) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaTestDto.java
@@ -62,6 +62,8 @@ import com.sequenceiq.it.cloudbreak.search.Searchable;
 public class FreeIpaTestDto extends AbstractFreeIpaTestDto<CreateFreeIpaRequest, DescribeFreeIpaResponse, FreeIpaTestDto>
         implements Purgable<ListFreeIpaResponse, FreeIpaClient>, Searchable, Investigable {
 
+    private static final String FREEIPA_RESOURCE_NAME = "freeipaName";
+
     @Inject
     private FreeIpaTestClient freeIpaTestClient;
 
@@ -102,6 +104,11 @@ public class FreeIpaTestDto extends AbstractFreeIpaTestDto<CreateFreeIpaRequest,
         getRequest().setName(name);
         setName(name);
         return this;
+    }
+
+    @Override
+    public String getResourceNameType() {
+        return FREEIPA_RESOURCE_NAME;
     }
 
     public FreeIpaTestDto withTelemetry(String telemetry) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/imagecatalog/ImageCatalogTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/imagecatalog/ImageCatalogTestDto.java
@@ -23,6 +23,8 @@ public class ImageCatalogTestDto extends AbstractCloudbreakTestDto<ImageCatalogV
 
     public static final String IMAGE_CATALOG_URL = "IMAGE_CATALOG_URL";
 
+    private static final String IMAGECATALOG_RESOURCE_NAME = "imagecatalogName";
+
     private ImagesV4Response imagesV4Response;
 
     private Boolean skipCleanup = Boolean.FALSE;
@@ -44,6 +46,11 @@ public class ImageCatalogTestDto extends AbstractCloudbreakTestDto<ImageCatalogV
         getRequest().setName(name);
         setName(name);
         return this;
+    }
+
+    @Override
+    public String getResourceNameType() {
+        return IMAGECATALOG_RESOURCE_NAME;
     }
 
     public ImageCatalogTestDto withUrl(String url) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/ldap/LdapTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/ldap/LdapTestDto.java
@@ -16,6 +16,8 @@ import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 @Prototype
 public class LdapTestDto extends AbstractFreeIpaTestDto<CreateLdapConfigRequest, DescribeLdapConfigResponse, LdapTestDto> {
 
+    private static final String LDAP_RESOURCE_NAME = "ldapName";
+
     @Inject
     private LdapTestClient ldapTestClient;
 
@@ -69,6 +71,11 @@ public class LdapTestDto extends AbstractFreeIpaTestDto<CreateLdapConfigRequest,
         getRequest().setName(name);
         setName(name);
         return this;
+    }
+
+    @Override
+    public String getResourceNameType() {
+        return LDAP_RESOURCE_NAME;
     }
 
     public LdapTestDto withEnvironmentCrn(String environmentCrn) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/mock/HttpMock.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/mock/HttpMock.java
@@ -55,6 +55,8 @@ public class HttpMock implements CloudbreakTestDto {
 
     private String name;
 
+    private String resourceNameType;
+
     private TestContext testContext;
 
     private List<RequestData> requestList = new LinkedList<>();
@@ -75,6 +77,10 @@ public class HttpMock implements CloudbreakTestDto {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getResourceNameType() {
+        return resourceNameType;
     }
 
     public TestParameter getTestParameter() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/proxy/ProxyTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/proxy/ProxyTestDto.java
@@ -11,6 +11,8 @@ public class ProxyTestDto extends AbstractEnvironmentTestDto<ProxyRequest, Proxy
 
     public static final String PROXY_CONFIG = "PROXY_CONFIG";
 
+    private static final String PROXYCONFIG_RESOURCE_NAME = "proxyName";
+
     ProxyTestDto(String newId) {
         super(newId);
     }
@@ -42,6 +44,11 @@ public class ProxyTestDto extends AbstractEnvironmentTestDto<ProxyRequest, Proxy
         getRequest().setName(name);
         setName(name);
         return this;
+    }
+
+    @Override
+    public String getResourceNameType() {
+        return PROXYCONFIG_RESOURCE_NAME;
     }
 
     public ProxyTestDto withDescription(String description) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/recipe/RecipeTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/recipe/RecipeTestDto.java
@@ -21,6 +21,8 @@ import com.sequenceiq.it.cloudbreak.util.ResponseUtil;
 @Prototype
 public class RecipeTestDto extends DeletableTestDto<RecipeV4Request, RecipeV4Response, RecipeTestDto, RecipeViewV4Response> {
 
+    private static final String RECIPE_RESOURCE_NAME = "recipeName";
+
     private RecipeViewV4Responses simpleResponses;
 
     public RecipeTestDto(TestContext testContext) {
@@ -53,6 +55,11 @@ public class RecipeTestDto extends DeletableTestDto<RecipeV4Request, RecipeV4Res
         getRequest().setName(name);
         setName(name);
         return this;
+    }
+
+    @Override
+    public String getResourceNameType() {
+        return RECIPE_RESOURCE_NAME;
     }
 
     public RecipeTestDto withDescription(String description) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxInternalTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxInternalTestDto.java
@@ -63,6 +63,8 @@ import com.sequenceiq.sdx.api.model.SdxRepairRequest;
 public class SdxInternalTestDto extends AbstractSdxTestDto<SdxInternalClusterRequest, SdxClusterDetailResponse, SdxInternalTestDto>
         implements Purgable<SdxClusterResponse, SdxClient>, Investigable, Searchable {
 
+    private static final String SDX_RESOURCE_NAME = "sdxName";
+
     private static final String DEFAULT_SDX_NAME = "test-sdx" + '-' + UUID.randomUUID().toString().replaceAll("-", "");
 
     private static final String DEFAULT_CM_PASSWORD = "Admin123";
@@ -242,6 +244,11 @@ public class SdxInternalTestDto extends AbstractSdxTestDto<SdxInternalClusterReq
     public SdxInternalTestDto withName(String name) {
         setName(name);
         return this;
+    }
+
+    @Override
+    public String getResourceNameType() {
+        return SDX_RESOURCE_NAME;
     }
 
     public SdxInternalTestDto withImageCatalogNameOnly(String imageCatalogName) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
@@ -50,6 +50,8 @@ import com.sequenceiq.sdx.api.model.SdxRepairRequest;
 public class SdxTestDto extends AbstractSdxTestDto<SdxClusterRequest, SdxClusterDetailResponse, SdxTestDto> implements Purgable<SdxClusterResponse, SdxClient>,
         Investigable {
 
+    private static final String SDX_RESOURCE_NAME = "sdxName";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(SdxTestDto.class);
 
     private static final String DEFAULT_SDX_NAME = "test-sdx" + '-' + UUID.randomUUID().toString().replaceAll("-", "");
@@ -232,6 +234,11 @@ public class SdxTestDto extends AbstractSdxTestDto<SdxClusterRequest, SdxCluster
     public SdxTestDto withName(String name) {
         setName(name);
         return this;
+    }
+
+    @Override
+    public String getResourceNameType() {
+        return SDX_RESOURCE_NAME;
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/stack/StackTestDtoBase.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/stack/StackTestDtoBase.java
@@ -47,6 +47,8 @@ import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
 
 public abstract class StackTestDtoBase<T extends StackTestDtoBase<T>> extends AbstractCloudbreakTestDto<StackV4Request, StackV4Response, T> {
 
+    private static final String STACK_RESOURCE_NAME = "stackName";
+
     public StackTestDtoBase(TestContext testContext) {
         super(new StackV4Request(), testContext);
     }
@@ -145,6 +147,11 @@ public abstract class StackTestDtoBase<T extends StackTestDtoBase<T>> extends Ab
         getRequest().setName(name);
         setName(name);
         return this;
+    }
+
+    @Override
+    public String getResourceNameType() {
+        return STACK_RESOURCE_NAME;
     }
 
     public StackTestDtoBase<T> withCluster() {


### PR DESCRIPTION
This is a part of [CB-7876 [E2E Environment] Cleanup collision on E2E builds](https://jira.cloudera.com/browse/CB-7876):
>We had issues because of, the previous E2E cleanup build is still ongoing when the new E2E build has been started on the same environment with same provider and user.
>
>So we need to prevent this with introducing the list of created resources (for example list of names of all the created distroxes, sdxes, environments and credentials) for cleanup job.

Preparation of the new Cleanup solution, we need to introduce a solution to collect the deletable resources for Cleanup job. This should be same in format as generating from GUI E2E project. This is mandatory, because of the common usage purposes.

After this was merged, we need to change the API Cleanup App based on these changes from E2E jobs.
