### PR TITLE
CB-8373 [ASRG] redbeams concurrent create and delete might leak resources

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/ResourceConnector.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/ResourceConnector.java
@@ -12,6 +12,7 @@ import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.cloudbreak.cloud.model.ExternalDatabaseStatus;
 import com.sequenceiq.cloudbreak.cloud.model.TlsInfo;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
+import com.sequenceiq.cloudbreak.event.CancellationToken;
 import com.sequenceiq.common.api.type.AdjustmentType;
 
 /**
@@ -74,10 +75,12 @@ public interface ResourceConnector<R> {
      * @param authenticatedContext the authenticated context which holds the client object
      * @param stack                contains the full description of infrastructure
      * @param persistenceNotifier  notifier for when a resource is allocated on the cloud platfrom
+     * @param cancellationToken    a token holding information whether cancellation was requested
      * @return the status of resources allocated on the cloud platform
      * @throws Exception in case of any error
      */
-    List<CloudResourceStatus> launchDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack, PersistenceNotifier persistenceNotifier)
+    List<CloudResourceStatus> launchDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack, PersistenceNotifier persistenceNotifier,
+            CancellationToken cancellationToken)
             throws Exception;
 
     /**

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnector.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnector.java
@@ -27,6 +27,7 @@ import com.sequenceiq.cloudbreak.cloud.model.ExternalDatabaseStatus;
 import com.sequenceiq.cloudbreak.cloud.model.Network;
 import com.sequenceiq.cloudbreak.cloud.model.TlsInfo;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
+import com.sequenceiq.cloudbreak.event.CancellationToken;
 import com.sequenceiq.common.api.type.AdjustmentType;
 
 import freemarker.template.Configuration;
@@ -97,7 +98,7 @@ public class AwsResourceConnector implements ResourceConnector<Object> {
 
     @Override
     public List<CloudResourceStatus> launchDatabaseServer(AuthenticatedContext ac, DatabaseStack stack,
-            PersistenceNotifier persistenceNotifier) throws Exception {
+            PersistenceNotifier persistenceNotifier, CancellationToken cancellationToken) throws Exception {
         return awsRdsLaunchService.launch(ac, stack, persistenceNotifier);
     }
 

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
@@ -36,6 +36,7 @@ import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.TlsInfo;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
 import com.sequenceiq.cloudbreak.cloud.template.AbstractResourceConnector;
+import com.sequenceiq.cloudbreak.event.CancellationToken;
 import com.sequenceiq.cloudbreak.service.Retry.ActionFailedException;
 import com.sequenceiq.common.api.type.AdjustmentType;
 import com.sequenceiq.common.api.type.ResourceType;
@@ -164,8 +165,8 @@ public class AzureResourceConnector extends AbstractResourceConnector {
 
     @Override
     public List<CloudResourceStatus> launchDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
-            PersistenceNotifier persistenceNotifier) {
-        return azureDatabaseResourceService.buildDatabaseResourcesForLaunch(authenticatedContext, stack, persistenceNotifier);
+            PersistenceNotifier persistenceNotifier, CancellationToken cancellationToken) {
+        return azureDatabaseResourceService.buildDatabaseResourcesForLaunch(authenticatedContext, stack, persistenceNotifier, cancellationToken);
     }
 
     @Override

--- a/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockResourceConnector.java
+++ b/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockResourceConnector.java
@@ -31,6 +31,7 @@ import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.TlsInfo;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
 import com.sequenceiq.cloudbreak.cloud.transform.CloudResourceHelper;
+import com.sequenceiq.cloudbreak.event.CancellationToken;
 import com.sequenceiq.common.api.type.AdjustmentType;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.ResourceType;
@@ -74,7 +75,7 @@ public class MockResourceConnector implements ResourceConnector<Object> {
 
     @Override
     public List<CloudResourceStatus> launchDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
-            PersistenceNotifier persistenceNotifier) {
+            PersistenceNotifier persistenceNotifier, CancellationToken cancellationToken) {
         List<CloudResource> cloudResources = List.of(
                 new Builder()
                         .type(ResourceType.RDS_HOSTNAME)

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/heat/OpenStackResourceConnector.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/heat/OpenStackResourceConnector.java
@@ -44,6 +44,7 @@ import com.sequenceiq.cloudbreak.cloud.openstack.common.OpenStackUtils;
 import com.sequenceiq.cloudbreak.cloud.openstack.heat.HeatTemplateBuilder.ModelContext;
 import com.sequenceiq.cloudbreak.cloud.openstack.view.KeystoneCredentialView;
 import com.sequenceiq.cloudbreak.cloud.openstack.view.NeutronNetworkView;
+import com.sequenceiq.cloudbreak.event.CancellationToken;
 import com.sequenceiq.cloudbreak.service.Retry;
 import com.sequenceiq.cloudbreak.service.Retry.ActionFailedException;
 import com.sequenceiq.common.api.type.AdjustmentType;
@@ -122,7 +123,7 @@ public class OpenStackResourceConnector implements ResourceConnector<Object> {
 
     @Override
     public List<CloudResourceStatus> launchDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
-        PersistenceNotifier persistenceNotifier) {
+            PersistenceNotifier persistenceNotifier, CancellationToken cancellationToken) {
         throw new UnsupportedOperationException("Database server launch is not supported for " + getClass().getName());
     }
 

--- a/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/AbstractResourceConnector.java
+++ b/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/AbstractResourceConnector.java
@@ -27,6 +27,7 @@ import com.sequenceiq.cloudbreak.cloud.template.context.ResourceBuilderContext;
 import com.sequenceiq.cloudbreak.cloud.template.group.GroupResourceService;
 import com.sequenceiq.cloudbreak.cloud.template.init.ContextBuilders;
 import com.sequenceiq.cloudbreak.cloud.template.network.NetworkResourceService;
+import com.sequenceiq.cloudbreak.event.CancellationToken;
 import com.sequenceiq.common.api.type.AdjustmentType;
 
 /**
@@ -78,7 +79,7 @@ public abstract class AbstractResourceConnector implements ResourceConnector<Lis
 
     @Override
     public List<CloudResourceStatus> launchDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
-        PersistenceNotifier persistenceNotifier) {
+            PersistenceNotifier persistenceNotifier, CancellationToken cancellationToken) {
         throw new UnsupportedOperationException("Database server launch is not supported for " + getClass().getName());
     }
 

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnResourceConnector.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnResourceConnector.java
@@ -55,6 +55,7 @@ import com.sequenceiq.cloudbreak.cloud.yarn.client.model.response.ApplicationDet
 import com.sequenceiq.cloudbreak.cloud.yarn.client.model.response.ApplicationErrorResponse;
 import com.sequenceiq.cloudbreak.cloud.yarn.client.model.response.ResponseContext;
 import com.sequenceiq.cloudbreak.cloud.yarn.status.YarnApplicationStatus;
+import com.sequenceiq.cloudbreak.event.CancellationToken;
 import com.sequenceiq.common.api.type.AdjustmentType;
 
 @Service
@@ -96,7 +97,7 @@ public class YarnResourceConnector implements ResourceConnector<Object> {
 
     @Override
     public List<CloudResourceStatus> launchDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
-            PersistenceNotifier persistenceNotifier) {
+            PersistenceNotifier persistenceNotifier, CancellationToken cancellationToken) {
         throw new UnsupportedOperationException("Database server launch is not supported for " + getClass().getName());
     }
 

--- a/common/src/main/java/com/sequenceiq/cloudbreak/event/CancellationToken.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/event/CancellationToken.java
@@ -1,0 +1,6 @@
+package com.sequenceiq.cloudbreak.event;
+
+public interface CancellationToken {
+
+    boolean isCancelled();
+}

--- a/flow/src/main/java/com/sequenceiq/flow/core/Flow.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/Flow.java
@@ -2,6 +2,7 @@ package com.sequenceiq.flow.core;
 
 import java.util.Map;
 
+import com.sequenceiq.cloudbreak.event.CancellationToken;
 import com.sequenceiq.flow.core.config.FlowConfiguration;
 
 import io.opentracing.SpanContext;
@@ -24,6 +25,12 @@ public interface Flow {
     void setFlowFailed(Exception exception);
 
     boolean isFlowFailed();
+
+    boolean isFlowStopped();
+
+    default CancellationToken getCancellationToken() {
+        return new FlowCancellationToken(this);
+    }
 
     Class<? extends FlowConfiguration<?>> getFlowConfigClass();
 }

--- a/flow/src/main/java/com/sequenceiq/flow/core/FlowAdapter.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/FlowAdapter.java
@@ -24,6 +24,8 @@ public class FlowAdapter<S extends FlowState, E extends FlowEvent> implements Fl
 
     private boolean flowFailed;
 
+    private boolean flowStopped;
+
     private final Class<? extends FlowConfiguration<E>> flowConfigClass;
 
     private final FlowEventListener<S, E> flowEventListener;
@@ -62,6 +64,7 @@ public class FlowAdapter<S extends FlowState, E extends FlowEvent> implements Fl
 
     @Override
     public void stop() {
+        flowStopped = true;
         flowMachine.stop();
     }
 
@@ -99,5 +102,10 @@ public class FlowAdapter<S extends FlowState, E extends FlowEvent> implements Fl
     @Override
     public boolean isFlowFailed() {
         return flowFailed;
+    }
+
+    @Override
+    public boolean isFlowStopped() {
+        return flowStopped;
     }
 }

--- a/flow/src/main/java/com/sequenceiq/flow/core/FlowCancellationToken.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/FlowCancellationToken.java
@@ -1,0 +1,17 @@
+package com.sequenceiq.flow.core;
+
+import com.sequenceiq.cloudbreak.event.CancellationToken;
+
+public class FlowCancellationToken implements CancellationToken {
+
+    private final Flow flow;
+
+    FlowCancellationToken(Flow flow) {
+        this.flow = flow;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return flow.isFlowStopped();
+    }
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/action/RedbeamsProvisionActions.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/action/RedbeamsProvisionActions.java
@@ -66,8 +66,9 @@ public class RedbeamsProvisionActions {
 
             @Override
             protected Selectable createRequest(RedbeamsContext context) {
+                Flow flow = getFlow(context.getFlowParameters().getFlowId());
                 return new AllocateDatabaseServerRequest(context.getCloudContext(), context.getCloudCredential(),
-                        context.getDatabaseStack());
+                        context.getDatabaseStack(), flow.getCancellationToken());
             }
         };
     }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/event/allocate/AllocateDatabaseServerRequest.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/event/allocate/AllocateDatabaseServerRequest.java
@@ -3,6 +3,7 @@ package com.sequenceiq.redbeams.flow.redbeams.provision.event.allocate;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
+import com.sequenceiq.cloudbreak.event.CancellationToken;
 import com.sequenceiq.redbeams.flow.redbeams.common.RedbeamsEvent;
 
 /**
@@ -16,11 +17,15 @@ public class AllocateDatabaseServerRequest extends RedbeamsEvent {
 
     private final DatabaseStack databaseStack;
 
-    public AllocateDatabaseServerRequest(CloudContext cloudContext, CloudCredential cloudCredential, DatabaseStack databaseStack) {
+    private final CancellationToken cancellationToken;
+
+    public AllocateDatabaseServerRequest(CloudContext cloudContext, CloudCredential cloudCredential, DatabaseStack databaseStack,
+            CancellationToken cancellationToken) {
         super(cloudContext != null ? cloudContext.getId() : null);
         this.cloudContext = cloudContext;
         this.cloudCredential = cloudCredential;
         this.databaseStack = databaseStack;
+        this.cancellationToken = cancellationToken;
     }
 
     public CloudContext getCloudContext() {
@@ -33,6 +38,10 @@ public class AllocateDatabaseServerRequest extends RedbeamsEvent {
 
     public DatabaseStack getDatabaseStack() {
         return databaseStack;
+    }
+
+    public CancellationToken getCancellationToken() {
+        return cancellationToken;
     }
 
     public String toString() {

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/handler/AllocateDatabaseServerHandler.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/handler/AllocateDatabaseServerHandler.java
@@ -27,6 +27,7 @@ import com.sequenceiq.redbeams.flow.redbeams.common.RedbeamsEvent;
 import com.sequenceiq.redbeams.flow.redbeams.provision.event.allocate.AllocateDatabaseServerFailed;
 import com.sequenceiq.redbeams.flow.redbeams.provision.event.allocate.AllocateDatabaseServerRequest;
 import com.sequenceiq.redbeams.flow.redbeams.provision.event.allocate.AllocateDatabaseServerSuccess;
+import com.sequenceiq.redbeams.service.stack.DBResourceService;
 
 import reactor.bus.Event;
 import reactor.bus.EventBus;
@@ -49,6 +50,9 @@ public class AllocateDatabaseServerHandler implements EventHandler<AllocateDatab
     private SyncPollingScheduler<ResourcesStatePollerResult> syncPollingScheduler;
 
     @Inject
+    private DBResourceService dbResourceService;
+
+    @Inject
     private EventBus eventBus;
 
     @Override
@@ -65,7 +69,7 @@ public class AllocateDatabaseServerHandler implements EventHandler<AllocateDatab
             CloudConnector<Object> connector = cloudPlatformConnectors.get(cloudContext.getPlatformVariant());
             AuthenticatedContext ac = connector.authentication().authenticate(cloudContext, request.getCloudCredential());
             List<CloudResourceStatus> resourceStatuses =
-                connector.resources().launchDatabaseServer(ac, request.getDatabaseStack(), persistenceNotifier);
+                    connector.resources().launchDatabaseServer(ac, request.getDatabaseStack(), persistenceNotifier, request.getCancellationToken());
             List<CloudResource> resources = ResourceLists.transform(resourceStatuses);
 
             PollTask<ResourcesStatePollerResult> task = statusCheckFactory.newPollResourcesStateTask(ac, resources, true);


### PR DESCRIPTION
Persistence of databaseserver resources in redbeams is reached after provisioning is ready. In case a delete is fired subsequently after the create, release of resources might happen before they are created and persisted, thus leading to a resource leakage.

See detailed description in the commit message.