### PR TITLE
CB-8093. Fail check_fluent_plugins silently

### DIFF
--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/init.sls
@@ -100,7 +100,7 @@ install_fluentd_plugins:
 
 check_fluentd_plugins:
    cmd.run:
-    - name: sh /etc/td-agent/check_fluent_plugins.sh
+    - name: sh /etc/td-agent/check_fluent_plugins.sh; exit 0
 
 {%- if fluent.is_systemd %}
 fluent_systemd_stop:


### PR DESCRIPTION
As old images can be built but I could not make a good deployment, in order to not fail on this check -> fail on this silently and hope there won't be any hard failure after that ("possibly" not: most likely things won't work with proxies or for ADLSv2, it won't be any log output if Storage contributor is used). With this way, connection problem is logged but won't be any failure, so if in the end we will have a td-agent start issue, there is a log about the connection issue. If there will be network available, plugins will update fine, so that why running the script anyway.