### PR TITLE
CB-6359 CB-6845 During decommission delete the unused credentials at last.

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterDecomissionService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterDecomissionService.java
@@ -25,6 +25,8 @@ public interface ClusterDecomissionService {
 
     void deleteHostFromCluster(InstanceMetaData data);
 
+    void deleteUnusedCredentialsFromCluster();
+
     void restartStaleServices() throws CloudbreakException;
 
     Map<String, Map<String, String>> getStatusOfComponentsForHost(String host);

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterDecomissionService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterDecomissionService.java
@@ -102,6 +102,11 @@ public class ClouderaManagerClusterDecomissionService implements ClusterDecomiss
     }
 
     @Override
+    public void deleteUnusedCredentialsFromCluster() {
+        clouderaManagerDecomissioner.deleteUnusedCredentialsFromCluster(stack, client);
+    }
+
+    @Override
     public void restartStaleServices() throws CloudbreakException {
         try {
             applicationContext.getBean(ClouderaManagerModificationService.class, stack, clientConfig)

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerDecomissioner.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerDecomissioner.java
@@ -258,17 +258,16 @@ public class ClouderaManagerDecomissioner {
         LOGGER.debug("Deleting host: [{}]", data.getDiscoveryFQDN());
         deleteRolesFromHost(stack, data, client);
         deleteHostFromClouderaManager(stack, data, client);
-        deleteUnusedCredentialsFromCluster(stack, data, client);
     }
 
-    private void deleteUnusedCredentialsFromCluster(Stack stack, InstanceMetaData data, ApiClient client) {
+    public void deleteUnusedCredentialsFromCluster(Stack stack, ApiClient client) {
         LOGGER.debug("Deleting unused credentials");
         ClouderaManagerResourceApi clouderaManagerResourceApi = clouderaManagerApiFactory.getClouderaManagerResourceApi(client);
         try {
             ApiCommand command = clouderaManagerResourceApi.deleteCredentialsCommand("unused");
             clouderaManagerPollingServiceProvider.startPollingCmKerberosJob(stack, client, command.getId());
         } catch (ApiException e) {
-            LOGGER.error("Failed to delete credentials of host: {}", data.getDiscoveryFQDN(), e);
+            LOGGER.error("Failed to delete unused credentials", e);
             throw new CloudbreakServiceException(e.getMessage(), e);
         }
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/DecommissionHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/DecommissionHandler.java
@@ -133,6 +133,7 @@ public class DecommissionHandler implements EventHandler<DecommissionRequest> {
                     .filter(Objects::nonNull)
                     .collect(Collectors.toList());
             decommisionedInstances.forEach(clusterDecomissionService::deleteHostFromCluster);
+            clusterDecomissionService.deleteUnusedCredentialsFromCluster();
             updateInstanceStatuses(decommisionedInstances, InstanceStatus.DECOMMISSIONED, "instance successfully downscaled");
             clusterDecomissionService.restartStaleServices();
 


### PR DESCRIPTION
1. The underlying CM API call is generic and it is not tied to any deleting host per se.
2. Saves time during large scale decommission with minimal change in behavior.
3. One of the lower hanging fruits identified at PR #8604

./gradlew build