### PR TITLE
CB-8895 added dynamic image catalog responder for cb mock service

### DIFF
--- a/integration-test/integcb/Profile_template
+++ b/integration-test/integcb/Profile_template
@@ -6,6 +6,7 @@ export DOCKER_TAG_ENVIRONMENT=dev
 export DOCKER_TAG_DATALAKE=dev
 export DOCKER_TAG_REDBEAMS=dev
 export DOCKER_TAG_PERISCOPE=dev
+export THUNDERHEAD_MOCK_VOLUME_HOST=$(PWD)/../../mock-thunderhead/build/libs/mock-thunderhead.jar
 export CB_JAVA_OPTS="-Dthunderhead.url=thunderhead-mock:8080 -Drest.debug=true -Dmock.spi.endpoint=https://test:9443"
 export UAA_DEFAULT_SECRET=cbsecret2015
 export UAA_DEFAULT_USER_PW=cloudbreak
@@ -16,7 +17,7 @@ export ENVIRONMENT_ENABLEDPLATFORMS=AZURE,AWS,YARN,MOCK
 export CB_DEFAULT_SUBSCRIPTION_ADDRESS=""
 export UMS_HOST=thunderhead-mock
 export CB_CLIENT_SECRET=cloudbreak
-export INGRESS_URLS=dev-gateway
+export INGRESS_URLS=dev-gateway,localhost
 export CLUSTERPROXY_ENABLED=false
 export ENVIRONMENT_AUTOSYNC_ENABLED=false
 export ENVIRONMENT_FREEIPA_SYNCHRONIZEONSTART=false

--- a/integration-test/it-application.yml
+++ b/integration-test/it-application.yml
@@ -1,9 +1,8 @@
 mock:
   server:
     address: test
