### PR TITLE
CB-8205: Fix NullPointerException in ycloud metric for region

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/metrics/CloudbreakMetricService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/metrics/CloudbreakMetricService.java
@@ -7,39 +7,45 @@ import com.sequenceiq.cloudbreak.common.metrics.type.MetricTag;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.view.StackView;
 
+import java.util.ArrayList;
+
 @Service("MetricService")
 public class CloudbreakMetricService extends AbstractMetricService {
 
     private static final String METRIC_PREFIX = "cloudbreak";
 
     public void incrementMetricCounter(MetricType metric, Stack stack) {
-        incrementMetricCounter(metric,
+        String[] tags = nullableValueTags(
                 CloudbreakMetricTag.STACK_TYPE.name(), stack.getType().name(),
                 MetricTag.CLOUD_PROVIDER.name(), stack.cloudPlatform(),
                 MetricTag.TUNNEL_TYPE.name(), stack.getTunnel().name());
+        incrementMetricCounter(metric, tags);
     }
 
     public void incrementMetricCounter(MetricType metric, Stack stack, Exception e) {
-        incrementMetricCounter(metric,
+        String[] tags = nullableValueTags(
                 MetricTag.EXCEPTION_TYPE.name(), e.getClass().getName(),
                 CloudbreakMetricTag.STACK_TYPE.name(), stack.getType().name(),
                 MetricTag.CLOUD_PROVIDER.name(), stack.cloudPlatform(),
                 MetricTag.TUNNEL_TYPE.name(), stack.getTunnel().name());
+        incrementMetricCounter(metric, tags);
     }
 
     public void incrementMetricCounter(MetricType metric, StackView stack) {
-        incrementMetricCounter(metric,
+        String[] tags = nullableValueTags(
                 CloudbreakMetricTag.STACK_TYPE.name(), stack.getType().name(),
                 MetricTag.CLOUD_PROVIDER.name(), stack.cloudPlatform(),
                 MetricTag.TUNNEL_TYPE.name(), stack.getTunnel().name());
+        incrementMetricCounter(metric, tags);
     }
 
     public void incrementMetricCounter(MetricType metric, StackView stack, Exception e) {
-        incrementMetricCounter(metric,
+        String[] tags = nullableValueTags(
                 MetricTag.EXCEPTION_TYPE.name(), e.getClass().getName(),
                 CloudbreakMetricTag.STACK_TYPE.name(), stack.getType().name(),
                 MetricTag.CLOUD_PROVIDER.name(), stack.cloudPlatform(),
                 MetricTag.TUNNEL_TYPE.name(), stack.getTunnel().name());
+        incrementMetricCounter(metric, tags);
     }
 
     @Override
@@ -48,9 +54,26 @@ public class CloudbreakMetricService extends AbstractMetricService {
     }
 
     public void recordImageCopyTime(Stack stack, Runnable checkImage) {
-        recordLongTaskTimer(MetricType.STACK_IMAGE_COPY, checkImage,
+        String[] tags = nullableValueTags(
                 MetricTag.TENANT.name(), stack.getTenant().getName(),
                 MetricTag.CLOUD_PROVIDER.name(), stack.cloudPlatform(),
                 MetricTag.REGION.name(), stack.getRegion());
+        recordLongTaskTimer(MetricType.STACK_IMAGE_COPY, checkImage, tags);
+    }
+
+    private String[] nullableValueTags(String... tags) {
+        if (tags.length % 2 == 1) {
+            throw new IllegalArgumentException("tags size must be even, it is a set of key=value pairs of tags");
+        }
+        ArrayList<String> accumulatedTags = new ArrayList<>();
+        for (int i = 0; i < tags.length; i += 2) {
+            if (tags[i + 1] != null) {
+                accumulatedTags.add(tags[i]);
+                accumulatedTags.add(tags[i + 1]);
+            }
+        }
+        String [] arrAccumulatedTags = new String[accumulatedTags.size()];
+        arrAccumulatedTags = accumulatedTags.toArray(arrAccumulatedTags);
+        return arrAccumulatedTags;
     }
 }


### PR DESCRIPTION
Ycloud does not have a region so the region metric was throwing a
NullPointerException. This was fixed to only include the region metric
if the value is non-null.

This was tested by deploying a ycloud datalake.

See detailed description in the commit message.