### PR TITLE
CB-9056. Prevent restart of clusters creating new machines user acces…

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
@@ -641,6 +641,24 @@ public class GrpcUmsClient {
     }
 
     /**
+     * Check that machine user has a specific access key in UMS
+     * @param actorCrn actor for the machine user request
+     * @param accountId the account ID
+     * @param machineUserCrn machine user crn that own the access key
+     * @param accessKeyId access key id that we need to check
+     * @return result that is true if the machine user has the queried access key in UMS
+     */
+    public boolean doesMachineUserHasAccessKey(String actorCrn, String accountId,
+            String machineUserCrn, String accessKeyId) {
+        try (ManagedChannelWrapper channelWrapper = makeWrapper()) {
+            UmsClient client = makeClient(channelWrapper.getChannel(), actorCrn);
+            String requestId = UUID.randomUUID().toString();
+            List<String> accessKeys = client.listMachineUserAccessKeys(requestId, actorCrn, accountId, machineUserCrn, true);
+            return accessKeys.contains(accessKeyId);
+        }
+    }
+
+    /**
      * Gather anonymization rules for a specific account
      * NOTE: not supported yet on UMS side
      *

--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/UmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/UmsClient.java
@@ -598,6 +598,20 @@ public class UmsClient {
      * @return access key CRNs
      */
     public List<String> listMachineUserAccessKeys(String requestId, String userCrn, String accountId, String machineUserName) {
+        return listMachineUserAccessKeys(requestId, userCrn, accountId, machineUserName, false);
+    }
+
+    /**
+     * Get a list of access key CRN (keys owned by a machine user)
+     *
+     * @param requestId       id of the request
+     * @param userCrn         actor that query the keys for the machine user
+     * @param machineUserName machine user that owns the access keys
+     * @param userAccessKeyId put access key id to the result instead of access key crns
+     * @return access key CRNs (or access key ids)
+     */
+    public List<String> listMachineUserAccessKeys(String requestId, String userCrn, String accountId,
+            String machineUserName, boolean userAccessKeyId) {
         checkNotNull(requestId);
         checkNotNull(userCrn);
         checkNotNull(machineUserName);
@@ -615,7 +629,13 @@ public class UmsClient {
                         newStub(requestId).listAccessKeys(listAccessKeysRequestBuilder.build());
                 accessKeys.addAll(
                         listAccessKeysResponse.getAccessKeyList().stream()
-                                .map(UserManagementProto.AccessKey::getCrn)
+                                .map(accessKeyObject -> {
+                                    if (userAccessKeyId) {
+                                        return accessKeyObject.getAccessKeyId();
+                                    } else {
+                                        return accessKeyObject.getCrn();
+                                    }
+                                })
                                 .collect(Collectors.toList()));
                 if (!listAccessKeysResponse.hasNextPageToken()) {
                     break;

--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/service/AltusIAMService.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/service/AltusIAMService.java
@@ -41,6 +41,27 @@ public class AltusIAMService {
     }
 
     /**
+     * Checks that machine user has a specific access key on UMS side
+     */
+    public boolean doesMachineUserHasAccessKey(String actorCrn, String accountId, String machineUserName, String accessKey,
+            boolean useSharedAltusCredentialEnabled) {
+        boolean result = false;
+        if (sharedAltusCredentialProvider.isSharedAltusCredentialInUse(useSharedAltusCredentialEnabled)) {
+            LOGGER.debug("Shared altus credential is used, no need for checking databus credentials against UMS");
+            result = true;
+        } else {
+            LOGGER.debug("Query (or create if needed) machine user with name {}", machineUserName);
+            Optional<String> machineUserCrn = umsClient.createMachineUser(machineUserName, actorCrn, accountId, Optional.empty());
+            if (machineUserCrn.isPresent()) {
+                return umsClient.doesMachineUserHasAccessKey(actorCrn, accountId, machineUserCrn.get(), accessKey);
+            } else {
+                LOGGER.debug("Machine user ('{}') does not exist (even after the creation).", machineUserName);
+            }
+        }
+        return result;
+    }
+
+    /**
      * Delete machine user with its access keys (and unassign databus role if required)
      */
     public void clearMachineUser(String machineUserName, String actorCrn, String accountId, boolean useSharedCredential) {

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/DataBusCredential.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/DataBusCredential.java
@@ -1,0 +1,45 @@
+package com.sequenceiq.common.api.telemetry.model;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DataBusCredential implements Serializable {
+
+    @JsonProperty("machineUserName")
+    private String machineUserName;
+
+    @JsonProperty("accessKey")
+    private String accessKey;
+
+    @JsonProperty("privateKey")
+    private String privateKey;
+
+    public String getMachineUserName() {
+        return machineUserName;
+    }
+
+    public void setMachineUserName(String machineUserName) {
+        this.machineUserName = machineUserName;
+    }
+
+    public String getAccessKey() {
+        return accessKey;
+    }
+
+    public void setAccessKey(String accessKey) {
+        this.accessKey = accessKey;
+    }
+
+    public String getPrivateKey() {
+        return privateKey;
+    }
+
+    public void setPrivateKey(String privateKey) {
+        this.privateKey = privateKey;
+    }
+}

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/cluster/Cluster.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/cluster/Cluster.java
@@ -196,6 +196,10 @@ public class Cluster implements ProvisionEntity, WorkspaceAwareResource {
     @SecretValue
     private Secret attributes = Secret.EMPTY;
 
+    @Convert(converter = SecretToString.class)
+    @SecretValue
+    private Secret databusCredential = Secret.EMPTY;
+
     @Convert(converter = JsonToString.class)
     @Column(columnDefinition = "TEXT")
     private Json customContainerDefinition;
@@ -451,6 +455,14 @@ public class Cluster implements ProvisionEntity, WorkspaceAwareResource {
 
     public void setAttributes(String attributes) {
         this.attributes = new Secret(attributes);
+    }
+
+    public String getDatabusCredential() {
+        return databusCredential.getRaw();
+    }
+
+    public void setDatabusCredential(String databusCredential) {
+        this.databusCredential = new Secret(databusCredential);
     }
 
     public Gateway getGateway() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/altus/AltusMachineUserService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/altus/AltusMachineUserService.java
@@ -2,25 +2,32 @@ package com.sequenceiq.cloudbreak.service.altus;
 
 import java.util.Optional;
 
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.auth.altus.model.AltusCredential;
 import com.sequenceiq.cloudbreak.auth.altus.service.AltusIAMService;
+import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
+import com.sequenceiq.common.api.telemetry.model.DataBusCredential;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
 
-@Component
+@Service
 public class AltusMachineUserService {
 
     private static final String FLUENT_DATABUS_MACHINE_USER_NAME_PATTERN = "%s-fluent-databus-uploader-%s";
 
     private final AltusIAMService altusIAMService;
 
-    public AltusMachineUserService(AltusIAMService altusIAMService) {
+    private final ClusterService clusterService;
+
+    public AltusMachineUserService(AltusIAMService altusIAMService, ClusterService clusterService) {
         this.altusIAMService = altusIAMService;
+        this.clusterService = clusterService;
     }
 
     /**
@@ -52,8 +59,46 @@ public class AltusMachineUserService {
         }
     }
 
+    /**
+     * Store databus access / secret keypair and machine user name in the cluster if altus credential exists
+     * @param altusCredential dto for databus access/private key
+     * @param stack component will be attached to this stack
+     * @return domain object that holds databus credential
+     */
+    public DataBusCredential storeDataBusCredential(Optional<AltusCredential> altusCredential, Stack stack) {
+        if (altusCredential.isPresent()) {
+            DataBusCredential dataBusCredential = new DataBusCredential();
+            dataBusCredential.setMachineUserName(getFluentDatabusMachineUserName(stack));
+            dataBusCredential.setAccessKey(altusCredential.get().getAccessKey());
+            dataBusCredential.setPrivateKey(altusCredential.get().getPrivateKey() != null ? new String(altusCredential.get().getPrivateKey()) : null);
+            String databusCredentialJsonString = new Json(dataBusCredential).getValue();
+            Cluster cluster = stack.getCluster();
+            if (cluster != null) {
+                cluster.setDatabusCredential(databusCredentialJsonString);
+                clusterService.updateCluster(cluster);
+            }
+            return dataBusCredential;
+        }
+        return null;
+    }
+
+    /**
+     * Check that machine user still have the access key on UMS side
+     * @param dataBusCredential databus credential DTO that comes from cloudbreak database which contains access key and machune user name as well.
+     * @param stack stack object holder that can be used to calculate the machine user name
+     * @return check result - if true, no need to regenerate keys
+     */
+    public boolean isDataBusCredentialStillExist(Telemetry telemetry, DataBusCredential dataBusCredential, Stack stack) {
+        return ThreadBasedUserCrnProvider.doAsInternalActor(
+                () -> altusIAMService.doesMachineUserHasAccessKey(
+                        ThreadBasedUserCrnProvider.getUserCrn(),
+                        Crn.fromString(stack.getResourceCrn()).getAccountId(),
+                        dataBusCredential.getMachineUserName(), dataBusCredential.getAccessKey(),
+                        telemetry.isUseSharedAltusCredentialEnabled()));
+    }
+
     // for datalake metering is not supported/required right now
-    private boolean isMeteringOrAnyDataBusBasedFeatureSupported(Stack stack, Telemetry telemetry) {
+    public boolean isMeteringOrAnyDataBusBasedFeatureSupported(Stack stack, Telemetry telemetry) {
         return telemetry != null && (telemetry.isAnyDataBusBasedFeatureEnablred() || (telemetry.isMeteringFeatureEnabled()
                 && !StackType.DATALAKE.equals(stack.getType())));
     }

--- a/core/src/main/resources/schema/app/20200930130154_CB-9056_add_dbus_secrets.sql
+++ b/core/src/main/resources/schema/app/20200930130154_CB-9056_add_dbus_secrets.sql
@@ -1,0 +1,9 @@
+-- // CB-9058 Prevent restart of clusters creating new machines user access keys in UMS
+-- Migration SQL that makes the change goes here.
+
+alter table cluster add COLUMN databuscredential varchar(255);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+alter table cluster drop COLUMN databuscredential;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecoratorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecoratorTest.java
@@ -42,6 +42,7 @@ import com.sequenceiq.cloudbreak.telemetry.metering.MeteringConfigView;
 import com.sequenceiq.cloudbreak.telemetry.monitoring.MonitoringConfigService;
 import com.sequenceiq.cloudbreak.telemetry.monitoring.MonitoringConfigView;
 import com.sequenceiq.cloudbreak.workspace.model.User;
+import com.sequenceiq.common.api.telemetry.model.DataBusCredential;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
 
 public class TelemetryDecoratorTest {
@@ -73,6 +74,13 @@ public class TelemetryDecoratorTest {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         AltusCredential altusCredential = new AltusCredential("myAccessKey", "mySecretKey".toCharArray());
+        DataBusCredential dataBusCredential = new DataBusCredential();
+        dataBusCredential.setAccessKey("myAccessKey");
+        dataBusCredential.setPrivateKey("mySecretKey");
+        given(altusMachineUserService.isMeteringOrAnyDataBusBasedFeatureSupported(any(Stack.class), any(Telemetry.class)))
+                .willReturn(true);
+        given(altusMachineUserService.storeDataBusCredential(any(Optional.class), any(Stack.class)))
+                .willReturn(dataBusCredential);
         given(altusMachineUserService.generateDatabusMachineUserForFluent(any(Stack.class), any(Telemetry.class)))
                 .willReturn(Optional.of(altusCredential));
         given(vmLogsService.getVmLogs()).willReturn(new ArrayList<>());

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/altus/AltusMachineUserServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/altus/AltusMachineUserServiceTest.java
@@ -20,6 +20,7 @@ import com.sequenceiq.cloudbreak.auth.altus.model.AltusCredential;
 import com.sequenceiq.cloudbreak.auth.altus.service.AltusIAMService;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
 import com.sequenceiq.cloudbreak.workspace.model.User;
 import com.sequenceiq.common.api.telemetry.model.Features;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
@@ -32,6 +33,9 @@ public class AltusMachineUserServiceTest {
 
     @Mock
     private AltusIAMService altusIAMService;
+
+    @Mock
+    private ClusterService clusterService;
 
     private Stack stack;
 
@@ -53,7 +57,7 @@ public class AltusMachineUserServiceTest {
         Features features = new Features();
         features.addClusterLogsCollection(true);
         telemetry.setFeatures(features);
-        underTest = new AltusMachineUserService(altusIAMService);
+        underTest = new AltusMachineUserService(altusIAMService, clusterService);
     }
 
     @Test


### PR DESCRIPTION
…s keys in UMS.

details:
- create a new column (secret) for cluster in order to store databus access/private keys
(could not use component table properly with secrets and cluster attributes are not really used I think, so i have created a new one)
- get this value during salt pillar config update (or during deployment), if not set, generate a new keypair and save it in the cluster entity
- the exact same thing will be needed for freeipa as well (not needed yet as no salt pillar config upgrade there yet)

See detailed description in the commit message.

also it requires some local testing as well (against UMS, using shared credential + local setup)

update: testing with local setup + with using remote UMS has finished (first one with the logic, second one is just for the calls to make sure those will work)