### PR TITLE
CB-8119 - Introduce --show-available-images - PR follow-ups

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/tags/upgrade/UpgradeV4Request.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/tags/upgrade/UpgradeV4Request.java
@@ -94,7 +94,7 @@ public class UpgradeV4Request {
 
     @ApiModelProperty(hidden = true)
     public boolean isShowAvailableImagesSet() {
-        return Objects.nonNull(showAvailableImages) && !UpgradeShowAvailableImages.DO_NOT_SHOW.equals(showAvailableImages);
+        return Objects.nonNull(showAvailableImages) && UpgradeShowAvailableImages.DO_NOT_SHOW != showAvailableImages;
     }
 
     private boolean isUnspecifiedUpgradeType() {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxUpgradeRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxUpgradeRequest.java
@@ -94,7 +94,7 @@ public class SdxUpgradeRequest {
 
     @ApiModelProperty(hidden = true)
     public boolean isShowAvailableImagesSet() {
-        return Objects.nonNull(showAvailableImages) && !SdxUpgradeShowAvailableImages.DO_NOT_SHOW.equals(showAvailableImages);
+        return Objects.nonNull(showAvailableImages) && SdxUpgradeShowAvailableImages.DO_NOT_SHOW != showAvailableImages;
     }
 
     private boolean isUnspecifiedUpgradeType() {

--- a/datalake/src/test/java/com/sequenceiq/datalake/controller/sdx/SdxUpgradeClusterConverterTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/controller/sdx/SdxUpgradeClusterConverterTest.java
@@ -1,0 +1,22 @@
+package com.sequenceiq.datalake.controller.sdx;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import com.sequenceiq.common.model.UpgradeShowAvailableImages;
+import com.sequenceiq.sdx.api.model.SdxUpgradeShowAvailableImages;
+
+public class SdxUpgradeClusterConverterTest {
+
+    @ParameterizedTest
+    @EnumSource(UpgradeShowAvailableImages.class)
+    public void testFromUpgradeShowAvailableImagesToSdxUpgradeShowAvailableImages(UpgradeShowAvailableImages upgradeShowAvailableImagesEnum) {
+        SdxUpgradeShowAvailableImages.valueOf(upgradeShowAvailableImagesEnum.name());
+    }
+
+    @ParameterizedTest
+    @EnumSource(SdxUpgradeShowAvailableImages.class)
+    public void testFromSdxUpgradeShowAvailableImagesToUpgradeShowAvailableImages(SdxUpgradeShowAvailableImages sdxUpgradeShowAvailableImagesEnum) {
+        UpgradeShowAvailableImages.valueOf(sdxUpgradeShowAvailableImagesEnum.name());
+    }
+}


### PR DESCRIPTION
This has the following enhancements:

- unit test for enum value set comparison
- some extra logging
- == instead of .equals for enum comparison