### PR TITLE
CB-8271: Bootstrap FreeIPA replica install without using /etc/hosts

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaConfigService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaConfigService.java
@@ -61,7 +61,7 @@ public class FreeIpaConfigService {
                 .withDnssecValidationEnabled(isDnsSecValidationEnabled(stack.getCloudPlatform()))
                 .withReverseZones(reverseZones)
                 .withAdminUser(freeIpaClientFactory.getAdminUser())
-                .withFreeIpaToReplicate(gatewayConfigService.getPrimaryGatewayConfig(stack).getHostname())
+                .withFreeIpaToReplicate(gatewayConfigService.getPrimaryGatewayConfig(stack))
                 .withHosts(hosts)
                 .withBackupConfig(determineAndSetBackup(stack, proxyConfig))
                 .build();

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaConfigView.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaConfigView.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.ObjectUtils;
@@ -31,6 +32,8 @@ public class FreeIpaConfigView {
 
     private final String freeipaToReplicate;
 
+    private final String freeipaToReplicateIp;
+
     private final Set<Object> hosts;
 
     private final FreeIpaBackupConfigView backup;
@@ -46,6 +49,7 @@ public class FreeIpaConfigView {
         this.reverseZones = builder.reverseZones;
         this.adminUser = builder.adminUser;
         this.freeipaToReplicate = builder.freeipaToReplicate;
+        this.freeipaToReplicateIp = builder.freeipaToReplicateIp;
         this.hosts = builder.hosts;
         this.backup = builder.backup;
     }
@@ -78,6 +82,10 @@ public class FreeIpaConfigView {
         return freeipaToReplicate;
     }
 
+    public String getFreeipaToReplicateIp() {
+        return freeipaToReplicateIp;
+    }
+
     public Set<Object> getHosts() {
         return hosts;
     }
@@ -96,6 +104,7 @@ public class FreeIpaConfigView {
         map.put("reverseZones", ObjectUtils.defaultIfNull(this.reverseZones, EMPTY_CONFIG_DEFAULT));
         map.put("admin_user", ObjectUtils.defaultIfNull(this.adminUser, EMPTY_CONFIG_DEFAULT));
         map.put("freeipa_to_replicate", ObjectUtils.defaultIfNull(this.freeipaToReplicate, EMPTY_CONFIG_DEFAULT));
+        map.put("freeipa_to_replicate_ip", ObjectUtils.defaultIfNull(this.freeipaToReplicateIp, EMPTY_CONFIG_DEFAULT));
         if (MapUtils.isNotEmpty(backup.toMap())) {
             map.put("backup", this.backup.toMap());
         }
@@ -118,6 +127,8 @@ public class FreeIpaConfigView {
         private String adminUser;
 
         private String freeipaToReplicate;
+
+        private String freeipaToReplicateIp;
 
         private Set<Object> hosts;
 
@@ -159,12 +170,14 @@ public class FreeIpaConfigView {
             return this;
         }
 
-        public Builder withFreeIpaToReplicate(String freeipaToReplicate) {
-            this.freeipaToReplicate = freeipaToReplicate;
+        public Builder withFreeIpaToReplicate(GatewayConfig freeipaToReplicate) {
+            this.freeipaToReplicate = freeipaToReplicate.getHostname();
+            this.freeipaToReplicateIp = freeipaToReplicate.getPrivateAddress();
             return this;
         }
 
         public Builder withHosts(Set<Node> hosts) {
+            // IP is needed for backwards compatibility with FreeIPA HA prior to 2.28.0
             this.hosts = hosts.stream().map(n ->
                     Map.of("ip", n.getPrivateIp(),
                             "fqdn", n.getHostname()))

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/init.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/init.sls
@@ -8,15 +8,6 @@ net.ipv6.conf.lo.disable_ipv6:
   sysctl.present:
     - value: 0
 
-{% for host in salt['pillar.get']('freeipa:hosts') %}
-/etc/hosts/{{ host['fqdn'] }}:
-  host.present:
-    - ip:
-      - {{ host['ip'] }}
-    - names:
-      - {{ host['fqdn'] }}
-{% endfor %}
-
 {% if salt['pillar.get']('freeipa:hosts') | length > 1 %}
 /cdp/ipahealthagent/freeipa_cluster_node:
   file.managed:

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/replica-install.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/replica-install.sls
@@ -1,3 +1,12 @@
+/etc/resolv.conf.install:
+  file.managed:
+    - makedirs: True
+    - user: root
+    - group: root
+    - mode: 644
+    - source: salt://freeipa/templates/resolv.conf.j2
+    - template: jinja
+
 install-freeipa-replica:
   cmd.run:
     - name: /opt/salt/scripts/freeipa_replica_install.sh && echo $(date +%Y-%m-%d:%H:%M:%S) >> /var/log/freeipa_install-executed
@@ -7,7 +16,9 @@ install-freeipa-replica:
         - REALM: {{salt['pillar.get']('freeipa:realm')}}
         - ADMIN_USER: {{salt['pillar.get']('freeipa:admin_user')}}
         - FREEIPA_TO_REPLICATE: {{salt['pillar.get']('freeipa:freeipa_to_replicate')}}
+        - FREEIPA_TO_REPLICATE_IP: {{salt['pillar.get']('freeipa:freeipa_to_replicate_ip')}}
     - failhard: True
     - unless: test -f /var/log/freeipa_install-executed
     - require:
         - file: /opt/salt/scripts/freeipa_replica_install.sh
+        - file: /etc/resolv.conf.install

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_install.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_install.sh
@@ -8,11 +8,11 @@ IPADDR=$(hostname -i)
 ipa-server-install --unattended --uninstall
 
 ipa-server-install \
-          --realm $REALM \
-          --domain $DOMAIN \
-          --hostname $FQDN \
-          -a $FPW \
-          -p $FPW \
+          --realm "$REALM" \
+          --domain "$DOMAIN" \
+          --hostname "$FQDN" \
+          -a "$FPW" \
+          -p "$FPW" \
           --setup-dns \
           --auto-reverse \
 {%- for zone in salt['pillar.get']('freeipa:reverseZones').split(',') %}

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_replica_install.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_replica_install.sh
@@ -5,22 +5,34 @@ set -e
 FQDN=$(hostname -f)
 IPADDR=$(hostname -i)
 
+install -m644 /etc/resolv.conf.install /etc/resolv.conf
+
 ipa-server-install --unattended --uninstall
 
+ipa-client-install \
+  --server "$FREEIPA_TO_REPLICATE" \
+  --realm "$REALM" \
+  --domain "$DOMAIN" \
+  --mkhomedir \
+  --hostname $FQDN \
+  --ip-address "$IPADDR" \
+  --principal "$ADMIN_USER" \
+  --password "$FPW" \
+  --unattended \
+  --force-join \
+  --ssh-trust-dns \
+  --no-ntp
+
 ipa-replica-install \
-          --server $FREEIPA_TO_REPLICATE \
           --setup-ca \
-          --realm $REALM \
-          --domain $DOMAIN \
-          --hostname $FQDN \
-          --principal $ADMIN_USER \
-          --admin-password $FPW \
+          --principal "$ADMIN_USER" \
+          --admin-password "$FPW" \
           --setup-dns \
           --auto-reverse \
           --allow-zone-overlap \
           --ssh-trust-dns \
           --mkhomedir \
-          --ip-address $IPADDR \
+          --ip-address "$IPADDR" \
           --auto-forwarders \
           --force-join \
 {%- if not salt['pillar.get']('freeipa:dnssecValidationEnabled') %}

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/templates/resolv.conf.j2
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/templates/resolv.conf.j2
@@ -1,0 +1,2 @@
+search {{ pillar['freeipa']['domain'] }}
+nameserver {{ pillar['freeipa']['freeipa_to_replicate_ip'] }}


### PR DESCRIPTION
When installing FreeIPA replicas, do not require /etc/hosts on all
FreeIPA servers to reference all other FreeIPA servers. Instead, use
/etc/resolv.conf to bootstrap DNS. Then run ipa-client-install to
bootstrap the replica's DNS record. Then run ipa-replica-install to
replicate the DNS records via LDAP to the localhost.

This was tested by doing several repairs on a FreeIPA cluster that was
provsioned using a local instance of cloudbreak.

See detailed description in the commit message.