### PR TITLE
DISTX-504 Optimize DB Cluster Update

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/AbstractMonitor.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/AbstractMonitor.java
@@ -42,7 +42,7 @@ public abstract class AbstractMonitor<M extends Monitored> implements Monitor<M>
                 monitored.setLastEvaluated(System.currentTimeMillis());
                 save(monitored);
             } catch (RejectedExecutionException ignore) {
-
+                LOGGER.info("Error in processing monitor: {}", monitored, ignore);
             }
         }
     }
@@ -64,7 +64,7 @@ public abstract class AbstractMonitor<M extends Monitored> implements Monitor<M>
 
     protected abstract List<M> getMonitored();
 
-    protected abstract M save(M monitored);
+    protected abstract void save(M monitored);
 
     protected RejectedThreadService getRejectedThreadService() {
         return rejectedThreadService;

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/ClusterMonitor.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/ClusterMonitor.java
@@ -31,8 +31,9 @@ public abstract class ClusterMonitor extends AbstractMonitor<Cluster> {
     }
 
     @Override
-    protected Cluster save(Cluster monitored) {
-        return clusterService.save(monitored);
+    protected void save(Cluster monitored) {
+        //In Monitor context, only lastEvaluated is updated.
+        clusterService.setLastEvaluated(monitored.getId(), monitored.getLastEvaluated());
     }
 
     PeriscopeNodeConfig getPeriscopeNodeConfig() {

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/RejectedThreadMonitor.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/RejectedThreadMonitor.java
@@ -55,8 +55,8 @@ public class RejectedThreadMonitor extends AbstractMonitor<RejectedThread> {
     }
 
     @Override
-    protected RejectedThread save(RejectedThread monitored) {
-        return getRejectedThreadService().save(monitored);
+    protected void save(RejectedThread monitored) {
+        getRejectedThreadService().save(monitored);
     }
 
     private int compareRejectedThreadsByCount(RejectedThread o1, RejectedThread o2) {

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ScalingHandler.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ScalingHandler.java
@@ -68,8 +68,7 @@ public class ScalingHandler implements ApplicationListener<ScalingEvent> {
 
             executorService.submit(scalingRequest);
             rejectedThreadService.remove(cluster.getId());
-            cluster.setLastScalingActivityCurrent();
-            clusterService.save(cluster);
+            clusterService.setLastScalingActivity(cluster.getId(), System.currentTimeMillis());
         } else {
             LOGGER.info("Autoscaling activity not required for config '{}', cluster '{}'.", alert.getName(), cluster.getStackCrn());
             if (alert instanceof TimeAlert) {

--- a/autoscale/src/main/java/com/sequenceiq/periscope/repository/ClusterRepository.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/repository/ClusterRepository.java
@@ -1,17 +1,19 @@
 package com.sequenceiq.periscope.repository;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
-import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
-import com.sequenceiq.periscope.api.model.ClusterState;
-import com.sequenceiq.periscope.domain.Cluster;
+import java.util.List;
+import java.util.Optional;
+
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 
-import javax.transaction.Transactional;
-import java.util.List;
-import java.util.Optional;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
+import com.sequenceiq.periscope.api.model.ClusterState;
+import com.sequenceiq.periscope.domain.Cluster;
 
 @EntityType(entityClass = Cluster.class)
 @Transactional(Transactional.TxType.REQUIRED)
@@ -68,4 +70,12 @@ public interface ClusterRepository extends CrudRepository<Cluster, Long> {
     @Modifying
     @Query("UPDATE Cluster c SET c.periscopeNodeId = NULL WHERE c.periscopeNodeId = :periscopeNodeId")
     void deallocateClustersOfNode(@Param("periscopeNodeId") String periscopeNodeId);
+
+    @Modifying
+    @Query("UPDATE Cluster c SET c.lastEvaluated = :lastEvaluated WHERE c.id = :clusterId")
+    void setClusterLastEvaluated(@Param("clusterId") Long clusterId, @Param("lastEvaluated") Long lastEvaluated);
+
+    @Modifying
+    @Query("UPDATE Cluster c SET c.lastScalingActivity = :lastScalingActivity WHERE c.id = :clusterId")
+    void setClusterLastScalingActivity(@Param("clusterId") Long clusterId, @Param("lastScalingActivity") Long lastScalingActivity);
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/ClusterService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/ClusterService.java
@@ -201,6 +201,14 @@ public class ClusterService {
         return cluster;
     }
 
+    public void setLastEvaluated(Long clusterId, Long lastEvaluated) {
+        clusterRepository.setClusterLastEvaluated(clusterId, lastEvaluated);
+    }
+
+    public void setLastScalingActivity(Long clusterId, Long lastScalingActivity) {
+        clusterRepository.setClusterLastScalingActivity(clusterId, lastScalingActivity);
+    }
+
     public List<Cluster> findAllByPeriscopeNodeId(String nodeId) {
         return clusterRepository.findAllByPeriscopeNodeId(nodeId);
     }

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/AbstractMonitorTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/AbstractMonitorTest.java
@@ -110,8 +110,7 @@ public class AbstractMonitorTest {
             }
 
             @Override
-            protected Monitored save(Monitored monitored) {
-                return null;
+            protected void save(Monitored monitored) {
             }
 
             @Override

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/handler/ScalingHandlerTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/handler/ScalingHandlerTest.java
@@ -102,7 +102,7 @@ public class ScalingHandlerTest {
         underTest.onApplicationEvent(scalingEventMock);
 
         verify(rejectedThreadService).remove(AUTOSCALE_CLUSTER_ID);
-        verify(clusterService).save(cluster);
+        verify(clusterService).setLastScalingActivity(eq(AUTOSCALE_CLUSTER_ID), anyLong());
         verify(executorService).submit(runnableMock);
     }
 
@@ -127,7 +127,7 @@ public class ScalingHandlerTest {
 
         verify(historyService, times(1)).createEntry(
                 eq(ScalingStatus.SUCCESS), anyString(), eq(2), eq(0), eq(scalingPolicyMock));
-        verify(clusterService, never()).save(cluster);
+        verify(clusterService, never()).setLastScalingActivity(eq(AUTOSCALE_CLUSTER_ID), anyLong());
         verify(applicationContext, never()).getBean("ScalingRequest");
     }
 
@@ -172,7 +172,7 @@ public class ScalingHandlerTest {
         underTest.onApplicationEvent(scalingEventMock);
 
         verify(rejectedThreadService).remove(AUTOSCALE_CLUSTER_ID);
-        verify(clusterService).save(cluster);
+        verify(clusterService).setLastScalingActivity(eq(AUTOSCALE_CLUSTER_ID), anyLong());
         verify(executorService).submit(runnableMock);
     }
 


### PR DESCRIPTION
AS Cluster's lastEvaluated and lastScalingActivity are updated at a very high rate for every alert monitor run. Saving the entire cluster object hierarchy in this flow is inefficient and unnecessary. Hence only the required single field is updated.

See detailed description in the commit message.