### PR TITLE
CB-7419 adding in Service Principals to Ranger User Sync

### DIFF
--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v2/StackToTemplatePreparationObjectConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v2/StackToTemplatePreparationObjectConverterTest.java
@@ -37,6 +37,7 @@ import org.mockito.Spy;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.service.ExposedServiceCollector;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
 import com.sequenceiq.cloudbreak.auth.altus.UmsRight;
 import com.sequenceiq.cloudbreak.auth.altus.VirtualGroupRequest;
 import com.sequenceiq.cloudbreak.auth.altus.VirtualGroupService;
@@ -238,6 +239,9 @@ public class StackToTemplatePreparationObjectConverterTest {
     @SuppressFBWarnings(value = "UrF", justification = "This gets injected")
     private IdBrokerConverterUtil idBrokerConverterUtil = new IdBrokerConverterUtil();
 
+    @Mock
+    private GrpcUmsClient grpcUmsClient;
+
     @Before
     public void setUp() throws IOException {
         MockitoAnnotations.initMocks(this);
@@ -290,6 +294,7 @@ public class StackToTemplatePreparationObjectConverterTest {
         cluster.setIdBroker(idbroker);
         when(idBrokerService.getByCluster(any(Cluster.class))).thenReturn(idbroker);
         when(idBrokerService.save(any(IdBroker.class))).thenReturn(idbroker);
+        when(grpcUmsClient.listServicePrincipalCloudIdentities(anyString(), anyString(), anyString(), any(Optional.class))).thenReturn(Collections.EMPTY_LIST);
     }
 
     @Test

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerUserSyncRoleConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerUserSyncRoleConfigProviderTest.java
@@ -1,0 +1,136 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.ranger;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ranger.RangerRoles.RANGER_USERSYNC;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.auth.altus.VirtualGroupService;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.cloudbreak.template.model.GeneralClusterConfigs;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RangerUserSyncRoleConfigProviderTest {
+
+    @Mock
+    private VirtualGroupService virtualGroupService;
+
+    @InjectMocks
+    private final RangerUserSyncRoleConfigProvider underTest = new RangerUserSyncRoleConfigProvider();
+
+    @Before
+    public void setup() {
+        when(virtualGroupService.getVirtualGroup(any(), anyString())).thenReturn("mockAdmin");
+    }
+
+    @Test
+    public void testAws() {
+        TemplatePreparationObject preparationObject = TemplatePreparationObject.Builder.builder()
+                .withCloudPlatform(CloudPlatform.AWS)
+                .withServicePrincipals(null)
+                .withGeneralClusterConfigs(new GeneralClusterConfigs())
+                .build();
+
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getRoleConfigs(RANGER_USERSYNC, preparationObject);
+
+        assertEquals(2, serviceConfigs.size());
+        assertEquals("conf/ranger-ugsync-site.xml_role_safety_valve", serviceConfigs.get(0).getName());
+        assertEquals("<property><name>ranger.usersync.unix.backend</name><value>nss</value></property>", serviceConfigs.get(0).getValue());
+
+        assertEquals("ranger.usersync.group.based.role.assignment.rules", serviceConfigs.get(1).getName());
+        assertEquals("&ROLE_SYS_ADMIN:g:mockAdmin", serviceConfigs.get(1).getValue());
+    }
+
+    @Test
+    public void testAzure() {
+        GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
+        generalClusterConfigs.setEnableRangerRaz(false);
+        TemplatePreparationObject preparationObject = TemplatePreparationObject.Builder.builder()
+                .withCloudPlatform(CloudPlatform.AZURE)
+                .withServicePrincipals(null)
+                .withGeneralClusterConfigs(generalClusterConfigs)
+                .build();
+
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getRoleConfigs(RANGER_USERSYNC, preparationObject);
+
+        assertEquals(2, serviceConfigs.size());
+        assertEquals("conf/ranger-ugsync-site.xml_role_safety_valve", serviceConfigs.get(0).getName());
+        assertEquals("<property><name>ranger.usersync.unix.backend</name><value>nss</value></property>", serviceConfigs.get(0).getValue());
+
+        assertEquals("ranger.usersync.group.based.role.assignment.rules", serviceConfigs.get(1).getName());
+        assertEquals("&ROLE_SYS_ADMIN:g:mockAdmin", serviceConfigs.get(1).getValue());
+    }
+
+    @Test
+    public void testAzureWithRaz() {
+        GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
+        generalClusterConfigs.setEnableRangerRaz(true);
+        TemplatePreparationObject preparationObject = TemplatePreparationObject.Builder.builder()
+                .withCloudPlatform(CloudPlatform.AZURE)
+                .withServicePrincipals(generateServicePrincipals())
+                .withGeneralClusterConfigs(generalClusterConfigs)
+                .build();
+
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getRoleConfigs(RANGER_USERSYNC, preparationObject);
+
+        assertEquals(3, serviceConfigs.size());
+
+        assertEquals("conf/ranger-ugsync-site.xml_role_safety_valve", serviceConfigs.get(0).getName());
+        assertEquals("<property><name>ranger.usersync.unix.backend</name><value>nss</value></property>", serviceConfigs.get(0).getValue());
+
+        assertEquals("ranger.usersync.group.based.role.assignment.rules", serviceConfigs.get(1).getName());
+        assertEquals("&ROLE_SYS_ADMIN:g:mockAdmin", serviceConfigs.get(1).getValue());
+
+        assertEquals("ranger_usersync_azure_user_mapping", serviceConfigs.get(2).getName());
+        assertEquals("hive=3d4fcb5f-51b7-473c-9ca4-9d1e501f47u8;" +
+                "ranger=f346892c-8d70-464c-8330-6ed1112bd880;hbase=286463ce-41c5-4f03-89f6-adb7109394ec", serviceConfigs.get(2).getValue());
+    }
+
+    @Test
+    public void testAzureWithRazNoServicePrincipals() {
+        GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
+        generalClusterConfigs.setEnableRangerRaz(true);
+        TemplatePreparationObject preparationObject = TemplatePreparationObject.Builder.builder()
+                .withCloudPlatform(CloudPlatform.AZURE)
+                .withServicePrincipals(Collections.emptyMap())
+                .withGeneralClusterConfigs(generalClusterConfigs)
+                .build();
+
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getRoleConfigs(RANGER_USERSYNC, preparationObject);
+
+        assertEquals(3, serviceConfigs.size());
+
+        assertEquals("conf/ranger-ugsync-site.xml_role_safety_valve", serviceConfigs.get(0).getName());
+        assertEquals("<property><name>ranger.usersync.unix.backend</name><value>nss</value></property>", serviceConfigs.get(0).getValue());
+
+        assertEquals("ranger.usersync.group.based.role.assignment.rules", serviceConfigs.get(1).getName());
+        assertEquals("&ROLE_SYS_ADMIN:g:mockAdmin", serviceConfigs.get(1).getValue());
+
+        assertEquals("ranger_usersync_azure_user_mapping", serviceConfigs.get(2).getName());
+        assertEquals("", serviceConfigs.get(2).getValue());
+    }
+
+    private Map<String, String> generateServicePrincipals() {
+        Map<String, String> servicePrincipals = new HashMap<>();
+        servicePrincipals.put("hive", "3d4fcb5f-51b7-473c-9ca4-9d1e501f47u8");
+        servicePrincipals.put("ranger", "f346892c-8d70-464c-8330-6ed1112bd880");
+        servicePrincipals.put("hbase", "286463ce-41c5-4f03-89f6-adb7109394ec");
+
+        return servicePrincipals;
+    }
+}

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/TemplatePreparationObject.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/TemplatePreparationObject.java
@@ -85,6 +85,8 @@ public class TemplatePreparationObject {
 
     private final IdBroker idBroker;
 
+    private final Map<String, String> servicePrincipals;
+
     private TemplatePreparationObject(Builder builder) {
         cloudPlatform = builder.cloudPlatform;
         rdsConfigs = builder.rdsConfigs.stream().collect(Collectors.toMap(
@@ -110,6 +112,7 @@ public class TemplatePreparationObject {
         virtualGroupRequest = builder.virtualGroupRequest;
         datalakeView = builder.datalakeView;
         idBroker = builder.idBroker;
+        servicePrincipals = builder.servicePrincipals;
     }
 
     public Stream<HostgroupView> getHostGroupsWithComponent(String component) {
@@ -207,6 +210,10 @@ public class TemplatePreparationObject {
         return idBroker;
     }
 
+    public Map<String, String> getServicePrincipals() {
+        return servicePrincipals;
+    }
+
     public static class Builder {
 
         private CloudPlatform cloudPlatform;
@@ -250,6 +257,8 @@ public class TemplatePreparationObject {
         private Optional<DatalakeView> datalakeView;
 
         private IdBroker idBroker;
+
+        private Map<String, String> servicePrincipals;
 
         public static Builder builder() {
             return new Builder();
@@ -380,6 +389,11 @@ public class TemplatePreparationObject {
 
         public Builder withIdBroker(IdBroker idBroker) {
             this.idBroker = idBroker;
+            return this;
+        }
+
+        public Builder withServicePrincipals(Map<String, String> servicePrincipals) {
+            this.servicePrincipals = servicePrincipals;
             return this;
         }
 


### PR DESCRIPTION
This adds a call to get Service Principals from Thunderhead during template
preparation that will be passed into the RangerUserSyncRoleConfigProvider
to sync OID before the datalake starts up.