### PR TITLE
RDS: BackupRetentionPeriod should be unified to 30

### DIFF
--- a/cloud-aws/src/main/resources/templates/aws-cf-dbstack.ftl
+++ b/cloud-aws/src/main/resources/templates/aws-cf-dbstack.ftl
@@ -17,7 +17,7 @@
         "Default": 3,
         "Description": "Backup retention period, in days",
         "MinValue": 0,
-        "MaxValue": 8
+        "MaxValue": 35
     },
     "DBInstanceClassParameter": {
         "Type": "String",

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/externaldatabase/AwsDatabaseServerParameterDecorator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/externaldatabase/AwsDatabaseServerParameterDecorator.java
@@ -11,16 +11,19 @@ import com.sequenceiq.redbeams.api.endpoint.v4.stacks.aws.AwsDatabaseServerV4Par
 @Component
 public class AwsDatabaseServerParameterDecorator implements DatabaseServerParameterDecorator {
 
-    @Value("${cb.aws.externaldatabase.retentionperiod:1}")
-    private int retentionPeriod;
+    @Value("${cb.aws.externaldatabase.ha.retentionperiod}")
+    private int retentionPeriodHa;
 
-    @Value("${cb.aws.externaldatabase.engineversion:10.6}")
+    @Value("${cb.aws.externaldatabase.nonha.retentionperiod}")
+    private int retentionPeriodNonHa;
+
+    @Value("${cb.aws.externaldatabase.engineversion}")
     private String engineVersion;
 
     @Override
     public void setParameters(DatabaseServerV4StackRequest request, DatabaseServerParameter serverParameter) {
         AwsDatabaseServerV4Parameters parameters = new AwsDatabaseServerV4Parameters();
-        parameters.setBackupRetentionPeriod(retentionPeriod);
+        parameters.setBackupRetentionPeriod(serverParameter.isHighlyAvailable() ? retentionPeriodHa : retentionPeriodNonHa);
         parameters.setMultiAZ(Boolean.toString(serverParameter.isHighlyAvailable()));
         parameters.setEngineVersion(engineVersion);
         request.setAws(parameters);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/externaldatabase/AzureDatabaseServerParameterDecorator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/externaldatabase/AzureDatabaseServerParameterDecorator.java
@@ -11,17 +11,30 @@ import com.sequenceiq.redbeams.api.endpoint.v4.stacks.azure.AzureDatabaseServerV
 @Component
 public class AzureDatabaseServerParameterDecorator implements DatabaseServerParameterDecorator {
 
-    @Value("${cb.azure.externaldatabase.retentionperiod:7}")
-    private int retentionPeriod;
+    @Value("${cb.azure.externaldatabase.ha.retentionperiod}")
+    private int retentionPeriodHa;
 
-    @Value("${cb.azure.externaldatabase.geoRedundantBackup:true}")
-    private Boolean geoRedundantBackup;
+    @Value("${cb.azure.externaldatabase.ha.georedundantbackup}")
+    private Boolean geoRedundantBackupHa;
+
+    @Value("${cb.azure.externaldatabase.nonha.retentionperiod}")
+    private int retentionPeriodNonHa;
+
+    @Value("${cb.azure.externaldatabase.nonha.georedundantbackup}")
+    private Boolean geoRedundantBackupNonHa;
 
     @Override
     public void setParameters(DatabaseServerV4StackRequest request, DatabaseServerParameter serverParameter) {
         AzureDatabaseServerV4Parameters parameters = new AzureDatabaseServerV4Parameters();
-        parameters.setBackupRetentionDays(retentionPeriod);
-        parameters.setGeoRedundantBackup(geoRedundantBackup);
+        if (serverParameter.isHighlyAvailable()) {
+            parameters.setBackupRetentionDays(retentionPeriodHa);
+            parameters.setGeoRedundantBackup(geoRedundantBackupHa);
+        } else {
+            parameters.setBackupRetentionDays(retentionPeriodNonHa);
+            parameters.setGeoRedundantBackup(geoRedundantBackupNonHa);
+        }
+        parameters.setBackupRetentionDays(retentionPeriodHa);
+        parameters.setGeoRedundantBackup(geoRedundantBackupHa);
         request.setAzure(parameters);
     }
 

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -197,12 +197,24 @@ cb:
     vpc:
     vpcendpoints:
       enabled.gateway.services: s3,dynamodb
-    externaldatabase.retentionperiod: 0
+    externaldatabase:
+      engineversion: 10.6
+      ha:
+        retentionperiod: 30
+      nonha:
+        retentionperiod: 0
     credential.cache.ttl: 60
 
   azure:
     host.name.prefix.length: 255
     database.template.batchSize: 1
+    externaldatabase:
+      ha:
+        retentionperiod: 30
+        georedundantbackup: true
+      nonha:
+        retentionperiod: 7
+        georedundantbackup: false
     distrox:
       enabled.instance.types: >
         Standard_D8_v3,

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/database/AwsDatabaseServerParameterSetter.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/database/AwsDatabaseServerParameterSetter.java
@@ -3,6 +3,7 @@ package com.sequenceiq.datalake.service.sdx.database;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4StackRequest;
 import com.sequenceiq.redbeams.api.endpoint.v4.stacks.aws.AwsDatabaseServerV4Parameters;
@@ -11,17 +12,25 @@ import com.sequenceiq.sdx.api.model.SdxDatabaseAvailabilityType;
 @Component
 public class AwsDatabaseServerParameterSetter implements DatabaseServerParameterSetter {
 
-    @Value("${sdx.db.aws.engineversion:10.6}")
+    @VisibleForTesting
+    @Value("${sdx.db.aws.ha.backupretentionperiod}")
+    int backupRetentionPeriodHa;
+
+    @VisibleForTesting
+    @Value("${sdx.db.aws.nonha.backupretentionperiod}")
+    int backupRetentionPeriodNonHa;
+
+    @Value("${sdx.db.aws.engineversion}")
     private String engineVersion;
 
     @Override
     public void setParameters(DatabaseServerV4StackRequest request, SdxDatabaseAvailabilityType availabilityType) {
         AwsDatabaseServerV4Parameters parameters = new AwsDatabaseServerV4Parameters();
         if (SdxDatabaseAvailabilityType.HA.equals(availabilityType)) {
-            parameters.setBackupRetentionPeriod(1);
+            parameters.setBackupRetentionPeriod(backupRetentionPeriodHa);
             parameters.setMultiAZ("true");
         } else if (SdxDatabaseAvailabilityType.NON_HA.equals(availabilityType)) {
-            parameters.setBackupRetentionPeriod(0);
+            parameters.setBackupRetentionPeriod(backupRetentionPeriodNonHa);
             parameters.setMultiAZ("false");
         } else {
             throw new IllegalArgumentException(availabilityType + " database availability type is not supported on AWS.");

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/database/AzureDatabaseServerParameterSetter.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/database/AzureDatabaseServerParameterSetter.java
@@ -1,7 +1,9 @@
 package com.sequenceiq.datalake.service.sdx.database;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4StackRequest;
 import com.sequenceiq.redbeams.api.endpoint.v4.stacks.azure.AzureDatabaseServerV4Parameters;
@@ -10,17 +12,31 @@ import com.sequenceiq.sdx.api.model.SdxDatabaseAvailabilityType;
 @Component
 public class AzureDatabaseServerParameterSetter implements DatabaseServerParameterSetter {
 
-    private static final int RETENTION_PERIOD = 7;
+    @VisibleForTesting
+    @Value("${sdx.db.azure.ha.backupretentionperiod}")
+    int backupRetentionPeriodHa;
+
+    @VisibleForTesting
+    @Value("${sdx.db.azure.nonha.backupretentionperiod}")
+    int backupRetentionPeriodNonHa;
+
+    @VisibleForTesting
+    @Value("${sdx.db.azure.ha.georedundantbackup}")
+    boolean geoRedundantBackupHa;
+
+    @VisibleForTesting
+    @Value("${sdx.db.azure.nonha.georedundantbackup}")
+    boolean geoRedundantBackupNonHa;
 
     @Override
     public void setParameters(DatabaseServerV4StackRequest request, SdxDatabaseAvailabilityType availabilityType) {
         AzureDatabaseServerV4Parameters parameters = new AzureDatabaseServerV4Parameters();
         if (SdxDatabaseAvailabilityType.HA.equals(availabilityType)) {
-            parameters.setBackupRetentionDays(RETENTION_PERIOD);
-            parameters.setGeoRedundantBackup(true);
+            parameters.setBackupRetentionDays(backupRetentionPeriodHa);
+            parameters.setGeoRedundantBackup(geoRedundantBackupHa);
         } else if (SdxDatabaseAvailabilityType.NON_HA.equals(availabilityType)) {
-            parameters.setBackupRetentionDays(RETENTION_PERIOD);
-            parameters.setGeoRedundantBackup(false);
+            parameters.setBackupRetentionDays(backupRetentionPeriodNonHa);
+            parameters.setGeoRedundantBackup(geoRedundantBackupNonHa);
         } else {
             throw new IllegalArgumentException(availabilityType + " database availability type is not supported on Azure.");
         }

--- a/datalake/src/main/resources/application.yml
+++ b/datalake/src/main/resources/application.yml
@@ -32,6 +32,21 @@ management:
         "[http.server.requests]": "0.5, 0.95"
 
 sdx:
+  db:
+    aws:
+      engineversion: 10.6
+      ha:
+        backupretentionperiod: 30
+      nonha:
+        backupretentionperiod: 0
+    azure:
+      ha:
+        backupretentionperiod: 30
+        georedundantbackup: true
+      nonha:
+        backupretentionperiod: 7
+        georedundantbackup: false
+
   gateway:
     topology:
       name: cdp-proxy

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/database/AwsDatabaseServerParameterSetterTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/database/AwsDatabaseServerParameterSetterTest.java
@@ -25,11 +25,13 @@ public class AwsDatabaseServerParameterSetterTest {
     @Captor
     private ArgumentCaptor<AwsDatabaseServerV4Parameters> captor;
 
-    private DatabaseServerParameterSetter underTest;
+    private AwsDatabaseServerParameterSetter underTest;
 
     @BeforeEach
     public void setUp() {
         underTest = new AwsDatabaseServerParameterSetter();
+        underTest.backupRetentionPeriodHa = 30;
+        underTest.backupRetentionPeriodNonHa = 0;
     }
 
     @Test
@@ -39,7 +41,7 @@ public class AwsDatabaseServerParameterSetterTest {
         verify(request).setAws(captor.capture());
         AwsDatabaseServerV4Parameters awsDatabaseServerV4Parameters = captor.getValue();
         assertEquals("true", awsDatabaseServerV4Parameters.getMultiAZ());
-        assertEquals(1, awsDatabaseServerV4Parameters.getBackupRetentionPeriod());
+        assertEquals(30, awsDatabaseServerV4Parameters.getBackupRetentionPeriod());
     }
 
     @Test

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/database/AzureDatabaseServerParameterSetterTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/database/AzureDatabaseServerParameterSetterTest.java
@@ -25,11 +25,15 @@ public class AzureDatabaseServerParameterSetterTest {
     @Captor
     private ArgumentCaptor<AzureDatabaseServerV4Parameters> captor;
 
-    private DatabaseServerParameterSetter underTest;
+    private AzureDatabaseServerParameterSetter underTest;
 
     @BeforeEach
     public void setUp() {
         underTest = new AzureDatabaseServerParameterSetter();
+        underTest.geoRedundantBackupHa = true;
+        underTest.geoRedundantBackupNonHa = false;
+        underTest.backupRetentionPeriodHa = 30;
+        underTest.backupRetentionPeriodNonHa = 7;
     }
 
     @Test
@@ -39,7 +43,7 @@ public class AzureDatabaseServerParameterSetterTest {
         verify(request).setAzure(captor.capture());
         AzureDatabaseServerV4Parameters azureDatabaseServerV4Parameters = captor.getValue();
         assertEquals(true, azureDatabaseServerV4Parameters.getGeoRedundantBackup());
-        assertEquals(7, azureDatabaseServerV4Parameters.getBackupRetentionDays());
+        assertEquals(30, azureDatabaseServerV4Parameters.getBackupRetentionDays());
     }
 
     @Test


### PR DESCRIPTION
BackupRetentionPeriod is handled differently between AWS and azure, as well as between SDX and Distrox. All of them should have a meaningful value and set to 30 days for HA and a different value for non-HA scenarios.

See detailed description in the commit message.