### PR TITLE
CB-8138 - Lock-components should only lock used parcels

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/component/StackRepoDetails.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/component/StackRepoDetails.java
@@ -13,8 +13,6 @@ public class StackRepoDetails implements Serializable {
 
     public static final String REPO_ID_TAG = "repoid";
 
-    public static final String MPACK_TAG = "mpack";
-
     public static final String REPOSITORY_VERSION = "repository-version";
 
     public static final String VDF_REPO_KEY_PREFIX = "vdf-";

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerParcelService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerParcelService.java
@@ -1,0 +1,50 @@
+package com.sequenceiq.cloudbreak.cm;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.cloudera.api.swagger.ParcelsResourceApi;
+import com.cloudera.api.swagger.client.ApiClient;
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.model.ApiParcel;
+import com.cloudera.api.swagger.model.ApiParcelList;
+import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
+import com.sequenceiq.cloudbreak.cm.model.ParcelStatus;
+
+@Service
+class ClouderaManagerParcelService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerParcelService.class);
+
+    @Inject
+    private ClouderaManagerApiFactory clouderaManagerApiFactory;
+
+    public Map<String, String> getActivatedParcels(ApiClient client, String stackName) throws ApiException {
+        return getClouderaManagerParcelsByStatus(client, stackName, ParcelStatus.ACTIVATED)
+                .stream()
+                .collect(Collectors.toMap(ApiParcel::getProduct, ApiParcel::getVersion));
+    }
+
+    private List<ApiParcel> getClouderaManagerParcelsByStatus(ApiClient client, String stackName, ParcelStatus parcelStatus) throws ApiException {
+        ApiParcelList parcelList = getClouderaManagerParcels(client, stackName);
+        return parcelList.getItems()
+                .stream()
+                .filter(parcel -> parcelStatus.name().equals(parcel.getStage()))
+                .peek(parcel -> LOGGER.debug("Parcel {} is found with status {}", parcel.getDisplayName(), parcelStatus))
+                .collect(toList());
+    }
+
+    private ApiParcelList getClouderaManagerParcels(ApiClient client, String stackName) throws ApiException {
+        ParcelsResourceApi parcelsResourceApi = clouderaManagerApiFactory.getParcelsResourceApi(client);
+        return parcelsResourceApi.readParcels(stackName, "summary");
+    }
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/SdxRuntimeUpgradeService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/SdxRuntimeUpgradeService.java
@@ -200,8 +200,14 @@ public class SdxRuntimeUpgradeService {
                     .map(ImageComponentVersions::getCdp)
                     .distinct()
                     .collect(Collectors.joining(","));
-            throw new BadRequestException(String.format("There is no image eligible for upgrading the cluster with runtime: %s. "
-                    + "Please choose a runtime from the following image(s): %s", runtime, availableRuntimes));
+            String errorMessage;
+            if (StringUtils.isEmpty(availableRuntimes)) {
+                errorMessage = String.format("There is no image eligible for the cluster upgrade with runtime: %s.", runtime);
+            } else {
+                errorMessage = String.format("There is no image eligible for the cluster upgrade with runtime: %s. "
+                        + "Please choose a runtime from the following: %s", runtime, availableRuntimes);
+            }
+            throw new BadRequestException(errorMessage);
         } else {
             ImageInfoV4Response imageInfoV4Response = imagesWithMatchingRuntime.get().max(getComparator()).orElseThrow();
             imageId = imageInfoV4Response.getImageId();
@@ -212,8 +218,8 @@ public class SdxRuntimeUpgradeService {
     private String validateImageId(List<ImageInfoV4Response> upgradeCandidates, String requestImageId) {
         if (upgradeCandidates.stream().noneMatch(imageInfoV4Response -> imageInfoV4Response.getImageId().equalsIgnoreCase(requestImageId))) {
             String candidates = upgradeCandidates.stream().map(ImageInfoV4Response::getImageId).collect(Collectors.joining(","));
-            throw new BadRequestException(String.format("The given image (%s) is not eligible for upgrading the cluster. "
-                    + "Please choose an id from the following image(s): %s", requestImageId, candidates));
+            throw new BadRequestException(String.format("The given image (%s) is not eligible for the cluster upgrade. "
+                    + "Please choose an id from the following: %s", requestImageId, candidates));
         }
         return requestImageId;
     }

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/upgrade/SdxRuntimeUpgradeServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/upgrade/SdxRuntimeUpgradeServiceTest.java
@@ -132,8 +132,8 @@ public class SdxRuntimeUpgradeServiceTest {
                 BadRequestException.class,
                 () -> underTest.triggerUpgradeByCrn(USER_CRN, STACK_CRN, sdxUpgradeRequest));
 
-        assertEquals(String.format("The given image (%s) is not eligible for upgrading the cluster. "
-                + "Please choose an id from the following image(s): %s", IMAGE_ID, ANOTHER_IMAGE_ID), exception.getMessage());
+        assertEquals(String.format("The given image (%s) is not eligible for the cluster upgrade. "
+                + "Please choose an id from the following: %s", IMAGE_ID, ANOTHER_IMAGE_ID), exception.getMessage());
     }
 
     @Test
@@ -179,8 +179,8 @@ public class SdxRuntimeUpgradeServiceTest {
                 BadRequestException.class,
                 () -> underTest.triggerUpgradeByCrn(USER_CRN, STACK_CRN, sdxUpgradeRequest));
 
-        assertEquals(String.format("There is no image eligible for upgrading the cluster with runtime: %s. "
-                + "Please choose a runtime from the following image(s): %s", ANOTHER_TARGET_RUNTIME, MATCHING_TARGET_RUNTIME), exception.getMessage());
+        assertEquals(String.format("There is no image eligible for the cluster upgrade with runtime: %s. "
+                + "Please choose a runtime from the following: %s", ANOTHER_TARGET_RUNTIME, MATCHING_TARGET_RUNTIME), exception.getMessage());
     }
 
     @Test


### PR DESCRIPTION
Lock components from now on only means locking down components that are actually used (have their parcel activated) on the cluster, eg. by default SDX only uses CDH and if Data Hub might use Nifi parcel then lock components should lock the Nifi version also.