### PR TITLE
CB-8644 Reduce flakiness of IT

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/deletion/handler/freeipa/FreeIpaDeletionHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/deletion/handler/freeipa/FreeIpaDeletionHandler.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import javax.ws.rs.NotFoundException;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,16 +105,24 @@ public class FreeIpaDeletionHandler extends EventSenderAwareHandler<EnvironmentD
     }
 
     private void detachChildEnvironmentFromFreeIpa(Environment environment) {
-        DetachChildEnvironmentRequest detachChildEnvironmentRequest = new DetachChildEnvironmentRequest();
-        detachChildEnvironmentRequest.setParentEnvironmentCrn(environment.getParentEnvironment().getResourceCrn());
-        detachChildEnvironmentRequest.setChildEnvironmentCrn(environment.getResourceCrn());
-        freeIpaService.detachChildEnvironment(detachChildEnvironmentRequest);
+        try {
+            DetachChildEnvironmentRequest detachChildEnvironmentRequest = new DetachChildEnvironmentRequest();
+            detachChildEnvironmentRequest.setParentEnvironmentCrn(environment.getParentEnvironment().getResourceCrn());
+            detachChildEnvironmentRequest.setChildEnvironmentCrn(environment.getResourceCrn());
+            freeIpaService.detachChildEnvironment(detachChildEnvironmentRequest);
 
-        if (lastChildEnvironmentInNetworkIsGettingDeleted(environment)) {
-            try {
-                dnsV1Endpoint.deleteDnsZoneBySubnet(environment.getParentEnvironment().getResourceCrn(), environment.getNetwork().getNetworkCidr());
-            } catch (Exception e) {
-                LOGGER.warn("Failed to delete dns zone of child environment.", e);
+            if (lastChildEnvironmentInNetworkIsGettingDeleted(environment)) {
+                try {
+                    dnsV1Endpoint.deleteDnsZoneBySubnet(environment.getParentEnvironment().getResourceCrn(), environment.getNetwork().getNetworkCidr());
+                } catch (Exception e) {
+                    LOGGER.warn("Failed to delete dns zone of child environment.", e);
+                }
+            }
+        } catch (FreeIpaOperationFailedException e) {
+            if (e.getCause() instanceof NotFoundException) {
+                LOGGER.warn("Child FreeIpa is already detached.", e);
+            } else {
+                throw e;
             }
         }
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
@@ -37,6 +37,8 @@ import com.sequenceiq.it.cloudbreak.ResourceGroupTest;
 import com.sequenceiq.it.cloudbreak.assign.Assignable;
 import com.sequenceiq.it.cloudbreak.client.EnvironmentTestClient;
 import com.sequenceiq.it.cloudbreak.cloud.v4.aws.AwsProperties;
+import com.sequenceiq.it.cloudbreak.context.Clue;
+import com.sequenceiq.it.cloudbreak.context.Investigable;
 import com.sequenceiq.it.cloudbreak.context.RunningParameter;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
@@ -48,7 +50,7 @@ import com.sequenceiq.it.cloudbreak.search.Searchable;
 @Prototype
 public class EnvironmentTestDto
         extends DeletableEnvironmentTestDto<EnvironmentRequest, DetailedEnvironmentResponse, EnvironmentTestDto, SimpleEnvironmentResponse>
-        implements Searchable, Assignable {
+        implements Searchable, Assignable, Investigable {
 
     public static final String ENVIRONMENT = "ENVIRONMENT";
 
@@ -377,5 +379,13 @@ public class EnvironmentTestDto
             throw new IllegalStateException("You have tried to assign to a Dto that hasn't been created and therefore has no Response object.");
         }
         return getResponse().getCrn();
+    }
+
+    @Override
+    public Clue investigate() {
+        if (getResponse() == null) {
+            return null;
+        }
+        return new Clue("Environment", null, getResponse(), false);
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentStartStopTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentStartStopTest.java
@@ -58,17 +58,14 @@ public class EnvironmentStartStopTest extends AbstractIntegrationTest {
             when = "create an attached SDX and Datahub",
             then = "should be stopped first and started after it")
     public void testCreateStopStartEnvironment(MockedTestContext testContext) {
-        MockedTestContext mockedTestContext = (MockedTestContext) testContext;
-        setUpFreeIpaRouteStubbing(mockedTestContext);
+        setUpFreeIpaRouteStubbing(testContext);
         testContext
                 .given(EnvironmentNetworkTestDto.class)
                 .given(EnvironmentTestDto.class).withNetwork().withCreateFreeIpa(false)
                 .when(environmentTestClient.create())
                 .await(EnvironmentStatus.AVAILABLE)
                 .given(FreeIpaTestDto.class)
-                .withCatalog(mockedTestContext
-                .getImageCatalogMockServerSetup()
-                        .getFreeIpaImageCatalogUrl())
+                .withCatalog(testContext.getImageCatalogMockServerSetup().getFreeIpaImageCatalogUrl())
                 .when(freeIpaTestClient.create())
                 .await(AVAILABLE)
                 .given(SdxInternalTestDto.class)
@@ -82,15 +79,16 @@ public class EnvironmentStartStopTest extends AbstractIntegrationTest {
                 .given("dx1", DistroXTestDto.class)
                 .await(STACK_AVAILABLE, key("dx1"))
                 .given("dx2", DistroXTestDto.class)
-                .await(STACK_AVAILABLE, key("dx2"))
+                .await(STACK_AVAILABLE, key("dx2"));
+        getFreeIpaRouteHandler().updateResponse("server_conncheck", new ServerConnCheckFreeipaRpcResponse(false, Collections.emptyList()));
+        testContext
                 .given(EnvironmentTestDto.class)
                 .when(environmentTestClient.stop())
                 .await(EnvironmentStatus.ENV_STOPPED, POLLING_INTERVAL);
-        getFreeIpaRouteHandler().updateResponse("server_conncheck", new ServerConnCheckFreeipaRpcResponse(false, Collections.emptyList()));
+        getFreeIpaRouteHandler().updateResponse("server_conncheck", new ServerConnCheckFreeipaRpcResponse());
         testContext.given(EnvironmentTestDto.class)
                 .when(environmentTestClient.start())
                 .await(EnvironmentStatus.AVAILABLE, POLLING_INTERVAL)
                 .validate();
-        getFreeIpaRouteHandler().updateResponse("server_conncheck", new ServerConnCheckFreeipaRpcResponse());
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/util/SimpleRetryUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/util/SimpleRetryUtil.java
@@ -1,0 +1,45 @@
+package com.sequenceiq.it.util;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+public class SimpleRetryUtil {
+
+    private SimpleRetryUtil() {
+    }
+
+    public static void retry(int retryTimes, int retryWaitSeconds, Runnable action) {
+        retry(retryTimes, retryWaitSeconds, () -> {
+            action.run();
+            return null;
+        });
+    }
+
+    public static <T> T retry(int retryTimes, int retryWaitSeconds, Supplier<T> action) {
+        T result = null;
+
+        int timesTried = 0;
+        RuntimeException exception;
+        do {
+            timesTried++;
+            exception = null;
+            try {
+                result = action.get();
+            } catch (RuntimeException e) {
+                exception = e;
+                try {
+                    TimeUnit.SECONDS.sleep(retryWaitSeconds);
+                } catch (InterruptedException ignored) {
+                }
+            }
+        } while (exception != null && timesTried < retryTimes);
+
+        if (Objects.isNull(exception)) {
+            return result;
+        }
+
+        throw new RuntimeException(String.format("Failed to run command %d times.", retryTimes), exception);
+    }
+
+}


### PR DESCRIPTION
- Add retry logic to MockVerification by introducing SimpleRetryUtil
- Fix FreeIpa stubbing in EnvironmentStartStopTest.testCreateStopStartEnvironment
- Refactor EnvironmentChildTest.testDeleteChildAndParentEnvironment for better readability
- Make FreeIpaDeletionHandler.detachChildEnvironmentFromFreeIpa idempotent
- Add clues from EnvironmentTestDto