### PR TITLE
CB-8308 [azure] image storage account public access should be false

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStorage.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStorage.java
@@ -29,6 +29,8 @@ import com.microsoft.azure.management.storage.StorageAccount;
 import com.microsoft.azure.management.storage.StorageAccounts;
 import com.microsoft.azure.management.storage.implementation.StorageAccountInner;
 import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.azure.connector.resource.AzureStorageAccountBuilderService;
+import com.sequenceiq.cloudbreak.cloud.azure.connector.resource.StorageAccountParameters;
 import com.sequenceiq.cloudbreak.cloud.azure.storage.SkuTypeResolver;
 import com.sequenceiq.cloudbreak.cloud.azure.view.AzureCredentialView;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
@@ -61,6 +63,9 @@ public class AzureStorage {
 
     @Inject
     private AzureResourceGroupMetadataProvider azureResourceGroupMetadataProvider;
+
+    @Inject
+    private AzureStorageAccountBuilderService azureStorageAccountBuilderService;
 
     public ArmAttachedStorageOption getArmAttachedStorageOption(Map<String, String> parameters) {
         String attachedStorageOption = parameters.get("attachedStorageOption");
@@ -107,7 +112,9 @@ public class AzureStorage {
             Map<String, String> tags)
             throws CloudException {
         if (!storageAccountExist(client, osStorageName)) {
-            client.createStorageAccount(storageGroup, osStorageName, region, skuTypeResolver.resolveFromAzureDiskType(storageType), encrypted, tags);
+            StorageAccountParameters storageAccountParameters = new StorageAccountParameters(
+                    storageGroup, osStorageName, region, skuTypeResolver.resolveFromAzureDiskType(storageType), encrypted, tags);
+            azureStorageAccountBuilderService.buildStorageAccount(client, storageAccountParameters);
         }
     }
 

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStorageAccountTemplateBuilder.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStorageAccountTemplateBuilder.java
@@ -1,0 +1,45 @@
+package com.sequenceiq.cloudbreak.cloud.azure;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.azure.connector.resource.StorageAccountParameters;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.util.FreeMarkerTemplateUtils;
+
+import freemarker.template.TemplateException;
+
+@Component
+public class AzureStorageAccountTemplateBuilder {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AzureStorageAccountTemplateBuilder.class);
+
+    @Inject
+    private FreeMarkerTemplateUtils freeMarkerTemplateUtils;
+
+    @Inject
+    private AzureStorageAccoutTemplateProviderService azureStorageAccoutTemplateProviderService;
+
+    public String build(StorageAccountParameters storageAccountParameters) {
+        try {
+            Map<String, Object> model = new HashMap<>();
+            model.put("storageAccountName", storageAccountParameters.getStorageAccountName());
+            model.put("location", storageAccountParameters.getStorageLocation());
+            model.put("skuName", storageAccountParameters.getStorageAccountSkuType().name().toString());
+            model.put("encrypted", storageAccountParameters.getEncrypted());
+            model.put("userDefinedTags", storageAccountParameters.getTags());
+            String generatedTemplate = freeMarkerTemplateUtils.processTemplateIntoString(azureStorageAccoutTemplateProviderService.getTemplate(), model);
+            LOGGER.info("Generated storage account Arm template: {}", generatedTemplate);
+            return generatedTemplate;
+        } catch (IOException | TemplateException e) {
+            throw new CloudConnectorException("Failed to process the storage account ARM Template", e);
+        }
+    }
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStorageAccoutTemplateProviderService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStorageAccoutTemplateProviderService.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.cloudbreak.cloud.azure;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+
+@Service
+public class AzureStorageAccoutTemplateProviderService {
+
+    @Value("${cb.arm.storageaccount.template.path:}")
+    private String armStorageAccountTemplatePath;
+
+    @Inject
+    private Configuration freemarkerConfiguration;
+
+    public Template getTemplate() {
+        try {
+            String armTemplate = freemarkerConfiguration.getTemplate(armStorageAccountTemplatePath, "UTF-8").toString();
+            return new Template(armStorageAccountTemplatePath, armTemplate, freemarkerConfiguration);
+        } catch (IOException e) {
+            throw new CloudConnectorException("Couldn't create template object", e);
+        }
+    }
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/AzureStorageAccountBuilderService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/AzureStorageAccountBuilderService.java
@@ -1,0 +1,53 @@
+package com.sequenceiq.cloudbreak.cloud.azure.connector.resource;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.microsoft.azure.CloudError;
+import com.microsoft.azure.CloudException;
+import com.microsoft.azure.management.resources.Deployment;
+import com.sequenceiq.cloudbreak.cloud.azure.AzureStorageAccountTemplateBuilder;
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.common.json.Json;
+
+@Service
+public class AzureStorageAccountBuilderService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AzureStorageAccountBuilderService.class);
+
+    @Inject
+    private AzureStorageAccountTemplateBuilder azureStorageAccountTemplateBuilder;
+
+    public void buildStorageAccount(AzureClient client, StorageAccountParameters storageAccountParameters) {
+        String resourceGroupName = storageAccountParameters.getResourceGroupName();
+        String storageAccountName = storageAccountParameters.getStorageAccountName();
+        try {
+            String template = azureStorageAccountTemplateBuilder.build(storageAccountParameters);
+            if (!client.templateDeploymentExists(resourceGroupName, storageAccountName)) {
+                String parameters = new Json(Map.of()).getValue();
+                Deployment templateDeployment = client.createTemplateDeployment(resourceGroupName, storageAccountName, template, parameters);
+                LOGGER.debug("Created template deployment for storage account: {}", templateDeployment.exportTemplate().template());
+            }
+        } catch (CloudException e) {
+            LOGGER.info("Provisioning error, cloud exception happened: ", e);
+            if (e.body() != null && e.body().details() != null) {
+                String details = e.body().details().stream().map(CloudError::message).collect(Collectors.joining(", "));
+                throw new CloudConnectorException(String.format("Storage account provisioning failed, status code %s, error message: %s, details: %s",
+                        e.body().code(), e.body().message(), details));
+            } else {
+                throw new CloudConnectorException(String.format("Storage account provisioning failed: '%s', please go to Azure Portal for detailed message", e));
+            }
+        } catch (Exception e) {
+            String message = String.format("Could not create storage account %s in resource group %s", storageAccountName, resourceGroupName);
+            LOGGER.warn(message, e);
+            throw new CloudConnectorException(message);
+        }
+    }
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/StorageAccountParameters.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/StorageAccountParameters.java
@@ -1,0 +1,54 @@
+package com.sequenceiq.cloudbreak.cloud.azure.connector.resource;
+
+import java.util.Map;
+
+import com.microsoft.azure.management.storage.StorageAccountSkuType;
+
+public class StorageAccountParameters {
+
+    private final String resourceGroupName;
+
+    private final String storageAccountName;
+
+    private final String storageLocation;
+
+    private final StorageAccountSkuType storageAccountSkuType;
+
+    private final Boolean encrypted;
+
+    private final Map<String, String> tags;
+
+    public StorageAccountParameters(String resourceGroupName, String storageAccountName, String storageLocation, StorageAccountSkuType storageAccountSkuType,
+            Boolean encrypted, Map<String, String> tags) {
+        this.resourceGroupName = resourceGroupName;
+        this.storageAccountName = storageAccountName;
+        this.storageLocation = storageLocation;
+        this.storageAccountSkuType = storageAccountSkuType;
+        this.encrypted = encrypted;
+        this.tags = tags;
+    }
+
+    public String getResourceGroupName() {
+        return resourceGroupName;
+    }
+
+    public String getStorageAccountName() {
+        return storageAccountName;
+    }
+
+    public String getStorageLocation() {
+        return storageLocation;
+    }
+
+    public StorageAccountSkuType getStorageAccountSkuType() {
+        return storageAccountSkuType;
+    }
+
+    public Boolean getEncrypted() {
+        return encrypted;
+    }
+
+    public Map<String, String> getTags() {
+        return tags;
+    }
+}

--- a/cloud-azure/src/main/resources/templates/arm-storageaccount.ftl
+++ b/cloud-azure/src/main/resources/templates/arm-storageaccount.ftl
@@ -1,0 +1,103 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "storageAccountName": {
+            "defaultValue": "${storageAccountName}",
+            "type": "String"
+        },
+        "location": {
+            "defaultValue": "${location}",
+            "type": "String"
+        },
+        "sku_name": {
+            "defaultValue": "${skuName}",
+            "type": "String"
+        },
+        "encrypted": {
+            "type":"bool",
+            "defaultValue": ${(encrypted!true)?c}
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "type": "Microsoft.Storage/storageAccounts",
+            "apiVersion": "2019-06-01",
+            "name": "[parameters('storageAccountName')]",
+            "location": "[parameters('location')]",
+            "tags": {
+                <#if userDefinedTags?? && userDefinedTags?has_content>
+                    <#list userDefinedTags?keys as key>
+                      "${key}": "${userDefinedTags[key]}"<#if key_has_next>,</#if>
+                      </#list>
+                </#if>
+            },
+            "sku": {
+                "name": "[parameters('sku_name')]"
+            },
+            "kind": "StorageV2",
+            "properties": {
+                "networkAcls": {
+                    "bypass": "AzureServices",
+                    "virtualNetworkRules": [],
+                    "ipRules": [],
+                    "defaultAction": "Allow"
+                },
+                "allowBlobPublicAccess": false,
+                "supportsHttpsTrafficOnly": true,
+                "encryption": {
+                    "services": {
+                        "file": {
+                            "keyType": "Account",
+                            "enabled": "[parameters('encrypted')]"
+                        },
+                        "blob": {
+                            "keyType": "Account",
+                            "enabled": "[parameters('encrypted')]"
+                        }
+                    },
+                    "keySource": "Microsoft.Storage"
+                },
+                "accessTier": "Hot"
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/blobServices",
+            "apiVersion": "2019-06-01",
+            "name": "[concat(parameters('storageAccountName'), '/default')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+            ],
+            "sku": {
+                "name": "Standard_LRS",
+                "tier": "Standard"
+            },
+            "properties": {
+                "cors": {
+                    "corsRules": []
+                },
+                "deleteRetentionPolicy": {
+                    "enabled": false
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts/fileServices",
+            "apiVersion": "2019-06-01",
+            "name": "[concat(parameters('storageAccountName'), '/default')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+            ],
+            "sku": {
+                "name": "Standard_LRS",
+                "tier": "Standard"
+            },
+            "properties": {
+                "cors": {
+                    "corsRules": []
+                }
+            }
+        }
+    ]
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStorageAccountTemplateBuilderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStorageAccountTemplateBuilderTest.java
@@ -1,0 +1,57 @@
+package com.sequenceiq.cloudbreak.cloud.azure;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.hamcrest.collection.IsMapContaining;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.microsoft.azure.management.storage.StorageAccountSkuType;
+import com.sequenceiq.cloudbreak.cloud.azure.connector.resource.StorageAccountParameters;
+import com.sequenceiq.cloudbreak.util.FreeMarkerTemplateUtils;
+
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+
+@ExtendWith(MockitoExtension.class)
+class AzureStorageAccountTemplateBuilderTest {
+
+    @Mock
+    private FreeMarkerTemplateUtils freeMarkerTemplateUtils;
+
+    @Mock
+    private AzureStorageAccoutTemplateProviderService azureStorageAccoutTemplateProviderService;
+
+    @InjectMocks
+    private AzureStorageAccountTemplateBuilder underTest;
+
+    @Test
+    void whenBuildTemplateThenModelParametersAreSet() throws IOException, TemplateException {
+        StorageAccountParameters storageAccountParameters =
+                new StorageAccountParameters("my-rg", "my-sa", "sa-location", StorageAccountSkuType.STANDARD_LRS, true, Map.of("tagKey", "tagValue"));
+        Template templateMock = mock(Template.class);
+        when(azureStorageAccoutTemplateProviderService.getTemplate()).thenReturn(templateMock);
+
+        underTest.build(storageAccountParameters);
+
+        ArgumentCaptor<Map<String, Object>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(freeMarkerTemplateUtils).processTemplateIntoString(any(), captor.capture());
+        Map<String, Object> templateModel = captor.getValue();
+        assertThat(templateModel, IsMapContaining.hasEntry("storageAccountName", "my-sa"));
+        assertThat(templateModel, IsMapContaining.hasEntry("location", "sa-location"));
+        assertThat(templateModel, IsMapContaining.hasEntry("encrypted", true));
+        assertThat(templateModel, IsMapContaining.hasEntry("skuName", StorageAccountSkuType.STANDARD_LRS.name().toString()));
+        assertThat(templateModel, IsMapContaining.hasKey("userDefinedTags"));
+    }
+}

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -340,6 +340,7 @@ cb:
     network.template.path: templates/arm-network.ftl
     parameter.path: templates/parameters.ftl
     database.template.path: templates/arm-database.ftl
+    storageaccount.template.path: templates/arm-storageaccount.ftl
     app.creation.template:
       command.path: templates/app-creation-command.ftl
       json.path: templates/app-creation.json

--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -186,6 +186,7 @@ cb:
   arm:
     template.path: templates/arm-v2-freeipa.ftl
     parameter.path: templates/parameters-freeipa.ftl
+    storageaccount.template.path: templates/arm-storageaccount.ftl
 
   openstack:
     heat.template.path: templates/openstack-heat.ftl


### PR DESCRIPTION
The storage account for holding images in customer subscription has a parameter "allow blob public access", the default is true. Some customers do have a policy that do not allow to create an account with such settings, so cloudbreak should also create SA with disallow blob public access.


Note: changed to master