### PR TITLE
[CB-8188] Add Medium Duty HA Entitlement enforcement

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
@@ -42,6 +42,9 @@ public class EntitlementService {
     static final String CDP_RAZ = "CDP_RAZ";
 
     @VisibleForTesting
+    static final String CDP_MEDIUM_DUTY_SDX = "CDP_MEDIUM_DUTY_SDX";
+
+    @VisibleForTesting
     static final String CDP_RUNTIME_UPGRADE = "CDP_RUNTIME_UPGRADE";
 
     @VisibleForTesting
@@ -100,6 +103,10 @@ public class EntitlementService {
 
     public boolean razEnabled(String actorCrn, String accountId) {
         return isEntitlementRegistered(actorCrn, accountId, CDP_RAZ);
+    }
+
+    public boolean mediumDutySdxEnabled(String actorCrn, String accountId) {
+        return isEntitlementRegistered(actorCrn, accountId, CDP_MEDIUM_DUTY_SDX);
     }
 
     public boolean runtimeUpgradeEnabled(String actorCrn, String accountId) {

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxServiceTest.java
@@ -694,7 +694,8 @@ class SdxServiceTest {
         when(entitlementService.mediumDutySdxEnabled(anyString(), anyString())).thenReturn(true);
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
                 () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
-        assertEquals("1. Provisioning a Medium Duty SDX shape is only valid for CM version >= 7.2.2 and not " + invalidRuntime, badRequestException.getMessage());
+        assertEquals("1. Provisioning a Medium Duty SDX shape is only valid for CM version >= 7.2.2 and not "
+                + invalidRuntime, badRequestException.getMessage());
     }
 
     @Test
@@ -713,7 +714,8 @@ class SdxServiceTest {
         when(entitlementService.mediumDutySdxEnabled(anyString(), anyString())).thenReturn(true);
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
                 () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
-        assertEquals("1. Provisioning a Medium Duty SDX shape is only valid for CM version >= 7.2.2 and not " + invalidRuntime, badRequestException.getMessage());
+        assertEquals("1. Provisioning a Medium Duty SDX shape is only valid for CM version >= 7.2.2 and not "
+                + invalidRuntime, badRequestException.getMessage());
     }
 
     private void setSpot(SdxClusterRequest sdxClusterRequest) {

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxServiceTest.java
@@ -3,6 +3,7 @@ package com.sequenceiq.datalake.service.sdx;
 import static com.sequenceiq.common.api.type.InstanceGroupType.CORE;
 import static com.sequenceiq.common.api.type.InstanceGroupType.GATEWAY;
 import static com.sequenceiq.sdx.api.model.SdxClusterShape.LIGHT_DUTY;
+import static com.sequenceiq.sdx.api.model.SdxClusterShape.MEDIUM_DUTY_HA;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -602,7 +603,7 @@ class SdxServiceTest {
         when(entitlementService.razEnabled(anyString(), anyString())).thenReturn(true);
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
                 () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
-        assertEquals("1. Provisioning Ranger Raz is only valid for CM version > 7.2.1 and not 7.1.0", badRequestException.getMessage());
+        assertEquals("1. Provisioning Ranger Raz is only valid for CM version >= 7.2.1 and not 7.1.0", badRequestException.getMessage());
     }
 
     @Test
@@ -621,7 +622,98 @@ class SdxServiceTest {
         when(entitlementService.razEnabled(anyString(), anyString())).thenReturn(true);
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
                 () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
-        assertEquals("1. Provisioning Ranger Raz is only valid for CM version > 7.2.1 and not 7.2.0", badRequestException.getMessage());
+        assertEquals("1. Provisioning Ranger Raz is only valid for CM version >= 7.2.1 and not 7.2.0", badRequestException.getMessage());
+    }
+
+    @Test
+    void testSdxCreateMediumDutySdxEnabled() throws IOException, TransactionExecutionException {
+        final String runtime = "7.2.2";
+        when(transactionService.required(isA(Supplier.class))).thenAnswer(invocation -> invocation.getArgument(0, Supplier.class).get());
+        String lightDutyJson = FileReaderUtils.readFileFromClasspath("/runtime/" + runtime + "/aws/medium_duty_ha.json");
+        when(cdpConfigService.getConfigForKey(any())).thenReturn(JsonUtil.readValue(lightDutyJson, StackV4Request.class));
+        when(sdxReactorFlowManager.triggerSdxCreation(any())).thenReturn(new FlowIdentifier(FlowType.FLOW, "FLOW_ID"));
+        SdxClusterRequest sdxClusterRequest = new SdxClusterRequest();
+        sdxClusterRequest.setRuntime(runtime);
+        sdxClusterRequest.setClusterShape(MEDIUM_DUTY_HA);
+        Map<String, String> tags = new HashMap<>();
+        tags.put("mytag", "tagecske");
+        sdxClusterRequest.addTags(tags);
+        sdxClusterRequest.setEnvironment("envir");
+        when(sdxClusterRepository.findByAccountIdAndEnvNameAndDeletedIsNull(anyString(), anyString())).thenReturn(new ArrayList<>());
+        long id = 10L;
+        when(sdxClusterRepository.save(any(SdxCluster.class))).thenAnswer(invocation -> {
+            SdxCluster sdxWithId = invocation.getArgument(0, SdxCluster.class);
+            sdxWithId.setId(id);
+            return sdxWithId;
+        });
+        when(clock.getCurrentTimeMillis()).thenReturn(1L);
+        mockEnvironmentCall(sdxClusterRequest, CloudPlatform.AWS);
+        when(entitlementService.mediumDutySdxEnabled(anyString(), anyString())).thenReturn(true);
+        Pair<SdxCluster, FlowIdentifier> result = underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null);
+        SdxCluster createdSdxCluster = result.getLeft();
+        Assertions.assertEquals(id, createdSdxCluster.getId());
+        final ArgumentCaptor<SdxCluster> captor = ArgumentCaptor.forClass(SdxCluster.class);
+        verify(sdxClusterRepository, times(1)).save(captor.capture());
+        SdxCluster capturedSdx = captor.getValue();
+        assertTrue(capturedSdx.getClusterShape().equals(MEDIUM_DUTY_HA));
+    }
+
+    @Test
+    void testSdxCreateMediumDutySdxNoEntitlement() throws IOException {
+        final String runtime = "7.2.2";
+        SdxClusterRequest sdxClusterRequest = new SdxClusterRequest();
+        sdxClusterRequest.setRuntime(runtime);
+        sdxClusterRequest.setClusterShape(MEDIUM_DUTY_HA);
+        Map<String, String> tags = new HashMap<>();
+        tags.put("mytag", "tagecske");
+        sdxClusterRequest.addTags(tags);
+        sdxClusterRequest.setEnvironment("envir");
+        when(sdxClusterRepository.findByAccountIdAndEnvNameAndDeletedIsNull(anyString(), anyString())).thenReturn(new ArrayList<>());
+        long id = 10L;
+        mockEnvironmentCall(sdxClusterRequest, CloudPlatform.AWS);
+        when(entitlementService.mediumDutySdxEnabled(anyString(), anyString())).thenReturn(false);
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
+        assertEquals("1. Provisioning a medium duty data lake cluster is not enabled for this account. " +
+                "Contact Cloudera support to enable CDP_MEDIUM_DUTY_SDX entitlement for the account.", badRequestException.getMessage());
+    }
+
+    @Test
+    void testSdxCreateMediumDutySdxEnabled710Runtime() {
+        final String invalidRuntime = "7.1.0";
+        SdxClusterRequest sdxClusterRequest = new SdxClusterRequest();
+        sdxClusterRequest.setRuntime(invalidRuntime);
+        sdxClusterRequest.setClusterShape(MEDIUM_DUTY_HA);
+        Map<String, String> tags = new HashMap<>();
+        tags.put("mytag", "tagecske");
+        sdxClusterRequest.addTags(tags);
+        sdxClusterRequest.setEnvironment("envir");
+        when(sdxClusterRepository.findByAccountIdAndEnvNameAndDeletedIsNull(anyString(), anyString())).thenReturn(new ArrayList<>());
+        long id = 10L;
+        mockEnvironmentCall(sdxClusterRequest, CloudPlatform.AWS);
+        when(entitlementService.mediumDutySdxEnabled(anyString(), anyString())).thenReturn(true);
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
+        assertEquals("1. Provisioning a Medium Duty SDX shape is only valid for CM version >= 7.2.2 and not " + invalidRuntime, badRequestException.getMessage());
+    }
+
+    @Test
+    void testSdxCreateMediumDutySdxEnabled720Runtime() {
+        final String invalidRuntime = "7.2.0";
+        SdxClusterRequest sdxClusterRequest = new SdxClusterRequest();
+        sdxClusterRequest.setRuntime(invalidRuntime);
+        sdxClusterRequest.setClusterShape(MEDIUM_DUTY_HA);
+        Map<String, String> tags = new HashMap<>();
+        tags.put("mytag", "tagecske");
+        sdxClusterRequest.addTags(tags);
+        sdxClusterRequest.setEnvironment("envir");
+        when(sdxClusterRepository.findByAccountIdAndEnvNameAndDeletedIsNull(anyString(), anyString())).thenReturn(new ArrayList<>());
+        long id = 10L;
+        mockEnvironmentCall(sdxClusterRequest, CloudPlatform.AWS);
+        when(entitlementService.mediumDutySdxEnabled(anyString(), anyString())).thenReturn(true);
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
+        assertEquals("1. Provisioning a Medium Duty SDX shape is only valid for CM version >= 7.2.2 and not " + invalidRuntime, badRequestException.getMessage());
     }
 
     private void setSpot(SdxClusterRequest sdxClusterRequest) {

--- a/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
+++ b/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
@@ -188,6 +188,8 @@ public class MockUserManagementService extends UserManagementImplBase {
 
     private static final String CDP_RAZ_ENABLEMENT = "CDP_RAZ";
 
+    private static final String CDP_MEDIUM_DUTY_SDX = "CDP_MEDIUM_DUTY_SDX";
+
     private static final String CDP_FREEIPA_DL_EBS_ENCRYPTION = "CDP_FREEIPA_DL_EBS_ENCRYPTION";
 
     private static final String DATAHUB_AWS_AUTOSCALING = "DATAHUB_AWS_AUTOSCALING";
@@ -251,6 +253,9 @@ public class MockUserManagementService extends UserManagementImplBase {
 
     @Value("${auth.mock.raz.enable}")
     private boolean razEnabled;
+
+    @Value("${auth.mock.mediumdutysdx.enable}")
+    private boolean mediumDutySdxEnabled;
 
     @Value("${auth.mock.freeipadlebsencryption.enable}")
     private boolean enableFreeIpaDlEbsEncryption;
@@ -527,6 +532,9 @@ public class MockUserManagementService extends UserManagementImplBase {
         }
         if (razEnabled) {
             builder.addEntitlements(createEntitlement(CDP_RAZ_ENABLEMENT));
+        }
+        if (mediumDutySdxEnabled) {
+            builder.addEntitlements(createEntitlement(CDP_MEDIUM_DUTY_SDX));
         }
         if (enableFreeIpaDlEbsEncryption) {
             builder.addEntitlements(createEntitlement(CDP_FREEIPA_DL_EBS_ENCRYPTION));

--- a/mock-thunderhead/src/main/resources/application.yml
+++ b/mock-thunderhead/src/main/resources/application.yml
@@ -24,3 +24,4 @@ auth:
     azure.single.resourcegroup.enable: false
     fastebsencryption.enable: true
     cloudidentitymappinng.enable: true
+    mediumdutysdx.enable: true


### PR DESCRIPTION
Added medium duty ha entitlement capabilities and tests to SDX cluster creation logic

Implementation inspired by: https://github.com/hortonworks/cloudbreak/commit/a04709441071729e4019c2c487f2f7f0c9ee5fd9 

Flow is as follows:

1. Request comes into cloudbreak via SdxClusterRequest.java with enableMediumDutyHA attribute 
2. Logic in SdxService.java validates that the entitlement is enabled via the EntitlementService.java and that the runtime is greater or equal to 7.2.2 if enableMediumDutyHA is requested - errors out otherwise

Tests added validate the following scenarios:

- Valid request, valid runtime, valid entitlement permissions
- Valid request, valid runtime, invalid entitlement permissions
- Valid request, invalid (7.1.0) runtime, valid entitlement permissions
- Valid request, invalid (7.2.0) runtime, valid entitlement permissions