### PR TITLE
CB-8546: Fix FreeIPA health check to work with nginx proxy

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/nginx/conf/ssl-locations.d/freeipahealthcheck.conf
+++ b/freeipa/src/main/resources/freeipa-salt/salt/nginx/conf/ssl-locations.d/freeipahealthcheck.conf
@@ -1,4 +1,7 @@
 location /freeipahealthcheck {
   proxy_pass         https://{{ salt['grains.get']('fqdn') }}:5080;
   proxy_read_timeout 300;
+  proxy_redirect     off;
+  proxy_set_header   Host $host;
+  rewrite /freeipahealthcheck(.*) /$1 break;
 }


### PR DESCRIPTION
Forward freeipa:9443/freeipahealthcheck to freeipa:8050/.

This was tested with a local deployment of cloudbreak.

See detailed description in the commit message.