### PR TITLE
CB-5742-EnhanceErrorHandling

### DIFF
--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/common/MessageCode.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/common/MessageCode.java
@@ -10,8 +10,6 @@ public class MessageCode {
 
     public static final String AUTOSCALING_ENTITLEMENT_NOT_ENABLED = "autoscale.entitlement.not.enabled";
 
-    public static final String CLUSTER_PROXY_NOT_CONFIGURED = "autoscale.load.clusterproxy.not.enabled";
-
     public static final String LOAD_CONFIG_ALREADY_DEFINED = "autoscale.load.config.already.defined";
 
     public static final String CLUSTER_EXISTS_FOR_CRN = "autoscale.cluster.exists.for.crn";

--- a/autoscale-api/src/main/resources/messages/messages.properties
+++ b/autoscale-api/src/main/resources/messages/messages.properties
@@ -4,7 +4,6 @@ autoscale.unsupported.hostgroups=Unsupported HostGroup ''{0}'' for {1} Autoscali
 autoscale.config.not.found= {0} Autoscale Configuration with identifier ''{1}'' not found for Cluster ''{2}''.
 autoscale.entitlement.not.enabled=Autoscaling Entitlement is not enabled for CloudPlatform ''{0}'', Cluster ''{1}''.
 
-autoscale.load.clusterproxy.not.enabled=Load-Based Autoscaling not supported for Cluster ''{0}'' since ClusterProxy is not enabled.
 autoscale.load.config.already.defined=Load-Based Autoscaling Configuration is already defined for Cluster ''{0}'', HostGroup ''{1}''
 
 autoscale.cluster.exists.for.crn=Cluster exists for the same CRN ''{0}'' and CM Variant ''{1}''.

--- a/autoscale/src/main/java/com/sequenceiq/periscope/controller/AlertController.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/controller/AlertController.java
@@ -33,7 +33,6 @@ import com.sequenceiq.periscope.converter.TimeAlertRequestConverter;
 import com.sequenceiq.periscope.converter.TimeAlertResponseConverter;
 import com.sequenceiq.periscope.domain.Cluster;
 import com.sequenceiq.periscope.domain.LoadAlert;
-import com.sequenceiq.periscope.domain.ScalingPolicy;
 import com.sequenceiq.periscope.domain.TimeAlert;
 import com.sequenceiq.periscope.service.AlertService;
 import com.sequenceiq.periscope.service.AutoscaleRecommendationService;
@@ -229,16 +228,6 @@ public class AlertController implements AlertEndpoint {
                 () -> {
                     validateAccountEntitlement(cluster);
                     validateSupportedHostGroup(cluster, json.getScalingPolicy().getHostGroup(), AlertType.LOAD);
-                    String requestHostGroup = json.getScalingPolicy().getHostGroup();
-                    cluster.getLoadAlerts().stream().map(LoadAlert::getScalingPolicy).map(ScalingPolicy::getHostGroup)
-                            .filter(hostGroup -> hostGroup.equalsIgnoreCase(requestHostGroup)).findAny()
-                            .ifPresent(hostGroup -> {
-                                throw new BadRequestException(messagesService
-                                        .getMessage(MessageCode.LOAD_CONFIG_ALREADY_DEFINED, List.of(cluster.getStackName(), requestHostGroup)));
-                            });
-                    clusterProxyConfigurationService.getClusterProxyUrl()
-                            .orElseThrow(() ->  new BadRequestException(
-                                    messagesService.getMessage(MessageCode.CLUSTER_PROXY_NOT_CONFIGURED, List.of(cluster.getStackName()))));
                 });
     }
 

