### PR TITLE
CB-8263 Adding getCredentialByName to the audit credential endpoints

### DIFF
--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/credential/endpoint/AuditCredentialEndpoint.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/credential/endpoint/AuditCredentialEndpoint.java
@@ -14,6 +14,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import com.sequenceiq.cloudbreak.auth.security.internal.AccountId;
 import com.sequenceiq.cloudbreak.cloud.response.CredentialPrerequisitesResponse;
 import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
 import com.sequenceiq.environment.api.doc.credential.CredentialDescriptor;
@@ -44,6 +45,13 @@ public interface AuditCredentialEndpoint {
     @ApiOperation(value = CredentialOpDescription.GET_BY_CRN, produces = MediaType.APPLICATION_JSON,
             notes = CredentialDescriptor.CREDENTIAL_NOTES, nickname = "getAuditCredentialByResourceCrnV1", httpMethod = "GET")
     CredentialResponse getByResourceCrn(@PathParam("crn") String credentialCrn);
+
+    @GET
+    @Path("name/{name}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = CredentialOpDescription.GET_BY_NAME, produces = MediaType.APPLICATION_JSON,
+            notes = CredentialDescriptor.CREDENTIAL_NOTES, nickname = "getAuditCredentialByResourceNameV1", httpMethod = "GET")
+    CredentialResponse getByResourceName(@PathParam("name") String credentialName, @AccountId @QueryParam("accountId") String accountId);
 
     @POST
     @Path("")

--- a/environment/src/main/java/com/sequenceiq/environment/credential/v1/AuditCredentialV1Controller.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/v1/AuditCredentialV1Controller.java
@@ -13,6 +13,7 @@ import com.sequenceiq.authorization.annotation.AuthorizationResource;
 import com.sequenceiq.authorization.annotation.CheckPermissionByAccount;
 import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.security.internal.AccountId;
 import com.sequenceiq.cloudbreak.auth.security.internal.InternalReady;
 import com.sequenceiq.cloudbreak.auth.security.internal.TenantAwareParam;
 import com.sequenceiq.cloudbreak.cloud.response.CredentialPrerequisitesResponse;
@@ -59,6 +60,13 @@ public class AuditCredentialV1Controller extends NotificationController implemen
     public CredentialResponse getByResourceCrn(@TenantAwareParam String credentialCrn) {
         String accountId = ThreadBasedUserCrnProvider.getAccountId();
         return credentialConverter.convert(credentialService.getByCrnForAccountId(credentialCrn, accountId, AUDIT));
+    }
+
+    @Override
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.DESCRIBE_AUDIT_CREDENTIAL)
+    public CredentialResponse getByResourceName(String credentialName, @AccountId String accountId) {
+        String userAccountId = ThreadBasedUserCrnProvider.getAccountId();
+        return credentialConverter.convert(credentialService.getByNameForAccountId(credentialName, userAccountId, AUDIT));
     }
 
     @Override


### PR DESCRIPTION
added /name/{name} endpoint to audit controller. Audit config service - also the CLI - using the name to identify audit credential. To make UI able to fetch credential by name we should extend the current audit credential endpoints with getCredentialByName capability.

See detailed description in the commit message.