### PR TITLE
CB-8206 Fix nifi.web.proxy.context.path property value in NifiKnoxRol…

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/nifi/NifiKnoxRoleConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/nifi/NifiKnoxRoleConfigProvider.java
@@ -48,7 +48,9 @@ public class NifiKnoxRoleConfigProvider extends AbstractRoleConfigProvider {
         if (!topologyNames.isEmpty()) {
             String clusterName = source.getGeneralClusterConfigs().getClusterName();
             String proxyContextPath = topologyNames.stream()
-                    .map(topologyName -> String.format("%s/%s/nifi-app", clusterName, topologyName))
+                    .map(topologyName -> String.format("%s/%s/nifi-app,%s/%s/nifi-app",
+                            clusterName, topologyName,
+                            clusterName, topologyName + "-api"))
                     .collect(Collectors.joining(","));
             LOGGER.debug("{} = {} added to template", PROXY_CONTEXT_PATH, proxyContextPath);
             configs.add(config(PROXY_CONTEXT_PATH, proxyContextPath));


### PR DESCRIPTION
…eConfigProvider

Nifi API config missing in the current configuration so added that to be populated in the generated blueprint

See detailed description in the commit message.