### PR TITLE
CB-8577 - cdp-proxy-api topology files needs ACLs for hbasejars service

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
@@ -135,6 +135,10 @@
                 <name>{{ aclsauthz_prefix ~ "webhdfs.acl" }}</name>
                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
             </param>
+            <param>
+                 <name>{{ aclsauthz_prefix ~ "hbasejars.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+            </param>
         </provider>
 {%- endif %}
 


### PR DESCRIPTION
HBASEJARS services in cdp-proxy-api topology needs acls just like other services defined in topology_api.xml.j2
This is a very simple change and should not have any side effects.