### PR TITLE
CB-8762: Fix FreeIPA replica install retry to allow the topology di...

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_replica_install.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_replica_install.sh
@@ -12,7 +12,7 @@ FORWARDERS=$(grep -Ev '^#|^;' /etc/resolv.conf.orig | grep nameserver | awk '{pr
 
 install -m644 /etc/resolv.conf.install /etc/resolv.conf
 
-ipa-server-install --unattended --uninstall
+ipa-server-install --unattended --uninstall --ignore-topology-disconnect --ignore-last-of-role
 
 ipa-client-install \
   --server "$FREEIPA_TO_REPLICATE" \


### PR DESCRIPTION
...sconnection

Allow the FreeIPA topology to be disconnected temporarily if FreeIPA
replicas are being reinstalled due salt retries.

See detailed description in the commit message.

Since I cannot reproduce the problem in CB-8762, it is not clear if this will actually resolve the intermittent problem with CB-8762.