### PR TITLE
CB-8137: Fix FreeIPA status for deleted, stopped, available, unreac...

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/failure/BootstrapMachinesFailedToUpscaleFailureEventConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/failure/BootstrapMachinesFailedToUpscaleFailureEventConverter.java
@@ -16,7 +16,7 @@ public class BootstrapMachinesFailedToUpscaleFailureEventConverter implements Pa
     @Override
     public UpscaleFailureEvent convert(Object payload) {
         BootstrapMachinesFailed result = (BootstrapMachinesFailed) payload;
-        UpscaleFailureEvent event = new UpscaleFailureEvent(result.getResourceId(), "Bootstrapping mahcines", Set.of(), Map.of(),
+        UpscaleFailureEvent event = new UpscaleFailureEvent(result.getResourceId(), "Bootstrapping machines", Set.of(), Map.of(),
                 new Exception("Payload failed: " + payload));
         return event;
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/failure/ClusterProxyUpdateRegistrationFailedToUpscaleFailureEventConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/failure/ClusterProxyUpdateRegistrationFailedToUpscaleFailureEventConverter.java
@@ -16,7 +16,7 @@ public class ClusterProxyUpdateRegistrationFailedToUpscaleFailureEventConverter 
     @Override
     public UpscaleFailureEvent convert(Object payload) {
         ClusterProxyUpdateRegistrationFailed result = (ClusterProxyUpdateRegistrationFailed) payload;
-        UpscaleFailureEvent event = new UpscaleFailureEvent(result.getResourceId(), "Bootstrapping mahcines", Set.of(), Map.of(),
+        UpscaleFailureEvent event = new UpscaleFailureEvent(result.getResourceId(), "Bootstrapping machines", Set.of(), Map.of(),
                 new Exception("Payload failed: " + payload));
         return event;
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/failure/InstallFreeIpaServicesFailedToUpscaleFailureEventConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/failure/InstallFreeIpaServicesFailedToUpscaleFailureEventConverter.java
@@ -16,7 +16,7 @@ public class InstallFreeIpaServicesFailedToUpscaleFailureEventConverter implemen
     @Override
     public UpscaleFailureEvent convert(Object payload) {
         InstallFreeIpaServicesFailed result = (InstallFreeIpaServicesFailed) payload;
-        UpscaleFailureEvent event = new UpscaleFailureEvent(result.getResourceId(), "Bootstrapping mahcines", Set.of(), Map.of(),
+        UpscaleFailureEvent event = new UpscaleFailureEvent(result.getResourceId(), "Bootstrapping machines", Set.of(), Map.of(),
                 new Exception("Payload failed: " + payload));
         return event;
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/failure/PostInstallFreeIpaFailedToUpscaleFailureEventConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/failure/PostInstallFreeIpaFailedToUpscaleFailureEventConverter.java
@@ -16,7 +16,7 @@ public class PostInstallFreeIpaFailedToUpscaleFailureEventConverter implements P
     @Override
     public UpscaleFailureEvent convert(Object payload) {
         PostInstallFreeIpaFailed result = (PostInstallFreeIpaFailed) payload;
-        UpscaleFailureEvent event = new UpscaleFailureEvent(result.getResourceId(), "Bootstrapping mahcines", Set.of(), Map.of(),
+        UpscaleFailureEvent event = new UpscaleFailureEvent(result.getResourceId(), "Bootstrapping machines", Set.of(), Map.of(),
                 new Exception("Payload failed: " + payload));
         return event;
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/FreeipaChecker.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/FreeipaChecker.java
@@ -5,24 +5,22 @@ import static com.sequenceiq.cloudbreak.util.Benchmark.checkedMeasure;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
 import com.sequenceiq.freeipa.client.FreeIpaClient;
-import com.sequenceiq.freeipa.client.FreeIpaClientException;
-import com.sequenceiq.freeipa.client.FreeIpaClientExceptionUtil;
-import com.sequenceiq.freeipa.client.FreeIpaHostNotAvailableException;
 import com.sequenceiq.freeipa.client.model.RPCResponse;
 import com.sequenceiq.freeipa.entity.InstanceMetaData;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
-import com.sequenceiq.freeipa.service.stack.instance.InstanceMetaDataService;
 
 @Component
 public class FreeipaChecker {
@@ -32,48 +30,66 @@ public class FreeipaChecker {
     @Inject
     private FreeIpaClientFactory freeIpaClientFactory;
 
-    @Inject
-    private InstanceMetaDataService instanceMetaDataService;
-
-    private List<RPCResponse<Boolean>> checkStatus(Stack stack, Set<InstanceMetaData> checkableInstances) throws Exception {
+    private Pair<List<DetailedStackStatus>, String> checkStatus(Stack stack, Set<InstanceMetaData> checkableInstances) throws Exception {
         return checkedMeasure(() -> {
-            List<RPCResponse<Boolean>> statuses = new LinkedList<>();
+            List<DetailedStackStatus> statuses = new LinkedList<>();
+            List<RPCResponse<Boolean>> responses = new LinkedList<>();
             for (InstanceMetaData instanceMetaData : checkableInstances) {
                 String hostname = instanceMetaData.getDiscoveryFQDN();
-                FreeIpaClient freeIpaClient = checkedMeasure(() -> freeIpaClientFactory.getFreeIpaClientForStackWithPing(stack, hostname), LOGGER,
-                        ":::Auto sync::: freeipa client is created in {}ms");
-                statuses.add(checkedMeasure(() -> freeIpaClient.serverConnCheck(freeIpaClient.getHostname(), hostname), LOGGER,
-                        ":::Auto sync::: freeipa server_conncheck ran in {}ms"));
+                try {
+                    FreeIpaClient freeIpaClient = checkedMeasure(() -> freeIpaClientFactory.getFreeIpaClientForStackWithPing(stack, hostname), LOGGER,
+                            ":::Auto sync::: freeipa client is created in {}ms");
+                    RPCResponse<Boolean> response = checkedMeasure(() -> freeIpaClient.serverConnCheck(freeIpaClient.getHostname(), hostname), LOGGER,
+                            ":::Auto sync::: freeipa server_conncheck ran in {}ms");
+                    responses.add(response);
+                    if (response.getResult()) {
+                        statuses.add(DetailedStackStatus.AVAILABLE);
+                    } else {
+                        statuses.add(DetailedStackStatus.UNHEALTHY);
+                    }
+                } catch (Exception e) {
+                    LOGGER.info("FreeIpaClientException occurred during status fetch: " + e.getMessage(), e);
+                    statuses.add(DetailedStackStatus.UNREACHABLE);
+                }
             }
-            return statuses;
+            String message = getMessages(responses);
+            return Pair.of(statuses, message);
         }, LOGGER, ":::Auto sync::: freeipa server status is checked in {}ms");
     }
 
     public SyncResult getStatus(Stack stack, Set<InstanceMetaData> checkableInstances) {
         try {
-            Set<InstanceMetaData> notTermiatedStackInstances = instanceMetaDataService.findNotTerminatedForStack(stack.getId());
-            List<RPCResponse<Boolean>> responses = checkStatus(stack, checkableInstances);
+            if (checkableInstances.isEmpty()) {
+                throw new UnsupportedOperationException("There are no instances of FreeIPA to check the status of");
+            }
+
+            // Exclude terminated but include deleted
+            Set<InstanceMetaData> notTermiatedStackInstances = stack.getAllInstanceMetaDataList().stream()
+                    .filter(Predicate.not(InstanceMetaData::isTerminated))
+                    .collect(Collectors.toSet());
+            Pair<List<DetailedStackStatus>, String> statusCheckPair = checkStatus(stack, checkableInstances);
+            List<DetailedStackStatus> responses = statusCheckPair.getFirst();
             DetailedStackStatus status;
-            String postFix = "";
-            Boolean result = !responses.isEmpty() && responses.stream().allMatch(RPCResponse::getResult);
-            if (result && responses.size() == notTermiatedStackInstances.size()) {
-                status = DetailedStackStatus.PROVISIONED;
+            if (areAllStatusTheSame(responses) && !hasMissingStatus(responses, notTermiatedStackInstances)) {
+                status = responses.get(0);
             } else {
                 status = DetailedStackStatus.UNHEALTHY;
-                postFix = "Freeipa is unhealthy, ";
             }
-            return new SyncResult(postFix + getMessages(responses), status, result);
-        } catch (FreeIpaClientException e) {
-            LOGGER.info("FreeIpaClientException occurred during status fetch: " + e.getMessage(), e);
-            Throwable t = FreeIpaClientExceptionUtil.getAncestorCauseBeforeFreeIpaClientExceptions(e);
-            if (t instanceof FreeIpaHostNotAvailableException) {
-                return new SyncResult("Freeipa is unreachable: " + t.getMessage(), DetailedStackStatus.UNREACHABLE, false);
-            }
-            return new SyncResult("Freeipa is unhealthy, error occurred: " + e.getMessage(), DetailedStackStatus.UNHEALTHY, false);
+
+            return new SyncResult("FreeIpa is " + status + ", " + statusCheckPair.getSecond(), status);
         } catch (Exception e) {
             LOGGER.info("Error occurred during status fetch: " + e.getMessage(), e);
-            return new SyncResult("Freeipa is unreachable, because error occurred: " + e.getMessage(), DetailedStackStatus.UNREACHABLE, false);
+            return new SyncResult("FreeIpa is unreachable, because error occurred: " + e.getMessage(), DetailedStackStatus.UNREACHABLE);
         }
+    }
+
+    private boolean areAllStatusTheSame(List<DetailedStackStatus> response) {
+        DetailedStackStatus first = response.get(0);
+        return response.stream().allMatch(Predicate.isEqual(first));
+    }
+
+    private boolean hasMissingStatus(List<DetailedStackStatus> response, Set<InstanceMetaData> notTermiatedStackInstances) {
+        return response.size() != notTermiatedStackInstances.size();
     }
 
     private String getMessages(List<RPCResponse<Boolean>> responses) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/StackStatusCheckerJob.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/StackStatusCheckerJob.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.cloudbreak.logger.MdcContext;
+import com.sequenceiq.cloudbreak.quartz.statuschecker.job.StatusCheckerJob;
 import com.sequenceiq.flow.core.FlowLogService;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceStatus;
@@ -25,8 +26,6 @@ import com.sequenceiq.freeipa.entity.InstanceMetaData;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.service.stack.StackService;
 import com.sequenceiq.freeipa.service.stack.StackUpdater;
-import com.sequenceiq.freeipa.service.stack.instance.InstanceMetaDataService;
-import com.sequenceiq.cloudbreak.quartz.statuschecker.job.StatusCheckerJob;
 
 @Component
 public class StackStatusCheckerJob extends StatusCheckerJob {
@@ -46,9 +45,6 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
     private StackService stackService;
 
     @Inject
-    private InstanceMetaDataService instanceMetaDataService;
-
-    @Inject
     private StackUpdater stackUpdater;
 
     @Inject
@@ -57,7 +53,7 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
     @Override
     protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
         Long stackId = getStackId();
-        Stack stack = stackService.getStackById(stackId);
+        Stack stack = stackService.getByIdWithListsInTransaction(stackId);
         try {
             prepareMdcContextWithStack(stack);
             if (flowLogService.isOtherFlowRunning(stackId)) {
@@ -88,8 +84,12 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
         try {
             checkedMeasure(() -> {
                 ThreadBasedUserCrnProvider.doAsInternalActor(() -> {
-                    Set<InstanceMetaData> notTerminatedForStack = instanceMetaDataService.findNotTerminatedForStack(stack.getId());
-                    Set<InstanceMetaData> checkableInstances = notTerminatedForStack.stream().filter(i -> !i.isDeletedOnProvider())
+                    // Exclude terminated but include deleted
+                    Set<InstanceMetaData> notTerminatedForStack = stack.getAllInstanceMetaDataList().stream()
+                            .filter(Predicate.not(InstanceMetaData::isTerminated))
+                            .collect(Collectors.toSet());
+                    Set<InstanceMetaData> checkableInstances = notTerminatedForStack.stream()
+                            .filter(Predicate.not(InstanceMetaData::isDeletedOnProvider))
                             .collect(Collectors.toSet());
 
                     int alreadyDeletedCount = notTerminatedForStack.size() - checkableInstances.size();
@@ -99,7 +99,7 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
                     if (!checkableInstances.isEmpty()) {
                         SyncResult syncResult = freeipaChecker.getStatus(stack, checkableInstances);
                         List<ProviderSyncResult> results = providerChecker.updateAndGetStatuses(stack, checkableInstances);
-                        updateStackStatus(stack, syncResult, results);
+                        updateStackStatus(stack, syncResult, results, alreadyDeletedCount);
                     }
                 });
                 return null;
@@ -109,8 +109,8 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
         }
     }
 
-    private void updateStackStatus(Stack stack, SyncResult result, List<ProviderSyncResult> providerSyncResults) {
-        DetailedStackStatus status = getStackStatus(providerSyncResults, result);
+    private void updateStackStatus(Stack stack, SyncResult result, List<ProviderSyncResult> providerSyncResults, int alreadyDeletedCount) {
+        DetailedStackStatus status = getStackStatus(providerSyncResults, result, alreadyDeletedCount);
         if (status != stack.getStackStatus().getDetailedStackStatus()) {
             if (autoSyncConfig.isUpdateStatus()) {
                 stackUpdater.updateStackStatus(stack, status, result.getMessage());
@@ -121,21 +121,19 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
         }
     }
 
-    private DetailedStackStatus getStackStatus(List<ProviderSyncResult> providerSyncResults, SyncResult result) {
-        if (result.getStatus() == DetailedStackStatus.PROVISIONED) {
-            return DetailedStackStatus.PROVISIONED;
+    private DetailedStackStatus getStackStatus(List<ProviderSyncResult> providerSyncResults, SyncResult result, int alreadyDeletedCount) {
+        if (providerSyncResults.stream().allMatch(hasStatus(InstanceStatus.DELETED_ON_PROVIDER_SIDE, InstanceStatus.DELETED_BY_PROVIDER))) {
+            return DetailedStackStatus.DELETED_ON_PROVIDER_SIDE;
+        }
+        if (alreadyDeletedCount > 0) {
+            return DetailedStackStatus.UNHEALTHY;
         }
         if (providerSyncResults.stream().allMatch(hasStatus(InstanceStatus.STOPPED))) {
             return DetailedStackStatus.STOPPED;
         }
-        if (providerSyncResults.stream().anyMatch(hasStatus(InstanceStatus.STOPPED))) {
-            return DetailedStackStatus.PROVISIONED;
-        }
-        if (providerSyncResults.stream().allMatch(hasStatus(InstanceStatus.DELETED_ON_PROVIDER_SIDE, InstanceStatus.DELETED_BY_PROVIDER))) {
-            return DetailedStackStatus.DELETED_ON_PROVIDER_SIDE;
-        }
-        if (providerSyncResults.stream().anyMatch(hasStatus(InstanceStatus.DELETED_ON_PROVIDER_SIDE, InstanceStatus.DELETED_BY_PROVIDER))) {
-            return DetailedStackStatus.PROVISIONED;
+        if (providerSyncResults.stream().anyMatch(
+                hasStatus(InstanceStatus.DELETED_ON_PROVIDER_SIDE, InstanceStatus.DELETED_BY_PROVIDER, InstanceStatus.STOPPED))) {
+            return DetailedStackStatus.UNHEALTHY;
         }
         return result.getStatus();
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/SyncResult.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/SyncResult.java
@@ -8,12 +8,9 @@ public class SyncResult {
 
     private DetailedStackStatus status;
 
-    private Boolean result;
-
-    public SyncResult(String message, DetailedStackStatus status, Boolean result) {
+    public SyncResult(String message, DetailedStackStatus status) {
         this.message = message;
         this.status = status;
-        this.result = result;
     }
 
     public String getMessage() {
@@ -22,9 +19,5 @@ public class SyncResult {
 
     public DetailedStackStatus getStatus() {
         return status;
-    }
-
-    public Boolean getResult() {
-        return result;
     }
 }


### PR DESCRIPTION
...hable, and unhealthy

Fixed FreeIPA status for HA clusters.
 * Stopped + Running = Unhealthy
 * Stopped + Terminated = Unhealthy (It may temporarily be unreachable)
 * Unreachable + Unreachable = Unreachable
 * Unreahable + Running = Unhealthy
 * Running + Deleted = Unhealthy

This was tested with unit tests and also manually with a local
deployment of cloudbreak.

See detailed description in the commit message.