### PR TITLE
CB-8470 Update AwsYcloudHybridCloudTest child environment with Telemetry steps

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/telemetry/TelemetryTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/telemetry/TelemetryTestDto.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
 import com.sequenceiq.common.api.telemetry.request.FeaturesRequest;
@@ -21,6 +22,8 @@ import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
 public class TelemetryTestDto extends AbstractCloudbreakTestDto<TelemetryRequest, TelemetryResponse, TelemetryTestDto> {
 
     private static final String TELEMETRY = "TELEMETRY";
+
+    private CloudPlatform cloudPlatform;
 
     @Inject
     private AwsCloudProvider awsCloudProvider;
@@ -40,10 +43,16 @@ public class TelemetryTestDto extends AbstractCloudbreakTestDto<TelemetryRequest
         return getCloudProvider().telemetry(this);
     }
 
+    public TelemetryTestDto withLogging(CloudPlatform customCloudPlatform) {
+        cloudPlatform = customCloudPlatform;
+        return withLogging();
+    }
+
     public TelemetryTestDto withLogging() {
         LoggingRequest loggingRequest = new LoggingRequest();
 
-        switch (getTestContext().getCloudProvider().getCloudPlatform()) {
+        cloudPlatform = (cloudPlatform == null) ? getTestContext().getCloudProvider().getCloudPlatform() : cloudPlatform;
+        switch (cloudPlatform) {
             case AWS:
                 S3CloudStorageV1Parameters s3CloudStorageV1Parameters = new S3CloudStorageV1Parameters();
                 s3CloudStorageV1Parameters.setInstanceProfile(awsCloudProvider.getInstanceProfile());
@@ -58,6 +67,9 @@ public class TelemetryTestDto extends AbstractCloudbreakTestDto<TelemetryRequest
                 loggingRequest.setAdlsGen2(adlsGen2CloudStorageV1Parameters);
                 loggingRequest.setStorageLocation(azureCloudProvider.getBaseLocation());
                 getRequest().setLogging(loggingRequest);
+                break;
+            case YARN:
+                getRequest().setLogging(null);
                 break;
             default:
                 break;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/hybrid/AwsYcloudHybridCloudTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/hybrid/AwsYcloudHybridCloudTest.java
@@ -12,12 +12,26 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import javax.inject.Inject;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.ClouderaManagerStackDescriptorV4Response;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.util.SanitizerUtil;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
 import com.sequenceiq.it.cloudbreak.client.BlueprintTestClient;
 import com.sequenceiq.it.cloudbreak.client.CredentialTestClient;
 import com.sequenceiq.it.cloudbreak.client.EnvironmentTestClient;
 import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
 import com.sequenceiq.it.cloudbreak.client.UtilTestClient;
+import com.sequenceiq.it.cloudbreak.cloud.HostGroupType;
+import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.RunningParameter;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.ClouderaManagerProductTestDto;
 import com.sequenceiq.it.cloudbreak.dto.ClouderaManagerTestDto;
 import com.sequenceiq.it.cloudbreak.dto.ClusterTestDto;
@@ -26,24 +40,11 @@ import com.sequenceiq.it.cloudbreak.dto.blueprint.BlueprintTestDto;
 import com.sequenceiq.it.cloudbreak.dto.credential.CredentialTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentNetworkTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentSecurityAccessTestDto;
-import com.sequenceiq.it.cloudbreak.dto.stack.StackTestDto;
-import com.sequenceiq.it.cloudbreak.dto.util.StackMatrixTestDto;
-import org.springframework.beans.factory.annotation.Value;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.Test;
-
-import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
-import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
-import com.sequenceiq.cloudbreak.util.SanitizerUtil;
-import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
-import com.sequenceiq.it.cloudbreak.cloud.HostGroupType;
-import com.sequenceiq.it.cloudbreak.context.Description;
-import com.sequenceiq.it.cloudbreak.context.RunningParameter;
-import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.dto.stack.StackTestDto;
+import com.sequenceiq.it.cloudbreak.dto.telemetry.TelemetryTestDto;
+import com.sequenceiq.it.cloudbreak.dto.util.StackMatrixTestDto;
 import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
 import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
 import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
@@ -116,13 +117,18 @@ public class AwsYcloudHybridCloudTest extends AbstractE2ETest {
                 .withSecurityAccess();
         createEnvironmentWithNetworkAndFreeIpa(testContext);
 
-        testContext.given(CHILD_ENVIRONMENT_CREDENTIAL_KEY, CredentialTestDto.class, CHILD_CLOUD_PLATFORM)
+        testContext
+                .given("childtelemetry", TelemetryTestDto.class)
+                .withLogging(CloudPlatform.YARN)
+                .withReportClusterLogs()
+                .given(CHILD_ENVIRONMENT_CREDENTIAL_KEY, CredentialTestDto.class, CHILD_CLOUD_PLATFORM)
                 .when(credentialTestClient.create(), RunningParameter.key(CHILD_ENVIRONMENT_CREDENTIAL_KEY))
                 .given(CHILD_ENVIRONMENT_NETWORK_KEY, EnvironmentNetworkTestDto.class, CHILD_CLOUD_PLATFORM)
                 .given(CHILD_ENVIRONMENT_KEY, EnvironmentTestDto.class, CHILD_CLOUD_PLATFORM)
                 .withCredentialName(testContext.get(CHILD_ENVIRONMENT_CREDENTIAL_KEY).getName())
                 .withParentEnvironment()
                 .withNetwork(CHILD_ENVIRONMENT_NETWORK_KEY)
+                .withTelemetry("childtelemetry")
                 .when(environmentTestClient.create(), RunningParameter.key(CHILD_ENVIRONMENT_KEY))
                 .await(EnvironmentStatus.AVAILABLE, RunningParameter.key(CHILD_ENVIRONMENT_KEY))
                 .when(environmentTestClient.describe(), RunningParameter.key(CHILD_ENVIRONMENT_KEY))


### PR DESCRIPTION
In case of failing Hybrid Cloud E2E test we have no chance to check the issue in Kibana. So we need to introduce the related Telemetry configuration steps to the Yarn Environment creation.

First of all Cloudbreak should [allow Telemetry with no Logging Object](https://github.com/hortonworks/cloudbreak/pull/8846), this is needed only for YCloud where the Cloud Storage is not available. Beyond this we should modify the related E2E test case [AwsYcloudHybridCloudTest](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/hybrid/AwsYcloudHybridCloudTest.java) as well.