### PR TITLE
DISTX-530 DE HA template does not work with telemetry publisher

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-702.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-702.bp
@@ -20,10 +20,6 @@
         "serviceType": "HDFS",
         "serviceConfigs": [
           {
-            "name": "redaction_policy_enabled",
-            "value": "false"
-          },
-          {
             "name": "zookeeper_service",
             "ref": "zookeeper"
           }

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-710.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-710.bp
@@ -20,10 +20,6 @@
         "serviceType": "HDFS",
         "serviceConfigs": [
           {
-            "name": "redaction_policy_enabled",
-            "value": "false"
-          },
-          {
             "name": "zookeeper_service",
             "ref": "zookeeper"
           }

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-720.bp
@@ -20,10 +20,6 @@
         "serviceType": "HDFS",
         "serviceConfigs": [
           {
-            "name": "redaction_policy_enabled",
-            "value": "false"
-          },
-          {
             "name": "zookeeper_service",
             "ref": "zookeeper"
           },

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-721.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-721.bp
@@ -20,10 +20,6 @@
         "serviceType": "HDFS",
         "serviceConfigs": [
           {
-            "name": "redaction_policy_enabled",
-            "value": "false"
-          },
-          {
             "name": "zookeeper_service",
             "ref": "zookeeper"
           },

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-722.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-722.bp
@@ -20,10 +20,6 @@
         "serviceType": "HDFS",
         "serviceConfigs": [
           {
-            "name": "redaction_policy_enabled",
-            "value": "false"
-          },
-          {
             "name": "zookeeper_service",
             "ref": "zookeeper"
           },


### PR DESCRIPTION
1. Telemetry publisher needs to have HDFS redaction enabled.
2. With these settings being false, the customer sees that the telemetry publisher does not start.
3. Since normal templates are working fine, removing the config to leave it to default.