### PR TITLE
Ranger authorizer support for cdp-proxy and cdp-proxy-api topologies

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.core.bootstrap.service.host;
 
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_0;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_1;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
 import static com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterDeletionBasedExitCriteriaModel.clusterDeletionBasedModel;
@@ -450,11 +451,13 @@ public class ClusterHostServiceRunner {
     private void decoratePillarWithClouderaManagerSettings(Map<String, SaltPillarProperties> servicePillar, Long clusterId) {
         ClouderaManagerRepo clouderaManagerRepo = clusterComponentConfigProvider.getClouderaManagerRepoDetails(clusterId);
         boolean deterministicUidGid = isVersionNewerOrEqualThanLimited(clouderaManagerRepo.getVersion(), CLOUDERAMANAGER_VERSION_7_2_1);
+        boolean enableKnoxRangerAuthorizer = isVersionNewerOrEqualThanLimited(clouderaManagerRepo.getVersion(), CLOUDERAMANAGER_VERSION_7_2_0);
         servicePillar.put("cloudera-manager-settings", new SaltPillarProperties("/cloudera-manager/settings.sls",
                 singletonMap("cloudera-manager", singletonMap("settings", Map.of(
                         "heartbeat_interval", cmHeartbeatInterval,
                         "missed_heartbeat_interval", cmMissedHeartbeatInterval,
-                        "deterministic_uid_gid", deterministicUidGid)))));
+                        "deterministic_uid_gid", deterministicUidGid,
+                        "enable_knox_ranger_authorizer", enableKnoxRangerAuthorizer)))));
     }
 
     private void decoratePillarWithTags(Stack stack, Map<String, SaltPillarProperties> servicePillarConfig) {

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -15,164 +15,180 @@
            </param>
         </provider>
 
-{% if salt['pillar.get']('gateway:envAccessGroup') is defined and salt['pillar.get']('gateway:envAccessGroup') | length > 0 %}
-        <provider>
-            <role>identity-assertion</role>
-            <name>HadoopGroupProvider</name>
-            <enabled>true</enabled>
-            <param>
-                <name>CENTRAL_GROUP_CONFIG_PREFIX</name>
-                <value>gateway.group.config.</value>
-            </param>
-        </provider>
+{%- if 'RANGER' in exposed and 'RANGER_ADMIN' in salt['pillar.get']('gateway:location') -%}
+    {% set ranger_installed = True %}
+    {% set aclsauthz_prefix = 'AclsAuthz.' %}
+{%- else -%}
+    {% set ranger_installed = False %}
+    {% set aclsauthz_prefix = '' %}
+{%- endif -%}
 
-        <provider>
-            <role>authorization</role>
-            <name>AclsAuthz</name>
-            <enabled>true</enabled>
-            <param>
-                <name>knox.acl.mode</name>
-                <value>AND</value>
-            </param>
-            <param>
-                <name>atlas.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>atlas-api.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>cm-api.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>cm-ui.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>das.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>hbaseui.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>hdfsui.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>hive.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>hue.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>impalaui.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>kuduui.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>jobhistoryui.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>livyserver.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>nifi.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>nifi-registry.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>oozie.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>oozieui.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>data-discovery-service-api.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>profiler-admin-api.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>profiler-metrics-api.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>profiler-scheduler-api.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>ranger.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>rangerui.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>schema-registry.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>smm-ui.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>solr.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>sparkhistoryui.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>spark3historyui.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>webhdfs.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>yarnuiv2.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>resourcemanager.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>zeppelinui.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>zeppelinws.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-            <param>
-                <name>flink.acl</name>
-                <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
-            </param>
-        </provider>
-{% endif %}
-
+{% if salt['pillar.get']('gateway:envAccessGroup') is defined and salt['pillar.get']('gateway:envAccessGroup') | length > 0 and salt['pillar.get']('cloudera-manager:settings:enable_knox_ranger_authorizer') == True %}
+    <provider>
+        <role>identity-assertion</role>
+        <name>HadoopGroupProvider</name>
+        <enabled>true</enabled>
+        <param>
+            <name>CENTRAL_GROUP_CONFIG_PREFIX</name>
+            <value>gateway.group.config.</value>
+        </param>
+    </provider>
+    <provider>
+    {%- if ranger_installed == True %}
+             <role>authorization</role>
+             <name>CompositeAuthz</name>
+             <enabled>true</enabled>
+             <param>
+                 <name>composite.provider.names</name>
+                 <value>AclsAuthz,XASecurePDPKnox</value>
+              </param>
+    {%- else %}
+             <role>authorization</role>
+             <name>AclsAuthz</name>
+             <enabled>true</enabled>
+    {%- endif %}
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "knox.acl.mode" }}</name>
+                 <value>AND</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "atlas.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "atlas-api.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "cm-api.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "cm-ui.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "das.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "hbaseui.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "hdfsui.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "hive.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "hue.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "impalaui.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "kuduui.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "jobhistoryui.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "livyserver.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "nifi.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "nifi-registry.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "oozie.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "oozieui.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "data-discovery-service-api.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "profiler-admin-api.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "profiler-metrics-api.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "profiler-scheduler-api.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "ranger.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "rangerui.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "schema-registry.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "smm-ui.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "solr.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "sparkhistoryui.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "spark3historyui.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "webhdfs.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "yarnuiv2.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "resourcemanager.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "zeppelinui.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "zeppelinws.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+             <param>
+                 <name>{{ aclsauthz_prefix ~ "flink.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+             </param>
+         </provider>
+    {%- endif %}
          <provider>
              <role>ha</role>
              <name>HaProvider</name>

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -17,13 +17,17 @@
 
 {%- if 'RANGER' in exposed and 'RANGER_ADMIN' in salt['pillar.get']('gateway:location') -%}
     {% set ranger_installed = True %}
-    {% set aclsauthz_prefix = 'AclsAuthz.' %}
+    {%- if salt['pillar.get']('gateway:enable_knox_ranger_authorizer') == True -%}
+        {% set aclsauthz_prefix = 'AclsAuthz.' %}
+    {%- else -%}
+        {% set aclsauthz_prefix = '' %}
+    {%- endif -%}
 {%- else -%}
     {% set ranger_installed = False %}
     {% set aclsauthz_prefix = '' %}
 {%- endif -%}
 
-{% if salt['pillar.get']('gateway:envAccessGroup') is defined and salt['pillar.get']('gateway:envAccessGroup') | length > 0 and salt['pillar.get']('gateway:enable_knox_ranger_authorizer') == True %}
+{% if salt['pillar.get']('gateway:envAccessGroup') is defined and salt['pillar.get']('gateway:envAccessGroup') | length > 0 %}
     <provider>
         <role>identity-assertion</role>
         <name>HadoopGroupProvider</name>
@@ -34,7 +38,7 @@
         </param>
     </provider>
     <provider>
-    {%- if ranger_installed == True %}
+    {%- if ranger_installed == True and salt['pillar.get']('gateway:enable_knox_ranger_authorizer') == True %}
              <role>authorization</role>
              <name>CompositeAuthz</name>
              <enabled>true</enabled>

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -23,7 +23,7 @@
     {% set aclsauthz_prefix = '' %}
 {%- endif -%}
 
-{% if salt['pillar.get']('gateway:envAccessGroup') is defined and salt['pillar.get']('gateway:envAccessGroup') | length > 0 and salt['pillar.get']('cloudera-manager:settings:enable_knox_ranger_authorizer') == True %}
+{% if salt['pillar.get']('gateway:envAccessGroup') is defined and salt['pillar.get']('gateway:envAccessGroup') | length > 0 and salt['pillar.get']('gateway:enable_knox_ranger_authorizer') == True %}
     <provider>
         <role>identity-assertion</role>
         <name>HadoopGroupProvider</name>

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
@@ -33,7 +33,7 @@
     {% set aclsauthz_prefix = '' %}
 {%- endif -%}
 
-{% if salt['pillar.get']('gateway:envAccessGroup') is defined and salt['pillar.get']('gateway:envAccessGroup') | length > 0 and salt['pillar.get']('cloudera-manager:settings:enable_knox_ranger_authorizer') == True %}
+{% if salt['pillar.get']('gateway:envAccessGroup') is defined and salt['pillar.get']('gateway:envAccessGroup') | length > 0 and salt['pillar.get']('gateway:enable_knox_ranger_authorizer') == True %}
         <provider>
             <role>identity-assertion</role>
             <name>HadoopGroupProvider</name>

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
@@ -27,13 +27,17 @@
 
 {%- if 'RANGER' in exposed and 'RANGER_ADMIN' in salt['pillar.get']('gateway:location') -%}
     {% set ranger_installed = True %}
-    {% set aclsauthz_prefix = 'AclsAuthz.' %}
+    {%- if salt['pillar.get']('gateway:enable_knox_ranger_authorizer') == True -%}
+        {% set aclsauthz_prefix = 'AclsAuthz.' %}
+    {%- else -%}
+        {% set aclsauthz_prefix = '' %}
+    {%- endif -%}
 {%- else -%}
     {% set ranger_installed = False %}
     {% set aclsauthz_prefix = '' %}
 {%- endif -%}
 
-{% if salt['pillar.get']('gateway:envAccessGroup') is defined and salt['pillar.get']('gateway:envAccessGroup') | length > 0 and salt['pillar.get']('gateway:enable_knox_ranger_authorizer') == True %}
+{% if salt['pillar.get']('gateway:envAccessGroup') is defined and salt['pillar.get']('gateway:envAccessGroup') | length > 0 %}
         <provider>
             <role>identity-assertion</role>
             <name>HadoopGroupProvider</name>
@@ -44,7 +48,7 @@
             </param>
         </provider>
         <provider>
-        {%- if ranger_installed == True %}
+        {%- if ranger_installed == True and salt['pillar.get']('gateway:enable_knox_ranger_authorizer') == True %}
             <role>authorization</role>
             <name>CompositeAuthz</name>
             <enabled>true</enabled>

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
@@ -25,7 +25,15 @@
            </param>
         </provider>
 
-{% if salt['pillar.get']('gateway:envAccessGroup') is defined and salt['pillar.get']('gateway:envAccessGroup') | length > 0 %}
+{%- if 'RANGER' in exposed and 'RANGER_ADMIN' in salt['pillar.get']('gateway:location') -%}
+    {% set ranger_installed = True %}
+    {% set aclsauthz_prefix = 'AclsAuthz.' %}
+{%- else -%}
+    {% set ranger_installed = False %}
+    {% set aclsauthz_prefix = '' %}
+{%- endif -%}
+
+{% if salt['pillar.get']('gateway:envAccessGroup') is defined and salt['pillar.get']('gateway:envAccessGroup') | length > 0 and salt['pillar.get']('cloudera-manager:settings:enable_knox_ranger_authorizer') == True %}
         <provider>
             <role>identity-assertion</role>
             <name>HadoopGroupProvider</name>
@@ -35,85 +43,94 @@
                 <value>gateway.group.config.</value>
             </param>
         </provider>
-
         <provider>
+        {%- if ranger_installed == True %}
+            <role>authorization</role>
+            <name>CompositeAuthz</name>
+            <enabled>true</enabled>
+            <param>
+                <name>composite.provider.names</name>
+                <value>AclsAuthz,XASecurePDPKnox</value>
+            </param>
+        {%- else %}
             <role>authorization</role>
             <name>AclsAuthz</name>
             <enabled>true</enabled>
+        {%- endif %}
             <param>
-                <name>knox.acl.mode</name>
+                <name>{{ aclsauthz_prefix ~ "knox.acl.mode" }}</name>
                 <value>AND</value>
             </param>
             <param>
-                <name>atlas-api.acl</name>
+                <name>{{ aclsauthz_prefix ~ "atlas-api.acl" }}</name>
                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
             </param>
             <param>
-                <name>avatica.acl</name>
+                <name>{{ aclsauthz_prefix ~ "avatica.acl" }}</name>
                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
             </param>
             <param>
-                <name>cm-api.acl</name>
+                <name>{{ aclsauthz_prefix ~ "cm-api.acl" }}</name>
                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
             </param>
             <param>
-                <name>hive.acl</name>
+                <name>{{ aclsauthz_prefix ~ "hive.acl" }}</name>
                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
             </param>
             <param>
-                <name>impala.acl</name>
+                <name>{{ aclsauthz_prefix ~ "impala.acl" }}</name>
                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
             </param>
             <param>
-                <name>jobtracker.acl</name>
+                <name>{{ aclsauthz_prefix ~ "jobtracker.acl" }}</name>
                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
             </param>
             <param>
-                <name>livyserver.acl</name>
+                <name>{{ aclsauthz_prefix ~ "livyserver.acl" }}</name>
                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
             </param>
             <param>
-                <name>namenode.acl</name>
+                <name>{{ aclsauthz_prefix ~ "namenode.acl" }}</name>
                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
             </param>
             <param>
-                <name>nifi.acl</name>
+                <name>{{ aclsauthz_prefix ~ "nifi.acl" }}</name>
                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
             </param>
             <param>
-                <name>nifi-registry.acl</name>
+                <name>{{ aclsauthz_prefix ~ "nifi-registry.acl" }}</name>
                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
             </param>
             <param>
-                <name>oozie.acl</name>
+                <name>{{ aclsauthz_prefix ~ "oozie.acl" }}</name>
                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
             </param>
             <param>
-                <name>ranger.acl</name>
+                <name>{{ aclsauthz_prefix ~ "ranger.acl" }}</name>
                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
             </param>
             <param>
-                <name>resourcemanager.acl</name>
+                <name>{{ aclsauthz_prefix ~ "resourcemanager.acl" }}</name>
                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
             </param>
             <param>
-                <name>smm-api.acl</name>
+                <name>{{ aclsauthz_prefix ~ "smm-api.acl" }}</name>
                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
             </param>
             <param>
-                <name>solr.acl</name>
+                <name>{{ aclsauthz_prefix ~ "solr.acl" }}</name>
                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
             </param>
             <param>
-                <name>webhbase.acl</name>
+                <name>{{ aclsauthz_prefix ~ "webhbase.acl" }}</name>
                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
             </param>
             <param>
-                <name>webhdfs.acl</name>
+                <name>{{ aclsauthz_prefix ~ "webhdfs.acl" }}</name>
                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
             </param>
         </provider>
-{% endif %}
+{%- endif %}
 
         <provider>
             <role>ha</role>


### PR DESCRIPTION
Describe the change you are making here!

This PR will add Ranger authorizer plugin to Knox topologies CB-5949. What this means is that ranger policies will be applied to all the requests flowing through Knox. This should not break any functionality as Ranger side will have policy that will allow all access going though Knox see OPSAPS-55862.
The changes will be ignored for releases < 7.2.0

Why is this change needed
Currently Knox and Ranger are disconnected, there is no way for Ranger to enforce policies on Knox without modifying Knox configs (and Ranger policies). This PR will enable Ranger plugin for Knox so users can update Ranger policies for Knox in on place (Ranger)

What the patch does:
This patch updates the salt files to add Knox composite authorization that uses ACL and Ranger authorization.
If Ranger is not installed the topologies should work as before and there would be no change.

Side effects:
No side effects to my knowledge.

Please include a short description.
Ranger authorizer support for Knox