### PR TITLE
CB-8329: Fix DNS forwarding on FreeIPA replicas

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_install.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_install.sh
@@ -5,6 +5,11 @@ set -e
 FQDN=$(hostname -f)
 IPADDR=$(hostname -i)
 
+if [ ! -f /etc/resolv.conf.orig ]; then
+  cp /etc/resolv.conf /etc/resolv.conf.orig
+fi
+FORWARDERS=$(grep -Ev '^#|^;' /etc/resolv.conf.orig | grep nameserver | awk '{print "--forwarder " $2}');
+
 ipa-server-install --unattended --uninstall
 
 ipa-server-install \
@@ -21,8 +26,8 @@ ipa-server-install \
           --allow-zone-overlap \
           --ssh-trust-dns \
           --mkhomedir \
-          --ip-address $IPADDR \
-          --auto-forwarders \
+          --ip-address "$IPADDR" \
+          $FORWARDERS \
 {%- if not salt['pillar.get']('freeipa:dnssecValidationEnabled') %}
           --no-dnssec-validation \
 {%- endif %}

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_replica_install.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_replica_install.sh
@@ -5,6 +5,11 @@ set -e
 FQDN=$(hostname -f)
 IPADDR=$(hostname -i)
 
+if [ ! -f /etc/resolv.conf.orig ]; then
+  cp /etc/resolv.conf /etc/resolv.conf.orig
+fi
+FORWARDERS=$(grep -Ev '^#|^;' /etc/resolv.conf.orig | grep nameserver | awk '{print "--forwarder " $2}');
+
 install -m644 /etc/resolv.conf.install /etc/resolv.conf
 
 ipa-server-install --unattended --uninstall
@@ -33,7 +38,7 @@ ipa-replica-install \
           --ssh-trust-dns \
           --mkhomedir \
           --ip-address "$IPADDR" \
-          --auto-forwarders \
+          $FORWARDERS \
           --force-join \
 {%- if not salt['pillar.get']('freeipa:dnssecValidationEnabled') %}
           --no-dnssec-validation \


### PR DESCRIPTION
Fixed the DNS forwarding to use the DNS server provided by the
original DHCP lease rather than pointing to the master which points to
the one from the cloud provider.

Use the same logic for the master too eventhough it didn't matter.

This was validated by deploying a FreeIPA HA cluster with a local
cloudbreak deployment and validating the dns forwarder settting in
LDAP.

See detailed description in the commit message.