### PR TITLE
CB-8165: Fix FreeIPA reboot to update the FreeIPA status

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/RebootService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/RebootService.java
@@ -1,7 +1,13 @@
 package com.sequenceiq.freeipa.flow.instance.reboot;
 
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus.REPAIR_COMPLETED;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus.REPAIR_FAILED;
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus.REPAIR_IN_PROGRESS;
+
 import javax.inject.Inject;
 
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.stack.StackUpdater;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -17,13 +23,18 @@ public class RebootService {
     private static final Logger LOGGER = LoggerFactory.getLogger(RebootService.class);
 
     @Inject
+    private StackUpdater stackUpdater;
+
+    @Inject
     private InstanceMetaDataService instanceMetaDataService;
 
     @Inject
     private FreeipaJobService jobService;
 
     public void startInstanceReboot(RebootContext context) {
-        instanceMetaDataService.updateStatus(context.getStack(), context.getInstanceIdList(), InstanceStatus.REBOOTING);
+        Stack stack = context.getStack();
+        stackUpdater.updateStackStatus(stack.getId(), REPAIR_IN_PROGRESS, "Starting to reboot instances");
+        instanceMetaDataService.updateStatus(stack, context.getInstanceIdList(), InstanceStatus.REBOOTING);
         stopStatusChecker(context);
     }
 
@@ -33,13 +44,17 @@ public class RebootService {
     }
 
     public void handleInstanceRebootError(RebootContext context) {
-        instanceMetaDataService.updateStatus(context.getStack(), context.getInstanceIdList(), InstanceStatus.FAILED);
+        Stack stack = context.getStack();
+        stackUpdater.updateStackStatus(stack.getId(), REPAIR_FAILED, "Rebooting instances failed");
+        instanceMetaDataService.updateStatus(stack, context.getInstanceIdList(), InstanceStatus.FAILED);
         LOGGER.error("Reboot failed for instances: {}", context.getInstanceIds());
         reenableStatusChecker(context);
     }
 
     public void finishInstanceReboot(RebootContext context, RebootInstancesResult rebootInstancesResult) {
-        instanceMetaDataService.updateStatus(context.getStack(), context.getInstanceIdList(), InstanceStatus.CREATED);
+        Stack stack = context.getStack();
+        stackUpdater.updateStackStatus(stack.getId(), REPAIR_COMPLETED, "Finished rebooting instances");
+        instanceMetaDataService.updateStatus(stack, context.getInstanceIdList(), InstanceStatus.CREATED);
         reenableStatusChecker(context);
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/action/RebootActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/action/RebootActions.java
@@ -153,7 +153,7 @@ public class RebootActions {
                 Long stackId = payload.getResourceId();
                 Stack stack = stackService.getStackById(stackId);
                 return new RebootContext(flowParameters, stack, instances, null, null);
-                }
+            }
         };
     }
 


### PR DESCRIPTION
Fixed the FreeIPA status so that it didn't get stuck in the "Update
Requested" status after a reboot type repair was issued. The flow now
updates the status each step and sets the final status to a completed
or failed state.

This was tested using a local deployment of cloudbreak.

See detailed description in the commit message.