### PR TITLE
CB-9130 Single RG is deleted when using new network

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/network/EnvironmentNetworkService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/EnvironmentNetworkService.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.environment.network;
 
 import static com.sequenceiq.environment.parameters.dao.domain.ResourceGroupUsagePattern.USE_MULTIPLE;
-import static com.sequenceiq.environment.parameters.dao.domain.ResourceGroupUsagePattern.USE_SINGLE;
 
 import java.util.Map;
 import java.util.Optional;
@@ -21,8 +20,8 @@ import com.sequenceiq.cloudbreak.cloud.model.network.CreatedCloudNetwork;
 import com.sequenceiq.cloudbreak.cloud.model.network.NetworkCreationRequest;
 import com.sequenceiq.cloudbreak.cloud.model.network.NetworkDeletionRequest;
 import com.sequenceiq.cloudbreak.cloud.network.NetworkCidr;
-import com.sequenceiq.cloudbreak.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.exception.BadRequestException;
 import com.sequenceiq.environment.credential.domain.Credential;
 import com.sequenceiq.environment.credential.v1.converter.CredentialToCloudCredentialConverter;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
@@ -121,7 +120,7 @@ public class EnvironmentNetworkService {
                 .map(AzureParametersDto::getAzureResourceGroupDto)
                 .map(AzureResourceGroupDto::getResourceGroupUsagePattern)
                 .orElse(USE_MULTIPLE);
-        return USE_SINGLE.equals(resourceGroupUsagePattern);
+        return resourceGroupUsagePattern.isSingleResourceGroup();
     }
 
     private Optional<NetworkConnector> getNetworkConnector(String cloudPlatform) {

--- a/environment/src/main/java/com/sequenceiq/environment/parameters/dao/domain/ResourceGroupUsagePattern.java
+++ b/environment/src/main/java/com/sequenceiq/environment/parameters/dao/domain/ResourceGroupUsagePattern.java
@@ -1,7 +1,11 @@
 package com.sequenceiq.environment.parameters.dao.domain;
 
 public enum ResourceGroupUsagePattern {
-    USE_SINGLE,
     USE_MULTIPLE,
-    USE_SINGLE_WITH_DEDICATED_STORAGE_ACCOUNT
+    USE_SINGLE,
+    USE_SINGLE_WITH_DEDICATED_STORAGE_ACCOUNT;
+
+    public boolean isSingleResourceGroup() {
+        return USE_SINGLE.equals(this) || USE_SINGLE_WITH_DEDICATED_STORAGE_ACCOUNT.equals(this);
+    }
 }

--- a/environment/src/test/java/com/sequenceiq/environment/parameters/dao/domain/ResourceGroupUsagePatternTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/parameters/dao/domain/ResourceGroupUsagePatternTest.java
@@ -1,0 +1,22 @@
+package com.sequenceiq.environment.parameters.dao.domain;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+public class ResourceGroupUsagePatternTest {
+
+    @ParameterizedTest
+    @EnumSource(value = ResourceGroupUsagePattern.class, names = {"USE_SINGLE", "USE_SINGLE_WITH_DEDICATED_STORAGE_ACCOUNT"})
+    void testIsSingleResourceGroupIsTrue(ResourceGroupUsagePattern resourceGroupUsagePattern) {
+        assertTrue(resourceGroupUsagePattern.isSingleResourceGroup());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ResourceGroupUsagePattern.class, names = {"USE_MULTIPLE"})
+    void testIsSingleResourceGroupIsFalse(ResourceGroupUsagePattern resourceGroupUsagePattern) {
+        assertFalse(resourceGroupUsagePattern.isSingleResourceGroup());
+    }
+}


### PR DESCRIPTION
On azure, when using single RG, then deleting the new network during environment deletion should delete the VNET resource but must not delete any resource groups (RG). With the recent introduction of resource group usage pattern USE_SINGLE_WITH_DEDICATED_STORAGE_ACCOUNT the check whether using a single RG or not was broken and was assumed that it is MULTIPLE, hence the single RG was deleted.

See detailed description in the commit message.