### PR TITLE
CB-8053 Enable RAZ for AWS

### DIFF
--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/service/identitymapping/AccountMappingSubject.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/service/identitymapping/AccountMappingSubject.java
@@ -7,7 +7,7 @@ import java.util.Set;
 public class AccountMappingSubject {
 
     /**
-     * Immutable set of data access service users. Always disjoint from {@link #RANGER_AUDIT_USERS}.
+     * Immutable set of data access service users. Always disjoint from {@link #RANGER_AUDIT_USERS}, and never contains {@link #RANGER_RAZ_USER}.
      *
      * Adapted from {@code com.cloudera.thunderhead.service.idbrokermappingmanagement.server.IdBrokerMappingManagementService.DATA_ACCESS_SERVICES}.
      */
@@ -15,21 +15,32 @@ public class AccountMappingSubject {
             "schemaregistry", "mapred");
 
     /**
-     * Immutable set of service users that are not data access ones but do need Ranger Audit access. Always disjoint from {@link #DATA_ACCESS_USERS}.
+     * Immutable set of service users that are not data access ones but do need Ranger Audit access. Always disjoint from {@link #DATA_ACCESS_USERS}, and
+     * never contains {@link #RANGER_RAZ_USER}.
      *
      * Adapted from {@code com.cloudera.thunderhead.service.idbrokermappingmanagement.server.IdBrokerMappingManagementService.BASELINE_SERVICES}.
      */
-    public static final Set<String> RANGER_AUDIT_USERS = Set.of("kafka", "solr", "knox", "atlas", "nifi", "nifiregistry", "rangerraz");
+    public static final Set<String> RANGER_AUDIT_USERS = Set.of("kafka", "solr", "knox", "atlas", "nifi", "nifiregistry");
 
     /**
-     * Convenience immutable set comprising the union of {@link #DATA_ACCESS_USERS} and {@link #RANGER_AUDIT_USERS}.
+     * Service user for Ranger RAZ. Never present in {@link #DATA_ACCESS_USERS} or {@link #RANGER_AUDIT_USERS}.
+     *
+     * Adapted from
+     * {@code com.cloudera.thunderhead.service.idbrokermappingmanagement.server.IdBrokerMappingManagementService.RANGER_CLOUD_ACCESS_AUTHORIZER_SERVICE}.
      */
-    public static final Set<String> DATA_ACCESS_AND_RANGER_AUDIT_USERS;
+    public static final String RANGER_RAZ_USER = "rangerraz";
+
+    /**
+     * Convenience immutable set comprising the union of {@link #DATA_ACCESS_USERS}, {@link #RANGER_AUDIT_USERS} and the singleton set of
+     * {@link #RANGER_RAZ_USER}.
+     */
+    public static final Set<String> ALL_SPECIAL_USERS;
 
     static {
         Set<String> dataAccessAndRangerAuditUsers = new HashSet<>(DATA_ACCESS_USERS);
         dataAccessAndRangerAuditUsers.addAll(RANGER_AUDIT_USERS);
-        DATA_ACCESS_AND_RANGER_AUDIT_USERS = Collections.unmodifiableSet(dataAccessAndRangerAuditUsers);
+        dataAccessAndRangerAuditUsers.add(RANGER_RAZ_USER);
+        ALL_SPECIAL_USERS = Collections.unmodifiableSet(dataAccessAndRangerAuditUsers);
     }
 
     private AccountMappingSubject() {

--- a/cloud-common/src/test/java/com/sequenceiq/cloudbreak/service/identitymapping/AccountMappingSubjectTest.java
+++ b/cloud-common/src/test/java/com/sequenceiq/cloudbreak/service/identitymapping/AccountMappingSubjectTest.java
@@ -9,14 +9,17 @@ class AccountMappingSubjectTest {
     @Test
     void testDisjunctiveUserSets() {
         assertThat(AccountMappingSubject.DATA_ACCESS_USERS).doesNotContainAnyElementsOf(AccountMappingSubject.RANGER_AUDIT_USERS);
+        assertThat(AccountMappingSubject.DATA_ACCESS_USERS).doesNotContain(AccountMappingSubject.RANGER_RAZ_USER);
+        assertThat(AccountMappingSubject.RANGER_AUDIT_USERS).doesNotContain(AccountMappingSubject.RANGER_RAZ_USER);
     }
 
     @Test
     void testUserSetsUnion() {
-        assertThat(AccountMappingSubject.DATA_ACCESS_AND_RANGER_AUDIT_USERS).containsAll(AccountMappingSubject.DATA_ACCESS_USERS);
-        assertThat(AccountMappingSubject.DATA_ACCESS_AND_RANGER_AUDIT_USERS).containsAll(AccountMappingSubject.RANGER_AUDIT_USERS);
-        assertThat(AccountMappingSubject.DATA_ACCESS_AND_RANGER_AUDIT_USERS)
-                .hasSize(AccountMappingSubject.DATA_ACCESS_USERS.size() + AccountMappingSubject.RANGER_AUDIT_USERS.size());
+        assertThat(AccountMappingSubject.ALL_SPECIAL_USERS).containsAll(AccountMappingSubject.DATA_ACCESS_USERS);
+        assertThat(AccountMappingSubject.ALL_SPECIAL_USERS).containsAll(AccountMappingSubject.RANGER_AUDIT_USERS);
+        assertThat(AccountMappingSubject.ALL_SPECIAL_USERS).contains(AccountMappingSubject.RANGER_RAZ_USER);
+        assertThat(AccountMappingSubject.ALL_SPECIAL_USERS)
+                .hasSize(AccountMappingSubject.DATA_ACCESS_USERS.size() + AccountMappingSubject.RANGER_AUDIT_USERS.size() + 1);
     }
 
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
@@ -306,7 +306,7 @@ public class ModelDescriptions {
         public static final String OPENSTACK_PARAMETERS = "openstack specific parameters for cloud storage";
         public static final String VARIANT = "Cluster manager variant";
         public static final String CLOUD_STORAGE_LOCATIONS = "storage locations by CDP services";
-        public static final String ENABLE_RANGER_RAZ = "Enables Ranger Raz for the cluster on ADLSv2.";
+        public static final String ENABLE_RANGER_RAZ = "Enables Ranger Raz for the cluster on S3 and ADLSv2.";
     }
 
     public static class GatewayModelDescription {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/identitymapping/AwsMockAccountMappingService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/identitymapping/AwsMockAccountMappingService.java
@@ -20,7 +20,7 @@ public class AwsMockAccountMappingService {
 
     private static final String FIXED_IAM_ROLE = "arn:aws:iam::${accountId}:role/mock-idbroker-admin-role";
 
-    private static final Map<String, String> MOCK_IDBROKER_USER_MAPPINGS = AccountMappingSubject.DATA_ACCESS_AND_RANGER_AUDIT_USERS
+    private static final Map<String, String> MOCK_IDBROKER_USER_MAPPINGS = AccountMappingSubject.ALL_SPECIAL_USERS
             .stream()
             .map(user -> Map.entry(user, FIXED_IAM_ROLE))
             .collect(Collectors.toUnmodifiableMap(Entry::getKey, Entry::getValue));

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/identitymapping/AzureMockAccountMappingService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/identitymapping/AzureMockAccountMappingService.java
@@ -18,7 +18,7 @@ public class AzureMockAccountMappingService {
     private static final String FIXED_MANAGED_IDENTITY = "/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupId}/" +
             "providers/Microsoft.ManagedIdentity/userAssignedIdentities/mock-idbroker-admin-identity";
 
-    private static final Map<String, String> MOCK_IDBROKER_USER_MAPPINGS = AccountMappingSubject.DATA_ACCESS_AND_RANGER_AUDIT_USERS
+    private static final Map<String, String> MOCK_IDBROKER_USER_MAPPINGS = AccountMappingSubject.ALL_SPECIAL_USERS
             .stream()
             .map(user -> Map.entry(user, FIXED_MANAGED_IDENTITY))
             .collect(Collectors.toUnmodifiableMap(Entry::getKey, Entry::getValue));

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/identitymapping/AwsMockAccountMappingServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/identitymapping/AwsMockAccountMappingServiceTest.java
@@ -69,8 +69,8 @@ class AwsMockAccountMappingServiceTest {
     void testGetUserMappings() {
         Map<String, String> userMappings = underTest.getUserMappings(REGION, credential);
         assertThat(userMappings).isNotNull();
-        AccountMappingSubject.DATA_ACCESS_AND_RANGER_AUDIT_USERS.forEach(user -> assertThat(userMappings).contains(Map.entry(user, IAM_ROLE)));
-        assertThat(userMappings).hasSize(AccountMappingSubject.DATA_ACCESS_AND_RANGER_AUDIT_USERS.size());
+        AccountMappingSubject.ALL_SPECIAL_USERS.forEach(user -> assertThat(userMappings).contains(Map.entry(user, IAM_ROLE)));
+        assertThat(userMappings).hasSize(AccountMappingSubject.ALL_SPECIAL_USERS.size());
     }
 
     @Test

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/identitymapping/AzureMockAccountMappingServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/identitymapping/AzureMockAccountMappingServiceTest.java
@@ -41,8 +41,8 @@ class AzureMockAccountMappingServiceTest {
     void testGetUserMappings() {
         Map<String, String> userMappings = underTest.getUserMappings(RESOURCE_GROUP, credential);
         assertThat(userMappings).isNotNull();
-        AccountMappingSubject.DATA_ACCESS_AND_RANGER_AUDIT_USERS.forEach(user -> assertThat(userMappings).contains(Map.entry(user, MANAGED_IDENTITY)));
-        assertThat(userMappings).hasSize(AccountMappingSubject.DATA_ACCESS_AND_RANGER_AUDIT_USERS.size());
+        AccountMappingSubject.ALL_SPECIAL_USERS.forEach(user -> assertThat(userMappings).contains(Map.entry(user, MANAGED_IDENTITY)));
+        assertThat(userMappings).hasSize(AccountMappingSubject.ALL_SPECIAL_USERS.size());
     }
 
     @Test

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.datalake.service.sdx;
 
+import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AWS;
 import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AZURE;
 import static com.sequenceiq.cloudbreak.exception.NotFoundException.notFound;
 import static com.sequenceiq.cloudbreak.util.Benchmark.measure;
@@ -18,6 +19,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.util.Strings;
@@ -441,11 +443,14 @@ public class SdxService implements ResourceIdProvider, ResourceBasedCrnProvider 
             if (!razEntitlementEnabled) {
                 validationBuilder.error("Provisioning Ranger Raz is not enabled for this account.");
             }
-            if (!AZURE.name().equalsIgnoreCase(environment.getCloudPlatform())) {
-                validationBuilder.error("Provisioning Ranger Raz is only valid for Microsoft Azure.");
+            CloudPlatform cloudPlatform = EnumUtils.getEnumIgnoreCase(CloudPlatform.class, environment.getCloudPlatform());
+            if (!(AWS.equals(cloudPlatform) || AZURE.equals(cloudPlatform))) {
+                validationBuilder.error("Provisioning Ranger Raz is only valid for Amazon Web Services and Microsoft Azure.");
             }
-            if (!isRazSupported(sdxClusterRequest.getRuntime())) {
-                validationBuilder.error("Provisioning Ranger Raz is only valid for CM version >= 7.2.1 and not " + sdxClusterRequest.getRuntime());
+            if (!isRazSupported(sdxClusterRequest.getRuntime(), cloudPlatform)) {
+                String errorMsg =  AWS.equals(cloudPlatform) ? "Provisioning Ranger Raz on Amazon Web Services is only valid for CM version >= 7.2.2 and not " :
+                        "Provisioning Ranger Raz on Microsoft Azure is only valid for CM version >= 7.2.1 and not ";
+                validationBuilder.error(errorMsg + sdxClusterRequest.getRuntime());
             }
         }
         ValidationResult validationResult = validationBuilder.build();
@@ -474,14 +479,15 @@ public class SdxService implements ResourceIdProvider, ResourceBasedCrnProvider 
     }
 
     /**
-     * Ranger Raz is only on 7.2.1 and later.  If runtime is empty, then sdx-internal call was used.
+     * Ranger Raz is only on 7.2.1 and later on Microsoft Azure, and only on 7.2.2 and later on Amazon Web Services.
+     * If runtime is empty, then sdx-internal call was used.
      */
-    private boolean isRazSupported(String runtime) {
+    private boolean isRazSupported(String runtime, CloudPlatform cloudPlatform) {
         if (StringUtils.isEmpty(runtime)) {
             return true;
         }
         Comparator<Versioned> versionComparator = new VersionComparator();
-        return versionComparator.compare(() -> runtime, () -> "7.2.1") > -1;
+        return versionComparator.compare(() -> runtime, () -> AWS.equals(cloudPlatform) ? "7.2.2" : "7.2.1") > -1;
     }
 
     /**

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxServiceTest.java
@@ -496,14 +496,23 @@ class SdxServiceTest {
         verify(stackV4Endpoint, times(1)).sync(eq(0L), eq(CLUSTER_NAME), anyString());
     }
 
-    @Test
-    void testSdxCreateRazEnabled() throws IOException, TransactionExecutionException {
+    static Object[][] razCloudPlatformDataProvider() {
+        return new Object[][]{
+                // testCaseName cloudPlatform
+                {"CloudPlatform.AWS", CloudPlatform.AWS},
+                {"CloudPlatform.AZURE", CloudPlatform.AZURE}
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("razCloudPlatformDataProvider")
+    void testSdxCreateRazNotRequested(String testCaseName, CloudPlatform cloudPlatform) throws IOException, TransactionExecutionException {
         when(transactionService.required(isA(Supplier.class))).thenAnswer(invocation -> invocation.getArgument(0, Supplier.class).get());
         String lightDutyJson = FileReaderUtils.readFileFromClasspath("/runtime/7.1.0/aws/light_duty.json");
         when(cdpConfigService.getConfigForKey(any())).thenReturn(JsonUtil.readValue(lightDutyJson, StackV4Request.class));
         when(sdxReactorFlowManager.triggerSdxCreation(any())).thenReturn(new FlowIdentifier(FlowType.FLOW, "FLOW_ID"));
         SdxClusterRequest sdxClusterRequest = new SdxClusterRequest();
-        sdxClusterRequest.setRuntime("7.2.1");
+        sdxClusterRequest.setRuntime("7.1.0");
         sdxClusterRequest.setClusterShape(LIGHT_DUTY);
         Map<String, String> tags = new HashMap<>();
         tags.put("mytag", "tagecske");
@@ -517,7 +526,48 @@ class SdxServiceTest {
             return sdxWithId;
         });
         when(clock.getCurrentTimeMillis()).thenReturn(1L);
-        mockEnvironmentCall(sdxClusterRequest, CloudPlatform.AZURE);
+        mockEnvironmentCall(sdxClusterRequest, cloudPlatform);
+        sdxClusterRequest.setEnableRangerRaz(false);
+        Pair<SdxCluster, FlowIdentifier> result = underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null);
+        SdxCluster createdSdxCluster = result.getLeft();
+        Assertions.assertEquals(id, createdSdxCluster.getId());
+        final ArgumentCaptor<SdxCluster> captor = ArgumentCaptor.forClass(SdxCluster.class);
+        verify(sdxClusterRepository, times(1)).save(captor.capture());
+        SdxCluster capturedSdx = captor.getValue();
+        assertFalse(capturedSdx.isRangerRazEnabled());
+    }
+
+    static Object[][] razCloudPlatformAndRuntimeDataProvider() {
+        return new Object[][]{
+                // testCaseName cloudPlatform runtime
+                {"CloudPlatform.AWS", CloudPlatform.AWS, "7.2.2"},
+                {"CloudPlatform.AZURE", CloudPlatform.AZURE, "7.2.1"}
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("razCloudPlatformAndRuntimeDataProvider")
+    void testSdxCreateRazEnabled(String testCaseName, CloudPlatform cloudPlatform, String runtime) throws IOException, TransactionExecutionException {
+        when(transactionService.required(isA(Supplier.class))).thenAnswer(invocation -> invocation.getArgument(0, Supplier.class).get());
+        String lightDutyJson = FileReaderUtils.readFileFromClasspath("/runtime/7.1.0/aws/light_duty.json");
+        when(cdpConfigService.getConfigForKey(any())).thenReturn(JsonUtil.readValue(lightDutyJson, StackV4Request.class));
+        when(sdxReactorFlowManager.triggerSdxCreation(any())).thenReturn(new FlowIdentifier(FlowType.FLOW, "FLOW_ID"));
+        SdxClusterRequest sdxClusterRequest = new SdxClusterRequest();
+        sdxClusterRequest.setRuntime(runtime);
+        sdxClusterRequest.setClusterShape(LIGHT_DUTY);
+        Map<String, String> tags = new HashMap<>();
+        tags.put("mytag", "tagecske");
+        sdxClusterRequest.addTags(tags);
+        sdxClusterRequest.setEnvironment("envir");
+        when(sdxClusterRepository.findByAccountIdAndEnvNameAndDeletedIsNull(anyString(), anyString())).thenReturn(new ArrayList<>());
+        long id = 10L;
+        when(sdxClusterRepository.save(any(SdxCluster.class))).thenAnswer(invocation -> {
+            SdxCluster sdxWithId = invocation.getArgument(0, SdxCluster.class);
+            sdxWithId.setId(id);
+            return sdxWithId;
+        });
+        when(clock.getCurrentTimeMillis()).thenReturn(1L);
+        mockEnvironmentCall(sdxClusterRequest, cloudPlatform);
         sdxClusterRequest.setEnableRangerRaz(true);
         when(entitlementService.razEnabled(anyString(), anyString())).thenReturn(true);
         Pair<SdxCluster, FlowIdentifier> result = underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null);
@@ -529,10 +579,11 @@ class SdxServiceTest {
         assertTrue(capturedSdx.isRangerRazEnabled());
     }
 
-    @Test
-    void testSdxCreateRazEnabledNoEntitlement() throws IOException {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("razCloudPlatformAndRuntimeDataProvider")
+    void testSdxCreateRazEnabledNoEntitlement(String testCaseName, CloudPlatform cloudPlatform, String runtime) throws IOException {
         SdxClusterRequest sdxClusterRequest = new SdxClusterRequest();
-        sdxClusterRequest.setRuntime("7.2.1");
+        sdxClusterRequest.setRuntime(runtime);
         sdxClusterRequest.setClusterShape(LIGHT_DUTY);
         Map<String, String> tags = new HashMap<>();
         tags.put("mytag", "tagecske");
@@ -540,7 +591,7 @@ class SdxServiceTest {
         sdxClusterRequest.setEnvironment("envir");
         when(sdxClusterRepository.findByAccountIdAndEnvNameAndDeletedIsNull(anyString(), anyString())).thenReturn(new ArrayList<>());
         long id = 10L;
-        mockEnvironmentCall(sdxClusterRequest, CloudPlatform.AZURE);
+        mockEnvironmentCall(sdxClusterRequest, cloudPlatform);
         sdxClusterRequest.setEnableRangerRaz(true);
         when(entitlementService.razEnabled(anyString(), anyString())).thenReturn(false);
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
@@ -549,9 +600,9 @@ class SdxServiceTest {
     }
 
     @Test
-    void testSdxCreateRazEnabledNotAzure() throws IOException {
+    void testSdxCreateRazEnabledNotAwsOrAzure() throws IOException {
         SdxClusterRequest sdxClusterRequest = new SdxClusterRequest();
-        sdxClusterRequest.setRuntime("7.2.1");
+        sdxClusterRequest.setRuntime("7.2.2");
         sdxClusterRequest.setClusterShape(LIGHT_DUTY);
         Map<String, String> tags = new HashMap<>();
         tags.put("mytag", "tagecske");
@@ -559,18 +610,18 @@ class SdxServiceTest {
         sdxClusterRequest.setEnvironment("envir");
         when(sdxClusterRepository.findByAccountIdAndEnvNameAndDeletedIsNull(anyString(), anyString())).thenReturn(new ArrayList<>());
         long id = 10L;
-        mockEnvironmentCall(sdxClusterRequest, CloudPlatform.AWS);
+        mockEnvironmentCall(sdxClusterRequest, CloudPlatform.YARN);
         sdxClusterRequest.setEnableRangerRaz(true);
         when(entitlementService.razEnabled(anyString(), anyString())).thenReturn(true);
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
                 () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
-        assertEquals("1. Provisioning Ranger Raz is only valid for Microsoft Azure.", badRequestException.getMessage());
+        assertEquals("1. Provisioning Ranger Raz is only valid for Amazon Web Services and Microsoft Azure.", badRequestException.getMessage());
     }
 
     @Test
-    void testSdxCreateRazEnabledNoEntitlmentAndNotAzure() throws IOException {
+    void testSdxCreateRazEnabledNoEntitlementAndNotAwsOrAzure() throws IOException {
         SdxClusterRequest sdxClusterRequest = new SdxClusterRequest();
-        sdxClusterRequest.setRuntime("7.2.1");
+        sdxClusterRequest.setRuntime("7.2.2");
         sdxClusterRequest.setClusterShape(LIGHT_DUTY);
         Map<String, String> tags = new HashMap<>();
         tags.put("mytag", "tagecske");
@@ -578,17 +629,28 @@ class SdxServiceTest {
         sdxClusterRequest.setEnvironment("envir");
         when(sdxClusterRepository.findByAccountIdAndEnvNameAndDeletedIsNull(anyString(), anyString())).thenReturn(new ArrayList<>());
         long id = 10L;
-        mockEnvironmentCall(sdxClusterRequest, CloudPlatform.AWS);
+        mockEnvironmentCall(sdxClusterRequest, CloudPlatform.YARN);
         sdxClusterRequest.setEnableRangerRaz(true);
         when(entitlementService.razEnabled(anyString(), anyString())).thenReturn(false);
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
                 () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
         assertEquals("1. Provisioning Ranger Raz is not enabled for this account.\n" +
-                "2. Provisioning Ranger Raz is only valid for Microsoft Azure.", badRequestException.getMessage());
+                "2. Provisioning Ranger Raz is only valid for Amazon Web Services and Microsoft Azure.", badRequestException.getMessage());
     }
 
-    @Test
-    void testSdxCreateRazEnabled710Runtime() {
+    static Object[][] razCloudPlatform710DataProvider() {
+        return new Object[][]{
+                // testCaseName cloudPlatform expectedErrorMsg
+                {"CloudPlatform.AWS", CloudPlatform.AWS,
+                        "1. Provisioning Ranger Raz on Amazon Web Services is only valid for CM version >= 7.2.2 and not 7.1.0"},
+                {"CloudPlatform.AZURE", CloudPlatform.AZURE,
+                        "1. Provisioning Ranger Raz on Microsoft Azure is only valid for CM version >= 7.2.1 and not 7.1.0"}
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("razCloudPlatform710DataProvider")
+    void testSdxCreateRazEnabled710Runtime(String testCaseName, CloudPlatform cloudPlatform, String expectedErrorMsg) {
         SdxClusterRequest sdxClusterRequest = new SdxClusterRequest();
         sdxClusterRequest.setRuntime("7.1.0");
         sdxClusterRequest.setClusterShape(LIGHT_DUTY);
@@ -598,16 +660,27 @@ class SdxServiceTest {
         sdxClusterRequest.setEnvironment("envir");
         when(sdxClusterRepository.findByAccountIdAndEnvNameAndDeletedIsNull(anyString(), anyString())).thenReturn(new ArrayList<>());
         long id = 10L;
-        mockEnvironmentCall(sdxClusterRequest, CloudPlatform.AZURE);
+        mockEnvironmentCall(sdxClusterRequest, cloudPlatform);
         sdxClusterRequest.setEnableRangerRaz(true);
         when(entitlementService.razEnabled(anyString(), anyString())).thenReturn(true);
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
                 () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
-        assertEquals("1. Provisioning Ranger Raz is only valid for CM version >= 7.2.1 and not 7.1.0", badRequestException.getMessage());
+        assertEquals(expectedErrorMsg, badRequestException.getMessage());
     }
 
-    @Test
-    void testSdxCreateRazEnabled720Runtime() {
+    static Object[][] razCloudPlatform720DataProvider() {
+        return new Object[][]{
+                // testCaseName cloudPlatform expectedErrorMsg
+                {"CloudPlatform.AWS", CloudPlatform.AWS,
+                        "1. Provisioning Ranger Raz on Amazon Web Services is only valid for CM version >= 7.2.2 and not 7.2.0"},
+                {"CloudPlatform.AZURE", CloudPlatform.AZURE,
+                        "1. Provisioning Ranger Raz on Microsoft Azure is only valid for CM version >= 7.2.1 and not 7.2.0"}
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("razCloudPlatform720DataProvider")
+    void testSdxCreateRazEnabled720Runtime(String testCaseName, CloudPlatform cloudPlatform, String expectedErrorMsg) {
         SdxClusterRequest sdxClusterRequest = new SdxClusterRequest();
         sdxClusterRequest.setRuntime("7.2.0");
         sdxClusterRequest.setClusterShape(LIGHT_DUTY);
@@ -617,12 +690,12 @@ class SdxServiceTest {
         sdxClusterRequest.setEnvironment("envir");
         when(sdxClusterRepository.findByAccountIdAndEnvNameAndDeletedIsNull(anyString(), anyString())).thenReturn(new ArrayList<>());
         long id = 10L;
-        mockEnvironmentCall(sdxClusterRequest, CloudPlatform.AZURE);
+        mockEnvironmentCall(sdxClusterRequest, cloudPlatform);
         sdxClusterRequest.setEnableRangerRaz(true);
         when(entitlementService.razEnabled(anyString(), anyString())).thenReturn(true);
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
                 () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
-        assertEquals("1. Provisioning Ranger Raz is only valid for CM version >= 7.2.1 and not 7.2.0", badRequestException.getMessage());
+        assertEquals(expectedErrorMsg, badRequestException.getMessage());
     }
 
     @Test

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory;
 
 import com.sequenceiq.cloudbreak.cloud.VersionComparator;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.common.type.Versioned;
 
 public class CMRepositoryVersionUtil {
@@ -66,13 +67,15 @@ public class CMRepositoryVersionUtil {
         return isVersionNewerOrEqualThanLimited(clouderaManagerRepoDetails::getVersion, CLOUDERAMANAGER_VERSION_7_1_0);
     }
 
-    public static boolean isRazConfigurationSupported(ClouderaManagerRepo clouderaManagerRepoDetails) {
-        return isRazConfigurationSupported(clouderaManagerRepoDetails.getVersion());
+    public static boolean isRazConfigurationSupportedInDatalake(ClouderaManagerRepo clouderaManagerRepoDetails, CloudPlatform cloudPlatform) {
+        LOGGER.info("ClouderaManagerRepo is compared for Raz Ranger support in Datalake");
+        return isVersionNewerOrEqualThanLimited(clouderaManagerRepoDetails::getVersion,
+                CloudPlatform.AWS == cloudPlatform ? CLOUDERAMANAGER_VERSION_7_2_2 : CLOUDERAMANAGER_VERSION_7_2_1);
     }
 
-    public static boolean isRazConfigurationSupported(String version) {
-        LOGGER.info("ClouderaManagerRepo is compared for Raz Ranger support");
-        return isVersionNewerOrEqualThanLimited(version, CLOUDERAMANAGER_VERSION_7_2_1);
+    public static boolean isRazConfigurationSupportedInDatahub(ClouderaManagerRepo clouderaManagerRepoDetails) {
+        LOGGER.info("ClouderaManagerRepo is compared for Raz Ranger support in Datahub");
+        return isVersionNewerOrEqualThanLimited(clouderaManagerRepoDetails::getVersion, CLOUDERAMANAGER_VERSION_7_2_2);
     }
 
     public static boolean isVersionNewerOrEqualThanLimited(Versioned currentVersion, Versioned limitedAPIVersion) {

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerCloudStorageServiceConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerCloudStorageServiceConfigProvider.java
@@ -39,11 +39,10 @@ public class RangerCloudStorageServiceConfigProvider implements CmTemplateCompon
 
     @Override
     public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject templatePreparationObject) {
-
         String cmVersion = templatePreparationObject.getProductDetailsView().getCm().getVersion();
+        CloudPlatform cloudPlatform = templatePreparationObject.getCloudPlatform();
         if (CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited(cmVersion, CLOUDERAMANAGER_VERSION_7_2_2)
-                && templatePreparationObject.getCloudPlatform().equals(CloudPlatform.AZURE)) {
-
+                && (cloudPlatform.equals(CloudPlatform.AWS) || cloudPlatform.equals(CloudPlatform.AZURE))) {
             List<String> cloudPaths = new ArrayList<>();
             ConfigUtils.getStorageLocationForServiceProperty(templatePreparationObject, HIVE_METASTORE_DIR)
                     .ifPresent(location -> cloudPaths.add(HIVE_METASTORE_WAREHOUSE.name() + "=" + location.getValue()));
@@ -102,4 +101,5 @@ public class RangerCloudStorageServiceConfigProvider implements CmTemplateCompon
 
         return "";
     }
+
 }

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/RangerRazDatahubConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/RangerRazDatahubConfigProvider.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.cmtemplate.configproviders.raz;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
@@ -16,8 +17,10 @@ public class RangerRazDatahubConfigProvider extends RangerRazBaseConfigProvider 
     @Override
     public boolean isConfigurationNeeded(CmTemplateProcessor cmTemplateProcessor, TemplatePreparationObject source) {
         return StackType.WORKLOAD == source.getStackType()
-                && CloudPlatform.AZURE == source.getCloudPlatform()
+                && (CloudPlatform.AWS == source.getCloudPlatform() || CloudPlatform.AZURE == source.getCloudPlatform())
+                && CMRepositoryVersionUtil.isRazConfigurationSupportedInDatahub(source.getProductDetailsView().getCm())
                 && source.getDatalakeView().isPresent()
                 && source.getDatalakeView().get().isRazEnabled();
     }
+
 }

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/RangerRazDatalakeConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/RangerRazDatalakeConfigProvider.java
@@ -17,8 +17,9 @@ public class RangerRazDatalakeConfigProvider extends RangerRazBaseConfigProvider
     @Override
     public boolean isConfigurationNeeded(CmTemplateProcessor cmTemplateProcessor, TemplatePreparationObject source) {
         return StackType.DATALAKE == source.getStackType()
-                && CloudPlatform.AZURE == source.getCloudPlatform()
-                && CMRepositoryVersionUtil.isRazConfigurationSupported(source.getProductDetailsView().getCm())
+                && (CloudPlatform.AWS == source.getCloudPlatform() || CloudPlatform.AZURE == source.getCloudPlatform())
+                && CMRepositoryVersionUtil.isRazConfigurationSupportedInDatalake(source.getProductDetailsView().getCm(), source.getCloudPlatform())
                 && source.getGeneralClusterConfigs().isEnableRangerRaz();
     }
+
 }

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerCloudStorageServiceConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerCloudStorageServiceConfigProviderTest.java
@@ -1,7 +1,7 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.ranger;
 
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -10,9 +10,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
@@ -32,15 +32,36 @@ import com.sequenceiq.common.api.filesystem.AdlsGen2FileSystem;
 import com.sequenceiq.common.api.filesystem.S3FileSystem;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class RangerCloudStorageServiceConfigProviderTest {
 
     private final RangerCloudStorageServiceConfigProvider underTest = new RangerCloudStorageServiceConfigProvider();
 
     @Test
-    public void testGetRangerAWSCloudStorageServiceConfigs() {
+    public void testGetRangerAwsCloudStorageServiceConfigs() {
         CmTemplateProcessor templateProcessor = mock(CmTemplateProcessor.class);
-        TemplatePreparationObject preparationObject = getTemplatePreparationObjectForAWS(true)
+        TemplatePreparationObject preparationObject = getTemplatePreparationObjectForAws(true, true)
+                .withBlueprintView(mock(BlueprintView.class))
+                .withCloudPlatform(CloudPlatform.AWS)
+                .withProductDetails(new ClouderaManagerRepo().withVersion("7.2.2"), List.of())
+                .build();
+
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(templateProcessor, preparationObject);
+
+        assertEquals(2, serviceConfigs.size());
+        assertEquals("ranger_plugin_hdfs_audit_url", serviceConfigs.get(0).getName());
+        assertEquals("s3a://bucket/ranger/audit", serviceConfigs.get(0).getValue());
+        assertEquals("cloud_storage_paths", serviceConfigs.get(1).getName());
+        assertEquals("HIVE_METASTORE_WAREHOUSE=s3a://bucket/warehouse/tablespace/managed/hive," +
+                "HIVE_REPLICA_WAREHOUSE=s3a://bucket/hive_replica_functions_dir," +
+                "HIVE_METASTORE_EXTERNAL_WAREHOUSE=s3a://bucket/warehouse/tablespace/external/hive," +
+                "RANGER_AUDIT=s3a://bucket/ranger/audit", serviceConfigs.get(1).getValue());
+    }
+
+    @Test
+    public void testGetRangerAws720CloudStorageServiceConfigs() {
+        CmTemplateProcessor templateProcessor = mock(CmTemplateProcessor.class);
+        TemplatePreparationObject preparationObject = getTemplatePreparationObjectForAws(true, false)
                 .withBlueprintView(mock(BlueprintView.class))
                 .withCloudPlatform(CloudPlatform.AWS)
                 .withProductDetails(new ClouderaManagerRepo().withVersion("7.2.1"), List.of())
@@ -50,7 +71,7 @@ public class RangerCloudStorageServiceConfigProviderTest {
 
         assertEquals(1, serviceConfigs.size());
         assertEquals("ranger_plugin_hdfs_audit_url", serviceConfigs.get(0).getName());
-        assertEquals("s3a://bucket/ranger/auditlogs", serviceConfigs.get(0).getValue());
+        assertEquals("s3a://bucket/ranger/audit", serviceConfigs.get(0).getValue());
     }
 
     @Test
@@ -66,12 +87,12 @@ public class RangerCloudStorageServiceConfigProviderTest {
 
         assertEquals(2, serviceConfigs.size());
         assertEquals("ranger_plugin_hdfs_audit_url", serviceConfigs.get(0).getName());
-        assertEquals("abfs://data@your-san.dfs.core.windows.net/ranger/audit/", serviceConfigs.get(0).getValue());
+        assertEquals("abfs://data@your-san.dfs.core.windows.net/ranger/audit", serviceConfigs.get(0).getValue());
         assertEquals("cloud_storage_paths", serviceConfigs.get(1).getName());
         assertEquals("HIVE_METASTORE_WAREHOUSE=abfs://data@your-san.dfs.core.windows.net/warehouse/tablespace/managed/hive," +
                 "HIVE_REPLICA_WAREHOUSE=abfs://data@your-san.dfs.core.windows.net/hive_replica_functions_dir," +
                 "HIVE_METASTORE_EXTERNAL_WAREHOUSE=abfs://data@your-san.dfs.core.windows.net/warehouse/tablespace/external/hive," +
-                "RANGER_AUDIT=abfs://data@your-san.dfs.core.windows.net/ranger/audit/", serviceConfigs.get(1).getValue());
+                "RANGER_AUDIT=abfs://data@your-san.dfs.core.windows.net/ranger/audit", serviceConfigs.get(1).getValue());
     }
 
     @Test
@@ -79,6 +100,7 @@ public class RangerCloudStorageServiceConfigProviderTest {
         CmTemplateProcessor templateProcessor = mock(CmTemplateProcessor.class);
         TemplatePreparationObject preparationObject = getTemplatePreparationObjectForAzure(false)
                 .withBlueprintView(mock(BlueprintView.class))
+                .withCloudPlatform(CloudPlatform.AZURE)
                 .withProductDetails(new ClouderaManagerRepo().withVersion("7.2.0"), List.of())
                 .build();
 
@@ -86,7 +108,7 @@ public class RangerCloudStorageServiceConfigProviderTest {
 
         assertEquals(1, serviceConfigs.size());
         assertEquals("ranger_plugin_hdfs_audit_url", serviceConfigs.get(0).getName());
-        assertEquals("abfs://data@your-san.dfs.core.windows.net/ranger/audit/", serviceConfigs.get(0).getValue());
+        assertEquals("abfs://data@your-san.dfs.core.windows.net/ranger/audit", serviceConfigs.get(0).getValue());
     }
 
     @Test
@@ -97,7 +119,7 @@ public class RangerCloudStorageServiceConfigProviderTest {
         when(templateProcessor.getHostGroupsWithComponent(HdfsRoles.NAMENODE)).thenReturn(Set.of("master"));
         when(templateProcessor.getRoleConfig(HdfsRoles.HDFS, HdfsRoles.NAMENODE, "dfs_federation_namenode_nameservice"))
                 .thenReturn(Optional.of(config("dfs_federation_namenode_nameservice", "ns")));
-        TemplatePreparationObject preparationObject = getTemplatePreparationObjectForAWS(false)
+        TemplatePreparationObject preparationObject = getTemplatePreparationObjectForAws(false, false)
                 .withBlueprintView(blueprintView)
                 .withProductDetails(new ClouderaManagerRepo().withVersion("7.2.0"), List.of())
                 .build();
@@ -115,7 +137,7 @@ public class RangerCloudStorageServiceConfigProviderTest {
         BlueprintView blueprintView = mock(BlueprintView.class);
         when(blueprintView.getProcessor()).thenReturn(templateProcessor);
         when(templateProcessor.getHostGroupsWithComponent(HdfsRoles.NAMENODE)).thenReturn(Set.of("gateway"));
-        TemplatePreparationObject preparationObject = getTemplatePreparationObjectForAWS(false)
+        TemplatePreparationObject preparationObject = getTemplatePreparationObjectForAws(false, false)
                 .withBlueprintView(blueprintView)
                 .withProductDetails(new ClouderaManagerRepo().withVersion("7.2.0"), List.of())
                 .build();
@@ -142,8 +164,6 @@ public class RangerCloudStorageServiceConfigProviderTest {
                     "abfs://data@your-san.dfs.core.windows.net/hive_replica_functions_dir")));
             locations.add(new StorageLocationView(buildStorageLocation("hive.metastore.warehouse.external.dir",
                     "abfs://data@your-san.dfs.core.windows.net/warehouse/tablespace/external/hive")));
-            locations.add(new StorageLocationView(buildStorageLocation("ranger_plugin_hdfs_audit_url",
-                    "abfs://data@your-san.dfs.core.windows.net/ranger/audit")));
         }
         AdlsGen2FileSystemConfigurationsView fileSystemConfigurationsView =
                 new AdlsGen2FileSystemConfigurationsView(new AdlsGen2FileSystem(), locations, false);
@@ -157,7 +177,7 @@ public class RangerCloudStorageServiceConfigProviderTest {
                 .withGeneralClusterConfigs(generalClusterConfigs);
     }
 
-    private TemplatePreparationObject.Builder getTemplatePreparationObjectForAWS(boolean includeLocations) {
+    private TemplatePreparationObject.Builder getTemplatePreparationObjectForAws(boolean includeLocations, boolean above721) {
         HostgroupView gateway = new HostgroupView("gateway", 1, InstanceGroupType.GATEWAY, Set.of("g"));
         HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.CORE, Set.of("m1", "m2"));
         HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, Set.of("w1", "w2", "w3"));
@@ -165,7 +185,15 @@ public class RangerCloudStorageServiceConfigProviderTest {
         List<StorageLocationView> locations = new ArrayList<>();
 
         if (includeLocations) {
-            locations.add(new StorageLocationView(getRangerAuditCloudStorageDir()));
+            locations.add(new StorageLocationView(getRangerAuditCloudStorageDirAws()));
+            if (above721) {
+                locations.add(new StorageLocationView(buildStorageLocation("hive.metastore.warehouse.dir",
+                        "s3a://bucket/warehouse/tablespace/managed/hive")));
+                locations.add(new StorageLocationView(buildStorageLocation("hive.repl.replica.functions.root.dir",
+                        "s3a://bucket/hive_replica_functions_dir")));
+                locations.add(new StorageLocationView(buildStorageLocation("hive.metastore.warehouse.external.dir",
+                        "s3a://bucket/warehouse/tablespace/external/hive")));
+            }
         }
         S3FileSystemConfigurationsView fileSystemConfigurationsView =
                 new S3FileSystemConfigurationsView(new S3FileSystem(), locations, false);
@@ -179,17 +207,17 @@ public class RangerCloudStorageServiceConfigProviderTest {
                 .withGeneralClusterConfigs(generalClusterConfigs);
     }
 
-    protected StorageLocation getRangerAuditCloudStorageDir() {
+    protected StorageLocation getRangerAuditCloudStorageDirAws() {
         StorageLocation rangerAuditLogLocation = new StorageLocation();
         rangerAuditLogLocation.setProperty("ranger_plugin_hdfs_audit_url");
-        rangerAuditLogLocation.setValue("s3a://bucket/ranger/auditlogs");
+        rangerAuditLogLocation.setValue("s3a://bucket/ranger/audit");
         return rangerAuditLogLocation;
     }
 
     protected StorageLocation getRangerAuditCloudStorageDirAzure() {
         StorageLocation rangerAuditLogLocation = new StorageLocation();
         rangerAuditLogLocation.setProperty("ranger_plugin_hdfs_audit_url");
-        rangerAuditLogLocation.setValue("abfs://data@your-san.dfs.core.windows.net/ranger/audit/");
+        rangerAuditLogLocation.setValue("abfs://data@your-san.dfs.core.windows.net/ranger/audit");
         return rangerAuditLogLocation;
     }
 
@@ -199,4 +227,5 @@ public class RangerCloudStorageServiceConfigProviderTest {
         rangerAuditLogLocation.setValue(value);
         return rangerAuditLogLocation;
     }
+
 }

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/RangerRazDatalakeConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/RangerRazDatalakeConfigProviderTest.java
@@ -9,6 +9,8 @@ import java.util.Set;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateRoleConfigGroup;
@@ -20,6 +22,7 @@ import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject.Builder;
 import com.sequenceiq.cloudbreak.template.model.GeneralClusterConfigs;
+import com.sequenceiq.cloudbreak.template.views.DatalakeView;
 import com.sequenceiq.cloudbreak.template.views.HostgroupView;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 
@@ -30,9 +33,18 @@ public class RangerRazDatalakeConfigProviderTest {
     @Mock
     private CmTemplateProcessor cmTemplateProcessor;
 
-    @Test
+    static Object[][] razCloudPlatformDataProvider() {
+        return new Object[][]{
+                // testCaseName cloudPlatform
+                {"CloudPlatform.AWS", CloudPlatform.AWS},
+                {"CloudPlatform.AZURE", CloudPlatform.AZURE}
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("razCloudPlatformDataProvider")
     @DisplayName("CM 7.2.0 DL is used but Raz is not requested, no additional service needs to be added to the template")
-    void getAdditionalServicesWhenRazIsNotEnabled() {
+    void getAdditionalServicesWhenRazIsNotEnabled(String testCaseName, CloudPlatform cloudPlatform) {
         ClouderaManagerRepo cmRepo = new ClouderaManagerRepo();
         cmRepo.setVersion("7.2.0");
         GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
@@ -41,7 +53,7 @@ public class RangerRazDatalakeConfigProviderTest {
         HostgroupView idbroker = new HostgroupView("idbroker", 0, InstanceGroupType.CORE, List.of());
         TemplatePreparationObject preparationObject = Builder.builder()
                 .withStackType(StackType.DATALAKE)
-                .withCloudPlatform(CloudPlatform.AZURE)
+                .withCloudPlatform(cloudPlatform)
                 .withProductDetails(cmRepo, List.of())
                 .withGeneralClusterConfigs(generalClusterConfigs)
                 .withHostgroupViews(Set.of(master, idbroker))
@@ -51,9 +63,10 @@ public class RangerRazDatalakeConfigProviderTest {
         assertEquals(0, additionalServices.size());
     }
 
-    @Test
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("razCloudPlatformDataProvider")
     @DisplayName("CM 7.1.0 DL is used and Raz is requested, no additional service needs to be added to the template")
-    void getAdditionalServicesWhenRazIsEnabledWithCm710() {
+    void getAdditionalServicesWhenRazIsEnabledWithCm710(String testCaseName, CloudPlatform cloudPlatform) {
         ClouderaManagerRepo cmRepo = new ClouderaManagerRepo();
         cmRepo.setVersion("7.1.0");
         GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
@@ -62,7 +75,7 @@ public class RangerRazDatalakeConfigProviderTest {
         HostgroupView idbroker = new HostgroupView("idbroker", 0, InstanceGroupType.CORE, List.of());
         TemplatePreparationObject preparationObject = Builder.builder()
                 .withStackType(StackType.DATALAKE)
-                .withCloudPlatform(CloudPlatform.AZURE)
+                .withCloudPlatform(cloudPlatform)
                 .withProductDetails(cmRepo, List.of())
                 .withGeneralClusterConfigs(generalClusterConfigs)
                 .withHostgroupViews(Set.of(master, idbroker))
@@ -72,9 +85,10 @@ public class RangerRazDatalakeConfigProviderTest {
         assertEquals(0, additionalServices.size());
     }
 
-    @Test
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("razCloudPlatformDataProvider")
     @DisplayName("CM 7.2.0 DL is used and Raz is requested, no additional service needs to be added to the template")
-    void getAdditionalServicesWhenRazIsEnabledWithCm720() {
+    void getAdditionalServicesWhenRazIsEnabledWithCm720(String testCaseName, CloudPlatform cloudPlatform) {
         ClouderaManagerRepo cmRepo = new ClouderaManagerRepo();
         cmRepo.setVersion("7.2.0");
         GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
@@ -83,7 +97,7 @@ public class RangerRazDatalakeConfigProviderTest {
         HostgroupView idbroker = new HostgroupView("idbroker", 0, InstanceGroupType.CORE, List.of());
         TemplatePreparationObject preparationObject = Builder.builder()
                 .withStackType(StackType.DATALAKE)
-                .withCloudPlatform(CloudPlatform.AZURE)
+                .withCloudPlatform(cloudPlatform)
                 .withProductDetails(cmRepo, List.of())
                 .withGeneralClusterConfigs(generalClusterConfigs)
                 .withHostgroupViews(Set.of(master, idbroker))
@@ -94,8 +108,8 @@ public class RangerRazDatalakeConfigProviderTest {
     }
 
     @Test
-    @DisplayName("CM 7.2.1 DL is used and Raz is requested, Raz service needs to be added to the template")
-    void getAdditionalServicesWhenRazIsEnabledWithCm721() {
+    @DisplayName("CM 7.2.1 DL is used and Raz is requested, AWS, no additional service needs to be added to the template")
+    void getAdditionalServicesWhenRazIsEnabledWithCm721AndAws() {
         ClouderaManagerRepo cmRepo = new ClouderaManagerRepo();
         cmRepo.setVersion("7.2.1");
         GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
@@ -104,7 +118,37 @@ public class RangerRazDatalakeConfigProviderTest {
         HostgroupView idbroker = new HostgroupView("idbroker", 0, InstanceGroupType.CORE, List.of());
         TemplatePreparationObject preparationObject = Builder.builder()
                 .withStackType(StackType.DATALAKE)
-                .withCloudPlatform(CloudPlatform.AZURE)
+                .withCloudPlatform(CloudPlatform.AWS)
+                .withProductDetails(cmRepo, List.of())
+                .withGeneralClusterConfigs(generalClusterConfigs)
+                .withHostgroupViews(Set.of(master, idbroker))
+                .build();
+        Map<String, ApiClusterTemplateService> additionalServices = configProvider.getAdditionalServices(cmTemplateProcessor, preparationObject);
+
+        assertEquals(0, additionalServices.size());
+    }
+
+    static Object[][] razCloudPlatformAndCmVersionDataProvider() {
+        return new Object[][]{
+                // testCaseName cloudPlatform runtime
+                {"CloudPlatform.AWS", CloudPlatform.AWS, "7.2.2"},
+                {"CloudPlatform.AZURE", CloudPlatform.AZURE, "7.2.1"}
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("razCloudPlatformAndCmVersionDataProvider")
+    @DisplayName("DL is used with the right CM and Raz is requested, Raz service needs to be added to the template")
+    void getAdditionalServicesWhenRazIsEnabledWithRightCm(String testCaseName, CloudPlatform cloudPlatform, String cmVersion) {
+        ClouderaManagerRepo cmRepo = new ClouderaManagerRepo();
+        cmRepo.setVersion(cmVersion);
+        GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
+        generalClusterConfigs.setEnableRangerRaz(true);
+        HostgroupView master = new HostgroupView("master", 0, InstanceGroupType.GATEWAY, List.of());
+        HostgroupView idbroker = new HostgroupView("idbroker", 0, InstanceGroupType.CORE, List.of());
+        TemplatePreparationObject preparationObject = Builder.builder()
+                .withStackType(StackType.DATALAKE)
+                .withCloudPlatform(cloudPlatform)
                 .withProductDetails(cmRepo, List.of())
                 .withGeneralClusterConfigs(generalClusterConfigs)
                 .withHostgroupViews(Set.of(master, idbroker))
@@ -122,21 +166,22 @@ public class RangerRazDatalakeConfigProviderTest {
         );
     }
 
-    @Test
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("razCloudPlatformDataProvider")
     @DisplayName("CM 7.2.0 DL is used and Raz is requested, but Data Hub, no additional service needs to be added to the template")
-    void getAdditionalServicesWhenRazIsEnabledAndDataHub() {
+    void getAdditionalServicesWhenRazIsEnabledAndDataHub(String testCaseName, CloudPlatform cloudPlatform) {
         ClouderaManagerRepo cmRepo = new ClouderaManagerRepo();
         cmRepo.setVersion("7.2.0");
         GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
-        generalClusterConfigs.setEnableRangerRaz(true);
         HostgroupView master = new HostgroupView("master", 0, InstanceGroupType.GATEWAY, List.of());
-        HostgroupView idbroker = new HostgroupView("idbroker", 0, InstanceGroupType.CORE, List.of());
+        HostgroupView worker = new HostgroupView("worker", 0, InstanceGroupType.CORE, List.of());
         TemplatePreparationObject preparationObject = Builder.builder()
                 .withStackType(StackType.WORKLOAD)
-                .withCloudPlatform(CloudPlatform.AZURE)
+                .withCloudPlatform(cloudPlatform)
                 .withProductDetails(cmRepo, List.of())
+                .withDataLakeView(new DatalakeView(true))
                 .withGeneralClusterConfigs(generalClusterConfigs)
-                .withHostgroupViews(Set.of(master, idbroker))
+                .withHostgroupViews(Set.of(master, worker))
                 .build();
         Map<String, ApiClusterTemplateService> additionalServices = configProvider.getAdditionalServices(cmTemplateProcessor, preparationObject);
 
@@ -144,8 +189,8 @@ public class RangerRazDatalakeConfigProviderTest {
     }
 
     @Test
-    @DisplayName("CM 7.2.0 DL is used and Raz is requested, but AWS, no additional service needs to be added to the template")
-    void getAdditionalServicesWhenRazIsEnabledAndAWS() {
+    @DisplayName("CM 7.2.0 DL is used and Raz is requested, but YARN, no additional service needs to be added to the template")
+    void getAdditionalServicesWhenRazIsEnabledAndNotAwsOrAzure() {
         ClouderaManagerRepo cmRepo = new ClouderaManagerRepo();
         cmRepo.setVersion("7.2.0");
         GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
@@ -154,7 +199,7 @@ public class RangerRazDatalakeConfigProviderTest {
         HostgroupView idbroker = new HostgroupView("idbroker", 0, InstanceGroupType.CORE, List.of());
         TemplatePreparationObject preparationObject = Builder.builder()
                 .withStackType(StackType.DATALAKE)
-                .withCloudPlatform(CloudPlatform.AWS)
+                .withCloudPlatform(CloudPlatform.YARN)
                 .withProductDetails(cmRepo, List.of())
                 .withGeneralClusterConfigs(generalClusterConfigs)
                 .withHostgroupViews(Set.of(master, idbroker))


### PR DESCRIPTION
* Refactor AccountMappingSubject: extract user rangerraz as the new
  constant RANGER_RAZ_USER, rename DATA_ACCESS_AND_RANGER_AUDIT_USERS
  to ALL_SPECIAL_USERS.
* Add S3 to ModelDescriptions.ClusterModelDescription.ENABLE_RANGER_RAZ.
* Extend cloud provider restriction with AWS in
  RangerCloudStorageServiceConfigProvider,
  RangerRazDatahubConfigProvider, RangerRazDatalakeConfigProvider and
  SdxService.validateRazEnablement.
* Change CM version check in RangerRazDatalakeConfigProvider to use
  7.2.2 for AWS and 7.2.1 for Azure.
* Add CM 7.2.2 version check to RangerRazDatahubConfigProvider (to make
  it in sync with RangerRazDatalakeConfigProvider).
* Update all related unit tests and add some new cases.

See detailed description in the commit message.