### PR TITLE
CDPCP-2678. Support syncing service principle cloud ids

### DIFF
--- a/auth-connector/src/generated/main/grpc/com/cloudera/thunderhead/service/usermanagement/UserManagementGrpc.java
+++ b/auth-connector/src/generated/main/grpc/com/cloudera/thunderhead/service/usermanagement/UserManagementGrpc.java
@@ -3509,6 +3509,43 @@ public final class UserManagementGrpc {
      }
      return getUnassignServicePrincipalCloudIdentityMethod;
   }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getListServicePrincipalCloudIdentitiesMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesResponse> METHOD_LIST_SERVICE_PRINCIPAL_CLOUD_IDENTITIES = getListServicePrincipalCloudIdentitiesMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesResponse> getListServicePrincipalCloudIdentitiesMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesResponse> getListServicePrincipalCloudIdentitiesMethod() {
+    return getListServicePrincipalCloudIdentitiesMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesResponse> getListServicePrincipalCloudIdentitiesMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesResponse> getListServicePrincipalCloudIdentitiesMethod;
+    if ((getListServicePrincipalCloudIdentitiesMethod = UserManagementGrpc.getListServicePrincipalCloudIdentitiesMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getListServicePrincipalCloudIdentitiesMethod = UserManagementGrpc.getListServicePrincipalCloudIdentitiesMethod) == null) {
+          UserManagementGrpc.getListServicePrincipalCloudIdentitiesMethod = getListServicePrincipalCloudIdentitiesMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "usermanagement.UserManagement", "ListServicePrincipalCloudIdentities"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("ListServicePrincipalCloudIdentities"))
+                  .build();
+          }
+        }
+     }
+     return getListServicePrincipalCloudIdentitiesMethod;
+  }
 
   /**
    * Creates a new async stub that supports all call types for the service
@@ -4518,6 +4555,16 @@ public final class UserManagementGrpc {
       asyncUnimplementedUnaryCall(getUnassignServicePrincipalCloudIdentityMethodHelper(), responseObserver);
     }
 
+    /**
+     * <pre>
+     * List cloud identity mappings for service principals.
+     * </pre>
+     */
+    public void listServicePrincipalCloudIdentities(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getListServicePrincipalCloudIdentitiesMethodHelper(), responseObserver);
+    }
+
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
@@ -5178,6 +5225,13 @@ public final class UserManagementGrpc {
                 com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityRequest,
                 com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityResponse>(
                   this, METHODID_UNASSIGN_SERVICE_PRINCIPAL_CLOUD_IDENTITY)))
+          .addMethod(
+            getListServicePrincipalCloudIdentitiesMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesResponse>(
+                  this, METHODID_LIST_SERVICE_PRINCIPAL_CLOUD_IDENTITIES)))
           .build();
     }
   }
@@ -6274,6 +6328,17 @@ public final class UserManagementGrpc {
       asyncUnaryCall(
           getChannel().newCall(getUnassignServicePrincipalCloudIdentityMethodHelper(), getCallOptions()), request, responseObserver);
     }
