### PR TITLE
CB-8909: Fix FreeIPA repair of deleted instances

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/action/AbstractDownscaleAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/action/AbstractDownscaleAction.java
@@ -103,8 +103,9 @@ public abstract class AbstractDownscaleAction<P extends Payload> extends Abstrac
     }
 
     protected List<CloudInstance> getNonTerminatedCloudInstances(Stack stack, List<String> instanceIds) {
+        // Exclude terminated but include deleted
         return getInstanceMetadataFromStack(stack, instanceIds).stream()
-                .filter(im -> !im.isTerminated() && !im.isDeletedOnProvider())
+                .filter(im -> !im.isTerminated())
                 .map(instanceMetaData -> instanceConverter.convert(instanceMetaData))
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
In AWS if a FreeIPA instance was deleted on the cloud provider side,
the repair operation would not properly clean up the instances. For
example, associated cloud watches were not cleaned up. Additionally, it
caused problems during the upscale since the instance group still
contained the terminated instance and so the upscale would wait until
the operation timed out.

Repair of a deleted instance was validated on AWS using a local
deployment of cloudbreak.

See detailed description in the commit message.