### PR TITLE
CB-9016 Make the RESOURCEMANAGERAPI service work in the cdp-proxy-api…

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
@@ -206,6 +206,12 @@
                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
             </param>
             {%- endif %}
+            {% if 'RESOURCEMANAGERAPI' in exposed and 'RESOURCEMANAGER' in salt['pillar.get']('gateway:location') -%}
+            <param>
+                <name>RESOURCEMANAGERAPI</name>
+                <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
+            </param>
+            {%- endif %}
             {% if 'WEBHBASE' in exposed and 'HBASERESTSERVER' in salt['pillar.get']('gateway:location') -%}
             <param>
                 <name>WEBHBASE</name>


### PR DESCRIPTION
We need to extend cm/topology_api.xml.j2#L208 to make the RESOURCEMANAGERAPI service work when Yarn is in HA mode.

[https://jira.cloudera.com/browse/CB-9016](https://jira.cloudera.com/browse/CB-9016)
