### PR TITLE
CB-9055: Put NO HDFS feature under entitlement

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
@@ -80,6 +80,9 @@ public class EntitlementService {
     @VisibleForTesting
     static final String CDP_UMS_USER_SYNC_MODEL_GENERATION = "CDP_UMS_USER_SYNC_MODEL_GENERATION";
 
+    @VisibleForTesting
+    static final String CDP_SDX_HBASE_CLOUD_STORAGE = "CDP_SDX_HBASE_CLOUD_STORAGE";
+
     @Inject
     private GrpcUmsClient umsClient;
 
@@ -165,6 +168,10 @@ public class EntitlementService {
 
     public boolean umsUserSyncModelGenerationEnabled(String actorCrn, String accountId) {
         return isEntitlementRegistered(actorCrn, accountId, CDP_UMS_USER_SYNC_MODEL_GENERATION);
+    }
+
+    public boolean sdxHbaseCloudStorageEnabled(String actorCrn, String accountId) {
+        return isEntitlementRegistered(actorCrn, accountId, CDP_SDX_HBASE_CLOUD_STORAGE);
     }
 
     public List<String> getEntitlements(String actorCrn, String accountId) {

--- a/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementServiceTest.java
+++ b/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementServiceTest.java
@@ -15,6 +15,7 @@ import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_FREEIP
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_GCP;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_RAZ;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_RUNTIME_UPGRADE;
+import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_SDX_HBASE_CLOUD_STORAGE;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_UMS_USER_SYNC_MODEL_GENERATION;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CLOUDERA_INTERNAL_ACCOUNT;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.LOCAL_DEV;
@@ -129,6 +130,10 @@ class EntitlementServiceTest {
                         (EntitlementCheckFunction) EntitlementService::umsUserSyncModelGenerationEnabled, false},
                 {"CDP_UMS_USER_SYNC_MODEL_GENERATION == true", CDP_UMS_USER_SYNC_MODEL_GENERATION,
                         (EntitlementCheckFunction) EntitlementService::umsUserSyncModelGenerationEnabled, true},
+                {"CDP_SDX_HBASE_CLOUD_STORAGE == false", CDP_SDX_HBASE_CLOUD_STORAGE,
+                        (EntitlementCheckFunction) EntitlementService::sdxHbaseCloudStorageEnabled, false},
+                {"CDP_SDX_HBASE_CLOUD_STORAGE == true", CDP_SDX_HBASE_CLOUD_STORAGE,
+                        (EntitlementCheckFunction) EntitlementService::sdxHbaseCloudStorageEnabled, true},
         };
     }
 

--- a/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
+++ b/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
@@ -216,6 +216,8 @@ public class MockUserManagementService extends UserManagementImplBase {
 
     private static final String CDP_ALLOW_INTERNAL_REPOSITORY_FOR_UPGRADE = "CDP_ALLOW_INTERNAL_REPOSITORY_FOR_UPGRADE";
 
+    private static final String CDP_SDX_HBASE_CLOUD_STORAGE = "CDP_SDX_HBASE_CLOUD_STORAGE";
+
     // See com.cloudera.thunderhead.service.common.entitlements.CdpEntitlements.CDP_CP_CUSTOM_DL_TEMPLATE
     private static final String CDP_CP_CUSTOM_DL_TEMPLATE = "CDP_CM_ADMIN_CREDENTIALS";
 
@@ -291,6 +293,9 @@ public class MockUserManagementService extends UserManagementImplBase {
 
     @Value("${auth.mock.upgrade.internalrepo.enable}")
     private boolean enableInternalRepositoryForUpgrade;
+
+    @Value("${auth.mock.hbase.cloudstorage.enable}")
+    private boolean enableHbaseCloudStorage;
 
     private String cbLicense;
 
@@ -585,6 +590,9 @@ public class MockUserManagementService extends UserManagementImplBase {
         }
         if (enableInternalRepositoryForUpgrade) {
             builder.addEntitlements(createEntitlement(CDP_ALLOW_INTERNAL_REPOSITORY_FOR_UPGRADE));
+        }
+        if (enableHbaseCloudStorage) {
+            builder.addEntitlements(createEntitlement(CDP_SDX_HBASE_CLOUD_STORAGE));
         }
         responseObserver.onNext(
                 GetAccountResponse.newBuilder()

--- a/mock-thunderhead/src/main/resources/application.yml
+++ b/mock-thunderhead/src/main/resources/application.yml
@@ -27,3 +27,4 @@ auth:
     cloudidentitymappinng.enable: true
     mediumdutysdx.enable: true
     upgrade.internalrepo.enable: true
+    hbase.cloudstorage.enable: true

--- a/mock-thunderhead/src/test/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementServiceTest.java
+++ b/mock-thunderhead/src/test/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementServiceTest.java
@@ -216,6 +216,9 @@ public class MockUserManagementServiceTest {
 
                 {"enableInternalRepositoryForUpgrade false", "enableInternalRepositoryForUpgrade", false, "CDP_ALLOW_INTERNAL_REPOSITORY_FOR_UPGRADE", false},
                 {"enableInternalRepositoryForUpgrade true", "enableInternalRepositoryForUpgrade", true, "CDP_ALLOW_INTERNAL_REPOSITORY_FOR_UPGRADE", true},
+
+                {"enableHbaseCloudStorage false", "enableHbaseCloudStorage", false, "CDP_SDX_HBASE_CLOUD_STORAGE", false},
+                {"enableHbaseCloudStorage true", "enableHbaseCloudStorage", true, "CDP_SDX_HBASE_CLOUD_STORAGE", true},
         };
     }
 

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hbase/HbaseCloudStorageServiceConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hbase/HbaseCloudStorageServiceConfigProvider.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.hbase;
 
+import static com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider.INTERNAL_ACTOR_CRN;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_2;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
@@ -7,9 +8,13 @@ import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.c
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.inject.Inject;
+
 import org.springframework.stereotype.Component;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateComponentConfigProvider;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils;
@@ -22,6 +27,9 @@ public class HbaseCloudStorageServiceConfigProvider implements CmTemplateCompone
     private static final String HBASE_ROOT_DIR = "hbase.rootdir";
 
     private static final String HBASE_ROOT_DIR_TEMPLATE_PARAM = "hdfs_rootdir";
+
+    @Inject
+    private EntitlementService entitlementService;
 
     @Override
     public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject source) {
@@ -48,9 +56,13 @@ public class HbaseCloudStorageServiceConfigProvider implements CmTemplateCompone
                 .orElse(false);
         String cdhVersion = getCdhVersion(source);
         boolean is722OrNewer = isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERAMANAGER_VERSION_7_2_2);
+        String actorCrn = INTERNAL_ACTOR_CRN;
+        String accountId = ThreadBasedUserCrnProvider.getAccountId();
+        boolean sdxHbaseCloudStorageEnabled =
+                entitlementService.sdxHbaseCloudStorageEnabled(actorCrn, accountId);
         return source.getFileSystemConfigurationView().isPresent()
                 && cmTemplateProcessor.isRoleTypePresentInService(getServiceType(), getRoleTypes())
-                && (!datalakeCluster || is722OrNewer);
+                && (!datalakeCluster || (is722OrNewer && sdxHbaseCloudStorageEnabled));
     }
 
     private String getCdhVersion(TemplatePreparationObject source) {

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hbase/HbaseCloudStorageServiceConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hbase/HbaseCloudStorageServiceConfigProviderTest.java
@@ -3,16 +3,24 @@ package com.sequenceiq.cloudbreak.cmtemplate.configproviders.hbase;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.domain.StorageLocation;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
@@ -29,7 +37,19 @@ import com.sequenceiq.common.api.type.InstanceGroupType;
 @RunWith(MockitoJUnitRunner.class)
 public class HbaseCloudStorageServiceConfigProviderTest {
 
+    @InjectMocks
     private final HbaseCloudStorageServiceConfigProvider underTest = new HbaseCloudStorageServiceConfigProvider();
+
+    @Mock
+    private EntitlementService entitlementService;
+
+    @Before
+    public void setUp() {
+        if (StringUtils.isEmpty(ThreadBasedUserCrnProvider.getUserCrn())) {
+            ThreadBasedUserCrnProvider.setUserCrn("crn:cdp:iam:us-west-1:1234:user:1");
+        }
+        when(entitlementService.sdxHbaseCloudStorageEnabled(anyString(), anyString())).thenReturn(true);
+    }
 
     @Test
     public void testGetHbaseStorageServiceConfigsWhenAttachedCluster() {


### PR DESCRIPTION
We should put the code change to remove HDFS from Data Lake behind entitlement. So customer can enable this feature for new SDX cluster, and existing SDX cluster upgrade does not hit this feature by accident.

The flag is committed in thunderhead at https://github.infra.cloudera.com/thunderhead/thunderhead/commit/aefabb467c204d196a3a421aa015e8895800137d#diff-78fd6bd58147c45d045cc080c7400665