### PR TITLE
CB-8797 - Reject Azure env creation request when only Resource Group …

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/EnvironmentValidatorService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/EnvironmentValidatorService.java
@@ -104,7 +104,7 @@ public class EnvironmentValidatorService {
         String accountId = ThreadBasedUserCrnProvider.getAccountId();
         String cloudPlatform = credentialService.getCloudPlatformByCredential(environmentRequest.getCredentialName(), accountId, ENVIRONMENT);
         resultBuilder.ifError(() -> !AWS.name().equalsIgnoreCase(cloudPlatform),
-                "Environment request is not for AWS.");
+                "Environment request is not for cloud platform AWS.");
 
         resultBuilder.ifError(() -> StringUtils.isBlank(Optional.ofNullable(environmentRequest.getAws())
                 .map(AwsEnvironmentParameters::getS3guard)

--- a/environment/src/test/java/com/sequenceiq/environment/environment/validation/EnvironmentValidatorServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/validation/EnvironmentValidatorServiceTest.java
@@ -84,7 +84,7 @@ class EnvironmentValidatorServiceTest {
         request.setCredentialName("azure-credential");
         ValidationResult result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.validateAwsEnvironmentRequest(request));
         assertTrue(result.hasError());
-        assertEquals("Environment request is not for AWS.", result.getErrors().get(0));
+        assertEquals("Environment request is not for cloud platform AWS.", result.getErrors().get(0));
     }
 
     @Test


### PR DESCRIPTION
…name is provided

If the RG name is provided in the env creation json, but RG Usage is not we should reject the request rather than falling back to multiple