### PR TITLE
CB-8703 fix authz framework to handle null queryparam

### DIFF
--- a/auth-internal/src/main/java/com/sequenceiq/cloudbreak/auth/security/internal/InternalCrnModifier.java
+++ b/auth-internal/src/main/java/com/sequenceiq/cloudbreak/auth/security/internal/InternalCrnModifier.java
@@ -34,9 +34,9 @@ public class InternalCrnModifier {
             return ThreadBasedUserCrnProvider.doAs(getNewUserCrnIfAccountIdParamDefined(proceedingJoinPoint, methodSignature, userCrnString)
                         .or(() -> getNewUserCrnIfTenantAwareParamDefined(proceedingJoinPoint, methodSignature, userCrnString))
                         .orElse(userCrnString),
-                    () -> reflectionUtil.proceed(proceedingJoinPoint, methodSignature));
+                    () -> reflectionUtil.proceed(proceedingJoinPoint));
         }
-        return reflectionUtil.proceed(proceedingJoinPoint, methodSignature);
+        return reflectionUtil.proceed(proceedingJoinPoint);
     }
 
     private Optional<String> getNewUserCrnIfAccountIdParamDefined(ProceedingJoinPoint proceedingJoinPoint, MethodSignature methodSignature,

--- a/auth-internal/src/test/java/com/sequenceiq/cloudbreak/auth/security/internal/InternalCrnModifierTest.java
+++ b/auth-internal/src/test/java/com/sequenceiq/cloudbreak/auth/security/internal/InternalCrnModifierTest.java
@@ -61,7 +61,7 @@ public class InternalCrnModifierTest {
     @Test
     public void testModificationIfUserCrnIsRealUser() {
         AtomicBoolean assertationHappened = new AtomicBoolean(false);
-        when(reflectionUtil.proceed(any(), any())).thenAnswer(invocation -> {
+        when(reflectionUtil.proceed(any())).thenAnswer(invocation -> {
             assertEquals(USER_CRN, ThreadBasedUserCrnProvider.getUserCrn());
             assertationHappened.set(true);
             return null;
@@ -78,7 +78,7 @@ public class InternalCrnModifierTest {
     @Test
     public void testModificationIfUserCrnIsNull() {
         AtomicBoolean assertationHappened = new AtomicBoolean(false);
-        when(reflectionUtil.proceed(any(), any())).thenAnswer(invocation -> {
+        when(reflectionUtil.proceed(any())).thenAnswer(invocation -> {
             assertNull(ThreadBasedUserCrnProvider.getUserCrn());
             assertationHappened.set(true);
             return null;
@@ -98,7 +98,7 @@ public class InternalCrnModifierTest {
         when(reflectionUtil.getParameter(any(), any(), eq(TenantAwareParam.class))).thenReturn(Optional.empty());
 
         AtomicBoolean assertationHappened = new AtomicBoolean(false);
-        when(reflectionUtil.proceed(any(), any())).thenAnswer(invocation -> {
+        when(reflectionUtil.proceed(any())).thenAnswer(invocation -> {
             assertEquals(INTERNAL_CRN, ThreadBasedUserCrnProvider.getUserCrn());
             assertationHappened.set(true);
             return null;
@@ -108,7 +108,7 @@ public class InternalCrnModifierTest {
             underTest.changeInternalCrn(proceedingJoinPoint);
         });
 
-        verify(reflectionUtil, times(1)).proceed(any(), any());
+        verify(reflectionUtil, times(1)).proceed(any());
         assertTrue(assertationHappened.get());
     }
 
@@ -118,7 +118,7 @@ public class InternalCrnModifierTest {
         when(reflectionUtil.getParameter(any(), any(), eq(TenantAwareParam.class))).thenReturn(Optional.of(2));
 
         AtomicBoolean assertationHappened = new AtomicBoolean(false);
-        when(reflectionUtil.proceed(any(), any())).thenAnswer(invocation -> {
+        when(reflectionUtil.proceed(any())).thenAnswer(invocation -> {
             assertEquals(INTERNAL_CRN, ThreadBasedUserCrnProvider.getUserCrn());
             assertationHappened.set(true);
             return null;
@@ -128,7 +128,7 @@ public class InternalCrnModifierTest {
             underTest.changeInternalCrn(proceedingJoinPoint);
         });
 
-        verify(reflectionUtil, times(1)).proceed(any(), any());
+        verify(reflectionUtil, times(1)).proceed(any());
         assertTrue(assertationHappened.get());
     }
 
@@ -138,7 +138,7 @@ public class InternalCrnModifierTest {
         when(reflectionUtil.getParameter(any(), any(), eq(TenantAwareParam.class))).thenReturn(Optional.of("not_crn"));
 
         AtomicBoolean assertationHappened = new AtomicBoolean(false);
-        when(reflectionUtil.proceed(any(), any())).thenAnswer(invocation -> {
+        when(reflectionUtil.proceed(any())).thenAnswer(invocation -> {
             assertEquals(INTERNAL_CRN, ThreadBasedUserCrnProvider.getUserCrn());
             assertationHappened.set(true);
             return null;
@@ -148,7 +148,7 @@ public class InternalCrnModifierTest {
             underTest.changeInternalCrn(proceedingJoinPoint);
         });
 
-        verify(reflectionUtil, times(1)).proceed(any(), any());
+        verify(reflectionUtil, times(1)).proceed(any());
         assertTrue(assertationHappened.get());
     }
 
@@ -159,7 +159,7 @@ public class InternalCrnModifierTest {
         doNothing().when(internalUserModifier).persistModifiedInternalUser(any());
 
         AtomicBoolean assertationHappened = new AtomicBoolean(false);
-        when(reflectionUtil.proceed(any(), any())).thenAnswer(invocation -> {
+        when(reflectionUtil.proceed(any())).thenAnswer(invocation -> {
             assertEquals(EXPECTED_INTERNAL_CRN, ThreadBasedUserCrnProvider.getUserCrn());
             assertationHappened.set(true);
             return null;
@@ -172,7 +172,7 @@ public class InternalCrnModifierTest {
         ArgumentCaptor<CrnUser> newUserCaptor = ArgumentCaptor.forClass(CrnUser.class);
         verify(internalUserModifier, times(1)).persistModifiedInternalUser(newUserCaptor.capture());
         assertEquals("1234", newUserCaptor.getValue().getTenant());
-        verify(reflectionUtil, times(1)).proceed(any(), any());
+        verify(reflectionUtil, times(1)).proceed(any());
         assertTrue(assertationHappened.get());
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/auth/ReflectionUtil.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/auth/ReflectionUtil.java
@@ -20,12 +20,12 @@ public class ReflectionUtil {
                 .findFirst();
         if (optionalParameter.isPresent()) {
             int parameterIndex = Lists.newArrayList(methodSignature.getMethod().getParameters()).indexOf(optionalParameter.get());
-            return Optional.of(proceedingJoinPoint.getArgs()[parameterIndex]);
+            return Optional.ofNullable(proceedingJoinPoint.getArgs()[parameterIndex]);
         }
         return Optional.empty();
     }
 
-    public Object proceed(ProceedingJoinPoint proceedingJoinPoint, MethodSignature methodSignature) {
+    public Object proceed(ProceedingJoinPoint proceedingJoinPoint) {
         try {
             return proceedingJoinPoint.proceed();
         } catch (Error | RuntimeException unchecked) {

--- a/common/src/test/java/com/sequenceiq/cloudbreak/auth/ReflectionUtilTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/auth/ReflectionUtilTest.java
@@ -1,0 +1,101 @@
+package com.sequenceiq.cloudbreak.auth;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.sql.SQLException;
+
+import javax.validation.constraints.NotNull;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+
+@ExtendWith(MockitoExtension.class)
+public class ReflectionUtilTest {
+
+    @Mock
+    private ProceedingJoinPoint proceedingJoinPoint;
+
+    @Mock
+    private MethodSignature methodSignature;
+
+    @InjectMocks
+    private ReflectionUtil underTest;
+
+    @Test
+    public void testParameterIfParamFilled() throws NoSuchMethodException {
+        Method method = TestClass.class.getMethod("methodB", String.class);
+        when(methodSignature.getMethod()).thenReturn(method);
+        when(proceedingJoinPoint.getArgs()).thenReturn(new Object[]{"param"});
+
+        assertTrue(underTest.getParameter(proceedingJoinPoint, methodSignature, NotNull.class).isPresent());
+    }
+
+    @Test
+    public void testParameterIfParamNull() throws NoSuchMethodException {
+        Method method = TestClass.class.getMethod("methodB", String.class);
+        when(methodSignature.getMethod()).thenReturn(method);
+        when(proceedingJoinPoint.getArgs()).thenReturn(new Object[]{null});
+
+        assertFalse(underTest.getParameter(proceedingJoinPoint, methodSignature, NotNull.class).isPresent());
+    }
+
+    @Test
+    public void testParameterIfParamNotExists() throws NoSuchMethodException {
+        Method method = TestClass.class.getMethod("methodA");
+        when(methodSignature.getMethod()).thenReturn(method);
+
+        assertFalse(underTest.getParameter(proceedingJoinPoint, methodSignature, NotNull.class).isPresent());
+    }
+
+    @Test
+    public void testProceedOk() {
+        try {
+            when(proceedingJoinPoint.proceed()).thenReturn("result");
+            underTest.proceed(proceedingJoinPoint);
+        } catch (Throwable throwable) {
+
+        }
+    }
+
+    @Test
+    public void testProceedNotRuntimeExceptionOccured() {
+        try {
+            when(proceedingJoinPoint.proceed()).thenThrow(new SQLException("wrong"));
+            assertThrows(AccessDeniedException.class, () -> underTest.proceed(proceedingJoinPoint));
+        } catch (Throwable throwable) {
+
+        }
+    }
+
+    @Test
+    public void testProceedRuntimeExceptionOccured() throws Exception {
+        try {
+            when(proceedingJoinPoint.proceed()).thenThrow(new NullPointerException("wrong"));
+            assertThrows(NullPointerException.class, () -> underTest.proceed(proceedingJoinPoint));
+        } catch (Throwable throwable) {
+
+        }
+    }
+
+    private class TestClass {
+
+        public void methodA() {
+
+        }
+
+        public void methodB(@NotNull String param) {
+
+        }
+    }
+
+}


### PR DESCRIPTION
If there is an API method which can be called with internal actor and @AccountId/@TenantAwareParam/@InitiatorUserCrn param is null, then the framework will throw an ugly NPE.
If this is occuring in PROD, the workaround is to fill in the parameter, so I opened this PR for 2.31, not for 2.29.