### PR TITLE
CB-8014: implement freeipa force delete

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/deletion/handler/freeipa/FreeIpaDeletionHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/deletion/handler/freeipa/FreeIpaDeletionHandler.java
@@ -71,7 +71,7 @@ public class FreeIpaDeletionHandler extends EventSenderAwareHandler<EnvironmentD
                 if (Objects.nonNull(environment.getParentEnvironment())) {
                     detachChildEnvironmentFromFreeIpa(environment);
                 } else {
-                    deleteFreeIpa(environment);
+                    deleteFreeIpa(environment, environmentDeletionDto.isForceDelete());
                 }
             }
             eventSender().sendEvent(getNextStepObject(environmentDeletionDto), environmentDtoEvent.getHeaders());
@@ -134,8 +134,8 @@ public class FreeIpaDeletionHandler extends EventSenderAwareHandler<EnvironmentD
         return Objects.equals(sibling.getNetwork().getNetworkCidr(), environment.getNetwork().getNetworkCidr());
     }
 
-    private void deleteFreeIpa(Environment environment) {
-        freeIpaService.delete(environment.getResourceCrn());
+    private void deleteFreeIpa(Environment environment, boolean forced) {
+        freeIpaService.delete(environment.getResourceCrn(), forced);
         Pair<PollingResult, Exception> result = freeIpaPollingService.pollWithTimeout(
                 new FreeIpaDeletionRetrievalTask(freeIpaService),
                 new FreeIpaPollerObject(environment.getId(), environment.getResourceCrn()),

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/freeipa/FreeIpaService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/freeipa/FreeIpaService.java
@@ -55,9 +55,9 @@ public class FreeIpaService {
         }
     }
 
-    public void delete(String environmentCrn) {
+    public void delete(String environmentCrn, boolean forced) {
         try {
-            freeIpaV1Endpoint.delete(environmentCrn);
+            freeIpaV1Endpoint.delete(environmentCrn, forced);
         } catch (WebApplicationException e) {
             String errorMessage = webApplicationExceptionMessageExtractor.getErrorMessage(e);
             LOGGER.error(String.format("Failed to delete FreeIpa cluster for environment '%s' due to: '%s'", environmentCrn, errorMessage), e);

--- a/environment/src/test/java/com/sequenceiq/environment/environment/flow/deletion/handler/freeipa/FreeIpaDeletionHandlerTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/flow/deletion/handler/freeipa/FreeIpaDeletionHandlerTest.java
@@ -144,7 +144,7 @@ class FreeIpaDeletionHandlerTest {
 
         victim.accept(new Event<>(environmentDeletionDto));
 
-        verify(freeIpaService).delete(ENVIRONMENT_CRN);
+        verify(freeIpaService).delete(ENVIRONMENT_CRN, true);
         verify(eventSender).sendEvent(any(BaseNamedFlowEvent.class), any(Event.Headers.class));
         verifyNoMoreInteractions(freeIpaService);
     }
@@ -163,7 +163,7 @@ class FreeIpaDeletionHandlerTest {
 
         victim.accept(new Event<>(environmentDeletionDto));
 
-        verify(freeIpaService, never()).delete(ENVIRONMENT_CRN);
+        verify(freeIpaService, never()).delete(ENVIRONMENT_CRN, true);
         verify(eventSender).sendEvent(any(BaseNamedFlowEvent.class), any(Event.Headers.class));
     }
 

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
@@ -6,6 +6,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
@@ -104,7 +105,7 @@ public interface FreeIpaV1Endpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = FreeIpaOperationDescriptions.DELETE_BY_ENVID, produces = MediaType.APPLICATION_JSON, notes = FreeIpaNotes.FREEIPA_NOTES,
             nickname = "deleteFreeIpaByEnvironmentV1")
-    void delete(@QueryParam("environment") @NotEmpty String environmentCrn);
+    void delete(@QueryParam("environment") @NotEmpty String environmentCrn, @QueryParam("forced") @DefaultValue("false") boolean forced);
 
     @POST
     @Path("cleanup")

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaV1Controller.java
@@ -176,9 +176,9 @@ public class FreeIpaV1Controller implements FreeIpaV1Endpoint {
 
     @Override
     @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.DELETE_ENVIRONMENT)
-    public void delete(@ResourceCrn String environmentCrn) {
+    public void delete(@ResourceCrn String environmentCrn, boolean forced) {
         String accountId = crnService.getCurrentAccountId();
-        freeIpaDeletionService.delete(environmentCrn, accountId);
+        freeIpaDeletionService.delete(environmentCrn, accountId, forced);
     }
 
     @Override

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/action/StackTerminationAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/action/StackTerminationAction.java
@@ -23,6 +23,11 @@ public class StackTerminationAction extends AbstractStackTerminationAction<Termi
     }
 
     @Override
+    protected void prepareExecution(TerminationEvent payload, Map<Object, Object> variables) {
+        variables.put("FORCEDTERMINATION", payload.getForced());
+    }
+
+    @Override
     protected void doExecute(StackTerminationContext context, TerminationEvent payload, Map<Object, Object> variables) {
         stackUpdater.updateStackStatus(context.getStack().getId(), DetailedStackStatus.DELETE_IN_PROGRESS, "Terminating FreeIPA and its infrastructure.");
         TerminateStackRequest<?> terminateRequest = createRequest(context);

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/controller/FreeIpaV1ControllerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/controller/FreeIpaV1ControllerTest.java
@@ -177,9 +177,9 @@ class FreeIpaV1ControllerTest {
 
     @Test
     void delete() {
-        underTest.delete(ENVIRONMENT_CRN);
+        underTest.delete(ENVIRONMENT_CRN, true);
 
-        verify(deletionService, times(1)).delete(ENVIRONMENT_CRN, ACCOUNT_ID);
+        verify(deletionService, times(1)).delete(ENVIRONMENT_CRN, ACCOUNT_ID, true);
     }
 
     @Test

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaDeletionServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaDeletionServiceTest.java
@@ -93,7 +93,7 @@ class FreeIpaDeletionServiceTest {
         when(stackService.findAllByEnvironmentCrnAndAccountId(eq(ENVIRONMENT_CRN), eq(ACCOUNT_ID))).thenReturn(Collections.singletonList(stack));
         when(flowLogService.findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(STACK_ID)).thenReturn(List.of());
 
-        underTest.delete(ENVIRONMENT_CRN, ACCOUNT_ID);
+        underTest.delete(ENVIRONMENT_CRN, ACCOUNT_ID, false);
 
         verify(stackService, times(1)).findAllByEnvironmentCrnAndAccountId(eq(ENVIRONMENT_CRN), eq(ACCOUNT_ID));
         ArgumentCaptor<TerminationEvent> terminationEventArgumentCaptor = ArgumentCaptor.forClass(TerminationEvent.class);
@@ -113,7 +113,7 @@ class FreeIpaDeletionServiceTest {
         stack.getStackStatus().setStatus(Status.DELETE_COMPLETED);
         when(stackService.findAllByEnvironmentCrnAndAccountId(eq(ENVIRONMENT_CRN), eq(ACCOUNT_ID))).thenReturn(Collections.singletonList(stack));
 
-        underTest.delete(ENVIRONMENT_CRN, ACCOUNT_ID);
+        underTest.delete(ENVIRONMENT_CRN, ACCOUNT_ID, false);
 
         verify(flowManager, never()).notify(anyString(), any(Acceptable.class));
         verify(flowCancelService, never()).cancelRunningFlows(stack.getId());
@@ -128,7 +128,7 @@ class FreeIpaDeletionServiceTest {
         flowLog.setCurrentState(StackTerminationState.INIT_STATE.name());
         when(flowLogService.findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(stack.getId())).thenReturn(List.of(flowLog));
 
-        underTest.delete(ENVIRONMENT_CRN, ACCOUNT_ID);
+        underTest.delete(ENVIRONMENT_CRN, ACCOUNT_ID, false);
 
         verify(flowManager, never()).notify(anyString(), any(Acceptable.class));
         verify(flowCancelService, never()).cancelRunningFlows(stack.getId());
@@ -139,7 +139,7 @@ class FreeIpaDeletionServiceTest {
         when(stackService.findAllByEnvironmentCrnAndAccountId(eq(ENVIRONMENT_CRN), eq(ACCOUNT_ID))).thenReturn(Collections.singletonList(stack));
         when(childEnvironmentService.findChildEnvironments(stack, ACCOUNT_ID)).thenReturn(Collections.singletonList(new ChildEnvironment()));
 
-        assertThrows(BadRequestException.class, () -> underTest.delete(ENVIRONMENT_CRN, ACCOUNT_ID));
+        assertThrows(BadRequestException.class, () -> underTest.delete(ENVIRONMENT_CRN, ACCOUNT_ID, false));
         verify(stackService, times(1)).findAllByEnvironmentCrnAndAccountId(eq(ENVIRONMENT_CRN), eq(ACCOUNT_ID));
         verify(childEnvironmentService, times(1)).findChildEnvironments(stack, ACCOUNT_ID);
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaDeleteAction.java
@@ -20,7 +20,7 @@ public class FreeIpaDeleteAction implements Action<FreeIpaTestDto, FreeIpaClient
         Log.whenJson(LOGGER, format(" FreeIPA delete:%n"), testDto.getRequest());
         client.getFreeIpaClient()
                 .getFreeIpaV1Endpoint()
-                .delete(testDto.getRequest().getEnvironmentCrn());
+                .delete(testDto.getRequest().getEnvironmentCrn(), false);
         Log.when(LOGGER, String.format(" FreeIPA deleted successfully. FreeIPA CRN: %s", testDto.getResponse().getCrn()));
         return testDto;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaTestDto.java
@@ -283,7 +283,7 @@ public class FreeIpaTestDto extends AbstractFreeIpaTestDto<CreateFreeIpaRequest,
 
     @Override
     public void delete(TestContext testContext, ListFreeIpaResponse entity, FreeIpaClient client) {
-        client.getFreeIpaClient().getFreeIpaV1Endpoint().delete(entity.getEnvironmentCrn());
+        client.getFreeIpaClient().getFreeIpaV1Endpoint().delete(entity.getEnvironmentCrn(), false);
     }
 
     @Override


### PR DESCRIPTION
CB-8014: implement freeipa force delete

- introducing new flag on FreeIpaV1Endpoint.delete() in freeipa microservice: boolean forced
- During environment deletion the forcedelete flag of environmentDeleteRequest will be passed to the freeipe deletion request
- in case of force delete the freeipa service will delete the freeipa related entities even if error occured during the deletion process
