### PR TITLE
CB-8775: Removed CUSTOM from list of cluster shapes used by external API.

### DIFF
--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterShape.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterShape.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.sdx.api.model;
 
 public enum SdxClusterShape {
-    CUSTOM,
     LIGHT_DUTY,
     MEDIUM_DUTY_HA
 }


### PR DESCRIPTION


See detailed description in the commit message.