### PR TITLE
CB-8663 Deploy IdBroker across multiple nodes

### DIFF
--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/cluster/Cluster.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/cluster/Cluster.java
@@ -170,6 +170,9 @@ public class Cluster implements ProvisionEntity, WorkspaceAwareResource {
     @OneToOne(mappedBy = "cluster", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
     private Gateway gateway;
 
+    @OneToOne(mappedBy = "cluster", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true, fetch = FetchType.LAZY)
+    private IdBroker idBroker;
+
     @OneToMany(mappedBy = "cluster", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<HostGroup> hostGroups = new HashSet<>();
 
@@ -733,6 +736,14 @@ public class Cluster implements ProvisionEntity, WorkspaceAwareResource {
     @Override
     public void setWorkspace(Workspace workspace) {
         this.workspace = workspace;
+    }
+
+    public IdBroker getIdBroker() {
+        return idBroker;
+    }
+
+    public void setIdBroker(IdBroker idBroker) {
+        this.idBroker = idBroker;
     }
 
     @Override

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/cluster/IdBroker.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/cluster/IdBroker.java
@@ -1,0 +1,121 @@
+package com.sequenceiq.cloudbreak.domain.stack.cluster;
+
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
+import javax.persistence.SequenceGenerator;
+
+import com.sequenceiq.cloudbreak.domain.ProvisionEntity;
+import com.sequenceiq.cloudbreak.service.secret.SecretValue;
+import com.sequenceiq.cloudbreak.service.secret.domain.Secret;
+import com.sequenceiq.cloudbreak.service.secret.domain.SecretToString;
+import com.sequenceiq.cloudbreak.workspace.model.Workspace;
+import com.sequenceiq.cloudbreak.workspace.model.WorkspaceAwareResource;
+
+@Entity
+public class IdBroker implements ProvisionEntity, WorkspaceAwareResource {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "idbroker_generator")
+    @SequenceGenerator(name = "idbroker_generator", sequenceName = "idbroker_id_seq", allocationSize = 1)
+    private Long id;
+
+    @OneToOne
+    private Cluster cluster;
+
+    @ManyToOne
+    private Workspace workspace;
+
+    @Convert(converter = SecretToString.class)
+    @SecretValue
+    private Secret masterSecret = Secret.EMPTY;
+
+    @Convert(converter = SecretToString.class)
+    @SecretValue
+    private Secret signKey = Secret.EMPTY;
+
+    private String signPub;
+
+    private String signCert;
+
+    public IdBroker copy() {
+        IdBroker copy = new IdBroker();
+        copy.id = id;
+        copy.cluster = cluster;
+        copy.workspace = workspace;
+        copy.signCert = signCert;
+        copy.signPub = signPub;
+        copy.signKey = signKey;
+        copy.masterSecret = masterSecret;
+
+        return copy;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    @Override
+    public Workspace getWorkspace() {
+        return workspace;
+    }
+
+    @Override
+    public String getName() {
+        return "idbroker-" + id;
+    }
+
+    @Override
+    public void setWorkspace(Workspace workspace) {
+        this.workspace = workspace;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Cluster getCluster() {
+        return cluster;
+    }
+
+    public void setCluster(Cluster cluster) {
+        this.cluster = cluster;
+    }
+
+    public String getMasterSecret() {
+        return masterSecret.getRaw();
+    }
+
+    public void setMasterSecret(String masterSecret) {
+        this.masterSecret = new Secret(masterSecret);
+    }
+
+    public String getSignKey() {
+        return signKey.getRaw();
+    }
+
+    public void setSignKey(String signKey) {
+        this.signKey = new Secret(signKey);
+    }
+
+    public String getSignPub() {
+        return signPub;
+    }
+
+    public void setSignPub(String signPub) {
+        this.signPub = signPub;
+    }
+
+    public String getSignCert() {
+        return signCert;
+    }
+
+    public void setSignCert(String signCert) {
+        this.signCert = signCert;
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/IdBrokerConverterUtil.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/IdBrokerConverterUtil.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.cloudbreak.converter;
+
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.certificate.PkiUtil;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.IdBroker;
+import com.sequenceiq.cloudbreak.util.PasswordUtil;
+import com.sequenceiq.cloudbreak.workspace.model.Workspace;
+
+@Component
+public class IdBrokerConverterUtil {
+
+    public IdBroker generateIdBrokerSignKeys(Cluster cluster, Workspace workspace) {
+        IdBroker idBroker = new IdBroker();
+
+        KeyPair identityKey = PkiUtil.generateKeypair();
+        KeyPair signKey = PkiUtil.generateKeypair();
+        X509Certificate cert = PkiUtil.cert(identityKey, "signing", signKey);
+
+        idBroker.setSignKey(PkiUtil.convert(identityKey.getPrivate()));
+        idBroker.setSignPub(PkiUtil.convert(identityKey.getPublic()));
+        idBroker.setSignCert(PkiUtil.convert(cert));
+        idBroker.setMasterSecret(PasswordUtil.generatePassword());
+
+        idBroker.setCluster(cluster);
+        idBroker.setWorkspace(workspace);
+        return idBroker;
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cluster/ClusterV4RequestToClusterConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cluster/ClusterV4RequestToClusterConverter.java
@@ -30,6 +30,7 @@ import com.sequenceiq.cloudbreak.cloud.model.component.StackType;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.type.ComponentType;
 import com.sequenceiq.cloudbreak.converter.AbstractConversionServiceAwareConverter;
+import com.sequenceiq.cloudbreak.converter.IdBrokerConverterUtil;
 import com.sequenceiq.cloudbreak.converter.util.CloudStorageValidationUtil;
 import com.sequenceiq.cloudbreak.converter.v4.stacks.cluster.clouderamanager.ClouderaManagerRepositoryV4RequestToClouderaManagerRepoConverter;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
@@ -38,6 +39,7 @@ import com.sequenceiq.cloudbreak.domain.FileSystem;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterComponent;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.IdBroker;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.gateway.Gateway;
 import com.sequenceiq.cloudbreak.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.exception.CloudbreakApiException;
@@ -67,6 +69,9 @@ public class ClusterV4RequestToClusterConverter extends AbstractConversionServic
     @Inject
     private CloudStorageConverter cloudStorageConverter;
 
+    @Inject
+    private IdBrokerConverterUtil idBrokerConverterUtil;
+
     @Override
     public Cluster convert(ClusterV4Request source) {
         Workspace workspace = workspaceService.getForCurrentUser();
@@ -77,6 +82,8 @@ public class ClusterV4RequestToClusterConverter extends AbstractConversionServic
         cluster.setDatabaseServerCrn(source.getDatabaseServerCrn());
         cluster.setBlueprint(getBlueprint(source.getBlueprintName(), workspace));
         convertGateway(source, cluster);
+        IdBroker idBroker = idBrokerConverterUtil.generateIdBrokerSignKeys(cluster, workspace);
+        cluster.setIdBroker(idBroker);
         if (cloudStorageValidationUtil.isCloudStorageConfigured(source.getCloudStorage())) {
             FileSystem fileSystem = cloudStorageConverter.requestToFileSystem(source.getCloudStorage());
             cluster.setFileSystem(fileSystem);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/GrainPropertiesService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/GrainPropertiesService.java
@@ -45,6 +45,7 @@ class GrainPropertiesService {
         Optional.ofNullable(addGatewayAddress(gatewayConfigs)).ifPresent(grainPropertiesList::add);
         Optional.ofNullable(addNameNodeRoleForHosts(cluster)).ifPresent(grainPropertiesList::add);
         Optional.ofNullable(addKnoxRoleForHosts(cluster)).ifPresent(grainPropertiesList::add);
+        Optional.ofNullable(addIdBrokerRoleForHosts(cluster)).ifPresent(grainPropertiesList::add);
         Optional.ofNullable(addCloudIdentityRolesForHosts(cluster, nodes)).ifPresent(grainPropertiesList::add);
         return grainPropertiesList;
     }
@@ -74,6 +75,14 @@ class GrainPropertiesService {
         Map<String, List<String>> knoxServiceLocations = getComponentLocationByHostname(cluster, KnoxRoles.KNOX_GATEWAY);
         knoxServiceLocations.getOrDefault(KnoxRoles.KNOX_GATEWAY, List.of())
                 .forEach(nmn -> grainProperties.computeIfAbsent(nmn, s -> new HashMap<>()).put(ROLES, "knox"));
+        return grainProperties.getProperties().isEmpty() ? null : grainProperties;
+    }
+
+    private GrainProperties addIdBrokerRoleForHosts(Cluster cluster) {
+        GrainProperties grainProperties = new GrainProperties();
+        Map<String, List<String>> knoxServiceLocations = getComponentLocationByHostname(cluster, KnoxRoles.IDBROKER);
+        knoxServiceLocations.getOrDefault(KnoxRoles.IDBROKER, List.of())
+                .forEach(nmn -> grainProperties.computeIfAbsent(nmn, s -> new HashMap<>()).put(ROLES, "idbroker"));
         return grainProperties.getProperties().isEmpty() ? null : grainProperties;
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/IdBrokerRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/IdBrokerRepository.java
@@ -1,0 +1,16 @@
+package com.sequenceiq.cloudbreak.repository;
+
+import javax.transaction.Transactional;
+import javax.transaction.Transactional.TxType;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.sequenceiq.cloudbreak.domain.stack.cluster.IdBroker;
+import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
+
+@EntityType(entityClass = IdBroker.class)
+@Transactional(TxType.REQUIRED)
+public interface IdBrokerRepository extends CrudRepository<IdBroker, Long> {
+
+    IdBroker findByClusterId(Long clusterId);
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterService.java
@@ -67,6 +67,7 @@ import com.sequenceiq.cloudbreak.service.altus.AltusMachineUserService;
 import com.sequenceiq.cloudbreak.service.filesystem.FileSystemConfigService;
 import com.sequenceiq.cloudbreak.service.gateway.GatewayService;
 import com.sequenceiq.cloudbreak.service.hostgroup.HostGroupService;
+import com.sequenceiq.cloudbreak.service.idbroker.IdBrokerService;
 import com.sequenceiq.cloudbreak.service.rdsconfig.RdsConfigService;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
@@ -125,6 +126,9 @@ public class ClusterService {
     @Inject
     private UsageLoggingUtil usageLoggingUtil;
 
+    @Inject
+    private IdBrokerService idBrokerService;
+
     public Cluster saveClusterAndComponent(Cluster cluster, List<ClusterComponent> components, String stackName) {
         Cluster savedCluster;
         try {
@@ -132,6 +136,9 @@ public class ClusterService {
             savedCluster = repository.save(cluster);
             if (savedCluster.getGateway() != null) {
                 gatewayService.save(savedCluster.getGateway());
+            }
+            if (savedCluster.getIdBroker() != null) {
+                idBrokerService.save(savedCluster.getIdBroker());
             }
             LOGGER.debug("Cluster object saved in {} ms for stack {}", System.currentTimeMillis() - start, stackName);
             clusterComponentConfigProvider.store(components, savedCluster);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/idbroker/IdBrokerService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/idbroker/IdBrokerService.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.cloudbreak.service.idbroker;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.IdBroker;
+import com.sequenceiq.cloudbreak.repository.IdBrokerRepository;
+
+@Service
+public class IdBrokerService {
+
+    @Inject
+    private IdBrokerRepository repository;
+
+    public IdBroker save(IdBroker idBroker) {
+        return repository.save(idBroker);
+    }
+
+    public IdBroker getByCluster(Cluster cluster) {
+        return repository.findByClusterId(cluster.getId());
+    }
+
+}

--- a/core/src/main/resources/defaults/blueprints/cdp-sdx-medium-ha-722.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-sdx-medium-ha-722.bp
@@ -48,7 +48,7 @@
         ]
       },
       {
-        "cardinality": 1,
+        "cardinality": 2,
         "refName": "idbroker",
         "roleConfigGroupsRefNames": [
           "knox-IDBROKER-BASE"

--- a/core/src/main/resources/schema/app/20200906200353_CB-8663_add_new_IdBroker_table.sql
+++ b/core/src/main/resources/schema/app/20200906200353_CB-8663_add_new_IdBroker_table.sql
@@ -1,0 +1,33 @@
+-- // CB-8663 add new IdBroker table.
+-- Migration SQL that makes the change goes here.
+
+CREATE SEQUENCE idbroker_id_seq START WITH 1
+  INCREMENT BY 1
+  NO MINVALUE
+  NO MAXVALUE
+  CACHE 1;
+
+CREATE TABLE idbroker (
+    id              bigint NOT NULL DEFAULT nextval('idbroker_id_seq'),
+    cluster_id      bigint NOT NULL,
+    workspace_id    int8 NOT NUll,
+    signkey         TEXT,
+    signcert        TEXT,
+    signpub         TEXT,
+    mastersecret    VARCHAR(255),
+    PRIMARY KEY (id)
+);
+
+ALTER TABLE idbroker
+   ADD CONSTRAINT fk_idbroker_cluster FOREIGN KEY (cluster_id)
+        REFERENCES cluster (id);
+ALTER TABLE idbroker
+   ADD CONSTRAINT fk_idbroker_workspace FOREIGN KEY (workspace_id)
+        REFERENCES workspace(id);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+DROP TABLE idbroker;
+DROP SEQUENCE idbroker_id_seq;
+

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/stack/cluster/ClusterRequestToClusterConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/stack/cluster/ClusterRequestToClusterConverterTest.java
@@ -13,12 +13,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.convert.ConversionService;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.cluster.ClusterV4Request;
 import com.sequenceiq.cloudbreak.cloud.model.component.StackType;
 import com.sequenceiq.cloudbreak.converter.AbstractJsonConverterTest;
+import com.sequenceiq.cloudbreak.converter.IdBrokerConverterUtil;
 import com.sequenceiq.cloudbreak.converter.util.CloudStorageValidationUtil;
 import com.sequenceiq.cloudbreak.converter.v4.stacks.cluster.CloudStorageConverter;
 import com.sequenceiq.cloudbreak.converter.v4.stacks.cluster.ClusterV4RequestToClusterConverter;
@@ -29,6 +31,8 @@ import com.sequenceiq.cloudbreak.domain.stack.cluster.gateway.Gateway;
 import com.sequenceiq.cloudbreak.service.blueprint.BlueprintService;
 import com.sequenceiq.cloudbreak.service.workspace.WorkspaceService;
 import com.sequenceiq.cloudbreak.workspace.model.Workspace;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ClusterRequestToClusterConverterTest extends AbstractJsonConverterTest<ClusterV4Request> {
@@ -53,6 +57,10 @@ public class ClusterRequestToClusterConverterTest extends AbstractJsonConverterT
 
     @Mock
     private CloudStorageConverter cloudStorageConverter;
+
+    @Spy
+    @SuppressFBWarnings(value = "UrF", justification = "This gets injected")
+    private IdBrokerConverterUtil idBrokerConverterUtil =  new IdBrokerConverterUtil();
 
     @Before
     public void setUp() {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v2/ClusterV4RequestToClusterConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v2/ClusterV4RequestToClusterConverterTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.convert.ConversionService;
 
@@ -39,6 +40,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.cluster.gateway.
 import com.sequenceiq.cloudbreak.cloud.model.component.StackType;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.type.ComponentType;
+import com.sequenceiq.cloudbreak.converter.IdBrokerConverterUtil;
 import com.sequenceiq.cloudbreak.converter.util.CloudStorageValidationUtil;
 import com.sequenceiq.cloudbreak.converter.util.GatewayConvertUtil;
 import com.sequenceiq.cloudbreak.converter.v4.stacks.cluster.CloudStorageConverter;
@@ -56,6 +58,8 @@ import com.sequenceiq.cloudbreak.service.workspace.WorkspaceService;
 import com.sequenceiq.cloudbreak.workspace.model.Workspace;
 import com.sequenceiq.common.api.cloudstorage.CloudStorageBase;
 import com.sequenceiq.common.api.cloudstorage.CloudStorageRequest;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @ExtendWith(MockitoExtension.class)
 public class ClusterV4RequestToClusterConverterTest {
@@ -85,6 +89,10 @@ public class ClusterV4RequestToClusterConverterTest {
 
     @Mock
     private CloudStorageConverter cloudStorageConverter;
+
+    @Spy
+    @SuppressFBWarnings(value = "UrF", justification = "This gets injected")
+    private IdBrokerConverterUtil idBrokerConverterUtil = new IdBrokerConverterUtil();
 
     private Workspace workspace;
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v2/StackToTemplatePreparationObjectConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v2/StackToTemplatePreparationObjectConverterTest.java
@@ -32,6 +32,7 @@ import org.junit.rules.ExpectedException;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.service.ExposedServiceCollector;
@@ -49,6 +50,7 @@ import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.common.user.CloudbreakUser;
+import com.sequenceiq.cloudbreak.converter.IdBrokerConverterUtil;
 import com.sequenceiq.cloudbreak.converter.StackToTemplatePreparationObjectConverter;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.container.postgres.PostgresConfigService;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
@@ -58,13 +60,13 @@ import com.sequenceiq.cloudbreak.domain.cloudstorage.CloudStorage;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.DatalakeResources;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.IdBroker;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.gateway.Gateway;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.dto.LdapView;
 import com.sequenceiq.cloudbreak.dto.credential.Credential;
 import com.sequenceiq.cloudbreak.kerberos.KerberosConfigService;
 import com.sequenceiq.cloudbreak.ldap.LdapConfigService;
-import com.sequenceiq.cloudbreak.structuredevent.CloudbreakRestRequestThreadLocalService;
 import com.sequenceiq.cloudbreak.service.GatewayConfigService;
 import com.sequenceiq.cloudbreak.service.ServiceEndpointCollector;
 import com.sequenceiq.cloudbreak.service.blueprint.BlueprintViewProvider;
@@ -75,8 +77,10 @@ import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
 import com.sequenceiq.cloudbreak.service.environment.credential.CredentialConverter;
 import com.sequenceiq.cloudbreak.service.environment.tag.AccountTagClientService;
 import com.sequenceiq.cloudbreak.service.hostgroup.HostGroupService;
+import com.sequenceiq.cloudbreak.service.idbroker.IdBrokerService;
 import com.sequenceiq.cloudbreak.service.identitymapping.AwsMockAccountMappingService;
 import com.sequenceiq.cloudbreak.service.resource.ResourceService;
+import com.sequenceiq.cloudbreak.structuredevent.CloudbreakRestRequestThreadLocalService;
 import com.sequenceiq.cloudbreak.tag.CostTagging;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.filesystem.BaseFileSystemConfigurationsView;
@@ -94,6 +98,8 @@ import com.sequenceiq.environment.api.v1.credential.model.response.CredentialRes
 import com.sequenceiq.environment.api.v1.environment.model.base.IdBrokerMappingSource;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse.Builder;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class StackToTemplatePreparationObjectConverterTest {
 
@@ -223,7 +229,14 @@ public class StackToTemplatePreparationObjectConverterTest {
     private ResourceService resourceService;
 
     @Mock
+    private IdBrokerService idBrokerService;
+
+    @Mock
     private GatewayConfigService gatewayConfigService;
+
+    @Spy
+    @SuppressFBWarnings(value = "UrF", justification = "This gets injected")
+    private IdBrokerConverterUtil idBrokerConverterUtil = new IdBrokerConverterUtil();
 
     @Before
     public void setUp() throws IOException {
@@ -273,6 +286,10 @@ public class StackToTemplatePreparationObjectConverterTest {
         when(clusterService.getById(anyLong())).thenReturn(cluster);
         when(exposedServiceCollector.getAllKnoxExposed()).thenReturn(Set.of());
         when(resourceService.getAllByStackId(anyLong())).thenReturn(Collections.EMPTY_LIST);
+        IdBroker idbroker = idBrokerConverterUtil.generateIdBrokerSignKeys(cluster, cluster.getWorkspace());
+        cluster.setIdBroker(idbroker);
+        when(idBrokerService.getByCluster(any(Cluster.class))).thenReturn(idbroker);
+        when(idBrokerService.save(any(IdBroker.class))).thenReturn(idbroker);
     }
 
     @Test

--- a/datalake/src/main/resources/runtime/7.2.2/aws/medium_duty_ha.json
+++ b/datalake/src/main/resources/runtime/7.2.2/aws/medium_duty_ha.json
@@ -63,7 +63,7 @@
           "size": 50
         }
       },
-      "nodeCount": 1,
+      "nodeCount": 2,
       "type": "CORE",
       "recoveryMode": "MANUAL",
       "recipeNames": []

--- a/datalake/src/main/resources/runtime/7.2.2/azure/medium_duty_ha.json
+++ b/datalake/src/main/resources/runtime/7.2.2/azure/medium_duty_ha.json
@@ -63,7 +63,7 @@
           "size": 50
         }
       },
-      "nodeCount": 1,
+      "nodeCount": 2,
       "type": "CORE",
       "recoveryMode": "MANUAL",
       "recipeNames": []

--- a/datalake/src/main/resources/runtime/7.2.2/yarn/medium_duty_ha.json
+++ b/datalake/src/main/resources/runtime/7.2.2/yarn/medium_duty_ha.json
@@ -38,7 +38,7 @@
           "memory": 16384
         }
       },
-      "nodeCount": 1,
+      "nodeCount": 2,
       "type": "CORE"
     }
   ]

--- a/orchestrator-salt/src/main/resources/salt/pillar/idbroker/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/pillar/idbroker/init.sls
@@ -1,0 +1,2 @@
+idbroker:
+  knoxDataRoot: /var/lib/knox/cloudbreak_resources/

--- a/orchestrator-salt/src/main/resources/salt/pillar/idbroker/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt/pillar/idbroker/settings.sls
@@ -1,0 +1,2 @@
+idbroker:
+  knoxDataRoot: /var/lib/knox/cloudbreak_resources/

--- a/orchestrator-salt/src/main/resources/salt/pillar/top.sls
+++ b/orchestrator-salt/src/main/resources/salt/pillar/top.sls
@@ -74,6 +74,11 @@ base:
     - match: grain
     - ldap.init
 
+  'roles:idbroker':
+    - match: grain
+    - idbroker.init
+    - idbroker.settings
+
   'roles:smartsense_agent_update':
     - match: grain
     - smartsense

--- a/orchestrator-salt/src/main/resources/salt/salt/idbroker/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/idbroker/init.sls
@@ -1,0 +1,38 @@
+{%- from 'idbroker/settings.sls' import idbroker with context %}
+
+{{ idbroker.knox_data_root }}/security/keystores/signkey.pem:
+  file.managed:
+    - contents_pillar: idbroker:signkey
+    - makedirs: True
+    - mode: 644
+
+{{ idbroker.knox_data_root }}/security/keystores/signcert.pem:
+  file.managed:
+    - contents_pillar: idbroker:signcert
+    - makedirs: True
+    - mode: 644
+
+# openssl pkcs12 -export -in cert.pem -inkey key.pem -out signing.p12 -name signing-identity -password pass:admin
+# keytool -importkeystore -deststorepass admin1 -destkeypass admin1 -destkeystore signing.jks -srckeystore signing.p12 -srcstoretype PKCS12 -srcstorepass admin -alias signing-identity
+
+knox-create-sign-pkcs12:
+  cmd.run:
+    - name: cd {{ idbroker.knox_data_root }}/security/keystores/ && openssl pkcs12 -export -in signcert.pem -inkey signkey.pem -out signing.p12 -name signing-identity -password pass:{{ salt['pillar.get']('idbroker:mastersecret') }}
+    - creates: {{ idbroker.knox_data_root }}/security/keystores/signing.p12
+    - output_loglevel: debug
+
+{{ idbroker.knox_data_root }}/security/keystores/signing.p12:
+  file.managed:
+    - mode: 644
+    - replace: False
+
+knox-create-sign-jks:
+  cmd.run:
+    - name: cd {{ idbroker.knox_data_root }}/security/keystores/ && keytool -importkeystore -deststorepass {{ salt['pillar.get']('idbroker:mastersecret') }} -destkeypass {{ salt['pillar.get']('idbroker:mastersecret') }} -destkeystore signing.jks -srckeystore signing.p12 -srcstoretype PKCS12 -srcstorepass {{ salt['pillar.get']('idbroker:mastersecret') }} -alias signing-identity
+    - creates: {{ idbroker.knox_data_root }}/security/keystores/signing.jks
+    - output_loglevel: debug
+
+{{ idbroker.knox_data_root }}/security/keystores/signing.jks:
+  file.managed:
+    - mode: 644
+    - replace: False

--- a/orchestrator-salt/src/main/resources/salt/salt/idbroker/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/idbroker/settings.sls
@@ -1,0 +1,6 @@
+{% set knox_data_root =  salt['pillar.get']('idbroker:knoxDataRoot') %}
+
+{% set idbroker = {} %}
+{% do idbroker.update({
+    'knox_data_root': knox_data_root
+}) %}

--- a/orchestrator-salt/src/main/resources/salt/salt/top.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/top.sls
@@ -56,6 +56,10 @@ base:
     - match: compound
     - gateway.knox
 
+  'G@roles:idbroker':
+    - match: compound
+    - idbroker
+
   'recipes:pre-cloudera-manager-start':
     - match: grain
     - recipes.pre-cloudera-manager-start

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxGatewayConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxGatewayConfigProvider.java
@@ -42,11 +42,17 @@ public class KnoxGatewayConfigProvider extends AbstractRoleConfigProvider {
 
     private static final String GATEWAY_PATH = "gateway_path";
 
-    private static final String SIGNING_KEYSTORE_NAME = "gateway_signing_keystore_name";
+    private static final String GATEWAY_SIGNING_KEYSTORE_NAME = "gateway_signing_keystore_name";
 
-    private static final String SIGNING_KEYSTORE_TYPE = "gateway_signing_keystore_type";
+    private static final String GATEWAY_SIGNING_KEYSTORE_TYPE = "gateway_signing_keystore_type";
 
-    private static final String SIGNING_KEY_ALIAS = "gateway_signing_key_alias";
+    private static final String GATEWAY_SIGNING_KEY_ALIAS = "gateway_signing_key_alias";
+
+    private static final String IDBROKER_SIGNING_KEYSTORE_NAME = "idbroker_gateway_signing_keystore_name";
+
+    private static final String IDBROKER_SIGNING_KEYSTORE_TYPE = "idbroker_gateway_signing_keystore_type";
+
+    private static final String IDBROKER_SIGNING_KEY_ALIAS = "idbroker_gateway_signing_key_alias";
 
     private static final String SIGNING_JKS = "signing.jks";
 
@@ -88,16 +94,20 @@ public class KnoxGatewayConfigProvider extends AbstractRoleConfigProvider {
                 config.add(config(GATEWAY_CM_AUTO_DISCOVERY_ENABLED, "false"));
                 if (gateway != null) {
                     config.add(config(GATEWAY_PATH, gateway.getPath()));
-                    config.add(config(SIGNING_KEYSTORE_NAME, SIGNING_JKS));
-                    config.add(config(SIGNING_KEYSTORE_TYPE, JKS));
-                    config.add(config(SIGNING_KEY_ALIAS, SIGNING_IDENTITY));
+                    config.add(config(GATEWAY_SIGNING_KEYSTORE_NAME, SIGNING_JKS));
+                    config.add(config(GATEWAY_SIGNING_KEYSTORE_TYPE, JKS));
+                    config.add(config(GATEWAY_SIGNING_KEY_ALIAS, SIGNING_IDENTITY));
                     config.add(getGatewayWhitelistConfig(source));
                 }
                 return config;
             case KnoxRoles.IDBROKER:
                 return List.of(
-                    config(IDBROKER_MASTER_SECRET, masterSecret),
-                    config(IDBROKER_GATEWAY_ADMIN_GROUPS, adminGroup)
+                    config(IDBROKER_MASTER_SECRET, source.getIdBroker().getMasterSecret()),
+                    config(IDBROKER_GATEWAY_ADMIN_GROUPS, adminGroup),
+                    config(IDBROKER_SIGNING_KEYSTORE_NAME, SIGNING_JKS),
+                    config(IDBROKER_SIGNING_KEYSTORE_TYPE, JKS),
+                    config(IDBROKER_SIGNING_KEY_ALIAS, SIGNING_IDENTITY)
+
                 );
             default:
                 return List.of();

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/TemplatePreparationObject.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/TemplatePreparationObject.java
@@ -22,6 +22,7 @@ import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.domain.Template;
 import com.sequenceiq.cloudbreak.domain.VolumeTemplate;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.IdBroker;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.gateway.Gateway;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
@@ -82,6 +83,8 @@ public class TemplatePreparationObject {
 
     private final Optional<DatalakeView> datalakeView;
 
+    private final IdBroker idBroker;
+
     private TemplatePreparationObject(Builder builder) {
         cloudPlatform = builder.cloudPlatform;
         rdsConfigs = builder.rdsConfigs.stream().collect(Collectors.toMap(
@@ -106,6 +109,7 @@ public class TemplatePreparationObject {
         stackType = builder.stackType;
         virtualGroupRequest = builder.virtualGroupRequest;
         datalakeView = builder.datalakeView;
+        idBroker = builder.idBroker;
     }
 
     public Stream<HostgroupView> getHostGroupsWithComponent(String component) {
@@ -199,6 +203,10 @@ public class TemplatePreparationObject {
         return datalakeView;
     }
 
+    public IdBroker getIdBroker() {
+        return idBroker;
+    }
+
     public static class Builder {
 
         private CloudPlatform cloudPlatform;
@@ -240,6 +248,8 @@ public class TemplatePreparationObject {
         private VirtualGroupRequest virtualGroupRequest;
 
         private Optional<DatalakeView> datalakeView;
+
+        private IdBroker idBroker;
 
         public static Builder builder() {
             return new Builder();
@@ -365,6 +375,11 @@ public class TemplatePreparationObject {
 
         public Builder withDataLakeView(DatalakeView dataLakeView) {
             this.datalakeView = Optional.ofNullable(dataLakeView);
+            return this;
+        }
+
+        public Builder withIdBroker(IdBroker idBroker) {
+            this.idBroker = idBroker;
             return this;
         }
 


### PR DESCRIPTION
This change add in a new table for IdBroker's certs that will be used to
sync IdBroker nodes together.  It includes it's own master secret and
changes to the Knox IdBroker config provider.  This also includes the
necessary salt changes to have these files set and generated for just
IdBroker nodes.

Testing Done:
Brought 2 IdBroker nodes up with no issue.  If settings are incorrect
they fail to start.  Had member of IdBroker team confirm configuration
looks good and nodes respond correctly.
Brought up 1 IdBroker with no issue.
Brought up 1 IdBroker node, then upgraded to this fix and resumed it
with no issue.

