### PR TITLE
ENGESC-4173 Ambari setup failed with Ambari 2.7.5.10 repository

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/ambari/scripts/ambari-server-init.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/ambari/scripts/ambari-server-init.sh
@@ -72,7 +72,7 @@ find_and_distribute_latest_jdbc_driver() {
 
 # https://issues.apache.org/jira/browse/AMBARI-14627
 silent_security_setup() {
-  ambari-server setup-security --security-option=encrypt-passwords --master-key='{{ security_master_key }}' --master-key-persist=true
+  echo -e '\n\n' | ambari-server setup-security --security-option=encrypt-passwords --master-key='{{ security_master_key }}' --master-key-persist=true
 }
 
 read_tarballs() {


### PR DESCRIPTION
A new extra return character is required in STDIN with Ambari 2.7.5.10 setup to confirm
Encryption algorithm.