### PR TITLE
CB-8031: Update pillar configuration when starting cluster

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/start/ClusterStartEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/start/ClusterStartEvent.java
@@ -1,18 +1,22 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.start;
 
+import com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.event.PillarConfigUpdateFailed;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.ClusterStartPillarConfigUpdateResult;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.ClusterStartPollingResult;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.ClusterStartResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.DnsUpdateFinished;
 import com.sequenceiq.flow.core.FlowEvent;
 import com.sequenceiq.flow.event.EventSelectorUtil;
-import com.sequenceiq.cloudbreak.reactor.api.event.cluster.ClusterStartPollingResult;
-import com.sequenceiq.cloudbreak.reactor.api.event.cluster.ClusterStartResult;
 
 public enum ClusterStartEvent implements FlowEvent {
     CLUSTER_START_EVENT("CLUSTER_START_TRIGGER_EVENT"),
+    CLUSTER_START_PILLAR_CONFIG_UPDATE_FINISHED_EVENT(EventSelectorUtil.selector(ClusterStartPillarConfigUpdateResult.class)),
+    CLUSTER_START_PILLAR_CONFIG_UPDATE_FAILED_EVENT(EventSelectorUtil.selector(PillarConfigUpdateFailed.class)),
     DNS_UPDATE_FINISHED_EVENT(EventSelectorUtil.selector(DnsUpdateFinished.class)),
     CLUSTER_START_FAILURE_EVENT(EventSelectorUtil.failureSelector(ClusterStartResult.class)),
     CLUSTER_START_POLLING_EVENT(EventSelectorUtil.selector(ClusterStartResult.class)),
     CLUSTER_START_POLLING_FAILURE_EVENT(EventSelectorUtil.failureSelector(ClusterStartPollingResult.class)),
-    CLUSTER_START_FINISHED_EVENT(EventSelectorUtil.selector(ClusterStartPollingResult.class)),
+    CLUSTER_START_POLLING_FINISHED_EVENT(EventSelectorUtil.selector(ClusterStartPollingResult.class)),
 
     FINALIZED_EVENT("CLUSTERSTARTFINALIZEDEVENT"),
     FAILURE_EVENT("CLUSTERSTARTFAILUREEVENT"),

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/start/ClusterStartState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/start/ClusterStartState.java
@@ -9,6 +9,7 @@ public enum ClusterStartState implements FlowState {
     INIT_STATE,
     CLUSTER_START_FAILED_STATE,
 
+    CLUSTER_START_UPDATE_PILLAR_CONFIG_STATE,
     UPDATING_DNS_IN_PEM_STATE,
     CLUSTER_STARTING_STATE,
     CLUSTER_START_POLLING_STATE(FillInMemoryStateStoreRestartAction.class),

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterStartPillarConfigUpdateRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterStartPillarConfigUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
+
+import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformRequest;
+
+public class ClusterStartPillarConfigUpdateRequest extends ClusterPlatformRequest {
+    public ClusterStartPillarConfigUpdateRequest(Long stackId) {
+        super(stackId);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterStartPillarConfigUpdateResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterStartPillarConfigUpdateResult.java
@@ -1,0 +1,10 @@
+package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
+
+import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformResult;
+
+public class ClusterStartPillarConfigUpdateResult extends ClusterPlatformResult<ClusterStartPillarConfigUpdateRequest> {
+
+    public ClusterStartPillarConfigUpdateResult(ClusterStartPillarConfigUpdateRequest request) {
+        super(request);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterStartPillarConfigUpdateHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterStartPillarConfigUpdateHandler.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.handler;
+package com.sequenceiq.cloudbreak.reactor.handler.cluster;
 
 import javax.inject.Inject;
 
@@ -9,22 +9,21 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.PillarConfigUpdateService;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.event.PillarConfigUpdateFailed;
-import com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.event.PillarConfigUpdateRequest;
-import com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.event.PillarConfigUpdateSuccess;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.ClusterStartPillarConfigUpdateRequest;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.ClusterStartPillarConfigUpdateResult;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
 
 @Component
-public class PillarConfigUpdateHandler extends ExceptionCatcherEventHandler<PillarConfigUpdateRequest> {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(PillarConfigUpdateHandler.class);
+public class ClusterStartPillarConfigUpdateHandler extends ExceptionCatcherEventHandler<ClusterStartPillarConfigUpdateRequest> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterStartPillarConfigUpdateHandler.class);
 
     @Inject
     private PillarConfigUpdateService pillarConfigUpdateService;
 
     @Override
     public String selector() {
-        return EventSelectorUtil.selector(PillarConfigUpdateRequest.class);
+        return EventSelectorUtil.selector(ClusterStartPillarConfigUpdateRequest.class);
     }
 
     @Override
@@ -34,11 +33,11 @@ public class PillarConfigUpdateHandler extends ExceptionCatcherEventHandler<Pill
 
     @Override
     protected Selectable doAccept(HandlerEvent event) {
-        PillarConfigUpdateRequest request = event.getData();
+        ClusterStartPillarConfigUpdateRequest request = event.getData();
         Selectable response;
         try {
             pillarConfigUpdateService.doConfigUpdate(request.getResourceId());
-            response = new PillarConfigUpdateSuccess(request.getResourceId());
+            response = new ClusterStartPillarConfigUpdateResult(request);
         } catch (Exception e) {
             LOGGER.warn("Pillar configuration update failed.", e);
             response = new PillarConfigUpdateFailed(request.getResourceId(), e);


### PR DESCRIPTION
Co-authored-by: Brian Towles <btowles@cloudera.com>

When a datalake or datahub is started, update the pillar
configuration. This ensures that if the FreeIPA IP addresses changed
while the datalake was stopped then cloudbreak will update the FreeIPA
IP addresses when starting the stopped instances.

This was tested manually by ensuring the pillar configuration was
called on a local instance of cloudbreak.

See detailed description in the commit message.