### PR TITLE
CB-8644 Reduce flakiness of IT

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/deletion/handler/freeipa/FreeIpaDeletionHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/deletion/handler/freeipa/FreeIpaDeletionHandler.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import javax.ws.rs.NotFoundException;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,16 +105,24 @@ public class FreeIpaDeletionHandler extends EventSenderAwareHandler<EnvironmentD
     }
 
     private void detachChildEnvironmentFromFreeIpa(Environment environment) {
-        DetachChildEnvironmentRequest detachChildEnvironmentRequest = new DetachChildEnvironmentRequest();
-        detachChildEnvironmentRequest.setParentEnvironmentCrn(environment.getParentEnvironment().getResourceCrn());
-        detachChildEnvironmentRequest.setChildEnvironmentCrn(environment.getResourceCrn());
-        freeIpaService.detachChildEnvironment(detachChildEnvironmentRequest);
+        try {
+            DetachChildEnvironmentRequest detachChildEnvironmentRequest = new DetachChildEnvironmentRequest();
+            detachChildEnvironmentRequest.setParentEnvironmentCrn(environment.getParentEnvironment().getResourceCrn());
+            detachChildEnvironmentRequest.setChildEnvironmentCrn(environment.getResourceCrn());
+            freeIpaService.detachChildEnvironment(detachChildEnvironmentRequest);
 
-        if (lastChildEnvironmentInNetworkIsGettingDeleted(environment)) {
-            try {
-                dnsV1Endpoint.deleteDnsZoneBySubnet(environment.getParentEnvironment().getResourceCrn(), environment.getNetwork().getNetworkCidr());
-            } catch (Exception e) {
-                LOGGER.warn("Failed to delete dns zone of child environment.", e);
+            if (lastChildEnvironmentInNetworkIsGettingDeleted(environment)) {
+                try {
+                    dnsV1Endpoint.deleteDnsZoneBySubnet(environment.getParentEnvironment().getResourceCrn(), environment.getNetwork().getNetworkCidr());
+                } catch (Exception e) {
+                    LOGGER.warn("Failed to delete dns zone of child environment.", e);
+                }
+            }
+        } catch (FreeIpaOperationFailedException e) {
+            if (e.getCause() instanceof NotFoundException) {
+                LOGGER.warn("Child FreeIpa is already detached.", e);
+            } else {
+                throw e;
             }
         }
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProvider.java
@@ -346,7 +346,7 @@ public class AwsCloudProvider extends AbstractCloudProvider {
                 return olderImage.getUuid();
             } catch (Exception e) {
                 LOGGER.error("Cannot fetch pre-warmed images of {} image catalog!", imageCatalogTestDto.getRequest().getName());
-                throw new TestFailException(" Cannot fetch pre-warmed images of " + imageCatalogTestDto.getRequest().getName() + " image catalog!");
+                throw new TestFailException(" Cannot fetch pre-warmed images of " + imageCatalogTestDto.getRequest().getName() + " image catalog!", e);
             }
         } else {
             Log.log(LOGGER, format(" Image Catalog Name: %s ", commonCloudProperties().getImageCatalogName()));
@@ -376,7 +376,7 @@ public class AwsCloudProvider extends AbstractCloudProvider {
                 return baseImage.getUuid();
             } catch (Exception e) {
                 LOGGER.error("Cannot fetch base images of {} image catalog, because of {}", imageCatalogTestDto.getRequest().getName(), e);
-                throw new TestFailException(" Cannot fetch base images of " + imageCatalogTestDto.getRequest().getName() + " image catalog, because of " + e);
+                throw new TestFailException(" Cannot fetch base images of " + imageCatalogTestDto.getRequest().getName() + " image catalog", e);
             }
         } else {
             Log.log(LOGGER, format(" Image Catalog Name: %s ", commonCloudProperties().getImageCatalogName()));

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
@@ -367,7 +367,7 @@ public class AzureCloudProvider extends AbstractCloudProvider {
                 return baseImage.getUuid();
             } catch (Exception e) {
                 LOGGER.error("Cannot fetch base images of {} image catalog, because of {}", imageCatalogTestDto.getRequest().getName(), e);
-                throw new TestFailException(" Cannot fetch base images of " + imageCatalogTestDto.getRequest().getName() + " image catalog, because of " + e);
+                throw new TestFailException(" Cannot fetch base images of " + imageCatalogTestDto.getRequest().getName() + " image catalog", e);
             }
         } else {
             Log.log(LOGGER, format(" Image Catalog Name: %s ", commonCloudProperties().getImageCatalogName()));

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/yarn/YarnCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/yarn/YarnCloudProvider.java
@@ -210,7 +210,7 @@ public class YarnCloudProvider extends AbstractCloudProvider {
                 return baseImage.getUuid();
             } catch (Exception e) {
                 LOGGER.error("Cannot fetch base images of {} image catalog, because of {}", imageCatalogTestDto.getRequest().getName(), e);
-                throw new TestFailException(" Cannot fetch base images of " + imageCatalogTestDto.getRequest().getName() + " image catalog, because of " + e);
+                throw new TestFailException(" Cannot fetch base images of " + imageCatalogTestDto.getRequest().getName() + " image catalog", e);
             }
         } else {
             Log.log(LOGGER, format(" Image Catalog Name: %s ", commonCloudProperties().getImageCatalogName()));

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
@@ -891,6 +891,13 @@ public abstract class TestContext implements ApplicationContextAware {
         if (!exceptionMap.isEmpty()) {
             List<Clue> clues = resources.values().stream()
                     .filter(Investigable.class::isInstance)
+                    .peek(cloudbreakTestDto -> {
+                        try {
+                            cloudbreakTestDto.refresh();
+                        } catch (Exception e) {
+                            LOGGER.warn("Failed to refresh {}, continue with using its last known state.", cloudbreakTestDto, e);
+                        }
+                    })
                     .map(Investigable.class::cast)
                     .map(Investigable::investigate)
                     .filter(Objects::nonNull)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/CloudbreakTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/CloudbreakTestDto.java
@@ -33,7 +33,7 @@ public interface CloudbreakTestDto extends Orderable, Assignable {
         LOGGER.warn("Did not clean up resource ({}): name={}", getClass().getSimpleName(), getName());
     }
 
-    default CloudbreakTestDto refresh(TestContext context, CloudbreakClient cloudbreakClient) {
+    default CloudbreakTestDto refresh() {
         LOGGER.warn("It is not refreshable resource: {}", getName());
         return this;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDto.java
@@ -118,7 +118,7 @@ public class DistroXTestDto extends DistroXTestDtoBase<DistroXTestDto> implement
     }
 
     @Override
-    public CloudbreakTestDto refresh(TestContext context, CloudbreakClient cloudbreakClient) {
+    public CloudbreakTestDto refresh() {
         return when(distroXTestClient.refresh(), RunningParameter.key("refresh-distrox-" + getName()).switchToAdmin());
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
@@ -296,7 +296,7 @@ public class EnvironmentTestDto
     }
 
     @Override
-    public EnvironmentTestDto refresh(TestContext context, CloudbreakClient client) {
+    public EnvironmentTestDto refresh() {
         LOGGER.info("Refresh resource with name: {}", getName());
         return when(environmentTestClient.describe(), key("refresh-environment-" + getName()));
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
@@ -37,6 +37,8 @@ import com.sequenceiq.it.cloudbreak.ResourceGroupTest;
 import com.sequenceiq.it.cloudbreak.assign.Assignable;
 import com.sequenceiq.it.cloudbreak.client.EnvironmentTestClient;
 import com.sequenceiq.it.cloudbreak.cloud.v4.aws.AwsProperties;
+import com.sequenceiq.it.cloudbreak.context.Clue;
+import com.sequenceiq.it.cloudbreak.context.Investigable;
 import com.sequenceiq.it.cloudbreak.context.RunningParameter;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
@@ -48,7 +50,7 @@ import com.sequenceiq.it.cloudbreak.search.Searchable;
 @Prototype
 public class EnvironmentTestDto
         extends DeletableEnvironmentTestDto<EnvironmentRequest, DetailedEnvironmentResponse, EnvironmentTestDto, SimpleEnvironmentResponse>
-        implements Searchable, Assignable {
+        implements Searchable, Assignable, Investigable {
 
     public static final String ENVIRONMENT = "ENVIRONMENT";
 
@@ -377,5 +379,13 @@ public class EnvironmentTestDto
             throw new IllegalStateException("You have tried to assign to a Dto that hasn't been created and therefore has no Response object.");
         }
         return getResponse().getCrn();
+    }
+
+    @Override
+    public Clue investigate() {
+        if (getResponse() == null) {
+            return null;
+        }
+        return new Clue("Environment", null, getResponse(), false);
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaTestDto.java
@@ -274,7 +274,7 @@ public class FreeIpaTestDto extends AbstractFreeIpaTestDto<CreateFreeIpaRequest,
     }
 
     @Override
-    public CloudbreakTestDto refresh(TestContext context, CloudbreakClient cloudbreakClient) {
+    public CloudbreakTestDto refresh() {
         return when(freeIpaTestClient.describe(), key("refresh-freeipa-" + getName()));
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/mock/answer/JsonRequestAnswer.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/mock/answer/JsonRequestAnswer.java
@@ -26,7 +26,7 @@ public class JsonRequestAnswer<S> extends AbstractRequestWithBodyHandler<S, Json
             return JsonUtil.readTree(request.body());
         } catch (IOException e) {
             LOGGER.error("Could not parse json from request body", e);
-            throw new TestFailException("Could not parse json from request body");
+            throw new TestFailException("Could not parse json from request body", e);
         }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxInternalTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxInternalTestDto.java
@@ -292,7 +292,7 @@ public class SdxInternalTestDto extends AbstractSdxTestDto<SdxInternalClusterReq
     }
 
     @Override
-    public CloudbreakTestDto refresh(TestContext context, CloudbreakClient cloudbreakClient) {
+    public CloudbreakTestDto refresh() {
         LOGGER.info("Refresh resource with name: {}", getName());
         return when(sdxTestClient.describeInternal(), key("refresh-sdx-" + getName()));
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
@@ -119,7 +119,7 @@ public class SdxTestDto extends AbstractSdxTestDto<SdxClusterRequest, SdxCluster
     }
 
     @Override
-    public SdxTestDto refresh(TestContext testContext, CloudbreakClient cloudbreakClient) {
+    public SdxTestDto refresh() {
         LOGGER.info("Refresh SDX with name: {}", getName());
         return when(sdxTestClient.refresh(), key("refresh-sdx-" + getName()));
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/stack/StackTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/stack/StackTestDto.java
@@ -112,7 +112,7 @@ public class StackTestDto extends StackTestDtoBase<StackTestDto> implements Purg
     }
 
     @Override
-    public CloudbreakTestDto refresh(TestContext context, CloudbreakClient cloudbreakClient) {
+    public CloudbreakTestDto refresh() {
         return when(stackTestClient.refreshV4(), key("refresh-stack-" + getName()));
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/exception/TestFailException.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/exception/TestFailException.java
@@ -6,4 +6,8 @@ public class TestFailException extends RuntimeException {
         super(message);
     }
 
+    public TestFailException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/spark/SparkServerPool.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/spark/SparkServerPool.java
@@ -90,7 +90,7 @@ public class SparkServerPool {
             }
         } catch (InterruptedException e) {
             LOGGER.error("Can't pop spark server", e);
-            throw new TestFailException("Can't take spark server from pool");
+            throw new TestFailException("Can't take spark server from pool", e);
         }
         LOGGER.info("POP chosen one: {}", sparkServer);
         LOGGER.info("POP state: {}", sparkServer.getEndpoint());
@@ -124,7 +124,7 @@ public class SparkServerPool {
                 servers.add(sparkServer);
             } catch (Exception e) {
                 LOGGER.error("Can't add spark server", e);
-                throw new TestFailException("Can't add spark server");
+                throw new TestFailException("Can't add spark server", e);
             }
         }
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentChildTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentChildTest.java
@@ -12,6 +12,7 @@ import org.testng.annotations.Test;
 
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
 import com.sequenceiq.environment.api.v1.environment.model.response.SimpleEnvironmentResponse;
+import com.sequenceiq.environment.api.v1.environment.model.response.SimpleEnvironmentResponses;
 import com.sequenceiq.it.cloudbreak.EnvironmentClient;
 import com.sequenceiq.it.cloudbreak.assertion.Assertion;
 import com.sequenceiq.it.cloudbreak.assertion.MockVerification;
@@ -141,23 +142,31 @@ public class EnvironmentChildTest extends AbstractIntegrationTest {
             given = "there is an available child environment with a referenced available parent environment",
             when = "a delete multiple request is sent for both environments",
             then = "the child and parent environments should be deleted")
-    public void testDeleteChildAndParentEnvironment(TestContext testContext) {
+    public void testDeleteChildAndParentEnvironment(MockedTestContext testContext) {
+        String parentEnvName = testContext.get(EnvironmentTestDto.class).getName();
         testContext
                 .given(CHILD_ENVIRONMENT, EnvironmentTestDto.class)
                     .withParentEnvironment()
-                .when(environmentTestClient.create())
-                .await(EnvironmentStatus.AVAILABLE)
+                .when(environmentTestClient.create(), RunningParameter.key(CHILD_ENVIRONMENT))
+                .await(EnvironmentStatus.AVAILABLE, RunningParameter.key(CHILD_ENVIRONMENT))
                 .when(environmentTestClient.deleteMultipleByNames(
-                        testContext.get(EnvironmentTestDto.class).getName(),
+                        parentEnvName,
                         testContext.get(CHILD_ENVIRONMENT).getName()
                 ))
-                .await(EnvironmentStatus.ARCHIVED)
-                .when(environmentTestClient.list())
-                .then(this::checkEnvIsNotListedByNameAndParentName)
+                .await(EnvironmentStatus.ARCHIVED, RunningParameter.key(CHILD_ENVIRONMENT))
                 .given(EnvironmentTestDto.class)
                 .await(EnvironmentStatus.ARCHIVED)
-                .when(environmentTestClient.list())
-                .then(this::checkEnvIsNotListedByNameAndParentName)
+                .then((testContext1, testDto, client) -> {
+                    SimpleEnvironmentResponses envs = client.getEnvironmentClient().environmentV1Endpoint().list();
+                    if (envs.getResponses().stream().anyMatch(env -> env.getName().equals(parentEnvName))) {
+                        throw new TestFailException("Parent env was not deleted");
+                    }
+                    String childEnvName = testContext.get(CHILD_ENVIRONMENT).getName();
+                    if (envs.getResponses().stream().anyMatch(env -> env.getName().equals(childEnvName))) {
+                        throw new TestFailException("Child env was not deleted");
+                    }
+                    return testDto;
+                })
                 .validate();
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ClouderaManagerUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ClouderaManagerUtil.java
@@ -81,7 +81,7 @@ public class ClouderaManagerUtil {
             }
         } catch (Exception e) {
             LOGGER.error("Can't get users' list at: {} or test user is not valid with {}", cmClient.getBasePath(), userDetails);
-            throw new TestFailException("Can't get users' list at: " + cmClient.getBasePath() + " or test user is not valid with " + userDetails);
+            throw new TestFailException("Can't get users' list at: " + cmClient.getBasePath() + " or test user is not valid with " + userDetails, e);
         }
         return stackTestDto;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ResponseUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ResponseUtil.java
@@ -2,7 +2,7 @@ package com.sequenceiq.it.cloudbreak.util;
 
 import java.io.IOException;
 
-import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.WebApplicationException;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
@@ -13,9 +13,9 @@ public class ResponseUtil {
     }
 
     public static String getErrorMessage(Exception ex) {
-        if (ex instanceof ClientErrorException) {
+        if (ex instanceof WebApplicationException) {
             try {
-                String responseJson = ((ClientErrorException) ex).getResponse().readEntity(String.class);
+                String responseJson = ((WebApplicationException) ex).getResponse().readEntity(String.class);
                 if (JsonUtil.isValid(responseJson)) {
                     JsonNode jsonNode = JsonUtil.readTree(responseJson);
                     if (jsonNode.has("message")) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazons3/action/S3ClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazons3/action/S3ClientActions.java
@@ -56,10 +56,10 @@ public class S3ClientActions extends S3Client {
                 } while (objectListing.isTruncated());
             } catch (AmazonServiceException e) {
                 LOGGER.error("Amazon S3 couldn't process the call. So it has been returned with error!", e);
-                throw new TestFailException(String.format("Amazon S3 couldn't process the call. So it has been returned the error: %s", e));
+                throw new TestFailException("Amazon S3 couldn't process the call.", e);
             } catch (SdkClientException e) {
                 LOGGER.error("Amazon S3 response could not been parsed, because of error!", e);
-                throw new TestFailException(String.format("Amazon S3 response could not been parsed, because of: %s", e));
+                throw new TestFailException("Amazon S3 response could not been parsed", e);
             } finally {
                 s3Client.shutdown();
             }
@@ -118,10 +118,10 @@ public class S3ClientActions extends S3Client {
                 }
             } catch (AmazonServiceException e) {
                 LOGGER.error("Amazon S3 couldn't process the call. So it has been returned with error!", e);
-                throw new TestFailException(String.format("Amazon S3 couldn't process the call. So it has been returned the error: %s", e));
+                throw new TestFailException("Amazon S3 couldn't process the call.", e);
             } catch (SdkClientException e) {
                 LOGGER.error("Amazon S3 response could not been parsed, because of error!", e);
-                throw new TestFailException(String.format("Amazon S3 response could not been parsed, because of: %s", e));
+                throw new TestFailException("Amazon S3 response could not been parsed", e);
             } finally {
                 s3Client.shutdown();
             }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurecloudblob/action/AzureCloudBlobClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurecloudblob/action/AzureCloudBlobClientActions.java
@@ -56,7 +56,7 @@ public class AzureCloudBlobClientActions extends AzureCloudBlobClient {
             cloudBlobContainer = createCloudBlobClient().getContainerReference(containerName);
         } catch (URISyntaxException | StorageException e) {
             LOGGER.error("The Storage Container is not exist: [{}]\n", containerName, e);
-            throw new TestFailException("The Storage Container is not exist: [" + containerName + "]\n" + e);
+            throw new TestFailException("The Storage Container is not exist: [" + containerName + "]", e);
         }
 
         return cloudBlobContainer;
@@ -224,7 +224,7 @@ public class AzureCloudBlobClientActions extends AzureCloudBlobClient {
                         + " at Base Location: " + baseLocation);
             } else {
                 LOGGER.error("Azure Adls Gen2 Blob Container delete cannot be succeed!", e);
-                throw new TestFailException("Azure Adls Gen2 Blob Container delete cannot be succeed!" + e);
+                throw new TestFailException("Azure Adls Gen2 Blob Container delete cannot be succeed!", e);
             }
         } finally {
             createCloudBlobContainer(containerName);
@@ -252,7 +252,7 @@ public class AzureCloudBlobClientActions extends AzureCloudBlobClient {
             }
         } catch (StorageException | URISyntaxException e) {
             LOGGER.error("Azure Adls Gen 2 Blob couldn't process the call. So it has been returned with error!", e);
-            throw new TestFailException(String.format("Azure Adls Gen 2 Blob couldn't process the call. So it has been returned the error: %s", e));
+            throw new TestFailException("Azure Adls Gen 2 Blob couldn't process the call.", e);
         }
 
         return sdxTestDto;
@@ -310,7 +310,7 @@ public class AzureCloudBlobClientActions extends AzureCloudBlobClient {
             }
         } catch (StorageException | URISyntaxException e) {
             LOGGER.error("Azure Adls Gen 2 Blob couldn't process the call. So it has been returned with error!", e);
-            throw new TestFailException(String.format("Azure Adls Gen 2 Blob couldn't process the call. So it has been returned the error: %s", e));
+            throw new TestFailException("Azure Adls Gen 2 Blob couldn't process the call.", e);
         }
     }
 
@@ -356,7 +356,7 @@ public class AzureCloudBlobClientActions extends AzureCloudBlobClient {
             }
         } catch (StorageException | URISyntaxException e) {
             LOGGER.error("Azure Adls Gen 2 Blob couldn't process the call. So it has been returned with error!", e);
-            throw new TestFailException(String.format("Azure Adls Gen 2 Blob couldn't process the call. So it has been returned the error: %s", e));
+            throw new TestFailException("Azure Adls Gen 2 Blob couldn't process the call.", e);
         }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/action/SshJClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/action/SshJClientActions.java
@@ -90,7 +90,7 @@ public class SshJClientActions extends SshJClient {
                         .filter(outputValue -> outputValue.strip().startsWith("/")).count());
             } catch (Exception e) {
                 LOGGER.error("SSH fail on [{}] while getting info for [{}] file", instanceIP, filePath);
-                throw new TestFailException(" SSH fail on [" + instanceIP + "] while getting info for [" + filePath + "] file.");
+                throw new TestFailException(" SSH fail on [" + instanceIP + "] while getting info for [" + filePath + "] file.", e);
             }
         });
 
@@ -124,7 +124,7 @@ public class SshJClientActions extends SshJClient {
             }
         } catch (Exception e) {
             LOGGER.error("SSH fail on [{}] while executing command [{}]", instanceIP, checkInternetCommand);
-            throw new TestFailException(" SSH fail on [" + instanceIP + "] while executing command [" + checkInternetCommand + "].");
+            throw new TestFailException(" SSH fail on [" + instanceIP + "] while executing command [" + checkInternetCommand + "].", e);
         }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/client/SshJClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/client/SshJClient.java
@@ -81,7 +81,7 @@ public class SshJClient {
             return cmdOut;
         } catch (Exception e) {
             LOGGER.error("SSH fail on [{}] while executing command [{}]. {}", instanceIP, command, e.getMessage());
-            throw new TestFailException(" SSH fail on [" + instanceIP + "] while executing command [" + command + "]. " + e.getMessage());
+            throw new TestFailException(" SSH fail on [" + instanceIP + "] while executing command [" + command + "].", e);
         }
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/ExceptionChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/ExceptionChecker.java
@@ -12,7 +12,7 @@ public abstract class ExceptionChecker<T> implements StatusChecker<T> {
     @Override
     public void handleException(Exception e) {
         LOGGER.error("Failing with exception", e);
-        throw new TestFailException(e.getMessage());
+        throw new TestFailException(e.getMessage(), e);
     }
 
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/cloudbreak/CloudbreakAwait.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/cloudbreak/CloudbreakAwait.java
@@ -46,11 +46,11 @@ public class CloudbreakAwait implements Await<CloudbreakTestDto, Status> {
             } else if (desiredStatuses.equals(STACK_FAILED)) {
                 waitForCloudbreakStatuses(new CloudbreakFailedChecker<>(), client, name, testContext, desiredStatuses,
                         pollingInterval, maxRetry);
-                entity.refresh(testContext, client);
+                entity.refresh();
             } else {
                 waitForCloudbreakStatuses(new CloudbreakOperationChecker<>(), client, name, testContext, desiredStatuses,
                         pollingInterval, maxRetry);
-                entity.refresh(testContext, client);
+                entity.refresh();
             }
         } catch (Exception e) {
             if (runningParameter.isLogError()) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/cloudbreak/CloudbreakFailedChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/cloudbreak/CloudbreakFailedChecker.java
@@ -39,7 +39,7 @@ public class CloudbreakFailedChecker<T extends CloudbreakWaitObject> extends Exc
             LOGGER.warn("No cluster found with name '{}'", name, e);
         } catch (Exception e) {
             LOGGER.error("Failed to get cluster status or statusReason: {}", e.getMessage(), e);
-            throw new TestFailException(String.format("Failed to get cluster status or statusReason: %s", e.getMessage()));
+            throw new TestFailException("Failed to get cluster status or statusReason", e);
         }
         return false;
     }
@@ -56,7 +56,7 @@ public class CloudbreakFailedChecker<T extends CloudbreakWaitObject> extends Exc
                     "statusReason: '%s'", name, actualStatuses, actualStatusReasons));
         } catch (Exception e) {
             LOGGER.error("Wait operation timed out! Failed to get cluster status or statusReason: {}", e.getMessage(), e);
-            throw new TestFailException(String.format("Wait operation timed out! Failed to get cluster status or statusReason: %s", e.getMessage()));
+            throw new TestFailException("Wait operation timed out! Failed to get cluster status or statusReason", e);
         }
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/cloudbreak/CloudbreakOperationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/cloudbreak/CloudbreakOperationChecker.java
@@ -54,7 +54,7 @@ public class CloudbreakOperationChecker<T extends CloudbreakWaitObject> extends 
             }
         } catch (Exception e) {
             LOGGER.error("Failed to get cluster status or statusReason: {}", e.getMessage(), e);
-            throw new TestFailException(String.format("Failed to get cluster status or statusReason: %s", e.getMessage()));
+            throw new TestFailException("Failed to get cluster status or statusReason", e);
         }
         return false;
     }
