### PR TITLE
CB-8342 Cluster product components should not come from DefaultCDHInfo

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/ClouderaManagerClusterCreationSetupService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/ClouderaManagerClusterCreationSetupService.java
@@ -6,7 +6,6 @@ import static com.sequenceiq.cloudbreak.exception.NotFoundException.notFound;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -16,7 +15,6 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
-import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -185,9 +183,7 @@ public class ClouderaManagerClusterCreationSetupService {
                     .withVersion(defaultCDHInfo.getVersion())
                     .withName(stack.get("repoid").split("-")[0])
                     .withParcel(stack.get(osType));
-            Set<ClouderaManagerProduct> products = CollectionUtils.isNotEmpty(defaultCDHInfo.getParcels())
-                    ? Sets.newHashSet(defaultCDHInfo.getParcels()) : new HashSet<>();
-            products.add(cmProduct);
+            Set<ClouderaManagerProduct> products = Sets.newHashSet(cmProduct);
             LOGGER.info("Product list before filter out products by blueprint: {}", products);
             Set<ClouderaManagerProduct> filteredProducts = parcelService.filterParcelsByBlueprint(products, cluster.getBlueprint(), true);
             LOGGER.info("Product list after filter out products by blueprint: {}", filteredProducts);


### PR DESCRIPTION
DefaultCDHInfo was filled out with parcels in 2.18 last time from the application.yml. Parcel configurations got removed in 2.19 but the related java code remained in the codebase. As a part of CB-7647 parcels got filled out again in the DefaultCDHInfo based on the latest greatest prewarmed image - it was necessary for the stack matrix - but the remained parcel fillup caused that cluster product components are coming from the DefaultCDHInfo. As a part of this PR I'm simply remove the DefaultCDHInfo based product fill-up as it was a dead code since 2.19.

It is a followup PR on https://github.com/hortonworks/cloudbreak/pull/8748