### PR TITLE
ENGESC-3627 Disable thrash related warnings in DE clusters.

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-702.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-702.bp
@@ -25,6 +25,10 @@
             "base": true,
             "configs": [
               {
+                "name": "role_config_suppression_fs_trash_interval_minimum_validator",
+                "value": "true"
+              },
+              {
                 "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
                 "value": "true"
               },
@@ -61,6 +65,10 @@
               {
                 "name": "dfs_client_use_trash",
                 "value": false
+              },
+              {
+                "name": "role_config_suppression_hdfs_trash_disabled_validator",
+                "value": "true"
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-710.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-710.bp
@@ -25,6 +25,10 @@
             "base": true,
             "configs": [
               {
+                "name": "role_config_suppression_fs_trash_interval_minimum_validator",
+                "value": "true"
+              },
+              {
                 "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
                 "value": "true"
               },
@@ -61,6 +65,10 @@
               {
                 "name": "dfs_client_use_trash",
                 "value": false
+              },
+              {
+                "name": "role_config_suppression_hdfs_trash_disabled_validator",
+                "value": "true"
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-720.bp
@@ -73,6 +73,10 @@
                 "value": false
               },
               {
+                "name": "role_config_suppression_hdfs_trash_disabled_validator",
+                "value": "true"
+              },
+              {
                 "name": "hdfs_client_env_safety_valve",
                 "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
               }

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-721.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-721.bp
@@ -31,6 +31,10 @@
             "base": true,
             "configs": [
               {
+                "name": "role_config_suppression_fs_trash_interval_minimum_validator",
+                "value": "true"
+              },
+              {
                 "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
                 "value": "true"
               },
@@ -71,6 +75,10 @@
               {
                 "name": "dfs_client_use_trash",
                 "value": false
+              },
+              {
+                "name": "role_config_suppression_hdfs_trash_disabled_validator",
+                "value": "true"
               },
               {
                 "name": "hdfs_client_env_safety_valve",

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-722.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-722.bp
@@ -31,6 +31,10 @@
             "base": true,
             "configs": [
               {
+                "name": "role_config_suppression_fs_trash_interval_minimum_validator",
+                "value": "true"
+              },
+              {
                 "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
                 "value": "true"
               },
@@ -71,6 +75,10 @@
               {
                 "name": "dfs_client_use_trash",
                 "value": false
+              },
+              {
+                "name": "role_config_suppression_hdfs_trash_disabled_validator",
+                "value": "true"
               },
               {
                 "name": "hdfs_client_env_safety_valve",

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-702.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-702.bp
@@ -75,6 +75,10 @@
               {
                 "name": "dfs_client_use_trash",
                 "value": false
+              },
+              {
+                "name": "role_config_suppression_hdfs_trash_disabled_validator",
+                "value": "true"
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-710.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-710.bp
@@ -75,6 +75,10 @@
               {
                 "name": "dfs_client_use_trash",
                 "value": false
+              },
+              {
+                "name": "role_config_suppression_hdfs_trash_disabled_validator",
+                "value": "true"
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-720.bp
@@ -35,6 +35,10 @@
             "base": true,
             "configs": [
               {
+                "name": "role_config_suppression_fs_trash_interval_minimum_validator",
+                "value": "true"
+              },
+              {
                 "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
                 "value": "true"
               },
@@ -91,6 +95,10 @@
               {
                 "name": "dfs_client_use_trash",
                 "value": false
+              },
+              {
+                "name": "role_config_suppression_hdfs_trash_disabled_validator",
+                "value": "true"
               },
               {
                 "name": "hdfs_client_env_safety_valve",

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-721.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-721.bp
@@ -35,6 +35,10 @@
             "base": true,
             "configs": [
               {
+                "name": "role_config_suppression_fs_trash_interval_minimum_validator",
+                "value": "true"
+              },
+              {
                 "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
                 "value": "true"
               },
@@ -91,6 +95,10 @@
               {
                 "name": "dfs_client_use_trash",
                 "value": false
+              },
+              {
+                "name": "role_config_suppression_hdfs_trash_disabled_validator",
+                "value": "true"
               },
               {
                 "name": "hdfs_client_env_safety_valve",

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-722.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-722.bp
@@ -35,6 +35,10 @@
             "base": true,
             "configs": [
               {
+                "name": "role_config_suppression_fs_trash_interval_minimum_validator",
+                "value": "true"
+              },
+              {
                 "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
                 "value": "true"
               },
@@ -91,6 +95,10 @@
               {
                 "name": "dfs_client_use_trash",
                 "value": false
+              },
+              {
+                "name": "role_config_suppression_hdfs_trash_disabled_validator",
+                "value": "true"
               },
               {
                 "name": "hdfs_client_env_safety_valve",

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-710.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-710.bp
@@ -14,6 +14,10 @@
             "base": true,
             "configs": [
               {
+                "name": "role_config_suppression_fs_trash_interval_minimum_validator",
+                "value": "true"
+              },
+              {
                 "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
                 "value": "true"
               },
@@ -50,6 +54,10 @@
               {
                 "name": "dfs_client_use_trash",
                 "value": false
+              },
+              {
+                "name": "role_config_suppression_hdfs_trash_disabled_validator",
+                "value": "true"
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-720.bp
@@ -31,6 +31,10 @@
             "base": true,
             "configs": [
               {
+                "name": "role_config_suppression_fs_trash_interval_minimum_validator",
+                "value": "true"
+              },
+              {
                 "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
                 "value": "true"
               },
@@ -71,6 +75,10 @@
               {
                 "name": "dfs_client_use_trash",
                 "value": false
+              },
+              {
+                "name": "role_config_suppression_hdfs_trash_disabled_validator",
+                "value": "true"
               },
               {
                 "name": "hdfs_client_env_safety_valve",

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-721.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-721.bp
@@ -31,6 +31,10 @@
             "base": true,
             "configs": [
               {
+                "name": "role_config_suppression_fs_trash_interval_minimum_validator",
+                "value": "true"
+              },
+              {
                 "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
                 "value": "true"
               },
@@ -71,6 +75,10 @@
               {
                 "name": "dfs_client_use_trash",
                 "value": false
+              },
+              {
+                "name": "role_config_suppression_hdfs_trash_disabled_validator",
+                "value": "true"
               },
               {
                 "name": "hdfs_client_env_safety_valve",

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-722.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-722.bp
@@ -31,6 +31,10 @@
             "base": true,
             "configs": [
               {
+                "name": "role_config_suppression_fs_trash_interval_minimum_validator",
+                "value": "true"
+              },
+              {
                 "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
                 "value": "true"
               },
@@ -71,6 +75,10 @@
               {
                 "name": "dfs_client_use_trash",
                 "value": false
+              },
+              {
+                "name": "role_config_suppression_hdfs_trash_disabled_validator",
+                "value": "true"
               },
               {
                 "name": "hdfs_client_env_safety_valve",


### PR DESCRIPTION
1. Trash interval was set to zero, and skip trash was set to false for performance reasons consciously CB-7053.
2. This triggered a couple of warnings in CM.
3. Suppressing these because the customer can not do anything about it, and in-fact wondering what those were.
4. The change here was convoluted so will explain what is going on,
  a. I did not copy the trash interval settings in the HA template in 702. That is why it is missing some configs in some templates.
  b. So the suppressions were added to the config only if there would have been a warning otherwise.
5. These settings were manually modified in the CM and then the template was exported so that we know what setting to add and at which level.

This is the second time for this patch after revert. Two changes after the first time to resolve a couple of merge conflicts. Also tested in both AWS and Azure.