### PR TITLE
CB-8754 Introduce the createDefaultImageCatalog setup step to the AwsYcloudHybridCloudTest

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXEncryptedVolumeTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXEncryptedVolumeTest.java
@@ -36,9 +36,10 @@ public class DistroXEncryptedVolumeTest extends AbstractE2ETest {
     protected void setupTest(TestContext testContext) {
         testContext.getCloudProvider().getCloudFunctionality().cloudStorageInitialize();
         createDefaultUser(testContext);
+        initializeDefaultBlueprints(testContext);
+        createDefaultImageCatalog(testContext);
         createDefaultCredential(testContext);
         createEnvironmentWithNetworkAndFreeIpa(testContext);
-        initializeDefaultBlueprints(testContext);
         createDatalake(testContext);
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/hybrid/AwsYcloudHybridCloudTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/hybrid/AwsYcloudHybridCloudTest.java
@@ -107,6 +107,7 @@ public class AwsYcloudHybridCloudTest extends AbstractE2ETest {
         checkCloudPlatform(CloudPlatform.AWS);
 
         createDefaultUser(testContext);
+        initializeDefaultBlueprints(testContext);
         createDefaultCredential(testContext);
         //Use a pre-prepared security group what allows inbound connections from ycloud
         testContext
@@ -116,6 +117,7 @@ public class AwsYcloudHybridCloudTest extends AbstractE2ETest {
                 .given(EnvironmentTestDto.class)
                 .withSecurityAccess();
         createEnvironmentWithNetworkAndFreeIpa(testContext);
+        createDefaultImageCatalog(testContext);
 
         testContext
                 .given("childtelemetry", TelemetryTestDto.class)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/PreconditionSdxE2ETest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/PreconditionSdxE2ETest.java
@@ -52,9 +52,10 @@ public class PreconditionSdxE2ETest extends AbstractE2ETest {
     protected void setupTest(TestContext testContext) {
         testContext.getCloudProvider().getCloudFunctionality().cloudStorageInitialize();
         createDefaultUser(testContext);
+        initializeDefaultBlueprints(testContext);
+        createDefaultImageCatalog(testContext);
         createDefaultCredential(testContext);
         createEnvironmentWithNetworkAndFreeIpa(testContext);
-        initializeDefaultBlueprints(testContext);
     }
 
     protected SdxTestClient sdxTestClient() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/spot/AwsDistroXSpotInstanceTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/spot/AwsDistroXSpotInstanceTest.java
@@ -30,9 +30,10 @@ public class AwsDistroXSpotInstanceTest extends AbstractE2ETest {
     protected void setupTest(TestContext testContext) {
         checkCloudPlatform(CloudPlatform.AWS);
         createDefaultUser(testContext);
+        initializeDefaultBlueprints(testContext);
+        createDefaultImageCatalog(testContext);
         createDefaultCredential(testContext);
         createEnvironmentWithNetworkAndFreeIpa(testContext);
-        initializeDefaultBlueprints(testContext);
         createDatalake(testContext);
     }
 


### PR DESCRIPTION
The `createDefaultImageCatalog(testContext);` required for the `AwsYcloudHybridCloudTest` setup. However the setup method does not contains this.

So the missing `createDefaultImageCatalog(testContext)` step has been introduced to the `AwsYcloudHybridCloudTest` setup.