### PR TITLE
CB-8398. Host group filter is not working properly for diagnostics co…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/DiagnosticsCollectionActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/DiagnosticsCollectionActions.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 
 import javax.inject.Inject;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
@@ -54,8 +55,10 @@ public class DiagnosticsCollectionActions {
                 String resourceCrn = payload.getResourceCrn();
                 LOGGER.debug("Flow entered into DIAGNOSTICS_INIT_STATE. resourceCrn: '{}'", resourceCrn);
                 InMemoryStateStore.putStack(resourceId, PollGroup.POLLABLE);
-                String hosts = payload.getHosts() == null ? "[ALL]" : String.format("[%s]", String.join(",", payload.getHosts()));
-                String hostGroups = payload.getHostGroups() == null ? "[ALL]" : String.format("[%s]", String.join(",", payload.getHostGroups()));
+                String hosts = CollectionUtils.isEmpty(payload.getHosts())
+                        ? "[ALL]" : String.format("[%s]", String.join(",", payload.getHosts()));
+                String hostGroups = CollectionUtils.isEmpty(payload.getHostGroups())
+                        ? "[ALL]" : String.format("[%s]", String.join(",", payload.getHostGroups()));
                 cloudbreakEventService.fireCloudbreakEvent(resourceId, UPDATE_IN_PROGRESS.name(),
                         ResourceEvent.STACK_DIAGNOSTICS_INIT_RUNNING, List.of(hosts, hostGroups));
                 DiagnosticsCollectionEvent event = DiagnosticsCollectionEvent.builder()
@@ -63,6 +66,8 @@ public class DiagnosticsCollectionActions {
                         .withResourceCrn(resourceCrn)
                         .withSelector(DiagnosticsCollectionHandlerSelectors.INIT_DIAGNOSTICS_EVENT.selector())
                         .withParameters(payload.getParameters())
+                        .withHosts(payload.getHosts())
+                        .withHostGroups(payload.getHostGroups())
                         .build();
                 sendEvent(context, event);
             }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/DiagnosticsFlowService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/DiagnosticsFlowService.java
@@ -12,6 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterDeletionBasedExitCriteriaModel;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
@@ -94,12 +95,13 @@ public class DiagnosticsFlowService {
                 .collect(Collectors.toSet());
     }
 
-    private boolean filterNodes(Node node, Set<String> hosts, Set<String> hostGroups) {
+    @VisibleForTesting
+    boolean filterNodes(Node node, Set<String> hosts, Set<String> hostGroups) {
         boolean result = true;
         if (CollectionUtils.isNotEmpty(hosts)) {
             result = hosts.contains(node.getHostname());
         }
-        if (!result && CollectionUtils.isNotEmpty(hostGroups)) {
+        if (result && CollectionUtils.isNotEmpty(hostGroups)) {
             result = hostGroups.contains(node.getHostGroup());
         }
         return result;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/DiagnosticsTriggerService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/DiagnosticsTriggerService.java
@@ -58,6 +58,8 @@ public class DiagnosticsTriggerService {
                 .withResourceCrn(stack.getResourceCrn())
                 .withSelector(DiagnosticsCollectionStateSelectors.START_DIAGNOSTICS_INIT_EVENT.selector())
                 .withParameters(parameters)
+                .withHosts(parameters.getHosts())
+                .withHostGroups(parameters.getHostGroups())
                 .build();
         return reactorNotifier.notify(diagnosticsCollectionEvent, getFlowHeaders(userCrn));
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/DiagnosticsFlowServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/DiagnosticsFlowServiceTest.java
@@ -1,0 +1,120 @@
+package com.sequenceiq.cloudbreak.core.flow2.diagnostics;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.orchestrator.model.Node;
+
+public class DiagnosticsFlowServiceTest {
+
+    private DiagnosticsFlowService underTest;
+
+    @BeforeEach
+    public void setUp() {
+        underTest = new DiagnosticsFlowService();
+    }
+
+    @Test
+    public void testFilterNodesWithHostsFilter() {
+        // GIVEN
+        Set<String> hosts = new HashSet<>();
+        hosts.add("host1");
+        // WHEN
+        boolean result = underTest.filterNodes(createNode(), hosts, new HashSet<>());
+        // THEN
+        assertTrue(result);
+    }
+
+    @Test
+    public void testFilterNodesWithWrongHostsFilter() {
+        // GIVEN
+        Set<String> hosts = new HashSet<>();
+        hosts.add("host2");
+        // WHEN
+        boolean result = underTest.filterNodes(createNode(), hosts, new HashSet<>());
+        // THEN
+        assertFalse(result);
+    }
+
+    @Test
+    public void testFilterNodesWithHostGroupFilter() {
+        // GIVEN
+        Set<String> hostGroups = new HashSet<>();
+        hostGroups.add("master");
+        // WHEN
+        boolean result = underTest.filterNodes(createNode(), new HashSet<>(), hostGroups);
+        // THEN
+        assertTrue(result);
+    }
+
+    @Test
+    public void testFilterNodesWithWrongHostGroupFilter() {
+        // GIVEN
+        Set<String> hostGroups = new HashSet<>();
+        hostGroups.add("idbroker");
+        // WHEN
+        boolean result = underTest.filterNodes(createNode(), new HashSet<>(), hostGroups);
+        // THEN
+        assertFalse(result);
+    }
+
+    @Test
+    public void testFilterNodesWithHostAndHostGroupFilter() {
+        // GIVEN
+        Set<String> hostGroups = new HashSet<>();
+        hostGroups.add("master");
+        Set<String> hosts = new HashSet<>();
+        hosts.add("host1");
+        // WHEN
+        boolean result = underTest.filterNodes(createNode(), hosts, hostGroups);
+        // THEN
+        assertTrue(result);
+    }
+
+    @Test
+    public void testFilterNodesWithHostAndWrongHostGroupFilter() {
+        // GIVEN
+        Set<String> hostGroups = new HashSet<>();
+        hostGroups.add("idbroker");
+        Set<String> hosts = new HashSet<>();
+        hosts.add("host1");
+        // WHEN
+        boolean result = underTest.filterNodes(createNode(), hosts, hostGroups);
+        // THEN
+        assertFalse(result);
+    }
+
+    @Test
+    public void testFilterNodesWithWrongHostAndHostGroupFilter() {
+        // GIVEN
+        Set<String> hostGroups = new HashSet<>();
+        hostGroups.add("master");
+        Set<String> hosts = new HashSet<>();
+        hosts.add("host2");
+        // WHEN
+        boolean result = underTest.filterNodes(createNode(), hosts, hostGroups);
+        // THEN
+        assertFalse(result);
+    }
+
+    @Test
+    public void testFilterNodesWithEmptyFilters() {
+        // GIVEN
+        // WHEN
+        boolean result = underTest.filterNodes(createNode(), new HashSet<>(), new HashSet<>());
+        // THEN
+        assertTrue(result);
+    }
+
+    private Node createNode() {
+        return new Node("privateIp", "publicIp", "instanceId",
+                "instanceType", "host1", "master");
+    }
+
+}


### PR DESCRIPTION
…llections

details:
- probably this should go as hotfix later
- why is it important: there is a use case when sdx instance profile/managed idenitty does not have access for cloud storage, there we will need to filter on host groups
- there is a fix against a wrong boolean usage
- hosts and hostgroup parameters are not passed everywhere in the events

See detailed description in the commit message.