### PR TITLE
CB-8910: Fix null pointer exception when repairing FreeIPA

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/RepairInstancesService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/RepairInstancesService.java
@@ -149,7 +149,7 @@ public class RepairInstancesService {
                 .filter(im -> im.isTerminated() || im.isDeletedOnProvider())
                 .map(InstanceMetaData::getInstanceId)
                 .filter(Objects::nonNull)
-                .filter(id -> !requestedInstanceIds.contains(id))
+                .filter(id -> Objects.isNull(requestedInstanceIds) || !requestedInstanceIds.contains(id))
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
Fix a null pointer exception that would be thrown when repairing
FreeIPA without specifying which instances to repair. This is
supposed to automatically detect which instance to repair.

This was texted manually using a local deployment of cloudbreak.

See detailed description in the commit message.