### PR TITLE
Added more fixes and validations for filecollector (used for diagnost…

### DIFF
--- a/common-model/src/main/java/com/sequenceiq/common/api/diagnostics/BaseDiagnosticsCollectionRequest.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/diagnostics/BaseDiagnosticsCollectionRequest.java
@@ -53,6 +53,9 @@ public class BaseDiagnosticsCollectionRequest {
     @ApiModelProperty(DiagnosticsModelDescription.UPDATE_PACKAGE)
     private Boolean updatePackage = Boolean.FALSE;
 
+    @ApiModelProperty(DiagnosticsModelDescription.SKIP_VALIDATION)
+    private Boolean skipValidation = Boolean.FALSE;
+
     public List<String> getLabels() {
         return labels;
     }
@@ -139,5 +142,13 @@ public class BaseDiagnosticsCollectionRequest {
 
     public void setUpdatePackage(Boolean updatePackage) {
         this.updatePackage = updatePackage;
+    }
+
+    public Boolean getSkipValidation() {
+        return skipValidation;
+    }
+
+    public void setSkipValidation(Boolean skipValidation) {
+        this.skipValidation = skipValidation;
     }
 }

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/doc/DiagnosticsModelDescription.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/doc/DiagnosticsModelDescription.java
@@ -13,6 +13,7 @@ public class DiagnosticsModelDescription {
     public static final String ADDITIONAL_LOGS = "Additional log path and label pairs that will be sent in the diagnostics collection";
     public static final String INCLUDE_SALT_LOGS = "Include salt logs in the diagnostic collections";
     public static final String UPDATE_PACKAGE = "Upgrade or install required telemetry cli tool on the nodes (works only with network)";
+    public static final String SKIP_VALIDATION = "Skip cloud storage write operation testing or databus connection check (depends on the destination) during init stage.";
 
     private DiagnosticsModelDescription() {
     }

--- a/common-model/src/main/java/com/sequenceiq/common/model/diagnostics/DiagnosticParameters.java
+++ b/common-model/src/main/java/com/sequenceiq/common/model/diagnostics/DiagnosticParameters.java
@@ -37,6 +37,8 @@ public class DiagnosticParameters {
 
     private Boolean updatePackage = Boolean.FALSE;
 
+    private Boolean skipValidation = Boolean.FALSE;
+
     public Map<String, Object> toMap() {
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("destination", destination.toString());
@@ -51,6 +53,7 @@ public class DiagnosticParameters {
         parameters.put("hosts", Optional.ofNullable(hosts).orElse(null));
         parameters.put("includeSaltLogs", Optional.ofNullable(includeSaltLogs).orElse(false));
         parameters.put("updatePackage", Optional.ofNullable(updatePackage).orElse(false));
+        parameters.put("skipValidation", Optional.ofNullable(skipValidation).orElse(false));
         parameters.put("additionalLogs", additionalLogs);
         Map<String, Object> fileCollector = new HashMap<>();
         fileCollector.put(FILECOLLECTOR_ROOT, parameters);
@@ -101,6 +104,10 @@ public class DiagnosticParameters {
         this.updatePackage = updatePackage;
     }
 
+    public void setSkipValidation(Boolean skipValidation) {
+        this.skipValidation = skipValidation;
+    }
+
     public String getIssue() {
         return issue;
     }
@@ -143,6 +150,10 @@ public class DiagnosticParameters {
 
     public Boolean getUpdatePackage() {
         return updatePackage;
+    }
+
+    public Boolean getSkipValidation() {
+        return skipValidation;
     }
 
     public static DiagnosticParametersBuilder builder() {
@@ -212,6 +223,11 @@ public class DiagnosticParameters {
 
         public DiagnosticParametersBuilder withUpdatePackage(Boolean updatePackage) {
             diagnosticParameters.setUpdatePackage(updatePackage);
+            return this;
+        }
+
+        public DiagnosticParametersBuilder withSkipValidation(Boolean skipValidation) {
+            diagnosticParameters.setSkipValidation(skipValidation);
             return this;
         }
 

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/converter/DiagnosticsDataToParameterConverter.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/converter/DiagnosticsDataToParameterConverter.java
@@ -59,6 +59,7 @@ public class DiagnosticsDataToParameterConverter {
         builder.withHosts(request.getHosts());
         builder.withIncludeSaltLogs(request.getIncludeSaltLogs());
         builder.withUpdatePackage(request.getUpdatePackage());
+        builder.withSkipValidation(request.getSkipValidation());
         builder.withAdditionalLogs(request.getAdditionalLogs());
         return builder.build();
     }

--- a/datalake/src/main/java/com/sequenceiq/datalake/converter/DiagnosticsParamsConverter.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/converter/DiagnosticsParamsConverter.java
@@ -40,6 +40,8 @@ public class DiagnosticsParamsConverter {
 
     private static final String PARAMS_UPDATE_PACKAGE = "updatePackage";
 
+    private static final String PARAMS_SKIP_VALIDATION = "skipValidation";
+
     public Map<String, Object> convertFromRequest(DiagnosticsCollectionRequest request) {
         Map<String, Object> props = new HashMap<>();
         props.put(PARAMS_STACK_CRN, request.getStackCrn());
@@ -54,6 +56,7 @@ public class DiagnosticsParamsConverter {
         props.put(PARAMS_ADDITIONAL_LOGS, request.getAdditionalLogs());
         props.put(PARAMS_INCLUDE_SALT_LOGS, request.getIncludeSaltLogs());
         props.put(PARAMS_UPDATE_PACKAGE, request.getUpdatePackage());
+        props.put(PARAMS_SKIP_VALIDATION, request.getSkipValidation());
         return props;
     }
 
@@ -71,7 +74,8 @@ public class DiagnosticsParamsConverter {
         request.setStartTime((Date) Optional.ofNullable(props.get(PARAMS_START_TIME)).orElse(null));
         request.setEndTime((Date) Optional.ofNullable(props.get(PARAMS_END_TIME)).orElse(null));
         request.setIncludeSaltLogs((Boolean) Optional.ofNullable(props.get(PARAMS_INCLUDE_SALT_LOGS)).orElse(false));
-        request.setIncludeSaltLogs((Boolean) Optional.ofNullable(props.get(PARAMS_UPDATE_PACKAGE)).orElse(false));
+        request.setUpdatePackage((Boolean) Optional.ofNullable(props.get(PARAMS_UPDATE_PACKAGE)).orElse(false));
+        request.setSkipValidation((Boolean) Optional.ofNullable(props.get(PARAMS_SKIP_VALIDATION)).orElse(false));
         return request;
     }
 

--- a/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/settings.sls
@@ -14,6 +14,7 @@
 {% set label_filter = salt['pillar.get']('filecollector:labelFilter') %}
 {% set include_salt_logs = salt['pillar.get']('filecollector:includeSaltLogs') %}
 {% set update_package = salt['pillar.get']('filecollector:updatePackage') %}
+{% set skip_test_cloud_storage = salt['pillar.get']('filecollector:skipTestCloudStorage') %}
 {% set additional_logs = salt['pillar.get']('filecollector:additionalLogs') %}
 
 {% if s3_location and not s3_region %}
@@ -22,15 +23,40 @@
 {% endif %}
 
 {% set cloud_storage_upload_params = None %}
+{% set test_cloud_storage_upload_params = None %}
 {% if s3_location %}
   {% set cloud_storage_upload_params = "s3 upload -e -p '/var/lib/filecollector/*.gz' --location " + s3_location + " --bucket " + s3_bucket +  " --region " + s3_region %}
+  {% set test_cloud_storage_upload_params = "s3 upload -e -p /tmp/.test_cloud_storage_upload.txt --location " + s3_location + " --bucket " + s3_bucket +  " --region " + s3_region %}
 {% elif adlsv2_storage_location %}
   {% set cloud_storage_upload_params = "abfs upload -p '/var/lib/filecollector/*.gz' --location " + adlsv2_storage_location + " --account " + adlsv2_storage_account + " --container " + adlsv2_storage_container%}
+  {% set test_cloud_storage_upload_params = "abfs upload -p /tmp/.test_cloud_storage_upload.txt --location " + adlsv2_storage_location + " --account " + adlsv2_storage_account + " --container " + adlsv2_storage_container%}
+{% endif %}
+
+{% set skip_validation = False %}
+{% if salt['pillar.get']('filecollector:skipValidation') %}
+    {% set skip_validation = True %}
+{% endif %}
+
+{% set proxy_full_url = None %}
+{% set proxy_protocol = None %}
+{% if salt['pillar.get']('proxy:host') %}
+  {% set proxy_host = salt['pillar.get']('proxy:host') %}
+  {% set proxy_port = salt['pillar.get']('proxy:port')|string %}
+  {% set proxy_protocol = salt['pillar.get']('proxy:protocol') %}
+  {% set proxy_url = proxy_protocol + "://" + proxy_host + ":" + proxy_port %}
+  {% if salt['pillar.get']('proxy:user') and salt['pillar.get']('proxy:password') %}
+    {% set proxy_user = salt['pillar.get']('proxy:user') %}
+    {% set proxy_password = salt['pillar.get']('proxy:password') %}
+    {% set proxy_full_url =  proxy_protocol + "://" + proxy_user + ":"+ proxy_password + "@" + proxy_host + ":" + proxy_port %}
+  {% else %}
+    {% set proxy_full_url = proxy_url %}
+  {% endif %}
 {% endif %}
 
 {% do filecollector.update({
     "destination": destination,
     "cloudStorageUploadParams": cloud_storage_upload_params,
+    "testCloudStorageUploadParams": test_cloud_storage_upload_params,
     "startTime": start_time,
     "endTime": end_time,
     "issue": issue,
@@ -38,5 +64,8 @@
     "labelFilter": label_filter,
     "additionalLogs": additional_logs,
     "includeSaltLogs": include_salt_logs,
-    "updatePackage" : update_package
+    "updatePackage": update_package,
+    "skipValidation": skip_validation,
+    "proxyUrl": proxy_full_url,
+    "proxyProtocol": proxy_protocol
 }) %}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/init.sls
@@ -291,12 +291,23 @@ fluentd_start_with_update_systemd_units:
   module.wait:
     - name: service.systemctl_reload
     - watch:
-      - file: /etc/systemd/system/td-agent.service
+      - file: /etc/systemd/system/td-agent.service{% if fluent.cloudStorageLoggingEnabled or fluent.cloudLoggingServiceEnabled %}
+      - file: /etc/td-agent/input.conf
+      - file: /etc/td-agent/output.conf{% endif %}
+      - file: /etc/td-agent/input_databus.conf
+      - file: /etc/td-agent/filter_databus.conf
+      - file: /etc/td-agent/output_databus.conf
+
   service.running:
     - enable: True
     - name: td-agent
     - watch:
-       - file: /etc/systemd/system/td-agent.service
+       - file: /etc/systemd/system/td-agent.service{% if fluent.cloudStorageLoggingEnabled or fluent.cloudLoggingServiceEnabled %}
+       - file: /etc/td-agent/input.conf
+       - file: /etc/td-agent/output.conf{% endif %}
+       - file: /etc/td-agent/input_databus.conf
+       - file: /etc/td-agent/filter_databus.conf
+       - file: /etc/td-agent/output_databus.conf
 {% else %}
 
 fs.file-max:

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/filter.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/filter.conf.j2
@@ -11,6 +11,24 @@
     </record>
 </filter>
 
+# handles CM command stdout logs if produced with databus.* label by filecollector - override raw tag
+<filter {{providerPrefix}}.var.run.cloudera-scm-agent.process.**.stdout.log>
+    @type record_transformer
+    enable_ruby true
+    <record>
+      raw_tag ${tag.sub('{{providerPrefix}}', '{{providerPrefix}}_CM_COMMAND.OUT')}
+    </record>
+</filter>
+
+# handles CM command stderr logs if produced with databus.* label by filecollector - override raw tag
+<filter {{providerPrefix}}.var.run.cloudera-scm-agent.process.**.stderr.log>
+    @type record_transformer
+    enable_ruby true
+    <record>
+      raw_tag ${tag.sub('{{providerPrefix}}', '{{providerPrefix}}_CM_COMMAND.ERROR')}
+    </record>
+</filter>
+
 <match {{providerPrefix}}**>
    @type rewrite_tag_filter
    <rule>

--- a/orchestrator-salt/src/main/resources/salt/errormessages.yaml
+++ b/orchestrator-salt/src/main/resources/salt/errormessages.yaml
@@ -1,2 +1,6 @@
 '/usr/local/bin/freeipa_backup': 'Failed to upload freeipa backup to object storage, please check the assigned permissions to the instance'
 '/etc/td-agent/check_fluent_plugins.sh': 'Connection has failed for "https://repository.cloudera.com/cloudera/api/gems/cloudera-gems/" or "https://api.rubygems.org". If servers are not down or no network: please check your firewall or use a newer OS image with newer fluent plugin versions!'
+'test_s3_put': 'Testing s3 put failed for dummy /tmp/.test_cloud_storage_upload.txt, please make sure you have write access from your nodes to your S3'
+'test_abfs_put': 'Testing abfs write failed for dummy /tmp/.test_cloud_storage_upload.txt, please make sure you have write access from your nodes to your Blob storage'
+'check_dbus_connection': 'DBus API is not available from your node(s). Please check you connection against "https://dbusapi.us-west-1.altus.cloudera.com" (or proper dev url on non-production environments)'
+'check_td_agent_running_systemctl': 'A running td-agent is required on your node(s) to collect and send diagnostics to ENG (engineering).'


### PR DESCRIPTION
…ics collections)

details:
- added new cloud storage validations (test writes) for CLOUD_STORAGE destination
- added dbus api check + td-agent running command for ENG destination
- map salt errors to human readable error messges
- filecollector sends every input for fluentd with databus.* label, cannot use multiple ones, cm command logs needs to be like databus_CM_COMMAND.OUT.* or databus_CM_COMMAND.ERROR.*, so change the filter.conf for fluentd to map those streams to use those flags
- add more watch files for td-agent (in order to restart if some other configs are changing)
- add new skipTestCloudStorage parameter - that can be used to skip S3/Abfs test writes (in case of CLOUD_STORAGE destinations)
- proxy support for rpm installation if. updatePackage is set
Also fixed a bug related with update packge (it was set to include salt logs)