### PR TITLE
CB-8066 create public DNS entry for all nodes within DL and DH clusters

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/publicendpoint/dns/AllHostPublicDnsEntryService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/publicendpoint/dns/AllHostPublicDnsEntryService.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.cloudbreak.service.publicendpoint.dns;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+
+@Service
+public class AllHostPublicDnsEntryService extends BaseDnsEntryService {
+    private static final int GROUP_WITH_SINGLE_NODE = 1;
+
+    @Override
+    protected Map<String, List<String>> getComponentLocation(Stack stack) {
+        InstanceMetaData primaryGatewayInstance = stack.getPrimaryGatewayInstance();
+        Function<InstanceGroup, List<String>> notTerminatedAndPrimaryGatewayInstances = ig -> ig.getNotTerminatedInstanceMetaDataSet()
+                .stream()
+                .filter(im -> !im.getDiscoveryFQDN().equals(primaryGatewayInstance.getDiscoveryFQDN()))
+                .map(InstanceMetaData::getDiscoveryFQDN)
+                .collect(Collectors.toList());
+
+        return stack.getInstanceGroups()
+                .stream()
+                .filter(ig -> !(ig.getNotTerminatedInstanceMetaDataSet().contains(primaryGatewayInstance) && ig.getNodeCount() == GROUP_WITH_SINGLE_NODE))
+                .collect(Collectors.toMap(InstanceGroup::getGroupName, notTerminatedAndPrimaryGatewayInstances));
+    }
+
+    @Override
+    protected String logName() {
+        return "all nodes except primary gateway node";
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/publicendpoint/dns/BaseDnsEntryService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/publicendpoint/dns/BaseDnsEntryService.java
@@ -56,7 +56,7 @@ public abstract class BaseDnsEntryService extends BasePublicEndpointManagementSe
         Map<String, String> result = new HashMap<>();
         if (stack.getCluster() != null && manageCertificateAndDnsInPem()) {
             LOGGER.info("Modifying DNS entries for {} on stack '{}'", logName(), stack.getName());
-            Map<String, String> ipsByFqdn = getBrokerIpsByFqdn(stack);
+            Map<String, String> ipsByFqdn = getCandidateIpsByFqdn(stack);
             if (!CollectionUtils.isEmpty(candidateAddressesByFqdn)) {
                 LOGGER.info("Modifying DNS entries for {} on stack '{}', whitelist of candidates for the update: '{}'", logName(), stack.getName(),
                         String.join(",", candidateAddressesByFqdn.keySet()));
@@ -69,7 +69,7 @@ public abstract class BaseDnsEntryService extends BasePublicEndpointManagementSe
         return result;
     }
 
-    private Map<String, String> getBrokerIpsByFqdn(Stack stack) {
+    private Map<String, String> getCandidateIpsByFqdn(Stack stack) {
         Map<String, List<String>> componentLocation = getComponentLocation(stack);
         final Set<InstanceMetaData> runningInstanceMetaData = stack.getNotDeletedInstanceMetaDataSet();
         final InstanceMetaData primaryGatewayInstanceMetadata = stack.getPrimaryGatewayInstance();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/publicendpoint/dns/KafkaBrokerPublicDnsEntryService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/publicendpoint/dns/KafkaBrokerPublicDnsEntryService.java
@@ -5,13 +5,10 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import org.springframework.stereotype.Service;
-
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaRoles;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.service.blueprint.ComponentLocatorService;
 
-@Service
 public class KafkaBrokerPublicDnsEntryService extends BaseDnsEntryService {
 
     @Inject

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/publicendpoint/dns/NifiHostPublicDnsEntryService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/publicendpoint/dns/NifiHostPublicDnsEntryService.java
@@ -5,13 +5,10 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import org.springframework.stereotype.Service;
-
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.nifi.NifiConfigProvider;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.service.blueprint.ComponentLocatorService;
 
-@Service
 public class NifiHostPublicDnsEntryService extends BaseDnsEntryService {
 
     @Inject

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/publicendpoint/dns/AllHostPublicDnsEntryServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/publicendpoint/dns/AllHostPublicDnsEntryServiceTest.java
@@ -1,0 +1,63 @@
+package com.sequenceiq.cloudbreak.service.publicendpoint.dns;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.TestUtil;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+
+@ExtendWith(MockitoExtension.class)
+class AllHostPublicDnsEntryServiceTest {
+
+    @InjectMocks
+    private AllHostPublicDnsEntryService underTest;
+
+    @Test
+    void getComponentLocationWhenPrimaryGatewayIsTheOnlyNodeWithinGroup() {
+        Stack stack = TestUtil.stack();
+
+        Map<String, List<String>> result = underTest.getComponentLocation(stack);
+
+        InstanceMetaData primaryGatewayInstance = stack.getPrimaryGatewayInstance();
+        Assertions.assertFalse(result.containsKey(primaryGatewayInstance.getInstanceGroupName()), "Result should not contain primary gateway's group name");
+        Assertions.assertFalse(resultContainsInstanceMetadata(primaryGatewayInstance, result), "Result should not contain primary gateway's instance metadata");
+    }
+
+    @Test
+    void getComponentLocationWhenPrimaryGatewayIsNotTheOnlyNodeWithinGatewayHostGroup() {
+        Stack stack = TestUtil.stack();
+        InstanceMetaData primaryGatewayInstance = stack.getPrimaryGatewayInstance();
+        InstanceGroup gatewayInstanceGroup = primaryGatewayInstance.getInstanceGroup();
+        InstanceMetaData otherGatewayInstanceMetadata = new InstanceMetaData();
+        otherGatewayInstanceMetadata.setDiscoveryFQDN("something.new");
+        otherGatewayInstanceMetadata.setInstanceGroup(gatewayInstanceGroup);
+        otherGatewayInstanceMetadata.setInstanceStatus(InstanceStatus.SERVICES_RUNNING);
+        Set<InstanceMetaData> updatedIM = gatewayInstanceGroup.getNotTerminatedInstanceMetaDataSet();
+        updatedIM.add(otherGatewayInstanceMetadata);
+        gatewayInstanceGroup.replaceInstanceMetadata(updatedIM);
+
+
+        Map<String, List<String>> result = underTest.getComponentLocation(stack);
+
+        Assertions.assertTrue(result.containsKey(primaryGatewayInstance.getInstanceGroupName()), "Result should contain primary gateway's group name");
+        Assertions.assertTrue(resultContainsInstanceMetadata(otherGatewayInstanceMetadata, result), "Result should contain other gateway's instance metadata");
+        Assertions.assertFalse(resultContainsInstanceMetadata(primaryGatewayInstance, result), "Result should not contain primary gateway's instance metadata");
+    }
+
+    private boolean resultContainsInstanceMetadata(InstanceMetaData primaryGatewayInstance, Map<String, List<String>> result) {
+        return result
+                .values()
+                .stream()
+                .anyMatch(ims -> ims.stream().anyMatch(im -> im.equals(primaryGatewayInstance.getDiscoveryFQDN())));
+    }
+}


### PR DESCRIPTION
 **Changes**
 - New service that creatse public DNS entry for all nodes within DL and DH clusters
 - Parking the Nifi and Kafka borker related DNS entry services due to the new logic, but leaving them reusable when the global public DNS entry feature will be configurable on hostgroup/role level