### PR TITLE
CB-8342 Cluster product components should not come from DefaultCDHInfo

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/ClouderaManagerClusterCreationSetupService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/ClouderaManagerClusterCreationSetupService.java
@@ -123,10 +123,6 @@ public class ClouderaManagerClusterCreationSetupService {
             Set<ClouderaManagerProduct> filteredProducts = determineCdhRepoConfig(cluster, stackCdhRepoConfig, osType,
                     blueprintCdhVersion, imageCatalogName);
             components.addAll(convertParcelsToClusterComponents(cluster, filteredProducts));
-        } else if (isCdhParcelOnly(products)) {
-            Set<ClouderaManagerProduct> filteredProducts = addDefaultProducts(cluster, blueprintCdhVersion, osType,
-                    cluster.getStack().getCloudPlatform(), imageCatalogName);
-            components.addAll(convertParcelsToClusterComponents(cluster, filteredProducts));
         }
         if (isCdhParcelMissing(products, components)) {
             throw new BadRequestException("CDH parcel is missing from the cluster. "
@@ -226,10 +222,6 @@ public class ClouderaManagerClusterCreationSetupService {
         return defaultCDHInfo;
     }
 
-    private boolean isCdhParcelOnly(List<ClouderaManagerProductV4Request> products) {
-        return products.size() == 1 && CDH.equals(products.get(0).getName());
-    }
-
     private boolean isCdhParcelMissing(List<ClouderaManagerProductV4Request> products, List<ClusterComponent> components) {
         boolean missingFromProducts = products.stream()
                 .noneMatch(product -> CDH.equals(product.getName()));
@@ -240,19 +232,5 @@ public class ClouderaManagerClusterCreationSetupService {
                 .noneMatch(product -> CDH.equals(product.getName()));
 
         return missingFromProducts && missingFromComponents;
-    }
-
-    private Set<ClouderaManagerProduct>  addDefaultProducts(Cluster cluster, String blueprintCdhVersion, String osType, String cloudPlatform,
-            String imageCatalogName) throws CloudbreakImageCatalogException {
-        DefaultCDHInfo defaultCDHInfo = getDefaultCDHInfo(cluster.getWorkspace().getId(), blueprintCdhVersion, osType, cloudPlatform, imageCatalogName);
-        Set<ClouderaManagerProduct> filteredProducts = new HashSet<>();
-        if (defaultCDHInfo != null) {
-            filteredProducts = parcelService.filterParcelsByBlueprint(Sets.newHashSet(defaultCDHInfo.getParcels()), cluster.getBlueprint());
-            if (CollectionUtils.isNotEmpty(filteredProducts)) {
-                LOGGER.info("Adding default products to CDH cluster with name '{}'.", cluster.getName());
-                return filteredProducts;
-            }
-        }
-        return filteredProducts;
     }
 }


### PR DESCRIPTION
DefaultCDHInfo was filled out with parcels in 2.18 last time from the application.yml. Parcel configurations got removed in 2.19 but the related java code remained in the codebase. As a part of CB-7647 parcels got filled out again in the DefaultCDHInfo based on the latest greatest prewarmed image - it was necessary for the stack matrix - but the remained parcel fillup caused that cluster product components are coming from the DefaultCDHInfo. As a part of this PR I'm simply remove the DefaultCDHInfo based product fill-up as it was a dead code since 2.19.