### PR TITLE
CB-3255 Add GCP support in KerberosDetailService

### DIFF
--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/kerberos/KerberosDetailService.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/kerberos/KerberosDetailService.java
@@ -112,6 +112,7 @@ public class KerberosDetailService {
 
         boolean supportedOnCloudPlatform = CloudPlatform.AWS.name().equals(cloudPlatform)
                 || CloudPlatform.AZURE.name().equals(cloudPlatform)
+                || CloudPlatform.GCP.name().equals(cloudPlatform)
                 || yarnChildEnvironment;
 
         return supportedOnCloudPlatform


### PR DESCRIPTION
1. Datalake does not come up without this because CM keytab will be missing while starting CM.
2. I am not sure about the TODO that says remove of FreeIPA registration being ready. It should be ready already, but just trying to keep the change minimal.