### PR TITLE
CB-8153 Azure Availability Sets should use the same region as the env…

### DIFF
--- a/cloud-azure/src/main/resources/templates/arm-v2-freeipa.ftl
+++ b/cloud-azure/src/main/resources/templates/arm-v2-freeipa.ftl
@@ -73,7 +73,7 @@
                 "type": "Microsoft.Compute/availabilitySets",
                 "name": "[variables('${group.compressedName}AsName')]",
                 "apiVersion": "2018-04-01",
-                "location": "[resourceGroup().location]",
+                "location": "[parameters('region')]",
                 <#if group.managedDisk == true>
                 "sku": {
                     "name": "Aligned"

--- a/cloud-azure/src/main/resources/templates/arm-v2.ftl
+++ b/cloud-azure/src/main/resources/templates/arm-v2.ftl
@@ -98,7 +98,7 @@
                 "type": "Microsoft.Compute/availabilitySets",
                 "name": "[variables('${group.compressedName}AsName')]",
                 "apiVersion": "2018-04-01",
-                "location": "[resourceGroup().location]",
+                "location": "[parameters('region')]",
                 "sku": {
                     "name": "Aligned"
                 },


### PR DESCRIPTION
…ironment

With the existing Resource Group feature, it can happen that the ENV region and
the RG region is different. In this case, the created Availability Sets should
use the ENV region instead of the RG region otherwise the deployment will fail.
