### PR TITLE
CB-8911: Fix FreeIPA repair when there are 2 instances without inst...

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/RepairInstancesService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/RepairInstancesService.java
@@ -101,6 +101,7 @@ public class RepairInstancesService {
 
     private Map<String, InstanceStatus> getInstanceHealthMap(String accountId, String environmentCrn) {
         return healthDetailsService.getHealthDetails(environmentCrn, accountId).getNodeHealthDetails().stream()
+                .filter(nodeHealthDetails -> Objects.nonNull(nodeHealthDetails.getInstanceId()))
                 .collect(Collectors.toMap(NodeHealthDetails::getInstanceId, NodeHealthDetails::getStatus));
     }
 


### PR DESCRIPTION
...ancese IDs and instance IDs are not provided in the repair request

If FreeIPA was repaired and there are two instances that do not have
instance IDs (e.g. state = requested) and also if the instances are
not specified during the request (e.g. auto detect), then there are
duplicate entries will a null value for the instance ID. This throws
an exception before starting the repair. This was fixed.

This was tested using a local cloudbreak instance.

See detailed description in the commit message.