### PR TITLE
CB-8776 update the CM license as part of upgrading the CM server

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeService.java
@@ -1,11 +1,11 @@
 package com.sequenceiq.cloudbreak.core.cluster;
 
 import static com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterDeletionBasedExitCriteriaModel.clusterDeletionBasedModel;
-import static java.util.Collections.singletonMap;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -88,8 +88,8 @@ public class ClusterManagerUpgradeService {
     private SaltConfig createSaltConfig(Cluster cluster) {
         Map<String, SaltPillarProperties> servicePillar = new HashMap<>();
         ClouderaManagerRepo clouderaManagerRepo = clusterComponentConfigProvider.getClouderaManagerRepoDetails(cluster.getId());
-        servicePillar.put("cloudera-manager-repo", new SaltPillarProperties("/cloudera-manager/repo.sls",
-                singletonMap("cloudera-manager", singletonMap("repo", clouderaManagerRepo))));
+        Optional<String> license = clusterHostServiceRunner.decoratePillarWithClouderaManagerLicense(cluster.getStack().getId(), servicePillar);
+        clusterHostServiceRunner.decoratePillarWithClouderaManagerRepo(clouderaManagerRepo, servicePillar, license);
         clusterHostServiceRunner.decoratePillarWithClouderaManagerSettings(servicePillar, clouderaManagerRepo);
         return new SaltConfig(servicePillar);
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunnerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunnerTest.java
@@ -3,7 +3,6 @@ package com.sequenceiq.cloudbreak.core.bootstrap.service.host;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -163,10 +162,9 @@ public class ClusterHostServiceRunnerTest {
         ClouderaManagerRepo clouderaManagerRepo = new ClouderaManagerRepo();
         clouderaManagerRepo.setVersion("7.2.0");
         clouderaManagerRepo.setBaseUrl("https://archive.cloudera.com/cm/7.2.0/");
-        when(clusterComponentConfigProvider.getClouderaManagerRepoDetails(CLUSTER_ID)).thenReturn(clouderaManagerRepo);
 
         Map<String, SaltPillarProperties> pillar = new HashMap<>();
-        underTest.decoratePillarWithClouderaManagerRepo(CLUSTER_ID, pillar, Optional.of(license));
+        underTest.decoratePillarWithClouderaManagerRepo(clouderaManagerRepo, pillar, Optional.of(license));
 
         SaltPillarProperties resultPillar = pillar.get("cloudera-manager-repo");
         Map<String, Object> properties = resultPillar.getProperties();
@@ -183,10 +181,9 @@ public class ClusterHostServiceRunnerTest {
         ClouderaManagerRepo clouderaManagerRepo = new ClouderaManagerRepo();
         clouderaManagerRepo.setVersion("7.2.0");
         clouderaManagerRepo.setBaseUrl("https://archive.cloudera.com/cm/7.2.0/");
-        when(clusterComponentConfigProvider.getClouderaManagerRepoDetails(CLUSTER_ID)).thenReturn(clouderaManagerRepo);
 
         Map<String, SaltPillarProperties> pillar = new HashMap<>();
-        underTest.decoratePillarWithClouderaManagerRepo(CLUSTER_ID, pillar, Optional.of(license));
+        underTest.decoratePillarWithClouderaManagerRepo(clouderaManagerRepo, pillar, Optional.of(license));
 
         SaltPillarProperties resultPillar = pillar.get("cloudera-manager-repo");
         Map<String, Object> properties = resultPillar.getProperties();
@@ -203,10 +200,9 @@ public class ClusterHostServiceRunnerTest {
         ClouderaManagerRepo clouderaManagerRepo = new ClouderaManagerRepo();
         clouderaManagerRepo.setVersion("7.2.0");
         clouderaManagerRepo.setBaseUrl("https://archive.cloudera.com/cm/7.2.0/");
-        when(clusterComponentConfigProvider.getClouderaManagerRepoDetails(CLUSTER_ID)).thenReturn(clouderaManagerRepo);
 
         Map<String, SaltPillarProperties> pillar = new HashMap<>();
-        underTest.decoratePillarWithClouderaManagerRepo(CLUSTER_ID, pillar, Optional.of(license));
+        underTest.decoratePillarWithClouderaManagerRepo(clouderaManagerRepo, pillar, Optional.of(license));
 
         SaltPillarProperties resultPillar = pillar.get("cloudera-manager-repo");
         Map<String, Object> properties = resultPillar.getProperties();


### PR DESCRIPTION
Older clusters might have CM licenses that is not valid to access
the paywall (archive.cloudeera.com/p/). During upgrade we're downloading
both CM server and CDP runtime from the paywall thus we need a valid
license for it. Even though upgrade involves updating the Salt states
and pillars there is an extra step when we only update the CM repo
details without the paywall credential being present. This PR changes
this behavior to always include the latest credentials from UMS. The CM
server doesn't store the license so we don't need to invoke any API to
update it in the server it will just use the one that is on the disk.
