### PR TITLE
CB-7490 avoid duplicate key value violates unique constraint "uk_user_crn" error during credential creation

### DIFF
--- a/environment/src/test/java/com/sequenceiq/environment/credential/service/CredentialServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/credential/service/CredentialServiceTest.java
@@ -290,6 +290,7 @@ class CredentialServiceTest {
         when(repository.findByNameAndAccountId(eq(CREDENTIAL_NAME), eq(ACCOUNT_ID), anyCollection(), any()))
                 .thenReturn(Optional.empty());
         when(credentialAdapter.verify(any(), anyString())).thenAnswer(i -> new CredentialVerification(i.getArgument(0), true));
+        when(repository.save(any())).thenAnswer(i -> i.getArgument(0));
         credentialServiceUnderTest.create(CREDENTIAL, ACCOUNT_ID, USER_ID, ENVIRONMENT);
         verify(credentialValidator).validateCredentialCloudPlatform(eq(PLATFORM), eq(USER_ID));
         verify(credentialValidator).validateParameters(any(), any());


### PR DESCRIPTION
- Remove long running credential verification code from the transactional block to avoid long transacition duration
- With verification removal the UserPreferencesService.getExternalId() will be removed from the transactional block. This method call in the transaction was the main reason of the duplicate key error
- Remove notification sending from the transactional block
