### PR TITLE
CB-8211: Set HBase root directory in Datalake as S3 path

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hbase/HbaseCloudStorageServiceConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hbase/HbaseCloudStorageServiceConfigProvider.java
@@ -12,7 +12,6 @@ import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateComponentConfigProvider;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
-import com.sequenceiq.cloudbreak.template.views.SharedServiceConfigsView;
 
 @Component
 public class HbaseCloudStorageServiceConfigProvider implements CmTemplateComponentConfigProvider {
@@ -41,12 +40,7 @@ public class HbaseCloudStorageServiceConfigProvider implements CmTemplateCompone
 
     @Override
     public boolean isConfigurationNeeded(CmTemplateProcessor cmTemplateProcessor, TemplatePreparationObject source) {
-        boolean datalakeCluster = source.getSharedServiceConfigs()
-                .map(SharedServiceConfigsView::isDatalakeCluster)
-                .orElse(false);
-
         return source.getFileSystemConfigurationView().isPresent()
-                && cmTemplateProcessor.isRoleTypePresentInService(getServiceType(), getRoleTypes())
-                && !datalakeCluster;
+                && cmTemplateProcessor.isRoleTypePresentInService(getServiceType(), getRoleTypes());
     }
 }

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hbase/HbaseCloudStorageServiceConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hbase/HbaseCloudStorageServiceConfigProviderTest.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.hbase;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -31,7 +30,7 @@ public class HbaseCloudStorageServiceConfigProviderTest {
     private final HbaseCloudStorageServiceConfigProvider underTest = new HbaseCloudStorageServiceConfigProvider();
 
     @Test
-    public void testGetHbaseStorageServiceConfigs() {
+    public void testGetHbaseStorageServiceConfigsWhenAttachedCluster() {
         TemplatePreparationObject preparationObject = getTemplatePreparationObject(true, false);
         String inputJson = getBlueprintText("input/clouderamanager.bp");
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
@@ -44,7 +43,20 @@ public class HbaseCloudStorageServiceConfigProviderTest {
     }
 
     @Test
-    public void testGetHbaseServiceConfigsWhenNoStorageConfigured() {
+    public void testGetHbaseStorageServiceConfigsWhenDataLake() {
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject(true, true);
+        String inputJson = getBlueprintText("input/clouderamanager.bp");
+        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(cmTemplateProcessor, preparationObject);
+
+        assertEquals(1, serviceConfigs.size());
+        assertEquals("hdfs_rootdir", serviceConfigs.get(0).getName());
+        assertEquals("s3a://bucket/cluster1/hbase", serviceConfigs.get(0).getValue());
+    }
+
+    @Test
+    public void testGetHbaseServiceConfigsWhenNoStorageConfiguredWithAttachedCluster() {
         TemplatePreparationObject preparationObject = getTemplatePreparationObject(false, false);
         String inputJson = getBlueprintText("input/clouderamanager.bp");
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
@@ -54,13 +66,23 @@ public class HbaseCloudStorageServiceConfigProviderTest {
     }
 
     @Test
-    public void testIsConfigurationNotNeededWhenDatalake() {
+    public void testGetHbaseServiceConfigsWhenNoStorageConfiguredWithDataLake() {
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject(false, true);
+        String inputJson = getBlueprintText("input/clouderamanager.bp");
+        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(cmTemplateProcessor, preparationObject);
+        assertEquals(0, serviceConfigs.size());
+    }
+
+    @Test
+    public void testConfigurationNeededWhenDatalake() {
         TemplatePreparationObject preparationObject = getTemplatePreparationObject(true, true);
         String inputJson = getBlueprintText("input/clouderamanager.bp");
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
 
         boolean configurationNeeded = underTest.isConfigurationNeeded(cmTemplateProcessor, preparationObject);
-        assertFalse(configurationNeeded);
+        assertTrue(configurationNeeded);
     }
 
     @Test

--- a/template-manager-cmtemplate/src/test/resources/output/clouderamanager-fixparam.bp
+++ b/template-manager-cmtemplate/src/test/resources/output/clouderamanager-fixparam.bp
@@ -89,6 +89,12 @@
     {
       "refName": "hbase",
       "serviceType": "HBASE",
+      "serviceConfigs": [
+        {
+          "name": "hdfs_rootdir",
+          "value": "s3a://bucket/cluster1/hbase"
+        }
+      ],
       "roleConfigGroups": [
         {
           "refName": "hbase-REGIONSERVER-BASE",

--- a/template-manager-cmtemplate/src/test/resources/output/clouderamanager-nometastore.bp
+++ b/template-manager-cmtemplate/src/test/resources/output/clouderamanager-nometastore.bp
@@ -81,6 +81,12 @@
     {
       "refName": "hbase",
       "serviceType": "HBASE",
+      "serviceConfigs": [
+        {
+          "name": "hdfs_rootdir",
+          "value": "s3a://bucket/cluster1/hbase"
+        }
+      ],
       "roleConfigGroups": [
         {
           "refName": "hbase-REGIONSERVER-BASE",

--- a/template-manager-cmtemplate/src/test/resources/output/clouderamanager-variables.bp
+++ b/template-manager-cmtemplate/src/test/resources/output/clouderamanager-variables.bp
@@ -80,6 +80,12 @@
     {
       "refName": "hbase",
       "serviceType": "HBASE",
+      "serviceConfigs": [
+        {
+          "name": "hdfs_rootdir",
+          "value": "s3a://bucket/cluster1/hbase"
+        }
+      ],
       "roleConfigGroups": [
         {
           "refName": "hbase-REGIONSERVER-BASE",

--- a/template-manager-cmtemplate/src/test/resources/output/clouderamanager-without-hosts.bp
+++ b/template-manager-cmtemplate/src/test/resources/output/clouderamanager-without-hosts.bp
@@ -81,6 +81,12 @@
     {
       "refName": "hbase",
       "serviceType": "HBASE",
+      "serviceConfigs": [
+        {
+          "name": "hdfs_rootdir",
+          "value": "s3a://bucket/cluster1/hbase"
+        }
+      ],
       "roleConfigGroups": [
         {
           "refName": "hbase-REGIONSERVER-BASE",

--- a/template-manager-cmtemplate/src/test/resources/output/clouderamanager.bp
+++ b/template-manager-cmtemplate/src/test/resources/output/clouderamanager.bp
@@ -80,6 +80,12 @@
     {
       "refName": "hbase",
       "serviceType": "HBASE",
+      "serviceConfigs": [
+        {
+          "name": "hdfs_rootdir",
+          "value": "s3a://bucket/cluster1/hbase"
+        }
+      ],
       "roleConfigGroups": [
         {
           "refName": "hbase-REGIONSERVER-BASE",


### PR DESCRIPTION
When the cluster is Data Lake, still set the HBase root directory to use cloud storage if the cloud storage base is configured.

In "DISTX-303 DistroX Hbase Cloud Storage", it only sets HBase root directory for workload cluster. We need to extend cloud storage for HBase to the Data Lake cluster.