@@ -74,7 +74,7 @@ public class CloudbreakOperationChecker<T extends CloudbreakWaitObject> extends 
                     + "statusReason: '%s'", name, actualStatuses, actualStatusReasons));
         } catch (Exception e) {
             LOGGER.error("Wait operation timed out! Failed to get cluster status or statusReason: {}", e.getMessage(), e);
-            throw new TestFailException(String.format("Wait operation timed out! Failed to get cluster status or statusReason: %s", e.getMessage()));
+            throw new TestFailException("Wait operation timed out! Failed to get cluster status or statusReason", e);
         }
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/cloudbreak/CloudbreakTerminationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/cloudbreak/CloudbreakTerminationChecker.java
@@ -45,7 +45,7 @@ public class CloudbreakTerminationChecker<T extends CloudbreakWaitObject> extend
             LOGGER.warn("No cluster found with name '{}'", name, e);
         } catch (Exception e) {
             LOGGER.error("Cluster termination failed, because of: {}", e.getMessage(), e);
-            throw new TestFailException(String.format("Cluster termination failed, because of: %s", e.getMessage()));
+            throw new TestFailException("Cluster termination failed", e);
         }
         return true;
     }
@@ -62,7 +62,7 @@ public class CloudbreakTerminationChecker<T extends CloudbreakWaitObject> extend
                     "statusReason: '%s'", name, actualStatuses, actualStatusReasons));
         } catch (Exception e) {
             LOGGER.error("Wait operation timed out! Failed to get cluster status or statusReason: {}", e.getMessage(), e);
-            throw new TestFailException(String.format("Wait operation timed out! Failed to get cluster status or statusReason:: %s", e.getMessage()));
+            throw new TestFailException("Wait operation timed out! Failed to get cluster status or statusReason", e);
         }
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/datalake/DatalakeAwait.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/datalake/DatalakeAwait.java
@@ -43,7 +43,7 @@ public class DatalakeAwait implements Await<SdxTestDto, SdxClusterStatusResponse
             } else {
                 waitForDatalakeStatus(new DatalakeOperationChecker<>(), client, name, testContext, desiredStatus,
                         pollingInterval, maxRetry);
-                entity.refresh(testContext, null);
+                entity.refresh();
             }
         } catch (Exception e) {
             if (runningParameter.isLogError()) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/datalake/DatalakeInternalAwait.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/datalake/DatalakeInternalAwait.java
@@ -42,7 +42,7 @@ public class DatalakeInternalAwait implements Await<SdxInternalTestDto, SdxClust
             } else {
                 waitForDatalakeStatus(new DatalakeOperationChecker<>(), client, name, testContext, desiredStatus,
                         pollingInterval, maxRetry);
-                entity.refresh(testContext, null);
+                entity.refresh();
             }
         } catch (Exception e) {
             if (runningParameter.isLogError()) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/datalake/DatalakeOperationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/datalake/DatalakeOperationChecker.java
@@ -50,7 +50,7 @@ public class DatalakeOperationChecker<T extends DatalakeWaitObject> extends Exce
             }
         } catch (Exception e) {
             LOGGER.error("Datalake has been failed. Also failed to get datalake status: {}", e.getMessage(), e);
-            throw new TestFailException(String.format("Datalake has been failed. Also failed to get datalake status: %s", e.getMessage()));
+            throw new TestFailException("Datalake has been failed. Also failed to get datalake status", e);
         }
         return false;
     }
