### PR TITLE
CB-7938: Enable delete protection for RDS to avoid accidental deletions.

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsStackRequestHelper.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsStackRequestHelper.java
@@ -69,7 +69,7 @@ public class AwsStackRequestHelper {
                 .withTemplateBody(cfTemplate)
                 .withTags(awsTaggingService.prepareCloudformationTags(ac, stack.getTags()))
                 .withCapabilities(CAPABILITY_IAM)
-                .withParameters(getStackParameters(ac, stack));
+                .withParameters(getStackParameters(ac, stack, true));
     }
 
     public UpdateStackRequest createUpdateStackRequest(AuthenticatedContext ac, CloudStack stack, String cFStackName, String cfTemplate) {
@@ -187,7 +187,7 @@ public class AwsStackRequestHelper {
     }
 
     @VisibleForTesting
-    Collection<Parameter> getStackParameters(AuthenticatedContext ac, DatabaseStack stack) {
+    Collection<Parameter> getStackParameters(AuthenticatedContext ac, DatabaseStack stack, boolean deleteProtection) {
         AwsNetworkView awsNetworkView = new AwsNetworkView(stack.getNetwork());
         AwsRdsInstanceView awsRdsInstanceView = new AwsRdsInstanceView(stack.getDatabaseServer());
         AwsRdsDbSubnetGroupView awsRdsDbSubnetGroupView = new AwsRdsDbSubnetGroupView(stack.getDatabaseServer());
@@ -199,7 +199,8 @@ public class AwsStackRequestHelper {
                 new Parameter().withParameterKey("DBSubnetGroupSubnetIdsParameter").withParameterValue(String.join(",", awsNetworkView.getSubnetList())),
                 new Parameter().withParameterKey("EngineParameter").withParameterValue(awsRdsInstanceView.getEngine()),
                 new Parameter().withParameterKey("MasterUsernameParameter").withParameterValue(awsRdsInstanceView.getMasterUsername()),
-                new Parameter().withParameterKey("MasterUserPasswordParameter").withParameterValue(awsRdsInstanceView.getMasterUserPassword()))
+                new Parameter().withParameterKey("MasterUserPasswordParameter").withParameterValue(awsRdsInstanceView.getMasterUserPassword()),
+                new Parameter().withParameterKey("DeletionProtectionParameter").withParameterValue(deleteProtection ? "true" : "false"))
         );
 
         addParameterIfNotNull(parameters, "AllocatedStorageParameter", awsRdsInstanceView.getAllocatedStorage());

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsModifyService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsModifyService.java
@@ -1,0 +1,63 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource;
+
+import static com.sequenceiq.cloudbreak.cloud.aws.scheduler.WaiterRunner.run;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.amazonaws.services.rds.AmazonRDS;
+import com.amazonaws.services.rds.model.DescribeDBInstancesRequest;
+import com.amazonaws.services.rds.model.ModifyDBInstanceRequest;
+import com.amazonaws.waiters.Waiter;
+import com.sequenceiq.cloudbreak.cloud.aws.AwsClient;
+import com.sequenceiq.cloudbreak.cloud.aws.scheduler.CustomAmazonWaiterProvider;
+import com.sequenceiq.cloudbreak.cloud.aws.scheduler.StackCancellationCheck;
+import com.sequenceiq.cloudbreak.cloud.aws.view.AwsCredentialView;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
+
+@Service
+public class AwsRdsModifyService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsRdsModifyService.class);
+
+    @Inject
+    private AwsClient awsClient;
+
+    @Inject
+    private CustomAmazonWaiterProvider customAmazonWaiterProvider;
+
+    public void disableDeleteProtection (AuthenticatedContext ac, DatabaseStack dbStack) throws ExecutionException, TimeoutException, InterruptedException {
+        AwsCredentialView credentialView = new AwsCredentialView(ac.getCloudCredential());
+        String regionName = ac.getCloudContext().getLocation().getRegion().value();
+        AmazonRDS rdsClient = awsClient.createRdsClient(credentialView, regionName);
+
+        String dbInstanceIdentifier = dbStack.getDatabaseServer().getServerId();
+
+        ModifyDBInstanceRequest modifyDBInstanceRequest = new ModifyDBInstanceRequest();
+        modifyDBInstanceRequest.setDBInstanceIdentifier(dbInstanceIdentifier);
+        modifyDBInstanceRequest.setDeletionProtection(false);
+
+        LOGGER.debug("RDS modify request to disable delete protection for DB: {}", dbInstanceIdentifier);
+        try {
+            rdsClient.modifyDBInstance(modifyDBInstanceRequest);
+        } catch (RuntimeException ex) {
+            throw new CloudConnectorException(ex.getMessage(), ex);
+        }
+
+        Waiter<DescribeDBInstancesRequest> rdsWaiter = customAmazonWaiterProvider
+                .getDbInstanceModifyWaiter(rdsClient);
+        DescribeDBInstancesRequest describeDBInstancesRequest = new DescribeDBInstancesRequest().withDBInstanceIdentifier(dbInstanceIdentifier);
+        StackCancellationCheck stackCancellationCheck = new StackCancellationCheck(ac.getCloudContext().getId());
+        run(rdsWaiter, describeDBInstancesRequest, stackCancellationCheck);
+        LOGGER.debug("RDS delete protection is disabled for DB Instance ID: {}", dbInstanceIdentifier);
+    }
+}
+

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsModifyService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsModifyService.java
@@ -34,7 +34,7 @@ public class AwsRdsModifyService {
     @Inject
     private CustomAmazonWaiterProvider customAmazonWaiterProvider;
 
-    public void disableDeleteProtection (AuthenticatedContext ac, DatabaseStack dbStack) throws ExecutionException, TimeoutException, InterruptedException {
+    public void disableDeleteProtection(AuthenticatedContext ac, DatabaseStack dbStack) throws ExecutionException, TimeoutException, InterruptedException {
         AwsCredentialView credentialView = new AwsCredentialView(ac.getCloudCredential());
         String regionName = ac.getCloudContext().getLocation().getRegion().value();
         AmazonRDS rdsClient = awsClient.createRdsClient(credentialView, regionName);

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsStatusLookupService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsStatusLookupService.java
@@ -49,7 +49,7 @@ public class AwsRdsStatusLookupService {
                 .get();
     }
 
-    public boolean isDeleteProtectonEnabled(AuthenticatedContext ac, DatabaseStack dbStack) {
+    public boolean isDeleteProtectionEnabled(AuthenticatedContext ac, DatabaseStack dbStack) {
         AwsCredentialView credentialView = new AwsCredentialView(ac.getCloudCredential());
         String regionName = ac.getCloudContext().getLocation().getRegion().value();
         AmazonRDS rdsClient = awsClient.createRdsClient(credentialView, regionName);

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsStatusLookupService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsStatusLookupService.java
@@ -1,5 +1,11 @@
 package com.sequenceiq.cloudbreak.cloud.aws.connector.resource;
 
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
 import com.amazonaws.services.rds.AmazonRDS;
 import com.amazonaws.services.rds.model.DBInstanceNotFoundException;
 import com.amazonaws.services.rds.model.DescribeDBInstancesRequest;
@@ -10,12 +16,11 @@ import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
 import com.sequenceiq.cloudbreak.cloud.model.ExternalDatabaseStatus;
-import org.springframework.stereotype.Service;
-
-import javax.inject.Inject;
 
 @Service
 public class AwsRdsStatusLookupService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsRdsStatusLookupService.class);
 
     @Inject
     private AwsClient awsClient;
@@ -42,6 +47,28 @@ public class AwsRdsStatusLookupService {
                 .map(i -> getExternalDatabaseStatus(i.getDBInstanceStatus()))
                 .findFirst()
                 .get();
+    }
+
+    public boolean isDeleteProtectonEnabled(AuthenticatedContext ac, DatabaseStack dbStack) {
+        AwsCredentialView credentialView = new AwsCredentialView(ac.getCloudCredential());
+        String regionName = ac.getCloudContext().getLocation().getRegion().value();
+        AmazonRDS rdsClient = awsClient.createRdsClient(credentialView, regionName);
+
+        String dbInstanceIdentifier = dbStack.getDatabaseServer().getServerId();
+
+        DescribeDBInstancesRequest describeDBInstancesRequest = new DescribeDBInstancesRequest().withDBInstanceIdentifier(dbInstanceIdentifier);
+        DescribeDBInstancesResult describeDBInstancesResult;
+        try {
+            LOGGER.debug("RDS Checking if delete protection is enabled");
+            describeDBInstancesResult = rdsClient.describeDBInstances(describeDBInstancesRequest);
+        } catch (RuntimeException ex) {
+            throw new CloudConnectorException(ex.getMessage(), ex);
+        }
+
+        return describeDBInstancesResult.getDBInstances()
+                .stream()
+                .findFirst()
+                .get().getDeletionProtection();
     }
 
     private ExternalDatabaseStatus getExternalDatabaseStatus(String dbInstanceStatus) {

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnector.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnector.java
@@ -121,7 +121,7 @@ public class AwsResourceConnector implements ResourceConnector<Object> {
     @Override
     public List<CloudResourceStatus> terminateDatabaseServer(AuthenticatedContext ac, DatabaseStack stack,
             List<CloudResource> resources, PersistenceNotifier persistenceNotifier, boolean force) throws Exception {
-        if(awsRdsStatusLookupService.isDeleteProtectonEnabled(ac, stack)) {
+        if (awsRdsStatusLookupService.isDeleteProtectionEnabled(ac, stack)) {
             LOGGER.debug("Delete protection is enabled for DB: {}, Disabling it", stack.getDatabaseServer().getServerId());
             awsRdsModifyService.disableDeleteProtection(ac, stack);
         }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnector.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnector.java
@@ -69,6 +69,9 @@ public class AwsResourceConnector implements ResourceConnector<Object> {
     private AwsRdsTerminateService awsRdsTerminateService;
 
     @Inject
+    private AwsRdsModifyService awsRdsModifyService;
+
+    @Inject
     private AwsTerminateService awsTerminateService;
 
     @Inject
@@ -118,6 +121,10 @@ public class AwsResourceConnector implements ResourceConnector<Object> {
     @Override
     public List<CloudResourceStatus> terminateDatabaseServer(AuthenticatedContext ac, DatabaseStack stack,
             List<CloudResource> resources, PersistenceNotifier persistenceNotifier, boolean force) throws Exception {
+        if(awsRdsStatusLookupService.isDeleteProtectonEnabled(ac, stack)) {
+            LOGGER.debug("Delete protection is enabled for DB: {}, Disabling it", stack.getDatabaseServer().getServerId());
+            awsRdsModifyService.disableDeleteProtection(ac, stack);
+        }
         return awsRdsTerminateService.terminate(ac, stack, force, persistenceNotifier, resources);
     }
 

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/CustomAmazonWaiterProvider.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/CustomAmazonWaiterProvider.java
@@ -88,7 +88,7 @@ public class CustomAmazonWaiterProvider {
                 .withAcceptors(new WaiterAcceptor<DescribeDBInstancesResult>() {
                     @Override
                     public boolean matches(DescribeDBInstancesResult describeDBInstancesResult) {
-                        return describeDBInstancesResult.getDBInstances().stream().allMatch(instance -> "avaialble".equals(instance.getDBInstanceStatus()));
+                        return describeDBInstancesResult.getDBInstances().stream().allMatch(instance -> "available".equals(instance.getDBInstanceStatus()));
                     }
 
                     @Override

--- a/cloud-aws/src/main/resources/templates/aws-cf-dbstack.ftl
+++ b/cloud-aws/src/main/resources/templates/aws-cf-dbstack.ftl
@@ -77,6 +77,12 @@
         "Description": "Storage type",
         "AllowedValues": [ "standard", "gp2", "io1" ]
     },
+    "DeletionProtectionParameter": {
+        "Type": "String",
+        "Default": "true",
+        "Description": "Value indicates whether the DB instance has deletion protection enabled.",
+        "AllowedValues": [ "true", "false"]
+    },
     <#if hasPort>
     "PortParameter": {
         "Type": "Number",
@@ -165,6 +171,7 @@
                 "EngineVersion": { "Ref": "EngineVersionParameter" },
                 "MasterUserPassword": { "Ref": "MasterUserPasswordParameter" },
                 "MasterUsername": { "Ref": "MasterUsernameParameter" },
+                "DeletionProtection": { "Ref": "DeletionProtectionParameter" },
                 "MultiAZ": { "Fn::If" : [ "UseMultiAZ", true, false ] },
                 <#if hasPort>
                 "Port": { "Ref": "PortParameter" },

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsStackRequestHelperTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsStackRequestHelperTest.java
@@ -152,7 +152,7 @@ public class AwsStackRequestHelperTest {
 
         when(cloudContext.getUserName()).thenReturn("bob@cloudera.com");
 
-        Collection<Parameter> parameters = underTest.getStackParameters(authenticatedContext, databaseStack);
+        Collection<Parameter> parameters = underTest.getStackParameters(authenticatedContext, databaseStack, false);
 
         assertContainsParameter(parameters, "AllocatedStorageParameter", "50");
         assertContainsParameter(parameters, "BackupRetentionPeriodParameter", "1");
@@ -168,6 +168,10 @@ public class AwsStackRequestHelperTest {
         assertContainsParameter(parameters, "PortParameter", "5432");
         assertContainsParameter(parameters, "StorageTypeParameter", "gp2");
         assertContainsParameter(parameters, "VPCSecurityGroupsParameter", "sg-1234,sg-5678");
+        assertContainsParameter(parameters, "DeletionProtectionParameter", "false");
+
+        parameters = underTest.getStackParameters(authenticatedContext, databaseStack, true);
+        assertContainsParameter(parameters, "DeletionProtectionParameter", "true");
     }
 
     @Test
@@ -189,7 +193,7 @@ public class AwsStackRequestHelperTest {
 
         when(cloudContext.getUserName()).thenReturn("bob@cloudera.com");
 
-        Collection<Parameter> parameters = underTest.getStackParameters(authenticatedContext, databaseStack);
+        Collection<Parameter> parameters = underTest.getStackParameters(authenticatedContext, databaseStack, false);
 
         assertDoesNotContainParameter(parameters, "AllocatedStorageParameter");
         assertDoesNotContainParameter(parameters, "BackupRetentionPeriodParameter");
@@ -197,6 +201,17 @@ public class AwsStackRequestHelperTest {
         assertDoesNotContainParameter(parameters, "MultiAZParameter");
         assertDoesNotContainParameter(parameters, "StorageTypeParameter");
         assertDoesNotContainParameter(parameters, "PortParameter");
+        assertContainsParameter(parameters, "DeletionProtectionParameter", "false");
+
+        parameters = underTest.getStackParameters(authenticatedContext, databaseStack, true);
+
+        assertDoesNotContainParameter(parameters, "AllocatedStorageParameter");
+        assertDoesNotContainParameter(parameters, "BackupRetentionPeriodParameter");
+        assertDoesNotContainParameter(parameters, "EngineVersionParameter");
+        assertDoesNotContainParameter(parameters, "MultiAZParameter");
+        assertDoesNotContainParameter(parameters, "StorageTypeParameter");
+        assertDoesNotContainParameter(parameters, "PortParameter");
+        assertContainsParameter(parameters, "DeletionProtectionParameter", "true");
     }
 
     @Test

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsModifyServiceTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsModifyServiceTest.java
@@ -40,7 +40,7 @@ public class AwsRdsModifyServiceTest {
     private static final String REGION = "region";
 
     private static final String DB_INSTANCE_IDENTIFIER = "dbInstance";
-    
+
     @Mock
     private AwsClient awsClient;
 

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsModifyServiceTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsModifyServiceTest.java
@@ -1,0 +1,123 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.amazonaws.services.rds.AmazonRDS;
+import com.amazonaws.services.rds.model.DescribeDBInstancesRequest;
+import com.amazonaws.services.rds.model.ModifyDBInstanceRequest;
+import com.amazonaws.waiters.Waiter;
+import com.amazonaws.waiters.WaiterTimedOutException;
+import com.sequenceiq.cloudbreak.cloud.aws.AwsClient;
+import com.sequenceiq.cloudbreak.cloud.aws.scheduler.CustomAmazonWaiterProvider;
+import com.sequenceiq.cloudbreak.cloud.aws.view.AwsCredentialView;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseServer;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
+import com.sequenceiq.cloudbreak.cloud.model.Location;
+import com.sequenceiq.cloudbreak.cloud.model.Region;
+
+public class AwsRdsModifyServiceTest {
+
+    private static final String REGION = "region";
+
+    private static final String DB_INSTANCE_IDENTIFIER = "dbInstance";
+    
+    @Mock
+    private AwsClient awsClient;
+
+    @Mock
+    private AuthenticatedContext authenticatedContext;
+
+    @Mock
+    private CloudCredential cloudCredential;
+
+    @Mock
+    private CloudContext cloudContext;
+
+    @Mock
+    private Location location;
+
+    @Mock
+    private Region region;
+
+    @Mock
+    private AmazonRDS amazonRDS;
+
+    @Mock
+    private DatabaseStack dbStack;
+
+    @Mock
+    private DatabaseServer databaseServer;
+
+    @Mock
+    private Waiter<DescribeDBInstancesRequest> rdsWaiter;
+
+    @Mock
+    private CustomAmazonWaiterProvider provider;
+
+    @InjectMocks
+    private AwsRdsModifyService victim;
+
+    @Before
+    public void initTests() {
+        initMocks(this);
+
+        when(authenticatedContext.getCloudCredential()).thenReturn(cloudCredential);
+        when(authenticatedContext.getCloudContext()).thenReturn(cloudContext);
+        when(cloudContext.getLocation()).thenReturn(location);
+        when(location.getRegion()).thenReturn(region);
+        when(region.value()).thenReturn(REGION);
+        when(awsClient.createRdsClient(any(AwsCredentialView.class), eq(REGION))).thenReturn(amazonRDS);
+        when(dbStack.getDatabaseServer()).thenReturn(databaseServer);
+        when(databaseServer.getServerId()).thenReturn(DB_INSTANCE_IDENTIFIER);
+        when(provider.getDbInstanceModifyWaiter(any())).thenReturn(rdsWaiter);
+    }
+
+    @Test
+    public void shouldStopAndScheduleTask() throws InterruptedException, ExecutionException, TimeoutException {
+        ArgumentCaptor<ModifyDBInstanceRequest> modifyDBInstanceRequestArgumentCaptor = ArgumentCaptor.forClass(ModifyDBInstanceRequest.class);
+        when(amazonRDS.modifyDBInstance(modifyDBInstanceRequestArgumentCaptor.capture())).thenReturn(null);
+
+        victim.disableDeleteProtection(authenticatedContext, dbStack);
+
+        assertEquals(DB_INSTANCE_IDENTIFIER, modifyDBInstanceRequestArgumentCaptor.getValue().getDBInstanceIdentifier());
+        verify(rdsWaiter, times(1)).run(any());
+    }
+
+    @Test(expected = CloudConnectorException.class)
+    public void shouldThrowCloudConnectorExceptionInCaseOfRdsClientException() throws InterruptedException, ExecutionException, TimeoutException {
+        ArgumentCaptor<ModifyDBInstanceRequest> modifyDBInstanceRequestArgumentCaptor = ArgumentCaptor.forClass(ModifyDBInstanceRequest.class);
+
+        when(amazonRDS.modifyDBInstance(modifyDBInstanceRequestArgumentCaptor.capture())).thenThrow(new RuntimeException());
+
+        victim.disableDeleteProtection(authenticatedContext, dbStack);
+    }
+
+    @Test(expected = CloudConnectorException.class)
+    public void shouldThrowCloudConnectorExceptionInCaseOfSchedulerException() throws InterruptedException, ExecutionException, TimeoutException {
+        ArgumentCaptor<ModifyDBInstanceRequest> modifyDBInstanceRequestArgumentCaptor = ArgumentCaptor.forClass(ModifyDBInstanceRequest.class);
+        when(amazonRDS.modifyDBInstance(modifyDBInstanceRequestArgumentCaptor.capture())).thenReturn(null);
+        doThrow(WaiterTimedOutException.class).when(rdsWaiter).run(any());
+
+        victim.disableDeleteProtection(authenticatedContext, dbStack);
+    }
+}

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsStatusLookupServiceTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsStatusLookupServiceTest.java
@@ -143,34 +143,32 @@ public class AwsRdsStatusLookupServiceTest {
     }
 
     @Test
-    public void isDeleteProtectonEnabledTest() {
+    public void isDeleteProtectionEnabledTest() {
         when(amazonRDS.describeDBInstances(any(DescribeDBInstancesRequest.class))).thenReturn(describeDBInstancesResult);
         when(describeDBInstancesResult.getDBInstances()).thenReturn(Arrays.asList(dbInstance));
         when(dbInstance.getDeletionProtection()).thenReturn(true);
 
-        boolean result = victim.isDeleteProtectonEnabled(authenticatedContext, dbStack);
+        boolean result = victim.isDeleteProtectionEnabled(authenticatedContext, dbStack);
         assertEquals(true, result);
 
         when(dbInstance.getDeletionProtection()).thenReturn(true);
 
-        result = victim.isDeleteProtectonEnabled(authenticatedContext, dbStack);
-        when(dbInstance.getDeletionProtection()).thenReturn(false);
+        result = victim.isDeleteProtectionEnabled(authenticatedContext, dbStack);
+        when(result).thenReturn(false);
 
     }
 
     @Test(expected = CloudConnectorException.class)
-    public void isDeleteProtectonEnabledShouldThrowCloudConnectorExceptionInCaseOfDBInstanceNotFoundException() {
+    public void isDeleteProtectionEnabledShouldThrowCloudConnectorExceptionInCaseOfDBInstanceNotFoundException() {
         when(amazonRDS.describeDBInstances(any(DescribeDBInstancesRequest.class))).thenThrow(DBInstanceNotFoundException.class);
-
-        boolean result = victim.isDeleteProtectonEnabled(authenticatedContext, dbStack);
-
+        victim.isDeleteProtectionEnabled(authenticatedContext, dbStack);
         fail("Exception should be been thrown");
     }
 
     @Test(expected = CloudConnectorException.class)
-    public void isDeleteProtectonEnabledShouldThrowCloudConnectorExceptionInCaseOfAnyRuntimeException() {
+    public void isDeleteProtectionEnabledShouldThrowCloudConnectorExceptionInCaseOfAnyRuntimeException() {
         when(amazonRDS.describeDBInstances(any(DescribeDBInstancesRequest.class))).thenThrow(RuntimeException.class);
 
-        victim.isDeleteProtectonEnabled(authenticatedContext, dbStack);
+        victim.isDeleteProtectionEnabled(authenticatedContext, dbStack);
     }
 }

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnectorTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnectorTest.java
@@ -1,0 +1,84 @@
+package com.sequenceiq.cloudbreak.cloud.aws.connector.resource;
+
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseServer;
+import com.sequenceiq.cloudbreak.cloud.model.DatabaseStack;
+import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
+
+public class AwsResourceConnectorTest {
+
+    private static final String DB_INSTANCE_IDENTIFIER = "dbInstance";
+
+    @Mock
+    private AuthenticatedContext authenticatedContext;
+
+    @Mock
+    private DatabaseStack dbStack;
+
+    @Mock
+    private DatabaseServer databaseServer;
+
+    @Mock
+    private AwsRdsStatusLookupService awsRdsStatusLookupService;
+
+    @Mock
+    private AwsRdsModifyService awsRdsModifyService;
+
+    @Mock
+    private AwsRdsTerminateService awsRdsTerminateService;
+
+    @InjectMocks
+    private AwsResourceConnector awsResourceConnector;
+
+    @Before
+    public void initTests() {
+        initMocks(this);
+        when(dbStack.getDatabaseServer()).thenReturn(databaseServer);
+        when(databaseServer.getServerId()).thenReturn(DB_INSTANCE_IDENTIFIER);
+    }
+
+    @Test
+    public void terminateDatabaseServerWithDeleteProtectionTest() {
+        PersistenceNotifier persistenceNotifier = mock(PersistenceNotifier.class);
+        when(awsRdsStatusLookupService.isDeleteProtectonEnabled(authenticatedContext, dbStack)).thenReturn(true);
+        try {
+            awsResourceConnector.terminateDatabaseServer(authenticatedContext, dbStack,
+                    Collections.emptyList(), persistenceNotifier, true);
+            verify(awsRdsModifyService, times(1)).disableDeleteProtection(any(), any());
+            verify(awsRdsTerminateService, times(1)).terminate(authenticatedContext, dbStack,
+                    true, persistenceNotifier, Collections.emptyList());
+        } catch (Exception e) {
+            fail("Exception observed while disabling delete protection");
+        }
+    }
+
+    @Test
+    public void terminateDatabaseServerWithOutDeleteProtectionTest() {
+        PersistenceNotifier persistenceNotifier = mock(PersistenceNotifier.class);
+        when(awsRdsStatusLookupService.isDeleteProtectonEnabled(authenticatedContext, dbStack)).thenReturn(false);
+        try {
+            awsResourceConnector.terminateDatabaseServer(authenticatedContext, dbStack,
+                    Collections.emptyList(), persistenceNotifier, true);
+            verify(awsRdsModifyService, times(0)).disableDeleteProtection(any(), any());
+            verify(awsRdsTerminateService, times(1)).terminate(authenticatedContext, dbStack,
+                    true, persistenceNotifier, Collections.emptyList());
+        } catch (Exception e) {
+            fail("Exception observed while disabling delete protection");
+        }
+    }
+}

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnectorTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnectorTest.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.cloudbreak.cloud.aws.connector.resource;
 
-import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -53,32 +52,27 @@ public class AwsResourceConnectorTest {
     }
 
     @Test
-    public void terminateDatabaseServerWithDeleteProtectionTest() {
+    public void terminateDatabaseServerWithDeleteProtectionTest() throws Exception {
         PersistenceNotifier persistenceNotifier = mock(PersistenceNotifier.class);
-        when(awsRdsStatusLookupService.isDeleteProtectonEnabled(authenticatedContext, dbStack)).thenReturn(true);
-        try {
-            awsResourceConnector.terminateDatabaseServer(authenticatedContext, dbStack,
-                    Collections.emptyList(), persistenceNotifier, true);
-            verify(awsRdsModifyService, times(1)).disableDeleteProtection(any(), any());
-            verify(awsRdsTerminateService, times(1)).terminate(authenticatedContext, dbStack,
-                    true, persistenceNotifier, Collections.emptyList());
-        } catch (Exception e) {
-            fail("Exception observed while disabling delete protection");
-        }
+        when(awsRdsStatusLookupService.isDeleteProtectionEnabled(authenticatedContext, dbStack)).thenReturn(true);
+
+        awsResourceConnector.terminateDatabaseServer(authenticatedContext, dbStack,
+                Collections.emptyList(), persistenceNotifier, true);
+        verify(awsRdsModifyService, times(1)).disableDeleteProtection(any(), any());
+        verify(awsRdsTerminateService, times(1)).terminate(authenticatedContext, dbStack,
+                true, persistenceNotifier, Collections.emptyList());
+
     }
 
     @Test
-    public void terminateDatabaseServerWithOutDeleteProtectionTest() {
+    public void terminateDatabaseServerWithOutDeleteProtectionTest() throws Exception {
         PersistenceNotifier persistenceNotifier = mock(PersistenceNotifier.class);
-        when(awsRdsStatusLookupService.isDeleteProtectonEnabled(authenticatedContext, dbStack)).thenReturn(false);
-        try {
-            awsResourceConnector.terminateDatabaseServer(authenticatedContext, dbStack,
-                    Collections.emptyList(), persistenceNotifier, true);
-            verify(awsRdsModifyService, times(0)).disableDeleteProtection(any(), any());
-            verify(awsRdsTerminateService, times(1)).terminate(authenticatedContext, dbStack,
-                    true, persistenceNotifier, Collections.emptyList());
-        } catch (Exception e) {
-            fail("Exception observed while disabling delete protection");
-        }
+        when(awsRdsStatusLookupService.isDeleteProtectionEnabled(authenticatedContext, dbStack)).thenReturn(false);
+
+        awsResourceConnector.terminateDatabaseServer(authenticatedContext, dbStack,
+                Collections.emptyList(), persistenceNotifier, true);
+        verify(awsRdsModifyService, times(0)).disableDeleteProtection(any(), any());
+        verify(awsRdsTerminateService, times(1)).terminate(authenticatedContext, dbStack,
+                true, persistenceNotifier, Collections.emptyList());
     }
 }


### PR DESCRIPTION
**Solution approach:**

When the RDS is created we should enable delete protection. This makes sure that customers don't accidentally delete the database. 

While terminating the database, we need to disable the delete protection if enabled, and then terminate the database.