### PR TITLE
CB-8261: Fix ExceptionCatcherEventHandler to set the event's data

### DIFF
--- a/flow/src/main/java/com/sequenceiq/flow/reactor/api/handler/ExceptionCatcherEventHandler.java
+++ b/flow/src/main/java/com/sequenceiq/flow/reactor/api/handler/ExceptionCatcherEventHandler.java
@@ -32,13 +32,12 @@ public abstract class ExceptionCatcherEventHandler<T extends Payload> implements
             doAccept(handlerEvent);
             if (handlerEvent.getCounter() < 1) {
                 LOGGER.error("No event has been sent from {}", handlerName);
-                IllegalStateException noEventHasBeenSentException = new IllegalStateException("No event has been sent from " + handlerName);
-                eventBus.notify(defaultFailureEvent(event.getData().getResourceId(), noEventHasBeenSentException).selector(),
-                        new Event<>(event.getHeaders(), event));
+                throw new IllegalStateException("No event has been sent from " + handlerName);
             }
         } catch (Exception e) {
             LOGGER.error("Something unexpected happened in handler {}", handlerName, e);
-            eventBus.notify(defaultFailureEvent(event.getData().getResourceId(), e).selector(), new Event<>(event.getHeaders(), event));
+            Selectable failureEvent = defaultFailureEvent(event.getData().getResourceId(), e);
+            eventBus.notify(failureEvent.selector(), new Event<>(event.getHeaders(), failureEvent));
         }
     }
 

--- a/flow/src/test/java/com/sequenceiq/cloudbreak/reactor/api/handler/ExceptionCatcherEventHandlerTest.java
+++ b/flow/src/test/java/com/sequenceiq/cloudbreak/reactor/api/handler/ExceptionCatcherEventHandlerTest.java
@@ -1,0 +1,97 @@
+package com.sequenceiq.cloudbreak.reactor.api.handler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.sequenceiq.cloudbreak.common.event.Payload;
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import reactor.bus.Event;
+import reactor.bus.EventBus;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ExceptionCatcherEventHandlerTest {
+
+    private static final Long RESOURCE_ID = 1L;
+
+    private static final String SELECTOR = "Selector";
+
+    @InjectMocks
+    private ExceptionCatcherEventHandlerTestHelper underTest;
+
+    @Mock
+    private EventBus eventBus;
+
+    @Test
+    public void testAcceptWhenNoEventNotification() {
+        Event<Payload> event = mock(Event.class);
+        Event.Headers headers = mock(Event.Headers.class);
+        Payload payload = mock(Payload.class);
+        Selectable failureEvent = mock(Selectable.class);
+        underTest.initialize(SELECTOR, failureEvent, false, null);
+
+        when(event.getData()).thenReturn(payload);
+        when(payload.getResourceId()).thenReturn(RESOURCE_ID);
+        when(event.getHeaders()).thenReturn(headers);
+        when(failureEvent.selector()).thenReturn(SELECTOR);
+
+
+        underTest.accept(event);
+
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(eventBus).notify(eq(SELECTOR), eventCaptor.capture());
+        Event eventBusEvent = eventCaptor.getValue();
+        assertNotNull(eventBusEvent);
+        assertEquals(failureEvent, eventBusEvent.getData());
+    }
+
+    @Test
+    public void testAcceptWhenException() {
+        Event<Payload> event = mock(Event.class);
+        Event.Headers headers = mock(Event.Headers.class);
+        Payload payload = mock(Payload.class);
+        Selectable failureEvent = mock(Selectable.class);
+        underTest.initialize(SELECTOR, failureEvent, true, null);
+
+        when(event.getData()).thenReturn(payload);
+        when(payload.getResourceId()).thenReturn(RESOURCE_ID);
+        when(event.getHeaders()).thenReturn(headers);
+        when(failureEvent.selector()).thenReturn(SELECTOR);
+
+        underTest.accept(event);
+
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(eventBus).notify(eq(SELECTOR), eventCaptor.capture());
+        Event eventBusEvent = eventCaptor.getValue();
+        assertNotNull(eventBusEvent);
+        assertEquals(failureEvent, eventBusEvent.getData());
+    }
+
+    @Test
+    public void testAcceptWhenSuccessful() {
+        Event<Payload> event = mock(Event.class);
+        Event.Headers headers = mock(Event.Headers.class);
+        Selectable sendEventObject = mock(Selectable.class);
+        underTest.initialize(SELECTOR, null, false, sendEventObject);
+
+        when(event.getHeaders()).thenReturn(headers);
+        when(sendEventObject.selector()).thenReturn(SELECTOR);
+
+        underTest.accept(event);
+
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(eventBus).notify(eq(SELECTOR), eventCaptor.capture());
+        Event eventBusEvent = eventCaptor.getValue();
+        assertNotNull(eventBusEvent);
+        assertEquals(sendEventObject, eventBusEvent.getData());
+    }
+}

--- a/flow/src/test/java/com/sequenceiq/cloudbreak/reactor/api/handler/ExceptionCatcherEventHandlerTestHelper.java
+++ b/flow/src/test/java/com/sequenceiq/cloudbreak/reactor/api/handler/ExceptionCatcherEventHandlerTestHelper.java
@@ -1,0 +1,46 @@
+package com.sequenceiq.cloudbreak.reactor.api.handler;
+
+import com.sequenceiq.cloudbreak.common.event.Payload;
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+class ExceptionCatcherEventHandlerTestHelper extends ExceptionCatcherEventHandler<Payload> {
+
+    private String selectorString;
+
+    private Selectable failureEvent;
+
+    private boolean throwException;
+
+    private Selectable sendEventObject;
+
+    @Override
+    protected Selectable defaultFailureEvent(Long resourceId, Exception e) {
+        return failureEvent;
+    }
+
+    @Override
+    protected void doAccept(HandlerEvent event) {
+        if (throwException) {
+            throw new RuntimeException("Expected exception");
+        }
+        if (sendEventObject != null) {
+            sendEvent(sendEventObject, event);
+        }
+    }
+
+    @Override
+    public String selector() {
+        return selectorString;
+    }
+
+    public void initialize(String selectorString, Selectable failureEvent, boolean throwException,
+            Selectable sendEventObject) {
+        this.selectorString = selectorString;
+        this.failureEvent = failureEvent;
+        this.throwException = throwException;
+        this.sendEventObject = sendEventObject;
+    }
+}


### PR DESCRIPTION
Fix ExceptionCatcherEventHandler to use the defaultFailureEvent's for
the event's data.

Added unit test.

See detailed description in the commit message.