### PR TITLE
CB-9060 Check if certificates on cluster are about to expire

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterStatusService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterStatusService.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import com.sequenceiq.cloudbreak.cloud.model.HostName;
 import com.sequenceiq.cloudbreak.cluster.status.ClusterStatusResult;
+import com.sequenceiq.cloudbreak.cluster.status.ExtendedHostStatuses;
 import com.sequenceiq.cloudbreak.common.type.ClusterManagerState;
 
 public interface ClusterStatusService {
@@ -18,7 +19,7 @@ public interface ClusterStatusService {
      */
     Map<HostName, ClusterManagerState.ClusterManagerStatus> getHostStatuses();
 
-    Map<HostName, ClusterManagerState> getExtendedHostStatuses();
+    ExtendedHostStatuses getExtendedHostStatuses();
 
     Map<HostName, String> getHostStatusesRaw();
 

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/status/ExtendedHostStatuses.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/status/ExtendedHostStatuses.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.cloudbreak.cluster.status;
+
+import java.util.Map;
+
+import com.sequenceiq.cloudbreak.cloud.model.HostName;
+import com.sequenceiq.cloudbreak.common.type.ClusterManagerState;
+
+public class ExtendedHostStatuses {
+
+    private final Map<HostName, ClusterManagerState> hostHealth;
+
+    private final boolean hostCertExpiring;
+
+    public ExtendedHostStatuses(Map<HostName, ClusterManagerState> hostHealth, boolean hostCertExpiring) {
+        this.hostHealth = hostHealth;
+        this.hostCertExpiring = hostCertExpiring;
+    }
+
+    public Map<HostName, ClusterManagerState> getHostHealth() {
+        return hostHealth;
+    }
+
+    public boolean isHostCertExpiring() {
+        return hostCertExpiring;
+    }
+
+    @Override
+    public String toString() {
+        return "ExtendedHostStatuses{" +
+                "hostHealth=" + hostHealth +
+                ", hostCertExpiring=" + hostCertExpiring +
+                '}';
+    }
+}

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusServiceTest.java
@@ -3,9 +3,11 @@ package com.sequenceiq.cloudbreak.cm;
 import static com.sequenceiq.cloudbreak.cloud.model.HostName.hostName;
 import static com.sequenceiq.cloudbreak.cm.ClouderaManagerClusterStatusService.FULL_VIEW;
 import static com.sequenceiq.cloudbreak.cm.ClouderaManagerClusterStatusService.FULL_WITH_EXPLANATION_VIEW;
+import static com.sequenceiq.cloudbreak.cm.ClouderaManagerClusterStatusService.HOST_AGENT_CERTIFICATE_EXPIRY;
 import static com.sequenceiq.cloudbreak.cm.ClouderaManagerClusterStatusService.HOST_SCM_HEALTH;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -45,10 +47,12 @@ import com.sequenceiq.cloudbreak.client.HttpClientConfig;
 import com.sequenceiq.cloudbreak.cloud.model.HostName;
 import com.sequenceiq.cloudbreak.cluster.status.ClusterStatus;
 import com.sequenceiq.cloudbreak.cluster.status.ClusterStatusResult;
+import com.sequenceiq.cloudbreak.cluster.status.ExtendedHostStatuses;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiClientProvider;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerClientInitException;
 import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
 import com.sequenceiq.cloudbreak.common.type.ClusterManagerState;
+import com.sequenceiq.cloudbreak.common.type.ClusterManagerState.ClusterManagerStatus;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 
@@ -230,10 +234,16 @@ public class ClouderaManagerClusterStatusServiceTest {
     @Test
     public void collectsExtendedHostHealthIfAvailable() throws ApiException {
         hostsAre(
-                new ApiHost().hostname("host1").addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.GOOD)),
-                new ApiHost().hostname("host2").addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.CONCERNING)),
-                new ApiHost().hostname("host3").addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.BAD)
-                        .explanation("explanation")),
+                new ApiHost().hostname("host1")
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.GOOD))
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_AGENT_CERTIFICATE_EXPIRY).summary(ApiHealthSummary.GOOD)),
+                new ApiHost().hostname("host2")
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.CONCERNING))
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_AGENT_CERTIFICATE_EXPIRY).summary(ApiHealthSummary.CONCERNING)
+                                .explanation("in 30 days")),
+                new ApiHost().hostname("host3")
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.BAD).explanation("explanation"))
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_AGENT_CERTIFICATE_EXPIRY).summary(ApiHealthSummary.BAD).explanation("in 2 days")),
                 new ApiHost().hostname("host4").addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.NOT_AVAILABLE)),
                 new ApiHost().hostname("host5").addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.HISTORY_NOT_AVAILABLE)),
                 new ApiHost().hostname("host6").addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.DISABLED))
