### PR TITLE
CB-6363: Create an Env api and flow which updates the Envs Stacks pillar configs

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
@@ -119,6 +119,10 @@ public enum ResourceEvent {
     ENVIRONMENT_START_FREEIPA_STARTED("environment.start.freeipa.started"),
     ENVIRONMENT_START_FREEIPA_FAILED("environment.start.freeipa.failed"),
 
+    ENVIRONMENT_STACK_CONFIGS_UPDATE_STARTED("environment.stack.config.updates.started"),
+    ENVIRONMENT_STACK_CONFIGS_UPDATE_FINISHED("environment.stack.config.updates.finished"),
+    ENVIRONMENT_STACK_CONFIGS_UPDATE_FAILED("environment.stack.config.updates.failed"),
+
     ENVIRONMENT_STARTED("environment.start.success"),
     ENVIRONMENT_START_FAILED("environment.start.failed"),
 

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -370,3 +370,7 @@ datalake.database.restore=Datalake database restore initiated.
 datalake.database.restore.finished=Database restore was successful.
 datalake.database.restore.failed=Failed to restore database. Reason: {0}.
 datalake.database.restore.could.not.start=Database restore could not be started due to the following reason: {0}
+
+environment.stack.config.updates.started=Environment configuration update of clusters started.
+environment.stack.config.updates.finished=Environment configuration update of clusters finished.
+environment.stack.config.updates.failed=Environment configuration update of clusters failed due to the following reason: {0}  

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
@@ -292,12 +292,21 @@ public interface StackV4Endpoint {
     FlowIdentifier updateSaltByName(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name,
             @AccountId @QueryParam("accountId") String accountId);
 
+    /**
+     * @deprecated Use updatePillarConfigurationByCrn instead
+     */
     @PUT
     @Path("{name}/pillar_config_update")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = UPDATE_PILLAR_CONFIG, nickname = "updatePillarConfigurationByName")
-    FlowIdentifier updatePillarConfigurationByName(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name,
-            @AccountId @QueryParam("accountId") String accountId);
+    @Deprecated
+    FlowIdentifier updatePillarConfigurationByName(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name);
+
+    @PUT
+    @Path("crn/{crn}/pillar_config_update")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = UPDATE_PILLAR_CONFIG, nickname = "updatePillarConfigurationByCrn")
+    FlowIdentifier updatePillarConfigurationByCrn(@PathParam("workspaceId") Long workspaceId, @PathParam("crn") String crn);
 
     @POST
     @Path("{name}/database_backup")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
@@ -40,6 +40,7 @@ import com.sequenceiq.cloudbreak.auth.security.internal.AccountId;
 import com.sequenceiq.cloudbreak.auth.security.internal.InternalReady;
 import com.sequenceiq.cloudbreak.auth.security.internal.TenantAwareParam;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.service.CloudbreakRestRequestThreadLocalService;
 import com.sequenceiq.cloudbreak.workspace.controller.WorkspaceEntityType;
 import com.sequenceiq.distrox.v1.distrox.StackOperations;
@@ -243,11 +244,20 @@ public class StackV4Controller extends NotificationController implements StackV4
         return stackOperations.updateSalt(NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId());
     }
 
+    /**
+     * @deprecated Use updatePillarConfigurationByCrn instead
+     */
     @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.POWERUSER_ONLY)
