### PR TITLE
CB-9034 Introduce a Hibernate event listener that will try to detect …

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/config/DatabaseConfig.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/config/DatabaseConfig.java
@@ -6,7 +6,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.sql.SQLException;
-import java.util.Properties;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -27,6 +26,8 @@ import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
+import com.sequenceiq.cloudbreak.common.database.JpaPropertiesFacory;
+import com.sequenceiq.cloudbreak.common.tx.CircuitBreakerType;
 import com.sequenceiq.cloudbreak.util.DatabaseUtil;
 import com.sequenceiq.periscope.service.ha.PeriscopeNodeConfig;
 import com.zaxxer.hikari.HikariConfig;
@@ -73,8 +74,8 @@ public class DatabaseConfig {
     @Value("${periscope.hibernate.debug:false}")
     private boolean debug;
 
-    @Value("${periscope.hibernate.statistics:true}")
-    private boolean statistics;
+    @Value("${periscope.hibernate.circuitbreaker:LOG}")
+    private CircuitBreakerType circuitBreakerType;
 
     @Inject
     @Named("databaseAddress")
@@ -127,7 +128,8 @@ public class DatabaseConfig {
         entityManagerFactory.setDataSource(dataSource());
 
         entityManagerFactory.setJpaVendorAdapter(jpaVendorAdapter());
-        entityManagerFactory.setJpaProperties(jpaProperties());
+        entityManagerFactory.setJpaProperties(JpaPropertiesFacory.create("hibernate.hbm2ddl.auto", hbm2ddlStrategy,
+                debug, dbSchemaName, circuitBreakerType));
         entityManagerFactory.afterPropertiesSet();
         return entityManagerFactory.getObject();
     }
@@ -138,20 +140,5 @@ public class DatabaseConfig {
         hibernateJpaVendorAdapter.setShowSql(true);
         hibernateJpaVendorAdapter.setDatabase(Database.POSTGRESQL);
         return hibernateJpaVendorAdapter;
-    }
-
-    private Properties jpaProperties() {
-        Properties properties = new Properties();
-        properties.setProperty("hibernate.hbm2ddl.auto", hbm2ddlStrategy);
-        properties.setProperty("hibernate.show_sql", Boolean.toString(debug));
-        properties.setProperty("hibernate.format_sql", Boolean.toString(debug));
-        properties.setProperty("hibernate.use_sql_comments", Boolean.toString(debug));
-        if (statistics) {
-            properties.setProperty("hibernate.session.events.auto", "com.sequenceiq.cloudbreak.common.tx.HibernateNPlusOneLogger");
-        }
-        properties.setProperty("hibernate.dialect", "org.hibernate.dialect.PostgreSQLDialect");
-        properties.setProperty("hibernate.default_schema", dbSchemaName);
-        properties.setProperty("hibernate.jdbc.lob.non_contextual_creation", Boolean.toString(true));
-        return properties;
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/database/JpaPropertiesFacory.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/database/JpaPropertiesFacory.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.cloudbreak.common.database;
+
+import java.util.Properties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.common.tx.CircuitBreakerType;
+import com.sequenceiq.cloudbreak.common.tx.HibernateNPlusOneCircuitBreaker;
+import com.sequenceiq.cloudbreak.common.tx.HibernateNPlusOneLogger;
+
+public class JpaPropertiesFacory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JpaPropertiesFacory.class);
+
+    private JpaPropertiesFacory() {
+    }
+
+    public static Properties create(String hbm2ddlPropertyName, String hbm2ddlStrategy,
+            boolean debug, String dbSchemaName, CircuitBreakerType circuitBreakerType) {
+        Properties properties = new Properties();
+        properties.setProperty(hbm2ddlPropertyName, hbm2ddlStrategy);
+        properties.setProperty("hibernate.show_sql", Boolean.toString(debug));
+        properties.setProperty("hibernate.format_sql", Boolean.toString(debug));
+        properties.setProperty("hibernate.use_sql_comments", Boolean.toString(debug));
+        properties.setProperty("hibernate.dialect", "org.hibernate.dialect.PostgreSQLDialect");
+        properties.setProperty("hibernate.default_schema", dbSchemaName);
+        properties.setProperty("hibernate.jdbc.lob.non_contextual_creation", Boolean.toString(true));
+
+        LOGGER.info("Hibernate NPlusOne Circuit Breaker type: {}", circuitBreakerType);
+        switch (circuitBreakerType) {
+            case LOG:
+                properties.setProperty("hibernate.session.events.auto", HibernateNPlusOneLogger.class.getName());
+                break;
+            case BREAK:
+                properties.setProperty("hibernate.session.events.auto", HibernateNPlusOneCircuitBreaker.class.getName());
+                break;
+            default:
+                LOGGER.info("Hibernate NPlusOne Circuit Breaker is disabled!");
+        }
+        LOGGER.info("JPA Properties: {}", properties);
+        return properties;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/tx/CircuitBreakerType.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/tx/CircuitBreakerType.java
@@ -1,0 +1,5 @@
+package com.sequenceiq.cloudbreak.common.tx;
+
+public enum CircuitBreakerType {
+    NONE, LOG, BREAK
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/tx/HibernateNPlusOneCircuitBreaker.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/tx/HibernateNPlusOneCircuitBreaker.java
@@ -1,0 +1,41 @@
+package com.sequenceiq.cloudbreak.common.tx;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.app.StaticApplicationContext;
+
+public class HibernateNPlusOneCircuitBreaker extends HibernateNPlusOneLogger {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HibernateNPlusOneCircuitBreaker.class);
+
+    private static final int DEFAULT_SESSION_MAX_STATEMENT_CIRCUIT_BREAK = 1500;
+
+    private final int maxStatementBreak;
+
+    public HibernateNPlusOneCircuitBreaker() {
+        maxStatementBreak = StaticApplicationContext.getEnvironmentProperty("hibernate.session.circuitbreak.max.count",
+                Integer.class, DEFAULT_SESSION_MAX_STATEMENT_CIRCUIT_BREAK);
+    }
+
+    @Override
+    public void jdbcPrepareStatementEnd() {
+        super.jdbcPrepareStatementEnd();
+        breakCircuit(getQueryCount());
+    }
+
+    @Override
+    public void jdbcExecuteStatementEnd() {
+        super.jdbcExecuteStatementEnd();
+        breakCircuit(getQueryCount());
+    }
+
+    private void breakCircuit(int queryCount) {
+        if (queryCount > maxStatementBreak) {
+            String message = constructLogline();
+            HibernateNPlusOneException e = new HibernateNPlusOneException(queryCount);
+            LOGGER.error(message, e);
+            throw e;
+        }
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/tx/HibernateNPlusOneException.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/tx/HibernateNPlusOneException.java
@@ -6,7 +6,8 @@ package com.sequenceiq.cloudbreak.common.tx;
  */
 public class HibernateNPlusOneException extends RuntimeException {
 
-    public HibernateNPlusOneException(String message) {
-        super(message);
+    public HibernateNPlusOneException(int queryCount) {
+        super(String.format("You have executed %d queries in a single transaction, " +
+                "please doublecheck the entity relationship!", queryCount));
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/conf/DatabaseConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/conf/DatabaseConfig.java
@@ -6,7 +6,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.sql.SQLException;
-import java.util.Properties;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -28,6 +27,8 @@ import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
+import com.sequenceiq.cloudbreak.common.database.JpaPropertiesFacory;
+import com.sequenceiq.cloudbreak.common.tx.CircuitBreakerType;
 import com.sequenceiq.cloudbreak.util.DatabaseUtil;
 import com.sequenceiq.flow.ha.NodeConfig;
 import com.zaxxer.hikari.HikariConfig;
@@ -73,8 +74,8 @@ public class DatabaseConfig {
     @Value("${cb.hibernate.debug:false}")
     private boolean debug;
 
-    @Value("${cb.hibernate.statistics:true}")
-    private boolean statistics;
+    @Value("${cb.hibernate.circuitbreaker:LOG}")
+    private CircuitBreakerType circuitBreakerType;
 
     @Inject
     @Named("databaseAddress")
@@ -133,7 +134,8 @@ public class DatabaseConfig {
         entityManagerFactory.setDataSource(dataSource());
 
         entityManagerFactory.setJpaVendorAdapter(jpaVendorAdapter());
-        entityManagerFactory.setJpaProperties(jpaProperties());
+        entityManagerFactory.setJpaProperties(JpaPropertiesFacory.create("hibernate.hbm2ddl.auto", hbm2ddlStrategy,
+                debug, dbSchemaName, circuitBreakerType));
         entityManagerFactory.afterPropertiesSet();
         return entityManagerFactory;
     }
@@ -144,20 +146,5 @@ public class DatabaseConfig {
         hibernateJpaVendorAdapter.setShowSql(true);
         hibernateJpaVendorAdapter.setDatabase(Database.POSTGRESQL);
         return hibernateJpaVendorAdapter;
-    }
-
-    private Properties jpaProperties() {
-        Properties properties = new Properties();
-        properties.setProperty("hibernate.hbm2ddl.auto", hbm2ddlStrategy);
-        properties.setProperty("hibernate.show_sql", Boolean.toString(debug));
-        properties.setProperty("hibernate.format_sql", Boolean.toString(debug));
-        properties.setProperty("hibernate.use_sql_comments", Boolean.toString(debug));
-        if (statistics) {
-            properties.setProperty("hibernate.session.events.auto", "com.sequenceiq.cloudbreak.common.tx.HibernateNPlusOneLogger");
-        }
-        properties.setProperty("hibernate.dialect", "org.hibernate.dialect.PostgreSQLDialect");
-        properties.setProperty("hibernate.default_schema", dbSchemaName);
-        properties.setProperty("hibernate.jdbc.lob.non_contextual_creation", Boolean.toString(true));
-        return properties;
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/configuration/DatabaseConfig.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/configuration/DatabaseConfig.java
@@ -6,7 +6,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.sql.SQLException;
-import java.util.Properties;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -26,6 +25,8 @@ import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
+import com.sequenceiq.cloudbreak.common.database.JpaPropertiesFacory;
+import com.sequenceiq.cloudbreak.common.tx.CircuitBreakerType;
 import com.sequenceiq.cloudbreak.util.DatabaseUtil;
 import com.sequenceiq.flow.ha.NodeConfig;
 import com.zaxxer.hikari.HikariConfig;
@@ -71,8 +72,8 @@ public class DatabaseConfig {
     @Value("${datalake.hibernate.debug:false}")
     private boolean debug;
 
-    @Value("${datalake.hibernate.statistics:true}")
-    private boolean statistics;
+    @Value("${datalake.hibernate.circuitbreaker:LOG}")
+    private CircuitBreakerType circuitBreakerType;
 
     @Inject
     @Named("databaseAddress")
@@ -126,7 +127,8 @@ public class DatabaseConfig {
         entityManagerFactory.setDataSource(dataSource());
 
         entityManagerFactory.setJpaVendorAdapter(jpaVendorAdapter());
-        entityManagerFactory.setJpaProperties(jpaProperties());
+        entityManagerFactory.setJpaProperties(JpaPropertiesFacory.create("hibernate.hbm2ddatalake.auto", hbm2ddlStrategy,
+                debug, dbSchemaName, circuitBreakerType));
         entityManagerFactory.afterPropertiesSet();
         return entityManagerFactory.getObject();
     }
@@ -137,20 +139,5 @@ public class DatabaseConfig {
         hibernateJpaVendorAdapter.setShowSql(true);
         hibernateJpaVendorAdapter.setDatabase(Database.POSTGRESQL);
         return hibernateJpaVendorAdapter;
-    }
-
-    private Properties jpaProperties() {
-        Properties properties = new Properties();
-        properties.setProperty("hibernate.hbm2ddatalake.auto", hbm2ddlStrategy);
-        properties.setProperty("hibernate.show_sql", Boolean.toString(debug));
-        properties.setProperty("hibernate.format_sql", Boolean.toString(debug));
-        properties.setProperty("hibernate.use_sql_comments", Boolean.toString(debug));
-        if (statistics) {
-            properties.setProperty("hibernate.session.events.auto", "com.sequenceiq.cloudbreak.common.tx.HibernateNPlusOneLogger");
-        }
-        properties.setProperty("hibernate.dialect", "org.hibernate.dialect.PostgreSQLDialect");
-        properties.setProperty("hibernate.default_schema", dbSchemaName);
-        properties.setProperty("hibernate.jdbc.lob.non_contextual_creation", Boolean.toString(true));
-        return properties;
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/DatabaseConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/DatabaseConfig.java
@@ -6,7 +6,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.sql.SQLException;
-import java.util.Properties;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -26,6 +25,8 @@ import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
+import com.sequenceiq.cloudbreak.common.database.JpaPropertiesFacory;
+import com.sequenceiq.cloudbreak.common.tx.CircuitBreakerType;
 import com.sequenceiq.cloudbreak.util.DatabaseUtil;
 import com.sequenceiq.flow.ha.NodeConfig;
 import com.zaxxer.hikari.HikariConfig;
@@ -71,8 +72,8 @@ public class DatabaseConfig {
     @Value("${freeipa.hibernate.debug:false}")
     private boolean debug;
 
-    @Value("${freeipa.hibernate.statistics:true}")
-    private boolean statistics;
+    @Value("${freeipa.hibernate.circuitbreaker:LOG}")
+    private CircuitBreakerType circuitBreakerType;
 
     @Inject
     @Named("databaseAddress")
@@ -126,7 +127,8 @@ public class DatabaseConfig {
         entityManagerFactory.setDataSource(dataSource());
 
         entityManagerFactory.setJpaVendorAdapter(jpaVendorAdapter());
-        entityManagerFactory.setJpaProperties(jpaProperties());
+        entityManagerFactory.setJpaProperties(JpaPropertiesFacory.create("hibernate.hbm2dfreeipa.auto", hbm2ddlStrategy,
+                debug, dbSchemaName, circuitBreakerType));
         entityManagerFactory.afterPropertiesSet();
         return entityManagerFactory.getObject();
     }
@@ -137,20 +139,5 @@ public class DatabaseConfig {
         hibernateJpaVendorAdapter.setShowSql(true);
         hibernateJpaVendorAdapter.setDatabase(Database.POSTGRESQL);
         return hibernateJpaVendorAdapter;
-    }
-
-    private Properties jpaProperties() {
-        Properties properties = new Properties();
-        properties.setProperty("hibernate.hbm2dfreeipa.auto", hbm2ddlStrategy);
-        properties.setProperty("hibernate.show_sql", Boolean.toString(debug));
-        properties.setProperty("hibernate.format_sql", Boolean.toString(debug));
-        properties.setProperty("hibernate.use_sql_comments", Boolean.toString(debug));
-        if (statistics) {
-            properties.setProperty("hibernate.session.events.auto", "com.sequenceiq.cloudbreak.common.tx.HibernateNPlusOneLogger");
-        }
-        properties.setProperty("hibernate.dialect", "org.hibernate.dialect.PostgreSQLDialect");
-        properties.setProperty("hibernate.default_schema", dbSchemaName);
-        properties.setProperty("hibernate.jdbc.lob.non_contextual_creation", Boolean.toString(true));
-        return properties;
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/DatabaseConfig.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/DatabaseConfig.java
@@ -6,7 +6,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.sql.SQLException;
-import java.util.Properties;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -26,6 +25,8 @@ import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
+import com.sequenceiq.cloudbreak.common.database.JpaPropertiesFacory;
+import com.sequenceiq.cloudbreak.common.tx.CircuitBreakerType;
 import com.sequenceiq.cloudbreak.util.DatabaseUtil;
 import com.sequenceiq.flow.ha.NodeConfig;
 import com.zaxxer.hikari.HikariConfig;
@@ -71,8 +72,8 @@ public class DatabaseConfig {
     @Value("${redbeams.hibernate.debug:false}")
     private boolean debug;
 
-    @Value("${redbeams.hibernate.statistics:true}")
-    private boolean statistics;
+    @Value("${redbeams.hibernate.circuitbreaker:LOG}")
+    private CircuitBreakerType circuitBreakerType;
 
     @Inject
     @Named("databaseAddress")
@@ -126,7 +127,8 @@ public class DatabaseConfig {
         entityManagerFactory.setDataSource(dataSource());
 
         entityManagerFactory.setJpaVendorAdapter(jpaVendorAdapter());
-        entityManagerFactory.setJpaProperties(jpaProperties());
+        entityManagerFactory.setJpaProperties(JpaPropertiesFacory.create("hibernate.hbm2ddl.auto", hbm2ddlStrategy,
+                debug, dbSchemaName, circuitBreakerType));
         entityManagerFactory.afterPropertiesSet();
         return entityManagerFactory.getObject();
     }
@@ -137,20 +139,5 @@ public class DatabaseConfig {
         hibernateJpaVendorAdapter.setShowSql(true);
         hibernateJpaVendorAdapter.setDatabase(Database.POSTGRESQL);
         return hibernateJpaVendorAdapter;
-    }
-
-    private Properties jpaProperties() {
-        Properties properties = new Properties();
-        properties.setProperty("hibernate.hbm2ddl.auto", hbm2ddlStrategy);
-        properties.setProperty("hibernate.show_sql", Boolean.toString(debug));
-        properties.setProperty("hibernate.format_sql", Boolean.toString(debug));
-        properties.setProperty("hibernate.use_sql_comments", Boolean.toString(debug));
-        if (statistics) {
-            properties.setProperty("hibernate.session.events.auto", "com.sequenceiq.cloudbreak.common.tx.HibernateNPlusOneLogger");
-        }
-        properties.setProperty("hibernate.dialect", "org.hibernate.dialect.PostgreSQLDialect");
-        properties.setProperty("hibernate.default_schema", dbSchemaName);
-        properties.setProperty("hibernate.jdbc.lob.non_contextual_creation", Boolean.toString(true));
-        return properties;
     }
 }


### PR DESCRIPTION
…inefficient queries executed by Hibernate. The goal is to catch those cases when more queries are executed than expected, this is usually referred as N + 1 query problem in Hibernate.

If we are over the treshold then the circuit breaker can do multiple things:
- break the tx if too many queries are executed in a tx (useful in dev and IT test, to catch the problem as early as possible)
- log a warning if too many queries are executed in a tx (useful for test environemnts, stage and prod)

See detailed description in the commit message.