### PR TITLE
CB-8077 AWS RDS: enable CopyTagsToSnapshot

### DIFF
--- a/cloud-aws/src/main/resources/templates/aws-cf-dbstack.ftl
+++ b/cloud-aws/src/main/resources/templates/aws-cf-dbstack.ftl
@@ -161,6 +161,7 @@
                 "DBInstanceIdentifier": { "Ref": "DBInstanceIdentifierParameter" },
                 "DBSubnetGroupName": { "Ref": "DBSubnetGroup" },
                 "Engine": { "Ref": "EngineParameter" },
+                "CopyTagsToSnapshot":true,
                 "EngineVersion": { "Ref": "EngineVersionParameter" },
                 "MasterUserPassword": { "Ref": "MasterUserPasswordParameter" },
                 "MasterUsername": { "Ref": "MasterUsernameParameter" },


### PR DESCRIPTION
Tags of an RDS should be copied to the created snapshots.

See detailed description in the commit message.