### PR TITLE
CB-8407 Filter images which are not configured to use archive.clouder…

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
@@ -62,6 +62,9 @@ public class EntitlementService {
     @VisibleForTesting
     static final String CDP_CLOUD_IDENTITY_MAPPING = "CDP_CLOUD_IDENTITY_MAPPING";
 
+    @VisibleForTesting
+    static final String CDP_ALLOW_INTERNAL_REPOSITORY_FOR_UPGRADE = "CDP_ALLOW_INTERNAL_REPOSITORY_FOR_UPGRADE";
+
     @Inject
     private GrpcUmsClient umsClient;
 
@@ -127,6 +130,10 @@ public class EntitlementService {
 
     public boolean cloudIdentityMappingEnabled(String actorCrn, String accountId) {
         return isEntitlementRegistered(actorCrn, accountId, CDP_CLOUD_IDENTITY_MAPPING);
+    }
+
+    public boolean isInternalRepositoryForUpgradeAllowed(String actorCrn, String accountId) {
+        return isEntitlementRegistered(actorCrn, accountId, CDP_ALLOW_INTERNAL_REPOSITORY_FOR_UPGRADE);
     }
 
     public List<String> getEntitlements(String actorCrn, String accountId) {

--- a/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementServiceTest.java
+++ b/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementServiceTest.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.auth.altus;
 
+import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_ALLOW_INTERNAL_REPOSITORY_FOR_UPGRADE;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_AUTOMATIC_USERSYNC_POLLER;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_AZURE;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_AZURE_SINGLE_RESOURCE_GROUP;
@@ -115,6 +116,10 @@ class EntitlementServiceTest {
                         (EntitlementCheckFunction) EntitlementService::cloudIdentityMappingEnabled, false},
                 {"CDP_CLOUD_IDENTITY_MAPPING == true", CDP_CLOUD_IDENTITY_MAPPING,
                         (EntitlementCheckFunction) EntitlementService::cloudIdentityMappingEnabled, true},
+                {"CDP_ALLOW_INTERNAL_REPOSITORY_FOR_UPGRADE == true", CDP_ALLOW_INTERNAL_REPOSITORY_FOR_UPGRADE,
+                        (EntitlementCheckFunction) EntitlementService::isInternalRepositoryForUpgradeAllowed, true},
+                {"CDP_ALLOW_INTERNAL_REPOSITORY_FOR_UPGRADE == false", CDP_ALLOW_INTERNAL_REPOSITORY_FOR_UPGRADE,
+                        (EntitlementCheckFunction) EntitlementService::isInternalRepositoryForUpgradeAllowed, false},
         };
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/CdhPackageLocationFilter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/CdhPackageLocationFilter.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.cloudbreak.service.upgrade;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+
+@Component
+public class CdhPackageLocationFilter implements PackageLocationFilter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CdhPackageLocationFilter.class);
+
+    @Override
+    public boolean filterImage(Image image, Image currentImage) {
+        if (isRelevantFieldNull(image, currentImage)) {
+            LOGGER.debug("Image or some part of it is null: {}", image);
+            return false;
+        } else {
+            String repoUrl = image.getStackDetails().getRepo().getStack().getOrDefault(currentImage.getOsType(), "");
+            LOGGER.debug("Matching URL: [{}]", repoUrl);
+            return URL_PATTERN.matcher(repoUrl).find();
+        }
+    }
+
+    private boolean isRelevantFieldNull(Image image, Image currentImage) {
+        return image == null
+                || image.getStackDetails() == null
+                || image.getStackDetails().getRepo() == null
+                || image.getStackDetails().getRepo().getStack() == null
+                || currentImage == null
+                || StringUtils.isBlank(currentImage.getOsType());
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ClouderaManagerPackageLocationFilter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ClouderaManagerPackageLocationFilter.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.cloudbreak.service.upgrade;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+
+@Component
+public class ClouderaManagerPackageLocationFilter implements PackageLocationFilter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerPackageLocationFilter.class);
+
+    @Override
+    public boolean filterImage(Image image, Image currentImage) {
+        if (image == null || image.getRepo() == null || currentImage == null || StringUtils.isBlank(currentImage.getOsType())) {
+            LOGGER.debug("Image or repo is null: {}", image);
+            return false;
+        } else {
+            String repoUrl = image.getRepo().getOrDefault(currentImage.getOsType(), "");
+            LOGGER.debug("Matching URL: [{}]", repoUrl);
+            return URL_PATTERN.matcher(repoUrl).find();
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeImageFilter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeImageFilter.java
@@ -53,6 +53,9 @@ public class ClusterUpgradeImageFilter {
     @Inject
     private PreWarmParcelParser preWarmParcelParser;
 
+    @Inject
+    private EntitlementDrivenPackageLocationFilter packageLocationFilter;
+
     private String reason;
 
     ImageFilterResult filter(List<Image> images, Versions versions, Image currentImage, String cloudPlatform, boolean lockComponents,
@@ -81,6 +84,7 @@ public class ClusterUpgradeImageFilter {
                 .filter(validateCloudPlatform(cloudPlatform))
                 .filter(validateOsVersion(currentImage))
                 .filter(validateSaltVersion(currentImage))
+                .filter(packageLocationFilter.filterImage(currentImage))
                 .collect(Collectors.toList());
 
         return new ImageFilterResult(new Images(null, images, null), getReason(images));

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/EntitlementDrivenPackageLocationFilter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/EntitlementDrivenPackageLocationFilter.java
@@ -1,0 +1,39 @@
+package com.sequenceiq.cloudbreak.service.upgrade;
+
+import static com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider.INTERNAL_ACTOR_CRN;
+
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+
+@Component
+public class EntitlementDrivenPackageLocationFilter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EntitlementDrivenPackageLocationFilter.class);
+
+    private final EntitlementService entitlementService;
+
+    private final Set<PackageLocationFilter> filters;
+
+    public EntitlementDrivenPackageLocationFilter(EntitlementService entitlementService, Set<PackageLocationFilter> filters) {
+        this.entitlementService = entitlementService;
+        this.filters = filters;
+    }
+
+    public Predicate<Image> filterImage(Image currentImage) {
+        String accountId = ThreadBasedUserCrnProvider.getAccountId();
+        if (entitlementService.isInternalRepositoryForUpgradeAllowed(INTERNAL_ACTOR_CRN, accountId)) {
+            LOGGER.debug("Skipping image filtering based on repository url");
+            return image -> true;
+        } else {
+            return image -> filters.stream().allMatch(filter -> filter.filterImage(image, currentImage));
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/PackageLocationFilter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/PackageLocationFilter.java
@@ -1,0 +1,11 @@
+package com.sequenceiq.cloudbreak.service.upgrade;
+
+import java.util.regex.Pattern;
+
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+
+public interface PackageLocationFilter {
+    Pattern URL_PATTERN = Pattern.compile("http[s]?://archive\\.cloudera\\.com.+");
+
+    boolean filterImage(Image image, Image currentImage);
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/CdhPackageLocationFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/CdhPackageLocationFilterTest.java
@@ -1,0 +1,113 @@
+package com.sequenceiq.cloudbreak.service.upgrade;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.StackDetails;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.StackRepoDetails;
+
+class CdhPackageLocationFilterTest {
+
+    private CdhPackageLocationFilter underTest = new CdhPackageLocationFilter();
+
+    @Test
+    public void testImageNull() {
+        boolean result = underTest.filterImage(null, mock(Image.class));
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testStackDetailIsNull() {
+        boolean result = underTest.filterImage(mock(Image.class), mock(Image.class));
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testRepoIsNull() {
+        Image image = mock(Image.class);
+        when(image.getStackDetails()).thenReturn(new StackDetails("1", null, "1"));
+
+        boolean result = underTest.filterImage(image, mock(Image.class));
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testStackIsNull() {
+        Image image = mock(Image.class);
+        when(image.getStackDetails()).thenReturn(new StackDetails("1", new StackRepoDetails(null, null), "1"));
+
+        boolean result = underTest.filterImage(image, mock(Image.class));
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testCurrentImageNull() {
+        Image image = mock(Image.class);
+        when(image.getStackDetails()).thenReturn(new StackDetails("1", new StackRepoDetails(Map.of(), Map.of()), "1"));
+
+        boolean result = underTest.filterImage(image, null);
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testCurrentImageOsTypeEmpty() {
+        Image image = mock(Image.class);
+        when(image.getStackDetails()).thenReturn(new StackDetails("1", new StackRepoDetails(Map.of(), Map.of()), "1"));
+        Image currentImage = mock(Image.class);
+        when(currentImage.getOsType()).thenReturn(" ");
+
+        boolean result = underTest.filterImage(image, currentImage);
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testOsTypeMissing() {
+        Image image = mock(Image.class);
+        when(image.getStackDetails()).thenReturn(new StackDetails("1", new StackRepoDetails(Map.of(), Map.of()), "1"));
+        Image currentImage = mock(Image.class);
+        when(currentImage.getOsType()).thenReturn("redhat7");
+
+        boolean result = underTest.filterImage(image, currentImage);
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testNotMatching() {
+        Image image = mock(Image.class);
+        when(image.getStackDetails()).thenReturn(new StackDetails("1", new StackRepoDetails(Map.of("redhat7", "http://random.org/asdf/"), Map.of()), "1"));
+        Image currentImage = mock(Image.class);
+        when(currentImage.getOsType()).thenReturn("redhat7");
+
+        boolean result = underTest.filterImage(image, currentImage);
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testMatching() {
+        Image image = mock(Image.class);
+        when(image.getStackDetails()).thenReturn(new StackDetails("1", new StackRepoDetails(Map.of("redhat7", "http://archive.cloudera.com/asdf/"),
+                Map.of()), "1"));
+        Image currentImage = mock(Image.class);
+        when(currentImage.getOsType()).thenReturn("redhat7");
+
+        boolean result = underTest.filterImage(image, currentImage);
+
+        assertTrue(result);
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ClouderaManagerPackageLocationFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ClouderaManagerPackageLocationFilterTest.java
@@ -1,0 +1,85 @@
+package com.sequenceiq.cloudbreak.service.upgrade;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+
+class ClouderaManagerPackageLocationFilterTest {
+
+    private ClouderaManagerPackageLocationFilter underTest = new ClouderaManagerPackageLocationFilter();
+
+    @Test
+    public void testImageNull() {
+        boolean result = underTest.filterImage(null, mock(Image.class));
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testRepoNull() {
+        boolean result = underTest.filterImage(mock(Image.class), mock(Image.class));
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testCurrentImageNull() {
+        Image image = mock(Image.class);
+        when(image.getRepo()).thenReturn(Map.of());
+        boolean result = underTest.filterImage(image, null);
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testCurrentImageOsTypeEmpty() {
+        Image image = mock(Image.class);
+        when(image.getRepo()).thenReturn(Map.of());
+        Image currentImage = mock(Image.class);
+        when(currentImage.getOsType()).thenReturn(" ");
+        boolean result = underTest.filterImage(image, currentImage);
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testOsTypeMissing() {
+        Image image = mock(Image.class);
+        when(image.getRepo()).thenReturn(Map.of());
+        Image currentImage = mock(Image.class);
+        when(currentImage.getOsType()).thenReturn("redhat7");
+        boolean result = underTest.filterImage(image, currentImage);
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testNotMatching() {
+        Image image = mock(Image.class);
+        when(image.getRepo()).thenReturn(Map.of("redhat7", "http://random.org/asdf/"));
+        Image currentImage = mock(Image.class);
+        when(currentImage.getOsType()).thenReturn("redhat7");
+        boolean result = underTest.filterImage(image, currentImage);
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testMatching() {
+        Image image = mock(Image.class);
+        when(image.getRepo()).thenReturn(Map.of("redhat7", "http://archive.cloudera.com/asdf/"));
+        Image currentImage = mock(Image.class);
+        when(currentImage.getOsType()).thenReturn("redhat7");
+        boolean result = underTest.filterImage(image, currentImage);
+
+        assertTrue(result);
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/EntitlementDrivenPackageLocationFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/EntitlementDrivenPackageLocationFilterTest.java
@@ -1,0 +1,102 @@
+package com.sequenceiq.cloudbreak.service.upgrade;
+
+import static com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider.INTERNAL_ACTOR_CRN;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+
+@ExtendWith(MockitoExtension.class)
+class EntitlementDrivenPackageLocationFilterTest {
+
+    private static final String USER_CRN = "crn:cdp:iam:us-west-1:123:user:321";
+
+    private EntitlementService entitlementService = mock(EntitlementService.class);
+
+    @BeforeEach
+    public void init() {
+        when(entitlementService.isInternalRepositoryForUpgradeAllowed(anyString(), anyString())).thenReturn(Boolean.FALSE);
+    }
+
+    @AfterEach
+    public void postCheck() {
+        verify(entitlementService).isInternalRepositoryForUpgradeAllowed(INTERNAL_ACTOR_CRN, "123");
+    }
+
+    @Test
+    public void testEnitlementEnabled() {
+        PackageLocationFilter filter = mock(PackageLocationFilter.class);
+        when(entitlementService.isInternalRepositoryForUpgradeAllowed(anyString(), anyString())).thenReturn(Boolean.TRUE);
+        EntitlementDrivenPackageLocationFilter underTest = new EntitlementDrivenPackageLocationFilter(entitlementService, Set.of(filter));
+        Predicate<Image> imagePredicate = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.filterImage(mock(Image.class)));
+
+        boolean result = imagePredicate.test(mock(Image.class));
+
+        assertTrue(result);
+        verify(filter, never()).filterImage(any(Image.class), any(Image.class));
+    }
+
+    @Test
+    public void testAcceptedImageMultipleFilters() {
+        Set<PackageLocationFilter> filters = Set.of(createAcceptingFilter(), createAcceptingFilter(), createAcceptingFilter(), createAcceptingFilter());
+        EntitlementDrivenPackageLocationFilter underTest = new EntitlementDrivenPackageLocationFilter(entitlementService, filters);
+        Predicate<Image> imagePredicate = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.filterImage(mock(Image.class)));
+
+        boolean result = imagePredicate.test(mock(Image.class));
+
+        assertTrue(result);
+        filters.forEach(filter -> verify(filter).filterImage(any(Image.class), any(Image.class)));
+    }
+
+    @Test
+    public void testRejectedImageMultipleFilters() {
+        Set<PackageLocationFilter> filters = Set.of(createAcceptingFilter(), createAcceptingFilter(), createRejectingFilter(), createAcceptingFilter());
+        EntitlementDrivenPackageLocationFilter underTest = new EntitlementDrivenPackageLocationFilter(entitlementService, filters);
+        Predicate<Image> imagePredicate = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.filterImage(mock(Image.class)));
+
+        boolean result = imagePredicate.test(mock(Image.class));
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testRejectedImageMultipleRejectingFilters() {
+        Set<PackageLocationFilter> filters = Set.of(createRejectingFilter(), createRejectingFilter(), createRejectingFilter());
+        EntitlementDrivenPackageLocationFilter underTest = new EntitlementDrivenPackageLocationFilter(entitlementService, filters);
+        Predicate<Image> imagePredicate = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.filterImage(mock(Image.class)));
+
+        boolean result = imagePredicate.test(mock(Image.class));
+
+        assertFalse(result);
+    }
+
+    private PackageLocationFilter createAcceptingFilter() {
+        PackageLocationFilter filter = mock(PackageLocationFilter.class);
+        lenient().when(filter.filterImage(any(Image.class), any(Image.class))).thenReturn(Boolean.TRUE);
+        return filter;
+    }
+
+    private PackageLocationFilter createRejectingFilter() {
+        PackageLocationFilter filter = mock(PackageLocationFilter.class);
+        lenient().when(filter.filterImage(any(Image.class), any(Image.class))).thenReturn(Boolean.FALSE);
+        return filter;
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/PackageLocationFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/PackageLocationFilterTest.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.cloudbreak.service.upgrade;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class PackageLocationFilterTest {
+
+    @ParameterizedTest
+    @MethodSource("providaTestData")
+    public void testPattern(String url, boolean expected) {
+        assertEquals(expected, PackageLocationFilter.URL_PATTERN.matcher(url).find());
+    }
+
+    private static Stream<Arguments> providaTestData() {
+        return Stream.of(
+                Arguments.of("http://archive.cloudera.com", false),
+                Arguments.of("https://archive.cloudera.com", false),
+                Arguments.of("http://archive.cloudera.com/asdf", true),
+                Arguments.of("https://archive.cloudera.com/asdf", true),
+                Arguments.of("http://archiveXcloudera.com/asdf", false),
+                Arguments.of("http://archive.clouderaXcom/asdf", false),
+                Arguments.of("http://archive.cloudera.com/build/4448967/cm7/7.2.1/redhat7/yum/", true),
+                Arguments.of("https://archive.cloudera.com/build/4448967/cm7/7.2.1/redhat7/yum/", true),
+                Arguments.of("http://archive.cloudera.com/s3/build/4452156/cdh/7.x/parcels/", true),
+                Arguments.of("https://archive.cloudera.com/s3/build/4452156/cdh/7.x/parcels/", true),
+                Arguments.of("https://cloudera.com/asdf", false),
+                Arguments.of("archive.cloudera.com/asdf", false),
+                Arguments.of("https://cloudera.com/asdf", false),
+                Arguments.of("https://archive.random.com/asdf", false)
+        );
+    }
+
+}

--- a/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
+++ b/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
@@ -204,6 +204,8 @@ public class MockUserManagementService extends UserManagementImplBase {
 
     private static final String CDP_CLOUD_IDENTITY_MAPPING = "CDP_CLOUD_IDENTITY_MAPPING";
 
+    private static final String CDP_ALLOW_INTERNAL_REPOSITORY_FOR_UPGRADE = "CDP_ALLOW_INTERNAL_REPOSITORY_FOR_UPGRADE";
+
     private static final String MOCK_RESOURCE = "mock_resource";
 
     private static final String SSH_PUBLIC_KEY_PATTERN = "^ssh-(rsa|ed25519)\\s+AAAA(B|C)3NzaC1.*(|\\n)";
@@ -270,6 +272,9 @@ public class MockUserManagementService extends UserManagementImplBase {
 
     @Value("${auth.mock.cloudidentitymappinng.enable}")
     private boolean enableCloudIdentityMappinng;
+
+    @Value("${auth.mock.upgrade.internalrepo.enable}")
+    private boolean enableInternalRepositoryForUpgrade;
 
     private String cbLicense;
 
@@ -559,6 +564,9 @@ public class MockUserManagementService extends UserManagementImplBase {
         }
         if (enableCloudIdentityMappinng) {
             builder.addEntitlements(createEntitlement(CDP_CLOUD_IDENTITY_MAPPING));
+        }
+        if (enableInternalRepositoryForUpgrade) {
+            builder.addEntitlements(createEntitlement(CDP_ALLOW_INTERNAL_REPOSITORY_FOR_UPGRADE));
         }
         responseObserver.onNext(
                 GetAccountResponse.newBuilder()

--- a/mock-thunderhead/src/main/resources/application.yml
+++ b/mock-thunderhead/src/main/resources/application.yml
@@ -25,3 +25,4 @@ auth:
     fastebsencryption.enable: true
     cloudidentitymappinng.enable: true
     mediumdutysdx.enable: true
+    upgrade.internalrepo.enable: true


### PR DESCRIPTION
…a.com

By default end user can't access any package which is not on archive
For the upgrade we currently depend on downloadable packages.
In this commit we will filter out those images which packeges repo is not
located on archive except if the account has the CDP_ALLOW_INTERNAL_REPOSITORY_FOR_UPGRADE
entitlement

See detailed description in the commit message.