+
+    /**
+     * <pre>
+     * List cloud identity mappings for service principals.
+     * </pre>
+     */
+    public void listServicePrincipalCloudIdentities(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getListServicePrincipalCloudIdentitiesMethodHelper(), getCallOptions()), request, responseObserver);
+    }
   }
 
   /**
@@ -7273,6 +7338,16 @@ public final class UserManagementGrpc {
     public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityResponse unassignServicePrincipalCloudIdentity(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityRequest request) {
       return blockingUnaryCall(
           getChannel(), getUnassignServicePrincipalCloudIdentityMethodHelper(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * List cloud identity mappings for service principals.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesResponse listServicePrincipalCloudIdentities(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getListServicePrincipalCloudIdentitiesMethodHelper(), getCallOptions(), request);
     }
   }
 
@@ -8368,6 +8443,17 @@ public final class UserManagementGrpc {
       return futureUnaryCall(
           getChannel().newCall(getUnassignServicePrincipalCloudIdentityMethodHelper(), getCallOptions()), request);
     }
+
+    /**
+     * <pre>
+     * List cloud identity mappings for service principals.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesResponse> listServicePrincipalCloudIdentities(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getListServicePrincipalCloudIdentitiesMethodHelper(), getCallOptions()), request);
+    }
   }
 
   private static final int METHODID_INTERACTIVE_LOGIN = 0;
@@ -8464,6 +8550,7 @@ public final class UserManagementGrpc {
   private static final int METHODID_UNASSIGN_CLOUD_IDENTITY = 91;
   private static final int METHODID_ASSIGN_SERVICE_PRINCIPAL_CLOUD_IDENTITY = 92;
   private static final int METHODID_UNASSIGN_SERVICE_PRINCIPAL_CLOUD_IDENTITY = 93;
+  private static final int METHODID_LIST_SERVICE_PRINCIPAL_CLOUD_IDENTITIES = 94;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -8858,6 +8945,10 @@ public final class UserManagementGrpc {
           serviceImpl.unassignServicePrincipalCloudIdentity((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityRequest) request,
               (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnassignServicePrincipalCloudIdentityResponse>) responseObserver);
           break;
+        case METHODID_LIST_SERVICE_PRINCIPAL_CLOUD_IDENTITIES:
+          serviceImpl.listServicePrincipalCloudIdentities((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesResponse>) responseObserver);
+          break;
         default:
           throw new AssertionError();
       }
@@ -9013,6 +9104,7 @@ public final class UserManagementGrpc {
               .addMethod(getUnassignCloudIdentityMethodHelper())
               .addMethod(getAssignServicePrincipalCloudIdentityMethodHelper())
               .addMethod(getUnassignServicePrincipalCloudIdentityMethodHelper())
+              .addMethod(getListServicePrincipalCloudIdentitiesMethodHelper())
               .build();
         }
       }

--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/UmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/UmsClient.java
@@ -33,6 +33,8 @@ import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListG
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListGroupsResponse;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListMachineUsersRequest;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListMachineUsersResponse;
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesRequest;
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesResponse;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListUsersRequest;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListUsersResponse;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListWorkloadAdministrationGroupsForMemberRequest;
@@ -327,6 +329,26 @@ public class UmsClient {
                 throw e;
             }
         }
+    }
+
+    /**
+     * Wraps a call to ListServicePrincipalCloudIdentities.
+     *
+     * @param requestId   the request ID for the request
+     * @param accountId   the account id
+     * @param environmentCrn   the environment crn
+     * @return the list of service principal cloud identities
+     */
+    public ListServicePrincipalCloudIdentitiesResponse listServicePrincipalCloudIdentities(
+            String requestId, String accountId, String environmentCrn, Optional<PagingProto.PageToken> pageToken) {
+        ListServicePrincipalCloudIdentitiesRequest.Builder requestBuilder = ListServicePrincipalCloudIdentitiesRequest.newBuilder()
+                .setAccountId(accountId)
+                .setEnvironmentCrn(environmentCrn)
+                .setPageSize(umsClientConfig.getListServicePrincipalCloudIdentitiesPageSize());
+        if (pageToken.isPresent()) {
+            requestBuilder.setPageToken(pageToken.get());
+        }
+        return newStub(requestId).listServicePrincipalCloudIdentities(requestBuilder.build());
     }
 
     private <T> void checkSingleUserResponse(List<T> users, String crnResource) {

--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/config/UmsClientConfig.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/config/UmsClientConfig.java
@@ -20,6 +20,9 @@ public class UmsClientConfig {
     @Value("${altus.ums.client.list_workload_administration_groups_for_member_page_size:100}")
     private int listWorkloadAdministrationGroupsForMemberPageSize;
 
+    @Value("${altus.ums.client.list_service_principal_cloud_identities_page_size:100}")
+    private int listServicePrincipalCloudIdentitiesPageSize;
+
     public int getListGroupsPageSize() {
         return listGroupsPageSize;
     }
@@ -38,5 +41,9 @@ public class UmsClientConfig {
 
     public int getListWorkloadAdministrationGroupsForMemberPageSize() {
         return listWorkloadAdministrationGroupsForMemberPageSize;
+    }
+
+    public int getListServicePrincipalCloudIdentitiesPageSize() {
+        return listServicePrincipalCloudIdentitiesPageSize;
     }
 }

--- a/auth-connector/src/main/proto/usermanagement.proto
+++ b/auth-connector/src/main/proto/usermanagement.proto
@@ -430,6 +430,10 @@ service UserManagement {
   // Unassign a cloud identity from a service principal.
   rpc UnassignServicePrincipalCloudIdentity (UnassignServicePrincipalCloudIdentityRequest)
     returns (UnassignServicePrincipalCloudIdentityResponse) {}
+
+  // List cloud identity mappings for service principals.
+  rpc ListServicePrincipalCloudIdentities (ListServicePrincipalCloudIdentitiesRequest)
+    returns (ListServicePrincipalCloudIdentitiesResponse) {}
 }
 
 // The state of the actor.
@@ -2716,10 +2720,18 @@ message CloudIdentityDomainStorage {
   }
 }
 
+// An object that represents the default domain for a given cloud provider.
+message DefaultCloudIdentityDomainStorage {
+}
+
 // Object used to represent an Azure cloud identity domain in dynamo.
 message AzureCloudIdentityDomainStorage {
-  // A unique identifier for an Azure AD instance.
-  string azureAdIdentifier = 1;
+  oneof azureDomain {
+    // A unique identifier for an Azure AD instance.
+    string azureAdIdentifier = 1;
+    // The default Azure domain.
+    DefaultCloudIdentityDomainStorage defaultAzureDomain = 2;
+  }
 }
 
 // An identifier for a cloud identity that is unique within the enclosing
@@ -2957,10 +2969,18 @@ message CloudIdentityDomain {
   }
 }
 
