### PR TITLE
CB-8170 reduce the logs in the build process

### DIFF
--- a/scripts/build-dev.sh
+++ b/scripts/build-dev.sh
@@ -3,7 +3,7 @@ set -x
 
 echo "Build version: $VERSION"
 
-./gradlew -Penv=jenkins -b build.gradle buildInfo build uploadBootArchives -Pversion=$VERSION --info --stacktrace --parallel -x checkstyleMain -x checkstyleTest -x spotbugsMain -x spotbugsTest
+./gradlew -Penv=jenkins -b build.gradle buildInfo build uploadBootArchives -Pversion=$VERSION --parallel -x checkstyleMain -x checkstyleTest -x spotbugsMain -x spotbugsTest
 
 aws s3 cp ./core/build/swagger/cb.json "s3://cloudbreak-swagger/swagger-${VERSION}.json" --acl public-read
 aws s3 cp ./environment/build/swagger/environment.json "s3://environment-swagger/swagger-${VERSION}.json" --acl public-read


### PR DESCRIPTION
this change was requested by the RE team because it is hard to debug build issues so shrinking down the gradle log level

See detailed description in the commit message.