### PR TITLE
CB-8088 Periscope Downscaling should use YARN downscale recommendation

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/CronTimeEvaluator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/CronTimeEvaluator.java
@@ -4,6 +4,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
@@ -13,17 +14,24 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.periscope.domain.BaseAlert;
 import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.ScalingPolicy;
 import com.sequenceiq.periscope.domain.TimeAlert;
+import com.sequenceiq.periscope.model.yarn.YarnScalingServiceV1Response;
 import com.sequenceiq.periscope.monitor.MonitorUpdateRate;
+import com.sequenceiq.periscope.monitor.client.YarnMetricsClient;
 import com.sequenceiq.periscope.monitor.context.ClusterIdEvaluatorContext;
 import com.sequenceiq.periscope.monitor.context.EvaluatorContext;
+import com.sequenceiq.periscope.monitor.evaluator.load.YarnResponseUtils;
 import com.sequenceiq.periscope.monitor.event.ScalingEvent;
+import com.sequenceiq.periscope.monitor.handler.CloudbreakCommunicator;
 import com.sequenceiq.periscope.repository.TimeAlertRepository;
 import com.sequenceiq.periscope.service.ClusterService;
 import com.sequenceiq.periscope.service.DateService;
+import com.sequenceiq.periscope.utils.StackResponseUtils;
 
 @Component("CronTimeEvaluator")
 @Scope("prototype")
