### PR TITLE
CB-8401: Add the operation ID to the FreeIPA logs

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/logger/LoggerContextKey.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/logger/LoggerContextKey.java
@@ -19,7 +19,8 @@ public enum LoggerContextKey {
     ACCOUNT_ID("accountId"),
     USER_CRN("userCrn"),
     TRACE_ID("traceId"),
-    SPAN_ID("spanId");
+    SPAN_ID("spanId"),
+    OPERATION_ID("operationId");
 
     private final String value;
 

--- a/common/src/main/java/com/sequenceiq/cloudbreak/logger/MDCBuilder.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/logger/MDCBuilder.java
@@ -68,6 +68,14 @@ public class MDCBuilder {
         MDC.put(LoggerContextKey.SPAN_ID.toString(), spanId);
     }
 
+    public static void addOperationId(String operationId) {
+        MDC.put(LoggerContextKey.OPERATION_ID.toString(), operationId);
+    }
+
+    public static void removeOperationId() {
+        removeMdcField(LoggerContextKey.OPERATION_ID.toString());
+    }
+
     public static void buildMdcContext(Object object) {
         if (object == null) {
             MDC.put(LoggerContextKey.USER_CRN.toString(), null);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/AbstractCommonChainAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/AbstractCommonChainAction.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sequenceiq.cloudbreak.common.event.Payload;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.flow.core.CommonContext;
 import com.sequenceiq.flow.core.FlowEvent;
 import com.sequenceiq.flow.core.FlowState;
@@ -51,6 +52,7 @@ public abstract class AbstractCommonChainAction<S extends FlowState, E extends F
 
     protected void setOperationId(Map<Object, Object> variables, String operationId) {
         variables.put(OPERATION_ID, operationId);
+        addMdcOperationIdIfPresent(variables);
     }
 
     protected String getOperationId(Map<Object, Object> variables) {
@@ -105,5 +107,12 @@ public abstract class AbstractCommonChainAction<S extends FlowState, E extends F
     protected void disableStatusChecker(Stack stack, String reason) {
         LOGGER.info("Disabling the status checker for stack ID {}. {}", stack.getId(), reason);
         jobService.unschedule(stack);
+    }
+
+    protected void addMdcOperationIdIfPresent(Map<Object, Object> varialbes) {
+        String operationId = getOperationId(varialbes);
+        if (operationId != null) {
+            MDCBuilder.addOperationId(operationId);
+        }
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/AbstractFreeIpaCleanupAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/AbstractFreeIpaCleanupAction.java
@@ -7,7 +7,7 @@ import javax.inject.Inject;
 
 import org.springframework.statemachine.StateContext;
 
-import com.sequenceiq.cloudbreak.common.event.Payload;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.flow.core.FlowParameters;
 import com.sequenceiq.freeipa.entity.FreeIpa;
 import com.sequenceiq.freeipa.flow.stack.AbstractStackAction;
@@ -15,7 +15,8 @@ import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
 import com.sequenceiq.freeipa.service.freeipa.FreeIpaService;
 import com.sequenceiq.freeipa.service.freeipa.cleanup.CleanupService;
 
-public abstract class AbstractFreeIpaCleanupAction<P extends Payload> extends AbstractStackAction<FreeIpaCleanupState, FreeIpaCleanupEvent, FreeIpaContext, P> {
+public abstract class AbstractFreeIpaCleanupAction<P extends CleanupEvent>
+        extends AbstractStackAction<FreeIpaCleanupState, FreeIpaCleanupEvent, FreeIpaContext, P> {
 
     @Inject
     private FreeIpaClientFactory freeIpaClientFactory;
@@ -34,6 +35,7 @@ public abstract class AbstractFreeIpaCleanupAction<P extends Payload> extends Ab
     protected FreeIpaContext createFlowContext(FlowParameters flowParameters, StateContext<FreeIpaCleanupState, FreeIpaCleanupEvent> stateContext,
             P payload) {
         FreeIpa freeIpa = freeIpaService.findByStackId(payload.getResourceId());
+        MDCBuilder.addOperationId(payload.getOperationId());
         return new FreeIpaContext(flowParameters, freeIpa);
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/action/AbstractDownscaleAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/action/AbstractDownscaleAction.java
@@ -69,6 +69,7 @@ public abstract class AbstractDownscaleAction<P extends Payload> extends Abstrac
             P payload) {
         Stack stack = stackService.getByIdWithListsInTransaction(payload.getResourceId());
         MDCBuilder.buildMdcContext(stack);
+        addMdcOperationIdIfPresent(stateContext.getExtendedState().getVariables());
         Location location = location(region(stack.getRegion()));
         CloudContext cloudContext = new CloudContext(stack.getId(), stack.getName(), stack.getCloudPlatform(), stack.getCloudPlatform(),
                 location, stack.getOwner(), stack.getOwner(), stack.getAccountId());

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/repair/changeprimarygw/action/AbstractChangePrimaryGatewayAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/repair/changeprimarygw/action/AbstractChangePrimaryGatewayAction.java
@@ -8,6 +8,7 @@ import javax.inject.Inject;
 import org.springframework.statemachine.StateContext;
 
 import com.sequenceiq.cloudbreak.common.event.Payload;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.flow.core.FlowParameters;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
 import com.sequenceiq.freeipa.entity.Stack;
@@ -32,6 +33,8 @@ public abstract class AbstractChangePrimaryGatewayAction<P extends Payload> exte
     protected ChangePrimaryGatewayContext createFlowContext(FlowParameters flowParameters,
             StateContext<ChangePrimaryGatewayState, ChangePrimaryGatewayFlowEvent> stateContext, P payload) {
         Stack stack = stackService.getByIdWithListsInTransaction(payload.getResourceId());
+        MDCBuilder.buildMdcContext(stack);
+        addMdcOperationIdIfPresent(stateContext.getExtendedState().getVariables());
         return new ChangePrimaryGatewayContext(flowParameters, stack);
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/action/AbstractUpscaleAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/action/AbstractUpscaleAction.java
@@ -56,6 +56,7 @@ public abstract class AbstractUpscaleAction<P extends Payload> extends AbstractC
             P payload) {
         Stack stack = stackService.getByIdWithListsInTransaction(payload.getResourceId());
         MDCBuilder.buildMdcContext(stack);
+        addMdcOperationIdIfPresent(stateContext.getExtendedState().getVariables());
         Location location = location(region(stack.getRegion()));
         CloudContext cloudContext = new CloudContext(stack.getId(), stack.getName(), stack.getCloudPlatform(), stack.getCloudPlatform(),
                 location, stack.getOwner(), stack.getOwner(), stack.getAccountId());

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/action/AbstractRebootAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/action/AbstractRebootAction.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sequenceiq.cloudbreak.common.event.Payload;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.freeipa.flow.instance.reboot.RebootContext;
 import com.sequenceiq.freeipa.flow.instance.reboot.RebootEvent;
 import com.sequenceiq.freeipa.flow.instance.reboot.RebootState;
@@ -24,9 +25,15 @@ public abstract class AbstractRebootAction<P extends Payload>
 
     protected void setOperationId(Map<Object, Object> variables, String operationId) {
         variables.put(OPERATION_ID, operationId);
+        addMdcOperationId(variables);
     }
 
     protected String getOperationId(Map<Object, Object> variables) {
         return (String) variables.get(OPERATION_ID);
+    }
+
+    protected void addMdcOperationId(Map<Object, Object> varialbes) {
+        String operationId = getOperationId(varialbes);
+        MDCBuilder.addOperationId(operationId);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/PasswordService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/PasswordService.java
@@ -112,8 +112,12 @@ public class PasswordService {
     }
 
     private void asyncSetPasswords(String operationId, String accountId, String actorCrn, String userCrn, String password, List<Stack> stacks) {
-        MDCBuilder.addFlowId(operationId);
-        asyncTaskExecutor.submit(() -> internalSetPasswords(operationId, accountId, actorCrn, userCrn, password, stacks));
+        try {
+            MDCBuilder.addOperationId(operationId);
+            asyncTaskExecutor.submit(() -> internalSetPasswords(operationId, accountId, actorCrn, userCrn, password, stacks));
+        } finally {
+            MDCBuilder.removeOperationId();
+        }
     }
 
     private void internalSetPasswords(String operationId, String accountId, String actorCrn, String userCrn, String password, List<Stack> stacks) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncService.java
@@ -193,9 +193,13 @@ public class UserSyncService {
     void asyncSynchronizeUsers(String operationId, String accountId, String actorCrn, List<Stack> stacks,
             Set<String> userCrnFilter, Set<String> machineUserCrnFilter, boolean fullSync) {
 
-        MDCBuilder.addFlowId(operationId);
-        asyncTaskExecutor.submit(() -> internalSynchronizeUsers(
-                operationId, accountId, actorCrn, stacks, userCrnFilter, machineUserCrnFilter, fullSync));
+        try {
+            MDCBuilder.addOperationId(operationId);
+            asyncTaskExecutor.submit(() -> internalSynchronizeUsers(
+                    operationId, accountId, actorCrn, stacks, userCrnFilter, machineUserCrnFilter, fullSync));
+        } finally {
+            MDCBuilder.removeOperationId();
+        }
 
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/StackStatusCheckerJob.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/StackStatusCheckerJob.java
@@ -58,14 +58,17 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
     protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
         Long stackId = getStackId();
         Stack stack = stackService.getStackById(stackId);
-        prepareMdcContextWithStack(stack);
-        if (flowLogService.isOtherFlowRunning(stackId)) {
-            LOGGER.debug("StackStatusCheckerJob cannot run, because flow is running for stack: {}", stackId);
-        } else {
-            LOGGER.debug("No flows running, trying to sync freeipa");
-            syncAStack(stack);
+        try {
+            prepareMdcContextWithStack(stack);
+            if (flowLogService.isOtherFlowRunning(stackId)) {
+                LOGGER.debug("StackStatusCheckerJob cannot run, because flow is running for stack: {}", stackId);
+            } else {
+                LOGGER.debug("No flows running, trying to sync freeipa");
+                syncAStack(stack);
+            }
+        } finally {
+            MDCBuilder.cleanupMdc();
         }
-        MDCBuilder.cleanupMdc();
     }
 
     private Long getStackId() {

--- a/freeipa/src/main/resources/logback.xml
+++ b/freeipa/src/main/resources/logback.xml
@@ -12,7 +12,7 @@
         <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
             <layout class="com.sequenceiq.cloudbreak.logger.MaskingPatternLayout">
                 <loggerNameFilter>com.sequenceiq</loggerNameFilter>
-                <pattern>%date{ISO8601} [%thread] %method:%line %-5level %logger{5} - [type:%X{resourceType:-springLog}] [crn:%X{resourceCrn:-}] [name:%X{resourceName:-}] [flow:%X{flowId:-}] [requestid:%X{requestId:-}] [tenant:%X{tenant:-}] [userCrn:%X{userCrn:-}] [environment:%X{environmentCrn:-}] [traceId:%X{traceId:-}] [spanId:%X{spanId:-}] %msg%n</pattern>
+                <pattern>%date{ISO8601} [%thread] %method:%line %-5level %logger{5} - [type:%X{resourceType:-springLog}] [crn:%X{resourceCrn:-}] [name:%X{resourceName:-}] [flow:%X{flowId:-}] [requestid:%X{requestId:-}] [tenant:%X{tenant:-}] [userCrn:%X{userCrn:-}] [environment:%X{environmentCrn:-}] [traceId:%X{traceId:-}] [spanId:%X{spanId:-}] [operationId:%X{operationId:-}] %msg%n</pattern>
             </layout>
         </encoder>
     </appender>
@@ -26,7 +26,7 @@
                 <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
                     <layout class="com.sequenceiq.cloudbreak.logger.MaskingPatternLayout">
                         <loggerNameFilter>com.sequenceiq</loggerNameFilter>
-                        <pattern>%date{ISO8601} [%thread] %method:%line %-5level %logger{5} - [instance:${nodeid}] [type:%X{resourceType:-springLog}] [crn:%X{resourceCrn:-}] [name:%X{resourceName:-}] [flow:%X{flowId:-}] [requestid:%X{requestId:-}] [tenant:%X{tenant:-}] [userCrn:%X{userCrn:-}] [environment:%X{environmentCrn:-}] [traceId:%X{traceId:-}] [spanId:%X{spanId:-}] %msg%n</pattern>
+                        <pattern>%date{ISO8601} [%thread] %method:%line %-5level %logger{5} - [instance:${nodeid}] [type:%X{resourceType:-springLog}] [crn:%X{resourceCrn:-}] [name:%X{resourceName:-}] [flow:%X{flowId:-}] [requestid:%X{requestId:-}] [tenant:%X{tenant:-}] [userCrn:%X{userCrn:-}] [environment:%X{environmentCrn:-}] [traceId:%X{traceId:-}] [spanId:%X{spanId:-}] [operationId:%X{operationId:-}] %msg%n</pattern>
                     </layout>
                 </encoder>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">


### PR DESCRIPTION
Add the operation ID to the FreeIPA logs for repair.

Change the user sync to use the operationId for the operation ID
rather than the flowId.

Ensure the MDC cleanup happens if an exception is thrown.

This was tested using a local deployment of cloudbreak.

See detailed description in the commit message.