### PR TITLE
ENGESC-3627 Suppress the CM warning about minimum heap size to be 4 GiB

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-702.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-702.bp
@@ -29,7 +29,11 @@
             "refName": "hdfs-NAMENODE-BASE",
             "roleType": "NAMENODE",
             "base": true,
-	    "configs": [
+            "configs": [
+              {
+                "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
+                "value": "true"
+              },
               {
                 "name": "role_config_suppression_fs_trash_interval_minimum_validator",
                 "value": "true"

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-710.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-710.bp
@@ -29,7 +29,11 @@
             "refName": "hdfs-NAMENODE-BASE",
             "roleType": "NAMENODE",
             "base": true,
-	    "configs": [
+            "configs": [
+              {
+                "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
+                "value": "true"
+              },
               {
                 "name": "role_config_suppression_fs_trash_interval_minimum_validator",
                 "value": "true"

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-720.bp
@@ -37,6 +37,10 @@
             "base": true,
             "configs": [
               {
+                "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
+                "value": "true"
+              },
+              {
                 "name": "role_config_suppression_fs_trash_interval_minimum_validator",
                 "value": "true"
               },

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-721.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-721.bp
@@ -37,6 +37,10 @@
             "base": true,
             "configs": [
               {
+                "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
+                "value": "true"
+              },
+              {
                 "name": "role_config_suppression_fs_trash_interval_minimum_validator",
                 "value": "true"
               },

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-722.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-722.bp
@@ -37,6 +37,10 @@
             "base": true,
             "configs": [
               {
+                "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
+                "value": "true"
+              },
+              {
                 "name": "role_config_suppression_fs_trash_interval_minimum_validator",
                 "value": "true"
               },

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-723.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-723.bp
@@ -37,6 +37,10 @@
             "base": true,
             "configs": [
               {
+                "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
+                "value": "true"
+              },
+              {
                 "name": "role_config_suppression_fs_trash_interval_minimum_validator",
                 "value": "true"
               },

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-702.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-702.bp
@@ -28,7 +28,13 @@
           {
             "refName": "hdfs-NAMENODE-BASE",
             "roleType": "NAMENODE",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
+                "value": "true"
+              }
+            ]
           },
           {
             "refName": "hdfs-FAILOVERCONTROLLER-BASE",

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-710.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-710.bp
@@ -28,7 +28,13 @@
           {
             "refName": "hdfs-NAMENODE-BASE",
             "roleType": "NAMENODE",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
+                "value": "true"
+              }
+            ]
           },
           {
             "refName": "hdfs-FAILOVERCONTROLLER-BASE",

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-720.bp
@@ -35,6 +35,10 @@
             "base": true,
             "configs": [
               {
+                "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
+                "value": "true"
+              },
+              {
                 "name": "role_config_suppression_fs_trash_interval_minimum_validator",
                 "value": "true"
               },

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-721.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-721.bp
@@ -35,6 +35,10 @@
             "base": true,
             "configs": [
               {
+                "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
+                "value": "true"
+              },
+              {
                 "name": "role_config_suppression_fs_trash_interval_minimum_validator",
                 "value": "true"
               },

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-722.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-722.bp
@@ -35,6 +35,10 @@
             "base": true,
             "configs": [
               {
+                "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
+                "value": "true"
+              },
+              {
                 "name": "role_config_suppression_fs_trash_interval_minimum_validator",
                 "value": "true"
               },

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-723.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-723.bp
@@ -35,6 +35,10 @@
             "base": true,
             "configs": [
               {
+                "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
+                "value": "true"
+              },
+              {
                 "name": "role_config_suppression_fs_trash_interval_minimum_validator",
                 "value": "true"
               },

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-710.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-710.bp
@@ -14,6 +14,10 @@
             "base": true,
             "configs": [
               {
+                "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
+                "value": "true"
+              },
+              {
                 "name": "role_config_suppression_fs_trash_interval_minimum_validator",
                 "value": "true"
               },

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-720.bp
@@ -31,6 +31,10 @@
             "base": true,
             "configs": [
               {
+                "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
+                "value": "true"
+              },
+              {
                 "name": "role_config_suppression_fs_trash_interval_minimum_validator",
                 "value": "true"
               },

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-721.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-721.bp
@@ -31,6 +31,10 @@
             "base": true,
             "configs": [
               {
+                "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
+                "value": "true"
+              },
+              {
                 "name": "role_config_suppression_fs_trash_interval_minimum_validator",
                 "value": "true"
               },

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-722.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-722.bp
@@ -31,6 +31,10 @@
             "base": true,
             "configs": [
               {
+                "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
+                "value": "true"
+              },
+              {
                 "name": "role_config_suppression_fs_trash_interval_minimum_validator",
                 "value": "true"
               },

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-723.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-723.bp
@@ -31,6 +31,10 @@
             "base": true,
             "configs": [
               {
+                "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
+                "value": "true"
+              },
+              {
                 "name": "role_config_suppression_fs_trash_interval_minimum_validator",
                 "value": "true"
               },


### PR DESCRIPTION
1. The default data engineering clusters already have memory overcommit warnings.
2. We are trying to reduce memory allocation for every service so there is no overcommit.
3. The HDFS is running there just to support services like Hive and Oozie. The customer data goes only to Cloud storage.
4. So the default 1 GiB is sufficient. If some customer has a use-case of storing the data in HDFS then the CM health check warnings are there to alert them about the issue.

Tested by suppressing the warning and exporting the template from it.