### PR TITLE
CB-8098 [ASRG] error message when missing entitlement is not clear

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/parameters/validation/validators/parameter/AzureParameterValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/parameters/validation/validators/parameter/AzureParameterValidator.java
@@ -59,7 +59,8 @@ public class AzureParameterValidator implements ParameterValidator {
         if (!singleResourceGroupDeploymentEnabled) {
             if (Objects.nonNull(azureParametersDto.getAzureResourceGroupDto())
                     && USE_SINGLE.equals(azureParametersDto.getAzureResourceGroupDto().getResourceGroupUsagePattern())) {
-                return validationResultBuilder.error("'SINGLE' usage pattern for Resource Groups could not be specified, as feature is disabled").build();
+                return validationResultBuilder.error(
+                        "You specified to use a single resource group for all of your resources, but that feature is currently disabled").build();
             } else {
                 return validationResultBuilder.build();
             }
@@ -72,7 +73,9 @@ public class AzureParameterValidator implements ParameterValidator {
         }
         if (USE_MULTIPLE.equals(azureResourceGroupDto.getResourceGroupUsagePattern())) {
             if (StringUtils.isNotBlank(azureResourceGroupDto.getName())) {
-                return validationResultBuilder.error(String.format("Resource group name '%s' cannot not be specified if MULTIPLE usage is defined.",
+                return validationResultBuilder.error(
+                        String.format("You specified to use multiple resource groups for your resources, " +
+                                        "but then the single resource group name '%s' cannot not be specified.",
                         azureResourceGroupDto.getName())).build();
             } else {
                 return validationResultBuilder.build();

--- a/environment/src/test/java/com/sequenceiq/environment/parameters/validation/validators/AzureParameterValidatorTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/parameters/validation/validators/AzureParameterValidatorTest.java
@@ -164,7 +164,8 @@ public class AzureParameterValidatorTest {
         ValidationResult validationResult = underTest.validate(environmentDto, environmentDto.getParameters(), ValidationResult.builder());
 
         assertTrue(validationResult.hasError());
-        assertEquals("1. Resource group name 'myResourceGroup' cannot not be specified if MULTIPLE usage is defined.",
+        assertEquals("1. You specified to use multiple resource groups for your resources, " +
+                        "but then the single resource group name 'myResourceGroup' cannot not be specified.",
                 validationResult.getFormattedErrors());
     }
 
@@ -232,7 +233,7 @@ public class AzureParameterValidatorTest {
         ValidationResult validationResult = underTest.validate(environmentDto, environmentDto.getParameters(), ValidationResult.builder());
 
         assertTrue(validationResult.hasError());
-        assertEquals("1. 'SINGLE' usage pattern for Resource Groups could not be specified, as feature is disabled",
+        assertEquals("1. You specified to use a single resource group for all of your resources, but that feature is currently disabled",
                 validationResult.getFormattedErrors());
     }
 


### PR DESCRIPTION
In case the user tries to create an env with single RG but the feature is turned off from entitlement then an error message comes up. It was too technical. Also, if a RG name is specified along with single RG name then another error message comes, it was also too technical.

See detailed description in the commit message.