### PR TITLE
CB-3261 For GCP support add the hostname to the instance while bringing it up.

### DIFF
--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilder.java
@@ -187,11 +187,12 @@ public class GcpInstanceResourceBuilder extends AbstractGcpComputeBuilder {
     }
 
     private String getHostname(CloudStack cloudStack, List<CloudResource> buildableResource) {
+        String hostname = null;
         if (!cloudStack.getGroups().isEmpty() && !cloudStack.getGroups().get(0).getInstances().isEmpty()) {
-            return cloudStack.getGroups().get(0).getInstances().get(0).getStringParameter(CloudInstance.DISCOVERY_NAME);
+            hostname = cloudStack.getGroups().get(0).getInstances().get(0).getStringParameter(CloudInstance.DISCOVERY_NAME);
+            LOGGER.debug("Setting FreeIPA hostname to {}", hostname);
         }
-
-        return buildableResource.get(0).getName();
+        return hostname;
     }
 
     private static String mergeAndTrimKV(String key, String value, char middle, int maxLen) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverter.java
@@ -144,6 +144,7 @@ public class StackToCloudStackConverter {
 
     public CloudInstance buildInstance(InstanceMetaData instanceMetaData, InstanceGroup instanceGroup,
             StackAuthentication stackAuthentication, Long privateId, InstanceStatus status) {
+        LOGGER.debug("Instance metadata is {}", instanceMetaData);
         String id = instanceMetaData == null ? null : instanceMetaData.getInstanceId();
         String instanceImageId = instanceMetaData == null ? null : instanceMetadataToImageIdConverter.convert(instanceMetaData);
         String name = instanceGroup.getGroupName();

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentCreationService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentCreationService.java
@@ -127,7 +127,7 @@ public class EnvironmentCreationService {
         ValidationResult parentChildValidation = validatorService.validateParentChildRelation(environment, creationDto.getParentEnvironmentName());
         validationBuilder.merge(parentChildValidation);
         validationBuilder.ifError(() -> isCloudPlatformInvalid(creationDto.getCreator(), creationDto.getCloudPlatform()),
-                "Provisioning in Microsoft Azure is not enabled for this account.");
+                "Provisioning in " + creationDto.getCloudPlatform() + " is not enabled for this account.");
         ValidationResult freeIpaCreationValidation = validatorService.validateFreeIpaCreation(creationDto.getFreeIpaCreation());
         validationBuilder.merge(freeIpaCreationValidation);
         ValidationResult validationResult = validationBuilder.build();

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/instance/InstanceGroupRequestToInstanceGroupConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/instance/InstanceGroupRequestToInstanceGroupConverter.java
@@ -26,7 +26,7 @@ public class InstanceGroupRequestToInstanceGroupConverter {
     @Inject
     private DefaultInstanceGroupProvider defaultInstanceGroupProvider;
 
-    public InstanceGroup convert(InstanceGroupRequest source, String accountId, String cloudPlatformString, String stackName) {
+    public InstanceGroup convert(InstanceGroupRequest source, String accountId, String cloudPlatformString, String stackName, String hostname, String domain) {
         InstanceGroup instanceGroup = new InstanceGroup();
         CloudPlatform cloudPlatform = CloudPlatform.valueOf(cloudPlatformString);
         instanceGroup.setTemplate(source.getInstanceTemplate() == null
@@ -38,17 +38,18 @@ public class InstanceGroupRequestToInstanceGroupConverter {
         instanceGroup.setInstanceGroupType(source.getType());
         instanceGroup.setAttributes(defaultInstanceGroupProvider.createAttributes(cloudPlatform, stackName, instanceGroupName));
         if (source.getNodeCount() > 0) {
-            addInstanceMetadatas(source, instanceGroup);
+            addInstanceMetadatas(source, instanceGroup, hostname, domain);
         }
         instanceGroup.setNodeCount(source.getNodeCount());
         return instanceGroup;
     }
 
-    private void addInstanceMetadatas(InstanceGroupRequest request, InstanceGroup instanceGroup) {
+    private void addInstanceMetadatas(InstanceGroupRequest request, InstanceGroup instanceGroup, String hostname, String domain) {
         Set<InstanceMetaData> instanceMetaDataSet = new HashSet<>();
         for (int i = 0; i < request.getNodeCount(); i++) {
             InstanceMetaData instanceMetaData = new InstanceMetaData();
             instanceMetaData.setInstanceGroup(instanceGroup);
+            instanceMetaData.setDiscoveryFQDN(hostname + "%d." + domain);
             instanceMetaDataSet.add(instanceMetaData);
         }
         instanceGroup.setInstanceMetaData(instanceMetaDataSet);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/CreateFreeIpaRequestToStackConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/CreateFreeIpaRequestToStackConverter.java
@@ -36,6 +36,7 @@ import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.cloudbreak.tag.CostTagging;
 import com.sequenceiq.cloudbreak.tag.request.CDPTagGenerationRequest;
 import com.sequenceiq.common.api.type.Tunnel;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.FreeIpaServerRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupType;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.region.PlacementBase;
@@ -250,7 +251,11 @@ public class CreateFreeIpaRequestToStackConverter {
         }
         Set<InstanceGroup> convertedSet = new HashSet<>();
         source.getInstanceGroups().stream()
-                .map(ig -> instanceGroupConverter.convert(ig, accountId, stack.getCloudPlatform(), stack.getName()))
+                .map(ig -> {
+                    FreeIpaServerRequest ipaServerRequest = source.getFreeIpa();
+                    return instanceGroupConverter.convert(ig, accountId, stack.getCloudPlatform(), stack.getName(),
+                            ipaServerRequest.getHostname(), ipaServerRequest.getDomain());
+                })
                 .forEach(ig -> {
                     ig.setStack(stack);
                     convertedSet.add(ig);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/InstanceMetaData.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/InstanceMetaData.java
@@ -16,6 +16,8 @@ import com.sequenceiq.freeipa.entity.util.InstanceLifeCycleConverter;
 import com.sequenceiq.freeipa.entity.util.InstanceMetadataTypeConverter;
 import com.sequenceiq.freeipa.entity.util.InstanceStatusConverter;
 
+import java.util.StringJoiner;
+
 @Entity
 public class InstanceMetaData {
     @Id
@@ -251,5 +253,19 @@ public class InstanceMetaData {
 
     public void setLifeCycle(InstanceLifeCycle lifeCycle) {
         this.lifeCycle = lifeCycle;
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", InstanceMetaData.class.getSimpleName() + "[", "]")
+                .add("id=" + id)
+                .add("privateId=" + privateId)
+                .add("privateIp='" + privateIp + "'")
+                .add("publicIp='" + publicIp + "'")
+                .add("instanceId='" + instanceId + "'")
+                .add("discoveryFQDN='" + discoveryFQDN + "'")
+                .add("instanceName='" + instanceName + "'")
+                .add("instanceStatus='" + instanceStatus + "'")
+                .toString();
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/instance/InstanceGroupRequestToInstanceGroupConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/instance/InstanceGroupRequestToInstanceGroupConverterTest.java
@@ -31,6 +31,10 @@ public class InstanceGroupRequestToInstanceGroupConverterTest {
 
     private static final String NAME = "NAME";
 
+    private static final String HOSTNAME = "HOSTNAME";
+
+    private static final String DOMAINNAME = "DOMAINNAME";
+
     @InjectMocks
     private InstanceGroupRequestToInstanceGroupConverter underTest;
 
@@ -60,7 +64,7 @@ public class InstanceGroupRequestToInstanceGroupConverterTest {
         given(defaultInstanceGroupProvider.createDefaultTemplate(eq(MOCK), eq(ACCOUNT_ID))).willReturn(template);
         given(securityGroupConverter.convert(eq(securityGroupRequest))).willReturn(securityGroup);
         // WHEN
-        InstanceGroup result = underTest.convert(request, ACCOUNT_ID, MOCK.name(), NAME);
+        InstanceGroup result = underTest.convert(request, ACCOUNT_ID, MOCK.name(), NAME, HOSTNAME, DOMAINNAME);
         // THEN
         assertThat(result).isNotNull();
         assertThat(result.getGroupName()).isEqualTo(NAME);
@@ -82,7 +86,7 @@ public class InstanceGroupRequestToInstanceGroupConverterTest {
         Template template = mock(Template.class);
         when(templateConverter.convert(instanceTemplateRequest, MOCK, ACCOUNT_ID)).thenReturn(template);
 
-        InstanceGroup result = underTest.convert(request, ACCOUNT_ID, MOCK.name(), NAME);
+        InstanceGroup result = underTest.convert(request, ACCOUNT_ID, MOCK.name(), NAME, HOSTNAME, DOMAINNAME);
 
         assertThat(result).isNotNull();
         assertThat(result.getTemplate()).isSameAs(template);


### PR DESCRIPTION
1. The hostname is reset by Google network manager https://groups.google.com/g/gce-discussion/c/fi2j7oP8bGM/m/mRYlt5OkDgAJ if the hostname is not set during creation.
2. This will break the freeipa health agent setup since it depends on the hostname of the instance having a proper domain.
3. Tested this change in the private stack to make sure Google does not reset the hostname that was set by salt.
4. Added a few more debug statements that were helpful in identifying why the hostname was null for the initial 100 seconds of GCP VM provisioning. Prior to this change, the hostname was available only in instance metadata only at the last host metadata collection step.