### PR TITLE
CDPCP-2998. Support deleted user as part of user sync

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/doc/UserModelDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/doc/UserModelDescriptions.java
@@ -6,6 +6,8 @@ public class UserModelDescriptions {
     public static final String USERSYNC_ENVIRONMENT_CRNS = "Optional environment crns to sync";
     public static final String USERSYNC_USER_CRNS = "Optional user crns to sync";
     public static final String USERSYNC_MACHINEUSER_CRNS = "Optional machine user crns to sync";
+    public static final String DELETED_WORKLOAD_USERS = "Optional workload user name to be deleted. Currently only 1 deleted user is supported. When this" +
+            " is included, there should also be exactly 1 crn in the machineUsers or users set that corresponds to the deleted workload user.";
     public static final String USERSYNC_ID = "User synchronization operation id";
     public static final String USERSYNC_STATUS = "User synchronization operation status";
     public static final String USERSYNC_STARTTIME = "User synchronization operation start time";

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SynchronizeAllUsersRequest.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SynchronizeAllUsersRequest.java
@@ -18,6 +18,9 @@ public class SynchronizeAllUsersRequest extends SynchronizeOperationRequestBase 
     @ApiModelProperty(value = UserModelDescriptions.USERSYNC_USER_CRNS)
     private Set<String> users = new HashSet<>();
 
+    @ApiModelProperty(value = UserModelDescriptions.DELETED_WORKLOAD_USERS)
+    private Set<String> deletedWorkloadUsers =  new HashSet<>();
+
     @ApiModelProperty(value = UserModelDescriptions.USERSYNC_ACCOUNT_ID)
     private String accountId;
 
@@ -53,11 +56,20 @@ public class SynchronizeAllUsersRequest extends SynchronizeOperationRequestBase 
         this.accountId = accountId;
     }
 
