### PR TITLE
CB-8806 e2e tests could fail if thread sleep caught interrupted exception

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitService.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitService.java
@@ -70,9 +70,8 @@ public class WaitService<T> {
     private void sleep(Duration duration) {
         try {
             Thread.sleep(duration.toMillis());
-        } catch (InterruptedException e) {
-            LOGGER.error("Interrupted exception occurred during waiting.", e);
-            Thread.currentThread().interrupt();
+        } catch (InterruptedException ignored) {
+            LOGGER.error("Interrupted exception occurred during waiting.", ignored);
         }
     }
 }


### PR DESCRIPTION
e2e tests could fail if thread sleep caught interrupted exception. now it is going to be ignored in waiterservice

closes: cb-8806