+// An object that represents the default domain for a given cloud provider.
+message DefaultCloudIdentityDomain {
+}
+
 // Object used to represent an Azure cloud identity domain in the wire protocol.
 message AzureCloudIdentityDomain {
-  // A unique identifier for an Azure AD instance.
-  string azureAdIdentifier = 1;
+  oneof azureDomain {
+    // A unique identifier for an Azure AD instance.
+    string azureAdIdentifier = 1;
+    // The default Azure domain.
+    DefaultCloudIdentityDomain defaultAzureDomain = 2;
+  }
 }
 
 // An identifier for a cloud identity that is unique within the enclosing
@@ -3034,4 +3054,33 @@ message UnassignServicePrincipalCloudIdentityRequest {
 }
 
 message UnassignServicePrincipalCloudIdentityResponse {
+}
+
+message ListServicePrincipalCloudIdentitiesRequest {
+  // The account id in which the service principal cloud identity mappings exist.
+  string accountId = 1;
+  // Optional list of service principals for which mappings should be listed.
+  // The default is to return cloud identity mappings for all service principals.
+  repeated string servicePrincipal = 2;
+  // Optional environment CRN. If provided, the response will contain service
+  // principal cloud identity mappings only for the given environment. By default,
+  // mappings for all environments are returned.
+  string environmentCrn = 3;
+  // See the PageToken comment in paging.proto on paging usage.
+  int32 pageSize = 4;
+  paging.PageToken pageToken = 5;
+}
+
+message ServicePrincipalCloudIdentities {
+  // The service principal.
+  string servicePrincipal = 1;
+  // List of cloud identities for the service principal.
+  repeated CloudIdentity cloudIdentities = 2;
+}
+
+message ListServicePrincipalCloudIdentitiesResponse {
+  // The list of service principal cloud identity mappings.
+  repeated ServicePrincipalCloudIdentities servicePrincipalCloudIdentities = 1;
+  // See the PageToken comment in paging.proto on paging usage.
+  paging.PageToken nextPageToken = 2;
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UmsUsersStateProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UmsUsersStateProvider.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.Group;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.MachineUser;
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ServicePrincipalCloudIdentities;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.User;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.WorkloadAdministrationGroup;
 import com.sequenceiq.authorization.service.UmsRightProvider;
@@ -124,6 +125,10 @@ public class UmsUsersStateProvider {
                     handleUser(umsUsersStateBuilder, usersStateBuilder, crnToFmsGroup, mu.getCrn(), fmsUser,
                             environmentAccessChecker.hasAccess(mu.getCrn(), requestIdOptional), requestIdOptional, wagNamesForOtherEnvironments);
                 });
