### PR TITLE
CB-8123. DH: Metering-related workload changes

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/TelemetryConfiguration.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/TelemetryConfiguration.java
@@ -4,25 +4,26 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
 import com.sequenceiq.cloudbreak.altus.AltusDatabusConfiguration;
+import com.sequenceiq.cloudbreak.telemetry.metering.MeteringConfiguration;
 
 @Configuration
 public class TelemetryConfiguration {
 
     private final AltusDatabusConfiguration altusDatabusConfiguration;
 
-    private final boolean clusterLogsCollection;
+    private final MeteringConfiguration meteringConfiguration;
 
-    private final boolean meteringEnabled;
+    private final boolean clusterLogsCollection;
 
     private final boolean monitoringEnabled;
 
     public TelemetryConfiguration(AltusDatabusConfiguration altusDatabusConfiguration,
+            MeteringConfiguration meteringConfiguration,
             @Value("${cluster.logs.collection.enabled:false}") boolean clusterLogsCollection,
-            @Value("${metering.enabled:false}") boolean meteringEnabled,
             @Value("${cluster.monitoring.enabled:false}") boolean monitoringEnabled) {
         this.altusDatabusConfiguration = altusDatabusConfiguration;
+        this.meteringConfiguration = meteringConfiguration;
         this.clusterLogsCollection = clusterLogsCollection;
-        this.meteringEnabled = meteringEnabled;
         this.monitoringEnabled = monitoringEnabled;
     }
 
@@ -30,12 +31,12 @@ public class TelemetryConfiguration {
         return altusDatabusConfiguration;
     }
 
-    public boolean isClusterLogsCollection() {
-        return clusterLogsCollection;
+    public MeteringConfiguration getMeteringConfiguration() {
+        return meteringConfiguration;
     }
 
-    public boolean isMeteringEnabled() {
-        return meteringEnabled;
+    public boolean isClusterLogsCollection() {
+        return clusterLogsCollection;
     }
 
     public boolean isMonitoringEnabled() {

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigService.java
@@ -14,6 +14,7 @@ import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.AdlsGen2Config;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.AdlsGen2ConfigGenerator;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.S3Config;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.S3ConfigGenerator;
+import com.sequenceiq.cloudbreak.telemetry.metering.MeteringConfiguration;
 import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
 import com.sequenceiq.common.api.telemetry.model.CloudwatchParams;
 import com.sequenceiq.common.api.telemetry.model.CloudwatchStreamKey;
@@ -39,12 +40,16 @@ public class FluentConfigService {
 
     private final AnonymizationRuleResolver anonymizationRuleResolver;
 
+    private final MeteringConfiguration meteringConfiguration;
+
     public FluentConfigService(S3ConfigGenerator s3ConfigGenerator,
             AdlsGen2ConfigGenerator adlsGen2ConfigGenerator,
-            AnonymizationRuleResolver anonymizationRuleResolver) {
+            AnonymizationRuleResolver anonymizationRuleResolver,
+            MeteringConfiguration meteringConfiguration) {
         this.s3ConfigGenerator = s3ConfigGenerator;
         this.adlsGen2ConfigGenerator = adlsGen2ConfigGenerator;
         this.anonymizationRuleResolver = anonymizationRuleResolver;
+        this.meteringConfiguration = meteringConfiguration;
     }
 
     public FluentConfigView createFluentConfigs(TelemetryClusterDetails clusterDetails,
@@ -61,6 +66,11 @@ public class FluentConfigService {
             if (telemetry.isClusterLogsCollectionEnabled()) {
                 LOGGER.debug("Set anonymization rules (only for cluster log collection)");
                 builder.withAnonymizationRules(anonymizationRuleResolver.decodeRules(telemetry.getRules()));
+            }
+            if (enabled && meteringEnabled) {
+                builder
+                        .withMeteringAppName(meteringConfiguration.getDbusAppName())
+                        .withMeteringStreamName(meteringConfiguration.getDbusAppName());
             }
         }
         if (!enabled) {

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigView.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigView.java
@@ -43,6 +43,10 @@ public class FluentConfigView implements TelemetryConfigView {
 
     private final boolean monitoringEnabled;
 
+    private final String meteringAppName;
+
+    private final String meteringStreamName;
+
     private final TelemetryClusterDetails clusterDetails;
 
     private final String user;
@@ -87,6 +91,8 @@ public class FluentConfigView implements TelemetryConfigView {
         this.cloudLoggingServiceEnabled = builder.cloudLoggingServiceEnabled;
         this.clusterLogsCollection = builder.clusterLogsCollection;
         this.meteringEnabled = builder.meteringEnabled;
+        this.meteringAppName = builder.meteringAppName;
+        this.meteringStreamName = builder.meteringStreamName;
         this.monitoringEnabled = builder.monitoringEnabled;
         this.clusterDetails = builder.clusterDetails;
         this.user = builder.user;
@@ -197,6 +203,14 @@ public class FluentConfigView implements TelemetryConfigView {
         return meteringEnabled;
     }
 
+    public String getMeteringAppName() {
+        return meteringAppName;
+    }
+
+    public String getMeteringStreamName() {
+        return meteringStreamName;
+    }
+
     public boolean isMonitoringEnabled() {
         return monitoringEnabled;
     }
@@ -212,6 +226,8 @@ public class FluentConfigView implements TelemetryConfigView {
         map.put("cloudStorageLoggingEnabled", this.cloudStorageLoggingEnabled);
         map.put("cloudLoggingServiceEnabled", this.cloudLoggingServiceEnabled);
         map.put("dbusMeteringEnabled", this.meteringEnabled);
+        map.put("dbusMeteringAppName", this.meteringAppName);
+        map.put("dbusMeteringStreamName", this.meteringStreamName);
         map.put("dbusMonitoringEnabled", this.monitoringEnabled);
         map.put("dbusClusterLogsCollection", this.clusterLogsCollection);
         map.put("dbusClusterLogsCollectionDisableStop", DBUS_DISABLE_STOP_CLUSTER_LOG_COLLECTION_DEFAULT);
@@ -261,6 +277,10 @@ public class FluentConfigView implements TelemetryConfigView {
         private boolean clusterLogsCollection;
 
         private boolean meteringEnabled;
+
+        private String meteringAppName;
+
+        private String meteringStreamName;
 
         private boolean monitoringEnabled;
 
@@ -413,6 +433,16 @@ public class FluentConfigView implements TelemetryConfigView {
 
         public Builder withMeteringEnabled(boolean meteringEnabled) {
             this.meteringEnabled = meteringEnabled;
+            return this;
+        }
+
+        public Builder withMeteringAppName(String meteringAppName) {
+            this.meteringAppName = meteringAppName;
+            return this;
+        }
+
+        public Builder withMeteringStreamName(String meteringStreamName) {
+            this.meteringStreamName = meteringStreamName;
             return this;
         }
 

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/metering/MeteringConfigService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/metering/MeteringConfigService.java
@@ -6,14 +6,22 @@ import org.springframework.stereotype.Service;
 @Service
 public class MeteringConfigService {
 
-    public MeteringConfigView createMeteringConfigs(boolean enabled, String platform, String clusterCrn, String serviceType,
+    private final MeteringConfiguration meteringConfiguration;
+
+    public MeteringConfigService(MeteringConfiguration meteringConfiguration) {
+        this.meteringConfiguration = meteringConfiguration;
+    }
+
+    public MeteringConfigView createMeteringConfigs(boolean enabled, String platform, String clusterCrn, String clusterName, String serviceType,
             String serviceVersion) {
         MeteringConfigView.Builder builder = new MeteringConfigView.Builder();
         if (enabled) {
             builder.withPlatform(platform)
                     .withClusterCrn(clusterCrn)
+                    .withClusterName(clusterName)
                     .withServiceType(StringUtils.upperCase(serviceType))
-                    .withServiceVersion(serviceVersion);
+                    .withServiceVersion(serviceVersion)
+                    .withStreamName(meteringConfiguration.getDbusStreamName());
         }
         return builder
                 .withEnabled(enabled)

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/metering/MeteringConfigView.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/metering/MeteringConfigView.java
@@ -11,17 +11,23 @@ public class MeteringConfigView implements TelemetryConfigView {
 
     private final String clusterCrn;
 
+    private final String clusterName;
+
     private final String serviceType;
 
     private final String serviceVersion;
+
+    private final String streamName;
 
     private final String platform;
 
     private MeteringConfigView(Builder builder) {
         this.enabled = builder.enabled;
         this.clusterCrn = builder.clusterCrn;
+        this.clusterName = builder.clusterName;
         this.serviceType = builder.serviceType;
         this.serviceVersion = builder.serviceVersion;
+        this.streamName = builder.streamName;
         this.platform = builder.platform;
     }
 
@@ -33,12 +39,20 @@ public class MeteringConfigView implements TelemetryConfigView {
         return clusterCrn;
     }
 
+    public String getClusterName() {
+        return clusterName;
+    }
+
     public String getServiceType() {
         return serviceType;
     }
 
     public String getServiceVersion() {
         return serviceVersion;
+    }
+
+    public String getStreamName() {
+        return streamName;
     }
 
     public String getPlatform() {
@@ -50,8 +64,10 @@ public class MeteringConfigView implements TelemetryConfigView {
         Map<String, Object> map = new HashMap<>();
         map.put("enabled", this.enabled);
         map.put("clusterCrn", this.clusterCrn);
+        map.put("clusterName", this.clusterName);
         map.put("serviceType", this.serviceType);
         map.put("serviceVersion", this.serviceVersion);
+        map.put("streamName", this.streamName);
         map.put("platform", this.platform);
         return map;
     }
@@ -62,9 +78,13 @@ public class MeteringConfigView implements TelemetryConfigView {
 
         private String clusterCrn;
 
+        private String clusterName;
+
         private String serviceType;
 
         private String serviceVersion;
+
+        private String streamName;
 
         private String platform;
 
@@ -82,6 +102,11 @@ public class MeteringConfigView implements TelemetryConfigView {
             return this;
         }
 
+        public MeteringConfigView.Builder withClusterName(String clusterName) {
+            this.clusterName = clusterName;
+            return this;
+        }
+
         public MeteringConfigView.Builder withServiceType(String serviceType) {
             this.serviceType = serviceType;
             return this;
@@ -89,6 +114,11 @@ public class MeteringConfigView implements TelemetryConfigView {
 
         public MeteringConfigView.Builder withServiceVersion(String serviceVersion) {
             this.serviceVersion = serviceVersion;
+            return this;
+        }
+
+        public MeteringConfigView.Builder withStreamName(String streamName) {
+            this.streamName = streamName;
             return this;
         }
 

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/metering/MeteringConfiguration.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/metering/MeteringConfiguration.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.cloudbreak.telemetry.metering;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MeteringConfiguration {
+
+    private final boolean enabled;
+
+    private final String dbusAppName;
+
+    private final String dbusStreamName;
+
+    public MeteringConfiguration(@Value("${metering.enabled:false}") boolean enabled,
+            @Value("${metering.dbus.app.name:}") String dbusAppName,
+            @Value("${metering.dbus.stream.name:Metering}") String dbusStreamName) {
+        this.enabled = enabled;
+        this.dbusAppName = dbusAppName;
+        this.dbusStreamName = dbusStreamName;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public String getDbusAppName() {
+        return dbusAppName;
+    }
+
+    public String getDbusStreamName() {
+        return dbusStreamName;
+    }
+}

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigServiceTest.java
@@ -12,6 +12,7 @@ import com.sequenceiq.cloudbreak.telemetry.TelemetryClusterDetails;
 import com.sequenceiq.cloudbreak.telemetry.common.AnonymizationRuleResolver;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.AdlsGen2ConfigGenerator;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.S3ConfigGenerator;
+import com.sequenceiq.cloudbreak.telemetry.metering.MeteringConfiguration;
 import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
 import com.sequenceiq.common.api.telemetry.model.Features;
@@ -31,7 +32,8 @@ public class FluentConfigServiceTest {
 
     @Before
     public void setUp() {
-        underTest = new FluentConfigService(new S3ConfigGenerator(), new AdlsGen2ConfigGenerator(), new AnonymizationRuleResolver());
+        MeteringConfiguration meteringConfiguration = new MeteringConfiguration(false, null, null);
+        underTest = new FluentConfigService(new S3ConfigGenerator(), new AdlsGen2ConfigGenerator(), new AnonymizationRuleResolver(), meteringConfiguration);
     }
 
     @Test

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/metering/MeteringConfigServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/metering/MeteringConfigServiceTest.java
@@ -13,25 +13,27 @@ public class MeteringConfigServiceTest {
 
     @Before
     public void setUp() {
-        underTest = new MeteringConfigService();
+        MeteringConfiguration meteringConfiguration = new MeteringConfiguration(true, "app", "stream");
+        underTest = new MeteringConfigService(meteringConfiguration);
     }
 
     @Test
     public void testCreateMeteringConfigs() {
         // GIVEN
         // WHEN
-        MeteringConfigView result = underTest.createMeteringConfigs(true, "AWS", "myCrn",
+        MeteringConfigView result = underTest.createMeteringConfigs(true, "AWS", "myName", "myCrn",
                 "DATAHUB", "1.0.0");
         // THEN
         assertTrue(result.isEnabled());
         assertEquals("DATAHUB", result.getServiceType());
+        assertEquals("stream", result.getStreamName());
     }
 
     @Test
     public void testCreateMeteringConfigsWithLowercaseServiceType() {
         // GIVEN
         // WHEN
-        MeteringConfigView result = underTest.createMeteringConfigs(true, "AWS", "myCrn",
+        MeteringConfigView result = underTest.createMeteringConfigs(true, "AWS", "myName", "myCrn",
                 "datahub", "1.0.0");
         // THEN
         assertTrue(result.isEnabled());
@@ -42,7 +44,7 @@ public class MeteringConfigServiceTest {
     public void testCreateMeteringConfigsIfDisabled() {
         // GIVEN
         // WHEN
-        MeteringConfigView result = underTest.createMeteringConfigs(false, "AWS", "myCrn",
+        MeteringConfigView result = underTest.createMeteringConfigs(false, "AWS", "myName", "myCrn",
                 "DATAHUB", "1.0.0");
         // THEN
         assertFalse(result.isEnabled());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
@@ -60,7 +60,7 @@ public class TelemetryConverter {
         this.telemetryPublisherDefaultValue = telemetryPublisherDefaultValue;
         this.databusEndpoint = configuration.getAltusDatabusConfiguration().getAltusDatabusEndpoint();
         this.useSharedAltusCredential = configuration.getAltusDatabusConfiguration().isUseSharedAltusCredential();
-        this.meteringEnabled = configuration.isMeteringEnabled();
+        this.meteringEnabled = configuration.getMeteringConfiguration().isEnabled();
         this.monitoringEnabled = configuration.isMonitoringEnabled();
         this.clusterLogsCollection = configuration.isClusterLogsCollection();
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import com.sequenceiq.cloudbreak.altus.AltusDatabusConfiguration;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryConfiguration;
+import com.sequenceiq.cloudbreak.telemetry.metering.MeteringConfiguration;
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
 import com.sequenceiq.common.api.telemetry.model.Features;
 import com.sequenceiq.common.api.telemetry.model.Logging;
@@ -40,7 +41,8 @@ public class TelemetryConverterTest {
     @Before
     public void setUp() {
         AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, true, "****", "****");
-        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true, true);
+        MeteringConfiguration meteringConfiguration = new MeteringConfiguration(true, "app", "stream");
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, true, true);
         underTest = new TelemetryConverter(telemetryConfiguration, true, true);
     }
 
@@ -174,7 +176,8 @@ public class TelemetryConverterTest {
         // GIVEN
         SdxClusterResponse sdxClusterResponse = null;
         AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, false, "", null);
-        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true, false);
+        MeteringConfiguration meteringConfiguration = new MeteringConfiguration(true, null, null);
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, true, false);
         TelemetryConverter converter = new TelemetryConverter(telemetryConfiguration, true, false);
         // WHEN
         TelemetryRequest result = converter.convert(null, sdxClusterResponse);
@@ -246,7 +249,8 @@ public class TelemetryConverterTest {
         sdxClusterResponse.setCrn("crn:cdp:cloudbreak:us-west-1:someone:sdxcluster:sdxId");
         sdxClusterResponse.setName("sdxName");
         AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, false, "", null);
-        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true, false);
+        MeteringConfiguration meteringConfiguration = new MeteringConfiguration(true, null, null);
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, true, false);
         TelemetryConverter converter = new TelemetryConverter(telemetryConfiguration, false, true);
         // WHEN
         TelemetryRequest result = converter.convert(response, sdxClusterResponse);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecoratorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecoratorTest.java
@@ -109,8 +109,8 @@ public class TelemetryDecoratorTest {
         assertEquals(results.get("user"), "root");
         verify(fluentConfigService, times(1)).createFluentConfigs(any(TelemetryClusterDetails.class),
                 anyBoolean(), anyBoolean(), any(Telemetry.class));
-        verify(meteringConfigService, times(1)).createMeteringConfigs(anyBoolean(), anyString(), anyString(), anyString(),
-                anyString());
+        verify(meteringConfigService, times(1)).createMeteringConfigs(anyBoolean(), anyString(), anyString(),
+                anyString(), anyString(), anyString());
     }
 
     @Test
@@ -275,7 +275,7 @@ public class TelemetryDecoratorTest {
                 anyBoolean(), anyBoolean(), any(Telemetry.class)))
                 .willReturn(fluentConfigView);
         given(meteringConfigService.createMeteringConfigs(anyBoolean(), anyString(), anyString(), anyString(),
-                anyString())).willReturn(meteringConfigView);
+                anyString(), anyString())).willReturn(meteringConfigView);
         given(monitoringConfigService.createMonitoringConfig(any(), any()))
                 .willReturn(monitoringConfigView);
         given(telemetryCommonConfigService.createTelemetryCommonConfigs(any(), anyList(), anyString(), anyString(),

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/TelemetryApiConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/TelemetryApiConverterTest.java
@@ -12,6 +12,7 @@ import org.mockito.MockitoAnnotations;
 
 import com.sequenceiq.cloudbreak.altus.AltusDatabusConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryConfiguration;
+import com.sequenceiq.cloudbreak.telemetry.metering.MeteringConfiguration;
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
 import com.sequenceiq.common.api.telemetry.model.Features;
 import com.sequenceiq.common.api.telemetry.request.FeaturesRequest;
@@ -34,7 +35,8 @@ public class TelemetryApiConverterTest {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration("", true, "****", "****");
-        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true, true);
+        MeteringConfiguration meteringConfiguration = new MeteringConfiguration(false, null, null);
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, true, true);
         underTest = new TelemetryApiConverter(telemetryConfiguration);
     }
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverterTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import com.sequenceiq.cloudbreak.altus.AltusDatabusConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryConfiguration;
+import com.sequenceiq.cloudbreak.telemetry.metering.MeteringConfiguration;
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
 import com.sequenceiq.common.api.telemetry.model.Logging;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
@@ -28,7 +29,8 @@ public class TelemetryConverterTest {
     @BeforeEach
     public void setUp() {
         AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, false, "", null);
-        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, true, true, false);
+        MeteringConfiguration meteringConfiguration = new MeteringConfiguration(false, null, null);
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, true, false);
         underTest = new TelemetryConverter(telemetryConfiguration, true);
     }
 

--- a/orchestrator-salt/src/main/resources/salt-common/pillar/fluent/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/pillar/fluent/init.sls
@@ -27,6 +27,8 @@ fluent:
   dbusClusterLogsCollection: false
   dbusClusterLogsCollectionDisableStop: false
   dbusMeteringEnabled: false
+  dbusMeteringAppName:
+  dbusMeteringStreamName:
   dbusMonitoringEnabled: false
   dbusIncludeSaltLogs: false
   anonymizationRules:

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/init.sls
@@ -296,7 +296,7 @@ fluentd_start_with_update_systemd_units:
       - file: /etc/td-agent/output.conf{% endif %}
       - file: /etc/td-agent/input_databus.conf
       - file: /etc/td-agent/filter_databus.conf
-      - file: /etc/td-agent/output_databus.conf
+      - file: /etc/td-agent/databus_metering.conf
 
   service.running:
     - enable: True
@@ -308,6 +308,7 @@ fluentd_start_with_update_systemd_units:
        - file: /etc/td-agent/input_databus.conf
        - file: /etc/td-agent/filter_databus.conf
        - file: /etc/td-agent/output_databus.conf
+       - file: /etc/td-agent/databus_metering.conf
 {% else %}
 
 fs.file-max:

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
@@ -140,6 +140,19 @@
   {% set proxy_full_url = None %}
 {% endif %}
 
+{% if dbus_metering_enabled %}
+  {% if salt['pillar.get']('fluent:dbusMeteringAppName') and salt['pillar.get']('fluent:dbusMeteringStreamName') %}
+    {% set dbus_metering_app_headers = 'app:' + cluster_type + ',@metering-app:' + salt['pillar.get']('fluent:dbusMeteringAppName') %}
+    {% set dbus_metering_stream_name = salt['pillar.get']('fluent:dbusMeteringStreamName') %}
+  {% else %}
+    {% set dbus_metering_app_headers = 'app:' + cluster_type %}
+    {% set dbus_metering_stream_name = 'Metering' %}
+  {% endif %}
+{% else %}
+  {% set dbus_metering_app_headers = None %}
+  {% set dbus_metering_stream_name = None %}
+{% endif %}
+
 {% set forward_port = 24224 %}
 
 {% do fluent.update({
@@ -172,6 +185,8 @@
     "dbusClusterLogsCollection": dbus_cluster_logs_collection_enabled,
     "dbusClusterLogsCollectionDisableStop": dbus_cluster_logs_collection_disable_stop,
     "dbusMeteringEnabled": dbus_metering_enabled,
+    "dbusMeteringAppHeaders": dbus_metering_app_headers,
+    "dbusMeteringStreamName": dbus_metering_stream_name,
     "dbusMonitoringEnabled": dbus_monitoring_enabled,
     "clouderaPublicGemRepo": cloudera_public_gem_repo,
     "clouderaAzurePluginVersion": cloudera_azure_plugin_version,

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/databus_metering.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/databus_metering.conf.j2
@@ -21,8 +21,8 @@
     debug                            false
     endpoint                         "{{ databus.endpoint }}"
     event_message_field              message
-    headers                          app:{{ fluent.clusterType }}
-    stream_name                      Metering
+    headers                          {{ fluent.dbusMeteringAppHeaders }}
+    stream_name                      {{ fluent.dbusMeteringStreamName }}
     partition_key                    "#{Socket.gethostname}"
     {%- if fluent.proxyUrl %}
     proxy_url                        "{{ fluent.proxyUrl }}"

--- a/orchestrator-salt/src/main/resources/salt/pillar/metering/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/pillar/metering/init.sls
@@ -3,4 +3,5 @@ metering:
   clusterCrn:
   serviceType:
   serviceVersion:
+  streamName:
   platform:

--- a/orchestrator-salt/src/main/resources/salt/salt/metering/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/metering/settings.sls
@@ -11,13 +11,27 @@
 {% endif %}
 {% set platform = salt['pillar.get']('metering:platform') %}
 {% set cluster_crn = salt['pillar.get']('metering:clusterCrn') %}
+{% set cluster_name = salt['pillar.get']('metering:clusterName') %}
 {% set service_type = salt['pillar.get']('metering:serviceType') %}
 {% set service_version = salt['pillar.get']('metering:serviceVersion') %}
+{% set stream_name = salt['pillar.get']('metering:streamName') %}
+
+{% if cluster_name and stream_name and stream_name != "Metering" %}
+    {% if "metering_prewarmed_v2" in grains.get('roles', []) or not salt['file.directory_exists' ]('/etc/metering') %}
+        {% set version = 2 %}
+    {% else %}
+        {% set version = 1 %}
+    {% endif %}
+{% else %}
+    {% set version = 1 %}
+{% endif %}
 
 {% do metering.update({
     "is_systemd" : is_systemd,
     "enabled": metering_enabled,
     "clusterCrn": cluster_crn,
+    "clusterName": cluster_name,
     "serviceType": service_type,
-    "serviceVersion": service_version
+    "serviceVersion": service_version,
+    "version": version
 }) %}

--- a/orchestrator-salt/src/main/resources/salt/salt/metering/template/generate_heartbeats.ini.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/metering/template/generate_heartbeats.ini.j2
@@ -2,13 +2,18 @@
 {%- from 'nodes/settings.sls' import host with context %}
 # CONFIGURED BY SALT - do not edit
 [Event]
+ServiceVersion = {{ metering.serviceVersion }}{% if metering.version > 1 %}
+ServiceType = "{{ metering.serviceType }}"
+MeteredResourceName = {{ metering.clusterName }}
+MeteredResourceCRN = {{ salt['pillar.get']('tags:Cloudera-Resource-Name') }}
+CreatorCRN = {{ salt['pillar.get']('tags:Cloudera-Creator-Resource-Name') }}
+EnvironmentCRN = {{ salt['pillar.get']('tags:Cloudera-Environment-Resource-Name') }}{% else %}
+ServiceType = "DATAHUB"
 ClusterCRN = {{ metering.clusterCrn }}
+WorkloadCRN = {{ metering.clusterCrn }}{% endif %}
 InstanceID = {{ host.instance_id }}
 InstanceType = {{ host.instance_type }}
 InstanceIP = {{ host.private_address }}
-ServiceType = {{ metering.serviceType }}
-ServiceVersion = {{ metering.serviceVersion }}
-WorkloadCRN = {{ metering.clusterCrn }}
 
 [Output]
 Path = /var/log/metering/heartbeats.json


### PR DESCRIPTION
details:
- adding 2 new global configs for CB - metering app and stream name (creating a new metering configuration object for those)
- the configs are passed to salt configurations (app & stream -> used by fluentd, stream also used by metering service for a check)
- added a few new fields based on the new metering version (v2), using cluster name + using tags for some specific fields (also start using the service type tag if that exists)
- old format will be still used, if: no metering_prewarmed_v2 role, no cluster name field, no stream name field, or if the stream name field is 'Metering' (as that is valid for the old format)
- metering_prewarmed_v2 will be set in cloudbreak-images project. as a snapshot version is used for metering, without versions, with that grain we can be sure we are using a fresh
- use metering v2 version in case of base images as well (see metering/settings.sls)

See detailed description in the commit message.