-    public FlowIdentifier updatePillarConfigurationByName(Long workspaceId, String name,
-            @AccountId String accountId) {
-        return stackOperations.updatePillarConfiguration(NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId());
+    @Deprecated
+    public FlowIdentifier updatePillarConfigurationByName(Long workspaceId, String name) {
+        throw new BadRequestException("Updating pillar config information by name is deprecated.  Please use update pillar config by CRN.");
+    }
+
+    @Override
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.POWERUSER_ONLY)
+    public FlowIdentifier updatePillarConfigurationByCrn(Long workspaceId, @TenantAwareParam String crn) {
+        return stackOperations.updatePillarConfiguration(NameOrCrn.ofCrn(crn), restRequestThreadLocalService.getRequestedWorkspaceId());
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/rest/urlparsers/V4ExistingResourceByCrnOrNameRestUrlParser.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/rest/urlparsers/V4ExistingResourceByCrnOrNameRestUrlParser.java
@@ -18,11 +18,11 @@ public class V4ExistingResourceByCrnOrNameRestUrlParser extends RestUrlParser {
     // v4/{workspaceId}/blueprints/name/{name}
     // v4/{workspaceId}/blueprints/crn/{name}
     private static final Pattern PATTERN = Pattern
-            .compile("v4/(\\d+)/(blueprints|image_catalogs|recipes|stacks|distrox|cluster_templates)/(?:name|crn)/([^/]+)");
+            .compile("v4/(\\d+)/(blueprints|image_catalogs|recipes|stacks|distrox|cluster_templates)/(?:name|crn)/([^/]+)(/\\w+)?");
 
     @Override
     protected List<String> parsedMethods() {
-        return List.of("DELETE", "GET");
+        return List.of("DELETE", "GET", "PUT");
     }
 
     @Override

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentOpDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentOpDescription.java
@@ -22,6 +22,7 @@ public class EnvironmentOpDescription {
     public static final String VERIFY_CREDENTIAL_BY_CRN = "Verifies the credential used by the given environment.";
     public static final String CLI_COMMAND = "produce cli command input for environment creation";
     public static final String GET_CRN_BY_NAME = "Get the crn of an environment by name.";
+    public static final String UPDATE_CONFIG_BY_CRN = "Update the configuration for all stacks in the Environment by the Environment CRN";
 
     private EnvironmentOpDescription() {
     }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/endpoint/EnvironmentEndpoint.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/endpoint/EnvironmentEndpoint.java
@@ -205,4 +205,11 @@ public interface EnvironmentEndpoint {
     @ApiOperation(value = EnvironmentOpDescription.CLI_COMMAND, produces = MediaType.APPLICATION_JSON, notes = ENVIRONMENT_NOTES,
             nickname = "getCreateEnvironmentForCli")
     Object getCreateEnvironmentForCli(@NotNull @Valid EnvironmentRequest environmentRequest);
+
+    @POST
+    @Path("/crn/{crn}/update_config")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = EnvironmentOpDescription.UPDATE_CONFIG_BY_CRN, produces = MediaType.APPLICATION_JSON, notes = ENVIRONMENT_NOTES,
+        nickname = "updateConfigsInEnvironmentByCrnV1")
+    void updateConfigsInEnvironmentByCrn(@PathParam("crn") String crn);
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/config/update/AbstractEnvStackConfigUpdatesAction.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/config/update/AbstractEnvStackConfigUpdatesAction.java
@@ -1,0 +1,47 @@
+package com.sequenceiq.environment.environment.flow.config.update;
+
+import com.sequenceiq.cloudbreak.common.event.ResourceCrnPayload;
+import com.sequenceiq.cloudbreak.logger.MdcContext;
+import com.sequenceiq.environment.environment.flow.config.update.event.EnvStackConfigUpdatesStateSelectors;
+import com.sequenceiq.flow.core.AbstractAction;
+import com.sequenceiq.flow.core.CommonContext;
+import com.sequenceiq.flow.core.FlowParameters;
+import java.util.Map;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.statemachine.StateContext;
+
+abstract class AbstractEnvStackConfigUpdatesAction<P extends ResourceCrnPayload> extends
+    AbstractAction<EnvStackConfigUpdatesState, EnvStackConfigUpdatesStateSelectors, CommonContext, P> {
+
+    private static final Logger LOGGER = LoggerFactory
+        .getLogger(AbstractEnvStackConfigUpdatesAction.class);
+
+    AbstractEnvStackConfigUpdatesAction(Class<P> payloadClass) {
+        super(payloadClass);
+    }
+
+    @Override
+    protected CommonContext createFlowContext(FlowParameters flowParameters,
+        StateContext<EnvStackConfigUpdatesState, EnvStackConfigUpdatesStateSelectors> stateContext,
+        P payload) {
+        return new CommonContext(flowParameters);
+    }
+
+    @Override
+    protected Object getFailurePayload(P payload, Optional<CommonContext> flowContext,
+        Exception ex) {
+        return payload;
+    }
+
+    @Override
+    protected void prepareExecution(P payload, Map<Object, Object> variables) {
+        if (payload != null) {
+            MdcContext.builder().resourceCrn(payload.getResourceCrn()).buildMdc();
+        } else {
+            LOGGER.warn(
+                "Payload was null in prepareExecution so resourceCrn cannot be added to the MdcContext!");
+        }
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/config/update/EnvStackConfigUpdatesActions.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/config/update/EnvStackConfigUpdatesActions.java
@@ -1,0 +1,111 @@
+package com.sequenceiq.environment.environment.flow.config.update;
+
+import static com.sequenceiq.environment.environment.flow.config.update.event.EnvStackConfigUpdatesStateSelectors.FINALIZE_ENV_STACK_CONIFG_UPDATES_EVENT;
+import static com.sequenceiq.environment.environment.flow.config.update.event.EnvStackConfigUpdatesStateSelectors.HANDLE_FAILED_ENV_STACK_CONIFG_UPDATES_EVENT;
+
+import com.sequenceiq.cloudbreak.common.event.ResourceCrnPayload;
+import com.sequenceiq.cloudbreak.event.ResourceEvent;
+import com.sequenceiq.environment.environment.EnvironmentStatus;
+import com.sequenceiq.environment.environment.domain.Environment;
+import com.sequenceiq.environment.environment.dto.EnvironmentDto;
+import com.sequenceiq.environment.environment.flow.config.update.event.EnvStackConfigUpdatesEvent;
+import com.sequenceiq.environment.environment.flow.config.update.event.EnvStackConfigUpdatesFailedEvent;
+import com.sequenceiq.environment.environment.flow.config.update.event.EnvStackConfigUpdatesHandlerSelectors;
+import com.sequenceiq.environment.environment.service.EnvironmentService;
+import com.sequenceiq.environment.environment.service.EnvironmentStatusUpdateService;
+import com.sequenceiq.environment.metrics.EnvironmentMetricService;
+import com.sequenceiq.environment.metrics.MetricType;
+import com.sequenceiq.flow.core.CommonContext;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.statemachine.action.Action;
+
+@Configuration
+public class EnvStackConfigUpdatesActions {
+    private static final Logger LOGGER = LoggerFactory.getLogger(EnvStackConfigUpdatesActions.class);
+
+    private final EnvironmentService environmentService;
+
+    private final EnvironmentStatusUpdateService environmentStatusUpdateService;
+
+    private final EnvironmentMetricService metricService;
+
+    public EnvStackConfigUpdatesActions(EnvironmentService environmentService,
+        EnvironmentStatusUpdateService environmentStatusUpdateService,
+        EnvironmentMetricService metricService) {
+        this.environmentService = environmentService;
+        this.environmentStatusUpdateService = environmentStatusUpdateService;
+        this.metricService = metricService;
+    }
+
+    @Bean(name = "STACK_CONFIG_UPDATES_START_STATE")
+    public Action<?, ?> collectClusterInfo() {
+        return new AbstractEnvStackConfigUpdatesAction<>(EnvStackConfigUpdatesEvent.class) {
+            @Override
+            protected void doExecute(CommonContext context, EnvStackConfigUpdatesEvent payload, Map<Object, Object> variables) {
+                EnvironmentDto environmentDto = environmentStatusUpdateService
+                    .updateEnvironmentStatusAndNotify(context, payload,
+                        getCurrentStatus(payload.getResourceId()),
+                        ResourceEvent.ENVIRONMENT_STACK_CONFIGS_UPDATE_STARTED,
+                        EnvStackConfigUpdatesState.STACK_CONFIG_UPDATES_START_STATE);
+
+                sendEvent(context,
+                    EnvStackConfigUpdatesHandlerSelectors.STACK_CONFIG_UPDATES_HANDLER_EVENT
+                        .selector(), environmentDto);
+            }
+        };
+    }
+
+    @Bean(name = "STACK_CONFIG_UPDATES_FINISHED_STATE")
+    public Action<?, ?> finishedAction() {
+        return new AbstractEnvStackConfigUpdatesAction<>(ResourceCrnPayload.class) {
+            @Override
+            protected void doExecute(CommonContext context, ResourceCrnPayload payload, Map<Object, Object> variables) {
+                EnvironmentDto environmentDto = environmentStatusUpdateService
+                    .updateEnvironmentStatusAndNotify(context, payload,
+                        getCurrentStatus(payload.getResourceId()),
+                        ResourceEvent.ENVIRONMENT_STACK_CONFIGS_UPDATE_FINISHED,
+                        EnvStackConfigUpdatesState.STACK_CONFIG_UPDATES_FINISHED_STATE);
+                metricService.incrementMetricCounter(MetricType.ENV_STACK_CONFIG_UPDATE_FINISHED,
+                    environmentDto);
+                LOGGER.info("Flow entered into STACK_CONFIG_UPDATES_FINISHED_STATE");
+                sendEvent(context, FINALIZE_ENV_STACK_CONIFG_UPDATES_EVENT.event(), payload);
+            }
+        };
+    }
+
+    @Bean(name = "STACK_CONFIG_UPDATES_FAILED_STATE")
+    public Action<?, ?> failedAction() {
+        return new AbstractEnvStackConfigUpdatesAction<>(EnvStackConfigUpdatesFailedEvent.class) {
+            @Override
+            protected void doExecute(CommonContext context, EnvStackConfigUpdatesFailedEvent payload, Map<Object, Object> variables) {
+                LOGGER.warn(
+                    String.format("Failed to update environments stack configs '%s'. Status: '%s'.",
+                        payload.getEnvironmentDto(), payload.getEnvironmentStatus()),
+                    payload.getException());
+                EnvironmentDto environmentDto = environmentStatusUpdateService
+                    .updateFailedEnvironmentStatusAndNotify(context, payload,
+                        getCurrentStatus(payload.getResourceId()),
+                        ResourceEvent.ENVIRONMENT_STACK_CONFIGS_UPDATE_FAILED,
+                        EnvStackConfigUpdatesState.STACK_CONFIG_UPDATES_FAILED_STATE);
+                metricService.incrementMetricCounter(MetricType.ENV_STACK_CONFIG_UPDATE_FAILED,
+                    environmentDto,
+                    payload.getException());
+                sendEvent(context, HANDLE_FAILED_ENV_STACK_CONIFG_UPDATES_EVENT.event(), payload);
+            }
+        };
+    }
+
+    private EnvironmentStatus getCurrentStatus(Long envId) {
+        return environmentService
+            .findEnvironmentById(envId)
+            .map(Environment::getStatus)
+            .orElseThrow(() -> new IllegalStateException(
+                String.format("Cannot get status of environment, because it does not exist: %s. ",
+                    envId)
+            ));
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/config/update/EnvStackConfigUpdatesState.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/config/update/EnvStackConfigUpdatesState.java
@@ -1,0 +1,11 @@
+package com.sequenceiq.environment.environment.flow.config.update;
+
+import com.sequenceiq.flow.core.FlowState;
+
+public enum EnvStackConfigUpdatesState implements FlowState {
+    INIT_STATE,
+    STACK_CONFIG_UPDATES_START_STATE,
+    STACK_CONFIG_UPDATES_FINISHED_STATE,
+    STACK_CONFIG_UPDATES_FAILED_STATE,
+    FINAL_STATE;
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/config/update/config/EnvStackConfigUpdatesFlowConfig.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/config/update/config/EnvStackConfigUpdatesFlowConfig.java
@@ -1,0 +1,75 @@
+package com.sequenceiq.environment.environment.flow.config.update.config;
+
+import static com.sequenceiq.environment.environment.flow.config.update.EnvStackConfigUpdatesState.FINAL_STATE;
+import static com.sequenceiq.environment.environment.flow.config.update.EnvStackConfigUpdatesState.INIT_STATE;
+import static com.sequenceiq.environment.environment.flow.config.update.EnvStackConfigUpdatesState.STACK_CONFIG_UPDATES_FAILED_STATE;
+import static com.sequenceiq.environment.environment.flow.config.update.EnvStackConfigUpdatesState.STACK_CONFIG_UPDATES_FINISHED_STATE;
+import static com.sequenceiq.environment.environment.flow.config.update.EnvStackConfigUpdatesState.STACK_CONFIG_UPDATES_START_STATE;
+import static com.sequenceiq.environment.environment.flow.config.update.event.EnvStackConfigUpdatesStateSelectors.ENV_STACK_CONFIG_UPDATES_START_EVENT;
+import static com.sequenceiq.environment.environment.flow.config.update.event.EnvStackConfigUpdatesStateSelectors.FAILED_ENV_STACK_CONIFG_UPDATES_EVENT;
+import static com.sequenceiq.environment.environment.flow.config.update.event.EnvStackConfigUpdatesStateSelectors.FINALIZE_ENV_STACK_CONIFG_UPDATES_EVENT;
+import static com.sequenceiq.environment.environment.flow.config.update.event.EnvStackConfigUpdatesStateSelectors.FINISH_ENV_STACK_CONFIG_UPDATES_EVENT;
+import static com.sequenceiq.environment.environment.flow.config.update.event.EnvStackConfigUpdatesStateSelectors.HANDLE_FAILED_ENV_STACK_CONIFG_UPDATES_EVENT;
+
+import com.sequenceiq.environment.environment.flow.config.update.EnvStackConfigUpdatesState;
+import com.sequenceiq.environment.environment.flow.config.update.event.EnvStackConfigUpdatesStateSelectors;
+import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
+import com.sequenceiq.flow.core.config.RetryableFlowConfiguration;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EnvStackConfigUpdatesFlowConfig extends
+    AbstractFlowConfiguration<EnvStackConfigUpdatesState, EnvStackConfigUpdatesStateSelectors>
+    implements RetryableFlowConfiguration<EnvStackConfigUpdatesStateSelectors> {
+
+    private static final List<Transition<EnvStackConfigUpdatesState, EnvStackConfigUpdatesStateSelectors>>
+        TRANSITIONS = new Transition.Builder<EnvStackConfigUpdatesState, EnvStackConfigUpdatesStateSelectors>()
+        .defaultFailureEvent(FAILED_ENV_STACK_CONIFG_UPDATES_EVENT)
+
+        .from(INIT_STATE).to(STACK_CONFIG_UPDATES_START_STATE)
+        .event(ENV_STACK_CONFIG_UPDATES_START_EVENT).defaultFailureEvent()
+
+        .from(STACK_CONFIG_UPDATES_START_STATE).to(STACK_CONFIG_UPDATES_FINISHED_STATE)
+        .event(FINISH_ENV_STACK_CONFIG_UPDATES_EVENT).defaultFailureEvent()
+
+        .from(STACK_CONFIG_UPDATES_FINISHED_STATE).to(FINAL_STATE)
+        .event(FINALIZE_ENV_STACK_CONIFG_UPDATES_EVENT).defaultFailureEvent()
+
+        .build();
+
+    protected EnvStackConfigUpdatesFlowConfig() {
+        super(EnvStackConfigUpdatesState.class, EnvStackConfigUpdatesStateSelectors.class);
+    }
+
+    @Override
+    protected List<Transition<EnvStackConfigUpdatesState, EnvStackConfigUpdatesStateSelectors>> getTransitions() {
+        return TRANSITIONS;
+    }
+
+    @Override
+    protected FlowEdgeConfig<EnvStackConfigUpdatesState, EnvStackConfigUpdatesStateSelectors> getEdgeConfig() {
+        return new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, STACK_CONFIG_UPDATES_FAILED_STATE,
+            HANDLE_FAILED_ENV_STACK_CONIFG_UPDATES_EVENT);
+    }
+
+    @Override
+    public EnvStackConfigUpdatesStateSelectors[] getEvents() {
+        return EnvStackConfigUpdatesStateSelectors.values();
+    }
+
+    @Override
+    public EnvStackConfigUpdatesStateSelectors[] getInitEvents() {
+        return new EnvStackConfigUpdatesStateSelectors[]{ENV_STACK_CONFIG_UPDATES_START_EVENT};
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Update all Environment Clusters configuration";
+    }
+
+    @Override
+    public EnvStackConfigUpdatesStateSelectors getRetryableEvent() {
+        return HANDLE_FAILED_ENV_STACK_CONIFG_UPDATES_EVENT;
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/config/update/event/EnvStackConfigUpdatesEvent.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/config/update/event/EnvStackConfigUpdatesEvent.java
@@ -1,0 +1,69 @@
+package com.sequenceiq.environment.environment.flow.config.update.event;
+
+import com.sequenceiq.cloudbreak.common.event.AcceptResult;
+import com.sequenceiq.flow.reactor.api.event.BaseNamedFlowEvent;
+import reactor.rx.Promise;
+
+public class EnvStackConfigUpdatesEvent extends BaseNamedFlowEvent {
+
+    public EnvStackConfigUpdatesEvent(String selector, Long resourceId, String resourceName,
+        String resourceCrn) {
+        super(selector, resourceId, resourceName, resourceCrn);
+    }
+
+    public EnvStackConfigUpdatesEvent(String selector, Long resourceId,
+        Promise<AcceptResult> accepted, String resourceName, String resourceCrn) {
+        super(selector, resourceId, accepted, resourceName, resourceCrn);
+    }
+
+    public static final class EnvStackConfigUpdatesEventBuilder {
+
+        private String resourceName;
+
+        private String resourceCrn;
+
+        private String selector;
+
+        private Long resourceId;
+
+        private Promise<AcceptResult> accepted;
+
+        private EnvStackConfigUpdatesEventBuilder() {
+        }
+
+        public static EnvStackConfigUpdatesEventBuilder anEnvStackConfigUpdatesEvent() {
+            return new EnvStackConfigUpdatesEventBuilder();
+        }
+
+        public EnvStackConfigUpdatesEventBuilder withResourceName(String resourceName) {
+            this.resourceName = resourceName;
+            return this;
+        }
+
+        public EnvStackConfigUpdatesEventBuilder withSelector(String selector) {
+            this.selector = selector;
+            return this;
+        }
+
+        public EnvStackConfigUpdatesEventBuilder withResourceId(Long resourceId) {
+            this.resourceId = resourceId;
+            return this;
+        }
+
+        public EnvStackConfigUpdatesEventBuilder withAccepted(Promise<AcceptResult> accepted) {
+            this.accepted = accepted;
+            return this;
+        }
+
+        public EnvStackConfigUpdatesEventBuilder withResourceCrn(String resourceCrn) {
+            this.resourceCrn = resourceCrn;
+            return this;
+        }
+
+        public EnvStackConfigUpdatesEvent build() {
+            EnvStackConfigUpdatesEvent event = new EnvStackConfigUpdatesEvent(selector, resourceId,
+                accepted, resourceName, resourceCrn);
+            return event;
+        }
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/config/update/event/EnvStackConfigUpdatesFailedEvent.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/config/update/event/EnvStackConfigUpdatesFailedEvent.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.environment.environment.flow.config.update.event;
+
+
+
+import static com.sequenceiq.environment.environment.flow.config.update.event.EnvStackConfigUpdatesStateSelectors.FAILED_ENV_STACK_CONIFG_UPDATES_EVENT;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.environment.environment.EnvironmentStatus;
+import com.sequenceiq.environment.environment.dto.EnvironmentDto;
+import com.sequenceiq.flow.reactor.api.event.BaseFailedFlowEvent;
+
+public class EnvStackConfigUpdatesFailedEvent extends BaseFailedFlowEvent implements Selectable {
+
+    private final EnvironmentDto environmentDto;
+
+    private final EnvironmentStatus environmentStatus;
+
+    public EnvStackConfigUpdatesFailedEvent(EnvironmentDto environmentDto, Exception exception, EnvironmentStatus environmentStatus) {
+        super(FAILED_ENV_STACK_CONIFG_UPDATES_EVENT.name(), environmentDto.getResourceId(),
+                environmentDto.getName(), environmentDto.getResourceCrn(), exception);
+        this.environmentDto = environmentDto;
+        this.environmentStatus = environmentStatus;
+    }
+
+    @Override
+    public String selector() {
+        return FAILED_ENV_STACK_CONIFG_UPDATES_EVENT.event();
+    }
+
+    public EnvironmentDto getEnvironmentDto() {
+        return environmentDto;
+    }
+
+    public EnvironmentStatus getEnvironmentStatus() {
+        return environmentStatus;
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/config/update/event/EnvStackConfigUpdatesHandlerSelectors.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/config/update/event/EnvStackConfigUpdatesHandlerSelectors.java
@@ -1,0 +1,12 @@
+package com.sequenceiq.environment.environment.flow.config.update.event;
+
+import com.sequenceiq.flow.core.FlowEvent;
+
+public enum EnvStackConfigUpdatesHandlerSelectors implements FlowEvent {
+    STACK_CONFIG_UPDATES_HANDLER_EVENT;
+
+    @Override
+    public String event() {
+        return name();
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/config/update/event/EnvStackConfigUpdatesStateSelectors.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/config/update/event/EnvStackConfigUpdatesStateSelectors.java
@@ -1,0 +1,16 @@
+package com.sequenceiq.environment.environment.flow.config.update.event;
+
+import com.sequenceiq.flow.core.FlowEvent;
+
+public enum EnvStackConfigUpdatesStateSelectors implements FlowEvent {
+    ENV_STACK_CONFIG_UPDATES_START_EVENT,
+    FINISH_ENV_STACK_CONFIG_UPDATES_EVENT,
+    FINALIZE_ENV_STACK_CONIFG_UPDATES_EVENT,
+    HANDLE_FAILED_ENV_STACK_CONIFG_UPDATES_EVENT,
+    FAILED_ENV_STACK_CONIFG_UPDATES_EVENT;
+
+    @Override
+    public String event() {
+        return name();
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/config/update/handler/StackConfigUpdatesHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/config/update/handler/StackConfigUpdatesHandler.java
@@ -1,0 +1,52 @@
+package com.sequenceiq.environment.environment.flow.config.update.handler;
+
+import com.sequenceiq.environment.environment.dto.EnvironmentDto;
+import com.sequenceiq.environment.environment.flow.config.update.event.EnvStackConfigUpdatesEvent;
+import com.sequenceiq.environment.environment.flow.config.update.event.EnvStackConfigUpdatesEvent.EnvStackConfigUpdatesEventBuilder;
+import com.sequenceiq.environment.environment.flow.config.update.event.EnvStackConfigUpdatesFailedEvent;
+import com.sequenceiq.environment.environment.flow.config.update.event.EnvStackConfigUpdatesHandlerSelectors;
+import com.sequenceiq.environment.environment.flow.config.update.event.EnvStackConfigUpdatesStateSelectors;
+import com.sequenceiq.environment.environment.service.stack.StackPollerService;
+import com.sequenceiq.flow.core.FlowConstants;
+import com.sequenceiq.flow.reactor.api.event.EventSender;
+import com.sequenceiq.flow.reactor.api.handler.EventSenderAwareHandler;
+import org.springframework.stereotype.Component;
+import reactor.bus.Event;
+
+@Component
+public class StackConfigUpdatesHandler extends EventSenderAwareHandler<EnvironmentDto> {
+
+    private final StackPollerService stackPollerService;
+
+    public StackConfigUpdatesHandler(EventSender eventSender,
+        StackPollerService stackPollerService) {
+        super(eventSender);
+        this.stackPollerService = stackPollerService;
+    }
+
+    @Override
+    public String selector() {
+        return EnvStackConfigUpdatesHandlerSelectors.STACK_CONFIG_UPDATES_HANDLER_EVENT.event();
+    }
+
+    @Override
+    public void accept(Event<EnvironmentDto> event) {
+        try {
+            stackPollerService.updateStackConfigurations(event.getData().getResourceId(),
+                event.getData().getResourceCrn(), event.getHeaders().get(FlowConstants.FLOW_ID));
+
+            EnvStackConfigUpdatesEvent envStackConfigUpdatesEvent = EnvStackConfigUpdatesEventBuilder
+                .anEnvStackConfigUpdatesEvent()
+                .withSelector(
+                    EnvStackConfigUpdatesStateSelectors.FINISH_ENV_STACK_CONFIG_UPDATES_EVENT
+                        .selector())
+                .withResourceId(event.getData().getResourceId())
+                .build();
+
+            eventSender().sendEvent(envStackConfigUpdatesEvent, event.getHeaders());
+        } catch (Exception e) {
+            eventSender().sendEvent(new EnvStackConfigUpdatesFailedEvent(event.getData(), e, null),
+                event.getHeaders());
+        }
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/poller/StackPollerProvider.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/poller/StackPollerProvider.java
@@ -1,0 +1,92 @@
+package com.sequenceiq.environment.environment.poller;
+
+import com.dyngr.core.AttemptMaker;
+import com.dyngr.core.AttemptResult;
+import com.dyngr.core.AttemptResults;
+import com.dyngr.core.AttemptState;
+import com.sequenceiq.environment.environment.service.stack.StackService;
+import com.sequenceiq.flow.core.FlowConstants;
+import com.sequenceiq.flow.domain.FlowLog;
+import com.sequenceiq.flow.service.flowlog.FlowLogDBService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.ws.rs.BadRequestException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StackPollerProvider {
+    private static final Logger LOGGER = LoggerFactory.getLogger(StackPollerProvider.class);
+
+    private final StackService stackService;
+
+    private final FlowLogDBService flowLogDBService;
+
+    public StackPollerProvider(
+        StackService stackService,
+        FlowLogDBService flowLogDBService) {
+        this.stackService = stackService;
+        this.flowLogDBService = flowLogDBService;
+    }
+
+    public AttemptMaker<Void> stackUpdateConfigPoller(List<String> stackCrns, Long envId, String flowId) {
+        List<String> mutableCrnsList = new ArrayList<>(stackCrns);
+        return () -> {
+            LOGGER.info("Attempting to update pillar information for {} clusters for environment id {}",
+                mutableCrnsList.size(), envId);
+            Optional<FlowLog> flowLog = flowLogDBService.getLastFlowLog(flowId);
+            if (flowLog.isPresent() && flowLog.get().getCurrentState().equals(FlowConstants.CANCELLED_STATE)) {
+                return AttemptResults.finishWith(null);
+            }
+            List<String> remaining = new ArrayList<>();
+            List<AttemptResult<Void>> results = collectStackUpdateConfigResults(mutableCrnsList,
+                remaining, envId);
+            mutableCrnsList.retainAll(remaining);
+            return evaluateResult(results);
+        };
+    }
+
+    private List<AttemptResult<Void>> collectStackUpdateConfigResults(List<String> stackCrns,
+        List<String> remaining, Long envId) {
+        return stackCrns.stream()
+            .map(stackCrn -> fetchStackUpdateConfigResults(remaining, stackCrn))
+            .collect(Collectors.toList());
+    }
+
+    private AttemptResult<Void> fetchStackUpdateConfigResults(List<String> remainingStacks, String stackCrn) {
+        try {
+            LOGGER.info("Calling cloudbreak to to update pillar config for cluster {}", stackCrn);
+            stackService.triggerConfigUpdateForStack(stackCrn);
+            return AttemptResults.finishWith(null);
+        } catch (BadRequestException e) {
+            LOGGER.info("Unable to start pillar config update for {}.  Cluster has flow running already. Retrying.",
+                stackCrn);
+            remainingStacks.add(stackCrn);
+            return AttemptResults.justContinue();
+        } catch (Exception e) {
+            LOGGER.warn("Failure asking Cloudbreak for a pillar config update, error message is: {}",
+                e.getMessage());
+            return AttemptResults.breakFor(e);
+        }
+    }
+
+    AttemptResult<Void> evaluateResult(List<AttemptResult<Void>> results) {
+        Optional<AttemptResult<Void>> error = results.stream()
+            .filter(it -> it.getState() == AttemptState.BREAK).findFirst();
+        if (error.isPresent()) {
+            return error.get();
+        }
+
+        if (shouldContinue(results)) {
+            return AttemptResults.justContinue();
+        }
+        return AttemptResults.finishWith(null);
+    }
+
+    private boolean shouldContinue(List<AttemptResult<Void>> results) {
+        return results.stream().anyMatch(result -> result.getState() == AttemptState.CONTINUE);
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentStackConfigUpdateService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentStackConfigUpdateService.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.environment.environment.service;
+
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
+import com.sequenceiq.environment.environment.domain.Environment;
+import com.sequenceiq.environment.environment.flow.EnvironmentReactorFlowManager;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EnvironmentStackConfigUpdateService {
+    private final EnvironmentService environmentService;
+
+    private final EnvironmentReactorFlowManager reactorFlowManager;
+
+    public EnvironmentStackConfigUpdateService(
+        EnvironmentService environmentService,
+        EnvironmentReactorFlowManager reactorFlowManager) {
+        this.environmentService = environmentService;
+        this.reactorFlowManager = reactorFlowManager;
+    }
+
+    public void updateAllStackConfigsByCrn(String envCrn) {
+        String accountId = Crn.safeFromString(envCrn).getAccountId();
+        Environment environment = environmentService
+            .findByResourceCrnAndAccountIdAndArchivedIsFalse(envCrn, accountId).
+                orElseThrow(() -> new NotFoundException(
+                    String.format("No environment found with crn '%s'", envCrn)));
+
+        String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
+        reactorFlowManager
+            .triggerStackConfigUpdatesFlow(environment, userCrn);
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/stack/StackPollerService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/stack/StackPollerService.java
@@ -1,0 +1,74 @@
+package com.sequenceiq.environment.environment.service.stack;
+
+import com.dyngr.Polling;
+import com.dyngr.core.AttemptMaker;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.StackV4Endpoint;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Responses;
+import com.sequenceiq.environment.environment.poller.StackPollerProvider;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class StackPollerService {
+
+    private static final List<Status> SKIPPED_STATES = List.of(
+        Status.CREATE_FAILED,
+        Status.STOPPED,
+        Status.STOP_IN_PROGRESS,
+        Status.STOP_REQUESTED,
+        Status.DELETE_IN_PROGRESS,
+        Status.DELETE_COMPLETED,
+        Status.DELETED_ON_PROVIDER_SIDE,
+        Status.DELETE_FAILED,
+        Status.PRE_DELETE_IN_PROGRESS,
+        Status.START_FAILED,
+        Status.EXTERNAL_DATABASE_CREATION_FAILED,
+        Status.EXTERNAL_DATABASE_DELETION_FINISHED,
+        Status.EXTERNAL_DATABASE_DELETION_FAILED
+    );
+
+    private final StackV4Endpoint stackV4Endpoint;
+
+    private final StackPollerProvider stackPollerProvider;
+
+    @Value("${env.stack.config.update.polling.maximum.seconds:7200}")
+    private Integer maxTime;
+
+    @Value("${env.stack.config.update.sleep.time.seconds:60}")
+    private Integer sleepTime;
+
+    public StackPollerService(
+        StackV4Endpoint stackV4Endpoint,
+        StackPollerProvider stackPollerProvider) {
+        this.stackV4Endpoint = stackV4Endpoint;
+        this.stackPollerProvider = stackPollerProvider;
+    }
+
+    public void updateStackConfigurations(Long envId, String envCrn, String flowId) {
+        List<String> stackCrns = getUpdateableStacks(envCrn);
+        startStackConfigUpdatePolling(stackCrns,
+            stackPollerProvider.stackUpdateConfigPoller(stackCrns, envId, flowId));
+    }
+
+    private void startStackConfigUpdatePolling(List<String> stackCrns, AttemptMaker<Void> attemptMaker) {
+        if (CollectionUtils.isNotEmpty(stackCrns)) {
+            Polling.stopAfterDelay(maxTime, TimeUnit.SECONDS)
+                .stopIfException(true)
+                .waitPeriodly(sleepTime, TimeUnit.SECONDS)
+                .run(attemptMaker);
+        }
+    }
+
+    private List<String> getUpdateableStacks(String envCrn) {
+        StackViewV4Responses stackViewV4Responses = stackV4Endpoint.list(0L, envCrn, false);
+        return stackViewV4Responses.getResponses().stream().
+            filter(stack -> !SKIPPED_STATES.contains(stack.getCluster().getStatus()))
+            .map(stack -> stack.getCrn())
+            .collect(Collectors.toList());
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/stack/StackService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/stack/StackService.java
@@ -1,0 +1,65 @@
+package com.sequenceiq.environment.environment.service.stack;
+
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.StackV4Endpoint;
+import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
+import com.sequenceiq.cloudbreak.common.exception.WebApplicationExceptionMessageExtractor;
+import com.sequenceiq.environment.environment.domain.Environment;
+import com.sequenceiq.environment.environment.flow.config.update.config.EnvStackConfigUpdatesFlowConfig;
+import com.sequenceiq.environment.store.EnvironmentInMemoryStateStore;
+import com.sequenceiq.flow.domain.FlowLog;
+import com.sequenceiq.flow.service.FlowCancelService;
+import com.sequenceiq.flow.service.flowlog.FlowLogDBService;
+import java.util.List;
+import javax.ws.rs.WebApplicationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class StackService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StackService.class);
+
+    private final StackV4Endpoint stackV4Endpoint;
+
+    private final FlowCancelService flowCancelService;
+
+    private final FlowLogDBService flowLogDBService;
+
+    private final WebApplicationExceptionMessageExtractor messageExtractor;
+
+    public StackService(
+        StackV4Endpoint stackV4Endpoint,
+        FlowCancelService flowCancelService,
+        FlowLogDBService flowLogDBService,
+        WebApplicationExceptionMessageExtractor messageExtractor) {
+        this.stackV4Endpoint = stackV4Endpoint;
+        this.flowCancelService = flowCancelService;
+        this.flowLogDBService = flowLogDBService;
+        this.messageExtractor = messageExtractor;
+    }
+
+    public void triggerConfigUpdateForStack(String stackCrn) {
+        try {
+            stackV4Endpoint.updatePillarConfigurationByCrn(0L, stackCrn);
+        } catch (WebApplicationException wae) {
+            LOGGER.info(String
+                .format("Unable to start config update for stack %s.  Message is %s", stackCrn,
+                    messageExtractor.getErrorMessage(wae)));
+            throw wae;
+        }
+    }
+
+    public void cancelRunningStackConfigUpdates(Environment environment) {
+        List<FlowLog> flowLogs = flowLogDBService.findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(environment.getId());
+        if (!flowLogs.isEmpty() && flowLogs.get(0).getFlowType() != null
+            && EnvStackConfigUpdatesFlowConfig.class.equals(flowLogs.get(0).getFlowType())) {
+            LOGGER.info("Canceling running Stack config update flow for environment {}", environment.getResourceCrn());
+            EnvironmentInMemoryStateStore.put(environment.getId(), PollGroup.CANCELLED);
+            flowCancelService.cancelFlowSilently(flowLogs.get(0));
+        } else {
+            LOGGER.debug("No running Stack config update flow to cancel");
+        }
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/EnvironmentController.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/EnvironmentController.java
@@ -21,6 +21,7 @@ import com.sequenceiq.authorization.annotation.CheckPermissionByResourceName;
 import com.sequenceiq.authorization.annotation.CheckPermissionByResourceNameList;
 import com.sequenceiq.authorization.annotation.CheckPermissionByResourceObject;
 import com.sequenceiq.authorization.annotation.DisableCheckPermissions;
+import com.sequenceiq.authorization.annotation.InternalOnly;
 import com.sequenceiq.authorization.annotation.ResourceCrn;
 import com.sequenceiq.authorization.annotation.ResourceCrnList;
 import com.sequenceiq.authorization.annotation.ResourceName;
@@ -52,6 +53,7 @@ import com.sequenceiq.environment.environment.service.EnvironmentCreationService
 import com.sequenceiq.environment.environment.service.EnvironmentDeletionService;
 import com.sequenceiq.environment.environment.service.EnvironmentModificationService;
 import com.sequenceiq.environment.environment.service.EnvironmentService;
+import com.sequenceiq.environment.environment.service.EnvironmentStackConfigUpdateService;
 import com.sequenceiq.environment.environment.service.EnvironmentStartService;
 import com.sequenceiq.environment.environment.service.EnvironmentStopService;
 import com.sequenceiq.environment.environment.v1.converter.EnvironmentApiConverter;
@@ -83,6 +85,8 @@ public class EnvironmentController implements EnvironmentEndpoint {
 
     private final CredentialToCredentialV1ResponseConverter credentialConverter;
 
+    private final EnvironmentStackConfigUpdateService stackConfigUpdateService;
+
     public EnvironmentController(
             EnvironmentApiConverter environmentApiConverter,
             EnvironmentResponseConverter environmentResponseConverter,
@@ -93,7 +97,8 @@ public class EnvironmentController implements EnvironmentEndpoint {
             EnvironmentStartService environmentStartService,
             EnvironmentStopService environmentStopService,
             CredentialService credentialService,
-            CredentialToCredentialV1ResponseConverter credentialConverter) {
+            CredentialToCredentialV1ResponseConverter credentialConverter,
+            EnvironmentStackConfigUpdateService stackConfigUpdateService) {
         this.environmentApiConverter = environmentApiConverter;
         this.environmentResponseConverter = environmentResponseConverter;
         this.environmentService = environmentService;
@@ -104,6 +109,7 @@ public class EnvironmentController implements EnvironmentEndpoint {
         this.environmentStopService = environmentStopService;
         this.credentialService = credentialService;
         this.credentialConverter = credentialConverter;
+        this.stackConfigUpdateService = stackConfigUpdateService;
     }
 
     @Override
@@ -304,5 +310,11 @@ public class EnvironmentController implements EnvironmentEndpoint {
         String accountId = ThreadBasedUserCrnProvider.getAccountId();
         Credential credential = credentialService.getByNameForAccountId(environmentRequest.getCredentialName(), accountId, ENVIRONMENT);
         return environmentService.getCreateEnvironmentForCli(environmentRequest, credential.getCloudPlatform());
+    }
+
+    @Override
+    @InternalOnly
+    public void updateConfigsInEnvironmentByCrn(@ResourceCrn @TenantAwareParam String crn) {
+        stackConfigUpdateService.updateAllStackConfigsByCrn(crn);
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/metrics/MetricType.java
+++ b/environment/src/main/java/com/sequenceiq/environment/metrics/MetricType.java
@@ -14,7 +14,10 @@ public enum MetricType implements Metric {
 
     ENV_DELETION_FINISHED("environment.deletion.finished"),
     ENV_DELETION_FAILED("environment.deletion.failed"),
-    ENV_CLUSTERS_DELETION_FAILED("environment.clusters.deletion.failed");
+    ENV_CLUSTERS_DELETION_FAILED("environment.clusters.deletion.failed"),
+
+    ENV_STACK_CONFIG_UPDATE_FINISHED("environment.stack.config.update.finished"),
+    ENV_STACK_CONFIG_UPDATE_FAILED("environment.stack.config.update.failed");
 
     private final String metricName;
 

--- a/environment/src/test/java/com/sequenceiq/environment/environment/poller/StackPollerProviderTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/poller/StackPollerProviderTest.java
@@ -1,0 +1,85 @@
+package com.sequenceiq.environment.environment.poller;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doThrow;
+
+import com.dyngr.core.AttemptResult;
+import com.dyngr.core.AttemptState;
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.environment.environment.flow.config.update.EnvStackConfigUpdatesState;
+import com.sequenceiq.environment.environment.flow.config.update.config.EnvStackConfigUpdatesFlowConfig;
+import com.sequenceiq.environment.environment.service.stack.StackService;
+import com.sequenceiq.flow.core.FlowConstants;
+import com.sequenceiq.flow.domain.FlowLog;
+import com.sequenceiq.flow.service.flowlog.FlowLogDBService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.WebApplicationException;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+
+public class StackPollerProviderTest {
+
+    private final StackService stackService = Mockito.mock(StackService.class);
+
+    private final FlowLogDBService flowLogDBService = Mockito.mock(FlowLogDBService.class);
+
+    private final StackPollerProvider underTest = new StackPollerProvider(stackService,
+        flowLogDBService);
+
+    @ParameterizedTest
+    @MethodSource("stackUpdateConfigStates")
+    public void testStackUpdateConfigPoller(Exception crn1Exception, Exception crn2Exception,
+        String flowState, AttemptState expectedResult) throws Exception {
+        List<String> stackCrns = new ArrayList<>();
+        stackCrns.add("crn1");
+        stackCrns.add("crn2");
+        if (crn1Exception != null) {
+            doThrow(crn1Exception).when(stackService).triggerConfigUpdateForStack("crn1");
+        }
+        if (crn2Exception != null) {
+            doThrow(crn2Exception).when(stackService).triggerConfigUpdateForStack("crn2");
+        }
+        Mockito.when(flowLogDBService.getLastFlowLog("1"))
+            .thenReturn(Optional.of(getFlowLog(flowState)));
+        AttemptResult<Void> result = underTest.stackUpdateConfigPoller(stackCrns, 1L, "1")
+            .process();
+        assertEquals(expectedResult, result.getState());
+    }
+
+    private static Stream<Arguments> stackUpdateConfigStates() {
+        return Stream.of(
+            Arguments.of(null, null, FlowConstants.CANCELLED_STATE, AttemptState.FINISH),
+            Arguments
+                .of(null, null, EnvStackConfigUpdatesState.STACK_CONFIG_UPDATES_START_STATE.name(),
+                    AttemptState.FINISH),
+            Arguments.of(new BadRequestException("flow running"), null,
+                EnvStackConfigUpdatesState.STACK_CONFIG_UPDATES_START_STATE.name(),
+                AttemptState.CONTINUE),
+            Arguments.of(new BadRequestException("flow running"),
+                new BadRequestException("flow running"),
+                EnvStackConfigUpdatesState.STACK_CONFIG_UPDATES_START_STATE.name(),
+                AttemptState.CONTINUE),
+            Arguments.of(new WebApplicationException("some 500 error"), null,
+                EnvStackConfigUpdatesState.STACK_CONFIG_UPDATES_START_STATE.name(),
+                AttemptState.BREAK)
+        );
+    }
+
+    private FlowLog getFlowLog(String state) {
+        FlowLog flowLog = new FlowLog();
+        flowLog.setId(1L);
+        flowLog.setFlowTriggerUserCrn(ThreadBasedUserCrnProvider.INTERNAL_ACTOR_CRN);
+        flowLog.setCurrentState(state);
+        flowLog.setCreated(1L);
+        flowLog.setFlowId("1");
+        flowLog.setResourceId(1L);
+        flowLog.setFlowType(EnvStackConfigUpdatesFlowConfig.class);
+        return flowLog;
+    }
+}


### PR DESCRIPTION
This adds an API and flow to the environment service which allows for
the updating of all of an Environments Stacks pillar configs.

This is primarily needed for FreeIPA right now, when a FreeIPA DNS
server changes IP to allow all of the Clusters within an environment
to update their DNS server IP addresses.

The API added is:
POST /v1/env/crn/{crn}/update_config

These do not have authorization on them and should only ever be
called from internal to the Control Plane.  They kick off the
EnvStackConfigUpdates Flow which collects all of the stacks for
the environment and calls the Cloudbreak API and Flow created in
CB-6364.  It does not monitor these flows, it just keeps
retrying until it successfully submits a request for the pillar configs
to be updated.

If another call to update the configs for the stacks come in while
one is processing and retrying, it first call will be canceled and the
second will start the process again for all stacks.  This is to make sure
that all stacks are updated for when the latest call comes in.

It will retry submitting pillar updates every 60 seconds for 120 tries.
This is to give enough time for current running flows to finish allows
the pillar configs update to catch up the stack that did have flows running.

This is covered by the one-pager here:
https://docs.google.com/document/d/1ntWZF1WP9BVRU8mP9IEzFnN63-qggG9CNEImVbXjs9I
