### PR TITLE
CB-8135 configure paywall credentials to CM yum repo file

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/JsonCMLicense.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/JsonCMLicense.java
@@ -1,0 +1,52 @@
+package com.sequenceiq.cloudbreak.core.bootstrap.service.host;
+
+import java.util.StringJoiner;
+
+import org.apache.commons.codec.digest.DigestUtils;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class JsonCMLicense {
+
+    private static final int FIRST_PW_CHAR = 0;
+
+    private static final int LAST_PW_CHAR = 12;
+
+    private String name;
+
+    private String uuid;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+
+    public String getPaywallUsername() {
+        return uuid;
+    }
+
+    public String getPaywallPassword() {
+        String hash = DigestUtils.sha256Hex(name + uuid);
+        return hash.substring(FIRST_PW_CHAR, LAST_PW_CHAR);
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", JsonCMLicense.class.getSimpleName() + "[", "]")
+                .add("name='" + name + "'")
+                .add("uuid=" + uuid)
+                .toString();
+    }
+}

--- a/core/src/test/resources/cm-license-empty.txt
+++ b/core/src/test/resources/cm-license-empty.txt
@@ -1,0 +1,14 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA256
+
+{
+  "deactivationDate" : "2020-01-01",
+  "features" : [ ],
+  "name" : "",
+  "uuid" : "",
+  "version" : 1,
+  "startDate" : "2019-02-25",
+  "expirationDate" : "2020-01-01"
+}
+-----BEGIN PGP SIGNATURE-----
+-----END PGP SIGNATURE-----

--- a/core/src/test/resources/cm-license-nojson.txt
+++ b/core/src/test/resources/cm-license-nojson.txt
@@ -1,0 +1,5 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA256
+
+-----BEGIN PGP SIGNATURE-----
+-----END PGP SIGNATURE-----

--- a/core/src/test/resources/cm-license.txt
+++ b/core/src/test/resources/cm-license.txt
@@ -1,0 +1,17 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA256
+
+{
+  "deactivationDate" : "2020-01-01",
+  "features" : [ ],
+  "name" : "License Name",
+  "uuid" : "d2834876-30fe-4000-ba85-6e99e537897e",
+  "version" : 1,
+  "someOtherField": {
+    "innerOtherField": {}
+  },
+  "startDate" : "2019-02-25",
+  "expirationDate" : "2020-01-01"
+}
+-----BEGIN PGP SIGNATURE-----
+-----END PGP SIGNATURE-----

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/repo/clustermanager.repo
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/repo/clustermanager.repo
@@ -11,3 +11,7 @@ enabled=1
 skip_if_unavailable=1
 autorefresh=0
 type=rpm-md
+{%- if salt['pillar.get']('cloudera-manager:paywall_username') %}
+username={{ salt['pillar.get']('cloudera-manager:paywall_username') }}
+password={{ salt['pillar.get']('cloudera-manager:paywall_password') }}
+{%- endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/repo/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/repo/init.sls
@@ -4,6 +4,7 @@
   file.managed:
     - source: salt://cloudera/repo/clustermanager.repo
     - template: jinja
+    - mode: 640
 
 {% elif grains['os_family'] == 'Debian' %}
 


### PR DESCRIPTION
Whenever a cluster is installed from https://archive.cloudera.com
a basic credential must be provided. This credential can be generated
from the CM license file that is provided by UMS. The test credential
can be used to authenticate to this paywall however, in production
each customer gets its own license file. The username is the uuid field
and the password is generated from sha256(name + uuid) and the first 12
characters.