+
+                List<ServicePrincipalCloudIdentities> servicePrincipalCloudIdentities =
+                        grpcUmsClient.listServicePrincipalCloudIdentities(INTERNAL_ACTOR_CRN, accountId, environmentCrn, requestIdOptional);
+                umsUsersStateBuilder.addServicePrincipalCloudIdentities(servicePrincipalCloudIdentities);
 
                 umsUsersStateBuilder.setUsersState(usersStateBuilder.build());
                 envUsersStateMap.put(environmentCrn, umsUsersStateBuilder.build());

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UmsUsersState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UmsUsersState.java
@@ -2,6 +2,7 @@ package com.sequenceiq.freeipa.service.freeipa.user.model;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -10,6 +11,8 @@ import java.util.Map;
 import java.util.Set;
 
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CloudIdentity;
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ServicePrincipalCloudIdentities;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
@@ -25,13 +28,17 @@ public class UmsUsersState {
 
     private final ImmutableMap<String, List<CloudIdentity>> userToCloudIdentityMap;
 
+    private final ImmutableList<ServicePrincipalCloudIdentities> servicePrincipalCloudIdentities;
+
     private UmsUsersState(UsersState usersState, Map<String, WorkloadCredential> usersWorkloadCredentialMap, Set<FmsUser> requestedWorkloadUsers,
-            Collection<FmsGroup> workloadAdministrationGroups, Map<String, List<CloudIdentity>> userToCloudIdentityMap) {
+        Collection<FmsGroup> workloadAdministrationGroups, Map<String, List<CloudIdentity>> userToCloudIdentityMap,
+        List<ServicePrincipalCloudIdentities> servicePrincipalCloudIdentities) {
         this.usersState = requireNonNull(usersState, "UsersState is null");
         this.usersWorkloadCredentialMap = ImmutableMap.copyOf(requireNonNull(usersWorkloadCredentialMap, "workload credential map is null"));
         this.requestedWorkloadUsers = ImmutableSet.copyOf(requireNonNull(requestedWorkloadUsers, "requested workload users is null"));
         this.workloadAdministrationGroups = ImmutableSet.copyOf(requireNonNull(workloadAdministrationGroups, "workloadAdministrationGroups is null"));
         this.userToCloudIdentityMap = ImmutableMap.copyOf(requireNonNull(userToCloudIdentityMap, "userToCloudIdentityMap is null"));
+        this.servicePrincipalCloudIdentities = ImmutableList.copyOf(requireNonNull(servicePrincipalCloudIdentities, "servicePrincipalCloudIdentities is null"));
     }
 
     public UsersState getUsersState() {
@@ -54,6 +61,10 @@ public class UmsUsersState {
         return userToCloudIdentityMap;
     }
 
+    public ImmutableList<ServicePrincipalCloudIdentities> getServicePrincipalCloudIdentities() {
+        return servicePrincipalCloudIdentities;
+    }
+
     public static class Builder {
         private UsersState usersState;
 
@@ -64,6 +75,8 @@ public class UmsUsersState {
         private Collection<FmsGroup> workloadAdministrationGroups = Set.of();
 
         private Map<String, List<CloudIdentity>> userToCloudIdentityMap = new HashMap<>();
+
+        private List<ServicePrincipalCloudIdentities> servicePrincipalCloudIdentities = new ArrayList<>();
 
         public Builder setUsersState(UsersState usersState) {
             this.usersState = usersState;
@@ -90,8 +103,15 @@ public class UmsUsersState {
             return this;
         }
 
+        public Builder addServicePrincipalCloudIdentities(List<ServicePrincipalCloudIdentities> cloudIdentities) {
+            servicePrincipalCloudIdentities.addAll(cloudIdentities);
+            return this;
+        }
+
         public UmsUsersState build() {
-            return new UmsUsersState(usersState, workloadCredentialMap, requestedWorkloadUsers, workloadAdministrationGroups, userToCloudIdentityMap);
+            return new UmsUsersState(usersState, workloadCredentialMap, requestedWorkloadUsers, workloadAdministrationGroups, userToCloudIdentityMap,
+                    servicePrincipalCloudIdentities);
         }
     }
+
 }

--- a/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
+++ b/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
@@ -85,6 +85,8 @@ import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListM
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListMachineUsersResponse;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListResourceAssigneesRequest;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListResourceAssigneesResponse;
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesRequest;
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesResponse;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListRolesRequest;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListRolesResponse;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListUsersRequest;
@@ -437,6 +439,16 @@ public class MockUserManagementService extends UserManagementImplBase {
             );
         }
 
+        responseObserver.onNext(responseBuilder.build());
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void listServicePrincipalCloudIdentities(ListServicePrincipalCloudIdentitiesRequest request,
+        StreamObserver<ListServicePrincipalCloudIdentitiesResponse> responseObserver) {
+        mockCrnService.ensureInternalActor();
+        LOGGER.info("List service principal cloud identities for account: {}, environment: {}", request.getAccountId(), request.getEnvironmentCrn());
+        ListServicePrincipalCloudIdentitiesResponse.Builder responseBuilder = ListServicePrincipalCloudIdentitiesResponse.newBuilder();
         responseObserver.onNext(responseBuilder.build());
         responseObserver.onCompleted();
     }


### PR DESCRIPTION
The ums client has been updated to allow listing cloud id assignments
for service principles This is used to sync the azure object ids
associated with service principles.