### PR TITLE
CB-8325 only reject runtime requests if the entitlement is disabled

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxUpgradeController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxUpgradeController.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.datalake.controller.sdx;
 
+import static com.sequenceiq.sdx.api.model.SdxUpgradeShowAvailableImages.LATEST_ONLY;
+import static com.sequenceiq.sdx.api.model.SdxUpgradeShowAvailableImages.SHOW;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 import javax.inject.Inject;
@@ -19,6 +21,7 @@ import com.sequenceiq.datalake.service.upgrade.SdxRuntimeUpgradeService;
 import com.sequenceiq.sdx.api.endpoint.SdxUpgradeEndpoint;
 import com.sequenceiq.sdx.api.model.SdxUpgradeRequest;
 import com.sequenceiq.sdx.api.model.SdxUpgradeResponse;
+import com.sequenceiq.sdx.api.model.SdxUpgradeShowAvailableImages;
 
 @Controller
 @AuthorizationResource
@@ -54,7 +57,8 @@ public class SdxUpgradeController implements SdxUpgradeEndpoint {
     }
 
     private void lockComponentsIfRuntimeUpgradeIsDisabled(SdxUpgradeRequest request, String userCrn, String clusterNameOrCrn) {
-        if (!requestSpecifiesUpgradeType(request) && !sdxRuntimeUpgradeService.isRuntimeUpgradeEnabled(userCrn)) {
+        boolean runtimeUpgradeEnabled = sdxRuntimeUpgradeService.isRuntimeUpgradeEnabled(userCrn);
+        if (!runtimeUpgradeEnabled && (!requestSpecifiesUpgradeType(request) || isShowOnly(request))) {
             LOGGER.info("Set lock-components since no upgrade type is specified and runtime upgrade is disabled for cluster: {}", clusterNameOrCrn);
             request.setLockComponents(true);
         }
@@ -65,6 +69,15 @@ public class SdxUpgradeController implements SdxUpgradeEndpoint {
     }
 
     private boolean isDryRunOnly(SdxUpgradeRequest request) {
-        return request.isDryRun() && isEmpty(request.getRuntime()) && isEmpty(request.getImageId()) && !sdxRuntimeUpgradeService.isOsUpgrade(request);
+        return request.isDryRun() && isRequestTypeEmpty(request);
+    }
+
+    private boolean isRequestTypeEmpty(SdxUpgradeRequest request) {
+        return isEmpty(request.getRuntime()) && isEmpty(request.getImageId()) && !sdxRuntimeUpgradeService.isOsUpgrade(request);
+    }
+
+    private boolean isShowOnly(SdxUpgradeRequest request) {
+        SdxUpgradeShowAvailableImages showOption = request.getShowAvailableImages();
+        return (LATEST_ONLY.equals(showOption) || SHOW.equals(showOption)) && isRequestTypeEmpty(request);
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/SdxRuntimeUpgradeService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/SdxRuntimeUpgradeService.java
@@ -100,7 +100,7 @@ public class SdxRuntimeUpgradeService {
     }
 
     private SdxUpgradeResponse checkForSdxUpgradeResponse(String userCrn, SdxUpgradeRequest upgradeSdxClusterRequest, String clusterName) {
-        verifyRuntimeUpgradeEntitlement(userCrn);
+        verifyRuntimeUpgradeEntitlement(userCrn, upgradeSdxClusterRequest);
         UpgradeV4Response upgradeV4Response = stackV4Endpoint.checkForClusterUpgradeByName(WORKSPACE_ID, clusterName,
                 sdxUpgradeClusterConverter.sdxUpgradeRequestToUpgradeV4Request(upgradeSdxClusterRequest));
         filterSdxUpgradeResponse(upgradeSdxClusterRequest, upgradeV4Response);
@@ -138,8 +138,8 @@ public class SdxRuntimeUpgradeService {
         return new SdxUpgradeResponse(message, flowIdentifier);
     }
 
-    private void verifyRuntimeUpgradeEntitlement(String userCrn) {
-        if (!isRuntimeUpgradeEnabled(userCrn)) {
+    private void verifyRuntimeUpgradeEntitlement(String userCrn, SdxUpgradeRequest upgradeSdxClusterRequest) {
+        if (upgradeSdxClusterRequest != null && !Boolean.TRUE.equals(upgradeSdxClusterRequest.getLockComponents()) && !isRuntimeUpgradeEnabled(userCrn)) {
             throw new BadRequestException("Runtime upgrade feature is not enabled");
         }
     }

--- a/datalake/src/test/java/com/sequenceiq/datalake/controller/sdx/SdxUpgradeControllerTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/controller/sdx/SdxUpgradeControllerTest.java
@@ -2,6 +2,8 @@ package com.sequenceiq.datalake.controller.sdx;
 
 import static com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider.doAs;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
@@ -11,8 +13,11 @@ import static org.mockito.Mockito.when;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -21,6 +26,7 @@ import com.sequenceiq.datalake.controller.exception.BadRequestException;
 import com.sequenceiq.datalake.service.upgrade.SdxRuntimeUpgradeService;
 import com.sequenceiq.sdx.api.model.SdxUpgradeRequest;
 import com.sequenceiq.sdx.api.model.SdxUpgradeResponse;
+import com.sequenceiq.sdx.api.model.SdxUpgradeShowAvailableImages;
 
 @ExtendWith(MockitoExtension.class)
 public class SdxUpgradeControllerTest {
@@ -37,6 +43,9 @@ public class SdxUpgradeControllerTest {
 
     @InjectMocks
     private SdxUpgradeController underTest;
+
+    @Captor
+    private ArgumentCaptor<SdxUpgradeRequest> upgradeRequestArgumentCaptor;
 
     @Test
     public void testUpgradeClusterByNameWhenRequestIsEmptyAndRuntimeIsDisabled() {
@@ -174,6 +183,63 @@ public class SdxUpgradeControllerTest {
 
         verify(sdxRuntimeUpgradeService, times(0)).checkForUpgradeByName(any(), any(), any());
         verify(sdxRuntimeUpgradeService).triggerUpgradeByName(USER_CRN, CLUSTER_NAME, request);
+        assertEquals("No image available to upgrade", response.getReason());
+    }
+
+    @Test
+    @DisplayName("when show images is requested and runtime upgrade is disabled it should set the lock components flag")
+    public void testUpgradeClusterByNameWhenRequestIsShowImagesAndRuntimeIsDisabledShouldSetLockComponent() {
+        when(sdxRuntimeUpgradeService.isRuntimeUpgradeEnabled(USER_CRN)).thenReturn(false);
+        SdxUpgradeRequest request = new SdxUpgradeRequest();
+        request.setShowAvailableImages(SdxUpgradeShowAvailableImages.SHOW);
+
+        SdxUpgradeResponse sdxUpgradeResponse = new SdxUpgradeResponse();
+        sdxUpgradeResponse.setReason("No image available to upgrade");
+        when(sdxRuntimeUpgradeService.checkForUpgradeByName(USER_CRN, CLUSTER_NAME, request)).thenReturn(sdxUpgradeResponse);
+
+        SdxUpgradeResponse response = doAs(USER_CRN, () -> underTest.upgradeClusterByName(CLUSTER_NAME, request));
+
+        verify(sdxRuntimeUpgradeService, times(1)).checkForUpgradeByName(any(), any(), upgradeRequestArgumentCaptor.capture());
+        SdxUpgradeRequest capturedRequest = upgradeRequestArgumentCaptor.getValue();
+        assertTrue(capturedRequest.getLockComponents());
+        assertEquals("No image available to upgrade", response.getReason());
+    }
+
+    @Test
+    @DisplayName("when show latest images is requested and runtime upgrade is disabled it should set the lock components flag")
+    public void testUpgradeClusterByNameWhenRequestIsShowLatestImagesAndRuntimeIsDisabledShouldSetLockComponent() {
+        when(sdxRuntimeUpgradeService.isRuntimeUpgradeEnabled(USER_CRN)).thenReturn(false);
+        SdxUpgradeRequest request = new SdxUpgradeRequest();
+        request.setShowAvailableImages(SdxUpgradeShowAvailableImages.LATEST_ONLY);
+
+        SdxUpgradeResponse sdxUpgradeResponse = new SdxUpgradeResponse();
+        sdxUpgradeResponse.setReason("No image available to upgrade");
+        when(sdxRuntimeUpgradeService.checkForUpgradeByName(USER_CRN, CLUSTER_NAME, request)).thenReturn(sdxUpgradeResponse);
+
+        SdxUpgradeResponse response = doAs(USER_CRN, () -> underTest.upgradeClusterByName(CLUSTER_NAME, request));
+
+        verify(sdxRuntimeUpgradeService, times(1)).checkForUpgradeByName(any(), any(), upgradeRequestArgumentCaptor.capture());
+        SdxUpgradeRequest capturedRequest = upgradeRequestArgumentCaptor.getValue();
+        assertTrue(capturedRequest.getLockComponents());
+        assertEquals("No image available to upgrade", response.getReason());
+    }
+
+    @Test
+    @DisplayName("when show images is requested and runtime upgrade is enabled it should not set the lock components flag")
+    public void testUpgradeClusterByNameWhenRequestIsShowImagesAndRuntimeIsDisabledShouldNotSetLockComponent() {
+        when(sdxRuntimeUpgradeService.isRuntimeUpgradeEnabled(USER_CRN)).thenReturn(true);
+        SdxUpgradeRequest request = new SdxUpgradeRequest();
+        request.setShowAvailableImages(SdxUpgradeShowAvailableImages.SHOW);
+
+        SdxUpgradeResponse sdxUpgradeResponse = new SdxUpgradeResponse();
+        sdxUpgradeResponse.setReason("No image available to upgrade");
+        when(sdxRuntimeUpgradeService.checkForUpgradeByName(USER_CRN, CLUSTER_NAME, request)).thenReturn(sdxUpgradeResponse);
+
+        SdxUpgradeResponse response = doAs(USER_CRN, () -> underTest.upgradeClusterByName(CLUSTER_NAME, request));
+
+        verify(sdxRuntimeUpgradeService, times(1)).checkForUpgradeByName(any(), any(), upgradeRequestArgumentCaptor.capture());
+        SdxUpgradeRequest capturedRequest = upgradeRequestArgumentCaptor.getValue();
+        assertNull(capturedRequest.getLockComponents());
         assertEquals("No image available to upgrade", response.getReason());
     }
 }

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/upgrade/SdxRuntimeUpgradeServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/upgrade/SdxRuntimeUpgradeServiceTest.java
@@ -216,7 +216,6 @@ public class SdxRuntimeUpgradeServiceTest {
         when(sdxService.getByCrn(anyString(), anyString())).thenReturn(sdxCluster);
         when(stackV4Endpoint.checkForClusterUpgradeByName(anyLong(), anyString(), any())).thenReturn(response);
         when(sdxUpgradeClusterConverter.upgradeResponseToSdxUpgradeResponse(response)).thenReturn(sdxUpgradeResponse);
-        when(entitlementService.runtimeUpgradeEnabled(any(), any())).thenReturn(true);
 
         ImageInfoV4Response imageInfo = new ImageInfoV4Response();
         imageInfo.setImageId(IMAGE_ID);
@@ -241,7 +240,6 @@ public class SdxRuntimeUpgradeServiceTest {
         when(sdxService.getByCrn(anyString(), anyString())).thenReturn(sdxCluster);
         when(stackV4Endpoint.checkForClusterUpgradeByName(anyLong(), anyString(), any())).thenReturn(response);
         when(sdxUpgradeClusterConverter.upgradeResponseToSdxUpgradeResponse(response)).thenReturn(sdxUpgradeResponse);
-        when(entitlementService.runtimeUpgradeEnabled(any(), any())).thenReturn(true);
 
         ImageInfoV4Response imageInfo = new ImageInfoV4Response();
         imageInfo.setImageId(IMAGE_ID);


### PR DESCRIPTION
When the Runtime upgrade entitlement is disabled and the SDX upgrade
request does not specify the type of the upgrade we should assume
OS upgrade. In this case the request should be accepted and treated
like OS upgrade. In case the entitlement is enabled we check for both
OS and Runtime images for upgrade candidate. If the user specifies
the --runtime flag and the entitlement is disabled the request should
be rejected.

When the Runtime upgrade is disabled and the show-all or show-latest-by-runtime is invoked
it should lock the components and treat it like an OS upgrade.