### PR TITLE
CB-8656 - Filter images during upgrade if they are older by date or either CM or CDP is older than before

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeImageFilter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeImageFilter.java
@@ -129,7 +129,7 @@ public class ClusterUpgradeImageFilter {
         return image -> {
             boolean result = lockComponents ? (permitLockedComponentsUpgrade(image, activatedParcels))
                     : (permitCmAndStackUpgrade(currentImage, image, CM_PACKAGE_KEY, CM_BUILD_NUMBER_KEY)
-                    || permitCmAndStackUpgrade(currentImage, image, STACK_PACKAGE_KEY, CDH_BUILD_NUMBER_KEY));
+                    && permitCmAndStackUpgrade(currentImage, image, STACK_PACKAGE_KEY, CDH_BUILD_NUMBER_KEY));
 
             if (lockComponents) {
                 setReason(result, "There is at least one activated parcel for which we cannot find image with matching version. "

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeImageFilter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeImageFilter.java
@@ -77,7 +77,7 @@ public class ClusterUpgradeImageFilter {
                 .filter(filterCurrentImage(currentImage))
                 .filter(filterNonCmImages())
                 .filter(filterIgnoredCmVersion())
-                .filter(filterPreviousImagesForOsUpgrades(currentImage, lockComponents))
+                .filter(filterPreviousImages(currentImage, lockComponents))
                 .filter(validateCmAndStackVersion(currentImage, lockComponents, activatedParcels))
                 .filter(validateCloudPlatform(cloudPlatform))
                 .filter(validateOsVersion(currentImage))
@@ -87,10 +87,9 @@ public class ClusterUpgradeImageFilter {
         return new ImageFilterResult(new Images(null, images, null), getReason(images));
     }
 
-    private Predicate<Image> filterPreviousImagesForOsUpgrades(Image currentImage, boolean lockComponents) {
+    private Predicate<Image> filterPreviousImages(Image currentImage, boolean lockComponents) {
         return image -> {
-            boolean result = !lockComponents
-                    || filterPreviousImages(currentImage, image);
+            boolean result = filterPreviousImages(currentImage, image);
             setReason(result, "There are no newer images available than " + currentImage.getDate() + ".");
             return result;
         };
@@ -98,8 +97,8 @@ public class ClusterUpgradeImageFilter {
 
     private boolean filterPreviousImages(Image currentImage, Image image) {
         return Objects.nonNull(image.getCreated())
-        && Objects.nonNull(currentImage.getCreated())
-        && image.getCreated() >= currentImage.getCreated();
+                && Objects.nonNull(currentImage.getCreated())
+                && image.getCreated() >= currentImage.getCreated();
     }
 
     private Predicate<Image> filterCurrentImage(Image currentImage) {
@@ -130,7 +129,7 @@ public class ClusterUpgradeImageFilter {
         return image -> {
             boolean result = lockComponents ? (permitLockedComponentsUpgrade(image, activatedParcels))
                     : (permitCmAndStackUpgrade(currentImage, image, CM_PACKAGE_KEY, CM_BUILD_NUMBER_KEY)
-                            || permitCmAndStackUpgrade(currentImage, image, STACK_PACKAGE_KEY, CDH_BUILD_NUMBER_KEY));
+                    || permitCmAndStackUpgrade(currentImage, image, STACK_PACKAGE_KEY, CDH_BUILD_NUMBER_KEY));
 
             if (lockComponents) {
                 setReason(result, "There is at least one activated parcel for which we cannot find image with matching version. "

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeImageFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeImageFilterTest.java
@@ -197,11 +197,10 @@ public class ClusterUpgradeImageFilterTest {
         ImageFilterResult imageFilterResult = new ImageFilterResult(new Images(null, allImage, null), "");
 
         when(versionBasedImageFilter.getCdhImagesForCbVersion(supportedCbVersions, allImage)).thenReturn(imageFilterResult);
-        when(upgradePermissionProvider.permitCmAndStackUpgrade(any(), any(), any(), any())).thenReturn(true);
 
         ImageFilterResult actual = underTest.filter(allImage, supportedCbVersions, currentImage, CLOUD_PLATFORM, lockComponents, activatedParcels);
 
-        assertEquals(1, actual.getAvailableImages().getCdhImages().size());
+        assertEquals(0, actual.getAvailableImages().getCdhImages().size());
     }
 
     @Test


### PR DESCRIPTION
`1 PR 2 related changes hence the 2 commits`

Previously, we only filtered the older images by date
when you wanted to perform an OS upgrade. With this change
the older images will be filtered even if you want to perform
a runtime upgrade.

We offered images for upgrade if either the CM or the CDP version
was newer on the image. However, this is not optimal as we would
allow you to upgrade to a newer CDP where the CM is older an it would
mean a downgrade on CM. It is true the other way around as well. With
this change we are only offering images where both CM & CDP versions
are newer than before.