### PR TITLE
CB-9096 Reduce thread count, because the tests fails randomly becuse …

### DIFF
--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -12,7 +12,7 @@ mock:
     address: localhost
 
 integrationtest:
-  threadCount: 8
+  threadCount: 1
   parallel: methods
   timeOut: 6000000
   spark:


### PR DESCRIPTION
…of parallel run.

See detailed description in the commit message.