### PR TITLE
DISTX-413 Single Line Autoscaling History

### DIFF
--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/common/MessageCode.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/common/MessageCode.java
@@ -8,9 +8,19 @@ public class MessageCode {
 
     public static final String AUTOSCALING_CONFIG_NOT_FOUND = "autoscale.config.not.found";
 
+    public static final String AUTOSCALING_CONFIG_UPDATED = "autoscale.config.updated";
+
+    public static final String AUTOSCALING_ENABLED = "autoscale.enabled";
+
+    public static final String AUTOSCALING_DISABLED = "autoscale.disabled";
+
     public static final String AUTOSCALING_ENTITLEMENT_NOT_ENABLED = "autoscale.entitlement.not.enabled";
 
-    public static final String LOAD_CONFIG_ALREADY_DEFINED = "autoscale.load.config.already.defined";
+    public static final String AUTOSCALING_ACTIVITY_NOT_REQUIRED = "autoscale.activity.not.required";
+
+    public static final String AUTOSCALING_ACTIVITY_SUCCESS = "autoscale.activity.success";
+
+    public static final String SCHEDULE_CONFIG_OVERLAPS = "autoscale.schedule.config.overlap";
 
     public static final String CLUSTER_EXISTS_FOR_CRN = "autoscale.cluster.exists.for.crn";
 

--- a/autoscale-api/src/main/resources/messages/messages.properties
+++ b/autoscale-api/src/main/resources/messages/messages.properties
@@ -1,14 +1,20 @@
 autoscale.unsupported.autoscaling.type=Unsupported Autoscaling Type: ''{0}'' in Cluster ''{1}''.
 autoscale.unsupported.hostgroups=Unsupported HostGroup ''{0}'' for {1} Autoscaling in Cluster ''{2}'', Supported HostGroups ''{3}''.
 
-autoscale.config.not.found= {0} Autoscale Configuration with identifier ''{1}'' not found for Cluster ''{2}''.
+autoscale.config.not.found=''{0}'' Autoscale Configuration with identifier ''{1}'' not found for Cluster ''{2}''.
 autoscale.entitlement.not.enabled=Autoscaling Entitlement is not enabled for CloudPlatform ''{0}'', Cluster ''{1}''.
+autoscale.config.updated=''{0}'' Autoscaling Configuration updated; HostGroup(s) ''{1}''.
+autoscale.disabled=Autoscaling has been disabled.
+autoscale.enabled=Autoscaling has been enabled.
 
-autoscale.load.config.already.defined=Load-Based Autoscaling Configuration is already defined for Cluster ''{0}'', HostGroup ''{1}''
+autoscale.schedule.config.overlap=''SCHEDULE-BASED'' Autoscaling Configuration ''{0}'' not triggered, overlaps with ''{1}''.
 
 autoscale.cluster.exists.for.crn=Cluster exists for the same CRN ''{0}'' and CM Variant ''{1}''.
-autoscale.cluster.not.available=''{0}'' could not be triggered for Cluster ''{1}'', since cluster is not in 'AVAILABLE' status.
-autoscale.cluster.update.in.progress=''{0}'' could not be triggered for Cluster ''{1}'', since cluster update is in progress.
+autoscale.cluster.not.available=''{0}'' Autoscaling could not be triggered; cluster was not in 'AVAILABLE' status.
+autoscale.cluster.update.in.progress=''{0}'' Autoscaling could not be triggered; cluster update was in progress.
+
+autoscale.activity.success=''{0}'' Autoscaling triggered for Host Group ''{1}'' from ''{2}'' to ''{3}''.
+autoscale.activity.not.required=''{0}'' Autoscaling not required for config ''{1}''; Host Group  ''{2}'' node count is ''{3}''.
 
 autoscale.validation.single.type=Cluster can be configured with only one type of autoscaling.
 autoscale.validation.load.single.hostgroup=Load-Based Autoscaling is supported for only one HostGroup in a Cluster.

--- a/autoscale/src/main/java/com/sequenceiq/periscope/domain/BaseAlert.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/domain/BaseAlert.java
@@ -12,6 +12,8 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
 import javax.persistence.SequenceGenerator;
 
+import com.sequenceiq.periscope.api.model.AlertType;
+
 @Entity
 @DiscriminatorColumn(name = "alert_type")
 @Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
@@ -75,4 +77,6 @@ public abstract class BaseAlert implements Clustered {
     public void setCluster(Cluster cluster) {
         this.cluster = cluster;
     }
+
+    public abstract AlertType getAlertType();
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/domain/LoadAlert.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/domain/LoadAlert.java
@@ -8,6 +8,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 
+import com.sequenceiq.periscope.api.model.AlertType;
 import com.sequenceiq.periscope.converter.db.LoadAlertConfigAttributeConverter;
 
 @Entity
@@ -40,5 +41,9 @@ public class LoadAlert extends BaseAlert {
 
     public void setLoadAlertConfiguration(LoadAlertConfiguration loadAlertConfiguration) {
         this.loadAlertConfiguration = loadAlertConfiguration;
+    }
+
+    public AlertType getAlertType() {
+        return AlertType.LOAD;
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/domain/MetricAlert.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/domain/MetricAlert.java
@@ -8,6 +8,7 @@ import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 
 import com.sequenceiq.periscope.api.model.AlertState;
+import com.sequenceiq.periscope.api.model.AlertType;
 import com.sequenceiq.periscope.converter.AlertStateConverter;
 
 @Entity
@@ -49,5 +50,9 @@ public class MetricAlert extends BaseAlert {
 
     public void setAlertState(AlertState alertState) {
         this.alertState = alertState;
+    }
+
+    public AlertType getAlertType() {
+        return AlertType.METRIC;
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/domain/PrometheusAlert.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/domain/PrometheusAlert.java
@@ -9,6 +9,7 @@ import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 
 import com.sequenceiq.periscope.api.model.AlertState;
+import com.sequenceiq.periscope.api.model.AlertType;
 import com.sequenceiq.periscope.converter.AlertStateConverter;
 import com.sequenceiq.periscope.model.json.Json;
 import com.sequenceiq.periscope.model.json.JsonToString;
@@ -75,5 +76,9 @@ public class PrometheusAlert extends BaseAlert {
 
     public void setParameters(Json parameters) {
         this.parameters = parameters;
+    }
+
+    public AlertType getAlertType() {
+        return AlertType.PROMETHEUS;
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/domain/TimeAlert.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/domain/TimeAlert.java
@@ -7,6 +7,8 @@ import javax.persistence.ManyToOne;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 
+import com.sequenceiq.periscope.api.model.AlertType;
+
 @Entity
 @DiscriminatorValue("TIME")
 @NamedQueries({
@@ -46,5 +48,9 @@ public class TimeAlert extends BaseAlert {
 
     public void setCluster(Cluster cluster) {
         this.cluster = cluster;
+    }
+
+    public AlertType getAlertType() {
+        return AlertType.TIME;
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/CronTimeEvaluator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/CronTimeEvaluator.java
@@ -16,7 +16,9 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.cloudbreak.message.CloudbreakMessagesService;
 import com.sequenceiq.periscope.api.model.ScalingStatus;
+import com.sequenceiq.periscope.common.MessageCode;
 import com.sequenceiq.periscope.domain.BaseAlert;
 import com.sequenceiq.periscope.domain.Cluster;
 import com.sequenceiq.periscope.domain.ScalingPolicy;
@@ -73,6 +75,9 @@ public class CronTimeEvaluator extends EvaluatorExecutor {
     @Inject
     private ScalingPolicyTargetCalculator scalingPolicyTargetCalculator;
 
+    @Inject
+    private CloudbreakMessagesService messagesService;
+
     private long clusterId;
 
     @Override
@@ -120,8 +125,8 @@ public class CronTimeEvaluator extends EvaluatorExecutor {
                 publish(alert);
                 triggeredAlert = alert;
             } else if (alertTriggerable && triggeredAlert != null) {
-                historyService.createEntry(ScalingStatus.TRIGGER_FAILED, String.format(
-                        "Autoscaling Schedule '%s' overlaps with '%s'.", alert.getName(), triggeredAlert.getName()),
+                historyService.createEntry(ScalingStatus.TRIGGER_FAILED,
+                        messagesService.getMessage(MessageCode.SCHEDULE_CONFIG_OVERLAPS, List.of(alert.getName(), triggeredAlert.getName())),
                         alert.getCluster());
             }
         }


### PR DESCRIPTION
Standardize single line history format and content for displaying in UI.

The new standardized event text is as below:
Autoscaling has been disabled.
Autoscaling has been enabled.
'LOAD-BASED' Autoscaling Configuration updated; HostGroup(s) 'compute'.
'LOAD-BASED' Autoscaling triggered for Host Group 'compute' from '2' to '0'.
'LOAD-BASED' Autoscaling triggered for Host Group 'compute' from '0' to '2'.
'SCHEDULE-BASED' Autoscaling Configuration updated; HostGroup(s) 'compute'.
'SCHEDULE-BASED' Autoscaling triggered for Host Group 'compute' from '1' to '3'.
'SCHEDULE-BASED' Autoscaling not required for config 'up2'; Host Group  'compute' node count is '3'.
'SCHEDULE-BASED' Autoscaling Configuration 'up3' not triggered, overlaps with 'up2'.
'SCHEDULE-BASED' Autoscaling triggered for Host Group 'compute' from '3' to '0'. 