### PR TITLE
CB-8250 invoke the CM setuid script with the migration flag during up…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
@@ -483,7 +483,7 @@ public class ClusterHostServiceRunner {
                         singletonMap("csd-urls", csdUrls))));
     }
 
-    private void decoratePillarWithClouderaManagerSettings(Map<String, SaltPillarProperties> servicePillar, ClouderaManagerRepo clouderaManagerRepo) {
+    public void decoratePillarWithClouderaManagerSettings(Map<String, SaltPillarProperties> servicePillar, ClouderaManagerRepo clouderaManagerRepo) {
         boolean deterministicUidGid = isVersionNewerOrEqualThanLimited(clouderaManagerRepo.getVersion(), CLOUDERAMANAGER_VERSION_7_2_1);
         servicePillar.put("cloudera-manager-settings", new SaltPillarProperties("/cloudera-manager/settings.sls",
                 singletonMap("cloudera-manager", singletonMap("settings", Map.of(

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.host.ClusterHostServiceRunner;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
@@ -50,6 +51,9 @@ public class ClusterManagerUpgradeService {
     @Inject
     private ClusterApiConnectors clusterApiConnectors;
 
+    @Inject
+    private ClusterHostServiceRunner clusterHostServiceRunner;
+
     public void upgradeClusterManager(Long stackId) throws CloudbreakOrchestratorException, CloudbreakException {
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
         stopClusterServices(stack);
@@ -75,6 +79,7 @@ public class ClusterManagerUpgradeService {
         ClouderaManagerRepo clouderaManagerRepo = clusterComponentConfigProvider.getClouderaManagerRepoDetails(cluster.getId());
         servicePillar.put("cloudera-manager-repo", new SaltPillarProperties("/cloudera-manager/repo.sls",
                 singletonMap("cloudera-manager", singletonMap("repo", clouderaManagerRepo))));
+        clusterHostServiceRunner.decoratePillarWithClouderaManagerSettings(servicePillar, clouderaManagerRepo);
         return new SaltConfig(servicePillar);
     }
 }

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
@@ -243,8 +243,8 @@ public class StackOperations implements ResourceBasedCrnProvider {
             UpgradeV4Response upgradeResponse = clusterUpgradeAvailabilityService.checkForUpgradesByName(workspaceId, stackName,
                     osUpgrade);
             clusterUpgradeAvailabilityService.filterUpgradeOptions(upgradeResponse, request);
-            String environmentCrn = getResourceCrnByResourceName(stackName);
-            StackViewV4Responses stackViewV4Responses = listByEnvironmentCrn(workspaceId, environmentCrn, List.of(StackType.WORKLOAD));
+            Stack stack = getStackByName(stackName);
+            StackViewV4Responses stackViewV4Responses = listByEnvironmentCrn(workspaceId, stack.getEnvironmentCrn(), List.of(StackType.WORKLOAD));
             clusterUpgradeAvailabilityService.checkForNotAttachedClusters(stackViewV4Responses, upgradeResponse);
             if (!osUpgrade && !request.isDryRun() && !request.isShowAvailableImagesSet()) {
                 clusterUpgradeAvailabilityService.checkIfClusterRuntimeUpgradable(workspaceId, stackName, upgradeResponse);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeServiceTest.java
@@ -15,6 +15,7 @@ import com.sequenceiq.cloudbreak.TestUtil;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.host.ClusterHostServiceRunner;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
@@ -50,6 +51,9 @@ public class ClusterManagerUpgradeServiceTest {
     @Mock
     private HostOrchestrator hostOrchestrator;
 
+    @Mock
+    private ClusterHostServiceRunner clusterHostServiceRunner;
+
     @InjectMocks
     private ClusterManagerUpgradeService underTest;
 
@@ -66,15 +70,15 @@ public class ClusterManagerUpgradeServiceTest {
     }
 
     @Test
-    public void testUpgradeClusterManagerWithHostOrchestrator() throws CloudbreakOrchestratorException, CloudbreakException {
+    public void testUpgradeClusterManager() throws CloudbreakOrchestratorException, CloudbreakException {
         Cluster cluster = stack.getCluster();
 
         underTest.upgradeClusterManager(STACK_ID);
 
-        verify(gatewayConfigService, times(1)).getGatewayConfig(stack, stack.getPrimaryGatewayInstance(),  cluster.getGateway() != null);
+        verify(gatewayConfigService, times(1)).getGatewayConfig(stack, stack.getPrimaryGatewayInstance(), cluster.getGateway() != null);
         verify(clusterComponentConfigProvider, times(1)).getClouderaManagerRepoDetails(cluster.getId());
         verify(hostOrchestrator, times(1)).upgradeClusterManager(any(), any(), any(), any(), any());
         verify(clusterApi).stopCluster(true);
-
+        verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerSettings(any(), any());
     }
 }

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/init.sls
@@ -48,7 +48,7 @@ generate_host_id:
     - name: /opt/scripts/generate-host-id.sh
     - shell: /bin/bash
 
-{% if salt['pillar.get']('cloudera-manager:settings:deterministic_uid_gid') == True %}
+{% if salt['pillar.get']('cloudera-manager:settings:deterministic_uid_gid') == True and not "manager_upgrade" in grains.get('roles', []) %}
 /opt/cloudera/cm-agent/service/inituids:
   file.directory:
     - user: cloudera-scm


### PR DESCRIPTION
…grade

As part of Upgrade we need to call the setuid script to configure deterministic
user and group ids. It can happen that the original setuid script is called
without the migration flag so I added an extra guard check to make sure it's
not called during upgrade. If the original installation called the script
alreeady we don't need to migrate anyways. Also in the Upgrade handler
we only updated the CM repo pillar and not the CM settings. However,
the CM settings contain an important upgrade to only call the setuid
script if the CM version is 7.2.1 or above. This was not updated previously
so upgrading from 7.2.0 to 7.2.1 didn't invoke the script.

This commit also fixes another issue when the incorrect Stack CRN was used
as ENV CRN and we didn't properly check for workloads.

See detailed description in the commit message.