### PR TITLE
CB-8157 Set default value for audit endpoint

### DIFF
--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -89,6 +89,7 @@ datalake:
 altus:
   audit:
     enabled: true
+    endpoint: localhost:8982
 
 cb:
   enabledplatforms: AZURE,AWS,GCP,OPENSTACK

--- a/datalake/src/main/resources/application.yml
+++ b/datalake/src/main/resources/application.yml
@@ -59,6 +59,7 @@ altus:
     host: localhost
   audit:
     enabled: true
+    endpoint: localhost:8982
 
 datalake:
   cert.dir: /certs/


### PR DESCRIPTION
Set to localhost:8982 as it is the default mock grpc service endpoint.

Since a41b1c64157fd30a49ee845c78f83a068e2d6391 the applications will stop with an exception on startup if the default value is not provided.

Now it is set within application.yml