### PR TITLE
CB-8144: Fix Cloudbreak Core DNS registration and TTL

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_promote_replica_to_master.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_promote_replica_to_master.sh
@@ -2,6 +2,12 @@
 
 set -e
 
+function cleanup() {
+  kdestroy
+}
+
+trap cleanup EXIT
+
 FQDN=$(hostname -f)
 
 echo "$FPW" | kinit $ADMIN_USER
@@ -12,6 +18,5 @@ if [[ "$CURRENT_CA_MASTER" != "$FQDN" ]]; then
   ccho "The current CA renewal master was changed to $FQDN"
 fi
 ipa-crlgen-manage enable
-kdestroy
 
 set +e

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/update_cnames.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/update_cnames.sh
@@ -2,6 +2,12 @@
 
 set -e
 
+function cleanup() {
+  kdestroy
+}
+
+trap cleanup EXIT
+
 FQDN=$(hostname -f)
 
 getCertRequestIdFromDir() {
@@ -131,7 +137,5 @@ addService HTTP/kerberos.$DOMAIN
 addHostToService HTTP/kerberos.$DOMAIN $FQDN
 HTTP_CERT_REQUEST_ID=`getCertRequestIdFromDir /etc/httpd/alias Server-Cert`
 setDomainsForCert $HTTP_CERT_REQUEST_ID "freeipa.$DOMAIN kdc.$DOMAIN kerberos.$DOMAIN"
-
-kdestroy
 
 set +e

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/scripts/setup-autotls.sh.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/scripts/setup-autotls.sh.j2
@@ -4,6 +4,12 @@
 
 set -ex
 
+function cleanup() {
+  kdestroy
+}
+
+trap cleanup EXIT
+
 HOSTNAME={{ manager_server_hostname }}
 FQDN={{ manager_server_fqdn }}
 CM_KEYTAB_FILE={{ cm_keytab.path }}
@@ -37,7 +43,5 @@ echo "# Auto-tls related configurations" >> /etc/cloudera-scm-server/cm.settings
 cat $CERTMANAGER_DIR/auto-tls.init.txt >> /etc/cloudera-scm-server/cm.settings
 
 echo "Auto-TLS initialization completed successfully."
-
-kdestroy
 
 echo $(date +%Y-%m-%d:%H:%M:%S) >> $CERTMANAGER_DIR/autotls_setup_success

--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/template/add_dns_record.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/template/add_dns_record.j2
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -e
+
+function cleanup() {
+  kdestroy
+}
+
+trap cleanup EXIT
+
+echo "$PW" | kinit {{ pillar['sssd-ipa']['principal'] }}
+
+set -x
+
+HOSTNAME=$(hostname)
+FQDN=$(hostname -f)
+IPADDR=$(hostname -i)
+REVERSE_IP=$(hostname -i | awk -F. '{print $4"."$3"." $2"."$1}')
+
+# dnsrecord-add must either add the record or modify it
+if ! ipa dnsrecord-find {{ pillar['sssd-ipa']['domain'] }}. "--name=${HOSTNAME}" "--a-rec=${IPADDR}"  --ttl {{ pillar['sssd-ipa']['dns_ttl'] }} --all; then
+  ipa dnsrecord-add {{ pillar['sssd-ipa']['domain'] }}. "${HOSTNAME}" "--a-rec=${IPADDR}" --ttl {{ pillar['sssd-ipa']['dns_ttl'] }}
+fi
+if ! ipa dnsrecord-find {{ pillar['sssd-ipa']['domain'] }}. "--name=${HOSTNAME}" "--a-rec=${IPADDR}"  --ttl {{ pillar['sssd-ipa']['dns_ttl'] }} --all; then
+  echo "Failed to set DNS A-record for ${HOSTNAME}"
+  false
+fi
+
+for zone in $(ipa dnszone-find --raw | grep "idnsname:.*\.in-addr\.arpa\." | cut -d':' -f2 | awk '{ print length, $0 }' | sort -n -r | awk '{ print $2 }' | xargs)
+do
+    ZONE_NET=${zone//.in-addr.arpa./}
+    if echo "$REVERSE_IP" | grep -qE "$ZONE_NET$"; then
+        REVERSE_RECORD_NAME=$(echo "$REVERSE_IP" | sed "s/.$ZONE_NET$//g")
+        # dnsrecord-add must either add the record or modify it
+        if ! ipa dnsrecord-find "$zone" "--name=$REVERSE_RECORD_NAME" "--ptr-rec=${FQDN}." --ttl {{ pillar['sssd-ipa']['dns_ttl'] }}; then
+          ipa dnsrecord-add "$zone" "$REVERSE_RECORD_NAME" "--ptr-rec=${FQDN}." --ttl {{ pillar['sssd-ipa']['dns_ttl'] }}
+        fi
+        if ipa dnsrecord-find "$zone" "--name=$REVERSE_RECORD_NAME" "--ptr-rec=${FQDN}." --ttl {{ pillar['sssd-ipa']['dns_ttl'] }}; then
+          break
+        else
+          echo "Failed to set Reverse DNS PTR-record for ${FQDN}"
+          false
+        fi
+    fi
+done
+
+set +x
+set +e

--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/template/generate_cm_keytab.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/template/generate_cm_keytab.j2
@@ -2,6 +2,12 @@
 
 set -e
 
+function cleanup() {
+  kdestroy
+}
+
+trap cleanup EXIT
+
 # auth to generate the keytab
 echo "$password" | kinit {{ ipa.principal }}
 
@@ -29,6 +35,3 @@ chown cloudera-scm:cloudera-scm /etc/cloudera-scm-server/cmf.principal
 sed -i "s/ipa env host/ipa env server/g" /opt/cloudera/cm/bin/gen_credentials_ipa.sh
 grep "MAX_RENEW_LIFE=0" /opt/cloudera/cm/bin/gen_credentials_ipa.sh || sed -i '/MAX_RENEW_LIFE=.*/a MAX_RENEW_LIFE=0' /opt/cloudera/cm/bin/gen_credentials_ipa.sh
 grep "MAX_RENEW_LIFE=0" /opt/cloudera/cm/bin/gen_credentials.sh || sed -i '/MAX_RENEW_LIFE=.*/a MAX_RENEW_LIFE=0' /opt/cloudera/cm/bin/gen_credentials.sh
-
-# Destroy the admin krbtgt
-kdestroy

--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/template/join_ipa.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/template/join_ipa.j2
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+function cleanup() {
+  kdestroy
+}
+
+trap cleanup EXIT
+
+ipa-client-install --unattended --uninstall
+
+set -e
+ipa-client-install \
+  --realm={{ pillar['sssd-ipa']['realm'] }} \
+  --domain={{ pillar['sssd-ipa']['domain'] }} \
+  --mkhomedir \
+  --principal={{ pillar['sssd-ipa']['principal'] }} \
+  {%- if "ID_BROKER_CLOUD_IDENTITY_ROLE" in grains.get('roles', []) %}
+    --no-sshd \
+    --no-ssh \
+  {%- endif %}
+  --password "$PW" \
+  --unattended \
+  --force-join \
+  --ssh-trust-dns \
+  --no-ntp
+
+echo "$PW" | kinit {{ pillar['sssd-ipa']['principal'] }}
+
+ipa env
+
+set +e

--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/template/remove_cm_sa.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/template/remove_cm_sa.j2
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+function cleanup() {
+  kdestroy
+}
+
+trap cleanup EXIT
+
 set -e
 
 # auth to remove the Service Account

--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/template/remove_dns.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/template/remove_dns.j2
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+function cleanup() {
+  kdestroy
+}
+
+trap cleanup EXIT
+
 reverse_ip=$(hostname -i | awk -F. '{OFS="."; print $4,$3,$2,$1}')
 FQDN=$(hostname -f)
 

--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/template/reverse_dns.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/template/reverse_dns.j2
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+function cleanup() {
+  kdestroy
+}
+
+trap cleanup EXIT
+
 reverse_ip=$(hostname -i | awk -F. '{OFS="."; print $4,$3,$2,$1}')
 FQDN=$(hostname -f)
 

--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/ycloud/dns_cleanup.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/ycloud/dns_cleanup.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+function cleanup() {
+  kdestroy
+}
+
+trap cleanup EXIT
+
 echo {{salt['pillar.get']('sssd-ipa:password')}} | kinit {{salt['pillar.get']('sssd-ipa:principal')}}
 
 set -x


### PR DESCRIPTION
Fix the cloudbreak core DNS A record and reverse registration to
always have a 30 second TTL and to be able to regsister both the
A record and reverse record with salt retries in the case of an
intermittent failure.

More Details:

Cloudbreak core had a fix put in to address scale with CB-6544. But
it turns out this does not always work. When ipa-client-install is
run, it sometimes (but for some reason it does not always) registers
the DNS and reverse DNS. If the ipa-client-install registers DNS
entries then the add_dns_record rule is not run because the unless
clause causes it to be skipped. This presents a few problems.

1. The flag file /var/log/dnsrecord-add-executed is never created. So
every time a salt high state is run the unless clauses which in turn
checks FreeIPA to see if the DNS entries are present. The intent of
CB-6544 was to fix this.

2. The actual rule is never run, so the TTL for the A record is not
set to 30. The intent of CB-7715 was to fix this.

Additionally, the reverse DNS TTL was never set so the default value
for the zone is used. See CB-7715 for more details on this.

It also appears that when the dnsrecord-add is run, it can fail with a
partially executed state (e.g. A record set but reverse not set). This
means that a retry will fail because it will not modify anything for
one of the 2 implicit commands, which makes the salt retry fail. But
this is silently happening because the retry is also checking the DNS
A record so in this case actually the reverse record never gets set.
Again, it is not clear exactly how or why this might happen.

What was tested:

A datalake was provsioned using local cloudbreak deployment. This was not validated at scale.

See detailed description in the commit message.