### PR TITLE
CB-8237 adding details to the aws waiters exceptions because it was a…

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsNetworkConnector.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsNetworkConnector.java
@@ -207,7 +207,7 @@ public class AwsNetworkConnector extends DefaultNetworkConnector {
         EnvironmentCancellationCheck environmentCancellationCheck = new EnvironmentCancellationCheck(networkRequest.getEnvId(), networkRequest.getEnvName());
 
         run(creationWaiter, stackRequestWithStackId,
-                environmentCancellationCheck);
+                environmentCancellationCheck, String.format("Network creation failed (cloudformation stack: %s)", networkRequest.getStackName()));
 
         return getCreatedCloudNetwork(cloudFormationRetryClient, networkRequest, subnetRequests);
     }
@@ -251,7 +251,8 @@ public class AwsNetworkConnector extends DefaultNetworkConnector {
             Waiter<DescribeStacksRequest> deletionWaiter = cfClient.waiters().stackDeleteComplete();
             LOGGER.debug("CloudFormation stack deletion request sent with stack name: '{}' ", networkDeletionRequest.getStackName());
             DescribeStacksRequest describeStacksRequest = new DescribeStacksRequest().withStackName(networkDeletionRequest.getStackName());
-            run(deletionWaiter, describeStacksRequest, null);
+            run(deletionWaiter, describeStacksRequest, null,
+                    String.format("Network delete failed (cloudformation: %s)", networkDeletionRequest.getStackName()));
         }
     }
 

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsDownscaleService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsDownscaleService.java
@@ -166,6 +166,7 @@ public class AwsDownscaleService {
         Waiter<DescribeInstancesRequest> instanceTerminatedWaiter = amazonEC2Client.waiters().instanceTerminated();
         DescribeInstancesRequest describeInstancesRequest = new DescribeInstancesRequest().withInstanceIds(instanceIds);
         StackCancellationCheck stackCancellationCheck = new StackCancellationCheck(stackId);
-        run(instanceTerminatedWaiter, describeInstancesRequest, stackCancellationCheck);
+        run(instanceTerminatedWaiter, describeInstancesRequest, stackCancellationCheck,
+                String.format("There was an error when application are deleting instances", String.join(",", instanceIds)));
     }
 }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsLaunchService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsLaunchService.java
@@ -150,7 +150,7 @@ public class AwsLaunchService {
         AmazonCloudFormationClient cfClient = awsClient.createCloudFormationClient(credentialView, regionName);
         Waiter<DescribeStacksRequest> creationWaiter = cfClient.waiters().stackCreateComplete();
         StackCancellationCheck stackCancellationCheck = new StackCancellationCheck(ac.getCloudContext().getId());
-        run(creationWaiter, describeStacksRequest, stackCancellationCheck);
+        run(creationWaiter, describeStacksRequest, stackCancellationCheck, "Stack creation failed");
 
         List<CloudResource> networkResources = saveGeneratedSubnet(ac, stack, cFStackName, cfRetryClient, resourceNotifier);
         suspendAutoscalingGoupsWhenNewInstancesAreReady(ac, stack);

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsLaunchService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsLaunchService.java
@@ -96,7 +96,7 @@ public class AwsRdsLaunchService {
         Waiter<DescribeStacksRequest> creationWaiter = cfClient.waiters().stackCreateComplete();
         StackCancellationCheck stackCancellationCheck = new StackCancellationCheck(ac.getCloudContext().getId());
         run(creationWaiter, describeStacksRequest,
-                stackCancellationCheck);
+                stackCancellationCheck, "RDS creation failed");
 
         List<CloudResource> databaseResources = getCreatedOutputs(ac, stack, cFStackName, cfRetryClient, resourceNotifier);
         databaseResources.forEach(dbr -> resourceNotifier.notifyAllocation(dbr, ac.getCloudContext()));

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsStartService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsStartService.java
@@ -47,6 +47,6 @@ public class AwsRdsStartService {
         Waiter<DescribeDBInstancesRequest> rdsWaiter = rdsClient.waiters().dBInstanceAvailable();
         DescribeDBInstancesRequest describeDBInstancesRequest = new DescribeDBInstancesRequest().withDBInstanceIdentifier(dbInstanceIdentifier);
         StackCancellationCheck stackCancellationCheck = new StackCancellationCheck(ac.getCloudContext().getId());
-        run(rdsWaiter, describeDBInstancesRequest, stackCancellationCheck);
+        run(rdsWaiter, describeDBInstancesRequest, stackCancellationCheck, "RDS start failed");
     }
 }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsStopService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsStopService.java
@@ -57,7 +57,7 @@ public class AwsRdsStopService {
                 .getDbInstanceStopWaiter(rdsClient);
         DescribeDBInstancesRequest describeDBInstancesRequest = new DescribeDBInstancesRequest().withDBInstanceIdentifier(dbInstanceIdentifier);
         StackCancellationCheck stackCancellationCheck = new StackCancellationCheck(ac.getCloudContext().getId());
-        run(rdsWaiter, describeDBInstancesRequest, stackCancellationCheck);
+        run(rdsWaiter, describeDBInstancesRequest, stackCancellationCheck, "RDS stop failed");
         LOGGER.debug("RDS stop process finished. DB Instance ID: {}", dbInstanceIdentifier);
     }
 }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsTerminateService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsTerminateService.java
