### PR TITLE
CB-7741 show images with same GBN without specifying --lock-components

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ComponentBuildNumberComparator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ComponentBuildNumberComparator.java
@@ -20,6 +20,6 @@ class ComponentBuildNumberComparator {
     }
 
     private boolean compare(Optional<String> currentVersion, Optional<String> newVersion) {
-        return currentVersion.map(Integer::parseInt).get() < newVersion.map(Integer::parseInt).get();
+        return currentVersion.map(Integer::parseInt).get() <= newVersion.map(Integer::parseInt).get();
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ComponentBuildNumberComparatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ComponentBuildNumberComparatorTest.java
@@ -37,13 +37,13 @@ public class ComponentBuildNumberComparatorTest {
     }
 
     @Test
-    public void testCompareShouldReturnFalseWhenTheCurrentIsEqualWithTheNewBuildNumber() {
+    public void testCompareShouldReturnTrueWhenTheCurrentIsEqualWithTheNewBuildNumber() {
         Image currentImage = createImage("1234");
         Image newImage = createImage("1234");
 
         boolean actual = underTest.compare(currentImage, newImage, BUILD_NUMBER_KEY);
 
-        assertFalse(actual);
+        assertTrue(actual);
     }
 
     @Test


### PR DESCRIPTION
The UI calls the upgrade API with --show-latest-available-image-per-runtime
which does not show images with the same GBN version. Whenever I specify
--lock-components it shows those images as well. However, since we don't
want to call the upgrade API 2 times with different parameters the show
latest should show the same GBN images as well.
