### PR TITLE
CB-8351 Fix the cluster installation if we can't copy the agent token

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/scripts/generate_agent_tokens.sh.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/scripts/generate_agent_tokens.sh.j2
@@ -26,8 +26,12 @@ do
   tokendir=$TOKEN_DIR/${AGENT_FQDN_TOKENDIR_MAP[${fqdn}]}
   if [[ ! -e ${tokendir}/agent_token_copied_to_client ]]; then
     # This can be fairly slow, for large clusters
-    salt ${fqdn} cp.get_file salt://agent-tls-tokens/${AGENT_FQDN_TOKENDIR_MAP[${fqdn}]}/cmagent.token /etc/cloudera-scm-agent/cmagent.token
-    echo $(date +%Y-%m-%d:%H:%M:%S) >> ${tokendir}/agent_token_copied_to_client
+    COPY_RESULT=$(salt ${fqdn} cp.get_file salt://agent-tls-tokens/${AGENT_FQDN_TOKENDIR_MAP[${fqdn}]}/cmagent.token /etc/cloudera-scm-agent/cmagent.token)
+    if [[ "$COPY_RESULT" != *"False"* ]]; then
+      echo $(date +%Y-%m-%d:%H:%M:%S) >> ${tokendir}/agent_token_copied_to_client
+    else
+      echo "Could not copy the token to agent: $fqdn"
+    fi
   else
     echo "CM agent token copy to ${fqdn} will be skipped as it was already copied to the agent instance."
   fi


### PR DESCRIPTION
It can happen that salt cp.get_file command returns False, but we still create
the check file so we don't try to generate and copy again. This process is time
consuming that is why we are trying to skip it whenever we can. However, if it
returns False the copy was not successful an we need to try again.

Example output when the result is False, no agent_token_copied_to_client is created.
```
+ [[ ! -e /srv/salt/agent-tls-tokens/krisz-datalake-1-master0.krisz-en.xcu2-8y8x.wl.cloudera.site-i-08b5a305ef6dfda31/agent_token_copied_to_client ]]
++ salt krisz-datalake-1-master0.krisz-en.xcu2-8y8x.wl.cloudera.site cp.get_file salt://agent-tls-tokens/krisz-datalake-1-master0.krisz-en.xcu2-8y8x.wl.cloudera.site-i-08b5a305ef6dfda31/cmagent.token alma/etc/cloudera-scm-agent/cmagent.token
+ COPY_RESULT='krisz-datalake-1-master0.krisz-en.xcu2-8y8x.wl.cloudera.site:
    False'
+ [[ krisz-datalake-1-master0.krisz-en.xcu2-8y8x.wl.cloudera.site:
    False != *\F\a\l\s\e* ]]
+ echo 'Could not copy the token to agent: krisz-datalake-1-master0.krisz-en.xcu2-8y8x.wl.cloudera.site'
```

See detailed description in the commit message.