### PR TITLE
Cb 8100

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/rest/StructuredEventFilter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/rest/StructuredEventFilter.java
@@ -38,6 +38,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.ext.WriterInterceptor;
 import javax.ws.rs.ext.WriterInterceptorContext;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
@@ -368,14 +369,11 @@ public class StructuredEventFilter implements WriterInterceptor, ContainerReques
                 stream = new BufferedInputStream(stream);
             }
             stream.mark(MAX_CONTENT_LENGTH + 1);
-            byte[] entity = new byte[MAX_CONTENT_LENGTH + 1];
-            int entitySize = stream.read(entity);
-            if (entitySize != -1) {
-                content.append(new String(entity, 0, Math.min(entitySize, MAX_CONTENT_LENGTH), charset));
-                if (entitySize > MAX_CONTENT_LENGTH) {
-                    content.append("...more...");
-                }
+            String entityString = IOUtils.toString(stream, charset);
+            if (entityString.length() > MAX_CONTENT_LENGTH) {
+                entityString = entityString.substring(0, MAX_CONTENT_LENGTH) + "...more...";
             }
+            content.append(entityString);
             content.append('\n');
             stream.reset();
         }


### PR DESCRIPTION
 In StructuredEventFilter we convert the entity stream to another stream. During this conversation the entity reader cut the end of the stream. This cutting caused an invalid json error