### PR TITLE
CB-8310: Fix failure handler for RemoveHostsFromOrchestrationRequest

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/DownscaleFlowEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/DownscaleFlowEvent.java
@@ -6,7 +6,6 @@ import com.sequenceiq.flow.core.FlowEvent;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.cert.RevokeCertsResponse;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.dns.RemoveDnsResponse;
-import com.sequenceiq.freeipa.flow.freeipa.downscale.event.DownscaleFailureEvent;
 import com.sequenceiq.freeipa.flow.freeipa.downscale.event.collecthostnames.CollectAdditionalHostnamesResponse;
 import com.sequenceiq.freeipa.flow.freeipa.downscale.event.removehosts.RemoveHostsFromOrchestrationSuccess;
 import com.sequenceiq.freeipa.flow.freeipa.downscale.event.removeserver.RemoveServersResponse;
@@ -20,7 +19,7 @@ public enum DownscaleFlowEvent implements FlowEvent {
     CLUSTERPROXY_REGISTRATION_FINISHED_EVENT(EventSelectorUtil.selector(ClusterProxyUpdateRegistrationSuccess.class)),
     CLUSTERPROXY_REGISTRATION_FAILED_EVENT(EventSelectorUtil.selector(ClusterProxyUpdateRegistrationFailed.class)),
     DOWNSCALE_COLLECT_ADDITIONAL_HOSTNAMES_FINISHED_EVENT(EventSelectorUtil.selector(CollectAdditionalHostnamesResponse.class)),
-    DOWNSCALE_COLLECT_ADDITIONAL_HOSTNAMES_FAILED_EVENT(EventSelectorUtil.selector(DownscaleFailureEvent.class)),
+    DOWNSCALE_COLLECT_ADDITIONAL_HOSTNAMES_FAILED_EVENT("DOWNSCALE_COLLECT_ADDITIONAL_HOSTNAMES_FAILED_EVENT"),
     DOWNSCALE_ADD_ADDITIONAL_HOSTNAMES_FINISHED_EVENT("DOWNSCALE_ADD_ADDITIONAL_HOSTNAMES_FINISHED_EVENT"),
     STOP_TELEMETRY_FINISHED_EVENT(EventSelectorUtil.selector(StopTelemetryResponse.class)),
     COLLECT_RESOURCES_FINISHED_EVENT(EventSelectorUtil.selector(DownscaleStackCollectResourcesResult.class)),
@@ -35,7 +34,7 @@ public enum DownscaleFlowEvent implements FlowEvent {
     REMOVE_DNS_FAILED_EVENT(EventSelectorUtil.failureSelector(RemoveDnsResponse.class)),
     UPDATE_METADATA_FINISHED_EVENT("UPDATE_METADATA_FINISHED_EVENT"),
     REMOVE_HOSTS_FROM_ORCHESTRATION_FINISHED_EVENT(EventSelectorUtil.selector(RemoveHostsFromOrchestrationSuccess.class)),
-    REMOVE_HOSTS_FROM_ORCHESTRATION_FAILED_EVENT(EventSelectorUtil.selector(DownscaleFailureEvent.class)),
+    REMOVE_HOSTS_FROM_ORCHESTRATION_FAILED_EVENT("REMOVE_HOSTS_FROM_ORCHESTRATION_FAILED_EVENT"),
     DOWNSCALE_FINISHED_EVENT("DOWNSCALE_FINISHED_EVENT"),
     FAILURE_EVENT("DOWNSCALE_FAILURE_EVENT"),
     FAIL_HANDLED_EVENT("DOWNSCALE_FAIL_HANDLED_EVENT");

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/event/DownscaleFailureEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/event/DownscaleFailureEvent.java
@@ -17,7 +17,12 @@ public class DownscaleFailureEvent extends StackEvent {
 
     public DownscaleFailureEvent(Long stackId, String failedPhase, Set<String> success, Map<String, String> failureDetails,
             Exception exception) {
-        super(null, stackId);
+        this(null, stackId, failedPhase, success, failureDetails, exception);
+    }
+
+    public DownscaleFailureEvent(String selector, Long stackId, String failedPhase, Set<String> success, Map<String, String> failureDetails,
+            Exception exception) {
+        super(selector, stackId);
         this.exception = exception;
         this.failedPhase = failedPhase;
         this.success = success;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/handler/CollectAdditionalHostnamesHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/handler/CollectAdditionalHostnamesHandler.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.freeipa.flow.freeipa.downscale.handler;
 
+import static com.sequenceiq.freeipa.flow.freeipa.downscale.DownscaleFlowEvent.DOWNSCALE_COLLECT_ADDITIONAL_HOSTNAMES_FAILED_EVENT;
+
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -31,8 +33,8 @@ public class CollectAdditionalHostnamesHandler extends ExceptionCatcherEventHand
 
     @Override
     protected Selectable defaultFailureEvent(Long resourceId, Exception e) {
-        return new DownscaleFailureEvent(resourceId, "Downscale Collect Additional Hostnames",
-                Set.of(), Map.of(), e);
+        return new DownscaleFailureEvent(DOWNSCALE_COLLECT_ADDITIONAL_HOSTNAMES_FAILED_EVENT.event(),
+                resourceId, "Downscale Collect Additional Hostnames", Set.of(), Map.of(), e);
     }
 
     @Override
@@ -51,8 +53,8 @@ public class CollectAdditionalHostnamesHandler extends ExceptionCatcherEventHand
             result = new CollectAdditionalHostnamesResponse(request.getResourceId(), fqdns);
         } catch (Exception e) {
             LOGGER.error("Collecting additional hostnames failed", e);
-            result = new DownscaleFailureEvent(request.getResourceId(), "Downscale Collect Additional Hostnames",
-                    Set.of(), Map.of(), e);
+            result = new DownscaleFailureEvent(DOWNSCALE_COLLECT_ADDITIONAL_HOSTNAMES_FAILED_EVENT.event(),
+                    request.getResourceId(), "Downscale Collect Additional Hostnames", Set.of(), Map.of(), e);
         }
         return result;
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/handler/RemoveHostsHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/handler/RemoveHostsHandler.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.freeipa.flow.freeipa.downscale.handler;
 
 import static com.sequenceiq.cloudbreak.polling.PollingResult.SUCCESS;
+import static com.sequenceiq.freeipa.flow.freeipa.downscale.DownscaleFlowEvent.REMOVE_HOSTS_FROM_ORCHESTRATION_FAILED_EVENT;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -85,7 +86,8 @@ public class RemoveHostsHandler implements EventHandler<RemoveHostsFromOrchestra
             result = new RemoveHostsFromOrchestrationSuccess(request.getResourceId());
         } catch (Exception e) {
             LOGGER.error("Failed to remove hosts from orchestration", e);
-            result = new DownscaleFailureEvent(request.getResourceId(), "Removing host from orchestration", Set.of(), Map.of(), e);
+            result = new DownscaleFailureEvent(REMOVE_HOSTS_FROM_ORCHESTRATION_FAILED_EVENT.event(),
+                    request.getResourceId(), "Removing host from orchestration", Set.of(), Map.of(), e);
         }
         eventBus.notify(result.selector(), new Event<>(removeHostsRequestEvent.getHeaders(), result));
     }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/freeipa/downscale/handler/RemoveHostsHandlerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/freeipa/downscale/handler/RemoveHostsHandlerTest.java
@@ -87,7 +87,7 @@ class RemoveHostsHandlerTest {
         RemoveHostsFromOrchestrationRequest request = new RemoveHostsFromOrchestrationRequest(cleanupEvent);
         when(stackService.getByIdWithListsInTransaction(any())).thenThrow(new RuntimeException("expected exception"));
         underTest.accept(new Event<>(request));
-        verify(eventBus, times(1)).notify(eq("DOWNSCALEFAILUREEVENT"), ArgumentMatchers.<Event>any());
+        verify(eventBus, times(1)).notify(eq("REMOVE_HOSTS_FROM_ORCHESTRATION_FAILED_EVENT"), ArgumentMatchers.<Event>any());
     }
 
     @Test


### PR DESCRIPTION
The failure handlers' selector was changed to be unique for
RemoveHostsFromOrchestrationRequest and CollectAdditionalHostnamesRequest
so that both failure handlers can be executed.

This was tested by forcing an error and validadting that the failure
handler executed for both flow steps.

See detailed description in the commit message.