### PR TITLE
CB-9091 Waiting for Flow throws java.lang.InterruptedException

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/FlowUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/FlowUtil.java
@@ -119,12 +119,9 @@ public class FlowUtil {
     private void sleep(long pollingInterval, String crn, String flowChainId, String flowId) {
         try {
             TimeUnit.MILLISECONDS.sleep(pollingInterval);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            LOGGER.error("Waiting for flowId:flowChainId '{}:{}' has been interrupted at resource {}, because of: {}", flowId, flowChainId, crn,
-                    e.getMessage(), e);
-            throw new TestFailException(String.format(" Waiting for flowId:flowChainId '%s:%s' has been interrupted at resource %s, because of: %s ",
-                    flowId, flowChainId, crn, e.getMessage()));
+        } catch (InterruptedException ignored) {
+            LOGGER.warn("Waiting for flowId:flowChainId '{}:{}' has been interrupted at resource {}, because of: {}", flowId, flowChainId, crn,
+                    ignored.getMessage(), ignored);
         }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitService.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitService.java
@@ -46,7 +46,7 @@ public class WaitService<T> {
                 testContext.setStatuses(getStatuses(statusChecker, t));
                 return Result.result(WaitResult.SUCCESS);
             }
-            sleep(interval);
+            sleep(interval, getStatuses(statusChecker, t));
             attempts++;
             timeout = timeoutChecker.checkTimeout();
             LOGGER.info("Checking if wait can exit.");
@@ -67,11 +67,11 @@ public class WaitService<T> {
         return statusChecker.getStatuses(t);
     }
 
-    private void sleep(Duration duration) {
+    private void sleep(Duration duration, Map<String, String> statusMap) {
         try {
             Thread.sleep(duration.toMillis());
         } catch (InterruptedException ignored) {
-            LOGGER.error("Interrupted exception occurred during waiting.", ignored);
+            LOGGER.warn("Waiting for '{}' has been interrupted, because of: {}", statusMap, ignored.getMessage(), ignored);
         }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/util/SimpleRetryWrapper.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/util/SimpleRetryWrapper.java
@@ -44,6 +44,7 @@ public class SimpleRetryWrapper<T> {
                     try {
                         TimeUnit.SECONDS.sleep(retryWaitSeconds);
                     } catch (InterruptedException ignored) {
+                        LOGGER.warn("[{}] action {} retry has been interrupted, because of: {}", action, timesTried, ignored.getMessage(), ignored);
                     }
                 } else {
                     LOGGER.error("Failed to run [{}] action {} times.", name, retryTimes, e);

--- a/integration-test/src/main/java/com/sequenceiq/it/util/cleanup/CleanupWaitUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/util/cleanup/CleanupWaitUtil.java
@@ -240,8 +240,8 @@ public class CleanupWaitUtil {
     private void sleep(long pollingInterval) {
         try {
             Thread.sleep(pollingInterval);
-        } catch (InterruptedException e) {
-            LOG.warn("Exception has been occurred during wait: {}", e.getMessage(), e);
+        } catch (InterruptedException ignored) {
+            LOG.warn("Waiting for cleanup has been interrupted, because of: {}", ignored.getMessage(), ignored);
         }
     }
 


### PR DESCRIPTION
Change the `InterruptedException` handling at the Test project. Introduced log `WARNING` instead of `throw new TestFailException` and log `ERROR`.