### PR TITLE
CB-8711 [e2e] [e2e] azure fails with NPE (Create failed) -- part 2

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/util/CloudProviderSideTagAssertion.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/util/CloudProviderSideTagAssertion.java
@@ -105,7 +105,7 @@ public class CloudProviderSideTagAssertion {
     }
 
     private void verifyTags(List<String> instanceIds, Map<String, String> customTags, TestContext testContext, String resourceName) {
-        if ((instanceIds != null && !instanceIds.isEmpty()) || !instanceIds.contains(null)) {
+        if ((instanceIds != null && !instanceIds.isEmpty()) && !instanceIds.contains(null)) {
             Map<String, Map<String, String>> tagsByInstanceId = cloudProviderProxy.getCloudFunctionality().listTagsByInstanceId(instanceIds);
             tagsByInstanceId.forEach((id, tags) -> {
                 LOGGER.info(" Verifying resource: {} instance ID: {} with tags: {}", resourceName, id, tags);


### PR DESCRIPTION
On azure there is an e2e test utility listing tags by instance id. If, however, the instance id is null, an NPE is produced, marking a test as failed, masking the real reason for failure. There was an additional condition that needed to be fixed.

See detailed description in the commit message.