### PR TITLE
CB-8215 OS upgrade should automatically replace the VM on Cloud Provider

### DIFF
--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxUpgradeRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxUpgradeRequest.java
@@ -17,7 +17,7 @@ public class SdxUpgradeRequest {
 
     private Boolean dryRun;
 
-    private SdxUpgradeReplaceVms replaceVms = SdxUpgradeReplaceVms.DISABLED;
+    private SdxUpgradeReplaceVms replaceVms;
 
     public String getImageId() {
         return imageId;


### PR DESCRIPTION
The default value of replaceVms was set to DISABLED. This means whenever
an upgrade request is sent without specifying this parameter we didn't
actually replace the VM on the Cloud Provider. This must have been introduced
as VM replacement doesn't work with Runtime upgrade yet. However, OS upgrade
doesn't do anything without VM replacement, hence removing the default value
of this parameter. The SdxRuntimeUpgradeService has a condition to properly
set this value based on the type of the upgrade. As of now the logic says:
isOsUpgrade(request) ? SdxUpgradeReplaceVms.ENABLED : SdxUpgradeReplaceVms.DISABLED.

See detailed description in the commit message.