+    public Set<String> getDeletedWorkloadUsers() {
+        return deletedWorkloadUsers;
+    }
+
+    public void setDeletedWorkloadUsers(Set<String> deletedWorkloadUsers) {
+        this.deletedWorkloadUsers = deletedWorkloadUsers;
+    }
+
     @Override
     public String toString() {
         return "SynchronizeAllUsersRequest{"
                 + "machineUsers=" + machineUsers
                 + ", users=" + users
+                + ", deletedWorkloadUsers=" + deletedWorkloadUsers
                 + ", accountId=" + accountId
                 + ", " + super.fieldsToString()
                 + '}';

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncRequestFilter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncRequestFilter.java
@@ -1,0 +1,61 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+public class UserSyncRequestFilter {
+
+    private final ImmutableSet<String> userCrnFilter;
+
+    private final ImmutableSet<String> machineUserCrnFilter;
+
+    private final Optional<String> deletedWorkloadUser;
+
+    public UserSyncRequestFilter(Set<String> userCrnFilter, Set<String> machineUserCrnFilter, Optional<String> deletedWorkloadUser) {
+        this.userCrnFilter = ImmutableSet.copyOf(userCrnFilter);
+        this.machineUserCrnFilter = ImmutableSet.copyOf(machineUserCrnFilter);
+        this.deletedWorkloadUser = deletedWorkloadUser;
+    }
+
+    public static UserSyncRequestFilter newFullSync() {
+        return new UserSyncRequestFilter(Set.of(), Set.of(), Optional.empty());
+    }
+
+    public boolean isFullSync() {
+        return userCrnFilter.isEmpty() && machineUserCrnFilter.isEmpty();
+    }
+
+    public ImmutableSet<String> getUserCrnFilter() {
+        return userCrnFilter;
+    }
+
+    public ImmutableSet<String> getMachineUserCrnFilter() {
+        return machineUserCrnFilter;
+    }
+
+    public Optional<String> getDeletedWorkloadUser() {
+        return deletedWorkloadUser;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserSyncRequestFilter that = (UserSyncRequestFilter) o;
+        return userCrnFilter.equals(that.userCrnFilter) &&
+                machineUserCrnFilter.equals(that.machineUserCrnFilter) &&
+                deletedWorkloadUser.equals(that.deletedWorkloadUser);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userCrnFilter, machineUserCrnFilter, deletedWorkloadUser);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncRequestValidator.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncRequestValidator.java
@@ -1,0 +1,66 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.cloudbreak.auth.altus.CrnParseException;
+import com.sequenceiq.freeipa.controller.exception.BadRequestException;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+@Component
+public class UserSyncRequestValidator {
+
+    public void validateParameters(String accountId, String actorCrn, Set<String> environmentCrnFilter, UserSyncRequestFilter userSyncRequestFilter) {
+        requireNonNull(accountId, "accountId must not be null");
+        requireNonNull(actorCrn, "actorCrn must not be null");
+        requireNonNull(environmentCrnFilter, "environmentCrnFilter must not be null");
+        requireNonNull(userSyncRequestFilter);
+        ImmutableSet<String> userCrnFilter = userSyncRequestFilter.getUserCrnFilter();
+        ImmutableSet<String> machineUserCrnFilter = userSyncRequestFilter.getMachineUserCrnFilter();
+        Optional<String> deletedWorkoadUser = userSyncRequestFilter.getDeletedWorkloadUser();
+        requireNonNull(userCrnFilter, "userCrnFilter must not be null");
+        requireNonNull(machineUserCrnFilter, "machineUserCrnFilter must not be null");
+        requireNonNull(deletedWorkoadUser, "deletedWorkoadUser must not be null");
+        validateCrnFilter(environmentCrnFilter, Crn.ResourceType.ENVIRONMENT);
+        validateCrnFilter(userCrnFilter, Crn.ResourceType.USER);
+        validateCrnFilter(machineUserCrnFilter, Crn.ResourceType.MACHINE_USER);
+        validateSameAccount(accountId, Iterables.concat(environmentCrnFilter, userCrnFilter, machineUserCrnFilter));
+        validateDeletedWorkloadUser(deletedWorkoadUser, userCrnFilter, machineUserCrnFilter);
+    }
+
+    private void validateDeletedWorkloadUser(Optional<String> deletedWorkloadUser, Set<String> userCrnFilter, Set<String> machineUserCrnFilter) {
+        if (deletedWorkloadUser.isPresent() && userCrnFilter.size() + machineUserCrnFilter.size() != 1) {
+            throw new BadRequestException("Exactly 1 user or machine user needs to be specified when deletedWorkloadUser is present");
+        }
+    }
+
+    private void validateSameAccount(String accountId, Iterable<String> crns) {
+        crns.forEach(crnString -> {
+            Crn crn = Crn.safeFromString(crnString);
+            if (!accountId.equals(crn.getAccountId())) {
+                throw new BadRequestException(String.format("Crn %s is not in the expected account %s", crnString, accountId));
+            }
+        });
+    }
+
+    @VisibleForTesting
+    void validateCrnFilter(Set<String> crnFilter, Crn.ResourceType resourceType) {
+        crnFilter.forEach(crnString -> {
+            try {
+                Crn crn = Crn.safeFromString(crnString);
+                if (crn.getResourceType() != resourceType) {
+                    throw new BadRequestException(String.format("Crn %s is not of expected type %s", crnString, resourceType));
+                }
+            } catch (CrnParseException e) {
+                throw new BadRequestException(e.getMessage(), e);
+            }
+        });
+    }
+
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UsersStateDifference.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UsersStateDifference.java
@@ -89,6 +89,18 @@ public class UsersStateDifference {
                 calculateGroupMembershipToRemove(umsState, ipaState));
     }
 
+    public static UsersStateDifference forDeletedUser(String deletedUser, Collection<String> groupsToRemove) {
+        Multimap<String, String> groupMembershipsToRemove = HashMultimap.create();
+        groupMembershipsToRemove.putAll(deletedUser, groupsToRemove);
+        return new UsersStateDifference(
+                ImmutableSet.of(),
+                ImmutableSet.of(),
+                ImmutableSet.of(),
+                ImmutableSet.of(deletedUser),
+                ImmutableMultimap.of(),
+                ImmutableMultimap.copyOf(groupMembershipsToRemove));
+    }
+
     public static ImmutableSet<FmsUser> calculateUsersToAdd(UmsUsersState umsState, UsersState ipaState) {
         ImmutableSet<FmsUser> usersToAdd = ImmutableSet.copyOf(Sets.difference(umsState.getUsersState().getUsers(), ipaState.getUsers())
                 .stream()

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/controller/UserV1ControllerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/controller/UserV1ControllerTest.java
@@ -10,9 +10,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
+import com.sequenceiq.freeipa.controller.exception.BadRequestException;
+import com.sequenceiq.freeipa.service.freeipa.user.UserSyncRequestFilter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -63,7 +66,7 @@ public class UserV1ControllerTest {
     @Test
     void synchronizeUser() {
         Operation operation = mock(Operation.class);
-        when(userSyncService.synchronizeUsersWithCustomPermissionCheck(any(), any(), any(), any(), any(), any())).thenReturn(operation);
+        when(userSyncService.synchronizeUsersWithCustomPermissionCheck(any(), any(), any(), any(), any())).thenReturn(operation);
         SyncOperationStatus status = mock(SyncOperationStatus.class);
         when(operationToSyncOperationStatus.convert(operation)).thenReturn(status);
 
@@ -71,14 +74,15 @@ public class UserV1ControllerTest {
 
         assertEquals(status, ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.synchronizeUser(request)));
 
+        UserSyncRequestFilter userSyncFilter = new UserSyncRequestFilter(Set.of(USER_CRN), Set.of(), Optional.empty());
         verify(userSyncService, times(1)).synchronizeUsersWithCustomPermissionCheck(ACCOUNT_ID, USER_CRN, Set.of(),
-                Set.of(USER_CRN), Set.of(), AuthorizationResourceAction.DESCRIBE_ENVIRONMENT);
+                userSyncFilter, AuthorizationResourceAction.DESCRIBE_ENVIRONMENT);
     }
 
     @Test
     void synchronizeUserMachineUser() {
         Operation operation = mock(Operation.class);
-        when(userSyncService.synchronizeUsersWithCustomPermissionCheck(any(), any(), any(), any(), any(), any())).thenReturn(operation);
+        when(userSyncService.synchronizeUsersWithCustomPermissionCheck(any(), any(), any(), any(), any())).thenReturn(operation);
         SyncOperationStatus status = mock(SyncOperationStatus.class);
         when(operationToSyncOperationStatus.convert(operation)).thenReturn(status);
 
@@ -86,14 +90,16 @@ public class UserV1ControllerTest {
 
         assertEquals(status, ThreadBasedUserCrnProvider.doAs(MACHINE_USER_CRN, () -> underTest.synchronizeUser(request)));
 
+        UserSyncRequestFilter userSyncFilter = new UserSyncRequestFilter(Set.of(), Set.of(MACHINE_USER_CRN), Optional.empty());
         verify(userSyncService, times(1)).synchronizeUsersWithCustomPermissionCheck(ACCOUNT_ID, MACHINE_USER_CRN,
-                Set.of(), Set.of(), Set.of(MACHINE_USER_CRN), AuthorizationResourceAction.DESCRIBE_ENVIRONMENT);
+                Set.of(), userSyncFilter, AuthorizationResourceAction.DESCRIBE_ENVIRONMENT);
     }
 
     @Test
     void synchronizeUserRejected() {
         Operation operation = mock(Operation.class);
-        when(userSyncService.synchronizeUsersWithCustomPermissionCheck(ACCOUNT_ID, USER_CRN, Set.of(), Set.of(USER_CRN), Set.of(),
+        UserSyncRequestFilter userSyncFilter = new UserSyncRequestFilter(Set.of(USER_CRN), Set.of(), Optional.empty());
+        when(userSyncService.synchronizeUsersWithCustomPermissionCheck(ACCOUNT_ID, USER_CRN, Set.of(), userSyncFilter,
                 AuthorizationResourceAction.DESCRIBE_ENVIRONMENT)).thenReturn(operation);
         SyncOperationStatus status = mock(SyncOperationStatus.class);
         when(status.getStatus()).thenReturn(SynchronizationStatus.REJECTED);
@@ -115,14 +121,47 @@ public class UserV1ControllerTest {
         request.setMachineUsers(machineUsers);
 
         Operation operation = mock(Operation.class);
-        when(userSyncService.synchronizeUsersWithCustomPermissionCheck(any(), any(), any(), any(), any(), any())).thenReturn(operation);
+        when(userSyncService.synchronizeUsersWithCustomPermissionCheck(any(), any(), any(), any(), any())).thenReturn(operation);
         SyncOperationStatus status = mock(SyncOperationStatus.class);
         when(operationToSyncOperationStatus.convert(operation)).thenReturn(status);
 
         assertEquals(status, ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.synchronizeAllUsers(request)));
 
+        UserSyncRequestFilter userSyncFilter = new UserSyncRequestFilter(users, machineUsers, Optional.empty());
         verify(userSyncService, times(1)).synchronizeUsersWithCustomPermissionCheck(ACCOUNT_ID, USER_CRN, environments,
-                users, machineUsers, AuthorizationResourceAction.DESCRIBE_ENVIRONMENT);
+                userSyncFilter, AuthorizationResourceAction.DESCRIBE_ENVIRONMENT);
+    }
+
+    @Test
+    void synchronizeAllUsersDeleteWorkloadUser() {
+        Set<String> users = Set.of(USER_CRN);
+        String deletedWorkloadUser = "workload-user";
+        SynchronizeAllUsersRequest request = new SynchronizeAllUsersRequest();
+        request.setEnvironments(Set.of());
+        request.setUsers(users);
+        request.setDeletedWorkloadUsers(Set.of(deletedWorkloadUser));
+
+        Operation operation = mock(Operation.class);
+        when(userSyncService.synchronizeUsersWithCustomPermissionCheck(any(), any(), any(), any(), any())).thenReturn(operation);
+        SyncOperationStatus status = mock(SyncOperationStatus.class);
+        when(operationToSyncOperationStatus.convert(operation)).thenReturn(status);
+
+        assertEquals(status, ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.synchronizeAllUsers(request)));
+
+        UserSyncRequestFilter userSyncFilter = new UserSyncRequestFilter(users, Set.of(), Optional.of(deletedWorkloadUser));
+        verify(userSyncService, times(1)).synchronizeUsersWithCustomPermissionCheck(ACCOUNT_ID, USER_CRN, Set.of(),
+                userSyncFilter, AuthorizationResourceAction.DESCRIBE_ENVIRONMENT);
+    }
+
+    @Test
+    void synchronizeAllUsersMultipleDeleteWorkloadUsers() {
+        Set<String> users = Set.of(USER_CRN);
+        String deletedWorkloadUser = "workload-user";
+        SynchronizeAllUsersRequest request = new SynchronizeAllUsersRequest();
+        request.setEnvironments(Set.of());
+        request.setUsers(users);
+        request.setDeletedWorkloadUsers(Set.of("workload-user-01",  "workload-user-02"));
+        assertThrows(BadRequestException.class, () -> ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.synchronizeAllUsers(request)));
     }
 
     @Test
@@ -137,14 +176,15 @@ public class UserV1ControllerTest {
         request.setAccountId(ACCOUNT_ID);
 
         Operation operation = mock(Operation.class);
-        when(userSyncService.synchronizeUsersWithCustomPermissionCheck(any(), any(), any(), any(), any(), any())).thenReturn(operation);
+        when(userSyncService.synchronizeUsersWithCustomPermissionCheck(any(), any(), any(), any(), any())).thenReturn(operation);
         SyncOperationStatus status = mock(SyncOperationStatus.class);
         when(operationToSyncOperationStatus.convert(operation)).thenReturn(status);
 
         assertEquals(status, ThreadBasedUserCrnProvider.doAsInternalActor(() -> underTest.synchronizeAllUsers(request)));
 
+        UserSyncRequestFilter userSyncFilter = new UserSyncRequestFilter(users, machineUsers, Optional.empty());
         verify(userSyncService, times(1)).synchronizeUsersWithCustomPermissionCheck(ACCOUNT_ID, INTERNAL_ACTOR_CRN,
-                environments, users, machineUsers, AuthorizationResourceAction.DESCRIBE_ENVIRONMENT);
+                environments, userSyncFilter, AuthorizationResourceAction.DESCRIBE_ENVIRONMENT);
     }
 
     @Test
@@ -164,7 +204,8 @@ public class UserV1ControllerTest {
         request.setUsers(users);
 
         Operation operation = mock(Operation.class);
-        when(userSyncService.synchronizeUsersWithCustomPermissionCheck(ACCOUNT_ID, USER_CRN, environments, users, Set.of(),
+        UserSyncRequestFilter userSyncFilter = new UserSyncRequestFilter(users, Set.of(), Optional.empty());
+        when(userSyncService.synchronizeUsersWithCustomPermissionCheck(ACCOUNT_ID, USER_CRN, environments, userSyncFilter,
                 AuthorizationResourceAction.DESCRIBE_ENVIRONMENT)).thenReturn(operation);
         SyncOperationStatus status = mock(SyncOperationStatus.class);
         when(status.getStatus()).thenReturn(SynchronizationStatus.REJECTED);

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncRequestValidatorTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncRequestValidatorTest.java
@@ -1,0 +1,110 @@
+package com.sequenceiq.freeipa.service.freeipa.user;
+
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.freeipa.controller.exception.BadRequestException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+@ExtendWith(MockitoExtension.class)
+class UserSyncRequestValidatorTest {
+
+    private static final String ACCOUNT_ID = UUID.randomUUID().toString();
+
+    private static final String NOT_CRN = "not:a:crn:";
+
+    private static final String OTHER_CRN = "crn:cdp:environments:us-west-1:"
+            + ACCOUNT_ID + ":database:" + UUID.randomUUID().toString();
+
+    private static final String ENV_CRN = "crn:cdp:environments:us-west-1:"
+            + ACCOUNT_ID + ":environment:" + UUID.randomUUID().toString();
+
+    private static final String USER_CRN = "crn:cdp:iam:us-west-1:"
+            + ACCOUNT_ID + ":user:" + UUID.randomUUID().toString();
+
+    private static final String MACHINE_USER_CRN = "crn:cdp:iam:us-west-1:"
+            + ACCOUNT_ID + ":machineUser:" + UUID.randomUUID().toString();
+
+    private static final String WORKLOAD_USER = "workloadUser";
+
+    @InjectMocks
+    UserSyncRequestValidator underTest;
+
+    @Test
+    void testValidateParameters() {
+        UserSyncRequestFilter filter = new UserSyncRequestFilter(Set.of(USER_CRN), Set.of(MACHINE_USER_CRN), Optional.empty());
+        underTest.validateParameters(ACCOUNT_ID, USER_CRN, Set.of(ENV_CRN), filter);
+    }
+
+    @Test
+    void testValidateParametersBadEnv() {
+        UserSyncRequestFilter filter = new UserSyncRequestFilter(Set.of(), Set.of(), Optional.empty());
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            underTest.validateParameters(ACCOUNT_ID, USER_CRN, Set.of(OTHER_CRN), filter);
+        });
+    }
+
+    @Test
+    void testValidateParametersBadUser() {
+        UserSyncRequestFilter filter = new UserSyncRequestFilter(Set.of(OTHER_CRN), Set.of(), Optional.empty());
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            underTest.validateParameters(ACCOUNT_ID, USER_CRN, Set.of(), filter);
+        });
+    }
+
+    @Test
+    void testValidateParametersBadMachineUser() {
+        UserSyncRequestFilter filter = new UserSyncRequestFilter(Set.of(), Set.of(OTHER_CRN), Optional.empty());
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            underTest.validateParameters(ACCOUNT_ID, USER_CRN, Set.of(), filter);
+        });
+    }
+
+    @Test
+    void testValidateParametersWrongAccount() {
+        String differentAccount = UUID.randomUUID().toString();
+        UserSyncRequestFilter filter = new UserSyncRequestFilter(Set.of(), Set.of(), Optional.empty());
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            underTest.validateParameters(differentAccount, USER_CRN, Set.of(ENV_CRN), filter);
+        });
+    }
+
+    @Test
+    void testValidateDeleteUsersRequest() {
+        UserSyncRequestFilter filter = new UserSyncRequestFilter(Set.of(USER_CRN), Set.of(), Optional.of(WORKLOAD_USER));
+        underTest.validateParameters(ACCOUNT_ID, USER_CRN, Set.of(), filter);
+    }
+
+    @Test
+    void testValidateParametersInvalidDeleteUsersRequest() {
+        UserSyncRequestFilter filter = new UserSyncRequestFilter(Set.of(USER_CRN), Set.of(MACHINE_USER_CRN), Optional.of(WORKLOAD_USER));
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            underTest.validateParameters(ACCOUNT_ID, USER_CRN, Set.of(), filter);
+        });
+    }
+
+    @Test
+    void testValidateCrnFilter() {
+        underTest.validateCrnFilter(Set.of(ENV_CRN), Crn.ResourceType.ENVIRONMENT);
+    }
+
+    @Test
+    void testValidateCrnFilterNotCrn() {
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            underTest.validateCrnFilter(Set.of(NOT_CRN), Crn.ResourceType.ENVIRONMENT);
+        });
+    }
+
+    @Test
+    void testValidateCrnFilterWrongResourceType() {
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            underTest.validateCrnFilter(Set.of(ENV_CRN), Crn.ResourceType.USER);
+        });
+    }
+}


### PR DESCRIPTION
This updates the existing synchronizeAllUsers request to
allow specifying a single workload user to be deleted
from the freeipa. Currently this won't remove CM ranger
cloud identities (azure object ids). That will come in
a following commit.
