### PR TITLE
CB-8924 AWS InsufficientInstanceCapacity fix on ASG

### DIFF
--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsAutoScalingServiceTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsAutoScalingServiceTest.java
@@ -66,6 +66,23 @@ public class AwsAutoScalingServiceTest {
     }
 
     @Test
+    public void testCheckLastScalingActivityWhenActivitiesFailedWithInsufficientInstanceCapacity() throws AmazonAutoscalingFailed {
+        DescribeScalingActivitiesResult result = new DescribeScalingActivitiesResult();
+        Activity activity1 = new Activity();
+        activity1.setStatusMessage("Status InsufficientInstanceCapacity blahblah");
+        activity1.setDescription("Description");
+        activity1.setCause("Cause");
+        activity1.setStatusCode("FAILED");
+        result.setActivities(List.of(activity1));
+        Group group = createGroup("master", InstanceGroupType.GATEWAY, List.of(new CloudInstance("anId", null, null)));
+        when(amazonAutoScalingRetryClient.describeScalingActivities(any(DescribeScalingActivitiesRequest.class))).thenReturn(result);
+        when(customAmazonWaiterProvider.getAutoscalingActivitiesWaiter(any(), any())).thenReturn(describeScalingActivitiesRequestWaiter);
+
+        Date date = new Date();
+        underTest.checkLastScalingActivity(amazonAutoScalingClient, amazonAutoScalingRetryClient, "asGroup", date, group);
+    }
+
+    @Test
     public void testCheckLastScalingActivityWhenActivitiesSuccessThenNoException() throws AmazonAutoscalingFailed {
         DescribeScalingActivitiesResult result = new DescribeScalingActivitiesResult();
         Activity activity1 = new Activity();


### PR DESCRIPTION
In case InsufficientInstanceCapacity is returned on an ASG request
either on launch or upscale, we need to keep waiting for the instances
to be provisioned by AWS as this failure seems recoverable, i.e. in a few
minutes AWS will likely launch the requested number of instances in the ASG.