--- a/autoscale/src/main/java/com/sequenceiq/periscope/controller/DistroXAutoScaleClusterV1Controller.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/controller/DistroXAutoScaleClusterV1Controller.java
@@ -121,11 +121,12 @@ public class DistroXAutoScaleClusterV1Controller implements DistroXAutoScaleClus
     private DistroXAutoscaleClusterResponse updateClusterAutoScaleConfig(Long clusterId,
             DistroXAutoscaleClusterRequest autoscaleClusterRequest) {
 
+        alertController.validateLoadAlertRequests(clusterId, autoscaleClusterRequest.getLoadAlertRequests());
+        alertController.validateTimeAlertRequests(clusterId, autoscaleClusterRequest.getTimeAlertRequests());
+
         try {
             transactionService.required(() -> {
                 clusterService.deleteAlertsForCluster(clusterId);
-                alertController.validateLoadAlertRequests(clusterId, autoscaleClusterRequest.getLoadAlertRequests());
-                alertController.validateTimeAlertRequests(clusterId, autoscaleClusterRequest.getTimeAlertRequests());
                 alertController.createLoadAlerts(clusterId, autoscaleClusterRequest.getLoadAlertRequests());
                 alertController.createTimeAlerts(clusterId, autoscaleClusterRequest.getTimeAlertRequests());
                 asClusterCommonService.setAutoscaleState(clusterId, autoscaleClusterRequest.getEnableAutoscaling());

--- a/autoscale/src/test/java/com/sequenceiq/periscope/controller/AlertControllerTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/controller/AlertControllerTest.java
@@ -2,8 +2,6 @@ package com.sequenceiq.periscope.controller;
 
 import static com.sequenceiq.periscope.common.MessageCode.AUTOSCALING_CONFIG_NOT_FOUND;
 import static com.sequenceiq.periscope.common.MessageCode.AUTOSCALING_ENTITLEMENT_NOT_ENABLED;
-import static com.sequenceiq.periscope.common.MessageCode.CLUSTER_PROXY_NOT_CONFIGURED;
-import static com.sequenceiq.periscope.common.MessageCode.LOAD_CONFIG_ALREADY_DEFINED;
 import static com.sequenceiq.periscope.common.MessageCode.UNSUPPORTED_AUTOSCALING_HOSTGROUP;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -164,24 +162,9 @@ public class AlertControllerTest {
         LoadAlertRequest request = getALoadAlertRequest();
 
         when(loadAlertRequestConverter.convert(request)).thenReturn(getALoadAlert());
-        when(clusterProxyConfigurationService.getClusterProxyUrl()).thenReturn(Optional.of("http://clusterproxy"));
 
         underTest.createLoadAlert(clusterId, request);
         verify(alertService).createLoadAlert(anyLong(), any(LoadAlert.class));
-    }
-
-    @Test
-    public void testLoadAlertCreateWhenClusterProxyNotRegistered() {
-        LoadAlertRequest request = getALoadAlertRequest();
-
-        when(clusterProxyConfigurationService.getClusterProxyUrl()).thenReturn(Optional.empty());
-        when(messagesService.getMessage(CLUSTER_PROXY_NOT_CONFIGURED,
-                List.of(aCluster.getStackName()))).thenReturn("clusterproxy.not.registered");
-
-        expectedException.expect(BadRequestException.class);
-        expectedException.expectMessage("clusterproxy.not.registered");
-
-        underTest.createLoadAlert(clusterId, request);
     }
 
     @Test
@@ -212,22 +195,6 @@ public class AlertControllerTest {
 
         expectedException.expect(BadRequestException.class);
         expectedException.expectMessage("account.not.entitled.for.platform");
-
-        underTest.createLoadAlert(clusterId, request);
-    }
-
-    @Test
-    public void testLoadAlertCreateDuplicate() {
-        LoadAlertRequest request = getALoadAlertRequest();
-
-        aCluster.setLoadAlerts(Set.of(getALoadAlert()));
-
-        when(restRequestThreadLocalService.getCloudbreakTenant()).thenReturn(tenant);
-        when(messagesService.getMessage(LOAD_CONFIG_ALREADY_DEFINED,
-                List.of(aCluster.getStackName(), request.getScalingPolicy().getHostGroup()))).thenReturn("load.config.already.defined");
-
-        expectedException.expect(BadRequestException.class);
-        expectedException.expectMessage("load.config.already.defined");
 
         underTest.createLoadAlert(clusterId, request);
     }


### PR DESCRIPTION
Removed user validation for clusterproxy since it is not User Controlled Configuration and duplicate validations.
Update periscope cluster status based on both CB Stack and Cluster Status.
 