### PR TITLE
CB-8248: FreeIPA reboot flow finishes before instances reboot

### DIFF
--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsInstanceConnectorTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsInstanceConnectorTest.java
@@ -245,6 +245,18 @@ public class AwsInstanceConnectorTest {
     }
 
     @Test
+    public void testRebootEveryInstancesStarted() {
+        mockDescribeInstancesAllisRebooted(POLLING_LIMIT - 2);
+        ArgumentCaptor<StopInstancesRequest> stopCaptor = ArgumentCaptor.forClass(StopInstancesRequest.class);
+        ArgumentCaptor<StartInstancesRequest> startCaptor = ArgumentCaptor.forClass(StartInstancesRequest.class);
+        List<CloudVmInstanceStatus> result = underTest.reboot(authenticatedContext, inputList);
+
+        verify(amazonEC2Client, times(2)).stopInstances(stopCaptor.capture());
+        verify(amazonEC2Client, times(2)).startInstances(startCaptor.capture());
+        Assert.assertThat(result, hasItem(allOf(hasProperty("status", is(InstanceStatus.STARTED)))));
+    }
+
+    @Test
     public void testStartEveryInstancesStartedAlready() {
         mockDescribeInstancesAllIsRunning(POLLING_LIMIT - 2);
         List<CloudVmInstanceStatus> result = underTest.start(authenticatedContext, List.of(), inputList);
@@ -340,6 +352,23 @@ public class AwsInstanceConnectorTest {
     private void mockDescribeInstancesAllIsRunning(int pollResponses) {
         mockListOfDescribeInstances(getDescribeInstancesResult("running", 16), pollResponses,
                 getDescribeInstancesResult("running", 16));
+    }
+
+    private void mockDescribeInstancesAllisRebooted(int pollResponses) {
+        mockListOfDescribeInstancesStopAndThenRunning(getDescribeInstancesResultOneRunning("running", 16), pollResponses,
+                getDescribeInstancesResult("stopped", 16));
+    }
+
+    private void mockListOfDescribeInstancesStopAndThenRunning(DescribeInstancesResult cons, int repeatNo, DescribeInstancesResult stopped) {
+        DescribeInstancesResult[] describeInstancesResults = new DescribeInstancesResult[repeatNo * 2];
+        Arrays.fill(describeInstancesResults, cons);
+        describeInstancesResults[2] = stopped;
+        describeInstancesResults[4] = stopped;
+        describeInstancesResults[5] = stopped;
+        describeInstancesResults[6] = stopped;
+        describeInstancesResults[8] = stopped;
+        when(amazonEC2Client.describeInstances(any(DescribeInstancesRequest.class))).thenReturn(cons,
+                describeInstancesResults);
     }
 
     private void mockListOfDescribeInstances(DescribeInstancesResult cons, int repeatNo, DescribeInstancesResult last) {

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureInstanceConnector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureInstanceConnector.java
@@ -78,7 +78,8 @@ public class AzureInstanceConnector implements InstanceConnector {
             AzureClient azureClient = ac.getParameter(AzureClient.class);
             String resourceGroupName = azureResourceGroupMetadataProvider.getResourceGroupName(ac.getCloudContext(), vm.getCloudInstance());
             if (vm.getStatus() == InstanceStatus.STARTED) {
-                doReboot(completables, vm, statuses, () -> azureClient.rebootVirtualMachineAsync(resourceGroupName, vm.getCloudInstance().getInstanceId()));
+                doReboot(completables, vm, statuses, () -> azureClient.stopVirtualMachineAsync(resourceGroupName, vm.getCloudInstance().getInstanceId())
+                        .andThen(azureClient.startVirtualMachineAsync(resourceGroupName, vm.getCloudInstance().getInstanceId())));
             } else if (vm.getStatus() == InstanceStatus.STOPPED) {
                 doReboot(completables, vm, statuses, () -> azureClient.startVirtualMachineAsync(resourceGroupName, vm.getCloudInstance().getInstanceId()));
             } else {

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
@@ -498,6 +498,10 @@ public class AzureClient {
         handleAuthException(() -> azure.virtualMachines().powerOff(resourceGroup, vmName));
     }
 
+    public Completable stopVirtualMachineAsync(String resourceGroup, String vmName) {
+        return handleAuthException(() -> azure.virtualMachines().powerOffAsync(resourceGroup, vmName));
+    }
+
     public Completable deletePublicIpAddressByNameAsync(String resourceGroup, String ipName) {
         return handleAuthException(() -> azure.publicIPAddresses().deleteByResourceGroupAsync(resourceGroup, ipName));
     }


### PR DESCRIPTION
Use combined stop/start operations in the FreeIPA instance reboot flow so that FreeIPA repair will wait for the AWS/Azure nodes to return to an actual running state. Currently, during a reboot operation, the AWS/Azure nodes always report a running state (this is so that the billing doesn't start billing a new session). With this fix, the reboot flow will actually finish. AWS will only bill for a minimum of 60 seconds each time a new instance is started.

See detailed description in the commit message.