### PR TITLE
CB-8211: Set HBase root directory in Datalake as S3 path

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hbase/HbaseCloudStorageServiceConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hbase/HbaseCloudStorageServiceConfigProvider.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.hbase;
 
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_2;
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
 
 import java.util.ArrayList;
@@ -44,9 +46,23 @@ public class HbaseCloudStorageServiceConfigProvider implements CmTemplateCompone
         boolean datalakeCluster = source.getSharedServiceConfigs()
                 .map(SharedServiceConfigsView::isDatalakeCluster)
                 .orElse(false);
-
+        String cdhVersion = getCdhVersion(source);
+        boolean is722OrNewer = isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERAMANAGER_VERSION_7_2_2);
         return source.getFileSystemConfigurationView().isPresent()
                 && cmTemplateProcessor.isRoleTypePresentInService(getServiceType(), getRoleTypes())
-                && !datalakeCluster;
+                && (!datalakeCluster || is722OrNewer);
+    }
+
+    private String getCdhVersion(TemplatePreparationObject source) {
+        if (source.getBlueprintView() == null) {
+            return "";
+        }
+
+        if (source.getBlueprintView().getProcessor() == null) {
+            return "";
+        }
+
+        return source.getBlueprintView().getProcessor().getStackVersion() == null ?
+                "" : source.getBlueprintView().getProcessor().getStackVersion();
     }
 }

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hbase/HbaseCloudStorageServiceConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hbase/HbaseCloudStorageServiceConfigProviderTest.java
@@ -1,8 +1,8 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.hbase;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,6 +19,7 @@ import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject.Builder;
 import com.sequenceiq.cloudbreak.template.filesystem.StorageLocationView;
 import com.sequenceiq.cloudbreak.template.filesystem.s3.S3FileSystemConfigurationsView;
+import com.sequenceiq.cloudbreak.template.views.BlueprintView;
 import com.sequenceiq.cloudbreak.template.views.HostgroupView;
 import com.sequenceiq.cloudbreak.template.views.SharedServiceConfigsView;
 import com.sequenceiq.cloudbreak.util.FileReaderUtils;
