### PR TITLE
CB-8239 Fix delete child environments at API Cleanup App

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentCascadingDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentCascadingDeleteAction.java
@@ -10,17 +10,17 @@ import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.log.Log;
 
-public class EnvironmentForceDeleteAction implements Action<EnvironmentTestDto, EnvironmentClient> {
+public class EnvironmentCascadingDeleteAction implements Action<EnvironmentTestDto, EnvironmentClient> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(EnvironmentForceDeleteAction.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(EnvironmentCascadingDeleteAction.class);
 
     @Override
     public EnvironmentTestDto action(TestContext testContext, EnvironmentTestDto testDto, EnvironmentClient environmentClient) throws Exception {
-        Log.when(LOGGER, "Environment forced delete request, crn: " +  testDto.getResponse().getCrn());
+        Log.when(LOGGER, "Environment cascading delete request, crn: " +  testDto.getResponse().getCrn());
         SimpleEnvironmentResponse delete = environmentClient.getEnvironmentClient()
                 .environmentV1Endpoint()
                 .deleteByCrn(testDto.getResponse().getCrn(), true, false);
-        Log.whenJson(LOGGER, " Environment forced delete response: ", delete);
+        Log.whenJson(LOGGER, " Environment cascading delete response: ", delete);
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/EnvironmentTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/EnvironmentTestClient.java
@@ -10,7 +10,7 @@ import com.sequenceiq.it.cloudbreak.action.v4.environment.EnvironmentCreateActio
 import com.sequenceiq.it.cloudbreak.action.v4.environment.EnvironmentDeleteAction;
 import com.sequenceiq.it.cloudbreak.action.v4.environment.EnvironmentDeleteByNameAction;
 import com.sequenceiq.it.cloudbreak.action.v4.environment.EnvironmentChangeAuthenticationAction;
-import com.sequenceiq.it.cloudbreak.action.v4.environment.EnvironmentForceDeleteAction;
+import com.sequenceiq.it.cloudbreak.action.v4.environment.EnvironmentCascadingDeleteAction;
 import com.sequenceiq.it.cloudbreak.action.v4.environment.EnvironmentGetAction;
 import com.sequenceiq.it.cloudbreak.action.v4.environment.EnvironmentInternalGetAction;
 import com.sequenceiq.it.cloudbreak.action.v4.environment.EnvironmentListAction;
@@ -37,8 +37,8 @@ public class EnvironmentTestClient {
         return new EnvironmentDeleteAction();
     }
 
-    public Action<EnvironmentTestDto, EnvironmentClient> forceDelete() {
-        return new EnvironmentForceDeleteAction();
+    public Action<EnvironmentTestDto, EnvironmentClient> cascadingDelete() {
+        return new EnvironmentCascadingDeleteAction();
     }
 
     public Action<EnvironmentTestDto, EnvironmentClient> deleteByName() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
@@ -295,7 +295,7 @@ public class EnvironmentTestDto
     public void cleanUp(TestContext context, CloudbreakClient client) {
         LOGGER.info("Cleaning up resource with name: {}", getName());
         if (getResponse() != null) {
-            when(environmentTestClient.forceDelete(), key("delete-environment-" + getName()).withSkipOnFail(false));
+            when(environmentTestClient.cascadingDelete(), key("delete-environment-" + getName()).withSkipOnFail(false));
             await(ARCHIVED, new RunningParameter().withSkipOnFail(true));
         } else {
             LOGGER.info("Response field is null for env: {}", getName());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/BasicEnvironmentTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/BasicEnvironmentTests.java
@@ -49,7 +49,7 @@ public class BasicEnvironmentTests extends AbstractE2ETest {
                 .when(environmentTestClient.create())
                 .await(EnvironmentStatus.AVAILABLE)
                 .then((tc, testDto, cc) -> environmentTestClient.describe().action(tc, testDto, cc))
-                .when(environmentTestClient.forceDelete())
+                .when(environmentTestClient.cascadingDelete())
                 .validate();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/hybrid/AwsYcloudHybridCloudTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/hybrid/AwsYcloudHybridCloudTest.java
@@ -154,7 +154,7 @@ public class AwsYcloudHybridCloudTest extends AbstractE2ETest {
 
         testContext
                 .given(CHILD_ENVIRONMENT_KEY, EnvironmentTestDto.class, CHILD_CLOUD_PLATFORM)
-                .when(environmentTestClient.forceDelete(), RunningParameter.key(CHILD_ENVIRONMENT_KEY))
+                .when(environmentTestClient.cascadingDelete(), RunningParameter.key(CHILD_ENVIRONMENT_KEY))
                 .await(EnvironmentStatus.ARCHIVED, RunningParameter.key(CHILD_ENVIRONMENT_KEY))
                 .validate();
 


### PR DESCRIPTION
@biharitomi or @lnardai please review.

This PR relates to [CB-8239 Introduce delete child environment steps to the AwsYcloudHybridCloudTest](https://github.com/hortonworks/cloudbreak/pull/8682).

Unfortunately AwsYcloudHybridCloudTest.testCreateSdxOnChildEnvironment is still failing, because of wait for child environment delete was not implemented along with the previous change. So I'm fixing this missing feature with this commit.