### PR TITLE
CB-8754 Introduce the createDefaultImageCatalog setup step to the E2E test

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
@@ -12,7 +12,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -515,8 +514,7 @@ public abstract class TestContext implements ApplicationContextAware {
 
     public <T extends CloudbreakTestDto> T get(String key) {
         if (!resources.containsKey(key) || resources.get(key) == null) {
-            throw new NoSuchElementException(
-                String.format("Key: '%s' has been provided but it has no result in the Test Context's Resources map", key));
+            LOGGER.warn("Key: '{}' has been provided but it has no result in the Test Context's Resources map.", key);
         }
         return (T) resources.get(key);
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/AbstractE2ETest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/AbstractE2ETest.java
@@ -37,8 +37,8 @@ public abstract class AbstractE2ETest extends AbstractIntegrationTest {
     protected void setupTest(TestContext testContext) {
         createDefaultUser(testContext);
         createDefaultCredential(testContext);
-        createDefaultEnvironment(testContext);
         initializeDefaultBlueprints(testContext);
+        createDefaultEnvironment(testContext);
     }
 
     @AfterMethod

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXEncryptedVolumeTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXEncryptedVolumeTest.java
@@ -37,7 +37,6 @@ public class DistroXEncryptedVolumeTest extends AbstractE2ETest {
         testContext.getCloudProvider().getCloudFunctionality().cloudStorageInitialize();
         createDefaultUser(testContext);
         initializeDefaultBlueprints(testContext);
-        createDefaultImageCatalog(testContext);
         createDefaultCredential(testContext);
         createEnvironmentWithNetworkAndFreeIpa(testContext);
         createDatalake(testContext);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXImagesTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXImagesTests.java
@@ -44,8 +44,8 @@ public class DistroXImagesTests extends AbstractE2ETest {
     protected void setupTest(TestContext testContext) {
         createDefaultUser(testContext);
         createDefaultCredential(testContext);
-        createEnvironmentWithNetworkAndFreeIpa(testContext);
         initializeDefaultBlueprints(testContext);
+        createEnvironmentWithNetworkAndFreeIpa(testContext);
         createDatalake(testContext);
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXScaleTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXScaleTest.java
@@ -29,8 +29,8 @@ public class DistroXScaleTest extends AbstractE2ETest {
         testContext.getCloudProvider().getCloudFunctionality().cloudStorageInitialize();
         createDefaultUser(testContext);
         createDefaultCredential(testContext);
-        createEnvironmentWithNetworkAndFreeIpa(testContext);
         initializeDefaultBlueprints(testContext);
+        createEnvironmentWithNetworkAndFreeIpa(testContext);
         createDatalake(testContext);
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/hybrid/AwsYcloudHybridCloudTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/hybrid/AwsYcloudHybridCloudTest.java
@@ -117,7 +117,6 @@ public class AwsYcloudHybridCloudTest extends AbstractE2ETest {
                 .given(EnvironmentTestDto.class)
                 .withSecurityAccess();
         createEnvironmentWithNetworkAndFreeIpa(testContext);
-        createDefaultImageCatalog(testContext);
 
         testContext
                 .given("childtelemetry", TelemetryTestDto.class)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/ImageValidatorE2ETest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/ImageValidatorE2ETest.java
@@ -23,8 +23,8 @@ public abstract class ImageValidatorE2ETest extends AbstractE2ETest {
         testContext.getCloudProvider().getCloudFunctionality().cloudStorageInitialize();
         createDefaultUser(testContext);
         createDefaultCredential(testContext);
-        createEnvironmentWithNetworkAndFreeIpa(testContext);
         initializeDefaultBlueprints(testContext);
+        createEnvironmentWithNetworkAndFreeIpa(testContext);
     }
 
     @BeforeMethod

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/PreconditionSdxE2ETest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/PreconditionSdxE2ETest.java
@@ -53,7 +53,6 @@ public class PreconditionSdxE2ETest extends AbstractE2ETest {
         testContext.getCloudProvider().getCloudFunctionality().cloudStorageInitialize();
         createDefaultUser(testContext);
         initializeDefaultBlueprints(testContext);
-        createDefaultImageCatalog(testContext);
         createDefaultCredential(testContext);
         createEnvironmentWithNetworkAndFreeIpa(testContext);
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/spot/AwsDistroXSpotInstanceTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/spot/AwsDistroXSpotInstanceTest.java
@@ -31,7 +31,6 @@ public class AwsDistroXSpotInstanceTest extends AbstractE2ETest {
         checkCloudPlatform(CloudPlatform.AWS);
         createDefaultUser(testContext);
         initializeDefaultBlueprints(testContext);
-        createDefaultImageCatalog(testContext);
         createDefaultCredential(testContext);
         createEnvironmentWithNetworkAndFreeIpa(testContext);
         createDatalake(testContext);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/spot/AwsSdxSpotInstanceTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/spot/AwsSdxSpotInstanceTest.java
@@ -35,8 +35,8 @@ public class AwsSdxSpotInstanceTest extends AbstractE2ETest {
         checkCloudPlatform(CloudPlatform.AWS);
         createDefaultUser(testContext);
         createDefaultCredential(testContext);
-        createEnvironmentWithNetworkAndFreeIpa(testContext);
         initializeDefaultBlueprints(testContext);
+        createEnvironmentWithNetworkAndFreeIpa(testContext);
     }
 
     @Test(dataProvider = TEST_CONTEXT)


### PR DESCRIPTION
The createDefaultImageCatalog(testContext); required for the E2E tests' setup, because of 
```
if (!resources.containsKey(key) || resources.get(key) == null) {
            throw new NoSuchElementException(
                String.format("Key: '%s' has been provided but it has no result in the Test Context's Resources map", key));
        }
```
However some of the setup methods do not contain this.

So the missing createDefaultImageCatalog(testContext) step has been introduced to these.