### PR TITLE
Fix for CDPD-11918

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-722.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-722.bp
@@ -204,6 +204,18 @@
           {
             "name": "tez.task.launch.cmd-opts",
             "value": "-XX:+PrintGCDetails -verbose:gc -XX:+UseNUMA -XX:+UseG1GC -XX:+ResizeTLAB"
+          },
+          {
+            "name": "tez.grouping.split-waves",
+            "value": 1.4
+          },
+          {
+            "name": "tez.grouping.min-size",
+            "value": 268435456
+          },
+          {
+            "name": "tez.grouping.max-size",
+            "value": 268435456
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-722.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-722.bp
@@ -335,6 +335,18 @@
           {
             "name": "tez.task.launch.cmd-opts",
             "value": "-XX:+PrintGCDetails -verbose:gc -XX:+UseNUMA -XX:+UseG1GC -XX:+ResizeTLAB"
+          },
+          {
+            "name": "tez.grouping.split-waves",
+            "value": 1.4
+          },
+          {
+            "name": "tez.grouping.min-size",
+            "value": 268435456
+          },
+          {
+            "name": "tez.grouping.max-size",
+            "value": 268435456
           }
         ],
         "roleConfigGroups": [


### PR DESCRIPTION
Fix for [CDPD-11918](https://jira.cloudera.com/browse/CDPD-11918)
Have tuned following tez configs in DE templates for 7.2.2 :-
tez.grouping.split-waves=1.4
tez.grouping.min-size=268435456
tez.grouping.max-size=268435456

These changes are also required for AutoScale.

Testing done:

1. Have created a DE cluster using a modified 7.2.2 template that includes above mentioned tez config changes. Cluster creation was successful on AWS using m5d.2xl instance types.
2. Ran some hive queries successfully.