### PR TITLE
CB-8393: FreeIPA should provide more detailed log messages for cluster proxy errors

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/polling/clusterproxy/ServiceEndpointHealthListenerTask.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/polling/clusterproxy/ServiceEndpointHealthListenerTask.java
@@ -44,7 +44,16 @@ public class ServiceEndpointHealthListenerTask implements StatusCheckerTask<Serv
 
     @Override
     public void handleTimeout(ServiceEndpointHealthPollerObject clusterProxyHealthPollerObject) {
-        throw new CloudbreakServiceException("Operation timed out. Failed to check cluster proxy endpoint health.");
+        String clusterIdentifer = clusterProxyHealthPollerObject.getClusterIdentifier();
+        String errorMessage;
+        try {
+            ClusterProxyRegistrationClient client = clusterProxyHealthPollerObject.getClient();
+            errorMessage = client.readConfig(clusterIdentifer).toString();
+        } catch (Exception e) {
+            errorMessage = String.format("Failed to check cluster proxy endpoint health for %s, error: %s", clusterIdentifer, e.getMessage());
+            LOGGER.error(errorMessage);
+        }
+        throw new CloudbreakServiceException("Operation timed out. Failed to check cluster proxy endpoint health. " + errorMessage);
     }
 
     @Override


### PR DESCRIPTION
Add FreeIPA instances' status details to log error messages as well as cloudera management console UI warnings when cluster proxy service errors out during FreeIPA provisioning. Currently, if FreeIPA creation fails, the error message ("Operation timed out. Failed to check cluster proxy endpoint health.") doesn't provide much information about the underlying instances from cloud provider. With this fix, the user will be able to see the actual status of failed instances.

See detailed description in the commit message.