### PR TITLE
CB-7040 Remove upgrade salt state presence check on GW instance

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeAvailabilityService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeAvailabilityService.java
@@ -36,10 +36,6 @@ import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterComponent;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.exception.NotFoundException;
-import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
-import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
-import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
-import com.sequenceiq.cloudbreak.service.GatewayConfigService;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterRepairService;
 import com.sequenceiq.cloudbreak.service.cluster.model.HostGroupName;
@@ -77,12 +73,6 @@ public class ClusterUpgradeAvailabilityService {
     private ClusterRepairService clusterRepairService;
 
     @Inject
-    private HostOrchestrator hostOrchestrator;
-
-    @Inject
-    private GatewayConfigService gatewayConfigService;
-
-    @Inject
     private ClusterApiConnectors clusterApiConnectors;
 
     @Inject
@@ -114,19 +104,6 @@ public class ClusterUpgradeAvailabilityService {
         if (!notStoppedAttachedClusters.isEmpty()) {
             upgradeOptions.setReason(String.format("There are attached Data Hub clusters in incorrect state: %s. "
                     + "Please stop those to be able to perform the upgrade.", notStoppedAttachedClusters));
-        }
-        return upgradeOptions;
-    }
-
-    public UpgradeV4Response checkIfClusterRuntimeUpgradable(Long workspaceId, String stackName, UpgradeV4Response upgradeOptions) {
-
-        Stack stack = stackService.getByNameInWorkspaceWithLists(stackName, workspaceId).orElseThrow();
-        GatewayConfig primaryGatewayConfig = gatewayConfigService.getPrimaryGatewayConfigWithoutLists(stack);
-
-        try {
-            hostOrchestrator.checkIfClusterUpgradable(primaryGatewayConfig);
-        } catch (CloudbreakOrchestratorFailedException e) {
-            upgradeOptions.appendReason(e.getMessage());
         }
         return upgradeOptions;
     }

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
@@ -238,9 +238,6 @@ public class StackOperations implements ResourceBasedCrnProvider {
             MDCBuilder.buildMdcContext(stack);
             StackViewV4Responses stackViewV4Responses = listByEnvironmentCrn(workspaceId, stack.getEnvironmentCrn(), List.of(StackType.WORKLOAD));
             clusterUpgradeAvailabilityService.checkForNotAttachedClusters(stackViewV4Responses, upgradeResponse);
-            if (!osUpgrade && !request.isDryRun() && !request.isShowAvailableImagesSet()) {
-                clusterUpgradeAvailabilityService.checkIfClusterRuntimeUpgradable(workspaceId, stackName, upgradeResponse);
-            }
             return upgradeResponse;
         } else {
             LOGGER.debug("No stack name provided for upgrade, found: " + nameOrCrn);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeAvailabilityServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeAvailabilityServiceTest.java
@@ -1,13 +1,9 @@
 package com.sequenceiq.cloudbreak.service.upgrade;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -16,7 +12,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -49,10 +44,6 @@ import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.StackStatus;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.exception.BadRequestException;
-import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
-import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
-import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
-import com.sequenceiq.cloudbreak.service.GatewayConfigService;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterRepairService;
 import com.sequenceiq.cloudbreak.service.cluster.model.HostGroupName;
@@ -111,15 +102,6 @@ public class ClusterUpgradeAvailabilityServiceTest {
 
     @Mock
     private ClusterRepairService clusterRepairService;
-
-    @Mock
-    private HostOrchestrator hostOrchestrator;
-
-    @Mock
-    private GatewayConfigService gatewayConfigService;
-
-    @Mock
-    private GatewayConfig gatewayConfig;
 
     @Mock
     private ClusterApiConnectors clusterApiConnectors;
@@ -320,32 +302,6 @@ public class ClusterUpgradeAvailabilityServiceTest {
         UpgradeV4Response actual = underTest.checkForNotAttachedClusters(stackViewV4Responses, response);
 
         assertNull(actual.getReason());
-    }
-
-    @Test
-    public void testSaltStatesArePresent() {
-        UpgradeV4Response response = new UpgradeV4Response();
-        when(stackService.getByNameInWorkspaceWithLists(anyString(), anyLong())).thenReturn(Optional.of(createStack(createStackStatus(Status.AVAILABLE))));
-
-        UpgradeV4Response actual = underTest.checkIfClusterRuntimeUpgradable(WORKSPACE_ID, STACK_NAME, response);
-
-        assertNull(actual.getReason());
-    }
-
-    @Test
-    public void testSaltStatesAreMissing() throws CloudbreakOrchestratorFailedException {
-        UpgradeV4Response response = new UpgradeV4Response();
-        when(stackService.getByNameInWorkspaceWithLists(anyString(), anyLong())).thenReturn(Optional.of(createStack(createStackStatus(Status.AVAILABLE))));
-        doThrow(new CloudbreakOrchestratorFailedException("Cluster is not upgradeable due to required Salt files not being present. "
-                        + "Please ensure that your cluster is up to date!"))
-                .when(hostOrchestrator).
-                checkIfClusterUpgradable(any());
-
-        UpgradeV4Response actual = underTest.checkIfClusterRuntimeUpgradable(WORKSPACE_ID, STACK_NAME, response);
-
-        assertNotNull(actual.getReason());
-        assertEquals("Cluster is not upgradeable due to required Salt files not being present. "
-                + "Please ensure that your cluster is up to date!", actual.getReason());
     }
 
     @Test

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
@@ -23,9 +23,6 @@ public interface HostOrchestrator extends HostRecipeExecutor {
     void bootstrap(List<GatewayConfig> allGatewayConfigs, Set<Node> targets, BootstrapParams params,
             ExitCriteriaModel exitCriteriaModel) throws CloudbreakOrchestratorException;
 
-    void checkIfClusterUpgradable(GatewayConfig primaryGatewayConfig)
-            throws CloudbreakOrchestratorFailedException;
-
     void bootstrapNewNodes(List<GatewayConfig> allGatewayConfigs, Set<Node> nodes, Set<Node> allNodes, byte[] stateConfigZip,
             BootstrapParams params, ExitCriteriaModel exitCriteriaModel) throws CloudbreakOrchestratorException;
 

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
@@ -56,7 +56,6 @@ import com.sequenceiq.cloudbreak.orchestrator.salt.client.target.Glob;
 import com.sequenceiq.cloudbreak.orchestrator.salt.client.target.HostList;
 import com.sequenceiq.cloudbreak.orchestrator.salt.client.target.RoleTarget;
 import com.sequenceiq.cloudbreak.orchestrator.salt.client.target.Target;
-import com.sequenceiq.cloudbreak.orchestrator.salt.domain.ApplyFullResponse;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.MinionIpAddressesResponse;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.MinionStatusSaltResponse;
 import com.sequenceiq.cloudbreak.orchestrator.salt.grain.GrainUploader;
@@ -223,19 +222,6 @@ SaltOrchestrator implements HostOrchestrator {
         } catch (Exception e) {
             LOGGER.info("Error occurred during the salt bootstrap", e);
             throw new CloudbreakOrchestratorFailedException(e);
-        }
-    }
-
-    @Override
-    public void checkIfClusterUpgradable(GatewayConfig primaryGatewayConfig)
-            throws CloudbreakOrchestratorFailedException {
-        SaltConnector sc = saltService.createSaltConnector(primaryGatewayConfig);
-        ApplyFullResponse applyFullResponse = SaltStates.showState(sc, "cloudera.agent.upgrade");
-        LOGGER.debug("Checking salt state response is: {}.", applyFullResponse.toString());
-        if (applyFullResponse.isError()) {
-            LOGGER.info("Checking the upgrade state failed {}", applyFullResponse.getResult());
-            throw new CloudbreakOrchestratorFailedException("Cluster is not upgradeable due to required Salt files not being present. "
-                    + "Please ensure that your cluster is up to date!");
         }
     }
 


### PR DESCRIPTION
As salt state upgrade made into codebase we don't have to check if
the correct states are present on the cluster as the upgrade starts
with pushing recent states to the cluster.