### PR TITLE
CB-8739 Consistent Hostnames Enhancements

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapper.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapper.java
@@ -9,11 +9,14 @@ import static org.apache.commons.lang3.StringUtils.isNoneBlank;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -90,6 +93,9 @@ public class ClusterBootstrapper {
 
     @Inject
     private HostOrchestrator hostOrchestrator;
+
+    @Inject
+    private ClusterNodeNameGenerator clusterNodeNameGenerator;
 
     @Inject
     private GatewayConfigService gatewayConfigService;
@@ -244,12 +250,16 @@ public class ClusterBootstrapper {
     private Set<Node> collectNodesForBootstrap(Stack stack) {
         Set<Node> nodes = new HashSet<>();
         String domain = hostDiscoveryService.determineDomain(stack.getCustomDomain(), stack.getName(), stack.isClusterNameAsSubdomain());
+
+        Map<String, AtomicLong> hostGroupNodeIndexes = new HashMap<>();
+        Set<String> clusterNodeNames = stack.getNotTerminatedInstanceMetaDataList().stream()
+                .map(InstanceMetaData::getShortHostname).collect(Collectors.toSet());
+
         for (InstanceMetaData im : stack.getNotDeletedInstanceMetaDataSet()) {
             if (im.getPrivateIp() == null && im.getPublicIpWrapper() == null) {
                 LOGGER.debug("Skipping instance metadata because the public ip and private ips are null '{}'.", im);
             } else {
-                String generatedHostName = hostDiscoveryService.calculateHostname(stack.getCustomHostname(), im.getShortHostname(), im.getInstanceGroupName(),
-                        im.getPrivateId(), stack.isHostgroupNameAsHostname());
+                String generatedHostName = clusterNodeNameGenerator.getNodeNameForInstanceMetadata(im, stack, hostGroupNodeIndexes, clusterNodeNames);
                 String instanceId = im.getInstanceId();
                 String instanceType = im.getInstanceGroup().getTemplate().getInstanceType();
                 nodes.add(new Node(im.getPrivateIp(), im.getPublicIpWrapper(), instanceId, instanceType, generatedHostName, domain, im.getInstanceGroupName()));
@@ -269,9 +279,13 @@ public class ClusterBootstrapper {
                 .collect(Collectors.toSet());
         String clusterDomain = getClusterDomain(metaDataSet, stack.getCustomDomain());
 
+        Map<String, AtomicLong> hostGroupNodeIndexes = new HashMap<>();
+        Set<String> clusterNodeNames = stack.getNotTerminatedInstanceMetaDataList().stream()
+                .map(InstanceMetaData::getShortHostname).collect(Collectors.toSet());
+
         Iterator<String> iterator = recoveryHostNames.iterator();
         for (InstanceMetaData im : metaDataSet) {
-            Node node = createNode(stack.getCustomHostname(), im, clusterDomain, stack.isHostgroupNameAsHostname());
+            Node node = createNode(stack, im, clusterDomain, hostGroupNodeIndexes, clusterNodeNames);
             if (upscaleCandidateAddresses.contains(im.getPrivateIp())) {
                 // use the hostname of the node we're recovering instead of generating a new one
                 // but only when we would have generated a hostname, otherwise use the cloud provider's default mechanism
@@ -343,14 +357,14 @@ public class ClusterBootstrapper {
      * Even if the domain has changed keep the rest of the nodes domain.
      * Note: if we recovered a node the private id is not the same as it is in the hostname
      */
-    private Node createNode(String customHostname, InstanceMetaData im, String domain, boolean hostgroupAsHostname) {
+    private Node createNode(Stack stack, InstanceMetaData im, String domain, Map<String, AtomicLong> hostGroupNodeIndexes, Set<String> clusterNodeNames) {
         String discoveryFQDN = im.getDiscoveryFQDN();
         String instanceId = im.getInstanceId();
         String instanceType = im.getInstanceGroup().getTemplate().getInstanceType();
         if (isNoneBlank(discoveryFQDN)) {
             return new Node(im.getPrivateIp(), im.getPublicIpWrapper(), instanceId, instanceType, im.getShortHostname(), domain, im.getInstanceGroupName());
         } else {
-            String hostname = hostDiscoveryService.generateHostname(customHostname, im.getInstanceGroupName(), im.getPrivateId(), hostgroupAsHostname);
+            String hostname = clusterNodeNameGenerator.getNodeNameForInstanceMetadata(im, stack, hostGroupNodeIndexes, clusterNodeNames);
             return new Node(im.getPrivateIp(), im.getPublicIpWrapper(), instanceId, instanceType, hostname, domain, im.getInstanceGroupName());
         }
     }
@@ -360,5 +374,4 @@ public class ClusterBootstrapper {
             throw new CancellationException(cancelledMessage);
         }
     }
-
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterNodeNameGenerator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterNodeNameGenerator.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.cloudbreak.core.bootstrap.service;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.service.HostDiscoveryService;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+
+@Component
+public class ClusterNodeNameGenerator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterNodeNameGenerator.class);
+
+    @Inject
+    private HostDiscoveryService hostDiscoveryService;
+
+    public String getNodeNameForInstanceMetadata(InstanceMetaData im, Stack stack, Map<String, AtomicLong> hostGroupNodeIndexes, Set<String> clusterNodeNames) {
+        if (isNotBlank(im.getShortHostname())) {
+            return im.getShortHostname();
+        } else {
+            String generatedHostName;
+            AtomicLong hostGroupNodeIndex = hostGroupNodeIndexes.computeIfAbsent(im.getInstanceGroupName(),
+                        instantGroup -> new AtomicLong(0L));
+            do {
+                generatedHostName = hostDiscoveryService.calculateHostname(stack.getCustomHostname(), im.getShortHostname(),
+                        im.getInstanceGroupName(), hostGroupNodeIndex.getAndIncrement(), stack.isHostgroupNameAsHostname());
+            } while (clusterNodeNames.contains(generatedHostName));
+
+            LOGGER.debug("Generated hostname {} for address: {}", generatedHostName, im.getPrivateIp());
+            clusterNodeNames.add(generatedHostName);
+            return generatedHostName;
+        }
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterNodeNameGeneratorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterNodeNameGeneratorTest.java
@@ -1,0 +1,176 @@
+package com.sequenceiq.cloudbreak.core.bootstrap.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.sequenceiq.cloudbreak.common.service.HostDiscoveryService;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClusterNodeNameGeneratorTest {
+
+    @Mock
+    private HostDiscoveryService hostDiscoveryService;
+
+    @InjectMocks
+    private ClusterNodeNameGenerator underTest;
+
+    @Before
+    public void setUp() {
+        when(hostDiscoveryService.calculateHostname(anyString(), nullable(String.class),
+                nullable(String.class), anyLong(), anyBoolean())).thenCallRealMethod();
+        when(hostDiscoveryService.generateHostname(anyString(), anyString(),
+                anyLong(), anyBoolean())).thenCallRealMethod();
+    }
+
+    @Test
+    public void testGetNodeNameForInstanceWhenNewCluster() {
+        Stack nodeNameStack = new Stack();
+        nodeNameStack.setHostgroupNameAsHostname(true);
+        nodeNameStack.setCustomHostname("teststack");
+
+        InstanceGroup master = new InstanceGroup();
+        master.setGroupName("master");
+        initializeHostGroupInstanceMetadata(1, master, List.of(""));
+
+        InstanceGroup worker = new InstanceGroup();
+        worker.setGroupName("worker");
+        initializeHostGroupInstanceMetadata(3, worker, List.of("", "", ""));
+
+        InstanceGroup compute = new InstanceGroup();
+        compute.setGroupName("compute");
+        initializeHostGroupInstanceMetadata(3, compute, List.of("", "", ""));
+        nodeNameStack.setInstanceGroups(Set.of(master, compute, worker));
+
+        Set<String> expectedNodeNames = Set.of("teststack-master0",
+                "teststack-compute0", "teststack-compute1", "teststack-compute2",
+                "teststack-worker0", "teststack-worker2", "teststack-worker1");
+        testHostNameGenerationForStack(nodeNameStack, expectedNodeNames);
+    }
+
+    @Test
+    public void testGetNodeNameForInstanceWhenScalingExistingPrivateIdBasedCluster() {
+        Stack nodeNameStack = new Stack();
+        nodeNameStack.setHostgroupNameAsHostname(true);
+        nodeNameStack.setCustomHostname("teststack");
+
+        InstanceGroup compute = new InstanceGroup();
+        compute.setGroupName("compute");
+
+        initializeHostGroupInstanceMetadata(6, compute, List.of("teststack-compute12.testdomain",
+                "teststack-compute13.testdomain", "teststack-compute14.testdomain", "", "", ""));
+        nodeNameStack.setInstanceGroups(Set.of(compute));
+
+        Set<String> expectedNodeNames = Set.of(
+                "teststack-compute12", "teststack-compute13", "teststack-compute14", "teststack-compute0",
+                "teststack-compute1", "teststack-compute2");
+        testHostNameGenerationForStack(nodeNameStack, expectedNodeNames);
+    }
+
+    @Test
+    public void testGetNodeNameForInstanceWhenScalingFromZero() {
+        Stack nodeNameStack = new Stack();
+        nodeNameStack.setHostgroupNameAsHostname(true);
+        nodeNameStack.setCustomHostname("teststack");
+
+        InstanceGroup compute = new InstanceGroup();
+        compute.setGroupName("compute");
+
+        initializeHostGroupInstanceMetadata(6, compute, List.of("", "", "", "", "", ""));
+        nodeNameStack.setInstanceGroups(Set.of(compute));
+
+        Set<String> expectedNodeNames = Set.of(
+                "teststack-compute0", "teststack-compute1", "teststack-compute2", "teststack-compute3",
+                "teststack-compute4", "teststack-compute5");
+        testHostNameGenerationForStack(nodeNameStack, expectedNodeNames);
+    }
+
+    @Test
+    public void testGetNodeNameForInstanceWhenScaling() {
+        Stack nodeNameStack = new Stack();
+        nodeNameStack.setHostgroupNameAsHostname(true);
+        nodeNameStack.setCustomHostname("teststack");
+
+        InstanceGroup compute = new InstanceGroup();
+        compute.setGroupName("compute");
+        //Scaling 3 node "compute" to 5 node "compute".
+        initializeHostGroupInstanceMetadata(5, compute, List.of("teststack-compute0.testdomain",
+                "teststack-compute1.testdomain", "teststack-compute2.testdomain", "", ""));
+        nodeNameStack.setInstanceGroups(Set.of(compute));
+
+        Set<String> expectedNodeNames = Set.of("teststack-compute0", "teststack-compute1",
+                "teststack-compute2", "teststack-compute3", "teststack-compute4");
+        testHostNameGenerationForStack(nodeNameStack, expectedNodeNames);
+    }
+
+    @Test
+    public void testGetNodeNameForInstanceWhenResizingAndWorker() {
+        Stack nodeNameStack = new Stack();
+        nodeNameStack.setHostgroupNameAsHostname(true);
+        nodeNameStack.setCustomHostname("teststack");
+
+        InstanceGroup worker = new InstanceGroup();
+        worker.setGroupName("worker");
+        initializeHostGroupInstanceMetadata(5, worker, List.of("teststack-worker3.testdomain",
+                "teststack-worker4.testdomain", "teststack-worker5.testdomain", "", ""));
+        nodeNameStack.setInstanceGroups(Set.of(worker));
+
+        Set<String> expectedNodeNames = Set.of("teststack-worker3", "teststack-worker4",
+                "teststack-worker5", "teststack-worker0", "teststack-worker1");
+        testHostNameGenerationForStack(nodeNameStack, expectedNodeNames);
+    }
+
+    private void testHostNameGenerationForStack(Stack underTestStack, Set<String> expectedNodeNames) {
+        Set<InstanceMetaData> testInstanceMetadata = underTestStack.getNotTerminatedInstanceMetaDataSet();
+        Map<String, AtomicLong> hostGroupNodeCount = new HashMap<>();
+        underTestStack.getInstanceGroups().stream().forEach(
+                instanceGroup -> hostGroupNodeCount.put(instanceGroup.getGroupName(), new AtomicLong(0L)));
+
+        Set<String> clusterNodeNames = underTestStack.getInstanceMetaDataAsList().stream()
+                .map(InstanceMetaData::getShortHostname).collect(Collectors.toSet());
+
+        Set<String> resultSet = new HashSet();
+        for (InstanceMetaData im : testInstanceMetadata) {
+            String generatedHostName = underTest.getNodeNameForInstanceMetadata(im, underTestStack, hostGroupNodeCount, clusterNodeNames);
+            resultSet.add(generatedHostName);
+        }
+        assertEquals("InstanceMetadata size should match", expectedNodeNames.size(), testInstanceMetadata.size());
+        assertEquals("Generated Hostname should match", expectedNodeNames, resultSet);
+    }
+
+    private void initializeHostGroupInstanceMetadata(int nodeCount, InstanceGroup instanceGroup, List<String> fqdns) {
+        IntStream.range(0, nodeCount).forEach(
+                nodeIndex -> {
+                    InstanceMetaData instanceMetaData = new InstanceMetaData();
+                    instanceMetaData.setInstanceGroup(instanceGroup);
+                    instanceGroup.getInstanceMetaDataSet().add(instanceMetaData);
+
+                    if (!fqdns.get(nodeIndex).isBlank()) {
+                        instanceMetaData.setDiscoveryFQDN(fqdns.get(nodeIndex));
+                    }
+                }
+        );
+    }
+}


### PR DESCRIPTION
Node name generation logic enhanced so that all  hostgroup's nodes start with index 0.

Testing done.
- Tested launch of new cluster with 0 based node indexes for every hostgroup.
- Tested scale up and scale down of hostgroup nodes with hostGroup based node index.
- Tested deleted on provider node and new node added with same name on repair.
- Tested manually deleted nodes and successful scale up.
- Tested scale up\down on existing clusters with privateId based names.