### PR TITLE
CB-8630. Metering OS support warning is logged even for CentOS

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/metering/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/metering/init.sls
@@ -80,6 +80,7 @@ warning_metering_systemd:
   cmd.run:
     - name: echo "Warning - Metering won't be installed/used as it requires systemd"
 {% endif %}
+{% else %}
 warning_metering_os:
   cmd.run:
     - name: echo "Warning - Metering is not supported on this OS ({{ os }})"


### PR DESCRIPTION
See detailed description in the commit message.