### PR TITLE
CLOUDQE-257: Add gateway hostgroup for Data Engineering Spark 3 template in Public Cloud

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-722.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-722.bp
@@ -278,7 +278,19 @@
           "yarn-NODEMANAGER-COMPUTE",
           "yarn-GATEWAY-BASE"
         ]
+      },
+      {
+        "refName": "gateway",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "hdfs-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
+          "spark3_on_yarn-GATEWAY-BASE",
+          "livy_for_spark3-GATEWAY-BASE",
+          "yarn-GATEWAY-BASE"
+        ]
       }
+
     ]
   }
 }


### PR DESCRIPTION
Hi Cloudbreak team,

The gateway hostgroup is missing from this Spark 3 cluster template. It is necessary for the Public Cloud QE testing. Could you please add it?

CC @dabondor 