### PR TITLE
CB-8435 StackStatusCheckerJob should always cleanup MDC

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/StackStatusCheckerJob.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/StackStatusCheckerJob.java
@@ -61,9 +61,10 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
         prepareMdcContextWithStack(stack);
         if (flowLogService.isOtherFlowRunning(stackId)) {
             LOGGER.debug("StackStatusCheckerJob cannot run, because flow is running for stack: {}", stackId);
-            return;
+        } else {
+            LOGGER.debug("No flows running, trying to sync freeipa");
+            syncAStack(stack);
         }
-        syncAStack(stack);
         MDCBuilder.cleanupMdc();
     }
 


### PR DESCRIPTION
Currently we set the MDCContext before checking if a flow is running. If a flow is running we skip sync, but the code will skip MDCContext cleanup also.
This commit modifies the code to ensure cleanup is happening.

See detailed description in the commit message.