@@ -69,8 +69,7 @@ public class DatalakeOperationChecker<T extends DatalakeWaitObject> extends Exce
                     + "statusReason: '%s'", name, crn, status, sdx.getStatusReason()));
         } catch (Exception e) {
             LOGGER.error("Wait operation timed out, datalake has been failed. Also failed to get datalake status: {}", e.getMessage(), e);
-            throw new TestFailException(String.format("Wait operation timed out, datalake has been failed. Also failed to get datalake status: %s",
-                    e.getMessage()));
+            throw new TestFailException("Wait operation timed out, datalake has been failed. Also failed to get datalake status", e);
         }
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/datalake/DatalakeTerminationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/datalake/DatalakeTerminationChecker.java
@@ -41,7 +41,7 @@ public class DatalakeTerminationChecker<T extends DatalakeWaitObject> extends Ex
             LOGGER.warn("No datalake found with name '{}'", name, e);
         } catch (Exception e) {
             LOGGER.error("Datalake termination failed: {}", e.getMessage(), e);
-            throw new TestFailException(String.format("Datalake termination failed: ", e.getMessage()));
+            throw new TestFailException("Datalake termination failed", e);
         }
         return true;
     }
@@ -55,8 +55,7 @@ public class DatalakeTerminationChecker<T extends DatalakeWaitObject> extends Ex
                     "statusReason: '%s'", name, sdx.getCrn(), sdx.getStatus(), sdx.getStatusReason()));
         } catch (Exception e) {
             LOGGER.error("Wait operation timed out, datalake termination failed. Also failed to get datalake status: {}", e.getMessage(), e);
-            throw new TestFailException(String.format("Wait operation timed out, datalake termination failed. Also failed to get datalake status: %s",
-                    e.getMessage()));
+            throw new TestFailException("Wait operation timed out, datalake termination failed. Also failed to get datalake status", e);
         }
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/environment/EnvironmentAwait.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/environment/EnvironmentAwait.java
@@ -42,11 +42,11 @@ public class EnvironmentAwait implements Await<EnvironmentTestDto, EnvironmentSt
             } else if (desiredStatus.equals(CREATE_FAILED)) {
                 waitForEnvironmentStatus(new EnvironmentFailedChecker<>(), client, crn, testContext, desiredStatus,
                         pollingInterval, maxRetry);
-                entity.refresh(testContext, null);
+                entity.refresh();
             } else {
                 waitForEnvironmentStatus(new EnvironmentOperationChecker<>(), client, crn, testContext, desiredStatus,
                         pollingInterval, maxRetry);
-                entity.refresh(testContext, null);
+                entity.refresh();
             }
         } catch (Exception e) {
             if (runningParameter.isLogError()) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/environment/EnvironmentFailedChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/environment/EnvironmentFailedChecker.java
@@ -40,7 +40,7 @@ public class EnvironmentFailedChecker<T extends EnvironmentWaitObject> extends E
             LOGGER.warn("No environment found with crn '{}'", crn, e);
         } catch (Exception e) {
             LOGGER.error("Failed to get environment status: {}", e.getMessage(), e);
-            throw new TestFailException(String.format("Failed to get environment status: %s", e.getMessage()));
+            throw new TestFailException("Failed to get environment status", e);
         }
         return false;
     }
