### PR TITLE
CB-8670 Introduce withSkipOnFail to TestDTO cleanup

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaDeleteAction.java
@@ -21,6 +21,11 @@ public class FreeIpaDeleteAction implements Action<FreeIpaTestDto, FreeIpaClient
         client.getFreeIpaClient()
                 .getFreeIpaV1Endpoint()
                 .delete(testDto.getRequest().getEnvironmentCrn(), false);
+        testDto.setResponse(
+                client.getFreeIpaClient()
+                        .getFreeIpaV1Endpoint()
+                        .describe(testDto.getRequest().getEnvironmentCrn())
+        );
         Log.when(LOGGER, String.format(" FreeIPA deleted successfully. FreeIPA CRN: %s", testDto.getResponse().getCrn()));
         return testDto;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXForceDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXForceDeleteAction.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.it.cloudbreak.action.v1.distrox;
 
+import java.util.HashSet;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,6 +20,10 @@ public class DistroXForceDeleteAction implements Action<DistroXTestDto, Cloudbre
         client.getCloudbreakClient()
                 .distroXV1Endpoint()
                 .deleteByName(testDto.getName(), true);
+        testDto.setResponse(
+                client.getCloudbreakClient()
+                        .distroXV1Endpoint()
+                        .getByName(testDto.getName(), new HashSet<>()));
         Log.when(LOGGER, " Stack deletion was successful.");
         return testDto;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentCascadingDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentCascadingDeleteAction.java
@@ -20,6 +20,7 @@ public class EnvironmentCascadingDeleteAction implements Action<EnvironmentTestD
         SimpleEnvironmentResponse delete = environmentClient.getEnvironmentClient()
                 .environmentV1Endpoint()
                 .deleteByCrn(testDto.getResponse().getCrn(), true, false);
+        testDto.setResponseSimpleEnv(delete);
         Log.whenJson(LOGGER, " Environment cascading delete response: ", delete);
         return testDto;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/kerberos/KerberosDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/kerberos/KerberosDeleteAction.java
@@ -2,6 +2,8 @@ package com.sequenceiq.it.cloudbreak.action.v4.kerberos;
 
 import static java.lang.String.format;
 