@@ -44,6 +52,21 @@ public class CronTimeEvaluator extends EvaluatorExecutor {
 
     @Inject
     private EventPublisher eventPublisher;
+
+    @Inject
+    private CloudbreakCommunicator cloudbreakCommunicator;
+
+    @Inject
+    private YarnMetricsClient yarnMetricsClient;
+
+    @Inject
+    private YarnResponseUtils yarnResponseUtils;
+
+    @Inject
+    private StackResponseUtils stackResponseUtils;
+
+    @Inject
+    private ScalingPolicyTargetCalculator scalingPolicyTargetCalculator;
 
     private long clusterId;
 
@@ -80,11 +103,11 @@ public class CronTimeEvaluator extends EvaluatorExecutor {
         long start = System.currentTimeMillis();
         Cluster cluster = clusterService.findById(clusterId);
         MDCBuilder.buildMdcContext(cluster);
-        publishIfNeeded(alertRepository.findAllByCluster(clusterId));
+        publishIfNeeded(alertRepository.findAllByClusterIdOrderById(clusterId));
         LOGGER.debug("Finished cronTimeEvaluator for cluster {} in {} ms", cluster.getStackCrn(), System.currentTimeMillis() - start);
     }
 
-    private void publishIfNeeded(List<TimeAlert> alerts) {
+    protected void publishIfNeeded(List<TimeAlert> alerts) {
         for (TimeAlert alert : alerts) {
             if (isPolicyAttached(alert) && isTrigger(alert)) {
                 publish(alert);
@@ -104,7 +127,36 @@ public class CronTimeEvaluator extends EvaluatorExecutor {
     }
 
     private void publish(TimeAlert alert) {
-        eventPublisher.publishEvent(new ScalingEvent(alert));
+        ScalingEvent event = new ScalingEvent(alert);
+
+        StackV4Response stackV4Response = cloudbreakCommunicator.getByCrn(alert.getCluster().getStackCrn());
+        int hostGroupNodeCount = stackResponseUtils.getNodeCountForHostGroup(stackV4Response, alert.getScalingPolicy().getHostGroup());
+        int desiredAbsoluteNodeCount = scalingPolicyTargetCalculator.getDesiredAbsoluteNodeCount(event, hostGroupNodeCount);
+        int targetIncrementNodeCount = desiredAbsoluteNodeCount - hostGroupNodeCount;
+
+        event.setHostGroupNodeCount(hostGroupNodeCount);
+        event.setDesiredAbsoluteHostGroupNodeCount(desiredAbsoluteNodeCount);
+        if (targetIncrementNodeCount < 0) {
+            populateDecommissionCandidates(event, stackV4Response, alert.getCluster(), alert.getScalingPolicy(), -targetIncrementNodeCount);
+        }
+
+        eventPublisher.publishEvent(event);
         LOGGER.debug("Time alert '{}' triggered  for cluster '{}'", alert.getName(), alert.getCluster().getStackCrn());
+    }
+
+    private void populateDecommissionCandidates(ScalingEvent event, StackV4Response stackV4Response, Cluster cluster,
+            ScalingPolicy policy, int mandatoryDownScaleCount) {
+        try {
+            YarnScalingServiceV1Response yarnResponse = yarnMetricsClient.getYarnMetricsForCluster(cluster,
+                    stackV4Response, policy.getHostGroup(), Optional.of(mandatoryDownScaleCount));
+            Map<String, String> hostFqdnsToInstanceId = stackResponseUtils.getCloudInstanceIdsForHostGroup(stackV4Response, policy.getHostGroup());
+
+            List<String> decommissionNodes = yarnResponseUtils.getYarnRecommendedDecommissionHostsForHostGroup(cluster.getStackCrn(), yarnResponse,
+                    hostFqdnsToInstanceId, mandatoryDownScaleCount, Optional.of(mandatoryDownScaleCount));
+            event.setDecommissionNodeIds(decommissionNodes);
+        } catch (Exception ex) {
+            LOGGER.error("Error retrieving decommission candidates for  policy '{}', adjustment type '{}', cluster '{}'",
+                    policy.getName(), policy.getAdjustmentType(), cluster.getStackCrn(), ex);
+        }
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ScalingConstants.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ScalingConstants.java
@@ -12,7 +12,7 @@ public class ScalingConstants {
 
     public static final int DEFAULT_HOSTGROUP_MAX_SIZE = 200;
 
-    public static final int DEFAULT_MAX_SCALE_UP_STEP_SIZE = 50;
+    public static final int DEFAULT_MAX_SCALE_UP_STEP_SIZE = 100;
 
     public static final Long UNINITIALIZED_WORKSPACE_ID = -1L;
 

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ScalingPolicyTargetCalculator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ScalingPolicyTargetCalculator.java
@@ -1,0 +1,47 @@
+package com.sequenceiq.periscope.monitor.evaluator;
+
+import static java.lang.Math.ceil;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.periscope.domain.ScalingPolicy;
+import com.sequenceiq.periscope.monitor.event.ScalingEvent;
+import com.sequenceiq.periscope.monitor.handler.CloudbreakCommunicator;
+import com.sequenceiq.periscope.utils.ClusterUtils;
+import com.sequenceiq.periscope.utils.StackResponseUtils;
+
+@Component
+public class ScalingPolicyTargetCalculator {
+
+    @Inject
+    private StackResponseUtils stackResponseUtils;
+
+    @Inject
+    private CloudbreakCommunicator cloudbreakCommunicator;
+
+    public Integer getDesiredAbsoluteNodeCount(ScalingEvent event, int hostGroupNodeCount) {
+        ScalingPolicy policy = event.getAlert().getScalingPolicy();
+        int scalingAdjustment = policy.getScalingAdjustment();
+        int desiredAbsoluteHostGroupNodeCount;
+        switch (policy.getAdjustmentType()) {
+            case NODE_COUNT:
+                desiredAbsoluteHostGroupNodeCount = hostGroupNodeCount + scalingAdjustment;
+                break;
+            case PERCENTAGE:
+                desiredAbsoluteHostGroupNodeCount = hostGroupNodeCount
+                        + (int) (ceil(hostGroupNodeCount * ((double) scalingAdjustment / ClusterUtils.MAX_CAPACITY)));
+                break;
+            case EXACT:
+                desiredAbsoluteHostGroupNodeCount = policy.getScalingAdjustment();
+                break;
+            default:
+                desiredAbsoluteHostGroupNodeCount = hostGroupNodeCount;
+        }
+        int minSize = ScalingConstants.DEFAULT_HOSTGROUP_MIN_SIZE;
+        int maxSize = ScalingConstants.DEFAULT_HOSTGROUP_MAX_SIZE;
+
+        return desiredAbsoluteHostGroupNodeCount < minSize ? minSize : desiredAbsoluteHostGroupNodeCount > maxSize ? maxSize : desiredAbsoluteHostGroupNodeCount;
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/load/YarnLoadEvaluator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/load/YarnLoadEvaluator.java
@@ -1,13 +1,8 @@
 package com.sequenceiq.periscope.monitor.evaluator.load;
 
-import static com.sequenceiq.periscope.monitor.evaluator.ScalingConstants.DEFAULT_MAX_SCALE_UP_STEP_SIZE;
-
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
@@ -23,8 +18,6 @@ import com.sequenceiq.periscope.domain.Cluster;
 import com.sequenceiq.periscope.domain.LoadAlert;
 import com.sequenceiq.periscope.domain.LoadAlertConfiguration;
 import com.sequenceiq.periscope.model.yarn.YarnScalingServiceV1Response;
-import com.sequenceiq.periscope.model.yarn.YarnScalingServiceV1Response.DecommissionCandidate;
-import com.sequenceiq.periscope.model.yarn.YarnScalingServiceV1Response.NewNodeManagerCandidates;
 import com.sequenceiq.periscope.monitor.client.YarnMetricsClient;
 import com.sequenceiq.periscope.monitor.context.ClusterIdEvaluatorContext;
 import com.sequenceiq.periscope.monitor.context.EvaluatorContext;
@@ -62,6 +55,9 @@ public class YarnLoadEvaluator extends EvaluatorExecutor {
 
     @Inject
     private CloudbreakCommunicator cloudbreakCommunicator;
+
+    @Inject
+    private YarnResponseUtils yarnResponseUtils;
 
     private long clusterId;
 
@@ -124,66 +120,44 @@ public class YarnLoadEvaluator extends EvaluatorExecutor {
         int maxAllowedUpScale = configMaxNodeCount < 0 ? 0 : configMaxNodeCount;
         int maxAllowedDownScale = configMinNodeCount > 0 ? configMinNodeCount : 0;
 
-        YarnScalingServiceV1Response yarnResponse = yarnMetricsClient.getYarnMetricsForCluster(cluster, stackV4Response, policyHostGroup);
-        int yarnRecommendedScaleUpCount =
-                getYarnRecommendedScaleUpCount(yarnResponse, maxAllowedUpScale);
-        List<String> yarnRecommendedDecommissionHosts =
-                getYarnRecommendedDecommissionHostsForHostGroup(yarnResponse, hostFqdnsToInstanceId, maxAllowedDownScale);
+        Optional<Integer> mandatoryUpScaleCount = Optional.of(configMinNodeCount)
+                .filter(mandatoryUpScale -> mandatoryUpScale < 0).map(upscale -> -1 * upscale);
 
-        int targetScaleUpCount = configMinNodeCount < 0 ?
-                Math.max(-configMinNodeCount, yarnRecommendedScaleUpCount) : yarnRecommendedScaleUpCount;
-        int targetScaleDownCount = configMaxNodeCount < 0 ?
-                Math.max(-configMaxNodeCount, yarnRecommendedDecommissionHosts.size()) : yarnRecommendedDecommissionHosts.size();
+        Optional<Integer> mandatoryDownScaleCount = Optional.of(configMaxNodeCount)
+                .filter(mandatoryDownscale -> mandatoryDownscale < 0).map(downscale -> -1 * downscale);
 
-        if (targetScaleUpCount > 0) {
-            sendScaleUpEvent(existingHostGroupSize, targetScaleUpCount);
-        } else if (targetScaleDownCount > 0) {
-            sendScaleDownEvent(targetScaleDownCount, existingHostGroupSize, yarnRecommendedDecommissionHosts);
+        YarnScalingServiceV1Response yarnResponse = yarnMetricsClient
+                .getYarnMetricsForCluster(cluster, stackV4Response, policyHostGroup, mandatoryDownScaleCount);
+
+        int yarnRecommendedScaleUpCount = yarnResponseUtils.
+                getYarnRecommendedScaleUpCount(yarnResponse, policyHostGroup, maxAllowedUpScale, mandatoryUpScaleCount);
+        List<String> yarnRecommendedDecommissionHosts = yarnResponseUtils.
+                getYarnRecommendedDecommissionHostsForHostGroup(cluster.getStackCrn(), yarnResponse,
+                        hostFqdnsToInstanceId, maxAllowedDownScale, mandatoryDownScaleCount);
+
+        if (yarnRecommendedScaleUpCount > 0) {
+            sendScaleUpEvent(existingHostGroupSize, yarnRecommendedScaleUpCount);
+        } else if (!yarnRecommendedDecommissionHosts.isEmpty()) {
+            sendScaleDownEvent(existingHostGroupSize, yarnRecommendedDecommissionHosts);
         }
-    }
-
-    public List<String> getYarnRecommendedDecommissionHostsForHostGroup(YarnScalingServiceV1Response yarnResponse,
-            Map<String, String> hostFqdnsToInstanceId, int maxAllowedDownScale) {
-        return yarnResponse.getScaleDownCandidates().orElse(List.of()).stream()
-                .sorted(Comparator.comparingInt(DecommissionCandidate::getAmCount))
-                .map(DecommissionCandidate::getNodeId)
-                .map(nodeFqdn -> nodeFqdn.split(":")[0])
-                .filter(s -> hostFqdnsToInstanceId.keySet().contains(s))
-                .map(nodeFqdn -> hostFqdnsToInstanceId.get(nodeFqdn))
-                .limit(maxAllowedDownScale)
-                .collect(Collectors.toList());
-    }
-
-    public Integer getYarnRecommendedScaleUpCount(YarnScalingServiceV1Response yarnResponse, Integer maxAllowedUpScale) {
-        return yarnResponse.getScaleUpCandidates()
-                .map(NewNodeManagerCandidates::getCandidates).orElse(List.of()).stream()
-                .filter(candidate -> candidate.getModelName().equalsIgnoreCase(policyHostGroup))
-                .findFirst()
-                .map(NewNodeManagerCandidates.Candidate::getCount)
-                .map(scaleUpCount -> IntStream.of(scaleUpCount, maxAllowedUpScale, DEFAULT_MAX_SCALE_UP_STEP_SIZE).min().getAsInt())
-                .orElse(0);
     }
 
     public void sendScaleUpEvent(Integer existingHostGroupSize, Integer targetScaleUpCount) {
         ScalingEvent scalingEvent = new ScalingEvent(loadAlert);
-        scalingEvent.setHostGroupNodeCount(Optional.of(existingHostGroupSize));
-        scalingEvent.setScalingNodeCount(Optional.of(targetScaleUpCount));
+        scalingEvent.setHostGroupNodeCount(existingHostGroupSize);
+        scalingEvent.setDesiredAbsoluteHostGroupNodeCount(existingHostGroupSize + targetScaleUpCount);
         eventPublisher.publishEvent(scalingEvent);
         LOGGER.info("Triggered ScaleUp for Cluster '{}', NodeCount '{}', HostGroup '{}'",
                 cluster.getStackCrn(), targetScaleUpCount, policyHostGroup);
     }
 
-    public void sendScaleDownEvent(Integer targetScaleDownCount, Integer existingHostGroupSize,
-            List<String> yarnRecommendedDecommissionHosts) {
+    public void sendScaleDownEvent(Integer existingHostGroupSize, List<String> yarnRecommendedDecommissionHosts) {
         ScalingEvent scalingEvent = new ScalingEvent(loadAlert);
-        scalingEvent.setHostGroupNodeCount(Optional.of(existingHostGroupSize));
-        if (!yarnRecommendedDecommissionHosts.isEmpty()) {
-            scalingEvent.setDecommissionNodeIds(yarnRecommendedDecommissionHosts);
-        } else {
-            scalingEvent.setScalingNodeCount(Optional.of(-targetScaleDownCount));
-        }
+        scalingEvent.setHostGroupNodeCount(existingHostGroupSize);
+        scalingEvent.setDesiredAbsoluteHostGroupNodeCount(existingHostGroupSize - yarnRecommendedDecommissionHosts.size());
+        scalingEvent.setDecommissionNodeIds(yarnRecommendedDecommissionHosts);
         eventPublisher.publishEvent(scalingEvent);
         LOGGER.info("Triggered ScaleDown for Cluster '{}', NodeCount '{}', HostGroup '{}', DecommissionNodeIds '{}'",
-                targetScaleDownCount, cluster.getStackCrn(), policyHostGroup, yarnRecommendedDecommissionHosts);
+                yarnRecommendedDecommissionHosts.size(), cluster.getStackCrn(), policyHostGroup, yarnRecommendedDecommissionHosts);
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/load/YarnResponseUtils.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/load/YarnResponseUtils.java
@@ -1,0 +1,70 @@
+package com.sequenceiq.periscope.monitor.evaluator.load;
+
+import static com.sequenceiq.periscope.monitor.evaluator.ScalingConstants.DEFAULT_MAX_SCALE_UP_STEP_SIZE;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.periscope.model.yarn.YarnScalingServiceV1Response;
+
+@Component
+public class YarnResponseUtils {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(YarnResponseUtils.class);
+
+    public List<String> getYarnRecommendedDecommissionHostsForHostGroup(String clusterCrn, YarnScalingServiceV1Response yarnResponse,
+            Map<String, String> hostFqdnsToInstanceId, int maxAllowedDownScale, Optional<Integer> mandatoryDownScaleCount) {
+        Set<String> consideredNodeIds = new HashSet<>();
+        Integer allowedDownscale = Math.max(maxAllowedDownScale, mandatoryDownScaleCount.orElse(0));
+        List<String> decommissionNodes = yarnResponse.getScaleDownCandidates().orElse(List.of()).stream()
+                .map(YarnScalingServiceV1Response.DecommissionCandidate::getNodeId)
+                .map(nodeFqdn -> nodeFqdn.split(":")[0])
+                .filter(s -> hostFqdnsToInstanceId.keySet().contains(s))
+                .map(nodeFqdn -> hostFqdnsToInstanceId.get(nodeFqdn))
+                .limit(allowedDownscale)
+                .map(nodeId -> {
+                    consideredNodeIds.add(nodeId);
+                    return nodeId;
+                })
+                .collect(Collectors.toList());
+
+        //HostGroup candidates if mandatoryDownScaleCount is not met based on yarnResponse.
+        int forcedCandidatesCount = mandatoryDownScaleCount.orElse(0) - decommissionNodes.size();
+        if (forcedCandidatesCount > 0) {
+            List forcedCandidates = hostFqdnsToInstanceId.keySet().stream()
+                    .filter(nodeId -> !consideredNodeIds.contains(nodeId))
+                    .limit(forcedCandidatesCount).collect(Collectors.toList());
+
+            LOGGER.info("Forced downscaling candidates count '{}', candidates '{}' in cluster '{}' to achieve mandatory " +
+                            "downscaletarget '{}'.", forcedCandidates.size(), forcedCandidates, clusterCrn,
+                    mandatoryDownScaleCount.orElse(0));
+            decommissionNodes.addAll(forcedCandidates);
+        }
+
+        return decommissionNodes;
+    }
+
+    public Integer getYarnRecommendedScaleUpCount(YarnScalingServiceV1Response yarnResponse, String policyHostGroup,
+            Integer maxAllowedUpScale, Optional<Integer> mandatoryUpScaleCount) {
+        Integer yarnRecommendedCount = yarnResponse.getScaleUpCandidates()
+                .map(YarnScalingServiceV1Response.NewNodeManagerCandidates::getCandidates).orElse(List.of()).stream()
+                .filter(candidate -> candidate.getModelName().equalsIgnoreCase(policyHostGroup))
+                .findFirst()
+                .map(YarnScalingServiceV1Response.NewNodeManagerCandidates.Candidate::getCount)
+                .map(scaleUpCount -> IntStream.of(scaleUpCount, maxAllowedUpScale, DEFAULT_MAX_SCALE_UP_STEP_SIZE).min().getAsInt())
+                .orElse(0);
+
+        return mandatoryUpScaleCount
+                .map(mandatoryCount -> Math.max(mandatoryCount, yarnRecommendedCount))
+                .orElse(yarnRecommendedCount);
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/event/ScalingEvent.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/event/ScalingEvent.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.periscope.monitor.event;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.context.ApplicationEvent;
 
@@ -13,9 +12,9 @@ public class ScalingEvent extends ApplicationEvent {
 
     private List<String> decommissionNodeIds;
 
-    private transient Optional<Integer> scalingNodeCount = Optional.empty();
+    private transient Integer hostGroupNodeCount;
 
-    private transient Optional<Integer> hostGroupNodeCount = Optional.empty();
+    private transient Integer desiredAbsoluteHostGroupNodeCount;
 
     public ScalingEvent(BaseAlert alert) {
         super(alert);
@@ -33,19 +32,19 @@ public class ScalingEvent extends ApplicationEvent {
         this.decommissionNodeIds = decommissionNodeIds;
     }
 
-    public Optional<Integer> getScalingNodeCount() {
-        return scalingNodeCount;
-    }
-
-    public void setScalingNodeCount(Optional<Integer> scalingNodeCount) {
-        this.scalingNodeCount = scalingNodeCount;
-    }
-
-    public Optional<Integer> getHostGroupNodeCount() {
+    public Integer getHostGroupNodeCount() {
         return hostGroupNodeCount;
     }
 
-    public void setHostGroupNodeCount(Optional<Integer> hostGroupNodeCount) {
+    public void setHostGroupNodeCount(Integer hostGroupNodeCount) {
         this.hostGroupNodeCount = hostGroupNodeCount;
+    }
+
+    public Integer getDesiredAbsoluteHostGroupNodeCount() {
+        return desiredAbsoluteHostGroupNodeCount;
+    }
+
+    public void setDesiredAbsoluteHostGroupNodeCount(Integer desiredAbsoluteHostGroupNodeCount) {
+        this.desiredAbsoluteHostGroupNodeCount = desiredAbsoluteHostGroupNodeCount;
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ScalingHandler.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ScalingHandler.java
@@ -1,7 +1,5 @@
 package com.sequenceiq.periscope.monitor.handler;
 
-import static java.lang.Math.ceil;
-
 import java.util.concurrent.ExecutorService;
 
 import javax.inject.Inject;
@@ -13,17 +11,14 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.periscope.domain.BaseAlert;
 import com.sequenceiq.periscope.domain.Cluster;
 import com.sequenceiq.periscope.domain.ScalingPolicy;
-import com.sequenceiq.periscope.monitor.evaluator.ScalingConstants;
+import com.sequenceiq.periscope.monitor.evaluator.ScalingPolicyTargetCalculator;
 import com.sequenceiq.periscope.monitor.event.ScalingEvent;
 import com.sequenceiq.periscope.service.ClusterService;
 import com.sequenceiq.periscope.service.RejectedThreadService;
-import com.sequenceiq.periscope.utils.ClusterUtils;
-import com.sequenceiq.periscope.utils.StackResponseUtils;
 
 @Component
 public class ScalingHandler implements ApplicationListener<ScalingEvent> {
@@ -44,10 +39,7 @@ public class ScalingHandler implements ApplicationListener<ScalingEvent> {
     private RejectedThreadService rejectedThreadService;
 
     @Inject
-    private StackResponseUtils stackResponseUtils;
-
-    @Inject
-    private CloudbreakCommunicator cloudbreakCommunicator;
+    private ScalingPolicyTargetCalculator scalingPolicyTargetCalculator;
 
     @Override
     public void onApplicationEvent(ScalingEvent event) {
@@ -56,11 +48,11 @@ public class ScalingHandler implements ApplicationListener<ScalingEvent> {
         MDCBuilder.buildMdcContext(cluster);
         ScalingPolicy policy = alert.getScalingPolicy();
 
-        int hostGroupNodeCount = getHostGroupNodeCount(event, cluster, policy);
-        int desiredNodeCount = getDesiredNodeCount(event, hostGroupNodeCount);
-        if (hostGroupNodeCount != desiredNodeCount) {
+        int hostGroupNodeCount = event.getHostGroupNodeCount();
+        int desiredAbsoluteHostGroupNodeCount = event.getDesiredAbsoluteHostGroupNodeCount();
+        if (hostGroupNodeCount != desiredAbsoluteHostGroupNodeCount) {
             Runnable scalingRequest = (Runnable) applicationContext.getBean("ScalingRequest", cluster, policy,
-                    hostGroupNodeCount, desiredNodeCount, event.getDecommissionNodeIds());
+                    hostGroupNodeCount, desiredAbsoluteHostGroupNodeCount, event.getDecommissionNodeIds());
 
             executorService.submit(scalingRequest);
             rejectedThreadService.remove(cluster.getId());
@@ -69,42 +61,5 @@ public class ScalingHandler implements ApplicationListener<ScalingEvent> {
         } else {
             LOGGER.debug("No scaling activity required for cluster crn {}", cluster.getStackCrn());
         }
-    }
-
-    private int getDesiredNodeCount(ScalingEvent event, int hostGroupNodeCount) {
-        ScalingPolicy policy = event.getAlert().getScalingPolicy();
-        int scalingAdjustment = policy.getScalingAdjustment();
-        int desiredHostGroupNodeCount;
-        switch (policy.getAdjustmentType()) {
-            case NODE_COUNT:
-                desiredHostGroupNodeCount = hostGroupNodeCount + scalingAdjustment;
-                break;
-            case PERCENTAGE:
-                desiredHostGroupNodeCount = hostGroupNodeCount
-                        + (int) (ceil(hostGroupNodeCount * ((double) scalingAdjustment / ClusterUtils.MAX_CAPACITY)));
-                break;
-            case EXACT:
-                desiredHostGroupNodeCount = policy.getScalingAdjustment();
-                break;
-            case LOAD_BASED:
-                desiredHostGroupNodeCount = hostGroupNodeCount + event.getScalingNodeCount()
-                        .orElseGet(() -> {
-                            return -1 * event.getDecommissionNodeIds().size();
-                        });
-                break;
-            default:
-                desiredHostGroupNodeCount = hostGroupNodeCount;
-        }
-        int minSize = ScalingConstants.DEFAULT_HOSTGROUP_MIN_SIZE;
-        int maxSize = ScalingConstants.DEFAULT_HOSTGROUP_MAX_SIZE;
-
-        return desiredHostGroupNodeCount < minSize ? minSize : desiredHostGroupNodeCount > maxSize ? maxSize : desiredHostGroupNodeCount;
-    }
-
-    private Integer getHostGroupNodeCount(ScalingEvent event, Cluster cluster, ScalingPolicy policy) {
-        return event.getHostGroupNodeCount().orElseGet(() -> {
-            StackV4Response stackV4Response = cloudbreakCommunicator.getByCrn(cluster.getStackCrn());
-            return stackResponseUtils.getNodeCountForHostGroup(stackV4Response, policy.getHostGroup());
-        });
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ScalingRequest.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ScalingRequest.java
@@ -198,6 +198,8 @@ public class ScalingRequest implements Runnable {
             case "HTTP 409 Conflict":
                 return messagesService.getMessage(MessageCode.CLUSTER_UPDATE_IN_PROGRESS, List.of(action, cluster.getStackName()));
             case "HTTP 400 Bad Request":
+            case "HTTP 500 Internal Server Error":
+            case "HTTP 404 Not Found":
                 return messagesService.getMessage(MessageCode.CLUSTER_NOT_AVAILABLE, List.of(action, cluster.getStackName()));
             default:
                 return cbMessage;

--- a/autoscale/src/main/java/com/sequenceiq/periscope/repository/TimeAlertRepository.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/repository/TimeAlertRepository.java
@@ -13,5 +13,5 @@ public interface TimeAlertRepository extends CrudRepository<TimeAlert, Long> {
 
     TimeAlert findByCluster(@Param("alertId") Long alertId, @Param("clusterId") Long clusterId);
 
-    List<TimeAlert> findAllByCluster(@Param("clusterId") Long clusterId);
+    List<TimeAlert> findAllByClusterIdOrderById(@Param("clusterId") Long clusterId);
 }

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/CronTimeEvaluatorTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/CronTimeEvaluatorTest.java
@@ -1,28 +1,57 @@
 package com.sequenceiq.periscope.monitor.evaluator;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.junit.Before;
-import org.junit.Test;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.verification.VerificationMode;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.periscope.api.model.AdjustmentType;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.domain.ScalingPolicy;
+import com.sequenceiq.periscope.domain.TimeAlert;
+import com.sequenceiq.periscope.model.yarn.YarnScalingServiceV1Response;
+import com.sequenceiq.periscope.monitor.client.YarnMetricsClient;
 import com.sequenceiq.periscope.monitor.context.ClusterIdEvaluatorContext;
+import com.sequenceiq.periscope.monitor.evaluator.load.YarnResponseUtils;
+import com.sequenceiq.periscope.monitor.event.ScalingEvent;
 import com.sequenceiq.periscope.monitor.executor.ExecutorServiceWithRegistry;
-import com.sequenceiq.periscope.repository.TimeAlertRepository;
+import com.sequenceiq.periscope.monitor.handler.CloudbreakCommunicator;
 import com.sequenceiq.periscope.service.ClusterService;
+import com.sequenceiq.periscope.service.DateService;
+import com.sequenceiq.periscope.utils.MockStackResponseGenerator;
+import com.sequenceiq.periscope.utils.StackResponseUtils;
 
+@ExtendWith(MockitoExtension.class)
 public class CronTimeEvaluatorTest {
 
     private static final long CLUSTER_ID = 1L;
-
-    @Mock
-    private TimeAlertRepository alertRepository;
 
     @Mock
     private ClusterService clusterService;
@@ -30,11 +59,38 @@ public class CronTimeEvaluatorTest {
     @Mock
     private ExecutorServiceWithRegistry executorServiceWithRegistry;
 
+    @Mock
+    private ScalingPolicyTargetCalculator scalingPolicyTargetCalculator;
+
+    @Mock
+    private StackResponseUtils stackResponseUtils;
+
+    @Mock
+    private YarnResponseUtils yarnResponseUtils;
+
+    @Mock
+    private CloudbreakCommunicator cloudbreakCommunicator;
+
+    @Mock
+    private YarnMetricsClient yarnMetricsClient;
+
+    @Mock
+    private DateService dateService;
+
+    @Mock
+    private EventPublisher eventPublisher;
+
     @InjectMocks
     private CronTimeEvaluator underTest;
 
-    @Before
-    public void setup() {
+    private String fqdnBase = "testFqdn";
+
+    private String testHostGroup = "compute";
+
+    private String clusterCrn = "testCrn";
+
+    @BeforeEach
+    private void setup() {
         MockitoAnnotations.initMocks(this);
     }
 
@@ -51,5 +107,124 @@ public class CronTimeEvaluatorTest {
         }
 
         verify(executorServiceWithRegistry).finished(underTest, CLUSTER_ID);
+    }
+
+    public static Stream<Arguments> scheduleBasedUpScaling() {
+        return Stream.of(
+                //TestCase, CurrentHostGroupCount,DesiredNodeCount, ExpectedNodeCount
+                Arguments.of("SCALE_UP", 2, 7, 7),
+                Arguments.of("SCALE_UP", 10, 50, 50),
+                Arguments.of("SCALE_UP", 1, 15, 15),
+                Arguments.of("SCALE_UP", 0, 5, 5),
+                Arguments.of("SCALE_UP", 15, 15, 15)
+        );
+    }
+
+    @ParameterizedTest(name = "{0}: With currentHostGroupCount={1}, desiredNodeCount ={2}, expectedNodeCount={3} ")
+    @MethodSource("scheduleBasedUpScaling")
+    public void testPublishIfNeededForUpscaling(String testType, Integer currentHostGroupCount,
+            Integer desiredNodeCount, Integer expectedScalingCount) throws Exception {
+
+        ScalingEvent scalingEvent = validateScheduleBasedScaling("SCALE_UP_MODE", currentHostGroupCount, desiredNodeCount, Optional.empty());
+
+        assertEquals("Scheduled-Based Autoscaling Expeced Node Count should match.",
+                expectedScalingCount.intValue(),
+                scalingEvent.getDesiredAbsoluteHostGroupNodeCount().intValue());
+    }
+
+    public static Stream<Arguments> scheduleBasedDownScaling() {
+        return Stream.of(
+                //TestCase, CurrentHostGroupCount,DesiredNodeCount,YarnGivenDecommissionCount,ExpectedNodeCount
+                Arguments.of("SCALE_DOWN_YARN_NODE_COUNT_MATCH  ", 10, 6, 4, 6),
+                Arguments.of("SCALE_DOWN_YARN_NODE_COUNT_PARTIAL", 10, 6, 2, 6),
+                Arguments.of("SCALE_DOWN_YARN_NODE_COUNT_ZERO   ", 10, 6, 0, 6),
+                Arguments.of("SCALE_DOWN_YARN_NODE_COUNT_EXTRA  ", 12, 6, 12, 6),
+
+                Arguments.of("SCALE_DOWN_YARN_NODE_COUNT_MATCH  ", 25, 22, 2, 22),
+                Arguments.of("SCALE_DOWN_YARN_NODE_COUNT_PARTIAL", 25, 10, 5, 10),
+                Arguments.of("SCALE_DOWN_YARN_NODE_COUNT_ZERO   ", 25, 12, 0, 12),
+                Arguments.of("SCALE_DOWN_YARN_NODE_COUNT_EXTRA  ", 25, 20, 25, 20)
+        );
+    }
+
+    @ParameterizedTest(name = "{0}: With currentHostGroupCount={1}, desiredNodeCount ={2}, yarnGivenDecommissionCount={3}, expectedNodeCount={4} ")
+    @MethodSource("scheduleBasedDownScaling")
+    public void testPublishIfNeededForDownScaling(String testType, Integer currentHostGroupCount,
+            Integer desiredNodeCount, Integer yarnGivenDecommissionCount, Integer expectedScalingCount) throws Exception {
+
+        ScalingEvent scalingEvent = validateScheduleBasedScaling("SCALE_DOWN_MODE", currentHostGroupCount,
+                desiredNodeCount, Optional.of(yarnGivenDecommissionCount));
+
+        int targetNodeCount = currentHostGroupCount - desiredNodeCount;
+        assertEquals("Scheduled-Based Autoscaling Expeced Node Count should match.", expectedScalingCount.intValue(),
+                scalingEvent.getDesiredAbsoluteHostGroupNodeCount().intValue());
+        assertEquals("Decommission Node Count Based on Yarn Response should match targetNodeCount.", targetNodeCount,
+                scalingEvent.getDecommissionNodeIds().size());
+        scalingEvent.getDecommissionNodeIds().forEach(
+                nodeId -> assertTrue("Node Id hostGroup should match", nodeId.contains(testHostGroup))
+        );
+    }
+
+    private ScalingEvent validateScheduleBasedScaling(String testMode, Integer currentHostGroupCount,
+            Integer desiredNodeCount, Optional<Integer> yarnGivenDecommissionCount) throws Exception {
+
+        TimeAlert alert = getAAlert(desiredNodeCount);
+        StackV4Response stackV4Response = MockStackResponseGenerator
+                .getMockStackV4Response(clusterCrn, testHostGroup, "testFqdn" + testHostGroup, currentHostGroupCount);
+
+        when(cloudbreakCommunicator.getByCrn(anyString())).thenReturn(stackV4Response);
+        when(stackResponseUtils.getNodeCountForHostGroup(stackV4Response, testHostGroup)).thenCallRealMethod();
+        when(scalingPolicyTargetCalculator.getDesiredAbsoluteNodeCount(any(ScalingEvent.class), anyInt())).thenCallRealMethod();
+        when(dateService.isTrigger(any(TimeAlert.class), anyLong())).thenReturn(true);
+
+        if (!"SCALE_UP_MODE".equals(testMode)) {
+            YarnScalingServiceV1Response yarnScalingServiceV1Response = getMockYarnScalingResponse("test", yarnGivenDecommissionCount.get());
+            when(stackResponseUtils.getCloudInstanceIdsForHostGroup(any(), any())).thenCallRealMethod();
+            when(yarnMetricsClient.getYarnMetricsForCluster(any(Cluster.class), any(StackV4Response.class), anyString(), any(Optional.class)))
+                    .thenReturn(yarnScalingServiceV1Response);
+            when(yarnResponseUtils.getYarnRecommendedDecommissionHostsForHostGroup(anyString(), any(YarnScalingServiceV1Response.class),
+                    any(Map.class), anyInt(), any(Optional.class))).thenCallRealMethod();
+        }
+
+        underTest.publishIfNeeded(List.of(alert));
+
+        VerificationMode verificationMode = "SCALE_UP_MODE".equals(testMode) ? never() : times(1);
+        ArgumentCaptor<ScalingEvent> captor = ArgumentCaptor.forClass(ScalingEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        verify(stackResponseUtils, verificationMode).getCloudInstanceIdsForHostGroup(any(), any());
+        verify(yarnMetricsClient, verificationMode).getYarnMetricsForCluster(any(Cluster.class), any(StackV4Response.class), anyString(), any(Optional.class));
+        verify(yarnResponseUtils, verificationMode).getYarnRecommendedDecommissionHostsForHostGroup(anyString(), any(YarnScalingServiceV1Response.class),
+                any(Map.class), anyInt(), any(Optional.class));
+
+        return captor.getValue();
+    }
+
+    private YarnScalingServiceV1Response getMockYarnScalingResponse(String instanceType, int yarnGivenDecommissionCount) {
+        YarnScalingServiceV1Response yarnScalingReponse = new YarnScalingServiceV1Response();
+        List decommissionCandidates = new ArrayList();
+        for (int i = 1; i <= yarnGivenDecommissionCount; i++) {
+            YarnScalingServiceV1Response.DecommissionCandidate decommissionCandidate = new YarnScalingServiceV1Response.DecommissionCandidate();
+            decommissionCandidate.setAmCount(2);
+            decommissionCandidate.setNodeId(fqdnBase + testHostGroup + i + ":8042");
+            decommissionCandidates.add(decommissionCandidate);
+        }
+        yarnScalingReponse.setDecommissionCandidates(Map.of("candidates", decommissionCandidates));
+        return yarnScalingReponse;
+    }
+
+    private TimeAlert getAAlert(int desiredNodeCount) {
+        TimeAlert alert = new TimeAlert();
+
+        Cluster cluster = new Cluster();
+        cluster.setStackCrn(clusterCrn);
+        alert.setCluster(cluster);
+
+        ScalingPolicy scalingPolicy = new ScalingPolicy();
+        scalingPolicy.setHostGroup(testHostGroup);
+        scalingPolicy.setAdjustmentType(AdjustmentType.EXACT);
+        scalingPolicy.setScalingAdjustment(desiredNodeCount);
+        alert.setScalingPolicy(scalingPolicy);
+
+        return alert;
     }
 }

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/ScalingPolicyTargetCalculatorTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/ScalingPolicyTargetCalculatorTest.java
@@ -1,0 +1,94 @@
+package com.sequenceiq.periscope.monitor.evaluator;
+
+import static com.sequenceiq.periscope.api.model.AdjustmentType.EXACT;
+import static com.sequenceiq.periscope.api.model.AdjustmentType.NODE_COUNT;
+import static com.sequenceiq.periscope.api.model.AdjustmentType.PERCENTAGE;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.stream.Stream;
+
+import org.junit.Before;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.periscope.api.model.AdjustmentType;
+import com.sequenceiq.periscope.domain.BaseAlert;
+import com.sequenceiq.periscope.domain.ScalingPolicy;
+import com.sequenceiq.periscope.domain.TimeAlert;
+import com.sequenceiq.periscope.monitor.event.ScalingEvent;
+
+@ExtendWith(MockitoExtension.class)
+public class ScalingPolicyTargetCalculatorTest {
+
+    private static final Integer TEST_HOSTGROUP_MAX_SIZE = 200;
+
+    private static final Integer TEST_HOSTGROUP_MIN_SIZE = 0;
+
+    @InjectMocks
+    private ScalingPolicyTargetCalculator underTest;
+
+    private ScalingPolicy scalingPolicyMock = mock(ScalingPolicy.class);
+
+    private ScalingEvent scalingEventMock = mock(ScalingEvent.class);
+
+    public static Stream<Arguments> policyScalingAdjustments() {
+        return Stream.of(
+                //TestCase, AdjustmentType, CurrentHostGroupCount,ScalingAdjustment,ExpectedScalingCount
+                Arguments.of("SCALING_POLICY_NODE_COUNT_WITHIN_MAX_LIMIT", NODE_COUNT, 2, 25, 27),
+                Arguments.of("SCALING_POLICY_NODE_COUNT_AT_MAX_LIMIT", NODE_COUNT, 2, 198, TEST_HOSTGROUP_MAX_SIZE),
+                Arguments.of("SCALING_POLICY_NODE_COUNT_BEYOND_MAX_LIMIT", NODE_COUNT, 2, 1000, TEST_HOSTGROUP_MAX_SIZE),
+
+                Arguments.of("SCALING_POLICY_PERCENTAGE_WITHIN_MAX_LIMIT", PERCENTAGE, 2, 50, 3),
+                Arguments.of("SCALING_POLICY_PERCENTAGE_WITHIN_MAX_LIMIT", PERCENTAGE, 2, 100, 4),
+                Arguments.of("SCALING_POLICY_PERCENTAGE_BEYOND_MAX_LIMIT", PERCENTAGE, 101, 1000, TEST_HOSTGROUP_MAX_SIZE),
+
+                Arguments.of("SCALING_POLICY_EXACT_WITHIN_MAX_LIMIT", EXACT, 2, 10, 10),
+                Arguments.of("SCALING_POLICY_EXACT_WITHIN_MAX_LIMIT", EXACT, 12, 24, 24),
+                Arguments.of("SCALING_POLICY_EXACT_BEYOND_MAX_LIMIT", EXACT, 40, 1000, TEST_HOSTGROUP_MAX_SIZE),
+
+                Arguments.of("SCALING_POLICY_NODE_COUNT_BEYOND_MIN_LIMIT", NODE_COUNT, 2, -12, TEST_HOSTGROUP_MIN_SIZE),
+                Arguments.of("SCALING_POLICY_PERCENTAGE_BEYOND_MIN_LIMIT", PERCENTAGE, 2, -100, TEST_HOSTGROUP_MIN_SIZE),
+                Arguments.of("SCALING_POLICY_EXACT_BEYOND_MIN_LIMIT", EXACT, 2, 0, TEST_HOSTGROUP_MIN_SIZE),
+
+                Arguments.of("SCALING_POLICY_NODE_COUNT_WITHIN_MIN_LIMIT", NODE_COUNT, 10, -2, 8),
+                Arguments.of("SCALING_POLICY_PERCENTAGE_WITHIN_MIN_LIMIT", PERCENTAGE, 10, -50, 5),
+                Arguments.of("SCALING_POLICY_EXACT_WITHIN_MIN_LIMIT", EXACT, 10, 6, 6)
+        );
+    }
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @ParameterizedTest(name = "{0}: With AdjustmentType{1}, currentHostGroupCount={2}, scalingAdjustment ={3}, expectedScalingCount={4} ")
+    @MethodSource("policyScalingAdjustments")
+    public void testPolicyScalingCalculation(String testType, AdjustmentType adjustmentType, int currentHostGroupCount,
+            int scalingAdjustment, int expectedScalingCount) {
+        TimeAlert timeAlertMock = mock(TimeAlert.class);
+        validateTargetCalculation(timeAlertMock, adjustmentType, currentHostGroupCount, scalingAdjustment, expectedScalingCount);
+    }
+
+    private void validateTargetCalculation(BaseAlert baseAlertMock, AdjustmentType adjustmentType,
+            int currentHostGroupCount, int scalingAdjument, int expectedScaleUpCount) {
+        MockitoAnnotations.initMocks(this);
+        String testHostGroup = "compute";
+
+        when(scalingEventMock.getAlert()).thenReturn(baseAlertMock);
+        when(baseAlertMock.getScalingPolicy()).thenReturn(scalingPolicyMock);
+
+        when(scalingPolicyMock.getAdjustmentType()).thenReturn(adjustmentType);
+        when(scalingPolicyMock.getHostGroup()).thenReturn(testHostGroup);
+        when(scalingPolicyMock.getScalingAdjustment()).thenReturn(scalingAdjument);
+
+        int desiredNodeCount = underTest.getDesiredAbsoluteNodeCount(scalingEventMock, currentHostGroupCount);
+        assertEquals("Desired NodeCount should match", desiredNodeCount, expectedScaleUpCount);
+    }
+}

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/handler/ScalingHandlerTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/handler/ScalingHandlerTest.java
@@ -1,11 +1,7 @@
 package com.sequenceiq.periscope.monitor.handler;
 
-import static com.sequenceiq.periscope.api.model.AdjustmentType.EXACT;
 import static com.sequenceiq.periscope.api.model.AdjustmentType.LOAD_BASED;
-import static com.sequenceiq.periscope.api.model.AdjustmentType.NODE_COUNT;
-import static com.sequenceiq.periscope.api.model.AdjustmentType.PERCENTAGE;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -14,7 +10,6 @@ import static org.mockito.Mockito.when;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Stream;
 
@@ -30,8 +25,6 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationContext;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
-import com.sequenceiq.periscope.api.model.AdjustmentType;
 import com.sequenceiq.periscope.api.model.ClusterState;
 import com.sequenceiq.periscope.domain.BaseAlert;
 import com.sequenceiq.periscope.domain.Cluster;
@@ -41,30 +34,17 @@ import com.sequenceiq.periscope.domain.TimeAlert;
 import com.sequenceiq.periscope.monitor.event.ScalingEvent;
 import com.sequenceiq.periscope.service.ClusterService;
 import com.sequenceiq.periscope.service.RejectedThreadService;
-import com.sequenceiq.periscope.utils.StackResponseUtils;
 
 @ExtendWith(MockitoExtension.class)
 public class ScalingHandlerTest {
 
     private static final long AUTOSCALE_CLUSTER_ID = 101L;
 
-    private static final String CLOUDBREAK_STACK_CRN = "someCrn";
-
-    private static final Integer TEST_HOSTGROUP_MAX_SIZE = 200;
-
-    private static final Integer TEST_HOSTGROUP_MIN_SIZE = 0;
-
     @InjectMocks
     private ScalingHandler underTest;
 
     @Mock
     private ClusterService clusterService;
-
-    @Mock
-    private CloudbreakCommunicator cloudbreakCommunicator;
-
-    @Mock
-    private StackResponseUtils stackResponseUtils;
 
     @Mock
     private RejectedThreadService rejectedThreadService;
@@ -80,8 +60,6 @@ public class ScalingHandlerTest {
     private ScalingEvent scalingEventMock = mock(ScalingEvent.class);
 
     private Runnable runnableMock = mock(Runnable.class);
-
-    private StackV4Response stackV4ResponseMock = mock(StackV4Response.class);
 
     @Before
     public void setup() {
@@ -102,7 +80,8 @@ public class ScalingHandlerTest {
         when(loadAlertMock.getScalingPolicy()).thenReturn(scalingPolicyMock);
         when(clusterService.findById(anyLong())).thenReturn(cluster);
         when(scalingPolicyMock.getAdjustmentType()).thenReturn(LOAD_BASED);
-        when(scalingEventMock.getHostGroupNodeCount()).thenReturn(Optional.of(hostGroupNodeCount));
+        when(scalingEventMock.getHostGroupNodeCount()).thenReturn(hostGroupNodeCount);
+        when(scalingEventMock.getDesiredAbsoluteHostGroupNodeCount()).thenReturn(expectedNodeCount);
         when(scalingEventMock.getDecommissionNodeIds()).thenReturn(nodeIds);
         when(applicationContext.getBean("ScalingRequest", cluster, scalingPolicyMock,
                 hostGroupNodeCount, expectedNodeCount, nodeIds)).thenReturn(runnableMock);
@@ -117,101 +96,56 @@ public class ScalingHandlerTest {
     @Test
     public void testOnApplicationEventWhenNoScaling() {
         Cluster cluster = getARunningCluster();
-        String testHostGroup = "compute";
         TimeAlert timeAlertMock = mock(TimeAlert.class);
+
+        when(scalingEventMock.getAlert()).thenReturn(timeAlertMock);
+        when(scalingEventMock.getHostGroupNodeCount()).thenReturn(2);
+        when(scalingEventMock.getDesiredAbsoluteHostGroupNodeCount()).thenReturn(2);
 
         when(clusterService.findById(anyLong())).thenReturn(cluster);
         when(timeAlertMock.getCluster()).thenReturn(cluster);
         when(timeAlertMock.getScalingPolicy()).thenReturn(scalingPolicyMock);
 
-        when(scalingPolicyMock.getAdjustmentType()).thenReturn(EXACT);
-        when(scalingPolicyMock.getHostGroup()).thenReturn(testHostGroup);
-        when(scalingPolicyMock.getScalingAdjustment()).thenReturn(2);
-
-        when(cloudbreakCommunicator.getByCrn(anyString())).thenReturn(stackV4ResponseMock);
-        when(stackResponseUtils.getNodeCountForHostGroup(stackV4ResponseMock, testHostGroup))
-                .thenReturn(2);
-
-        underTest.onApplicationEvent(new ScalingEvent(timeAlertMock));
+        underTest.onApplicationEvent(scalingEventMock);
 
         verify(clusterService, never()).save(cluster);
         verify(applicationContext, never()).getBean("ScalingRequest");
     }
 
-    public static Stream<Arguments> dataLoadScaling() {
+    public static Stream<Arguments> dataClusterScaling() {
         return Stream.of(
-                //TestCase, AdjustmentType, CurrentHostGroupCount,ScalingAdjustment,ExpectedScalingCount
-                Arguments.of("LOAD_SCALEUP_WITHIN_MAX_LIMIT",  2,  5, 7),
-                Arguments.of("LOAD_SCALEUP_WITHIN_MAX_LIMIT", 10, 40, 50),
-                Arguments.of("LOAD_SCALEUP_WITHIN_MAX_LIMIT", 10, 15, 25),
-                Arguments.of("LOAD_SCALEUP_WITHIN_MAX_LIMIT", 10, 40, 50),
-                Arguments.of("LOAD_SCALEUP_BEYOND_MAX_LIMIT",  4, 202, TEST_HOSTGROUP_MAX_SIZE)
+                //TestCase, CurrentHostGroupCount,ScalingAdjustment,ExpectedScalingCount
+                Arguments.of("SCALE_UP",  2,  5, 7),
+                Arguments.of("SCALE_UP", 10, 40, 50),
+                Arguments.of("SCALE_UP", 10, 15, 25),
+                Arguments.of("SCALE_UP", 10, 40, 50),
+                Arguments.of("SCALE_DOWN", 10, -5, 5),
+                Arguments.of("SCALE_DOWN", 15, -14, 1),
+                Arguments.of("SCALE_DOWN", 10, -7, 3)
         );
     }
 
     @ParameterizedTest(name = "{0}: With currentHostGroupCount={1}, scalingAdjustment ={2}, expectedScalingCount={3} ")
-    @MethodSource("dataLoadScaling")
-    public void testLoadBasedScaling(String testType, int currentHostGroupCount,
+    @MethodSource("dataClusterScaling")
+    public void testClusterScaling(String testType, int currentHostGroupCount,
             int scalingAdjustment, int expectedScalingCount) {
         LoadAlert loadAlertMock = mock(LoadAlert.class);
-        validateClusterScaling(loadAlertMock, LOAD_BASED, currentHostGroupCount, scalingAdjustment, expectedScalingCount);
+        validateClusterScaling(loadAlertMock, currentHostGroupCount, scalingAdjustment, expectedScalingCount);
     }
 
-    public static Stream<Arguments> dataTmeScaling() {
-        return Stream.of(
-                            //TestCase, AdjustmentType, CurrentHostGroupCount,ScalingAdjustment,ExpectedScalingCount
-                Arguments.of("TIME_SCALEUP_NODE_COUNT_WITHIN_MAX_LIMIT", NODE_COUNT, 2, 25, 27),
-                Arguments.of("TIME_SCALEUP_NODE_COUNT_AT_MAX_LIMIT", NODE_COUNT, 2, 198, TEST_HOSTGROUP_MAX_SIZE),
-                Arguments.of("TIME_SCALEUP_NODE_COUNT_BEYOND_MAX_LIMIT", NODE_COUNT, 2,  1000, TEST_HOSTGROUP_MAX_SIZE),
-
-                Arguments.of("TIME_SCALEUP_PERCENTAGE_WITHIN_MAX_LIMIT", PERCENTAGE, 2, 50, 3),
-                Arguments.of("TIME_SCALEUP_PERCENTAGE_WITHIN_MAX_LIMIT", PERCENTAGE, 2, 100, 4),
-                Arguments.of("TIME_SCALEUP_PERCENTAGE_BEYOND_MAX_LIMIT", PERCENTAGE, 101, 1000, TEST_HOSTGROUP_MAX_SIZE),
-
-                Arguments.of("TIME_SCALEUP_EXACT_WITHIN_MAX_LIMIT", EXACT,  2, 10, 10),
-                Arguments.of("TIME_SCALEUP_EXACT_WITHIN_MAX_LIMIT", EXACT, 12, 24, 24),
-                Arguments.of("TIME_SCALEUP_EXACT_BEYOND_MAX_LIMIT", EXACT, 40, 1000, TEST_HOSTGROUP_MAX_SIZE),
-
-                Arguments.of("TIME_SCALEDOWN_NODE_COUNT_BEYOND_MIN_LIMIT", NODE_COUNT, 2, -12, TEST_HOSTGROUP_MIN_SIZE),
-                Arguments.of("TIME_SCALEDOWN_PERCENTAGE_BEYOND_MIN_LIMIT", PERCENTAGE, 2, -100, TEST_HOSTGROUP_MIN_SIZE),
-                Arguments.of("TIME_SCALEDOWN_EXACT_BEYOND_MIN_LIMIT", EXACT, 2, 0, TEST_HOSTGROUP_MIN_SIZE),
-
-                Arguments.of("TIME_SCALEDOWN_NODE_COUNT_WITHIN_MIN_LIMIT", NODE_COUNT, 10, -2, 8),
-                Arguments.of("TIME_SCALEDOWN_PERCENTAGE_WITHIN_MIN_LIMIT", PERCENTAGE, 10, -50, 5),
-                Arguments.of("TIME_SCALEDOWN_EXACT_WITHIN_MIN_LIMIT", EXACT, 10, 6, 6)
-                );
-    }
-
-    @ParameterizedTest(name = "{0}: With AdjustmentType{1}, currentHostGroupCount={2}, scalingAdjustment ={3}, expectedScalingCount={4} ")
-    @MethodSource("dataTmeScaling")
-    public void testTimeBasedScaling(String testType, AdjustmentType adjustmentType, int currentHostGroupCount,
-            int scalingAdjustment, int expectedScalingCount) {
-        TimeAlert timeAlertMock = mock(TimeAlert.class);
-        validateClusterScaling(timeAlertMock, adjustmentType, currentHostGroupCount, scalingAdjustment, expectedScalingCount);
-    }
-
-    private void validateClusterScaling(BaseAlert baseAlertMock, AdjustmentType adjustmentType,
+    private void validateClusterScaling(BaseAlert baseAlertMock,
             int currentHostGroupCount, int scalingAdjument, int expectedScaleUpCount) {
         MockitoAnnotations.initMocks(this);
         Cluster cluster = getARunningCluster();
-        String testHostGroup = "compute";
 
         when(scalingEventMock.getAlert()).thenReturn(baseAlertMock);
-        if (LOAD_BASED.equals(adjustmentType)) {
-            when(scalingEventMock.getHostGroupNodeCount()).thenReturn(Optional.of(currentHostGroupCount));
-            when(scalingEventMock.getScalingNodeCount()).thenReturn(Optional.of(scalingAdjument));
-        } else {
-            when(cloudbreakCommunicator.getByCrn(anyString())).thenReturn(stackV4ResponseMock);
-            when(stackResponseUtils.getNodeCountForHostGroup(stackV4ResponseMock, testHostGroup))
-                    .thenReturn(currentHostGroupCount);
-        }
+        when(scalingEventMock.getHostGroupNodeCount()).thenReturn(currentHostGroupCount);
+        when(scalingEventMock.getDesiredAbsoluteHostGroupNodeCount()).thenReturn(currentHostGroupCount + scalingAdjument);
+
         when(clusterService.findById(anyLong())).thenReturn(cluster);
         when(baseAlertMock.getCluster()).thenReturn(cluster);
         when(baseAlertMock.getScalingPolicy()).thenReturn(scalingPolicyMock);
 
-        when(scalingPolicyMock.getAdjustmentType()).thenReturn(adjustmentType);
-        when(scalingPolicyMock.getHostGroup()).thenReturn(testHostGroup);
-        when(scalingPolicyMock.getScalingAdjustment()).thenReturn(scalingAdjument);
         when(scalingEventMock.getDecommissionNodeIds()).thenCallRealMethod();
         when(applicationContext.getBean("ScalingRequest", cluster, scalingPolicyMock,
                 currentHostGroupCount, expectedScaleUpCount, List.of())).thenReturn(runnableMock);
@@ -226,7 +160,6 @@ public class ScalingHandlerTest {
     private Cluster getARunningCluster() {
         Cluster cluster = new Cluster();
         cluster.setId(AUTOSCALE_CLUSTER_ID);
-        cluster.setStackCrn(CLOUDBREAK_STACK_CRN);
         cluster.setState(ClusterState.RUNNING);
         cluster.setLastScalingActivity(Instant.now()
                 .minus(45, ChronoUnit.MINUTES).toEpochMilli());

--- a/autoscale/src/test/java/com/sequenceiq/periscope/utils/StackResponseUtilsTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/utils/StackResponseUtilsTest.java
@@ -8,14 +8,12 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.Set;
 
 import org.junit.Test;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.blueprint.responses.BlueprintV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.cluster.ClusterV4Response;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
 import com.sequenceiq.cloudbreak.util.FileReaderUtils;
 
 public class StackResponseUtilsTest {
@@ -31,11 +29,11 @@ public class StackResponseUtilsTest {
 
         assertEquals("Retrieved Instance Ids size should match", instanceIdsForHostGroups.size(), 3);
         assertEquals("Retrieved Instance Id should match",
-                instanceIdsForHostGroups.get("test_fqdn1"), "test_instanceid1");
+                instanceIdsForHostGroups.get("test_fqdn1"), "test_instanceid_compute1");
         assertEquals("Retrieved Instance Id should match",
-                instanceIdsForHostGroups.get("test_fqdn2"), "test_instanceid2");
+                instanceIdsForHostGroups.get("test_fqdn2"), "test_instanceid_compute2");
         assertEquals("Retrieved Instance Id should match",
-                instanceIdsForHostGroups.get("test_fqdn3"), "test_instanceid3");
+                instanceIdsForHostGroups.get("test_fqdn3"), "test_instanceid_compute3");
     }
 
     @Test
@@ -91,23 +89,8 @@ public class StackResponseUtilsTest {
     }
 
     private StackV4Response getMockStackV4Response(String hostGroup) {
-        Set hostGroupInstanceType = Set.of("compute1", "master1", "worker1", hostGroup);
-
-        InstanceMetaDataV4Response metadata1 = new InstanceMetaDataV4Response();
-        metadata1.setDiscoveryFQDN("test_fqdn1");
-        metadata1.setInstanceId("test_instanceid1");
-
-        InstanceMetaDataV4Response metadata2 = new InstanceMetaDataV4Response();
-        metadata2.setDiscoveryFQDN("test_fqdn2");
-        metadata2.setInstanceId("test_instanceid2");
-
-        InstanceMetaDataV4Response metadata3 = new InstanceMetaDataV4Response();
-        metadata3.setDiscoveryFQDN("test_fqdn3");
-        metadata3.setInstanceId("test_instanceid3");
-
-        return MockStackResponseGenerator.getMockStackV4Response("test-crn",
-                hostGroupInstanceType,
-                Set.of(metadata1, metadata2, metadata3));
+        return MockStackResponseGenerator
+                .getMockStackV4Response("test-crn", hostGroup, "test_fqdn", 3);
     }
 
     private String getTestBP() throws IOException {

--- a/autoscale/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/autoscale/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Periscope Downscaling Candidates selection is integrated with Yarn Response.
Yarn Scaling Response refactored to be reused between Schedule-Based and Load-Based Autoscaling.
