### PR TITLE
CDPCP-2986. Include internal machine users in user sync

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
@@ -209,28 +209,34 @@ public class GrpcUmsClient {
      * Retrieves list of all machine users from UMS.
      *
      * @param accountId the account Id
+     * @param includeInternal whether to include internal machine users
      * @param requestId an optional request Id
      * @return the user associated with this user CRN
      */
-    public List<MachineUser> listAllMachineUsers(String actorCrn, String accountId, Optional<String> requestId) {
-        return listMachineUsers(actorCrn, accountId, null, requestId);
+    public List<MachineUser> listAllMachineUsers(
+            String actorCrn, String accountId, boolean includeInternal, Optional<String> requestId) {
+        return listMachineUsers(actorCrn, accountId, null, includeInternal, requestId);
     }
 
     /**
      * Retrieves machine user list from UMS.
      *
      * @param accountId       the account Id
-     * @param requestId       an optional request Id
      * @param machineUserCrns machine users to list. if null or empty then all machine users will be listed
+     * @param includeInternal whether to include internal machine users
+     * @param requestId       an optional request Id
      * @return the user associated with this user CRN
      */
-    public List<MachineUser> listMachineUsers(String actorCrn, String accountId, List<String> machineUserCrns, Optional<String> requestId) {
+    public List<MachineUser> listMachineUsers(
+            String actorCrn, String accountId, List<String> machineUserCrns, boolean includeInternal, Optional<String> requestId) {
+
         try (ManagedChannelWrapper channelWrapper = makeWrapper()) {
             UmsClient client = makeClient(channelWrapper.getChannel(), actorCrn);
             LOGGER.debug("Listing machine user information for account {} using request ID {}", accountId, requestId);
-            List<MachineUser> users = client.listMachineUsers(requestId.orElse(UUID.randomUUID().toString()), accountId, machineUserCrns);
-            LOGGER.debug("{} Users found for account {}", users.size(), accountId);
-            return users;
+            List<MachineUser> machineUsers = client.listMachineUsers(requestId.orElse(UUID.randomUUID().toString()),
+                    accountId, machineUserCrns, includeInternal);
+            LOGGER.debug("{} Machine users found for account {}", machineUsers.size(), accountId);
+            return machineUsers;
         }
     }
 

--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/UmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/UmsClient.java
@@ -246,9 +246,12 @@ public class UmsClient {
      * @param requestId                the request ID for the request
      * @param accountId                the account ID
      * @param machineUserNameOrCrnList a list of users to list. If null or empty then all users will be listed
+     * @param includeInternal          whether to include internal machine users
      * @return the list of machine users
      */
-    public List<MachineUser> listMachineUsers(String requestId, String accountId, List<String> machineUserNameOrCrnList) {
+    public List<MachineUser> listMachineUsers(
+            String requestId, String accountId, List<String> machineUserNameOrCrnList, boolean includeInternal) {
+
         checkNotNull(requestId);
         checkNotNull(accountId);
 
@@ -256,6 +259,7 @@ public class UmsClient {
 
         ListMachineUsersRequest.Builder requestBuilder = ListMachineUsersRequest.newBuilder()
                 .setAccountId(accountId)
+                .setIncludeInternal(includeInternal)
                 .setPageSize(umsClientConfig.getListMachineUsersPageSize());
 
         if (machineUserNameOrCrnList != null && !machineUserNameOrCrnList.isEmpty()) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UmsUsersStateProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UmsUsersStateProvider.java
@@ -43,6 +43,8 @@ public class UmsUsersStateProvider {
 
     private static final String ADMIN_FREEIPA_GROUP = "admins";
 
+    private static final boolean INCLUDE_INTERNAL_MACHINE_USERS = true;
+
     @Inject
     private GrpcUmsClient grpcUmsClient;
 
@@ -153,9 +155,11 @@ public class UmsUsersStateProvider {
     private List<MachineUser> getMachineUsers(String actorCrn, String accountId, Optional<String> requestIdOptional,
         boolean fullSync, Set<String> machineUserCrns) {
         if (fullSync) {
-            return grpcUmsClient.listAllMachineUsers(actorCrn, accountId, requestIdOptional);
+            return grpcUmsClient.listAllMachineUsers(actorCrn, accountId,
+                    INCLUDE_INTERNAL_MACHINE_USERS, requestIdOptional);
         } else if (!machineUserCrns.isEmpty()) {
-            return grpcUmsClient.listMachineUsers(actorCrn, accountId, List.copyOf(machineUserCrns), requestIdOptional);
+            return grpcUmsClient.listMachineUsers(actorCrn, accountId, List.copyOf(machineUserCrns),
+                    INCLUDE_INTERNAL_MACHINE_USERS, requestIdOptional);
         } else {
             return List.of();
         }


### PR DESCRIPTION
Internal machine users are needed in user sync. This commit adds
the includeInternal flag to the listMachineUsers calls.

See detailed description in the commit message.