### PR TITLE
CDPCP-2673. Poll status of refresh when syncing OIDs

### DIFF
--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxEndpoint.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxEndpoint.java
@@ -203,8 +203,14 @@ public interface SdxEndpoint {
     @POST
     @Path("/envcrn/{envCrn}/ranger_cloud_identity_mapping")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "set ranger cloud identity mapping", produces = MediaType.APPLICATION_JSON, nickname = "setRangerCloudIdentityMapping")
+    @ApiOperation(value = "Set ranger cloud identity mapping", produces = MediaType.APPLICATION_JSON, nickname = "setRangerCloudIdentityMapping")
     RangerCloudIdentitySyncStatus setRangerCloudIdentityMapping(@PathParam("envCrn") @ValidCrn String envCrn,
             @NotNull @Valid SetRangerCloudIdentityMappingRequest request);
+
+    @GET
+    @Path("/envcrn/{envCrn}/ranger_cloud_identity_sync_status")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Get status of a ranger cloud identity sync", produces = MediaType.APPLICATION_JSON, nickname = "getRangerCloudIdentitySyncStatus")
+    RangerCloudIdentitySyncStatus getRangerCloudIdentitySyncStatus(@PathParam("envCrn") @ValidCrn String envCrn, long commandId);
 
 }

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/RangerCloudIdentitySyncState.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/RangerCloudIdentitySyncState.java
@@ -1,0 +1,8 @@
+package com.sequenceiq.sdx.api.model;
+
+public enum RangerCloudIdentitySyncState {
+    SUCCESS,
+    ACTIVE,
+    FAILED,
+    NOT_APPLICABLE,
+}

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/RangerCloudIdentitySyncStatus.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/RangerCloudIdentitySyncStatus.java
@@ -1,4 +1,51 @@
 package com.sequenceiq.sdx.api.model;
 
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.constraints.NotNull;
+
 public class RangerCloudIdentitySyncStatus {
+
+    @ApiModelProperty
+    private Long commandId;
+
+    @ApiModelProperty
+    @NotNull
+    private RangerCloudIdentitySyncState state;
+
+    @ApiModelProperty
+    private String statusReason;
+
+    public Long getCommandId() {
+        return commandId;
+    }
+
+    public RangerCloudIdentitySyncState getState() {
+        return state;
+    }
+
+    public String getStatusReason() {
+        return statusReason;
+    }
+
+    public void setCommandId(Long commandId) {
+        this.commandId = commandId;
+    }
+
+    public void setState(RangerCloudIdentitySyncState state) {
+        this.state = state;
+    }
+
+    public void setStatusReason(String statusReason) {
+        this.statusReason = statusReason;
+    }
+
+    @Override
+    public String toString() {
+        return "RangerCloudIdentitySyncStatus{" +
+                ", commandId=" + commandId +
+                ", state=" + state +
+                ", statusReason='" + statusReason + '\'' +
+                '}';
+    }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/cm/RangerCloudIdentityService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/cm/RangerCloudIdentityService.java
@@ -1,9 +1,12 @@
 package com.sequenceiq.datalake.cm;
 
 import com.cloudera.api.swagger.client.ApiException;
-import com.sequenceiq.datalake.controller.exception.RangerCloudIdentitySyncException;
+import com.cloudera.api.swagger.model.ApiCommand;
+import com.google.common.collect.Iterables;
 import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.service.sdx.SdxService;
+import com.sequenceiq.sdx.api.model.RangerCloudIdentitySyncState;
+import com.sequenceiq.sdx.api.model.RangerCloudIdentitySyncStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -11,7 +14,7 @@ import org.springframework.stereotype.Service;
 import javax.inject.Inject;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.Optional;
 
 @Service
 public class RangerCloudIdentityService {
@@ -24,21 +27,81 @@ public class RangerCloudIdentityService {
     @Inject
     private SdxService sdxService;
 
-    private void setAzureCloudIdentityMapping(SdxCluster sdxCluster, Map<String, String> azureUserMapping) {
+    private RangerCloudIdentitySyncStatus newSyncStatus(RangerCloudIdentitySyncState state, String message) {
+        RangerCloudIdentitySyncStatus status = new RangerCloudIdentitySyncStatus();
+        status.setState(state);
+        status.setStatusReason(message);
+        return status;
+    }
+
+    private RangerCloudIdentitySyncStatus setAzureCloudIdentityMapping(String envCrn, SdxCluster sdxCluster, Map<String, String> azureUserMapping) {
         String stackCrn = sdxCluster.getStackCrn();
-        LOGGER.info("Updating azure cloud id mappings for datalake stack crn = {}", stackCrn);
+        LOGGER.info("Updating azure cloud id mappings for envCrn = {}, datalake stack crn = {}", envCrn, stackCrn);
         try {
-            clouderaManagerRangerUtil.setAzureCloudIdentityMapping(stackCrn, azureUserMapping);
+            if (!clouderaManagerRangerUtil.isCloudIdMappingSupported(sdxCluster.getStackCrn())) {
+                return newSyncStatus(RangerCloudIdentitySyncState.NOT_APPLICABLE,
+                        "The datalake does not support cloud identity sync. Sync request is ignored.");
+            }
+            Optional<ApiCommand> apiCommand = clouderaManagerRangerUtil.setAzureCloudIdentityMapping(stackCrn, azureUserMapping);
+            if (apiCommand.isEmpty()) {
+                return newSyncStatus(RangerCloudIdentitySyncState.SUCCESS, "Sucessfully synced, no role refresh required");
+            }
+            return toRangerCloudIdentitySyncStatus(apiCommand.get());
         } catch (ApiException e) {
             LOGGER.error("Encountered api exception", e);
-            throw new RangerCloudIdentitySyncException("Encountered api exception", e);
+            return newSyncStatus(RangerCloudIdentitySyncState.FAILED, "Encountered cloudera manager api exception");
         }
     }
 
-    public void setAzureCloudIdentityMapping(String environmentCrn, Map<String, String> azureUserMapping) {
-        List<SdxCluster> sdxClusters = sdxService.listSdxByEnvCrn(environmentCrn);
-        List<String> sdxClusterCrns = sdxClusters.stream().map(SdxCluster::getCrn).collect(Collectors.toList());
-        LOGGER.info("Setting Azure cloud id mappings for datalake clusters = {}, environment = {}", sdxClusterCrns, environmentCrn);
-        sdxClusters.forEach(sdxCluster -> setAzureCloudIdentityMapping(sdxCluster, azureUserMapping));
+    private Optional<SdxCluster> getSdxCluster(String envCrn) {
+        List<SdxCluster> sdxClusters = sdxService.listSdxByEnvCrn(envCrn);
+        if (sdxClusters.isEmpty()) {
+            return Optional.empty();
+        } else if (sdxClusters.size() > 1) {
+            LOGGER.error("Multiple datalakes per environment not supported, environmentCrn = {}", envCrn);
+            throw new IllegalStateException("Multiple datalakes per environment not supported");
+        }
+        return Optional.of(Iterables.getOnlyElement(sdxClusters));
     }
+
+    public RangerCloudIdentitySyncStatus setAzureCloudIdentityMapping(String envCrn, Map<String, String> azureUserMapping) {
+        Optional<SdxCluster> sdxCluster = getSdxCluster(envCrn);
+        if (sdxCluster.isEmpty()) {
+            return newSyncStatus(RangerCloudIdentitySyncState.NOT_APPLICABLE, "No datalakes associated with the environment.");
+        }
+        return setAzureCloudIdentityMapping(envCrn, sdxCluster.get(), azureUserMapping);
+    }
+
+    public RangerCloudIdentitySyncStatus getRangerCloudIdentitySyncStatus(String envCrn, long commandId) {
+        Optional<SdxCluster> sdxCluster = getSdxCluster(envCrn);
+        if (sdxCluster.isEmpty()) {
+            return newSyncStatus(RangerCloudIdentitySyncState.NOT_APPLICABLE, "No datalakes associated with the environment.");
+        }
+        try {
+            ApiCommand apiCommand = clouderaManagerRangerUtil.getApiCommand(sdxCluster.get().getStackCrn(), commandId);
+            return toRangerCloudIdentitySyncStatus(apiCommand);
+        } catch (ApiException e) {
+            LOGGER.error("Encountered cloudera manager api exception", e);
+            return newSyncStatus(RangerCloudIdentitySyncState.FAILED, "Encountered cloudera manager api exception");
+        }
+    }
+
+    private RangerCloudIdentitySyncStatus toRangerCloudIdentitySyncStatus(ApiCommand apiCommand) {
+        RangerCloudIdentitySyncStatus status = new RangerCloudIdentitySyncStatus();
+        status.setCommandId(apiCommand.getId().longValue());
+        status.setStatusReason(apiCommand.getResultMessage());
+        status.setState(toRangerCloudIdentitySyncState(apiCommand));
+        return status;
+    }
+
+    private RangerCloudIdentitySyncState toRangerCloudIdentitySyncState(ApiCommand apiCommand) {
+        if (apiCommand.getActive()) {
+            return RangerCloudIdentitySyncState.ACTIVE;
+        } else if (apiCommand.getSuccess()) {
+            return RangerCloudIdentitySyncState.SUCCESS;
+        } else {
+            return RangerCloudIdentitySyncState.FAILED;
+        }
+    }
+
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
@@ -291,7 +291,13 @@ public class SdxController implements SdxEndpoint {
         if (request.getAzureGroupMapping() != null) {
             throw new IllegalArgumentException("Azure group mappings is unsupported");
         }
-        rangerCloudIdentityService.setAzureCloudIdentityMapping(envCrn, request.getAzureUserMapping());
-        return new RangerCloudIdentitySyncStatus();
+        return rangerCloudIdentityService.setAzureCloudIdentityMapping(envCrn, request.getAzureUserMapping());
     }
+
+    @Override
+    @InternalOnly
+    public RangerCloudIdentitySyncStatus getRangerCloudIdentitySyncStatus(String envCrn, long commandId) {
+        return rangerCloudIdentityService.getRangerCloudIdentitySyncStatus(envCrn, commandId);
+    }
+
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -610,12 +610,12 @@ public class SdxService implements ResourceIdProvider, ResourceBasedCrnProvider 
                 .toString();
     }
 
-    public String getAccountIdFromCrn(String userCrn) {
+    public String getAccountIdFromCrn(String crnStr) {
         try {
-            Crn crn = Crn.safeFromString(userCrn);
+            Crn crn = Crn.safeFromString(crnStr);
             return crn.getAccountId();
         } catch (NullPointerException | CrnParseException e) {
-            throw new BadRequestException("Can not parse CRN to find account ID: " + userCrn);
+            throw new BadRequestException("Can not parse CRN to find account ID: " + crnStr);
         }
     }
 

--- a/datalake/src/test/java/com/sequenceiq/datalake/cm/ClouderaManagerRangerUtilTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/cm/ClouderaManagerRangerUtilTest.java
@@ -14,7 +14,6 @@ import com.cloudera.api.swagger.model.ApiConfigStalenessStatus;
 import com.cloudera.api.swagger.model.ApiRole;
 import com.cloudera.api.swagger.model.ApiRoleList;
 import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
-import com.sequenceiq.datalake.controller.exception.RangerCloudIdentitySyncException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -24,10 +23,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.hasItems;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -116,11 +117,12 @@ class ClouderaManagerRangerUtilTest {
         when(clouderaManagerApiFactory.getRoleCommandsResourceApi(any())).thenReturn(roleCommandsResourceApi);
         setupCluster();
         setupRangerUserSyncRole();
-        setupRangerUserSyncRoleConig(true);
         setupRoleRefreshRequired(true);
         setupRoleRefreshResponse(true);
 
-        underTest.setAzureCloudIdentityMapping("stackCrn", Map.of("user01", "val01", "user02", "val02"));
+        Optional<ApiCommand> apiCommand = underTest.setAzureCloudIdentityMapping("stackCrn", Map.of("user01", "val01", "user02", "val02"));
+
+        assertTrue(apiCommand.isPresent());
 
         ArgumentCaptor<ApiConfigList> apiConfigListCaptor = ArgumentCaptor.forClass(ApiConfigList.class);
         verify(rolesResourceApi, times(1)).updateRoleConfig(eq(CLUSTER), eq(RANGER_USER_SYNC_ROLE), anyString(), anyString(), apiConfigListCaptor.capture());
@@ -140,10 +142,10 @@ class ClouderaManagerRangerUtilTest {
         when(clouderaManagerApiFactory.getRolesResourceApi(any())).thenReturn(rolesResourceApi);
         setupCluster();
         setupRangerUserSyncRole();
-        setupRangerUserSyncRoleConig(true);
         setupRoleRefreshRequired(false);
 
-        underTest.setAzureCloudIdentityMapping("stackCrn", Map.of("user01", "val01", "user02", "val02"));
+        Optional<ApiCommand> apiCommand = underTest.setAzureCloudIdentityMapping("stackCrn", Map.of("user01", "val01", "user02", "val02"));
+        assertTrue(apiCommand.isEmpty());
 
         ArgumentCaptor<ApiConfigList> apiConfigListCaptor = ArgumentCaptor.forClass(ApiConfigList.class);
         verify(rolesResourceApi, times(1)).updateRoleConfig(eq(CLUSTER), eq(RANGER_USER_SYNC_ROLE), anyString(), anyString(), apiConfigListCaptor.capture());
@@ -151,31 +153,29 @@ class ClouderaManagerRangerUtilTest {
     }
 
     @Test
-    public void testSetAzureCloudIdentityMappingUnsuccessfulRefresh() throws ApiException {
+    public void testCloudIdMappingSupported() throws ApiException {
         when(clouderaManagerApiFactory.getClustersResourceApi(any())).thenReturn(clustersResourceApi);
         when(clouderaManagerApiFactory.getRolesResourceApi(any())).thenReturn(rolesResourceApi);
-        when(clouderaManagerApiFactory.getRoleCommandsResourceApi(any())).thenReturn(roleCommandsResourceApi);
         setupCluster();
         setupRangerUserSyncRole();
         setupRangerUserSyncRoleConig(true);
-        setupRoleRefreshRequired(true);
-        setupRoleRefreshResponse(false);
 
-        assertThrows(RangerCloudIdentitySyncException.class, () -> underTest.setAzureCloudIdentityMapping("stackCrn",
-                Map.of("user01", "val01", "user02", "val02")));
+        boolean result = underTest.isCloudIdMappingSupported("stackCrn");
+
+        assertTrue(result);
     }
 
     @Test
-    public void testSetAzureCloudIdentityMappingUnsupported() throws ApiException {
+    public void testCloudIdMappingUnsupported() throws ApiException {
         when(clouderaManagerApiFactory.getClustersResourceApi(any())).thenReturn(clustersResourceApi);
         when(clouderaManagerApiFactory.getRolesResourceApi(any())).thenReturn(rolesResourceApi);
         setupCluster();
         setupRangerUserSyncRole();
         setupRangerUserSyncRoleConig(false);
 
-        underTest.setAzureCloudIdentityMapping("stackCrn", Map.of("user01", "val01", "user02", "val02"));
+        boolean result = underTest.isCloudIdMappingSupported("stackCrn");
 
-        verify(rolesResourceApi, never()).updateRoleConfig(any(), any(), any(), any(), any());
+        assertFalse(result);
     }
 
 }

--- a/datalake/src/test/java/com/sequenceiq/datalake/cm/RangerCloudIdentityServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/cm/RangerCloudIdentityServiceTest.java
@@ -1,23 +1,32 @@
 package com.sequenceiq.datalake.cm;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.model.ApiCommand;
 import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.service.sdx.SdxService;
+import com.sequenceiq.sdx.api.model.RangerCloudIdentitySyncState;
+import com.sequenceiq.sdx.api.model.RangerCloudIdentitySyncStatus;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
 class RangerCloudIdentityServiceTest {
@@ -32,12 +41,56 @@ class RangerCloudIdentityServiceTest {
     private RangerCloudIdentityService underTest;
 
     @Test
-    public void testSetAzureCloudIdentityMapping() throws ApiException {
+    public void testSetAzureCloudIdentityMappingSuccessSync() throws ApiException {
+        ApiCommand apiCommand = mock(ApiCommand.class);
+        when(apiCommand.getId()).thenReturn(BigDecimal.ONE);
+        when(apiCommand.getSuccess()).thenReturn(true);
+        testSetAzureCloudIdentityMapping(Optional.of(apiCommand), RangerCloudIdentitySyncState.SUCCESS);
+    }
+
+    @Test
+    public void testSetAzureCloudIdentityMappingActiveSync() throws ApiException {
+        ApiCommand apiCommand = mock(ApiCommand.class);
+        when(apiCommand.getId()).thenReturn(BigDecimal.ONE);
+        when(apiCommand.getActive()).thenReturn(true);
+        testSetAzureCloudIdentityMapping(Optional.of(apiCommand), RangerCloudIdentitySyncState.ACTIVE);
+    }
+
+    @Test
+    public void testSetAzureCloudIdentityMappingFailSync() throws ApiException {
+        ApiCommand apiCommand = mock(ApiCommand.class);
+        when(apiCommand.getId()).thenReturn(BigDecimal.ONE);
+        when(apiCommand.getSuccess()).thenReturn(false);
+        testSetAzureCloudIdentityMapping(Optional.of(apiCommand), RangerCloudIdentitySyncState.FAILED);
+    }
+
+    @Test
+    public void testSetAzureCloudIdentityMappingNoApiCommand() throws ApiException {
+        testSetAzureCloudIdentityMapping(Optional.empty(), RangerCloudIdentitySyncState.SUCCESS);
+    }
+
+    @Test
+    public void testSetAzureCloudIdentityMappingNoDatalake() throws ApiException {
+        when(sdxService.listSdxByEnvCrn(anyString())).thenReturn(Collections.emptyList());
+
+        Map<String, String> userMapping = Map.of("user", "val1");
+        RangerCloudIdentitySyncStatus status = underTest.setAzureCloudIdentityMapping("env-crn", userMapping);
+
+        assertEquals(RangerCloudIdentitySyncState.NOT_APPLICABLE, status.getState());
+        verify(clouderaManagerRangerUtil, never()).setAzureCloudIdentityMapping(eq("stack-crn"), eq(userMapping));
+    }
+
+    private void testSetAzureCloudIdentityMapping(Optional<ApiCommand> apiCommand, RangerCloudIdentitySyncState expectedStatus) throws ApiException {
         SdxCluster cluster = mock(SdxCluster.class);
         when(cluster.getStackCrn()).thenReturn("stack-crn");
         when(sdxService.listSdxByEnvCrn(anyString())).thenReturn(List.of(cluster));
+        when(clouderaManagerRangerUtil.isCloudIdMappingSupported(any())).thenReturn(true);
+        when(clouderaManagerRangerUtil.setAzureCloudIdentityMapping(any(), any())).thenReturn(apiCommand);
+
         Map<String, String> userMapping = Map.of("user", "val1");
-        underTest.setAzureCloudIdentityMapping("env-crn", userMapping);
+        RangerCloudIdentitySyncStatus status = underTest.setAzureCloudIdentityMapping("env-crn", userMapping);
+
+        assertEquals(expectedStatus, status.getState());
         verify(clouderaManagerRangerUtil, times(1)).setAzureCloudIdentityMapping(eq("stack-crn"), eq(userMapping));
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/CloudIdSyncConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/CloudIdSyncConfig.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.freeipa.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CloudIdSyncConfig {
+
+    private static final int MS_IN_SECOND = 1000;
+
+    @Value("${freeipa.cloudidsync.poller.timeoutMs}")
+    private long pollerTimeoutMs;
+
+    @Value("${freeipa.cloudidsync.poller.sleepIntervalMs}")
+    private long pollerSleepIntervalMs;
+
+    public long getPollerTimeoutMs() {
+        return pollerTimeoutMs;
+    }
+
+    public long getPollerTimeoutSeconds() {
+        return pollerTimeoutMs * MS_IN_SECOND;
+    }
+
+    public long getPollerSleepIntervalMs() {
+        return pollerSleepIntervalMs;
+    }
+
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/CloudIdentitySyncService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/CloudIdentitySyncService.java
@@ -5,11 +5,19 @@ import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.Cloud
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.common.service.Clock;
+import com.sequenceiq.cloudbreak.polling.PollingResult;
+import com.sequenceiq.cloudbreak.polling.PollingService;
+import com.sequenceiq.freeipa.configuration.CloudIdSyncConfig;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.service.freeipa.user.model.FmsUser;
 import com.sequenceiq.freeipa.service.freeipa.user.model.UmsUsersState;
+import com.sequenceiq.freeipa.service.polling.usersync.CloudIdSyncPollerObject;
+import com.sequenceiq.freeipa.service.polling.usersync.CloudIdSyncStatusListenerTask;
 import com.sequenceiq.sdx.api.endpoint.SdxEndpoint;
+import com.sequenceiq.sdx.api.model.RangerCloudIdentitySyncStatus;
 import com.sequenceiq.sdx.api.model.SetRangerCloudIdentityMappingRequest;
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -28,8 +36,22 @@ public class CloudIdentitySyncService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CloudIdentitySyncService.class);
 
+    private static final int ONE_MAX_CONSECUTIVE_FAILURE = 1;
+
+    @Inject
+    private Clock clock;
+
     @Inject
     private SdxEndpoint sdxEndpoint;
+
+    @Inject
+    private CloudIdSyncConfig config;
+
+    @Inject
+    private PollingService<CloudIdSyncPollerObject> cloudIdSyncPollingService;
+
+    @Inject
+    private CloudIdSyncStatusListenerTask cloudIdSyncStatusListenerTask;
 
     public void syncCloudIdentites(Stack stack, UmsUsersState umsUsersState, BiConsumer<String, String> warnings) {
         LOGGER.info("Syncing cloud identities for stack = {}", stack);
@@ -47,10 +69,12 @@ public class CloudIdentitySyncService {
             Map<String, String> azureUserMapping = getAzureUserMapping(umsUsersState);
             SetRangerCloudIdentityMappingRequest setRangerCloudIdentityMappingRequest = new SetRangerCloudIdentityMappingRequest();
             setRangerCloudIdentityMappingRequest.setAzureUserMapping(azureUserMapping);
-            // TODO The SDX endpoint currently sets the config and triggers refresh. The SDX endpoint should also be updated
-            //      to allow polling the status of the refresh.
+
             LOGGER.debug("Setting ranger cloud identity mapping: {}", setRangerCloudIdentityMappingRequest);
-            sdxEndpoint.setRangerCloudIdentityMapping(envCrn, setRangerCloudIdentityMappingRequest);
+            RangerCloudIdentitySyncStatus syncStatus = sdxEndpoint.setRangerCloudIdentityMapping(envCrn, setRangerCloudIdentityMappingRequest);
+
+            // The sync status represents a cloud identity sync that may still be in progress, which we need to poll to check for completion.
+            checkSyncStatus(syncStatus, envCrn, warnings);
         } catch (Exception e) {
             LOGGER.warn("Failed to set cloud identity mapping for environment {}", envCrn, e);
             warnings.accept(envCrn, "Failed to set cloud identity mapping");
@@ -66,6 +90,42 @@ public class CloudIdentitySyncService {
         azureUserMapping.putAll(userToAzureObjectIdMap);
         azureUserMapping.putAll(servicePrincipalObjectIdMap);
         return azureUserMapping;
+    }
+
+    private void checkSyncStatus(RangerCloudIdentitySyncStatus syncStatus, String envCrn, BiConsumer<String, String> warnings) {
+        LOGGER.info("syncStatus = {}", syncStatus);
+        switch (syncStatus.getState()) {
+            case SUCCESS:
+                LOGGER.info("Successfully synced cloud identity, envCrn = {}", envCrn);
+                return;
+            case NOT_APPLICABLE:
+                LOGGER.info("Cloud identity sync not applicable, envCrn = {}", envCrn);
+                return;
+            case FAILED:
+                LOGGER.error("Failed to sync cloud identity, envCrn = {}", envCrn);
+                warnings.accept(envCrn, "Failed to sync cloud identity into environment");
+                return;
+            case ACTIVE:
+                // NOTE: Although it's synchronously polling, in practice this sync takes less than a second to complete
+                LOGGER.info("Sync is still in progress, attempting to poll sync status for envCrn = {}", envCrn);
+                pollSyncStatus(envCrn, syncStatus.getCommandId(), warnings);
+                break;
+            default:
+                warnings.accept(envCrn, "Encountered unknown cloud identity sync state");
+        }
+    }
+
+    private void pollSyncStatus(String environmentCrn, long commandId, BiConsumer<String, String> warnings) {
+        CloudIdSyncPollerObject pollerObject = new CloudIdSyncPollerObject(environmentCrn, commandId);
+        Pair<PollingResult, Exception> resultPair = cloudIdSyncPollingService.pollWithAbsoluteTimeout(cloudIdSyncStatusListenerTask, pollerObject,
+                config.getPollerSleepIntervalMs(), config.getPollerTimeoutSeconds(), ONE_MAX_CONSECUTIVE_FAILURE);
+        PollingResult result = resultPair.getLeft();
+        if (!result.equals(PollingResult.SUCCESS)) {
+            String errMsg = String.format("Failed to poll cloud id sync status, envCrn = %s, polling result = %s", environmentCrn, result);
+            Exception ex = resultPair.getRight();
+            LOGGER.error(errMsg, ex);
+            warnings.accept(environmentCrn, "Failed to sync cloud identity into environment");
+        }
     }
 
     private Map<String, String> getAzureObjectIdMap(Map<String, List<CloudIdentity>> cloudIdentityMapping) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/polling/usersync/CloudIdSyncPollerObject.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/polling/usersync/CloudIdSyncPollerObject.java
@@ -1,0 +1,41 @@
+package com.sequenceiq.freeipa.service.polling.usersync;
+
+import java.util.Objects;
+
+public class CloudIdSyncPollerObject {
+
+    private final String environmentCrn;
+
+    private final long commandId;
+
+    public CloudIdSyncPollerObject(String environmentCrn, long commandId) {
+        this.environmentCrn = environmentCrn;
+        this.commandId = commandId;
+    }
+
+    public String getEnvironmentCrn() {
+        return environmentCrn;
+    }
+
+    public long getCommandId() {
+        return commandId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CloudIdSyncPollerObject that = (CloudIdSyncPollerObject) o;
+        return commandId == that.commandId &&
+                Objects.equals(environmentCrn, that.environmentCrn);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(environmentCrn, commandId);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/polling/usersync/CloudIdSyncStatusListenerTask.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/polling/usersync/CloudIdSyncStatusListenerTask.java
@@ -1,0 +1,65 @@
+package com.sequenceiq.freeipa.service.polling.usersync;
+
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.polling.StatusCheckerTask;
+import com.sequenceiq.sdx.api.endpoint.SdxEndpoint;
+import com.sequenceiq.sdx.api.model.RangerCloudIdentitySyncStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+
+@Component
+public class CloudIdSyncStatusListenerTask implements StatusCheckerTask<CloudIdSyncPollerObject> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CloudIdSyncStatusListenerTask.class);
+
+    @Inject
+    private SdxEndpoint sdxEndpoint;
+
+    @Override
+    public boolean checkStatus(CloudIdSyncPollerObject pollerObject) {
+        RangerCloudIdentitySyncStatus syncStatus = sdxEndpoint.getRangerCloudIdentitySyncStatus(pollerObject.getEnvironmentCrn(), pollerObject.getCommandId());
+        LOGGER.info("syncStatus = {}", syncStatus);
+        switch (syncStatus.getState()) {
+            case SUCCESS:
+                LOGGER.info("Successfully synced cloud identity, envCrn = {}", pollerObject.getEnvironmentCrn());
+                return true;
+            case NOT_APPLICABLE:
+                LOGGER.info("Cloud identity sync not applicable, envCrn = {}", pollerObject.getEnvironmentCrn());
+                return true;
+            case FAILED:
+                LOGGER.error("Failed to sync cloud identity, envCrn = {}", pollerObject.getEnvironmentCrn());
+                throw new CloudbreakServiceException("Failed to sync cloud identity");
+            case ACTIVE:
+                LOGGER.info("Sync is still in progress");
+                return false;
+            default:
+                LOGGER.error("Encountered unknown cloud identity sync state");
+                throw new CloudbreakServiceException("Failed to sync cloud identity");
+        }
+    }
+
+    @Override
+    public void handleTimeout(CloudIdSyncPollerObject pollerObject) {
+        String message = String.format("Operation timed out. Failed to sync cloud identity for environment = %s.", pollerObject.getEnvironmentCrn());
+        throw new CloudbreakServiceException(message);
+    }
+
+    @Override
+    public String successMessage(CloudIdSyncPollerObject pollerObject) {
+        return String.format("Successfully synced cloud identity for envCrn = %s", pollerObject.getEnvironmentCrn());
+    }
+
+    @Override
+    public boolean exitPolling(CloudIdSyncPollerObject pollerObject) {
+        return false;
+    }
+
+    @Override
+    public void handleException(Exception e) {
+        throw new CloudbreakServiceException("Failed to sync cloud identity", e);
+    }
+
+}

--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -92,7 +92,10 @@ freeipa:
     threadpool:
       core.size: 100
       capacity.size: 4000
-
+  cloudidsync:
+    poller:
+      timeoutMs: 4000
+      sleepIntervalMs: 400
 
 info:
   app:


### PR DESCRIPTION
When setting cloud identity settings in ranger, the SDX service
now also returns a status object that the caller can use to
poll the status of the sync (which is just the status of the underlying
CM refresh command). The FreeIPA service polls this object to verify
that the sync is successful.

In order to simplify the design, the cloud identity sync code
has been modified to only work for single datalake per environment
and fail if there are multiple datalakes present (which we currently
don't support anyway).