### PR TITLE
CB-8703 Rotate the CM host certificates

### DIFF
--- a/client-cm/src/main/java/com/sequenceiq/cloudbreak/cm/client/retry/ClouderaManagerApiFactory.java
+++ b/client-cm/src/main/java/com/sequenceiq/cloudbreak/cm/client/retry/ClouderaManagerApiFactory.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 
 import com.cloudera.api.swagger.AllHostsResourceApi;
 import com.cloudera.api.swagger.AuthRolesResourceApi;
+import com.cloudera.api.swagger.BatchResourceApi;
 import com.cloudera.api.swagger.CdpResourceApi;
 import com.cloudera.api.swagger.ClouderaManagerResourceApi;
 import com.cloudera.api.swagger.ClustersResourceApi;
@@ -95,6 +96,9 @@ public class ClouderaManagerApiFactory {
     @Inject
     private Function<ApiClient, ExternalAccountsResourceApi> externalAccountsResourceApiFactory;
 
+    @Inject
+    private Function<ApiClient, BatchResourceApi> batchResourceApiFactory;
+
     public ClouderaManagerResourceApi getClouderaManagerResourceApi(ApiClient apiClient) {
         return clouderaManagerResourceApiFactory.apply(apiClient);
     }
@@ -177,5 +181,9 @@ public class ClouderaManagerApiFactory {
 
     public ExternalAccountsResourceApi getExternalAccountsResourceApi(ApiClient client) {
         return externalAccountsResourceApiFactory.apply(client);
+    }
+
+    public BatchResourceApi getBatchResourceApi(ApiClient client) {
+        return batchResourceApiFactory.apply(client);
     }
 }

--- a/client-cm/src/main/java/com/sequenceiq/cloudbreak/cm/client/retry/CmClientConfig.java
+++ b/client-cm/src/main/java/com/sequenceiq/cloudbreak/cm/client/retry/CmClientConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Scope;
 
 import com.cloudera.api.swagger.AllHostsResourceApi;
 import com.cloudera.api.swagger.AuthRolesResourceApi;
+import com.cloudera.api.swagger.BatchResourceApi;
 import com.cloudera.api.swagger.CdpResourceApi;
 import com.cloudera.api.swagger.ClouderaManagerResourceApi;
 import com.cloudera.api.swagger.ClustersResourceApi;
@@ -138,6 +139,11 @@ public class CmClientConfig {
         return this::externalAccountsResourceApi;
     }
 
+    @Bean
+    public Function<ApiClient, BatchResourceApi> batchResourceApiFactory() {
+        return this::batchResourceApi;
+    }
+
     // prototype bean declarations:
     // CHECKSTYLE:OFF
     @Bean
@@ -264,6 +270,12 @@ public class CmClientConfig {
     @Scope(value = "prototype")
     public ExternalAccountsResourceApi externalAccountsResourceApi(ApiClient apiClient) {
         return new ExternalAccountsResourceApi(apiClient);
+    }
+
+    @Bean
+    @Scope(value = "prototype")
+    public BatchResourceApi batchResourceApi(ApiClient apiClient) {
+        return new BatchResourceApi(apiClient);
     }
     // CHECKSTYLE:ON
 }

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
@@ -108,6 +108,10 @@ public interface ClusterApi {
         clusterModificationService().restartAll();
     }
 
+    default void rotateHostCertificates() throws CloudbreakException {
+        clusterSecurityService().rotateHostCertificates();
+    }
+
     default ClusterStatus getStatus(boolean blueprintPresent) {
         return clusterStatusService().getStatus(blueprintPresent).getClusterStatus();
     }

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterSecurityService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterSecurityService.java
@@ -39,4 +39,6 @@ public interface ClusterSecurityService {
     String getKeystorePassword();
 
     String getMasterKey();
+
+    void rotateHostCertificates() throws CloudbreakException;
 }

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/ClouderaManagerCommandListPollerObject.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/ClouderaManagerCommandListPollerObject.java
@@ -1,0 +1,20 @@
+package com.sequenceiq.cloudbreak.cm.polling;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import com.cloudera.api.swagger.client.ApiClient;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+
+public class ClouderaManagerCommandListPollerObject extends ClouderaManagerPollerObject {
+    private final List<BigDecimal> idList;
+
+    public ClouderaManagerCommandListPollerObject(Stack stack, ApiClient apiClient, List<BigDecimal> idList) {
+        super(stack, apiClient);
+        this.idList = idList;
+    }
+
+    public List<BigDecimal> getIdList() {
+        return idList;
+    }
+}

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/ClouderaManagerCommandPollerObject.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/ClouderaManagerCommandPollerObject.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.cloudbreak.cm.polling;
+
+import java.math.BigDecimal;
+
+import com.cloudera.api.swagger.client.ApiClient;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+
+public class ClouderaManagerCommandPollerObject extends ClouderaManagerPollerObject {
+
+    private final Stack stack;
+
+    private final ApiClient apiClient;
+
+    private final BigDecimal id;
+
+    public ClouderaManagerCommandPollerObject(Stack stack, ApiClient apiClient, BigDecimal id) {
+        super(stack, apiClient);
+        this.stack = stack;
+        this.apiClient = apiClient;
+        this.id = id;
+    }
+
+    public BigDecimal getId() {
+        return id;
+    }
+}

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/ClouderaManagerPollerObject.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/ClouderaManagerPollerObject.java
@@ -1,7 +1,5 @@
 package com.sequenceiq.cloudbreak.cm.polling;
 
-import java.math.BigDecimal;
-
 import com.cloudera.api.swagger.client.ApiClient;
 import com.sequenceiq.cloudbreak.cluster.service.StackAware;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
@@ -12,21 +10,14 @@ public class ClouderaManagerPollerObject implements StackAware {
 
     private final ApiClient apiClient;
 
-    private final BigDecimal id;
-
-    public ClouderaManagerPollerObject(Stack stack, ApiClient apiClient, BigDecimal id) {
+    public ClouderaManagerPollerObject(Stack stack, ApiClient apiClient) {
         this.stack = stack;
         this.apiClient = apiClient;
-        this.id = id;
     }
 
     @Override
     public Stack getStack() {
         return stack;
-    }
-
-    public BigDecimal getId() {
-        return id;
     }
 
     public ApiClient getApiClient() {

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/AbstractClouderaManagerApiCheckerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/AbstractClouderaManagerApiCheckerTask.java
@@ -1,0 +1,143 @@
+package com.sequenceiq.cloudbreak.cm.polling.task;
+
+import java.net.ConnectException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.CollectionUtils;
+
+import com.cloudera.api.swagger.CommandsResourceApi;
+import com.cloudera.api.swagger.client.ApiClient;
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.model.ApiCommand;
+import com.cloudera.api.swagger.model.ApiCommandList;
+import com.google.common.annotations.VisibleForTesting;
+import com.sequenceiq.cloudbreak.cluster.service.ClusterBasedStatusCheckerTask;
+import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
+import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.event.ResourceEvent;
+import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
+
+public abstract class AbstractClouderaManagerApiCheckerTask<T extends ClouderaManagerPollerObject> extends ClusterBasedStatusCheckerTask<T> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractClouderaManagerApiCheckerTask.class);
+
+    private static final int TOLERATED_ERROR_LIMIT = 5;
+
+    //CHECKSTYLE:OFF
+    protected final ClouderaManagerApiPojoFactory clouderaManagerApiPojoFactory;
+
+    private final CloudbreakEventService cloudbreakEventService;
+
+    private int toleratedErrorCounter = 0;
+
+    private boolean connectExceptionOccurred = false;
+    //CHECKSTYLE:ON
+
+    protected AbstractClouderaManagerApiCheckerTask(ClouderaManagerApiPojoFactory clouderaManagerApiPojoFactory,
+            CloudbreakEventService cloudbreakEventService) {
+        this.clouderaManagerApiPojoFactory = clouderaManagerApiPojoFactory;
+        this.cloudbreakEventService = cloudbreakEventService;
+    }
+
+    @Override
+    public final boolean checkStatus(T pollerObject) {
+        ApiClient apiClient = pollerObject.getApiClient();
+        CommandsResourceApi commandsResourceApi = clouderaManagerApiPojoFactory.getCommandsResourceApi(apiClient);
+        try {
+            return doStatusCheck(pollerObject, commandsResourceApi);
+        } catch (ApiException e) {
+            return handleApiException(pollerObject, e);
+        }
+    }
+
+    private boolean handleApiException(T pollerObject, ApiException e) {
+        if (e.getCode() == HttpStatus.BAD_GATEWAY.value()) {
+            LOGGER.debug("Cloudera Manager is not (yet) available.", e);
+            return false;
+        } else if (e.getCause() instanceof ConnectException) {
+            return handleConnectException(pollerObject, e);
+        } else if (isToleratedError(e)) {
+            return handleToleratedError(pollerObject, e);
+        } else {
+            throw new ClouderaManagerOperationFailedException(String.format("Cloudera Manager [%s] operation  failed.", getCommandName()), e);
+        }
+    }
+
+    private boolean handleConnectException(T pollerObject, ApiException e) {
+        LOGGER.warn("Command [{}] with id [{}] failed with a ConnectException '{}'. Notification is sent to the UI.",
+                getCommandName(), getOperationIdentifier(pollerObject), e.getMessage());
+        if (!connectExceptionOccurred) {
+            connectExceptionOccurred = true;
+            Stack stack = pollerObject.getStack();
+            cloudbreakEventService.fireCloudbreakEvent(stack.getId(), stack.getStatus().name(),
+                    ResourceEvent.CLUSTER_CM_SECURITY_GROUP_TOO_STRICT, List.of(e.getMessage()));
+        }
+        return false;
+    }
+
+    private boolean handleToleratedError(T pollerObject, ApiException e) {
+        if (toleratedErrorCounter < TOLERATED_ERROR_LIMIT) {
+            toleratedErrorCounter++;
+            LOGGER.warn("Command [{}] with id [{}] failed with a tolerated error '{}' for the {}. time(s). Tolerating till {} occasions.",
+                    getCommandName(), getOperationIdentifier(pollerObject), e.getMessage(), toleratedErrorCounter, TOLERATED_ERROR_LIMIT);
+            return false;
+        } else {
+            throw new ClouderaManagerOperationFailedException(
+                    String.format("Command [%s] with id [%s] failed with a tolerated error '%s' for %s times. Operation is considered failed.",
+                            getCommandName(), getOperationIdentifier(pollerObject), e.getMessage(), TOLERATED_ERROR_LIMIT));
+        }
+    }
+
+    private boolean isToleratedError(ApiException e) {
+        // Retry for BAD_REQUEST is not ideal, but sometimes CM sends back BAD_REQUESTS even for INTERNAL_SERVER_ERROR
+        return e.getCode() == HttpStatus.INTERNAL_SERVER_ERROR.value()
+                || e.getCode() == HttpStatus.BAD_REQUEST.value()
+                || e.getCause() instanceof SocketException
+                || e.getCause() instanceof SocketTimeoutException;
+    }
+
+    protected abstract boolean doStatusCheck(T pollerObject, CommandsResourceApi commandsResourceApi) throws ApiException;
+
+    @VisibleForTesting
+    List<String> parseResultMessageFromChildren(ApiCommandList apiCommandList) {
+        if (CollectionUtils.isEmpty(apiCommandList.getItems())) {
+            return Collections.emptyList();
+        }
+        List<String> ret = new ArrayList<>();
+        apiCommandList.getItems().forEach(s -> {
+            if (s.getChildren() == null) {
+                ret.add(formatToLine(s));
+            } else {
+                ret.add(formatToLine(s));
+                ret.addAll(parseResultMessageFromChildren(s.getChildren()));
+            }
+        });
+        return ret;
+    }
+
+    private String formatToLine(ApiCommand s) {
+        LOGGER.debug("ApiCommand to format: {}", s);
+        String ret = "";
+        if (s != null) {
+            ret += s.getName();
+            if (s.getServiceRef() != null) {
+                ret += "(" + s.getServiceRef().getServiceName() + "): ";
+            }
+            ret += s.getResultMessage();
+        }
+        return ret;
+    }
+
+    protected abstract String getCommandName();
+
+    protected abstract String getOperationIdentifier(T pollerObject);
+}

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/AbstractClouderaManagerCommandCheckerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/AbstractClouderaManagerCommandCheckerTask.java
@@ -1,108 +1,24 @@
 package com.sequenceiq.cloudbreak.cm.polling.task;
 
-import java.net.ConnectException;
-import java.net.SocketException;
-import java.net.SocketTimeoutException;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpStatus;
-import org.springframework.util.CollectionUtils;
 
 import com.cloudera.api.swagger.CommandsResourceApi;
-import com.cloudera.api.swagger.client.ApiClient;
 import com.cloudera.api.swagger.client.ApiException;
 import com.cloudera.api.swagger.model.ApiCommand;
-import com.cloudera.api.swagger.model.ApiCommandList;
-import com.google.common.annotations.VisibleForTesting;
-import com.sequenceiq.cloudbreak.cluster.service.ClusterBasedStatusCheckerTask;
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
-import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
-import com.sequenceiq.cloudbreak.event.ResourceEvent;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 
-public abstract class AbstractClouderaManagerCommandCheckerTask<T extends ClouderaManagerPollerObject> extends ClusterBasedStatusCheckerTask<T> {
-
+public abstract class AbstractClouderaManagerCommandCheckerTask<T extends ClouderaManagerCommandPollerObject> extends AbstractClouderaManagerApiCheckerTask<T> {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractClouderaManagerCommandCheckerTask.class);
-
-    private static final int TOLERATED_ERROR_LIMIT = 5;
-
-    //CHECKSTYLE:OFF
-    protected final ClouderaManagerApiPojoFactory clouderaManagerApiPojoFactory;
-
-    private final CloudbreakEventService cloudbreakEventService;
-
-    private int toleratedErrorCounter = 0;
-
-    private boolean connectExceptionOccurred = false;
-    //CHECKSTYLE:ON
 
     protected AbstractClouderaManagerCommandCheckerTask(ClouderaManagerApiPojoFactory clouderaManagerApiPojoFactory,
             CloudbreakEventService cloudbreakEventService) {
-        this.clouderaManagerApiPojoFactory = clouderaManagerApiPojoFactory;
-        this.cloudbreakEventService = cloudbreakEventService;
-    }
-
-    @Override
-    public final boolean checkStatus(T pollerObject) {
-        ApiClient apiClient = pollerObject.getApiClient();
-        CommandsResourceApi commandsResourceApi = clouderaManagerApiPojoFactory.getCommandsResourceApi(apiClient);
-        try {
-            return doStatusCheck(pollerObject, commandsResourceApi);
-        } catch (ApiException e) {
-            return handleApiException(pollerObject, e);
-        }
-    }
-
-    private boolean handleApiException(T pollerObject, ApiException e) {
-        if (e.getCode() == HttpStatus.BAD_GATEWAY.value()) {
-            LOGGER.debug("Cloudera Manager is not (yet) available.", e);
-            return false;
-        } else if (e.getCause() instanceof ConnectException) {
-            return handleConnectException(pollerObject, e);
-        } else if (isToleratedError(e)) {
-            return handleToleratedError(pollerObject, e);
-        } else {
-            throw new ClouderaManagerOperationFailedException(String.format("Cloudera Manager [%s] operation  failed.", getCommandName()), e);
-        }
-    }
-
-    private boolean handleConnectException(T pollerObject, ApiException e) {
-        LOGGER.warn("Command [{}] with id [{}] failed with a ConnectException '{}'. Notification is sent to the UI.",
-                getCommandName(), pollerObject.getId(), e.getMessage());
-        if (!connectExceptionOccurred) {
-            connectExceptionOccurred = true;
-            Stack stack = pollerObject.getStack();
-            cloudbreakEventService.fireCloudbreakEvent(stack.getId(), stack.getStatus().name(),
-                    ResourceEvent.CLUSTER_CM_SECURITY_GROUP_TOO_STRICT, List.of(e.getMessage()));
-        }
-        return false;
-    }
-
-    private boolean handleToleratedError(T pollerObject, ApiException e) {
-        if (toleratedErrorCounter < TOLERATED_ERROR_LIMIT) {
-            toleratedErrorCounter++;
-            LOGGER.warn("Command [{}] with id [{}] failed with a tolerated error '{}' for the {}. time(s). Tolerating till {} occasions.",
-                    getCommandName(), pollerObject.getId(), e.getMessage(), toleratedErrorCounter, TOLERATED_ERROR_LIMIT);
-            return false;
-        } else {
-            throw new ClouderaManagerOperationFailedException(
-                    String.format("Command [%s] with id [%s] failed with a tolerated error '%s' for %s times. Operation is considered failed.",
-                            getCommandName(), pollerObject.getId(), e.getMessage(), TOLERATED_ERROR_LIMIT));
-        }
-    }
-
-    private boolean isToleratedError(ApiException e) {
-        // Retry for BAD_REQUEST is not ideal, but sometimes CM sends back BAD_REQUESTS even for INTERNAL_SERVER_ERROR
-        return e.getCode() == HttpStatus.INTERNAL_SERVER_ERROR.value()
-                || e.getCode() == HttpStatus.BAD_REQUEST.value()
-                || e.getCause() instanceof SocketException
-                || e.getCause() instanceof SocketTimeoutException;
+        super(clouderaManagerApiPojoFactory, cloudbreakEventService);
     }
 
     protected boolean doStatusCheck(T pollerObject, CommandsResourceApi commandsResourceApi) throws ApiException {
@@ -121,35 +37,7 @@ public abstract class AbstractClouderaManagerCommandCheckerTask<T extends Cloude
         }
     }
 
-    @VisibleForTesting
-    List<String> parseResultMessageFromChildren(ApiCommandList apiCommandList) {
-        if (CollectionUtils.isEmpty(apiCommandList.getItems())) {
-            return Collections.emptyList();
-        }
-        List<String> ret = new ArrayList<>();
-        apiCommandList.getItems().forEach(s -> {
-            if (s.getChildren() == null) {
-                ret.add(formatToLine(s));
-            } else {
-                ret.add(formatToLine(s));
-                ret.addAll(parseResultMessageFromChildren(s.getChildren()));
-            }
-        });
-        return ret;
+    protected String getOperationIdentifier(T pollerObject) {
+        return String.valueOf(pollerObject.getId());
     }
-
-    private String formatToLine(ApiCommand s) {
-        LOGGER.debug("ApiCommand to format: {}", s);
-        String ret = "";
-        if (s != null) {
-            ret += s.getName();
-            if (s.getServiceRef() != null) {
-                ret += "(" + s.getServiceRef().getServiceName() + "): ";
-            }
-            ret += s.getResultMessage();
-        }
-        return ret;
-    }
-
-    protected abstract String getCommandName();
 }

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/AbstractClouderaManagerCommandListCheckerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/AbstractClouderaManagerCommandListCheckerTask.java
@@ -1,0 +1,75 @@
+package com.sequenceiq.cloudbreak.cm.polling.task;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.cloudera.api.swagger.CommandsResourceApi;
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.model.ApiCommand;
+import com.cloudera.api.swagger.model.ApiHostRef;
+import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
+import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandListPollerObject;
+import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
+
+public abstract class AbstractClouderaManagerCommandListCheckerTask<T extends ClouderaManagerCommandListPollerObject>
+        extends AbstractClouderaManagerApiCheckerTask<T> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractClouderaManagerCommandListCheckerTask.class);
+
+    protected AbstractClouderaManagerCommandListCheckerTask(ClouderaManagerApiPojoFactory clouderaManagerApiPojoFactory,
+            CloudbreakEventService cloudbreakEventService) {
+        super(clouderaManagerApiPojoFactory, cloudbreakEventService);
+    }
+
+    protected boolean doStatusCheck(T pollerObject, CommandsResourceApi commandsResourceApi) throws ApiException {
+        List<ApiCommand> apiCommands = collectApiCommands(pollerObject, commandsResourceApi);
+        boolean allCommandsFinished = apiCommands.stream().noneMatch(ApiCommand::getActive);
+        if (allCommandsFinished) {
+            validateApiCommandResults(apiCommands);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private List<ApiCommand> collectApiCommands(T pollerObject, CommandsResourceApi commandsResourceApi)  throws ApiException {
+        List<ApiCommand> apiCommands = new ArrayList<>();
+        for (BigDecimal commandId : pollerObject.getIdList()) {
+            ApiCommand apiCommand = commandsResourceApi.readCommand(commandId);
+            apiCommands.add(apiCommand);
+            if (apiCommand.getActive()) {
+                LOGGER.debug("Command [" + getCommandName() + "] with id [" + commandId + "] is active, so it hasn't finished yet");
+                break;
+            }
+        }
+        return apiCommands;
+    }
+
+    private void validateApiCommandResults(List<ApiCommand> apiCommands) {
+        List<ApiCommand> failedCommands = apiCommands.stream().filter(cmd -> !cmd.getSuccess()).collect(Collectors.toList());
+        if (!failedCommands.isEmpty()) {
+            String message = failedCommands.stream().map(cmd -> createFailedCommandResultString(cmd)).collect(Collectors.joining(","));
+            LOGGER.info(message);
+            throw new ClouderaManagerOperationFailedException(message);
+        }
+    }
+
+    private String createFailedCommandResultString(ApiCommand cmd) {
+        String resultMessage = cmd.getResultMessage();
+        List<String> detailedMessages = parseResultMessageFromChildren(cmd.getChildren());
+        ApiHostRef hostRef = cmd.getHostRef();
+        String hostRefStr = hostRef == null ? "Unknown" : hostRef.getHostname();
+        return "Command [" + cmd.getName() + ":" + cmd.getId() + "] failed on host [" + hostRefStr + "]: " + resultMessage +
+                ". Detailed messages: " + String.join("\n", detailedMessages);
+    }
+
+    protected String getOperationIdentifier(T pollerObject) {
+        return StringUtils.join(pollerObject.getIdList(), ",");
+    }
+}

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerApplyHostTemplateListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerApplyHostTemplateListenerTask.java
@@ -2,10 +2,10 @@ package com.sequenceiq.cloudbreak.cm.polling.task;
 
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
-import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 
-public class ClouderaManagerApplyHostTemplateListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerPollerObject> {
+public class ClouderaManagerApplyHostTemplateListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     public ClouderaManagerApplyHostTemplateListenerTask(ClouderaManagerApiPojoFactory clouderaManagerApiPojoFactory,
             CloudbreakEventService cloudbreakEventService) {
@@ -13,12 +13,12 @@ public class ClouderaManagerApplyHostTemplateListenerTask extends AbstractCloude
     }
 
     @Override
-    public void handleTimeout(ClouderaManagerPollerObject toolsResourceApi) {
+    public void handleTimeout(ClouderaManagerCommandPollerObject toolsResourceApi) {
         throw new ClouderaManagerOperationFailedException("Operation timed out. Failed to apply host template.");
     }
 
     @Override
-    public String successMessage(ClouderaManagerPollerObject toolsResourceApi) {
+    public String successMessage(ClouderaManagerCommandPollerObject toolsResourceApi) {
         return "Cloudera Manager applied host template finished with success result.";
     }
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerBatchCommandsListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerBatchCommandsListenerTask.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.cloudbreak.cm.polling.task;
+
+import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
+import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandListPollerObject;
+import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
+
+public class ClouderaManagerBatchCommandsListenerTask extends AbstractClouderaManagerCommandListCheckerTask<ClouderaManagerCommandListPollerObject> {
+    private String commandName;
+
+    public ClouderaManagerBatchCommandsListenerTask(ClouderaManagerApiPojoFactory clouderaManagerApiPojoFactory,
+            CloudbreakEventService cloudbreakEventService, String commandName) {
+        super(clouderaManagerApiPojoFactory, cloudbreakEventService);
+        this.commandName = commandName;
+    }
+
+    @Override
+    public void handleTimeout(ClouderaManagerCommandListPollerObject pollerObject) {
+        throw new ClouderaManagerOperationFailedException(String.format("Operation timed out. Failed to execute all of the following commands: %s.",
+                pollerObject.getIdList()));
+    }
+
+    @Override
+    public String successMessage(ClouderaManagerCommandListPollerObject pollerObject) {
+        return String.format("Cloudera Manager executed the following commands: %s", pollerObject.getIdList());
+    }
+
+    @Override
+    protected String getCommandName() {
+        return "Batch command of " + commandName + " commands";
+    }
+}

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerCollectDiagnosticsListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerCollectDiagnosticsListenerTask.java
@@ -17,10 +17,10 @@ import com.cloudera.api.swagger.model.ApiCommand;
 import com.cloudera.api.swagger.model.ApiCommandList;
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
-import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 
-public class ClouderaManagerCollectDiagnosticsListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerPollerObject> {
+public class ClouderaManagerCollectDiagnosticsListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerCollectDiagnosticsListenerTask.class);
 
@@ -29,7 +29,7 @@ public class ClouderaManagerCollectDiagnosticsListenerTask extends AbstractCloud
     }
 
     @Override
-    protected boolean doStatusCheck(ClouderaManagerPollerObject pollerObject, CommandsResourceApi commandsResourceApi) throws ApiException {
+    protected boolean doStatusCheck(ClouderaManagerCommandPollerObject pollerObject, CommandsResourceApi commandsResourceApi) throws ApiException {
         commandsResourceApi = clouderaManagerApiPojoFactory.getCommandsResourceApi(pollerObject.getApiClient());
         ApiCommand apiCommand = commandsResourceApi.readCommand(pollerObject.getId());
         if (apiCommand.getActive()) {
@@ -47,12 +47,12 @@ public class ClouderaManagerCollectDiagnosticsListenerTask extends AbstractCloud
     }
 
     @Override
-    public void handleTimeout(ClouderaManagerPollerObject clouderaManagerPollerObject) {
+    public void handleTimeout(ClouderaManagerCommandPollerObject clouderaManagerCommandPollerObject) {
         throw new ClouderaManagerOperationFailedException("Operation timed out. Failed to collect diagnostics.");
     }
 
     @Override
-    public String successMessage(ClouderaManagerPollerObject clouderaManagerPollerObject) {
+    public String successMessage(ClouderaManagerCommandPollerObject clouderaManagerCommandPollerObject) {
         return "Cloudera Manager diagnostics collection finished with success result.";
     }
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerDecommissionHostListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerDecommissionHostListenerTask.java
@@ -2,10 +2,10 @@ package com.sequenceiq.cloudbreak.cm.polling.task;
 
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
-import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 
-public class ClouderaManagerDecommissionHostListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerPollerObject> {
+public class ClouderaManagerDecommissionHostListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     public ClouderaManagerDecommissionHostListenerTask(ClouderaManagerApiPojoFactory clouderaManagerApiPojoFactory,
             CloudbreakEventService cloudbreakEventService) {
@@ -13,12 +13,12 @@ public class ClouderaManagerDecommissionHostListenerTask extends AbstractClouder
     }
 
     @Override
-    public void handleTimeout(ClouderaManagerPollerObject toolsResourceApi) {
+    public void handleTimeout(ClouderaManagerCommandPollerObject toolsResourceApi) {
         throw new ClouderaManagerOperationFailedException("Operation timed out. Failed to decommission host.");
     }
 
     @Override
-    public String successMessage(ClouderaManagerPollerObject toolsResourceApi) {
+    public String successMessage(ClouderaManagerCommandPollerObject toolsResourceApi) {
         return "Cloudera Manager host decommission finished with success result.";
     }
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerDeployClientConfigListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerDeployClientConfigListenerTask.java
@@ -2,10 +2,10 @@ package com.sequenceiq.cloudbreak.cm.polling.task;
 
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
-import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 
-public class ClouderaManagerDeployClientConfigListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerPollerObject> {
+public class ClouderaManagerDeployClientConfigListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     public ClouderaManagerDeployClientConfigListenerTask(ClouderaManagerApiPojoFactory clouderaManagerApiPojoFactory,
             CloudbreakEventService cloudbreakEventService) {
@@ -13,12 +13,12 @@ public class ClouderaManagerDeployClientConfigListenerTask extends AbstractCloud
     }
 
     @Override
-    public void handleTimeout(ClouderaManagerPollerObject toolsResourceApi) {
+    public void handleTimeout(ClouderaManagerCommandPollerObject toolsResourceApi) {
         throw new ClouderaManagerOperationFailedException("Operation timed out. Failed to refresh cluster configs.");
     }
 
     @Override
-    public String successMessage(ClouderaManagerPollerObject toolsResourceApi) {
+    public String successMessage(ClouderaManagerCommandPollerObject toolsResourceApi) {
         return "Successfully refreshed cluster configs.";
     }
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerGenerateCredentialsListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerGenerateCredentialsListenerTask.java
@@ -2,10 +2,10 @@ package com.sequenceiq.cloudbreak.cm.polling.task;
 
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
-import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 
-public class ClouderaManagerGenerateCredentialsListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerPollerObject> {
+public class ClouderaManagerGenerateCredentialsListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     public ClouderaManagerGenerateCredentialsListenerTask(ClouderaManagerApiPojoFactory clouderaManagerApiPojoFactory,
             CloudbreakEventService cloudbreakEventService) {
@@ -13,12 +13,12 @@ public class ClouderaManagerGenerateCredentialsListenerTask extends AbstractClou
     }
 
     @Override
-    public void handleTimeout(ClouderaManagerPollerObject toolsResourceApi) {
+    public void handleTimeout(ClouderaManagerCommandPollerObject toolsResourceApi) {
         throw new ClouderaManagerOperationFailedException("Operation timed out. Failed to generate credentials.");
     }
 
     @Override
-    public String successMessage(ClouderaManagerPollerObject toolsResourceApi) {
+    public String successMessage(ClouderaManagerCommandPollerObject toolsResourceApi) {
         return "Successfully generated credentials.";
     }
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerKerberosConfigureListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerKerberosConfigureListenerTask.java
@@ -2,10 +2,10 @@ package com.sequenceiq.cloudbreak.cm.polling.task;
 
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
-import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 
-public class ClouderaManagerKerberosConfigureListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerPollerObject> {
+public class ClouderaManagerKerberosConfigureListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     public ClouderaManagerKerberosConfigureListenerTask(ClouderaManagerApiPojoFactory clouderaManagerApiPojoFactory,
             CloudbreakEventService cloudbreakEventService) {
@@ -13,12 +13,12 @@ public class ClouderaManagerKerberosConfigureListenerTask extends AbstractCloude
     }
 
     @Override
-    public void handleTimeout(ClouderaManagerPollerObject toolsResourceApi) {
+    public void handleTimeout(ClouderaManagerCommandPollerObject toolsResourceApi) {
         throw new ClouderaManagerOperationFailedException("Operation timed out. Failed to configure kerberos Cloudera Manager services.");
     }
 
     @Override
-    public String successMessage(ClouderaManagerPollerObject toolsResourceApi) {
+    public String successMessage(ClouderaManagerCommandPollerObject toolsResourceApi) {
         return "Cloudera Manager succesfully configure Kerberos.";
     }
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerParcelActivationListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerParcelActivationListenerTask.java
@@ -23,7 +23,7 @@ import com.sequenceiq.cloudbreak.cloud.model.component.StackType;
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
 import com.sequenceiq.cloudbreak.cm.model.ParcelStatus;
-import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.type.ComponentType;
@@ -32,7 +32,7 @@ import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterComponent;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 
-public class ClouderaManagerParcelActivationListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerPollerObject> {
+public class ClouderaManagerParcelActivationListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerParcelActivationListenerTask.class);
 
@@ -42,7 +42,7 @@ public class ClouderaManagerParcelActivationListenerTask extends AbstractClouder
     }
 
     @Override
-    protected boolean doStatusCheck(ClouderaManagerPollerObject pollerObject, CommandsResourceApi commandsResourceApi) throws ApiException {
+    protected boolean doStatusCheck(ClouderaManagerCommandPollerObject pollerObject, CommandsResourceApi commandsResourceApi) throws ApiException {
         ApiClient apiClient = pollerObject.getApiClient();
         Stack stack = pollerObject.getStack();
         List<ClouderaManagerProduct> clouderaManagerProducts = getClouderaManagerProductsFromStack(stack);
@@ -130,12 +130,12 @@ public class ClouderaManagerParcelActivationListenerTask extends AbstractClouder
     }
 
     @Override
-    public void handleTimeout(ClouderaManagerPollerObject toolsResourceApi) {
+    public void handleTimeout(ClouderaManagerCommandPollerObject toolsResourceApi) {
         throw new ClouderaManagerOperationFailedException("Operation timed out. Failed to deploy client configurations.");
     }
 
     @Override
-    public String successMessage(ClouderaManagerPollerObject toolsResourceApi) {
+    public String successMessage(ClouderaManagerCommandPollerObject toolsResourceApi) {
         return "Cloudera Manager deployed client configurations finished with success result.";
     }
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerParcelDeletedListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerParcelDeletedListenerTask.java
@@ -16,11 +16,11 @@ import com.cloudera.api.swagger.model.ApiParcelList;
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
 import com.sequenceiq.cloudbreak.cm.model.ParcelStatus;
-import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 
-public class ClouderaManagerParcelDeletedListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerPollerObject> {
+public class ClouderaManagerParcelDeletedListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
     private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerParcelDeletedListenerTask.class);
 
     private Map<String, String> parcelVersions;
@@ -32,7 +32,7 @@ public class ClouderaManagerParcelDeletedListenerTask extends AbstractClouderaMa
     }
 
     @Override
-    protected boolean doStatusCheck(ClouderaManagerPollerObject pollerObject, CommandsResourceApi commandsResourceApi) throws ApiException {
+    protected boolean doStatusCheck(ClouderaManagerCommandPollerObject pollerObject, CommandsResourceApi commandsResourceApi) throws ApiException {
         ApiClient apiClient = pollerObject.getApiClient();
         Stack stack = pollerObject.getStack();
         ApiParcelList parcels = getClouderaManagerParcels(apiClient, stack.getName());
@@ -69,12 +69,12 @@ public class ClouderaManagerParcelDeletedListenerTask extends AbstractClouderaMa
     }
 
     @Override
-    public void handleTimeout(ClouderaManagerPollerObject toolsResourceApi) {
+    public void handleTimeout(ClouderaManagerCommandPollerObject toolsResourceApi) {
         throw new ClouderaManagerOperationFailedException("Operation timed out. Parcels are not deleted.");
     }
 
     @Override
-    public String successMessage(ClouderaManagerPollerObject toolsResourceApi) {
+    public String successMessage(ClouderaManagerCommandPollerObject toolsResourceApi) {
         return String.format("Cloudera Manager parcels %s are deleted.", parcelVersions);
     }
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerParcelRepositoryRefreshChecker.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerParcelRepositoryRefreshChecker.java
@@ -5,10 +5,10 @@ import org.slf4j.LoggerFactory;
 
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
-import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 
-public class ClouderaManagerParcelRepositoryRefreshChecker extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerPollerObject> {
+public class ClouderaManagerParcelRepositoryRefreshChecker extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerParcelRepositoryRefreshChecker.class);
 
@@ -18,14 +18,14 @@ public class ClouderaManagerParcelRepositoryRefreshChecker extends AbstractCloud
     }
 
     @Override
-    public void handleTimeout(ClouderaManagerPollerObject clouderaManagerPollerObject) {
+    public void handleTimeout(ClouderaManagerCommandPollerObject clouderaManagerCommandPollerObject) {
         throw new ClouderaManagerOperationFailedException("Operation timed out. Parcel repo sync timed out with this command id: "
-                + clouderaManagerPollerObject.getId());
+                + clouderaManagerCommandPollerObject.getId());
     }
 
     @Override
-    public String successMessage(ClouderaManagerPollerObject clouderaManagerPollerObject) {
-        return String.format("Parcel repo sync success for stack '%s'", clouderaManagerPollerObject.getStack().getId());
+    public String successMessage(ClouderaManagerCommandPollerObject clouderaManagerCommandPollerObject) {
+        return String.format("Parcel repo sync success for stack '%s'", clouderaManagerCommandPollerObject.getStack().getId());
     }
 
     @Override

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerParcelStatusListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerParcelStatusListenerTask.java
@@ -16,11 +16,11 @@ import com.cloudera.api.swagger.model.ApiParcelList;
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
 import com.sequenceiq.cloudbreak.cm.model.ParcelStatus;
-import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 
-public class ClouderaManagerParcelStatusListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerPollerObject> {
+public class ClouderaManagerParcelStatusListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
     private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerParcelStatusListenerTask.class);
 
     private Map<String, String> parcelVersions;
@@ -35,7 +35,7 @@ public class ClouderaManagerParcelStatusListenerTask extends AbstractClouderaMan
     }
 
     @Override
-    protected boolean doStatusCheck(ClouderaManagerPollerObject pollerObject, CommandsResourceApi commandsResourceApi) throws ApiException {
+    protected boolean doStatusCheck(ClouderaManagerCommandPollerObject pollerObject, CommandsResourceApi commandsResourceApi) throws ApiException {
         ApiClient apiClient = pollerObject.getApiClient();
         Stack stack = pollerObject.getStack();
         ApiParcelList parcels = getClouderaManagerParcels(apiClient, stack.getName());
@@ -69,12 +69,12 @@ public class ClouderaManagerParcelStatusListenerTask extends AbstractClouderaMan
     }
 
     @Override
-    public void handleTimeout(ClouderaManagerPollerObject toolsResourceApi) {
+    public void handleTimeout(ClouderaManagerCommandPollerObject toolsResourceApi) {
         throw new ClouderaManagerOperationFailedException("Operation timed out. Parcels are not in the proper state.");
     }
 
     @Override
-    public String successMessage(ClouderaManagerPollerObject toolsResourceApi) {
+    public String successMessage(ClouderaManagerCommandPollerObject toolsResourceApi) {
         return String.format("Cloudera Manager parcels %s are in the proper state [%s]", parcelVersions, parcelStatus);
     }
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerParcelsApiListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerParcelsApiListenerTask.java
@@ -12,10 +12,10 @@ import com.cloudera.api.swagger.client.ApiException;
 import com.cloudera.api.swagger.model.ApiParcelList;
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
-import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 
-public class ClouderaManagerParcelsApiListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerPollerObject> {
+public class ClouderaManagerParcelsApiListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerParcelsApiListenerTask.class);
 
@@ -25,7 +25,7 @@ public class ClouderaManagerParcelsApiListenerTask extends AbstractClouderaManag
     }
 
     @Override
-    protected boolean doStatusCheck(ClouderaManagerPollerObject pollerObject, CommandsResourceApi commandsResourceApi) {
+    protected boolean doStatusCheck(ClouderaManagerCommandPollerObject pollerObject, CommandsResourceApi commandsResourceApi) {
         try {
             boolean parcelsAvailable = pollParcels(pollerObject);
             LOGGER.debug("Polling for parcel's availability returned: {}", parcelsAvailable);
@@ -37,18 +37,18 @@ public class ClouderaManagerParcelsApiListenerTask extends AbstractClouderaManag
     }
 
     @Override
-    public void handleTimeout(ClouderaManagerPollerObject toolsResourceApi) {
+    public void handleTimeout(ClouderaManagerCommandPollerObject toolsResourceApi) {
         throw new ClouderaManagerOperationFailedException("Operation timed out. Failed to start Parcels API.");
     }
 
-    private boolean pollParcels(ClouderaManagerPollerObject pollerObject) throws ApiException {
+    private boolean pollParcels(ClouderaManagerCommandPollerObject pollerObject) throws ApiException {
         ParcelsResourceApi parcelsResourceApi = clouderaManagerApiPojoFactory.getParcelsResourceApi(pollerObject.getApiClient());
         ApiParcelList apiParcelList = parcelsResourceApi.readParcels(pollerObject.getStack().getName(), "");
         return Objects.nonNull(apiParcelList) && CollectionUtils.isNotEmpty(apiParcelList.getItems());
     }
 
     @Override
-    public String successMessage(ClouderaManagerPollerObject toolsResourceApi) {
+    public String successMessage(ClouderaManagerCommandPollerObject toolsResourceApi) {
         return "Parcels API is finally available";
     }
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerRefreshServiceConfigsListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerRefreshServiceConfigsListenerTask.java
@@ -2,10 +2,10 @@ package com.sequenceiq.cloudbreak.cm.polling.task;
 
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
-import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 
-public class ClouderaManagerRefreshServiceConfigsListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerPollerObject> {
+public class ClouderaManagerRefreshServiceConfigsListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     public ClouderaManagerRefreshServiceConfigsListenerTask(ClouderaManagerApiPojoFactory clouderaManagerApiPojoFactory,
             CloudbreakEventService cloudbreakEventService) {
@@ -13,12 +13,12 @@ public class ClouderaManagerRefreshServiceConfigsListenerTask extends AbstractCl
     }
 
     @Override
-    public void handleTimeout(ClouderaManagerPollerObject toolsResourceApi) {
+    public void handleTimeout(ClouderaManagerCommandPollerObject toolsResourceApi) {
         throw new ClouderaManagerOperationFailedException("Operation timed out. Failed to refresh cluster configs.");
     }
 
     @Override
-    public String successMessage(ClouderaManagerPollerObject toolsResourceApi) {
+    public String successMessage(ClouderaManagerCommandPollerObject toolsResourceApi) {
         return "Successfully refreshed cluster configs.";
     }
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerRestartServicesListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerRestartServicesListenerTask.java
@@ -2,10 +2,10 @@ package com.sequenceiq.cloudbreak.cm.polling.task;
 
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
-import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 
-public class ClouderaManagerRestartServicesListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerPollerObject> {
+public class ClouderaManagerRestartServicesListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     public ClouderaManagerRestartServicesListenerTask(ClouderaManagerApiPojoFactory clouderaManagerApiPojoFactory,
             CloudbreakEventService cloudbreakEventService) {
@@ -13,12 +13,12 @@ public class ClouderaManagerRestartServicesListenerTask extends AbstractCloudera
     }
 
     @Override
-    public void handleTimeout(ClouderaManagerPollerObject toolsResourceApi) {
+    public void handleTimeout(ClouderaManagerCommandPollerObject toolsResourceApi) {
         throw new ClouderaManagerOperationFailedException("Operation timed out. Failed to restart services.");
     }
 
     @Override
-    public String successMessage(ClouderaManagerPollerObject toolsResourceApi) {
+    public String successMessage(ClouderaManagerCommandPollerObject toolsResourceApi) {
         return "Successfully restarted services.";
     }
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerServiceStartListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerServiceStartListenerTask.java
@@ -2,10 +2,10 @@ package com.sequenceiq.cloudbreak.cm.polling.task;
 
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
-import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 
-public class ClouderaManagerServiceStartListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerPollerObject> {
+public class ClouderaManagerServiceStartListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     public ClouderaManagerServiceStartListenerTask(ClouderaManagerApiPojoFactory clouderaManagerApiPojoFactory,
             CloudbreakEventService cloudbreakEventService) {
@@ -13,12 +13,12 @@ public class ClouderaManagerServiceStartListenerTask extends AbstractClouderaMan
     }
 
     @Override
-    public void handleTimeout(ClouderaManagerPollerObject toolsResourceApi) {
+    public void handleTimeout(ClouderaManagerCommandPollerObject toolsResourceApi) {
         throw new ClouderaManagerOperationFailedException("Operation timed out. Failed to start Cloudera Manager services.");
     }
 
     @Override
-    public String successMessage(ClouderaManagerPollerObject toolsResourceApi) {
+    public String successMessage(ClouderaManagerCommandPollerObject toolsResourceApi) {
         return "Cloudera Manager all service start finished with success result.";
     }
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerStartManagementServiceListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerStartManagementServiceListenerTask.java
@@ -2,10 +2,10 @@ package com.sequenceiq.cloudbreak.cm.polling.task;
 
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
-import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 
-public class ClouderaManagerStartManagementServiceListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerPollerObject> {
+public class ClouderaManagerStartManagementServiceListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     public ClouderaManagerStartManagementServiceListenerTask(ClouderaManagerApiPojoFactory clouderaManagerApiPojoFactory,
             CloudbreakEventService cloudbreakEventService) {
@@ -13,12 +13,12 @@ public class ClouderaManagerStartManagementServiceListenerTask extends AbstractC
     }
 
     @Override
-    public void handleTimeout(ClouderaManagerPollerObject toolsResourceApi) {
+    public void handleTimeout(ClouderaManagerCommandPollerObject toolsResourceApi) {
         throw new ClouderaManagerOperationFailedException("Operation timed out. Failed to start management service.");
     }
 
     @Override
-    public String successMessage(ClouderaManagerPollerObject toolsResourceApi) {
+    public String successMessage(ClouderaManagerCommandPollerObject toolsResourceApi) {
         return "Successfully started management service.";
     }
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerStartupListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerStartupListenerTask.java
@@ -14,10 +14,10 @@ import com.cloudera.api.swagger.client.ApiException;
 import com.cloudera.api.swagger.model.ApiEcho;
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
-import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 
-public class ClouderaManagerStartupListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerPollerObject> {
+public class ClouderaManagerStartupListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerStartupListenerTask.class);
 
@@ -31,7 +31,7 @@ public class ClouderaManagerStartupListenerTask extends AbstractClouderaManagerC
     }
 
     @Override
-    protected boolean doStatusCheck(ClouderaManagerPollerObject pollerObject, CommandsResourceApi commandsResourceApi) throws ApiException {
+    protected boolean doStatusCheck(ClouderaManagerCommandPollerObject pollerObject, CommandsResourceApi commandsResourceApi) throws ApiException {
         try {
             ToolsResourceApi toolsResourceApi = clouderaManagerApiPojoFactory.getToolsResourceApi(pollerObject.getApiClient());
             String testMessage = "test";
@@ -59,12 +59,12 @@ public class ClouderaManagerStartupListenerTask extends AbstractClouderaManagerC
     }
 
     @Override
-    public void handleTimeout(ClouderaManagerPollerObject pollerObject) {
+    public void handleTimeout(ClouderaManagerCommandPollerObject pollerObject) {
         throw new ClouderaManagerOperationFailedException("Operation timed out. Failed to check Cloudera Manager startup.");
     }
 
     @Override
-    public String successMessage(ClouderaManagerPollerObject pollerObject) {
+    public String successMessage(ClouderaManagerCommandPollerObject pollerObject) {
         return "Cloudera Manager startup finished with success result.";
     }
 }

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerStopListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerStopListenerTask.java
@@ -2,10 +2,10 @@ package com.sequenceiq.cloudbreak.cm.polling.task;
 
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
-import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 
-public class ClouderaManagerStopListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerPollerObject> {
+public class ClouderaManagerStopListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     public ClouderaManagerStopListenerTask(ClouderaManagerApiPojoFactory clouderaManagerApiPojoFactory,
             CloudbreakEventService cloudbreakEventService) {
@@ -13,12 +13,12 @@ public class ClouderaManagerStopListenerTask extends AbstractClouderaManagerComm
     }
 
     @Override
-    public void handleTimeout(ClouderaManagerPollerObject toolsResourceApi) {
+    public void handleTimeout(ClouderaManagerCommandPollerObject toolsResourceApi) {
         throw new ClouderaManagerOperationFailedException("Operation timed out. Failed to stop Cloudera Manager services.");
     }
 
     @Override
-    public String successMessage(ClouderaManagerPollerObject toolsResourceApi) {
+    public String successMessage(ClouderaManagerCommandPollerObject toolsResourceApi) {
         return "Cloudera Manager all service stop finished with success result.";
     }
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerStopManagementServiceListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerStopManagementServiceListenerTask.java
@@ -2,10 +2,10 @@ package com.sequenceiq.cloudbreak.cm.polling.task;
 
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
-import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 
-public class ClouderaManagerStopManagementServiceListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerPollerObject> {
+public class ClouderaManagerStopManagementServiceListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     public ClouderaManagerStopManagementServiceListenerTask(ClouderaManagerApiPojoFactory clouderaManagerApiPojoFactory,
             CloudbreakEventService cloudbreakEventService) {
@@ -13,12 +13,12 @@ public class ClouderaManagerStopManagementServiceListenerTask extends AbstractCl
     }
 
     @Override
-    public void handleTimeout(ClouderaManagerPollerObject toolsResourceApi) {
+    public void handleTimeout(ClouderaManagerCommandPollerObject toolsResourceApi) {
         throw new ClouderaManagerOperationFailedException("Operation timed out. Failed to stop management service.");
     }
 
     @Override
-    public String successMessage(ClouderaManagerPollerObject toolsResourceApi) {
+    public String successMessage(ClouderaManagerCommandPollerObject toolsResourceApi) {
         return "Successfully stopped management service.";
     }
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerTemplateInstallationChecker.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerTemplateInstallationChecker.java
@@ -17,10 +17,10 @@ import com.cloudera.api.swagger.model.ApiCommand;
 import com.cloudera.api.swagger.model.ApiCommandList;
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
-import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 
-public class ClouderaManagerTemplateInstallationChecker extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerPollerObject> {
+public class ClouderaManagerTemplateInstallationChecker extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerTemplateInstallationChecker.class);
 
@@ -30,7 +30,7 @@ public class ClouderaManagerTemplateInstallationChecker extends AbstractCloudera
     }
 
     @Override
-    protected boolean doStatusCheck(ClouderaManagerPollerObject pollerObject, CommandsResourceApi commandsResourceApi) throws ApiException {
+    protected boolean doStatusCheck(ClouderaManagerCommandPollerObject pollerObject, CommandsResourceApi commandsResourceApi) throws ApiException {
         commandsResourceApi = clouderaManagerApiPojoFactory.getCommandsResourceApi(pollerObject.getApiClient());
         ApiCommand apiCommand = commandsResourceApi.readCommand(pollerObject.getId());
         if (apiCommand.getActive()) {
@@ -78,14 +78,14 @@ public class ClouderaManagerTemplateInstallationChecker extends AbstractCloudera
     }
 
     @Override
-    public void handleTimeout(ClouderaManagerPollerObject clouderaManagerPollerObject) {
+    public void handleTimeout(ClouderaManagerCommandPollerObject clouderaManagerCommandPollerObject) {
         throw new ClouderaManagerOperationFailedException("Operation timed out. Template install timed out with this command id: "
-                + clouderaManagerPollerObject.getId());
+                + clouderaManagerCommandPollerObject.getId());
     }
 
     @Override
-    public String successMessage(ClouderaManagerPollerObject clouderaManagerPollerObject) {
-        return String.format("Template installation success for stack '%s'", clouderaManagerPollerObject.getStack().getId());
+    public String successMessage(ClouderaManagerCommandPollerObject clouderaManagerCommandPollerObject) {
+        return String.format("Template installation success for stack '%s'", clouderaManagerCommandPollerObject.getStack().getId());
     }
 
     @Override

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerUpgradeParcelDistributeListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerUpgradeParcelDistributeListenerTask.java
@@ -12,10 +12,10 @@ import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
 import com.sequenceiq.cloudbreak.cm.model.ParcelResource;
 import com.sequenceiq.cloudbreak.cm.model.ParcelStatus;
-import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 
-public class ClouderaManagerUpgradeParcelDistributeListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerPollerObject> {
+public class ClouderaManagerUpgradeParcelDistributeListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerUpgradeParcelDistributeListenerTask.class);
 
@@ -33,7 +33,7 @@ public class ClouderaManagerUpgradeParcelDistributeListenerTask extends Abstract
     }
 
     @Override
-    protected boolean doStatusCheck(ClouderaManagerPollerObject pollerObject, CommandsResourceApi commandsResourceApi) throws ApiException {
+    protected boolean doStatusCheck(ClouderaManagerCommandPollerObject pollerObject, CommandsResourceApi commandsResourceApi) throws ApiException {
 
         ApiClient apiClient = pollerObject.getApiClient();
         ParcelResourceApi parcelResourceApi = clouderaManagerApiPojoFactory.getParcelResourceApi(apiClient);
@@ -50,12 +50,12 @@ public class ClouderaManagerUpgradeParcelDistributeListenerTask extends Abstract
     }
 
     @Override
-    public void handleTimeout(ClouderaManagerPollerObject toolsResourceApi) {
+    public void handleTimeout(ClouderaManagerCommandPollerObject toolsResourceApi) {
         throw new ClouderaManagerOperationFailedException("Operation timed out. Failed to distribute parcel in time.");
     }
 
     @Override
-    public String successMessage(ClouderaManagerPollerObject toolsResourceApi) {
+    public String successMessage(ClouderaManagerCommandPollerObject toolsResourceApi) {
         return "Successfully distributed CDP Runtime parcel.";
     }
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerUpgradeParcelDownloadListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerUpgradeParcelDownloadListenerTask.java
@@ -12,10 +12,10 @@ import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
 import com.sequenceiq.cloudbreak.cm.model.ParcelResource;
 import com.sequenceiq.cloudbreak.cm.model.ParcelStatus;
-import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 
-public class ClouderaManagerUpgradeParcelDownloadListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerPollerObject> {
+public class ClouderaManagerUpgradeParcelDownloadListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerUpgradeParcelDownloadListenerTask.class);
 
@@ -33,7 +33,7 @@ public class ClouderaManagerUpgradeParcelDownloadListenerTask extends AbstractCl
     }
 
     @Override
-    protected boolean doStatusCheck(ClouderaManagerPollerObject pollerObject, CommandsResourceApi commandsResourceApi) throws ApiException {
+    protected boolean doStatusCheck(ClouderaManagerCommandPollerObject pollerObject, CommandsResourceApi commandsResourceApi) throws ApiException {
 
         ApiClient apiClient = pollerObject.getApiClient();
         ParcelResourceApi parcelResourceApi = clouderaManagerApiPojoFactory.getParcelResourceApi(apiClient);
@@ -51,12 +51,12 @@ public class ClouderaManagerUpgradeParcelDownloadListenerTask extends AbstractCl
     }
 
     @Override
-    public void handleTimeout(ClouderaManagerPollerObject toolsResourceApi) {
+    public void handleTimeout(ClouderaManagerCommandPollerObject toolsResourceApi) {
         throw new ClouderaManagerOperationFailedException("Operation timed out. Failed to download parcel in time.");
     }
 
     @Override
-    public String successMessage(ClouderaManagerPollerObject toolsResourceApi) {
+    public String successMessage(ClouderaManagerCommandPollerObject toolsResourceApi) {
         return "Successfully downloaded CDP Runtime parcel.";
     }
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerUpgradeRuntimeListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerUpgradeRuntimeListenerTask.java
@@ -2,10 +2,10 @@ package com.sequenceiq.cloudbreak.cm.polling.task;
 
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
-import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 
-public class ClouderaManagerUpgradeRuntimeListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerPollerObject> {
+public class ClouderaManagerUpgradeRuntimeListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
 
     public ClouderaManagerUpgradeRuntimeListenerTask(ClouderaManagerApiPojoFactory clouderaManagerApiPojoFactory,
             CloudbreakEventService cloudbreakEventService) {
@@ -13,12 +13,12 @@ public class ClouderaManagerUpgradeRuntimeListenerTask extends AbstractClouderaM
     }
 
     @Override
-    public void handleTimeout(ClouderaManagerPollerObject toolsResourceApi) {
+    public void handleTimeout(ClouderaManagerCommandPollerObject toolsResourceApi) {
         throw new ClouderaManagerOperationFailedException("Operation timed out. Failed to upgrade Runtime services.");
     }
 
     @Override
-    public String successMessage(ClouderaManagerPollerObject toolsResourceApi) {
+    public String successMessage(ClouderaManagerCommandPollerObject toolsResourceApi) {
         return "Successfully upgraded CDP Runtime services.";
     }
 

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/polling/task/AbstractClouderaManagerCommandCheckerTaskTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/polling/task/AbstractClouderaManagerCommandCheckerTaskTest.java
@@ -36,7 +36,7 @@ import com.cloudera.api.swagger.model.ApiServiceRef;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
-import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.StackStatus;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
@@ -75,7 +75,7 @@ public class AbstractClouderaManagerCommandCheckerTaskTest {
     public void testPollingWithFiveInternalServerErrors() throws ApiException {
         Stack stack = new Stack();
         BigDecimal id = new BigDecimal(ID);
-        ClouderaManagerPollerObject pollerObject = new ClouderaManagerPollerObject(stack, apiClient, id);
+        ClouderaManagerCommandPollerObject pollerObject = new ClouderaManagerCommandPollerObject(stack, apiClient, id);
         when(commandsResourceApi.readCommand(id)).thenAnswer(new Http500Answer(FIVE));
 
         for (int i = 0; i < FIVE; i++) {
@@ -91,7 +91,7 @@ public class AbstractClouderaManagerCommandCheckerTaskTest {
     public void testPollingWithSixInternalServerErrors() throws ApiException {
         Stack stack = new Stack();
         BigDecimal id = new BigDecimal(1);
-        ClouderaManagerPollerObject pollerObject = new ClouderaManagerPollerObject(stack, apiClient, id);
+        ClouderaManagerCommandPollerObject pollerObject = new ClouderaManagerCommandPollerObject(stack, apiClient, id);
         when(commandsResourceApi.readCommand(id)).thenAnswer(new Http500Answer(SIX));
 
         expectedEx.expect(ClouderaManagerOperationFailedException.class);
@@ -108,7 +108,7 @@ public class AbstractClouderaManagerCommandCheckerTaskTest {
     public void testPollingWithFiveSocketExceptions() throws ApiException {
         Stack stack = new Stack();
         BigDecimal id = new BigDecimal(ID);
-        ClouderaManagerPollerObject pollerObject = new ClouderaManagerPollerObject(stack, apiClient, id);
+        ClouderaManagerCommandPollerObject pollerObject = new ClouderaManagerCommandPollerObject(stack, apiClient, id);
         SocketTimeoutException socketTimeoutException = new SocketTimeoutException("timeout");
         ApiException apiException0 = new ApiException(socketTimeoutException);
         SocketException socketException = new SocketException("Network is unreachable (connect failed)");
@@ -129,7 +129,7 @@ public class AbstractClouderaManagerCommandCheckerTaskTest {
     public void testPollingWithThreeInternalServerErrorAndThreeSocketExceptions() throws ApiException {
         Stack stack = new Stack();
         BigDecimal id = new BigDecimal(1);
-        ClouderaManagerPollerObject pollerObject = new ClouderaManagerPollerObject(stack, apiClient, id);
+        ClouderaManagerCommandPollerObject pollerObject = new ClouderaManagerCommandPollerObject(stack, apiClient, id);
         SocketException socketException = new SocketException("Network is unreachable (connect failed)");
         ApiException socketApiException = new ApiException(socketException);
         ApiException internalServerError = new ApiException(HttpStatus.INTERNAL_SERVER_ERROR.value(), "error");
@@ -154,7 +154,7 @@ public class AbstractClouderaManagerCommandCheckerTaskTest {
         stackStatus.setStatus(Status.UPDATE_IN_PROGRESS);
         stack.setStackStatus(stackStatus);
         BigDecimal id = new BigDecimal(1);
-        ClouderaManagerPollerObject pollerObject = new ClouderaManagerPollerObject(stack, apiClient, id);
+        ClouderaManagerCommandPollerObject pollerObject = new ClouderaManagerCommandPollerObject(stack, apiClient, id);
         ConnectException connectException = new ConnectException("Connect failed.");
         ApiException apiException = new ApiException(connectException);
         ApiException[] exceptions = new ApiException[TEN];

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerHostStatusCheckerTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerHostStatusCheckerTest.java
@@ -26,7 +26,7 @@ import com.cloudera.api.swagger.model.ApiHost;
 import com.cloudera.api.swagger.model.ApiHostList;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
-import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
@@ -252,12 +252,12 @@ public class ClouderaManagerHostStatusCheckerTest {
         return instanceMetaData;
     }
 
-    private ClouderaManagerPollerObject getPollerObject(InstanceMetaData... instanceMetaDatas) {
+    private ClouderaManagerCommandPollerObject getPollerObject(InstanceMetaData... instanceMetaDatas) {
         Stack stack = new Stack();
         InstanceGroup instanceGroup = new InstanceGroup();
         instanceGroup.setInstanceMetaData(Set.of(instanceMetaDatas));
         stack.setInstanceGroups(Set.of(instanceGroup));
-        return new ClouderaManagerPollerObject(stack, new ApiClient(), BigDecimal.ONE);
+        return new ClouderaManagerCommandPollerObject(stack, new ApiClient(), BigDecimal.ONE);
     }
 
 }

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerParcelActivationListenerTaskTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerParcelActivationListenerTaskTest.java
@@ -27,7 +27,7 @@ import com.cloudera.api.swagger.client.ApiException;
 import com.cloudera.api.swagger.model.ApiParcel;
 import com.cloudera.api.swagger.model.ApiParcelList;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
-import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 import com.sequenceiq.cloudbreak.cm.util.TestUtil;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.json.Json;
@@ -80,53 +80,53 @@ class ClouderaManagerParcelActivationListenerTaskTest {
     @Test
     void checkStatusOneActivating() throws ApiException {
         when(clouderaManagerApiPojoFactory.getParcelsResourceApi(apiClientMock)).thenReturn(parcelsResourcesApi);
-        ClouderaManagerPollerObject clouderaManagerPollerObject = new ClouderaManagerPollerObject(stack, apiClientMock, COMMAND_ID);
+        ClouderaManagerCommandPollerObject clouderaManagerCommandPollerObject = new ClouderaManagerCommandPollerObject(stack, apiClientMock, COMMAND_ID);
 
         ApiParcel apiParcel1 = TestUtil.apiParcel(CDH, ACTIVATED);
         ApiParcel apiParcel2 = TestUtil.apiParcel(CDSW, ACTIVATING);
         ApiParcelList apiParcelList = new ApiParcelList().items(List.of(apiParcel1, apiParcel2));
         when(parcelsResourcesApi.readParcels(eq(STACK_NAME), eq(SUMMARY))).thenReturn(apiParcelList);
-        assertFalse(underTest.checkStatus(clouderaManagerPollerObject));
+        assertFalse(underTest.checkStatus(clouderaManagerCommandPollerObject));
     }
 
     @Test
     void checkStatusBothActivating() throws ApiException {
         when(clouderaManagerApiPojoFactory.getParcelsResourceApi(eq(apiClientMock))).thenReturn(parcelsResourcesApi);
-        ClouderaManagerPollerObject clouderaManagerPollerObject = new ClouderaManagerPollerObject(stack, apiClientMock, COMMAND_ID);
+        ClouderaManagerCommandPollerObject clouderaManagerCommandPollerObject = new ClouderaManagerCommandPollerObject(stack, apiClientMock, COMMAND_ID);
 
         ApiParcel apiParcel1 = TestUtil.apiParcel(CDH, ACTIVATING);
         ApiParcel apiParcel2 = TestUtil.apiParcel(CDSW, ACTIVATING);
         ApiParcelList apiParcelList = new ApiParcelList().items(List.of(apiParcel1, apiParcel2));
         when(parcelsResourcesApi.readParcels(eq(STACK_NAME), eq(SUMMARY))).thenReturn(apiParcelList);
-        assertFalse(underTest.checkStatus(clouderaManagerPollerObject));
+        assertFalse(underTest.checkStatus(clouderaManagerCommandPollerObject));
     }
 
     @Test
     void checkStatusMissing() throws ApiException {
         when(clouderaManagerApiPojoFactory.getParcelsResourceApi(eq(apiClientMock))).thenReturn(parcelsResourcesApi);
-        ClouderaManagerPollerObject clouderaManagerPollerObject = new ClouderaManagerPollerObject(stack, apiClientMock, COMMAND_ID);
+        ClouderaManagerCommandPollerObject clouderaManagerCommandPollerObject = new ClouderaManagerCommandPollerObject(stack, apiClientMock, COMMAND_ID);
 
         ApiParcel apiParcel1 = TestUtil.apiParcel(CDH, ACTIVATED);
         ApiParcelList apiParcelList = new ApiParcelList().items(List.of(apiParcel1));
         when(parcelsResourcesApi.readParcels(eq(STACK_NAME), eq(SUMMARY))).thenReturn(apiParcelList);
-        assertFalse(underTest.checkStatus(clouderaManagerPollerObject));
+        assertFalse(underTest.checkStatus(clouderaManagerCommandPollerObject));
     }
 
     @Test
     void checkStatusActivated() throws ApiException {
         when(clouderaManagerApiPojoFactory.getParcelsResourceApi(eq(apiClientMock))).thenReturn(parcelsResourcesApi);
-        ClouderaManagerPollerObject clouderaManagerPollerObject = new ClouderaManagerPollerObject(stack, apiClientMock, COMMAND_ID);
+        ClouderaManagerCommandPollerObject clouderaManagerCommandPollerObject = new ClouderaManagerCommandPollerObject(stack, apiClientMock, COMMAND_ID);
 
         ApiParcel apiParcel1 = TestUtil.apiParcel(CDH, ACTIVATED);
         ApiParcel apiParcel2 = TestUtil.apiParcel(CDSW, ACTIVATED);
         ApiParcelList apiParcelList = new ApiParcelList().items(List.of(apiParcel1, apiParcel2));
         when(parcelsResourcesApi.readParcels(eq(STACK_NAME), eq(SUMMARY))).thenReturn(apiParcelList);
-        assertTrue(underTest.checkStatus(clouderaManagerPollerObject));
+        assertTrue(underTest.checkStatus(clouderaManagerCommandPollerObject));
     }
 
     @Test
     void checkStatusJsonParseException() throws ApiException {
-        ClouderaManagerPollerObject clouderaManagerPollerObject = new ClouderaManagerPollerObject(stack, apiClientMock, COMMAND_ID);
+        ClouderaManagerCommandPollerObject clouderaManagerCommandPollerObject = new ClouderaManagerCommandPollerObject(stack, apiClientMock, COMMAND_ID);
 
         ClusterComponent cdhComponent = new ClusterComponent(
                 ComponentType.CDH_PRODUCT_DETAILS,
@@ -135,7 +135,7 @@ class ClouderaManagerParcelActivationListenerTaskTest {
         cluster.setComponents(Set.of(cdhComponent));
 
         CloudbreakServiceException cloudbreakServiceException = assertThrows(CloudbreakServiceException.class,
-                () -> underTest.checkStatus(clouderaManagerPollerObject));
+                () -> underTest.checkStatus(clouderaManagerCommandPollerObject));
         assertEquals("Cannot deserialize the component: class com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct",
                 cloudbreakServiceException.getMessage());
         verify(parcelsResourcesApi, never()).readParcels(eq(STACK_NAME), eq(SUMMARY));
@@ -143,7 +143,7 @@ class ClouderaManagerParcelActivationListenerTaskTest {
 
     @Test
     void checkStatusNullJson() throws ApiException {
-        ClouderaManagerPollerObject clouderaManagerPollerObject = new ClouderaManagerPollerObject(stack, apiClientMock, COMMAND_ID);
+        ClouderaManagerCommandPollerObject clouderaManagerCommandPollerObject = new ClouderaManagerCommandPollerObject(stack, apiClientMock, COMMAND_ID);
 
         ClusterComponent cdhComponent = new ClusterComponent(
                 ComponentType.CDH_PRODUCT_DETAILS,
@@ -152,7 +152,7 @@ class ClouderaManagerParcelActivationListenerTaskTest {
         cluster.setComponents(Set.of(cdhComponent));
 
         CloudbreakServiceException cloudbreakServiceException = assertThrows(CloudbreakServiceException.class,
-                () -> underTest.checkStatus(clouderaManagerPollerObject));
+                () -> underTest.checkStatus(clouderaManagerCommandPollerObject));
         assertEquals("Cluster component attribute json cannot be null.",
                 cloudbreakServiceException.getMessage());
         verify(parcelsResourcesApi, never()).readParcels(eq(STACK_NAME), eq(SUMMARY));

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerTemplateInstallationCheckerTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerTemplateInstallationCheckerTest.java
@@ -25,7 +25,7 @@ import com.cloudera.api.swagger.model.ApiCommand;
 import com.cloudera.api.swagger.model.ApiCommandList;
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
-import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollerObject;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 
@@ -60,13 +60,13 @@ class ClouderaManagerTemplateInstallationCheckerTest {
     private ClouderaManagerTemplateInstallationChecker underTest
             = new ClouderaManagerTemplateInstallationChecker(clouderaManagerApiPojoFactory, cloudbreakEventService);
 
-    private ClouderaManagerPollerObject pollerObject;
+    private ClouderaManagerCommandPollerObject pollerObject;
 
     @BeforeEach
     void setUp() throws ApiException {
         when(commandsResourceApi.readCommand(any())).thenReturn(apiCommand);
         when(clouderaManagerApiPojoFactory.getCommandsResourceApi(eq(apiClient))).thenReturn(commandsResourceApi);
-        pollerObject = new ClouderaManagerPollerObject(new Stack(), apiClient, TEMPLATE_INSTALL_ID);
+        pollerObject = new ClouderaManagerCommandPollerObject(new Stack(), apiClient, TEMPLATE_INSTALL_ID);
     }
 
     @Test

--- a/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
@@ -291,6 +291,10 @@ public enum ResourceEvent {
     CLUSTER_CERTIFICATE_REDEPLOY("cluster.certificate.redeploy"),
     CLUSTER_CERTIFICATE_RENEWAL_FINISHED("cluster.certificate.renewal.finished"),
     CLUSTER_CERTIFICATE_RENEWAL_FAILED("cluster.certificate.renewal.failed"),
+    CLUSTER_CERTIFICATES_ROTATION_STARTED("cluster.certificates.rotation.started"),
+    CLUSTER_HOST_CERTIFICATES_ROTATION("cluster.host.certificates.rotation"),
+    CLUSTER_CERTIFICATES_ROTATION_FINISHED("cluster.certificates.rotation.finished"),
+    CLUSTER_CERTIFICATES_ROTATION_FAILED("cluster.certificates.rotation.failed"),
 
     CLUSTER_EXTERNAL_DATABASE_DELETION_STARTED("cluster.externaldatabase.deletion.started"),
     CLUSTER_EXTERNAL_DATABASE_DELETION_FAILED("cluster.externaldatabase.deletion.failed"),

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -81,6 +81,11 @@ cluster.certificate.redeploy=The redeployment of the reissued certificate to the
 cluster.certificate.renewal.finished=Renewal of the cluster's certificate finished.
 cluster.certificate.renewal.failed=Renewal of the cluster's certificate failed: '{0}'.
 
+cluster.certificates.rotation.started=Certificates rotation of the cluster has been started.
+cluster.host.certificates.rotation=Host certificates rotation of the cluster has been started.
+cluster.certificates.rotation.finished=Rotation of the cluster's certificates finished.
+cluster.certificates.rotation.failed=Rotations of the cluster's certificates failed: '{0}'.
+
 cluster.scaling.up=Scaling up host group: {0}
 cluster.re.register.with.cluster.proxy=Re-registering with Cluster Proxy service
 cluster.scaled.up=Scaled up host group: {0}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
@@ -30,6 +30,7 @@ import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescrip
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescription.REPAIR_CLUSTER_IN_WORKSPACE;
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescription.REPAIR_CLUSTER_IN_WORKSPACE_INTERNAL;
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescription.RETRY_BY_NAME_IN_WORKSPACE;
+import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescription.ROTATE_CERTIFICATES;
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescription.SCALE_BY_NAME_IN_WORKSPACE;
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescription.STACK_UPGRADE;
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescription.STACK_UPGRADE_INTERNAL;
@@ -58,6 +59,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.CertificatesRotationV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.ClusterRepairV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.MaintenanceModeV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackImageChangeV4Request;
@@ -66,6 +68,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.UpdateClusterV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.UserNamePasswordV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.tags.upgrade.UpgradeV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.CertificatesRotationV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.GeneratedBlueprintV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.RetryableFlowResponse;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackStatusV4Response;
@@ -411,4 +414,11 @@ public interface StackV4Endpoint {
     RestoreV4Response restoreDatabaseByNameInternal(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name,
             @QueryParam("backupLocation") String backupLocation, @QueryParam("backupId") String backupId,
             @QueryParam("initiatorUserCrn") String initiatorUserCrn);
+
+    @PUT
+    @Path("internal/{name}/rotate_certificates")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = ROTATE_CERTIFICATES, nickname = "rotateCertificates")
+    CertificatesRotationV4Response rotateCertificates(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name,
+            @QueryParam("initiatorUserCrn") String initiatorUserCrn, @Valid CertificatesRotationV4Request rotateCertificateRequest);
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/CertificateRotationType.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/CertificateRotationType.java
@@ -1,0 +1,5 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base;
+
+public enum CertificateRotationType {
+    HOST_CERTS
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/CertificatesRotationV4Request.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/CertificatesRotationV4Request.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request;
+
+import java.util.StringJoiner;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.CertificateRotationType;
+import com.sequenceiq.cloudbreak.doc.ModelDescriptions.ClusterModelDescription;
+import com.sequenceiq.common.model.JsonEntity;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CertificatesRotationV4Request implements JsonEntity {
+    @ApiModelProperty(value = ClusterModelDescription.CERTIFICATE_ROTATION_TYPE, allowableValues = "HOST_CERTS")
+    private CertificateRotationType certificateRotationType = CertificateRotationType.HOST_CERTS;
+
+    public CertificateRotationType getRotateCertificatesType() {
+        return certificateRotationType;
+    }
+
+    public void setRotateCertificatesType(CertificateRotationType certificateRotationType) {
+        this.certificateRotationType = certificateRotationType;
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", CertificatesRotationV4Request.class.getSimpleName() + "[", "]")
+                .add("certificateRotationType=" + certificateRotationType)
+                .toString();
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/CertificatesRotationV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/CertificatesRotationV4Response.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response;
+
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+
+public class CertificatesRotationV4Response {
+    private FlowIdentifier flowIdentifier;
+
+    public CertificatesRotationV4Response() {
+    }
+
+    public CertificatesRotationV4Response(FlowIdentifier flowIdentifier) {
+        this.flowIdentifier = flowIdentifier;
+    }
+
+    public FlowIdentifier getFlowIdentifier() {
+        return flowIdentifier;
+    }
+
+    public void setFlowIdentifier(FlowIdentifier flowIdentifier) {
+        this.flowIdentifier = flowIdentifier;
+    }
+
+    @Override
+    public String toString() {
+        return "CertificateRotationV4Response{" +
+                "flowIdentifier=" + flowIdentifier +
+                '}';
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
@@ -307,6 +307,7 @@ public class ModelDescriptions {
         public static final String VARIANT = "Cluster manager variant";
         public static final String CLOUD_STORAGE_LOCATIONS = "storage locations by CDP services";
         public static final String ENABLE_RANGER_RAZ = "Enables Ranger Raz for the cluster on S3 and ADLSv2.";
+        public static final String CERTIFICATE_ROTATION_TYPE = "the type of the certificate rotation";
     }
 
     public static class GatewayModelDescription {

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
@@ -57,6 +57,7 @@ public class OperationDescriptions {
         public static final String DATABASE_BACKUP_INTERNAL = "Performs a backup of the database to a provided location, internal only";
         public static final String DATABASE_RESTORE = "Performs a restore of the database from a provided location";
         public static final String DATABASE_RESTORE_INTERNAL = "Performs a restore of the database from a provided location, internal only";
+        public static final String ROTATE_CERTIFICATES = "Rotates the certificates of the cluster";
     }
 
     public static class ClusterOpDescription {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
@@ -19,6 +19,7 @@ import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.StackV4Endpoint;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.CertificatesRotationV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.ClusterRepairV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.MaintenanceModeV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackImageChangeV4Request;
@@ -27,6 +28,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.UpdateClusterV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.UserNamePasswordV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.tags.upgrade.UpgradeV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.CertificatesRotationV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.GeneratedBlueprintV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.RetryableFlowResponse;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.RetryableFlowResponse.Builder;
@@ -344,5 +346,12 @@ public class StackV4Controller extends NotificationController implements StackV4
         FlowIdentifier flowIdentifier = stackOperations.restoreClusterDatabase(NameOrCrn.ofName(name),
                 restRequestThreadLocalService.getRequestedWorkspaceId(), backupLocation, backupId);
         return new RestoreV4Response(flowIdentifier);
+    }
+
+    @Override
+    @InternalOnly
+    public CertificatesRotationV4Response rotateCertificates(Long workspaceId, String name, @InitiatorUserCrn String initiatorUserCrn,
+            @Valid CertificatesRotationV4Request certificatesRotationV4Request) {
+        return stackOperations.rotateClusterCertificates(NameOrCrn.ofName(name), workspaceId, certificatesRotationV4Request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/util/ExceptionMessageFormatterUtil.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/util/ExceptionMessageFormatterUtil.java
@@ -2,6 +2,9 @@ package com.sequenceiq.cloudbreak.converter.util;
 
 import org.springframework.security.access.AccessDeniedException;
 
+import com.sequenceiq.cloudbreak.common.service.TransactionService;
+import com.sequenceiq.cloudbreak.service.CloudbreakException;
+
 public class ExceptionMessageFormatterUtil {
 
     private ExceptionMessageFormatterUtil() {
@@ -22,6 +25,16 @@ public class ExceptionMessageFormatterUtil {
         } catch (AccessDeniedException e) {
             throw new AccessDeniedException(
                     String.format("Access to %s '%s' is denied or %s doesn't exist.", resourceType, resourceName, resourceType), e);
+        }
+    }
+
+    public static String getErrorMessageFromException(Exception exception) {
+        boolean transactionRuntimeException = exception instanceof TransactionService.TransactionRuntimeExecutionException;
+        if (transactionRuntimeException && exception.getCause() != null && exception.getCause().getCause() != null) {
+            return exception.getCause().getCause().getMessage();
+        } else {
+            return exception instanceof CloudbreakException && exception.getCause() != null
+                    ? exception.getCause().getMessage() : exception.getMessage();
         }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
@@ -55,6 +55,7 @@ import com.sequenceiq.cloudbreak.cloud.model.StackTags;
 import com.sequenceiq.cloudbreak.cloud.scheduler.CancellationException;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterPreCreationApi;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
+import com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.container.postgres.PostgresConfigService;
@@ -482,7 +483,8 @@ public class ClusterHostServiceRunner {
                         "heartbeat_interval", cmHeartbeatInterval,
                         "missed_heartbeat_interval", cmMissedHeartbeatInterval,
                         "set_cdp_env", isVersionNewerOrEqualThanLimited(cmVersion, CLOUDERAMANAGER_VERSION_7_0_2),
-                        "deterministic_uid_gid", isVersionNewerOrEqualThanLimited(cmVersion, CLOUDERAMANAGER_VERSION_7_2_1))))));
+                        "deterministic_uid_gid", isVersionNewerOrEqualThanLimited(cmVersion, CLOUDERAMANAGER_VERSION_7_2_1),
+                        "cloudera_scm_sudo_access", CMRepositoryVersionUtil.isSudoAccessNeededForHostCertRotation(clouderaManagerRepo))))));
     }
 
     private void decoratePillarWithTags(Stack stack, Map<String, SaltPillarProperties> servicePillarConfig) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/certrotate/ClusterCertificatesRotationActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/certrotate/ClusterCertificatesRotationActions.java
@@ -1,0 +1,96 @@
+package com.sequenceiq.cloudbreak.core.flow2.cluster.certrotate;
+
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.certrotate.ClusterCertificatesRotationEvent.CLUSTER_CERTIFICATES_ROTATION_FAILURE_HANDLED_EVENT;
+
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.statemachine.action.Action;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.core.flow2.stack.AbstractStackFailureAction;
+import com.sequenceiq.cloudbreak.core.flow2.stack.StackContext;
+import com.sequenceiq.cloudbreak.core.flow2.stack.StackFailureContext;
+import com.sequenceiq.cloudbreak.core.flow2.stack.provision.action.AbstractStackCreationAction;
+import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+import com.sequenceiq.cloudbreak.reactor.api.event.StackFailureEvent;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.certrotate.ClusterCMCARotationSuccess;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.certrotate.ClusterHostCertificatesRotationRequest;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.certrotate.ClusterHostCertificatesRotationSuccess;
+
+@Configuration
+public class ClusterCertificatesRotationActions {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterCertificatesRotationActions.class);
+
+    @Inject
+    private ClusterCertificatesRotationService clusterCertificatesRotationService;
+
+    @Bean(name = "CLUSTER_CMCA_ROTATION_STATE")
+    public Action<?, ?> clusterCMCARotationAction() {
+        return new AbstractStackCreationAction<>(StackEvent.class) {
+            @Override
+            protected void doExecute(StackContext context, StackEvent payload, Map<Object, Object> variables) {
+                clusterCertificatesRotationService.initClusterCertificatesRotation(payload.getResourceId());
+                sendEvent(context);
+            }
+
+            @Override
+            protected Selectable createRequest(StackContext context) {
+                return new ClusterCMCARotationSuccess(context.getStack().getId());
+            }
+        };
+    }
+
+    @Bean(name = "CLUSTER_HOST_CERTIFICATES_ROTATION_STATE")
+    public Action<?, ?> clusterHostCertificatesRotationAction() {
+        return new AbstractStackCreationAction<>(ClusterCMCARotationSuccess.class) {
+            @Override
+            protected void doExecute(StackContext context, ClusterCMCARotationSuccess payload, Map<Object, Object> variables) {
+                clusterCertificatesRotationService.hostCertificatesRotationStarted(payload.getResourceId());
+                sendEvent(context);
+            }
+
+            @Override
+            protected Selectable createRequest(StackContext context) {
+                return new ClusterHostCertificatesRotationRequest(context.getStack().getId());
+            }
+        };
+    }
+
+    @Bean(name = "CLUSTER_CERTIFICATES_ROTATION_FINISHED_STATE")
+    public Action<?, ?> clusterCertificatesRotationFinishedAction() {
+        return new AbstractStackCreationAction<>(ClusterHostCertificatesRotationSuccess.class) {
+            @Override
+            protected void doExecute(StackContext context, ClusterHostCertificatesRotationSuccess payload, Map<Object, Object> variables) {
+                clusterCertificatesRotationService.certificatesRotationFinished(payload.getResourceId());
+                sendEvent(context);
+            }
+
+            @Override
+            protected Selectable createRequest(StackContext context) {
+                return new StackEvent(ClusterCertificatesRotationEvent.CLUSTER_CERTIFICATES_ROTATION_FINISHED_EVENT.event(), context.getStack().getId());
+            }
+        };
+    }
+
+    @Bean(name = "CLUSTER_CERTIFICATES_ROTATION_FAILED_STATE")
+    public Action<?, ?> clusterCertificatesRotationFailedAction() {
+        return new AbstractStackFailureAction<ClusterCertificatesRotationState, ClusterCertificatesRotationEvent>() {
+            @Override
+            protected void doExecute(StackFailureContext context, StackFailureEvent payload, Map<Object, Object> variables) {
+                clusterCertificatesRotationService.certificatesRotationFailed(context.getStackView(), payload.getException());
+                sendEvent(context);
+            }
+
+            @Override
+            protected Selectable createRequest(StackFailureContext context) {
+                return new StackEvent(CLUSTER_CERTIFICATES_ROTATION_FAILURE_HANDLED_EVENT.event(), context.getStackView().getId());
+            }
+        };
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/certrotate/ClusterCertificatesRotationEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/certrotate/ClusterCertificatesRotationEvent.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.cloudbreak.core.flow2.cluster.certrotate;
+
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.certrotate.ClusterCMCARotationSuccess;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.certrotate.ClusterCertificatesRotationFailed;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.certrotate.ClusterHostCertificatesRotationSuccess;
+import com.sequenceiq.flow.core.FlowEvent;
+import com.sequenceiq.flow.event.EventSelectorUtil;
+
+public enum ClusterCertificatesRotationEvent implements FlowEvent {
+    CLUSTER_CMCA_ROTATION_EVENT("CLUSTER_CERTIFICATES_ROTATION_EVENT"),
+    CLUSTER_HOST_CERTIFICATES_ROTATION_EVENT(EventSelectorUtil.selector(ClusterCMCARotationSuccess.class)),
+    CLUSTER_HOST_CERTIFICATES_ROTATION_FINISHED_EVENT(EventSelectorUtil.selector(ClusterHostCertificatesRotationSuccess.class)),
+    CLUSTER_CERTIFICATES_ROTATION_FAILED_EVENT(EventSelectorUtil.selector(ClusterCertificatesRotationFailed.class)),
+    CLUSTER_CERTIFICATES_ROTATION_FINISHED_EVENT("CLUSTER_CERTIFICATES_ROTATION_FINISHED_EVENT"),
+    CLUSTER_CERTIFICATES_ROTATION_FAILURE_HANDLED_EVENT("CLUSTER_CERTIFICATES_ROTATION_FAILURE_HANDLED_EVENT");
+
+    private final String event;
+
+    ClusterCertificatesRotationEvent(String event) {
+        this.event = event;
+    }
+
+    @Override
+    public String event() {
+        return event;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/certrotate/ClusterCertificatesRotationFlowConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/certrotate/ClusterCertificatesRotationFlowConfig.java
@@ -1,0 +1,78 @@
+package com.sequenceiq.cloudbreak.core.flow2.cluster.certrotate;
+
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.certrotate.ClusterCertificatesRotationEvent.CLUSTER_CERTIFICATES_ROTATION_FAILED_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.certrotate.ClusterCertificatesRotationEvent.CLUSTER_CERTIFICATES_ROTATION_FAILURE_HANDLED_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.certrotate.ClusterCertificatesRotationEvent.CLUSTER_CERTIFICATES_ROTATION_FINISHED_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.certrotate.ClusterCertificatesRotationEvent.CLUSTER_CMCA_ROTATION_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.certrotate.ClusterCertificatesRotationEvent.CLUSTER_HOST_CERTIFICATES_ROTATION_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.certrotate.ClusterCertificatesRotationEvent.CLUSTER_HOST_CERTIFICATES_ROTATION_FINISHED_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.certrotate.ClusterCertificatesRotationState.CLUSTER_CERTIFICATES_ROTATION_FINISHED_STATE;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.certrotate.ClusterCertificatesRotationState.CLUSTER_CERTIFICATES_ROTATION_FAILED_STATE;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.certrotate.ClusterCertificatesRotationState.CLUSTER_CMCA_ROTATION_STATE;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.certrotate.ClusterCertificatesRotationState.CLUSTER_HOST_CERTIFICATES_ROTATION_STATE;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.certrotate.ClusterCertificatesRotationState.FINAL_STATE;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.certrotate.ClusterCertificatesRotationState.INIT_STATE;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
+import com.sequenceiq.flow.core.config.RetryableFlowConfiguration;
+
+@Component
+public class ClusterCertificatesRotationFlowConfig extends AbstractFlowConfiguration<ClusterCertificatesRotationState, ClusterCertificatesRotationEvent>
+        implements RetryableFlowConfiguration<ClusterCertificatesRotationEvent> {
+
+    private static final List<Transition<ClusterCertificatesRotationState, ClusterCertificatesRotationEvent>> TRANSITIONS =
+            new Transition.Builder<ClusterCertificatesRotationState, ClusterCertificatesRotationEvent>()
+                    .defaultFailureEvent(CLUSTER_CERTIFICATES_ROTATION_FAILED_EVENT)
+                    .from(INIT_STATE).to(CLUSTER_CMCA_ROTATION_STATE).event(CLUSTER_CMCA_ROTATION_EVENT)
+                        .noFailureEvent()
+                    .from(CLUSTER_CMCA_ROTATION_STATE).to(CLUSTER_HOST_CERTIFICATES_ROTATION_STATE).event(CLUSTER_HOST_CERTIFICATES_ROTATION_EVENT)
+                        .defaultFailureEvent()
+                    .from(CLUSTER_HOST_CERTIFICATES_ROTATION_STATE).to(CLUSTER_CERTIFICATES_ROTATION_FINISHED_STATE)
+                        .event(CLUSTER_HOST_CERTIFICATES_ROTATION_FINISHED_EVENT).defaultFailureEvent()
+                    .from(CLUSTER_CERTIFICATES_ROTATION_FINISHED_STATE).to(FINAL_STATE).event(CLUSTER_CERTIFICATES_ROTATION_FINISHED_EVENT)
+                        .defaultFailureEvent()
+                    .build();
+
+    private static final FlowEdgeConfig<ClusterCertificatesRotationState, ClusterCertificatesRotationEvent> EDGE_CONFIG =
+            new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, CLUSTER_CERTIFICATES_ROTATION_FAILED_STATE, CLUSTER_CERTIFICATES_ROTATION_FAILURE_HANDLED_EVENT);
+
+    public ClusterCertificatesRotationFlowConfig() {
+        super(ClusterCertificatesRotationState.class, ClusterCertificatesRotationEvent.class);
+    }
+
+    @Override
+    protected List<Transition<ClusterCertificatesRotationState, ClusterCertificatesRotationEvent>> getTransitions() {
+        return TRANSITIONS;
+    }
+
+    @Override
+    protected FlowEdgeConfig<ClusterCertificatesRotationState, ClusterCertificatesRotationEvent> getEdgeConfig() {
+        return EDGE_CONFIG;
+    }
+
+    @Override
+    public ClusterCertificatesRotationEvent[] getEvents() {
+        return ClusterCertificatesRotationEvent.values();
+    }
+
+    @Override
+    public ClusterCertificatesRotationEvent[] getInitEvents() {
+        return new ClusterCertificatesRotationEvent[]{
+                CLUSTER_CMCA_ROTATION_EVENT
+        };
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Renew certificate of an existing cluster";
+    }
+
+    @Override
+    public ClusterCertificatesRotationEvent getRetryableEvent() {
+        return CLUSTER_CERTIFICATES_ROTATION_FAILURE_HANDLED_EVENT;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/certrotate/ClusterCertificatesRotationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/certrotate/ClusterCertificatesRotationService.java
@@ -1,0 +1,64 @@
+package com.sequenceiq.cloudbreak.core.flow2.cluster.certrotate;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
+import com.sequenceiq.cloudbreak.converter.util.ExceptionMessageFormatterUtil;
+import com.sequenceiq.cloudbreak.core.flow2.stack.CloudbreakFlowMessageService;
+import com.sequenceiq.cloudbreak.domain.view.StackView;
+import com.sequenceiq.cloudbreak.event.ResourceEvent;
+import com.sequenceiq.cloudbreak.service.StackUpdater;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
+
+@Service
+public class ClusterCertificatesRotationService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterCertificatesRotationService.class);
+
+    @Inject
+    private StackUpdater stackUpdater;
+
+    @Inject
+    private CloudbreakFlowMessageService flowMessageService;
+
+    @Inject
+    private ClusterService clusterService;
+
+    void initClusterCertificatesRotation(long stackId) {
+        String statusReason = "Rotating the certificates of the cluster.";
+        LOGGER.debug(statusReason);
+        stackUpdater.updateStackStatus(stackId, DetailedStackStatus.CLUSTER_OPERATION, statusReason);
+        clusterService.updateClusterStatusByStackId(stackId, Status.UPDATE_IN_PROGRESS);
+        flowMessageService.fireEventAndLog(stackId, Status.UPDATE_IN_PROGRESS.name(), ResourceEvent.CLUSTER_CERTIFICATES_ROTATION_STARTED);
+    }
+
+    void hostCertificatesRotationStarted(long stackId) {
+        String statusReason = "The rotation of the host certificates of the cluster has been started.";
+        LOGGER.debug(statusReason);
+        stackUpdater.updateStackStatus(stackId, DetailedStackStatus.CLUSTER_OPERATION, statusReason);
+        clusterService.updateClusterStatusByStackId(stackId, Status.UPDATE_IN_PROGRESS);
+        flowMessageService.fireEventAndLog(stackId, Status.UPDATE_IN_PROGRESS.name(), ResourceEvent.CLUSTER_HOST_CERTIFICATES_ROTATION);
+    }
+
+    void certificatesRotationFinished(long stackId) {
+        clusterService.updateClusterStatusByStackId(stackId, Status.AVAILABLE);
+        stackUpdater.updateStackStatus(stackId, DetailedStackStatus.AVAILABLE, "Rotation of the cluster's certificates finished.");
+        flowMessageService.fireEventAndLog(stackId, Status.AVAILABLE.name(), ResourceEvent.CLUSTER_CERTIFICATES_ROTATION_FINISHED);
+    }
+
+    void certificatesRotationFailed(StackView stackView, Exception exception) {
+        if (stackView.getClusterView() != null) {
+            Long stackId = stackView.getId();
+            String errorMessage = ExceptionMessageFormatterUtil.getErrorMessageFromException(exception);
+            clusterService.updateClusterStatusByStackId(stackId, Status.UPDATE_FAILED, errorMessage);
+            stackUpdater.updateStackStatus(stackId, DetailedStackStatus.AVAILABLE);
+            flowMessageService.fireEventAndLog(stackId, Status.UPDATE_FAILED.name(), ResourceEvent.CLUSTER_CERTIFICATES_ROTATION_FAILED, errorMessage);
+        } else {
+            LOGGER.info("Cluster was null. Flow action was not required.");
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/certrotate/ClusterCertificatesRotationState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/certrotate/ClusterCertificatesRotationState.java
@@ -1,0 +1,12 @@
+package com.sequenceiq.cloudbreak.core.flow2.cluster.certrotate;
+
+import com.sequenceiq.flow.core.FlowState;
+
+public enum ClusterCertificatesRotationState implements FlowState {
+    INIT_STATE,
+    CLUSTER_CMCA_ROTATION_STATE,
+    CLUSTER_HOST_CERTIFICATES_ROTATION_STATE,
+    CLUSTER_CERTIFICATES_ROTATION_FINISHED_STATE,
+    CLUSTER_CERTIFICATES_ROTATION_FAILED_STATE,
+    FINAL_STATE;
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterCertificatesRotationTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterCertificatesRotationTriggerEvent.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.cloudbreak.core.flow2.event;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.CertificateRotationType;
+import com.sequenceiq.cloudbreak.common.event.AcceptResult;
+import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+
+import reactor.rx.Promise;
+
+public class ClusterCertificatesRotationTriggerEvent extends StackEvent {
+    private final CertificateRotationType certificateRotationType;
+
+    public ClusterCertificatesRotationTriggerEvent(String selector, Long stackId, CertificateRotationType certificateRotationType) {
+        super(selector, stackId);
+        this.certificateRotationType = certificateRotationType;
+    }
+
+    public ClusterCertificatesRotationTriggerEvent(String event, Long resourceId, Promise<AcceptResult> accepted,
+            CertificateRotationType certificateRotationType) {
+        super(event, resourceId, accepted);
+        this.certificateRotationType = certificateRotationType;
+    }
+
+    public CertificateRotationType getCertificateRotationType() {
+        return certificateRotationType;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
@@ -28,13 +28,16 @@ import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.InstanceGroupAdjustmentV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.CertificatesRotationV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.HostGroupAdjustmentV4Request;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.common.event.Acceptable;
 import com.sequenceiq.cloudbreak.common.type.ScalingType;
 import com.sequenceiq.cloudbreak.core.flow2.chain.FlowChainTriggers;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.certrotate.ClusterCertificatesRotationEvent;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.EphemeralClusterEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterAndStackDownscaleTriggerEvent;
+import com.sequenceiq.cloudbreak.core.flow2.event.ClusterCertificatesRotationTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterCredentialChangeTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterDownscaleDetails;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterScaleTriggerEvent;
@@ -283,4 +286,10 @@ public class ReactorFlowManager {
         return reactorNotifier.notify(stackId, selector, new DatabaseRestoreTriggerEvent(selector, stackId, location, backupId));
     }
 
+    public FlowIdentifier triggerClusterCertificatesRotation(Long stackId, CertificatesRotationV4Request certificatesRotationV4Request) {
+        String selector = ClusterCertificatesRotationEvent.CLUSTER_CMCA_ROTATION_EVENT.event();
+        ClusterCertificatesRotationTriggerEvent clusterCertificatesRotationTriggerEvent = new ClusterCertificatesRotationTriggerEvent(selector, stackId,
+                certificatesRotationV4Request.getRotateCertificatesType());
+        return reactorNotifier.notify(stackId, selector, clusterCertificatesRotationTriggerEvent);
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/certrotate/ClusterCMCARotationRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/certrotate/ClusterCMCARotationRequest.java
@@ -1,0 +1,9 @@
+package com.sequenceiq.cloudbreak.reactor.api.event.cluster.certrotate;
+
+import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+
+public class ClusterCMCARotationRequest extends StackEvent {
+    public ClusterCMCARotationRequest(Long stackId) {
+        super(stackId);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/certrotate/ClusterCMCARotationSuccess.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/certrotate/ClusterCMCARotationSuccess.java
@@ -1,0 +1,9 @@
+package com.sequenceiq.cloudbreak.reactor.api.event.cluster.certrotate;
+
+import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+
+public class ClusterCMCARotationSuccess extends StackEvent {
+    public ClusterCMCARotationSuccess(Long stackId) {
+        super(stackId);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/certrotate/ClusterCertificatesRotationFailed.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/certrotate/ClusterCertificatesRotationFailed.java
@@ -1,0 +1,13 @@
+package com.sequenceiq.cloudbreak.reactor.api.event.cluster.certrotate;
+
+import com.sequenceiq.cloudbreak.reactor.api.event.StackFailureEvent;
+
+public class ClusterCertificatesRotationFailed extends StackFailureEvent {
+    public ClusterCertificatesRotationFailed(Long stackId, Exception exception) {
+        super(stackId, exception);
+    }
+
+    public ClusterCertificatesRotationFailed(String selector, Long stackId, Exception exception) {
+        super(selector, stackId, exception);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/certrotate/ClusterHostCertificatesRotationRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/certrotate/ClusterHostCertificatesRotationRequest.java
@@ -1,0 +1,9 @@
+package com.sequenceiq.cloudbreak.reactor.api.event.cluster.certrotate;
+
+import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+
+public class ClusterHostCertificatesRotationRequest extends StackEvent {
+    public ClusterHostCertificatesRotationRequest(Long stackId) {
+        super(stackId);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/certrotate/ClusterHostCertificatesRotationSuccess.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/certrotate/ClusterHostCertificatesRotationSuccess.java
@@ -1,0 +1,9 @@
+package com.sequenceiq.cloudbreak.reactor.api.event.cluster.certrotate;
+
+import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+
+public class ClusterHostCertificatesRotationSuccess extends StackEvent {
+    public ClusterHostCertificatesRotationSuccess(Long stackId) {
+        super(stackId);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/certrotate/ClusterHostCertificatesRotationHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/certrotate/ClusterHostCertificatesRotationHandler.java
@@ -1,0 +1,56 @@
+package com.sequenceiq.cloudbreak.reactor.handler.cluster.certrotate;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.certrotate.ClusterCertificatesRotationFailed;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.certrotate.ClusterHostCertificatesRotationRequest;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.certrotate.ClusterHostCertificatesRotationSuccess;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.flow.event.EventSelectorUtil;
+import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+
+import reactor.bus.Event;
+
+@Component
+public class ClusterHostCertificatesRotationHandler extends ExceptionCatcherEventHandler<ClusterHostCertificatesRotationRequest> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterHostCertificatesRotationHandler.class);
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private ClusterApiConnectors apiConnectors;
+
+    @Override
+    public String selector() {
+        return EventSelectorUtil.selector(ClusterHostCertificatesRotationRequest.class);
+    }
+
+    @Override
+    protected Selectable defaultFailureEvent(Long resourceId, Exception e, Event<ClusterHostCertificatesRotationRequest> event) {
+        return new ClusterCertificatesRotationFailed(resourceId, e);
+    }
+
+    @Override
+    protected Selectable doAccept(HandlerEvent event) {
+        LOGGER.debug("Accepting Cluster Manager host certificates rotation request...");
+        ClusterHostCertificatesRotationRequest request = event.getData();
+        Selectable result;
+        try {
+            Stack stack = stackService.getByIdWithListsInTransaction(request.getResourceId());
+            apiConnectors.getConnector(stack).rotateHostCertificates();
+            result = new ClusterHostCertificatesRotationSuccess(request.getResourceId());
+        } catch (Exception e) {
+            LOGGER.info("Cluster Manager host certificates rotation failed", e);
+            result = new ClusterCertificatesRotationFailed(request.getResourceId(), e);
+        }
+        return result;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/ClusterCommonService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/ClusterCommonService.java
@@ -19,9 +19,11 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.MaintenanceModeStatus;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.CertificatesRotationV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.HostGroupV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.UpdateClusterV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.UserNamePasswordV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.CertificatesRotationV4Response;
 import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateValidator;
@@ -272,13 +274,22 @@ public class ClusterCommonService {
     public FlowIdentifier updatePillarConfiguration(NameOrCrn nameOrCrn, Long workspaceId) {
         Stack stack = stackService.getByNameOrCrnInWorkspace(nameOrCrn, workspaceId);
         MDCBuilder.buildMdcContext(stack);
-        if (!stack.isAvailable()) {
-            throw new BadRequestException(String.format(
-                "Stack '%s' is currently in '%s' state. Updates to the Pillar Configuration can "
-                    + "only be made when the underlying stack is 'AVAILABLE'.",
-                stack.getName(),
-                stack.getStatus()));
-        }
+        validateOperationOnStack(stack, "Updates to the Pillar Configuration");
         return clusterOperationService.updatePillarConfiguration(stack);
+    }
+
+    public CertificatesRotationV4Response rotateClusterCertificates(NameOrCrn nameOrCrn, Long workspaceId,
+            CertificatesRotationV4Request certificatesRotationV4Request) {
+        Stack stack = stackService.getByNameOrCrnInWorkspace(nameOrCrn, workspaceId);
+        MDCBuilder.buildMdcContext(stack);
+        validateOperationOnStack(stack, "Certificates rotation");
+        return new CertificatesRotationV4Response(clusterOperationService.rotateClusterCertificates(stack, certificatesRotationV4Request));
+    }
+
+    private void validateOperationOnStack(Stack stack, String operationDescription) {
+        if (!stack.isAvailable()) {
+            throw new BadRequestException(String.format("Stack '%s' is currently in '%s' state. %s can only be made when the underlying stack is 'AVAILABLE'.",
+                    stack.getName(), stack.getStatus(), operationDescription));
+        }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/ClusterOperationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/ClusterOperationService.java
@@ -36,6 +36,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.RecoveryMode;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.StatusRequest;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.CertificatesRotationV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.HostGroupAdjustmentV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.UserNamePasswordV4Request;
 import com.sequenceiq.cloudbreak.aspect.Measure;
@@ -515,5 +516,9 @@ public class ClusterOperationService {
 
     public FlowIdentifier updatePillarConfiguration(Stack stack) {
         return flowManager.triggerPillarConfigurationUpdate(stack.getId());
+    }
+
+    public FlowIdentifier rotateClusterCertificates(Stack stack, CertificatesRotationV4Request certificatesRotationV4Request) {
+        return flowManager.triggerClusterCertificatesRotation(stack.getId(), certificatesRotationV4Request);
     }
 }

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
@@ -20,6 +20,7 @@ import com.sequenceiq.authorization.resource.AuthorizationResourceType;
 import com.sequenceiq.authorization.service.ResourceBasedCrnProvider;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.CertificatesRotationV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.ClusterRepairV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.MaintenanceModeV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackImageChangeV4Request;
@@ -28,6 +29,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.UpdateClusterV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.UserNamePasswordV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.tags.upgrade.UpgradeV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.CertificatesRotationV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.GeneratedBlueprintV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackStatusV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
@@ -357,4 +359,9 @@ public class StackOperations implements ResourceBasedCrnProvider {
         return Optional.of(stackService.getByCrn(resourceCrn).getEnvironmentCrn());
     }
 
+    public CertificatesRotationV4Response rotateClusterCertificates(@NotNull NameOrCrn nameOrCrn, Long workspaceId,
+            CertificatesRotationV4Request certificatesRotationV4Request) {
+        LOGGER.debug("Starting cluster certificates rotation: " + nameOrCrn);
+        return clusterCommonService.rotateClusterCertificates(nameOrCrn, workspaceId, certificatesRotationV4Request);
+    }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
@@ -27,6 +27,7 @@ import org.springframework.core.task.AsyncTaskExecutor;
 
 import com.sequenceiq.cloudbreak.TestUtil;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.InstanceGroupAdjustmentV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.CertificatesRotationV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.HostGroupAdjustmentV4Request;
 import com.sequenceiq.cloudbreak.common.event.AcceptResult;
 import com.sequenceiq.cloudbreak.common.event.Acceptable;
@@ -125,6 +126,7 @@ public class ReactorFlowManagerTest {
         underTest.triggerPillarConfigurationUpdate(STACK_ID);
         underTest.triggerDatalakeDatabaseBackup(STACK_ID, null, null);
         underTest.triggerDatalakeDatabaseRestore(STACK_ID, null, null);
+        underTest.triggerClusterCertificatesRotation(STACK_ID, new CertificatesRotationV4Request());
 
         int count = 0;
         for (Method method : underTest.getClass().getDeclaredMethods()) {

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/init.sls
@@ -11,6 +11,18 @@ install-cloudera-manager-agent:
     - unless:
       - rpm -q cloudera-manager-daemons cloudera-manager-agent
 
+{% if cloudera_manager.settings.cloudera_scm_sudo_access == True %}
+
+/etc/sudoers.d/cloudera-scm:
+  file.managed:
+    - contents:
+      - cloudera-scm ALL=(ALL) NOPASSWD:ALL
+    - user: root
+    - group: root
+    - mode: 440
+
+{% endif %}
+
 {%- if not salt['pkg.version']('python-psycopg2') and not salt['pkg.version']('python2-psycopg2') %}
 install-psycopg2:
   cmd.run:
@@ -66,3 +78,4 @@ set_service_uids:
     - require:
         - file: /opt/cloudera/cm-agent/service/inituids
 {% endif %}
+

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
@@ -30,6 +30,8 @@ public class CMRepositoryVersionUtil {
 
     public static final Versioned CLOUDERAMANAGER_VERSION_7_2_2 = () -> "7.2.2";
 
+    public static final Versioned CLOUDERAMANAGER_VERSION_7_2_3 = () -> "7.2.3";
+
     public static final Versioned CFM_VERSION_2_0_0_0 = () -> "2.0.0.0";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CMRepositoryVersionUtil.class);
@@ -78,6 +80,11 @@ public class CMRepositoryVersionUtil {
         return isVersionNewerOrEqualThanLimited(clouderaManagerRepoDetails::getVersion, CLOUDERAMANAGER_VERSION_7_2_2);
     }
 
+    public static boolean isSudoAccessNeededForHostCertRotation(ClouderaManagerRepo clouderaManagerRepoDetails) {
+        LOGGER.info("ClouderaManagerRepo is compared for Host certs rotation Sudo access");
+        return isVersionOlderThanLimited(clouderaManagerRepoDetails::getVersion, CLOUDERAMANAGER_VERSION_7_2_3);
+    }
+
     public static boolean isVersionNewerOrEqualThanLimited(Versioned currentVersion, Versioned limitedAPIVersion) {
         LOGGER.info("Compared: Versioned {} with Versioned {}", currentVersion.getVersion(), limitedAPIVersion.getVersion());
         Comparator<Versioned> versionComparator = new VersionComparator();
@@ -87,5 +94,16 @@ public class CMRepositoryVersionUtil {
     public static boolean isVersionNewerOrEqualThanLimited(String currentVersion, Versioned limitedAPIVersion) {
         LOGGER.info("Compared: String version {} with Versioned {}", currentVersion, limitedAPIVersion.getVersion());
         return isVersionNewerOrEqualThanLimited(() -> currentVersion, limitedAPIVersion);
+    }
+
+    public static boolean isVersionOlderThanLimited(Versioned currentVersion, Versioned limitedAPIVersion) {
+        LOGGER.info("Compared: Versioned {} with Versioned {}", currentVersion.getVersion(), limitedAPIVersion.getVersion());
+        Comparator<Versioned> versionComparator = new VersionComparator();
+        return versionComparator.compare(currentVersion, limitedAPIVersion) < 0;
+    }
+
+    public static boolean isVersionOlderThanLimited(String currentVersion, Versioned limitedAPIVersion) {
+        LOGGER.info("Compared: String version {} with Versioned {}", currentVersion, limitedAPIVersion.getVersion());
+        return isVersionOlderThanLimited(() -> currentVersion, limitedAPIVersion);
     }
 }


### PR DESCRIPTION
CB-8703 Rotate the CM host certificates:

* new internal API call on StackV4Controller: rotateCertificates
* new flow for certificates rotation: ClusterCertificatesRotationFlowConfig
* currently host certificates rotation is implemented, but there is a flow step for the CMCA rotation but it's not implemented yet
* Host certificates rotation is implemented with BatchResourceApi, multiple host certificates rotation commands are requested in one request