@@ -56,8 +56,7 @@ public class EnvironmentFailedChecker<T extends EnvironmentWaitObject> extends E
                     + "statusReason: '%s'", name, crn, status, environment.getStatusReason()));
         } catch (Exception e) {
             LOGGER.error("Wait operation timed out, failed to get environment status: {}", e.getMessage(), e);
-            throw new TestFailException(String.format("Wait operation timed out, failed to get environment status: %s",
-                    e.getMessage()));
+            throw new TestFailException("Wait operation timed out, failed to get environment status", e);
         }
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/environment/EnvironmentOperationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/environment/EnvironmentOperationChecker.java
@@ -46,7 +46,7 @@ public class EnvironmentOperationChecker<T extends EnvironmentWaitObject> extend
             }
         } catch (Exception e) {
             LOGGER.error("Environment has been failed. Also failed to get environment status: {}", e.getMessage(), e);
-            throw new TestFailException(String.format("Environment has been failed. Also failed to get environment status: ", e.getMessage()));
+            throw new TestFailException("Environment has been failed. Also failed to get environment status", e);
         }
         return false;
     }
@@ -65,8 +65,7 @@ public class EnvironmentOperationChecker<T extends EnvironmentWaitObject> extend
                     + "statusReason: '%s'", name, crn, status, environment.getStatusReason()));
         } catch (Exception e) {
             LOGGER.error("Wait operation timed out, environment has been failed. Also failed to get environment status: {}", e.getMessage(), e);
-            throw new TestFailException(String.format("Wait operation timed out, environment has been failed. Also failed to get environment status: ",
-                    e.getMessage()));
+            throw new TestFailException("Wait operation timed out, environment has been failed. Also failed to get environment status", e);
         }
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/environment/EnvironmentTerminationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/environment/EnvironmentTerminationChecker.java
@@ -41,7 +41,7 @@ public class EnvironmentTerminationChecker<T extends EnvironmentWaitObject> exte
             LOGGER.warn("No environment found with crn '{}'", crn, e);
         } catch (Exception e) {
             LOGGER.error("Environment termination failed: {}", e.getMessage(), e);
-            throw new TestFailException(String.format("Environment termination failed: %s", e.getMessage()));
+            throw new TestFailException("Environment termination failed", e);
         }
         return true;
     }
