### PR TITLE
CB-8735 set CDP_ENV to PUBLIC_CLOUD when CM server starts rather than…

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerConfigService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerConfigService.java
@@ -16,7 +16,6 @@ import com.cloudera.api.swagger.ServicesResourceApi;
 import com.cloudera.api.swagger.client.ApiClient;
 import com.cloudera.api.swagger.client.ApiException;
 import com.cloudera.api.swagger.model.ApiConfig;
-import com.cloudera.api.swagger.model.ApiConfigList;
 import com.cloudera.api.swagger.model.ApiService;
 import com.cloudera.api.swagger.model.ApiServiceConfig;
 import com.cloudera.api.swagger.model.ApiServiceList;
@@ -35,29 +34,6 @@ public class ClouderaManagerConfigService {
 
     @Inject
     private ClouderaManagerApiFactory clouderaManagerApiFactory;
-
-    public void setCdpEnvironmentIfCmVersionAtLeast(Versioned versionAtLeast, ApiClient apiClient) {
-
-        try {
-            ClouderaManagerResourceApi resourceApiInstance = clouderaManagerApiFactory.getClouderaManagerResourceApi(apiClient);
-            if (isVersionAtLeast(versionAtLeast, resourceApiInstance)) {
-                setCdpEnvironment(resourceApiInstance);
-            }
-        } catch (ApiException e) {
-            LOGGER.debug("Failed to set cdp_environment on CM", e);
-            throw new ClouderaManagerOperationFailedException("Failed to set cdp_environment to PUBLIC_CLOUD on CM", e);
-        }
-    }
-
-    private void setCdpEnvironment(ClouderaManagerResourceApi resourceApiInstance) throws ApiException {
-        ApiConfigList apiConfigListResponse = resourceApiInstance.updateConfig("",
-                new ApiConfigList().addItemsItem(
-                        new ApiConfig()
-                                .name("cdp_environment")
-                                .value("PUBLIC_CLOUD")
-                ));
-        LOGGER.debug("Response of setting cdp_environment: {}", apiConfigListResponse);
-    }
 
     private boolean isVersionAtLeast(Versioned requiredVersion, ClouderaManagerResourceApi resourceApiInstance) throws ApiException {
         ApiVersionInfo versionInfo = resourceApiInstance.getVersion();
@@ -93,12 +69,12 @@ public class ClouderaManagerConfigService {
     }
 
     private void modifyKnoxAutorestart(ApiClient client, String clusterName, boolean autorestart) {
-            ServicesResourceApi servicesResourceApi = clouderaManagerApiFactory.getServicesResourceApi(client);
-            LOGGER.info("Try to modify Knox auto restart to {}", autorestart);
-            getKnoxServiceName(clusterName, servicesResourceApi)
-                    .ifPresentOrElse(
-                            modifyKnoxAutorestart(clusterName, servicesResourceApi, autorestart),
-                            () -> LOGGER.info("KNOX service name is missing, skip modifying the autorestart property."));
+        ServicesResourceApi servicesResourceApi = clouderaManagerApiFactory.getServicesResourceApi(client);
+        LOGGER.info("Try to modify Knox auto restart to {}", autorestart);
+        getKnoxServiceName(clusterName, servicesResourceApi)
+                .ifPresentOrElse(
+                        modifyKnoxAutorestart(clusterName, servicesResourceApi, autorestart),
+                        () -> LOGGER.info("KNOX service name is missing, skip modifying the autorestart property."));
     }
 
     private Consumer<String> modifyKnoxAutorestart(String clusterName, ServicesResourceApi servicesResourceApi, boolean autorestart) {

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerSetupService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerSetupService.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.cloudbreak.cm;
 
-import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_0_2;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_1_0;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
 import static com.sequenceiq.cloudbreak.polling.PollingResult.isExited;
@@ -104,9 +103,6 @@ public class ClouderaManagerSetupService implements ClusterSetupService {
 
     @Inject
     private ClouderaManagerKerberosService kerberosService;
-
-    @Inject
-    private ClouderaManagerConfigService clouderaManagerConfigService;
 
     @Inject
     private ClouderaManagerMgmtLaunchService clouderaManagerMgmtLaunchService;
@@ -242,7 +238,6 @@ public class ClouderaManagerSetupService implements ClusterSetupService {
             if (prewarmed) {
                 refreshParcelRepos(clouderaManagerResourceApi);
             }
-            clouderaManagerConfigService.setCdpEnvironmentIfCmVersionAtLeast(CLOUDERAMANAGER_VERSION_7_0_2, apiClient);
             installCluster(cluster, apiClusterTemplate, clouderaManagerResourceApi, prewarmed);
             clouderaManagerMgmtLaunchService.startManagementServices(stack, apiClient);
             clouderaManagerYarnSetupService.suppressWarnings(stack, apiClient);

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerConfigServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerConfigServiceTest.java
@@ -1,9 +1,6 @@
 package com.sequenceiq.cloudbreak.cm;
 
-import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_0_2;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_1_0;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
@@ -13,8 +10,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -28,7 +23,6 @@ import com.cloudera.api.swagger.ServicesResourceApi;
 import com.cloudera.api.swagger.client.ApiClient;
 import com.cloudera.api.swagger.client.ApiException;
 import com.cloudera.api.swagger.model.ApiConfig;
-import com.cloudera.api.swagger.model.ApiConfigList;
 import com.cloudera.api.swagger.model.ApiService;
 import com.cloudera.api.swagger.model.ApiServiceConfig;
 import com.cloudera.api.swagger.model.ApiServiceList;
@@ -55,37 +49,6 @@ public class ClouderaManagerConfigServiceTest {
     public void setup() {
 
         MockitoAnnotations.initMocks(this);
-    }
-
-    @Test
-    public void testSetCdpEnvironmentWhenCmVersion702() throws ApiException {
-        ClouderaManagerResourceApi clouderaManagerResourceApi = mock(ClouderaManagerResourceApi.class);
-        when(clouderaManagerApiFactory.getClouderaManagerResourceApi(any())).thenReturn(clouderaManagerResourceApi);
-        ApiVersionInfo version702 = new ApiVersionInfo().version(VERSION_7_0_2);
-        when(clouderaManagerResourceApi.getVersion()).thenReturn(version702);
-
-        underTest.setCdpEnvironmentIfCmVersionAtLeast(CLOUDERAMANAGER_VERSION_7_0_2, new ApiClient());
-
-        ArgumentCaptor<ApiConfigList> apiConfigListCaptor = ArgumentCaptor.forClass(ApiConfigList.class);
-        verify(clouderaManagerResourceApi).updateConfig(eq(""), apiConfigListCaptor.capture());
-        List<ApiConfigList> capturedApiConfigList = apiConfigListCaptor.getAllValues();
-        assertThat(capturedApiConfigList, hasSize(1));
-        assertThat(capturedApiConfigList.get(0).getItems(), hasSize(1));
-        ApiConfig apiConfig = capturedApiConfigList.get(0).getItems().get(0);
-        assertEquals(apiConfig.getName(), "cdp_environment");
-        assertEquals(apiConfig.getValue(), "PUBLIC_CLOUD");
-    }
-
-    @Test
-    public void testSetCdpEnvironmentWhenCmVersion701() throws ApiException {
-        ClouderaManagerResourceApi clouderaManagerResourceApi = mock(ClouderaManagerResourceApi.class);
-        when(clouderaManagerApiFactory.getClouderaManagerResourceApi(any())).thenReturn(clouderaManagerResourceApi);
-        ApiVersionInfo version701 = new ApiVersionInfo().version(VERSION_7_0_1);
-        when(clouderaManagerResourceApi.getVersion()).thenReturn(version701);
-
-        underTest.setCdpEnvironmentIfCmVersionAtLeast(CLOUDERAMANAGER_VERSION_7_0_2, new ApiClient());
-
-        verify(clouderaManagerResourceApi, never()).updateConfig(any(), any());
     }
 
     @Test

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.core.bootstrap.service.host;
 
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_0_2;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_0;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_1;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
@@ -501,12 +502,13 @@ public class ClusterHostServiceRunner {
     }
 
     public void decoratePillarWithClouderaManagerSettings(Map<String, SaltPillarProperties> servicePillar, ClouderaManagerRepo clouderaManagerRepo) {
-        boolean deterministicUidGid = isVersionNewerOrEqualThanLimited(clouderaManagerRepo.getVersion(), CLOUDERAMANAGER_VERSION_7_2_1);
+        String cmVersion = clouderaManagerRepo.getVersion();
         servicePillar.put("cloudera-manager-settings", new SaltPillarProperties("/cloudera-manager/settings.sls",
                 singletonMap("cloudera-manager", singletonMap("settings", Map.of(
                         "heartbeat_interval", cmHeartbeatInterval,
                         "missed_heartbeat_interval", cmMissedHeartbeatInterval,
-                        "deterministic_uid_gid", deterministicUidGid)))));
+                        "set_cdp_env", isVersionNewerOrEqualThanLimited(cmVersion, CLOUDERAMANAGER_VERSION_7_0_2),
+                        "deterministic_uid_gid", isVersionNewerOrEqualThanLimited(cmVersion, CLOUDERAMANAGER_VERSION_7_2_1))))));
     }
 
     private void decoratePillarWithTags(Stack stack, Map<String, SaltPillarProperties> servicePillarConfig) {

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/init.sls
@@ -30,6 +30,18 @@ setup_missed_cm_heartbeat:
     - text: setsettings MISSED_HB_BAD {{ cloudera_manager.settings.missed_heartbeat_interval }}
     - unless: grep "MISSED_HB_BAD" /etc/cloudera-scm-server/cm.settings
 
+add_settings_file_to_cfm_server_args:
+  file.replace:
+    - name: /etc/default/cloudera-scm-server
+    - pattern: "CMF_SERVER_ARGS=.*"
+{% if salt['pillar.get']('cloudera-manager:settings:set_cdp_env') == True %}
+    - repl: CMF_SERVER_ARGS="-i /etc/cloudera-scm-server/cm.settings -env PUBLIC_CLOUD"
+    - unless: grep "CMF_SERVER_ARGS=\"-i /etc/cloudera-scm-server/cm.settings -env PUBLIC_CLOUD\"" /etc/default/cloudera-scm-server
+{% else %}
+    - repl: CMF_SERVER_ARGS="-i /etc/cloudera-scm-server/cm.settings"
+    - unless: grep "CMF_SERVER_ARGS=\"-i /etc/cloudera-scm-server/cm.settings\"" /etc/default/cloudera-scm-server
+{% endif %}
+
 {% if salt['pillar.get']('ldap', None) != None and salt['pillar.get']('ldap:local', None) == None %}
 
 add_ldap_settings_to_cm:
@@ -41,13 +53,6 @@ add_ldap_settings_to_cm:
     - context:
         ldap: {{ cloudera_manager.ldap }}
     - unless: grep "AUTH_BACKEND_ORDER" /etc/cloudera-scm-server/cm.settings
-
-cloudera_manager_setup_ldap:
-  file.replace:
-    - name: /etc/default/cloudera-scm-server
-    - pattern: "CMF_SERVER_ARGS=.*"
-    - repl: CMF_SERVER_ARGS="-i /etc/cloudera-scm-server/cm.settings"
-    - unless: grep "CMF_SERVER_ARGS=\"-i /etc/cloudera-scm-server/cm.settings\"" /etc/default/cloudera-scm-server
 
 {% endif %}
 

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/cm.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/cm.sls
@@ -11,11 +11,3 @@ add_knox_settings_to_cm:
     - unless: grep "PROXYUSER_KNOX_GROUPS" /etc/cloudera-scm-server/cm.settings
     - context:
         knox_address: {{ salt['pillar.get']('gateway:address') }}
-
-cloudera_manager_setup_knox:
-  file.replace:
-    - name: /etc/default/cloudera-scm-server
-    - pattern: "CMF_SERVER_ARGS=.*"
-    - repl: CMF_SERVER_ARGS="-i /etc/cloudera-scm-server/cm.settings"
-    - unless: grep "CMF_SERVER_ARGS=\"-i /etc/cloudera-scm-server/cm.settings\"" /etc/default/cloudera-scm-server
-


### PR DESCRIPTION
… with API

Previously, we set this env var with API call after them CM server has started.
However, CM team would like to rely on this env var during CM startup so they can
initialise the application accordingly. Making this change in the cm.settings
file is not viable as the different initialisation processes do not use this file
and it would be too late for the CM server to use this file hence the -env server
argumentum.