@@ -31,7 +32,7 @@ public class HbaseCloudStorageServiceConfigProviderTest {
     private final HbaseCloudStorageServiceConfigProvider underTest = new HbaseCloudStorageServiceConfigProvider();
 
     @Test
-    public void testGetHbaseStorageServiceConfigs() {
+    public void testGetHbaseStorageServiceConfigsWhenAttachedCluster() {
         TemplatePreparationObject preparationObject = getTemplatePreparationObject(true, false);
         String inputJson = getBlueprintText("input/clouderamanager.bp");
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
@@ -44,7 +45,33 @@ public class HbaseCloudStorageServiceConfigProviderTest {
     }
 
     @Test
-    public void testGetHbaseServiceConfigsWhenNoStorageConfigured() {
+    public void testGetHbaseStorageServiceConfigsWhenDataLake721() {
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject(true, true, "7.2.1");
+        String inputJson = getBlueprintText("input/clouderamanager.bp");
+        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(cmTemplateProcessor, preparationObject);
+
+        assertEquals(1, serviceConfigs.size());
+        assertEquals("hdfs_rootdir", serviceConfigs.get(0).getName());
+        assertEquals("s3a://bucket/cluster1/hbase", serviceConfigs.get(0).getValue());
+    }
+
+    @Test
+    public void testGetHbaseStorageServiceConfigsWhenDataLake722() {
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject(true, true, "7.2.2");
+        String inputJson = getBlueprintText("input/clouderamanager.bp");
+        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(cmTemplateProcessor, preparationObject);
+
+        assertEquals(1, serviceConfigs.size());
+        assertEquals("hdfs_rootdir", serviceConfigs.get(0).getName());
+        assertEquals("s3a://bucket/cluster1/hbase", serviceConfigs.get(0).getValue());
+    }
+
+    @Test
+    public void testGetHbaseServiceConfigsWhenNoStorageConfiguredWithAttachedCluster() {
         TemplatePreparationObject preparationObject = getTemplatePreparationObject(false, false);
         String inputJson = getBlueprintText("input/clouderamanager.bp");
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
@@ -54,13 +81,43 @@ public class HbaseCloudStorageServiceConfigProviderTest {
     }
 
     @Test
-    public void testIsConfigurationNotNeededWhenDatalake() {
-        TemplatePreparationObject preparationObject = getTemplatePreparationObject(true, true);
+    public void testGetHbaseServiceConfigsWhenNoStorageConfiguredWithDataLake() {
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject(false, true);
+        String inputJson = getBlueprintText("input/clouderamanager.bp");
+        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(cmTemplateProcessor, preparationObject);
+        assertEquals(0, serviceConfigs.size());
+    }
+
+    @Test
+    public void testConfigurationNotNeededWhenDataLake721() {
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject(true, true, "7.2.1");
         String inputJson = getBlueprintText("input/clouderamanager.bp");
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
 
         boolean configurationNeeded = underTest.isConfigurationNeeded(cmTemplateProcessor, preparationObject);
         assertFalse(configurationNeeded);
+    }
+
+    @Test
+    public void testConfigurationNeededWhenDatalake722() {
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject(true, true, "7.2.2");
+        String inputJson = getBlueprintText("input/clouderamanager.bp");
+        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+
+        boolean configurationNeeded = underTest.isConfigurationNeeded(cmTemplateProcessor, preparationObject);
+        assertTrue(configurationNeeded);
+    }
+
+    @Test
+    public void testConfigurationNeededWhenDatalake723() {
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject(true, true, "7.2.3");
+        String inputJson = getBlueprintText("input/clouderamanager.bp");
+        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+
+        boolean configurationNeeded = underTest.isConfigurationNeeded(cmTemplateProcessor, preparationObject);
+        assertTrue(configurationNeeded);
     }
 
     @Test
@@ -74,6 +131,10 @@ public class HbaseCloudStorageServiceConfigProviderTest {
     }
 
     private TemplatePreparationObject getTemplatePreparationObject(boolean includeLocations, boolean datalakeCluster) {
+        return getTemplatePreparationObject(includeLocations, datalakeCluster, "7.2.1");
+    }
+
+    private TemplatePreparationObject getTemplatePreparationObject(boolean includeLocations, boolean datalakeCluster, String cdhVersion) {
         HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, 1);
         HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, 2);
 
@@ -90,7 +151,12 @@ public class HbaseCloudStorageServiceConfigProviderTest {
         SharedServiceConfigsView sharedServicesConfigsView = new SharedServiceConfigsView();
         sharedServicesConfigsView.setDatalakeCluster(datalakeCluster);
 
+        String inputJson = getBlueprintText("input/clouderamanager.bp");
+        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+        cmTemplateProcessor.setCdhVersion(cdhVersion);
+
         return Builder.builder().withFileSystemConfigurationView(fileSystemConfigurationsView)
+                .withBlueprintView(new BlueprintView(inputJson, "", "", cmTemplateProcessor))
                 .withSharedServiceConfigs(sharedServicesConfigsView)
                 .withHostgroupViews(Set.of(master, worker)).build();
     }

--- a/template-manager-cmtemplate/src/test/resources/output/clouderamanager-fixparam.bp
+++ b/template-manager-cmtemplate/src/test/resources/output/clouderamanager-fixparam.bp
@@ -89,6 +89,12 @@
     {
       "refName": "hbase",
       "serviceType": "HBASE",
+      "serviceConfigs": [
+        {
+          "name": "hdfs_rootdir",
+          "value": "s3a://bucket/cluster1/hbase"
+        }
+      ],
       "roleConfigGroups": [
         {
           "refName": "hbase-REGIONSERVER-BASE",

--- a/template-manager-cmtemplate/src/test/resources/output/clouderamanager-nometastore.bp
+++ b/template-manager-cmtemplate/src/test/resources/output/clouderamanager-nometastore.bp
@@ -81,6 +81,12 @@
     {
       "refName": "hbase",
       "serviceType": "HBASE",
+      "serviceConfigs": [
+        {
+          "name": "hdfs_rootdir",
+          "value": "s3a://bucket/cluster1/hbase"
+        }
+      ],
       "roleConfigGroups": [
         {
           "refName": "hbase-REGIONSERVER-BASE",

--- a/template-manager-cmtemplate/src/test/resources/output/clouderamanager-variables.bp
+++ b/template-manager-cmtemplate/src/test/resources/output/clouderamanager-variables.bp
@@ -80,6 +80,12 @@
     {
       "refName": "hbase",
       "serviceType": "HBASE",
+      "serviceConfigs": [
+        {
+          "name": "hdfs_rootdir",
+          "value": "s3a://bucket/cluster1/hbase"
+        }
+      ],
       "roleConfigGroups": [
         {
           "refName": "hbase-REGIONSERVER-BASE",

--- a/template-manager-cmtemplate/src/test/resources/output/clouderamanager-without-hosts.bp
+++ b/template-manager-cmtemplate/src/test/resources/output/clouderamanager-without-hosts.bp
@@ -81,6 +81,12 @@
     {
       "refName": "hbase",
       "serviceType": "HBASE",
+      "serviceConfigs": [
+        {
+          "name": "hdfs_rootdir",
+          "value": "s3a://bucket/cluster1/hbase"
+        }
+      ],
       "roleConfigGroups": [
         {
           "refName": "hbase-REGIONSERVER-BASE",

--- a/template-manager-cmtemplate/src/test/resources/output/clouderamanager.bp
+++ b/template-manager-cmtemplate/src/test/resources/output/clouderamanager.bp
@@ -80,6 +80,12 @@
     {
       "refName": "hbase",
       "serviceType": "HBASE",
+      "serviceConfigs": [
+        {
+          "name": "hdfs_rootdir",
+          "value": "s3a://bucket/cluster1/hbase"
+        }
+      ],
       "roleConfigGroups": [
         {
           "refName": "hbase-REGIONSERVER-BASE",


### PR DESCRIPTION
This is updated version of previous pull request https://github.com/hortonworks/cloudbreak/pull/8912.

Check the CDH version of the blueprint, and only configure HBase root directory if the SDX blueprint version is 7.2.2 or newer. So we can avoid regression in older SDX blueprint.