@@ -55,8 +55,7 @@ public class EnvironmentTerminationChecker<T extends EnvironmentWaitObject> exte
                     "statusReason: '%s'", environment.getName(), crn, environment.getEnvironmentStatus(), environment.getStatusReason()));
         } catch (Exception e) {
             LOGGER.error("Wait operation timed out, environment termination failed. Also failed to get environment status: {}", e.getMessage(), e);
-            throw new TestFailException(String.format("Wait operation timed out, environment termination failed. Also failed to get environment status: %s",
-                    e.getMessage()));
+            throw new TestFailException("Wait operation timed out, environment termination failed. Also failed to get environment status", e);
         }
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaAwait.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaAwait.java
@@ -42,7 +42,7 @@ public class FreeIpaAwait implements Await<FreeIpaTestDto, Status> {
             } else {
                 waitForFreeIpaStatus(new FreeIpaOperationChecker<>(), client, environmentCrn, testContext, desiredStatus,
                         pollingInterval, maxRetry);
-                entity.refresh(testContext, null);
+                entity.refresh();
             }
         } catch (Exception e) {
             if (runningParameter.isLogError()) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaOperationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaOperationChecker.java
@@ -48,7 +48,7 @@ public class FreeIpaOperationChecker<T extends FreeIpaWaitObject> extends Except
             }
         } catch (Exception e) {
             LOGGER.error("FreeIpa creation failed. Also failed to get freeIpa status: {}", e.getMessage(), e);
-            throw new TestFailException(String.format("FreeIpa creation failed. Also failed to get freeIpa status: %s", e.getMessage()));
+            throw new TestFailException("FreeIpa creation failed. Also failed to get freeIpa status", e);
         }
         return false;
     }
