### PR TITLE
CB-8531 m5.xlarge missing in the instance type list

### DIFF
--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -153,6 +153,7 @@ cb:
       enabled.instance.types: >
         t2.large,
         t2.xlarge,
+        m5.xlarge,
         m5.2xlarge,
         m5.4xlarge,
         m5.8xlarge,


### PR DESCRIPTION
See detailed description in the commit message.