### PR TITLE
CB-9092 Hibernate SessionEventListeners are not spring managed beans,…

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/app/ApplicationContextProvider.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/app/ApplicationContextProvider.java
@@ -1,0 +1,19 @@
+package com.sequenceiq.cloudbreak.app;
+
+import static org.springframework.core.Ordered.HIGHEST_PRECEDENCE;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+
+@Configuration
+@Order(HIGHEST_PRECEDENCE)
+public class ApplicationContextProvider implements ApplicationContextAware {
+
+    public void setApplicationContext(@NotNull ApplicationContext applicationContext) throws BeansException {
+        StaticApplicationContext.setApplicationContext(applicationContext);
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/app/StaticApplicationContext.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/app/StaticApplicationContext.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.cloudbreak.app;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
+
+/**
+ * This grants you access to Spring ApplicationContext from non-Spring beans. Use it only from non-Spring beans,
+ * since in a regular Spring bean you can just use the @Inject annotation.
+ */
+public class StaticApplicationContext {
+
+    private static ApplicationContext context;
+
+    private StaticApplicationContext() {
+    }
+
+    static void setApplicationContext(ApplicationContext applicationContext) {
+        context = applicationContext;
+    }
+
+    public static ApplicationContext getApplicationContext() {
+        return context;
+    }
+
+    public static <T> T getEnvironmentProperty(String key, Class<T> targetType, T defaultValue) {
+        T ret = defaultValue;
+        if (getApplicationContext() != null) {
+            Environment environment = getApplicationContext().getEnvironment();
+            if (environment != null) {
+                ret = environment.getProperty(key, targetType, defaultValue);
+            }
+        }
+        return ret;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/tx/HibernateNPlusOneLogger.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/tx/HibernateNPlusOneLogger.java
@@ -3,11 +3,13 @@ package com.sequenceiq.cloudbreak.common.tx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.sequenceiq.cloudbreak.app.StaticApplicationContext;
+
 public class HibernateNPlusOneLogger extends HibernateStatementStatistics {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HibernateNPlusOneLogger.class);
 
-    private static final int SESSION_MAX_STATEMENT_WARNING = 1000;
+    private static final int DEFAULT_SESSION_MAX_STATEMENT_WARNING = 1000;
 
     @Override
     public void end() {
@@ -18,7 +20,9 @@ public class HibernateNPlusOneLogger extends HibernateStatementStatistics {
 
     private void logStack(int queryCount) {
         String message = constructLogline();
-        if (queryCount > SESSION_MAX_STATEMENT_WARNING) {
+        int maxStatementWarning = StaticApplicationContext.getEnvironmentProperty("hibernate.session.warning.max.count",
+                Integer.class, DEFAULT_SESSION_MAX_STATEMENT_WARNING);
+        if (queryCount > maxStatementWarning) {
             HibernateNPlusOneException e = new HibernateNPlusOneException(
                     String.format("You have executed %d queries in a single transaction, " +
                             "please doublecheck the entity relationship!", queryCount));

--- a/common/src/test/java/com/sequenceiq/cloudbreak/common/tx/HibernateNPlusOneLoggerTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/common/tx/HibernateNPlusOneLoggerTest.java
@@ -11,12 +11,12 @@ public class HibernateNPlusOneLoggerTest {
     private HibernateNPlusOneLogger underTest;
 
     @BeforeEach
-    void setUp() {
+    public void setUp() {
         underTest = new HibernateNPlusOneLogger();
     }
 
     @Test
-    void testNoWarning() {
+    public void testNoWarning() {
         callSQL(1000);
         underTest.end();
 


### PR DESCRIPTION
… since Hiberate instantiates the directly with new keyword.

In order to make sure that we still can use the powerful config features of Spring we shall make sure that we can access to Spring ApplicationContext and Environment variables through a static functions which can be used from non-Spring managed java objects.

See detailed description in the commit message.