### PR TITLE
CB-8646 PTR record added to another zone

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/template/add_dns_record.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/template/add_dns_record.j2
@@ -29,8 +29,8 @@ fi
 for zone in $(ipa dnszone-find --raw | grep "idnsname:.*\.in-addr\.arpa\." | cut -d':' -f2 | awk '{ print length, $0 }' | sort -n -r | awk '{ print $2 }' | xargs)
 do
     ZONE_NET=${zone//.in-addr.arpa./}
-    if echo "$REVERSE_IP" | grep -qE "$ZONE_NET$"; then
-        REVERSE_RECORD_NAME=$(echo "$REVERSE_IP" | sed "s/.$ZONE_NET$//g")
+    if echo "$REVERSE_IP" | grep -qE "\.$ZONE_NET$"; then
+        REVERSE_RECORD_NAME=$(echo "$REVERSE_IP" | sed "s/\.$ZONE_NET$//g")
         # dnsrecord-add must either add the record or modify it
         if ! ipa dnsrecord-find "$zone" "--name=$REVERSE_RECORD_NAME" "--ptr-rec=${FQDN}." --ttl {{ pillar['sssd-ipa']['dns_ttl'] }}; then
           ipa dnsrecord-add "$zone" "$REVERSE_RECORD_NAME" "--ptr-rec=${FQDN}." --ttl {{ pillar['sssd-ipa']['dns_ttl'] }}


### PR DESCRIPTION
In case there are 2 subnets, say 222.a.b and 2.a.b, then the script add_dns_record tries to add IP addresses to both DNS zones which is incorrect. However, because of another error in the script an error message was produced instead of silently adding the dns record to the wrong dns zone.

See detailed description in the commit message.