### PR TITLE
CB-8641 Include DistroX user tags on DistroX RDS

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/provision/handler/CreateExternalDatabaseHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/provision/handler/CreateExternalDatabaseHandler.java
@@ -64,9 +64,9 @@ public class CreateExternalDatabaseHandler implements EventHandler<CreateExterna
         LOGGER.debug("External database: {} for stack {}", externalDatabase.name(), stack.getName());
         Selectable result;
         try {
+            String resourceCrn = null;
             if (externalDatabase == DatabaseAvailabilityType.NONE) {
                 LOGGER.info("External database for stack {} is not requested.", stack.getName());
-                result = new CreateExternalDatabaseResult(stack.getId(), EXTERNAL_DATABASE_WAIT_SUCCESS_EVENT.event(), stack.getName(), null);
             } else {
                 LOGGER.debug("Updating stack {} status from {} to {}",
                         stack.getName(), stack.getStatus().name(), DetailedStackStatus.EXTERNAL_DATABASE_CREATION_IN_PROGRESS.name());
@@ -80,9 +80,9 @@ public class CreateExternalDatabaseHandler implements EventHandler<CreateExterna
                         stack.getName(), stack.getStatus().name(), DetailedStackStatus.PROVISION_REQUESTED.name());
                 stackUpdaterService.updateStatus(stack.getId(), DetailedStackStatus.PROVISION_REQUESTED,
                         ResourceEvent.CLUSTER_EXTERNAL_DATABASE_CREATION_FINISHED, "External database creation finished");
-                result = new CreateExternalDatabaseResult(stack.getId(), EXTERNAL_DATABASE_WAIT_SUCCESS_EVENT.event(),
-                        stack.getName(), stack.getCluster().getDatabaseServerCrn());
+                resourceCrn = stack.getCluster().getDatabaseServerCrn();
             }
+            result = new CreateExternalDatabaseResult(stack.getId(), EXTERNAL_DATABASE_WAIT_SUCCESS_EVENT.event(), stack.getName(), resourceCrn);
         } catch (UserBreakException e) {
             LOGGER.info("Database polling exited before timeout. Cause: ", e);
             result = createFailedEvent(stack, e);

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterDetailResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterDetailResponse.java
@@ -18,7 +18,7 @@ public class SdxClusterDetailResponse extends SdxClusterResponse implements Tagg
                 sdxClusterResponse.getEnvironmentCrn(), sdxClusterResponse.getStackCrn(),
                 sdxClusterResponse.getClusterShape(), sdxClusterResponse.getCloudStorageBaseLocation(),
                 sdxClusterResponse.getCloudStorageFileSystemType(), sdxClusterResponse.getRuntime(),
-                sdxClusterResponse.getRangerRazEnabled());
+                sdxClusterResponse.getRangerRazEnabled(), sdxClusterResponse.getTags());
         this.stackV4Response = stackV4Response;
     }
 

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterResponse.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.sdx.api.model;
 
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.sequenceiq.authorization.resource.ResourceCrnAwareApiModel;
 import com.sequenceiq.common.model.FileSystemType;
