### PR TITLE
CB-8300 and CB-8347. Add e2e diagnostics tests for FreeIpa/Sdx (+ abstrac…

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
@@ -130,8 +130,10 @@ public class AzureResourceConnector extends AbstractResourceConnector {
         } finally {
             if (!resourcesPersisted) {
                 Deployment templateDeployment = client.getTemplateDeployment(resourceGroupName, stackName);
-                LOGGER.debug("Get template deployment to persist created resources: {}", templateDeployment.exportTemplate().template());
-                persistCloudResources(ac, stack, notifier, cloudContext, stackName, resourceGroupName, templateDeployment);
+                if (templateDeployment != null && templateDeployment.exportTemplate() != null) {
+                    LOGGER.debug("Get template deployment to persist created resources: {}", templateDeployment.exportTemplate().template());
+                    persistCloudResources(ac, stack, notifier, cloudContext, stackName, resourceGroupName, templateDeployment);
+                }
             }
         }
 

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/AzureDatabaseResourceService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/AzureDatabaseResourceService.java
@@ -95,8 +95,10 @@ public class AzureDatabaseResourceService {
             throw new CloudConnectorException(String.format("Error in provisioning database stack %s: %s", stackName, e.getMessage()), e);
         } finally {
             deployment = client.getTemplateDeployment(resourceGroupName, stackName);
-            List<CloudResource> cloudResources = azureCloudResourceService.getDeploymentCloudResources(deployment);
-            cloudResources.forEach(cloudResource -> persistenceNotifier.notifyAllocation(cloudResource, cloudContext));
+            if (deployment != null) {
+                List<CloudResource> cloudResources = azureCloudResourceService.getDeploymentCloudResources(deployment);
+                cloudResources.forEach(cloudResource -> persistenceNotifier.notifyAllocation(cloudResource, cloudContext));
+            }
         }
 
         String fqdn = (String) ((Map) ((Map) deployment.outputs()).get(DATABASE_SERVER_FQDN)).get("value");

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxCollectCMDiagnosticsAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxCollectCMDiagnosticsAction.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.it.cloudbreak.action.sdx;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+import com.sequenceiq.it.cloudbreak.SdxClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCMDiagnosticsTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+
+public class SdxCollectCMDiagnosticsAction implements Action<SdxCMDiagnosticsTestDto, SdxClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxCollectCMDiagnosticsAction.class);
+
+    @Override
+    public SdxCMDiagnosticsTestDto action(TestContext testContext, SdxCMDiagnosticsTestDto testDto, SdxClient client) throws Exception {
+        Log.whenJson(LOGGER, " SDX collect CM based diagnostics request: ", testDto.getRequest());
+        FlowIdentifier flowIdentifier = client.getSdxClient()
+                .diagnosticsEndpoint()
+                .collectCmDiagnostics(testDto.getRequest());
+        testDto.setFlow("SDX CM based diagnostic collection", flowIdentifier);
+        Log.log(LOGGER, " SDX name: %s", client.getSdxClient().sdxEndpoint().get(testDto.getName()).getName());
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/SdxTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/SdxTestClient.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import com.sequenceiq.it.cloudbreak.SdxClient;
 import com.sequenceiq.it.cloudbreak.action.Action;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxCheckForUpgradeAction;
+import com.sequenceiq.it.cloudbreak.action.sdx.SdxCollectCMDiagnosticsAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxCollectDiagnosticsAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxCreateAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxCreateInternalAction;
@@ -25,6 +26,7 @@ import com.sequenceiq.it.cloudbreak.action.sdx.SdxStopAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxSyncAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxSyncInternalAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxUpgradeAction;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCMDiagnosticsTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxDiagnosticsTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
@@ -115,4 +117,9 @@ public class SdxTestClient {
     public Action<SdxDiagnosticsTestDto, SdxClient> collectDiagnostics() {
         return new SdxCollectDiagnosticsAction();
     }
+
+    public Action<SdxCMDiagnosticsTestDto, SdxClient> collectCMDiagnostics() {
+        return new SdxCollectCMDiagnosticsAction();
+    }
+
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/diagnostics/BaseCMDiagnosticsTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/diagnostics/BaseCMDiagnosticsTestDto.java
@@ -1,0 +1,119 @@
+package com.sequenceiq.it.cloudbreak.dto.diagnostics;
+
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.emptyRunningParameter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.NotImplementedException;
+
+import com.sequenceiq.cloudbreak.exception.BadRequestException;
+import com.sequenceiq.common.api.diagnostics.BaseCmDiagnosticsCollectionRequest;
+import com.sequenceiq.common.api.telemetry.model.DiagnosticsDestination;
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+import com.sequenceiq.it.cloudbreak.MicroserviceClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.assertion.Assertion;
+import com.sequenceiq.it.cloudbreak.context.RunningParameter;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractTestDto;
+import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
+
+public abstract class BaseCMDiagnosticsTestDto<R extends BaseCmDiagnosticsCollectionRequest,
+        D extends BaseCMDiagnosticsTestDto,
+        C extends MicroserviceClient> extends AbstractTestDto<R, FlowIdentifier, D, C> {
+
+    private final Class<C> clientTypeClass;
+
+    public BaseCMDiagnosticsTestDto(String newId, Class<C> clientTypeClass) {
+        super(newId);
+        this.clientTypeClass = clientTypeClass;
+    }
+
+    public BaseCMDiagnosticsTestDto(R request, TestContext testContext, Class<C> clientTypeClass) {
+        super(request, testContext);
+        this.clientTypeClass = clientTypeClass;
+    }
+
+    public D withDefaults() {
+        withDestination(DiagnosticsDestination.CLOUD_STORAGE);
+        withSkipValidation(true);
+        // set this to false for no network test case !
+        withUpdatePackage(true);
+        return (D) this;
+    }
+
+    public D withDestination(DiagnosticsDestination destination) {
+        getRequest().setDestination(destination);
+        return (D) this;
+    }
+
+    public D withUpdatePackage(boolean updatePackage) {
+        getRequest().setUpdatePackage(updatePackage);
+        return (D) this;
+    }
+
+    public D withSkipValidation(boolean skipValidation) {
+        getRequest().setSkipValidation(skipValidation);
+        return (D) this;
+    }
+
+    @Override
+    public D when(Class<D> entityClass, Action<D, C> action) {
+        return getTestContext().when(entityClass, clientTypeClass, action, emptyRunningParameter());
+    }
+
+    @Override
+    public D when(Action<D, C> action) {
+        return getTestContext().when((D) this, clientTypeClass, action, emptyRunningParameter());
+    }
+
+    @Override
+    public D when(Class<D> entityClass, Action<D, C> action, RunningParameter runningParameter) {
+        return getTestContext().when(entityClass, clientTypeClass, action, runningParameter);
+    }
+
+    @Override
+    public D when(Action<D, C> action, RunningParameter runningParameter) {
+        return getTestContext().when((D) this, clientTypeClass, action, runningParameter);
+    }
+
+    @Override
+    public D then(Assertion<D, C> assertion) {
+        return then(assertion, emptyRunningParameter());
+    }
+
+    @Override
+    public D then(Assertion<D, C> assertion, RunningParameter runningParameter) {
+        return getTestContext().then((D) this, clientTypeClass, assertion, runningParameter);
+    }
+
+    @Override
+    public D then(List<Assertion<D, C>> assertions) {
+        List<RunningParameter> runningParameters = new ArrayList<>(assertions.size());
+        for (int i = 0; i < assertions.size(); i++) {
+            runningParameters.add(emptyRunningParameter());
+        }
+        return then(assertions, runningParameters);
+    }
+
+    @Override
+    public D then(List<Assertion<D, C>> assertions, List<RunningParameter> runningParameters) {
+        for (int i = 0; i < assertions.size() - 1; i++) {
+            getTestContext().then((D) this, clientTypeClass, assertions.get(i), runningParameters.get(i));
+        }
+        return getTestContext()
+                .then((D) this, clientTypeClass, assertions.get(assertions.size() - 1), runningParameters.get(runningParameters.size() - 1));
+    }
+
+    @Override
+    public <T extends CloudbreakTestDto> T deleteGiven(Class<T> clazz, Action<T, C> action, RunningParameter runningParameter) {
+        getTestContext().when((T) getTestContext().given(clazz), clientTypeClass, action, runningParameter);
+        return getTestContext().expect((T) getTestContext().given(clazz), BadRequestException.class, runningParameter);
+    }
+
+    @Override
+    public void validate() {
+        throw new NotImplementedException(String.format("The entity(%s) must be implement the valid() method.", getClass()));
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/diagnostics/DistroXDiagnosticsTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/diagnostics/DistroXDiagnosticsTestDto.java
@@ -24,8 +24,13 @@ public class DistroXDiagnosticsTestDto extends BaseDiagnosticsTestDto<Diagnostic
         return getTestContext().awaitForFlow(this, runningParameter);
     }
 
+    public DistroXDiagnosticsTestDto withDistroX() {
+        return withDistroX(null);
+    }
+
     public DistroXDiagnosticsTestDto withDistroX(String distroX) {
-        DistroXTestDto distroXTestDto = getTestContext().given(distroX, DistroXTestDto.class);
+        DistroXTestDto distroXTestDto = distroX == null ? getTestContext().given(DistroXTestDto.class)
+                : getTestContext().given(distroX, DistroXTestDto.class);
         getRequest().setStackCrn(distroXTestDto.getResponse().getCrn());
         return this;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaDiagnosticsTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaDiagnosticsTestDto.java
@@ -27,8 +27,13 @@ public class FreeIpaDiagnosticsTestDto extends BaseDiagnosticsTestDto<Diagnostic
         return getTestContext().awaitForFlow(this, runningParameter);
     }
 
+    public FreeIpaDiagnosticsTestDto withFreeIpa() {
+        return withFreeIpa(null);
+    }
+
     public FreeIpaDiagnosticsTestDto withFreeIpa(String freeIpa) {
-        FreeIpaTestDto freeIpaTestDto = getTestContext().given(freeIpa, FreeIpaTestDto.class);
+        FreeIpaTestDto freeIpaTestDto = freeIpa == null ? getTestContext().given(FreeIpaTestDto.class)
+                : getTestContext().given(freeIpa, FreeIpaTestDto.class);
         getRequest().setEnvironmentCrn(freeIpaTestDto.getResponse().getEnvironmentCrn());
         this.freeIpaCrn = freeIpaTestDto.getResponse().getCrn();
         return this;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxCMDiagnosticsTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxCMDiagnosticsTestDto.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.it.cloudbreak.dto.sdx;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.diagnostics.model.CmDiagnosticsCollectionRequest;
+import com.sequenceiq.it.cloudbreak.Prototype;
+import com.sequenceiq.it.cloudbreak.SdxClient;
+import com.sequenceiq.it.cloudbreak.context.RunningParameter;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.diagnostics.BaseCMDiagnosticsTestDto;
+
+@Prototype
+public class SdxCMDiagnosticsTestDto extends BaseCMDiagnosticsTestDto<CmDiagnosticsCollectionRequest, SdxCMDiagnosticsTestDto, SdxClient> {
+
+    public SdxCMDiagnosticsTestDto(TestContext testContext) {
+        super(new CmDiagnosticsCollectionRequest(), testContext, SdxClient.class);
+    }
+
+    @Override
+    public SdxCMDiagnosticsTestDto valid() {
+        withDefaults();
+        return this;
+    }
+
+    @Override
+    public SdxCMDiagnosticsTestDto awaitForFlow(RunningParameter runningParameter) {
+        return getTestContext().awaitForFlow(this, runningParameter);
+    }
+
+    public SdxCMDiagnosticsTestDto withSdx() {
+        return withSdx(null);
+    }
+
+    public SdxCMDiagnosticsTestDto withSdx(String sdx) {
+        SdxTestDto sdxTestDto = sdx == null ? getTestContext().given(SdxTestDto.class)
+                : getTestContext().given(sdx, SdxTestDto.class);
+        getRequest().setStackCrn(sdxTestDto.getResponse().getCrn());
+        return this;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxDiagnosticsTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxDiagnosticsTestDto.java
@@ -31,8 +31,13 @@ public class SdxDiagnosticsTestDto extends BaseDiagnosticsTestDto<DiagnosticsCol
         return getTestContext().awaitForFlow(this, runningParameter);
     }
 
+    public SdxDiagnosticsTestDto withSdx() {
+        return withSdx(null);
+    }
+
     public SdxDiagnosticsTestDto withSdx(String sdx) {
-        SdxTestDto sdxTestDto = getTestContext().given(sdx, SdxTestDto.class);
+        SdxTestDto sdxTestDto = sdx == null ? getTestContext().given(SdxTestDto.class)
+                : getTestContext().given(sdx, SdxTestDto.class);
         getRequest().setStackCrn(sdxTestDto.getResponse().getCrn());
         return this;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/diagnostics/DiagnosticsTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/diagnostics/DiagnosticsTests.java
@@ -1,0 +1,58 @@
+package com.sequenceiq.it.cloudbreak.testcase.e2e.diagnostics;
+
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
+
+import javax.inject.Inject;
+
+import org.testng.annotations.Test;
+
+import com.sequenceiq.it.cloudbreak.client.FreeIpaTestClient;
+import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
+import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaDiagnosticsTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCMDiagnosticsTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxDiagnosticsTestDto;
+import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
+
+public class DiagnosticsTests extends AbstractE2ETest {
+
+    @Inject
+    private FreeIpaTestClient freeIpaTestClient;
+
+    @Inject
+    private SdxTestClient sdxTestClient;
+
+    @Override
+    protected void setupTest(TestContext testContext) {
+        testContext.getCloudProvider().getCloudFunctionality().cloudStorageInitialize();
+        createDefaultUser(testContext);
+        createDefaultCredential(testContext);
+        createEnvironmentWithNetworkAndFreeIpa(testContext);
+        initializeDefaultBlueprints(testContext);
+        createDatalake(testContext);
+    }
+
+    @Test(dataProvider = TEST_CONTEXT)
+    @Description(
+            given = "there is a running cloudbreak",
+            when = "a valid SDX create request is sent with FreeIPA instances AND run diagnostics on the instances",
+            then = "the diagnostics flows should be executed successfully")
+    public void testDiagnosticsOnFreeIpaAndDatalake(TestContext testContext) {
+        String freeIpaDiagnostics = resourcePropertyProvider().getName();
+        String sdxDiagnostics = resourcePropertyProvider().getName();
+        String sdxCMDiagnostics = resourcePropertyProvider().getName();
+        testContext
+                .given(freeIpaDiagnostics, FreeIpaDiagnosticsTestDto.class)
+                .withFreeIpa()
+                .when(freeIpaTestClient.collectDiagnostics(), key(freeIpaDiagnostics))
+                .awaitForFlow(key(freeIpaDiagnostics))
+                .given(sdxDiagnostics, SdxDiagnosticsTestDto.class)
+                .withSdx()
+                .when(sdxTestClient.collectDiagnostics(), key(sdxDiagnostics))
+                .given(sdxCMDiagnostics, SdxCMDiagnosticsTestDto.class)
+                .withSdx()
+                .when(sdxTestClient.collectCMDiagnostics(), key(sdxCMDiagnostics))
+                .valid();
+    }
+}


### PR DESCRIPTION
…tions) - extended basic test cases with those

Also extended awaitFlow calls in order to make it work against freeipa + new dto
Added a distrox diagnostics dto as well, that is not used yet. (not clear how exactly use that as related tests are more like old-style stack tests not really distrox api tests, so i have to find a way to fit there)

Im using existing test cases -> it won't slow that much down the e2e test time + plan is to run diagnostics for every test case if possible (+ use recipe to gather some data from the nodes and put that as well in the diagnostics)

The PR is in draft until i did not checked against Azure

also adding a custom folder to gitignore, in order to use own/custom testsuites, as those needs to be on the classpath