@@ -92,7 +92,7 @@ public class AwsRdsTerminateService {
                 LOGGER.warn("Stack deletion for '{}' failed, continuing because termination is forced", cFStackName, e);
             } else {
                 if (e instanceof RuntimeException) {
-                    throw new CloudConnectorException(e.getMessage(), e);
+                    throw new CloudConnectorException("RDS termination failed " + e.getMessage(), e);
                 } else {
                     throw e;
                 }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/encryption/EncryptedImageCopyService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/encryption/EncryptedImageCopyService.java
@@ -75,7 +75,7 @@ public class EncryptedImageCopyService {
             Waiter<DescribeImagesRequest> imageWaiter = client.waiters().imageAvailable();
             DescribeImagesRequest describeImagesRequest = new DescribeImagesRequest().withImageIds(imageIds);
             StackCancellationCheck stackCancellationCheck = new StackCancellationCheck(ac.getCloudContext().getId());
-            run(imageWaiter, describeImagesRequest, stackCancellationCheck);
+            run(imageWaiter, describeImagesRequest, stackCancellationCheck, "Encrypted image creation failed");
             LOGGER.info("All created encrypted AMIs are available: '{}'", String.join(",", imageIds));
         }
         return imageIdByGroupName;

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/encryption/EncryptedSnapshotService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/encryption/EncryptedSnapshotService.java
@@ -142,14 +142,15 @@ public class EncryptedSnapshotService {
         Waiter<DescribeSnapshotsRequest> snapshotWaiter = client.waiters().snapshotCompleted();
         DescribeSnapshotsRequest describeSnapshotsRequest = new DescribeSnapshotsRequest().withSnapshotIds(snapshotResult.getSnapshot().getSnapshotId());
         StackCancellationCheck stackCancellationCheck = new StackCancellationCheck(ac.getCloudContext().getId());
-        run(snapshotWaiter, describeSnapshotsRequest, stackCancellationCheck);
+        run(snapshotWaiter, describeSnapshotsRequest, stackCancellationCheck, String.format("Snapshot creation failed (snapshot id: %s)",
+                snapshotResult.getSnapshot().getSnapshotId()));
     }
 
     private void checkEbsVolumeStatus(AuthenticatedContext ac, AmazonEC2Client client, String volumeId) {
         Waiter<DescribeVolumesRequest> volumeChecker = client.waiters().volumeAvailable();
         DescribeVolumesRequest describeVolumesRequest = new DescribeVolumesRequest().withVolumeIds(volumeId);
         StackCancellationCheck stackCancellationCheck = new StackCancellationCheck(ac.getCloudContext().getId());
-        run(volumeChecker, describeVolumesRequest, stackCancellationCheck);
+        run(volumeChecker, describeVolumesRequest, stackCancellationCheck, String.format("Volume creation failed (volume id: %s)", volumeId));
     }
 
     private CreateSnapshotRequest prepareCreateSnapshotRequest(CreateVolumeResult volumeResult) {

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/WaiterRunner.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/WaiterRunner.java
@@ -2,6 +2,12 @@ package com.sequenceiq.cloudbreak.cloud.aws.scheduler;
 
 import static com.sequenceiq.cloudbreak.cloud.aws.scheduler.BackoffCancellablePollingStrategy.getBackoffCancellablePollingStrategy;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.util.StringUtils;
+
 import com.amazonaws.AmazonWebServiceRequest;
 import com.amazonaws.waiters.Waiter;
 import com.amazonaws.waiters.WaiterParameters;
@@ -12,13 +18,25 @@ public class WaiterRunner {
     }
 
     public static <I extends AmazonWebServiceRequest> void run(Waiter<I> waiter, I input, CancellationCheck cancellationCheck) {
+        run(waiter, input, cancellationCheck, null);
+    }
+
+    public static <I extends AmazonWebServiceRequest> void run(Waiter<I> waiter, I input, CancellationCheck cancellationCheck, String exceptionMessage) {
         try {
             waiter.run(new WaiterParameters<I>()
                     .withRequest(input)
                     .withPollingStrategy(getBackoffCancellablePollingStrategy(cancellationCheck))
             );
         } catch (Exception e) {
-            throw new CloudConnectorException(e.getMessage(), e);
+            List<String> messages = new ArrayList<>();
+            if (StringUtils.hasText(exceptionMessage)) {
+                messages.add(exceptionMessage);
+            }
+            if (StringUtils.hasText(e.getMessage())) {
+                messages.add(e.getMessage());
+            }
+            Optional.ofNullable(e.getCause()).ifPresent(throwable -> messages.add(throwable.getMessage()));
+            throw new CloudConnectorException(String.join(" ", messages), e);
         }
     }
 }


### PR DESCRIPTION
Amazon waiters gave back message like 'Resource never entered the desired state as it failed' which was unclear and had no information what resource went failed, so now waiters have some clarification in the exception what kind of activity failed 
Closes CB-8237