+import javax.ws.rs.NotFoundException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,11 +18,18 @@ public class KerberosDeleteAction implements Action<KerberosTestDto, FreeIpaClie
     private static final Logger LOGGER = LoggerFactory.getLogger(KerberosDeleteAction.class);
 
     public KerberosTestDto action(TestContext testContext, KerberosTestDto testDto, FreeIpaClient client) throws Exception {
-        Log.whenJson(LOGGER, format(" Kerberos delete:%n"), testDto.getName());
+        Log.whenJson(LOGGER, format(" Kerberos config delete: %n"), testDto.getName());
         client.getFreeIpaClient()
                 .getKerberosConfigV1Endpoint()
                 .delete(testDto.getName());
-        Log.when(LOGGER, String.format(" Kerberos config was deleted successfully for environment " + testDto.getName()));
+        try {
+            testDto.setResponse(
+                    client.getFreeIpaClient()
+                            .getKerberosConfigV1Endpoint()
+                            .describe(testDto.getName()));
+        } catch (NotFoundException e) {
+            Log.when(LOGGER, String.format(" Kerberos config was deleted successfully for environment %s", testDto.getName()));
+        }
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/ldap/LdapDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/ldap/LdapDeleteAction.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.it.cloudbreak.action.v4.ldap;
 
+import javax.ws.rs.NotFoundException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,7 +20,14 @@ public class LdapDeleteAction implements Action<LdapTestDto, FreeIpaClient> {
         client.getFreeIpaClient()
             .getLdapConfigV1Endpoint()
             .delete(testDto.getName());
-        Log.when(LOGGER, String.format(" LDAP config was deleted successfully for environment %s", testDto.getName()));
+        try {
+            testDto.setResponse(
+                    client.getFreeIpaClient()
+                            .getLdapConfigV1Endpoint()
+                            .describe(testDto.getName()));
+        } catch (NotFoundException e) {
+            Log.when(LOGGER, String.format(" LDAP config was deleted successfully for environment %s", testDto.getName()));
+        }
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackForceDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackForceDeleteAction.java
@@ -2,6 +2,8 @@ package com.sequenceiq.it.cloudbreak.action.v4.stack;
 
 import static java.lang.String.format;
 
+import java.util.HashSet;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,7 +25,11 @@ public class StackForceDeleteAction implements Action<StackTestDto, CloudbreakCl
         client.getCloudbreakClient()
                 .stackV4Endpoint()
                 .delete(client.getWorkspaceId(), testDto.getName(), true, testContext.getActingUserCrn().getAccountId());
-        Log.whenJson(LOGGER, " Stack deletion was successful:\n", testDto.getResponse());
+        testDto.setResponse(
+                client.getCloudbreakClient()
+                        .stackV4Endpoint()
+                        .get(client.getWorkspaceId(), testDto.getName(), new HashSet<>(), testContext.getActingUserCrn().getAccountId()));
+        Log.whenJson(LOGGER, " Stack deletion was successful: ", testDto.getResponse());
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -513,6 +514,10 @@ public abstract class TestContext implements ApplicationContextAware {
     }
 
     public <T extends CloudbreakTestDto> T get(String key) {
+        if (!resources.containsKey(key) || resources.get(key) == null) {
+            throw new NoSuchElementException(
+                String.format("Key: '%s' has been provided but it has no result in the Test Context's Resources map", key));
+        }
         return (T) resources.get(key);
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/CloudbreakTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/CloudbreakTestDto.java
@@ -30,7 +30,7 @@ public interface CloudbreakTestDto extends Orderable, Assignable {
     CloudPlatform getCloudPlatform();
 
     default void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
-        LOGGER.warn("Did not clean up resource ({}): name={}", getClass().getSimpleName(), getName());
+        LOGGER.warn(String.format("Cleanup WARN: 'cleanUp' is not implemented for TestDto: %s with name: %s", getClass().getSimpleName(), getName()));
     }
 
     default CloudbreakTestDto refresh() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/audit/AuditTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/audit/AuditTestDto.java
@@ -3,10 +3,9 @@ package com.sequenceiq.it.cloudbreak.dto.audit;
 import javax.ws.rs.core.Response;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.audits.responses.AuditEventV4Response;
-import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
-import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
 
 @Prototype
 public class AuditTestDto extends AbstractCloudbreakTestDto<Object, AuditEventV4Response, AuditTestDto> {
@@ -21,11 +20,6 @@ public class AuditTestDto extends AbstractCloudbreakTestDto<Object, AuditEventV4
 
     public AuditTestDto(TestContext testContext) {
         super(null, testContext);
-    }
-
-    @Override
-    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
-        LOGGER.info("Cleaning up resource with name: {}", getName());
     }
 
     public AuditTestDto valid() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/blueprint/BlueprintTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/blueprint/BlueprintTestDto.java
@@ -1,18 +1,21 @@
 package com.sequenceiq.it.cloudbreak.dto.blueprint;
 
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import javax.ws.rs.WebApplicationException;
+import javax.inject.Inject;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.blueprint.requests.BlueprintV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.blueprint.responses.BlueprintV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.blueprint.responses.BlueprintV4ViewResponse;
-import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
+import com.sequenceiq.it.cloudbreak.client.BlueprintTestClient;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
 
 @Prototype
 public class BlueprintTestDto extends AbstractCloudbreakTestDto<BlueprintV4Request, BlueprintV4Response, BlueprintTestDto> {
@@ -23,17 +26,20 @@ public class BlueprintTestDto extends AbstractCloudbreakTestDto<BlueprintV4Reque
 
     private Collection<BlueprintV4ViewResponse> viewResponses;
 
+    @Inject
+    private BlueprintTestClient blueprintTestClient;
+
     public BlueprintTestDto(TestContext testContext) {
         super(new BlueprintV4Request(), testContext);
     }
 
     @Override
     public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
-        LOGGER.info("Cleaning up resource with name: {}", getName());
-        try {
-            cloudbreakClient.getCloudbreakClient().clusterTemplateV4EndPoint().deleteByName(cloudbreakClient.getWorkspaceId(), getName());
-        } catch (WebApplicationException ignore) {
-            LOGGER.info("Something happend.");
+        LOGGER.info("Cleaning up blueprint with name: {}", getName());
+        if (getResponse() != null) {
+            when(blueprintTestClient.deleteV4(), key("delete-blueprint-" + getName()).withSkipOnFail(false));
+        } else {
+            LOGGER.info("Blueprint: {} response is null!", getName());
         }
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/clustertemplate/ClusterTemplateTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/clustertemplate/ClusterTemplateTestDto.java
@@ -1,6 +1,10 @@
 package com.sequenceiq.it.cloudbreak.dto.clustertemplate;
 
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
+
 import java.util.Collection;
+
+import javax.inject.Inject;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.ClusterTemplateV4Type;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.requests.ClusterTemplateV4Request;
@@ -8,6 +12,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.responses.Clust
 import com.sequenceiq.distrox.api.v1.distrox.model.DistroXV1Request;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
+import com.sequenceiq.it.cloudbreak.client.ClusterTemplateTestClient;
 import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.DeletableTestDto;
@@ -20,6 +25,9 @@ import com.sequenceiq.it.cloudbreak.util.ResponseUtil;
 @Prototype
 public class ClusterTemplateTestDto extends DeletableTestDto<ClusterTemplateV4Request, ClusterTemplateV4Response,
         ClusterTemplateTestDto, ClusterTemplateV4Response> {
+
+    @Inject
+    private ClusterTemplateTestClient clusterTemplateTestClient;
 
     public ClusterTemplateTestDto(TestContext testContext) {
         super(new ClusterTemplateV4Request(), testContext);
@@ -110,7 +118,12 @@ public class ClusterTemplateTestDto extends DeletableTestDto<ClusterTemplateV4Re
 
     @Override
     public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
-        delete(context, getResponse(), cloudbreakClient);
+        LOGGER.info("Cleaning up cluster template with name: {}", getName());
+        if (getResponse() != null) {
+            when(clusterTemplateTestClient.deleteV4(), key("delete-clustertemplate-" + getName()).withSkipOnFail(false));
+        } else {
+            LOGGER.info("Cluster template: {} response is null!", getName());
+        }
     }
 
     public Long count() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/connector/PlatformAccessConfigsTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/connector/PlatformAccessConfigsTestDto.java
@@ -4,7 +4,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sequenceiq.environment.api.v1.platformresource.model.PlatformAccessConfigsResponse;
-import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
@@ -68,11 +67,6 @@ public class PlatformAccessConfigsTestDto extends AbstractCloudbreakTestDto<Obje
     public PlatformAccessConfigsTestDto withAvailabilityZone(String availabilityZone) {
         this.availabilityZone = availabilityZone;
         return this;
-    }
-
-    @Override
-    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
-        LOGGER.debug("this entry point does not have any clean up operation");
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/connector/PlatformDiskTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/connector/PlatformDiskTestDto.java
@@ -1,10 +1,9 @@
 package com.sequenceiq.it.cloudbreak.dto.connector;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses.PlatformDisksV4Response;
-import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
-import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
 
 @Prototype
 public class PlatformDiskTestDto extends AbstractCloudbreakTestDto<Object, PlatformDisksV4Response, PlatformDiskTestDto> {
@@ -16,11 +15,6 @@ public class PlatformDiskTestDto extends AbstractCloudbreakTestDto<Object, Platf
     @Override
     public PlatformDiskTestDto valid() {
         return this;
-    }
-
-    @Override
-    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
-        LOGGER.debug("this entry point does not have any clean up operation");
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/connector/PlatformEncryptionKeysTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/connector/PlatformEncryptionKeysTestDto.java
@@ -4,10 +4,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses.PlatformEncryptionKeysV4Response;
-import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
-import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
 
 @Prototype
 public class PlatformEncryptionKeysTestDto extends AbstractCloudbreakTestDto<Object, PlatformEncryptionKeysV4Response, PlatformEncryptionKeysTestDto> {
@@ -68,11 +67,6 @@ public class PlatformEncryptionKeysTestDto extends AbstractCloudbreakTestDto<Obj
     public PlatformEncryptionKeysTestDto withAvailabilityZone(String availabilityZone) {
         this.availabilityZone = availabilityZone;
         return this;
-    }
-
-    @Override
-    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
-        LOGGER.debug("this entry point does not have any clean up operation");
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/connector/PlatformGatewaysTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/connector/PlatformGatewaysTestDto.java
@@ -4,10 +4,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses.PlatformGatewaysV4Response;
-import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
-import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
 
 @Prototype
 public class PlatformGatewaysTestDto extends AbstractCloudbreakTestDto<Object, PlatformGatewaysV4Response, PlatformGatewaysTestDto> {
@@ -68,11 +67,6 @@ public class PlatformGatewaysTestDto extends AbstractCloudbreakTestDto<Object, P
     public PlatformGatewaysTestDto withAvailabilityZone(String availabilityZone) {
         this.availabilityZone = availabilityZone;
         return this;
-    }
-
-    @Override
-    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
-        LOGGER.debug("this entry point does not have any clean up operation");
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/connector/PlatformIpPoolsTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/connector/PlatformIpPoolsTestDto.java
@@ -4,10 +4,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses.PlatformIpPoolsV4Response;
-import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
-import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
 
 @Prototype
 public class PlatformIpPoolsTestDto extends AbstractCloudbreakTestDto<Object, PlatformIpPoolsV4Response, PlatformIpPoolsTestDto> {
@@ -68,11 +67,6 @@ public class PlatformIpPoolsTestDto extends AbstractCloudbreakTestDto<Object, Pl
     public PlatformIpPoolsTestDto withAvailabilityZone(String availabilityZone) {
         this.availabilityZone = availabilityZone;
         return this;
-    }
-
-    @Override
-    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
-        LOGGER.debug("this entry point does not have any clean up operation");
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/connector/PlatformNetworksTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/connector/PlatformNetworksTestDto.java
@@ -4,10 +4,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses.PlatformNetworksV4Response;
-import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
-import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
 
 @Prototype
 public class PlatformNetworksTestDto extends AbstractCloudbreakTestDto<Object, PlatformNetworksV4Response, PlatformNetworksTestDto> {
@@ -68,11 +67,6 @@ public class PlatformNetworksTestDto extends AbstractCloudbreakTestDto<Object, P
     public PlatformNetworksTestDto withAvailabilityZone(String availabilityZone) {
         this.availabilityZone = availabilityZone;
         return this;
-    }
-
-    @Override
-    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
-        LOGGER.debug("this entry point does not have any clean up operation");
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/connector/PlatformRegionTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/connector/PlatformRegionTestDto.java
@@ -4,10 +4,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses.RegionV4Response;
-import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
-import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
 
 @Prototype
 public class PlatformRegionTestDto extends AbstractCloudbreakTestDto<Object, RegionV4Response, PlatformRegionTestDto> {
@@ -68,11 +67,6 @@ public class PlatformRegionTestDto extends AbstractCloudbreakTestDto<Object, Reg
     public PlatformRegionTestDto withAvailabilityZone(String availabilityZone) {
         this.availabilityZone = availabilityZone;
         return this;
-    }
-
-    @Override
-    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
-        LOGGER.debug("this entry point does not have any clean up operation");
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/connector/PlatformSecurityGroupsTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/connector/PlatformSecurityGroupsTestDto.java
@@ -4,10 +4,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses.PlatformSecurityGroupsV4Response;
-import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
-import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
 
 @Prototype
 public class PlatformSecurityGroupsTestDto extends AbstractCloudbreakTestDto<Object, PlatformSecurityGroupsV4Response, PlatformSecurityGroupsTestDto> {
@@ -68,11 +67,6 @@ public class PlatformSecurityGroupsTestDto extends AbstractCloudbreakTestDto<Obj
     public PlatformSecurityGroupsTestDto withAvailabilityZone(String availabilityZone) {
         this.availabilityZone = availabilityZone;
         return this;
-    }
-
-    @Override
-    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
-        LOGGER.debug("this entry point does not have any clean up operation");
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/connector/PlatformSshKeysTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/connector/PlatformSshKeysTestDto.java
@@ -4,10 +4,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses.PlatformSshKeysV4Response;
-import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
-import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
 
 @Prototype
 public class PlatformSshKeysTestDto extends AbstractCloudbreakTestDto<Object, PlatformSshKeysV4Response, PlatformSshKeysTestDto> {
@@ -68,11 +67,6 @@ public class PlatformSshKeysTestDto extends AbstractCloudbreakTestDto<Object, Pl
     public PlatformSshKeysTestDto withAvailabilityZone(String availabilityZone) {
         this.availabilityZone = availabilityZone;
         return this;
-    }
-
-    @Override
-    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
-        LOGGER.debug("this entry point does not have any clean up operation");
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/connector/PlatformVmTypesTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/connector/PlatformVmTypesTestDto.java
@@ -4,10 +4,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses.PlatformVmtypesV4Response;
-import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
-import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
 
 @Prototype
 public class PlatformVmTypesTestDto extends AbstractCloudbreakTestDto<Object, PlatformVmtypesV4Response, PlatformVmTypesTestDto> {
@@ -68,11 +67,6 @@ public class PlatformVmTypesTestDto extends AbstractCloudbreakTestDto<Object, Pl
     public PlatformVmTypesTestDto withAvailabilityZone(String availabilityZone) {
         this.availabilityZone = availabilityZone;
         return this;
-    }
-
-    @Override
-    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
-        LOGGER.debug("this entry point does not have any clean up operation");
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/credential/CredentialTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/credential/CredentialTestDto.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.it.cloudbreak.dto.credential;
 
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
+
 import java.util.Collection;
 
 import javax.inject.Inject;
@@ -98,8 +100,12 @@ public class CredentialTestDto extends DeletableEnvironmentTestDto<CredentialReq
 
     @Override
     public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
-        LOGGER.info("CLEAN UP :: Deleting credential with name: [{}]", getName());
-        when(credentialTestClient.delete()).withName(getName());
+        LOGGER.info("Cleaning up credential with name: {}", getName());
+        if (getResponse() != null) {
+            when(credentialTestClient.delete(), key("delete-credential-" + getName()).withSkipOnFail(false));
+        } else {
+            LOGGER.info("Credential: {} response is null!", getName());
+        }
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
@@ -243,7 +243,7 @@ public class EnvironmentTestDto
     }
 
     public EnvironmentTestDto withParentEnvironment() {
-        CloudbreakTestDto parentEnvDto = getTestContext().given(EnvironmentTestDto.class);
+        EnvironmentTestDto parentEnvDto = getTestContext().given(EnvironmentTestDto.class);
         return withParentEnvironment(parentEnvDto);
     }
 
@@ -385,7 +385,7 @@ public class EnvironmentTestDto
     @Override
     public String getCrn() {
         if (getResponse() == null) {
-            throw new IllegalStateException("You have tried to assign to a Dto that hasn't been created and therefore has no Response object.");
+            throw new IllegalStateException("Environment response hasn't been set, therefore 'getCrn' cannot be fulfilled.");
         }
         return getResponse().getCrn();
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaTestDto.java
@@ -307,9 +307,13 @@ public class FreeIpaTestDto extends AbstractFreeIpaTestDto<CreateFreeIpaRequest,
 
     @Override
     public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
-        LOGGER.info("Cleaning up freeipa with name: {}", getName());
-        when(freeIpaTestClient.delete(), key("delete-freeipa-" + getName()).withSkipOnFail(false));
-        await(DELETE_COMPLETED, new RunningParameter().withSkipOnFail(true));
+        LOGGER.info("Cleaning up freeIpa with name: {}", getName());
+        if (getResponse() != null) {
+            when(freeIpaTestClient.delete(), key("delete-freeipa-" + getName()).withSkipOnFail(false));
+            await(DELETE_COMPLETED, new RunningParameter().withSkipOnFail(true));
+        } else {
+            LOGGER.info("FreeIpa: {} response is null!", getName());
+        }
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/imagecatalog/ImageCatalogTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/imagecatalog/ImageCatalogTestDto.java
@@ -1,13 +1,18 @@
 package com.sequenceiq.it.cloudbreak.dto.imagecatalog;
 
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
+
 import java.util.Collection;
 import java.util.function.Function;
+
+import javax.inject.Inject;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.requests.ImageCatalogV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImageCatalogV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImagesV4Response;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
+import com.sequenceiq.it.cloudbreak.client.ImageCatalogTestClient;
 import com.sequenceiq.it.cloudbreak.context.Purgable;
 import com.sequenceiq.it.cloudbreak.context.RunningParameter;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
@@ -28,6 +33,9 @@ public class ImageCatalogTestDto extends AbstractCloudbreakTestDto<ImageCatalogV
     private ImagesV4Response imagesV4Response;
 
     private Boolean skipCleanup = Boolean.FALSE;
+
+    @Inject
+    private ImageCatalogTestClient imageCatalogTestClient;
 
     public ImageCatalogTestDto(TestContext testContext) {
         super(new ImageCatalogV4Request(), testContext);
@@ -94,7 +102,12 @@ public class ImageCatalogTestDto extends AbstractCloudbreakTestDto<ImageCatalogV
     @Override
     public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
         if (!skipCleanup) {
-            delete(context, getResponse(), cloudbreakClient);
+            LOGGER.info("Cleaning up image catalog with name: {}", getName());
+            if (getResponse() != null) {
+                when(imageCatalogTestClient.deleteV4(), key("delete-imagecatalog-" + getName()).withSkipOnFail(false));
+            } else {
+                LOGGER.info("Image catalog: {} response is null!", getName());
+            }
         }
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/kerberos/KerberosTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/kerberos/KerberosTestDto.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.it.cloudbreak.dto.kerberos;
 
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
+
 import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
 
@@ -32,9 +34,9 @@ public class KerberosTestDto extends AbstractFreeIpaTestDto<CreateKerberosConfig
     public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
         LOGGER.info("Cleaning up kerberos config with name: {}", getName());
         try {
-            when(kerberosTestClient.deleteV1());
+            when(kerberosTestClient.deleteV1(), key("delete-kerberos-" + getName()).withSkipOnFail(false));
         } catch (WebApplicationException ignore) {
-            LOGGER.info("Something happend during the kerberos resource delete operation.");
+            LOGGER.warn("Something went wrong during {} kerberos config delete, because of: {}", getName(), ignore.getMessage(), ignore);
         }
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/ldap/LdapTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/ldap/LdapTestDto.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.it.cloudbreak.dto.ldap;
 
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
+
 import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
 
@@ -27,11 +29,11 @@ public class LdapTestDto extends AbstractFreeIpaTestDto<CreateLdapConfigRequest,
 
     @Override
     public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
-        LOGGER.info("Cleaning up ldapconfig with name: {}", getName());
+        LOGGER.info("Cleaning up LDAP config with name: {}", getName());
         try {
-            when(ldapTestClient.deleteV1());
+            when(ldapTestClient.deleteV1(), key("delete-ldap-" + getName()).withSkipOnFail(false));
         } catch (WebApplicationException ignore) {
-            LOGGER.info("Something happend.");
+            LOGGER.warn("Something went wrong during {} LDAP config delete, because of: {}", getName(), ignore.getMessage(), ignore);
         }
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/recipe/RecipeTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/recipe/RecipeTestDto.java
@@ -1,9 +1,12 @@
 package com.sequenceiq.it.cloudbreak.dto.recipe;
 
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
+
 import java.util.Base64;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.recipes.RecipeV4Endpoint;
@@ -12,10 +15,11 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.recipes.requests.RecipeV4Type;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.recipes.responses.RecipeV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.recipes.responses.RecipeViewV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.recipes.responses.RecipeViewV4Responses;
-import com.sequenceiq.it.cloudbreak.dto.DeletableTestDto;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
+import com.sequenceiq.it.cloudbreak.client.RecipeTestClient;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.DeletableTestDto;
 import com.sequenceiq.it.cloudbreak.util.ResponseUtil;
 
 @Prototype
@@ -25,17 +29,20 @@ public class RecipeTestDto extends DeletableTestDto<RecipeV4Request, RecipeV4Res
 
     private RecipeViewV4Responses simpleResponses;
 
+    @Inject
+    private RecipeTestClient recipeTestClient;
+
     public RecipeTestDto(TestContext testContext) {
         super(new RecipeV4Request(), testContext);
     }
 
     @Override
     public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
-        LOGGER.info("Cleaning up resource with name: {}", getName());
+        LOGGER.info("Cleaning up recipe with name: {}", getName());
         try {
-            cloudbreakClient.getCloudbreakClient().recipeV4Endpoint().deleteByName(cloudbreakClient.getWorkspaceId(), getName());
+            when(recipeTestClient.deleteV4(), key("delete-recipe-" + getName()).withSkipOnFail(false));
         } catch (WebApplicationException ignore) {
-            LOGGER.info("Something happend.");
+            LOGGER.warn("Something went wrong during {} recipe delete, because of: {}", getName(), ignore.getMessage(), ignore);
         }
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxInternalTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxInternalTestDto.java
@@ -88,9 +88,10 @@ public class SdxInternalTestDto extends AbstractSdxTestDto<SdxInternalClusterReq
     public SdxInternalTestDto valid() {
         withName(getResourcePropertyProvider().getName(getCloudPlatform()))
                 .withDefaultSDXSettings()
-                .withEnvironment()
+                .withEnvironmentName(getTestContext().get(EnvironmentTestDto.class).getResponse().getName())
                 .withClusterShape(getCloudProvider().getInternalClusterShape())
-                .withTags(getCloudProvider().getTags());
+                .withTags(getCloudProvider().getTags())
+                .withRuntimeVersion(commonClusterManagerProperties.getRuntimeVersion());
         return getCloudProvider().sdxInternal(this);
     }
 
@@ -125,19 +126,6 @@ public class SdxInternalTestDto extends AbstractSdxTestDto<SdxInternalClusterReq
 
     public SdxInternalTestDto withCloudStorage(SdxCloudStorageRequest cloudStorage) {
         getRequest().setCloudStorage(cloudStorage);
-        return this;
-    }
-
-    public SdxInternalTestDto withEnvironmentKey(RunningParameter key) {
-        EnvironmentTestDto env = getTestContext().get(key.getKey());
-        if (env == null) {
-            throw new IllegalArgumentException("Environment is not given with key: " + key.getKey());
-        }
-        if (env.getResponse() == null) {
-            throw new IllegalArgumentException("Environment is not created, or GET response is not included");
-        }
-        String name = env.getResponse().getName();
-        getRequest().setEnvironment(name);
         return this;
     }
 
@@ -240,13 +228,33 @@ public class SdxInternalTestDto extends AbstractSdxTestDto<SdxInternalClusterReq
     public SdxInternalTestDto withEnvironment() {
         EnvironmentTestDto environment = getTestContext().given(EnvironmentTestDto.class);
         if (environment == null) {
-            throw new IllegalArgumentException("Environment does not exist!");
+            throw new IllegalArgumentException(String.format("Environment has not been provided for this internal Sdx: '%s' response!", getName()));
         }
-        return withEnvironmentName(environment.getName());
+        return withEnvironmentName(environment.getResponse().getName());
     }
 
-    public SdxInternalTestDto withEnvironmentName(String environment) {
-        getRequest().setEnvironment(environment);
+    private SdxInternalTestDto withEnvironmentDto(EnvironmentTestDto environmentTestDto) {
+        return withEnvironmentName(environmentTestDto.getResponse().getName());
+    }
+
+    public SdxInternalTestDto withEnvironmentClass(Class<EnvironmentTestDto> environmentClass) {
+        EnvironmentTestDto environment = getTestContext().get(environmentClass.getSimpleName());
+        if (environment == null) {
+            throw new IllegalArgumentException(String.format("Environment has not been provided for this Sdx: '%s' response!", getName()));
+        }
+        return withEnvironmentName(environment.getResponse().getName());
+    }
+
+    public SdxInternalTestDto withEnvironmentKey(RunningParameter key) {
+        EnvironmentTestDto environment = getTestContext().get(key.getKey());
+        if (environment == null) {
+            throw new IllegalArgumentException(String.format("Environment has not been provided for this internal Sdx: '%s' response!", getName()));
+        }
+        return withEnvironmentName(environment.getResponse().getName());
+    }
+
+    public SdxInternalTestDto withEnvironmentName(String environmentName) {
+        getRequest().setEnvironment(environmentName);
         return this;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
@@ -70,7 +70,7 @@ public class SdxTestDto extends AbstractSdxTestDto<SdxClusterRequest, SdxCluster
     @Override
     public SdxTestDto valid() {
         withName(getResourcePropertyProvider().getName(getCloudPlatform()))
-                .withEnvironment(getTestContext().get(EnvironmentTestDto.class).getName())
+                .withEnvironmentName(getTestContext().get(EnvironmentTestDto.class).getResponse().getName())
                 .withClusterShape(getCloudProvider().getClusterShape())
                 .withTags(getCloudProvider().getTags())
                 .withRuntimeVersion(commonClusterManagerProperties.getRuntimeVersion());
@@ -214,31 +214,34 @@ public class SdxTestDto extends AbstractSdxTestDto<SdxClusterRequest, SdxCluster
     public SdxTestDto withEnvironment() {
         EnvironmentTestDto environment = getTestContext().given(EnvironmentTestDto.class);
         if (environment == null) {
-            throw new IllegalArgumentException("Environment does not exist!");
+            throw new IllegalArgumentException(String.format("Environment has not been provided for this Sdx: '%s' response!", getName()));
         }
-        return withEnvironment(environment.getName());
+        return withEnvironmentName(environment.getResponse().getName());
     }
 
-    public SdxTestDto withEnvironment(String environmentName) {
-        getRequest().setEnvironment(environmentName);
-        return this;
+    public SdxTestDto withEnvironmentClass(Class<EnvironmentTestDto> environmentClass) {
+        EnvironmentTestDto environment = getTestContext().get(environmentClass.getSimpleName());
+        if (environment == null) {
+            throw new IllegalArgumentException(String.format("Environment has not been provided for this Sdx: '%s' response!", getName()));
+        }
+        return withEnvironmentName(environment.getResponse().getName());
     }
 
-    public SdxTestDto withEnvironmentKey(String environmentKey) {
-        getRequest().setEnvironment(getTestContext().get(environmentKey).getName());
-        return this;
+    private SdxTestDto withEnvironmentDto(EnvironmentTestDto environmentTestDto) {
+        return withEnvironmentName(environmentTestDto.getResponse().getName());
     }
 
-    public SdxTestDto withEnvironment(Class<EnvironmentTestDto> environmentKey) {
-        return withEnvironment(key(environmentKey.getSimpleName()));
-    }
-
-    public SdxTestDto withEnvironment(RunningParameter environmentKey) {
+    public SdxTestDto withEnvironmentKey(RunningParameter environmentKey) {
         EnvironmentTestDto env = getTestContext().get(environmentKey.getKey());
         if (env == null) {
-            throw new IllegalArgumentException("Env is null with given key: " + environmentKey);
+            throw new IllegalArgumentException(String.format("Environment has not been provided for this Sdx: '%s' response!", getName()));
         }
-        return withEnvironment(env.getResponse().getName());
+        return withEnvironmentName(env.getResponse().getName());
+    }
+
+    public SdxTestDto withEnvironmentName(String environmentName) {
+        getRequest().setEnvironment(environmentName);
+        return this;
     }
 
     public SdxTestDto withName(String name) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/securityrule/SecurityRulesTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/securityrule/SecurityRulesTestDto.java
@@ -5,9 +5,8 @@ import org.slf4j.LoggerFactory;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.SecurityRulesV4Response;
 import com.sequenceiq.it.cloudbreak.Prototype;
-import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
-import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
 
 @Prototype
 public class SecurityRulesTestDto extends AbstractCloudbreakTestDto<Object, SecurityRulesV4Response, SecurityRulesTestDto> {
@@ -32,11 +31,6 @@ public class SecurityRulesTestDto extends AbstractCloudbreakTestDto<Object, Secu
     @Override
     public SecurityRulesTestDto valid() {
         return withKnoxEnabled(false);
-    }
-
-    @Override
-    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
-        LOGGER.debug("this entry point does not have any clean up operation");
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/stack/StackTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/stack/StackTestDto.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.it.cloudbreak.dto.stack;
 
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
-import static com.sequenceiq.it.cloudbreak.context.RunningParameter.withoutLogError;
 import static com.sequenceiq.it.cloudbreak.testcase.AbstractIntegrationTest.STACK_DELETED;
 
 import java.util.List;
@@ -68,14 +67,18 @@ public class StackTestDto extends StackTestDtoBase<StackTestDto> implements Purg
 
     @Override
     public StackTestDtoBase<StackTestDto> valid() {
-        return super.valid().withEnvironment(EnvironmentTestDto.class);
+        return super.valid().withEnvironmentClass(EnvironmentTestDto.class);
     }
 
     @Override
     public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
-        LOGGER.info("Cleaning up resource with name: {}", getName());
-        when(stackTestClient.forceDeleteV4(), withoutLogError());
-        await(STACK_DELETED);
+        LOGGER.info("Cleaning up stack with name: {}", getName());
+        if (getResponse() != null) {
+            when(stackTestClient.forceDeleteV4(), key("delete-stack-" + getName()).withSkipOnFail(false));
+            await(STACK_DELETED, new RunningParameter().withSkipOnFail(true));
+        } else {
+            LOGGER.info("Stack: {} response is null!", getName());
+        }
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/stack/StackTestDtoBase.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/stack/StackTestDtoBase.java
@@ -31,6 +31,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.I
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.it.cloudbreak.SecurityRulesEntity;
+import com.sequenceiq.it.cloudbreak.context.RunningParameter;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
 import com.sequenceiq.it.cloudbreak.dto.ClusterTestDto;
@@ -100,29 +101,8 @@ public abstract class StackTestDtoBase<T extends StackTestDtoBase<T>> extends Ab
         return getCloudProvider().stack(this);
     }
 
-    public StackTestDtoBase<T> withEnvironmentCrn() {
-        return withEnvironmentCrn("");
-    }
-
-    public StackTestDtoBase<T> withEnvironmentCrn(String environmentCrn) {
-        getRequest().setEnvironmentCrn(environmentCrn);
-        return this;
-    }
-
     public StackTestDtoBase<T> withCloudPlatform(CloudPlatform cloudPlatform) {
         getRequest().setCloudPlatform(cloudPlatform);
-        return this;
-    }
-
-    public StackTestDtoBase<T> withEnvironment(Class<EnvironmentTestDto> environmentTestDtoClass) {
-        EnvironmentTestDto env = getTestContext().get(environmentTestDtoClass);
-        if (env != null) {
-            if (env.getResponse() == null) {
-                throw new IllegalArgumentException("Environment is not created, or GET response is not included");
-            }
-            String crn = env.getResponse().getCrn();
-            getRequest().setEnvironmentCrn(crn);
-        }
         return this;
     }
 
@@ -135,12 +115,41 @@ public abstract class StackTestDtoBase<T extends StackTestDtoBase<T>> extends Ab
         return this;
     }
 
-    public StackTestDtoBase<T> withEnvironmentKey(String environmentKey) {
-        EnvironmentTestDto env = getTestContext().get(environmentKey);
+    public StackTestDtoBase<T> withEnvironmentClass(Class<EnvironmentTestDto> environmentTestDtoClass) {
+        EnvironmentTestDto env = getTestContext().get(environmentTestDtoClass.getSimpleName());
         if (env == null) {
-            throw new IllegalArgumentException("Env is null with given key: " + environmentKey);
+            throw new IllegalArgumentException(String.format("Environment has not been provided for this stack: '%s' response!", getName()));
         }
-        return withEnvironmentCrn(env.getResponse().getCrn());
+        return withEnvironmentCrn(env.getCrn());
+    }
+
+    public StackTestDtoBase<T> withEnvironmentName(String environmentName) {
+        EnvironmentTestDto env = getTestContext().get(environmentName);
+        if (env == null) {
+            throw new IllegalArgumentException(String.format("Environment has not been provided for this stack: '%s' response!", getName()));
+        }
+        return withEnvironmentCrn(env.getCrn());
+    }
+
+    public StackTestDtoBase<T> withEnvironmentKey(RunningParameter key) {
+        EnvironmentTestDto env = getTestContext().get(key.getKey());
+        if (env == null) {
+            throw new IllegalArgumentException(String.format("Environment has not been provided for this stack: '%s' response!", getName()));
+        }
+        return withEnvironmentCrn(env.getCrn());
+    }
+
+    public StackTestDtoBase<T> withEnvironment() {
+        EnvironmentTestDto env = getTestContext().given(EnvironmentTestDto.class);
+        if (env == null) {
+            throw new IllegalArgumentException(String.format("Environment has not been provided for this stack: '%s' response!", getName()));
+        }
+        return withEnvironmentCrn(env.getCrn());
+    }
+
+    public StackTestDtoBase<T> withEnvironmentCrn(String environmentCrn) {
+        getRequest().setEnvironmentCrn(environmentCrn);
+        return this;
     }
 
     public StackTestDtoBase<T> withName(String name) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/util/CloudStorageMatrixTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/util/CloudStorageMatrixTestDto.java
@@ -4,10 +4,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.CloudStorageSupportedV4Response;
-import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
-import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
 
 @Prototype
 public class CloudStorageMatrixTestDto extends AbstractCloudbreakTestDto<Object, CloudStorageSupportedV4Response, CloudStorageMatrixTestDto> {
@@ -32,11 +31,6 @@ public class CloudStorageMatrixTestDto extends AbstractCloudbreakTestDto<Object,
     @Override
     public CloudStorageMatrixTestDto valid() {
         return withStackVersion("3.1");
-    }
-
-    @Override
-    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
-        LOGGER.debug("this entry point does not have any clean up operation");
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/util/DeploymentPreferencesTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/util/DeploymentPreferencesTestDto.java
@@ -4,10 +4,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.DeploymentPreferencesV4Response;
-import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
-import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
 
 @Prototype
 public class DeploymentPreferencesTestDto extends AbstractCloudbreakTestDto<Object, DeploymentPreferencesV4Response, DeploymentPreferencesTestDto> {
@@ -21,11 +20,6 @@ public class DeploymentPreferencesTestDto extends AbstractCloudbreakTestDto<Obje
     @Override
     public DeploymentPreferencesTestDto valid() {
         return this;
-    }
-
-    @Override
-    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
-        LOGGER.debug("this entry point does not have any clean up operation");
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/util/NotificationTestingTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/util/NotificationTestingTestDto.java
@@ -3,10 +3,9 @@ package com.sequenceiq.it.cloudbreak.dto.util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
-import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
 
 @Prototype
 public class NotificationTestingTestDto extends AbstractCloudbreakTestDto<Object, Object, NotificationTestingTestDto> {
@@ -20,11 +19,6 @@ public class NotificationTestingTestDto extends AbstractCloudbreakTestDto<Object
     @Override
     public NotificationTestingTestDto valid() {
         return this;
-    }
-
-    @Override
-    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
-        LOGGER.debug("this entry point does not have any clean up operation");
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/util/RepoConfigValidationTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/util/RepoConfigValidationTestDto.java
@@ -5,10 +5,9 @@ import org.slf4j.LoggerFactory;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.requests.RepoConfigValidationV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.RepoConfigValidationV4Response;
-import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
-import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
 
 @Prototype
 public class RepoConfigValidationTestDto extends AbstractCloudbreakTestDto<RepoConfigValidationV4Request, RepoConfigValidationV4Response,
@@ -58,11 +57,6 @@ public class RepoConfigValidationTestDto extends AbstractCloudbreakTestDto<RepoC
     @Override
     public RepoConfigValidationTestDto valid() {
         return this;
-    }
-
-    @Override
-    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
-        LOGGER.debug("this entry point does not have any clean up operation");
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/util/StackMatrixTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/util/StackMatrixTestDto.java
@@ -4,10 +4,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.StackMatrixV4Response;
-import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
-import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
 
 @Prototype
 public class StackMatrixTestDto extends AbstractCloudbreakTestDto<Object, StackMatrixV4Response, StackMatrixTestDto> {
@@ -21,11 +20,6 @@ public class StackMatrixTestDto extends AbstractCloudbreakTestDto<Object, StackM
     @Override
     public StackMatrixTestDto valid() {
         return this;
-    }
-
-    @Override
-    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
-        LOGGER.debug("this entry point does not have any clean up operation");
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/util/TagSpecificationsTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/util/TagSpecificationsTestDto.java
@@ -1,10 +1,9 @@
 package com.sequenceiq.it.cloudbreak.dto.util;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.connector.responses.TagSpecificationsV4Response;
-import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
-import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
 
 @Prototype
 public class TagSpecificationsTestDto extends AbstractCloudbreakTestDto<Object, TagSpecificationsV4Response, TagSpecificationsTestDto> {
@@ -16,11 +15,6 @@ public class TagSpecificationsTestDto extends AbstractCloudbreakTestDto<Object, 
     @Override
     public TagSpecificationsTestDto valid() {
         return this;
-    }
-
-    @Override
-    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
-        LOGGER.debug("this entry point does not have any clean up operation");
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/util/VersionCheckTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/util/VersionCheckTestDto.java
@@ -4,7 +4,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sequenceiq.common.api.util.versionchecker.VersionCheckResult;
-import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
@@ -32,11 +31,6 @@ public class VersionCheckTestDto extends AbstractCloudbreakTestDto<Object, Versi
     public VersionCheckTestDto withVersion(String version) {
         this.version = version;
         return this;
-    }
-
-    @Override
-    public void cleanUp(TestContext context, CloudbreakClient cloudbreakClient) {
-        LOGGER.debug("this entry point does not have any clean up operation");
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/AuditTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/AuditTest.java
@@ -78,7 +78,7 @@ public class AuditTest extends AbstractIntegrationTest {
         testContext
                 .given(EnvironmentTestDto.class)
                 .given("stackTemplate", StackTemplateTestDto.class)
-                .withEnvironment(EnvironmentTestDto.class)
+                .withEnvironmentClass(EnvironmentTestDto.class)
                 .given(ClusterTemplateTestDto.class)
                 .withName(clusterTemplateName)
                 .when(clusterTemplateTestClient.createV4(), key(clusterTemplateName))

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
@@ -73,7 +73,7 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
 
         testContext
                 .given(stackTemplate, StackTemplateTestDto.class)
-                .withEnvironment(EnvironmentTestDto.class)
+                .withEnvironmentClass(EnvironmentTestDto.class)
                 .given(ClusterTemplateTestDto.class)
                 .withName(resourcePropertyProvider().getName())
                 .when(clusterTemplateTestClient.createV4(), RunningParameter.key(generatedKey))
@@ -262,7 +262,7 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
 
         testContext
                 .given(stackTemplate, StackTemplateTestDto.class)
-                .withEnvironment(EnvironmentTestDto.class)
+                .withEnvironmentClass(EnvironmentTestDto.class)
                 .given(ClusterTemplateTestDto.class)
                 .withName(name)
                 .when(clusterTemplateTestClient.createV4(), RunningParameter.key(generatedKey))
@@ -359,7 +359,7 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
                 .given("placementSettings", PlacementSettingsTestDto.class)
                 .withRegion(MockCloudProvider.LONDON)
                 .given("stackTemplate", StackTemplateTestDto.class)
-                .withEnvironment(EnvironmentTestDto.class)
+                .withEnvironmentClass(EnvironmentTestDto.class)
                 .withPlacement("placementSettings")
                 .given(ClusterTemplateTestDto.class)
                 .withName(resourcePropertyProvider().getName())

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentClusterTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentClusterTest.java
@@ -64,7 +64,7 @@ public class EnvironmentClusterTest extends AbstractIntegrationTest {
         String newStack = resourcePropertyProvider().getName();
         testContext
                 .given(StackTestDto.class)
-                .withEnvironment(EnvironmentTestDto.class)
+                .withEnvironmentClass(EnvironmentTestDto.class)
                 .when(stackTestClient.createV4())
                 .await(STACK_AVAILABLE)
                 .given(newStack, StackTestDto.class)
@@ -84,7 +84,7 @@ public class EnvironmentClusterTest extends AbstractIntegrationTest {
                 .given(EnvironmentTestDto.class)
                 .when(environmentTestClient.create())
                 .given(StackTestDto.class)
-                .withEnvironment(EnvironmentTestDto.class)
+                .withEnvironmentClass(EnvironmentTestDto.class)
                 .withCluster(setResources(testContext, testContext.get(RedbeamsDatabaseTestDto.class).getName(),
                         null, null))
                 .when(stackTestClient.createV4())
@@ -102,7 +102,7 @@ public class EnvironmentClusterTest extends AbstractIntegrationTest {
                 .when(environmentTestClient.create())
                 .when(environmentTestClient.describe())
                 .given(StackTestDto.class)
-                .withEnvironment(EnvironmentTestDto.class)
+                .withEnvironmentClass(EnvironmentTestDto.class)
                 .when(stackTestClient.createV4())
                 .await(STACK_AVAILABLE)
                 .given(NEW_CREDENTIAL_KEY, CredentialTestDto.class)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentDatalakeClusterTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentDatalakeClusterTest.java
@@ -68,7 +68,7 @@ public class EnvironmentDatalakeClusterTest extends AbstractIntegrationTest {
                 .given("placement", PlacementSettingsTestDto.class)
 
                 .given(StackTestDto.class).withPlacement("placement")
-                .withEnvironment(EnvironmentTestDto.class)
+                .withEnvironmentClass(EnvironmentTestDto.class)
                 .withInstanceGroupsEntity(InstanceGroupTestDto.defaultHostGroup(testContext))
 
                 .when(stackTestClient.createV4())
@@ -100,7 +100,7 @@ public class EnvironmentDatalakeClusterTest extends AbstractIntegrationTest {
                 .withRdsConfigNames(rdsList)
                 .given("placement", PlacementSettingsTestDto.class)
                 .given(StackTestDto.class).withPlacement("placement")
-                .withEnvironment(EnvironmentTestDto.class)
+                .withEnvironmentClass(EnvironmentTestDto.class)
                 .withInstanceGroupsEntity(InstanceGroupTestDto.defaultHostGroup(testContext))
                 .when(stackTestClient.createV4())
                 .given(LdapTestDto.class)
@@ -146,7 +146,7 @@ public class EnvironmentDatalakeClusterTest extends AbstractIntegrationTest {
                 .given(StackTestDto.class)
                 .withName(dlName)
                 .withPlacement("placement")
-                .withEnvironment(EnvironmentTestDto.class)
+                .withEnvironmentClass(EnvironmentTestDto.class)
                 .when(stackTestClient.createV4())
                 .validate();
         createDatalake(testContext, rdsList);
@@ -159,7 +159,7 @@ public class EnvironmentDatalakeClusterTest extends AbstractIntegrationTest {
                 .given(StackTestDto.class)
                 .withName(resourcePropertyProvider().getName())
                 .withPlacement("placement")
-                .withEnvironment(EnvironmentTestDto.class)
+                .withEnvironmentClass(EnvironmentTestDto.class)
                 .withInstanceGroupsEntity(InstanceGroupTestDto.defaultHostGroup(testContext))
                 .when(stackTestClient.createV4())
                 .validate();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ImageCatalogPrewarmedTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ImageCatalogPrewarmedTest.java
@@ -53,7 +53,7 @@ public class ImageCatalogPrewarmedTest extends AbstractIntegrationTest {
                 // .when(imageCatalogTestClient.setAsDefault(), key(imgCatalogName))
                 .given(StackTestDto.class)
                 .withCatalog(ImageCatalogTestDto.class)
-                .withEnvironment(EnvironmentTestDto.class)
+                .withEnvironmentClass(EnvironmentTestDto.class)
                 .withName(stackName)
                 .when(stackTestClient.createV4(), key(imgCatalogName))
                 .await(STACK_AVAILABLE)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxTests.java
@@ -43,6 +43,7 @@ public class MockSdxTests extends AbstractIntegrationTest {
     protected void setupTest(TestContext testContext) {
         createDefaultUser(testContext);
         createDefaultCredential(testContext);
+        createDefaultEnvironmentWithNetwork(testContext);
         createDefaultImageCatalog(testContext);
         initializeDefaultBlueprints(testContext);
     }
@@ -65,17 +66,17 @@ public class MockSdxTests extends AbstractIntegrationTest {
                 .withNetwork(networkKey)
                 .withCreateFreeIpa(Boolean.FALSE)
                 .withName(resourcePropertyProvider().getEnvironmentName())
-                .when(getEnvironmentTestClient().create())
-                .await(EnvironmentStatus.AVAILABLE)
+                .when(getEnvironmentTestClient().create(), key(envKey))
+                .await(EnvironmentStatus.AVAILABLE, key(envKey))
                 .given(sdxInternal, SdxInternalTestDto.class)
                 .withDefaultSDXSettings(Optional.of(testContext.getSparkServer().getPort()))
                 .withEnvironmentKey(key(envKey))
                 .when(sdxTestClient.createInternal(), key(sdxInternal))
                 .awaitForFlow(key(sdxInternal))
-                .await(SdxClusterStatusResponse.RUNNING)
+                .await(SdxClusterStatusResponse.RUNNING, key(sdxInternal))
                 .then((tc, testDto, client) -> sdxTestClient.deleteInternal().action(tc, testDto, client))
                 .awaitForFlow(key(sdxInternal))
-                .await(SdxClusterStatusResponse.DELETED)
+                .await(SdxClusterStatusResponse.DELETED, key(sdxInternal))
                 .validate();
     }
 
@@ -98,17 +99,17 @@ public class MockSdxTests extends AbstractIntegrationTest {
                 .withNetwork(networkKey)
                 .withCreateFreeIpa(Boolean.FALSE)
                 .withName(resourcePropertyProvider().getEnvironmentName())
-                .when(getEnvironmentTestClient().create())
-                .await(EnvironmentStatus.AVAILABLE)
+                .when(getEnvironmentTestClient().create(), key(envKey))
+                .await(EnvironmentStatus.AVAILABLE, key(envKey))
                 .given(sdxInternal, SdxInternalTestDto.class)
                 .withTemplate(jsonObject)
                 .withEnvironmentKey(key(envKey))
                 .when(sdxTestClient.createInternal(), key(sdxInternal))
                 .awaitForFlow(key(sdxInternal))
-                .await(SdxClusterStatusResponse.RUNNING)
+                .await(SdxClusterStatusResponse.RUNNING, key(sdxInternal))
                 .then((tc, testDto, client) -> sdxTestClient.deleteInternal().action(tc, testDto, client))
                 .awaitForFlow(key(sdxInternal))
-                .await(SdxClusterStatusResponse.DELETED)
+                .await(SdxClusterStatusResponse.DELETED, key(sdxInternal))
                 .validate();
     }
 
@@ -130,20 +131,20 @@ public class MockSdxTests extends AbstractIntegrationTest {
                 .withNetwork(networkKey)
                 .withCreateFreeIpa(Boolean.FALSE)
                 .withName(resourcePropertyProvider().getEnvironmentName())
-                .when(getEnvironmentTestClient().create())
-                .await(EnvironmentStatus.AVAILABLE)
+                .when(getEnvironmentTestClient().create(), key(envKey))
+                .await(EnvironmentStatus.AVAILABLE, key(envKey))
                 .given(sdxInternal, SdxInternalTestDto.class)
                 .withDefaultSDXSettings(Optional.of(testContext.getSparkServer().getPort()))
                 .withEnvironmentKey(key(envKey))
                 .when(sdxTestClient.createInternal(), key(sdxInternal))
                 .awaitForFlow(key(sdxInternal))
-                .await(SdxClusterStatusResponse.RUNNING)
-                .when(sdxTestClient.stopInternal())
+                .await(SdxClusterStatusResponse.RUNNING, key(sdxInternal))
+                .when(sdxTestClient.stopInternal(), key(sdxInternal))
                 .awaitForFlow(key(sdxInternal))
-                .await(SdxClusterStatusResponse.STOPPED)
-                .when(sdxTestClient.startInternal())
+                .await(SdxClusterStatusResponse.STOPPED, key(sdxInternal))
+                .when(sdxTestClient.startInternal(), key(sdxInternal))
                 .awaitForFlow(key(sdxInternal))
-                .await(SdxClusterStatusResponse.RUNNING)
+                .await(SdxClusterStatusResponse.RUNNING, key(sdxInternal))
                 .validate();
     }
 
@@ -172,8 +173,8 @@ public class MockSdxTests extends AbstractIntegrationTest {
                 .withNetwork(networkKey)
                 .withCreateFreeIpa(Boolean.FALSE)
                 .withName(resourcePropertyProvider().getEnvironmentName())
-                .when(getEnvironmentTestClient().create())
-                .await(EnvironmentStatus.AVAILABLE)
+                .when(getEnvironmentTestClient().create(), key(envKey))
+                .await(EnvironmentStatus.AVAILABLE, key(envKey))
                 .given(sdxInternal, SdxInternalTestDto.class)
                 .withDefaultSDXSettings(Optional.of(testContext.getSparkServer().getPort()))
                 .withDatabase(sdxDatabaseRequest)
@@ -181,17 +182,17 @@ public class MockSdxTests extends AbstractIntegrationTest {
                 .withEnvironmentKey(key(envKey))
                 .when(sdxTestClient.createInternal(), key(sdxInternal))
                 .awaitForFlow(key(sdxInternal))
-                .await(SdxClusterStatusResponse.RUNNING)
+                .await(SdxClusterStatusResponse.RUNNING, key(sdxInternal))
                 .then((tc, testDto, client) -> {
                     List<String> instancesToDelete = sdxUtil.getInstanceIds(testDto, client, MASTER.getName());
                     instancesToDelete.addAll(sdxUtil.getInstanceIds(testDto, client, IDBROKER.getName()));
                     instancesToDelete.forEach(id -> testContext.getModel().terminateInstance(testContext.getModel().getInstanceMap(), id));
                     return testDto;
                 })
-                .await(SdxClusterStatusResponse.DELETED_ON_PROVIDER_SIDE)
-                .when(sdxTestClient.repairInternal())
+                .await(SdxClusterStatusResponse.DELETED_ON_PROVIDER_SIDE, key(sdxInternal))
+                .when(sdxTestClient.repairInternal(), key(sdxInternal))
                 .awaitForFlow(key(sdxInternal))
-                .await(SdxClusterStatusResponse.RUNNING)
+                .await(SdxClusterStatusResponse.RUNNING, key(sdxInternal))
                 .validate();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/FlowUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/FlowUtil.java
@@ -120,6 +120,7 @@ public class FlowUtil {
         try {
             TimeUnit.MILLISECONDS.sleep(pollingInterval);
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             LOGGER.error("Waiting for flowId:flowChainId '{}:{}' has been interrupted at resource {}, because of: {}", flowId, flowChainId, crn,
                     e.getMessage(), e);
             throw new TestFailException(String.format(" Waiting for flowId:flowChainId '%s:%s' has been interrupted at resource %s, because of: %s ",

--- a/integration-test/src/main/java/com/sequenceiq/it/util/cleanup/CleanupUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/util/cleanup/CleanupUtil.java
@@ -44,6 +44,8 @@ public class CleanupUtil extends CleanupClientUtil {
 
     private final Map<String, Map<Class<? extends MicroserviceClient>, MicroserviceClient>> clients = new HashMap<>();
 
+    private final MultiValueMap<String, String> deletedResources = new LinkedMultiValueMap<>();
+
     @Value("${integrationtest.outputdir:.}")
     private String outputDirectory;
 
@@ -227,7 +229,6 @@ public class CleanupUtil extends CleanupClientUtil {
 
     private void deleteResources(List<String> foundResources, String resourceNameType) {
         List<Path> fileList = new ArrayList<>();
-        MultiValueMap<String, String> deletedResources = new LinkedMultiValueMap<>();
         AtomicBoolean e2eCleanupFailed = new AtomicBoolean(false);
 
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(Paths.get(outputDirectory))) {


### PR DESCRIPTION
- Introduce `withSkipOnFail(false))` to all the TestDtos' cleanUp
  - Along with the previous change introduce `testDto.setResponse` to all the related DeleteActions
- Update and standardised all the TestDtos' not implemented cleanUp with: `LOGGER.warn(String.format("Cleanup WARN: 'cleanUp' is not implemented for TestDto: %s with name: %s", this, getName()));` 
- Make `deletedResources` MultiValueMap CleanupUtil class global
- Some additional changes for Integration Tests:
  - FlowUtil: `Thread.currentThread().interrupt()`
  - EnvironmentChildTest: `checkEnvsAreNotListedByName`