### PR TITLE
CB-8997. Enable/disable phone home usage for CM based diagnostics bas…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/validation/diagnostics/DiagnosticsCollectionValidator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/validation/diagnostics/DiagnosticsCollectionValidator.java
@@ -31,7 +31,7 @@ public class DiagnosticsCollectionValidator {
         } else if (DiagnosticsDestination.ENG.equals(destination) && isClusterLogCollectionDisabled(telemetry)) {
             validationBuilder.error(
                     String.format("Cluster log collection is not enabled for this stack '%s'", stackCrn));
-        } else if (DiagnosticsDestination.SUPPORT.equals(destination)) {
+        } else if (DiagnosticsDestination.SUPPORT.equals(destination) && !cmBundle) {
             validationBuilder.error(
                     String.format("Destination %s is not supported yet.", DiagnosticsDestination.SUPPORT.name()));
         }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/CmDiagnosticsCollectionActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/CmDiagnosticsCollectionActions.java
@@ -116,7 +116,7 @@ public class CmDiagnosticsCollectionActions {
                         message = "Engineering will receive the logs.";
                         break;
                     case SUPPORT:
-                        message = String.format("Support ticket will be created for the logs. Ticket: '%s' Comments: '%s'",
+                        message = String.format("Diagnostics bundle sent to support. Ticket: '%s' Comments: '%s'",
                                 parameters.getTicketNumber(), parameters.getComments());
                         break;
                     default:

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/CmDiagnosticsCleanupHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/CmDiagnosticsCleanupHandler.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.core.flow2.diagnostics.DiagnosticsFlowService;
 import com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.CmDiagnosticsCollectionEvent;
 import com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.CmDiagnosticsCollectionFailureEvent;
+import com.sequenceiq.common.api.telemetry.model.DiagnosticsDestination;
 import com.sequenceiq.common.model.diagnostics.CmDiagnosticsParameters;
 import com.sequenceiq.flow.reactor.api.event.EventSender;
 import com.sequenceiq.flow.reactor.api.handler.EventSenderAwareHandler;
@@ -50,7 +51,11 @@ public class CmDiagnosticsCleanupHandler extends EventSenderAwareHandler<CmDiagn
         Map<String, Object> parameterMap = parameters.toMap();
         try {
             LOGGER.debug("CM based diagnostics cleanup started. resourceCrn: '{}', parameters: '{}'", resourceCrn, parameterMap);
-            diagnosticsFlowService.cleanup(resourceId, parameterMap);
+            if (DiagnosticsDestination.SUPPORT.equals(parameters.getDestination())) {
+                LOGGER.debug("CM based diagnostics uses SUPPORT destination, no support specific cleanup step yet.");
+            } else {
+                diagnosticsFlowService.cleanup(resourceId, parameterMap);
+            }
             CmDiagnosticsCollectionEvent diagnosticsCollectionEvent = CmDiagnosticsCollectionEvent.builder()
                     .withResourceCrn(resourceCrn)
                     .withResourceId(resourceId)

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/CmDiagnosticsInitHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/CmDiagnosticsInitHandler.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.core.flow2.diagnostics.DiagnosticsFlowService;
 import com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.CmDiagnosticsCollectionEvent;
 import com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.CmDiagnosticsCollectionFailureEvent;
+import com.sequenceiq.common.api.telemetry.model.DiagnosticsDestination;
 import com.sequenceiq.common.model.diagnostics.CmDiagnosticsParameters;
 import com.sequenceiq.flow.reactor.api.event.EventSender;
 import com.sequenceiq.flow.reactor.api.handler.EventSenderAwareHandler;
@@ -50,7 +51,11 @@ public class CmDiagnosticsInitHandler extends EventSenderAwareHandler<CmDiagnost
         Map<String, Object> parameterMap = parameters.toMap();
         try {
             LOGGER.debug("CM based diagnostics collection initialization started. resourceCrn: '{}', parameters: '{}'", resourceCrn, parameterMap);
-            diagnosticsFlowService.init(resourceId, parameterMap);
+            if (DiagnosticsDestination.SUPPORT.equals(parameters.getDestination())) {
+                LOGGER.debug("CM based diagnostics uses SUPPORT destination, no support specific init step yet.");
+            } else {
+                diagnosticsFlowService.init(resourceId, parameterMap);
+            }
             CmDiagnosticsCollectionEvent diagnosticsCollectionEvent = CmDiagnosticsCollectionEvent.builder()
                     .withResourceCrn(resourceCrn)
                     .withResourceId(resourceId)

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/CmDiagnosticsUploadHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/CmDiagnosticsUploadHandler.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.core.flow2.diagnostics.DiagnosticsFlowService;
 import com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.CmDiagnosticsCollectionEvent;
 import com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.CmDiagnosticsCollectionFailureEvent;
+import com.sequenceiq.common.api.telemetry.model.DiagnosticsDestination;
 import com.sequenceiq.common.model.diagnostics.CmDiagnosticsParameters;
 import com.sequenceiq.flow.reactor.api.event.EventSender;
 import com.sequenceiq.flow.reactor.api.handler.EventSenderAwareHandler;
@@ -50,7 +51,11 @@ public class CmDiagnosticsUploadHandler extends EventSenderAwareHandler<CmDiagno
         Map<String, Object> parameterMap = parameters.toMap();
         try {
             LOGGER.debug("CM based diagnostics upload started. resourceCrn: '{}', parameters: '{}'", resourceCrn, parameterMap);
-            diagnosticsFlowService.upload(resourceId, parameterMap);
+            if (DiagnosticsDestination.SUPPORT.equals(parameters.getDestination())) {
+                LOGGER.debug("CM based diagnostics uses SUPPORT destination, no support specific upload step yet.");
+            } else {
+                diagnosticsFlowService.upload(resourceId, parameterMap);
+            }
             CmDiagnosticsCollectionEvent diagnosticsCollectionEvent = CmDiagnosticsCollectionEvent.builder()
                     .withResourceCrn(resourceCrn)
                     .withResourceId(resourceId)

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxReactorFlowManager.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/SdxReactorFlowManager.java
@@ -28,6 +28,7 @@ import com.sequenceiq.cloudbreak.exception.FlowsAlreadyRunningException;
 import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.flow.datalake.upgrade.event.DatalakeUpgradeStartEvent;
 import com.sequenceiq.datalake.flow.delete.event.SdxDeleteStartEvent;
+import com.sequenceiq.datalake.flow.diagnostics.event.SdxCmDiagnosticsCollectionEvent;
 import com.sequenceiq.datalake.flow.diagnostics.event.SdxDiagnosticsCollectionEvent;
 import com.sequenceiq.datalake.flow.dr.backup.event.DatalakeDatabaseBackupStartEvent;
 import com.sequenceiq.datalake.flow.dr.restore.event.DatalakeDatabaseRestoreStartEvent;
@@ -118,7 +119,7 @@ public class SdxReactorFlowManager {
         return notify(selector, startEvent);
     }
 
-    public FlowIdentifier triggerCmDiagnosticsCollection(SdxDiagnosticsCollectionEvent startEvent) {
+    public FlowIdentifier triggerCmDiagnosticsCollection(SdxCmDiagnosticsCollectionEvent startEvent) {
         String selector = SDX_CM_DIAGNOSTICS_COLLECTION_EVENT.event();
         return notify(selector, startEvent);
     }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/diagnostics/DiagnosticsService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/diagnostics/DiagnosticsService.java
@@ -19,6 +19,7 @@ import com.sequenceiq.common.api.telemetry.response.VmLogsResponse;
 import com.sequenceiq.datalake.converter.DiagnosticsParamsConverter;
 import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.flow.SdxReactorFlowManager;
+import com.sequenceiq.datalake.flow.diagnostics.event.SdxCmDiagnosticsCollectionEvent;
 import com.sequenceiq.datalake.flow.diagnostics.event.SdxDiagnosticsCollectionEvent;
 import com.sequenceiq.datalake.service.sdx.SdxService;
 import com.sequenceiq.datalake.service.validation.diagnostics.DiagnosticsCollectionValidator;
@@ -62,7 +63,7 @@ public class DiagnosticsService {
         StackV4Response stackV4Response = sdxService.getDetail(cluster.getClusterName(), new HashSet<>(), cluster.getAccountId());
         diagnosticsCollectionValidator.validate(request, stackV4Response);
         Map<String, Object> properties = diagnosticsParamsConverter.convertFromCmRequest(request);
-        SdxDiagnosticsCollectionEvent event = new SdxDiagnosticsCollectionEvent(cluster.getId(), userId, properties, null);
+        SdxCmDiagnosticsCollectionEvent event = new SdxCmDiagnosticsCollectionEvent(cluster.getId(), userId, properties, null);
         FlowIdentifier flowIdentifier = sdxReactorFlowManager.triggerCmDiagnosticsCollection(event);
         LOGGER.debug("Start CM based diagnostics collection with flow pollable identifier: {}", flowIdentifier.getPollableId());
         return flowIdentifier;

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/validation/diagnostics/DiagnosticsCollectionValidator.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/validation/diagnostics/DiagnosticsCollectionValidator.java
@@ -33,7 +33,7 @@ public class DiagnosticsCollectionValidator {
         } else if (DiagnosticsDestination.ENG.equals(destination) && isClusterLogCollectionDisabled(telemetry)) {
             validationBuilder.error(
                     String.format("Cluster log collection is not enabled for this stack '%s'", stackV4Response.getName()));
-        } else if (DiagnosticsDestination.SUPPORT.equals(destination)) {
+        } else if (DiagnosticsDestination.SUPPORT.equals(destination) && !cmBundle) {
             validationBuilder.error(
                     String.format("Destination %s is not supported yet.", DiagnosticsDestination.SUPPORT.name()));
         }

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/init.sls
@@ -129,15 +129,6 @@ copy_autotls_setup_to_cm_settings:
       - cmd: run_autotls_setup
     - unless: grep "# Auto-tls related configurations" /etc/cloudera-scm-server/cm.settings
 
-disable_phone_home:
-  file.blockreplace:
-    - name: /etc/cloudera-scm-server/cm.settings
-    - marker_start: "# BLOCK TOP : salt managed zone : please do not edit"
-    - marker_end: "# BLOCK BOTTOM : end of salt managed zone --"
-    - content: "setsettings PHONE_HOME false"
-    - show_changes: True
-    - append_if_not_found: True
-
 /opt/salt/scripts/cm_generate_agent_tokens.sh:
   file.managed:
     - makedirs: True


### PR DESCRIPTION
…ed on destination

details:
- SDX CM based diagnostics flow is broken, fixing that
- Enable Support destination (only for CM based diagnostics)
- No proxy support yet
- Removed global phone home disabling for the cluster
- During diagnostics collect flow step, enable/disable global phone home setting based on the destination
-> cloud storage destination: disable phone home (in order to only upload data to cloud storage)
-> support destination: enable phone home
- If the original phone home setting was different (from that we want to use) - setting it back
- It's fine if setting phone home config back fails (post config set), it's fine as it will be re-set on next diagnostics usage anyway

See detailed description in the commit message.