@@ -66,8 +66,7 @@ public class FreeIpaOperationChecker<T extends FreeIpaWaitObject> extends Except
                     + "statusReason: '%s'", freeIpa.getName(), freeIpa.getCrn(), environmentCrn, freeIpa.getStatus(), freeIpa.getStatusReason()));
         } catch (Exception e) {
             LOGGER.error("Wait operation timed out, freeIpa has been failed. Also failed to get freeIpa status: {}", e.getMessage(), e);
-            throw new TestFailException(String.format("Wait operation timed out, freeIpa has been failed. Also failed to get freeIpa status: %s",
-                    e.getMessage()));
+            throw new TestFailException("Wait operation timed out, freeIpa has been failed. Also failed to get freeIpa status", e);
         }
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaTerminationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaTerminationChecker.java
@@ -38,7 +38,7 @@ public class FreeIpaTerminationChecker<T extends FreeIpaWaitObject> extends Exce
             LOGGER.warn("No freeIpa found with environmentCrn '{}'! It has been deleted successfully.", environmentCrn, e);
         } catch (Exception e) {
             LOGGER.error("FreeIpa termination failed: {}", e.getMessage(), e);
-            throw new TestFailException(String.format("FreeIpa termination failed: %s", e.getMessage()));
+            throw new TestFailException("FreeIpa termination failed", e);
         }
         return true;
     }
