### PR TITLE
CB-8363 The MGMT services (like SERVICEMONITOR) only runs on the gate…

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/config/CmMgmtServiceConfigLocationService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/config/CmMgmtServiceConfigLocationService.java
@@ -1,14 +1,13 @@
 package com.sequenceiq.cloudbreak.cm.config;
 
-import java.util.List;
 import java.util.Optional;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.springframework.stereotype.Service;
 
 import com.cloudera.api.swagger.model.ApiConfig;
 import com.cloudera.api.swagger.model.ApiRole;
 import com.cloudera.api.swagger.model.ApiRoleList;
-import com.sequenceiq.cloudbreak.domain.Resource;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.template.VolumeUtils;
 
@@ -17,32 +16,32 @@ class CmMgmtServiceConfigLocationService implements CmConfigServiceDelegate {
 
     @Override
     public void setConfigs(Stack stack, ApiRoleList apiRoleList) {
-        List<Resource> attachedDisks = stack.getDiskResources();
-        if (!attachedDisks.isEmpty()) {
-            Optional<ApiRole> eventServer = getApiRole("EVENTSERVER", apiRoleList);
-            eventServer.ifPresent(apiRole -> addConfig(apiRole, createApiConfig("eventserver_index_dir", "cloudera-scm-eventserver", attachedDisks.size())));
+        Optional<ApiRole> eventServer = getApiRole("EVENTSERVER", apiRoleList);
+        eventServer.ifPresent(apiRole -> addConfig(apiRole, createApiConfig("eventserver_index_dir", "cloudera-scm-eventserver")));
 
-            Optional<ApiRole> hostMonitor = getApiRole("HOSTMONITOR", apiRoleList);
-            hostMonitor.ifPresent(apiRole -> addConfig(apiRole, createApiConfig("firehose_storage_dir", "cloudera-host-monitor", attachedDisks.size())));
+        Optional<ApiRole> hostMonitor = getApiRole("HOSTMONITOR", apiRoleList);
+        hostMonitor.ifPresent(apiRole -> addConfig(apiRole, createApiConfig("firehose_storage_dir", "cloudera-host-monitor")));
 
-            Optional<ApiRole> reportsManager = getApiRole("REPORTSMANAGER", apiRoleList);
-            reportsManager.ifPresent(apiRole -> addConfig(apiRole, createApiConfig("headlamp_scratch_dir", "cloudera-scm-headlamp", attachedDisks.size())));
+        Optional<ApiRole> reportsManager = getApiRole("REPORTSMANAGER", apiRoleList);
+        reportsManager.ifPresent(apiRole -> addConfig(apiRole, createApiConfig("headlamp_scratch_dir", "cloudera-scm-headlamp")));
 
-            Optional<ApiRole> serviceMonitor = getApiRole("SERVICEMONITOR", apiRoleList);
-            serviceMonitor.ifPresent(apiRole -> addConfig(apiRole, createApiConfig("firehose_storage_dir", "cloudera-service-monitor", attachedDisks.size())));
-        }
+        Optional<ApiRole> serviceMonitor = getApiRole("SERVICEMONITOR", apiRoleList);
+        serviceMonitor.ifPresent(apiRole -> addConfig(apiRole, createApiConfig("firehose_storage_dir", "cloudera-service-monitor")));
     }
 
     private Optional<ApiRole> getApiRole(String roleName, ApiRoleList apiRoleList) {
+        if (CollectionUtils.isEmpty(apiRoleList.getItems())) {
+            return Optional.empty();
+        }
         return apiRoleList.getItems().stream()
-                .filter(apiRole -> apiRole.getName().equals(roleName))
+                .filter(apiRole -> apiRole != null && apiRole.getName().equals(roleName))
                 .findFirst();
     }
 
-    private ApiConfig createApiConfig(String name, String configDir, int numberOfVolumes) {
+    private ApiConfig createApiConfig(String name, String configDir) {
         ApiConfig apiConfig = new ApiConfig();
         apiConfig.setName(name);
-        apiConfig.setValue(VolumeUtils.buildSingleVolumePath(numberOfVolumes, configDir));
+        apiConfig.setValue(VolumeUtils.buildSingleVolumePath(1, configDir));
         apiConfig.setSensitive(false);
         return apiConfig;
     }

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/config/CmMgmtServiceConfigLocationServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/config/CmMgmtServiceConfigLocationServiceTest.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.cloudbreak.cm.config;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 import java.util.List;
 import java.util.Set;
@@ -63,20 +62,6 @@ public class CmMgmtServiceConfigLocationServiceTest {
         assertEquals(VOLUME_PREFIX + "cloudera-scm-headlamp", getApiConfig(REPORTSMANAGER, "headlamp_scratch_dir", apiRoleList).getValue());
         assertEquals(VOLUME_PREFIX + "cloudera-service-monitor", getApiConfig(SERVICEMONITOR, "firehose_storage_dir", apiRoleList).getValue());
         assertEquals(TEST_CONFIG_VALUE, getApiConfig(TEST_ROLE, TEST_CONFIG_NAME, apiRoleList).getValue());
-    }
-
-    @Test
-    public void testSetConfigLocationsShouldNotSetLocationsWhenThereAreNoAttachedVolumes() {
-        Stack stack = new Stack();
-        stack.setPlatformVariant(CloudConstants.AWS);
-        ApiRoleList apiRoleList = createApiRoleListWithoutConfig();
-
-        underTest.setConfigs(stack, apiRoleList);
-
-        assertNull(apiRoleList.getItems().stream().filter(apiRole -> apiRole.getName().equals(EVENTSERVER)).findFirst().get().getConfig());
-        assertNull(apiRoleList.getItems().stream().filter(apiRole -> apiRole.getName().equals(HOSTMONITOR)).findFirst().get().getConfig());
-        assertNull(apiRoleList.getItems().stream().filter(apiRole -> apiRole.getName().equals(REPORTSMANAGER)).findFirst().get().getConfig());
-        assertNull(apiRoleList.getItems().stream().filter(apiRole -> apiRole.getName().equals(SERVICEMONITOR)).findFirst().get().getConfig());
     }
 
     private ApiConfig getApiConfig(String roleName, String configName, ApiRoleList apiRoleList) {


### PR DESCRIPTION
…way node and the gateway node minimum value of volume is 1. Therefor we assign the dirs for the first attached disk by default. I removed the determinatin of volume counts from the code.

See detailed description in the commit message.