@@ -244,12 +254,61 @@ public class ClouderaManagerClusterStatusServiceTest {
                 hostName("host2"), ClusterManagerState.ClusterManagerStatus.HEALTHY,
                 hostName("host3"), ClusterManagerState.ClusterManagerStatus.UNHEALTHY
         );
-        Map<HostName, ClusterManagerState> extendedStateMap = subject.getExtendedHostStatuses();
+
+        ExtendedHostStatuses extendedHostStatuses = subject.getExtendedHostStatuses();
+        Map<HostName, ClusterManagerState> extendedStateMap = extendedHostStatuses.getHostHealth();
         Map<HostName, ClusterManagerState.ClusterManagerStatus> actual = new TreeMap<>(extendedStateMap.entrySet().stream()
                 .map(e -> Pair.of(e.getKey(), e.getValue().getClusterManagerStatus()))
                 .collect(Collectors.toMap(Pair::getLeft, Pair::getRight)));
         assertEquals(expected, actual);
         assertEquals("HOST_SCM_HEALTH: BAD. Reason: explanation", extendedStateMap.get(hostName("host3")).getStatusReason());
+        assertTrue(extendedHostStatuses.isHostCertExpiring());
+    }
+
+    @Test
+    public void testCertExpiringEverythingElseGood() throws ApiException {
+        hostsAre(
+                new ApiHost().hostname("host1")
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.GOOD))
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_AGENT_CERTIFICATE_EXPIRY).summary(ApiHealthSummary.GOOD)),
+                new ApiHost().hostname("host2")
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.GOOD))
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_AGENT_CERTIFICATE_EXPIRY).summary(ApiHealthSummary.CONCERNING)
+                                .explanation("in 30 days"))
+        );
+
+        ExtendedHostStatuses extendedHostStatuses = subject.getExtendedHostStatuses();
+        Map<HostName, ClusterManagerState> extendedStateMap = extendedHostStatuses.getHostHealth();
+
+        Map<HostName, ClusterManagerState> expected = Map.of(hostName("host1"), new ClusterManagerState(ClusterManagerStatus.HEALTHY, null),
+                hostName("host2"), new ClusterManagerState(ClusterManagerStatus.HEALTHY, null));
+
+        assertEquals(expected.keySet(), extendedStateMap.keySet());
+        extendedStateMap.values().forEach(state -> assertEquals(ClusterManagerStatus.HEALTHY, state.getClusterManagerStatus()));
+        assertTrue(extendedHostStatuses.isHostCertExpiring());
+    }
+
+    @Test
+    public void testEverythingGood() throws ApiException {
+        hostsAre(
+                new ApiHost().hostname("host1")
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.GOOD))
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_AGENT_CERTIFICATE_EXPIRY).summary(ApiHealthSummary.GOOD)),
+                new ApiHost().hostname("host2")
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.GOOD))
+                        .addHealthChecksItem(new ApiHealthCheck().name(HOST_AGENT_CERTIFICATE_EXPIRY).summary(ApiHealthSummary.GOOD)
+                                .explanation("in 30 days"))
+        );
+
+        ExtendedHostStatuses extendedHostStatuses = subject.getExtendedHostStatuses();
+        Map<HostName, ClusterManagerState> extendedStateMap = extendedHostStatuses.getHostHealth();
+
+        Map<HostName, ClusterManagerState> expected = Map.of(hostName("host1"), new ClusterManagerState(ClusterManagerStatus.HEALTHY, null),
+                hostName("host2"), new ClusterManagerState(ClusterManagerStatus.HEALTHY, null));
+
+        assertEquals(expected.keySet(), extendedStateMap.keySet());
+        extendedStateMap.values().forEach(state -> assertEquals(ClusterManagerStatus.HEALTHY, state.getClusterManagerStatus()));
+        assertFalse(extendedHostStatuses.isHostCertExpiring());
     }
 
     @Test
