### PR TITLE
CB-8275: Fix FreeIPA downscale to remove SSHFP DNS records

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/model/DnsRecord.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/model/DnsRecord.java
@@ -65,12 +65,15 @@ public class DnsRecord {
     }
 
     public boolean isHostRelatedRecord(String fqdn, String domain) {
+        String hostname = StringUtils.substringBefore(fqdn, domain);
         if (isARecord()) {
-            String hostname = StringUtils.substringBefore(fqdn, domain);
             return idnsname.equalsIgnoreCase(StringUtils.removeEnd(hostname, "."));
         }
         if (isPtrRecord()) {
             return ptrrecord.contains(StringUtils.appendIfMissing(fqdn, "."));
+        }
+        if (isSshfpRecord()) {
+            return idnsname.equalsIgnoreCase(StringUtils.removeEnd(hostname, "."));
         }
         return false;
     }
@@ -118,6 +121,10 @@ public class DnsRecord {
 
     public boolean isPtrRecord() {
         return ptrrecord != null && !ptrrecord.isEmpty();
+    }
+
+    public boolean isSshfpRecord() {
+        return sshfprecord != null && !sshfprecord.isEmpty();
     }
 
     public boolean isSrvRecord() {

--- a/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/model/DnsRecordTest.java
+++ b/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/model/DnsRecordTest.java
@@ -82,6 +82,19 @@ public class DnsRecordTest {
     }
 
     @Test
+    public void testIsSshfpRecordTrue() {
+        underTest.setIdnsname("server");
+        underTest.setSshfprecord(List.of("1 1 ABCDEF"));
+        assertTrue(underTest.isSshfpRecord());
+    }
+
+    @Test
+    public void testIsSshfpRecordFalse() {
+        underTest.setArecord(List.of("192.168.1.2"));
+        assertFalse(underTest.isSshfpRecord());
+    }
+
+    @Test
     public void testIsHostRelatedRecordFalseIfSrvRecrod() {
         underTest.setSrvrecord(List.of("0 5 5060 example.com."));
         assertFalse(underTest.isHostRelatedRecord("example.com.", "example.com"));
@@ -107,5 +120,28 @@ public class DnsRecordTest {
         underTest.setSrvrecord(List.of("0 5 5060 example.com.", "0 5 5060 example1.com."));
         assertTrue(underTest.isHostRelatedSrvRecord("example.com."));
         assertTrue(underTest.isHostRelatedSrvRecord("example1.com."));
+    }
+
+    @Test
+    public void testIsHostRelatedRecordWhenARecord() {
+        underTest.setIdnsname("server");
+        underTest.setArecord(List.of("192.168.1.2"));
+        assertTrue(underTest.isHostRelatedRecord("server.example.com", "example.com"));
+        assertFalse(underTest.isHostRelatedRecord("server1.example.com", "example.com"));
+    }
+
+    @Test
+    public void testIsHostRelatedRecordWhenPtrRecord() {
+        underTest.setPtrrecord(List.of("server.example.com."));
+        assertTrue(underTest.isHostRelatedRecord("server.example.com", "example.com"));
+        assertFalse(underTest.isHostRelatedRecord("server1.example.com", "example.com"));
+    }
+
+    @Test
+    public void testIsHostRelatedRecordWhenSshfpRecord() {
+        underTest.setIdnsname("server");
+        underTest.setSshfprecord(List.of("1 1 ABCDEF"));
+        assertTrue(underTest.isHostRelatedRecord("server.example.com", "example.com"));
+        assertFalse(underTest.isHostRelatedRecord("server1.example.com", "example.com"));
     }
 }


### PR DESCRIPTION
When FreeIPA is downscaled or repaired, the SSHFP DNS records were fix
to be removed.

This was tested with unittests and using a local deployment of
cloudbreak.

See detailed description in the commit message.