### PR TITLE
CB-8744 enable Azure Single Resource Group feature locally (UMS mock)

### DIFF
--- a/mock-thunderhead/src/main/resources/application.yml
+++ b/mock-thunderhead/src/main/resources/application.yml
@@ -21,8 +21,8 @@ auth:
     sshpublickey.file: key.pub
     raz.enable: true
     freeipadlebsencryption.enable: true
-    azure.single.resourcegroup.enable: false
-    azure.single.resourcegroup.dedicated.storage.account.enable: false
+    azure.single.resourcegroup.enable: true
+    azure.single.resourcegroup.dedicated.storage.account.enable: true
     fastebsencryption.enable: true
     cloudidentitymappinng.enable: true
     mediumdutysdx.enable: true


### PR DESCRIPTION
Azure Single Resource Group feature is behind an Entitlement and up until
now it was disabled. In order to enable it we had to extend the feature with
an additional 'resourceGroupUsage' type to use dedicated Storage Accounts
for the images. Without this feature each and every person would copy our images
into their personal Storage Account that would generate a lot of cost for Cloudera.
Given the above we're granting this additional Entitlement locally so everyone
would use the same SA for the images as it would be a multi RG setup. This way
all of their resources will go to the selected RG except the images which will
be stored in a common SA generated per Azure subscription.

See detailed description in the commit message.