### PR TITLE
CB-8516 the crn field for templates were wrong so this PR modifies it…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/blueprint/BlueprintService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/blueprint/BlueprintService.java
@@ -381,7 +381,7 @@ public class BlueprintService extends AbstractWorkspaceAwareResourceService<Blue
         return Crn.builder()
                 .setService(Crn.Service.DATAHUB)
                 .setAccountId(accountId)
-                .setResourceType(ResourceType.CLUSTER_DEFINITION)
+                .setResourceType(ResourceType.CLUSTER_TEMPLATE)
                 .setResource(UUID.randomUUID().toString())
                 .build()
                 .toString();

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/blueprint/BlueprintServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/blueprint/BlueprintServiceTest.java
@@ -294,7 +294,7 @@ public class BlueprintServiceTest {
         underTest.decorateWithCrn(blueprint, ACCOUNT_ID, CREATOR);
 
         assertThat(blueprint.getCreator(), is(CREATOR));
-        assertTrue(blueprint.getResourceCrn().matches("crn:cdp:datahub:us-west-1:" + ACCOUNT_ID + ":clusterdefinition:.*"));
+        assertTrue(blueprint.getResourceCrn().matches("crn:cdp:datahub:us-west-1:" + ACCOUNT_ID + ":clustertemplate:.*"));
     }
 
     @Test


### PR DESCRIPTION
… but I can not migrate the previous blueprints because then probably we will broke some automation.

See detailed description in the commit message.