### PR TITLE
CB-8094 Image selection fails for yarn tests

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogService.java
@@ -48,6 +48,7 @@ import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakImageCatalogV3;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakVersion;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Images;
+import com.sequenceiq.cloudbreak.cloud.model.component.StackType;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
 import com.sequenceiq.cloudbreak.common.service.TransactionService.TransactionExecutionException;
 import com.sequenceiq.cloudbreak.common.service.TransactionService.TransactionRuntimeExecutionException;
@@ -223,28 +224,36 @@ public class ImageCatalogService extends AbstractWorkspaceAwareResourceService<I
             throws CloudbreakImageCatalogException, CloudbreakImageNotFoundException {
         String platform = imageFilter.getPlatforms().stream().findFirst().isPresent() ? imageFilter.getPlatforms().stream().findFirst().get() : "";
         StatedImages statedImages = getStatedImagesFilteredByOperatingSystems(imageFilter, imageFilterPredicate);
-        List<Image> baseImages = statedImages.getImages().getBaseImages();
-        Optional<Image> defaultBaseImage = getLatestImageDefaultPreferred(baseImages);
-        if (!defaultBaseImage.isPresent()) {
+        Optional<Image> defaultBaseImage = getLatestBaseImageDefaultPreferred(statedImages);
+        if (defaultBaseImage.isPresent()) {
+            return statedImage(defaultBaseImage.get(), statedImages.getImageCatalogUrl(), statedImages.getImageCatalogName());
+        } else {
             throw new CloudbreakImageNotFoundException(imageNotFoundErrorMessage(platform));
         }
-        return statedImage(defaultBaseImage.get(), statedImages.getImageCatalogUrl(), statedImages.getImageCatalogName());
+    }
+
+    private Optional<Image> getLatestBaseImageDefaultPreferred(StatedImages statedImages) {
+        List<Image> baseImages = statedImages.getImages().getBaseImages();
+        return getLatestImageDefaultPreferred(baseImages);
     }
 
     public StatedImage getImagePrewarmedDefaultPreferred(ImageFilter imageFilter, Predicate<Image> imageFilterPredicate)
             throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
+        Set<String> platforms = imageFilter.getPlatforms();
+        String platform = platforms.stream().findFirst().isPresent() ? platforms.stream().findFirst().get() : "";
         StatedImages statedImages = getStatedImagesFilteredByOperatingSystems(imageFilter, imageFilterPredicate);
         Optional<Image> selectedImage = getLatestPrewarmedImage(imageFilter.getClusterVersion(), statedImages);
         if (selectedImage.isEmpty()) {
-            Set<String> platforms = imageFilter.getPlatforms();
-            String platform = platforms.stream().findFirst().isPresent() ? platforms.stream().findFirst().get() : "";
+            selectedImage = getLatestBaseImageDefaultPreferred(statedImages);
+        }
+        if (selectedImage.isEmpty()) {
             throw new CloudbreakImageNotFoundException(imageNotFoundErrorMessage(platform));
         }
         return statedImage(selectedImage.get(), statedImages.getImageCatalogUrl(), statedImages.getImageCatalogName());
     }
 
     private Optional<Image> getLatestPrewarmedImage(String clusterVersion, StatedImages statedImages) {
-        List<Image> images = statedImages.getImages().getCdhImages();
+        List<Image> images = getImagesForClusterType(statedImages, StackType.CDH.name());
         Optional<Image> selectedImage = Optional.empty();
         if (!CollectionUtils.isEmpty(images)) {
             List<Image> matchingVersionImages = images.stream().filter(img -> {
@@ -254,6 +263,18 @@ public class ImageCatalogService extends AbstractWorkspaceAwareResourceService<I
             selectedImage = getLatestImageDefaultPreferred(matchingVersionImages);
         }
         return selectedImage;
+    }
+
+    public StatedImage getLatestPrewarmedImageDefaultPreferred(ImageFilter imageFilter, Predicate<Image> imageFilterPredicate)
+            throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
+        StatedImages statedImages = getStatedImagesFilteredByOperatingSystems(imageFilter, imageFilterPredicate);
+        Optional<Image> selectedImage = getLatestPrewarmedImage(imageFilter.getClusterVersion(), statedImages);
+        Set<String> platforms = imageFilter.getPlatforms();
+        String platform = platforms.stream().findFirst().isPresent() ? platforms.stream().findFirst().get() : "";
+        if (selectedImage.isEmpty()) {
+            throw new CloudbreakImageNotFoundException(imageNotFoundErrorMessage(platform));
+        }
+        return statedImage(selectedImage.get(), statedImages.getImageCatalogUrl(), statedImages.getImageCatalogName());
     }
 
     private String imageNotFoundErrorMessage(String platform) {
@@ -597,6 +618,15 @@ public class ImageCatalogService extends AbstractWorkspaceAwareResourceService<I
     private Comparator<Image> getImageComparing(List<Image> images) {
         return images.stream().map(Image::getCreated).anyMatch(Objects::isNull) ? Comparator.comparing(Image::getDate)
                 : Comparator.comparing(Image::getCreated);
+    }
+
+    private List<Image> getImagesForClusterType(StatedImages statedImages, String clusterType) {
+        switch (clusterType) {
+            case "CDH":
+                return statedImages.getImages().getCdhImages();
+            default:
+                return emptyList();
+        }
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageService.java
@@ -178,14 +178,19 @@ public class ImageService {
         ImageCatalog imageCatalog = getImageCatalogFromRequestOrDefault(workspaceId, imageSettings, user);
         ImageFilter imageFilter = new ImageFilter(imageCatalog, ImmutableSet.of(platformString), null, baseImageEnabled, operatingSystems, clusterVersion);
         LOGGER.info("Image id is not specified for the stack.");
-        if (baseImageEnabled && useBaseImage)
-        {
-            LOGGER.info("Trying to select a base image.");
-            return imageCatalogService.getLatestBaseImageDefaultPreferred(imageFilter, imagePredicate);
+        if (baseImageEnabled) {
+            LOGGER.info("Base image usage is enabled.");
+            if (useBaseImage) {
+                LOGGER.debug("Falling back to a base imageSettings, because repo information is provided");
+                return imageCatalogService.getLatestBaseImageDefaultPreferred(imageFilter, imagePredicate);
+            }
+            LOGGER.debug("Falling back to a prewarmed imageSettings of CDH-{} or to a base imageSettings if prewarmed doesn't exist", clusterVersion);
+            return imageCatalogService.getImagePrewarmedDefaultPreferred(imageFilter, imagePredicate);
+        } else {
+            LOGGER.info("Base image usage is disabled.");
+            LOGGER.debug("Falling back to a prewarmed imageSettings of CDH-{}", clusterVersion);
+            return imageCatalogService.getLatestPrewarmedImageDefaultPreferred(imageFilter, imagePredicate);
         }
-
-        LOGGER.info("Trying to select a prewarmed image.");
-        return imageCatalogService.getImagePrewarmedDefaultPreferred(imageFilter, imagePredicate);
     }
 
     private String getClusterVersion(Blueprint blueprint) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogServiceDefaultNotFoundTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogServiceDefaultNotFoundTest.java
@@ -1,10 +1,8 @@
 package com.sequenceiq.cloudbreak.service.image;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -17,22 +15,16 @@ import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakImageCatalogV3;
-import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
 import com.sequenceiq.cloudbreak.domain.ImageCatalog;
 import com.sequenceiq.cloudbreak.repository.ImageCatalogRepository;
 import com.sequenceiq.cloudbreak.service.account.PreferencesService;
 import com.sequenceiq.cloudbreak.service.user.UserProfileService;
-import com.sequenceiq.cloudbreak.util.FileReaderUtils;
 import com.sequenceiq.cloudbreak.workspace.model.User;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ImageCatalogServiceDefaultNotFoundTest {
-
     private static final String[] PROVIDERS = {"aws", "azure", "openstack", "gcp"};
-
-    private static final String DEFAULT_CDH_IMAGE_CATALOG = "com/sequenceiq/cloudbreak/service/image/default-cdh-imagecatalog.json";
 
     @Mock
     private ImageCatalogProvider imageCatalogProvider;
@@ -58,32 +50,19 @@ public class ImageCatalogServiceDefaultNotFoundTest {
     @InjectMocks
     private ImageCatalogService underTest;
 
-    @Mock
-    private LatestDefaultImageUuidProvider latestDefaultImageUuidProvider;
-
     @Before
     public void beforeTest() {
-        ReflectionTestUtils.setField(underTest, "cbVersion", "5.0.0");
-        ReflectionTestUtils.setField(underTest, "defaultCatalogUrl", "");
-
         when(preferencesService.enabledPlatforms()).thenReturn(new HashSet<>(Arrays.asList(PROVIDERS)));
     }
 
     @Test(expected = CloudbreakImageNotFoundException.class)
     public void testGetDefaultImageShouldThrowNotFoundException() throws Exception {
+        // GIVEN
+        ReflectionTestUtils.setField(underTest, "cbVersion", "5.0.0");
+        ReflectionTestUtils.setField(underTest, "defaultCatalogUrl", "");
+        // WHEN
         ImageFilter imageFilter = new ImageFilter(imageCatalog, Set.of("gcp"), null, true, Set.of("notimportant"), null);
         underTest.getImagePrewarmedDefaultPreferred(imageFilter, image -> true);
-    }
-
-    @Test(expected = CloudbreakImageNotFoundException.class)
-    public void testGetDefaultImageShouldThrowNotFoundException2() throws Exception {
-        String catalogJson = FileReaderUtils.readFileFromClasspath(DEFAULT_CDH_IMAGE_CATALOG);
-        CloudbreakImageCatalogV3 catalog = JsonUtil.readValue(catalogJson, CloudbreakImageCatalogV3.class);
-        when(imageCatalogProvider.getImageCatalogV3(DEFAULT_CDH_IMAGE_CATALOG)).thenReturn(catalog);
-        when(imageCatalog.getImageCatalogUrl()).thenReturn(DEFAULT_CDH_IMAGE_CATALOG);
-        when(latestDefaultImageUuidProvider.getLatestDefaultImageUuids(any(), any())).thenReturn(Collections.EMPTY_LIST);
-
-        ImageFilter imageFilter = new ImageFilter(imageCatalog, Set.of("aws"), "2.6", true, Set.of("centos7", "amazonlinux2"), null);
-        underTest.getImagePrewarmedDefaultPreferred(imageFilter, image -> true);
+        // THEN throw CloudbreakImageNotFoundException
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogServiceDefaultTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogServiceDefaultTest.java
@@ -42,10 +42,7 @@ import com.sequenceiq.cloudbreak.workspace.model.User;
 
 @RunWith(Parameterized.class)
 public class ImageCatalogServiceDefaultTest {
-
     private static final String[] PROVIDERS = { "aws", "azure", "openstack", "gcp" };
-
-    private static final String DEFAULT_CDH_IMAGE_CATALOG = "com/sequenceiq/cloudbreak/service/image/default-cdh-imagecatalog.json";
 
     private final String catalogFile;
 
@@ -111,12 +108,27 @@ public class ImageCatalogServiceDefaultTest {
     @Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-                {DEFAULT_CDH_IMAGE_CATALOG, "aws", "2.6", "latest-hdp", "5.0.0", "" },
-                {DEFAULT_CDH_IMAGE_CATALOG, "aws", "2.6", "latest-hdp", "5.0.0", "centos7" },
-                {DEFAULT_CDH_IMAGE_CATALOG, "aws", "2.6", "latest-amazonlinux-hdp", "5.0.0", "amazonlinux2" },
-                {DEFAULT_CDH_IMAGE_CATALOG, "aws", "2.6", "second-latest-hdp", "6.0.0", "" },
-                {DEFAULT_CDH_IMAGE_CATALOG, "aws", "2.6", "second-latest-hdp", "6.1.0", "" },
-                {DEFAULT_CDH_IMAGE_CATALOG, "aws", "2.6", "latest-hdp", "9.0.0", "" }
+                { "com/sequenceiq/cloudbreak/service/image/default-cdh-imagecatalog.json", "aws", "2.6", "latest-hdp", "5.0.0", "" },
+                { "com/sequenceiq/cloudbreak/service/image/default-cdh-imagecatalog.json", "aws", "2.6", "latest-hdp", "5.0.0", "centos7" },
+                { "com/sequenceiq/cloudbreak/service/image/default-cdh-imagecatalog.json", "aws", "2.6", "latest-amazonlinux-hdp",
+                        "5.0.0", "amazonlinux2" },
+                { "com/sequenceiq/cloudbreak/service/image/default-cdh-imagecatalog.json", "aws", "missing", "third-latest-base-amazonlinux",
+                        "5.0.0", "amazonlinux2" },
+                { "com/sequenceiq/cloudbreak/service/image/default-cdh-imagecatalog.json", "aws", "missing", "forth-latest-base-amazonlinux",
+                        "6.0.0", "amazonlinux2" },
+                { "com/sequenceiq/cloudbreak/service/image/default-cdh-imagecatalog.json", "aws", "missing", "latest-base", "5.0.0", "" },
+                { "com/sequenceiq/cloudbreak/service/image/default-cdh-imagecatalog.json", "aws", "missing", "second-latest-base", "6.0.0", "" },
+                { "com/sequenceiq/cloudbreak/service/image/default-cdh-imagecatalog.json", "aws", "2.6", "second-latest-hdp", "6.0.0", "" },
+                { "com/sequenceiq/cloudbreak/service/image/default-cdh-imagecatalog.json", "aws", "missing", "latest-base", "6.1.0", "" },
+                { "com/sequenceiq/cloudbreak/service/image/default-cdh-imagecatalog.json", "aws", "2.6", "second-latest-hdp", "6.1.0", "" },
+                { "com/sequenceiq/cloudbreak/service/image/default-cdh-imagecatalog.json", "aws", "missing", "latest-base", "7.0.0-dev.20", "" },
+                { "com/sequenceiq/cloudbreak/service/image/default-cdh-imagecatalog.json", "aws", "missing", "second-latest-base", "8.0.0-dev.30", "" },
+                { "com/sequenceiq/cloudbreak/service/image/default-cdh-imagecatalog.json", "aws", "missing", "latest-base", "9.0.0", "" },
+                { "com/sequenceiq/cloudbreak/service/image/default-cdh-imagecatalog.json", "aws", "2.6", "latest-hdp", "9.0.0", "" },
+                { "com/sequenceiq/cloudbreak/service/image/default-base-imagecatalog.json", "aws",
+                        ImageCatalogService.UNDEFINED, "latest-base", "5.0.0", "" },
+                { "com/sequenceiq/cloudbreak/service/image/default-base-imagecatalog-with-timestamp.json", "aws",
+                        ImageCatalogService.UNDEFINED, "latest-base", "5.0.0", "" }
         });
     }
 
@@ -129,11 +141,13 @@ public class ImageCatalogServiceDefaultTest {
         when(preferencesService.enabledPlatforms()).thenReturn(new HashSet<>(Arrays.asList(PROVIDERS)));
 
         when(userProfileService.getOrCreate(user)).thenReturn(new UserProfile());
-        when(userProfileService.getOrCreate(user)).thenReturn(new UserProfile());
+        when(userProfileService.getOrCreate(user))
+                .thenReturn(new UserProfile());
         when(imageCatalog.getImageCatalogUrl()).thenReturn(catalogFile);
         lenient().when(user.getUserCrn()).thenReturn(TestConstants.CRN);
         when(userService.getOrCreate(any())).thenReturn(user);
         when(entitlementService.baseImageEnabled(anyString(), anyString())).thenReturn(true);
+        // when(prefixMatcherService.prefixMatchForCBVersion(any(), any()))
     }
 
     @Test

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageServiceTest.java
@@ -283,7 +283,7 @@ public class ImageServiceTest {
     @Test
     public void testDisabledBaseImageShouldReturnCorrectImage() throws CloudbreakImageCatalogException, CloudbreakImageNotFoundException {
         imageSettingsV4Request.setId(null);
-        when(imageCatalogService.getImagePrewarmedDefaultPreferred(any(), any())).thenReturn(getImageFromCatalog(true, "uuid", STACK_VERSION));
+        when(imageCatalogService.getLatestPrewarmedImageDefaultPreferred(any(), any())).thenReturn(getImageFromCatalog(true, "uuid", STACK_VERSION));
         StatedImage statedImage = underTest.determineImageFromCatalog(
                 WORKSPACE_ID,
                 imageSettingsV4Request,

--- a/core/src/test/resources/com/sequenceiq/cloudbreak/service/image/default-base-imagecatalog-with-timestamp.json
+++ b/core/src/test/resources/com/sequenceiq/cloudbreak/service/image/default-base-imagecatalog-with-timestamp.json
@@ -1,0 +1,134 @@
+{
+  "images": {
+    "base-images": [
+      {
+        "created": 1474329600,
+        "date": "irrelevant",
+        "description": "Cloudbreak official base image",
+        "images": {
+          "aws": {
+            "ap-northeast-1": "ami-0fc3016e",
+            "ap-northeast-2": "ami-4d6aa023",
+            "ap-southeast-1": "ami-ced60fad",
+            "ap-southeast-2": "ami-9f9eaafc",
+            "eu-central-1": "ami-cd4cbaa2",
+            "eu-west-1": "ami-0b067378",
+            "sa-east-1": "ami-70a5331c",
+            "us-east-1": "ami-70a73c67",
+            "us-west-1": "ami-3fe8ab5f",
+            "us-west-2": "ami-6bf9330b"
+          },
+          "gcp": {
+            "default": "sequenceiqimage/hdc-hdp--1710161226.tar.gz"
+          },
+          "openstack": {
+            "default": "hdc-hdp--1710161226"
+          }
+        },
+        "os": "centos7",
+        "os_type": "",
+        "uuid": "3"
+      },
+      {
+        "created": 975628800,
+        "date": "irrelevant",
+        "description": "Cloudbreak official base image",
+        "images": {
+          "aws": {
+            "ap-northeast-1": "ami-0fc3016e",
+            "ap-northeast-2": "ami-4d6aa023",
+            "ap-southeast-1": "ami-ced60fad",
+            "ap-southeast-2": "ami-9f9eaafc",
+            "eu-central-1": "ami-cd4cbaa2",
+            "eu-west-1": "ami-0b067378",
+            "sa-east-1": "ami-70a5331c",
+            "us-east-1": "ami-70a73c67",
+            "us-west-1": "ami-3fe8ab5f",
+            "us-west-2": "ami-6bf9330b"
+          },
+          "gcp": {
+            "default": "sequenceiqimage/hdc-hdp--1710161226.tar.gz"
+          },
+          "openstack": {
+            "default": "hdc-hdp--1710161226"
+          }
+        },
+        "os": "centos7",
+        "os_type": "",
+        "uuid": "2"
+      },
+      {
+        "created": 1474416000,
+        "date": "irrelevant",
+        "description": "Cloudbreak official base image",
+        "images": {
+          "aws": {
+            "ap-northeast-1": "ami-0fc3016e",
+            "ap-northeast-2": "ami-4d6aa023",
+            "ap-southeast-1": "ami-ced60fad",
+            "ap-southeast-2": "ami-9f9eaafc",
+            "eu-central-1": "ami-cd4cbaa2",
+            "eu-west-1": "ami-0b067378",
+            "sa-east-1": "ami-70a5331c",
+            "us-east-1": "ami-70a73c67",
+            "us-west-1": "ami-3fe8ab5f",
+            "us-west-2": "ami-6bf9330b"
+          },
+          "gcp": {
+            "default": "sequenceiqimage/hdc-hdp--1710161226.tar.gz"
+          },
+          "openstack": {
+            "default": "hdc-hdp--1710161226"
+          }
+        },
+        "os": "centos7",
+        "os_type": "",
+        "uuid": "latest-base"
+      },
+      {
+        "created": -1713052800,
+        "date": "irrelevant",
+        "description": "Cloudbreak official base image",
+        "images": {
+          "aws": {
+            "ap-northeast-1": "ami-0fc3016e",
+            "ap-northeast-2": "ami-4d6aa023",
+            "ap-southeast-1": "ami-ced60fad",
+            "ap-southeast-2": "ami-9f9eaafc",
+            "eu-central-1": "ami-cd4cbaa2",
+            "eu-west-1": "ami-0b067378",
+            "sa-east-1": "ami-70a5331c",
+            "us-east-1": "ami-70a73c67",
+            "us-west-1": "ami-3fe8ab5f",
+            "us-west-2": "ami-6bf9330b"
+          },
+          "gcp": {
+            "default": "sequenceiqimage/hdc-hdp--1710161226.tar.gz"
+          },
+          "openstack": {
+            "default": "hdc-hdp--1710161226"
+          }
+        },
+        "os": "centos7",
+        "os_type": "",
+        "uuid": "1"
+      }
+    ]
+  },
+  "versions": {
+    "cloudbreak": [
+      {
+        "images": [
+          "3",
+          "1",
+          "2",
+          "latest-base"
+        ],
+        "defaults": null,
+        "versions": [
+          "5.0.0"
+        ]
+      }
+    ]
+  }
+}

--- a/core/src/test/resources/com/sequenceiq/cloudbreak/service/image/default-base-imagecatalog.json
+++ b/core/src/test/resources/com/sequenceiq/cloudbreak/service/image/default-base-imagecatalog.json
@@ -1,0 +1,195 @@
+{
+  "images": {
+    "base-images": [
+      {
+        "uuid": "3",
+        "date": "2016-09-20",
+        "os": "centos7",
+        "images": {
+          "aws": {
+            "ap-northeast-1": "ami-0fc3016e",
+            "ap-northeast-2": "ami-4d6aa023",
+            "ap-southeast-1": "ami-ced60fad",
+            "ap-southeast-2": "ami-9f9eaafc",
+            "eu-central-1": "ami-cd4cbaa2",
+            "eu-west-1": "ami-0b067378",
+            "sa-east-1": "ami-70a5331c",
+            "us-east-1": "ami-70a73c67",
+            "us-west-1": "ami-3fe8ab5f",
+            "us-west-2": "ami-6bf9330b"
+          },
+          "azure_rm": {
+            "Brazil South": "https://sequenceiqbrazilsouth2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "Canada Central": "https://sequenceiqcanadacentral.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "Canada East": "https://sequenceiqcanadaeast.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "Central US": "https://sequenceiqcentralus2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "East Asia": "https://sequenceiqeastasia2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "East US": "https://sequenceiqeastus12.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "East US 2": "https://sequenceiqeastus22.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "Japan East": "https://sequenceiqjapaneast2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "Japan West": "https://sequenceiqjapanwest2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "North Central US": "https://sequenceiqorthcentralus2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "North Europe": "https://sequenceiqnortheurope2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "South Central US": "https://sequenceiqouthcentralus2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "Southeast Asia": "https://sequenceiqsoutheastasia2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "West Europe": "https://sequenceiqwesteurope2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "West US": "https://sequenceiqwestus2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd"
+          },
+          "gcp": {
+            "default": "sequenceiqimage/hdc-hdp--1710161226.tar.gz"
+          },
+          "openstack": {
+            "default": "hdc-hdp--1710161226"
+          }
+        },
+        "description": "Cloudbreak official base image"
+      },
+      {
+        "uuid": "2",
+        "created": 9999999999,
+        "date": "2000-12-01",
+        "os": "centos7",
+        "images": {
+          "aws": {
+            "ap-northeast-1": "ami-0fc3016e",
+            "ap-northeast-2": "ami-4d6aa023",
+            "ap-southeast-1": "ami-ced60fad",
+            "ap-southeast-2": "ami-9f9eaafc",
+            "eu-central-1": "ami-cd4cbaa2",
+            "eu-west-1": "ami-0b067378",
+            "sa-east-1": "ami-70a5331c",
+            "us-east-1": "ami-70a73c67",
+            "us-west-1": "ami-3fe8ab5f",
+            "us-west-2": "ami-6bf9330b"
+          },
+          "azure_rm": {
+            "Brazil South": "https://sequenceiqbrazilsouth2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "Canada Central": "https://sequenceiqcanadacentral.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "Canada East": "https://sequenceiqcanadaeast.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "Central US": "https://sequenceiqcentralus2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "East Asia": "https://sequenceiqeastasia2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "East US": "https://sequenceiqeastus12.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "East US 2": "https://sequenceiqeastus22.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "Japan East": "https://sequenceiqjapaneast2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "Japan West": "https://sequenceiqjapanwest2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "North Central US": "https://sequenceiqorthcentralus2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "North Europe": "https://sequenceiqnortheurope2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "South Central US": "https://sequenceiqouthcentralus2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "Southeast Asia": "https://sequenceiqsoutheastasia2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "West Europe": "https://sequenceiqwesteurope2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "West US": "https://sequenceiqwestus2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd"
+          },
+          "gcp": {
+            "default": "sequenceiqimage/hdc-hdp--1710161226.tar.gz"
+          },
+          "openstack": {
+            "default": "hdc-hdp--1710161226"
+          }
+        },
+        "description": "Cloudbreak official base image"
+      },
+      {
+        "uuid": "latest-base",
+        "date": "2016-09-21",
+        "os": "centos7",
+        "images": {
+          "aws": {
+            "ap-northeast-1": "ami-0fc3016e",
+            "ap-northeast-2": "ami-4d6aa023",
+            "ap-southeast-1": "ami-ced60fad",
+            "ap-southeast-2": "ami-9f9eaafc",
+            "eu-central-1": "ami-cd4cbaa2",
+            "eu-west-1": "ami-0b067378",
+            "sa-east-1": "ami-70a5331c",
+            "us-east-1": "ami-70a73c67",
+            "us-west-1": "ami-3fe8ab5f",
+            "us-west-2": "ami-6bf9330b"
+          },
+          "azure_rm": {
+            "Brazil South": "https://sequenceiqbrazilsouth2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "Canada Central": "https://sequenceiqcanadacentral.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "Canada East": "https://sequenceiqcanadaeast.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "Central US": "https://sequenceiqcentralus2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "East Asia": "https://sequenceiqeastasia2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "East US": "https://sequenceiqeastus12.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "East US 2": "https://sequenceiqeastus22.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "Japan East": "https://sequenceiqjapaneast2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "Japan West": "https://sequenceiqjapanwest2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "North Central US": "https://sequenceiqorthcentralus2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "North Europe": "https://sequenceiqnortheurope2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "South Central US": "https://sequenceiqouthcentralus2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "Southeast Asia": "https://sequenceiqsoutheastasia2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "West Europe": "https://sequenceiqwesteurope2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "West US": "https://sequenceiqwestus2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd"
+          },
+          "gcp": {
+            "default": "sequenceiqimage/hdc-hdp--1710161226.tar.gz"
+          },
+          "openstack": {
+            "default": "hdc-hdp--1710161226"
+          }
+        },
+        "description": "Cloudbreak official base image"
+      },
+      {
+        "uuid": "1",
+        "created": 9999999999,
+        "date": "1915-09-20",
+        "os": "centos7",
+        "images": {
+          "aws": {
+            "ap-northeast-1": "ami-0fc3016e",
+            "ap-northeast-2": "ami-4d6aa023",
+            "ap-southeast-1": "ami-ced60fad",
+            "ap-southeast-2": "ami-9f9eaafc",
+            "eu-central-1": "ami-cd4cbaa2",
+            "eu-west-1": "ami-0b067378",
+            "sa-east-1": "ami-70a5331c",
+            "us-east-1": "ami-70a73c67",
+            "us-west-1": "ami-3fe8ab5f",
+            "us-west-2": "ami-6bf9330b"
+          },
+          "azure_rm": {
+            "Brazil South": "https://sequenceiqbrazilsouth2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "Canada Central": "https://sequenceiqcanadacentral.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "Canada East": "https://sequenceiqcanadaeast.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "Central US": "https://sequenceiqcentralus2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "East Asia": "https://sequenceiqeastasia2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "East US": "https://sequenceiqeastus12.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "East US 2": "https://sequenceiqeastus22.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "Japan East": "https://sequenceiqjapaneast2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "Japan West": "https://sequenceiqjapanwest2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "North Central US": "https://sequenceiqorthcentralus2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "North Europe": "https://sequenceiqnortheurope2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "South Central US": "https://sequenceiqouthcentralus2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "Southeast Asia": "https://sequenceiqsoutheastasia2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "West Europe": "https://sequenceiqwesteurope2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd",
+            "West US": "https://sequenceiqwestus2.blob.core.windows.net/images/hdc-hdp-25-1611041452.vhd"
+          },
+          "gcp": {
+            "default": "sequenceiqimage/hdc-hdp--1710161226.tar.gz"
+          },
+          "openstack": {
+            "default": "hdc-hdp--1710161226"
+          }
+        },
+        "description": "Cloudbreak official base image"
+      }
+    ]
+  },
+  "versions": {
+    "cloudbreak": [
+      {
+        "versions": [
+          "5.0.0"
+        ],
+        "images": [
+          "3",
+          "1",
+          "2",
+          "latest-base"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Revert "CB-7805: Avoid automatic fallback to base images"
This reverts commit f27320d11b96061cd5b62898619773f9996e433b.

