### PR TITLE
CB-8778 validate paywall access before starting the upgrade process

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/auth/CMLicenseUtil.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/auth/CMLicenseUtil.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.cloudbreak.auth;
+
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import static org.apache.commons.lang3.StringUtils.substringAfter;
+import static org.apache.commons.lang3.StringUtils.substringBeforeLast;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.common.json.JsonUtil;
+
+public class CMLicenseUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CMLicenseUtil.class);
+
+    private CMLicenseUtil() {
+    }
+
+    public static Optional<JsonCMLicense> parseLicense(String license) {
+        Optional<JsonCMLicense> result = Optional.empty();
+        if (isNotEmpty(license)) {
+            try {
+                String json = '{' + substringBeforeLast(substringAfter(license, "{"), "}") + '}';
+                JsonCMLicense jsonCMLicense = JsonUtil.readValue(json, JsonCMLicense.class);
+                result = Optional.of(jsonCMLicense);
+            } catch (IOException e) {
+                LOGGER.warn("Cannot parse CM license", e);
+            }
+        }
+        return result;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/auth/JsonCMLicense.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/auth/JsonCMLicense.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.cloudbreak.core.bootstrap.service.host;
+package com.sequenceiq.cloudbreak.auth;
 
 import java.util.StringJoiner;
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/SdxRuntimeUpgradeService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/SdxRuntimeUpgradeService.java
@@ -13,22 +13,35 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.inject.Inject;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.Account;
 import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.StackV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.image.ImageComponentVersions;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.image.ImageInfoV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.upgrade.UpgradeV4Response;
+import com.sequenceiq.cloudbreak.auth.CMLicenseUtil;
+import com.sequenceiq.cloudbreak.auth.JsonCMLicense;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
+import com.sequenceiq.cloudbreak.client.RestClientFactory;
 import com.sequenceiq.cloudbreak.event.ResourceEvent;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.cloudbreak.logger.MDCUtils;
 import com.sequenceiq.cloudbreak.message.CloudbreakMessagesService;
 import com.sequenceiq.datalake.controller.exception.BadRequestException;
 import com.sequenceiq.datalake.controller.sdx.SdxUpgradeClusterConverter;
@@ -48,6 +61,9 @@ public class SdxRuntimeUpgradeService {
 
     private static final long WORKSPACE_ID = 0L;
 
+    @Value("${sdx.paywall.url}")
+    private String paywallUrl;
+
     @Inject
     private StackV4Endpoint stackV4Endpoint;
 
@@ -65,6 +81,12 @@ public class SdxRuntimeUpgradeService {
 
     @Inject
     private EntitlementService entitlementService;
+
+    @Inject
+    private GrpcUmsClient umsClient;
+
+    @Inject
+    private RestClientFactory restClientFactory;
 
     public SdxUpgradeResponse checkForUpgradeByName(String userCrn, String clusterName, SdxUpgradeRequest upgradeSdxClusterRequest, String accountId) {
         return checkForSdxUpgradeResponse(userCrn, upgradeSdxClusterRequest, clusterName, accountId);
@@ -84,19 +106,24 @@ public class SdxRuntimeUpgradeService {
         SdxCluster cluster = sdxService.getByNameInAccount(userCrn, clusterName);
         SdxUpgradeResponse sdxUpgradeResponse = checkForUpgradeByName(userCrn, clusterName, upgradeRequest, accountId);
         List<ImageInfoV4Response> imageInfoV4Responses = validateUpgradeCandidates(clusterName, sdxUpgradeResponse);
-        return initSdxUpgrade(imageInfoV4Responses, upgradeRequest, cluster);
+        return initSdxUpgrade(userCrn, imageInfoV4Responses, upgradeRequest, cluster);
     }
 
     public SdxUpgradeResponse triggerUpgradeByCrn(String userCrn, String clusterCrn, SdxUpgradeRequest upgradeRequest, String accountId) {
         SdxCluster cluster = sdxService.getByCrn(userCrn, clusterCrn);
         SdxUpgradeResponse sdxUpgradeResponse = checkForUpgradeByCrn(userCrn, clusterCrn, upgradeRequest, accountId);
         List<ImageInfoV4Response> imageInfoV4Responses = validateUpgradeCandidates(cluster.getClusterName(), sdxUpgradeResponse);
-        return initSdxUpgrade(imageInfoV4Responses, upgradeRequest, cluster);
+        return initSdxUpgrade(userCrn, imageInfoV4Responses, upgradeRequest, cluster);
     }
 
     public boolean isRuntimeUpgradeEnabled(String userCrn) {
         String accountId = sdxService.getAccountIdFromCrn(userCrn);
         return entitlementService.runtimeUpgradeEnabled(INTERNAL_ACTOR_CRN, accountId);
+    }
+
+    private boolean isInternalRepoAllowedForUpgrade(String userCrn) {
+        String accountId = sdxService.getAccountIdFromCrn(userCrn);
+        return entitlementService.isInternalRepositoryForUpgradeAllowed(INTERNAL_ACTOR_CRN, accountId);
     }
 
     private SdxUpgradeResponse checkForSdxUpgradeResponse(String userCrn, SdxUpgradeRequest upgradeSdxClusterRequest,
@@ -133,9 +160,10 @@ public class SdxRuntimeUpgradeService {
         }
     }
 
-    private SdxUpgradeResponse initSdxUpgrade(List<ImageInfoV4Response> upgradeCandidates, SdxUpgradeRequest upgradeRequest, SdxCluster cluster) {
-        String imageId = determineImageId(upgradeRequest, upgradeCandidates);
-        FlowIdentifier flowIdentifier = triggerDatalakeUpgradeFlow(imageId, cluster, shouldReplaceVmsAfterUpgrade(upgradeRequest));
+    private SdxUpgradeResponse initSdxUpgrade(String userCrn, List<ImageInfoV4Response> upgradeCandidates, SdxUpgradeRequest request, SdxCluster cluster) {
+        verifyPaywallAccess(userCrn, request);
+        String imageId = determineImageId(request, upgradeCandidates);
+        FlowIdentifier flowIdentifier = triggerDatalakeUpgradeFlow(imageId, cluster, shouldReplaceVmsAfterUpgrade(request));
         String message = getMessage(imageId);
         return new SdxUpgradeResponse(message, flowIdentifier);
     }
@@ -143,6 +171,46 @@ public class SdxRuntimeUpgradeService {
     private void verifyRuntimeUpgradeEntitlement(String userCrn, SdxUpgradeRequest upgradeSdxClusterRequest) {
         if (upgradeSdxClusterRequest != null && !Boolean.TRUE.equals(upgradeSdxClusterRequest.getLockComponents()) && !isRuntimeUpgradeEnabled(userCrn)) {
             throw new BadRequestException("Runtime upgrade feature is not enabled");
+        }
+    }
+
+    private void verifyPaywallAccess(String userCrn, SdxUpgradeRequest upgradeRequest) {
+        if (upgradeRequest != null && !Boolean.TRUE.equals(upgradeRequest.getLockComponents())) {
+            if (!isInternalRepoAllowedForUpgrade(userCrn)) {
+                verifyCMLicenseValidity(userCrn);
+            } else {
+                LOGGER.info("Internal repo is allowed for upgrade, skip CM license validation");
+            }
+        }
+    }
+
+    private void verifyCMLicenseValidity(String userCrn) {
+        LOGGER.info("Verify if the CM license is valid to authenticate to {}", paywallUrl);
+        String accountId = sdxService.getAccountIdFromCrn(userCrn);
+        Account account = umsClient.getAccountDetails(INTERNAL_ACTOR_CRN, accountId, MDCUtils.getRequestId());
+        JsonCMLicense license = CMLicenseUtil.parseLicense(account.getClouderaManagerLicenseKey())
+                .orElseThrow(() -> new BadRequestException("No valid CM license is present"));
+        checkPaywallAccess(license);
+    }
+
+    private void checkPaywallAccess(JsonCMLicense license) {
+        Client client = restClientFactory.getOrCreateDefault();
+        WebTarget target = client.target(paywallUrl);
+        HttpAuthenticationFeature basicAuth = HttpAuthenticationFeature.basicBuilder()
+                .credentials(license.getPaywallUsername(), license.getPaywallPassword()).build();
+        target.register(basicAuth);
+        LOGGER.info("Send paywall probe request to {}", paywallUrl);
+        String errorMessage = "The Cloudera Manager license is not valid to authenticate to paywall, "
+                + "please contact a Cloudera administrator to update it.";
+        try (Response response = target.request().get()) {
+            int responseStatus = response.getStatus();
+            LOGGER.info("Paywall probe response status code: {}", responseStatus);
+            if (HttpStatus.OK.value() != responseStatus) {
+                throw new BadRequestException(errorMessage);
+            }
+        } catch (ProcessingException e) {
+            LOGGER.info("Cannot send probe request to paywall", e);
+            throw new BadRequestException(errorMessage);
         }
     }
 

--- a/datalake/src/main/resources/application.yml
+++ b/datalake/src/main/resources/application.yml
@@ -52,6 +52,8 @@ sdx:
       name: cdp-proxy
     ssotype: SSO_PROVIDER
 
+  paywall.url: "https://archive.cloudera.com/p/cdp-public/"
+
 altus:
   idbmms:
     host: localhost

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/ProvisionerServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/ProvisionerServiceTest.java
@@ -94,7 +94,7 @@ class ProvisionerServiceTest {
         SdxCluster sdxCluster = generateValidSdxCluster(clusterId);
         StackV4Response stackV4Response = new StackV4Response();
         when(stackV4Endpoint.getByCrn(anyLong(), nullable(String.class), nullable(Set.class))).thenThrow(new NotFoundException());
-        when(stackV4Endpoint.postInternal(anyLong(), any(StackV4Request.class), anyString())).thenReturn(stackV4Response);
+        when(stackV4Endpoint.postInternal(anyLong(), any(StackV4Request.class), nullable(String.class))).thenReturn(stackV4Response);
         when(sdxService.getById(clusterId)).thenReturn(sdxCluster);
 
         underTest.startStackProvisioning(clusterId, getEnvironmentResponse());


### PR DESCRIPTION
For runtime upgrade, we have to download the CM and CDP builds from paywall
(archive.cloudera.com/p/). The CM license that is configured uniquely for each
CDP account can be used to authenticate. However, it can happen that customers
do not have an updated license that can be used. In this case, it would be a
mistake to even start the upgrade process. Instead, whenever an upgrade is
requested we'll validate if we can use the configured license to access the paywall.
If it's not valid we will reject the request. Once they update the license in UMS
we will also update the license as part of the upgrade process to make sure
we can download everything. We're also NOT checking the validity of the license
when we're searching for upgrade candidates. This is because this operation happens
very frequently (each time you open up the Datalake details page on the UI). Due to
this we will show a message on the UI that upgrades are available, but when they
try to trigger it we will reject the request.

