### PR TITLE
CB-8629 [ASRG] single RG and custom network: single RG is deleted whe…

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/network/NetworkDeletionRequest.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/network/NetworkDeletionRequest.java
@@ -12,14 +12,20 @@ public class NetworkDeletionRequest {
 
     private final String resourceGroup;
 
+    private final String networkId;
+
     private final boolean existing;
+
+    private final boolean singleResourceGroup;
 
     private NetworkDeletionRequest(Builder builder) {
         this.stackName = builder.stackName;
         this.cloudCredential = builder.cloudCredential;
         this.region = builder.region;
         this.resourceGroup = builder.resourceGroup;
+        this.networkId = builder.networkId;
         this.existing = builder.existing;
+        this.singleResourceGroup = builder.singleResourceGroup;
     }
 
     public String getStackName() {
@@ -38,8 +44,16 @@ public class NetworkDeletionRequest {
         return resourceGroup;
     }
 
+    public String getNetworkId() {
+        return networkId;
+    }
+
     public boolean isExisting() {
         return existing;
+    }
+
+    public boolean isSingleResourceGroup() {
+        return singleResourceGroup;
     }
 
     public static final class Builder {
@@ -52,7 +66,11 @@ public class NetworkDeletionRequest {
 
         private String resourceGroup;
 
+        private String networkId;
+
         private boolean existing;
+
+        private boolean singleResourceGroup;
 
         public Builder() {
         }
@@ -77,8 +95,18 @@ public class NetworkDeletionRequest {
             return this;
         }
 
+        public Builder withNetworkId(String networkId) {
+            this.networkId = networkId;
+            return this;
+        }
+
         public Builder withExisting(boolean existing) {
             this.existing = existing;
+            return this;
+        }
+
+        public Builder withSingleResourceGroup(boolean singleResourceGroup) {
+            this.singleResourceGroup = singleResourceGroup;
             return this;
         }
 

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtils.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtils.java
@@ -499,4 +499,15 @@ public class AzureUtils {
             return true;
         });
     }
+
+    public CloudConnectorException convertToCloudConnectorException(CloudException e, String actionDescription) {
+        LOGGER.warn("{} failed, cloud exception happened: ", actionDescription, e);
+        if (e.body() != null && e.body().details() != null) {
+            String details = e.body().details().stream().map(CloudError::message).collect(Collectors.joining(", "));
+            return new CloudConnectorException(String.format("%s failed, status code %s, error message: %s, details: %s",
+                    actionDescription, e.body().code(), e.body().message(), details));
+        } else {
+            return new CloudConnectorException(String.format("%s failed: '%s', please go to Azure Portal for detailed message", actionDescription, e));
+        }
+    }
 }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
@@ -622,6 +622,10 @@ public class AzureClient {
         return handleAuthException(() -> azure.networks().deleteByIdsAsync(networkIds));
     }
 
+    public void deleteNetworkInResourceGroup(String resourceGroup, String networkId) {
+        handleAuthException(() -> azure.networks().deleteByResourceGroup(resourceGroup, networkId));
+    }
+
     public Observable<String> deleteStorageAccountsAsync(Collection<String> accountIds) {
         return handleAuthException(() -> azure.storageAccounts().deleteByIdsAsync(accountIds));
     }

--- a/environment/src/main/java/com/sequenceiq/environment/network/EnvironmentNetworkService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/EnvironmentNetworkService.java
@@ -1,5 +1,9 @@
 package com.sequenceiq.environment.network;
 
+
+import static com.sequenceiq.environment.parameters.dao.domain.ResourceGroupUsagePattern.USE_MULTIPLE;
+import static com.sequenceiq.environment.parameters.dao.domain.ResourceGroupUsagePattern.USE_SINGLE;
+
 import java.util.Map;
 import java.util.Optional;
 
@@ -29,6 +33,10 @@ import com.sequenceiq.environment.network.dto.AzureParams;
 import com.sequenceiq.environment.network.dto.NetworkDto;
 import com.sequenceiq.environment.network.service.NetworkCreationRequestFactory;
 import com.sequenceiq.environment.network.v1.converter.EnvironmentNetworkConverter;
+import com.sequenceiq.environment.parameters.dao.domain.ResourceGroupUsagePattern;
+import com.sequenceiq.environment.parameters.dto.AzureParametersDto;
+import com.sequenceiq.environment.parameters.dto.AzureResourceGroupDto;
+import com.sequenceiq.environment.parameters.dto.ParametersDto;
 
 @Component
 public class EnvironmentNetworkService {
@@ -86,14 +94,29 @@ public class EnvironmentNetworkService {
         NetworkDeletionRequest.Builder builder = new NetworkDeletionRequest.Builder()
                 .withStackName(networkCreationRequestFactory.getStackName(environment))
                 .withCloudCredential(cloudCredential)
-                .withRegion(environment.getLocation().getName());
+                .withRegion(environment.getLocation().getName())
+                .withSingleResourceGroup(isSingleResourceGroup(environment));
         getResourceGroupName(environment.getNetwork()).ifPresent(builder::withResourceGroup);
+        getNetworkId(environment.getNetwork()).ifPresent(builder::withNetworkId);
         builder.withExisting(environment.getNetwork().getRegistrationType() == RegistrationType.EXISTING);
         return builder.build();
     }
 
     private Optional<String> getResourceGroupName(NetworkDto networkDto) {
         return Optional.of(networkDto).map(NetworkDto::getAzure).map(AzureParams::getResourceGroupName);
+    }
+
+    private Optional<String> getNetworkId(NetworkDto networkDto) {
+        return Optional.of(networkDto).map(NetworkDto::getAzure).map(AzureParams::getNetworkId);
+    }
+
+    private boolean isSingleResourceGroup(EnvironmentDto environmentDto) {
+        ResourceGroupUsagePattern resourceGroupUsagePattern = Optional.ofNullable(environmentDto.getParameters())
+                .map(ParametersDto::azureParametersDto)
+                .map(AzureParametersDto::getAzureResourceGroupDto)
+                .map(AzureResourceGroupDto::getResourceGroupUsagePattern)
+                .orElse(USE_MULTIPLE);
+        return USE_SINGLE.equals(resourceGroupUsagePattern);
     }
 
     private Optional<NetworkConnector> getNetworkConnector(String cloudPlatform) {


### PR DESCRIPTION
…n network is deleted

On azure when deleting a network created by cloudbreak the resource group of the network is deleted. In case of single RG the network and deployment resources themselves should be deleted instead of the resource group.

See detailed description in the commit message.