### PR TITLE
CB-8372 Make the upgrade CM API calls idempotent

### DIFF
--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationServiceTest.java
@@ -333,6 +333,7 @@ class ClouderaManagerModificationServiceTest {
         when(clouderaManagerPollingServiceProvider.startPollingCmParcelActivation(stack, apiClientMock, apiCommandId)).thenReturn(successPollingResult);
 
         // Restart services
+        when(clustersResourceApi.listActiveCommands(stack.getName(), "SUMMARY")).thenReturn(new ApiCommandList().items(List.of()));
         when(clustersResourceApi.restartCommand(eq(stack.getName()), any(ApiRestartClusterArgs.class))).thenReturn(new ApiCommand().id(apiCommandId));
         when(clouderaManagerPollingServiceProvider.startPollingCmServicesRestart(stack, apiClientMock, apiCommandId)).thenReturn(successPollingResult);
 


### PR DESCRIPTION
ClouderaManagerModificationService changes
- callUpgradeCdhCommand()
  - if upgrade command is running, cb won't call a new command, but polling the current one
  - if upgrade command throws exception, that the cluster is already upgraded, skip this step and continue with the following steps
- in case of patch upgrade: restartServices()
  - if there is an already running Restart Services command, polling the result of that command, otherwise start a new Restart Services command and waiting its result
