### PR TITLE
CB-8269 FreeIPA Termination Checker Success reporter throws 404

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaOperationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaOperationChecker.java
@@ -21,13 +21,14 @@ public class FreeIpaOperationChecker<T extends FreeIpaWaitObject> extends Except
     @Override
     public boolean checkStatus(T waitObject) {
         String environmentCrn = waitObject.getEnvironmentCrn();
-        String crn = waitObject.getFreeIpaCrn();
         Status desiredStatus = waitObject.getDesiredStatus();
         try {
             DescribeFreeIpaResponse freeIpa = waitObject.getEndpoint().describe(environmentCrn);
             if (freeIpa == null) {
-                throw new TestFailException(String.format("'%s' freeIpa cluster was not found for environment '%s'", crn, environmentCrn));
+                LOGGER.error("No freeIpa found with environmentCrn '{}'! Check '{}' status.", environmentCrn, desiredStatus);
+                throw new TestFailException(String.format("No freeIpa found with environmentCrn '%s'! Check '%s' status.", environmentCrn, desiredStatus));
             }
+            String crn = freeIpa.getCrn();
             String name = freeIpa.getName();
             Status status = freeIpa.getStatus();
             LOGGER.info("Waiting for the '{}' state of '{}' '{}' freeIpa at '{}' environment. Actual state is: '{}'", desiredStatus, name, crn, environmentCrn,
@@ -55,16 +56,14 @@ public class FreeIpaOperationChecker<T extends FreeIpaWaitObject> extends Except
     @Override
     public void handleTimeout(T waitObject) {
         String environmentCrn = waitObject.getEnvironmentCrn();
-        String crn = waitObject.getFreeIpaCrn();
         try {
             DescribeFreeIpaResponse freeIpa = waitObject.getEndpoint().describe(environmentCrn);
             if (freeIpa == null) {
-                throw new TestFailException(String.format("'%s' freeIpa cluster was not found for environment '%s'", crn, environmentCrn));
+                LOGGER.error("No freeIpa found with environmentCrn '{}'! Wait operation timed out.", environmentCrn);
+                throw new TestFailException(String.format("No freeIpa found with environmentCrn '%s'! Wait operation timed out.", environmentCrn));
             }
-            String name = freeIpa.getName();
-            Status status = freeIpa.getStatus();
             throw new TestFailException(String.format("Wait operation timed out, freeIpa '%s' '%s' has been failed for environment '%s'. FreeIpa status: '%s' "
-                    + "statusReason: '%s'", name, crn, environmentCrn, status, freeIpa.getStatusReason()));
+                    + "statusReason: '%s'", freeIpa.getName(), freeIpa.getCrn(), environmentCrn, freeIpa.getStatus(), freeIpa.getStatusReason()));
         } catch (Exception e) {
             LOGGER.error("Wait operation timed out, freeIpa has been failed. Also failed to get freeIpa status: {}", e.getMessage(), e);
             throw new TestFailException(String.format("Wait operation timed out, freeIpa has been failed. Also failed to get freeIpa status: %s",
@@ -74,18 +73,17 @@ public class FreeIpaOperationChecker<T extends FreeIpaWaitObject> extends Except
 
     @Override
     public String successMessage(T waitObject) {
-        return String.format("Wait operation was successfully done. '%s' freeIpa is in the desired state '%s'", waitObject.getFreeIpaCrn(),
-                waitObject.getDesiredStatus());
+        return String.format("Wait operation has successfully been done with '%s' freeIpa state for '%s' environment.", waitObject.getDesiredStatus(),
+                waitObject.getEnvironmentCrn());
     }
 
     @Override
     public boolean exitWaiting(T waitObject) {
         String environmentCrn = waitObject.getEnvironmentCrn();
-        String crn = waitObject.getFreeIpaCrn();
         try {
             DescribeFreeIpaResponse freeIpa = waitObject.getEndpoint().describe(environmentCrn);
             if (freeIpa == null) {
-                LOGGER.info("'{}' freeIpa was not found for environment '{}'. Exit waiting", crn, environmentCrn);
+                LOGGER.info("No freeIpa found with environmentCrn '{}'! Exit waiting.", environmentCrn);
                 return true;
             }
             Status status = freeIpa.getStatus();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaTerminationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaTerminationChecker.java
@@ -23,12 +23,11 @@ public class FreeIpaTerminationChecker<T extends FreeIpaWaitObject> extends Exce
     @Override
     public boolean checkStatus(T waitObject) {
         String environmentCrn = waitObject.getEnvironmentCrn();
-        String crn = waitObject.getFreeIpaCrn();
         Status desiredStatus = waitObject.getDesiredStatus();
         try {
             DescribeFreeIpaResponse freeIpa = waitObject.getEndpoint().describe(environmentCrn);
-            LOGGER.info("Waiting for the '{}' state of '{}' freeIpa at '{}' environment. Actual state is: '{}'", desiredStatus, crn, environmentCrn,
-                    freeIpa.getStatus());
+            LOGGER.info("Waiting for the '{}' state of '{}' freeIpa at '{}' environment. Actual state is: '{}'", desiredStatus, freeIpa.getCrn(),
+                    environmentCrn, freeIpa.getStatus());
             if (freeIpa.getStatus().equals(DELETE_FAILED)) {
                 throw new TestFailException("FreeIpa termination failed: " + freeIpa.getStatusReason());
             }
@@ -36,7 +35,7 @@ public class FreeIpaTerminationChecker<T extends FreeIpaWaitObject> extends Exce
                 return false;
             }
         } catch (NotFoundException e) {
-            LOGGER.warn("No freeIpa found with crn '{}'", crn, e);
+            LOGGER.warn("No freeIpa found with environmentCrn '{}'! It has been deleted successfully.", environmentCrn, e);
         } catch (Exception e) {
             LOGGER.error("FreeIpa termination failed: {}", e.getMessage(), e);
             throw new TestFailException(String.format("FreeIpa termination failed: %s", e.getMessage()));
@@ -48,20 +47,19 @@ public class FreeIpaTerminationChecker<T extends FreeIpaWaitObject> extends Exce
     public void handleTimeout(T waitObject) {
         try {
             String environmentCrn = waitObject.getEnvironmentCrn();
-            String crn = waitObject.getFreeIpaCrn();
             DescribeFreeIpaResponse freeIpa = waitObject.getEndpoint().describe(environmentCrn);
             throw new TestFailException(String.format("Wait operation timed out, '%s' freeIpa termination failed for '%s' environment. FreeIpa status: '%s' " +
-                    "statusReason: '%s'", crn, environmentCrn, freeIpa.getStatus(), freeIpa.getStatusReason()));
+                    "statusReason: '%s'", freeIpa.getCrn(), environmentCrn, freeIpa.getStatus(), freeIpa.getStatusReason()));
         } catch (Exception e) {
-            LOGGER.error("Wait operation timed out, freeIpa termination failed. Also failed to get freeIpa status: {}", e.getMessage(), e);
-            throw new TestFailException(String.format("Wait operation timed out, freeIpa termination failed. Also failed to get freeIpa status: %s",
+            LOGGER.error("Wait operation timed out, freeIpa termination failed: {}", e.getMessage(), e);
+            throw new TestFailException(String.format("Wait operation timed out, freeIpa termination failed: %s",
                     e.getMessage()));
         }
     }
 
     @Override
     public String successMessage(T waitObject) {
-        return String.format("'%s' FreeIpa termination successfully finished.", waitObject.getFreeIpaCrn());
+        return String.format("FreeIpa termination have successfully been finished for '%s' environment.", waitObject.getEnvironmentCrn());
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaWaitObject.java
@@ -29,8 +29,4 @@ public class FreeIpaWaitObject {
     public Status getDesiredStatus() {
         return desiredStatus;
     }
-
-    public String getFreeIpaCrn() {
-        return client.getFreeIpaClient().getFreeIpaV1Endpoint().describe(getEnvironmentCrn()).getCrn();
-    }
 }


### PR DESCRIPTION
`FreeIpaTests.testCreateStopStartFreeIpaWithTwoInstances` is failing, because of:
```
await FreeIpaTestDto[name: aws-test-fa865a9c43084e57bcf78e0a20fc1d7] for desired statuses DELETE_COMPLETED: Stack by environment [crn:cdp:environments:us-west-1:qe-aws:environment:31eb02d0-47b1-459f-b79e-9ce1dc352eaa] not found
```
```
2020-08-04 12:08:38,936 [TestNG-test=aws-e2e-tests-3] ERROR c.s.i.c.u.w.s.freeipa.FreeIpaAwait [FreeIpaTests.testCreateStopStartFreeIpaWithTwoInstances] - await [FreeIpaTestDto[name: aws-test-fa865a9c43084e57bcf78e0a20fc1d7]] is failed for statuses DELETE_COMPLETED: javax.ws.rs.NotFoundException: HTTP 404 Not Found, name: aws-test-fa865a9c43084e57bcf78e0a20fc1d7
2020-08-04 12:08:38,944 [TestNG-test=aws-e2e-tests-3] ERROR c.s.i.c.util.ErrorLogMessageProvider [FreeIpaTests.testCreateStopStartFreeIpaWithTwoInstances] - Exception during test: await FreeIpaTestDto[name: aws-test-fa865a9c43084e57bcf78e0a20fc1d7] for desired statuses DELETE_COMPLETED
javax.ws.rs.NotFoundException: HTTP 404 Not Found
```
**Root cause:**
[integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaTerminationChecker.java: successMessage](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaTerminationChecker.java#L62-L65)
```
    @Override
    public String successMessage(T waitObject) {
        return String.format("'%s' FreeIpa termination successfully finished.", waitObject.getFreeIpaCrn());
    }
```
Here is the `waitObject.getFreeIpaCrn()` causes the issue.

[integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaWaitObject.java:getFreeIpaCrn](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaWaitObject.java#L33-L35)
```
    public String getFreeIpaCrn() {
        return client.getFreeIpaClient().getFreeIpaV1Endpoint().describe(getEnvironmentCrn()).getCrn();
    }
```
this method throws the unhandled `javax.ws.rs.NotFoundException: HTTP 404 Not Found`.

**Solution:**
`getFreeIpaCrn` should be moved out from the `FreeIpaWaitObject`, because of this value is based on the actual state of the service and availability of FreeIPA resources.