### PR TITLE
CB-8274: Re-write ranger admin group in ranger policies.

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/BackupRestoreSaltConfigGenerator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/BackupRestoreSaltConfigGenerator.java
@@ -26,7 +26,7 @@ public class BackupRestoreSaltConfigGenerator {
 
     public static final String AWS_REGION_KEY = "aws_region";
 
-    public static final String RANGER_ADMIN_GROUP = "ranger_admin_group";
+    public static final String RANGER_ADMIN_GROUP_KEY = "ranger_admin_group";
 
     public SaltConfig createSaltConfig(String location, String backupId, String rangerAdminGroup, Stack stack) throws URISyntaxException {
         String fullLocation = buildFullLocation(location, backupId, stack.getCloudPlatform());
@@ -36,7 +36,7 @@ public class BackupRestoreSaltConfigGenerator {
         Map<String, String> disasterRecoveryValues = new HashMap<>();
         disasterRecoveryValues.put(OBJECT_STORAGE_URL_KEY, fullLocation);
         disasterRecoveryValues.put(AWS_REGION_KEY, stack.getRegion());
-        disasterRecoveryValues.put(RANGER_ADMIN_GROUP, rangerAdminGroup);
+        disasterRecoveryValues.put(RANGER_ADMIN_GROUP_KEY, rangerAdminGroup);
 
         servicePillar.put("disaster-recovery", new SaltPillarProperties(POSTGRESQL_DISASTER_RECOVERY_PILLAR_PATH,
             singletonMap(DISASTER_RECOVERY_KEY, disasterRecoveryValues)));

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/BackupRestoreSaltConfigGenerator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/BackupRestoreSaltConfigGenerator.java
@@ -2,12 +2,7 @@ package com.sequenceiq.cloudbreak.reactor.handler.cluster.dr;
 
 import static com.sequenceiq.cloudbreak.common.type.CloudConstants.AWS;
 import static com.sequenceiq.cloudbreak.common.type.CloudConstants.AZURE;
-
 import static java.util.Collections.singletonMap;
-
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
-import com.sequenceiq.cloudbreak.orchestrator.model.SaltConfig;
-import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -15,6 +10,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.orchestrator.model.SaltConfig;
+import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
 
 @Component
 public class BackupRestoreSaltConfigGenerator {
@@ -27,7 +26,9 @@ public class BackupRestoreSaltConfigGenerator {
 
     public static final String AWS_REGION_KEY = "aws_region";
 
-    public SaltConfig createSaltConfig(String location, String backupId, Stack stack) throws URISyntaxException {
+    public static final String RANGER_ADMIN_GROUP = "ranger_admin_group";
+
+    public SaltConfig createSaltConfig(String location, String backupId, String rangerAdminGroup, Stack stack) throws URISyntaxException {
         String fullLocation = buildFullLocation(location, backupId, stack.getCloudPlatform());
 
         Map<String, SaltPillarProperties> servicePillar = new HashMap<>();
@@ -35,6 +36,7 @@ public class BackupRestoreSaltConfigGenerator {
         Map<String, String> disasterRecoveryValues = new HashMap<>();
         disasterRecoveryValues.put(OBJECT_STORAGE_URL_KEY, fullLocation);
         disasterRecoveryValues.put(AWS_REGION_KEY, stack.getRegion());
+        disasterRecoveryValues.put(RANGER_ADMIN_GROUP, rangerAdminGroup);
 
         servicePillar.put("disaster-recovery", new SaltPillarProperties(POSTGRESQL_DISASTER_RECOVERY_PILLAR_PATH,
             singletonMap(DISASTER_RECOVERY_KEY, disasterRecoveryValues)));

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/RangerVirtualGroupService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/RangerVirtualGroupService.java
@@ -1,0 +1,42 @@
+package com.sequenceiq.cloudbreak.reactor.handler.cluster.dr;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.auth.altus.UmsRight;
+import com.sequenceiq.cloudbreak.auth.altus.VirtualGroupRequest;
+import com.sequenceiq.cloudbreak.auth.altus.VirtualGroupService;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.dto.LdapView;
+import com.sequenceiq.cloudbreak.ldap.LdapConfigService;
+import com.sequenceiq.cloudbreak.service.environment.EnvironmentConfigProvider;
+
+@Service
+public class RangerVirtualGroupService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RangerVirtualGroupService.class);
+
+    @Inject
+    private VirtualGroupService virtualGroupService;
+
+    @Inject
+    private LdapConfigService ldapConfigService;
+
+    @Inject
+    private EnvironmentConfigProvider environmentConfigProvider;
+
+    public String getRangerVirtualGroup(Stack stack) {
+        Optional<LdapView> ldapView = ldapConfigService.get(stack.getEnvironmentCrn(), stack.getName());
+        String virtualGroupsEnvironmentCrn = environmentConfigProvider.getParentEnvironmentCrn(stack.getEnvironmentCrn());
+        String adminGroup = ldapView.orElseThrow(() -> new CloudbreakServiceException("Ranger admin group not found."))
+                .getAdminGroup();
+        LOGGER.debug("Admin Group:", adminGroup);
+        VirtualGroupRequest virtualGroupRequest = new VirtualGroupRequest(virtualGroupsEnvironmentCrn, adminGroup);
+        return virtualGroupService.getVirtualGroup(virtualGroupRequest, UmsRight.RANGER_ADMIN.getRight());
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/backup/DatabaseBackupHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/backup/DatabaseBackupHandler.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.cloudbreak.reactor.handler.cluster.dr.backup;
 
 import java.util.Collections;
-import java.util.Optional;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -11,17 +10,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
-import com.sequenceiq.cloudbreak.auth.altus.UmsRight;
-import com.sequenceiq.cloudbreak.auth.altus.VirtualGroupRequest;
-import com.sequenceiq.cloudbreak.auth.altus.VirtualGroupService;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
-import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterDeletionBasedExitCriteriaModel;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
-import com.sequenceiq.cloudbreak.dto.LdapView;
-import com.sequenceiq.cloudbreak.ldap.LdapConfigService;
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.orchestrator.model.SaltConfig;
@@ -30,8 +23,8 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.dr.backup.DatabaseBac
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.dr.backup.DatabaseBackupRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.dr.backup.DatabaseBackupSuccess;
 import com.sequenceiq.cloudbreak.reactor.handler.cluster.dr.BackupRestoreSaltConfigGenerator;
+import com.sequenceiq.cloudbreak.reactor.handler.cluster.dr.RangerVirtualGroupService;
 import com.sequenceiq.cloudbreak.service.GatewayConfigService;
-import com.sequenceiq.cloudbreak.service.environment.EnvironmentConfigProvider;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.util.StackUtil;
 import com.sequenceiq.flow.event.EventSelectorUtil;
@@ -57,13 +50,7 @@ public class DatabaseBackupHandler extends ExceptionCatcherEventHandler<Database
     private StackUtil stackUtil;
 
     @Inject
-    private VirtualGroupService virtualGroupService;
-
-    @Inject
-    private LdapConfigService ldapConfigService;
-
-    @Inject
-    private EnvironmentConfigProvider environmentConfigProvider;
+    private RangerVirtualGroupService rangerVirtualGroupService;
 
     @Override
     public String selector() {
@@ -88,13 +75,7 @@ public class DatabaseBackupHandler extends ExceptionCatcherEventHandler<Database
             GatewayConfig gatewayConfig = gatewayConfigService.getGatewayConfig(stack, gatewayInstance, cluster.hasGateway());
             Set<String> gatewayFQDN = Collections.singleton(gatewayInstance.getDiscoveryFQDN());
             ExitCriteriaModel exitModel = ClusterDeletionBasedExitCriteriaModel.clusterDeletionBasedModel(stackId, cluster.getId());
-            Optional<LdapView> ldapView = ldapConfigService.get(stack.getEnvironmentCrn(), stack.getName());
-            String virtualGroupsEnvironmentCrn = environmentConfigProvider.getParentEnvironmentCrn(stack.getEnvironmentCrn());
-            String adminGroup = ldapView.orElseThrow(() -> new CloudbreakServiceException("Ranger admin group not found."))
-                    .getAdminGroup();
-            LOGGER.error("Admin Group:", adminGroup);
-            VirtualGroupRequest virtualGroupRequest = new VirtualGroupRequest(virtualGroupsEnvironmentCrn, adminGroup);
-            String rangerAdminGroup = virtualGroupService.getVirtualGroup(virtualGroupRequest, UmsRight.RANGER_ADMIN.getRight());
+            String rangerAdminGroup = rangerVirtualGroupService.getRangerVirtualGroup(stack);
             SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(request.getBackupLocation(), request.getBackupId(), rangerAdminGroup, stack);
             hostOrchestrator.backupDatabase(gatewayConfig, gatewayFQDN, stackUtil.collectReachableNodes(stack), saltConfig, exitModel);
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/BackupRestoreSaltConfigGeneratorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/BackupRestoreSaltConfigGeneratorTest.java
@@ -3,20 +3,21 @@ package com.sequenceiq.cloudbreak.reactor.handler.cluster.dr;
 import static com.sequenceiq.cloudbreak.reactor.handler.cluster.dr.BackupRestoreSaltConfigGenerator.AWS_REGION_KEY;
 import static com.sequenceiq.cloudbreak.reactor.handler.cluster.dr.BackupRestoreSaltConfigGenerator.DISASTER_RECOVERY_KEY;
 import static com.sequenceiq.cloudbreak.reactor.handler.cluster.dr.BackupRestoreSaltConfigGenerator.OBJECT_STORAGE_URL_KEY;
+import static com.sequenceiq.cloudbreak.reactor.handler.cluster.dr.BackupRestoreSaltConfigGenerator.RANGER_ADMIN_GROUP;
 import static org.junit.Assert.assertEquals;
-
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
 
 import java.net.URISyntaxException;
 import java.util.Map;
 
 import javax.inject.Inject;
 
-import com.sequenceiq.cloudbreak.orchestrator.model.SaltConfig;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.orchestrator.model.SaltConfig;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = {BackupRestoreSaltConfigGenerator.class})
@@ -33,16 +34,18 @@ public class BackupRestoreSaltConfigGeneratorTest {
     public void testCreateSaltConfig() throws URISyntaxException {
         String cloudPlatform = "aws";
         String location = "/test/backups";
+        String rangerAdminGroup = "ranger-admin";
         Stack placeholderStack = new Stack();
         placeholderStack.setCloudPlatform(cloudPlatform);
         placeholderStack.setRegion(US_WEST_2);
 
-        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, placeholderStack);
+        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, rangerAdminGroup, placeholderStack);
 
         Map<String, Object> disasterRecoveryProperties = saltConfig.getServicePillarConfig().get("disaster-recovery").getProperties();
         Map<String, String> disasterRecoveryKeyValuePairs = (Map<String, String>) disasterRecoveryProperties.get(DISASTER_RECOVERY_KEY);
 
         assertEquals("s3://test/backups/backupId_database_backup", disasterRecoveryKeyValuePairs.get(OBJECT_STORAGE_URL_KEY));
         assertEquals(US_WEST_2, disasterRecoveryKeyValuePairs.get(AWS_REGION_KEY));
+        assertEquals(rangerAdminGroup, disasterRecoveryKeyValuePairs.get(RANGER_ADMIN_GROUP));
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/BackupRestoreSaltConfigGeneratorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/BackupRestoreSaltConfigGeneratorTest.java
@@ -3,7 +3,7 @@ package com.sequenceiq.cloudbreak.reactor.handler.cluster.dr;
 import static com.sequenceiq.cloudbreak.reactor.handler.cluster.dr.BackupRestoreSaltConfigGenerator.AWS_REGION_KEY;
 import static com.sequenceiq.cloudbreak.reactor.handler.cluster.dr.BackupRestoreSaltConfigGenerator.DISASTER_RECOVERY_KEY;
 import static com.sequenceiq.cloudbreak.reactor.handler.cluster.dr.BackupRestoreSaltConfigGenerator.OBJECT_STORAGE_URL_KEY;
-import static com.sequenceiq.cloudbreak.reactor.handler.cluster.dr.BackupRestoreSaltConfigGenerator.RANGER_ADMIN_GROUP;
+import static com.sequenceiq.cloudbreak.reactor.handler.cluster.dr.BackupRestoreSaltConfigGenerator.RANGER_ADMIN_GROUP_KEY;
 import static org.junit.Assert.assertEquals;
 
 import java.net.URISyntaxException;
@@ -46,6 +46,6 @@ public class BackupRestoreSaltConfigGeneratorTest {
 
         assertEquals("s3://test/backups/backupId_database_backup", disasterRecoveryKeyValuePairs.get(OBJECT_STORAGE_URL_KEY));
         assertEquals(US_WEST_2, disasterRecoveryKeyValuePairs.get(AWS_REGION_KEY));
-        assertEquals(rangerAdminGroup, disasterRecoveryKeyValuePairs.get(RANGER_ADMIN_GROUP));
+        assertEquals(rangerAdminGroup, disasterRecoveryKeyValuePairs.get(RANGER_ADMIN_GROUP_KEY));
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/RangerVirtualGroupServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/RangerVirtualGroupServiceTest.java
@@ -1,0 +1,65 @@
+package com.sequenceiq.cloudbreak.reactor.handler.cluster.dr;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.sequenceiq.cloudbreak.auth.altus.VirtualGroupService;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.dto.LdapView;
+import com.sequenceiq.cloudbreak.ldap.LdapConfigService;
+import com.sequenceiq.cloudbreak.service.environment.EnvironmentConfigProvider;
+import com.sequenceiq.cloudbreak.util.TestConstants;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RangerVirtualGroupServiceTest {
+    @Mock
+    private VirtualGroupService virtualGroupService;
+
+    @Mock
+    private LdapConfigService ldapConfigService;
+
+    @Mock
+    private EnvironmentConfigProvider environmentConfigProvider;
+
+    @InjectMocks
+    private final RangerVirtualGroupService underTest = new RangerVirtualGroupService();
+
+    @Test(expected = CloudbreakServiceException.class)
+    public void getRangerVirtualGroupTestFailed() {
+        when(ldapConfigService.get(anyString(), anyString())).thenReturn(Optional.empty());
+        when(environmentConfigProvider.getParentEnvironmentCrn(anyString())).thenReturn(TestConstants.CRN);
+        Stack stack = new Stack();
+        stack.setEnvironmentCrn(TestConstants.CRN);
+        stack.setName("datalake-stack");
+        Assert.assertEquals("_c_environments_adminranger", underTest.getRangerVirtualGroup(stack));
+    }
+
+    @Test
+    public void getRangerVirtualGroupTestSuccess() {
+        Mockito.when(virtualGroupService.getVirtualGroup(
+                any(), any()))
+                .thenReturn("_c_environments_adminranger");
+        LdapView ldapView = LdapView.LdapViewBuilder.aLdapView().withProtocol("")
+                .withAdminGroup("admin<>")
+                .build();
+        when(ldapConfigService.get(anyString(), anyString())).thenReturn(Optional.of(ldapView));
+        when(environmentConfigProvider.getParentEnvironmentCrn(anyString())).thenReturn(TestConstants.CRN);
+        Stack stack = new Stack();
+        stack.setEnvironmentCrn(TestConstants.CRN);
+        stack.setName("datalake-stack");
+        Assert.assertEquals("_c_environments_adminranger", underTest.getRangerVirtualGroup(stack));
+    }
+}
+

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/runner/SaltRunner.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/runner/SaltRunner.java
@@ -31,4 +31,11 @@ public class SaltRunner {
     public Callable<Boolean> runner(OrchestratorBootstrap bootstrap, ExitCriteria exitCriteria, ExitCriteriaModel exitCriteriaModel) {
         return runner(bootstrap, exitCriteria, exitCriteriaModel, maxRetry, false);
     }
+
+    public Callable<Boolean> runner(OrchestratorBootstrap bootstrap, ExitCriteria exitCriteria, ExitCriteriaModel exitCriteriaModel, int maxRetry,
+            int maxRetryOnError) {
+        return new OrchestratorBootstrapRunner(bootstrap, exitCriteria, exitCriteriaModel, MDC.getCopyOfContextMap(), maxRetry, SLEEP_TIME,
+                maxRetryOnError);
+    }
+
 }

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/backup.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/backup.sls
@@ -7,7 +7,7 @@ include:
 {% if 'None' != configure_remote_db %}
 backup_postgresql_db:
   cmd.run:
-    - name: /opt/salt/scripts/backup_db.sh {{salt['pillar.get']('platform')}} {{salt['pillar.get']('disaster_recovery:object_storage_url')}} {{salt['pillar.get']('postgres:remote_db_url')}} {{salt['pillar.get']('postgres:remote_db_port')}} {{salt['pillar.get']('postgres:remote_admin')}} {{salt['pillar.get']('disaster_recovery:aws_region')}}
+    - name: /opt/salt/scripts/backup_db.sh {{salt['pillar.get']('platform')}} {{salt['pillar.get']('disaster_recovery:object_storage_url')}} {{salt['pillar.get']('postgres:remote_db_url')}} {{salt['pillar.get']('postgres:remote_db_port')}} {{salt['pillar.get']('postgres:remote_admin')}} {{salt['pillar.get']('disaster_recovery:aws_region')}} {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}}
     - require:
       - sls: postgresql.disaster_recovery
 

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/restore.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/restore.sls
@@ -6,7 +6,7 @@ include:
 {% if 'None' != configure_remote_db %}
 restore_postgresql_db:
   cmd.run:
-    - name: /opt/salt/scripts/restore_db.sh {{salt['pillar.get']('platform')}} {{salt['pillar.get']('disaster_recovery:object_storage_url')}} {{salt['pillar.get']('postgres:remote_db_url')}} {{salt['pillar.get']('postgres:remote_db_port')}} {{salt['pillar.get']('postgres:remote_admin')}} {{salt['pillar.get']('disaster_recovery:aws_region')}}
+    - name: /opt/salt/scripts/restore_db.sh {{salt['pillar.get']('platform')}} {{salt['pillar.get']('disaster_recovery:object_storage_url')}} {{salt['pillar.get']('postgres:remote_db_url')}} {{salt['pillar.get']('postgres:remote_db_port')}} {{salt['pillar.get']('postgres:remote_admin')}} {{salt['pillar.get']('disaster_recovery:aws_region')}} {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}}
     - require:
         - sls: postgresql.disaster_recovery
 

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 # backup_db.sh
 # This script uses the 'pg_dump' utility to dump the contents of hive and ranger PostgreSQL databases as plain SQL.
 # After PostgreSQL contents are dumped, the SQL is uploaded to AWS or Azure using their CLI clients, 'aws s3 cp' and 'azcopy copy' respectively.
@@ -8,6 +8,7 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+set -o xtrace
 
 if [[ $# -ne 6 && $# -ne 7 ]]; then
   echo "Invalid inputs provided"
@@ -88,9 +89,8 @@ run_azure_backup() {
 }
 
 replace_ranger_group_before_export() {
-  doLog "INFO Replacing "$1" with RANGER_WAG in the dump before export"
-  echo "sed --in-place="original" 's/"$1"/RANGER_WAG/g' $2"
-  ret_code=$(sed --in-place="original" -e s/"$1"/RANGER_WAG/g "$2" || echo $?)
+  doLog "INFO Replacing "$1" with _RANGER_WAG_2f0264fa-0a04-462b-af85-7c09891568ef in the dump before export"
+  ret_code=$(sed --in-place="original" -e s/"$1"/_RANGER_WAG_2f0264fa-0a04-462b-af85-7c09891568ef/g "$2" || echo $?)
   if [[ -n "$ret_code" ]] && [[ "$ret_code" -ne 0 ]]; then
     errorExit "Unable to re-write file $2"
   fi

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/restore_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/restore_db.sh
@@ -7,6 +7,7 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+set -o xtrace
 
 if [[ $# -ne 6 && $# -ne 7 ]]; then
   echo "Invalid inputs provided"
@@ -57,9 +58,8 @@ errorExit() {
 }
 
 replace_ranger_group_before_import() {
-  doLog "INFO Replacing RANGER_WAG with "$1" in the dump before import"
-  echo "sed --in-place="original" 's/RANGER_WAG/"$1"/g' $2"
-  ret_code=$(sed --in-place="original" -e s/RANGER_WAG/"$1"/g "$2" || echo $?)
+  doLog "INFO Replacing _RANGER_WAG_2f0264fa-0a04-462b-af85-7c09891568ef with "$1" in the dump before import"
+  ret_code=$(sed --in-place="original" -e s/_RANGER_WAG_2f0264fa-0a04-462b-af85-7c09891568ef/"$1"/g "$2" || echo $?)
   if [[ -n "$ret_code" ]] && [[ "$ret_code" -ne 0 ]]; then
     errorExit "Unable to re-write file $2"
   fi


### PR DESCRIPTION
Here is the summary of the code changes.
1. Pass the ranger_admin_group name from  CB -> salt pillar on the datalake database backup.
2. Pass the ranger_admin_group name from CB -> salt pillar on the datalake database restore.
3. Use a configured retry attempts to get the status of datalake database backup-restore operations and also retry count on failures.
4. Changes to database backup script to replace the group name in the ranger back up with the hardcoded KEYWORD before writing to S3.
5. Changes to database restore script to replace the hardcoded KEYWORD with the group name in the ranger back up with before using to restore the database.

**Tests:**

1. Updated existing tests to cover the change that was made.
2. I created an environment with these changes in place and made sure that the pillar information was correct and also triggered database backup-restore operations and made sure that the ranger permissions are re-written as expected.