@@ -52,8 +52,7 @@ public class FreeIpaTerminationChecker<T extends FreeIpaWaitObject> extends Exce
                     "statusReason: '%s'", freeIpa.getCrn(), environmentCrn, freeIpa.getStatus(), freeIpa.getStatusReason()));
         } catch (Exception e) {
             LOGGER.error("Wait operation timed out, freeIpa termination failed: {}", e.getMessage(), e);
-            throw new TestFailException(String.format("Wait operation timed out, freeIpa termination failed: %s",
-                    e.getMessage()));
+            throw new TestFailException("Wait operation timed out, freeIpa termination failed", e);
         }
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceFailedChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceFailedChecker.java
@@ -60,7 +60,7 @@ public class InstanceFailedChecker<T extends InstanceWaitObject> extends Excepti
             LOGGER.warn("No instance group found with name '{}'", hostGroup, e);
         } catch (Exception e) {
             LOGGER.error("Failed to get instance group status: '{}', because of {}", hostGroup, e.getMessage(), e);
-            throw new TestFailException(String.format("Failed to get instance group status: '%s', because of %s", hostGroup, e.getMessage()));
+            throw new TestFailException(String.format("Failed to get instance group status: '%s'", hostGroup), e);
         }
         return false;
     }
@@ -84,7 +84,7 @@ public class InstanceFailedChecker<T extends InstanceWaitObject> extends Excepti
                     "statusReason: '%s'", instanceGroupName, instanceStatus, hostStatusReason));
         } catch (Exception e) {
             LOGGER.error("Wait operation timed out! Failed to get instance status: {}", e.getMessage(), e);
-            throw new TestFailException(String.format("Wait operation timed out! Failed to get instance status: %s", e.getMessage()));
+            throw new TestFailException("Wait operation timed out! Failed to get instance status", e);
         }
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceOperationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceOperationChecker.java
@@ -67,7 +67,7 @@ public class InstanceOperationChecker<T extends InstanceWaitObject> extends Exce
             }
         } catch (Exception e) {
             LOGGER.error("Failed to get '{}' instance group status, because of {}", hostGroup, e.getMessage(), e);
-            throw new TestFailException(String.format("Failed to get '%s' instance group status, because of %s", hostGroup, e.getMessage()));
+            throw new TestFailException(String.format("Failed to get '%s' instance group status", hostGroup), e);
         }
         return false;
     }
@@ -101,8 +101,7 @@ public class InstanceOperationChecker<T extends InstanceWaitObject> extends Exce
             }
         } catch (Exception e) {
             LOGGER.error("Wait operation timed out, failed to get instance status: {}", e.getMessage(), e);
-            throw new TestFailException(String.format("Wait operation timed out, failed to get instance status: %s",
-                    e.getMessage()));
+            throw new TestFailException("Wait operation timed out, failed to get instance status", e);
         }
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceTerminationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceTerminationChecker.java
@@ -59,7 +59,7 @@ public class InstanceTerminationChecker<T extends InstanceWaitObject> extends Ex
             LOGGER.warn("{} instance group is not present, may this was deleted.", hostGroup, e);
         } catch (Exception e) {
             LOGGER.error("'{}' instance group deletion has been failed, because of: {}", hostGroup, e.getMessage(), e);
-            throw new TestFailException(String.format("'%s' instance group deletion has been failed, because of: %s", hostGroup, e.getMessage()));
+            throw new TestFailException(String.format("'%s' instance group deletion has been failed", hostGroup), e);
         }
         return true;
     }
@@ -91,7 +91,7 @@ public class InstanceTerminationChecker<T extends InstanceWaitObject> extends Ex
             }
         } catch (Exception e) {
             LOGGER.error("Wait operation timed out! Failed to get instance status: {}", e.getMessage(), e);
-            throw new TestFailException(String.format("Wait operation timed out! Failed to get instance status: %s", e.getMessage()));
+            throw new TestFailException("Wait operation timed out! Failed to get instance status", e);
         }
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceWaitObject.java
@@ -62,7 +62,7 @@ public class InstanceWaitObject {
             return testContext.getSdxClient().getSdxClient().sdxEndpoint().getDetail(name, Set.of()).getStackV4Response().getInstanceGroups();
         } catch (Exception e) {
             LOGGER.error("Instance groups cannot be determined, because of: {}", e.getMessage(), e);
-            throw new TestFailException(String.format("Instance groups cannot be determined, because of: %s", e.getMessage()));
+            throw new TestFailException("Instance groups cannot be determined", e);
         }
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/redbeams/RedbeamsOperationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/redbeams/RedbeamsOperationChecker.java
@@ -50,7 +50,7 @@ public class RedbeamsOperationChecker<T extends RedbeamsWaitObject> extends Exce
             }
         } catch (Exception e) {
             LOGGER.error("Redbeams has been failed. Also failed to get redbeams status: {}", e.getMessage(), e);
-            throw new TestFailException(String.format("Redbeams has been failed. Also failed to get redbeams status: %s", e.getMessage()));
+            throw new TestFailException("Redbeams has been failed. Also failed to get redbeams status", e);
         }
         return false;
     }
@@ -69,8 +69,7 @@ public class RedbeamsOperationChecker<T extends RedbeamsWaitObject> extends Exce
                     + "statusReason: '%s'", name, crn, status, redbeams.getStatusReason()));
         } catch (Exception e) {
             LOGGER.error("Wait operation timed out, redbeams has been failed. Also failed to get redbeams status: {}", e.getMessage(), e);
-            throw new TestFailException(String.format("Wait operation timed out, redbeams has been failed. Also failed to get redbeams status: %s",
-                    e.getMessage()));
+            throw new TestFailException("Wait operation timed out, redbeams has been failed. Also failed to get redbeams status", e);
         }
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/redbeams/RedbeamsTerminationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/redbeams/RedbeamsTerminationChecker.java
@@ -41,7 +41,7 @@ public class RedbeamsTerminationChecker<T extends RedbeamsWaitObject> extends Ex
             LOGGER.warn("No DatabaseServerConfig found with crn '{}'", crn, e);
         } catch (Exception e) {
             LOGGER.error("Redbeams termination failed: {}", e.getMessage(), e);
-            throw new TestFailException(String.format("Redbeams termination failed: ", e.getMessage()));
+            throw new TestFailException("Redbeams termination failed", e);
         }
         return true;
     }
@@ -55,8 +55,7 @@ public class RedbeamsTerminationChecker<T extends RedbeamsWaitObject> extends Ex
                     "statusReason: '%s'", redbeams.getName(), crn, redbeams.getStatus(), redbeams.getStatusReason()));
         } catch (Exception e) {
             LOGGER.error("Wait operation timed out, redbeams termination failed. Also failed to get redbeams status: {}", e.getMessage(), e);
-            throw new TestFailException(String.format("Wait operation timed out, redbeams termination failed. Also failed to get redbeams status: %s",
-                    e.getMessage()));
+            throw new TestFailException("Wait operation timed out, redbeams termination failed. Also failed to get redbeams status", e);
         }
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/util/SimpleRetryUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/util/SimpleRetryUtil.java
@@ -1,10 +1,16 @@
 package com.sequenceiq.it.util;
 
