### PR TITLE
CB-8875 cherry pick Azure resource group related null checks

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
@@ -130,8 +130,10 @@ public class AzureResourceConnector extends AbstractResourceConnector {
         } finally {
             if (!resourcesPersisted) {
                 Deployment templateDeployment = client.getTemplateDeployment(resourceGroupName, stackName);
-                LOGGER.debug("Get template deployment to persist created resources: {}", templateDeployment.exportTemplate().template());
-                persistCloudResources(ac, stack, notifier, cloudContext, stackName, resourceGroupName, templateDeployment);
+                if (templateDeployment != null && templateDeployment.exportTemplate() != null) {
+                    LOGGER.debug("Get template deployment to persist created resources: {}", templateDeployment.exportTemplate().template());
+                    persistCloudResources(ac, stack, notifier, cloudContext, stackName, resourceGroupName, templateDeployment);
+                }
             }
         }
 

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/AzureDatabaseResourceService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/AzureDatabaseResourceService.java
@@ -94,8 +94,10 @@ public class AzureDatabaseResourceService {
             throw new CloudConnectorException(String.format("Error in provisioning database stack %s: %s", stackName, e.getMessage()), e);
         } finally {
             deployment = client.getTemplateDeployment(resourceGroupName, stackName);
-            List<CloudResource> cloudResources = azureCloudResourceService.getDeploymentCloudResources(deployment);
-            cloudResources.forEach(cloudResource -> persistenceNotifier.notifyAllocation(cloudResource, cloudContext));
+            if (deployment != null) {
+                List<CloudResource> cloudResources = azureCloudResourceService.getDeploymentCloudResources(deployment);
+                cloudResources.forEach(cloudResource -> persistenceNotifier.notifyAllocation(cloudResource, cloudContext));
+            }
         }
 
         String fqdn = (String) ((Map) ((Map) deployment.outputs()).get(DATABASE_SERVER_FQDN)).get("value");


### PR DESCRIPTION
With the single Resource Group feature we force the customers to select
and existing RG on the UI. However, if there is a ready-only lock on the
group then the provisioning will fail and it will capture the proper error
message returned by Azure. However, there is a finally block to always gather
the created resources based on the Deployment object, but the Deployment itself
could not be created. This change fixes this problem so we can return the proper
error message to the UI/CLI.

See detailed description in the commit message.