### PR TITLE
switch integration tests to 7.2.1 default runtime version

### DIFF
--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -68,7 +68,7 @@ integrationtest:
     defaultPassword: Admin123
     defaultPort: 7180
   cloudProvider: MOCK
-  runtimeVersion: 7.2.0
+  runtimeVersion: 7.2.1
 
   spot:
     enabledCloudPlatforms:


### PR DESCRIPTION
See detailed description in the commit message.