### PR TITLE
CB-8497 Improve tag validation and introduce result logs

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/util/CloudProviderSideTagAssertion.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/util/CloudProviderSideTagAssertion.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
@@ -18,6 +20,7 @@ import com.sequenceiq.it.cloudbreak.FreeIpaClient;
 import com.sequenceiq.it.cloudbreak.SdxClient;
 import com.sequenceiq.it.cloudbreak.assertion.Assertion;
 import com.sequenceiq.it.cloudbreak.cloud.v4.CloudProviderProxy;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
@@ -25,6 +28,8 @@ import com.sequenceiq.it.util.TagsUtil;
 
 @Service
 public class CloudProviderSideTagAssertion {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CloudProviderSideTagAssertion.class);
 
     private final CloudProviderProxy cloudProviderProxy;
 
@@ -48,7 +53,7 @@ public class CloudProviderSideTagAssertion {
                     .map(InstanceMetaDataResponse::getInstanceId)
                     .collect(Collectors.toList());
 
-            verifyTags(instanceIds, customTags);
+            verifyTags(instanceIds, customTags, testContext);
 
             return testDto;
         };
@@ -61,7 +66,7 @@ public class CloudProviderSideTagAssertion {
                     .map(InstanceMetaDataV4Response::getInstanceId)
                     .collect(Collectors.toList());
 
-            verifyTags(instanceIds, customTags);
+            verifyTags(instanceIds, customTags, testContext);
 
             return testDto;
         };
@@ -74,16 +79,16 @@ public class CloudProviderSideTagAssertion {
                     .map(InstanceMetaDataV4Response::getInstanceId)
                     .collect(Collectors.toList());
 
-            verifyTags(instanceIds, customTags);
+            verifyTags(instanceIds, customTags, testContext);
 
             return testDto;
         };
     }
 
-    private void verifyTags(List<String> instanceIds, Map<String, String> customTags) {
+    private void verifyTags(List<String> instanceIds, Map<String, String> customTags, TestContext testContext) {
         Map<String, Map<String, String>> tagsByInstanceId = cloudProviderProxy.getCloudFunctionality().listTagsByInstanceId(instanceIds);
         tagsByInstanceId.forEach((id, tags) -> {
-            tagsUtil.verifyTags(new MapToTaggedResponseAdapter(tags));
+            tagsUtil.verifyTags(new MapToTaggedResponseAdapter(tags), testContext);
             customTags.forEach((key, value) -> assertThat(tags.get(key)).isEqualTo(value));
         });
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/SparklessTestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/SparklessTestContext.java
@@ -27,6 +27,6 @@ public class SparklessTestContext extends TestContext {
     @Override
     public void cleanupTestContext() {
         super.cleanupTestContext();
-        getResources().values().forEach(tagsUtil::verifyTags);
+        getResources().values().forEach(value -> tagsUtil.verifyTags(value, this));
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
@@ -427,6 +427,10 @@ public abstract class TestContext implements ApplicationContextAware {
         return Crn.fromString(new String(Base64.getDecoder().decode(getActingUserAccessKey())));
     }
 
+    public String getActingUserName() {
+        return Crn.fromString(new String(Base64.getDecoder().decode(getActingUserAccessKey()))).getUserId();
+    }
+
     protected void setActingUser(CloudbreakUser actingUser) {
         this.actingUser = actingUser;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazonec2/action/EC2ClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazonec2/action/EC2ClientActions.java
@@ -170,9 +170,17 @@ public class EC2ClientActions extends EC2Client {
     public Map<String, Map<String, String>> listTagsByInstanceId(List<String> instanceIds) {
         DescribeInstancesRequest describeInstancesRequest = new DescribeInstancesRequest().withInstanceIds(instanceIds);
         DescribeInstancesResult describeInstancesResult = buildEC2Client().describeInstances(describeInstancesRequest);
-        return describeInstancesResult.getReservations().stream()
+        Map<String, Map<String, String>> tagsByInstanceId = describeInstancesResult.getReservations().stream()
                 .flatMap(reservation -> reservation.getInstances().stream())
                 .collect(Collectors.toMap(Instance::getInstanceId, this::getTagsForInstance));
+
+        tagsByInstanceId.forEach((instance, tags) -> {
+            LOGGER.info(" Tags for EC2 instance [{}]: ", instance);
+            tags.forEach((key, value) -> {
+                LOGGER.info(" [{}] : [{}] ", key, value);
+            });
+        });
+        return tagsByInstanceId;
     }
 
     private Map<String, String> getTagsForInstance(Instance instance) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurevm/action/AzureClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurevm/action/AzureClientActions.java
@@ -109,8 +109,16 @@ public class AzureClientActions {
     }
 
     public Map<String, Map<String, String>> listTagsByInstanceId(List<String> instanceIds) {
-        return instanceIds.stream()
+        Map<String, Map<String, String>> tagsByInstanceId = instanceIds.stream()
                 .map(id -> azure.virtualMachines().getByResourceGroup(getResourceGroupName(id), id))
                 .collect(Collectors.toMap(VirtualMachine::id, VirtualMachine::tags));
+
+        tagsByInstanceId.forEach((instance, tags) -> {
+            LOGGER.info(" Tags for Azure instance [{}]: ", instance);
+            tags.forEach((key, value) -> {
+                LOGGER.info(" [{}] : [{}] ", key, value);
+            });
+        });
+        return tagsByInstanceId;
     }
 }


### PR DESCRIPTION
We have [CB-7706](https://jira.cloudera.com/browse/CB-7706) for E2E tag validation. The affected test case is [EnvironmentStopStartTests](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/EnvironmentStopStartTests.java).

However we cannot check the validation at test logs, because of the related log messages (Console and HTML) are missing. Beyond this `Owner` and `Cloudera-Creator-Resource-Name` not null validation should be extended with asserts. If these two do not contain the acting user, we need to fail the test.