### PR TITLE
CDPSDX-2405: Use environments/repairFreeIPA for FreeIPA repair auth

### DIFF
--- a/authorization-common-api/src/main/java/com/sequenceiq/authorization/resource/AuthorizationResourceAction.java
+++ b/authorization-common-api/src/main/java/com/sequenceiq/authorization/resource/AuthorizationResourceAction.java
@@ -12,6 +12,7 @@ public enum AuthorizationResourceAction {
     DESCRIBE_ENVIRONMENT("environments/describeEnvironment", AuthorizationResourceType.ENVIRONMENT),
     ACCESS_ENVIRONMENT("environments/accessEnvironment", AuthorizationResourceType.ENVIRONMENT),
     ADMIN_FREEIPA("environments/adminFreeIPA", AuthorizationResourceType.ENVIRONMENT),
+    REPAIR_FREEIPA("environments/repairFreeIPA", AuthorizationResourceType.ENVIRONMENT),
     CREATE_CREDENTIAL("environments/createCredential", AuthorizationResourceType.CREDENTIAL),
     CREATE_ENVIRONMENT("environments/createEnvironment", AuthorizationResourceType.ENVIRONMENT),
     GET_KEYTAB("environments/getKeytab", AuthorizationResourceType.ENVIRONMENT),

--- a/authorization-common/src/main/resources/legacyRights.json
+++ b/authorization-common/src/main/resources/legacyRights.json
@@ -9,6 +9,7 @@
   "environments/deleteCdpEnvironment": "environments/write",
   "environments/describeEnvironment": "environments/read",
   "environments/accessEnvironment": "environments/accessEnvironment",
+  "environments/repairFreeIPA": "environments/write",
   "environments/adminFreeIPA": "environments/adminFreeIPA",
   "environments/createCredential": "environments/write",
   "environments/createEnvironment": "environments/write",

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/reboot/RebootInstancesRequest.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/reboot/RebootInstancesRequest.java
@@ -20,7 +20,7 @@ import io.swagger.annotations.ApiModelProperty;
 public class RebootInstancesRequest {
     @NotEmpty
     @ApiModelProperty(value = ModelDescriptions.ENVIRONMENT_CRN, required = true)
-    @ResourceObjectField(action = AuthorizationResourceAction.EDIT_ENVIRONMENT, variableType = AuthorizationVariableType.CRN)
+    @ResourceObjectField(action = AuthorizationResourceAction.REPAIR_FREEIPA, variableType = AuthorizationVariableType.CRN)
     private String environmentCrn;
 
     @ApiModelProperty(ModelDescriptions.FORCE_REBOOT)

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/repair/RepairInstancesRequest.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/repair/RepairInstancesRequest.java
@@ -21,7 +21,7 @@ public class RepairInstancesRequest {
 
     @NotEmpty
     @ApiModelProperty(value = ModelDescriptions.ENVIRONMENT_CRN, required = true)
-    @ResourceObjectField(action = AuthorizationResourceAction.EDIT_ENVIRONMENT, variableType = AuthorizationVariableType.CRN)
+    @ResourceObjectField(action = AuthorizationResourceAction.REPAIR_FREEIPA, variableType = AuthorizationVariableType.CRN)
     private String environmentCrn;
 
     @ApiModelProperty(ModelDescriptions.FORCE_REPAIR)


### PR DESCRIPTION
Use environments/repairFreeIPA when checking the authorization action
for FreeIPA repair and reboot.

See detailed description in the commit message.