### PR TITLE
CB-8555 Introduce Await For Flow exceptions to TestContext

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaRefreshAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaRefreshAction.java
@@ -1,0 +1,24 @@
+package com.sequenceiq.it.cloudbreak.action.freeipa;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.FreeIpaClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+
+public class FreeIpaRefreshAction implements Action<FreeIpaTestDto, FreeIpaClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FreeIpaRefreshAction.class);
+
+    @Override
+    public FreeIpaTestDto action(TestContext testContext, FreeIpaTestDto testDto, FreeIpaClient client) throws Exception {
+        testDto.setResponse(
+                client.getFreeIpaClient().getFreeIpaV1Endpoint().describe(testDto.getRequest().getEnvironmentCrn())
+        );
+        Log.whenJson(LOGGER, " FreeIPA get response: ", testDto.getResponse());
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxDeleteAction.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.it.cloudbreak.action.sdx;
 
+import java.util.Collections;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -7,9 +9,9 @@ import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.it.cloudbreak.SdxClient;
 import com.sequenceiq.it.cloudbreak.action.Action;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
-import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
 import com.sequenceiq.it.cloudbreak.log.Log;
+import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
 
 public class SdxDeleteAction implements Action<SdxTestDto, SdxClient> {
 
@@ -18,12 +20,16 @@ public class SdxDeleteAction implements Action<SdxTestDto, SdxClient> {
     @Override
     public SdxTestDto action(TestContext testContext, SdxTestDto testDto, SdxClient client) throws Exception {
         Log.when(LOGGER, " SDX endpoint: %s" + client.getSdxClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
+        Log.whenJson(LOGGER, " SDX delete request: ", testDto.getRequest());
         FlowIdentifier flowIdentifier = client.getSdxClient()
                 .sdxEndpoint()
                 .delete(testDto.getName(), false);
         testDto.setFlow("SDX delete", flowIdentifier);
-        Log.whenJson(LOGGER, " SDX delete response: ",
-                client.getSdxClient().sdxEndpoint().list(testContext.get(EnvironmentTestDto.class).getName()));
+        SdxClusterDetailResponse detailedResponse = client.getSdxClient()
+                .sdxEndpoint()
+                .getDetail(testDto.getName(), Collections.emptySet());
+        testDto.setResponse(detailedResponse);
+        Log.whenJson(LOGGER, " SDX delete response: ", detailedResponse);
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxDeleteInternalAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxDeleteInternalAction.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.it.cloudbreak.action.sdx;
 
+import java.util.Collections;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -7,9 +9,9 @@ import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.it.cloudbreak.SdxClient;
 import com.sequenceiq.it.cloudbreak.action.Action;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
-import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.log.Log;
+import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
 
 public class SdxDeleteInternalAction implements Action<SdxInternalTestDto, SdxClient> {
 
@@ -18,12 +20,16 @@ public class SdxDeleteInternalAction implements Action<SdxInternalTestDto, SdxCl
     @Override
     public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
         Log.when(LOGGER, " SDX endpoint: %s" + client.getSdxClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
+        Log.whenJson(LOGGER, " SDX Internal delete request: ", testDto.getRequest());
         FlowIdentifier flowIdentifier = client.getSdxClient()
                 .sdxEndpoint()
                 .delete(testDto.getName(), false);
         testDto.setFlow("SDX delete", flowIdentifier);
-        Log.whenJson(LOGGER, " Delete internal response: ",
-                client.getSdxClient().sdxEndpoint().list(testContext.get(EnvironmentTestDto.class).getName()));
+        SdxClusterDetailResponse detailedResponse = client.getSdxClient()
+                .sdxEndpoint()
+                .getDetail(testDto.getName(), Collections.emptySet());
+        testDto.setResponse(detailedResponse);
+        Log.whenJson(LOGGER, " SDX Internal delete response: ", detailedResponse);
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxForceDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxForceDeleteAction.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.it.cloudbreak.action.sdx;
 
+import java.util.Collections;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -7,9 +9,9 @@ import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.it.cloudbreak.SdxClient;
 import com.sequenceiq.it.cloudbreak.action.Action;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
-import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
 import com.sequenceiq.it.cloudbreak.log.Log;
+import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
 
 public class SdxForceDeleteAction implements Action<SdxTestDto, SdxClient> {
 
@@ -18,12 +20,16 @@ public class SdxForceDeleteAction implements Action<SdxTestDto, SdxClient> {
     @Override
     public SdxTestDto action(TestContext testContext, SdxTestDto testDto, SdxClient client) throws Exception {
         Log.when(LOGGER, " SDX endpoint: %s" + client.getSdxClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
+        Log.whenJson(LOGGER, " SDX force delete request: ", testDto.getRequest());
         FlowIdentifier flowIdentifier = client.getSdxClient()
                 .sdxEndpoint()
                 .delete(testDto.getName(), true);
         testDto.setFlow("SDX force delete", flowIdentifier);
-        Log.whenJson(LOGGER, " SDX delete response: ",
-                client.getSdxClient().sdxEndpoint().list(testContext.get(EnvironmentTestDto.class).getName()));
+        SdxClusterDetailResponse detailedResponse = client.getSdxClient()
+                .sdxEndpoint()
+                .getDetail(testDto.getName(), Collections.emptySet());
+        testDto.setResponse(detailedResponse);
+        Log.whenJson(LOGGER, " SDX force delete response: ", detailedResponse);
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxForceDeleteInternalAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxForceDeleteInternalAction.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.it.cloudbreak.action.sdx;
 
+import java.util.Collections;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -7,9 +9,9 @@ import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.it.cloudbreak.SdxClient;
 import com.sequenceiq.it.cloudbreak.action.Action;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
-import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.log.Log;
+import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
 
 public class SdxForceDeleteInternalAction implements Action<SdxInternalTestDto, SdxClient> {
 
@@ -21,9 +23,12 @@ public class SdxForceDeleteInternalAction implements Action<SdxInternalTestDto, 
         FlowIdentifier flowIdentifier = client.getSdxClient()
                 .sdxEndpoint()
                 .delete(testDto.getName(), true);
-        testDto.setFlow("SDX force delete", flowIdentifier);
-        Log.whenJson(LOGGER, " Delete internal response: ",
-                client.getSdxClient().sdxEndpoint().list(testContext.get(EnvironmentTestDto.class).getName()));
+        testDto.setFlow("SDX Internal force delete", flowIdentifier);
+        SdxClusterDetailResponse detailedResponse = client.getSdxClient()
+                .sdxEndpoint()
+                .getDetail(testDto.getName(), Collections.emptySet());
+        testDto.setResponse(detailedResponse);
+        Log.whenJson(LOGGER, " SDX Internal force delete response: ", detailedResponse);
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRefreshInternalAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRefreshInternalAction.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.it.cloudbreak.action.sdx;
+
+import java.util.Collections;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.SdxClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+
+public class SdxRefreshInternalAction implements Action<SdxInternalTestDto, SdxClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxRefreshInternalAction.class);
+
+    @Override
+    public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
+        testDto.setResponse(
+                client.getSdxClient().sdxEndpoint().getDetail(testDto.getName(), Collections.emptySet())
+        );
+        Log.whenJson(LOGGER, " SDX Internal get detail response: ", testDto.getResponse());
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRepairAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRepairAction.java
@@ -2,6 +2,8 @@ package com.sequenceiq.it.cloudbreak.action.sdx;
 
 import static java.lang.String.format;
 
+import java.util.Collections;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,6 +13,7 @@ import com.sequenceiq.it.cloudbreak.action.Action;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
 import com.sequenceiq.it.cloudbreak.log.Log;
+import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
 
 public class SdxRepairAction implements Action<SdxTestDto, SdxClient> {
 
@@ -24,7 +27,11 @@ public class SdxRepairAction implements Action<SdxTestDto, SdxClient> {
                 .sdxEndpoint()
                 .repairCluster(testDto.getName(), testDto.getSdxRepairRequest());
         testDto.setFlow("SDX repair", flowIdentifier);
-        Log.when(LOGGER, " SDX repair have been initiated.");
+        SdxClusterDetailResponse detailedResponse = client.getSdxClient()
+                .sdxEndpoint()
+                .getDetail(testDto.getName(), Collections.emptySet());
+        testDto.setResponse(detailedResponse);
+        Log.whenJson(LOGGER, " SDX repair response: ", detailedResponse);
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRepairInternalAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRepairInternalAction.java
@@ -2,6 +2,8 @@ package com.sequenceiq.it.cloudbreak.action.sdx;
 
 import static java.lang.String.format;
 
+import java.util.Collections;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,6 +13,7 @@ import com.sequenceiq.it.cloudbreak.action.Action;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.log.Log;
+import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
 
 public class SdxRepairInternalAction implements Action<SdxInternalTestDto, SdxClient> {
 
@@ -18,13 +21,17 @@ public class SdxRepairInternalAction implements Action<SdxInternalTestDto, SdxCl
 
     @Override
     public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
-        Log.when(LOGGER, format(" Starting repair on SDX: %s ", testDto.getName()));
-        Log.whenJson(LOGGER, " SDX repair request: ", testDto.getSdxRepairRequest());
+        Log.when(LOGGER, format(" Starting repair on SDX Internal: %s ", testDto.getName()));
+        Log.whenJson(LOGGER, " SDX Internal repair request: ", testDto.getSdxRepairRequest());
         FlowIdentifier flowIdentifier = client.getSdxClient()
                 .sdxEndpoint()
                 .repairCluster(testDto.getName(), testDto.getSdxRepairRequest());
-        testDto.setFlow("SDX repair", flowIdentifier);
-        Log.when(LOGGER, " SDX repair have been initiated.");
+        testDto.setFlow("SDX Internal repair", flowIdentifier);
+        SdxClusterDetailResponse detailedResponse = client.getSdxClient()
+                .sdxEndpoint()
+                .getDetail(testDto.getName(), Collections.emptySet());
+        testDto.setResponse(detailedResponse);
+        Log.whenJson(LOGGER, " SDX Internal repair response: ", detailedResponse);
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxStartAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxStartAction.java
@@ -2,6 +2,8 @@ package com.sequenceiq.it.cloudbreak.action.sdx;
 
 import static java.lang.String.format;
 
+import java.util.Collections;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,6 +13,7 @@ import com.sequenceiq.it.cloudbreak.action.Action;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.log.Log;
+import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
 
 public class SdxStartAction implements Action<SdxInternalTestDto, SdxClient> {
 
@@ -18,10 +21,15 @@ public class SdxStartAction implements Action<SdxInternalTestDto, SdxClient> {
 
     @Override
     public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
-        Log.when(LOGGER, format(" Start SDX: %s ", testDto.getName()));
+        Log.when(LOGGER, format(" Starting SDX: %s ", testDto.getName()));
+        Log.whenJson(LOGGER, " SDX start request: ", testDto.getRequest());
         FlowIdentifier flowIdentifier = client.getSdxClient().sdxEndpoint().startByName(testDto.getName());
         testDto.setFlow("SDX start", flowIdentifier);
-        Log.when(LOGGER, " SDX Start have been initiated. ");
+        SdxClusterDetailResponse detailedResponse = client.getSdxClient()
+                .sdxEndpoint()
+                .getDetail(testDto.getName(), Collections.emptySet());
+        testDto.setResponse(detailedResponse);
+        Log.whenJson(LOGGER, " SDX start response: ", detailedResponse);
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxStopAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxStopAction.java
@@ -2,6 +2,8 @@ package com.sequenceiq.it.cloudbreak.action.sdx;
 
 import static java.lang.String.format;
 
+import java.util.Collections;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,6 +13,7 @@ import com.sequenceiq.it.cloudbreak.action.Action;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.log.Log;
+import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
 
 public class SdxStopAction implements Action<SdxInternalTestDto, SdxClient> {
 
@@ -19,9 +22,14 @@ public class SdxStopAction implements Action<SdxInternalTestDto, SdxClient> {
     @Override
     public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
         Log.when(LOGGER, format(" Stop SDX: %s ", testDto.getName()));
+        Log.whenJson(LOGGER, " SDX stop request: ", testDto.getRequest());
         FlowIdentifier flowIdentifier = client.getSdxClient().sdxEndpoint().stopByName(testDto.getName());
         testDto.setFlow("SDX stop", flowIdentifier);
-        Log.when(LOGGER, " SDX Stop have been initiated. ");
+        SdxClusterDetailResponse detailedResponse = client.getSdxClient()
+                .sdxEndpoint()
+                .getDetail(testDto.getName(), Collections.emptySet());
+        testDto.setResponse(detailedResponse);
+        Log.whenJson(LOGGER, " SDX stop response: ", detailedResponse);
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxUpgradeAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxUpgradeAction.java
@@ -1,6 +1,6 @@
 package com.sequenceiq.it.cloudbreak.action.sdx;
 
-import static java.lang.String.format;
+import java.util.Collections;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,6 +10,7 @@ import com.sequenceiq.it.cloudbreak.action.Action;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
 import com.sequenceiq.it.cloudbreak.log.Log;
+import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
 import com.sequenceiq.sdx.api.model.SdxUpgradeRequest;
 import com.sequenceiq.sdx.api.model.SdxUpgradeResponse;
 
@@ -18,14 +19,19 @@ public class SdxUpgradeAction implements Action<SdxTestDto, SdxClient> {
 
     @Override
     public SdxTestDto action(TestContext testContext, SdxTestDto testDto, SdxClient client) throws Exception {
-        Log.log(LOGGER, format(" Environment: %s", testDto.getRequest().getEnvironment()));
-        Log.whenJson(LOGGER, " SDX upgrade request: ", testDto.getRequest());
         SdxUpgradeRequest upgradeRequest = testDto.getSdxUpgradeRequest();
+
+        Log.when(LOGGER, " SDX endpoint: %s" + client.getSdxClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
+        Log.whenJson(LOGGER, " SDX upgrade request: ", upgradeRequest);
         SdxUpgradeResponse upgradeResponse = client.getSdxClient()
                 .sdxUpgradeEndpoint()
                 .upgradeClusterByName(testDto.getName(), upgradeRequest);
         testDto.setFlow("SDX upgrade", upgradeResponse.getFlowIdentifier());
-        Log.log(LOGGER, " SDX name: %s", client.getSdxClient().sdxEndpoint().get(testDto.getName()).getName());
+        SdxClusterDetailResponse detailedResponse = client.getSdxClient()
+                .sdxEndpoint()
+                .getDetail(testDto.getName(), Collections.emptySet());
+        testDto.setResponse(detailedResponse);
+        Log.whenJson(LOGGER, " SDX upgrade response: ", detailedResponse);
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXCreateAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXCreateAction.java
@@ -16,13 +16,13 @@ public class DistroXCreateAction implements Action<DistroXTestDto, CloudbreakCli
 
     @Override
     public DistroXTestDto action(TestContext testContext, DistroXTestDto testDto, CloudbreakClient client) throws Exception {
-        Log.whenJson(LOGGER, " Stack post request:\n", testDto.getRequest());
-        StackV4Response response = client.getCloudbreakClient()
+        Log.whenJson(LOGGER, " Distrox create request: ", testDto.getRequest());
+        StackV4Response stackV4Response = client.getCloudbreakClient()
                         .distroXV1Endpoint()
                         .post(testDto.getRequest());
-        testDto.setResponse(response);
-        testDto.setFlow("DistroX create", response.getFlowIdentifier());
-        Log.whenJson(LOGGER, " Stack created was successful:\n", testDto.getResponse());
+        testDto.setFlow("Distrox create", stackV4Response.getFlowIdentifier());
+        testDto.setResponse(stackV4Response);
+        Log.whenJson(LOGGER, " Distrox create response: ", stackV4Response);
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXRefreshAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXRefreshAction.java
@@ -20,7 +20,7 @@ public class DistroXRefreshAction implements Action<DistroXTestDto, CloudbreakCl
         testDto.setResponse(
                 client.getCloudbreakClient().distroXV1Endpoint().getByName(testDto.getName(), Collections.emptySet())
         );
-        Log.whenJson(LOGGER, " Stack get was successful:\n", testDto.getResponse());
+        Log.whenJson(LOGGER, " Distrox get response: ", testDto.getResponse());
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXScaleAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXScaleAction.java
@@ -30,7 +30,8 @@ public class DistroXScaleAction implements Action<DistroXTestDto, CloudbreakClie
 
     @Override
     public DistroXTestDto action(TestContext testContext, DistroXTestDto testDto, CloudbreakClient client) throws Exception {
-        Log.when(LOGGER, String.format("Stack scale request on: %s. Hostgroup: %s, desiredCount: %d", testDto.getName(), hostGroup, count));
+        Log.when(LOGGER, String.format("Distrox scale request on: %s. Hostgroup: %s, desiredCount: %d", testDto.getName(), hostGroup, count));
+        Log.whenJson(LOGGER, " Distrox scale request: ", testDto.getRequest());
         DistroXScaleV1Request scaleRequest = new DistroXScaleV1Request();
         scaleRequest.setGroup(hostGroup);
         scaleRequest.setDesiredCount(count);
@@ -40,7 +41,9 @@ public class DistroXScaleAction implements Action<DistroXTestDto, CloudbreakClie
         StackV4Response stackV4Response = client.getCloudbreakClient()
                 .distroXV1Endpoint()
                 .getByName(testDto.getName(), new HashSet<>(Arrays.asList("hardware_info", "events")));
-        testDto.setFlow("DistroX scale", flowIdentifier);
+        testDto.setFlow("Distrox scale", flowIdentifier);
+        testDto.setResponse(stackV4Response);
+        Log.whenJson(LOGGER, " Distrox scale response: ", stackV4Response);
         LOGGER.info("Hardware info for stack after upscale: {}", stackV4Response.getHardwareInfoGroups());
         return testDto;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXStartAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXStartAction.java
@@ -1,8 +1,13 @@
 package com.sequenceiq.it.cloudbreak.action.v1.distrox;
 
+import static java.lang.String.format;
+
+import java.util.Collections;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.action.Action;
@@ -16,11 +21,16 @@ public class DistroXStartAction implements Action<DistroXTestDto, CloudbreakClie
 
     @Override
     public DistroXTestDto action(TestContext testContext, DistroXTestDto testDto, CloudbreakClient client) throws Exception {
-        Log.when(LOGGER, " Stack start request on: " + testDto.getName());
-        FlowIdentifier flow = client.getCloudbreakClient()
+        Log.when(LOGGER, format(" Starting Distrox: %s ", testDto.getName()));
+        Log.whenJson(LOGGER, " Distrox start request: ", testDto.getRequest());
+        FlowIdentifier flowIdentifier = client.getCloudbreakClient()
                 .distroXV1Endpoint()
                 .putStartByName(testDto.getName());
-        testDto.setFlow("DistroX start", flow);
+        testDto.setFlow("DistroX start", flowIdentifier);
+        StackV4Response stackV4Response = client.getCloudbreakClient()
+                .distroXV1Endpoint().getByName(testDto.getName(), Collections.emptySet());
+        testDto.setResponse(stackV4Response);
+        Log.whenJson(LOGGER, " Distrox start response: ", stackV4Response);
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXStopAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXStopAction.java
@@ -1,8 +1,13 @@
 package com.sequenceiq.it.cloudbreak.action.v1.distrox;
 
+import static java.lang.String.format;
+
+import java.util.Collections;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.action.Action;
@@ -16,11 +21,16 @@ public class DistroXStopAction implements Action<DistroXTestDto, CloudbreakClien
 
     @Override
     public DistroXTestDto action(TestContext testContext, DistroXTestDto testDto, CloudbreakClient client) throws Exception {
-        Log.when(LOGGER, " Stack stop request on: " + testDto.getName());
+        Log.when(LOGGER, format(" Stop Distrox: %s ", testDto.getName()));
+        Log.whenJson(LOGGER, " Distrox stop request: ", testDto.getRequest());
         FlowIdentifier flow = client.getCloudbreakClient()
                 .distroXV1Endpoint()
                 .putStopByName(testDto.getName());
-        testDto.setFlow("DistroX stop", flow);
+        testDto.setFlow("Distrox stop", flow);
+        StackV4Response stackV4Response = client.getCloudbreakClient()
+                .distroXV1Endpoint().getByName(testDto.getName(), Collections.emptySet());
+        testDto.setResponse(stackV4Response);
+        Log.whenJson(LOGGER, " Distrox stop response: ", stackV4Response);
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentRefreshAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentRefreshAction.java
@@ -1,0 +1,24 @@
+package com.sequenceiq.it.cloudbreak.action.v4.environment;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.EnvironmentClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+
+public class EnvironmentRefreshAction implements Action<EnvironmentTestDto, EnvironmentClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EnvironmentRefreshAction.class);
+
+    @Override
+    public EnvironmentTestDto action(TestContext testContext, EnvironmentTestDto testDto, EnvironmentClient client) throws Exception {
+        testDto.setResponse(
+                client.getEnvironmentClient().environmentV1Endpoint().getByName(testDto.getName())
+        );
+        Log.whenJson(LOGGER, " Environment get response: ", testDto.getResponse());
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackCreateAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackCreateAction.java
@@ -16,14 +16,13 @@ public class StackCreateAction implements Action<StackTestDto, CloudbreakClient>
 
     @Override
     public StackTestDto action(TestContext testContext, StackTestDto testDto, CloudbreakClient client) throws Exception {
-        Log.whenJson(LOGGER, " Stack post request:\n", testDto.getRequest());
+        Log.whenJson(LOGGER, " Stack create request: ", testDto.getRequest());
         StackV4Response response = client.getCloudbreakClient()
                         .stackV4Endpoint()
                         .post(client.getWorkspaceId(), testDto.getRequest(), testContext.getActingUserCrn().getAccountId());
         testDto.setResponse(response);
         testDto.setFlow("Stack create", response.getFlowIdentifier());
-        Log.whenJson(LOGGER, " Stack created was successfully:\n", testDto.getResponse());
-
+        Log.whenJson(LOGGER, " Stack create response ",  response);
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackScalePostAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackScalePostAction.java
@@ -1,6 +1,12 @@
 package com.sequenceiq.it.cloudbreak.action.v4.stack;
 
+import java.util.HashSet;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackScaleV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.action.Action;
@@ -9,6 +15,8 @@ import com.sequenceiq.it.cloudbreak.dto.stack.StackTestDto;
 import com.sequenceiq.it.cloudbreak.log.Log;
 
 public class StackScalePostAction implements Action<StackTestDto, CloudbreakClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StackScalePostAction.class);
 
     private StackScaleV4Request request = new StackScaleV4Request();
 
@@ -33,12 +41,20 @@ public class StackScalePostAction implements Action<StackTestDto, CloudbreakClie
 
     @Override
     public StackTestDto action(TestContext testContext, StackTestDto testDto, CloudbreakClient client) throws Exception {
-        Log.whenJson(" StackScale post request:\n", request);
+        Log.when(LOGGER, String.format("Stack scale request on: %s. Hostgroup: %s, desiredCount: %d", testDto.getName(), request.getGroup(),
+                request.getDesiredCount()));
+        Log.whenJson(LOGGER, " Stack scale request: ", testDto.getRequest());
         FlowIdentifier flowIdentifier = client.getCloudbreakClient()
                 .stackV4Endpoint()
                 .putScaling(client.getWorkspaceId(), testDto.getName(), request,
                         testContext.getActingUserCrn().getAccountId());
         testDto.setFlow("Stack scale", flowIdentifier);
+        StackV4Response stackV4Response = client.getCloudbreakClient()
+                .stackV4Endpoint()
+                .get(client.getWorkspaceId(), testDto.getName(), new HashSet<>(), testContext.getActingUserCrn().getAccountId());
+        testDto.setResponse(stackV4Response);
+        Log.whenJson(LOGGER, " Stack scale response: ", stackV4Response);
+        LOGGER.info("Hardware info for stack after upscale: {}", stackV4Response.getHardwareInfoGroups());
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/EnvironmentTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/EnvironmentTestClient.java
@@ -19,6 +19,7 @@ import com.sequenceiq.it.cloudbreak.action.v4.environment.EnvironmentDeleteMulti
 import com.sequenceiq.it.cloudbreak.action.v4.environment.EnvironmentGetAction;
 import com.sequenceiq.it.cloudbreak.action.v4.environment.EnvironmentInternalGetAction;
 import com.sequenceiq.it.cloudbreak.action.v4.environment.EnvironmentListAction;
+import com.sequenceiq.it.cloudbreak.action.v4.environment.EnvironmentRefreshAction;
 import com.sequenceiq.it.cloudbreak.action.v4.environment.EnvironmentStartAction;
 import com.sequenceiq.it.cloudbreak.action.v4.environment.EnvironmentStopAction;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
@@ -33,6 +34,10 @@ public class EnvironmentTestClient {
 
     public Action<EnvironmentTestDto, EnvironmentClient> describe() {
         return new EnvironmentGetAction();
+    }
+
+    public Action<EnvironmentTestDto, EnvironmentClient> refresh() {
+        return new EnvironmentRefreshAction();
     }
 
     public Action<EnvironmentTestDto, EnvironmentClient> list() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/FreeIpaTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/FreeIpaTestClient.java
@@ -5,12 +5,13 @@ import org.springframework.stereotype.Service;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceMetadataType;
 import com.sequenceiq.it.cloudbreak.FreeIpaClient;
 import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaAttachChildEnvironmentAction;
 import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaCollectDiagnosticsAction;
 import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaCreateAction;
 import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaDeleteAction;
 import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaDescribeAction;
-import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaAttachChildEnvironmentAction;
 import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaDetachChildEnvironmentAction;
+import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaRefreshAction;
 import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaRepairAction;
 import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaStartAction;
 import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaStopAction;
@@ -39,6 +40,10 @@ public class FreeIpaTestClient {
 
     public Action<FreeIpaTestDto, FreeIpaClient>  describe() {
         return new FreeIpaDescribeAction();
+    }
+
+    public Action<FreeIpaTestDto, FreeIpaClient>  refresh() {
+        return new FreeIpaRefreshAction();
     }
 
     public Action<FreeIpaTestDto, FreeIpaClient> start() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/SdxTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/SdxTestClient.java
@@ -4,8 +4,8 @@ import org.springframework.stereotype.Service;
 
 import com.sequenceiq.it.cloudbreak.SdxClient;
 import com.sequenceiq.it.cloudbreak.action.Action;
-import com.sequenceiq.it.cloudbreak.action.sdx.SdxCollectDiagnosticsAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxCheckForUpgradeAction;
+import com.sequenceiq.it.cloudbreak.action.sdx.SdxCollectDiagnosticsAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxCreateAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxCreateInternalAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxDeleteAction;
@@ -16,6 +16,7 @@ import com.sequenceiq.it.cloudbreak.action.sdx.SdxForceDeleteAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxForceDeleteInternalAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxListAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxRefreshAction;
+import com.sequenceiq.it.cloudbreak.action.sdx.SdxRefreshInternalAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxRepairAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxRepairInternalAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxStartAction;
@@ -72,6 +73,10 @@ public class SdxTestClient {
 
     public Action<SdxTestDto, SdxClient> refresh() {
         return new SdxRefreshAction();
+    }
+
+    public Action<SdxInternalTestDto, SdxClient> refreshInternal() {
+        return new SdxRefreshInternalAction();
     }
 
     public Action<SdxTestDto, SdxClient> repair() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/MeasuredTestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/MeasuredTestContext.java
@@ -243,6 +243,11 @@ public class MeasuredTestContext extends MockedTestContext {
     }
 
     @Override
+    public <T extends CloudbreakTestDto> T awaitForFlow(T entity, RunningParameter runningParameter) {
+        return wrappedTestContext.awaitForFlow(entity, runningParameter);
+    }
+
+    @Override
     public <T extends SdxTestDto> T awaitForFlow(T entity, RunningParameter runningParameter) {
         return wrappedTestContext.awaitForFlow(entity, runningParameter);
     }
@@ -253,7 +258,12 @@ public class MeasuredTestContext extends MockedTestContext {
     }
 
     @Override
-    public <T extends CloudbreakTestDto> T awaitForFlow(T entity, RunningParameter runningParameter) {
+    public <T extends DistroXTestDto> T awaitForFlow(T entity, RunningParameter runningParameter) {
+        return wrappedTestContext.awaitForFlow(entity, runningParameter);
+    }
+
+    @Override
+    public <T extends EnvironmentTestDto> T awaitForFlow(T entity, RunningParameter runningParameter) {
         return wrappedTestContext.awaitForFlow(entity, runningParameter);
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
@@ -295,18 +295,18 @@ public class EnvironmentTestDto
 
     @Override
     public EnvironmentTestDto refresh(TestContext context, CloudbreakClient client) {
-        LOGGER.info("Refresh resource with name: {}", getName());
-        return when(environmentTestClient.describe(), key("refresh-environment-" + getName()));
+        LOGGER.info("Refresh Environment with name: {}", getName());
+        return when(environmentTestClient.refresh(), key("refresh-environment-" + getName()));
     }
 
     @Override
     public void cleanUp(TestContext context, CloudbreakClient client) {
-        LOGGER.info("Cleaning up resource with name: {}", getName());
+        LOGGER.info("Cleaning up environment with name: {}", getName());
         if (getResponse() != null) {
             when(environmentTestClient.cascadingDelete(), key("delete-environment-" + getName()).withSkipOnFail(false));
             await(ARCHIVED, new RunningParameter().withSkipOnFail(true));
         } else {
-            LOGGER.info("Response field is null for env: {}", getName());
+            LOGGER.info("Environment: {} response is null!", getName());
         }
     }
 
@@ -337,6 +337,15 @@ public class EnvironmentTestDto
 
     public EnvironmentTestDto await(EnvironmentStatus status, Duration pollingInterval) {
         return await(status, emptyRunningParameter(), pollingInterval);
+    }
+
+    public EnvironmentTestDto awaitForFlow() {
+        return awaitForFlow(emptyRunningParameter());
+    }
+
+    @Override
+    public EnvironmentTestDto awaitForFlow(RunningParameter runningParameter) {
+        return getTestContext().awaitForFlow(this, runningParameter);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaTestDto.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.it.cloudbreak.dto.freeipa;
 
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.DELETE_COMPLETED;
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.emptyRunningParameter;
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
 
@@ -275,7 +276,8 @@ public class FreeIpaTestDto extends AbstractFreeIpaTestDto<CreateFreeIpaRequest,
 
     @Override
     public CloudbreakTestDto refresh(TestContext context, CloudbreakClient cloudbreakClient) {
-        return when(freeIpaTestClient.describe(), key("refresh-freeipa-" + getName()));
+        LOGGER.info("Refresh FreeIPA with name: {}", getName());
+        return when(freeIpaTestClient.refresh(), key("refresh-freeipa-" + getName()));
     }
 
     @Override
@@ -305,8 +307,9 @@ public class FreeIpaTestDto extends AbstractFreeIpaTestDto<CreateFreeIpaRequest,
 
     @Override
     public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
-        LOGGER.info("Cleaning up resource with name: {}", getName());
+        LOGGER.info("Cleaning up freeipa with name: {}", getName());
         when(freeIpaTestClient.delete(), key("delete-freeipa-" + getName()).withSkipOnFail(false));
+        await(DELETE_COMPLETED, new RunningParameter().withSkipOnFail(true));
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
@@ -79,10 +79,14 @@ public class SdxTestDto extends AbstractSdxTestDto<SdxClusterRequest, SdxCluster
 
     @Override
     public void cleanUp(TestContext context, CloudbreakClient client) {
-        LOGGER.info("Cleaning up SDX with name: {}", getName());
-        when(sdxTestClient.forceDelete(), key("delete-sdx-" + getName()).withSkipOnFail(false));
-        awaitForFlow(key("delete-sdx-" + getName()));
-        await(DELETED, new RunningParameter().withSkipOnFail(true));
+        LOGGER.info("Cleaning up sdx with name: {}", getName());
+        if (getResponse() != null) {
+            when(sdxTestClient.forceDelete(), key("delete-sdx-" + getName()).withSkipOnFail(false));
+            awaitForFlow(key("delete-sdx-" + getName()));
+            await(DELETED, new RunningParameter().withSkipOnFail(true));
+        } else {
+            LOGGER.info("Sdx: {} response is null!", getName());
+        }
     }
 
     @Override
@@ -137,6 +141,11 @@ public class SdxTestDto extends AbstractSdxTestDto<SdxClusterRequest, SdxCluster
         return getTestContext().await(this, status, runningParameter);
     }
 
+    public SdxTestDto awaitForFlow() {
+        return awaitForFlow(emptyRunningParameter());
+    }
+
+    @Override
     public SdxTestDto awaitForFlow(RunningParameter runningParameter) {
         return getTestContext().awaitForFlow(this, runningParameter);
     }
@@ -245,6 +254,15 @@ public class SdxTestDto extends AbstractSdxTestDto<SdxClusterRequest, SdxCluster
     @Override
     public String getName() {
         return super.getName() == null ? DEFAULT_SDX_NAME : super.getName();
+    }
+
+    @Override
+    public String getCrn() {
+        if (getResponse() == null) {
+            throw new IllegalStateException("You have tried to assign to SdxTestDto," +
+                    " that hasn't been created and therefore has no Response object yet.");
+        }
+        return getResponse().getCrn();
     }
 
     public SdxRepairRequest getSdxRepairRequest() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/EnvironmentCreateTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/EnvironmentCreateTest.java
@@ -79,7 +79,6 @@ public class EnvironmentCreateTest extends AbstractIntegrationTest {
                 .given(EnvironmentTestDto.class)
                 .when(environmentTestClient.describe(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_B)))
                 .when(environmentTestClient.delete())
-                .awaitForFlow(RunningParameter.key("EnvironmentDeleteAction"))
                 .validate();
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/InternalSdxDistroxTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/InternalSdxDistroxTest.java
@@ -54,6 +54,7 @@ public class InternalSdxDistroxTest extends ImageValidatorE2ETest {
                         .withImageCatalog(testContext.get(SdxInternalTestDto.class).getResponse().getStackV4Response().getImage().getCatalogName())
                         .withImageId(testContext.get(SdxInternalTestDto.class).getResponse().getStackV4Response().getImage().getId()))
                 .when(distroXTestClient.create())
+                .awaitForFlow(key(resourcePropertyProvider().getName()))
                 .await(STACK_AVAILABLE)
                 .then((context, distrox, client) -> {
                     distrox.getResponse();


### PR DESCRIPTION
Await for flow errors/exceptions should be present in the TestContext's ExceptionMap as well. So we can see these issues on the test suite's logs and HTML reports.

We can see these errors in the HTML report as:

|Step | Details|
|---|---|
| Await | Sdx internal await for flow SdxInternalTestDto |
|           | Sdx internal await for flow 'SdxInternalTestDto[name: aws-test-654a07c3f43d4ab497577e79b82dd2b]' is failed for 'aws-test-654a07c3f43d4ab497577e79b82dd2b', because of Error during polling flow. Crn=crn:cdp:datalake:us-west-1:qe-aws:datalake:838ac751-2493-4b2c-baaa-5ea4b72c6201, FlowId=da25d4fc-fc27-4a3c-a7d2-dae90cd568e3 , FlowChainId=null, Message=The template variable 'flowId' has no value |
|          | Datalake Internal await should be skipped because of previous error. await [RUNNING] |