### PR TITLE
CB-8901: Fix FreeIPA repair with a requested instance

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/action/FreeIpaDownscaleActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/action/FreeIpaDownscaleActions.java
@@ -297,7 +297,9 @@ public class FreeIpaDownscaleActions {
                 stackUpdater.updateStackStatus(stack.getId(), getInProgressStatus(variables), "Updating metadata");
                 List<String> repairInstanceIds = getInstanceIds(variables);
                 terminationService.finalizeTermination(stack.getId(), repairInstanceIds);
-                if (!isRepair(variables)) {
+                if (isRepair(variables)) {
+                    terminationService.finalizeTerminationForInstancesWithoutInstanceIds(stack.getId());
+                } else {
                     int nodeCount = getInstanceCountByGroup(variables);
                     for (InstanceGroup instanceGroup : stack.getInstanceGroups()) {
                         instanceGroup.setNodeCount(nodeCount);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/ClusterProxyService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/ClusterProxyService.java
@@ -144,6 +144,7 @@ public class ClusterProxyService {
             tunnelGatewayConfigs = List.of(primaryGatewayConfig);
         } else if (ClusterProxyServiceAvailabilityChecker.isDnsBasedServiceNameAvailable(stack)) {
             List<GatewayConfig> targetGatewayConfigs = gatewayConfigs.stream()
+                    .filter(gatewayConfig -> Objects.nonNull(gatewayConfig.getInstanceId()))
                     .filter(gatewayConfig -> Objects.isNull(instanceIdsToRegister) || instanceIdsToRegister.contains(gatewayConfig.getInstanceId()))
                     .collect(Collectors.toList());
             serviceConfigs.addAll(createDnsMappedServiceConfigs(stack, targetGatewayConfigs, clientCertificate, usePrivateIpToTls));

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/termination/action/TerminationServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/termination/action/TerminationServiceTest.java
@@ -1,0 +1,66 @@
+package com.sequenceiq.freeipa.flow.stack.termination.action;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.service.Clock;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceStatus;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.stack.StackService;
+import com.sequenceiq.freeipa.service.stack.instance.InstanceMetaDataService;
+
+@ExtendWith(MockitoExtension.class)
+class TerminationServiceTest {
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private InstanceMetaDataService instanceMetaDataService;
+
+    @Mock
+    private Clock clock;
+
+    @InjectMocks
+    private TerminationService underTest;
+
+    @Test
+    void testFinalizeTerminationFroInstancesWithoutInstanceIds() {
+        Stack stack = mock(Stack.class);
+        InstanceMetaData im1 = mock(InstanceMetaData.class);
+        InstanceMetaData im2 = mock(InstanceMetaData.class);
+        InstanceMetaData im3 = mock(InstanceMetaData.class);
+        InstanceMetaData im4 = mock(InstanceMetaData.class);
+
+        when(stackService.getByIdWithListsInTransaction(1L)).thenReturn(stack);
+        when(stack.getAllInstanceMetaDataList()).thenReturn(List.of(im1, im2, im3, im4));
+        when(im1.isTerminated()).thenReturn(true);
+        when(im2.isTerminated()).thenReturn(false);
+        when(im3.isTerminated()).thenReturn(false);
+        when(im4.isTerminated()).thenReturn(false);
+        when(im2.getInstanceId()).thenReturn(null);
+        when(im3.getInstanceId()).thenReturn("i-3");
+        when(im4.getInstanceId()).thenReturn(null);
+        when(clock.getCurrentTimeMillis()).thenReturn(1L);
+
+        underTest.finalizeTerminationForInstancesWithoutInstanceIds(1L);
+
+        verify(im2).setTerminationDate(any());
+        verify(im2).setInstanceStatus(eq(InstanceStatus.TERMINATED));
+        verify(im4).setTerminationDate(any());
+        verify(im4).setInstanceStatus(eq(InstanceStatus.TERMINATED));
+        verify(instanceMetaDataService).saveAll(any());
+    }
+}


### PR DESCRIPTION
Fix FreeIPA repair so that if there is an instance stuck in the
requsted state, the repair operation is able to succeed and it clean
up as much as possible.

This was tested manully using a local instance of cloudbreak.

See detailed description in the commit message.