-  image:
-    catalog:
-      url: https://test:9443/imagecatalog
+  imagecatalog:
+    server: thunderhead-mock:8080
 
 integrationtest:
   outputdir: /it

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/CloudbreakTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/CloudbreakTest.java
@@ -26,6 +26,8 @@ public class CloudbreakTest extends GherkinTest {
 
     public static final String CLOUDBREAK_SERVER_ROOT = "CLOUDBREAK_SERVER_ROOT";
 
+    public static final String IMAGE_CATALOG_MOCK_SERVER_ROOT = "IMAGE_CATALOG_MOCK_SERVER_ROOT";
+
     public static final String CLOUDBREAK_SERVER_INTERNAL_ROOT = "CLOUDBREAK_SERVER_INTERNAL_ROOT";
 
     public static final String AUTOSCALE_CLIENT_ID = "AUTOSCALE_CLIENTID";
@@ -60,6 +62,9 @@ public class CloudbreakTest extends GherkinTest {
     @Value("${integrationtest.user.secretkey}")
     private String secretkey;
 
+    @Value("${mock.imagecatalog.server:localhost}")
+    private String mockImageCatalogAddr;
+
     @Value("${integrationtest.uaa.autoscale.clientId:periscope}")
     private String autoscaleUaaClientId;
 
@@ -91,6 +96,8 @@ public class CloudbreakTest extends GherkinTest {
         testContext.putContextParam(CLOUDBREAK_SERVER_ROOT, server + cbRootContextPath);
         testContext.putContextParam(ACCESS_KEY, accesskey);
         testContext.putContextParam(SECRET_KEY, secretkey);
+
+        testContext.putContextParam(IMAGE_CATALOG_MOCK_SERVER_ROOT, mockImageCatalogAddr);
 
         testContext.putContextParam(AUTOSCALE_CLIENT_ID, autoscaleUaaClientId);
         testContext.putContextParam(AUTOSCALE_SECRET, autoscaleUaaClientSecret);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/config/server/CloudbreakServer.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/config/server/CloudbreakServer.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.it.cloudbreak.config.server;
 
+import static com.sequenceiq.it.cloudbreak.CloudbreakTest.IMAGE_CATALOG_MOCK_SERVER_ROOT;
+
 import java.io.IOException;
 import java.util.Map;
 
@@ -42,6 +44,9 @@ public class CloudbreakServer {
     @Value("${integrationtest.dp.profile:}")
     private String profile;
 
+    @Value("${mock.imagecatalog.server:localhost}")
+    private String mockImageCatalogAddr;
+
     @Inject
     private TestParameter testParameter;
 
@@ -66,6 +71,8 @@ public class CloudbreakServer {
         testParameter.put(CloudbreakTest.CLOUDBREAK_SERVER_INTERNAL_ROOT, "http://" + cloudbreakUrl + cbRootContextPath);
         testParameter.put(CloudbreakTest.ACCESS_KEY, accessKey);
         testParameter.put(CloudbreakTest.SECRET_KEY, secretKey);
+
+        testParameter.put(IMAGE_CATALOG_MOCK_SERVER_ROOT, mockImageCatalogAddr);
     }
 
     private void configureFromCliProfile() throws IOException {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/MockedTestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/MockedTestContext.java
@@ -1,14 +1,22 @@
 package com.sequenceiq.it.cloudbreak.context;
 
+import static com.sequenceiq.it.cloudbreak.CloudbreakTest.CLOUDBREAK_SERVER_ROOT;
+import static com.sequenceiq.it.cloudbreak.CloudbreakTest.IMAGE_CATALOG_MOCK_SERVER_ROOT;
+
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 
+import com.sequenceiq.cloudbreak.client.RestClientUtil;
 import com.sequenceiq.it.TestParameter;
 import com.sequenceiq.it.cloudbreak.Prototype;
+import com.sequenceiq.it.cloudbreak.mock.CBVersion;
 import com.sequenceiq.it.cloudbreak.mock.DefaultModel;
 import com.sequenceiq.it.cloudbreak.mock.ImageCatalogMockServerSetup;
 import com.sequenceiq.it.cloudbreak.mock.ThreadLocalProfiles;
@@ -72,8 +80,23 @@ public class MockedTestContext extends TestContext implements MockTestContext {
 
     private void initImageCatalogIfNecessary(String runtime) {
         if (imageCatalogMockServerSetup == null) {
-            imageCatalogMockServerSetup = new ImageCatalogMockServerSetup(sparkServerPool.popInsecure());
-            imageCatalogMockServerSetup.configureImgCatalogWithExistingSparkServer(testParameter, runtime);
+            imageCatalogMockServerSetup = new ImageCatalogMockServerSetup(
+                    testParameter.get(IMAGE_CATALOG_MOCK_SERVER_ROOT),
+                    getCloudbreakUnderTestVersion(testParameter.get(CLOUDBREAK_SERVER_ROOT)),
+                    runtime);
+        }
+    }
+
+    private String getCloudbreakUnderTestVersion(String cbServerAddress) {
+        Client client = RestClientUtil.get();
+        WebTarget target = client.target(cbServerAddress + "/info");
+        try (Response response = target.request().get()) {
+            CBVersion cbVersion = response.readEntity(CBVersion.class);
+            LOGGER.info("CB version: Appname: {}, version: {}", cbVersion.getApp().getName(), cbVersion.getApp().getVersion());
+            return cbVersion.getApp().getVersion();
+        } catch (Exception e) {
+            LOGGER.error("Cannot fetch the CB version", e);
+            throw e;
         }
     }
 
@@ -94,7 +117,6 @@ public class MockedTestContext extends TestContext implements MockTestContext {
         if (sparkServer != null) {
             LOGGER.info("Cleaning up MockedTestContext. {}", sparkServer.getEndpoint());
             sparkServerPool.putSecure(sparkServer);
-            sparkServerPool.putInsecure(imageCatalogMockServerSetup.getSparkServer());
             imageCatalogMockServerSetup = null;
             sparkServer = null;
             model = null;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/ImageCatalogMockServerSetup.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/ImageCatalogMockServerSetup.java
@@ -1,121 +1,53 @@
 package com.sequenceiq.it.cloudbreak.mock;
 
-import static com.sequenceiq.it.cloudbreak.CloudbreakTest.CLOUDBREAK_SERVER_ROOT;
-import static com.sequenceiq.it.cloudbreak.mock.ITResponse.FREEIPA_IMAGE_CATALOG;
-import static com.sequenceiq.it.cloudbreak.mock.ITResponse.IMAGE_CATALOG;
-import static com.sequenceiq.it.cloudbreak.mock.ITResponse.IMAGE_CATALOG_PREWARMED;
-import static com.sequenceiq.it.cloudbreak.mock.ITResponse.IMAGE_CATALOG_UPGRADE;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.Response;
-
-import org.apache.commons.io.IOUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.sequenceiq.cloudbreak.client.RestClientUtil;
-import com.sequenceiq.it.TestParameter;
-import com.sequenceiq.it.cloudbreak.spark.SparkServer;
 
 public class ImageCatalogMockServerSetup {
 
     public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ImageCatalogMockServerSetup.class);
+    private String cdhRuntime;
 
-    private SparkServer sparkServer;
+    private String cbVersion;
 
-    public ImageCatalogMockServerSetup(SparkServer sparkServer) {
-        this.sparkServer = sparkServer;
+    private String mockImageCatalogServer;
+
+    public ImageCatalogMockServerSetup(String mockImageCatalogServer, String cbVersion, String cdhRuntime) {
+        this.cbVersion = cbVersion;
+        this.cdhRuntime = cdhRuntime;
+        this.mockImageCatalogServer = mockImageCatalogServer;
     }
 
-    public static String responseFromJsonFile(String path) {
-        try (InputStream inputStream = ITResponse.class.getResourceAsStream("/mockresponse/" + path)) {
-            return IOUtils.toString(inputStream);
-        } catch (IOException e) {
-            return "";
-        }
-    }
-
-    private void startMockImageCatalogs(TestParameter testParameter, String runTime) {
-        String jsonPreparedICResponse = patchCbVersionAndRuntime(responseFromJsonFile("imagecatalog/catalog.json"), testParameter);
-        String jsonFreeIpaCatalogResponse = responseFromJsonFile("imagecatalog/freeipa.json");
-        String jsonPreparedPrewarmICResponseString = responseFromJsonFile("imagecatalog/catalog-with-prewarmed.json")
-                .replaceAll("CDH_RUNTIME", runTime);
-        String jsonPreparedPrewarmICResponse = patchCbVersionAndRuntime(jsonPreparedPrewarmICResponseString, testParameter);
-
-        String upgradeImageCatalogString = responseFromJsonFile("imagecatalog/catalog-with-for-upgrade.json")
-                .replaceAll("CDH_RUNTIME", runTime);
-        String upgradeImageCatalog = patchCbVersionAndRuntime(upgradeImageCatalogString, testParameter);
-
-        startImageCatalog(IMAGE_CATALOG, jsonPreparedICResponse);
-        startImageCatalog(FREEIPA_IMAGE_CATALOG, jsonFreeIpaCatalogResponse);
-        startImageCatalog(IMAGE_CATALOG_PREWARMED, jsonPreparedPrewarmICResponse);
-        startImageCatalog(IMAGE_CATALOG_UPGRADE, upgradeImageCatalog);
-    }
-
-    private String getCloudbreakUnderTestVersion(String cbServerAddress) {
-        Client client = RestClientUtil.get();
-        WebTarget target = client.target(cbServerAddress + "/info");
-        try (Response response = target.request().get()) {
-            CBVersion cbVersion = response.readEntity(CBVersion.class);
-            LOGGER.info("CB version: Appname: {}, version: {}", cbVersion.getApp().getName(), cbVersion.getApp().getVersion());
-            return cbVersion.getApp().getVersion();
-        } catch (Exception e) {
-            LOGGER.error("Cannot fetch the CB version", e);
-            throw e;
-        }
-    }
-
-    public void configureImgCatalogWithExistingSparkServer(TestParameter testParameter, String runtime) {
-        startMockImageCatalogs(testParameter, runtime);
-    }
-
-    public void startImageCatalog(String url, String imageCatalogText) {
-        sparkServer.getSparkService().get(url, (request, response) -> {
-            LOGGER.info("IC get was called at: {}, {}, {}", url, request.url(), LocalDateTime.now()
-                    .format(DATE_TIME_FORMATTER));
-            return imageCatalogText;
-        });
-        sparkServer.getSparkService().head(url, (request, response) -> {
-            LOGGER.info("IC head was called at: {}, {}, {}", url, request.url(), LocalDateTime.now()
-                    .format(DATE_TIME_FORMATTER));
-            response.header("Content-Length", String.valueOf(imageCatalogText.length()));
-            return "";
-        });
-        sparkServer.waitEndpointToBeReady(url, imageCatalogText);
-        LOGGER.info("ImageCatalog has started at: {}", sparkServer.getEndpoint() + url);
-    }
-
+    // DYNAMIC address http://localhost:10080/thunderhead/mock-image-catalog?catalog-name=cb-catalog&cb-version=CB-2.29.0&runtime=7.2.2
     public String getFreeIpaImageCatalogUrl() {
-        return String.join("", sparkServer.getEndpoint(), FREEIPA_IMAGE_CATALOG);
+        return String.format("http://%s/thunderhead/mock-image-catalog?catalog-name=%s&cb-version=%s&runtime=%s",
+                mockImageCatalogServer,
+                "freeipa-catalog",
+                cbVersion,
+                cdhRuntime);
     }
 
     public String getImageCatalogUrl() {
-        return String.join("", sparkServer.getEndpoint(), IMAGE_CATALOG);
+        return String.format("http://%s/thunderhead/mock-image-catalog?catalog-name=%s&cb-version=%s&runtime=%s",
+                mockImageCatalogServer,
+                "cb-catalog",
+                cbVersion,
+                cdhRuntime);
     }
 
     public String getPreWarmedImageCatalogUrl() {
-        return String.join("", sparkServer.getEndpoint(), IMAGE_CATALOG_PREWARMED);
+        return String.format("http://%s/thunderhead/mock-image-catalog?catalog-name=%s&cb-version=%s&runtime=%s",
+                mockImageCatalogServer,
+                "catalog-with-prewarmed",
+                cbVersion,
+                cdhRuntime);
     }
 
     public String getUpgradeImageCatalogUrl() {
-        return String.join("", sparkServer.getEndpoint(), IMAGE_CATALOG_UPGRADE);
-    }
-
-    public SparkServer getSparkServer() {
-        return sparkServer;
-    }
-
-    public String patchCbVersionAndRuntime(String catalogJson, TestParameter testParameter) {
-        return catalogJson
-                .replace("CB_VERSION", getCloudbreakUnderTestVersion(testParameter.get(CLOUDBREAK_SERVER_ROOT)))
-                .replace("RUNTIME", getCloudbreakUnderTestVersion(testParameter.get(CLOUDBREAK_SERVER_ROOT)));
+        return String.format("http://%s/thunderhead/mock-image-catalog?catalog-name=%s&cb-version=%s&runtime=%s",
+                mockImageCatalogServer,
+                "catalog-with-for-upgrade",
+                cbVersion,
+                cdhRuntime);
     }
 }

--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -10,9 +10,6 @@ logging:
 mock:
   server:
     address: localhost
-  image:
-    catalog:
-      url: https://localhost:9443/imagecatalog
 
 integrationtest:
   threadCount: 8

--- a/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/controller/MockImageCatalogController.java
+++ b/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/controller/MockImageCatalogController.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.thunderhead.controller;
+
+import javax.inject.Inject;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sequenceiq.thunderhead.service.ImageCatalogMockService;
+
+@RestController
+public class MockImageCatalogController {
+
+    @Inject
+    private ImageCatalogMockService imageCatalogMockService;
+
+    @GetMapping("/thunderhead/mock-image-catalog")
+    @ResponseBody
+    public String auth(@RequestParam("catalog-name") String name,
+            @RequestParam("cb-version") String cbVersion,
+            @RequestParam("runtime") String runtime) {
+        return imageCatalogMockService.getImageCatalogByName(name, cbVersion, runtime);
+    }
+}

--- a/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/service/ImageCatalogMockService.java
+++ b/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/service/ImageCatalogMockService.java
@@ -1,0 +1,17 @@
+package com.sequenceiq.thunderhead.service;
+
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.util.FileReaderUtils;
+
+@Component
+public class ImageCatalogMockService {
+
+    public String getImageCatalogByName(String name, String cbVersion, String runtimeVersion) {
+        String catalog = FileReaderUtils.readFileFromClasspathQuietly(String.format("mock-image-catalogs/%s.json", name));
+        return catalog.replace("CB_VERSION", cbVersion)
+                .replace("CDH_RUNTIME", runtimeVersion);
+    }
+
+}

--- a/mock-thunderhead/src/main/resources/mock-image-catalogs/catalog-with-for-upgrade.json
+++ b/mock-thunderhead/src/main/resources/mock-image-catalogs/catalog-with-for-upgrade.json
@@ -1,0 +1,155 @@
+{
+  "images": {
+    "cdh-images": [
+      {
+        "created": 1583391600,
+        "date": "2020-03-06",
+        "description": "Official Cloudbreak image",
+        "images": {
+          "mock": {
+            "default": "mockimage/hdc-hdp--1710161226.tar.gz"
+          }
+        },
+        "os": "centos7",
+        "os_type": "redhat7",
+        "uuid": "aaa778fc-7f17-4535-9021-515351df3691",
+        "package-versions": {
+          "cm": "CDH_RUNTIME",
+          "salt": "2017.7.5",
+          "salt-bootstrap": "0.13.0-2018-05-03T07:39:07",
+          "stack": "CDH_RUNTIME"
+        },
+        "stack-details": {
+          "repo": {
+            "stack": {
+              "redhat7": "http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/1922354/cdh/7.x/parcels/",
+              "repoid": "CDH-CDH_RUNTIME",
+              "repository-version": "CDH_RUNTIME-1.cdhCDH_RUNTIME.p0.1922354"
+            },
+            "util": null
+          },
+          "version": "CDH_RUNTIME",
+          "build-number": "1922354"
+        },
+        "repo": {
+          "redhat7": "http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/1922616/cm7/CDH_RUNTIME/redhat7/yum/"
+        },
+        "version": "CDH_RUNTIME",
+        "pre_warm_parcels": [
+          [
+            "SCHEMAREGISTRY-0.8.1.3.0.0.0-118-el7.parcel",
+            "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-118/tars/parcel"
+          ],
+          [
+            "STREAMS_MESSAGING_MANAGER-2.1.0.3.0.0.0-118-el7.parcel",
+            "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-118/tars/parcel"
+          ],
+          [
+            "PROFILER_MANAGER-2.0.3.2.0.3.0-50-el7.parcel",
+            "http://s3.amazonaws.com/dev.hortonworks.com/DSS/centos7/2.x/BUILDS/2.0.3.0-50/tars/dataplane_profilers"
+          ],
+          [
+            "PROFILER_SCHEDULER-2.0.3.2.0.3.0-50-el7.parcel",
+            "http://s3.amazonaws.com/dev.hortonworks.com/DSS/centos7/2.x/BUILDS/2.0.3.0-50/tars/dataplane_profilers"
+          ],
+          [
+            "CFM-2.0.0.0-el7.parcel",
+            "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-176/tars/parcel"
+          ]
+        ],
+        "pre_warm_csd": [
+          "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-118/tars/parcel/SCHEMAREGISTRY-0.8.1.jar",
+          "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-118/tars/parcel/STREAMS_MESSAGING_MANAGER-2.1.0.jar",
+          "http://s3.amazonaws.com/dev.hortonworks.com/DSS/centos7/2.x/BUILDS/2.0.3.0-50/tars/dataplane_profilers/PROFILER_MANAGER-2.0.3.2.0.3.0-50.jar",
+          "http://s3.amazonaws.com/dev.hortonworks.com/DSS/centos7/2.x/BUILDS/2.0.3.0-50/tars/dataplane_profilers/PROFILER_SCHEDULER-2.0.3.2.0.3.0-50.jar",
+          "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-176/tars/parcel/NIFI-1.11.1.2.0.0.0-176.jar",
+          "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-176/tars/parcel/NIFICA-1.11.1.2.0.0.0-176.jar",
+          "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-176/tars/parcel/NIFIREGISTRY-0.5.0.2.0.0.0-176.jar"
+        ]
+      },
+      {
+        "created": 1583877600,
+        "date": "2020-03-10",
+        "description": "Official Cloudbreak image Upgrade Target",
+        "images": {
+          "mock": {
+            "default": "mockimage/hdc-hdp--1710161226.tar.gz"
+          }
+        },
+        "os": "centos7",
+        "os_type": "redhat7",
+        "uuid": "bbbeadd2-5B95-4EC9-B300-13dc43208b64",
+        "package-versions": {
+          "cm": "CDH_RUNTIME",
+          "salt": "2017.7.5",
+          "salt-bootstrap": "0.13.0-2018-05-03T07:39:07",
+          "stack": "CDH_RUNTIME"
+        },
+        "stack-details": {
+          "repo": {
+            "stack": {
+              "redhat7": "http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/1922354/cdh/7.x/parcels/",
+              "repoid": "CDH-CDH_RUNTIME",
+              "repository-version": "CDH_RUNTIME-1.cdhCDH_RUNTIME.p0.1922354"
+            },
+            "util": null
+          },
+          "version": "CDH_RUNTIME",
+          "build-number": "1922354"
+        },
+        "repo": {
+          "redhat7": "http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/1922616/cm7/CDH_RUNTIME/redhat7/yum/"
+        },
+        "version": "CDH_RUNTIME",
+        "pre_warm_parcels": [
+          [
+            "SCHEMAREGISTRY-0.8.1.3.0.0.0-118-el7.parcel",
+            "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-118/tars/parcel"
+          ],
+          [
+            "STREAMS_MESSAGING_MANAGER-2.1.0.3.0.0.0-118-el7.parcel",
+            "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-118/tars/parcel"
+          ],
+          [
+            "PROFILER_MANAGER-2.0.3.2.0.3.0-50-el7.parcel",
+            "http://s3.amazonaws.com/dev.hortonworks.com/DSS/centos7/2.x/BUILDS/2.0.3.0-50/tars/dataplane_profilers"
+          ],
+          [
+            "PROFILER_SCHEDULER-2.0.3.2.0.3.0-50-el7.parcel",
+            "http://s3.amazonaws.com/dev.hortonworks.com/DSS/centos7/2.x/BUILDS/2.0.3.0-50/tars/dataplane_profilers"
+          ],
+          [
+            "CFM-2.0.0.0-el7.parcel",
+            "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-176/tars/parcel"
+          ]
+        ],
+        "pre_warm_csd": [
+          "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-118/tars/parcel/SCHEMAREGISTRY-0.8.1.jar",
+          "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-118/tars/parcel/STREAMS_MESSAGING_MANAGER-2.1.0.jar",
+          "http://s3.amazonaws.com/dev.hortonworks.com/DSS/centos7/2.x/BUILDS/2.0.3.0-50/tars/dataplane_profilers/PROFILER_MANAGER-2.0.3.2.0.3.0-50.jar",
+          "http://s3.amazonaws.com/dev.hortonworks.com/DSS/centos7/2.x/BUILDS/2.0.3.0-50/tars/dataplane_profilers/PROFILER_SCHEDULER-2.0.3.2.0.3.0-50.jar",
+          "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-176/tars/parcel/NIFI-1.11.1.2.0.0.0-176.jar",
+          "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-176/tars/parcel/NIFICA-1.11.1.2.0.0.0-176.jar",
+          "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-176/tars/parcel/NIFIREGISTRY-0.5.0.2.0.0.0-176.jar"
+        ]
+      }
+    ]
+  },
+  "versions": {
+    "cloudbreak": [
+      {
+        "images": [
+          "aaa778fc-7f17-4535-9021-515351df3691",
+          "bbbeadd2-5B95-4EC9-B300-13dc43208b64"
+        ],
+        "defaults": [
+          "aaa778fc-7f17-4535-9021-515351df3691",
+          "bbbeadd2-5B95-4EC9-B300-13dc43208b64"
+        ],
+        "versions": [
+          "CB_VERSION"
+        ]
+      }
+    ]
+  }
+}

--- a/mock-thunderhead/src/main/resources/mock-image-catalogs/catalog-with-prewarmed.json
+++ b/mock-thunderhead/src/main/resources/mock-image-catalogs/catalog-with-prewarmed.json
@@ -1,0 +1,133 @@
+{
+  "images": {
+    "cdh-images": [
+      {
+        "created": 1569369600,
+        "date": "2019-09-25",
+        "description": "Official Cloudbreak image",
+        "images": {
+          "mock": {
+            "default": "mockimage/hdc-hdp--1710161226.tar.gz"
+          }
+        },
+        "os": "centos7",
+        "os_type": "redhat7",
+        "uuid": "f6e778fc-7f17-4535-9021-515351df3691",
+        "defaultImage": true,
+        "package-versions": {
+          "cm": "7.x.0",
+          "salt": "2017.7.5",
+          "salt-bootstrap": "0.13.0-2018-05-03T07:39:07",
+          "stack": "CDH_RUNTIME"
+        },
+        "stack-details": {
+          "repo": {
+            "stack": {
+              "redhat7": "http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/1454941/cdh/7.x/parcels/",
+              "repoid": "CDH-CDH_RUNTIME",
+              "repository-version": "CDH_RUNTIME-1.cdhCDH_RUNTIME.p0.1454941"
+            },
+            "util": null
+          },
+          "version": "CDH_RUNTIME"
+        },
+        "repo": {
+          "redhat7": "http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/1455819/cm7/CDH_RUNTIME/redhat7/yum/"
+        },
+        "version": "7.x.0",
+        "pre_warm_parcels": [
+          [
+            "SCHEMAREGISTRY-0.8.0.3.0.0.0-21-el7.parcel",
+            "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-21/tars/parcel"
+          ],
+          [
+            "STREAMS_MESSAGING_MANAGER-2.1.0.3.0.0.0-21-el7.parcel",
+            "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-21/tars/parcel"
+          ],
+          [
+            "CFM-2.0.0.0-el7.parcel",
+            "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-23/tars/parcel"
+          ]
+        ],
+        "pre_warm_csd": [
+          "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-21/tars/parcel/SCHEMAREGISTRY-0.8.0.jar",
+          "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-21/tars/parcel/STREAMS_MESSAGING_MANAGER-2.1.0.jar",
+          "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-23/tars/parcel/NIFI-1.10.0.2.0.0.0-23.jar",
+          "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-23/tars/parcel/NIFICA-1.10.0.2.0.0.0-23.jar",
+          "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-23/tars/parcel/NIFIREGISTRY-0.5.0.2.0.0.0-23.jar"
+        ]
+      },
+      {
+        "created": 1569369600,
+        "date": "2019-09-25",
+        "description": "Official Cloudbreak image 2",
+        "images": {
+          "mock": {
+            "default": "mockimage/hdc-hdp--1710171220.tar.gz"
+          }
+        },
+        "os": "centos7",
+        "os_type": "redhat7",
+        "uuid": "1a6eadd2-5B95-4EC9-B300-13dc43208b64",
+        "package-versions": {
+          "cm": "7.x.0",
+          "salt": "2017.7.5",
+          "salt-bootstrap": "0.13.0-2018-05-03T07:39:07",
+          "stack": "CDH_RUNTIME"
+        },
+        "stack-details": {
+          "repo": {
+            "stack": {
+              "redhat7": "http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/1454941/cdh/7.x/parcels/",
+              "repoid": "CDH-CDH_RUNTIME",
+              "repository-version": "CDH_RUNTIME-1.cdhCDH_RUNTIME.p0.1454941"
+            },
+            "util": null
+          },
+          "version": "CDH_RUNTIME"
+        },
+        "repo": {
+          "redhat7": "http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/1455819/cm7/CDH_RUNTIME/redhat7/yum/"
+        },
+        "version": "7.x.0",
+        "pre_warm_parcels": [
+          [
+            "SCHEMAREGISTRY-0.8.0.3.0.0.0-21-el7.parcel",
+            "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-21/tars/parcel"
+          ],
+          [
+            "STREAMS_MESSAGING_MANAGER-2.1.0.3.0.0.0-21-el7.parcel",
+            "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-21/tars/parcel"
+          ],
+          [
+            "CFM-2.0.0.0-el7.parcel",
+            "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-23/tars/parcel"
+          ]
+        ],
+        "pre_warm_csd": [
+          "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-21/tars/parcel/SCHEMAREGISTRY-0.8.0.jar",
+          "http://s3.amazonaws.com/dev.hortonworks.com/CSP/centos7/3.x/BUILDS/3.0.0.0-21/tars/parcel/STREAMS_MESSAGING_MANAGER-2.1.0.jar",
+          "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-23/tars/parcel/NIFI-1.10.0.2.0.0.0-23.jar",
+          "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-23/tars/parcel/NIFICA-1.10.0.2.0.0.0-23.jar",
+          "http://s3.amazonaws.com/dev.hortonworks.com/CFM/centos7/2.x/BUILDS/2.0.0.0-23/tars/parcel/NIFIREGISTRY-0.5.0.2.0.0.0-23.jar"
+        ]
+      }
+    ]
+  },
+  "versions": {
+    "cloudbreak": [
+      {
+        "images": [
+          "f6e778fc-7f17-4535-9021-515351df3691",
+          "1a6eadd2-5B95-4EC9-B300-13dc43208b64"
+        ],
+        "defaults": [
+          "f6e778fc-7f17-4535-9021-515351df3691"
+        ],
+        "versions": [
+          "CB_VERSION"
+        ]
+      }
+    ]
+  }
+}

--- a/mock-thunderhead/src/main/resources/mock-image-catalogs/cb-catalog.json
+++ b/mock-thunderhead/src/main/resources/mock-image-catalogs/cb-catalog.json
@@ -1,0 +1,47 @@
+{
+  "images": {
+    "base-images": [
+      {
+        "date": "2017-10-13",
+        "description": "Cloudbreak official base image",
+        "images": {
+          "mock": {
+            "default": "mockimage/hdc-hdp--1710161226.tar.gz"
+          }
+        },
+        "os": "centos7",
+        "os_type": "redhat7",
+        "uuid": "f6e778fc-7f17-4535-9021-515351df3691",
+        "package-versions": {
+          "salt": "2017.7.5",
+          "salt-bootstrap": "0.13.0-2018-05-03T07:39:07"
+        }
+      },
+      {
+        "date": "2017-10-17",
+        "description": "Cloudbreak official base image 2",
+        "images": {
+          "mock": {
+            "default": "mockimage/hdc-hdp--1710171220.tar.gz"
+          }
+        },
+        "os": "centos7",
+        "os_type": "redhat7",
+        "uuid": "1a6eadd2-5B95-4EC9-B300-13dc43208b64"
+      }
+    ]
+  },
+  "versions": {
+    "cloudbreak": [
+      {
+        "images": [
+          "f6e778fc-7f17-4535-9021-515351df3691",
+          "1a6eadd2-5B95-4EC9-B300-13dc43208b64"
+        ],
+        "versions": [
+          "CB_VERSION"
+        ]
+      }
+    ]
+  }
+}

--- a/mock-thunderhead/src/main/resources/mock-image-catalogs/freeipa-catalog.json
+++ b/mock-thunderhead/src/main/resources/mock-image-catalogs/freeipa-catalog.json
@@ -1,0 +1,18 @@
+{
+  "images": {
+    "freeipa-images": [
+      {
+        "date": "2019-05-07",
+        "description": "Cloudbreak official prewarmed IPA image",
+        "images": {
+          "mock": {
+            "default": "mockimage"
+          }
+        },
+        "os": "redhat7",
+        "os_type": "redhat7",
+        "uuid": "81851893-8340-411d-afb7-e1b55107fb10"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Moved all image catalog to mock-service so it won't take up additional spark threads.

Sadly I was not able to measure any significant reduction in execution time since there is great variance in the tests. 