### PR TITLE
CB-9064 restart minions if master repair is happening

### DIFF
--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/model/BootstrapParams.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/model/BootstrapParams.java
@@ -7,6 +7,8 @@ public class BootstrapParams {
 
     private boolean saltBootstrapFpSupported;
 
+    private boolean restartNeeded;
+
     public String getCloud() {
         return cloud;
     }
@@ -29,6 +31,14 @@ public class BootstrapParams {
 
     public void setSaltBootstrapFpSupported(boolean saltBootstrapFpSupported) {
         this.saltBootstrapFpSupported = saltBootstrapFpSupported;
+    }
+
+    public boolean isRestartNeeded() {
+        return restartNeeded;
+    }
+
+    public void setRestartNeeded(boolean restartNeeded) {
+        this.restartNeeded = restartNeeded;
     }
 
     @Override

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
@@ -290,6 +290,7 @@ SaltOrchestrator implements HostOrchestrator {
         try (SaltConnector sc = saltService.createSaltConnector(primaryGateway)) {
             if (!gatewayTargets.isEmpty()) {
                 uploadSaltConfig(sc, gatewayTargets, stateConfigZip, exitModel);
+                params.setRestartNeeded(true);
             }
             uploadSignKey(sc, primaryGateway, gatewayTargets, targets.stream().map(Node::getPrivateIp).collect(Collectors.toSet()), exitModel);
             // if there is a new salt master then re-bootstrap all nodes

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/domain/Minion.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/domain/Minion.java
@@ -20,6 +20,8 @@ public class Minion {
 
     private String hostName;
 
+    private boolean restartNeeded;
+
     public String getAddress() {
         return address;
     }
@@ -78,6 +80,14 @@ public class Minion {
 
     public String getId() {
         return hostName + '.' + domain;
+    }
+
+    public boolean isRestartNeeded() {
+        return restartNeeded;
+    }
+
+    public void setRestartNeeded(boolean restartNeeded) {
+        this.restartNeeded = restartNeeded;
     }
 
     @Override


### PR DESCRIPTION
We found an issue in e2e tests, master repair failed sometimes on azure. I was able to reproduce it, Mihaly Laszlo Molnar  and Krisztian Horvath helped me to figure out what could happen. It occurs if the master node has the same private IP address after repair as the original.

Discovered things:

salt-minion does not print anything into the log if you stop the master node, just hangs
salt-minion does not print anything into the log if you remove it's key from salt-master
salt-minion has some cache in it for master, maybe half an hour or an hour, something like this
It appears on azure because azure usually sets the same IP address for the new node as for the previous because it allocates addresses incrementally and it reuses the IP addresses.

Most of the times the e2e test is successful because our polling timeout is 30 minutes and the salt minion's master cache could be something like this. I discovered most of my clusters almost failed, but they didn't because the minion started to talk to the new master after a long time. (poll ~172/180)

If the master's IP address changes in a repair process, then we restart salt minions at the moment. The solution for this issue is to restart salt minions on every master repair case, not only if the IP address changed.

See detailed description in the commit message.