### PR TITLE
CB-8119 - Introduce --show-available-images

### DIFF
--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/validation/LoggingRequestValidator.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/validation/LoggingRequestValidator.java
@@ -20,17 +20,17 @@ public class LoggingRequestValidator implements ConstraintValidator<ValidLogging
     public boolean isValid(LoggingRequest value, ConstraintValidatorContext context) {
         if (value != null) {
             if (StringUtils.isEmpty(value.getStorageLocation())) {
-                String msg = "Storage location paramater is empty in logging request";
+                String msg = "Storage location parameter is empty in logging request";
                 context.buildConstraintViolationWithTemplate(msg).addConstraintViolation();
                 return false;
             }
             if (value.getS3() != null && !isValidPath(value.getStorageLocation())) {
-                String msg = "Storage location paramater is invalid (s3) in logging request";
+                String msg = "Storage location parameter is invalid (s3) in logging request";
                 context.buildConstraintViolationWithTemplate(msg).addConstraintViolation();
                 return false;
             }
             if (value.getS3() == null && value.getAdlsGen2() == null) {
-                String msg = "Provide at least 1 cloud storage details in logging request";
+                String msg = "Provide at least 1 cloud storage detail in logging request";
                 context.buildConstraintViolationWithTemplate(msg).addConstraintViolation();
                 return false;
             }

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/validation/ValidLoggingRequest.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/validation/ValidLoggingRequest.java
@@ -15,7 +15,7 @@ import javax.validation.Payload;
 @Constraint(validatedBy = LoggingRequestValidator.class)
 public @interface ValidLoggingRequest {
 
-    String message() default "LoggingV4Request contains one or more invalid data.";
+    String message() default "LoggingV4Request contains one or more invalid input field.";
 
     Class<?>[] groups() default {};
 

--- a/common-model/src/main/java/com/sequenceiq/common/model/UpgradeShowAvailableImages.java
+++ b/common-model/src/main/java/com/sequenceiq/common/model/UpgradeShowAvailableImages.java
@@ -1,0 +1,8 @@
+package com.sequenceiq.common.model;
+
+public enum UpgradeShowAvailableImages {
+
+    SHOW,
+    LATEST_ONLY,
+    DO_NOT_SHOW
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/tags/upgrade/UpgradeV4Request.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/tags/upgrade/UpgradeV4Request.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.sequenceiq.cloudbreak.doc.ModelDescriptions;
 import com.sequenceiq.cloudbreak.validation.ValidUpgradeRequest;
+import com.sequenceiq.common.model.UpgradeShowAvailableImages;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -25,6 +26,9 @@ public class UpgradeV4Request {
 
     @ApiModelProperty(ModelDescriptions.UpgradeModelDescription.DRY_RUN)
     private Boolean dryRun;
+
+    @ApiModelProperty(ModelDescriptions.UpgradeModelDescription.SHOW_AVAILABLE_IMAGES)
+    private UpgradeShowAvailableImages showAvailableImages = UpgradeShowAvailableImages.DO_NOT_SHOW;
 
     public String getImageId() {
         return imageId;
@@ -50,19 +54,53 @@ public class UpgradeV4Request {
         this.lockComponents = lockComponents;
     }
 
-    public Boolean isDryRun() {
+    public Boolean getDryRun() {
         return dryRun;
+    }
+
+    public boolean isDryRun() {
+        return Boolean.TRUE.equals(dryRun);
     }
 
     public void setDryRun(Boolean dryRun) {
         this.dryRun = dryRun;
     }
 
+    public UpgradeShowAvailableImages getShowAvailableImages() {
+        return showAvailableImages;
+    }
+
+    public void setShowAvailableImages(UpgradeShowAvailableImages showAvailableImages) {
+        this.showAvailableImages = showAvailableImages;
+    }
+
     public boolean isEmpty() {
+        return isUnspecifiedUpgradeType() &&
+                !Boolean.TRUE.equals(dryRun) &&
+                !isShowAvailableImagesSet();
+    }
+
+    @ApiModelProperty(hidden = true)
+    public boolean isDryRunOnly() {
+        return isUnspecifiedUpgradeType() &&
+                Boolean.TRUE.equals(dryRun);
+    }
+
+    @ApiModelProperty(hidden = true)
+    public boolean isShowAvailableImagesOnly() {
+        return isUnspecifiedUpgradeType() &&
+                isShowAvailableImagesSet();
+    }
+
+    @ApiModelProperty(hidden = true)
+    public boolean isShowAvailableImagesSet() {
+        return Objects.nonNull(showAvailableImages) && !UpgradeShowAvailableImages.DO_NOT_SHOW.equals(showAvailableImages);
+    }
+
+    private boolean isUnspecifiedUpgradeType() {
         return Objects.isNull(imageId) &&
                 Objects.isNull(runtime) &&
-                !Boolean.TRUE.equals(lockComponents) &&
-                !Boolean.TRUE.equals(dryRun);
+                !Boolean.TRUE.equals(lockComponents);
     }
 
     @Override
@@ -72,6 +110,7 @@ public class UpgradeV4Request {
                 ", runtime='" + runtime + '\'' +
                 ", lockComponents=" + lockComponents +
                 ", dryRun=" + dryRun +
+                ", showAvailableImages=" + showAvailableImages +
                 '}';
     }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
@@ -730,5 +730,6 @@ public class ModelDescriptions {
         public static final String RUNTIME = "Cloudera Runtime version";
         public static final String LOCK_COMPONENTS = "Upgrades to image with the same version of stack and clustermanager, if available";
         public static final String DRY_RUN = "Checks the eligibility of an image to upgrade";
+        public static final String SHOW_AVAILABLE_IMAGES = "Returns the list of images that are eligible for the upgrade";
     }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/UpgradeRequestValidator.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/UpgradeRequestValidator.java
@@ -13,10 +13,32 @@ public class UpgradeRequestValidator implements ConstraintValidator<ValidUpgrade
 
     @Override
     public boolean isValid(UpgradeV4Request value, ConstraintValidatorContext context) {
-        if (Objects.isNull(value)) {
+        if (!validateEmptyRequest(value, context)) {
             return false;
         }
-        return isOsUpgrade(value) || isRuntimeUpgrade(value);
+        if (!mutuallyExclusiveDryRunOrShowImages(value, context)) {
+            return false;
+        }
+        return isOsUpgrade(value) || isRuntimeUpgrade(value) || value.isDryRunOnly() || value.isShowAvailableImagesOnly() || value.isEmpty();
+    }
+
+    private boolean validateEmptyRequest(UpgradeV4Request value, ConstraintValidatorContext context) {
+        if (Objects.isNull(value)) {
+            String msg = "Invalid upgrade request: empty content";
+            context.buildConstraintViolationWithTemplate(msg).addConstraintViolation().disableDefaultConstraintViolation();
+            return false;
+        }
+        return true;
+    }
+
+    private boolean mutuallyExclusiveDryRunOrShowImages(UpgradeV4Request request, ConstraintValidatorContext context) {
+        if (request.isDryRun()  && request.isShowAvailableImagesSet()) {
+            String msg = "Invalid upgrade request: 'dry-run' cannot be used in parallel with  'show-available-images' or "
+                    + "'show-latest-available-image-per-runtime' in the request";
+            context.buildConstraintViolationWithTemplate(msg).addConstraintViolation().disableDefaultConstraintViolation();
+            return false;
+        }
+        return true;
     }
 
     private boolean isOsUpgrade(UpgradeV4Request request) {

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/ValidUpgradeRequest.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/ValidUpgradeRequest.java
@@ -13,9 +13,9 @@ import javax.validation.Payload;
 @Constraint(validatedBy = UpgradeRequestValidator.class)
 public @interface ValidUpgradeRequest {
 
-    String message() default "Upgrade request is invalid. "
+    String message() default "Invalid upgrade request: "
             + "Either one of 'runtime', 'imageId', 'lockComponents' parameters "
-            + "or both 'imageId' and 'lockComponents' parameter must be specified in the request";
+            + "or both 'imageId' and 'lockComponents' parameter or none must be specified in the request";
 
     Class<?>[] groups() default { };
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeImageFilter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeImageFilter.java
@@ -86,7 +86,7 @@ public class ClusterUpgradeImageFilter {
     private boolean filterPreviousImages(Image currentImage, Image image) {
         return Objects.nonNull(image.getCreated())
         && Objects.nonNull(currentImage.getCreated())
-        && image.getCreated() > currentImage.getCreated();
+        && image.getCreated() >= currentImage.getCreated();
     }
 
     private Predicate<Image> filterCurrentImage(Image currentImage) {

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
@@ -9,7 +9,6 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.BadRequestException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -240,14 +239,12 @@ public class StackOperations implements ResourceBasedCrnProvider {
             boolean osUpgrade = upgradeService.isOsUpgrade(request);
             UpgradeV4Response upgradeResponse = clusterUpgradeAvailabilityService.checkForUpgradesByName(workspaceId, stackName,
                     osUpgrade);
-            if (StringUtils.isEmpty(upgradeResponse.getReason())) {
-                clusterUpgradeAvailabilityService.filterUpgradeOptions(upgradeResponse, request);
-                String environmentCrn = getResourceCrnByResourceName(stackName);
-                StackViewV4Responses stackViewV4Responses = listByEnvironmentCrn(workspaceId, environmentCrn, List.of(StackType.WORKLOAD));
-                clusterUpgradeAvailabilityService.checkForNotAttachedClusters(stackViewV4Responses, upgradeResponse);
-                if (!osUpgrade) {
-                    clusterUpgradeAvailabilityService.checkIfClusterRuntimeUpgradable(workspaceId, stackName, upgradeResponse);
-                }
+            clusterUpgradeAvailabilityService.filterUpgradeOptions(upgradeResponse, request);
+            String environmentCrn = getResourceCrnByResourceName(stackName);
+            StackViewV4Responses stackViewV4Responses = listByEnvironmentCrn(workspaceId, environmentCrn, List.of(StackType.WORKLOAD));
+            clusterUpgradeAvailabilityService.checkForNotAttachedClusters(stackViewV4Responses, upgradeResponse);
+            if (!osUpgrade && !request.isDryRun() && !request.isShowAvailableImagesSet()) {
+                clusterUpgradeAvailabilityService.checkIfClusterRuntimeUpgradable(workspaceId, stackName, upgradeResponse);
             }
             return upgradeResponse;
         } else {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxUpgradeRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxUpgradeRequest.java
@@ -17,6 +17,8 @@ public class SdxUpgradeRequest {
 
     private Boolean dryRun;
 
+    private SdxUpgradeShowAvailableImages showAvailableImages;
+
     private SdxUpgradeReplaceVms replaceVms;
 
     public String getImageId() {
@@ -43,16 +45,24 @@ public class SdxUpgradeRequest {
         this.lockComponents = lockComponents;
     }
 
-    public Boolean isDryRun() {
+    public Boolean getDryRun() {
         return dryRun;
     }
 
-    public boolean isDryRun(SdxUpgradeRequest request) {
-        return Boolean.TRUE.equals(request.isDryRun());
+    public boolean isDryRun() {
+        return Boolean.TRUE.equals(dryRun);
     }
 
     public void setDryRun(Boolean dryRun) {
         this.dryRun = dryRun;
+    }
+
+    public SdxUpgradeShowAvailableImages getShowAvailableImages() {
+        return showAvailableImages;
+    }
+
+    public void setShowAvailableImages(SdxUpgradeShowAvailableImages showAvailableImages) {
+        this.showAvailableImages = showAvailableImages;
     }
 
     public SdxUpgradeReplaceVms getReplaceVms() {
@@ -65,10 +75,32 @@ public class SdxUpgradeRequest {
 
     @ApiModelProperty(hidden = true)
     public boolean isEmpty() {
+        return isUnspecifiedUpgradeType() &&
+                !Boolean.TRUE.equals(dryRun) &&
+                !isShowAvailableImagesSet();
+    }
+
+    @ApiModelProperty(hidden = true)
+    public boolean isDryRunOnly() {
+        return isUnspecifiedUpgradeType() &&
+                Boolean.TRUE.equals(dryRun);
+    }
+
+    @ApiModelProperty(hidden = true)
+    public boolean isShowAvailableImagesOnly() {
+        return isUnspecifiedUpgradeType() &&
+                isShowAvailableImagesSet();
+    }
+
+    @ApiModelProperty(hidden = true)
+    public boolean isShowAvailableImagesSet() {
+        return Objects.nonNull(showAvailableImages) && !SdxUpgradeShowAvailableImages.DO_NOT_SHOW.equals(showAvailableImages);
+    }
+
+    private boolean isUnspecifiedUpgradeType() {
         return Objects.isNull(imageId) &&
                 Objects.isNull(runtime) &&
-                !Boolean.TRUE.equals(lockComponents) &&
-                !Boolean.TRUE.equals(dryRun);
+                !Boolean.TRUE.equals(lockComponents);
     }
 
     @Override

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxUpgradeShowAvailableImages.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxUpgradeShowAvailableImages.java
@@ -1,0 +1,8 @@
+package com.sequenceiq.sdx.api.model;
+
+public enum SdxUpgradeShowAvailableImages {
+
+    SHOW,
+    LATEST_ONLY,
+    DO_NOT_SHOW
+}

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/validation/ValidUpgradeRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/validation/ValidUpgradeRequest.java
@@ -13,9 +13,9 @@ import javax.validation.Payload;
 @Constraint(validatedBy = UpgradeRequestValidator.class)
 public @interface ValidUpgradeRequest {
 
-    String message() default "Upgrade request is invalid. "
+    String message() default "Invalid upgrade request: "
             + "Either one of 'runtime', 'imageId', 'lockComponents' parameters "
-            + "or both 'imageId' and 'lockComponents' parameter must be specified in the request";
+            + "or both 'imageId' and 'lockComponents' parameter or none must be specified in the request";
 
     Class<?>[] groups() default { };
 

--- a/datalake-api/src/test/java/com/sequenceiq/sdx/validation/UpgradeRequestValidatorTest.java
+++ b/datalake-api/src/test/java/com/sequenceiq/sdx/validation/UpgradeRequestValidatorTest.java
@@ -1,0 +1,162 @@
+package com.sequenceiq.sdx.validation;
+
+import static com.sequenceiq.sdx.api.model.SdxUpgradeShowAvailableImages.DO_NOT_SHOW;
+import static com.sequenceiq.sdx.api.model.SdxUpgradeShowAvailableImages.LATEST_ONLY;
+import static com.sequenceiq.sdx.api.model.SdxUpgradeShowAvailableImages.SHOW;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+import java.util.stream.Stream;
+
+import javax.validation.ConstraintValidatorContext;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.sdx.api.model.SdxUpgradeReplaceVms;
+import com.sequenceiq.sdx.api.model.SdxUpgradeRequest;
+import com.sequenceiq.sdx.api.model.SdxUpgradeShowAvailableImages;
+
+@ExtendWith(MockitoExtension.class)
+public class UpgradeRequestValidatorTest {
+
+    private static final String IMAGE_ID = "36e85842-ea01-4cbc-6b1d-8f7a27fec49e";
+
+    private static final String RUNTIME = "7.2.1";
+
+    @Mock
+    private ConstraintValidatorContext.ConstraintViolationBuilder constraintViolationBuilder;
+
+    @Mock
+    private ConstraintValidatorContext validatorContext;
+
+    @InjectMocks
+    private UpgradeRequestValidator underTest;
+
+    @ParameterizedTest
+    @MethodSource("validUpgradeRequests")
+    public void testValidRequests(String imageId, String runtime, Boolean lockComponents, Boolean dryRun,
+            SdxUpgradeShowAvailableImages showAvailableImages, SdxUpgradeReplaceVms replaceVms) {
+        SdxUpgradeRequest sdxUpgradeRequest = new SdxUpgradeRequest();
+        sdxUpgradeRequest.setImageId(imageId);
+        sdxUpgradeRequest.setRuntime(runtime);
+        sdxUpgradeRequest.setLockComponents(lockComponents);
+        sdxUpgradeRequest.setDryRun(dryRun);
+        sdxUpgradeRequest.setShowAvailableImages(showAvailableImages);
+        sdxUpgradeRequest.setReplaceVms(replaceVms);
+        Assertions.assertTrue(underTest.isValid(sdxUpgradeRequest, validatorContext));
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidUpgradeRequests")
+    public void testInvalidRequests(String imageId, String runtime, Boolean lockComponents, Boolean dryRun,
+            SdxUpgradeShowAvailableImages showAvailableImages, SdxUpgradeReplaceVms replaceVms) {
+        SdxUpgradeRequest sdxUpgradeRequest = new SdxUpgradeRequest();
+        sdxUpgradeRequest.setImageId(imageId);
+        sdxUpgradeRequest.setRuntime(runtime);
+        sdxUpgradeRequest.setLockComponents(lockComponents);
+        sdxUpgradeRequest.setDryRun(dryRun);
+        sdxUpgradeRequest.setShowAvailableImages(showAvailableImages);
+        sdxUpgradeRequest.setReplaceVms(replaceVms);
+        Assertions.assertFalse(underTest.isValid(sdxUpgradeRequest, validatorContext));
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidUpgradeRequestsWithContext")
+    public void testInvalidRequestsWithContext(String imageId, String runtime, Boolean lockComponents, Boolean dryRun,
+            SdxUpgradeShowAvailableImages showAvailableImages, SdxUpgradeReplaceVms replaceVms) {
+
+        when(validatorContext.buildConstraintViolationWithTemplate(any())).thenReturn(constraintViolationBuilder);
+        when(constraintViolationBuilder.addConstraintViolation()).thenReturn(validatorContext);
+        doNothing().when(validatorContext).disableDefaultConstraintViolation();
+
+        SdxUpgradeRequest sdxUpgradeRequest = new SdxUpgradeRequest();
+        sdxUpgradeRequest.setImageId(imageId);
+        sdxUpgradeRequest.setRuntime(runtime);
+        sdxUpgradeRequest.setLockComponents(lockComponents);
+        sdxUpgradeRequest.setDryRun(dryRun);
+        sdxUpgradeRequest.setShowAvailableImages(showAvailableImages);
+        sdxUpgradeRequest.setReplaceVms(replaceVms);
+        Assertions.assertFalse(underTest.isValid(sdxUpgradeRequest, validatorContext));
+    }
+
+    static Stream<Arguments> validUpgradeRequests() {
+        return Stream.of(
+                Arguments.of(IMAGE_ID, null, null, null, null, SdxUpgradeReplaceVms.DISABLED),
+                Arguments.of(IMAGE_ID, null, null, null, null, SdxUpgradeReplaceVms.ENABLED),
+                Arguments.of(null, RUNTIME, null, null, null, SdxUpgradeReplaceVms.DISABLED),
+                Arguments.of(null, RUNTIME, null, null, null, SdxUpgradeReplaceVms.ENABLED),
+                Arguments.of(null, null, true, null, null, SdxUpgradeReplaceVms.DISABLED),
+                Arguments.of(null, null, true, null, null, SdxUpgradeReplaceVms.ENABLED),
+                // dry-run-s
+                Arguments.of(IMAGE_ID, null, null, true, null, SdxUpgradeReplaceVms.DISABLED),
+                Arguments.of(IMAGE_ID, null, null, true, null, SdxUpgradeReplaceVms.ENABLED),
+                Arguments.of(null, RUNTIME, null, true, null, SdxUpgradeReplaceVms.DISABLED),
+                Arguments.of(null, RUNTIME, null, true, null, SdxUpgradeReplaceVms.ENABLED),
+                Arguments.of(null, null, true, true, null, SdxUpgradeReplaceVms.DISABLED),
+                Arguments.of(null, null, true, true, null, SdxUpgradeReplaceVms.ENABLED),
+                // SHOW
+                Arguments.of(IMAGE_ID, null, null, null, SHOW, SdxUpgradeReplaceVms.DISABLED),
+                Arguments.of(IMAGE_ID, null, null, null, SHOW, SdxUpgradeReplaceVms.ENABLED),
+                Arguments.of(null, RUNTIME, null, null, SHOW, SdxUpgradeReplaceVms.DISABLED),
+                Arguments.of(null, RUNTIME, null, null, SHOW, SdxUpgradeReplaceVms.ENABLED),
+                Arguments.of(null, null, true, null, SHOW, SdxUpgradeReplaceVms.DISABLED),
+                Arguments.of(null, null, true, null, SHOW, SdxUpgradeReplaceVms.ENABLED),
+                // DO_NOT_SHOW
+                Arguments.of(IMAGE_ID, null, null, null, DO_NOT_SHOW, SdxUpgradeReplaceVms.DISABLED),
+                Arguments.of(IMAGE_ID, null, null, null, DO_NOT_SHOW, SdxUpgradeReplaceVms.ENABLED),
+                Arguments.of(null, RUNTIME, null, null, DO_NOT_SHOW, SdxUpgradeReplaceVms.DISABLED),
+                Arguments.of(null, RUNTIME, null, null, DO_NOT_SHOW, SdxUpgradeReplaceVms.ENABLED),
+                Arguments.of(null, null, true, null, DO_NOT_SHOW, SdxUpgradeReplaceVms.DISABLED),
+                Arguments.of(null, null, true, null, DO_NOT_SHOW, SdxUpgradeReplaceVms.ENABLED),
+                // LATEST_ONLY
+                Arguments.of(IMAGE_ID, null, null, null, LATEST_ONLY, SdxUpgradeReplaceVms.DISABLED),
+                Arguments.of(IMAGE_ID, null, null, null, LATEST_ONLY, SdxUpgradeReplaceVms.ENABLED),
+                Arguments.of(null, RUNTIME, null, null, LATEST_ONLY, SdxUpgradeReplaceVms.DISABLED),
+                Arguments.of(null, RUNTIME, null, null, LATEST_ONLY, SdxUpgradeReplaceVms.ENABLED),
+                Arguments.of(null, null, true, null, LATEST_ONLY, SdxUpgradeReplaceVms.DISABLED),
+                Arguments.of(null, null, true, null, LATEST_ONLY, SdxUpgradeReplaceVms.ENABLED),
+                // DO_NOT_SHOW + dry-run
+                Arguments.of(IMAGE_ID, null, null, true, DO_NOT_SHOW, SdxUpgradeReplaceVms.DISABLED),
+                Arguments.of(IMAGE_ID, null, null, true, DO_NOT_SHOW, SdxUpgradeReplaceVms.ENABLED),
+                Arguments.of(null, RUNTIME, null, true, DO_NOT_SHOW, SdxUpgradeReplaceVms.DISABLED),
+                Arguments.of(null, RUNTIME, null, true, DO_NOT_SHOW, SdxUpgradeReplaceVms.ENABLED),
+                Arguments.of(null, null, true, true, DO_NOT_SHOW, SdxUpgradeReplaceVms.DISABLED),
+                Arguments.of(null, null, true, true, DO_NOT_SHOW, SdxUpgradeReplaceVms.ENABLED)
+        );
+    }
+
+    static Stream<Arguments> invalidUpgradeRequests() {
+        return Stream.of(
+                Arguments.of(IMAGE_ID, RUNTIME, null, null, null, SdxUpgradeReplaceVms.DISABLED),
+                Arguments.of(IMAGE_ID, RUNTIME, true, null, null, SdxUpgradeReplaceVms.DISABLED),
+                Arguments.of(null, RUNTIME, true, null, null, SdxUpgradeReplaceVms.DISABLED)
+        );
+    }
+
+    static Stream<Arguments> invalidUpgradeRequestsWithContext() {
+        return Stream.of(
+                // SHOW + dry-run
+                Arguments.of(IMAGE_ID, null, null, true, SHOW, SdxUpgradeReplaceVms.DISABLED),
+                Arguments.of(IMAGE_ID, null, null, true, SHOW, SdxUpgradeReplaceVms.ENABLED),
+                Arguments.of(null, RUNTIME, null, true, SHOW, SdxUpgradeReplaceVms.DISABLED),
+                Arguments.of(null, RUNTIME, null, true, SHOW, SdxUpgradeReplaceVms.ENABLED),
+                Arguments.of(null, null, true, true, SHOW, SdxUpgradeReplaceVms.DISABLED),
+                Arguments.of(null, null, true, true, SHOW, SdxUpgradeReplaceVms.ENABLED),
+                // LATEST_ONLY + dry-run
+                Arguments.of(IMAGE_ID, null, null, true, LATEST_ONLY, SdxUpgradeReplaceVms.DISABLED),
+                Arguments.of(IMAGE_ID, null, null, true, LATEST_ONLY, SdxUpgradeReplaceVms.ENABLED),
+                Arguments.of(null, RUNTIME, null, true, LATEST_ONLY, SdxUpgradeReplaceVms.DISABLED),
+                Arguments.of(null, RUNTIME, null, true, LATEST_ONLY, SdxUpgradeReplaceVms.ENABLED),
+                Arguments.of(null, null, true, true, LATEST_ONLY, SdxUpgradeReplaceVms.DISABLED),
+                Arguments.of(null, null, true, true, LATEST_ONLY, SdxUpgradeReplaceVms.ENABLED)
+        );
+    }
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
@@ -114,7 +114,7 @@ public class SdxController implements SdxEndpoint {
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.DESCRIBE_DATALAKE)
     public SdxClusterResponse get(@ResourceName String name) {
         String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
-        SdxCluster sdxCluster = sdxService.getSdxByNameInAccount(userCrn, name);
+        SdxCluster sdxCluster = sdxService.getByNameInAccount(userCrn, name);
         return sdxClusterConverter.sdxClusterToResponse(sdxCluster);
     }
 
@@ -150,7 +150,7 @@ public class SdxController implements SdxEndpoint {
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.DESCRIBE_DETAILED_DATALAKE)
     public SdxClusterDetailResponse getDetail(@ResourceName String name, Set<String> entries) {
         String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
-        SdxCluster sdxCluster = sdxService.getSdxByNameInAccount(userCrn, name);
+        SdxCluster sdxCluster = sdxService.getByNameInAccount(userCrn, name);
         StackV4Response stackV4Response = sdxService.getDetail(name, entries);
         SdxClusterResponse sdxClusterResponse = sdxClusterConverter.sdxClusterToResponse(sdxCluster);
         return new SdxClusterDetailResponse(sdxClusterResponse, stackV4Response);
@@ -197,7 +197,7 @@ public class SdxController implements SdxEndpoint {
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.RETRY_DATALAKE_OPERATION)
     public FlowIdentifier retry(@ResourceName String name) {
         String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
-        SdxCluster sdxCluster = sdxService.getSdxByNameInAccount(userCrn, name);
+        SdxCluster sdxCluster = sdxService.getByNameInAccount(userCrn, name);
         return sdxRetryService.retrySdx(sdxCluster);
     }
 
@@ -213,7 +213,7 @@ public class SdxController implements SdxEndpoint {
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.START_DATALAKE)
     public FlowIdentifier startByName(@ResourceName String name) {
         String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
-        SdxCluster sdxCluster = sdxService.getSdxByNameInAccount(userCrn, name);
+        SdxCluster sdxCluster = sdxService.getByNameInAccount(userCrn, name);
         return sdxStartService.triggerStartIfClusterNotRunning(sdxCluster);
     }
 
@@ -229,7 +229,7 @@ public class SdxController implements SdxEndpoint {
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.STOP_DATALAKE)
     public FlowIdentifier stopByName(@ResourceName String name) {
         String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
-        SdxCluster sdxCluster = sdxService.getSdxByNameInAccount(userCrn, name);
+        SdxCluster sdxCluster = sdxService.getByNameInAccount(userCrn, name);
         return sdxStopService.triggerStopIfClusterNotStopped(sdxCluster);
     }
 
@@ -257,7 +257,7 @@ public class SdxController implements SdxEndpoint {
     @CheckPermissionByAccount(action = AuthorizationResourceAction.BACKUP_DATALAKE)
     public SdxDatabaseBackupResponse backupDatabaseByName(@ResourceName String name, String backupId, String backupLocation) {
         String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
-        SdxCluster sdxCluster = sdxService.getSdxByNameInAccount(userCrn, name);
+        SdxCluster sdxCluster = sdxService.getByNameInAccount(userCrn, name);
         return sdxDatabaseDrService.triggerDatabaseBackup(sdxCluster, backupId, backupLocation);
     }
 
@@ -265,7 +265,7 @@ public class SdxController implements SdxEndpoint {
     @CheckPermissionByAccount(action = AuthorizationResourceAction.RESTORE_DATALAKE)
     public SdxDatabaseRestoreResponse restoreDatabaseByName(@ResourceName String name, String backupId, String backupLocation) {
         String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
-        SdxCluster sdxCluster = sdxService.getSdxByNameInAccount(userCrn, name);
+        SdxCluster sdxCluster = sdxService.getByNameInAccount(userCrn, name);
         return sdxDatabaseDrService.triggerDatabaseRestore(sdxCluster, backupId, backupLocation);
     }
 
@@ -273,7 +273,7 @@ public class SdxController implements SdxEndpoint {
     @CheckPermissionByAccount(action = AuthorizationResourceAction.BACKUP_DATALAKE)
     public SdxDatabaseBackupStatusResponse getBackupDatabaseStatusByName(@ResourceName String name, String operationId) {
         String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
-        SdxCluster sdxCluster = sdxService.getSdxByNameInAccount(userCrn, name);
+        SdxCluster sdxCluster = sdxService.getByNameInAccount(userCrn, name);
         return sdxDatabaseDrService.getDatabaseBackupStatus(sdxCluster, operationId);
     }
 
@@ -281,7 +281,7 @@ public class SdxController implements SdxEndpoint {
     @CheckPermissionByAccount(action = AuthorizationResourceAction.RESTORE_DATALAKE)
     public SdxDatabaseRestoreStatusResponse getRestoreDatabaseStatusByName(@ResourceName String name, String operationId) {
         String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
-        SdxCluster sdxCluster = sdxService.getSdxByNameInAccount(userCrn, name);
+        SdxCluster sdxCluster = sdxService.getByNameInAccount(userCrn, name);
         return sdxDatabaseDrService.getDatabaseRestoreStatus(sdxCluster, operationId);    }
 
     @Override

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxUpgradeClusterConverter.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxUpgradeClusterConverter.java
@@ -1,18 +1,17 @@
 package com.sequenceiq.datalake.controller.sdx;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.Objects;
+
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.tags.upgrade.UpgradeV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.upgrade.UpgradeV4Response;
+import com.sequenceiq.common.model.UpgradeShowAvailableImages;
 import com.sequenceiq.sdx.api.model.SdxUpgradeRequest;
 import com.sequenceiq.sdx.api.model.SdxUpgradeResponse;
 
 @Service
 public class SdxUpgradeClusterConverter {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(SdxUpgradeClusterConverter.class);
 
     public SdxUpgradeResponse upgradeResponseToSdxUpgradeResponse(UpgradeV4Response upgradeV4Response) {
         return new SdxUpgradeResponse(
@@ -28,6 +27,9 @@ public class SdxUpgradeClusterConverter {
         upgradeV4Request.setRuntime(sdxUpgradeRequest.getRuntime());
         upgradeV4Request.setDryRun(sdxUpgradeRequest.isDryRun());
         upgradeV4Request.setLockComponents(sdxUpgradeRequest.getLockComponents());
+        if (Objects.nonNull(sdxUpgradeRequest.getShowAvailableImages())) {
+            upgradeV4Request.setShowAvailableImages(UpgradeShowAvailableImages.valueOf(sdxUpgradeRequest.getShowAvailableImages().name()));
+        }
         return upgradeV4Request;
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxUpgradeController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxUpgradeController.java
@@ -34,7 +34,7 @@ public class SdxUpgradeController implements SdxUpgradeEndpoint {
     public SdxUpgradeResponse upgradeClusterByName(@ResourceName String clusterName, SdxUpgradeRequest request) {
         String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
         lockComponentsIfRuntimeUpgradeIsDisabled(request, userCrn, clusterName);
-        if (request.isDryRun(request)) {
+        if (request.isDryRun() || request.isShowAvailableImagesSet()) {
             return sdxRuntimeUpgradeService.checkForUpgradeByName(userCrn, clusterName, request);
         } else {
             return sdxRuntimeUpgradeService.triggerUpgradeByName(userCrn, clusterName, request);
@@ -46,7 +46,7 @@ public class SdxUpgradeController implements SdxUpgradeEndpoint {
     public SdxUpgradeResponse upgradeClusterByCrn(@ResourceCrn String clusterCrn, SdxUpgradeRequest request) {
         String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
         lockComponentsIfRuntimeUpgradeIsDisabled(request, userCrn, clusterCrn);
-        if (request.isDryRun(request)) {
+        if (request.isDryRun() || request.isShowAvailableImagesSet()) {
             return sdxRuntimeUpgradeService.checkForUpgradeByCrn(userCrn, clusterCrn, request);
         } else {
             return sdxRuntimeUpgradeService.triggerUpgradeByCrn(userCrn, clusterCrn, request);
@@ -65,6 +65,6 @@ public class SdxUpgradeController implements SdxUpgradeEndpoint {
     }
 
     private boolean isDryRunOnly(SdxUpgradeRequest request) {
-        return request.isDryRun(request) && isEmpty(request.getRuntime()) && isEmpty(request.getImageId()) && !sdxRuntimeUpgradeService.isOsUpgrade(request);
+        return request.isDryRun() && isEmpty(request.getRuntime()) && isEmpty(request.getImageId()) && !sdxRuntimeUpgradeService.isOsUpgrade(request);
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxReactorFlowManager.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxReactorFlowManager.java
@@ -81,7 +81,7 @@ public class SdxReactorFlowManager {
     }
 
     public FlowIdentifier triggerDatalakeRuntimeUpgradeFlow(SdxCluster cluster, String imageId, SdxUpgradeReplaceVms replaceVms) {
-        LOGGER.info("Trigger Datalake runtimeUpgrade for: {} with imageId: {} and replace vm param: {}", cluster, imageId, replaceVms);
+        LOGGER.info("Trigger Datalake runtime upgrade for: {} with imageId: {} and replace vm param: {}", cluster, imageId, replaceVms);
         String selector = DATALAKE_UPGRADE_EVENT.event();
         String userId = ThreadBasedUserCrnProvider.getUserCrn();
         return notify(selector, new DatalakeUpgradeStartEvent(selector, cluster.getId(),

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxRepairService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxRepairService.java
@@ -73,7 +73,7 @@ public class SdxRepairService {
     }
 
     public FlowIdentifier triggerRepairByName(String userCrn, String clusterName, SdxRepairRequest clusterRepairRequest) {
-        SdxCluster cluster = sdxService.getSdxByNameInAccount(userCrn, clusterName);
+        SdxCluster cluster = sdxService.getByNameInAccount(userCrn, clusterName);
         MDCBuilder.buildMdcContext(cluster);
         return sdxReactorFlowManager.triggerSdxRepairFlow(cluster, clusterRepairRequest);
     }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -165,7 +165,7 @@ public class SdxService implements ResourceIdProvider, ResourceBasedCrnProvider 
         }
     }
 
-    public SdxCluster getSdxByNameInAccount(String userCrn, String name) {
+    public SdxCluster getByNameInAccount(String userCrn, String name) {
         LOGGER.info("Searching for SDX cluster by name {}", name);
         String accountIdFromCrn = getAccountIdFromCrn(userCrn);
         Optional<SdxCluster> sdxCluster = measure(() -> sdxClusterRepository.findByAccountIdAndClusterNameAndDeletedIsNull(accountIdFromCrn, name), LOGGER,
@@ -385,7 +385,7 @@ public class SdxService implements ResourceIdProvider, ResourceBasedCrnProvider 
     @Override
     public Long getResourceIdByResourceName(String resourceName) {
         String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
-        return getSdxByNameInAccount(userCrn, resourceName).getId();
+        return getByNameInAccount(userCrn, resourceName).getId();
     }
 
     private void validateCloudStorageRequest(SdxCloudStorageRequest cloudStorage, DetailedEnvironmentResponse environment) {
@@ -593,13 +593,13 @@ public class SdxService implements ResourceIdProvider, ResourceBasedCrnProvider 
 
     @Override
     public String getResourceCrnByResourceName(String resourceName) {
-        return getSdxByNameInAccount(ThreadBasedUserCrnProvider.getUserCrn(), resourceName).getCrn();
+        return getByNameInAccount(ThreadBasedUserCrnProvider.getUserCrn(), resourceName).getCrn();
     }
 
     @Override
     public List<String> getResourceCrnListByResourceNameList(List<String> resourceNames) {
         return resourceNames.stream()
-                .map(resourceName -> getSdxByNameInAccount(ThreadBasedUserCrnProvider.getUserCrn(), resourceName).getCrn())
+                .map(resourceName -> getByNameInAccount(ThreadBasedUserCrnProvider.getUserCrn(), resourceName).getCrn())
                 .collect(Collectors.toList());
     }
 

--- a/datalake/src/test/java/com/sequenceiq/datalake/controller/sdx/SdxControllerTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/controller/sdx/SdxControllerTest.java
@@ -97,7 +97,7 @@ class SdxControllerTest {
     @Test
     void getTest() throws NoSuchFieldException {
         SdxCluster sdxCluster = getValidSdxCluster();
-        when(sdxService.getSdxByNameInAccount(anyString(), anyString())).thenReturn(sdxCluster);
+        when(sdxService.getByNameInAccount(anyString(), anyString())).thenReturn(sdxCluster);
 
         SdxStatusEntity sdxStatusEntity = new SdxStatusEntity();
         sdxStatusEntity.setStatus(DatalakeStatusEnum.REQUESTED);

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxServiceTest.java
@@ -164,7 +164,7 @@ class SdxServiceTest {
         sdxCluser.setClusterName(CLUSTER_NAME);
         when(sdxClusterRepository.findByAccountIdAndClusterNameAndDeletedIsNull(eq("hortonworks"), eq(CLUSTER_NAME)))
                 .thenReturn(Optional.of(sdxCluser));
-        SdxCluster returnedSdxCluster = underTest.getSdxByNameInAccount(USER_CRN, CLUSTER_NAME);
+        SdxCluster returnedSdxCluster = underTest.getByNameInAccount(USER_CRN, CLUSTER_NAME);
         assertEquals(sdxCluser, returnedSdxCluster);
     }
 
@@ -181,7 +181,7 @@ class SdxServiceTest {
     @Test
     void testGetSdxClusterByAccountIdWhenNoDeployedClusterShouldThrowSdxNotFoundException() {
         when(sdxClusterRepository.findByAccountIdAndClusterNameAndDeletedIsNull(anyString(), anyString())).thenReturn(Optional.empty());
-        NotFoundException notFoundException = assertThrows(NotFoundException.class, () -> underTest.getSdxByNameInAccount(USER_CRN, "sdxcluster"));
+        NotFoundException notFoundException = assertThrows(NotFoundException.class, () -> underTest.getByNameInAccount(USER_CRN, "sdxcluster"));
         assertEquals("SDX cluster 'sdxcluster' not found.", notFoundException.getMessage());
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/datalake/SdxUpgradeTestAssertion.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/datalake/SdxUpgradeTestAssertion.java
@@ -1,10 +1,8 @@
 package com.sequenceiq.it.cloudbreak.assertion.datalake;
 
 import static com.sequenceiq.it.cloudbreak.assertion.CBAssertion.assertEquals;
+import static com.sequenceiq.it.cloudbreak.assertion.CBAssertion.assertTrue;
 import static org.junit.Assert.assertNotNull;
-import static org.testng.Assert.expectThrows;
-
-import javax.ws.rs.BadRequestException;
 
 import com.sequenceiq.it.cloudbreak.SdxClient;
 import com.sequenceiq.it.cloudbreak.assertion.Assertion;
@@ -18,13 +16,15 @@ public class SdxUpgradeTestAssertion {
 
     }
 
-    public static Assertion<SdxInternalTestDto, SdxClient> validateUnsuccessfulUpgrade() {
+    public static Assertion<SdxInternalTestDto, SdxClient> validateUnsuccessfulUpgrade(String reason) {
         return (testContext, entity, sdxClient) -> {
             SdxUpgradeRequest request = new SdxUpgradeRequest();
             request.setLockComponents(true);
             request.setDryRun(true);
-            expectThrows(BadRequestException.class, () ->
-                    sdxClient.getSdxClient().sdxUpgradeEndpoint().upgradeClusterByName(entity.getName(), request));
+            SdxUpgradeResponse upgradeResponse =
+                    sdxClient.getSdxClient().sdxUpgradeEndpoint().upgradeClusterByName(entity.getName(), request);
+            assertNotNull(upgradeResponse);
+            assertTrue(upgradeResponse.getReason().contains(reason));
             return entity;
         };
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxUpgradeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxUpgradeTests.java
@@ -85,7 +85,7 @@ public class MockSdxUpgradeTests extends AbstractIntegrationTest {
                 .awaitForFlow(key(sdxInternal))
                 .await(SdxClusterStatusResponse.RUNNING)
                 .then(SdxUpgradeTestAssertion
-                        .validateUnsuccessfulUpgrade())
+                        .validateUnsuccessfulUpgrade("Action is only supported if Cloudera Manager state is stored in external Database."))
                 .validate();
     }
 


### PR DESCRIPTION
The commit contains fixes for the following jira tickets:

- CB-8119 - Introduce --show-available-images and --show-latest-available-image-per-runtime
- CB-8120 - --dry-run should return at most one image candidate

The DP CLI counterpart of the effort can be tracked here: https://github.com/hortonworks/cb-cli/pull/763
The documentation will be refreshed here: https://cloudera.atlassian.net/wiki/spaces/ENG/pages/488638097/SDX+upgrade