### PR TITLE
CB-8213 [ASRG] dl and dh might leak resources in case of provisioning…

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTerminationHelperService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTerminationHelperService.java
@@ -81,7 +81,7 @@ public class AzureTerminationHelperService {
         List<String> networkInterfaceNames = getResourceNamesByResourceType(resourcesToRemove, ResourceType.AZURE_NETWORK_INTERFACE);
         azureUtils.waitForDetachNetworkInterfaces(ac, client, resourceGroupName, networkInterfaceNames);
         azureUtils.deleteNetworkInterfaces(client, resourceGroupName, networkInterfaceNames);
-        deleteCloudResourceList(ac, resourcesToRemove, ResourceType.AZURE_INSTANCE);
+        deleteCloudResourceList(ac, resourcesToRemove, ResourceType.AZURE_NETWORK_INTERFACE);
 
 
         List<String> publicAddressNames = getResourceNamesByResourceType(resourcesToRemove, ResourceType.AZURE_PUBLIC_IP);

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureVirtualMachineService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureVirtualMachineService.java
@@ -144,7 +144,8 @@ public class AzureVirtualMachineService {
                         cloudInstance.putParameter(INSTANCE_NAME, computerName);
                         statuses.add(new CloudVmInstanceStatus(cloudInstance, AzureInstanceStatus.get(virtualMachinePowerState)));
                     }, () -> statuses.stream()
-                            .filter(cvis -> cvis.getCloudInstance().getInstanceId().equals(cloudInstance.getInstanceId()))
+                            .filter(cvis -> cvis.getCloudInstance().getInstanceId() != null
+                                    && cvis.getCloudInstance().getInstanceId().equals(cloudInstance.getInstanceId()))
                             .findAny()
                             .ifPresentOrElse(cloudInstanceWithStatus -> logTheStatusOfTheCloudInstance(cloudInstanceWithStatus),
                                     () -> statuses.add(new CloudVmInstanceStatus(cloudInstance, InstanceStatus.TERMINATED))));


### PR DESCRIPTION
… error

In case datalake of datahub is provisioned but some error comes up during stack provisioning then the created cloud resources might not be persisted into cloudbreak resources table. This leads to resource leakage in the azure single RG use case during deletion.

See detailed description in the commit message.