-import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+
 public class SimpleRetryUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SimpleRetryUtil.class);
 
     private SimpleRetryUtil() {
     }
@@ -17,29 +23,30 @@ public class SimpleRetryUtil {
     }
 
     public static <T> T retry(int retryTimes, int retryWaitSeconds, Supplier<T> action) {
+        LOGGER.info("Trying action {} times, waiting {} seconds between.", retryTimes, retryWaitSeconds);
+
         T result = null;
 
-        int timesTried = 0;
-        RuntimeException exception;
-        do {
-            timesTried++;
-            exception = null;
+        for (int timesTried = 1; timesTried <= retryTimes; timesTried++) {
             try {
                 result = action.get();
+                LOGGER.info("Action was successful on try {}.", timesTried);
+                break;
             } catch (RuntimeException e) {
-                exception = e;
-                try {
-                    TimeUnit.SECONDS.sleep(retryWaitSeconds);
-                } catch (InterruptedException ignored) {
+                if (timesTried < retryTimes) {
+                    LOGGER.warn("Action failed on try {}, retrying after {} seconds.", timesTried, retryWaitSeconds, e);
+                    try {
+                        TimeUnit.SECONDS.sleep(retryWaitSeconds);
+                    } catch (InterruptedException ignored) {
+                    }
+                } else {
+                    LOGGER.error("Failed to run command {} times.", retryTimes, e);
+                    throw new TestFailException(String.format("Failed to run command %d times.", retryTimes), e);
                 }
             }
-        } while (exception != null && timesTried < retryTimes);
-
-        if (Objects.isNull(exception)) {
-            return result;
         }
 
-        throw new RuntimeException(String.format("Failed to run command %d times.", retryTimes), exception);
+        return result;
     }
 
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/util/SimpleRetryUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/util/SimpleRetryUtil.java
@@ -1,0 +1,45 @@
+package com.sequenceiq.it.util;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+public class SimpleRetryUtil {
+
+    private SimpleRetryUtil() {
+    }
+
+    public static void retry(int retryTimes, int retryWaitSeconds, Runnable action) {
+        retry(retryTimes, retryWaitSeconds, () -> {
+            action.run();
+            return null;
+        });
+    }
+
+    public static <T> T retry(int retryTimes, int retryWaitSeconds, Supplier<T> action) {
+        T result = null;
+
+        int timesTried = 0;
+        RuntimeException exception;
+        do {
+            timesTried++;
+            exception = null;
+            try {
+                result = action.get();
+            } catch (RuntimeException e) {
+                exception = e;
+                try {
+                    TimeUnit.SECONDS.sleep(retryWaitSeconds);
+                } catch (InterruptedException ignored) {
+                }
+            }
+        } while (exception != null && timesTried < retryTimes);
+
+        if (Objects.isNull(exception)) {
+            return result;
+        }
+
+        throw new RuntimeException(String.format("Failed to run command %d times.", retryTimes), exception);
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/util/TagsUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/util/TagsUtil.java
@@ -79,8 +79,7 @@ public class TagsUtil {
             softAssert.assertAll();
         } catch (NullPointerException e) {
             LOGGER.error("Tag validation is not possible, because of response: {} throws: {}!", response, e.getMessage(), e);
-            throw new TestFailException(String.format(" Tag validation is not possible, because of response: %s throws: %s ", response,
-                    e.getMessage()));
+            throw new TestFailException(String.format(" Tag validation is not possible, because of response: %s", response), e);
         }
     }
 

--- a/integration-test/src/test/java/com/sequenceiq/it/util/SimpleRetryUtilTest.java
+++ b/integration-test/src/test/java/com/sequenceiq/it/util/SimpleRetryUtilTest.java
@@ -1,0 +1,59 @@
+package com.sequenceiq.it.util;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class SimpleRetryUtilTest {
+
+    private static final int RETRY_WAIT_SECONDS = 0;
+
+    private static final int RETRY_TIMES = 5;
+
+    @Test
+    void shouldSucceed() {
+        int expectedResult = 5;
+        AtomicInteger tries = new AtomicInteger();
+        Integer result = SimpleRetryUtil.retry(RETRY_TIMES, RETRY_WAIT_SECONDS, () -> {
+            tries.incrementAndGet();
+            return expectedResult;
+        });
+
+        Assertions.assertThat(result).isEqualTo(expectedResult);
+        Assertions.assertThat(tries.get()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldRetry() {
+        AtomicInteger tries = new AtomicInteger();
+        RuntimeException exception = new RuntimeException("failure");
+
+        Assertions.assertThatThrownBy(() -> SimpleRetryUtil.retry(RETRY_TIMES, RETRY_WAIT_SECONDS, () -> {
+            tries.incrementAndGet();
+            throw exception;
+        }))
+                .hasMessage("Failed to run command 5 times.")
+                .hasCause(exception);
+
+        Assertions.assertThat(tries.get()).isEqualTo(RETRY_TIMES);
+    }
+
+    @Test
+    void shouldRetryJustOnce() {
+        AtomicInteger tries = new AtomicInteger();
+        RuntimeException exception = new RuntimeException("failure");
+        int expectedResult = 5;
+
+        int result = SimpleRetryUtil.retry(RETRY_TIMES, RETRY_WAIT_SECONDS, () -> {
+            if (tries.incrementAndGet() == 1) {
+                throw exception;
+            }
+            return expectedResult;
+        });
+
+        Assertions.assertThat(result).isEqualTo(expectedResult);
+        Assertions.assertThat(tries.get()).isEqualTo(2);
+    }
+
+}


### PR DESCRIPTION
Contains 2 commits:
1st is cherry-picked from master
2nd contains logging fixes:
- Fix TestFailException message in EnvironmentOperationChecker
- Remove unnecessary arguments from CloudbreakTestDto.refresh
- Refresh testdtos before collecting clues
- Refactor EnvironmentStartStopTest
- Add cause to TestFailExceptions
- Simplify and add log messages to SimpleRetryUtil
- Extract message from every WebApplicationException, not just ClientErrorException