### PR TITLE
CB-8414 Enable SSL on Salt-API (rest_cherrypy)

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/nginx/conf/ssl-locations.d/saltapi.conf
+++ b/freeipa/src/main/resources/freeipa-salt/salt/nginx/conf/ssl-locations.d/saltapi.conf
@@ -1,6 +1,10 @@
 location ~ /saltapi/(?<section>.*) {
+{%- if salt['file.file_exists' ]('/etc/pki/tls/certs/saltapi.crt') %}
+  proxy_pass         https://saltapi/$section$is_args$args;
+{%- else %}
   proxy_pass         http://saltapi/$section$is_args$args;
-    proxy_read_timeout 300;
+{%- endif %}
+  proxy_read_timeout 300;
   proxy_redirect     off;
   proxy_set_header   Host $host;
   proxy_set_header   X-Forwarded-Host $server_name;

--- a/freeipa/src/main/resources/freeipa-salt/salt/nginx/init.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/nginx/init.sls
@@ -14,6 +14,7 @@
   file.managed:
     - makedirs: True
     - source: salt://nginx/conf/ssl-locations.d/saltapi.conf
+    - template: jinja
 
 /etc/nginx/sites-enabled/ssl-locations.d/saltboot.conf:
   file.managed:

--- a/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/ssl-locations.d/saltapi.conf
+++ b/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/ssl-locations.d/saltapi.conf
@@ -1,6 +1,10 @@
 location ~ /saltapi/(?<section>.*) {
+{%- if salt['file.file_exists' ]('/etc/pki/tls/certs/saltapi.crt') %}
+  proxy_pass         https://saltapi/$section$is_args$args;
+{%- else %}
   proxy_pass         http://saltapi/$section$is_args$args;
-    proxy_read_timeout 300;
+{%- endif %}
+  proxy_read_timeout 300;
   proxy_redirect     off;
   proxy_set_header   Host $host;
   proxy_set_header   X-Forwarded-Host $server_name;

--- a/orchestrator-salt/src/main/resources/salt/salt/nginx/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/nginx/init.sls
@@ -20,6 +20,7 @@
   file.managed:
     - makedirs: True
     - source: salt://nginx/conf/ssl-locations.d/saltapi.conf
+    - template: jinja
 
 /etc/nginx/sites-enabled/ssl-locations.d/saltboot.conf:
   file.managed:


### PR DESCRIPTION
This commit modifies nginx configuration to access salt-api via https
if the cert is present on the node.
The cert will be present only on instance which are from a new image
configured with SSL for salt-api

See detailed description in the commit message.