### PR TITLE
CB-8698 In this commit, I change to 'FETCH' the findAllActive's query…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/cluster/ClusterTemplateViewRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/cluster/ClusterTemplateViewRepository.java
@@ -16,7 +16,9 @@ import com.sequenceiq.cloudbreak.workspace.repository.workspace.WorkspaceResourc
 @Transactional(TxType.REQUIRED)
 public interface ClusterTemplateViewRepository extends WorkspaceResourceRepository<ClusterTemplateView, Long> {
 
-    @Query("SELECT b FROM ClusterTemplateView b WHERE b.workspace.id= :workspaceId AND b.status <> 'DEFAULT_DELETED'")
+    @Query("SELECT b FROM ClusterTemplateView b " +
+            "LEFT JOIN FETCH b.stackTemplate " +
+            "WHERE b.workspace.id= :workspaceId AND b.status <> 'DEFAULT_DELETED'")
     Set<ClusterTemplateView> findAllActive(@Param("workspaceId") Long workspaceId);
 
     @Override

--- a/integration-test/src/main/resources/testsuites/v4/mock/cluster-template.yaml
+++ b/integration-test/src/main/resources/testsuites/v4/mock/cluster-template.yaml
@@ -1,0 +1,5 @@
+name: "mock-cluster-template-tests"
+tests:
+  - name: "ClusterTemplateTest mock testcases"
+    classes:
+      - com.sequenceiq.it.cloudbreak.testcase.mock.ClusterTemplateTest


### PR DESCRIPTION
…. Reason:

The original hibernate OneToOne fetching execute two separated SQL to fetch the object and the reference. If the SQL is too slow, then another thread can delete the reference object. In this case, the second SQL will throw a not found exception.
The integration tests are running parallel and all the cluster template tests running at the same time, therefore, we have a big chance to run the deletion while the other test selects the templates from the DB.
My suspected timeline
* execute the select of cluster templates
* the other test (thread in CB) delete the USER_DEFINED template
* try to fetch the referenced stack, but this deleted by the other thread

See detailed description in the commit message.