### PR TITLE
CB-8505-AssociatePeriscopeRepositoryWithTransaction

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/repository/ClusterPertainRepository.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/repository/ClusterPertainRepository.java
@@ -1,14 +1,15 @@
 package com.sequenceiq.periscope.repository;
 
-import java.util.Optional;
-
+import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
+import com.sequenceiq.periscope.domain.ClusterPertain;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 
-import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
-import com.sequenceiq.periscope.domain.ClusterPertain;
+import javax.transaction.Transactional;
+import java.util.Optional;
 
 @EntityType(entityClass = ClusterPertain.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface ClusterPertainRepository extends CrudRepository<ClusterPertain, Long> {
     Optional<ClusterPertain> findByUserCrn(@Param("userCrn") String userCrn);
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/repository/ClusterRepository.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/repository/ClusterRepository.java
@@ -1,19 +1,20 @@
 package com.sequenceiq.periscope.repository;
 
-import java.util.List;
-import java.util.Optional;
-
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
+import com.sequenceiq.periscope.api.model.ClusterState;
+import com.sequenceiq.periscope.domain.Cluster;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
-import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
-import com.sequenceiq.periscope.api.model.ClusterState;
-import com.sequenceiq.periscope.domain.Cluster;
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.Optional;
 
 @EntityType(entityClass = Cluster.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface ClusterRepository extends CrudRepository<Cluster, Long> {
 
     Cluster findByStackId(@Param("stackId") Long stackId);

--- a/autoscale/src/main/java/com/sequenceiq/periscope/repository/HistoryRepository.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/repository/HistoryRepository.java
@@ -1,15 +1,16 @@
 package com.sequenceiq.periscope.repository;
 
-import java.util.List;
-
+import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
+import com.sequenceiq.periscope.domain.History;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 
-import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
-import com.sequenceiq.periscope.domain.History;
+import javax.transaction.Transactional;
+import java.util.List;
 
 @EntityType(entityClass = History.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface HistoryRepository extends CrudRepository<History, Long> {
 
     List<History> findByClusterId(@Param("clusterId")Long clusterId, Pageable pageRequest);

--- a/autoscale/src/main/java/com/sequenceiq/periscope/repository/LoadAlertRepository.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/repository/LoadAlertRepository.java
@@ -6,7 +6,10 @@ import org.springframework.data.repository.query.Param;
 import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
 import com.sequenceiq.periscope.domain.LoadAlert;
 
+import javax.transaction.Transactional;
+
 @EntityType(entityClass = LoadAlert.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface LoadAlertRepository extends CrudRepository<LoadAlert, Long> {
 
     LoadAlert findByCluster(@Param("alertId") Long alertId, @Param("clusterId") Long clusterId);

--- a/autoscale/src/main/java/com/sequenceiq/periscope/repository/PeriscopeNodeRepository.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/repository/PeriscopeNodeRepository.java
@@ -1,16 +1,17 @@
 package com.sequenceiq.periscope.repository;
 
-import java.util.List;
-
+import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
+import com.sequenceiq.periscope.domain.PeriscopeNode;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 
-import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
-import com.sequenceiq.periscope.domain.PeriscopeNode;
+import javax.transaction.Transactional;
+import java.util.List;
 
 @EntityType(entityClass = PeriscopeNode.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface PeriscopeNodeRepository extends CrudRepository<PeriscopeNode, String> {
 
     long countByLeaderIsTrueAndLastUpdatedIsGreaterThan(long than);

--- a/autoscale/src/main/java/com/sequenceiq/periscope/repository/ScalingPolicyRepository.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/repository/ScalingPolicyRepository.java
@@ -1,14 +1,15 @@
 package com.sequenceiq.periscope.repository;
 
-import java.util.List;
-
+import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
+import com.sequenceiq.periscope.domain.ScalingPolicy;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 
-import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
-import com.sequenceiq.periscope.domain.ScalingPolicy;
+import javax.transaction.Transactional;
+import java.util.List;
 
 @EntityType(entityClass = ScalingPolicy.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface ScalingPolicyRepository extends CrudRepository<ScalingPolicy, Long> {
 
     ScalingPolicy findByCluster(@Param("clusterId") Long clusterId, @Param("policyId") Long policyId);

--- a/autoscale/src/main/java/com/sequenceiq/periscope/repository/SecurityConfigRepository.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/repository/SecurityConfigRepository.java
@@ -7,7 +7,10 @@ import org.springframework.data.repository.query.Param;
 import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
 import com.sequenceiq.periscope.domain.SecurityConfig;
 
+import javax.transaction.Transactional;
+
 @EntityType(entityClass = SecurityConfig.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface SecurityConfigRepository extends CrudRepository<SecurityConfig, Long> {
 
     @Query("SELECT sc FROM SecurityConfig sc WHERE sc.cluster.id = :clusterId")

--- a/autoscale/src/main/java/com/sequenceiq/periscope/repository/SubscriptionRepository.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/repository/SubscriptionRepository.java
@@ -1,14 +1,15 @@
 package com.sequenceiq.periscope.repository;
 
-import java.util.Optional;
-
+import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
+import com.sequenceiq.periscope.domain.Subscription;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 
-import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
-import com.sequenceiq.periscope.domain.Subscription;
+import javax.transaction.Transactional;
+import java.util.Optional;
 
 @EntityType(entityClass = Subscription.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface SubscriptionRepository extends CrudRepository<Subscription, Long> {
 
     Optional<Subscription> findByClientId(@Param("clientId") String clientId);

--- a/autoscale/src/main/java/com/sequenceiq/periscope/repository/TimeAlertRepository.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/repository/TimeAlertRepository.java
@@ -1,14 +1,15 @@
 package com.sequenceiq.periscope.repository;
 
-import java.util.List;
-
+import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
+import com.sequenceiq.periscope.domain.TimeAlert;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 
-import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
-import com.sequenceiq.periscope.domain.TimeAlert;
+import javax.transaction.Transactional;
+import java.util.List;
 
 @EntityType(entityClass = TimeAlert.class)
+@Transactional(Transactional.TxType.REQUIRED)
 public interface TimeAlertRepository extends CrudRepository<TimeAlert, Long> {
 
     TimeAlert findByCluster(@Param("alertId") Long alertId, @Param("clusterId") Long clusterId);


### PR DESCRIPTION
All existing Periscope Repository interfaces should be annotated with Transactional attribute similar to CB Repository interfaces, since without that Query Results will not be pre-flushed and stale data will be returned in certain scenarios.

See detailed description in the commit message.