### PR TITLE
If RedbeamsDatabaseServerTest.createRedbeamsDatabaseServerTest and Mo…

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxUpgradeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxUpgradeTests.java
@@ -2,10 +2,13 @@ package com.sequenceiq.it.cloudbreak.testcase.mock;
 
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
 
+import java.util.UUID;
+
 import javax.inject.Inject;
 
 import org.testng.annotations.Test;
 
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkMockParams;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
 import com.sequenceiq.it.cloudbreak.assertion.datalake.SdxUpgradeTestAssertion;
@@ -101,7 +104,14 @@ public class MockSdxUpgradeTests extends AbstractIntegrationTest {
         String cluster = "cmcluster";
         String imageSettings = "imageSettingsUpgrade";
         String networkKey = "someOtherNetwork";
-        String clusterCrn = "crn:cdp:datalake:us-west-1:cloudera:datalake:793fef8e-81f3-4f80-b158-0d65abd13104";
+        String clusterCrn = Crn.builder()
+                .setResource(UUID.randomUUID().toString())
+                .setResourceType(Crn.ResourceType.DATALAKE)
+                .setAccountId("cloudera")
+                .setService(Crn.Service.DATALAKE)
+                .setPartition(Crn.Partition.CDP)
+                .build()
+                .toString();
 
         testContext
                 .given(networkKey, EnvironmentNetworkTestDto.class)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/RedbeamsDatabaseServerTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/RedbeamsDatabaseServerTest.java
@@ -1,9 +1,12 @@
 package com.sequenceiq.it.cloudbreak.testcase.mock;
 
+import java.util.UUID;
+
 import javax.inject.Inject;
 
 import org.testng.annotations.Test;
 
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkMockParams;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
 import com.sequenceiq.it.cloudbreak.client.RedbeamsDatabaseServerTestClient;
@@ -35,7 +38,14 @@ public class RedbeamsDatabaseServerTest extends AbstractIntegrationTest {
     public void createRedbeamsDatabaseServerTest(MockedTestContext testContext) {
         String databaseName = resourcePropertyProvider().getName();
         String networkKey = "someOtherNetwork";
-        String clusterCrn = "crn:cdp:datalake:us-west-1:cloudera:datalake:793fef8e-81f3-4f80-b158-0d65abd13104";
+        String clusterCrn = Crn.builder()
+                .setResource(UUID.randomUUID().toString())
+                .setResourceType(Crn.ResourceType.DATALAKE)
+                .setAccountId("cloudera")
+                .setService(Crn.Service.DATALAKE)
+                .setPartition(Crn.Partition.CDP)
+                .build()
+                .toString();
         testContext
                 .given(networkKey, EnvironmentNetworkTestDto.class)
                 .withMock(new EnvironmentNetworkMockParams())


### PR DESCRIPTION
…ckSdxUpgradeTests.testSdxUpgradeSuccessful runs parallel successfully but the cleanup failed somehow, the leftover is broke the other tests because the crn hard coded. In this PR I changed to a generated one.

See detailed description in the commit message.