### PR TITLE
Disable databus based logging stop for E2E tests (other way it will stop after 20 m…

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/telemetry/TelemetryTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/telemetry/TelemetryTestDto.java
@@ -71,6 +71,7 @@ public class TelemetryTestDto extends AbstractCloudbreakTestDto<TelemetryRequest
         getRequest().setFeatures(featuresRequest);
         Map<String, Object> fluentAttributes = new HashMap<>();
         fluentAttributes.put("dbusIncludeSaltLogs", true);
+        fluentAttributes.put("dbusClusterLogsCollectionDisableStop", true);
         getRequest().setFluentAttributes(fluentAttributes);
         return this;
     }


### PR DESCRIPTION
…inutes during deployment)

See detailed description in the commit message.