### PR TITLE
CB-8200 getResourceGroups API call using required name parameter

### DIFF
--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/platformresource/PlatformResourceEndpoint.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/platformresource/PlatformResourceEndpoint.java
@@ -182,7 +182,7 @@ public interface PlatformResourceEndpoint {
     @ApiOperation(value = OpDescription.GET_RESOURCE_GROUPS, produces = MediaType.APPLICATION_JSON, notes = CONNECTOR_NOTES,
             nickname = "getResourceGroups")
     PlatformResourceGroupsResponse getResourceGroups(
-            @QueryParam("credentialName") @NotEmpty String credentialName,
+            @QueryParam("credentialName") String credentialName,
             @QueryParam("credentialCrn") String credentialCrn,
             @QueryParam("region") String region,
             @QueryParam("platformVariant") String platformVariant,


### PR DESCRIPTION
the current endpoint using required name parameter so it means if you specify the crn that is not enough. removing the required flag because that is not necessary

See detailed description in the commit message.