### PR TITLE
CB-8773 remove yarn_nodemanager_resource_memory_mb

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-opdb-722.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-opdb-722.bp
@@ -226,10 +226,6 @@
               {
                 "name": "node_manager_java_heapsize",
                 "value": "536870912"
-              },
-              {
-                "name": "yarn_nodemanager_resource_memory_mb",
-                "value": "3584"
               }
             ],
             "base": true

--- a/core/src/main/resources/defaults/blueprints/cdp-opdb-723.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-opdb-723.bp
@@ -226,10 +226,6 @@
               {
                 "name": "node_manager_java_heapsize",
                 "value": "536870912"
-              },
-              {
-                "name": "yarn_nodemanager_resource_memory_mb",
-                "value": "3584"
               }
             ],
             "base": true


### PR DESCRIPTION
CB-8773 remove yarn_nodemanager_resource_memory_mb property from opdb templates because by OPSAPS-56088 CM now autogenerate several property