### PR TITLE
CB-8412 Gracefully fail if gateway metadata missing during repair

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleActions.java
@@ -30,6 +30,7 @@ import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.transform.ResourceLists;
 import com.sequenceiq.cloudbreak.clusterproxy.ClusterProxyEnablementService;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.service.TransactionService.TransactionExecutionException;
 import com.sequenceiq.cloudbreak.converter.spi.InstanceMetaDataToCloudInstanceConverter;
 import com.sequenceiq.cloudbreak.converter.spi.ResourceToCloudResourceConverter;
@@ -214,6 +215,9 @@ public class StackUpscaleActions {
                 if (InstanceGroupType.GATEWAY == ig.getInstanceGroupType()) {
                     Stack stack = stackService.getByIdWithListsInTransaction(context.getStack().getId());
                     InstanceMetaData gatewayMetaData = stack.getPrimaryGatewayInstance();
+                    if (null == gatewayMetaData && isRepair(variables)) {
+                        throw new CloudbreakServiceException("Could not get gateway instance metadata from the cloud provider.");
+                    }
                     CloudInstance gatewayInstance = metadataConverter.convert(gatewayMetaData);
                     Selectable sshFingerPrintReq = new GetSSHFingerprintsRequest<GetSSHFingerprintsResult>(context.getCloudContext(),
                             context.getCloudCredential(), gatewayInstance);


### PR DESCRIPTION
Azure DL master repair failed due to missing instance metadata:
`Error during execution of com.sequenceiq.cloudbreak.core.flow2.stack.upscale.StackUpscaleActions$5
java.lang.NullPointerException: null
	at com.sequenceiq.cloudbreak.converter.spi.InstanceMetaDataToCloudInstanceConverter.convert(InstanceMetaDataToCloudInstanceConverter.java:34)`

Azure did not respond with VM data for some reason:
`August 12th 2020, 08:32:40.293 | 2020-08-12 06:32:40,293 [reactorDispatcher-93] hasMissingVm:85 INFO  c.s.c.c.a.AzureVirtualMachineService - [...] Fetched VM id-s ([]) do not contain one of the following id-s: [azure-test-d79e97e7d96d4624b1f6d47c385c64090m2]`

`August 12th 2020, 08:32:40.293 | 2020-08-12 06:32:40,293 [reactorDispatcher-93] hasMissingVm:85 INFO  c.s.c.c.a.AzureVirtualMachineService - [...] Fetched VM id-s ([]) do not contain one of the following id-s: [azure-test-d79e97e7d96d4624b1f6d47c385c64090m2]`

`August 12th 2020, 08:32:40.293 | 2020-08-12 06:32:40,293 [reactorDispatcher-93] validateResponse:98 WARN  c.s.c.c.a.AzureVirtualMachineService - [...] Failed to retrieve all host from Azure. Only 0 found from the 1.`

Since we are upscaling with best effort policy, this should not result in instant failure, however in case of gateway repair it is, and our error message should be clear.