### PR TITLE
CB-7991 Payload converters overriden for ClusterTerminationAction

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/termination/ClusterTerminationActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/termination/ClusterTerminationActions.java
@@ -10,22 +10,22 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.statemachine.action.Action;
 
 import com.sequenceiq.cloudbreak.common.event.Selectable;
-import com.sequenceiq.cloudbreak.core.flow2.stack.provision.DisableKerberosResultToStackFailureEventConverter;
-import com.sequenceiq.cloudbreak.reactor.api.event.cluster.DeregisterServicesRequest;
-import com.sequenceiq.cloudbreak.reactor.api.event.cluster.DeregisterServicesResult;
-import com.sequenceiq.flow.core.PayloadConverter;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.AbstractClusterAction;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.ClusterViewContext;
 import com.sequenceiq.cloudbreak.core.flow2.stack.AbstractStackFailureAction;
 import com.sequenceiq.cloudbreak.core.flow2.stack.StackFailureContext;
 import com.sequenceiq.cloudbreak.core.flow2.stack.provision.DisableKerberosResultToStackEventConverter;
+import com.sequenceiq.cloudbreak.core.flow2.stack.provision.DisableKerberosResultToStackFailureEventConverter;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackFailureEvent;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.DeregisterServicesRequest;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.DeregisterServicesResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.DisableKerberosRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.PrepareClusterTerminationRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.PrepareClusterTerminationResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.ClusterTerminationRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.ClusterTerminationResult;
+import com.sequenceiq.flow.core.PayloadConverter;
 import com.sequenceiq.statuschecker.service.JobService;
 
 @Configuration
@@ -131,6 +131,7 @@ public class ClusterTerminationActions {
 
             @Override
             protected void initPayloadConverterMap(List<PayloadConverter<StackFailureEvent>> payloadConverters) {
+                super.initPayloadConverterMap(payloadConverters);
                 payloadConverters.add(new DisableKerberosResultToStackFailureEventConverter());
             }
 


### PR DESCRIPTION
Default payload converters were overriden:

`2020-07-16 11:25:05,302 [reactorDispatcher-10] convertPayload:206 ERROR c.s.f.c.AbstractAction - [type:springLog] [crn:] [name:] [flow:4f9984f2-0160-480d-bdd1-3e1bf52f158d] [requestid:] [tenant:] [userCrn:] [environment:] [traceId:cca5abf45afe607e] [spanId:cca5abf45afe607e] No payload converter found for ClusterPlatformResult{status=FAILED, statusReason='query did not return a unique result: 2; nested exception is javax.persistence.NonUniqueResultException: query did not return a unique result: 2', errorDetails=org.springframework.dao.IncorrectResultSizeDataAccessException: query did not return a unique result: 2; nested exception is javax.persistence.NonUniqueResultException: query did not return a unique result: 2}, payload will be null`