@@ -261,8 +320,7 @@ public class ClouderaManagerClusterStatusServiceTest {
                         .addHealthChecksItem(new ApiHealthCheck().name("another").summary(ApiHealthSummary.BAD))
         );
 
-        Map<HostName, ClusterManagerState.ClusterManagerStatus> expected = Collections.singletonMap(hostName("host"),
-                ClusterManagerState.ClusterManagerStatus.HEALTHY);
+        Map<HostName, ClusterManagerStatus> expected = Collections.singletonMap(hostName("host"), ClusterManagerStatus.HEALTHY);
         assertEquals(expected, subject.getHostStatuses());
     }
 

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/common/CertExpirationState.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/common/CertExpirationState.java
@@ -1,0 +1,6 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.common;
+
+public enum CertExpirationState {
+    VALID,
+    HOST_CERT_EXPIRING;
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/cluster/ClusterV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/cluster/ClusterV4Response.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.CertExpirationState;
 import com.sequenceiq.common.model.JsonEntity;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.blueprint.responses.BlueprintV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
@@ -117,6 +118,9 @@ public class ClusterV4Response implements JsonEntity {
 
     @ApiModelProperty(ClusterModelDescription.ENABLE_RANGER_RAZ)
     private boolean rangerRazEnabled;
+
+    @ApiModelProperty(ClusterModelDescription.CERT_EXPIRATION)
+    private CertExpirationState certExpirationState;
 
     public Long getId() {
         return id;
@@ -348,5 +352,13 @@ public class ClusterV4Response implements JsonEntity {
 
     public void setRangerRazEnabled(boolean rangerRazEnabled) {
         this.rangerRazEnabled = rangerRazEnabled;
+    }
+
+    public CertExpirationState getCertExpirationState() {
+        return certExpirationState;
+    }
+
+    public void setCertExpirationState(CertExpirationState certExpirationState) {
+        this.certExpirationState = certExpirationState;
     }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
@@ -308,6 +308,7 @@ public class ModelDescriptions {
         public static final String CLOUD_STORAGE_LOCATIONS = "storage locations by CDP services";
         public static final String ENABLE_RANGER_RAZ = "Enables Ranger Raz for the cluster on S3 and ADLSv2.";
         public static final String CERTIFICATE_ROTATION_TYPE = "the type of the certificate rotation";
+        public static final String CERT_EXPIRATION = "Indicates the certificate status on the cluster";
     }
 
     public static class GatewayModelDescription {

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/converter/CertExpirationStateConverter.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/converter/CertExpirationStateConverter.java
@@ -1,0 +1,11 @@
+package com.sequenceiq.cloudbreak.domain.converter;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.CertExpirationState;
+import com.sequenceiq.cloudbreak.converter.DefaultEnumConverter;
+
+public class CertExpirationStateConverter extends DefaultEnumConverter<CertExpirationState> {
+    @Override
+    public CertExpirationState getDefault() {
+        return CertExpirationState.VALID;
+    }
+}

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/cluster/Cluster.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/cluster/Cluster.java
@@ -37,6 +37,7 @@ import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.CertExpirationState;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ExecutorType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.ConfigStrategy;
@@ -47,6 +48,7 @@ import com.sequenceiq.cloudbreak.domain.Container;
 import com.sequenceiq.cloudbreak.domain.FileSystem;
 import com.sequenceiq.cloudbreak.domain.ProvisionEntity;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
+import com.sequenceiq.cloudbreak.domain.converter.CertExpirationStateConverter;
 import com.sequenceiq.cloudbreak.domain.converter.ConfigStrategyConverter;
 import com.sequenceiq.cloudbreak.domain.converter.ExecutorTypeConverter;
 import com.sequenceiq.cloudbreak.domain.converter.StatusConverter;
@@ -224,6 +226,9 @@ public class Cluster implements ProvisionEntity, WorkspaceAwareResource {
 
     @Column(name = "ranger_raz_enabled")
     private boolean rangerRazEnabled;
+
+    @Convert(converter = CertExpirationStateConverter.class)
+    private CertExpirationState certExpirationState = CertExpirationState.VALID;
 
     public String getEnvironmentCrn() {
         return environmentCrn;
@@ -744,6 +749,14 @@ public class Cluster implements ProvisionEntity, WorkspaceAwareResource {
 
     public void setIdBroker(IdBroker idBroker) {
         this.idBroker = idBroker;
+    }
+
+    public CertExpirationState getCertExpirationState() {
+        return certExpirationState;
+    }
+
+    public void setCertExpirationState(CertExpirationState certExpirationState) {
+        this.certExpirationState = certExpirationState;
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cluster/ClusterToClusterV4ResponseConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cluster/ClusterToClusterV4ResponseConverter.java
@@ -97,6 +97,7 @@ public class ClusterToClusterV4ResponseConverter extends AbstractConversionServi
         clusterResponse.setServerUrl(serviceEndpointCollector.getManagerServerUrl(source, managerAddress));
         clusterResponse.setDatabaseServerCrn(source.getDatabaseServerCrn());
         clusterResponse.setRangerRazEnabled(source.isRangerRazEnabled());
+        clusterResponse.setCertExpirationState(source.getCertExpirationState());
         return clusterResponse;
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/cluster/ClusterRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/cluster/ClusterRepository.java
@@ -8,9 +8,11 @@ import java.util.Set;
 import javax.transaction.Transactional;
 import javax.transaction.Transactional.TxType;
 
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.CertExpirationState;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
@@ -46,4 +48,8 @@ public interface ClusterRepository extends WorkspaceResourceRepository<Cluster, 
 
     @Query("SELECT COUNT(c) FROM Cluster c WHERE c.workspace.id = :workspaceId AND c.environmentCrn = :environmentCrn AND c.status != 'DELETE_COMPLETED'")
     Long countAliveOnesByWorkspaceAndEnvironment(@Param("workspaceId") Long workspaceId, @Param("environmentCrn") String environmentCrn);
+
+    @Modifying
+    @Query("UPDATE Cluster c SET c.certExpirationState = :state WHERE c.id = :id")
+    void updateCertExpirationState(@Param("id") Long id, @Param("state") CertExpirationState state);
 }

--- a/core/src/main/resources/schema/app/20201002104732_CB-9060_alter_cluster_add_CertExpirationState.sql
+++ b/core/src/main/resources/schema/app/20201002104732_CB-9060_alter_cluster_add_CertExpirationState.sql
@@ -1,0 +1,14 @@
+-- // CB-9060 alter cluster add CertExpirationState
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE cluster ADD COLUMN IF NOT EXISTS certexpirationstate VARCHAR(255);
+
+ALTER TABLE cluster ALTER COLUMN certexpirationstate SET DEFAULT 'VALID';
+
+UPDATE cluster SET certexpirationstate = 'VALID' WHERE certexpirationstate IS NULL;
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE cluster DROP COLUMN IF EXISTS certexpirationstate;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/stack/cluster/ClusterToClusterV4ResponseConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/stack/cluster/ClusterToClusterV4ResponseConverterTest.java
@@ -24,6 +24,7 @@ import org.springframework.core.convert.ConversionService;
 import com.google.common.collect.Lists;
 import com.sequenceiq.cloudbreak.TestUtil;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.blueprint.responses.BlueprintV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.CertExpirationState;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.ConfigStrategy;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.cluster.ClusterV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.cluster.gateway.topology.ClusterExposedServiceV4Response;
@@ -81,6 +82,7 @@ public class ClusterToClusterV4ResponseConverterTest extends AbstractEntityConve
         getSource().setBlueprint(new Blueprint());
         getSource().setExtendedBlueprintText("asdf");
         getSource().setFqdn("some.fqdn");
+        getSource().setCertExpirationState(CertExpirationState.HOST_CERT_EXPIRING);
         given(stackUtil.extractClusterManagerIp(any(Stack.class))).willReturn("10.0.0.1");
         given(stackUtil.extractClusterManagerAddress(any(Stack.class))).willReturn("some.fqdn");
         Cluster source = getSource();
@@ -97,6 +99,7 @@ public class ClusterToClusterV4ResponseConverterTest extends AbstractEntityConve
         // THEN
         assertEquals(1L, (long) result.getId());
         assertEquals(getSource().getExtendedBlueprintText(), result.getExtendedBlueprintText());
+        assertEquals(CertExpirationState.HOST_CERT_EXPIRING, result.getCertExpirationState());
 
         List<String> skippedFields = Lists.newArrayList("customContainers", "cm", "creationFinished", "cloudStorage", "gateway");
         assertAllFieldsNotNull(result, skippedFields);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusIntegrationTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusIntegrationTest.java
@@ -44,6 +44,7 @@ import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterStatusService;
 import com.sequenceiq.cloudbreak.cluster.status.ClusterStatus;
 import com.sequenceiq.cloudbreak.cluster.status.ClusterStatusResult;
+import com.sequenceiq.cloudbreak.cluster.status.ExtendedHostStatuses;
 import com.sequenceiq.cloudbreak.cluster.util.ResourceAttributeUtil;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
 import com.sequenceiq.cloudbreak.common.type.ClusterManagerState;
@@ -176,7 +177,7 @@ class StackStatusIntegrationTest {
         when(clusterApiConnectors.getConnector(stack)).thenReturn(clusterApi);
 
         hostStatuses = new HashMap<>();
-        when(clusterStatusService.getExtendedHostStatuses()).thenReturn(hostStatuses);
+        when(clusterStatusService.getExtendedHostStatuses()).thenReturn(new ExtendedHostStatuses(hostStatuses, false));
     }
 
     @Test
@@ -201,6 +202,7 @@ class StackStatusIntegrationTest {
         verify(flowManager, never()).triggerClusterRepairFlow(anyLong(), any(), anyBoolean(), anyBoolean());
         verify(instanceMetaDataService, never()).saveAll(any());
         verify(clusterService, never()).updateClusterStatusByStackId(any(), any(), any());
+        verify(clusterService).updateClusterCertExpirationState(stack.getCluster(), false);
 
         verify(instanceMetaDataService, never()).save(any());
         verify(stackUpdater, never()).updateStackStatus(eq(STACK_ID), any());
@@ -229,6 +231,7 @@ class StackStatusIntegrationTest {
         verify(flowManager, never()).triggerClusterRepairFlow(anyLong(), any(), anyBoolean(), anyBoolean());
         verify(instanceMetaDataService, never()).saveAll(any());
         verify(clusterService, never()).updateClusterStatusByStackId(any(), any(), any());
+        verify(clusterService).updateClusterCertExpirationState(stack.getCluster(), false);
 
         assertInstancesSavedWithStatuses(Map.of(INSTANCE_2, InstanceStatus.DELETED_BY_PROVIDER));
 
@@ -259,6 +262,7 @@ class StackStatusIntegrationTest {
         verify(flowManager, never()).triggerClusterRepairFlow(anyLong(), any(), anyBoolean(), anyBoolean());
         verify(instanceMetaDataService, never()).saveAll(any());
         verify(clusterService, never()).updateClusterStatusByStackId(any(), any(), any());
+        verify(clusterService).updateClusterCertExpirationState(stack.getCluster(), false);
 
         assertInstancesSavedWithStatuses(Map.of(
                 INSTANCE_1, InstanceStatus.DELETED_BY_PROVIDER,
@@ -290,6 +294,7 @@ class StackStatusIntegrationTest {
         verify(flowManager, never()).triggerClusterRepairFlow(anyLong(), any(), anyBoolean(), anyBoolean());
         verify(instanceMetaDataService, never()).saveAll(any());
         verify(clusterService, never()).updateClusterStatusByStackId(any(), any(), any());
+        verify(clusterService).updateClusterCertExpirationState(stack.getCluster(), false);
 
         assertInstancesSavedWithStatuses(Map.of(
                 INSTANCE_1, InstanceStatus.DELETED_BY_PROVIDER,

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ClusterServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ClusterServiceTest.java
@@ -1,0 +1,54 @@
+package com.sequenceiq.cloudbreak.service.cluster;
+
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.CertExpirationState.HOST_CERT_EXPIRING;
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.CertExpirationState.VALID;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.CertExpirationState;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.repository.cluster.ClusterRepository;
+
+@ExtendWith(MockitoExtension.class)
+class ClusterServiceTest {
+
+    @Mock
+    private ClusterRepository repository;
+
+    @InjectMocks
+    private ClusterService underTest;
+
+    static Object[][] updateClusterCertExpirationStateScenarios() {
+        return new Object[][]{
+                {"Change from valid to expiring", VALID, Boolean.TRUE, Boolean.TRUE, HOST_CERT_EXPIRING},
+                {"Change from expiring to valid", HOST_CERT_EXPIRING, Boolean.FALSE, Boolean.TRUE, VALID},
+                {"No change when valid", VALID, Boolean.FALSE, Boolean.FALSE, null},
+                {"No change when expiring", HOST_CERT_EXPIRING, Boolean.TRUE, Boolean.FALSE, null}
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("updateClusterCertExpirationStateScenarios")
+    public void testUpdateClusterCertExpirationState(String name, CertExpirationState current, Boolean hostCertificateExpiring, Boolean stateChanged,
+            CertExpirationState newState) {
+        Cluster cluster = new Cluster();
+        cluster.setId(1L);
+        cluster.setCertExpirationState(current);
+
+        underTest.updateClusterCertExpirationState(cluster, hostCertificateExpiring);
+
+        if (stateChanged) {
+            verify(repository, times(1)).updateCertExpirationState(cluster.getId(), newState);
+        } else {
+            verifyNoInteractions(repository);
+        }
+    }
+}


### PR DESCRIPTION
We are setting up clusters with autotls, which means every host has it's own certificate.
These certificates expiry every year and we must detect it and notify the customer before expiration date.
In this commit `StackStatusCheckerJob` has been enriched with checking the result from Cloudera Manager for
host certificate expiration related health info. Although these are not stored per host, they are aggregated
and if there is at least one which is expiring we are setting a new field in `Cluster` entity, `certExpirationState`
from `VALID` to `HOST_CERT_EXPIRING`.
This field is an enum to allow further expansion if we later would like to indicate eg CMCA expiration.
The value of this field is available on DistroX API in `ClusterV4Response` and on SDX API in `SdxClusterDetailResponse`.