### PR TITLE
CB-8311 - Ranger authorizer should be enabled for datahub clusters

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -295,7 +295,6 @@
              {%- endif %}
              {% if 'HUE' in exposed and 'HUE_LOAD_BALANCER' in salt['pillar.get']('gateway:location') -%}
              <param>
-             <param>
                  <name>HUE</name>
                  <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
              </param>

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -15,15 +15,9 @@
            </param>
         </provider>
 
-{%- if 'RANGER' in exposed and 'RANGER_ADMIN' in salt['pillar.get']('gateway:location') -%}
-    {% set ranger_installed = True %}
-    {%- if salt['pillar.get']('gateway:enable_knox_ranger_authorizer') == True -%}
-        {% set aclsauthz_prefix = 'AclsAuthz.' %}
-    {%- else -%}
-        {% set aclsauthz_prefix = '' %}
-    {%- endif -%}
+{%- if salt['pillar.get']('gateway:enable_knox_ranger_authorizer') == True -%}
+    {% set aclsauthz_prefix = 'AclsAuthz.' %}
 {%- else -%}
-    {% set ranger_installed = False %}
     {% set aclsauthz_prefix = '' %}
 {%- endif -%}
 
@@ -38,7 +32,7 @@
         </param>
     </provider>
     <provider>
-    {%- if ranger_installed == True and salt['pillar.get']('gateway:enable_knox_ranger_authorizer') == True %}
+    {%- if salt['pillar.get']('gateway:enable_knox_ranger_authorizer') == True %}
              <role>authorization</role>
              <name>CompositeAuthz</name>
              <enabled>true</enabled>
@@ -300,6 +294,7 @@
              </param>
              {%- endif %}
              {% if 'HUE' in exposed and 'HUE_LOAD_BALANCER' in salt['pillar.get']('gateway:location') -%}
+             <param>
              <param>
                  <name>HUE</name>
                  <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
@@ -25,15 +25,9 @@
            </param>
         </provider>
 
-{%- if 'RANGER' in exposed and 'RANGER_ADMIN' in salt['pillar.get']('gateway:location') -%}
-    {% set ranger_installed = True %}
-    {%- if salt['pillar.get']('gateway:enable_knox_ranger_authorizer') == True -%}
-        {% set aclsauthz_prefix = 'AclsAuthz.' %}
-    {%- else -%}
-        {% set aclsauthz_prefix = '' %}
-    {%- endif -%}
+{%- if salt['pillar.get']('gateway:enable_knox_ranger_authorizer') == True -%}
+    {% set aclsauthz_prefix = 'AclsAuthz.' %}
 {%- else -%}
-    {% set ranger_installed = False %}
     {% set aclsauthz_prefix = '' %}
 {%- endif -%}
 
@@ -48,7 +42,7 @@
             </param>
         </provider>
         <provider>
-        {%- if ranger_installed == True and salt['pillar.get']('gateway:enable_knox_ranger_authorizer') == True %}
+        {%- if salt['pillar.get']('gateway:enable_knox_ranger_authorizer') == True %}
             <role>authorization</role>
             <name>CompositeAuthz</name>
             <enabled>true</enabled>


### PR DESCRIPTION
**Describe the change you are making here!**
CB-5949 Adds ranger authorization support for requests flowing through Knox. This only works for SDX cluster and not for DistroX clusters. This is because the logic to enable ranger authorizer checks if Ranger is installed and ranger is not installed on DistroX clusters but rather installed in SDX cluster. This PR proposes eliminating condition that checks whether ranger is installed on the cluster. By default all public cloud clusters have Ranger installed so this change will not affect any functionality.

**Testing**
This patch was locally tested (tested to see that the topology file is generated correctly)