### PR TITLE
CB-4915 Respect region disablement policies of customer AWS accounts

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudCredentialStatus.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudCredentialStatus.java
@@ -10,6 +10,8 @@ public class CloudCredentialStatus {
 
     private final Exception exception;
 
+    private final boolean defaultRegionChanged;
+
     public CloudCredentialStatus(CloudCredential cloudResource, CredentialStatus status) {
         this(cloudResource, status, null, null);
     }
@@ -19,6 +21,15 @@ public class CloudCredentialStatus {
         this.status = status;
         this.statusReason = statusReason;
         this.exception = exception;
+        this.defaultRegionChanged = false;
+    }
+
+    public CloudCredentialStatus(CloudCredentialStatus cloudCredentialStatus, boolean defaultRegionChanged) {
+        this.cloudCredential = cloudCredentialStatus.getCloudCredential();
+        this.status = cloudCredentialStatus.getStatus();
+        this.statusReason = cloudCredentialStatus.getStatusReason();
+        this.exception = cloudCredentialStatus.getException();
+        this.defaultRegionChanged = defaultRegionChanged;
     }
 
     public CloudCredential getCloudCredential() {
@@ -37,6 +48,10 @@ public class CloudCredentialStatus {
         return exception;
     }
 
+    public boolean isDefaultRegionChanged() {
+        return defaultRegionChanged;
+    }
+
     //BEGIN GENERATED CODE
     @Override
     public String toString() {
@@ -44,6 +59,7 @@ public class CloudCredentialStatus {
                 + "cloudCredential=" + cloudCredential
                 + ", status=" + status
                 + ", statusReason='" + statusReason + '\''
+                + ", defaultRegionChanged='" + defaultRegionChanged + '\''
                 + '}';
     }
     //END GENERATED CODE

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsClient.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsClient.java
@@ -52,7 +52,7 @@ public class AwsClient {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AwsClient.class);
 
-    // Default retries is 3. This allows for more time for backoff during throttling
+    // Default retries is 3. This allows more time for backoff during throttling
     private static final int MAX_CLIENT_RETRIES = 30;
 
     private static final int MAX_CONSECUTIVE_RETRIES_BEFORE_THROTTLING = 200;
@@ -89,19 +89,27 @@ public class AwsClient {
     }
 
     public AmazonEC2Client createAccess(AwsCredentialView awsCredential, String regionName) {
+        return createAccessWithClientConfiguration(awsCredential, regionName, getDefaultClientConfiguration());
+    }
+
+    public AmazonEC2Client createAccessWithMinimalRetries(AwsCredentialView awsCredential, String regionName) {
+        return createAccessWithClientConfiguration(awsCredential, regionName, getClientConfigurationWithMinimalRetries());
+    }
+
+    public AmazonEC2Client createAccessWithClientConfiguration(AwsCredentialView awsCredential, String regionName, ClientConfiguration clientConfiguration) {
         AmazonEC2Client client = isRoleAssumeRequired(awsCredential) ?
-                getAmazonEC2Client(createAwsSessionCredentialProvider(awsCredential)) :
-                getAmazonEC2Client(createAwsCredentials(awsCredential));
+                getAmazonEC2Client(createAwsSessionCredentialProvider(awsCredential), clientConfiguration) :
+                getAmazonEC2Client(createAwsCredentials(awsCredential), clientConfiguration);
         client.setRegion(RegionUtils.getRegion(regionName));
         return client;
     }
 
-    public AmazonEC2Client getAmazonEC2Client(AwsSessionCredentialProvider awsSessionCredentialProvider) {
-        return new AmazonEC2Client(awsSessionCredentialProvider, getDefaultClientConfiguration());
+    public AmazonEC2Client getAmazonEC2Client(AwsSessionCredentialProvider awsSessionCredentialProvider, ClientConfiguration clientConfiguration) {
+        return new AmazonEC2Client(awsSessionCredentialProvider, clientConfiguration);
     }
 
-    public AmazonEC2Client getAmazonEC2Client(BasicAWSCredentials basicAWSCredentials) {
-        return new AmazonEC2Client(basicAWSCredentials, getDefaultClientConfiguration());
+    public AmazonEC2Client getAmazonEC2Client(BasicAWSCredentials basicAWSCredentials, ClientConfiguration clientConfiguration) {
+        return new AmazonEC2Client(basicAWSCredentials, clientConfiguration);
     }
 
     public AmazonCloudWatchClient createCloudWatchClient(AwsCredentialView awsCredential, String regionName) {
@@ -192,6 +200,13 @@ public class AwsClient {
                 .withRetryPolicy(PredefinedRetryPolicies.getDefaultRetryPolicyWithCustomMaxRetries(MAX_CLIENT_RETRIES));
     }
 
+    private ClientConfiguration getClientConfigurationWithMinimalRetries() {
+        return new ClientConfiguration()
+                .withThrottledRetries(true)
+                .withMaxConsecutiveRetriesBeforeThrottling(MAX_CONSECUTIVE_RETRIES_BEFORE_THROTTLING)
+                .withRetryPolicy(PredefinedRetryPolicies.getDefaultRetryPolicy());
+    }
+
     private ClientConfiguration getDynamoDbClientConfiguration() {
         return new ClientConfiguration()
                 .withRetryPolicy(PredefinedRetryPolicies.getDynamoDBDefaultRetryPolicyWithCustomMaxRetries(MAX_CLIENT_RETRIES));
@@ -252,10 +267,6 @@ public class AwsClient {
 
     public InstanceProfileCredentialsProvider getInstanceProfileProvider() {
         return new InstanceProfileCredentialsProvider();
-    }
-
-    public boolean roleBasedCredential(AwsCredentialView awsCredential) {
-        return isNotEmpty(awsCredential.getRoleArn());
     }
 
     private boolean isRoleAssumeRequired(AwsCredentialView awsCredential) {

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsDefaultRegionSelector.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsDefaultRegionSelector.java
@@ -1,0 +1,112 @@
+package com.sequenceiq.cloudbreak.cloud.aws;
+
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.amazonaws.services.ec2.AmazonEC2Client;
+import com.amazonaws.services.ec2.model.AmazonEC2Exception;
+import com.amazonaws.services.ec2.model.DescribeRegionsRequest;
+import com.sequenceiq.cloudbreak.cloud.aws.view.AwsCredentialView;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.Region;
+
+@Service
+public class AwsDefaultRegionSelector {
+    static final String EC2_AUTH_FAILURE_ERROR_CODE = "AuthFailure";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsDefaultRegionSelector.class);
+
+    @Inject
+    private AwsPlatformResources platformResources;
+
+    @Inject
+    private AwsClient awsClient;
+
+    @Inject
+    private AwsDefaultZoneProvider defaultZoneProvider;
+
+    public String determineDefaultRegion(CloudCredential cloudCredential) {
+        String result = null;
+        AwsCredentialView awsCredential = new AwsCredentialView(cloudCredential);
+        String originalDefaultRegion = defaultZoneProvider.getDefaultZone(cloudCredential);
+        Set<Region> enabledRegions = platformResources.getEnabledRegions();
+        LOGGER.debug("Try to describe regions by using the global default region '{}' in EC2.", originalDefaultRegion);
+        boolean globalDefaultRegionViable = describeRegionsViaEc2Region(awsCredential, originalDefaultRegion);
+        if (!globalDefaultRegionViable && CollectionUtils.isNotEmpty(enabledRegions)) {
+            LOGGER.info("Regions could not be described by using the global default region '{}' in EC2. Starting to describe regions with other regions",
+                    originalDefaultRegion);
+            String regionSelected = enabledRegions.stream()
+                    .filter(r -> describeRegionsViaEc2Region(awsCredential, r.getRegionName()))
+                    .findFirst()
+                    .orElseThrow(() -> {
+                        List<String> usedRegions = enabledRegions.stream().map(Region::getRegionName).collect(Collectors.toList());
+                        usedRegions.add(originalDefaultRegion);
+                        String regions = String.join(",", usedRegions);
+                        String msg = String.format("Failed to describe available EC2 regions by configuring SDK to use the following regions: '%s'", regions);
+                        LOGGER.warn(msg);
+                        return new AwsDefaultRegionSelectionFailed(msg);
+                    })
+                    .getRegionName();
+            if (!originalDefaultRegion.equals(regionSelected)) {
+                LOGGER.info("The default region for credential needs to be changed from '{}' to '{}'", originalDefaultRegion, regionSelected);
+                result = regionSelected;
+            }
+        } else if (!globalDefaultRegionViable) {
+            String msg = String.format("Failed to describe available EC2 regions in region '%s'", originalDefaultRegion);
+            LOGGER.warn(msg);
+            throw new AwsDefaultRegionSelectionFailed(msg);
+        }
+        return result;
+    }
+
+    private boolean describeRegionsViaEc2Region(AwsCredentialView awsCredential, String region) {
+        boolean regionIsViable = false;
+        try {
+            LOGGER.debug("Describing regions on EC2 API in '{}'", region);
+            AmazonEC2Client access = awsClient.createAccessWithMinimalRetries(awsCredential, region);
+            DescribeRegionsRequest describeRegionsRequest = new DescribeRegionsRequest();
+            access.describeRegions(describeRegionsRequest);
+            regionIsViable = true;
+        } catch (AmazonEC2Exception ec2Exception) {
+            String errorMessage = String.format("Unable to describe regions via using EC2 region '%s' APIs, due to: '%s'", region, ec2Exception.getMessage());
+            LOGGER.debug(errorMessage, ec2Exception);
+            if (!EC2_AUTH_FAILURE_ERROR_CODE.equals(ec2Exception.getErrorCode())) {
+                throw ec2Exception;
+            }
+        } catch (RuntimeException e) {
+            String errorMessage = String.format("Unable to describe EC2 regions from AWS: %s", e.getMessage());
+            LOGGER.warn(errorMessage, e);
+            throw e;
+        }
+        return regionIsViable;
+    }
+
+    protected static class AwsDefaultRegionSelectionFailed extends CloudConnectorException {
+
+        public AwsDefaultRegionSelectionFailed(String message) {
+            super(message);
+        }
+
+        public AwsDefaultRegionSelectionFailed(String message, Throwable cause) {
+            super(message, cause);
+        }
+
+        public AwsDefaultRegionSelectionFailed(Throwable cause) {
+            super(cause);
+        }
+
+        protected AwsDefaultRegionSelectionFailed(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+            super(message, cause, enableSuppression, writableStackTrace);
+        }
+    }
+}

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsDefaultZoneProvider.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsDefaultZoneProvider.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.cloud.aws;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -20,7 +21,15 @@ public class AwsDefaultZoneProvider {
     }
 
     public String getDefaultZone(AwsCredentialView awsCredentialView) {
-        return awsCredentialView.isGovernmentCloudEnabled() ? awsGovZoneParameterDefault : awsZoneParameterDefault;
+        return awsCredentialView.isGovernmentCloudEnabled() ? awsGovZoneParameterDefault : getCredentialOrGlobalDefault(awsCredentialView);
+    }
+
+    private String getCredentialOrGlobalDefault(AwsCredentialView credentialView) {
+        String credentialDefaultRegion = credentialView.getDefaultRegion();
+        if (StringUtils.isNoneEmpty(credentialDefaultRegion)) {
+            return credentialDefaultRegion;
+        }
+        return awsZoneParameterDefault;
     }
 
 }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsPlatformResources.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsPlatformResources.java
@@ -835,6 +835,10 @@ public class AwsPlatformResources implements PlatformResources {
         return new CloudResourceGroups();
     }
 
+    Set<Region> getEnabledRegions() {
+        return enabledRegions;
+    }
+
     private AmazonDynamoDB getAmazonDynamoDB(CloudCredential cloudCredential, Region region) {
         AwsCredentialView awsCredentialView = new AwsCredentialView(cloudCredential);
         return awsClient.createDynamoDbClient(awsCredentialView, region.value());

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsCredentialView.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsCredentialView.java
@@ -7,8 +7,9 @@ import java.util.Map;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 
 public class AwsCredentialView {
+    public static final String DEFAULT_REGION_KEY = "defaultRegion";
 
-    private static final String AWS = "aws";
+    public static final String AWS = "aws";
 
     private static final String ROLE_ARN = "roleArn";
 
@@ -101,5 +102,9 @@ public class AwsCredentialView {
 
     public String getCredentialCrn() {
         return cloudCredential.getId();
+    }
+
+    public String getDefaultRegion() {
+        return (String) cloudCredential.getParameter(AWS, Map.class).get(DEFAULT_REGION_KEY);
     }
 }

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsAuthenticatorTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsAuthenticatorTest.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.cloud.aws;
 import static org.junit.Assert.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -24,6 +25,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.amazonaws.AmazonClientException;
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.services.ec2.AmazonEC2Client;
@@ -56,9 +58,9 @@ public class AwsAuthenticatorTest {
 
     @BeforeEach
     public void awsClientSetup() {
-        when(awsClient.getAmazonEC2Client(any(AwsSessionCredentialProvider.class))).thenReturn(amazonEC2Client);
-        when(awsClient.getAmazonEC2Client(any(BasicAWSCredentials.class))).thenReturn(amazonEC2Client);
-        when(awsClient.getInstanceProfileProvider()).thenReturn(instanceProfileCredentialsProvider);
+        doReturn(amazonEC2Client).when(awsClient).getAmazonEC2Client(any(AwsSessionCredentialProvider.class), any(ClientConfiguration.class));
+        doReturn(amazonEC2Client).when(awsClient).getAmazonEC2Client(any(BasicAWSCredentials.class), any(ClientConfiguration.class));
+        doReturn(instanceProfileCredentialsProvider).when(awsClient).getInstanceProfileProvider();
     }
 
     @Test

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsCredentialConnectorTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsCredentialConnectorTest.java
@@ -48,6 +48,9 @@ public class AwsCredentialConnectorTest {
     @Mock
     private AwsCredentialView credentialView;
 
+    @Mock
+    private AwsDefaultRegionSelector defaultRegionSelector;
+
     @InjectMocks
     private AwsCredentialConnector underTest;
 
@@ -71,6 +74,8 @@ public class AwsCredentialConnectorTest {
         when(credentialView.getRoleArn()).thenReturn(roleArn);
 
         String exceptionMessageComesFromSdk = "SomethingTerribleHappened!";
+        String expectedExceptionMessage = String.format("Unable to verify credential: check if the role '%s' exists and it's created with the correct " +
+                "external ID. Cause: '%s'", roleArn, exceptionMessageComesFromSdk);
         Exception sdkException = new SdkBaseException(exceptionMessageComesFromSdk);
 
         doThrow(sdkException).when(awsCredentialVerifier).validateAws(credentialView);
@@ -78,7 +83,7 @@ public class AwsCredentialConnectorTest {
 
         assertNotNull(result);
         assertEquals(CredentialStatus.FAILED, result.getStatus());
-        assertEquals(exceptionMessageComesFromSdk, result.getStatusReason());
+        assertEquals(expectedExceptionMessage, result.getStatusReason());
         assertEquals(sdkException, result.getException());
 
         verify(awsCredentialVerifier, times(1)).validateAws(any());

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsDefaultRegionSelectorTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsDefaultRegionSelectorTest.java
@@ -1,0 +1,156 @@
+package com.sequenceiq.cloudbreak.cloud.aws;
+
+import static com.sequenceiq.cloudbreak.cloud.aws.AwsDefaultRegionSelector.EC2_AUTH_FAILURE_ERROR_CODE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.amazonaws.services.ec2.AmazonEC2Client;
+import com.amazonaws.services.ec2.model.AmazonEC2Exception;
+import com.amazonaws.services.ec2.model.DescribeRegionsRequest;
+import com.amazonaws.services.ec2.model.DescribeRegionsResult;
+import com.sequenceiq.cloudbreak.cloud.aws.AwsDefaultRegionSelector.AwsDefaultRegionSelectionFailed;
+import com.sequenceiq.cloudbreak.cloud.aws.view.AwsCredentialView;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.Region;
+
+@ExtendWith(MockitoExtension.class)
+class AwsDefaultRegionSelectorTest {
+
+    private static final String GLOBAL_DEFAULT_ZONE = "us-east-1";
+
+    @Mock
+    private AmazonEC2Client ec2Client;
+
+    @Mock
+    private AwsPlatformResources platformResources;
+
+    @Mock
+    private AwsClient awsClient;
+
+    @Mock
+    private AwsDefaultZoneProvider defaultZoneProvider;
+
+    @InjectMocks
+    private AwsDefaultRegionSelector underTest;
+
+    @BeforeEach
+    void setUp() {
+        Set<Region> possibleDefaultRegions = Set.of(Region.region("sa-east-1"), Region.region("eu-central-1"), Region.region("eu-north-1"));
+        when(platformResources.getEnabledRegions()).thenReturn(possibleDefaultRegions);
+        when(defaultZoneProvider.getDefaultZone(any(CloudCredential.class))).thenReturn(GLOBAL_DEFAULT_ZONE);
+    }
+
+    @Test
+    void testDetermineDefaultRegionWhenGlobalDefaultRegionIsViable() {
+        when(awsClient.createAccessWithMinimalRetries(any(AwsCredentialView.class), eq(GLOBAL_DEFAULT_ZONE))).thenReturn(ec2Client);
+
+        String actual = underTest.determineDefaultRegion(new CloudCredential());
+
+        assertNull(actual);
+        verify(awsClient, times(1)).createAccessWithMinimalRetries(any(AwsCredentialView.class), eq(GLOBAL_DEFAULT_ZONE));
+        verify(ec2Client, times(1)).describeRegions(any(DescribeRegionsRequest.class));
+    }
+
+    @Test
+    void testDetermineDefaultRegionWhenGlobalDefaultRegionDescribeFailsWithAwsClientException() {
+        when(awsClient.createAccessWithMinimalRetries(any(AwsCredentialView.class), eq(GLOBAL_DEFAULT_ZONE))).thenReturn(ec2Client);
+        when(ec2Client.describeRegions(any(DescribeRegionsRequest.class))).thenThrow(new AmazonEC2Exception("SomethingBadHappened"));
+
+        assertThrows(AmazonEC2Exception.class, () -> underTest.determineDefaultRegion(new CloudCredential()));
+
+        verify(awsClient, times(1)).createAccessWithMinimalRetries(any(AwsCredentialView.class), eq(GLOBAL_DEFAULT_ZONE));
+        verify(ec2Client, times(1)).describeRegions(any(DescribeRegionsRequest.class));
+    }
+
+    @Test
+    void testDetermineDefaultRegionWhenGlobalDefaultRegionDescribeFailsWithRuntimeException() {
+        when(awsClient.createAccessWithMinimalRetries(any(AwsCredentialView.class), eq(GLOBAL_DEFAULT_ZONE))).thenReturn(ec2Client);
+        when(ec2Client.describeRegions(any(DescribeRegionsRequest.class))).thenThrow(new RuntimeException());
+
+        assertThrows(RuntimeException.class, () -> underTest.determineDefaultRegion(new CloudCredential()));
+
+        verify(awsClient, times(1)).createAccessWithMinimalRetries(any(AwsCredentialView.class), eq(GLOBAL_DEFAULT_ZONE));
+        verify(ec2Client, times(1)).describeRegions(any(DescribeRegionsRequest.class));
+    }
+
+    @Test
+    void testDetermineDefaultRegionWhenGlobalDefaultRegionDescribeFailsWithAuthExceptionAndNoAdditionalRegionsAreConfigured() {
+        AmazonEC2Exception amazonEC2Exception = new AmazonEC2Exception("SomethingBadHappened");
+        amazonEC2Exception.setErrorCode(EC2_AUTH_FAILURE_ERROR_CODE);
+        when(ec2Client.describeRegions(any(DescribeRegionsRequest.class))).thenThrow(amazonEC2Exception);
+        when(awsClient.createAccessWithMinimalRetries(any(AwsCredentialView.class), eq(GLOBAL_DEFAULT_ZONE))).thenReturn(ec2Client);
+        when(platformResources.getEnabledRegions()).thenReturn(null);
+
+        AwsDefaultRegionSelectionFailed ex = assertThrows(AwsDefaultRegionSelectionFailed.class, () -> underTest.determineDefaultRegion(new CloudCredential()));
+
+        assertEquals(String.format("Failed to describe available EC2 regions in region '%s'", GLOBAL_DEFAULT_ZONE), ex.getMessage());
+        verify(awsClient, times(1)).createAccessWithMinimalRetries(any(AwsCredentialView.class), eq(GLOBAL_DEFAULT_ZONE));
+        verify(ec2Client, times(1)).describeRegions(any(DescribeRegionsRequest.class));
+    }
+
+    @Test
+    void testDetermineDefaultRegionWhenGlobalDefaultRegionIsNotViableAndOneOfTheAdditionalRegionsIsViable() {
+        AmazonEC2Exception amazonEC2Exception = new AmazonEC2Exception("SomethingBadHappened");
+        amazonEC2Exception.setErrorCode(EC2_AUTH_FAILURE_ERROR_CODE);
+        when(ec2Client.describeRegions(any(DescribeRegionsRequest.class))).thenReturn(new DescribeRegionsResult());
+        when(awsClient.createAccessWithMinimalRetries(any(AwsCredentialView.class), any()))
+                .thenThrow(amazonEC2Exception)
+                .thenThrow(amazonEC2Exception)
+                .thenThrow(amazonEC2Exception)
+                .thenReturn(ec2Client);
+
+        String actual = underTest.determineDefaultRegion(new CloudCredential());
+
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(awsClient, times(4)).createAccessWithMinimalRetries(any(AwsCredentialView.class), captor.capture());
+        final String expected = captor.getValue();
+        assertEquals(expected, actual);
+        verify(ec2Client, times(1)).describeRegions(any(DescribeRegionsRequest.class));
+    }
+
+    @Test
+    void testDetermineDefaultRegionWhenGlobalDefaultRegionIsNotViableAndNoneOfTheAdditionalRegionsIsViable() {
+        when(awsClient.createAccessWithMinimalRetries(any(AwsCredentialView.class), any())).thenReturn(ec2Client);
+        AmazonEC2Exception amazonEC2Exception = new AmazonEC2Exception("SomethingBadHappened");
+        amazonEC2Exception.setErrorCode(EC2_AUTH_FAILURE_ERROR_CODE);
+        when(ec2Client.describeRegions(any(DescribeRegionsRequest.class))).thenThrow(amazonEC2Exception);
+
+        AwsDefaultRegionSelectionFailed exception = assertThrows(AwsDefaultRegionSelectionFailed.class,
+                () -> underTest.determineDefaultRegion(new CloudCredential()));
+
+        assertTrue(exception.getMessage().startsWith("Failed to describe available EC2 regions by configuring SDK to use the following regions:"));
+        verify(awsClient, times(4)).createAccessWithMinimalRetries(any(AwsCredentialView.class), any());
+        verify(ec2Client, times(4)).describeRegions(any(DescribeRegionsRequest.class));
+    }
+
+    @Test
+    void testDetermineDefaultRegionShouldReturnNullWhenCredentialSpecificDefaultRegionIsViable() {
+        String credentialSpecificDefaultRegion = "eu-central-1";
+        CloudCredential aCloudCredential = new CloudCredential();
+        when(defaultZoneProvider.getDefaultZone(aCloudCredential)).thenReturn(credentialSpecificDefaultRegion);
+        when(awsClient.createAccessWithMinimalRetries(any(AwsCredentialView.class), eq(credentialSpecificDefaultRegion))).thenReturn(ec2Client);
+
+        String actual = underTest.determineDefaultRegion(aCloudCredential);
+
+        assertNull(actual);
+        verify(awsClient, times(1)).createAccessWithMinimalRetries(any(AwsCredentialView.class), eq(credentialSpecificDefaultRegion));
+        verify(ec2Client, times(1)).describeRegions(any(DescribeRegionsRequest.class));
+    }
+}

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsInstanceConnectorTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsInstanceConnectorTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -39,6 +40,7 @@ import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
@@ -105,9 +107,9 @@ public class AwsInstanceConnectorTest {
 
     @BeforeEach
     public void awsClientSetup() {
-        when(awsClient.getAmazonEC2Client(any(AwsSessionCredentialProvider.class))).thenReturn(amazonEC2Client);
-        when(awsClient.getAmazonEC2Client(any(BasicAWSCredentials.class))).thenReturn(amazonEC2Client);
-        when(awsClient.getInstanceProfileProvider()).thenReturn(instanceProfileCredentialsProvider);
+        doReturn(amazonEC2Client).when(awsClient).getAmazonEC2Client(any(AwsSessionCredentialProvider.class), any(ClientConfiguration.class));
+        doReturn(amazonEC2Client).when(awsClient).getAmazonEC2Client(any(BasicAWSCredentials.class), any(ClientConfiguration.class));
+        doReturn(instanceProfileCredentialsProvider).when(awsClient).getInstanceProfileProvider();
 
         CloudContext context = new CloudContext(1L, "context", "AWS", "AWS",
                 Location.location(Region.region("region")), "user", "account");

--- a/environment/src/main/java/com/sequenceiq/environment/credential/service/ServiceProviderCredentialAdapter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/service/ServiceProviderCredentialAdapter.java
@@ -85,11 +85,15 @@ public class ServiceProviderCredentialAdapter {
                 LOGGER.info(message, res.getErrorDetails());
                 throw new CredentialVerificationException(message + res.getErrorDetails(), res.getErrorDetails());
             }
-            if (CredentialStatus.FAILED.equals(res.getCloudCredentialStatus().getStatus())) {
-                return new CredentialVerification(credential, setNewStatusText(credential, res.getCloudCredentialStatus()));
+            CloudCredentialStatus cloudCredentialStatus = res.getCloudCredentialStatus();
+            if (CredentialStatus.FAILED.equals(cloudCredentialStatus.getStatus())) {
+                return new CredentialVerification(credential, setNewStatusText(credential, cloudCredentialStatus));
             }
-            changed = setNewStatusText(credential, res.getCloudCredentialStatus());
-            CloudCredential cloudCredentialResponse = res.getCloudCredentialStatus().getCloudCredential();
+            changed = setNewStatusText(credential, cloudCredentialStatus);
+            CloudCredential cloudCredentialResponse = cloudCredentialStatus.getCloudCredential();
+            if (cloudCredentialStatus.isDefaultRegionChanged()) {
+                changed = mergeCloudProviderParameters(credential, cloudCredentialResponse, Collections.singleton(SMART_SENSE_ID));
+            }
             changed = changed || mergeCloudProviderParameters(credential, cloudCredentialResponse, Collections.singleton(SMART_SENSE_ID));
         } catch (InterruptedException e) {
             LOGGER.error("Error while executing credential verification", e);


### PR DESCRIPTION
Regarding CB-4915 a new mechanism has been implemented that verifies that the credential which is under creation is able to query regions. If regions could not be described using the globally set default region which is `us-east-1` then it tries to describe regions in different EC2 regions. This list of possible default is configurable, but the defaults are stored in environment service's `application.yml`. Once the describe of regions works from a region then the region is persisted on credential side as a new attribute. This means that AWS related services will picked the credential specific region as default when it is possible/necessary.

During the tests it turned out this describe region process takes some time due to a bug in AWS Java SDK:
https://github.com/aws/aws-sdk-java/issues/2204
The SDK's retrying client identifies 401 `AuthFailure` responses as skew errors which is retryable this way and results in 30 failures/retries from the client side. But this doesn't prevent the customer to have a credential with proper default region configured, just the creation takes much more time then it's expected.