### PR TITLE
ENGESC-3405 Fix mpack validation issue for urls behind paywall

### DIFF
--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/common/OpenStackImageImporter.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/common/OpenStackImageImporter.java
@@ -33,7 +33,7 @@ public class OpenStackImageImporter {
 
         String importLocation = openStackImageImportTaskParameters.getImportLocation(name);
         LOGGER.info("Import OpenStack image from: {}", importLocation);
-        if (!urlAccessValidationService.isAccessible(importLocation)) {
+        if (!urlAccessValidationService.isAccessible(importLocation, null)) {
             throw new CloudConnectorException(String.format("OpenStack image '%s' is not accessible, therefore it cannot be imported automatically",
                     importLocation));
         }

--- a/cloud-openstack/src/test/java/com/sequenceiq/cloudbreak/cloud/openstack/common/OpenStackImageImageImporterTest.java
+++ b/cloud-openstack/src/test/java/com/sequenceiq/cloudbreak/cloud/openstack/common/OpenStackImageImageImporterTest.java
@@ -48,7 +48,7 @@ public class OpenStackImageImageImporterTest {
         when(osClient.imagesV2()).thenReturn(imageService);
         when(imageService.tasks()).thenReturn(taskService);
 
-        when(urlAccessValidationService.isAccessible("https://myimage.img")).thenReturn(true);
+        when(urlAccessValidationService.isAccessible("https://myimage.img", null)).thenReturn(true);
         when(openStackImageImportTaskParameters.getImportLocation("myimage")).thenReturn("https://myimage.img");
         when(openStackImageImportTaskParameters.buildInput(any())).thenReturn(new HashMap<>());
     }
@@ -64,7 +64,7 @@ public class OpenStackImageImageImporterTest {
     @Test(expected = CloudConnectorException.class)
     public void testImportNotExsist() {
         try {
-            when(urlAccessValidationService.isAccessible("https://not-exist.img")).thenReturn(false);
+            when(urlAccessValidationService.isAccessible("https://not-exist.img", null)).thenReturn(false);
             when(openStackImageImportTaskParameters.getImportLocation("not-exist")).thenReturn("https://not-exist.img");
             underTest.importImage(osClient, "not-exist");
         } catch (CloudConnectorException e) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/ManagementPackDetailsToManagementPackComponentConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/ManagementPackDetailsToManagementPackComponentConverter.java
@@ -14,6 +14,7 @@ import com.sequenceiq.cloudbreak.domain.ManagementPack;
 import com.sequenceiq.cloudbreak.domain.workspace.Workspace;
 import com.sequenceiq.cloudbreak.domain.workspace.User;
 import com.sequenceiq.cloudbreak.service.RestRequestThreadLocalService;
+import com.sequenceiq.cloudbreak.service.credential.PaywallCredentialService;
 import com.sequenceiq.cloudbreak.service.mpack.ManagementPackService;
 import com.sequenceiq.cloudbreak.service.workspace.WorkspaceService;
 import com.sequenceiq.cloudbreak.service.user.UserService;
@@ -33,6 +34,9 @@ public class ManagementPackDetailsToManagementPackComponentConverter
     @Inject
     private RestRequestThreadLocalService restRequestThreadLocalService;
 
+    @Inject
+    private PaywallCredentialService paywallCredentialService;
+
     @Override
     public ManagementPackComponent convert(ManagementPackDetails source) {
         ManagementPackComponent mpack = new ManagementPackComponent();
@@ -41,7 +45,7 @@ public class ManagementPackDetailsToManagementPackComponentConverter
             Workspace workspace = workspaceService.get(restRequestThreadLocalService.getRequestedWorkspaceId(), user);
             ManagementPack dmpack = managementPackService.getByNameForWorkspace(source.getName(), workspace);
             mpack.setName(source.getName());
-            mpack.setMpackUrl(dmpack.getMpackUrl());
+            mpack.setMpackUrl(getMpackUrl(dmpack.getMpackUrl()));
             mpack.setStackDefault(false);
             mpack.setPreInstalled(false);
             mpack.setForce(dmpack.isForce());
@@ -53,5 +57,11 @@ public class ManagementPackDetailsToManagementPackComponentConverter
             throw new BadRequestException("Mpack name cannot be empty!");
         }
         return mpack;
+    }
+
+    private String getMpackUrl(String url) {
+        return paywallCredentialService.paywallCredentialAvailable()
+                ? paywallCredentialService.addCredentialForUrl(url)
+                : url;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v2/cli/StackRepoDetailsToStackRepoDetailsJsonConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v2/cli/StackRepoDetailsToStackRepoDetailsJsonConverter.java
@@ -17,6 +17,7 @@ import com.sequenceiq.cloudbreak.api.model.mpack.ManagementPackDetails;
 import com.sequenceiq.cloudbreak.cloud.model.component.ManagementPackComponent;
 import com.sequenceiq.cloudbreak.cloud.model.component.StackRepoDetails;
 import com.sequenceiq.cloudbreak.converter.AbstractConversionServiceAwareConverter;
+import com.sequenceiq.cloudbreak.service.credential.PaywallCredentialService;
 
 @Component
 public class StackRepoDetailsToStackRepoDetailsJsonConverter
@@ -34,6 +35,9 @@ public class StackRepoDetailsToStackRepoDetailsJsonConverter
 
     @Inject
     private ConversionService conversionService;
+
+    @Inject
+    private PaywallCredentialService paywallCredentialService;
 
     @Override
     public AmbariStackDetailsJson convert(StackRepoDetails source) {
@@ -78,8 +82,14 @@ public class StackRepoDetailsToStackRepoDetailsJsonConverter
                     mp, ManagementPackDetails.class)).collect(Collectors.toList());
             ambariStackDetailsJson.setMpacks(mpacks);
             Optional<ManagementPackComponent> stackDefaultMpack = source.getMpacks().stream().filter(ManagementPackComponent::isStackDefault).findFirst();
-            stackDefaultMpack.ifPresent(mp -> ambariStackDetailsJson.setMpackUrl(mp.getMpackUrl()));
+            stackDefaultMpack.ifPresent(mp -> ambariStackDetailsJson.setMpackUrl(getMpackUrl(mp.getMpackUrl())));
         }
         return ambariStackDetailsJson;
+    }
+
+    private String getMpackUrl(String url) {
+        return paywallCredentialService.paywallCredentialAvailable()
+                ? paywallCredentialService.addCredentialForUrl(url)
+                : url;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/credential/PaywallCredentialService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/credential/PaywallCredentialService.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.service.credential;
 
 import static java.util.Collections.singletonMap;
 
+import java.util.Base64;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -45,6 +46,10 @@ public class PaywallCredentialService {
 
     public void getPaywallCredential(Map<String, SaltPillarProperties> servicePillar) {
         servicePillar.put("paywall", new SaltPillarProperties("/hdp/paywall.sls", singletonMap("paywall", createCredential())));
+    }
+
+    public String getBasicAuthorizationEncoded() {
+        return Base64.getEncoder().encodeToString(String.format("%s:%s", paywallUserName, paywallPassword).getBytes());
     }
 
     private Map<String, String> createCredential() {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/mpack/ManagementPackCreationValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/mpack/ManagementPackCreationValidatorTest.java
@@ -4,6 +4,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import javax.ws.rs.client.Client;
@@ -12,6 +17,7 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 
 import org.hamcrest.CoreMatchers;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -21,6 +27,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import com.sequenceiq.cloudbreak.controller.validation.ValidationResult;
 import com.sequenceiq.cloudbreak.domain.ManagementPack;
+import com.sequenceiq.cloudbreak.service.credential.PaywallCredentialService;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ManagementPackCreationValidatorTest {
@@ -30,8 +37,16 @@ public class ManagementPackCreationValidatorTest {
     @Mock
     private Client client;
 
+    @Mock
+    private PaywallCredentialService paywallCredentialService;
+
     @InjectMocks
     private ManagementPackCreationValidator underTest;
+
+    @Before
+    public void setUp() {
+        when(paywallCredentialService.paywallCredentialAvailable()).thenReturn(false);
+    }
 
     @Test
     public void testWithInvalidMediaType() {
@@ -68,6 +83,23 @@ public class ManagementPackCreationValidatorTest {
             managementPack.setMpackUrl("url");
             ValidationResult validationResult = underTest.validate(managementPack);
             assertFalse(subType, validationResult.hasError());
+            verify(webTargetRequest, never()).header(eq("Authorization"), anyString());
+        }
+    }
+
+    @Test
+    public void testPaywallAuthorization() {
+        WebTarget webTarget = Mockito.mock(WebTarget.class);
+        Builder webTargetRequest = Mockito.mock(Builder.class);
+        when(webTarget.request()).thenReturn(webTargetRequest);
+        when(client.target(anyString())).thenReturn(webTarget);
+        when(paywallCredentialService.paywallCredentialAvailable()).thenReturn(true);
+        try (Response response = Response.ok().header("Content-Type", "application/octet-stream").build()) {
+            when(webTargetRequest.head()).thenReturn(response);
+            ManagementPack managementPack = new ManagementPack();
+            managementPack.setMpackUrl("url");
+            ValidationResult validationResult = underTest.validate(managementPack);
+            verify(webTargetRequest, times(1)).header(eq("Authorization"), startsWith("Basic"));
         }
     }
 


### PR DESCRIPTION
Neither on the fly validation on the UI upon entering (or changing) the
mpack URL, nor for the check upon registration did not send the basic
authorization header with the request thus getting a HTTP 401.
This had to be fixed in 2 places.