### PR TITLE
CB-8497 Fix validation for cloud provider resource tags

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazonec2/action/EC2ClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazonec2/action/EC2ClientActions.java
@@ -170,17 +170,9 @@ public class EC2ClientActions extends EC2Client {
     public Map<String, Map<String, String>> listTagsByInstanceId(List<String> instanceIds) {
         DescribeInstancesRequest describeInstancesRequest = new DescribeInstancesRequest().withInstanceIds(instanceIds);
         DescribeInstancesResult describeInstancesResult = buildEC2Client().describeInstances(describeInstancesRequest);
-        Map<String, Map<String, String>> tagsByInstanceId = describeInstancesResult.getReservations().stream()
+        return describeInstancesResult.getReservations().stream()
                 .flatMap(reservation -> reservation.getInstances().stream())
                 .collect(Collectors.toMap(Instance::getInstanceId, this::getTagsForInstance));
-
-        tagsByInstanceId.forEach((instance, tags) -> {
-            LOGGER.info(" Tags for EC2 instance [{}]: ", instance);
-            tags.forEach((key, value) -> {
-                LOGGER.info(" [{}] : [{}] ", key, value);
-            });
-        });
-        return tagsByInstanceId;
     }
 
     private Map<String, String> getTagsForInstance(Instance instance) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurevm/action/AzureClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurevm/action/AzureClientActions.java
@@ -109,16 +109,8 @@ public class AzureClientActions {
     }
 
     public Map<String, Map<String, String>> listTagsByInstanceId(List<String> instanceIds) {
-        Map<String, Map<String, String>> tagsByInstanceId = instanceIds.stream()
+        return instanceIds.stream()
                 .map(id -> azure.virtualMachines().getByResourceGroup(getResourceGroupName(id), id))
                 .collect(Collectors.toMap(VirtualMachine::id, VirtualMachine::tags));
-
-        tagsByInstanceId.forEach((instance, tags) -> {
-            LOGGER.info(" Tags for Azure instance [{}]: ", instance);
-            tags.forEach((key, value) -> {
-                LOGGER.info(" [{}] : [{}] ", key, value);
-            });
-        });
-        return tagsByInstanceId;
     }
 }


### PR DESCRIPTION
We have [CB-7706](https://github.com/hortonworks/cloudbreak/pull/8534) for tag validation during E2E tests. The affected test case is [EnvironmentStopStartTests](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/EnvironmentStopStartTests.java). However we cannot check the validation process at test logs, because of the related log messages are missing.