### PR TITLE
CB-8377 Updating Medium Duty layout

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-sdx-medium-ha-722.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx-medium-ha-722.bp
@@ -20,9 +20,7 @@
           "kafka-GATEWAY-BASE",
           "kafka-KAFKA_BROKER-BASE",
           "solr-SOLR_SERVER-BASE",
-          "ranger-RANGER_ADMIN-BASE",
-          "hbase-REGIONSERVER-BASE",
-          "hbase-MASTER-BASE"
+          "ranger-RANGER_ADMIN-BASE"
         ]
       },
       {
@@ -36,11 +34,13 @@
           "ranger-RANGER_TAGSYNC-BASE",
           "zookeeper-SERVER-BASE",
           "knox-KNOX_GATEWAY-BASE",
-          "atlas-ATLAS_SERVER-BASE"
+          "atlas-ATLAS_SERVER-BASE",
+          "hbase-REGIONSERVER-BASE",
+          "hbase-MASTER-BASE"
         ]
       },
       {
-        "cardinality": 1,
+        "cardinality": 2,
         "refName": "idbroker",
         "roleConfigGroupsRefNames": [
           "knox-IDBROKER-BASE"
@@ -178,6 +178,10 @@
               {
                 "name": "solr_https_port",
                 "value": "8985"
+              },
+              {
+                "name": "solr_java_opts",
+                "value": "{{JAVA_GC_ARGS}} -Dsolr.hdfs.allow.location.override=true"
               }
             ],
             "refName": "solr-SOLR_SERVER-BASE",
@@ -228,7 +232,7 @@
           {
             "name": "hbase_wal_dir",
             "value": "/hbase-wals"
-          },          
+          },
           {
             "name": "service_config_suppression_hadoop_secure_web_ui",
             "value": "true"

--- a/datalake/src/main/resources/runtime/7.2.2/aws/medium_duty_ha.json
+++ b/datalake/src/main/resources/runtime/7.2.2/aws/medium_duty_ha.json
@@ -11,7 +11,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "m5.4xlarge",
+        "instanceType": "m5.2xlarge",
         "attachedVolumes": [
           {
             "count": 1,
@@ -31,7 +31,7 @@
     {
       "name": "gateway",
       "template": {
-        "instanceType": "m5.4xlarge",
+        "instanceType": "m5.xlarge",
         "attachedVolumes": [
           {
             "count": 1,
@@ -63,7 +63,7 @@
           "size": 50
         }
       },
-      "nodeCount": 1,
+      "nodeCount": 2,
       "type": "CORE",
       "recoveryMode": "MANUAL",
       "recipeNames": []

--- a/datalake/src/main/resources/runtime/7.2.2/azure/medium_duty_ha.json
+++ b/datalake/src/main/resources/runtime/7.2.2/azure/medium_duty_ha.json
@@ -16,7 +16,7 @@
           {
             "count": 1,
             "size": 250,
-            "type": "StandardSSD_LRS"
+            "type": "Standard_D8s_v3"
           }
         ],
         "rootVolume": {
@@ -31,7 +31,7 @@
     {
       "name": "gateway",
       "template": {
-        "instanceType": "Standard_D16s_v3",
+        "instanceType": "Standard_D4s_v3",
         "attachedVolumes": [
           {
             "count": 1,
@@ -63,7 +63,7 @@
           "size": 50
         }
       },
-      "nodeCount": 1,
+      "nodeCount": 2,
       "type": "CORE",
       "recoveryMode": "MANUAL",
       "recipeNames": []

--- a/datalake/src/main/resources/runtime/7.2.2/yarn/medium_duty_ha.json
+++ b/datalake/src/main/resources/runtime/7.2.2/yarn/medium_duty_ha.json
@@ -28,7 +28,7 @@
         }
       },
       "nodeCount": 1,
-      "type": "CORE"
+      "type": "GATEWAY"
     },
     {
       "name": "idbroker",
@@ -38,7 +38,7 @@
           "memory": 16384
         }
       },
-      "nodeCount": 1,
+      "nodeCount": 2,
       "type": "CORE"
     }
   ]


### PR DESCRIPTION
This updates the SDX Medium Duty templates to have hbase on the gateway node and
resizes the node instances.  This also enables 2 nodes for IdBroker as well.

See detailed description in the commit message.