### PR TITLE
CB-8126 Hard fail if audit endpoint configuration is missing

### DIFF
--- a/audit-connector/src/main/java/com/sequenceiq/cloudbreak/audit/config/AuditConfig.java
+++ b/audit-connector/src/main/java/com/sequenceiq/cloudbreak/audit/config/AuditConfig.java
@@ -1,7 +1,15 @@
 package com.sequenceiq.cloudbreak.audit.config;
 
-import com.sequenceiq.cloudbreak.audit.converter.AttemptAuditEventResultBuilderUpdater;
-import com.sequenceiq.cloudbreak.audit.converter.AuditEventBuilderUpdater;
+import static com.sequenceiq.cloudbreak.util.NullUtil.getIfNotNull;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -10,14 +18,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import javax.annotation.PostConstruct;
-import javax.inject.Inject;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import static com.sequenceiq.cloudbreak.util.NullUtil.getIfNotNull;
+import com.sequenceiq.cloudbreak.audit.converter.AttemptAuditEventResultBuilderUpdater;
+import com.sequenceiq.cloudbreak.audit.converter.AuditEventBuilderUpdater;
+import com.sequenceiq.cloudbreak.structuredevent.conf.StructuredEventEnablementConfig;
 
 @Configuration
 public class AuditConfig {
@@ -32,6 +35,9 @@ public class AuditConfig {
     private String host;
 
     private int port;
+
+    @Inject
+    private StructuredEventEnablementConfig structuredEventEnablementConfig;
 
     @Inject
     private List<AuditEventBuilderUpdater> auditEventBuilderUpdaters;
@@ -50,6 +56,8 @@ public class AuditConfig {
             port = parts.length == 2
                     ? Integer.parseInt(parts[1])
                     : DEFAULT_AUDIT_PORT;
+        } else if (structuredEventEnablementConfig.isAuditServiceEnabled()) {
+            throw new IllegalStateException("Audit service is enabled, but altus.audit.endpoint is not configured");
         }
     }
 

--- a/audit-connector/src/test/java/com/sequenceiq/cloudbreak/audit/config/AuditConfigTest.java
+++ b/audit-connector/src/test/java/com/sequenceiq/cloudbreak/audit/config/AuditConfigTest.java
@@ -2,25 +2,43 @@ package com.sequenceiq.cloudbreak.audit.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
 
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.util.ReflectionUtils;
 
+import com.sequenceiq.cloudbreak.structuredevent.conf.StructuredEventEnablementConfig;
+
+@ExtendWith(MockitoExtension.class)
 class AuditConfigTest {
+
+    @Mock
+    private StructuredEventEnablementConfig structuredEventEnablementConfig;
+
+    @InjectMocks
+    private AuditConfig underTest;
 
     // @formatter:off
     // CHECKSTYLE:OFF
     static Object[][] scenarios() {
         return new Object[][]{
-                // testCaseName      endpoint                  valid  configured   host         port  exception
-                { "null endpoint",   null,                     true,  false,       null,        null, null },
-                { "blank endpoint",  "   ",                    true,  false,       null,        null, null },
-                { "host only",       "hostname",               true,  true,        "hostname",  8982,   null },
-                { "host:port",       "hostname:1234",          true,  true,        "hostname",  1234, null },
-                { "host:port:extra", "hostname:1234:whatelse", false, false,       null,        null, IllegalArgumentException.class },
+                // testCaseName      endpoint                            valid  enabled  configured   host         port  exception
+                { "null endpoint, disabled",   null,                     true,  false,   false,       null,        null, null },
+                { "blank endpoint, disabled",  "   ",                    true,  false,   false,       null,        null, null },
+                { "null endpoint, enabled",    null,                     false, true,    false,       null,        null, IllegalStateException.class },
+                { "blank endpoint, enabled",   "   ",                    false, true,    false,       null,        null, IllegalStateException.class },
+                { "host only",                 "hostname",               true,  true,    true,        "hostname",  8982, null },
+                { "host:port",                 "hostname:1234",          true,  true,    true,        "hostname",  1234, null },
+                { "host:port:extra",           "hostname:1234:whatelse", false, true,    false,       null,        null, IllegalArgumentException.class },
         };
     }
     // CHECKSTYLE:ON
@@ -28,11 +46,15 @@ class AuditConfigTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("scenarios")
-    void init(String testName, String endpoint, boolean valid, boolean configured, String host, Integer port, Class<? extends Exception> exceptionClass) {
-        AuditConfig underTest = new AuditConfig();
+    @MockitoSettings(strictness = Strictness.LENIENT)
+    void init(String testName, String endpoint, boolean valid, boolean enabled, boolean configured,
+            String host, Integer port, Class<? extends Exception> exceptionClass) {
+
         Field endpointField = ReflectionUtils.findField(AuditConfig.class, "endpoint");
         ReflectionUtils.makeAccessible(endpointField);
         ReflectionUtils.setField(endpointField, underTest, endpoint);
+        when(structuredEventEnablementConfig.isAuditServiceEnabled()).thenReturn(enabled);
+
         if (valid) {
             underTest.init();
             if (configured) {

--- a/integration-test/src/main/java/com/sequenceiq/it/config/AuditBeanConfig.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/config/AuditBeanConfig.java
@@ -7,6 +7,7 @@ import com.sequenceiq.cloudbreak.audit.AuditClient;
 
 @Configuration()
 @ComponentScan(basePackages = {
+        "com.sequenceiq.cloudbreak.structuredevent.conf",
         "com.sequenceiq.cloudbreak.audit.config",
         "com.sequenceiq.cloudbreak.audit.converter",
         "com.sequenceiq.cloudbreak.audit.model",

--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -88,7 +88,7 @@ integrationtest:
     publicKeyId: api-e2e-test
     credential:
       type: role
-      roleArn: 
+      roleArn:
       accessKeyId:
       secretKey:
     instance:
@@ -240,6 +240,8 @@ integrationtest:
     url: https://logs-dev.sre.cloudera.com/app/kibana#/discover
     cluster:
     app:
+
 altus:
   audit:
     endpoint: localhost:8982
+    enabled: false


### PR DESCRIPTION
This configuration item has no default value and it was not asserted before.
Upon audit service call, the endpoint and port was always used and in case it was null, an NPE
was raised by the GRPC client library