### PR TITLE
ENGESC-2921 Need cloudbreak APIs to enable autoscaling

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/HistoryService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/HistoryService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import com.sequenceiq.periscope.api.model.ScalingStatus;
 import com.sequenceiq.periscope.domain.Cluster;
 import com.sequenceiq.periscope.domain.History;
+import com.sequenceiq.periscope.domain.PeriscopeUser;
 import com.sequenceiq.periscope.domain.ScalingPolicy;
 import com.sequenceiq.periscope.repository.HistoryRepository;
 
@@ -20,17 +21,24 @@ public class HistoryService {
     @Autowired
     private ClusterService clusterService;
 
+    @Autowired
+    private AuthenticatedUserService authenticatedUserService;
+
     public History createEntry(ScalingStatus scalingStatus, String statusReason, int originalNodeCount, ScalingPolicy scalingPolicy) {
         History history = new History(scalingStatus, statusReason, originalNodeCount)
                 .withScalingPolicy(scalingPolicy)
                 .withAlert(scalingPolicy.getAlert())
                 .withCluster(scalingPolicy.getAlert().getCluster());
+        PeriscopeUser periscopeUser = authenticatedUserService.getPeriscopeUser();
+        history.setUser(periscopeUser.getId());
         return historyRepository.save(history);
     }
 
     public History createEntry(ScalingStatus scalingStatus, String statusReason, int originalNodeCount, Cluster cluster) {
         History history = new History(scalingStatus, statusReason, originalNodeCount)
                 .withCluster(cluster);
+        PeriscopeUser periscopeUser = authenticatedUserService.getPeriscopeUser();
+        history.setUser(periscopeUser.getId());
         return historyRepository.save(history);
     }
 


### PR DESCRIPTION
when different user tries to enable or disable autoscaling on the cluster then the creator, we throw an access denied exception even if the users added to the workspace. From now, the history will be assigned to the operation executor instead of the cluster creator

See detailed description in the commit message.