### PR TITLE
CDPSDX-2413: Increase FreeIPA operation timeout to 1 hour

### DIFF
--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -76,7 +76,7 @@ freeipa:
     lockout-duration: 10
   operation:
     cleanup:
-      timeout-millis: 1800000
+      timeout-millis: 3600000
       initial-delay-millis: 60000
       fixed-delay-millis: 60000
   max:


### PR DESCRIPTION
Increase the FreeIPA operation serivice timeout from 30 minutes to 1
hour. This will allow the repair to complete without a timeout. A
repair may take more than 30 minutes if there are multiple instances
being repaired.

This was manually tested using a local cloudbreak.

See detailed description in the commit message.

I am suggesting this for 2.29 since has affected FreeIPA HA and that is planned for 2.29. Without this fix, it will likely allow only repairing a single instance of FreeIPA HA at a time without timing out.