### PR TITLE
CDPCP-2987. Make sure 'metering_prewarmed_v2' role exists for setting…

### DIFF
--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
@@ -141,7 +141,7 @@
 {% endif %}
 
 {% if dbus_metering_enabled %}
-  {% if salt['pillar.get']('fluent:dbusMeteringAppName') and salt['pillar.get']('fluent:dbusMeteringStreamName') %}
+  {% if "metering_prewarmed_v2" in grains.get('roles', []) and salt['pillar.get']('fluent:dbusMeteringAppName') and salt['pillar.get']('fluent:dbusMeteringStreamName') %}
     {% set dbus_metering_app_headers = 'app:' + cluster_type + ',@metering-app:' + salt['pillar.get']('fluent:dbusMeteringAppName') %}
     {% set dbus_metering_stream_name = salt['pillar.get']('fluent:dbusMeteringStreamName') %}
   {% else %}


### PR DESCRIPTION
… stream and app name for fluentd

See detailed description in the commit message.

adding an extra check to make sure we wont apply any configs on older clusters