### PR TITLE
CB-8362 Fix ErrorLogMessageProvider NPE

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -867,6 +868,7 @@ public abstract class TestContext implements ApplicationContextAware {
                     .filter(Investigable.class::isInstance)
                     .map(Investigable.class::cast)
                     .map(Investigable::investigate)
+                    .filter(Objects::nonNull)
                     .collect(Collectors.toList());
             String errorMessage = errorLogMessageProvider.getMessage(exceptionMap, clues);
             testErrorLog.report(LOGGER, errorMessage);


### PR DESCRIPTION
Investigables may return null (for example when they do not have a response), so the clues should be filtered out before getting passed to ErrorLogMessageProvider.