### PR TITLE
CB-8547: Use FreeIPA healthcheck for cluster proxy

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/StackToDescribeFreeIpaResponseConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/StackToDescribeFreeIpaResponseConverter.java
@@ -58,6 +58,9 @@ public class StackToDescribeFreeIpaResponseConverter {
     @Inject
     private UserSyncStatusToUserSyncStatusResponseConverter userSyncStatusConverter;
 
+    @Inject
+    private BalancedDnsAvailabilityChecker balancedDnsAvailabilityChecker;
+
     public DescribeFreeIpaResponse convert(Stack stack, ImageEntity image, FreeIpa freeIpa, UserSyncStatus userSyncStatus) {
         DescribeFreeIpaResponse describeFreeIpaResponse = new DescribeFreeIpaResponse();
         describeFreeIpaResponse.setName(stack.getName());
@@ -108,7 +111,7 @@ public class StackToDescribeFreeIpaResponseConverter {
     }
 
     private void decoreateFreeIpaServerResponseWithLoadBalancedHost(Stack stack, FreeIpaServerResponse freeIpaServerResponse, FreeIpa freeIpa) {
-        if (Objects.nonNull(freeIpaServerResponse) && BalancedDnsAvailabilityChecker.isBalancedDnsAvailable(stack)) {
+        if (Objects.nonNull(freeIpaServerResponse) && balancedDnsAvailabilityChecker.isBalancedDnsAvailable(stack)) {
             freeIpaServerResponse.setFreeIpaHost(FreeIpaDomainUtils.getFreeIpaFqdn(freeIpa.getDomain()));
             freeIpaServerResponse.setFreeIpaPort(stack.getGatewayport());
         }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/config/KerberosConfigRegisterService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/config/KerberosConfigRegisterService.java
@@ -29,6 +29,9 @@ public class KerberosConfigRegisterService extends AbstractConfigRegister {
     @Inject
     private KerberosConfigService kerberosConfigService;
 
+    @Inject
+    private BalancedDnsAvailabilityChecker balancedDnsAvailabilityChecker;
+
     @Override
     public void register(Long stackId) {
         createKerberosConfig(stackId, FREEIPA_DEFAULT_ADMIN, null, null, null);
@@ -58,7 +61,7 @@ public class KerberosConfigRegisterService extends AbstractConfigRegister {
     }
 
     private void addServerAddress(FreeIpa freeIpa, Stack stack, KerberosConfig kerberosConfig, Set<InstanceMetaData> allNotDeletedInstances) {
-        if (BalancedDnsAvailabilityChecker.isBalancedDnsAvailable(stack)) {
+        if (balancedDnsAvailabilityChecker.isBalancedDnsAvailable(stack)) {
             kerberosConfig.setUrl(FreeIpaDomainUtils.getKdcFqdn(freeIpa.getDomain()));
             kerberosConfig.setAdminUrl(FreeIpaDomainUtils.getKerberosFqdn(freeIpa.getDomain()));
         } else {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/config/LdapConfigRegisterService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/config/LdapConfigRegisterService.java
@@ -47,6 +47,9 @@ public class LdapConfigRegisterService extends AbstractConfigRegister {
     @Inject
     private LdapConfigService ldapConfigService;
 
+    @Inject
+    private BalancedDnsAvailabilityChecker balancedDnsAvailabilityChecker;
+
     @Override
     public void register(Long stackId) {
         createLdapConfig(stackId, null, null, null, null);
@@ -88,7 +91,7 @@ public class LdapConfigRegisterService extends AbstractConfigRegister {
      * old FreeIPA instance doesn't have ldap CNAME so we have to create the config differently
      */
     private void addServerHost(Stack stack, FreeIpa freeIpa, LdapConfig ldapConfig) {
-        if (BalancedDnsAvailabilityChecker.isBalancedDnsAvailable(stack)) {
+        if (balancedDnsAvailabilityChecker.isBalancedDnsAvailable(stack)) {
             ldapConfig.setServerHost(FreeIpaDomainUtils.getLdapFqdn(freeIpa.getDomain()));
         } else {
             ldapConfig.setServerHost(getMasterInstance(stack).getDiscoveryFQDN());

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactory.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactory.java
@@ -74,6 +74,9 @@ public class FreeIpaClientFactory {
     @Inject
     private TlsSecurityService tlsSecurityService;
 
+    @Inject
+    private ClusterProxyServiceAvailabilityChecker clusterProxyServiceAvailabilityChecker;
+
     public FreeIpaClient getFreeIpaClientForStackId(Long stackId) throws FreeIpaClientException {
         LOGGER.debug("Retrieving stack for stack id {}", stackId);
 
@@ -96,7 +99,7 @@ public class FreeIpaClientFactory {
     }
 
     private boolean useLegacyClusterProxyRegistration(Stack stack) {
-        return !ClusterProxyServiceAvailabilityChecker.isDnsBasedServiceNameAvailable(stack);
+        return !clusterProxyServiceAvailabilityChecker.isDnsBasedServiceNameAvailable(stack);
     }
 
     private FreeIpaClient getFreeIpaClient(Stack stack, boolean withPing, boolean forceCheckUnreachable, Optional<String> freeIpaFqdn)

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/ClusterProxyService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/ClusterProxyService.java
@@ -44,6 +44,7 @@ import com.sequenceiq.freeipa.service.polling.clusterproxy.ServiceEndpointHealth
 import com.sequenceiq.freeipa.util.ClusterProxyServiceAvailabilityChecker;
 import com.sequenceiq.freeipa.service.config.FreeIpaDomainUtils;
 import com.sequenceiq.freeipa.service.freeipa.FreeIpaService;
+import com.sequenceiq.freeipa.util.HealthCheckAvailabilityChecker;
 import com.sequenceiq.freeipa.vault.FreeIpaCertVaultComponent;
 
 @Service
@@ -59,17 +60,29 @@ public class ClusterProxyService {
 
     private static final int MILLIS_PER_SEC = 1000;
 
-    @Value("${clusterProxy.intervalInSec}")
-    private int intervalInSec;
+    @Value("${clusterProxy.healthCheckV1.intervalInSec}")
+    private int intervalInSecV1;
 
-    @Value("${clusterProxy.healthStatusEndpoint}")
-    private String healthStatusEndpoint;
+    @Value("${clusterProxy.healthCheckV1.healthStatusEndpoint}")
+    private String healthStatusEndpointV1;
 
-    @Value("${clusterProxy.timeoutInSec}")
-    private int timeoutInSec;
+    @Value("${clusterProxy.healthCheckV1.timeoutInSec}")
+    private int timeoutInSecV1;
 
-    @Value("${clusterProxy.healthyStatusCode}")
-    private int healthyStatusCode;
+    @Value("${clusterProxy.healthCheckV1.healthyStatusCode}")
+    private int healthyStatusCodeV1;
+
+    @Value("${clusterProxy.healthCheckV2.intervalInSec}")
+    private int intervalInSecV2;
+
+    @Value("${clusterProxy.healthCheckV2.healthStatusEndpoint}")
+    private String healthStatusEndpointV2;
+
+    @Value("${clusterProxy.healthCheckV2.timeoutInSec}")
+    private int timeoutInSecV2;
+
+    @Value("${clusterProxy.healthCheckV2.healthyStatusCode}")
+    private int healthyStatusCodeV2;
 
     @Value("${clusterProxy.maxAttempts}")
     private int maxAttempts;
@@ -116,6 +129,12 @@ public class ClusterProxyService {
     @Inject
     private ServiceEndpointHealthListenerTask serviceEndpointHealthListenerTask;
 
+    @Inject
+    private HealthCheckAvailabilityChecker healthCheckAvailabilityChecker;
+
+    @Inject
+    private ClusterProxyServiceAvailabilityChecker clusterProxyServiceAvailabilityChecker;
+
     public Optional<ConfigRegistrationResponse> registerFreeIpa(String accountId, String environmentCrn) {
         return registerFreeIpa(stackService.getByEnvironmentCrnAndAccountId(environmentCrn, accountId), null, false, false);
     }
@@ -149,7 +168,7 @@ public class ClusterProxyService {
 
         if (bootstrap) {
             tunnelGatewayConfigs = List.of(primaryGatewayConfig);
-        } else if (ClusterProxyServiceAvailabilityChecker.isDnsBasedServiceNameAvailable(stack)) {
+        } else if (clusterProxyServiceAvailabilityChecker.isDnsBasedServiceNameAvailable(stack)) {
             List<GatewayConfig> targetGatewayConfigs = gatewayConfigs.stream()
                     .filter(gatewayConfig -> Objects.isNull(instanceIdsToRegister) || instanceIdsToRegister.contains(gatewayConfig.getInstanceId()))
                     .collect(Collectors.toList());
@@ -230,9 +249,27 @@ public class ClusterProxyService {
                 endpoints,
                 List.of(),
                 clientCertificate,
-                new ClusterServiceHealthCheck(intervalInSec, healthStatusEndpoint, timeoutInSec, healthyStatusCode)
+                getHealthCheck(stack)
         ));
         return serviceConfigs;
+    }
+
+    private ClusterServiceHealthCheck getHealthCheck(Stack stack) {
+        ClusterServiceHealthCheck clusterServiceHealthCheck;
+        int intervalInSec = getIntervalInSec(stack);
+        if (healthCheckAvailabilityChecker.isCdpFreeIpaHeathAgentAvailable(stack)) {
+            clusterServiceHealthCheck = new ClusterServiceHealthCheck(intervalInSec, healthStatusEndpointV2, timeoutInSecV2, healthyStatusCodeV2);
+        } else {
+            clusterServiceHealthCheck = new ClusterServiceHealthCheck(intervalInSec, healthStatusEndpointV1, timeoutInSecV1, healthyStatusCodeV1);
+        }
+        return clusterServiceHealthCheck;
+    }
+
+    private int getIntervalInSec(Stack stack) {
+        if (healthCheckAvailabilityChecker.isCdpFreeIpaHeathAgentAvailable(stack)) {
+            return intervalInSecV2;
+        }
+        return intervalInSecV1;
     }
 
     private List<TunnelEntry> createTunnelEntries(Stack stack, List<GatewayConfig> gatewayConfigs) {
@@ -295,7 +332,7 @@ public class ClusterProxyService {
     public void pollForGoodHealth(Stack stack) {
         serviceEndpointHealthPollingService.pollWithTimeout(
                 serviceEndpointHealthListenerTask, new ServiceEndpointHealthPollerObject(stack.getResourceCrn(), clusterProxyRegistrationClient),
-                intervalInSec * MILLIS_PER_SEC, maxAttempts, maxFailure);
+                getIntervalInSec(stack) * MILLIS_PER_SEC, maxAttempts, maxFailure);
     }
 
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/util/BalancedDnsAvailabilityChecker.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/util/BalancedDnsAvailabilityChecker.java
@@ -1,20 +1,19 @@
 package com.sequenceiq.freeipa.util;
 
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.cloud.VersionComparator;
 import com.sequenceiq.cloudbreak.common.type.Versioned;
 import com.sequenceiq.freeipa.entity.Stack;
 
+@Component
 public class BalancedDnsAvailabilityChecker {
 
     // feature supported from 2.20
     private static final Versioned BALANCED_DNS_NAME_AFTER_VERSION = () -> "2.19.0";
 
-    private BalancedDnsAvailabilityChecker() {
-    }
-
-    public static boolean isBalancedDnsAvailable(Stack stack) {
+    public boolean isBalancedDnsAvailable(Stack stack) {
         if (StringUtils.isNotBlank(stack.getAppVersion())) {
             Versioned currentVersion = stack::getAppVersion;
             return new VersionComparator().compare(currentVersion, BALANCED_DNS_NAME_AFTER_VERSION) > 0;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/util/HealthCheckAvailabilityChecker.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/util/HealthCheckAvailabilityChecker.java
@@ -8,15 +8,15 @@ import com.sequenceiq.cloudbreak.common.type.Versioned;
 import com.sequenceiq.freeipa.entity.Stack;
 
 @Component
-public class ClusterProxyServiceAvailabilityChecker {
+public class HealthCheckAvailabilityChecker {
 
-    // feature supported from 2.21
-    private static final Versioned DNS_BASED_SERVICE_NAME_AFTER_VERSION = () -> "2.20.0";
+    // feature supported from 2.29
+    private static final Versioned CDP_FREEIPA_HEALTH_AGENT_AFTER_VERSION = () -> "2.28.0";
 
-    public boolean isDnsBasedServiceNameAvailable(Stack stack) {
+    public boolean isCdpFreeIpaHeathAgentAvailable(Stack stack) {
         if (StringUtils.isNotBlank(stack.getAppVersion())) {
             Versioned currentVersion = () -> stack.getAppVersion();
-            return new VersionComparator().compare(currentVersion, DNS_BASED_SERVICE_NAME_AFTER_VERSION) > 0;
+            return new VersionComparator().compare(currentVersion, CDP_FREEIPA_HEALTH_AGENT_AFTER_VERSION) > 0;
         } else {
             return false;
         }

--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -244,10 +244,16 @@ clusterProxy:
   registerConfigPath: /rpc/forceRegisterConfig
   updateConfigPath: /rpc/updateConfig
   removeConfigPath: /rpc/removeConfig
-  intervalInSec: 5
-  healthStatusEndpoint: /ipa/session/login_password
-  timeoutInSec: 5
-  # the login page returns a 400, update this after CDPAM-609 which will provide a better health check
-  healthyStatusCode: 400
   maxAttempts: 10
   maxFailure: 1
+  healthCheckV1:
+    # the login page returns a 400
+    healthStatusEndpoint: /ipa/session/login_password
+    healthyStatusCode: 400
+    timeoutInSec: 5
+    intervalInSec: 5
+  healthCheckV2:
+    healthStatusEndpoint: /freeipahealthcheck
+    healthyStatusCode: 200
+    timeoutInSec: 5
+    intervalInSec: 5

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/stack/StackToDescribeFreeIpaResponseConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/stack/StackToDescribeFreeIpaResponseConverterTest.java
@@ -34,6 +34,7 @@ import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.entity.StackAuthentication;
 import com.sequenceiq.freeipa.entity.StackStatus;
 import com.sequenceiq.freeipa.entity.UserSyncStatus;
+import com.sequenceiq.freeipa.util.BalancedDnsAvailabilityChecker;
 
 @ExtendWith(MockitoExtension.class)
 class StackToDescribeFreeIpaResponseConverterTest {
@@ -98,6 +99,9 @@ class StackToDescribeFreeIpaResponseConverterTest {
     @Mock
     private UserSyncStatusToUserSyncStatusResponseConverter userSyncStatusConverter;
 
+    @Mock
+    private BalancedDnsAvailabilityChecker balancedDnsAvailabilityChecker;
+
     @BeforeAll
     static void initInstanceGroupResponse() {
         InstanceMetaDataResponse instanceMetaDataResponse = new InstanceMetaDataResponse();
@@ -118,6 +122,7 @@ class StackToDescribeFreeIpaResponseConverterTest {
         when(freeIpaServerResponseConverter.convert(freeIpa)).thenReturn(freeIpaServerResponse);
         when(instanceGroupConverter.convert(stack.getInstanceGroups())).thenReturn(INSTANCE_GROUP_RESPONSES);
         when(userSyncStatusConverter.convert(userSyncStatus)).thenReturn(USERSYNC_STATUS_RESPONSE);
+        when(balancedDnsAvailabilityChecker.isBalancedDnsAvailable(stack)).thenReturn(true);
 
         DescribeFreeIpaResponse result = underTest.convert(stack, image, freeIpa, userSyncStatus);
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/config/KerberosConfigRegisterServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/config/KerberosConfigRegisterServiceTest.java
@@ -24,6 +24,7 @@ import com.sequenceiq.freeipa.kerberos.KerberosConfig;
 import com.sequenceiq.freeipa.kerberos.KerberosConfigService;
 import com.sequenceiq.freeipa.service.freeipa.FreeIpaService;
 import com.sequenceiq.freeipa.service.stack.StackService;
+import com.sequenceiq.freeipa.util.BalancedDnsAvailabilityChecker;
 
 @ExtendWith(MockitoExtension.class)
 class KerberosConfigRegisterServiceTest {
@@ -39,6 +40,9 @@ class KerberosConfigRegisterServiceTest {
 
     @Mock
     private StackService stackService;
+
+    @Mock
+    private BalancedDnsAvailabilityChecker balancedDnsAvailabilityChecker;
 
     @Test
     void testRegister() {
@@ -59,6 +63,7 @@ class KerberosConfigRegisterServiceTest {
         freeIpa.setDomain("testdomain.local");
         freeIpa.setAdminPassword("asdf");
         when(freeIpaService.findByStackId(anyLong())).thenReturn(freeIpa);
+        when(balancedDnsAvailabilityChecker.isBalancedDnsAvailable(stack)).thenReturn(true);
 
         underTest.register(1L);
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/config/LdapConfigRegisterServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/config/LdapConfigRegisterServiceTest.java
@@ -35,6 +35,7 @@ import com.sequenceiq.freeipa.ldap.LdapConfig;
 import com.sequenceiq.freeipa.ldap.LdapConfigService;
 import com.sequenceiq.freeipa.service.freeipa.FreeIpaService;
 import com.sequenceiq.freeipa.service.stack.StackService;
+import com.sequenceiq.freeipa.util.BalancedDnsAvailabilityChecker;
 
 @ExtendWith(MockitoExtension.class)
 class LdapConfigRegisterServiceTest {
@@ -50,6 +51,9 @@ class LdapConfigRegisterServiceTest {
 
     @Mock
     private LdapConfigService ldapConfigService;
+
+    @Mock
+    private BalancedDnsAvailabilityChecker balancedDnsAvailabilityChecker;
 
     @Test
     void testRegister() {
@@ -70,6 +74,7 @@ class LdapConfigRegisterServiceTest {
         freeIpa.setDomain("testdomain.local");
         freeIpa.setAdminPassword("asdf");
         when(freeIpaService.findByStackId(anyLong())).thenReturn(freeIpa);
+        when(balancedDnsAvailabilityChecker.isBalancedDnsAvailable(stack)).thenReturn(true);
 
         underTest.register(1L);
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/util/BalancedDnsAvailabilityCheckerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/util/BalancedDnsAvailabilityCheckerTest.java
@@ -3,27 +3,38 @@ package com.sequenceiq.freeipa.util;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.freeipa.entity.Stack;
 
+@ExtendWith(MockitoExtension.class)
 public class BalancedDnsAvailabilityCheckerTest {
+
+    private BalancedDnsAvailabilityChecker underTest;
+
+    @Before
+    public void before() {
+        underTest = new BalancedDnsAvailabilityChecker();
+    }
 
     @Test
     public void testBalancedDnsAvailable() {
         Stack stack = new Stack();
 
         stack.setAppVersion("2.20.0-rc.1");
-        assertTrue(BalancedDnsAvailabilityChecker.isBalancedDnsAvailable(stack));
+        assertTrue(underTest.isBalancedDnsAvailable(stack));
 
         stack.setAppVersion("2.21.0-rc.1");
-        assertTrue(BalancedDnsAvailabilityChecker.isBalancedDnsAvailable(stack));
+        assertTrue(underTest.isBalancedDnsAvailable(stack));
 
         stack.setAppVersion("2.20.0");
-        assertTrue(BalancedDnsAvailabilityChecker.isBalancedDnsAvailable(stack));
+        assertTrue(underTest.isBalancedDnsAvailable(stack));
 
         stack.setAppVersion("2.20.0-dev.2");
-        assertTrue(BalancedDnsAvailabilityChecker.isBalancedDnsAvailable(stack));
+        assertTrue(underTest.isBalancedDnsAvailable(stack));
     }
 
     @Test
@@ -31,34 +42,34 @@ public class BalancedDnsAvailabilityCheckerTest {
         Stack stack = new Stack();
 
         stack.setAppVersion("2.19.0");
-        assertFalse(BalancedDnsAvailabilityChecker.isBalancedDnsAvailable(stack));
+        assertFalse(underTest.isBalancedDnsAvailable(stack));
 
         stack.setAppVersion("2.19.0-rc.23");
-        assertFalse(BalancedDnsAvailabilityChecker.isBalancedDnsAvailable(stack));
+        assertFalse(underTest.isBalancedDnsAvailable(stack));
 
         stack.setAppVersion("2.19.0-rc.122");
-        assertFalse(BalancedDnsAvailabilityChecker.isBalancedDnsAvailable(stack));
+        assertFalse(underTest.isBalancedDnsAvailable(stack));
 
         stack.setAppVersion("2.19.0-dev.23");
-        assertFalse(BalancedDnsAvailabilityChecker.isBalancedDnsAvailable(stack));
+        assertFalse(underTest.isBalancedDnsAvailable(stack));
 
         stack.setAppVersion("2.18.0");
-        assertFalse(BalancedDnsAvailabilityChecker.isBalancedDnsAvailable(stack));
+        assertFalse(underTest.isBalancedDnsAvailable(stack));
 
         stack.setAppVersion("2.18.0-rc.2");
-        assertFalse(BalancedDnsAvailabilityChecker.isBalancedDnsAvailable(stack));
+        assertFalse(underTest.isBalancedDnsAvailable(stack));
     }
 
     @Test
     public void testAppVersionIsBlank() {
         Stack stack = new Stack();
-        assertFalse(BalancedDnsAvailabilityChecker.isBalancedDnsAvailable(stack));
+        assertFalse(underTest.isBalancedDnsAvailable(stack));
 
         stack.setAppVersion("");
-        assertFalse(BalancedDnsAvailabilityChecker.isBalancedDnsAvailable(stack));
+        assertFalse(underTest.isBalancedDnsAvailable(stack));
 
         stack.setAppVersion(" ");
-        assertFalse(BalancedDnsAvailabilityChecker.isBalancedDnsAvailable(stack));
+        assertFalse(underTest.isBalancedDnsAvailable(stack));
     }
 
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/util/ClusterProxyServiceAvailabilityCheckerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/util/ClusterProxyServiceAvailabilityCheckerTest.java
@@ -3,27 +3,38 @@ package com.sequenceiq.freeipa.util;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.freeipa.entity.Stack;
 
+@ExtendWith(MockitoExtension.class)
 public class ClusterProxyServiceAvailabilityCheckerTest {
+
+    private ClusterProxyServiceAvailabilityChecker underTest;
+
+    @Before
+    public void before() {
+        underTest = new ClusterProxyServiceAvailabilityChecker();
+    }
 
     @Test
     public void testisBalancedDnsAvailable() {
         Stack stack = new Stack();
 
         stack.setAppVersion("2.21.0-rc.1");
-        assertTrue(ClusterProxyServiceAvailabilityChecker.isDnsBasedServiceNameAvailable(stack));
+        assertTrue(underTest.isDnsBasedServiceNameAvailable(stack));
 
         stack.setAppVersion("2.22.0-rc.1");
-        assertTrue(ClusterProxyServiceAvailabilityChecker.isDnsBasedServiceNameAvailable(stack));
+        assertTrue(underTest.isDnsBasedServiceNameAvailable(stack));
 
         stack.setAppVersion("2.21.0");
-        assertTrue(ClusterProxyServiceAvailabilityChecker.isDnsBasedServiceNameAvailable(stack));
+        assertTrue(underTest.isDnsBasedServiceNameAvailable(stack));
 
         stack.setAppVersion("2.21.0-dev.2");
-        assertTrue(ClusterProxyServiceAvailabilityChecker.isDnsBasedServiceNameAvailable(stack));
+        assertTrue(underTest.isDnsBasedServiceNameAvailable(stack));
     }
 
     @Test
@@ -31,34 +42,34 @@ public class ClusterProxyServiceAvailabilityCheckerTest {
         Stack stack = new Stack();
 
         stack.setAppVersion("2.20.0");
-        assertFalse(ClusterProxyServiceAvailabilityChecker.isDnsBasedServiceNameAvailable(stack));
+        assertFalse(underTest.isDnsBasedServiceNameAvailable(stack));
 
         stack.setAppVersion("2.20.0-rc.23");
-        assertFalse(ClusterProxyServiceAvailabilityChecker.isDnsBasedServiceNameAvailable(stack));
+        assertFalse(underTest.isDnsBasedServiceNameAvailable(stack));
 
         stack.setAppVersion("2.20.0-rc.122");
-        assertFalse(ClusterProxyServiceAvailabilityChecker.isDnsBasedServiceNameAvailable(stack));
+        assertFalse(underTest.isDnsBasedServiceNameAvailable(stack));
 
         stack.setAppVersion("2.20.0-dev.23");
-        assertFalse(ClusterProxyServiceAvailabilityChecker.isDnsBasedServiceNameAvailable(stack));
+        assertFalse(underTest.isDnsBasedServiceNameAvailable(stack));
 
         stack.setAppVersion("2.19.0");
-        assertFalse(ClusterProxyServiceAvailabilityChecker.isDnsBasedServiceNameAvailable(stack));
+        assertFalse(underTest.isDnsBasedServiceNameAvailable(stack));
 
         stack.setAppVersion("2.19.0-rc.2");
-        assertFalse(ClusterProxyServiceAvailabilityChecker.isDnsBasedServiceNameAvailable(stack));
+        assertFalse(underTest.isDnsBasedServiceNameAvailable(stack));
     }
 
     @Test
     public void testAppVersionIsBlank() {
         Stack stack = new Stack();
-        assertFalse(ClusterProxyServiceAvailabilityChecker.isDnsBasedServiceNameAvailable(stack));
+        assertFalse(underTest.isDnsBasedServiceNameAvailable(stack));
 
         stack.setAppVersion("");
-        assertFalse(ClusterProxyServiceAvailabilityChecker.isDnsBasedServiceNameAvailable(stack));
+        assertFalse(underTest.isDnsBasedServiceNameAvailable(stack));
 
         stack.setAppVersion(" ");
-        assertFalse(ClusterProxyServiceAvailabilityChecker.isDnsBasedServiceNameAvailable(stack));
+        assertFalse(underTest.isDnsBasedServiceNameAvailable(stack));
     }
 
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/util/HealthCheckAvailabilityCheckerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/util/HealthCheckAvailabilityCheckerTest.java
@@ -1,0 +1,75 @@
+package com.sequenceiq.freeipa.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.freeipa.entity.Stack;
+
+@ExtendWith(MockitoExtension.class)
+public class HealthCheckAvailabilityCheckerTest {
+
+    private HealthCheckAvailabilityChecker underTest;
+
+    @Before
+    public void before() {
+        underTest = new HealthCheckAvailabilityChecker();
+    }
+
+    @Test
+    public void testHealthCheckAvailable() {
+        Stack stack = new Stack();
+
+        stack.setAppVersion("2.29.0-b1");
+        assertTrue(underTest.isCdpFreeIpaHeathAgentAvailable(stack));
+
+        stack.setAppVersion("2.30.0-b1");
+        assertTrue(underTest.isCdpFreeIpaHeathAgentAvailable(stack));
+
+        stack.setAppVersion("2.29.0");
+        assertTrue(underTest.isCdpFreeIpaHeathAgentAvailable(stack));
+
+        stack.setAppVersion("2.29.0-b2");
+        assertTrue(underTest.isCdpFreeIpaHeathAgentAvailable(stack));
+    }
+
+    @Test
+    public void testHealthCheckUnavailable() {
+        Stack stack = new Stack();
+
+        stack.setAppVersion("2.28.0");
+        assertFalse(underTest.isCdpFreeIpaHeathAgentAvailable(stack));
+
+        stack.setAppVersion("2.28.0-b23");
+        assertFalse(underTest.isCdpFreeIpaHeathAgentAvailable(stack));
+
+        stack.setAppVersion("2.28.0-b122");
+        assertFalse(underTest.isCdpFreeIpaHeathAgentAvailable(stack));
+
+        stack.setAppVersion("2.28.0-b23");
+        assertFalse(underTest.isCdpFreeIpaHeathAgentAvailable(stack));
+
+        stack.setAppVersion("2.27.0");
+        assertFalse(underTest.isCdpFreeIpaHeathAgentAvailable(stack));
+
+        stack.setAppVersion("2.27.0-b2");
+        assertFalse(underTest.isCdpFreeIpaHeathAgentAvailable(stack));
+    }
+
+    @Test
+    public void testAppVersionIsBlank() {
+        Stack stack = new Stack();
+        assertFalse(underTest.isCdpFreeIpaHeathAgentAvailable(stack));
+
+        stack.setAppVersion("");
+        assertFalse(underTest.isCdpFreeIpaHeathAgentAvailable(stack));
+
+        stack.setAppVersion(" ");
+        assertFalse(underTest.isCdpFreeIpaHeathAgentAvailable(stack));
+    }
+
+}


### PR DESCRIPTION
Register the FreeIPA healthcheck with cluster proxy for new clusters.
Continue using the old login page as the status check for clusters
that were provisioned prior to the healthcheck's existence.

This was tested with a local deployment of cloudbreak.

See detailed description in the commit message.