### PR TITLE
CB-8239 Introduce delete child environment steps to the AwsYcloudHybridCloudTest

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/hybrid/AwsYcloudHybridCloudTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/hybrid/AwsYcloudHybridCloudTest.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import javax.inject.Inject;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
@@ -144,13 +145,20 @@ public class AwsYcloudHybridCloudTest extends AbstractE2ETest {
                     }
                     return dto;
                 })
+                .validate();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown(Object[] data) {
+        TestContext testContext = (TestContext) data[0];
+
+        testContext
                 .given(CHILD_ENVIRONMENT_KEY, EnvironmentTestDto.class, CHILD_CLOUD_PLATFORM)
                 .when(environmentTestClient.forceDelete(), RunningParameter.key(CHILD_ENVIRONMENT_KEY))
                 .await(EnvironmentStatus.ARCHIVED, RunningParameter.key(CHILD_ENVIRONMENT_KEY))
                 .validate();
-        //Cleaned up during the test case by forced environment delete
-        testContext.getResources().remove(sdxInternal);
-        testContext.getResources().remove(CHILD_ENVIRONMENT_KEY);
+
+        testContext.cleanupTestContext();
     }
 
     private void testShhAuthenticationSuccessfull(String username, String host) throws IOException, UserAuthException {

--- a/integration-test/src/main/java/com/sequenceiq/it/util/cleanup/CleanupUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/util/cleanup/CleanupUtil.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -13,9 +14,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Response;
 import com.sequenceiq.cloudbreak.client.CloudbreakClient;
+import com.sequenceiq.environment.api.v1.credential.model.CredentialBase;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentBaseResponse;
 import com.sequenceiq.environment.client.EnvironmentClient;
 import com.sequenceiq.it.cloudbreak.util.WaitResult;
+import com.sequenceiq.sdx.api.model.SdxClusterResponse;
 import com.sequenceiq.sdx.client.SdxClient;
 
 @Component
@@ -31,8 +36,8 @@ public class CleanupUtil extends CleanupClientUtil {
         List<String> distroxNames = getDistroxes(environment, cloudbreak);
 
         if (!distroxNames.isEmpty()) {
-            distroxNames.stream().forEach(distroxName -> LOG.info("Distrox with name: {} will be deleted!", distroxName));
-            distroxNames.stream().forEach(distroxName -> {
+            distroxNames.forEach(distroxName -> LOG.info("Distrox with name: {} will be deleted!", distroxName));
+            distroxNames.forEach(distroxName -> {
                 LOG.info("Deleting distrox with name: {}", distroxName);
                 try {
                     cloudbreak.distroXV1Endpoint().deleteByName(distroxName, true);
@@ -60,8 +65,8 @@ public class CleanupUtil extends CleanupClientUtil {
         List<String> sdxNames = getSdxes(environment, sdx);
 
         if (!sdxNames.isEmpty()) {
-            sdxNames.stream().forEach(sdxName -> LOG.info("Sdx with name: {} will be deleted!", sdxName));
-            sdxNames.stream().forEach(sdxName -> {
+            sdxNames.forEach(sdxName -> LOG.info("Sdx with name: {} will be deleted!", sdxName));
+            sdxNames.forEach(sdxName -> {
                 LOG.info("Deleting sdx with name: {}", sdxName);
                 try {
                     sdx.sdxEndpoint().delete(sdxName, true);
@@ -85,26 +90,15 @@ public class CleanupUtil extends CleanupClientUtil {
 
     public void cleanupEnvironments() {
         EnvironmentClient environment = createEnvironmentClient();
-        Set<String> environmentNames = new HashSet<>(getEnvironments(environment).values());
+        Set<String> deletableChildEnvironmentNames = new HashSet<>(getChildEnvironments(environment).values());
+        Set<String> deletableEnvironmentNames = new HashSet<>(getEnvironments(environment).values());
 
-        if (!environmentNames.isEmpty()) {
-            environmentNames.stream().forEach(environmentName -> LOG.info("Environment with name: {} will be deleted!", environmentName));
-            try {
-                environment.environmentV1Endpoint().deleteMultipleByNames(environmentNames, true, false);
-            } catch (Exception e) {
-                LOG.error("One or more environment cannot be deleted, because of: ", e);
-            }
-            for (int i = 0; i < 3; i++) {
-                WaitResult waitResult = waitUtil.waitForEnvironmentsCleanup(environment);
-                if (waitResult == WaitResult.FAILED) {
-                    throw new RuntimeException("Environment deletion has been failed!");
-                }
-                if (waitResult == WaitResult.TIMEOUT) {
-                    throw new RuntimeException("Timeout happened during the wait for environments deletion!");
-                }
-            }
+        if (!deletableChildEnvironmentNames.isEmpty()) {
+            deleteEnvironments(deletableChildEnvironmentNames, environment);
+        } else if (!deletableEnvironmentNames.isEmpty()) {
+            deleteEnvironments(deletableEnvironmentNames, environment);
         } else {
-            LOG.info("Cannot find any environment");
+            LOG.info("Cannot find any deletable environment!");
         }
     }
 
@@ -114,7 +108,7 @@ public class CleanupUtil extends CleanupClientUtil {
 
         if (!credentialNames.isEmpty()) {
             waitUtil.waitForEnvironmentsCleanup(environment);
-            credentialNames.stream().forEach(credentialName -> LOG.info("Credential with name: {} will be deleted!", credentialName));
+            credentialNames.forEach(credentialName -> LOG.info("Credential with name: {} will be deleted!", credentialName));
             try {
                 environment.credentialV1Endpoint().deleteMultiple(credentialNames);
             } catch (Exception e) {
@@ -125,24 +119,41 @@ public class CleanupUtil extends CleanupClientUtil {
         }
     }
 
-    public Map<String, String> getEnvironments(EnvironmentClient environment) {
-        return environment.environmentV1Endpoint().list().getResponses().stream()
-                .collect(Collectors.toMap(response -> response.getCrn(), response -> response.getName()));
+    public Map<String, String> getAllEnvironments(EnvironmentClient environmentClient) {
+        return environmentClient.environmentV1Endpoint().list().getResponses().stream()
+                .collect(Collectors.toMap(EnvironmentBaseResponse::getCrn, EnvironmentBaseResponse::getName));
+    }
+
+    public Map<String, String> getEnvironments(EnvironmentClient environmentClient) {
+        return environmentClient.environmentV1Endpoint().list().getResponses().stream()
+                .filter(environment -> {
+                    String parentEnvironment = Optional.ofNullable(environment.getParentEnvironmentCrn()).orElse("");
+                    return parentEnvironment.trim().isEmpty();
+                }).collect(Collectors.toMap(EnvironmentBaseResponse::getCrn, EnvironmentBaseResponse::getName));
+    }
+
+    public Map<String, String> getChildEnvironments(EnvironmentClient environmentClient) {
+        return environmentClient.environmentV1Endpoint().list().getResponses().stream()
+                .filter(environment -> {
+                    String parentEnvironment = Optional.ofNullable(environment.getParentEnvironmentCrn()).orElse("");
+                    return !parentEnvironment.trim().isEmpty();
+                })
+                .collect(Collectors.toMap(EnvironmentBaseResponse::getCrn, EnvironmentBaseResponse::getName));
     }
 
     public Set<String> getCredentials(EnvironmentClient environment) {
         return environment.credentialV1Endpoint().list().getResponses().stream()
-                .map(response -> response.getName())
+                .map(CredentialBase::getName)
                 .collect(Collectors.toSet());
     }
 
     public List<String> getDistroxes(EnvironmentClient environment, CloudbreakClient cloudbreak) {
         List<String> distroxNames = new ArrayList<>();
 
-        getEnvironments(environment).entrySet().stream().forEach(env -> {
-            LOG.info("Collecting available distroxes for environment: {}", env.getValue());
-            distroxNames.addAll(cloudbreak.distroXV1Endpoint().list(env.getValue(), env.getKey()).getResponses().stream()
-                    .map(response -> response.getName())
+        getAllEnvironments(environment).forEach((key, value) -> {
+            LOG.info("Collecting available distroxes for environment: {}", value);
+            distroxNames.addAll(cloudbreak.distroXV1Endpoint().list(value, key).getResponses().stream()
+                    .map(StackViewV4Response::getName)
                     .collect(Collectors.toList()));
         });
         return distroxNames;
@@ -151,12 +162,30 @@ public class CleanupUtil extends CleanupClientUtil {
     public List<String> getSdxes(EnvironmentClient environment, SdxClient sdx) {
         List<String> sdxNames = new ArrayList<>();
 
-        getEnvironments(environment).entrySet().stream().forEach(env -> {
-            LOG.info("Collecting available sdxes for environment: {}", env.getValue());
-            sdxNames.addAll(sdx.sdxEndpoint().list(env.getValue()).stream()
-                    .map(response -> response.getName())
+        getAllEnvironments(environment).forEach((key, value) -> {
+            LOG.info("Collecting available sdxes for environment: {}", value);
+            sdxNames.addAll(sdx.sdxEndpoint().list(value).stream()
+                    .map(SdxClusterResponse::getName)
                     .collect(Collectors.toList()));
         });
         return sdxNames;
+    }
+
+    private void deleteEnvironments(Set<String> environmentNames, EnvironmentClient environment) {
+        environmentNames.forEach(environmentName -> LOG.info("Environment with name: {} will be deleted!", environmentName));
+        try {
+            environment.environmentV1Endpoint().deleteMultipleByNames(environmentNames, true, true);
+        } catch (Exception e) {
+            LOG.error("One or more environment cannot be deleted, because of: ", e);
+        }
+        for (int i = 0; i < 3; i++) {
+            WaitResult waitResult = waitUtil.waitForEnvironmentsCleanup(environment);
+            if (waitResult == WaitResult.FAILED) {
+                throw new RuntimeException("Environment deletion has been failed!");
+            }
+            if (waitResult == WaitResult.TIMEOUT) {
+                throw new RuntimeException("Timeout happened during the wait for environments deletion!");
+            }
+        }
     }
 }


### PR DESCRIPTION
@lnardai or @Bajzathd please review.

AwsYcloudHybridCloudTest.testCreateSdxOnChildEnvironment is continuously failing, because of the cascading delete is not available right now for environments. Until the backend change is getting ready we need to introduce additional test steps to can deal with deletion of child environment.

I can see:
```
.given(CHILD_ENVIRONMENT_KEY, EnvironmentTestDto.class, CHILD_CLOUD_PLATFORM)
                .when(environmentTestClient.forceDelete(), RunningParameter.key(CHILD_ENVIRONMENT_KEY))
                .await(EnvironmentStatus.ARCHIVED, RunningParameter.key(CHILD_ENVIRONMENT_KEY))
                .validate();
```
However somehow it seems cannot working correctly. May would be worthy to move these steps to an AfterMethod.