### PR TITLE
CB-7605 Enable premium SSD in Azure for Kafka, add 7.2.2 Streaming templates for Azure

### DIFF
--- a/core/src/main/resources/defaults/clustertemplates/azure/azure-streaming-720.json
+++ b/core/src/main/resources/defaults/clustertemplates/azure/azure-streaming-720.json
@@ -74,12 +74,12 @@
       {
         "name": "broker",
         "template": {
-          "instanceType": "Standard_D8_v3",
+          "instanceType": "Standard_D8s_v3",
           "attachedVolumes": [
             {
-              "count": 2,
-              "size": 500,
-              "type": "StandardSSD_LRS"
+              "count": 1,
+              "size": 1000,
+              "type": "Premium_LRS"
             }
           ]
         },

--- a/core/src/main/resources/defaults/clustertemplates/azure/azure-streaming-722.json
+++ b/core/src/main/resources/defaults/clustertemplates/azure/azure-streaming-722.json
@@ -1,11 +1,11 @@
 {
-  "name": "7.2.1 - Streams Messaging Heavy Duty for Azure",
+  "name": "7.2.2 - Streams Messaging Heavy Duty for Azure",
   "description": "",
   "type": "STREAMING",
   "cloudPlatform": "AZURE",
   "distroXTemplate": {
     "cluster": {
-      "blueprintName": "7.2.1 - Streams Messaging Heavy Duty: Apache Kafka, Schema Registry, Streams Messaging Manager"
+      "blueprintName": "7.2.2 - Streams Messaging Heavy Duty: Apache Kafka, Schema Registry, Streams Messaging Manager"
     },
     "externalDatabase": {
       "availabilityType": "HA"

--- a/core/src/main/resources/defaults/clustertemplates/azure/azure-streaming-small-722.json
+++ b/core/src/main/resources/defaults/clustertemplates/azure/azure-streaming-small-722.json
@@ -1,0 +1,49 @@
+{
+  "name": "7.2.2 - Streams Messaging Light Duty for Azure",
+  "description": "",
+  "type": "STREAMING",
+  "cloudPlatform": "AZURE",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.2 - Streams Messaging Light Duty: Apache Kafka, Schema Registry, Streams Messaging Manager"
+    },
+    "externalDatabase": {
+      "availabilityType": "NON_HA"
+    },
+    "instanceGroups": [
+      {
+        "name": "master",
+        "template": {
+          "instanceType": "Standard_D8_v3",
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "StandardSSD_LRS"
+            }
+          ]
+        },
+        "nodeCount": 1,
+        "type": "GATEWAY",
+        "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "broker",
+        "template": {
+          "instanceType": "Standard_D8_v3",
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 1000,
+              "type": "Standard_LRS"
+            }
+          ]
+        },
+        "nodeCount": 3,
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "recipeNames": []
+      }
+    ]
+  }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
@@ -434,7 +434,7 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
         assertNotNull(entity);
         assertNotNull(entity.getResponses());
         long defaultCount = entity.getResponses().stream().filter(template -> ResourceStatus.DEFAULT.equals(template.getStatus())).count();
-        long expectedCount = 96;
+        long expectedCount = 98;
         assertEquals("Should have " + expectedCount + " of default cluster templates.", expectedCount, defaultCount);
         return entity;
     }


### PR DESCRIPTION
This PR enables premium SSD for Kafka brokers in Azure streaming templates. Also adds Azure templates for 7.2.2 (AWS templates already exist)

Testing: tested manual cluster installation on 7.2.0 / 7.2.1 / 7.2.2

Closes: CB-7605