### PR TITLE
CB-7876 Fail API Cleanup Jenkins build in case of left resources

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/IntegrationTestApp.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/IntegrationTestApp.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
@@ -124,8 +125,8 @@ public class IntegrationTestApp implements CommandLineRunner {
         setupSuites(testng);
         if (!CLEANUP_COMMAND.equals(itCommand)) {
             testng.run();
-            LOG.info("Html result of test run: file://{}/test-output/index.html", outputDirectory);
-            LOG.info("Text based result of test run: file://{}/test-output/emailable-report.html", outputDirectory);
+            LOG.info("Html result of test run: file://{}/test-output/index.html", Paths.get(outputDirectory).toAbsolutePath().normalize());
+            LOG.info("Text based result of test run: file://{}/test-output/emailable-report.html", Paths.get(outputDirectory).toAbsolutePath().normalize());
         }
     }
 
@@ -143,10 +144,7 @@ public class IntegrationTestApp implements CommandLineRunner {
                 removeOldResourceFiles();
                 break;
             case CLEANUP_COMMAND:
-                cleanupUtil.cleanupDistroxes();
-                cleanupUtil.cleanupSdxes();
-                cleanupUtil.cleanupEnvironments();
-                cleanupUtil.cleanupCredentials();
+                cleanupUtil.cleanupAllResources();
                 break;
             default:
                 LOG.info("Unknown command: {}", itCommand);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/listener/TestInvocationListener.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/listener/TestInvocationListener.java
@@ -1,14 +1,15 @@
 package com.sequenceiq.it.cloudbreak.listener;
 
-import java.io.BufferedWriter;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -58,18 +59,35 @@ public class TestInvocationListener implements IInvokedMethodListener {
             try {
                 String resourceNameType = Optional.ofNullable(testDto.getResourceNameType()).orElse("");
                 if (!resourceNameType.trim().isEmpty()) {
-                    jsonObject.put(resourceNameType, testDto.getName());
+                    if (jsonObject.has(resourceNameType)) {
+                        List<String> resourceNames = new ArrayList<>();
+                        try {
+                            JSONArray resources = jsonObject.getJSONArray(resourceNameType);
+                            for (int i = 0; i < resources.length(); i++) {
+                                String resource = resources.getString(i);
+                                resourceNames.add(resource);
+                            }
+                        } catch (JSONException e) {
+                            String resource = jsonObject.getString(resourceNameType);
+                            resourceNames.add(resource);
+                        }
+                        resourceNames.add(testDto.getName());
+                        LOGGER.info("Created resource name array: '{}'.", resourceNames);
+                        JSONArray resourceNameArray = new JSONArray(resourceNames);
+                        jsonObject.put(resourceNameType, resourceNameArray);
+                    } else {
+                        jsonObject.put(resourceNameType, testDto.getName());
+                    }
+                    LOGGER.info("Put Resource Name: '{}' to JSON Object.", testDto.getName());
                 }
-            } catch (JSONException e) {
-                LOGGER.info("Appending JSON object throws exception: {}", e.getMessage(), e);
             } catch (Exception e) {
                 LOGGER.info("Appending JSON object is failing, because of: {}", e.getMessage(), e);
             }
         }
         if (jsonObject.length() != 0) {
             String fileName = "resource_names_" + testContext.getTestMethodName().orElseGet(() -> getDefaultFileNameTag()) + ".json";
-            try (BufferedWriter writer = new BufferedWriter(new FileWriter(fileName))) {
-                writer.write(jsonObject.toString());
+            try {
+                Files.writeString(Paths.get(fileName), jsonObject.toString());
                 LOGGER.info("Resource file have been created with name: {} and content: {}.", fileName, jsonObject);
             } catch (IOException e) {
                 LOGGER.info("Creating/Appending resource file throws exception: {}", e.getMessage(), e);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/AuditTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/AuditTest.java
@@ -19,7 +19,7 @@ import com.sequenceiq.it.cloudbreak.client.RecipeTestClient;
 import com.sequenceiq.it.cloudbreak.client.RedbeamsDatabaseTestClient;
 import com.sequenceiq.it.cloudbreak.client.StackTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
-import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
 import com.sequenceiq.it.cloudbreak.dto.audit.AuditTestDto;
 import com.sequenceiq.it.cloudbreak.dto.clustertemplate.ClusterTemplateTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
@@ -73,7 +73,7 @@ public class AuditTest extends AbstractIntegrationTest {
             given = "there is a running cloudbreak",
             when = "a Cluster Template is created",
             then = "and audit record must be available in the database")
-    public void createValidClusterTemplateThenAuditRecordMustBeAvailableForTheResource(TestContext testContext) {
+    public void createValidClusterTemplateThenAuditRecordMustBeAvailableForTheResource(MockedTestContext testContext) {
         String clusterTemplateName = resourcePropertyProvider().getName();
         testContext
                 .given(EnvironmentTestDto.class)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
@@ -67,7 +67,7 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
             when = "a valid cluster template create request is sent",
             then = "the cluster template is created and can be deleted"
     )
-    public void testClusterTemplateCreateAndGetAndDelete(TestContext testContext) {
+    public void testClusterTemplateCreateAndGetAndDelete(MockedTestContext testContext) {
         String generatedKey = resourcePropertyProvider().getName();
         String stackTemplate = resourcePropertyProvider().getName();
 
@@ -135,7 +135,7 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
             when = "a cluster template create request with null environment name is sent",
             then = "the cluster template is cannot be created"
     )
-    public void testCreateClusterTemplateWithoutEnvironmentName(TestContext testContext) {
+    public void testCreateClusterTemplateWithoutEnvironmentName(MockedTestContext testContext) {
         String generatedKey = resourcePropertyProvider().getName();
 
         testContext.given(DistroXTemplateTestDto.class)
@@ -222,7 +222,7 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
             when = " list requested",
             then = " the response has defined number of cluster templates"
     )
-    public void testListDefaultClusterTemplate(TestContext testContext) {
+    public void testListDefaultClusterTemplate(MockedTestContext testContext) {
         String generatedKey = resourcePropertyProvider().getName();
         testContext
                 .given(ClusterTemplateTestDto.class)
@@ -237,7 +237,7 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
             when = "a cluster template create request is sent with invalid name",
             then = "the cluster template cannot be created"
     )
-    public void testCreateInvalidNameClusterTemplate(TestContext testContext) {
+    public void testCreateInvalidNameClusterTemplate(MockedTestContext testContext) {
         String generatedKey = resourcePropertyProvider().getName();
 
         testContext
@@ -255,7 +255,7 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
             when = "a cluster template create request is sent with a special name",
             then = "the cluster template creation should be successful"
     )
-    public void testCreateSpecialNameClusterTemplate(TestContext testContext) {
+    public void testCreateSpecialNameClusterTemplate(MockedTestContext testContext) {
         String generatedKey = resourcePropertyProvider().getName();
         String stackTemplate = resourcePropertyProvider().getName();
         String name = StringUtils.substring(resourcePropertyProvider().getName(), 0, 40 - SPECIAL_CT_NAME.length()) + SPECIAL_CT_NAME;
@@ -276,7 +276,7 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
             when = "a cluster template create request is sent with a too short name",
             then = "the cluster template cannot be created"
     )
-    public void testCreateInvalidShortNameClusterTemplate(TestContext testContext) {
+    public void testCreateInvalidShortNameClusterTemplate(MockedTestContext testContext) {
         String generatedKey = resourcePropertyProvider().getName();
 
         testContext
@@ -295,7 +295,7 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
             when = "a cluster definition create request is sent without blueprint name",
             then = "the cluster definition cannot be created"
     )
-    public void testCreateWithoutBlueprintInCluster(TestContext testContext) {
+    public void testCreateWithoutBlueprintInCluster(MockedTestContext testContext) {
         String generatedKey = resourcePropertyProvider().getName();
 
         testContext
@@ -314,7 +314,7 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
             when = "a cluster definition create request is sent with an empty blueprint name",
             then = "the cluster definition cannot be created"
     )
-    public void testCreateWithEmptyBlueprintInCluster(TestContext testContext) {
+    public void testCreateWithEmptyBlueprintInCluster(MockedTestContext testContext) {
         String generatedKey = resourcePropertyProvider().getName();
 
         testContext
@@ -333,7 +333,7 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
             when = "a cluster definition create request is sent with a not existing blueprint name",
             then = "the cluster definition cannot be created"
     )
-    public void testCreateWithNotExistingBlueprintInCluster(TestContext testContext) {
+    public void testCreateWithNotExistingBlueprintInCluster(MockedTestContext testContext) {
         String generatedKey = resourcePropertyProvider().getName();
 
         testContext
@@ -352,7 +352,7 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
             when = "the cluster template create request is sent again",
             then = "a BadRequest should be returned"
     )
-    public void testCreateAgainClusterTemplate(TestContext testContext) {
+    public void testCreateAgainClusterTemplate(MockedTestContext testContext) {
         String generatedKey = resourcePropertyProvider().getName();
 
         testContext
@@ -376,7 +376,7 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
             when = "a create cluster template request is sent with too long description",
             then = "the a cluster template should not be created"
     )
-    public void testCreateLongDescriptionClusterTemplate(TestContext testContext) {
+    public void testCreateLongDescriptionClusterTemplate(MockedTestContext testContext) {
         String generatedKey = resourcePropertyProvider().getName();
         String invalidLongDescripton = getLongNameGenerator().stringGenerator(1001);
         testContext
@@ -395,7 +395,7 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
             when = "a cluster template create request without stack template is sent",
             then = "the a cluster template should not be created"
     )
-    public void testCreateEmptyStackTemplateClusterTemplateException(TestContext testContext) {
+    public void testCreateEmptyStackTemplateClusterTemplateException(MockedTestContext testContext) {
         String generatedKey = resourcePropertyProvider().getName();
 
         testContext.given(ClusterTemplateTestDto.class)
@@ -412,7 +412,7 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
             when = "a cluster tempalte create request with null name is sent",
             then = "the a cluster template should not be created"
     )
-    public void testCreateEmptyClusterTemplateNameException(TestContext testContext) {
+    public void testCreateEmptyClusterTemplateNameException(MockedTestContext testContext) {
         String generatedKey1 = resourcePropertyProvider().getName();
         String generatedKey2 = resourcePropertyProvider().getName();
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/CmTemplateBlueprintTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/CmTemplateBlueprintTest.java
@@ -9,6 +9,7 @@ import org.testng.annotations.Test;
 import com.sequenceiq.it.cloudbreak.assertion.CBAssertion;
 import com.sequenceiq.it.cloudbreak.client.BlueprintTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.blueprint.BlueprintTestDto;
 
@@ -22,12 +23,12 @@ public class CmTemplateBlueprintTest extends BlueprintTestBase {
         createDefaultUser(testContext);
     }
 
-    @Test(dataProvider = TEST_CONTEXT)
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
     @Description(
             given = "there is a running cloudbreak",
             when = "a valid CM Template based blueprint create request is sent",
             then = "the blueprint should be in the response")
-    public void testCreateCMBlueprint(TestContext testContext) {
+    public void testCreateCMBlueprint(MockedTestContext testContext) {
         String blueprintName = resourcePropertyProvider().getName();
         testContext.given(BlueprintTestDto.class)
                 .withName(blueprintName)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DatabaseTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DatabaseTest.java
@@ -53,7 +53,7 @@ public class DatabaseTest extends AbstractIntegrationTest {
             given = "there is a prepared database",
             when = "the database is deleted and then a create request is sent with the same database name",
             then = "the database should be created again")
-    public void createAndDeleteAndCreateWithSameNameThenShouldRecreatedDatabase(TestContext testContext) {
+    public void createAndDeleteAndCreateWithSameNameThenShouldRecreatedDatabase(MockedTestContext testContext) {
         String databaseName = resourcePropertyProvider().getName();
         testContext
                 .given(RedbeamsDatabaseTestDto.class)
@@ -76,7 +76,7 @@ public class DatabaseTest extends AbstractIntegrationTest {
             given = "there is a prepared database",
             when = "when a database create request is sent with the same database name",
             then = "the create should return a BadRequestException")
-    public void createAndCreateWithSameNameThenShouldThrowBadRequestException(TestContext testContext) {
+    public void createAndCreateWithSameNameThenShouldThrowBadRequestException(MockedTestContext testContext) {
         String databaseName = resourcePropertyProvider().getName();
         testContext
                 .given(RedbeamsDatabaseTestDto.class)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DeploymentPreferencesTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DeploymentPreferencesTest.java
@@ -10,7 +10,6 @@ import com.sequenceiq.it.cloudbreak.assertion.util.DeploymentPreferencesTestAsse
 import com.sequenceiq.it.cloudbreak.client.UtilTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
-import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.util.DeploymentPreferencesTestDto;
 import com.sequenceiq.it.cloudbreak.testcase.AbstractIntegrationTest;
 
@@ -21,7 +20,7 @@ public class DeploymentPreferencesTest extends AbstractIntegrationTest {
 
     @BeforeMethod
     public void beforeMethod(Object[] data) {
-        createDefaultUser((TestContext) data[0]);
+        createDefaultUser((MockedTestContext) data[0]);
     }
 
     @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXClusterCreationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXClusterCreationTest.java
@@ -292,7 +292,7 @@ public class DistroXClusterCreationTest extends AbstractClouderaManagerTest {
         return blueprintTestClient;
     }
 
-    private String getImageCatalogName(TestContext testContext) {
+    private String getImageCatalogName(MockedTestContext testContext) {
         return testContext.get(ImageCatalogTestDto.class).getRequest().getName();
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXClusterStopStartTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXClusterStopStartTest.java
@@ -17,7 +17,6 @@ import com.sequenceiq.it.cloudbreak.client.DistroXTestClient;
 import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
-import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
 import com.sequenceiq.it.cloudbreak.dto.distrox.cluster.DistroXClusterTestDto;
 import com.sequenceiq.it.cloudbreak.dto.distrox.cluster.clouderamanager.DistroXClouderaManagerTestDto;
@@ -106,7 +105,7 @@ public class DistroXClusterStopStartTest extends AbstractClouderaManagerTest {
         return blueprintTestClient;
     }
 
-    private String getImageCatalogName(TestContext testContext) {
+    private String getImageCatalogName(MockedTestContext testContext) {
         return testContext.get(ImageCatalogTestDto.class).getRequest().getName();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentChildTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentChildTest.java
@@ -68,7 +68,7 @@ public class EnvironmentChildTest extends AbstractIntegrationTest {
             given = "there is an available child environment with a referenced available parent environment",
             when = "child create request is sent but parent environment is a child environment",
             then = "a BadRequestException should be returned")
-    public void testCreateChildEnvironmentWhereParentIsAChild(TestContext testContext) {
+    public void testCreateChildEnvironmentWhereParentIsAChild(MockedTestContext testContext) {
         String forbiddenKey = resourcePropertyProvider().getName();
         testContext
                 .given(CHILD_ENVIRONMENT, EnvironmentTestDto.class)
@@ -87,7 +87,7 @@ public class EnvironmentChildTest extends AbstractIntegrationTest {
             given = "there is a running cloudbreak",
             when = "child create request is sent but parent is not created yet",
             then = "a BadRequestException should be returned")
-    public void testCreateChildWithoutParentEnvironment(TestContext testContext) {
+    public void testCreateChildWithoutParentEnvironment(MockedTestContext testContext) {
         String forbiddenKey = resourcePropertyProvider().getName();
         testContext
                 .given(PARENT_ENVIRONMENT, EnvironmentTestDto.class)
@@ -103,7 +103,7 @@ public class EnvironmentChildTest extends AbstractIntegrationTest {
             given = "there is an available child environment with a referenced available parent environment",
             when = "a delete request is sent for the parent environment without cascading",
             then = "a BadRequestException should be returned")
-    public void testDeleteParentEnvironmentWithExistingChild(TestContext testContext) {
+    public void testDeleteParentEnvironmentWithExistingChild(MockedTestContext testContext) {
         String forbiddenKey = resourcePropertyProvider().getName();
         testContext
                 .given(CHILD_ENVIRONMENT, EnvironmentTestDto.class)
@@ -122,7 +122,7 @@ public class EnvironmentChildTest extends AbstractIntegrationTest {
             when = "a delete request is sent for the child environment",
             then = "the child environment should be deleted",
             and = "dns zone should be deleted")
-    public void testDeleteChildEnvironment(TestContext testContext) {
+    public void testDeleteChildEnvironment(MockedTestContext testContext) {
         testContext
                 .given(CHILD_ENVIRONMENT, EnvironmentTestDto.class)
                     .withParentEnvironment()
@@ -141,7 +141,7 @@ public class EnvironmentChildTest extends AbstractIntegrationTest {
             given = "there is an available child environment with a referenced available parent environment",
             when = "a delete multiple request is sent for both environments",
             then = "the child and parent environments should be deleted")
-    public void testDeleteChildAndParentEnvironment(TestContext testContext) {
+    public void testDeleteChildAndParentEnvironment(MockedTestContext testContext) {
         testContext
                 .given(CHILD_ENVIRONMENT, EnvironmentTestDto.class)
                     .withParentEnvironment()
@@ -166,7 +166,7 @@ public class EnvironmentChildTest extends AbstractIntegrationTest {
             given = "there is an available child environment with a referenced available parent environment",
             when = "a delete request is sent for the child environment",
             then = "the child environment should be deleted, but dns zone should not be removed")
-    public void testDeleteChildEnvironmentThatHasSibling(TestContext testContext) {
+    public void testDeleteChildEnvironmentThatHasSibling(MockedTestContext testContext) {
         testContext
                 .given(CHILD_ENVIRONMENT, EnvironmentTestDto.class)
                     .withParentEnvironment()

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentClusterTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentClusterTest.java
@@ -58,7 +58,7 @@ public class EnvironmentClusterTest extends AbstractIntegrationTest {
             given = "there is an environment with a cluster in it",
             when = "calling create cluster with a different cluster name",
             then = "the second cluster should be created")
-    public void testSameEnvironmentWithDifferentClusters(TestContext testContext) {
+    public void testSameEnvironmentWithDifferentClusters(MockedTestContext testContext) {
         createDefaultEnvironment(testContext);
 
         String newStack = resourcePropertyProvider().getName();
@@ -78,7 +78,7 @@ public class EnvironmentClusterTest extends AbstractIntegrationTest {
             given = "there is an environment and a database which in not attached to the environment",
             when = "a cluster is created in the environment and with the non-attached database",
             then = "the cluster create should succeed")
-    public void testClusterWithRdsWithoutEnvironment(TestContext testContext) {
+    public void testClusterWithRdsWithoutEnvironment(MockedTestContext testContext) {
         createDefaultRdsConfig(testContext);
         testContext
                 .given(EnvironmentTestDto.class)
@@ -120,7 +120,7 @@ public class EnvironmentClusterTest extends AbstractIntegrationTest {
             given = "there is an available environment",
             when = "create cluster request is sent with missing environment settings",
             then = "a BadRequestException should be returned")
-    public void testClusterWithEmptyEnvironmentRequest(TestContext testContext) {
+    public void testClusterWithEmptyEnvironmentRequest(MockedTestContext testContext) {
         testContext
                 .given(EnvironmentTestDto.class)
                 .when(environmentTestClient.create())
@@ -133,13 +133,13 @@ public class EnvironmentClusterTest extends AbstractIntegrationTest {
                 .validate();
     }
 
-    private void createEnvWithResources(TestContext testContext) {
+    private void createEnvWithResources(MockedTestContext testContext) {
         testContext.given(EnvironmentTestDto.class)
                 .when(environmentTestClient.create())
                 .when(environmentTestClient.describe());
     }
 
-    private void checkCredentialAttachedToCluster(TestContext testContext) {
+    private void checkCredentialAttachedToCluster(MockedTestContext testContext) {
         testContext.given(StackTestDto.class)
                 .withName(testContext.get(StackTestDto.class).getName())
                 .when(stackTestClient.getV4())
@@ -147,7 +147,7 @@ public class EnvironmentClusterTest extends AbstractIntegrationTest {
                 .validate();
     }
 
-    private ClusterTestDto setResources(TestContext testContext, String rdsName, String ldapName, String proxyName) {
+    private ClusterTestDto setResources(MockedTestContext testContext, String rdsName, String ldapName, String proxyName) {
         ClusterTestDto cluster = testContext.given(ClusterTestDto.class)
                 .valid();
         if (rdsName != null) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentDatalakeClusterTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentDatalakeClusterTest.java
@@ -13,6 +13,7 @@ import com.sequenceiq.it.cloudbreak.client.LdapTestClient;
 import com.sequenceiq.it.cloudbreak.client.RedbeamsDatabaseTestClient;
 import com.sequenceiq.it.cloudbreak.client.StackTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
 import com.sequenceiq.it.cloudbreak.context.RunningParameter;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.ClusterTestDto;
@@ -55,7 +56,7 @@ public class EnvironmentDatalakeClusterTest extends AbstractIntegrationTest {
             given = "Create datalake cluster and then delete",
             when = "create cluster and if available then delete",
             then = "the cluster should work")
-    public void testCreateDatalakeDelete(TestContext testContext) {
+    public void testCreateDatalakeDelete(MockedTestContext testContext) {
         String hivedb = resourcePropertyProvider().getName();
         String rangerdb = resourcePropertyProvider().getName();
         Set<String> rdsList = createDatalakeResources(testContext, hivedb, rangerdb);
@@ -87,7 +88,7 @@ public class EnvironmentDatalakeClusterTest extends AbstractIntegrationTest {
             given = "Create datalake cluster and then delete resources",
             when = "create cluster and then delete resources",
             then = "the resource deletion does not work because the resources attached to the cluster")
-    public void testCreateDatalakeDeleteFails(TestContext testContext) {
+    public void testCreateDatalakeDeleteFails(MockedTestContext testContext) {
         String forbiddenKey = resourcePropertyProvider().getName();
         String hivedb = resourcePropertyProvider().getName();
         String rangerdb = resourcePropertyProvider().getName();
@@ -117,7 +118,7 @@ public class EnvironmentDatalakeClusterTest extends AbstractIntegrationTest {
             given = "Create two datalake cluster in one environment",
             when = "create cluster called twice",
             then = "the cluster creation should work in both case")
-    public void testSameEnvironmentWithDifferentDatalakes(TestContext testContext) {
+    public void testSameEnvironmentWithDifferentDatalakes(MockedTestContext testContext) {
         String hivedb = resourcePropertyProvider().getName();
         String rangerdb = resourcePropertyProvider().getName();
         Set<String> rdsList = createDatalakeResources(testContext, hivedb, rangerdb);
@@ -134,7 +135,7 @@ public class EnvironmentDatalakeClusterTest extends AbstractIntegrationTest {
             given = "Create datalake cluster and workload",
             when = "call create cluster with datalake and with workload config",
             then = "will work fine")
-    public void testSameEnvironmentInDatalakeAndWorkload(TestContext testContext) {
+    public void testSameEnvironmentInDatalakeAndWorkload(MockedTestContext testContext) {
         String dlName = resourcePropertyProvider().getName();
         String hivedb = resourcePropertyProvider().getName();
         String rangerdb = resourcePropertyProvider().getName();
@@ -151,7 +152,7 @@ public class EnvironmentDatalakeClusterTest extends AbstractIntegrationTest {
         createDatalake(testContext, rdsList);
     }
 
-    private void createDatalake(TestContext testContext, Set<String> rdsList) {
+    private void createDatalake(MockedTestContext testContext, Set<String> rdsList) {
         testContext.given("placement", PlacementSettingsTestDto.class)
                 .given(ClusterTestDto.class).valid()
                 .withRdsConfigNames(rdsList)
@@ -164,7 +165,7 @@ public class EnvironmentDatalakeClusterTest extends AbstractIntegrationTest {
                 .validate();
     }
 
-    private Set<String> createDatalakeResources(TestContext testContext, String hiveDb, String rangerDb) {
+    private Set<String> createDatalakeResources(MockedTestContext testContext, String hiveDb, String rangerDb) {
         createDefaultLdapConfig(testContext);
         createDefaultKerberosConfig(testContext);
         testContext

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentEditTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentEditTest.java
@@ -10,6 +10,7 @@ import org.testng.annotations.Test;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
 import com.sequenceiq.it.cloudbreak.client.EnvironmentTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentAuthenticationTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentSecurityAccessTestDto;
@@ -42,7 +43,7 @@ public class EnvironmentEditTest extends AbstractIntegrationTest {
             given = "there is a running cloudbreak managed ssh key",
             when = "change managed ssh key to existing one",
             then = "delete managed ssh key but not create new one")
-    public void authenticationEditWhenSetExistingKeyAndDeleteManagedSuccessfully(TestContext testContext) {
+    public void authenticationEditWhenSetExistingKeyAndDeleteManagedSuccessfully(MockedTestContext testContext) {
         testContext
                 .given(HttpMock.class).whenRequested(SpiEndpoints.RegisterPublicKey.class).post()
                 .thenReturn((s, model, uriParameters) -> "")
@@ -83,7 +84,7 @@ public class EnvironmentEditTest extends AbstractIntegrationTest {
             given = "there is a running cloudbreak with existed ssh key",
             when = "change existing ssh key to managed one",
             then = "delete managed ssh key but not create new one")
-    public void authenticationEditWhenSetManagedKeyAndNotDeleteExisted(TestContext testContext) {
+    public void authenticationEditWhenSetManagedKeyAndNotDeleteExisted(MockedTestContext testContext) {
         testContext
                 .given(HttpMock.class)
                 .whenRequested(SpiEndpoints.GetPublicKey.class).get()
@@ -126,7 +127,7 @@ public class EnvironmentEditTest extends AbstractIntegrationTest {
             given = "there is a running cloudbreak",
             when = "change authentication",
             then = "get validation errors")
-    public void authenticationEditValidationErrors(TestContext testContext) {
+    public void authenticationEditValidationErrors(MockedTestContext testContext) {
         testContext
                 .given(HttpMock.class).whenRequested(SpiEndpoints.GetPublicKey.class).get()
                 .thenReturn((s, model, uriParameters) -> {
@@ -161,7 +162,7 @@ public class EnvironmentEditTest extends AbstractIntegrationTest {
             given = "there is a running cloudbreak",
             when = "change authentication",
             then = "get validation errors")
-    public void securityAccessEditValidationErrors(TestContext testContext) {
+    public void securityAccessEditValidationErrors(MockedTestContext testContext) {
         testContext
                 .given(EnvironmentTestDto.class)
                 .withCreateFreeIpa(false)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentStartStopTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentStartStopTest.java
@@ -57,7 +57,7 @@ public class EnvironmentStartStopTest extends AbstractIntegrationTest {
             given = "there is a running cloudbreak",
             when = "create an attached SDX and Datahub",
             then = "should be stopped first and started after it")
-    public void testCreateStopStartEnvironment(TestContext testContext) {
+    public void testCreateStopStartEnvironment(MockedTestContext testContext) {
         MockedTestContext mockedTestContext = (MockedTestContext) testContext;
         setUpFreeIpaRouteStubbing(mockedTestContext);
         testContext

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentTest.java
@@ -48,7 +48,7 @@ public class EnvironmentTest extends AbstractIntegrationTest {
             given = "there is a running cloudbreak",
             when = "valid create environment request is sent",
             then = "environment should be created")
-    public void testCreateEnvironment(TestContext testContext) {
+    public void testCreateEnvironment(MockedTestContext testContext) {
         testContext
                 .given(CredentialTestDto.class)
                 .when(credentialTestClient.create())
@@ -64,7 +64,7 @@ public class EnvironmentTest extends AbstractIntegrationTest {
             given = "there is a running cloudbreak",
             when = "a create environment request with reference to a non-existing credential is sent",
             then = "a BadRequestException should be returned")
-    public void testCreateEnvironmentNotExistCredential(TestContext testContext) {
+    public void testCreateEnvironmentNotExistCredential(MockedTestContext testContext) {
         String forbiddenKey = resourcePropertyProvider().getName();
         testContext
                 .given(CredentialTestDto.class)
@@ -79,7 +79,7 @@ public class EnvironmentTest extends AbstractIntegrationTest {
             given = "there is an available environment",
             when = "a delete request is sent for the environment",
             then = "the environment should be deleted")
-    public void testDeleteEnvironment(TestContext testContext) {
+    public void testDeleteEnvironment(MockedTestContext testContext) {
         testContext
                 .given(CredentialTestDto.class)
                 .when(credentialTestClient.create())
@@ -97,7 +97,7 @@ public class EnvironmentTest extends AbstractIntegrationTest {
             given = "there is a running cloudbreak",
             when = "a delete request is sent for a non-existing environment",
             then = "a NotFoundException should be returned")
-    public void testDeleteEnvironmentNotExist(TestContext testContext) {
+    public void testDeleteEnvironmentNotExist(MockedTestContext testContext) {
         String forbiddenKey = resourcePropertyProvider().getName();
         testContext
                 .given(CredentialTestDto.class)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ImageCatalogPrewarmedTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ImageCatalogPrewarmedTest.java
@@ -13,7 +13,6 @@ import com.sequenceiq.it.cloudbreak.client.ImageCatalogTestClient;
 import com.sequenceiq.it.cloudbreak.client.StackTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
-import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
 import com.sequenceiq.it.cloudbreak.dto.stack.StackTestDto;
@@ -38,7 +37,7 @@ public class ImageCatalogPrewarmedTest extends AbstractIntegrationTest {
             given = "get prewarmed image if stack info is presented",
             when = "posting a stack with all the repository version",
             then = "getting back a stack which using a prewarmed image")
-    public void testGetImageCatalogByNameAndStackWhenPreWarmedImageHasBeenUsed(TestContext testContext) {
+    public void testGetImageCatalogByNameAndStackWhenPreWarmedImageHasBeenUsed(MockedTestContext testContext) {
         initializeDefaultBlueprints(testContext);
 
         String imgCatalogName = resourcePropertyProvider().getName();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ImageCatalogTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ImageCatalogTest.java
@@ -54,7 +54,7 @@ public class ImageCatalogTest extends AbstractIntegrationTest {
             given = "image catalog valid URL",
             when = "calling create image catalog with that URL",
             then = "getting image catalog response so the creation success")
-    public void testImageCatalogCreationWhenURLIsValidAndExists(TestContext testContext) {
+    public void testImageCatalogCreationWhenURLIsValidAndExists(MockedTestContext testContext) {
         String imgCatalogName = resourcePropertyProvider().getName();
         MockedTestContext mockedTestContext = (MockedTestContext) testContext;
 
@@ -72,7 +72,7 @@ public class ImageCatalogTest extends AbstractIntegrationTest {
             given = "image catalog invalid URL but too short name",
             when = "calling create image catalog with that URL and name",
             then = "getting a BadRequestException")
-    public void testImageCatalogCreationWhenNameIsTooShort(TestContext testContext) {
+    public void testImageCatalogCreationWhenNameIsTooShort(MockedTestContext testContext) {
         String imgCatalogName = resourcePropertyProvider().getName().substring(0, 4);
 
         testContext
@@ -90,7 +90,7 @@ public class ImageCatalogTest extends AbstractIntegrationTest {
             given = "image catalog invalid URL but too long name",
             when = "calling create image catalog with that URL and name",
             then = "getting a BadRequestException")
-    public void testImageCatalogCreationWhenNameIsTooLong(TestContext testContext) {
+    public void testImageCatalogCreationWhenNameIsTooLong(MockedTestContext testContext) {
         String imgCatalogName = resourcePropertyProvider().getName().concat(getLongNameGenerator().stringGenerator(100));
 
         testContext
@@ -108,7 +108,7 @@ public class ImageCatalogTest extends AbstractIntegrationTest {
             given = "image catalog invalid name contains specific characters",
             when = "calling create image catalog with that URL and name",
             then = "getting a BadRequestException")
-    public void testImageCatalogCreationWhenNameContainsSpecialCharacters(TestContext testContext) {
+    public void testImageCatalogCreationWhenNameContainsSpecialCharacters(MockedTestContext testContext) {
         String imgCatalogName = resourcePropertyProvider().getName().concat(IMAGECATALOG_NAME_WITH_SPECIAL_CHARS);
 
         testContext
@@ -125,7 +125,7 @@ public class ImageCatalogTest extends AbstractIntegrationTest {
             given = "image catalog invalid url",
             when = "calling create image catalog with that URL",
             then = "getting a BadRequestException")
-    public void testImageCatalogCreationWhenTheCatalogURLIsInvalid(TestContext testContext) {
+    public void testImageCatalogCreationWhenTheCatalogURLIsInvalid(MockedTestContext testContext) {
         String imgCatalogName = resourcePropertyProvider().getName();
         String invalidURL = "https:/google.com/imagecatalog";
 
@@ -144,7 +144,7 @@ public class ImageCatalogTest extends AbstractIntegrationTest {
             given = "image catalog valid url but does not contain a catalog",
             when = "calling create image catalog with that URL",
             then = "getting a BadRequestException")
-    public void testImageCatalogCreationWhenTheCatalogURLPointsNotToAnImageCatalogJson(TestContext testContext) {
+    public void testImageCatalogCreationWhenTheCatalogURLPointsNotToAnImageCatalogJson(MockedTestContext testContext) {
         String imgCatalogName = resourcePropertyProvider().getName();
 
         testContext
@@ -162,7 +162,7 @@ public class ImageCatalogTest extends AbstractIntegrationTest {
             given = "image catalog valid url but the JSON is invalid",
             when = "calling create image catalog with that URL",
             then = "getting a BadRequestException")
-    public void testImageCatalogCreationWhenTheCatalogURLPointsToAnInvalidImageCatalogJson(TestContext testContext) {
+    public void testImageCatalogCreationWhenTheCatalogURLPointsToAnInvalidImageCatalogJson(MockedTestContext testContext) {
         String imgCatalogName = resourcePropertyProvider().getName();
 
         testContext
@@ -180,7 +180,7 @@ public class ImageCatalogTest extends AbstractIntegrationTest {
             given = "image catalog in the database",
             when = "calling delete on the existing one and create a new one with the same name",
             then = "getting an image catalog response so the request was valid")
-    public void testImageCatalogCreationWhenCatalogWithTheSameNameDeletedRightBeforeCreation(TestContext testContext) {
+    public void testImageCatalogCreationWhenCatalogWithTheSameNameDeletedRightBeforeCreation(MockedTestContext testContext) {
         String imgCatalogName = resourcePropertyProvider().getName();
         MockedTestContext mockedTestContext = (MockedTestContext) testContext;
 
@@ -208,7 +208,7 @@ public class ImageCatalogTest extends AbstractIntegrationTest {
             given = "image catalog deletion",
             when = "calling delete on the existing one",
             then = "the deletion was success")
-    public void testImageCatalogDeletion(TestContext testContext) {
+    public void testImageCatalogDeletion(MockedTestContext testContext) {
         String imgCatalogName = resourcePropertyProvider().getName();
         String catalogKey = resourcePropertyProvider().getName();
         MockedTestContext mockedTestContext = (MockedTestContext) testContext;
@@ -230,7 +230,7 @@ public class ImageCatalogTest extends AbstractIntegrationTest {
             given = "image catalog get the default catalog with MOCK provider",
             when = "calling get on the default",
             then = "the response contains MOCK images")
-    public void testGetImageCatalogWhenCatalogContainsTheRequestedProvider(TestContext testContext) {
+    public void testGetImageCatalogWhenCatalogContainsTheRequestedProvider(MockedTestContext testContext) {
         String imgCatalogName = resourcePropertyProvider().getName();
         MockedTestContext mockedTestContext = (MockedTestContext) testContext;
 
@@ -255,7 +255,7 @@ public class ImageCatalogTest extends AbstractIntegrationTest {
             given = "image catalog get the default catalog with AWS provider but catalog does not contain AWS entry",
             when = "calling get on the default",
             then = "the response does not contains AWS images")
-    public void testGetImageCatalogWhenCatalogDoesNotContainTheRequestedProvider(TestContext testContext) {
+    public void testGetImageCatalogWhenCatalogDoesNotContainTheRequestedProvider(MockedTestContext testContext) {
         String imgCatalogName = resourcePropertyProvider().getName();
         MockedTestContext mockedTestContext = (MockedTestContext) testContext;
 
@@ -280,7 +280,7 @@ public class ImageCatalogTest extends AbstractIntegrationTest {
             given = "image catalog get with a non existing name",
             when = "calling get with that name",
             then = "getting a NotFoundException")
-    public void testGetImageCatalogWhenTheSpecifiedCatalogDoesNotExistWithName(TestContext testContext) {
+    public void testGetImageCatalogWhenTheSpecifiedCatalogDoesNotExistWithName(MockedTestContext testContext) {
         String imgCatalogName = resourcePropertyProvider().getName();
         MockedTestContext mockedTestContext = (MockedTestContext) testContext;
 
@@ -298,7 +298,7 @@ public class ImageCatalogTest extends AbstractIntegrationTest {
             given = "image catalog get with AWS provider if exist in catalog",
             when = "calling get AWS provider",
             then = "getting a list with AWS specific images")
-    public void testGetImageCatalogWhenDefaultCatalogContainsTheRequestedProvider(TestContext testContext) {
+    public void testGetImageCatalogWhenDefaultCatalogContainsTheRequestedProvider(MockedTestContext testContext) {
         String imgCatalogName = resourcePropertyProvider().getName();
         MockedTestContext mockedTestContext = (MockedTestContext) testContext;
 
@@ -323,7 +323,7 @@ public class ImageCatalogTest extends AbstractIntegrationTest {
             given = "image catalog get with AWS provider if exist in catalog",
             when = "calling get AWS provider",
             then = "getting a list with AWS specific images")
-    public void testGetImageCatalogWhenDefaultCatalogDoesNotContainTheRequestedProvider(TestContext testContext) {
+    public void testGetImageCatalogWhenDefaultCatalogDoesNotContainTheRequestedProvider(MockedTestContext testContext) {
         String imgCatalogName = resourcePropertyProvider().getName();
         MockedTestContext mockedTestContext = (MockedTestContext) testContext;
 
@@ -348,7 +348,7 @@ public class ImageCatalogTest extends AbstractIntegrationTest {
             given = "image catalog get request",
             when = "calling get request on catalog endpoint",
             then = "getting back the catalog request")
-    public void testGetImageCatalogsRequestFromExistingImageCatalog(TestContext testContext) {
+    public void testGetImageCatalogsRequestFromExistingImageCatalog(MockedTestContext testContext) {
         String imgCatalogName = resourcePropertyProvider().getName();
         MockedTestContext mockedTestContext = (MockedTestContext) testContext;
 
@@ -381,7 +381,7 @@ public class ImageCatalogTest extends AbstractIntegrationTest {
             given = "image catalog update request",
             when = "calling update request with new url",
             then = "the image catalog list should contains the new url")
-    public void testUpdateImageCatalog(TestContext testContext) {
+    public void testUpdateImageCatalog(MockedTestContext testContext) {
         String imgCatalogName = resourcePropertyProvider().getName();
         MockedTestContext mockedTestContext = (MockedTestContext) testContext;
 
@@ -420,7 +420,7 @@ public class ImageCatalogTest extends AbstractIntegrationTest {
             given = "image catalog list",
             when = "calling list all the catalog",
             then = "getting back the account related catalogs")
-    public void testGetListOfImageCatalogs(TestContext testContext) {
+    public void testGetListOfImageCatalogs(MockedTestContext testContext) {
         String imgCatalogName = resourcePropertyProvider().getName();
 
         testContext

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/LdapConfigTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/LdapConfigTest.java
@@ -10,6 +10,7 @@ import org.testng.annotations.Test;
 import com.sequenceiq.freeipa.api.v1.ldap.model.DirectoryType;
 import com.sequenceiq.it.cloudbreak.client.LdapTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
 import com.sequenceiq.it.cloudbreak.context.RunningParameter;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.ldap.LdapTestDto;
@@ -35,7 +36,7 @@ public class LdapConfigTest extends AbstractIntegrationTest {
             given = "a valid ldap request",
             when = "calling create ldap",
             then = "the ldap should be created")
-    public void testCreateValidLdap(TestContext testContext) {
+    public void testCreateValidLdap(MockedTestContext testContext) {
         String name = resourcePropertyProvider().getName();
         testContext
                 .given(LdapTestDto.class)
@@ -55,7 +56,7 @@ public class LdapConfigTest extends AbstractIntegrationTest {
             given = "a valid active directory request",
             when = "calling create ldap",
             then = "the ldap should be created")
-    public void testCreateValidAd(TestContext testContext) {
+    public void testCreateValidAd(MockedTestContext testContext) {
         String name = resourcePropertyProvider().getName();
         testContext
                 .given(LdapTestDto.class)
@@ -76,7 +77,7 @@ public class LdapConfigTest extends AbstractIntegrationTest {
             given = "an invalid ldap request with empty name",
             when = "calling create ldap",
             then = "getting BadRequestException because ldap needs a valid name")
-    public void testCreateLdapWithMissingName(TestContext testContext) {
+    public void testCreateLdapWithMissingName(MockedTestContext testContext) {
         String key = resourcePropertyProvider().getName();
         testContext
                 .given(LdapTestDto.class)
@@ -94,7 +95,7 @@ public class LdapConfigTest extends AbstractIntegrationTest {
             given = "an invalid ldap request with empty environmentCrn",
             when = "calling create ldap",
             then = "getting BadRequestException because ldap needs a valid environmentCrn")
-    public void testCreateLdapWithMissingEnvironmentCrn(TestContext testContext) {
+    public void testCreateLdapWithMissingEnvironmentCrn(MockedTestContext testContext) {
         String key = resourcePropertyProvider().getName();
         testContext
                 .given(LdapTestDto.class)
@@ -112,7 +113,7 @@ public class LdapConfigTest extends AbstractIntegrationTest {
             given = "an invalid ldap request with specific characters in the name",
             when = "calling create ldap",
             then = "getting BadRequestException because ldap needs a valid name")
-    public void testCreateLdapWithInvalidName(TestContext testContext) {
+    public void testCreateLdapWithInvalidName(MockedTestContext testContext) {
         testContext
                 .given(LdapTestDto.class)
                 .valid()
@@ -129,7 +130,7 @@ public class LdapConfigTest extends AbstractIntegrationTest {
             given = "an invalid ldap request with too long name",
             when = "calling create ldap",
             then = "getting BadRequestException because ldap needs a valid name")
-    public void testCreateLdapWithLongName(TestContext testContext) {
+    public void testCreateLdapWithLongName(MockedTestContext testContext) {
         String longName = getLongNameGenerator().stringGenerator(101);
         testContext
                 .given(LdapTestDto.class)
@@ -147,7 +148,7 @@ public class LdapConfigTest extends AbstractIntegrationTest {
             given = "an invalid ldap request with too long description",
             when = "calling create ldap",
             then = "getting BadRequestException because ldap needs a valid description")
-    public void testCreateLdapWithLongDesc(TestContext testContext) {
+    public void testCreateLdapWithLongDesc(MockedTestContext testContext) {
         String name = resourcePropertyProvider().getName();
         String longDesc = getLongNameGenerator().stringGenerator(1001);
         testContext
@@ -167,7 +168,7 @@ public class LdapConfigTest extends AbstractIntegrationTest {
             given = "a valid ldap request",
             when = "calling create ldap and delete and create again with the same name",
             then = "ldap should be created")
-    public void testCreateDeleteCreateAgain(TestContext testContext) {
+    public void testCreateDeleteCreateAgain(MockedTestContext testContext) {
         String name = resourcePropertyProvider().getName();
         testContext
                 .given(name, LdapTestDto.class)
@@ -189,7 +190,7 @@ public class LdapConfigTest extends AbstractIntegrationTest {
             given = "a valid ldap request",
             when = "calling create ldap and create again with the same environment",
             then = "getting BadRequestException because only one ldap can exist with same environment in an account at the same time")
-    public void testCreateLdapWithSameEnvironment(TestContext testContext) {
+    public void testCreateLdapWithSameEnvironment(MockedTestContext testContext) {
         String name = resourcePropertyProvider().getName();
         testContext
                 .given(name, LdapTestDto.class)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxUpgradeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxUpgradeTests.java
@@ -140,12 +140,11 @@ public class MockSdxUpgradeTests extends AbstractIntegrationTest {
                 .validate();
     }
 
-    protected ImageCatalogTestDto createImageCatalogForOsUpgrade(TestContext testContext, String name) {
-        MockedTestContext mockedTestContext = (MockedTestContext) testContext;
+    protected ImageCatalogTestDto createImageCatalogForOsUpgrade(MockedTestContext testContext, String name) {
         return testContext
                 .given(ImageCatalogTestDto.class)
                 .withName(name)
-                .withUrl(mockedTestContext.getImageCatalogMockServerSetup().getUpgradeImageCatalogUrl())
+                .withUrl(testContext.getImageCatalogMockServerSetup().getUpgradeImageCatalogUrl())
                 .when(imageCatalogTestClient.createV4(), key(name));
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockStackCreationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockStackCreationTest.java
@@ -7,8 +7,8 @@ import org.testng.annotations.Test;
 
 import com.sequenceiq.it.cloudbreak.client.StackTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
 import com.sequenceiq.it.cloudbreak.context.RunningParameter;
-import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.stack.StackTestDto;
 import com.sequenceiq.it.cloudbreak.testcase.AbstractIntegrationTest;
 
@@ -22,7 +22,7 @@ public class MockStackCreationTest extends AbstractIntegrationTest {
             given = "a valid stack request",
             when = "create stack twice",
             then = "getting BadRequestException in the second time because the names are same")
-    public void testAttemptToCreateTwoRegularClusterWithTheSameName(TestContext testContext) {
+    public void testAttemptToCreateTwoRegularClusterWithTheSameName(MockedTestContext testContext) {
         String badRequest = resourcePropertyProvider().getName();
         testContext.given(StackTestDto.class)
                 .when(stackTestClient.createV4())

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MultiThreadTenantTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MultiThreadTenantTest.java
@@ -91,13 +91,13 @@ public class MultiThreadTenantTest extends AbstractTestNGSpringContextTests {
     @BeforeMethod
     public void beforeTest(Method method, Object[] params) {
         MDC.put("testlabel", method.getDeclaringClass().getSimpleName() + '.' + method.getName());
-        TestContext testContext = (TestContext) params[0];
+        MockedTestContext testContext = (MockedTestContext) params[0];
         testContext.setTestMethodName(method.getName());
         collectTestCaseDescription(testContext, method, params);
     }
 
-    protected TestContext prepareTestContext(TestContext testContext, String tenant, String user) {
-        ((MockedTestContext) testContext).initModelAndImageCatalogIfNecessary();
+    protected TestContext prepareTestContext(MockedTestContext testContext, String tenant, String user) {
+        testContext.initModelAndImageCatalogIfNecessary();
         createUser(testContext, tenant, user);
         createDefaultCredential(testContext);
         createDefaultImageCatalog(testContext);
@@ -105,7 +105,7 @@ public class MultiThreadTenantTest extends AbstractTestNGSpringContextTests {
         return testContext;
     }
 
-    private TestCaseDescription collectTestCaseDescription(TestContext testContext, Method method, Object[] params) {
+    private TestCaseDescription collectTestCaseDescription(MockedTestContext testContext, Method method, Object[] params) {
         Description declaredAnnotation = method.getDeclaredAnnotation(Description.class);
         TestCaseDescription testCaseDescription = null;
         if (declaredAnnotation != null) {
@@ -141,7 +141,7 @@ public class MultiThreadTenantTest extends AbstractTestNGSpringContextTests {
 
     @AfterMethod(alwaysRun = true)
     public void tearDown(Object[] data) {
-        ((TestContext) data[0]).cleanupTestContext();
+        ((MockedTestContext) data[0]).cleanupTestContext();
     }
 
     @AfterClass(alwaysRun = true)
@@ -159,22 +159,22 @@ public class MultiThreadTenantTest extends AbstractTestNGSpringContextTests {
         };
     }
 
-    protected void createDefaultCredential(TestContext testContext) {
+    protected void createDefaultCredential(MockedTestContext testContext) {
         testContext.given(CredentialTestDto.class)
                 .when(credentialTestClient.create());
     }
 
-    protected void createDefaultImageCatalog(TestContext testContext) {
+    protected void createDefaultImageCatalog(MockedTestContext testContext) {
         testContext
                 .given(ImageCatalogTestDto.class)
                 .when(new ImageCatalogCreateRetryAction());
     }
 
-    protected void createUser(TestContext testContext, String tenant, String user) {
+    protected void createUser(MockedTestContext testContext, String tenant, String user) {
         testContext.as(Actor.create(tenant, user));
     }
 
-    protected void initializeDefaultBlueprints(TestContext testContext) {
+    protected void initializeDefaultBlueprints(MockedTestContext testContext) {
         testContext
                 .init(BlueprintTestDto.class)
                 .when(blueprintTestClient.listV4());
@@ -207,7 +207,7 @@ public class MultiThreadTenantTest extends AbstractTestNGSpringContextTests {
             given = "there is a running cloudbreak",
             when = "create an attached SDX and Datahub",
             then = "should not get 404 errors due to thread safe operations")
-    public void testParallelMultiTenantStacks(TestContext testContext) {
+    public void testParallelMultiTenantStacks(MockedTestContext testContext) {
         testContext
                 .given(EnvironmentNetworkTestDto.class)
                 .given(EnvironmentTestDto.class).withNetwork().withCreateFreeIpa(true)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/NotificationTestingTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/NotificationTestingTest.java
@@ -8,7 +8,6 @@ import org.testng.annotations.Test;
 import com.sequenceiq.it.cloudbreak.client.NotificationTestingTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
-import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.util.NotificationTestingTestDto;
 import com.sequenceiq.it.cloudbreak.testcase.AbstractIntegrationTest;
 
@@ -19,7 +18,7 @@ public class NotificationTestingTest extends AbstractIntegrationTest {
 
     @BeforeMethod
     public void beforeMethod(Object[] data) {
-        createDefaultUser((TestContext) data[0]);
+        createDefaultUser((MockedTestContext) data[0]);
     }
 
     @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ProxyConfigTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ProxyConfigTest.java
@@ -12,7 +12,7 @@ import org.testng.annotations.Test;
 
 import com.sequenceiq.it.cloudbreak.client.ProxyTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
-import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
 import com.sequenceiq.it.cloudbreak.dto.proxy.ProxyTestDto;
 import com.sequenceiq.it.cloudbreak.testcase.AbstractIntegrationTest;
 
@@ -44,7 +44,7 @@ public class ProxyConfigTest extends AbstractIntegrationTest {
             given = "a valid http proxy request",
             when = "calling create proxy",
             then = "getting back a list which contains the proxy object")
-    public void testCreateValidProxy(TestContext testContext) {
+    public void testCreateValidProxy(MockedTestContext testContext) {
         String name = resourcePropertyProvider().getName();
         testContext
                 .given(ProxyTestDto.class)
@@ -69,7 +69,7 @@ public class ProxyConfigTest extends AbstractIntegrationTest {
             given = "a valid https proxy request",
             when = "calling create proxy",
             then = "getting back a list which contains the proxy object")
-    public void testCreateValidHttpsProxy(TestContext testContext) {
+    public void testCreateValidHttpsProxy(MockedTestContext testContext) {
         String name = resourcePropertyProvider().getName();
         testContext
                 .given(ProxyTestDto.class)
@@ -94,7 +94,7 @@ public class ProxyConfigTest extends AbstractIntegrationTest {
             given = "an invalid proxy request with too long name",
             when = "calling create proxy",
             then = "getting back a BadRequestException")
-    public void testCreateProxyWithTooLongName(TestContext testContext) {
+    public void testCreateProxyWithTooLongName(MockedTestContext testContext) {
         String name = getLongNameGenerator().stringGenerator(101);
         testContext
                 .given(ProxyTestDto.class)
@@ -117,7 +117,7 @@ public class ProxyConfigTest extends AbstractIntegrationTest {
             given = "an invalid proxy request with too short name",
             when = "calling create proxy",
             then = "getting back a BadRequestException")
-    public void testCreateProxyWithShortName(TestContext testContext) {
+    public void testCreateProxyWithShortName(MockedTestContext testContext) {
         String name = resourcePropertyProvider().getName();
         testContext
                 .given(ProxyTestDto.class)
@@ -139,7 +139,7 @@ public class ProxyConfigTest extends AbstractIntegrationTest {
             given = "an invalid proxy request with specific characters in the name",
             when = "calling create proxy",
             then = "getting back a BadRequestException")
-    public void testCreateProxyWithInvalidName(TestContext testContext) {
+    public void testCreateProxyWithInvalidName(MockedTestContext testContext) {
         testContext
                 .given(ProxyTestDto.class)
                 .withName(INVALID_PROXY_NAME)
@@ -161,7 +161,7 @@ public class ProxyConfigTest extends AbstractIntegrationTest {
             given = "an invalid proxy request with empty name",
             when = "calling create proxy",
             then = "getting back a BadRequestException")
-    public void testCreateProxyWithoutName(TestContext testContext) {
+    public void testCreateProxyWithoutName(MockedTestContext testContext) {
         String key = "noname";
         testContext
                 .given(ProxyTestDto.class)
@@ -184,7 +184,7 @@ public class ProxyConfigTest extends AbstractIntegrationTest {
             given = "an invalid proxy request with too long description",
             when = "calling create proxy",
             then = "getting back a BadRequestException")
-    public void testCreateProxyLongDesc(TestContext testContext) {
+    public void testCreateProxyLongDesc(MockedTestContext testContext) {
         String name = resourcePropertyProvider().getName();
         String longDescription = getLongNameGenerator().stringGenerator(1001);
         testContext
@@ -208,7 +208,7 @@ public class ProxyConfigTest extends AbstractIntegrationTest {
             given = "an invalid proxy request without host",
             when = "calling create proxy",
             then = "getting back a BadRequestException")
-    public void testCreateProxyWithoutHost(TestContext testContext) {
+    public void testCreateProxyWithoutHost(MockedTestContext testContext) {
         String name = resourcePropertyProvider().getName();
         String key = "nohost";
         testContext
@@ -232,7 +232,7 @@ public class ProxyConfigTest extends AbstractIntegrationTest {
             given = "an invalid proxy request without port",
             when = "calling create proxy",
             then = "getting back a BadRequestException")
-    public void testCreateProxyWithoutPort(TestContext testContext) {
+    public void testCreateProxyWithoutPort(MockedTestContext testContext) {
         String name = resourcePropertyProvider().getName();
         String key = "noport";
         testContext
@@ -256,7 +256,7 @@ public class ProxyConfigTest extends AbstractIntegrationTest {
             given = "a valid proxy request",
             when = "calling create proxy then delete that and create again",
             then = "getting back list with proxy which contains the proxy object")
-    public void testCreateDeleteCreateAgain(TestContext testContext) {
+    public void testCreateDeleteCreateAgain(MockedTestContext testContext) {
         String name = resourcePropertyProvider().getName();
         testContext
                 .given(name, ProxyTestDto.class)
@@ -283,7 +283,7 @@ public class ProxyConfigTest extends AbstractIntegrationTest {
             given = "a valid proxy request",
             when = "calling create proxy then create again",
             then = "getting a BadRequestException")
-    public void testCreateProxyWithSameName(TestContext testContext) {
+    public void testCreateProxyWithSameName(MockedTestContext testContext) {
 
         String name = resourcePropertyProvider().getName();
         testContext

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/RecipeClusterTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/RecipeClusterTest.java
@@ -111,7 +111,7 @@ public class RecipeClusterTest extends AbstractIntegrationTest {
             given = "a deleted recipe",
             when = "starting cluster with deleted recipe",
             then = "badrequest exception is received")
-    public void testDeletedRecipeCannotBeAssignedToCluster(TestContext testContext) {
+    public void testDeletedRecipeCannotBeAssignedToCluster(MockedTestContext testContext) {
         LOGGER.info("testing recipe execution for type: {}", PRE_CLOUDERA_MANAGER_START.name());
         String recipeName = resourcePropertyProvider().getName();
         String stackName = resourcePropertyProvider().getName();
@@ -143,7 +143,7 @@ public class RecipeClusterTest extends AbstractIntegrationTest {
             given = "a created cluster with pretermination recipe",
             when = "calling termination",
             then = "the pretermination highstate has to called on pretermination recipes")
-    public void testRecipePreTerminationRecipeHasGotHighStateOnCluster(TestContext testContext) {
+    public void testRecipePreTerminationRecipeHasGotHighStateOnCluster(MockedTestContext testContext) {
         String recipeName = resourcePropertyProvider().getName();
         testContext
                 .given(RecipeTestDto.class)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/RecipeTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/RecipeTest.java
@@ -16,6 +16,7 @@ import org.testng.annotations.Test;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.client.RecipeTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
 import com.sequenceiq.it.cloudbreak.context.RunningParameter;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.recipe.RecipeTestDto;
@@ -31,24 +32,24 @@ public class RecipeTest extends AbstractIntegrationTest {
         createDefaultUser(testContext);
     }
 
-    @Test(dataProvider = TEST_CONTEXT)
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
     @Description(
             given = "a valid recipe request",
             when = "create recipe",
             then = "recipe created")
-    public void testCreateValidRecipe(TestContext testContext) {
+    public void testCreateValidRecipe(MockedTestContext testContext) {
         testContext
                 .given(RecipeTestDto.class)
                 .when(recipeTestClient.createV4())
                 .validate();
     }
 
-    @Test(dataProvider = TEST_CONTEXT)
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
     @Description(
             given = "a valid recipe request",
             when = "create recipe and then delete and create again",
             then = "recipe created")
-    public void testCreateDeleteValidCreateAgain(TestContext testContext) {
+    public void testCreateDeleteValidCreateAgain(MockedTestContext testContext) {
         testContext
                 .given(RecipeTestDto.class)
                 .when(recipeTestClient.createV4())
@@ -57,12 +58,12 @@ public class RecipeTest extends AbstractIntegrationTest {
                 .validate();
     }
 
-    @Test(dataProvider = TEST_CONTEXT)
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
     @Description(
             given = "an invalid recipe request with specific characters in name",
             when = "create recipe",
             then = "getting a BadRequestException")
-    public void testCreateSpecialNameRecipe(TestContext testContext) {
+    public void testCreateSpecialNameRecipe(MockedTestContext testContext) {
         String spacialName = resourcePropertyProvider().getName();
         testContext
                 .given(RecipeTestDto.class)
@@ -74,12 +75,12 @@ public class RecipeTest extends AbstractIntegrationTest {
                 .validate();
     }
 
-    @Test(dataProvider = TEST_CONTEXT)
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
     @Description(
             given = "a valid recipe request",
             when = "create recipe twice",
             then = "getting a BadRequestException")
-    public void testCreateAgainRecipe(TestContext testContext) {
+    public void testCreateAgainRecipe(MockedTestContext testContext) {
         String againName = resourcePropertyProvider().getName();
         testContext.given(RecipeTestDto.class)
                 .when(recipeTestClient.createV4())
@@ -89,12 +90,12 @@ public class RecipeTest extends AbstractIntegrationTest {
                 .validate();
     }
 
-    @Test(dataProvider = TEST_CONTEXT)
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
     @Description(
             given = "an invalid recipe request with too short name",
             when = "create recipe",
             then = "getting a BadRequestException")
-    public void testCreateInvalidRecipeShortName(TestContext testContext) {
+    public void testCreateInvalidRecipeShortName(MockedTestContext testContext) {
         String shortName = resourcePropertyProvider().getName();
         testContext
                 .given(RecipeTestDto.class)
@@ -105,12 +106,12 @@ public class RecipeTest extends AbstractIntegrationTest {
                 .validate();
     }
 
-    @Test(dataProvider = TEST_CONTEXT)
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
     @Description(
             given = "an invalid recipe request with too long name",
             when = "create recipe",
             then = "getting a BadRequestException")
-    public void testCreateInvalidRecipeLongName(TestContext testContext) {
+    public void testCreateInvalidRecipeLongName(MockedTestContext testContext) {
         String longName = resourcePropertyProvider().getName();
         testContext
                 .given(RecipeTestDto.class)
@@ -121,12 +122,12 @@ public class RecipeTest extends AbstractIntegrationTest {
                 .validate();
     }
 
-    @Test(dataProvider = TEST_CONTEXT)
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
     @Description(
             given = "an invalid recipe request with too long description",
             when = "create recipe",
             then = "getting a BadRequestException")
-    public void testCreateInvalidRecipeLongDescription(TestContext testContext) {
+    public void testCreateInvalidRecipeLongDescription(MockedTestContext testContext) {
         String longDesc = resourcePropertyProvider().getName();
         testContext
                 .given(RecipeTestDto.class)
@@ -137,12 +138,12 @@ public class RecipeTest extends AbstractIntegrationTest {
                 .validate();
     }
 
-    @Test(dataProvider = TEST_CONTEXT)
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
     @Description(
             given = "a deleted valid recipe",
             when = "list recipes",
             then = "recipe is not present")
-    public void testCreateDeleteValidAndList(TestContext testContext) {
+    public void testCreateDeleteValidAndList(MockedTestContext testContext) {
         String recipeName = resourcePropertyProvider().getName();
         testContext
                 .given(RecipeTestDto.class)
@@ -158,12 +159,12 @@ public class RecipeTest extends AbstractIntegrationTest {
                 .validate();
     }
 
-    @Test(dataProvider = TEST_CONTEXT)
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
     @Description(
             given = "a valid recipe",
             when = "list recipes",
             then = "recipe is present")
-    public void testCreateValidAndList(TestContext testContext) {
+    public void testCreateValidAndList(MockedTestContext testContext) {
         String recipeName = resourcePropertyProvider().getName();
         testContext
                 .given(RecipeTestDto.class)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/RedbeamsDatabaseTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/RedbeamsDatabaseTest.java
@@ -8,6 +8,7 @@ import org.testng.annotations.Test;
 import com.sequenceiq.it.cloudbreak.assertion.database.RedbeamsDatabaseTestAssertion;
 import com.sequenceiq.it.cloudbreak.client.RedbeamsDatabaseTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
 import com.sequenceiq.it.cloudbreak.context.RunningParameter;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.database.RedbeamsDatabaseTestDto;
@@ -30,7 +31,7 @@ public class RedbeamsDatabaseTest extends AbstractIntegrationTest {
             given = "there is a prepared database",
             when = "the database is deleted and then a create request is sent with the same database name",
             then = "the database should be created again")
-    public void createAndDeleteAndCreateWithSameNameThenShouldRecreatedDatabase(TestContext testContext) {
+    public void createAndDeleteAndCreateWithSameNameThenShouldRecreatedDatabase(MockedTestContext testContext) {
         String databaseName = resourcePropertyProvider().getName();
         testContext
                 .given(RedbeamsDatabaseTestDto.class)
@@ -52,7 +53,7 @@ public class RedbeamsDatabaseTest extends AbstractIntegrationTest {
             given = "there is a prepared database",
             when = "when a database create request is sent with the same database name",
             then = "the create should return a BadRequestException")
-    public void createAndCreateWithSameNameThenShouldThrowBadRequestException(TestContext testContext) {
+    public void createAndCreateWithSameNameThenShouldThrowBadRequestException(MockedTestContext testContext) {
         String databaseName = resourcePropertyProvider().getName();
         testContext
                 .given(RedbeamsDatabaseTestDto.class)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/RepairTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/RepairTest.java
@@ -23,7 +23,6 @@ import com.sequenceiq.it.cloudbreak.client.StackTestClient;
 import com.sequenceiq.it.cloudbreak.cloud.HostGroupType;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
-import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.ClusterTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.kerberos.KerberosTestDto;
@@ -63,7 +62,7 @@ public class RepairTest extends AbstractIntegrationTest {
 
     @BeforeMethod
     public void beforeMethod(Object[] data) {
-        TestContext testContext = (TestContext) data[0];
+        MockedTestContext testContext = (MockedTestContext) data[0];
         createDefaultUser(testContext);
         createDefaultImageCatalog(testContext);
         initializeDefaultBlueprints(testContext);
@@ -71,7 +70,7 @@ public class RepairTest extends AbstractIntegrationTest {
 
     @AfterMethod(alwaysRun = true)
     public void tearDown(Object[] data) {
-        TestContext testContext = (TestContext) data[0];
+        MockedTestContext testContext = (MockedTestContext) data[0];
         testContext.cleanupTestContext();
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/SharedServiceTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/SharedServiceTest.java
@@ -124,7 +124,7 @@ public class SharedServiceTest extends AbstractIntegrationTest {
 
     @Test(dataProvider = TEST_CONTEXT_WITH_MOCK, enabled = false)
     @Description(given = "a datalake cluster", when = "hive rds, ranger rds and ldap are attached", then = "cluster creation is failed by invalid hostgroups")
-    public void testCreateDatalakeClusterWithMoreHostgroupThanSpecifiedInBlueprint(TestContext testContext) {
+    public void testCreateDatalakeClusterWithMoreHostgroupThanSpecifiedInBlueprint(MockedTestContext testContext) {
         String hiveRdsName = resourcePropertyProvider().getName();
         String rangerRdsName = resourcePropertyProvider().getName();
         String ldapName = resourcePropertyProvider().getName();
@@ -154,7 +154,7 @@ public class SharedServiceTest extends AbstractIntegrationTest {
 
     @Test(dataProvider = TEST_CONTEXT_WITH_MOCK, enabled = false)
     @Description(given = "a datalake cluster", when = "hive rds, ranger rds are attached", then = "cluster creation is failed by missing ldap")
-    public void testCreateDatalakeClusterWithoutLdap(TestContext testContext) {
+    public void testCreateDatalakeClusterWithoutLdap(MockedTestContext testContext) {
         String hiveRdsName = resourcePropertyProvider().getName();
         String rangerRdsName = resourcePropertyProvider().getName();
         String blueprintName = resourcePropertyProvider().getName();
@@ -182,7 +182,7 @@ public class SharedServiceTest extends AbstractIntegrationTest {
 
     @Test(dataProvider = TEST_CONTEXT_WITH_MOCK, enabled = false)
     @Description(given = "a datalake cluster", when = "hive rds and ldap are attached", then = "cluster creation is failed by missing ranger rds")
-    public void testCreateDatalakeClusterWithOnlyOneRdsWhichIsHive(TestContext testContext) {
+    public void testCreateDatalakeClusterWithOnlyOneRdsWhichIsHive(MockedTestContext testContext) {
         String hiveRdsName = resourcePropertyProvider().getName();
         String ldapName = resourcePropertyProvider().getName();
         String blueprintName = resourcePropertyProvider().getName();
@@ -210,7 +210,7 @@ public class SharedServiceTest extends AbstractIntegrationTest {
 
     @Test(dataProvider = TEST_CONTEXT_WITH_MOCK, enabled = false)
     @Description(given = "a datalake cluster", when = "ranger rds and ldap are attached", then = "cluster creation is failed by missing hive rds")
-    public void testCreateDatalakeClusterWithOnlyOneRdsWhichIsRanger(TestContext testContext) {
+    public void testCreateDatalakeClusterWithOnlyOneRdsWhichIsRanger(MockedTestContext testContext) {
         String rangerRdsName = resourcePropertyProvider().getName();
         String ldapName = resourcePropertyProvider().getName();
         String blueprintName = resourcePropertyProvider().getName();
@@ -238,7 +238,7 @@ public class SharedServiceTest extends AbstractIntegrationTest {
 
     @Test(dataProvider = TEST_CONTEXT_WITH_MOCK, enabled = false)
     @Description(given = "a datalake cluster", when = "ldap are attached", then = "cluster creation is failed by missing hive and ranger rds")
-    public void testCreateDatalakeClusterWithoutRds(TestContext testContext) {
+    public void testCreateDatalakeClusterWithoutRds(MockedTestContext testContext) {
         String ldapName = resourcePropertyProvider().getName();
         String blueprintName = resourcePropertyProvider().getName();
         testContext
@@ -265,7 +265,7 @@ public class SharedServiceTest extends AbstractIntegrationTest {
     @Test(dataProvider = TEST_CONTEXT_WITH_MOCK, enabled = false)
     @Description(given = "a datalake cluster", when = "without ldap, ranger and hive rds",
             then = "cluster creation is failed by missing hive and ranger rds and ldap")
-    public void testCreateDatalakeClusterWithoutRdsAndLdap(TestContext testContext) {
+    public void testCreateDatalakeClusterWithoutRdsAndLdap(MockedTestContext testContext) {
         String blueprintName = resourcePropertyProvider().getName();
         testContext
                 .given(BlueprintTestDto.class).withName(blueprintName)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/StackMatrixTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/StackMatrixTest.java
@@ -22,7 +22,7 @@ public class StackMatrixTest extends AbstractIntegrationTest {
 
     @BeforeMethod
     public void beforeMethod(Object[] data) {
-        createDefaultUser((TestContext) data[0]);
+        createDefaultUser((MockedTestContext) data[0]);
     }
 
     @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/VersionCheckTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/VersionCheckTest.java
@@ -12,7 +12,6 @@ import com.sequenceiq.it.cloudbreak.client.UtilTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
 import com.sequenceiq.it.cloudbreak.context.TestCaseDescription;
-import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.util.VersionCheckTestDto;
 import com.sequenceiq.it.cloudbreak.testcase.AbstractIntegrationTest;
 
@@ -23,7 +22,7 @@ public class VersionCheckTest extends AbstractIntegrationTest {
 
     @BeforeMethod
     public void beforeMethod(Object[] data) {
-        createDefaultUser((TestContext) data[0]);
+        createDefaultUser((MockedTestContext) data[0]);
     }
 
     @Test(dataProvider = "contextWithTestContextAndInvalidVersionValue")

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/WorkspaceTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/WorkspaceTest.java
@@ -17,7 +17,6 @@ import com.sequenceiq.it.cloudbreak.client.RecipeTestClient;
 import com.sequenceiq.it.cloudbreak.client.StackTestClient;
 import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
 import com.sequenceiq.it.cloudbreak.context.RunningParameter;
-import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.blueprint.BlueprintTestDto;
 import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
 import com.sequenceiq.it.cloudbreak.dto.kerberos.KerberosTestDto;
@@ -71,7 +70,7 @@ public class WorkspaceTest extends AbstractIntegrationTest {
     }
 
     @Test(dataProvider = TEST_CONTEXT_WITH_MOCK, enabled = false)
-    public void testCreateABlueprintAndGetOtherUser(TestContext testContext) {
+    public void testCreateABlueprintAndGetOtherUser(MockedTestContext testContext) {
         testContext
                 .given(BlueprintTestDto.class)
                 .withBlueprint(BLUEPRINT_TEXT)
@@ -82,7 +81,7 @@ public class WorkspaceTest extends AbstractIntegrationTest {
     }
 
     @Test(dataProvider = TEST_CONTEXT_WITH_MOCK, enabled = false)
-    public void testCreateARecipeAndGetOtherUser(TestContext testContext) {
+    public void testCreateARecipeAndGetOtherUser(MockedTestContext testContext) {
         testContext
                 .given(RecipeTestDto.class)
                 .when(recipeTestClient.createV4())
@@ -92,7 +91,7 @@ public class WorkspaceTest extends AbstractIntegrationTest {
     }
 
     @Test(dataProvider = TEST_CONTEXT_WITH_MOCK, enabled = false)
-    public void testCreateAnLdapAndGetOtherUser(TestContext testContext) {
+    public void testCreateAnLdapAndGetOtherUser(MockedTestContext testContext) {
         testContext
                 .given(LdapTestDto.class)
                 .when(ldapTestClient.createV1())
@@ -102,7 +101,7 @@ public class WorkspaceTest extends AbstractIntegrationTest {
     }
 
     @Test(dataProvider = TEST_CONTEXT_WITH_MOCK, enabled = false)
-    public void testCreateAnImageCatalogWithImagesAndGetOtherUser(TestContext testContext) {
+    public void testCreateAnImageCatalogWithImagesAndGetOtherUser(MockedTestContext testContext) {
         testContext
                 .given(ImageCatalogTestDto.class)
                 .when(imageCatalogTestClient.createV4())
@@ -113,7 +112,7 @@ public class WorkspaceTest extends AbstractIntegrationTest {
     }
 
     @Test(dataProvider = TEST_CONTEXT_WITH_MOCK, enabled = false)
-    public void testCreateAnImageCatalogWithoutImagesAndGetOtherUser(TestContext testContext) {
+    public void testCreateAnImageCatalogWithoutImagesAndGetOtherUser(MockedTestContext testContext) {
         testContext
                 .given(ImageCatalogTestDto.class)
                 .when(imageCatalogTestClient.createV4())
@@ -124,7 +123,7 @@ public class WorkspaceTest extends AbstractIntegrationTest {
     }
 
     @Test(dataProvider = TEST_CONTEXT_WITH_MOCK, enabled = false)
-    public void testCreateAProxyConfigAndGetOtherUser(TestContext testContext) {
+    public void testCreateAProxyConfigAndGetOtherUser(MockedTestContext testContext) {
         testContext
                 .given(ProxyTestDto.class)
                 .when(proxyTestClient.create())
@@ -134,7 +133,7 @@ public class WorkspaceTest extends AbstractIntegrationTest {
     }
 
     @Test(dataProvider = TEST_CONTEXT_WITH_MOCK, enabled = false)
-    public void testCreateKerberosConfigAndGetOtherUser(TestContext testContext) {
+    public void testCreateKerberosConfigAndGetOtherUser(MockedTestContext testContext) {
         testContext
                 .given(KerberosTestDto.class)
                 .when(kerberosTestClient.createV1())

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/YcloudHybridCloudTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/YcloudHybridCloudTest.java
@@ -83,7 +83,7 @@ public class YcloudHybridCloudTest extends AbstractIntegrationTest {
     @Inject
     private UtilTestClient utilTestClient;
 
-    protected void setupTest(TestContext testContext) {
+    protected void setupTest(MockedTestContext testContext) {
         createDefaultUser(testContext);
         initializeDefaultBlueprints(testContext);
         createDefaultCredential(testContext);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/YcloudHybridCloudTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/YcloudHybridCloudTest.java
@@ -83,7 +83,7 @@ public class YcloudHybridCloudTest extends AbstractIntegrationTest {
     @Inject
     private UtilTestClient utilTestClient;
 
-    protected void setupTest(MockedTestContext testContext) {
+    protected void setupTest(TestContext testContext) {
         createDefaultUser(testContext);
         initializeDefaultBlueprints(testContext);
         createDefaultCredential(testContext);
@@ -105,7 +105,7 @@ public class YcloudHybridCloudTest extends AbstractIntegrationTest {
 
     @AfterMethod(alwaysRun = true)
     public void tearDown(Object[] data) {
-        TestContext testContext = (TestContext) data[0];
+        MockedTestContext testContext = (MockedTestContext) data[0];
 
         testContext
                 .given(CHILD_ENVIRONMENT, EnvironmentTestDto.class)
@@ -116,14 +116,14 @@ public class YcloudHybridCloudTest extends AbstractIntegrationTest {
         testContext.cleanupTestContext();
     }
 
-    private void validateParentEnvironment(TestContext testContext) {
+    private void validateParentEnvironment(MockedTestContext testContext) {
         testContext
                 .given(EnvironmentTestDto.class)
                 .when(environmentTestClient.list())
                 .then(this::checkEnvIsListedByNameAndParentName);
     }
 
-    private void createAndValidateChildEnvironment(TestContext testContext)  {
+    private void createAndValidateChildEnvironment(MockedTestContext testContext)  {
         testContext
                 .given(CHILD_ENVIRONMENT, EnvironmentTestDto.class)
                     .withParentEnvironment()
@@ -135,7 +135,7 @@ public class YcloudHybridCloudTest extends AbstractIntegrationTest {
                 .validate();
     }
 
-    private void createAndValidateSdx(TestContext testContext) {
+    private void createAndValidateSdx(MockedTestContext testContext) {
         String sdxInternal = resourcePropertyProvider().getName();
         String clouderaManager = resourcePropertyProvider().getName();
         String cluster = resourcePropertyProvider().getName();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/clouderamanager/ClouderaManagerSetupTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/clouderamanager/ClouderaManagerSetupTest.java
@@ -8,7 +8,7 @@ import org.testng.annotations.Test;
 import com.sequenceiq.it.cloudbreak.assertion.MockVerification;
 import com.sequenceiq.it.cloudbreak.client.StackTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
-import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
 import com.sequenceiq.it.cloudbreak.dto.stack.StackTestDto;
 import com.sequenceiq.it.cloudbreak.mock.model.ClouderaManagerMock;
 import com.sequenceiq.it.cloudbreak.testcase.AbstractIntegrationTest;
@@ -23,7 +23,7 @@ public class ClouderaManagerSetupTest extends AbstractIntegrationTest {
             given = "a working environment",
             when = "a stack is created",
             then = "ClouderaManager user endpoints should be invoked with the proper requests")
-    public void verifyCallsAgainstCmUserCreation(TestContext testContext) {
+    public void verifyCallsAgainstCmUserCreation(MockedTestContext testContext) {
         testContext
                 .given(StackTestDto.class)
                 .when(stackTestClient.createV4())

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/clouderamanager/ClouderaManagerStackCreationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/clouderamanager/ClouderaManagerStackCreationTest.java
@@ -8,8 +8,8 @@ import org.testng.annotations.Test;
 import com.sequenceiq.it.cloudbreak.client.BlueprintTestClient;
 import com.sequenceiq.it.cloudbreak.client.StackTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
 import com.sequenceiq.it.cloudbreak.context.RunningParameter;
-import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.ClouderaManagerProductTestDto;
 import com.sequenceiq.it.cloudbreak.dto.ClouderaManagerTestDto;
 import com.sequenceiq.it.cloudbreak.dto.ClusterTestDto;
@@ -29,7 +29,7 @@ public class ClouderaManagerStackCreationTest extends AbstractClouderaManagerTes
             given = "there is a running cloudbreak",
             when = "a cluster with Cloudera Manager is created",
             then = "the cluster should be available")
-    public void testCreateNewRegularCluster(TestContext testContext) {
+    public void testCreateNewRegularCluster(MockedTestContext testContext) {
         String name = testContext.get(BlueprintTestDto.class).getRequest().getName();
         String clouderaManager = "cm";
         String cluster = "cmcluster";
@@ -50,7 +50,7 @@ public class ClouderaManagerStackCreationTest extends AbstractClouderaManagerTes
             given = "there is a running cloudbreak",
             when = "a cluster with incomplete product posted",
             then = "validation error")
-    public void testCreateClusterWithIncompleteProduct(TestContext testContext) {
+    public void testCreateClusterWithIncompleteProduct(MockedTestContext testContext) {
         String name = testContext.get(BlueprintTestDto.class).getRequest().getName();
         String clouderaManager = "cm";
         String cluster = "cmcluster";

--- a/integration-test/src/main/java/com/sequenceiq/it/util/cleanup/CleanupClientUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/util/cleanup/CleanupClientUtil.java
@@ -13,6 +13,13 @@ import com.sequenceiq.sdx.client.SdxServiceApiKeyClient;
 
 @Service
 public class CleanupClientUtil {
+
+    private EnvironmentClient environmentClient;
+
+    private SdxClient sdxClient;
+
+    private CloudbreakClient cloudbreakClient;
+
     @Value("${integrationtest.cloudbreak.server}")
     private String server;
 
@@ -35,23 +42,50 @@ public class CleanupClientUtil {
     }
 
     public CloudbreakClient createCloudbreakClient() {
-        return new CloudbreakApiKeyClient(
+        cloudbreakClient = new CloudbreakApiKeyClient(
                 server + cbRootContextPath,
                 new ConfigKey(false, true, true))
                 .withKeys(accesskey, secretkey);
+        return cloudbreakClient;
+    }
+
+    public void setCloudbreakClient(CloudbreakClient cloudbreakClient) {
+        this.cloudbreakClient = cloudbreakClient;
+    }
+
+    public CloudbreakClient getCloudbreakClient() {
+        return cloudbreakClient;
     }
 
     public EnvironmentClient createEnvironmentClient() {
-        return new EnvironmentServiceApiKeyClient(
+        environmentClient = new EnvironmentServiceApiKeyClient(
                 server + envRootContextPath,
                 new ConfigKey(false, true, true))
                 .withKeys(accesskey, secretkey);
+        return environmentClient;
+    }
+
+    public void setEnvironmentClient(EnvironmentClient environmentClient) {
+        this.environmentClient = environmentClient;
+    }
+
+    public EnvironmentClient getEnvironmentClient() {
+        return environmentClient;
     }
 
     public SdxClient createSdxClient() {
-        return new SdxServiceApiKeyClient(
+        sdxClient = new SdxServiceApiKeyClient(
                 server + sdxRootContextPath,
                 new ConfigKey(false, true, true))
                 .withKeys(accesskey, secretkey);
+        return sdxClient;
+    }
+
+    public void setSdxClient(SdxClient sdxClient) {
+        this.sdxClient = sdxClient;
+    }
+
+    public SdxClient getSdxClient() {
+        return sdxClient;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/util/cleanup/CleanupUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/util/cleanup/CleanupUtil.java
@@ -1,16 +1,29 @@
 package com.sequenceiq.it.util.cleanup;
 
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
+import javax.ws.rs.NotFoundException;
 
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Response;
@@ -18,6 +31,7 @@ import com.sequenceiq.cloudbreak.client.CloudbreakClient;
 import com.sequenceiq.environment.api.v1.credential.model.CredentialBase;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentBaseResponse;
 import com.sequenceiq.environment.client.EnvironmentClient;
+import com.sequenceiq.it.cloudbreak.MicroserviceClient;
 import com.sequenceiq.it.cloudbreak.util.WaitResult;
 import com.sequenceiq.sdx.api.model.SdxClusterResponse;
 import com.sequenceiq.sdx.client.SdxClient;
@@ -26,62 +40,68 @@ import com.sequenceiq.sdx.client.SdxClient;
 public class CleanupUtil extends CleanupClientUtil {
     private static final Logger LOG = LoggerFactory.getLogger(CleanupUtil.class);
 
+    private final Map<String, Map<Class<? extends MicroserviceClient>, MicroserviceClient>> clients = new HashMap<>();
+
+    @Value("${integrationtest.outputdir:.}")
+    private String outputDirectory;
+
     @Inject
     private CleanupWaitUtil waitUtil;
 
-    public void cleanupDistroxes() {
-        CloudbreakClient cloudbreak = createCloudbreakClient();
-        EnvironmentClient environment = createEnvironmentClient();
-        List<String> distroxNames = getDistroxes(environment, cloudbreak);
+    public void cleanupAllResources() {
+        if (resourceFilesArePresent()) {
+            cleanupDistroxes();
+            cleanupSdxes();
+            cleanupEnvironments();
+            cleanupCredentials();
+        } else {
+            EnvironmentClient environmentClient = createEnvironmentClient();
+            List<String> foundChildEnvironmentNames = new ArrayList<>(getChildEnvironments(environmentClient).values());
+            List<String> foundEnvironmentNames = new ArrayList<>(getEnvironments(environmentClient).values());
+            List<String> foundCredentialNames = getCredentials(environmentClient);
 
-        if (!distroxNames.isEmpty()) {
-            distroxNames.forEach(distroxName -> LOG.info("Distrox with name: {} will be deleted!", distroxName));
-            distroxNames.forEach(distroxName -> {
-                LOG.info("Deleting distrox with name: {}", distroxName);
-                try {
-                    cloudbreak.distroXV1Endpoint().deleteByName(distroxName, true);
-                } catch (Exception e) {
-                    LOG.error("Distrox with name: {} cannot be deleted, because of: {}", distroxName, e);
-                }
-            });
-            for (int i = 0; i < 3; i++) {
-                WaitResult waitResult = waitUtil.waitForDistroxesCleanup(cloudbreak, environment);
-                if (waitResult == WaitResult.FAILED) {
-                    throw new RuntimeException("Distrox deletion has been failed!");
-                }
-                if (waitResult == WaitResult.TIMEOUT) {
-                    throw new RuntimeException("Timeout happened during the wait for distrox deletion!");
-                }
+            if (!foundChildEnvironmentNames.isEmpty()) {
+                LOG.info("Found child environments: '{}'", foundChildEnvironmentNames);
+                deleteEnvironments(environmentClient, foundChildEnvironmentNames);
             }
+            if (!foundEnvironmentNames.isEmpty()) {
+                LOG.info("Found environments: '{}'", foundEnvironmentNames);
+                deleteEnvironments(environmentClient, foundEnvironmentNames);
+            } else {
+                LOG.info("Cannot find any environment!");
+            }
+            if (!foundCredentialNames.isEmpty()) {
+                LOG.info("Found credentials: '{}'", foundCredentialNames);
+                deleteCredentials(environmentClient, foundCredentialNames);
+            } else {
+                LOG.info("Cannot find any credential!");
+            }
+        }
+    }
+
+    public void cleanupDistroxes() {
+        CloudbreakClient cloudbreakClient = createCloudbreakClient();
+        EnvironmentClient environmentClient = createEnvironmentClient();
+        List<String> foundDistroxNames = getDistroxes(environmentClient, cloudbreakClient);
+
+        setCloudbreakClient(cloudbreakClient);
+        LOG.info("Found distroxes: '{}'", foundDistroxNames);
+        if (!foundDistroxNames.isEmpty()) {
+            deleteResources(foundDistroxNames, "distroxName");
         } else {
             LOG.info("Cannot find any distrox");
         }
     }
 
     public void cleanupSdxes() {
-        SdxClient sdx = createSdxClient();
-        EnvironmentClient environment = createEnvironmentClient();
-        List<String> sdxNames = getSdxes(environment, sdx);
+        SdxClient sdxClient = createSdxClient();
+        EnvironmentClient environmentClient = createEnvironmentClient();
+        List<String> foundSdxNames = getSdxes(environmentClient, sdxClient);
 
-        if (!sdxNames.isEmpty()) {
-            sdxNames.forEach(sdxName -> LOG.info("Sdx with name: {} will be deleted!", sdxName));
-            sdxNames.forEach(sdxName -> {
-                LOG.info("Deleting sdx with name: {}", sdxName);
-                try {
-                    sdx.sdxEndpoint().delete(sdxName, true);
-                } catch (Exception e) {
-                    LOG.error("Sdx with name: {} cannot be deleted, because of: {}", sdxName, e);
-                }
-            });
-            for (int i = 0; i < 3; i++) {
-                WaitResult waitResult = waitUtil.waitForSdxesCleanup(sdx, environment);
-                if (waitResult == WaitResult.FAILED) {
-                    throw new RuntimeException("Sdx deletion has been failed!");
-                }
-                if (waitResult == WaitResult.TIMEOUT) {
-                    throw new RuntimeException("Timeout happened during the wait for sdx deletion!");
-                }
-            }
+        setSdxClient(sdxClient);
+        LOG.info("Found data lakes (sdxes): '{}'", foundSdxNames);
+        if (!foundSdxNames.isEmpty()) {
+            deleteResources(foundSdxNames, "sdxName");
         } else {
             LOG.info("Cannot find any sdx");
         }
@@ -89,35 +109,32 @@ public class CleanupUtil extends CleanupClientUtil {
 
     public void cleanupEnvironments() {
         EnvironmentClient environmentClient = createEnvironmentClient();
-        Set<String> deletableChildEnvironmentNames = new HashSet<>(getChildEnvironments(environmentClient).values());
-        Set<String> deletableEnvironmentNames = new HashSet<>(getEnvironments(environmentClient).values());
+        List<String> foundChildEnvironmentNames = new ArrayList<>(getChildEnvironments(environmentClient).values());
+        List<String> foundEnvironmentNames = new ArrayList<>(getEnvironments(environmentClient).values());
 
-        if (!deletableChildEnvironmentNames.isEmpty()) {
-            LOG.info("Deletable child environments: {}", deletableChildEnvironmentNames);
-            deleteEnvironments(deletableChildEnvironmentNames, environmentClient);
+        setEnvironmentClient(environmentClient);
+        if (!foundChildEnvironmentNames.isEmpty()) {
+            LOG.info("Found child environments: '{}'", foundChildEnvironmentNames);
+            deleteResources(foundChildEnvironmentNames, "environmentName");
         }
-        if (!deletableEnvironmentNames.isEmpty()) {
-            LOG.info("Deletable environments: {}", deletableEnvironmentNames);
-            deleteEnvironments(deletableEnvironmentNames, environmentClient);
+        if (!foundEnvironmentNames.isEmpty()) {
+            LOG.info("Found environments: '{}'", foundEnvironmentNames);
+            deleteResources(foundEnvironmentNames, "environmentName");
         } else {
-            LOG.info("Cannot find any deletable environment!");
+            LOG.info("Cannot find any environment!");
         }
     }
 
     public void cleanupCredentials() {
-        EnvironmentClient environment = createEnvironmentClient();
-        Set<String> credentialNames = getCredentials(environment);
+        EnvironmentClient environmentClient = createEnvironmentClient();
+        List<String> foundCredentialNames = getCredentials(environmentClient);
 
-        if (!credentialNames.isEmpty()) {
-            waitUtil.waitForEnvironmentsCleanup(environment);
-            credentialNames.forEach(credentialName -> LOG.info("Credential with name: {} will be deleted!", credentialName));
-            try {
-                environment.credentialV1Endpoint().deleteMultiple(credentialNames);
-            } catch (Exception e) {
-                LOG.error("One or more credential cannot be deleted, because of: ", e);
-            }
+        setEnvironmentClient(environmentClient);
+        LOG.info("Found credentials: '{}'", foundCredentialNames);
+        if (!foundCredentialNames.isEmpty()) {
+            deleteResources(foundCredentialNames, "credentialName");
         } else {
-            LOG.info("Cannot find any credential");
+            LOG.info("Cannot find any credential!");
         }
     }
 
@@ -142,10 +159,10 @@ public class CleanupUtil extends CleanupClientUtil {
         return childEnvironments;
     }
 
-    public Set<String> getCredentials(EnvironmentClient environment) {
+    public List<String> getCredentials(EnvironmentClient environment) {
         return environment.credentialV1Endpoint().list().getResponses().stream()
                 .map(CredentialBase::getName)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toList());
     }
 
     public List<String> getDistroxes(EnvironmentClient environment, CloudbreakClient cloudbreak) {
@@ -172,21 +189,208 @@ public class CleanupUtil extends CleanupClientUtil {
         return sdxNames;
     }
 
-    private void deleteEnvironments(Set<String> environmentNames, EnvironmentClient environmentClient) {
-        environmentNames.forEach(environmentName -> LOG.info("Environment with name: {} will be deleted!", environmentName));
+    private List<String> getResourcesFromFile(String resourceNameType, Path filePath) {
+        List<String> resourceNames = new ArrayList<>();
         try {
-            environmentClient.environmentV1Endpoint().deleteMultipleByNames(environmentNames, true, true);
+            String resourcesFromFile = Files.readString(filePath);
+            JSONObject jsonObject = new JSONObject(resourcesFromFile);
+            if (jsonObject.has(resourceNameType)) {
+                try {
+                    JSONArray resources = jsonObject.getJSONArray(resourceNameType);
+                    for (int i = 0; i < resources.length(); i++) {
+                        String resource = resources.getString(i);
+                        resourceNames.add(resource);
+                        LOG.info("Get '{}' JSON array '{}' element from resource file with: '{}'.", resourceNameType, i, resource);
+                    }
+                } catch (JSONException e) {
+                    String resource = jsonObject.getString(resourceNameType);
+                    resourceNames.add(resource);
+                    LOG.info("Get '{}' JSON object from resource file with: '{}'.", resourceNameType, resource);
+                }
+            } else {
+                LOG.error("Cannot find '{}' in resource file '{}'.", resourceNameType, filePath.getFileName());
+            }
+            return resourceNames;
+        } catch (JSONException e) {
+            LOG.warn("Cannot get '{}' key, because of: {}", resourceNameType, e.getMessage(), e);
+            return resourceNames;
+        } catch (FileNotFoundException e) {
+            LOG.warn("'{}' file not found, because of: {}", filePath, e.getMessage(), e);
+            return resourceNames;
+        } catch (IOException e) {
+            LOG.warn("Reading '{}' file throws exception: {}", filePath, e.getMessage(), e);
+            return resourceNames;
+        }
+    }
+
+    private void deleteResources(List<String> foundResources, String resourceNameType) {
+        List<Path> fileList = new ArrayList<>();
+        List<String> deletedCredentials = new ArrayList<>();
+        AtomicBoolean e2eCleanupFailed = new AtomicBoolean(false);
+
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(Paths.get(outputDirectory))) {
+            for (Path path : stream) {
+                String fileName = path.getFileName().toString();
+                if (fileName.startsWith("resource_names") && fileName.endsWith(".json")) {
+                    LOG.info("Found resource file: '{}' is going to be added to resource files' list", path.getFileName().toAbsolutePath().normalize());
+                    fileList.add(path);
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Cannot find resource file at path: '{}', because of: {}", Paths.get(outputDirectory).toAbsolutePath().normalize(), e.getMessage(), e);
+            throw new RuntimeException(String.format("Cannot find resource file at path: '%s', because of: %s",
+                    Paths.get(outputDirectory).toAbsolutePath().normalize(), e.getMessage()));
+        }
+        fileList.forEach(filePath -> {
+            LOG.info("Processing resource file: '{}'", filePath.getFileName());
+            List<String> resourcesName = Optional.ofNullable(getResourcesFromFile(resourceNameType, filePath))
+                    .orElse(List.of());
+            resourcesName.forEach(resourceName -> {
+                if (foundResources.contains(resourceName)) {
+                    LOG.info("{}:{} will be deleted!", resourceNameType, foundResources.stream()
+                            .filter(resourceName::equals).findAny().orElse(null));
+                    switch (resourceNameType) {
+                        case "distroxName":
+                        case "stackName":
+                            deleteDistrox(getCloudbreakClient(), resourceName);
+                            break;
+                        case "sdxName":
+                            deleteSdx(getSdxClient(), resourceName);
+                            break;
+                        case "credentialName":
+                            deleteCredential(getEnvironmentClient(), resourceName);
+                            e2eCleanupFailed.set(true);
+                            deletedCredentials.add(resourceName);
+                            break;
+                        default:
+                            deleteEnvironment(getEnvironmentClient(), resourceName);
+                            break;
+                    }
+                } else {
+                    LOG.info("Cannot find '{}:{}'! So End To End cleanup have been done successfully.", resourceNameType, resourceName);
+                }
+            });
+        });
+        validateE2ECleanup(e2eCleanupFailed, deletedCredentials);
+    }
+
+    private void deleteEnvironments(EnvironmentClient environmentClient, List<String> environmentNames) {
+        try {
+            environmentNames.forEach(environmentName -> LOG.info("Environment with name: {} will be deleted!", environmentName));
+            environmentClient.environmentV1Endpoint().deleteMultipleByNames(new HashSet<>(environmentNames), true, false);
+            environmentNames.forEach(environmentName -> {
+                WaitResult waitResult = waitUtil.waitForEnvironmentCleanup(environmentClient, environmentName);
+                if (waitResult == WaitResult.FAILED) {
+                    throw new RuntimeException(String.format("Failed: Deleting %s environment has been failed!", environmentName));
+                }
+                if (waitResult == WaitResult.TIMEOUT) {
+                    throw new RuntimeException(String.format("Timeout: Deleting %s environment has been timed out!", environmentName));
+                }
+            });
         } catch (Exception e) {
             LOG.error("One or more environment cannot be deleted, because of: {}", e.getMessage(), e);
+            throw new RuntimeException(String.format("One or more environment cannot be deleted, because of: %s", e.getMessage()));
         }
-        environmentNames.forEach(environmentName -> {
+    }
+
+    private void deleteEnvironment(EnvironmentClient environmentClient, String environmentName) {
+        try {
+            environmentClient.environmentV1Endpoint().deleteByName(environmentName, true, false);
             WaitResult waitResult = waitUtil.waitForEnvironmentCleanup(environmentClient, environmentName);
             if (waitResult == WaitResult.FAILED) {
-                throw new RuntimeException(String.format("Deleting %s environment has been failed!", environmentName));
+                throw new RuntimeException(String.format("Failed: Deleting %s environment has been failed!", environmentName));
             }
             if (waitResult == WaitResult.TIMEOUT) {
-                throw new RuntimeException(String.format("Timeout happened during the wait for deleting %s environment!", environmentName));
+                throw new RuntimeException(String.format("Timeout: Deleting %s environment has been timed out!", environmentName));
             }
-        });
+        } catch (NotFoundException e) {
+            LOG.info("{} environment have already been deleted", environmentName);
+        } catch (Exception e) {
+            LOG.error("{} environment cannot be deleted, because of: {}", environmentName, e.getMessage(), e);
+            throw new RuntimeException(String.format("%s environment cannot be deleted, because of: %s", environmentName, e.getMessage()));
+        }
+    }
+
+    public void deleteCredentials(EnvironmentClient environmentClient, List<String> credentialNames) {
+        waitUtil.waitForEnvironmentsCleanup(environmentClient);
+        try {
+            credentialNames.forEach(credentialName -> LOG.info("Credential with name: {} will be deleted!", credentialName));
+            environmentClient.credentialV1Endpoint().deleteMultiple(new HashSet<>(credentialNames));
+        } catch (Exception e) {
+            LOG.error("One or more credential cannot be deleted, because of: {}", e.getMessage(), e);
+            throw new RuntimeException(String.format("One or more credential cannot be deleted, because of: %s", e.getMessage()));
+        }
+    }
+
+    private void deleteCredential(EnvironmentClient environmentClient, String credentialName) {
+        try {
+            environmentClient.credentialV1Endpoint().deleteByName(credentialName);
+        } catch (NotFoundException e) {
+            LOG.info("{} credential have already been deleted", credentialName);
+        } catch (Exception e) {
+            LOG.error("{} credential cannot be deleted, because of: {}", credentialName, e.getMessage(), e);
+            throw new RuntimeException(String.format("%s credential cannot be deleted, because of: %s", credentialName, e.getMessage()));
+        }
+    }
+
+    private void deleteSdx(SdxClient sdxClient, String sdxName) {
+        try {
+            sdxClient.sdxEndpoint().delete(sdxName, true);
+            WaitResult waitResult = waitUtil.waitForSdxCleanup(sdxClient, sdxName);
+            if (waitResult == WaitResult.FAILED) {
+                throw new RuntimeException(String.format("Failed: Deleting %s data lake (sdx) has been failed!", sdxName));
+            }
+            if (waitResult == WaitResult.TIMEOUT) {
+                throw new RuntimeException(String.format("Timeout: Deleting %s data lake (sdx) has been timed out!", sdxName));
+            }
+        } catch (NotFoundException e) {
+            LOG.info("{} data lake (sdx) have already been deleted", sdxName);
+        } catch (Exception e) {
+            LOG.error("{} data lake (sdx) cannot be deleted, because of: {}", sdxName, e.getMessage(), e);
+            throw new RuntimeException(String.format("%s data lake (sdx) cannot be deleted, because of: %s", sdxName, e.getMessage()));
+        }
+    }
+
+    private void deleteDistrox(CloudbreakClient cloudbreakClient, String distroxName) {
+        try {
+            cloudbreakClient.distroXV1Endpoint().deleteByName(distroxName, true);
+            WaitResult waitResult = waitUtil.waitForDistroxCleanup(cloudbreakClient, distroxName);
+            if (waitResult == WaitResult.FAILED) {
+                throw new RuntimeException(String.format("Failed: Deleting %s data hub (distrox) has been failed!", distroxName));
+            }
+            if (waitResult == WaitResult.TIMEOUT) {
+                throw new RuntimeException(String.format("Timeout: Deleting %s data hub (distrox) has been timed out!", distroxName));
+            }
+        } catch (NotFoundException e) {
+            LOG.info("{} data hub (distrox) have already been deleted", distroxName);
+        } catch (Exception e) {
+            LOG.error("{} data hub (distrox) cannot be deleted, because of: {}", distroxName, e.getMessage(), e);
+            throw new RuntimeException(String.format("%s data hub (distrox) cannot be deleted, because of: %s", distroxName, e.getMessage()));
+        }
+    }
+
+    private void validateE2ECleanup(AtomicBoolean e2eCleanupFailed, List<String> credentialNames) {
+        if (e2eCleanupFailed.get()) {
+            LOG.error("End To End cleanup have been failed, because of credential(s) '{}' found left behind!", credentialNames);
+            throw new RuntimeException(String.format("End To End cleanup have been failed, because of credential(s) '%s' found left behind!", credentialNames));
+        } else {
+            LOG.info("End To End cleanup have been success, because of cannot found any resource left behind!");
+        }
+    }
+
+    private boolean resourceFilesArePresent() {
+        boolean result = false;
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(Paths.get(outputDirectory))) {
+            for (Path path : stream) {
+                String fileName = path.getFileName().toString();
+                if (fileName.startsWith("resource_names") && fileName.endsWith(".json")) {
+                    LOG.info("Found resource file at path: '{}'.", path.getFileName().toAbsolutePath().normalize());
+                    result = true;
+                }
+            }
+        } catch (Exception e) {
+            LOG.info("Cannot find resource file at path: '{}'.", Paths.get(outputDirectory).toAbsolutePath().normalize());
+        }
+        return result;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/util/cleanup/CleanupWaitUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/util/cleanup/CleanupWaitUtil.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.it.util.cleanup;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -36,13 +37,13 @@ public class CleanupWaitUtil {
      * Wait till all the distroxes in all the environments is going to be teminated. However not more than the "integrationtest.testsuite.maxRetry"
      *
      * Returns with:
-     * FAILED: At least one of the distroxes gets in DELETE_FAILED state
-     * TIMEOUT: There is at least one distrox, out of all, that is still available. However the "maxRetry" has been reached.
-     * SUCCESSFUL: All the distroxes in all the environments have been terminated successfully.
+     * FAILED:      At least one of the distroxes gets in DELETE_FAILED state
+     * TIMEOUT:     There is at least one distrox, out of all, that is still available. However the "maxRetry" has been reached.
+     * SUCCESSFUL:  All the distroxes in all the environments have been terminated successfully.
      *
-     * @param cloudbreak    com.sequenceiq.cloudbreak.client.CloudbreakClient
-     * @param environment   com.sequenceiq.environment.client.EnvironmentClient
-     * @return              FAILED, TIMEOUT, SUCCESSFUL com.sequenceiq.it.cloudbreak.util.WaitResult
+     * @param cloudbreak   com.sequenceiq.cloudbreak.client.CloudbreakClient
+     * @param environment  com.sequenceiq.environment.client.EnvironmentClient
+     * @return             FAILED, TIMEOUT, SUCCESSFUL com.sequenceiq.it.cloudbreak.util.WaitResult
      */
     public WaitResult waitForDistroxesCleanup(CloudbreakClient cloudbreak, EnvironmentClient environment) {
         int retryCount = 0;
@@ -68,16 +69,50 @@ public class CleanupWaitUtil {
     }
 
     /**
+     * Wait till the data hub (distrox) is going to be deleted (teminated). However not more than the "integrationtest.testsuite.maxRetry"
+     *
+     * Returns with:
+     * FAILED:      The distrox gets in DELETE_FAILED state
+     * TIMEOUT:     The distrox is still available. However the "maxRetry" has been reached.
+     * SUCCESSFUL:  The distrox have been terminated successfully.
+     *
+     * @param cloudbreakClient  com.sequenceiq.cloudbreak.client.CloudbreakClient
+     * @param distroxName       Provided distrox name
+     * @return                  FAILED, TIMEOUT, SUCCESSFUL com.sequenceiq.it.cloudbreak.util.WaitResult
+     */
+    public WaitResult waitForDistroxCleanup(CloudbreakClient cloudbreakClient, String distroxName) {
+        int retryCount = 0;
+
+        while (retryCount < maxRetry && checkDistroxIsAvailable(cloudbreakClient, distroxName)
+                && !checkDistroxDeleteFailedStatus(cloudbreakClient, distroxName)) {
+            sleep(pollingInterval);
+            retryCount++;
+        }
+
+        if (checkDistroxDeleteFailedStatus(cloudbreakClient, distroxName)) {
+            LOG.info("Failed: {} distrox cannot be terminated!", distroxName);
+            return WaitResult.FAILED;
+        } else if (checkDistroxIsAvailable(cloudbreakClient, distroxName)) {
+            LOG.info("Timeout: {} distrox cannot be terminated during {} retries", distroxName, maxRetry);
+            return WaitResult.TIMEOUT;
+        } else {
+            sleep(DELETE_SLEEP);
+            LOG.info("Success: {} distrox have been terminated", distroxName);
+            return WaitResult.SUCCESSFUL;
+        }
+    }
+
+    /**
      * Wait till all the sdxes in all the environments is going to be teminated. However not more than the "integrationtest.testsuite.maxRetry"
      *
      * Returns with:
-     * FAILED: At least one of the sdxes gets in DELETE_FAILED state
-     * TIMEOUT: There is at least one sdx, out of all, that is still available. However the "maxRetry" has been reached.
-     * SUCCESSFUL: All the sdxes in all the environments have been terminated successfully.
+     * FAILED:      At least one of the sdxes gets in DELETE_FAILED state
+     * TIMEOUT:     There is at least one sdx, out of all, that is still available. However the "maxRetry" has been reached.
+     * SUCCESSFUL:  All the sdxes in all the environments have been terminated successfully.
      *
-     * @param sdx           com.sequenceiq.sdx.client.SdxClient
-     * @param environment   com.sequenceiq.environment.client.EnvironmentClient
-     * @return              FAILED, TIMEOUT, SUCCESSFUL com.sequenceiq.it.cloudbreak.util.WaitResult
+     * @param sdx          com.sequenceiq.sdx.client.SdxClient
+     * @param environment  com.sequenceiq.environment.client.EnvironmentClient
+     * @return             FAILED, TIMEOUT, SUCCESSFUL com.sequenceiq.it.cloudbreak.util.WaitResult
      */
     public WaitResult waitForSdxesCleanup(SdxClient sdx, EnvironmentClient environment) {
         int retryCount = 0;
@@ -103,15 +138,49 @@ public class CleanupWaitUtil {
     }
 
     /**
+     * Wait till the data lake (sdx) is going to be deleted (terminated). However not more than the "integrationtest.testsuite.maxRetry"
+     *
+     * Returns with:
+     * FAILED:      The sdx gets in DELETE_FAILED state
+     * TIMEOUT:     The sdx is still available. However the "maxRetry" has been reached.
+     * SUCCESSFUL:  The sdx have been terminated successfully.
+     *
+     * @param sdxClient  com.sequenceiq.sdx.client.SdxClient
+     * @param sdxName    Provided sdx name
+     * @return           FAILED, TIMEOUT, SUCCESSFUL com.sequenceiq.it.cloudbreak.util.WaitResult
+     */
+    public WaitResult waitForSdxCleanup(SdxClient sdxClient, String sdxName) {
+        int retryCount = 0;
+
+        while (retryCount < maxRetry && checkSdxIsAvailable(sdxClient, sdxName)
+                && !checkSdxDeleteFailedStatus(sdxClient, sdxName)) {
+            sleep(pollingInterval);
+            retryCount++;
+        }
+
+        if (checkSdxDeleteFailedStatus(sdxClient, sdxName)) {
+            LOG.info("Failed: {} sdx cannot be terminated", sdxName);
+            return WaitResult.FAILED;
+        } else if (checkSdxIsAvailable(sdxClient, sdxName)) {
+            LOG.info("Timeout: {} sdx cannot be terminated during {} retries", sdxName, maxRetry);
+            return WaitResult.TIMEOUT;
+        } else {
+            sleep(DELETE_SLEEP);
+            LOG.info("Success: {} sdx have been terminated", sdxName);
+            return WaitResult.SUCCESSFUL;
+        }
+    }
+
+    /**
      * Wait till all the environments is going to be teminated. However not more than the "integrationtest.testsuite.maxRetry"
      *
      * Returns with:
-     * FAILED: At least one of the environment gets in DELETE_FAILED state
-     * TIMEOUT: There is at least one environment, out of all, that is still available. However the "maxRetry" has been reached.
-     * SUCCESSFUL: All the environments have been terminated successfully.
+     * FAILED:      At least one of the environment gets in DELETE_FAILED state
+     * TIMEOUT:     There is at least one environment, out of all, that is still available. However the "maxRetry" has been reached.
+     * SUCCESSFUL:  All the environments have been terminated successfully.
      *
-     * @param environment   com.sequenceiq.environment.client.EnvironmentClient
-     * @return              FAILED, TIMEOUT, SUCCESSFUL com.sequenceiq.it.cloudbreak.util.WaitResult
+     * @param environment  com.sequenceiq.environment.client.EnvironmentClient
+     * @return             FAILED, TIMEOUT, SUCCESSFUL com.sequenceiq.it.cloudbreak.util.WaitResult
      */
     public WaitResult waitForEnvironmentsCleanup(EnvironmentClient environment) {
         int retryCount = 0;
@@ -122,14 +191,14 @@ public class CleanupWaitUtil {
         }
 
         if (checkEnvironmentsDeleteFailedStatus(environment)) {
-            LOG.info("One or more environment cannot be terminated");
+            LOG.info("Failed: One or more environment cannot be terminated");
             return WaitResult.FAILED;
         } else if (checkEnvironmentsAreAvailable(environment)) {
             LOG.info("Timeout: Environments cannot be terminated during {} retries", maxRetry);
             return WaitResult.TIMEOUT;
         } else {
             sleep(DELETE_SLEEP);
-            LOG.info("All the environments have been terminated");
+            LOG.info("Success: All the environments have been terminated");
             return WaitResult.SUCCESSFUL;
         }
     }
@@ -138,13 +207,13 @@ public class CleanupWaitUtil {
      * Wait till the environment is going to be deleted (archived). However not more than the "integrationtest.testsuite.maxRetry"
      *
      * Returns with:
-     * FAILED:     The environment gets in DELETE_FAILED state
-     * TIMEOUT:    The environment is still available. However the "maxRetry" has been reached.
-     * SUCCESSFUL: The environments have been terminated successfully.
+     * FAILED:      The environment gets in DELETE_FAILED state
+     * TIMEOUT:     The environment is still available. However the "maxRetry" has been reached.
+     * SUCCESSFUL:  The environments have been terminated successfully.
      *
-     * @param environmentClient com.sequenceiq.environment.client.EnvironmentClient
-     * @param environmentName   Provided environment name
-     * @return                  FAILED, TIMEOUT, SUCCESSFUL com.sequenceiq.it.cloudbreak.util.WaitResult
+     * @param environmentClient  com.sequenceiq.environment.client.EnvironmentClient
+     * @param environmentName    Provided environment name
+     * @return                   FAILED, TIMEOUT, SUCCESSFUL com.sequenceiq.it.cloudbreak.util.WaitResult
      */
     public WaitResult waitForEnvironmentCleanup(EnvironmentClient environmentClient, String environmentName) {
         int retryCount = 0;
@@ -180,8 +249,8 @@ public class CleanupWaitUtil {
      * Checking the number of available distroxes across all the environments.
      *
      * Returns with:
-     * TRUE: At least one distrox is still available in one of the environment.
-     * FALSE: Distroxes cannot be found in any of the available environent.
+     * TRUE:   At least one distrox is still available in one of the environment.
+     * FALSE:  Distroxes cannot be found in any of the available environent.
      *
      * @param cloudbreak    com.sequenceiq.cloudbreak.client.CloudbreakClient
      * @param environments  Map of available environments CRN and Name
@@ -201,11 +270,32 @@ public class CleanupWaitUtil {
     }
 
     /**
+     * Checking the data hub (distrox) is still available.
+     *
+     * Returns with:
+     * TRUE:   The distrox is still available.
+     * FALSE:  The distrox cannot be found.
+     *
+     * @param cloudbreakClient  com.sequenceiq.cloudbreak.client.CloudbreakClient
+     * @param distroxName       Provided distrox name
+     * @return                  TRUE or FALSE based on distrox availability
+     */
+    private boolean checkDistroxIsAvailable(CloudbreakClient cloudbreakClient, String distroxName) {
+        try {
+            cloudbreakClient.distroXV1Endpoint().getByName(distroxName, Collections.emptySet());
+            return true;
+        } catch (Exception e) {
+            LOG.warn("Exception has been occurred while checking {} distrox is available: {}", distroxName, e.getMessage(), e);
+            return false;
+        }
+    }
+
+    /**
      * Checking the number of available sdxes across all the environments.
      *
      * Returns with:
-     * TRUE: At least one sdx is still available in one of the environment.
-     * FALSE: Sdxes cannot be found in any of the available environent.
+     * TRUE:   At least one sdx is still available in one of the environment.
+     * FALSE:  Sdxes cannot be found in any of the available environent.
      *
      * @param sdx           com.sequenceiq.sdx.client.SdxClient
      * @param environments  Map of available environments CRN and Name
@@ -224,14 +314,35 @@ public class CleanupWaitUtil {
     }
 
     /**
+     * Checking the data lake (sdx) is still available.
+     *
+     * Returns with:
+     * TRUE:   The sdx is still available.
+     * FALSE:  The sdx cannot be found.
+     *
+     * @param sdxClient  com.sequenceiq.sdx.client.SdxClient
+     * @param sdxName    Provided sdx name
+     * @return           TRUE or FALSE based on sdx availability
+     */
+    private boolean checkSdxIsAvailable(SdxClient sdxClient, String sdxName) {
+        try {
+            sdxClient.sdxEndpoint().get(sdxName);
+            return true;
+        } catch (Exception e) {
+            LOG.warn("Exception has been occurred while checking {} sdx is available: {}", sdxName, e.getMessage(), e);
+            return false;
+        }
+    }
+
+    /**
      * Checking the number of available environments.
      *
      * Returns with:
-     * TRUE: At least one environment is still available.
-     * FALSE: Environments cannot be found.
+     * TRUE:   At least one environment is still available.
+     * FALSE:  Environments cannot be found.
      *
-     * @param environment   com.sequenceiq.environment.client.EnvironmentClient
-     * @return              TRUE or FALSE based on environments availability
+     * @param environment  com.sequenceiq.environment.client.EnvironmentClient
+     * @return             TRUE or FALSE based on environments availability
      */
     private boolean checkEnvironmentsAreAvailable(EnvironmentClient environment) {
         try {
@@ -247,12 +358,12 @@ public class CleanupWaitUtil {
      * Checking the environment is still available.
      *
      * Returns with:
-     * TRUE:    The environment is still available.
-     * FALSE:   The environment cannot be found.
+     * TRUE:   The environment is still available.
+     * FALSE:  The environment cannot be found.
      *
-     * @param environmentClient   com.sequenceiq.environment.client.EnvironmentClient
-     * @param environmentName     Provided environment name
-     * @return                    TRUE or FALSE based on environments availability
+     * @param environmentClient  com.sequenceiq.environment.client.EnvironmentClient
+     * @param environmentName    Provided environment name
+     * @return                   TRUE or FALSE based on environments availability
      */
     private boolean checkEnvironmentIsAvailable(EnvironmentClient environmentClient, String environmentName) {
         try {
@@ -268,8 +379,8 @@ public class CleanupWaitUtil {
      * Checking DELETE_FAILED state of available distroxes across all the environments.
      *
      * Returns with:
-     * TRUE: DELETE_FAILED state is available.
-     * FALSE: DELETE_FAILED state cannot be found.
+     * TRUE:   DELETE_FAILED state is available.
+     * FALSE:  DELETE_FAILED state cannot be found.
      *
      * @param cloudbreak    com.sequenceiq.cloudbreak.client.CloudbreakClient
      * @param environments  Map of available environments CRN and Name
@@ -288,11 +399,31 @@ public class CleanupWaitUtil {
     }
 
     /**
+     * Checking the data hub (distrox) is in DELETE_FAILED state.
+     *
+     * Returns with:
+     * TRUE:   DELETE_FAILED state is available.
+     * FALSE:  DELETE_FAILED state cannot be found.
+     *
+     * @param cloudbreakClient  com.sequenceiq.cloudbreak.client.CloudbreakClient
+     * @param distroxName       Provided distrox name
+     * @return                  TRUE or FALSE based on existing DELETE_FAILED status
+     */
+    private boolean checkDistroxDeleteFailedStatus(CloudbreakClient cloudbreakClient, String distroxName) {
+        try {
+            return cloudbreakClient.distroXV1Endpoint().getByName(distroxName, Collections.emptySet()).getStatus().equals(Status.DELETE_FAILED);
+        } catch (Exception e) {
+            LOG.warn("Exception has been occurred while checking {} distrox's DELETE_FAILED state: {}", distroxName, e.getMessage(), e);
+            return false;
+        }
+    }
+
+    /**
      * Checking DELETE_FAILED state of available sdxes across all the environments.
      *
      * Returns with:
-     * TRUE: DELETE_FAILED state is available.
-     * FALSE: DELETE_FAILED state cannot be found.
+     * TRUE:   DELETE_FAILED state is available.
+     * FALSE:  DELETE_FAILED state cannot be found.
      *
      * @param sdx           com.sequenceiq.sdx.client.SdxClient
      * @param environments  Map of available environments CRN and Name
@@ -311,14 +442,34 @@ public class CleanupWaitUtil {
     }
 
     /**
+     * Checking the data lake (sdx) is in DELETE_FAILED state.
+     *
+     * Returns with:
+     * TRUE:   DELETE_FAILED state is available.
+     * FALSE:  DELETE_FAILED state cannot be found.
+     *
+     * @param sdxClient  com.sequenceiq.sdx.client.SdxClient
+     * @param sdxName    Provided sdx name
+     * @return           TRUE or FALSE based on existing DELETE_FAILED status
+     */
+    private boolean checkSdxDeleteFailedStatus(SdxClient sdxClient, String sdxName) {
+        try {
+            return sdxClient.sdxEndpoint().get(sdxName).getStatus().equals(SdxClusterStatusResponse.DELETE_FAILED);
+        } catch (Exception e) {
+            LOG.warn("Exception has been occurred while checking {} sdx's DELETE_FAILED state: {}", sdxName, e.getMessage(), e);
+            return false;
+        }
+    }
+
+    /**
      * Checking DELETE_FAILED state of available environments.
      *
      * Returns with:
-     * TRUE: DELETE_FAILED state is available.
-     * FALSE: DELETE_FAILED state cannot be found.
+     * TRUE:   DELETE_FAILED state is available.
+     * FALSE:  DELETE_FAILED state cannot be found.
      *
-     * @param environment   com.sequenceiq.environment.client.EnvironmentClient
-     * @return              TRUE or FALSE based on existing DELETE_FAILED status
+     * @param environment  com.sequenceiq.environment.client.EnvironmentClient
+     * @return             TRUE or FALSE based on existing DELETE_FAILED status
      */
     private boolean checkEnvironmentsDeleteFailedStatus(EnvironmentClient environment) {
         try {
@@ -334,12 +485,12 @@ public class CleanupWaitUtil {
      * Checking the environment is in DELETE_FAILED state.
      *
      * Returns with:
-     * TRUE:  DELETE_FAILED state is available.
-     * FALSE: DELETE_FAILED state is not available.
+     * TRUE:   DELETE_FAILED state is available.
+     * FALSE:  DELETE_FAILED state is not available.
      *
-     * @param environmentClient com.sequenceiq.environment.client.EnvironmentClient
-     * @param environmentName   Provided environment name
-     * @return                  TRUE or FALSE based on existing DELETE_FAILED status
+     * @param environmentClient  com.sequenceiq.environment.client.EnvironmentClient
+     * @param environmentName    Provided environment name
+     * @return                   TRUE or FALSE based on existing DELETE_FAILED status
      */
     private boolean checkEnvironmentDeleteFailedStatus(EnvironmentClient environmentClient, String environmentName) {
         try {


### PR DESCRIPTION
This is the final improvement of the API Cleanup App:

- Provided resource JSON files are driving the cleanup instead of the found resources in the given tenant.
- If JSON file(s) is(are) present at `integrationtest.outputdir` path, listed resources are going to be checked. Otherwise all the found resources are going to be deleted/terminated as fallback.
- If a test generates more than one resource per type, that will generate an Array instead of Object:
  ```
  {
    "sdxName": "yarn-test-8206e51801004830a4a90e730a1ffc",
    "blueprintName": "yarn-test-94f1651394dd491a9a03a6714e66e9",
    "environmentName": [
      "yarn-test-18f9dd8b60ed492388",
      "aws-test-6f1adc4012e94028987"
    ],
    "stackName": [
      "yarn-test-af9ea",
      "aws-test-902939"
    ],
    "credentialName": [
      "aws-test-1b8a1afafded4daca3e1cc5e9533f37",
      "yarn-test-54daadca706347818431edc9c6b560"
    ]
  }
  ```
- If other resource(s) is(are) present at the given tenant, that won't be touched by the Cleanup App except resource JSON file cannot be found.
- If the Cleanup finds one or more credential(s) present from the resource JSON at the given tenant, Cleanup exits with error:
`ERROR c.s.it.util.cleanup.CleanupUtil [nolabel] - End To End cleanup have been failed, because of credential(s) '[aws-test-1b8a1afafded4daca3e1cc5e9533f37, yarn-test-54daadca706347818431edc9c6b560]' found left behind!` after all the found resources have been deleted/terminated.