### PR TITLE
CDPCP-2674. Allow syncing single cloud identity

### DIFF
--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxEndpoint.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxEndpoint.java
@@ -16,6 +16,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import com.sequenceiq.sdx.api.model.UpdateUserRangerCloudIdentityRequest;
 import org.springframework.validation.annotation.Validated;
 
 import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
@@ -206,6 +207,13 @@ public interface SdxEndpoint {
     @ApiOperation(value = "Set ranger cloud identity mapping", produces = MediaType.APPLICATION_JSON, nickname = "setRangerCloudIdentityMapping")
     RangerCloudIdentitySyncStatus setRangerCloudIdentityMapping(@PathParam("envCrn") @ValidCrn String envCrn,
             @NotNull @Valid SetRangerCloudIdentityMappingRequest request);
+
+    @POST
+    @Path("/envcrn/{envCrn}/ranger_user_cloud_identity")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Update ranger cloud id mapping for a single user", produces = MediaType.APPLICATION_JSON, nickname = "updateUserRangerCloudIdentity")
+    RangerCloudIdentitySyncStatus updateUserRangerCloudIdentity(@PathParam("envCrn") @ValidCrn String envCrn,
+                                                                @NotNull @Valid UpdateUserRangerCloudIdentityRequest request);
 
     @GET
     @Path("/envcrn/{envCrn}/ranger_cloud_identity_sync_status")

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/UpdateUserRangerCloudIdentityRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/UpdateUserRangerCloudIdentityRequest.java
@@ -1,0 +1,68 @@
+package com.sequenceiq.sdx.api.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.constraints.NotNull;
+import java.util.Objects;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UpdateUserRangerCloudIdentityRequest {
+
+    private static final String USER_DESCRIPTION = "The user to update ranger cloud identity mapping for";
+
+    private static final String AZURE_USER_VALUE_DESCRIPTION = "The updated value for the user in the ranger azure user mapping. A null / not-present value " +
+            "indicates the value will be removed from the azure user mapping";
+
+    @NotNull
+    @ApiModelProperty(USER_DESCRIPTION)
+    private String user;
+
+    @ApiModelProperty(AZURE_USER_VALUE_DESCRIPTION)
+    private String azureUserValue;
+
+    public String getUser() {
+        return user;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    public String getAzureUserValue() {
+        return azureUserValue;
+    }
+
+    public void setAzureUserValue(String azureUserValue) {
+        this.azureUserValue = azureUserValue;
+    }
+
+    @Override
+    public String toString() {
+        return "SetSingleRangerCloudIdentityRequest{" +
+                "user='" + user + '\'' +
+                ", azureUserValue='" + azureUserValue + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UpdateUserRangerCloudIdentityRequest that = (UpdateUserRangerCloudIdentityRequest) o;
+        return Objects.equals(user, that.user) &&
+                Objects.equals(azureUserValue, that.azureUserValue);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(user, azureUserValue);
+    }
+
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
@@ -1,12 +1,14 @@
 package com.sequenceiq.datalake.controller.sdx;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
 
+import com.sequenceiq.sdx.api.model.UpdateUserRangerCloudIdentityRequest;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Controller;
 
@@ -293,6 +295,13 @@ public class SdxController implements SdxEndpoint {
             throw new IllegalArgumentException("Azure group mappings is unsupported");
         }
         return rangerCloudIdentityService.setAzureCloudIdentityMapping(envCrn, request.getAzureUserMapping());
+    }
+
+    @Override
+    @InternalOnly
+    public RangerCloudIdentitySyncStatus updateUserRangerCloudIdentity(String envCrn, UpdateUserRangerCloudIdentityRequest request) {
+        Optional<String> azureUserValue = Optional.ofNullable(request.getAzureUserValue());
+        return rangerCloudIdentityService.updateAzureUserMapping(envCrn, request.getUser(), azureUserValue);
     }
 
     @Override

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncService.java
@@ -17,6 +17,7 @@ import java.util.stream.Stream;
 
 import javax.inject.Inject;
 
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CloudIdentity;
 import com.google.common.collect.ImmutableCollection;
 import com.sequenceiq.freeipa.service.freeipa.user.ums.UmsEventGenerationIdsProvider;
 import com.sequenceiq.freeipa.service.freeipa.user.ums.UmsUsersStateProviderDispatcher;
@@ -350,10 +351,15 @@ public class UserSyncService {
                 LOGGER.debug("Finished {}.", LogEvent.SET_WORKLOAD_CREDENTIALS);
             }
 
-            // TODO For now we only sync cloud ids during full sync. We should eventually allow more granular syncs (actor level and group level sync).
-            if (fullSync && entitlementService.cloudIdentityMappingEnabled(INTERNAL_ACTOR_CRN, stack.getAccountId())) {
+            if (entitlementService.cloudIdentityMappingEnabled(INTERNAL_ACTOR_CRN, stack.getAccountId())) {
                 LOGGER.debug("Starting {} ...", LogEvent.SYNC_CLOUD_IDENTITIES);
-                cloudIdentitySyncService.syncCloudIdentities(stack, umsUsersState, warnings::put);
+                // For cloud identites we only allow full sync or syncing a single user
+                if (fullSync) {
+                    cloudIdentitySyncService.syncCloudIdentities(stack, umsUsersState, warnings::put);
+                } else if (umsUsersState.getUserToCloudIdentityMap().size() == 1) {
+                    Map.Entry<String, List<CloudIdentity>> entry = umsUsersState.getUserToCloudIdentityMap().entrySet().iterator().next();
+                    cloudIdentitySyncService.updateUserCloudIdentity(stack, entry.getKey(), entry.getValue(), warnings::put);
+                }
                 LOGGER.debug("Finished {}.", LogEvent.SYNC_CLOUD_IDENTITIES);
             }
 
@@ -384,6 +390,10 @@ public class UserSyncService {
                 LOGGER.debug("Starting {} ...", LogEvent.APPLY_DIFFERENCE_TO_IPA);
                 applyStateDifferenceToIpa(stack.getEnvironmentCrn(), freeIpaClient, usersStateDifference, warnings::put);
                 LOGGER.debug("Finished {}.", LogEvent.APPLY_DIFFERENCE_TO_IPA);
+
+                if (entitlementService.cloudIdentityMappingEnabled(INTERNAL_ACTOR_CRN, stack.getAccountId())) {
+                    cloudIdentitySyncService.updateUserCloudIdentity(stack, deletedWorkloadUser, List.of(), warnings::put);
+                }
             }
 
             LOGGER.debug("Finished {} for environment {} and deleted user {} ...", LogEvent.USER_SYNC_DELETE, environmentCrn, deletedWorkloadUser);


### PR DESCRIPTION
The datalake service has been updated with a new
`updateUserRangerCloudIdentity` endpoint that allows
updating the cloud identity values for a single user.
The user sync service in FMS has been updated to call
this endpoint for syncs involving a single user.