### PR TITLE
CB-7975 - [ASRG] Save and manage managed images and storage accounts …

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/Setup.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/Setup.java
@@ -18,7 +18,7 @@ import com.sequenceiq.common.api.type.ImageStatusResult;
 public interface Setup {
 
     /**
-     * Creates the VM if it is not available. Some platform does not allow to start a VM from a central image but it forces the user to copy the image to
+     * Creates the VM if it is not available. Some platforms do not allow to start a VM from a central image but it forces the user to copy the image to
      * its own storage.
      * <br>
      * To check whether the image copy is finished use {@link #checkImageStatus(AuthenticatedContext, CloudStack, Image)}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureCloudResourceService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureCloudResourceService.java
@@ -177,6 +177,17 @@ public class AzureCloudResourceService {
         return vmResourceList;
     }
 
+    public CloudResource buildCloudResource(String name, String id, ResourceType type) {
+        LOGGER.debug("{} {} is being created with id {}", type.name(), name, id);
+        return CloudResource.builder()
+                .name(name)
+                .status(CommonStatus.CREATED)
+                .persistent(true)
+                .reference(id)
+                .type(type)
+                .build();
+    }
+
     private CloudResource buildVm(CloudResource sourceResource, String instanceGroupName, String resourceGroupName) {
         return CloudResource.builder()
                 .type(sourceResource.getType())

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureImage.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureImage.java
@@ -1,0 +1,49 @@
+package com.sequenceiq.cloudbreak.cloud.azure;
+
+public class AzureImage {
+
+    private String id;
+
+    private String name;
+
+    private boolean alreadyExists;
+
+    public AzureImage(String id, String name, boolean alreadyExists) {
+        this.id = id;
+        this.name = name;
+        this.alreadyExists = alreadyExists;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public boolean getAlreadyExists() {
+        return alreadyExists;
+    }
+
+    public void setAlreadyExists(boolean alreadyExists) {
+        this.alreadyExists = alreadyExists;
+    }
+
+    @Override
+    public String toString() {
+        return "AzureImage{" +
+                "id='" + id + '\'' +
+                ", name='" + name + '\'' +
+                ", alreadyExists=" + alreadyExists +
+                '}';
+    }
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStackViewProvider.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStackViewProvider.java
@@ -58,7 +58,8 @@ class AzureStackViewProvider {
             for (CloudInstance instance : group.getInstances()) {
                 String imageId = instance.getTemplate().getImageId();
                 if (StringUtils.isNotBlank(imageId)) {
-                    String imageCustomName = imageNameMap.computeIfAbsent(imageId, s -> azureStorage.getCustomImageId(client, ac, cloudStack, imageId));
+                    String imageCustomName = imageNameMap.computeIfAbsent(
+                            imageId, s -> azureStorage.getCustomImage(client, ac, cloudStack, imageId).getId());
                     customImageNamePerInstance.put(instance.getInstanceId(), imageCustomName);
                 }
             }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStorage.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStorage.java
@@ -36,6 +36,7 @@ import com.sequenceiq.cloudbreak.cloud.azure.view.AzureCredentialView;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 
 @Service
 public class AzureStorage {
@@ -75,23 +76,24 @@ public class AzureStorage {
         return ArmAttachedStorageOption.valueOf(attachedStorageOption);
     }
 
-    public String getCustomImageId(AzureClient client, AuthenticatedContext ac, CloudStack stack) {
-        return getCustomImageId(client, ac, stack, stack.getImage().getImageName());
+    public AzureImage getCustomImage(AzureClient client, AuthenticatedContext ac, CloudStack stack) {
+        return getCustomImage(client, ac, stack, stack.getImage().getImageName());
     }
 
-    public String getCustomImageId(AzureClient client, AuthenticatedContext ac, CloudStack stack, String imageName) {
+    public AzureImage getCustomImage(AzureClient client, AuthenticatedContext ac, CloudStack stack, String imageName) {
         String imageResourceGroupName = azureResourceGroupMetadataProvider.getImageResourceGroupName(ac.getCloudContext(), stack);
         AzureCredentialView acv = new AzureCredentialView(ac.getCloudCredential());
         String imageStorageName = getImageStorageName(acv, ac.getCloudContext(), stack);
         String imageBlobUri = client.getImageBlobUri(imageResourceGroupName, imageStorageName, IMAGES_CONTAINER, imageName);
         String region = ac.getCloudContext().getLocation().getRegion().value();
-        return getCustomImageId(imageBlobUri, imageResourceGroupName, region, client);
+        return getCustomImage(imageBlobUri, imageResourceGroupName, region, client);
     }
 
-    private String getCustomImageId(String vhd, String imageResourceGroupName, String region, AzureClient client) {
-        String customImageId = client.getCustomImageId(imageResourceGroupName, vhd, region);
+    private AzureImage getCustomImage(String vhd, String imageResourceGroupName, String region, AzureClient client) {
+        AzureImage image = client.getCustomImageId(imageResourceGroupName, vhd, region);
+        String customImageId = image.getId();
         LOGGER.debug("Custom image id: {}", customImageId);
-        return customImageId;
+        return image;
     }
 
     public String getImageStorageName(AzureCredentialView acv, CloudContext cloudContext, CloudStack cloudStack) {
@@ -108,14 +110,15 @@ public class AzureStorage {
         return buildStorageName(armAttachedStorageOption, acv, vmId, cloudContext, storageType);
     }
 
-    public void createStorage(AzureClient client, String osStorageName, AzureDiskType storageType, String storageGroup, String region, Boolean encrypted,
-            Map<String, String> tags)
+    public StorageAccount createStorage(AzureClient client, String osStorageName, AzureDiskType storageType, String storageGroup,
+            String region, Boolean encrypted, Map<String, String> tags)
             throws CloudException {
         if (!storageAccountExist(client, osStorageName)) {
             StorageAccountParameters storageAccountParameters = new StorageAccountParameters(
                     storageGroup, osStorageName, region, skuTypeResolver.resolveFromAzureDiskType(storageType), encrypted, tags);
-            azureStorageAccountBuilderService.buildStorageAccount(client, storageAccountParameters);
+            return azureStorageAccountBuilderService.buildStorageAccount(client, storageAccountParameters);
         }
+        throw new CloudbreakServiceException(String.format("Trying to delete non-existing storage account %s", osStorageName));
     }
 
     public void deleteStorage(AzureClient client, String osStorageName, String storageGroup)

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStorageAccountService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStorageAccountService.java
@@ -3,6 +3,8 @@ package com.sequenceiq.cloudbreak.cloud.azure;
 import static com.sequenceiq.cloudbreak.cloud.azure.AzureDiskType.LOCALLY_REDUNDANT;
 import static com.sequenceiq.cloudbreak.cloud.azure.AzureStorage.IMAGES_CONTAINER;
 
+import java.util.List;
+
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
@@ -16,9 +18,12 @@ import com.sequenceiq.cloudbreak.cloud.azure.task.AzurePollTaskFactory;
 import com.sequenceiq.cloudbreak.cloud.azure.task.storageaccount.StorageAccountCheckerContext;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.notification.ResourceNotifier;
 import com.sequenceiq.cloudbreak.cloud.scheduler.SyncPollingScheduler;
 import com.sequenceiq.cloudbreak.cloud.task.PollTask;
+import com.sequenceiq.common.api.type.ResourceType;
 
 @Service
 public class AzureStorageAccountService {
@@ -40,13 +45,22 @@ public class AzureStorageAccountService {
     @Inject
     private AzureStorage armStorage;
 
+    @Inject
+    private AzureCloudResourceService azureCloudResourceService;
+
+    @Inject
+    private ResourceNotifier resourceNotifier;
+
     public void createStorageAccount(AuthenticatedContext ac, AzureClient client, String resourceGroup, String storageName, String region, CloudStack stack) {
         StorageAccount storageAccount = client.getStorageAccountByGroup(resourceGroup, storageName);
         if (storageAccount == null) {
             try {
                 LOGGER.info("Creating storage account: {}", storageName);
-                armStorage.createStorage(client, storageName, LOCALLY_REDUNDANT, resourceGroup, region, isEncryptionNeeded(stack), stack.getTags());
+                StorageAccount storage = armStorage.createStorage(client, storageName, LOCALLY_REDUNDANT, resourceGroup, region, isEncryptionNeeded(stack),
+                        stack.getTags());
                 pollStorageAccountCreation(ac, new StorageAccountCheckerContext(client, resourceGroup, storageName));
+                CloudResource cloudResource = azureCloudResourceService.buildCloudResource(storage.name(), storage.id(), ResourceType.AZURE_STORAGE);
+                azureCloudResourceService.saveCloudResources(resourceNotifier, ac.getCloudContext(), List.of(cloudResource));
             } catch (CloudException e) {
                 LOGGER.error("Error during storage account creation: {}.", storageName, e);
                 throw new CloudConnectorException("Storage account creation failed.", e);

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTerminationHelperService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTerminationHelperService.java
@@ -95,18 +95,31 @@ public class AzureTerminationHelperService {
         deleteVolumeSets(ac, stack, resourcesToRemove, networkResources, resourceGroupName);
 
         if (deleteWholeDeployment) {
+            // deleting availability sets
             List<String> availabiltySetNames = getResourceNamesByResourceType(resourcesToRemove, ResourceType.AZURE_AVAILABILITY_SET);
             azureUtils.deleteAvailabilitySets(client, resourceGroupName, availabiltySetNames);
             deleteCloudResourceList(ac, resourcesToRemove, ResourceType.AZURE_AVAILABILITY_SET);
 
+            // deleting networks
             List<String> networkIds = getResourceIdsByResourceType(resourcesToRemove, ResourceType.AZURE_NETWORK);
             azureUtils.deleteNetworks(client, networkIds);
             deleteCloudResourceList(ac, resourcesToRemove, ResourceType.AZURE_NETWORK);
             deleteCloudResourceList(ac, resourcesToRemove, ResourceType.AZURE_SUBNET);
 
+            // deleting security groups
             List<String> securityGroupIds = getResourceIdsByResourceType(resourcesToRemove, ResourceType.AZURE_SECURITY_GROUP);
             azureUtils.deleteSecurityGroups(client, securityGroupIds);
             deleteCloudResourceList(ac, resourcesToRemove, ResourceType.AZURE_SECURITY_GROUP);
+
+            // deleting images
+            List<String> imageIds = getResourceIdsByResourceType(resourcesToRemove, ResourceType.AZURE_MANAGED_IMAGE);
+            azureUtils.deleteImages(client, imageIds);
+            deleteCloudResourceList(ac, resourcesToRemove, ResourceType.AZURE_MANAGED_IMAGE);
+
+            // deleting storage account
+            List<String> accountIds = getResourceIdsByResourceType(resourcesToRemove, ResourceType.AZURE_STORAGE);
+            azureUtils.deleteStorageAccounts(client, accountIds);
+            deleteCloudResourceList(ac, resourcesToRemove, ResourceType.AZURE_STORAGE);
         }
 
         LOGGER.debug("All the necessary resources have been deleted successfully");

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/storageaccount/StorageAccountChecker.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/storageaccount/StorageAccountChecker.java
@@ -32,10 +32,10 @@ public class StorageAccountChecker extends PollBooleanStateTask {
         StorageAccount storageAccount = client.getStorageAccountByGroup(context.getResourceGroupName(), context.getResourceGroupName());
         if (storageAccount == null) {
             LOGGER.info("Storage account creation not finished yet");
-            return true;
+            return false;
         } else {
             LOGGER.info("Storage account creation has been finished");
-            return false;
+            return true;
         }
     }
 }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/template/AzureTemplateDeploymentService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/template/AzureTemplateDeploymentService.java
@@ -44,7 +44,7 @@ public class AzureTemplateDeploymentService {
 
     private String getTemplate(CloudStack stack, AzureStackView azureStackView, AuthenticatedContext ac, CloudContext cloudContext,
             String stackName, AzureClient client, AzureInstanceTemplateOperation azureInstanceTemplateOperation) {
-        String customImageId = azureStorage.getCustomImageId(client, ac, stack);
+        String customImageId = azureStorage.getCustomImage(client, ac, stack).getId();
         return azureTemplateBuilder.build(stackName, customImageId, createCredential(ac), azureStackView, cloudContext, stack, azureInstanceTemplateOperation);
     }
 

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnectorTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnectorTest.java
@@ -105,12 +105,14 @@ public class AzureResourceConnectorTest {
         CloudResource cloudResource = mock(CloudResource.class);
         instances = List.of(cloudResource);
         network = new Network(new Subnet("0.0.0.0/16"));
+        AzureImage image = new AzureImage("id", "name", true);
         when(stack.getGroups()).thenReturn(groups);
         when(stack.getNetwork()).thenReturn(network);
         when(ac.getCloudContext()).thenReturn(cloudContext);
         when(ac.getParameter(AzureClient.class)).thenReturn(client);
         when(ac.getCloudCredential()).thenReturn(new CloudCredential("aCredentialId", "aCredentialName"));
         when(azureUtils.getStackName(cloudContext)).thenReturn(STACK_NAME);
+        when(azureStorage.getCustomImage(any(), any(), any())).thenReturn(image);
         when(deployment.exportTemplate()).thenReturn(deploymentExportResult);
         when(azureResourceGroupMetadataProvider.getResourceGroupName(cloudContext, stack)).thenReturn(RESOURCE_GROUP_NAME);
         when(azureCloudResourceService.getDeploymentCloudResources(deployment)).thenReturn(instances);

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStackViewProviderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStackViewProviderTest.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.cloud.azure;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -73,7 +74,8 @@ public class AzureStackViewProviderTest {
         AzureCredentialView azureCredentialView = new AzureCredentialView(cloudCredential);
         AuthenticatedContext ac = new AuthenticatedContext(createCloudContext(), cloudCredential);
         Network network = mock(Network.class);
-
+        AzureImage image = new AzureImage("id", "name", true);
+        when(azureStorage.getCustomImage(any(), any(), any(), any())).thenReturn(image);
         List<Group> groups = createScaledGroups();
         when(cloudStack.getGroups()).thenReturn(groups);
         when(cloudStack.getParameters()).thenReturn(Collections.emptyMap());

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
@@ -512,7 +512,7 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
     @Override
     public Map<String, String> gatherInstalledComponents(String stackName) {
         try {
-        return clouderaManagerParcelService.getActivatedParcels(apiClient, stackName);
+            return clouderaManagerParcelService.getActivatedParcels(apiClient, stackName);
         } catch (ApiException e) {
             LOGGER.info("Unable to fetch the list of activated parcels", e);
             throw new ClouderaManagerOperationFailedException(e.getMessage(), e);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/action/CheckImageAction.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/action/CheckImageAction.java
@@ -65,7 +65,7 @@ public class CheckImageAction extends AbstractStackCreationAction<StackEvent> {
                     }
                     break;
                 default:
-                    LOGGER.error("Unknown imagestatus: {}", checkImageResult.getImageStatus());
+                    LOGGER.error("Unknown image status: {}", checkImageResult.getImageStatus());
                     break;
             }
         });

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/provision/action/CheckImageAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/provision/action/CheckImageAction.java
@@ -65,7 +65,7 @@ public class CheckImageAction extends AbstractStackProvisionAction<StackEvent> {
                 }
                 break;
             default:
-                LOGGER.error("Unknown imagestatus: {}", checkImageResult.getImageStatus());
+                LOGGER.error("Unknown image status: {}", checkImageResult.getImageStatus());
                 break;
         }
     }


### PR DESCRIPTION
…if CB created RG

Currently, we do not delete the storage account and managed image components in single RG use-cases. 

This PR does this:

- save storage accounts and managed images as Resources, too
- if they got created via an SDX or FreeIPA creation then they get deleted by deleting them
- otherwise, we do not touch them