### PR TITLE
[ASRG] Azure DB is created based on Resource Group region instead of …

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/DatabaseServer.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/DatabaseServer.java
@@ -1,9 +1,9 @@
 package com.sequenceiq.cloudbreak.cloud.model;
 
-import com.sequenceiq.cloudbreak.cloud.model.generic.DynamicModel;
-
 import java.util.HashMap;
 import java.util.Map;
+
+import com.sequenceiq.cloudbreak.cloud.model.generic.DynamicModel;
 
 public class DatabaseServer extends DynamicModel {
 
@@ -29,9 +29,11 @@ public class DatabaseServer extends DynamicModel {
 
     private final InstanceStatus status;
 
+    private final String location;
+
     private DatabaseServer(String serverId, String flavor, DatabaseEngine engine, String connectionDriver,
             String connectorJarUrl, String rootUserName, String rootPassword,
-            Integer port, Long storageSize, Security security, InstanceStatus status, Map<String, Object> parameters) {
+            Integer port, Long storageSize, Security security, InstanceStatus status, String location, Map<String, Object> parameters) {
         super(parameters);
         this.serverId = serverId;
         this.flavor = flavor;
@@ -44,6 +46,7 @@ public class DatabaseServer extends DynamicModel {
         this.storageSize = storageSize;
         this.security = security;
         this.status = status;
+        this.location = location;
     }
 
     public String getServerId() {
@@ -90,6 +93,10 @@ public class DatabaseServer extends DynamicModel {
         return status;
     }
 
+    public String getLocation() {
+        return location;
+    }
+
     @Override
     public String toString() {
         return "DatabaseServer{"
@@ -133,6 +140,8 @@ public class DatabaseServer extends DynamicModel {
         private Security security;
 
         private InstanceStatus status;
+
+        private String location;
 
         private Map<String, Object> params = new HashMap<>();
 
@@ -191,6 +200,11 @@ public class DatabaseServer extends DynamicModel {
             return this;
         }
 
+        public Builder location(String location) {
+            this.location = location;
+            return this;
+        }
+
         public Builder params(Map<String, Object> params) {
             this.params = params;
             return this;
@@ -198,7 +212,7 @@ public class DatabaseServer extends DynamicModel {
 
         public DatabaseServer build() {
             return new DatabaseServer(serverId, flavor, engine, connectionDriver, connectorJarUrl, rootUserName, rootPassword,
-                port, storageSize, security, status, params);
+                port, storageSize, security, status, location, params);
         }
 
     }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilder.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilder.java
@@ -154,6 +154,7 @@ public class AzureTemplateBuilder {
             model.put("subnets", azureNetworkView.getSubnets());
             // if subnet number is 1 then Azure does not create the endpoints if the batchsize is 5
             model.put("batchSize", azureNetworkView.getSubnets().split(",").length >= defaultBatchSize ? defaultBatchSize : 1);
+            model.put("location", azureDatabaseServerView.getLocation());
             String generatedTemplate = freeMarkerTemplateUtils.processTemplateIntoString(getTemplate(databaseStack), model);
             LOGGER.debug("Generated ARM database template: {}", AnonymizerUtil.anonymize(generatedTemplate));
             return generatedTemplate;

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureDatabaseServerView.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureDatabaseServerView.java
@@ -97,4 +97,8 @@ public class AzureDatabaseServerView {
     public Integer getPort() {
         return databaseServer.getPort();
     }
+
+    public String getLocation() {
+        return databaseServer.getLocation();
+    }
 }

--- a/cloud-azure/src/main/resources/templates/arm-dbstack.ftl
+++ b/cloud-azure/src/main/resources/templates/arm-dbstack.ftl
@@ -119,7 +119,7 @@
         },
         "location": {
             "type": "string",
-            "defaultValue": "[resourceGroup().location]",
+            "defaultValue": "${location}",
             "metadata": {
                 "description": "The location in which the database should be deployed."
             }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/converter/spi/DBStackToDatabaseStackConverter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/converter/spi/DBStackToDatabaseStackConverter.java
@@ -96,6 +96,7 @@ public class DBStackToDatabaseStackConverter {
             .security(securityGroup == null ? null : new Security(Collections.emptyList(), securityGroup.getSecurityGroupIds()))
             // TODO / FIXME converter caller decides this?
             .status(CREATE_REQUESTED)
+                .location(dbStack.getRegion())
             .params(params);
 
         return builder.build();


### PR DESCRIPTION
…ENV region

With the existing Resource Group feature, it can happen that the ENV region and the RG region is different. In this case, Redbeams should use the ENV region instead of the RG region otherwise it won't be able to create the VNet rules, because the VNets are based in the ENV region.

See detailed description in the commit message.