@@ -37,6 +39,8 @@ public class SdxClusterResponse implements ResourceCrnAwareApiModel {
 
     private boolean rangerRazEnabled;
 
+    private Map<String, String> tags;
+
     public SdxClusterResponse() {
     }
 
@@ -44,7 +48,7 @@ public class SdxClusterResponse implements ResourceCrnAwareApiModel {
             String statusReason, String environmentName, String environmentCrn, String stackCrn,
             SdxClusterShape clusterShape, String cloudStorageBaseLocation,
             FileSystemType cloudStorageFileSystemType, String runtime,
-            boolean rangerRazEnabled) {
+            boolean rangerRazEnabled, Map<String, String> tags) {
         this.crn = crn;
         this.name = name;
         this.status = status;
@@ -57,6 +61,7 @@ public class SdxClusterResponse implements ResourceCrnAwareApiModel {
         this.cloudStorageFileSystemType = cloudStorageFileSystemType;
         this.runtime = runtime;
         this.rangerRazEnabled = rangerRazEnabled;
+        this.tags = tags;
     }
 
     public String getCrn() {
@@ -177,6 +182,14 @@ public class SdxClusterResponse implements ResourceCrnAwareApiModel {
 
     public boolean getRangerRazEnabled() {
         return rangerRazEnabled;
+    }
+
+    public Map<String, String> getTags() {
+        return tags;
+    }
+
+    public void setTags(Map<String, String> tags) {
+        this.tags = tags;
     }
 
     @JsonIgnore

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxClusterConverter.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxClusterConverter.java
@@ -2,12 +2,18 @@ package com.sequenceiq.datalake.controller.sdx;
 
 import static com.sequenceiq.cloudbreak.util.Benchmark.measure;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.datalake.controller.exception.BadRequestException;
 import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.entity.SdxStatusEntity;
 import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
@@ -42,6 +48,19 @@ public class SdxClusterConverter {
         sdxClusterResponse.setCloudStorageFileSystemType(sdxCluster.getCloudStorageFileSystemType());
         sdxClusterResponse.setDatabaseServerCrn(sdxCluster.getDatabaseCrn());
         sdxClusterResponse.setRangerRazEnabled(sdxCluster.isRangerRazEnabled());
+        sdxClusterResponse.setTags(getTags(sdxCluster.getTags()));
         return sdxClusterResponse;
+    }
+
+    private Map<String, String> getTags(Json tag) {
+        try {
+            if (tag != null && tag.getValue() != null) {
+                return tag.get(new TypeReference<Map<String, String>>() { });
+            } else {
+                return new HashMap<>();
+            }
+        } catch (Exception e) {
+            throw new BadRequestException("Cannot convert tags", e);
+        }
     }
 }

--- a/redbeams/build.gradle
+++ b/redbeams/build.gradle
@@ -85,11 +85,12 @@ dependencies {
     testImplementation group: 'org.springframework.boot',  name: 'spring-boot-starter-test',       version: springBootVersion
   }
   compile project(':authorization-common')
-  
+
   implementation project(':flow')
   implementation project(':cloud-reactor')
   implementation project(':cloud-reactor-api')
   implementation project(':environment-api')
+  implementation project(':datalake-api')
   implementation project(':status-checker')
 
   compile project(':cloud-common')
@@ -119,7 +120,7 @@ bootRun {
   if (project.hasProperty("jvmArgs")) {
     jvmArgs += project.jvmArgs.split("\\s+").toList()
   }
-} 
+}
 
 springBoot {
   mainClassName = 'com.sequenceiq.redbeams.RedbeamsApplication'

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/RedbeamsApplication.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/RedbeamsApplication.java
@@ -50,6 +50,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
         "com.sequenceiq.authorization",
         "com.sequenceiq.statuschecker",
         "com.sequenceiq.environment.client",
+        "com.sequenceiq.sdx.client",
         "com.sequenceiq.cloudbreak.client",
         "com.sequenceiq.cloudbreak.service",
         "com.sequenceiq.cloudbreak.ha.service",

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/CloudbreakApiConfig.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/CloudbreakApiConfig.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.redbeams.configuration;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.sequenceiq.cloudbreak.client.internal.CloudbreakApiClientParams;
+
+@Configuration
+public class CloudbreakApiConfig {
+
+    @Inject
+    @Named("cloudbreakUrl")
+    private String cloudbreakServerUrl;
+
+    @Value("${rest.debug:false}")
+    private boolean restDebug;
+
+    @Value("${cert.validation:true}")
+    private boolean certificateValidation;
+
+    @Value("${cert.ignorePreValidation:true}")
+    private boolean ignorePreValidation;
+
+    @Bean
+    public CloudbreakApiClientParams cloudbreakClient() {
+        return new CloudbreakApiClientParams(restDebug, certificateValidation, ignorePreValidation, cloudbreakServerUrl);
+    }
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/SdxApiConfig.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/SdxApiConfig.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.redbeams.configuration;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.sequenceiq.sdx.client.internal.SdxApiClientParams;
+
+@Configuration
+public class SdxApiConfig {
+
+    @Value("${rest.debug:false}")
+    private boolean restDebug;
+
+    @Value("${cert.validation:true}")
+    private boolean certificateValidation;
+
+    @Value("${cert.ignorePreValidation:false}")
+    private boolean ignorePreValidation;
+
+    @Inject
+    @Named("sdxServerUrl")
+    private String sdxServerUrl;
+
+    @Bean
+    public SdxApiClientParams sdxApiClientParams() {
+        return new SdxApiClientParams(restDebug, certificateValidation, ignorePreValidation, sdxServerUrl);
+    }
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/ServiceEndpointConfig.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/ServiceEndpointConfig.java
@@ -30,11 +30,23 @@ public class ServiceEndpointConfig {
     @Value("${redbeams.cloudbreak.serviceid:}")
     private String cloudbreakServiceId;
 
+    @Value("${redbeams.cloudbreak.server.contextPath:/cb}")
+    private String cbRootContextPath;
+
     @Value("${redbeams.environment.url}")
     private String environmentServiceUrl;
 
     @Value("${redbeams.environment.contextPath}")
     private String environmentRootContextPath;
+
+    @Value("${redbeams.sdx.url:}")
+    private String sdxServiceUrl;
+
+    @Value("${redbeams.sdx.serviceId:}")
+    private String sdxServiceId;
+
+    @Value("${redbeams.sdx.server.contextPath:/dl}")
+    private String sdxRootContextPath;
 
     @Bean
     public ServiceAddressResolver serviceAddressResolver() {
@@ -50,12 +62,18 @@ public class ServiceEndpointConfig {
     @Bean
     @DependsOn("serviceAddressResolver")
     public String cloudbreakUrl(ServiceAddressResolver serviceAddressResolver) throws ServiceAddressResolvingException {
-        return serviceAddressResolver.resolveUrl(cloudbreakUrl, "http", cloudbreakServiceId);
+        return serviceAddressResolver.resolveUrl(cloudbreakUrl + cbRootContextPath, "http", cloudbreakServiceId);
     }
 
     @Bean
     @DependsOn("serviceAddressResolver")
     public String environmentServiceUrl(ServiceAddressResolver serviceAddressResolver) throws ServiceAddressResolvingException {
         return serviceAddressResolver.resolveUrl(environmentServiceUrl + environmentRootContextPath, "", null);
+    }
+
+    @Bean
+    @DependsOn("serviceAddressResolver")
+    public String sdxServerUrl() throws ServiceAddressResolvingException {
+        return serviceAddressResolver().resolveUrl(sdxServiceUrl + sdxRootContextPath, "http", sdxServiceId);
     }
 }

--- a/redbeams/src/main/resources/application.yml
+++ b/redbeams/src/main/resources/application.yml
@@ -29,7 +29,7 @@ management:
 
 redbeams:
   schema.migration.auto: true
-  cloudbreak.url: http://127.0.0.1:8080
+  cloudbreak.url: http://localhost:9091
   cert.dir: /certs/
   client.id: redbeams
   structuredevent:
@@ -51,6 +51,9 @@ redbeams:
   environment:
     url: http://localhost:8088
     contextPath: /environmentservice
+  sdx:
+    url: http://localhost:8086
+    contextPath: /dl
   intermediate.threadpool:
     core.size: 40
     capacity.size: 4000


### PR DESCRIPTION
And do the same for SDX user tags (for future compatibility). For this SDX service's SdxClusterResponse had to be extended also
as it did not return the Tags property.
Redbeams spring config was incorrect regarding Cloudbreak endpoint configuration values.
Redbeams also had to be linked to SDX service.