### PR TITLE
CB-8691: It is not possible to launch an sdx on ycloud

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/StackCreatorService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/StackCreatorService.java
@@ -15,6 +15,7 @@ import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
 import com.sequenceiq.cloudbreak.cloud.event.validation.ParametersValidationRequest;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
 import com.sequenceiq.cloudbreak.common.service.TransactionService.TransactionExecutionException;
 import com.sequenceiq.cloudbreak.common.service.TransactionService.TransactionRuntimeExecutionException;
@@ -430,7 +431,7 @@ public class StackCreatorService {
         if (clusterRequest == null) {
             return null;
         }
-        boolean shouldUseBaseCMImage = shouldUseBaseCMImage(clusterRequest);
+        boolean shouldUseBaseCMImage = shouldUseBaseCMImage(clusterRequest, platformString);
         boolean baseImageEnabled = imageCatalogService.baseImageEnabled();
         Map<String, String> mdcContext = MDCBuilder.getMdcContextMap();
         CloudbreakUser cbUser = restRequestThreadLocalService.getCloudbreakUser();
@@ -460,9 +461,9 @@ public class StackCreatorService {
         });
     }
 
-    boolean shouldUseBaseCMImage(ClusterV4Request clusterRequest) {
+    boolean shouldUseBaseCMImage(ClusterV4Request clusterRequest, String platformString) {
         ClouderaManagerV4Request cmRequest = clusterRequest.getCm();
-        return hasCmParcelInfo(cmRequest);
+        return hasCmParcelInfo(cmRequest) || CloudPlatform.YARN.equalsIgnoreCase(platformString);
     }
 
     private boolean hasCmParcelInfo(ClouderaManagerV4Request cmRequest) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/controller/StackCreatorServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/controller/StackCreatorServiceTest.java
@@ -85,6 +85,10 @@ public class StackCreatorServiceTest {
 
     private static final String STACK_VERSION = "STACK_VERSION";
 
+    private static final String AWS_PLATFORM = "AWS";
+
+    private static final String YARN_PLATFORM = "YARN";
+
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
@@ -280,29 +284,51 @@ public class StackCreatorServiceTest {
     }
 
     @Test
-    public void testShouldUseBaseImageShouldReturnFalseWhenCmRequestIsNotPresent() {
+    public void testShouldUseBaseCMImageShouldReturnFalseWhenCmRequestIsNotPresentAndPlatformIsNotYarn() {
         ClusterV4Request clusterV4Request = new ClusterV4Request();
 
-        boolean actual = underTest.shouldUseBaseCMImage(clusterV4Request);
+        boolean actual = underTest.shouldUseBaseCMImage(clusterV4Request, AWS_PLATFORM);
 
         assertFalse(actual);
     }
 
     @Test
-    public void testShouldUseBaseShouldReturnTrueWithCMImageWithCmRepoAndImageIsNotPresent() {
+    public void testShouldUseBaseCMImageShouldReturnTrueWhenCmRequestIsNotPresentAndPlatformIsYarn() {
+        ClusterV4Request clusterV4Request = new ClusterV4Request();
+
+        boolean actual = underTest.shouldUseBaseCMImage(clusterV4Request, YARN_PLATFORM);
+
+        assertTrue(actual);
+    }
+
+    @Test
+    public void testShouldUseBaseCMImageShouldReturnTrueWithCMImageWithCmRepoAndImageIsNotPresentAndPlatformIsNotYarn() {
         ClusterV4Request clusterV4Request = new ClusterV4Request();
         ClouderaManagerV4Request cmRequest = new ClouderaManagerV4Request();
         ClouderaManagerRepositoryV4Request cmRepoRequest = new ClouderaManagerRepositoryV4Request();
         cmRequest.setRepository(cmRepoRequest);
         clusterV4Request.setCm(cmRequest);
 
-        boolean base = underTest.shouldUseBaseCMImage(clusterV4Request);
+        boolean base = underTest.shouldUseBaseCMImage(clusterV4Request, AWS_PLATFORM);
 
         assertTrue(base);
     }
 
     @Test
-    public void testShouldUseBaseCMImageWithProducts() {
+    public void testShouldUseBaseCMImageShouldReturnTrueWithCMImageWithCmRepoAndImageIsNotPresentAndPlatformIsYarn() {
+        ClusterV4Request clusterV4Request = new ClusterV4Request();
+        ClouderaManagerV4Request cmRequest = new ClouderaManagerV4Request();
+        ClouderaManagerRepositoryV4Request cmRepoRequest = new ClouderaManagerRepositoryV4Request();
+        cmRequest.setRepository(cmRepoRequest);
+        clusterV4Request.setCm(cmRequest);
+
+        boolean base = underTest.shouldUseBaseCMImage(clusterV4Request, YARN_PLATFORM);
+
+        assertTrue(base);
+    }
+
+    @Test
+    public void testShouldUseBaseCMImageWithProductsAndPlatformIsNotYarn() {
         ClusterV4Request clusterV4Request = new ClusterV4Request();
         ClouderaManagerV4Request cmRequest = new ClouderaManagerV4Request();
         ClouderaManagerProductV4Request cdpRequest = new ClouderaManagerProductV4Request();
@@ -313,13 +339,30 @@ public class StackCreatorServiceTest {
         cmRequest.setProducts(List.of(cdpRequest));
         clusterV4Request.setCm(cmRequest);
 
-        boolean base = underTest.shouldUseBaseCMImage(clusterV4Request);
+        boolean base = underTest.shouldUseBaseCMImage(clusterV4Request, AWS_PLATFORM);
 
         assertTrue(base);
     }
 
     @Test
-    public void testShouldUseBaseCMImageWithProductsAndCmRepo() {
+    public void testShouldUseBaseCMImageWithProductsAndPlatformIsYarn() {
+        ClusterV4Request clusterV4Request = new ClusterV4Request();
+        ClouderaManagerV4Request cmRequest = new ClouderaManagerV4Request();
+        ClouderaManagerProductV4Request cdpRequest = new ClouderaManagerProductV4Request();
+        cdpRequest.setName("CDP");
+        cdpRequest.setParcel("parcel");
+        cdpRequest.setVersion("version");
+        cdpRequest.setCsd(List.of("csd"));
+        cmRequest.setProducts(List.of(cdpRequest));
+        clusterV4Request.setCm(cmRequest);
+
+        boolean base = underTest.shouldUseBaseCMImage(clusterV4Request, YARN_PLATFORM);
+
+        assertTrue(base);
+    }
+
+    @Test
+    public void testShouldUseBaseCMImageWithProductsAndCmRepoAndPlatformIsNotYarn() {
         ClusterV4Request clusterV4Request = new ClusterV4Request();
         ClouderaManagerV4Request cmRequest = new ClouderaManagerV4Request();
         ClouderaManagerProductV4Request cdpRequest = new ClouderaManagerProductV4Request();
@@ -332,7 +375,26 @@ public class StackCreatorServiceTest {
         cmRequest.setRepository(cmRepoRequest);
         clusterV4Request.setCm(cmRequest);
 
-        boolean base = underTest.shouldUseBaseCMImage(clusterV4Request);
+        boolean base = underTest.shouldUseBaseCMImage(clusterV4Request, AWS_PLATFORM);
+
+        assertTrue(base);
+    }
+
+    @Test
+    public void testShouldUseBaseCMImageWithProductsAndCmRepoAndPlatformIsYarn() {
+        ClusterV4Request clusterV4Request = new ClusterV4Request();
+        ClouderaManagerV4Request cmRequest = new ClouderaManagerV4Request();
+        ClouderaManagerProductV4Request cdpRequest = new ClouderaManagerProductV4Request();
+        cdpRequest.setName("CDP");
+        cdpRequest.setParcel("parcel");
+        cdpRequest.setVersion("version");
+        cdpRequest.setCsd(List.of("csd"));
+        cmRequest.setProducts(List.of(cdpRequest));
+        ClouderaManagerRepositoryV4Request cmRepoRequest = new ClouderaManagerRepositoryV4Request();
+        cmRequest.setRepository(cmRepoRequest);
+        clusterV4Request.setCm(cmRequest);
+
+        boolean base = underTest.shouldUseBaseCMImage(clusterV4Request, YARN_PLATFORM);
 
         assertTrue(base);
     }


### PR DESCRIPTION
So far, the condition for the separation of the base and prewarmed images have been extended with a further check on the cloud platform. In case of yCloud base image should be selected.