### PR TITLE
CB-8158-ForcedDownscale

### DIFF
--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/CronTimeEvaluatorTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/CronTimeEvaluatorTest.java
@@ -136,13 +136,9 @@ public class CronTimeEvaluatorTest {
         return Stream.of(
                 //TestCase, CurrentHostGroupCount,DesiredNodeCount,YarnGivenDecommissionCount,ExpectedNodeCount
                 Arguments.of("SCALE_DOWN_YARN_NODE_COUNT_MATCH  ", 10, 6, 4, 6),
-                Arguments.of("SCALE_DOWN_YARN_NODE_COUNT_PARTIAL", 10, 6, 2, 6),
-                Arguments.of("SCALE_DOWN_YARN_NODE_COUNT_ZERO   ", 10, 6, 0, 6),
                 Arguments.of("SCALE_DOWN_YARN_NODE_COUNT_EXTRA  ", 12, 6, 12, 6),
 
-                Arguments.of("SCALE_DOWN_YARN_NODE_COUNT_MATCH  ", 25, 22, 2, 22),
-                Arguments.of("SCALE_DOWN_YARN_NODE_COUNT_PARTIAL", 25, 10, 5, 10),
-                Arguments.of("SCALE_DOWN_YARN_NODE_COUNT_ZERO   ", 25, 12, 0, 12),
+                Arguments.of("SCALE_DOWN_YARN_NODE_COUNT_MATCH  ", 25, 22, 3, 22),
                 Arguments.of("SCALE_DOWN_YARN_NODE_COUNT_EXTRA  ", 25, 20, 25, 20)
         );
     }

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/load/YarnLoadEvaluatorTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/evaluator/load/YarnLoadEvaluatorTest.java
@@ -143,10 +143,9 @@ public class YarnLoadEvaluatorTest {
         return Stream.of(
                 //TestCase,CurrentHostGroupCount,YarnRecommendedDecommissionCount,ExpectedDecommissionCount
                 Arguments.of("DOWN_SCALE_ALLOWED", 7, 5, 7 - TEST_HOSTGROUP_MIN_SIZE),
-                Arguments.of("DOWN_SCALE_FORCED", TEST_HOSTGROUP_MAX_SIZE + 20, 0, 20),
-                Arguments.of("DOWN_SCALE_MAX_RECOMMENDED", TEST_HOSTGROUP_MAX_SIZE + 20, 30, 30),
-                Arguments.of("DOWN_SCALE_BEYOND_MAX_LIMIT", TEST_HOSTGROUP_MAX_SIZE + 20, 5, 20),
-                Arguments.of("DOWN_SCALE_AT_YARN_LIMIT", TEST_HOSTGROUP_MAX_SIZE + 20, 10, 20),
+                Arguments.of("DOWN_SCALE_FORCED", TEST_HOSTGROUP_MAX_SIZE + 20, 20, 20),
+                Arguments.of("DOWN_SCALE_FORCED_AND_EXTRA", TEST_HOSTGROUP_MAX_SIZE + 20, 30, 20),
+                Arguments.of("DOWN_SCALE_RECOMMENDED", TEST_HOSTGROUP_MAX_SIZE, 100, 100),
                 Arguments.of("DOWN_SCALE_ALLOWED_MIN_LIMIT", 10, 10, 10 - TEST_HOSTGROUP_MIN_SIZE),
                 Arguments.of("DOWN_SCALE_ALLOWED_AT_MIN_LIMIT", 20, 20 - TEST_HOSTGROUP_MIN_SIZE, 20 - TEST_HOSTGROUP_MIN_SIZE),
                 Arguments.of("DOWN_SCALE_BEYOND_MIN_LIMIT", 10, 52, 10 - TEST_HOSTGROUP_MIN_SIZE),


### PR DESCRIPTION
Forced Downscale should pass DOWNSCALE_FACTOR_IN_NODE_COUNT as QueryParam and not HeaderParam.
Forced Downscale should be limited to MandatoryDownscale NodeCount
