### PR TITLE
CB-9074 handle null values of ProductDetailsView in RangerRazDatahubConfigProvider that corrupted cluster template generation

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/RangerRazDatahubConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/RangerRazDatahubConfigProvider.java
@@ -18,6 +18,8 @@ public class RangerRazDatahubConfigProvider extends RangerRazBaseConfigProvider 
     public boolean isConfigurationNeeded(CmTemplateProcessor cmTemplateProcessor, TemplatePreparationObject source) {
         return StackType.WORKLOAD == source.getStackType()
                 && (CloudPlatform.AWS == source.getCloudPlatform() || CloudPlatform.AZURE == source.getCloudPlatform())
+                && source.getProductDetailsView() != null
+                && source.getProductDetailsView().getCm() != null
                 && CMRepositoryVersionUtil.isRazConfigurationSupportedInDatahub(source.getProductDetailsView().getCm())
                 && source.getDatalakeView().isPresent()
                 && source.getDatalakeView().get().isRazEnabled();

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/RangerRazDatahubConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/RangerRazDatahubConfigProviderTest.java
@@ -202,4 +202,42 @@ public class RangerRazDatahubConfigProviderTest {
         assertEquals(0, additionalServices.size());
     }
 
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("razCloudPlatformDataProvider")
+    @DisplayName("CM 7.2.2 DH is used and product details contains null as CM details at template generation before datahub cluster creations")
+    void getAdditionalServicesWhenCmDetailsIsNullInProductDetails(String testCaseName, CloudPlatform cloudPlatform) {
+        GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
+        HostgroupView master = new HostgroupView("master", 0, InstanceGroupType.GATEWAY, List.of());
+        HostgroupView worker = new HostgroupView("worker", 0, InstanceGroupType.CORE, List.of());
+        TemplatePreparationObject preparationObject = Builder.builder()
+                .withStackType(StackType.WORKLOAD)
+                .withCloudPlatform(cloudPlatform)
+                .withProductDetails(null, null)
+                .withDataLakeView(new DatalakeView(true))
+                .withGeneralClusterConfigs(generalClusterConfigs)
+                .withHostgroupViews(Set.of(master, worker))
+                .build();
+        Map<String, ApiClusterTemplateService> additionalServices = configProvider.getAdditionalServices(cmTemplateProcessor, preparationObject);
+
+        assertEquals(0, additionalServices.size());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("razCloudPlatformDataProvider")
+    @DisplayName("CM 7.2.2 DH is used and product details is missing at template generation before datahub cluster creations")
+    void getAdditionalServicesWhenProductDetailsIsMissing(String testCaseName, CloudPlatform cloudPlatform) {
+        GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
+        HostgroupView master = new HostgroupView("master", 0, InstanceGroupType.GATEWAY, List.of());
+        HostgroupView worker = new HostgroupView("worker", 0, InstanceGroupType.CORE, List.of());
+        TemplatePreparationObject preparationObject = Builder.builder()
+                .withStackType(StackType.WORKLOAD)
+                .withCloudPlatform(cloudPlatform)
+                .withDataLakeView(new DatalakeView(true))
+                .withGeneralClusterConfigs(generalClusterConfigs)
+                .withHostgroupViews(Set.of(master, worker))
+                .build();
+        Map<String, ApiClusterTemplateService> additionalServices = configProvider.getAdditionalServices(cmTemplateProcessor, preparationObject);
+
+        assertEquals(0, additionalServices.size());
+    }
 }


### PR DESCRIPTION
 - This PR is intended to handle null pointers that corrupted cluster template generation before cluster creation. As the `ProductDetailsView` is null in case of cluster template generation.
 - Also that has been validated that the `7.2.2 - Flow Management Light Duty with Apache NiFi, Apache NiFi Registry` template works at is expected and datahub clusters could be created with it.