### PR TITLE
CB-8711 [e2e] azure fails with NPE (Create failed)

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurevm/action/AzureClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurevm/action/AzureClientActions.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -110,6 +111,7 @@ public class AzureClientActions {
 
     public Map<String, Map<String, String>> listTagsByInstanceId(List<String> instanceIds) {
         return instanceIds.stream()
+                .filter(StringUtils::isNotEmpty)
                 .map(id -> azure.virtualMachines().getByResourceGroup(getResourceGroupName(id), id))
                 .collect(Collectors.toMap(VirtualMachine::id, VirtualMachine::tags));
     }


### PR DESCRIPTION
On azure there is an e2e test utility listing tags bz instance id. If, however, the instance id is null, an NPE is produced, marking a test as failed, masking the real reason for failure.

See detailed description in the commit message.