### PR TITLE
CB-8131 Fix image catalog lookup

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/cloud/model/component/ImageBasedDefaultCDHEntries.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/cloud/model/component/ImageBasedDefaultCDHEntries.java
@@ -48,7 +48,10 @@ public class ImageBasedDefaultCDHEntries {
     public Map<String, ImageBasedDefaultCDHInfo> getEntries(Images images) {
         return images.getCdhImages().stream()
                 .filter(Image::isDefaultImage)
-                .collect(Collectors.toMap(Image::getVersion, i -> new ImageBasedDefaultCDHInfo(getDefaultCDHInfo(i), i)));
+                .collect(Collectors.toMap(Image::getVersion, i -> new ImageBasedDefaultCDHInfo(getDefaultCDHInfo(i), i),
+                        //The generated CDHInfo should be the same for the same version so it does not matter which one is used.
+                        //It can happend when calling for an image catalog with images.
+                        (i1, i2) -> i1));
     }
 
     private DefaultCDHInfo getDefaultCDHInfo(Image image) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/cloud/model/component/ImageBasedDefaultCDHEntriesTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/cloud/model/component/ImageBasedDefaultCDHEntriesTest.java
@@ -123,7 +123,9 @@ public class ImageBasedDefaultCDHEntriesTest {
         Image nonDefaultImage = mock(Image.class);
         when(nonDefaultImage.isDefaultImage()).thenReturn(false);
 
-        return asList(defaultImage, nonDefaultImage);
+        //Default image added double times to test
+        //the algorithm is not failing on multiple default images for the same version
+        return asList(defaultImage, defaultImage, nonDefaultImage);
     }
 
     private Map<String, String> getRepo() {


### PR DESCRIPTION
CB-8131 Image catalog lookup should not fail on multiple default images for the same CDH version. The generated DefaultCDHInfo should be the same so it does not matter which one is used.