### PR TITLE
CB-6796 E2E test for SDX cluster upgrade flow

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxCheckForUpgradeAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxCheckForUpgradeAction.java
@@ -8,17 +8,17 @@ import org.slf4j.LoggerFactory;
 import com.sequenceiq.it.cloudbreak.SdxClient;
 import com.sequenceiq.it.cloudbreak.action.Action;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
-import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
 import com.sequenceiq.it.cloudbreak.log.Log;
 import com.sequenceiq.sdx.api.model.SdxUpgradeRequest;
 import com.sequenceiq.sdx.api.model.SdxUpgradeResponse;
 
-public class SdxCheckForOsUpgradeAction implements Action<SdxInternalTestDto, SdxClient> {
+public class SdxCheckForUpgradeAction implements Action<SdxTestDto, SdxClient> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SdxCheckForOsUpgradeAction.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxCheckForUpgradeAction.class);
 
     @Override
-    public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
+    public SdxTestDto action(TestContext testContext, SdxTestDto testDto, SdxClient client) throws Exception {
         Log.log(LOGGER, format(" Environment: %s", testDto.getRequest().getEnvironment()));
         Log.whenJson(LOGGER, " SDX check for upgrade request: ", testDto.getRequest());
         SdxUpgradeRequest request = new SdxUpgradeRequest();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxUpgradeAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxUpgradeAction.java
@@ -5,28 +5,26 @@ import static java.lang.String.format;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.it.cloudbreak.SdxClient;
 import com.sequenceiq.it.cloudbreak.action.Action;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
-import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
 import com.sequenceiq.it.cloudbreak.log.Log;
 import com.sequenceiq.sdx.api.model.SdxUpgradeRequest;
+import com.sequenceiq.sdx.api.model.SdxUpgradeResponse;
 
-public class SdxOsUpgradeAction implements Action<SdxInternalTestDto, SdxClient> {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(SdxOsUpgradeAction.class);
+public class SdxUpgradeAction implements Action<SdxTestDto, SdxClient> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxUpgradeAction.class);
 
     @Override
-    public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
+    public SdxTestDto action(TestContext testContext, SdxTestDto testDto, SdxClient client) throws Exception {
         Log.log(LOGGER, format(" Environment: %s", testDto.getRequest().getEnvironment()));
         Log.whenJson(LOGGER, " SDX upgrade request: ", testDto.getRequest());
-        SdxUpgradeRequest upgradeRequest = new SdxUpgradeRequest();
-        upgradeRequest.setLockComponents(true);
-        FlowIdentifier flowIdentifier = client.getSdxClient()
+        SdxUpgradeRequest upgradeRequest = testDto.getSdxUpgradeRequest();
+        SdxUpgradeResponse upgradeResponse = client.getSdxClient()
                 .sdxUpgradeEndpoint()
-                .upgradeClusterByName(testDto.getName(), upgradeRequest).getFlowIdentifier();
-        testDto.setFlow("SDX upgrade", flowIdentifier);
+                .upgradeClusterByName(testDto.getName(), upgradeRequest);
+        testDto.setFlow("SDX upgrade", upgradeResponse.getFlowIdentifier());
         Log.log(LOGGER, " SDX name: %s", client.getSdxClient().sdxEndpoint().get(testDto.getName()).getName());
         return testDto;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/SdxTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/SdxTestClient.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Service;
 
 import com.sequenceiq.it.cloudbreak.SdxClient;
 import com.sequenceiq.it.cloudbreak.action.Action;
-import com.sequenceiq.it.cloudbreak.action.sdx.SdxCheckForOsUpgradeAction;
+import com.sequenceiq.it.cloudbreak.action.sdx.SdxCheckForUpgradeAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxCreateAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxCreateInternalAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxDeleteAction;
@@ -14,7 +14,6 @@ import com.sequenceiq.it.cloudbreak.action.sdx.SdxDescribeInternalAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxForceDeleteAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxForceDeleteInternalAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxListAction;
-import com.sequenceiq.it.cloudbreak.action.sdx.SdxOsUpgradeAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxRefreshAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxRepairAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxRepairInternalAction;
@@ -22,6 +21,7 @@ import com.sequenceiq.it.cloudbreak.action.sdx.SdxStartAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxStopAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxSyncAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxSyncInternalAction;
+import com.sequenceiq.it.cloudbreak.action.sdx.SdxUpgradeAction;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
 
@@ -76,6 +76,14 @@ public class SdxTestClient {
         return new SdxRepairAction();
     }
 
+    public Action<SdxTestDto, SdxClient> checkForUpgrade() {
+        return new SdxCheckForUpgradeAction();
+    }
+
+    public Action<SdxTestDto, SdxClient> upgrade() {
+        return new SdxUpgradeAction();
+    }
+
     public Action<SdxInternalTestDto, SdxClient> repairInternal() {
         return new SdxRepairInternalAction();
     }
@@ -90,13 +98,5 @@ public class SdxTestClient {
 
     public Action<SdxInternalTestDto, SdxClient> stopInternal() {
         return new SdxStopAction();
-    }
-
-    public Action<SdxInternalTestDto, SdxClient> checkForOsUpgrade() {
-        return new SdxCheckForOsUpgradeAction();
-    }
-
-    public Action<SdxInternalTestDto, SdxClient> upgradeOs() {
-        return new SdxOsUpgradeAction();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CommonClusterManagerProperties.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CommonClusterManagerProperties.java
@@ -21,6 +21,8 @@ public class CommonClusterManagerProperties {
 
     private String internalDistroXBlueprintName;
 
+    private UpgradeProperties upgradeProperties = new UpgradeProperties();
+
     public String getRuntimeVersion() {
         return runtimeVersion;
     }
@@ -65,6 +67,10 @@ public class CommonClusterManagerProperties {
         this.internalDistroXBlueprintName = internalDistroXBlueprintName;
     }
 
+    public UpgradeProperties getUpgrade() {
+        return upgradeProperties;
+    }
+
     public static class ClouderaManager {
 
         private String defaultUser;
@@ -95,6 +101,28 @@ public class CommonClusterManagerProperties {
 
         public void setDefaultPort(String defaultPort) {
             this.defaultPort = defaultPort;
+        }
+    }
+
+    public static class UpgradeProperties {
+        private String currentRuntimeVersion;
+
+        private String targetRuntimeVersion;
+
+        public String getCurrentRuntimeVersion() {
+            return currentRuntimeVersion;
+        }
+
+        public void setCurrentRuntimeVersion(String currentRuntimeVersion) {
+            this.currentRuntimeVersion = currentRuntimeVersion;
+        }
+
+        public String getTargetRuntimeVersion() {
+            return targetRuntimeVersion;
+        }
+
+        public void setTargetRuntimeVersion(String targetRuntimeVersion) {
+            this.targetRuntimeVersion = targetRuntimeVersion;
         }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
@@ -45,6 +45,7 @@ import com.sequenceiq.sdx.api.model.SdxClusterShape;
 import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 import com.sequenceiq.sdx.api.model.SdxDatabaseRequest;
 import com.sequenceiq.sdx.api.model.SdxRepairRequest;
+import com.sequenceiq.sdx.api.model.SdxUpgradeRequest;
 
 @Prototype
 public class SdxTestDto extends AbstractSdxTestDto<SdxClusterRequest, SdxClusterDetailResponse, SdxTestDto> implements Purgable<SdxClusterResponse, SdxClient>,
@@ -252,6 +253,14 @@ public class SdxTestDto extends AbstractSdxTestDto<SdxClusterRequest, SdxCluster
             throw new IllegalArgumentException("SDX Repair does not exist!");
         }
         return repair.getRequest();
+    }
+
+    public SdxUpgradeRequest getSdxUpgradeRequest() {
+        SdxUpgradeTestDto upgrade = given(SdxUpgradeTestDto.class);
+        if (upgrade == null) {
+            throw new IllegalArgumentException("SDX Upgrade does not exist!");
+        }
+        return upgrade.getRequest();
     }
 
     public SdxTestDto withRuntimeVersion(String runtimeVersion) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxUpgradeTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxUpgradeTestDto.java
@@ -1,0 +1,45 @@
+package com.sequenceiq.it.cloudbreak.dto.sdx;
+
+import javax.inject.Inject;
+
+import com.sequenceiq.it.cloudbreak.Prototype;
+import com.sequenceiq.it.cloudbreak.cloud.v4.CommonClusterManagerProperties;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractSdxTestDto;
+import com.sequenceiq.sdx.api.model.SdxUpgradeReplaceVms;
+import com.sequenceiq.sdx.api.model.SdxUpgradeRequest;
+import com.sequenceiq.sdx.api.model.SdxUpgradeResponse;
+
+@Prototype
+public class SdxUpgradeTestDto extends AbstractSdxTestDto<SdxUpgradeRequest, SdxUpgradeResponse, SdxUpgradeTestDto> {
+    @Inject
+    private CommonClusterManagerProperties commonClusterManagerProperties;
+
+    public SdxUpgradeTestDto(SdxUpgradeRequest request, TestContext testContext) {
+        super(request, testContext);
+    }
+
+    public SdxUpgradeTestDto(TestContext testContext) {
+        super(new SdxUpgradeRequest(), testContext);
+    }
+
+    public SdxUpgradeTestDto() {
+        super(SdxUpgradeTestDto.class.getSimpleName().toUpperCase());
+    }
+
+    @Override
+    public SdxUpgradeTestDto valid() {
+        return withRuntime(commonClusterManagerProperties.getUpgrade().getTargetRuntimeVersion())
+                .withReplaceVms(SdxUpgradeReplaceVms.ENABLED);
+    }
+
+    public SdxUpgradeTestDto withRuntime(String runtime) {
+        getRequest().setRuntime(runtime);
+        return this;
+    }
+
+    public SdxUpgradeTestDto withReplaceVms(SdxUpgradeReplaceVms replaceVms) {
+        getRequest().setReplaceVms(replaceVms);
+        return this;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxUpgradeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxUpgradeTests.java
@@ -1,0 +1,74 @@
+package com.sequenceiq.it.cloudbreak.testcase.e2e.sdx;
+
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.IDBROKER;
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.MASTER;
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.testng.annotations.Test;
+
+import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
+import com.sequenceiq.it.cloudbreak.cloud.v4.CommonClusterManagerProperties;
+import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
+import com.sequenceiq.it.cloudbreak.util.SdxUtil;
+import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
+import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
+
+public class SdxUpgradeTests extends PreconditionSdxE2ETest {
+    @Inject
+    private SdxTestClient sdxTestClient;
+
+    @Inject
+    private SdxUtil sdxUtil;
+
+    @Inject
+    private CommonClusterManagerProperties commonClusterManagerProperties;
+
+    @Test(dataProvider = TEST_CONTEXT)
+    @UseSpotInstances
+    @Description(
+            given = "there is a running Cloudbreak, and an SDX cluster in available state",
+            when = "upgrade called on the SDX cdluster",
+            then = "SDX upgrade should be successful, the cluster should be up and running"
+    )
+    public void testSDXUpgrade(TestContext testContext) {
+        String sdx = resourcePropertyProvider().getName();
+
+        List<String> actualVolumeIds = new ArrayList<>();
+        List<String> expectedVolumeIds = new ArrayList<>();
+
+        testContext
+                .given(sdx, SdxTestDto.class)
+                .withCloudStorage()
+                .withRuntimeVersion(commonClusterManagerProperties.getUpgrade().getCurrentRuntimeVersion())
+                .when(sdxTestClient.create(), key(sdx))
+                .awaitForFlow(key(sdx))
+                .await(SdxClusterStatusResponse.RUNNING, key(sdx))
+                .awaitForInstance(getSdxInstancesHealthyState())
+                .then((tc, testDto, client) -> {
+                    List<String> instances = sdxUtil.getInstanceIds(testDto, client, MASTER.getName());
+                    instances.addAll(sdxUtil.getInstanceIds(testDto, client, IDBROKER.getName()));
+                    expectedVolumeIds.addAll(getCloudFunctionality(tc).listInstanceVolumeIds(instances));
+                    return testDto;
+                })
+                .when(sdxTestClient.upgrade(), key(sdx))
+                .await(SdxClusterStatusResponse.DATALAKE_UPGRADE_IN_PROGRESS, key(sdx))
+                .awaitForFlow(key(sdx))
+                .await(SdxClusterStatusResponse.RUNNING, key(sdx))
+                .awaitForInstance(getSdxInstancesHealthyState())
+                .then((tc, testDto, client) -> {
+                    List<String> instanceIds = sdxUtil.getInstanceIds(testDto, client, MASTER.getName());
+                    instanceIds.addAll(sdxUtil.getInstanceIds(testDto, client, IDBROKER.getName()));
+                    actualVolumeIds.addAll(getCloudFunctionality(tc).listInstanceVolumeIds(instanceIds));
+                    return testDto;
+                })
+                .then((tc, testDto, client) -> compareVolumeIdsAfterRepair(testDto, actualVolumeIds, expectedVolumeIds))
+                .validate();
+    }
+}

--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -69,6 +69,9 @@ integrationtest:
     defaultPort: 7180
   cloudProvider: MOCK
   runtimeVersion: 7.2.1
+  upgrade:
+    currentRuntimeVersion: 7.2.0
+    targetRuntimeVersion: 7.2.1
 
   spot:
     enabledCloudPlatforms:

--- a/integration-test/src/main/resources/testsuites/e2e/aws-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/aws-e2e-tests.yaml
@@ -10,3 +10,4 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxImagesTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRepairTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.spot.AwsDistroXSpotInstanceTest
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxUpgradeTests

--- a/integration-test/src/main/resources/testsuites/e2e/azure-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/azure-e2e-tests.yaml
@@ -8,3 +8,4 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.InternalSdxDistroxTest
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxImagesTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRepairTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxUpgradeTests

--- a/integration-test/src/main/resources/testsuites/e2e/sdx-upgrade-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/sdx-upgrade-tests.yaml
@@ -1,0 +1,5 @@
+name: "sdx-upgrade-tests"
+tests:
+  - name: "sdx e2e upgrade tests"
+    classes:
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxUpgradeTests


### PR DESCRIPTION
- The test creates an SDX cluster with integrationtest.upgrade.currentRuntimeVersion runtime version
- The test upgrades the SDX cluster to the integrationtest.upgrade.targetRuntimeVersion runtime version
- The test checks that the attached volumes are the same after the upgrade
