### PR TITLE
CB-8605 - New SINGLE option to use Dedicated Storage Account

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
@@ -57,6 +57,9 @@ public class EntitlementService {
     static final String CDP_AZURE_SINGLE_RESOURCE_GROUP = "CDP_AZURE_SINGLE_RESOURCE_GROUP";
 
     @VisibleForTesting
+    static final String CDP_AZURE_SINGLE_RESOURCE_GROUP_DEDICATED_STORAGE_ACCOUNT = "CDP_AZURE_SINGLE_RESOURCE_GROUP_DEDICATED_STORAGE_ACCOUNT";
+
+    @VisibleForTesting
     static final String CDP_CB_FAST_EBS_ENCRYPTION = "CDP_CB_FAST_EBS_ENCRYPTION";
 
     @VisibleForTesting
@@ -122,6 +125,10 @@ public class EntitlementService {
 
     public boolean azureSingleResourceGroupDeploymentEnabled(String actorCrn, String accountId) {
         return isEntitlementRegistered(actorCrn, accountId, CDP_AZURE_SINGLE_RESOURCE_GROUP);
+    }
+
+    public boolean azureSingleResourceGroupDedicatedStorageAccountEnabled(String actorCrn, String accountId) {
+        return isEntitlementRegistered(actorCrn, accountId, CDP_AZURE_SINGLE_RESOURCE_GROUP_DEDICATED_STORAGE_ACCOUNT);
     }
 
     public boolean fastEbsEncryptionEnabled(String actorCrn, String accountId) {

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
@@ -222,9 +222,9 @@ public class AzureResourceConnector extends AbstractResourceConnector {
     public List<CloudResourceStatus> terminate(AuthenticatedContext ac, CloudStack stack, List<CloudResource> resources) {
         AzureClient client = ac.getParameter(AzureClient.class);
         String resourceGroupName = azureResourceGroupMetadataProvider.getResourceGroupName(ac.getCloudContext(), stack);
-        Boolean singleResourceGroup = azureResourceGroupMetadataProvider.useSingleResourceGroup(stack);
+        ResourceGroupUsage resourceGroupUsage = azureResourceGroupMetadataProvider.getResourceGroupUsage(stack);
 
-        if (singleResourceGroup) {
+        if (resourceGroupUsage != ResourceGroupUsage.MULTIPLE) {
             azureTerminationHelperService.terminate(ac, stack, resources);
             return check(ac, Collections.emptyList());
         } else {

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceGroupMetadataProvider.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceGroupMetadataProvider.java
@@ -42,14 +42,18 @@ public class AzureResourceGroupMetadataProvider {
     }
 
     public Boolean useSingleResourceGroup(CloudStack cloudStack) {
-        String resourceGroupUsageParameter = cloudStack.getParameters().get(RESOURCE_GROUP_USAGE_PARAMETER);
-        return ResourceGroupUsage.SINGLE.name().equals(resourceGroupUsageParameter) ? Boolean.TRUE : Boolean.FALSE;
+        return ResourceGroupUsage.SINGLE == getResourceGroupUsage(cloudStack) ? Boolean.TRUE : Boolean.FALSE;
     }
 
-    public Boolean useSingleResourceGroup(DatabaseStack cloudStack) {
+    public ResourceGroupUsage getResourceGroupUsage(CloudStack cloudStack) {
+        String resourceGroupUsageParameter = cloudStack.getParameters().get(RESOURCE_GROUP_USAGE_PARAMETER);
+        return ResourceGroupUsage.valueOf(resourceGroupUsageParameter);
+    }
+
+    public ResourceGroupUsage getResourceGroupUsage(DatabaseStack cloudStack) {
         String resourceGroupUsageParameter = cloudStack.getDatabaseServer().getParameters()
-                .getOrDefault(RESOURCE_GROUP_USAGE_PARAMETER, "").toString();
-        return ResourceGroupUsage.SINGLE.name().equals(resourceGroupUsageParameter) ? Boolean.TRUE : Boolean.FALSE;
+                .getOrDefault(RESOURCE_GROUP_USAGE_PARAMETER, ResourceGroupUsage.MULTIPLE.name()).toString();
+        return ResourceGroupUsage.valueOf(resourceGroupUsageParameter);
     }
 
     public String getImageResourceGroupName(CloudContext cloudContext, CloudStack cloudStack) {

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureSetup.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureSetup.java
@@ -116,7 +116,7 @@ public class AzureSetup implements Setup {
             LOGGER.debug("Multiple RG mode is active, checking existence of resource group {}", resourceGroupName);
             ResourceGroup resourceGroup = client.getResourceGroup(resourceGroupName);
             if (resourceGroup != null) {
-                throw new BadRequestException("Resourcegroup name already exists: " + resourceGroup.name());
+                throw new BadRequestException("Resource group name already exists: " + resourceGroup.name());
             }
         }
     }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/ResourceGroupUsage.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/ResourceGroupUsage.java
@@ -2,5 +2,6 @@ package com.sequenceiq.cloudbreak.cloud.azure;
 
 public enum ResourceGroupUsage {
     SINGLE,
-    MULTIPLE
+    MULTIPLE,
+    SINGLE_WITH_DEDICATED_STORAGE_ACCOUNT
 }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureImageSetupService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureImageSetupService.java
@@ -105,7 +105,8 @@ public class AzureImageSetupService {
         AzureImage customImage = client.getCustomImageId(imageResourceGroupName, image.getImageName(), cloudContext.getLocation().getRegion().getRegionName(),
                 false);
         if (isCustomImageAvailable(customImage)) {
-            LOGGER.info("Custom image with id {} already exists in the target resource group {}, bypassing VHD check!", customImage.getId(), resourceGroupName);
+            LOGGER.info("Custom image with id {} already exists in the target resource group {}, bypassing VHD check!",
+                    customImage.getId(), imageResourceGroupName);
             return;
         }
 

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/AzureDatabaseResourceServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/AzureDatabaseResourceServiceTest.java
@@ -28,6 +28,7 @@ import com.microsoft.azure.management.resources.ResourceGroup;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureResourceGroupMetadataProvider;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureTemplateBuilder;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureUtils;
+import com.sequenceiq.cloudbreak.cloud.azure.ResourceGroupUsage;
 import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
@@ -100,7 +101,7 @@ class AzureDatabaseResourceServiceTest {
     void shouldReturnDeletedDbServerWhenTerminateDatabaseServerAndSingleResourceGroup() {
         PersistenceNotifier persistenceNotifier = mock(PersistenceNotifier.class);
         DatabaseStack databaseStack = mock(DatabaseStack.class);
-        when(azureResourceGroupMetadataProvider.useSingleResourceGroup(any(DatabaseStack.class))).thenReturn(true);
+        when(azureResourceGroupMetadataProvider.getResourceGroupUsage(any(DatabaseStack.class))).thenReturn(ResourceGroupUsage.SINGLE);
         when(azureUtils.deleteDatabaseServer(any(), anyString(), anyBoolean())).thenReturn(Optional.empty());
         List<CloudResource> cloudResources = List.of(
                 CloudResource.builder()
@@ -125,7 +126,7 @@ class AzureDatabaseResourceServiceTest {
     void shouldReturnDeletedResourceGroupWhenTerminateDatabaseServerAndMultipleResourceGroups() {
         PersistenceNotifier persistenceNotifier = mock(PersistenceNotifier.class);
         DatabaseStack databaseStack = mock(DatabaseStack.class);
-        when(azureResourceGroupMetadataProvider.useSingleResourceGroup(any(DatabaseStack.class))).thenReturn(false);
+        when(azureResourceGroupMetadataProvider.getResourceGroupUsage(any(DatabaseStack.class))).thenReturn(ResourceGroupUsage.MULTIPLE);
         when(azureResourceGroupMetadataProvider.getResourceGroupName(cloudContext, databaseStack)).thenReturn(RESOURCE_GROUP_NAME);
         when(azureUtils.deleteResourceGroup(any(), anyString(), anyBoolean())).thenReturn(Optional.empty());
         List<CloudResource> cloudResources = List.of(

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
@@ -10,6 +10,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.BadRequestException;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -234,7 +235,9 @@ public class StackOperations implements ResourceBasedCrnProvider {
             boolean osUpgrade = upgradeService.isOsUpgrade(request);
             UpgradeV4Response upgradeResponse = clusterUpgradeAvailabilityService.checkForUpgradesByName(workspaceId, stackName,
                     osUpgrade);
-            clusterUpgradeAvailabilityService.filterUpgradeOptions(upgradeResponse, request);
+            if (CollectionUtils.isNotEmpty(upgradeResponse.getUpgradeCandidates())) {
+                clusterUpgradeAvailabilityService.filterUpgradeOptions(upgradeResponse, request);
+            }
             Stack stack = getStackByName(stackName);
             MDCBuilder.buildMdcContext(stack);
             StackViewV4Responses stackViewV4Responses = listByEnvironmentCrn(workspaceId, stack.getEnvironmentCrn(), List.of(StackType.WORKLOAD));

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/azure/ResourceGroupUsage.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/azure/ResourceGroupUsage.java
@@ -2,5 +2,6 @@ package com.sequenceiq.environment.api.v1.environment.model.request.azure;
 
 public enum ResourceGroupUsage {
     SINGLE,
-    MULTIPLE
+    MULTIPLE,
+    SINGLE_WITH_DEDICATED_STORAGE_ACCOUNT
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverter.java
@@ -231,6 +231,8 @@ public class EnvironmentApiConverter {
                 return ResourceGroupUsagePattern.USE_SINGLE;
             case MULTIPLE:
                 return ResourceGroupUsagePattern.USE_MULTIPLE;
+            case SINGLE_WITH_DEDICATED_STORAGE_ACCOUNT:
+                return ResourceGroupUsagePattern.USE_SINGLE_WITH_DEDICATED_STORAGE_ACCOUNT;
             default:
                 throw new RuntimeException("Unknown usage pattern: %s" + resourceGroupUsage);
         }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverter.java
@@ -191,6 +191,8 @@ public class EnvironmentResponseConverter {
                 return ResourceGroupUsage.SINGLE;
             case USE_MULTIPLE:
                 return ResourceGroupUsage.MULTIPLE;
+            case USE_SINGLE_WITH_DEDICATED_STORAGE_ACCOUNT:
+                return ResourceGroupUsage.SINGLE_WITH_DEDICATED_STORAGE_ACCOUNT;
                 default:
                     throw new RuntimeException("Unknown resource group usage pattern: %s" + resourceGroupUsagePattern);
         }

--- a/environment/src/main/java/com/sequenceiq/environment/parameters/dao/domain/ResourceGroupUsagePattern.java
+++ b/environment/src/main/java/com/sequenceiq/environment/parameters/dao/domain/ResourceGroupUsagePattern.java
@@ -2,5 +2,6 @@ package com.sequenceiq.environment.parameters.dao.domain;
 
 public enum ResourceGroupUsagePattern {
     USE_SINGLE,
-    USE_MULTIPLE
+    USE_MULTIPLE,
+    USE_SINGLE_WITH_DEDICATED_STORAGE_ACCOUNT
 }

--- a/environment/src/main/java/com/sequenceiq/environment/parameters/validation/validators/parameter/AzureParameterValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/parameters/validation/validators/parameter/AzureParameterValidator.java
@@ -3,7 +3,6 @@ package com.sequenceiq.environment.parameters.validation.validators.parameter;
 import static com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider.INTERNAL_ACTOR_CRN;
 import static com.sequenceiq.environment.parameters.dao.domain.ResourceGroupCreation.USE_EXISTING;
 import static com.sequenceiq.environment.parameters.dao.domain.ResourceGroupUsagePattern.USE_MULTIPLE;
-import static com.sequenceiq.environment.parameters.dao.domain.ResourceGroupUsagePattern.USE_SINGLE;
 
 import java.util.Objects;
 
@@ -48,30 +47,28 @@ public class AzureParameterValidator implements ParameterValidator {
     @Override
     public ValidationResult validate(EnvironmentDto environmentDto, ParametersDto parametersDto, ValidationResultBuilder validationResultBuilder) {
 
-        boolean singleResourceGroupDeploymentEnabled =
-                entitlementService.azureSingleResourceGroupDeploymentEnabled(INTERNAL_ACTOR_CRN, environmentDto.getAccountId());
-
-        LOGGER.debug("ParametersDto: {}, featureSwitch: {}", parametersDto, singleResourceGroupDeploymentEnabled);
+        LOGGER.debug("ParametersDto: {}", parametersDto);
         AzureParametersDto azureParametersDto = parametersDto.azureParametersDto();
         if (Objects.isNull(azureParametersDto)) {
             return validationResultBuilder.build();
-        }
-        if (!singleResourceGroupDeploymentEnabled) {
-            return validateNoEntitlement(validationResultBuilder, azureParametersDto);
         }
 
         AzureResourceGroupDto azureResourceGroupDto = azureParametersDto.getAzureResourceGroupDto();
         if (Objects.isNull(azureResourceGroupDto)) {
             return validationResultBuilder.build();
         }
+
+        ValidationResult validationResult = validateEntitlement(validationResultBuilder, azureResourceGroupDto, environmentDto.getAccountId());
+        if (validationResult.hasError()) {
+            return validationResult;
+        }
+
         if (USE_MULTIPLE.equals(azureResourceGroupDto.getResourceGroupUsagePattern())) {
             return validateResourceGroupUsageMultiple(validationResultBuilder, azureResourceGroupDto);
         }
         if (USE_EXISTING.equals(azureResourceGroupDto.getResourceGroupCreation()) && StringUtils.isBlank(azureResourceGroupDto.getName())) {
-            return validationResultBuilder.error(
-                    String.format("If you specify to use a single resource group for your resources then please " +
-                                    "provide the name of the resource group to use.",
-                            azureResourceGroupDto.getName())).build();
+            return validationResultBuilder.error("If you use a single resource group for your resources then please " +
+                                    "provide the name of that resource group.").build();
         }
 
         LOGGER.debug("Using single, existing resource group {}", azureResourceGroupDto.getName());
@@ -94,16 +91,31 @@ public class AzureParameterValidator implements ParameterValidator {
             return validationResultBuilder.build();
         }
     }
+    //CHECKSTYLE:OFF:FallThroughCheck
+    private ValidationResult validateEntitlement(ValidationResultBuilder validationResultBuilder, AzureResourceGroupDto azureResourceGroupDto,
+            String accountId) {
 
-    private ValidationResult validateNoEntitlement(ValidationResultBuilder validationResultBuilder, AzureParametersDto azureParametersDto) {
-        if (Objects.nonNull(azureParametersDto.getAzureResourceGroupDto())
-                && USE_SINGLE.equals(azureParametersDto.getAzureResourceGroupDto().getResourceGroupUsagePattern())) {
-            return validationResultBuilder.error(
-                    "You specified to use a single resource group for all of your resources, but that feature is currently disabled").build();
-        } else {
-            return validationResultBuilder.build();
+        switch (azureResourceGroupDto.getResourceGroupUsagePattern()) {
+            case USE_SINGLE_WITH_DEDICATED_STORAGE_ACCOUNT:
+                if (!entitlementService.azureSingleResourceGroupDedicatedStorageAccountEnabled(INTERNAL_ACTOR_CRN, accountId)) {
+                    LOGGER.info("Invalid request, singleResourceGroupDedicatedStorageAccountEnabled entitlement turned off for account {}", accountId);
+                    return validationResultBuilder.error(
+                            "You specified to use a single resource group with dedicated storage account for the images, "
+                                    + "but that feature is currently disabled").
+                            build();
+                }
+            case USE_SINGLE:
+                if (!entitlementService.azureSingleResourceGroupDeploymentEnabled(INTERNAL_ACTOR_CRN, accountId)) {
+                    LOGGER.info("Invalid request, singleResourceGroupDeploymentEnabled entitlement turned off for account {}", accountId);
+                    return validationResultBuilder.error(
+                            "You specified to use a single resource group for all of your resources, "
+                                    + "but that feature is currently disabled").build();
+                }
+            default:
+                return validationResultBuilder.build();
         }
     }
+    //CHECKSTYLE:ON
 
     @Override
     public CloudPlatform getcloudPlatform() {

--- a/environment/src/main/resources/schema/app/20200908071723_CB-8605_single_resource_group_with_storage.sql
+++ b/environment/src/main/resources/schema/app/20200908071723_CB-8605_single_resource_group_with_storage.sql
@@ -1,0 +1,10 @@
+-- // single_resource_group_with_storage
+-- Migration SQL that makes the change goes here.
+ALTER TABLE environment_parameters ALTER COLUMN resource_group_single TYPE varchar(50) USING resource_group_single::varchar;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+UPDATE environment_parameters
+	SET resource_group_single='USE_SINGLE'
+	WHERE resource_group_single='USE_SINGLE_WITH_DEDICATED_STORAGE_ACCOUNT';
+ALTER TABLE environment_parameters ALTER COLUMN resource_group_single TYPE varchar(20) USING resource_group_single::varchar;

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverterTest.java
@@ -22,7 +22,6 @@ import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
-import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.common.api.telemetry.model.Features;
 import com.sequenceiq.common.api.telemetry.request.TelemetryRequest;
@@ -88,9 +87,6 @@ public class EnvironmentApiConverterTest {
 
     @Mock
     private NetworkRequestToDtoConverter networkRequestToDtoConverter;
-
-    @Mock
-    private EntitlementService entitlementService;
 
     @BeforeAll
     static void before() {
@@ -189,7 +185,6 @@ public class EnvironmentApiConverterTest {
         when(telemetryApiConverter.convert(eq(request.getTelemetry()), any())).thenReturn(environmentTelemetry);
         when(tunnelConverter.convert(request.getTunnel())).thenReturn(request.getTunnel());
         when(networkRequestToDtoConverter.convert(request.getNetwork())).thenReturn(networkDto);
-        when(entitlementService.azureSingleResourceGroupDeploymentEnabled(anyString(), anyString())).thenReturn(true);
 
         EnvironmentCreationDto actual = underTest.initCreationDto(request);
 
@@ -219,7 +214,6 @@ public class EnvironmentApiConverterTest {
         when(telemetryApiConverter.convert(eq(request.getTelemetry()), any())).thenReturn(environmentTelemetry);
         when(tunnelConverter.convert(request.getTunnel())).thenReturn(request.getTunnel());
         when(networkRequestToDtoConverter.convert(request.getNetwork())).thenReturn(networkDto);
-        when(entitlementService.azureSingleResourceGroupDeploymentEnabled(anyString(), anyString())).thenReturn(true);
 
         EnvironmentCreationDto actual = underTest.initCreationDto(request);
 

--- a/environment/src/test/java/com/sequenceiq/environment/parameters/validation/validators/AzureParameterValidatorTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/parameters/validation/validators/AzureParameterValidatorTest.java
@@ -171,7 +171,7 @@ public class AzureParameterValidatorTest {
         ValidationResult validationResult = underTest.validate(environmentDto, environmentDto.getParameters(), ValidationResult.builder());
 
         assertTrue(validationResult.hasError());
-        assertEquals("1. If you specify to use a single resource group for your resources then please provide the name of the resource group to use.",
+        assertEquals("1. If you use a single resource group for your resources then please provide the name of that resource group.",
                 validationResult.getFormattedErrors());
     }
 
@@ -201,9 +201,7 @@ public class AzureParameterValidatorTest {
         EnvironmentDto environmentDto = new EnvironmentDtoBuilder()
                 .withAzureParameters(AzureParametersDto.builder()
                         .withResourceGroup(AzureResourceGroupDto.builder()
-                                .withResourceGroupUsagePattern(ResourceGroupUsagePattern.USE_MULTIPLE)
-                                .withResourceGroupCreation(ResourceGroupCreation.USE_EXISTING)
-                                .withName("myResourceGroup").build())
+                                .withResourceGroupUsagePattern(ResourceGroupUsagePattern.USE_MULTIPLE).build())
                         .build())
                 .build();
         when(credentialToCloudCredentialConverter.convert(any())).thenReturn(new CloudCredential());
@@ -217,7 +215,7 @@ public class AzureParameterValidatorTest {
         assertFalse(validationResult.hasError());
         verify(credentialToCloudCredentialConverter, never()).convert(any());
         verify(azureClientService, never()).getClient(any());
-        verify(entitlementService, times(1)).azureSingleResourceGroupDeploymentEnabled(anyString(), anyString());
+        verify(entitlementService, times(0)).azureSingleResourceGroupDeploymentEnabled(anyString(), anyString());
     }
 
     @Test

--- a/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
+++ b/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
@@ -200,6 +200,8 @@ public class MockUserManagementService extends UserManagementImplBase {
 
     private static final String CDP_AZURE_SINGLE_RESOURCE_GROUP = "CDP_AZURE_SINGLE_RESOURCE_GROUP";
 
+    private static final String CDP_AZURE_SINGLE_RESOURCE_GROUP_DEDICATED_STORAGE_ACCOUNT = "CDP_AZURE_SINGLE_RESOURCE_GROUP_DEDICATED_STORAGE_ACCOUNT";
+
     private static final String CDP_CB_FAST_EBS_ENCRYPTION = "CDP_CB_FAST_EBS_ENCRYPTION";
 
     private static final String CDP_CLOUD_IDENTITY_MAPPING = "CDP_CLOUD_IDENTITY_MAPPING";
@@ -266,6 +268,9 @@ public class MockUserManagementService extends UserManagementImplBase {
 
     @Value("${auth.mock.azure.single.resourcegroup.enable}")
     private boolean enableAzureSingleResourceGroupDeployment;
+
+    @Value("${auth.mock.azure.single.resourcegroup.dedicated.storage.account.enable}")
+    private boolean enableAzureSingleResourceGroupDedicatedStorageAccount;
 
     @Value("${auth.mock.fastebsencryption.enable}")
     private boolean enableFastEbsEncryption;
@@ -558,6 +563,9 @@ public class MockUserManagementService extends UserManagementImplBase {
         }
         if (enableAzureSingleResourceGroupDeployment) {
             builder.addEntitlements(createEntitlement(CDP_AZURE_SINGLE_RESOURCE_GROUP));
+        }
+        if (enableAzureSingleResourceGroupDedicatedStorageAccount) {
+            builder.addEntitlements(createEntitlement(CDP_AZURE_SINGLE_RESOURCE_GROUP_DEDICATED_STORAGE_ACCOUNT));
         }
         if (enableFastEbsEncryption) {
             builder.addEntitlements(createEntitlement(CDP_CB_FAST_EBS_ENCRYPTION));

--- a/mock-thunderhead/src/main/resources/application.yml
+++ b/mock-thunderhead/src/main/resources/application.yml
@@ -22,6 +22,7 @@ auth:
     raz.enable: true
     freeipadlebsencryption.enable: true
     azure.single.resourcegroup.enable: false
+    azure.single.resourcegroup.dedicated.storage.account.enable: false
     fastebsencryption.enable: true
     cloudidentitymappinng.enable: true
     mediumdutysdx.enable: true


### PR DESCRIPTION
This change introduces a SINGLE_WITH_DEDICATED_STORAGE_ACCOUNT option for Azure resourceGroup request which calculates the storage account and resource group names for the VHD as it used to be in the legacy "MULTIPLE" RG use-case.

The intent is to use this internally (mow-dev) to save the time and cost of many image copies.

The feature is behind entitlement CDP_AZURE_SINGLE_RESOURCE_GROUP_DEDICATED_STORAGE_ACCOUNT and also CDP_AZURE_SINGLE_RESOURCE_GROUP entitlement has to be turned on, too.