### PR TITLE
CB-8376. Label filter is not working for diagnostics collections.

### DIFF
--- a/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/collect.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/collect.sls
@@ -10,13 +10,7 @@
   {% set extra_params = extra_params + " --end-time " + endTimeStr %}
 {% endif %}
 {% if filecollector.labelFilter %}
-  {% set labels_str = "" %}
-  {% for label in filecollector.labelFilter.items() %}
-    {% set labels_str = label_str + " --label " + label %}
-  {% endfor %}
-  {% if labels_str %}
-    {% set extra_params = extra_params + labels_str %}
-  {% endif %}
+  {% set extra_params = extra_params + " --label " + " --label ".join(filecollector.labelFilter) %}
 {% endif %}
 
 filecollector_collect_start:


### PR DESCRIPTION
Came out during e2e test writing
- seems like it's not possible to concat string inside a for loop with jninja (that way how I did)
- items cannot be called on jinja list object
- `label_str` is not exists anyway, so that would throw an exception