### PR TITLE
CB-8207: Add --region flag to aws s3 cp command for datalake backup/restore

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/BackupRestoreSaltConfigGenerator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/BackupRestoreSaltConfigGenerator.java
@@ -5,6 +5,7 @@ import static com.sequenceiq.cloudbreak.common.type.CloudConstants.AZURE;
 
 import static java.util.Collections.singletonMap;
 
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.orchestrator.model.SaltConfig;
 import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
 
@@ -17,17 +18,31 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class BackupRestoreSaltConfigGenerator {
+    // these values are tightly coupled to the `postgresql/disaster_recovery.sls` salt pillar in `orchestrator-salt`
+    public static final String POSTGRESQL_DISASTER_RECOVERY_PILLAR_PATH = "/postgresql/disaster_recovery.sls";
 
-    public SaltConfig createSaltConfig(String location, String backupId, String cloudPlatform) throws URISyntaxException {
-        String fullLocation = buildFullLocation(location, backupId, cloudPlatform);
+    public static final String DISASTER_RECOVERY_KEY = "disaster_recovery";
+
+    public static final String OBJECT_STORAGE_URL_KEY = "object_storage_url";
+
+    public static final String AWS_REGION_KEY = "aws_region";
+
+    public SaltConfig createSaltConfig(String location, String backupId, Stack stack) throws URISyntaxException {
+        String fullLocation = buildFullLocation(location, backupId, stack.getCloudPlatform());
 
         Map<String, SaltPillarProperties> servicePillar = new HashMap<>();
-        servicePillar.put("disaster-recovery", new SaltPillarProperties("/postgresql/disaster_recovery.sls",
-            singletonMap("disaster_recovery", singletonMap("object_storage_url", fullLocation))));
+
+        Map<String, String> disasterRecoveryValues = new HashMap<>();
+        disasterRecoveryValues.put(OBJECT_STORAGE_URL_KEY, fullLocation);
+        disasterRecoveryValues.put(AWS_REGION_KEY, stack.getRegion());
+
+        servicePillar.put("disaster-recovery", new SaltPillarProperties(POSTGRESQL_DISASTER_RECOVERY_PILLAR_PATH,
+            singletonMap(DISASTER_RECOVERY_KEY, disasterRecoveryValues)));
+
         return new SaltConfig(servicePillar);
     }
 
-    String buildFullLocation(String location, String backupId, String cloudPlatform) throws URISyntaxException {
+    private String buildFullLocation(String location, String backupId, String cloudPlatform) throws URISyntaxException {
         URI uri = new URI(location);
         String suffix = '/' + backupId + "_database_backup";
         String fullLocation;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/backup/DatabaseBackupHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/backup/DatabaseBackupHandler.java
@@ -71,7 +71,7 @@ public class DatabaseBackupHandler extends ExceptionCatcherEventHandler<Database
             GatewayConfig gatewayConfig = gatewayConfigService.getGatewayConfig(stack, gatewayInstance, cluster.hasGateway());
             Set<String> gatewayFQDN = Collections.singleton(gatewayInstance.getDiscoveryFQDN());
             ExitCriteriaModel exitModel = ClusterDeletionBasedExitCriteriaModel.clusterDeletionBasedModel(stackId, cluster.getId());
-            SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(request.getBackupLocation(), request.getBackupId(), stack.getCloudPlatform());
+            SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(request.getBackupLocation(), request.getBackupId(), stack);
             hostOrchestrator.backupDatabase(gatewayConfig, gatewayFQDN, stackUtil.collectReachableNodes(stack), saltConfig, exitModel);
 
             result = new DatabaseBackupSuccess(stackId);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/restore/DatabaseRestoreHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/restore/DatabaseRestoreHandler.java
@@ -71,7 +71,7 @@ public class DatabaseRestoreHandler extends ExceptionCatcherEventHandler<Databas
             GatewayConfig gatewayConfig = gatewayConfigService.getGatewayConfig(stack, gatewayInstance, cluster.hasGateway());
             Set<String> gatewayFQDN = Collections.singleton(gatewayInstance.getDiscoveryFQDN());
             ExitCriteriaModel exitModel = ClusterDeletionBasedExitCriteriaModel.clusterDeletionBasedModel(stackId, cluster.getId());
-            SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(request.getBackupLocation(), request.getBackupId(), stack.getCloudPlatform());
+            SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(request.getBackupLocation(), request.getBackupId(), stack);
             hostOrchestrator.restoreDatabase(gatewayConfig, gatewayFQDN, stackUtil.collectReachableNodes(stack), saltConfig, exitModel);
 
             result = new DatabaseRestoreSuccess(stackId);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/BackupRestoreSaltConfigGeneratorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/BackupRestoreSaltConfigGeneratorTest.java
@@ -1,17 +1,19 @@
 package com.sequenceiq.cloudbreak.reactor.handler.cluster.dr;
 
+import static com.sequenceiq.cloudbreak.reactor.handler.cluster.dr.BackupRestoreSaltConfigGenerator.AWS_REGION_KEY;
+import static com.sequenceiq.cloudbreak.reactor.handler.cluster.dr.BackupRestoreSaltConfigGenerator.DISASTER_RECOVERY_KEY;
+import static com.sequenceiq.cloudbreak.reactor.handler.cluster.dr.BackupRestoreSaltConfigGenerator.OBJECT_STORAGE_URL_KEY;
 import static org.junit.Assert.assertEquals;
 
-import com.sequenceiq.cloudbreak.orchestrator.model.SaltConfig;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
 
 import java.net.URISyntaxException;
 import java.util.Map;
 
 import javax.inject.Inject;
 
-import org.junit.Rule;
+import com.sequenceiq.cloudbreak.orchestrator.model.SaltConfig;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -22,8 +24,7 @@ public class BackupRestoreSaltConfigGeneratorTest {
 
     private static final String BACKUP_ID = "backupId";
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
+    private static final String US_WEST_2 = "us-west-2";
 
     @Inject
     private BackupRestoreSaltConfigGenerator saltConfigGenerator;
@@ -32,14 +33,16 @@ public class BackupRestoreSaltConfigGeneratorTest {
     public void testCreateSaltConfig() throws URISyntaxException {
         String cloudPlatform = "aws";
         String location = "/test/backups";
-        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, cloudPlatform);
-        Map<String, Object> properties = saltConfig.getServicePillarConfig().values().iterator().next().getProperties();
-        assertEquals(1, properties.size());
-        Object object = properties.values().iterator().next();
-        assert object instanceof Map;
-        Map<String, String> map = (Map<String, String>) object;
-        assertEquals(1, map.size());
-        assertEquals("object_storage_url", map.keySet().iterator().next());
-        assertEquals("s3://test/backups/backupId_database_backup", map.values().iterator().next());
+        Stack placeholderStack = new Stack();
+        placeholderStack.setCloudPlatform(cloudPlatform);
+        placeholderStack.setRegion(US_WEST_2);
+
+        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, placeholderStack);
+
+        Map<String, Object> disasterRecoveryProperties = saltConfig.getServicePillarConfig().get("disaster-recovery").getProperties();
+        Map<String, String> disasterRecoveryKeyValuePairs = (Map<String, String>) disasterRecoveryProperties.get(DISASTER_RECOVERY_KEY);
+
+        assertEquals("s3://test/backups/backupId_database_backup", disasterRecoveryKeyValuePairs.get(OBJECT_STORAGE_URL_KEY));
+        assertEquals(US_WEST_2, disasterRecoveryKeyValuePairs.get(AWS_REGION_KEY));
     }
 }

--- a/orchestrator-salt/src/main/resources/salt/pillar/postgresql/disaster_recovery.sls
+++ b/orchestrator-salt/src/main/resources/salt/pillar/postgresql/disaster_recovery.sls
@@ -1,3 +1,4 @@
 disaster_recovery:
   object_storage_url:
+  aws_region: '' # empty string to prevent salt from passing the literal 'None'
 

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/backup.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/backup.sls
@@ -7,14 +7,14 @@ include:
 {% if 'None' != configure_remote_db %}
 backup_postgresql_db:
   cmd.run:
-    - name: /opt/salt/scripts/backup_db.sh {{salt['pillar.get']('platform')}} {{salt['pillar.get']('disaster_recovery:object_storage_url')}} {{salt['pillar.get']('postgres:remote_db_url')}} {{salt['pillar.get']('postgres:remote_db_port')}} {{salt['pillar.get']('postgres:remote_admin')}}
+    - name: /opt/salt/scripts/backup_db.sh {{salt['pillar.get']('platform')}} {{salt['pillar.get']('disaster_recovery:object_storage_url')}} {{salt['pillar.get']('postgres:remote_db_url')}} {{salt['pillar.get']('postgres:remote_db_port')}} {{salt['pillar.get']('postgres:remote_admin')}} {{salt['pillar.get']('disaster_recovery:aws_region')}}
     - require:
       - sls: postgresql.disaster_recovery
 
 {%- else %}
 backup_postgresql_db:
   cmd.run:
-    - name: /opt/salt/scripts/backup_db.sh {{salt['pillar.get']('platform')}} {{salt['pillar.get']('disaster_recovery:object_storage_url')}} "" "" "" "/var/lib/pgsql"
+    - name: /opt/salt/scripts/backup_db.sh {{salt['pillar.get']('platform')}} {{salt['pillar.get']('disaster_recovery:object_storage_url')}} "" "" "" "" "/var/lib/pgsql"
     - runas: postgres
     - require:
       - sls: postgresql.disaster_recovery

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/restore.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/restore.sls
@@ -6,14 +6,14 @@ include:
 {% if 'None' != configure_remote_db %}
 restore_postgresql_db:
   cmd.run:
-    - name: /opt/salt/scripts/restore_db.sh {{salt['pillar.get']('platform')}} {{salt['pillar.get']('disaster_recovery:object_storage_url')}} {{salt['pillar.get']('postgres:remote_db_url')}} {{salt['pillar.get']('postgres:remote_db_port')}} {{salt['pillar.get']('postgres:remote_admin')}}
+    - name: /opt/salt/scripts/restore_db.sh {{salt['pillar.get']('platform')}} {{salt['pillar.get']('disaster_recovery:object_storage_url')}} {{salt['pillar.get']('postgres:remote_db_url')}} {{salt['pillar.get']('postgres:remote_db_port')}} {{salt['pillar.get']('postgres:remote_admin')}} {{salt['pillar.get']('disaster_recovery:aws_region')}}
     - require:
         - sls: postgresql.disaster_recovery
 
 {%- else %}
 restore_postgresql_db:
   cmd.run:
-    - name: /opt/salt/scripts/restore_db.sh {{salt['pillar.get']('platform')}} {{salt['pillar.get']('disaster_recovery:object_storage_url')}} "" "" "" "/var/lib/pgsql"
+    - name: /opt/salt/scripts/restore_db.sh {{salt['pillar.get']('platform')}} {{salt['pillar.get']('disaster_recovery:object_storage_url')}} "" "" "" "" "/var/lib/pgsql"
     - runas: postgres
     - require:
         - sls: postgresql.disaster_recovery


### PR DESCRIPTION
Closes [CB-8207](https://jira.cloudera.com/browse/CB-8207)
* Add `aws_region` pillar value
* Add `--region` parameter to backup and restore script `aws` invocations 
* Add `aws_region` to the `BackupRestoreSaltConfigGenerator`
* Update test for `BackupRestoreSaltConfigGenerator`
* Pass in `Stack` object to `BackupRestoreSaltConfigGenerator`

Tested by:
* Running salt `state.apply postgresql.disaster_recovery.bakup` and `state.apply postgresql.disaster_recovery.restore` manually in Data Lake with external DB.
* Triggering backup + restore using the Datalake API while running with an external DB.