### PR TITLE
CB-8937: FreeIPA doesn't automatically restart polkit

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/pillar/freeipa/services.sls
+++ b/freeipa/src/main/resources/freeipa-salt/pillar/freeipa/services.sls
@@ -9,3 +9,4 @@ freeipa:
     - certmonger
     - sssd
     - nginx
+    - polkit


### PR DESCRIPTION
Add polkit service systemd salt sls restart setting in FreeIPA instances. Polkit is a component for controlling system-wide privileges in Unix-like operating systems. Currently, polkit service won't restart after it fails. With this fix, polkit service will restart after a three-second delay. This is in consistent with all other services running in FreeIpa instances.

See detailed description in the commit message.