### PR TITLE
CB-8478: Fix freeipa_healthagent_setup.sh to work with FreeIPA HA

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_healthagent_setup.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_healthagent_setup.sh
@@ -11,12 +11,20 @@ REPLICA_BASE="cn=${ESCAPED_DOMAIN},cn=mapping tree,cn=config"
 #
 # Add anonymous access for replication agreements
 #
-ldapmodify -x -D "cn=directory manager" -w $FPW -h localhost << EOF
+set +e
+ldapmodify -x -D "cn=directory manager" -w "$FPW" -h localhost << EOF
 dn: ${REPLICA_BASE}
 changetype: modify
 add: aci
 aci: (targetattr="cn||objectClass||nsDS5ReplicaHost||nsds5replicaLastUpdateEnd||nsds5replicaLastUpdateStatus")(targetfilter="(|(objectclass=nsds5replicationagreement)(objectclass=nsDSWindowsReplicationAgreement))")(version 3.0; aci "permission:Read Replication Agreements"; allow (read, search, compare) groupdn = "ldap:///anyone";)
 EOF
+LDAPMODIFY_RET=$?
+set -e
+LDAP_TYPE_OR_VALUE_EXISTS=20
+if [[ $LDAPMODIFY_RET -ne 0 && $LDAPMODIFY_RET -ne $LDAP_TYPE_OR_VALUE_EXISTS ]]; then
+  echo ldapmodify failed
+  false
+fi
 
 #
 # Setup cert copy and service refstart on cert update


### PR DESCRIPTION
Fix the freeipa_healthagent_setup.sh so that it works with multiple
instances of FreeIPA.

This was tested with a local deployment of cloudbreak by deploying a
2 node FreeIPA cluster.

See detailed description in the commit message.