### PR TITLE
CB-8246: Fix NullPointerException for InternalOnly API access

### DIFF
--- a/authorization-common/src/main/java/com/sequenceiq/authorization/service/PermissionCheckService.java
+++ b/authorization-common/src/main/java/com/sequenceiq/authorization/service/PermissionCheckService.java
@@ -107,7 +107,7 @@ public class PermissionCheckService {
     private void checkPrerequisitesOnMethod(MethodSignature methodSignature, List<? extends Annotation> annotations) {
         if (annotations.stream().anyMatch(annotation -> annotation instanceof InternalOnly) &&
             !InternalCrnBuilder.isInternalCrn(ThreadBasedUserCrnProvider.getUserCrn())) {
-            getAccessDeniedAndLogInternalActorRestriction(methodSignature);
+            throw getAccessDeniedAndLogInternalActorRestriction(methodSignature);
         }
     }
 


### PR DESCRIPTION
When an API that is annotated with InternalOnly is called by a non-
internal actor, it should report "You have no access to this resource"
rather than null.

This was tested by calling an InternalOnly API on a local deployment
of cloudbreak. Unitests were added.

See detailed description in the commit message.