### PR TITLE
CB-8541 Cluster logs in AWS YCloud hybrid e2e test

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/stack/StackTestDtoBase.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/stack/StackTestDtoBase.java
@@ -45,6 +45,7 @@ import com.sequenceiq.it.cloudbreak.dto.SecurityGroupTestDto;
 import com.sequenceiq.it.cloudbreak.dto.StackAuthenticationTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
+import com.sequenceiq.it.cloudbreak.dto.telemetry.TelemetryTestDto;
 
 public abstract class StackTestDtoBase<T extends StackTestDtoBase<T>> extends AbstractCloudbreakTestDto<StackV4Request, StackV4Response, T> {
 
@@ -402,5 +403,11 @@ public abstract class StackTestDtoBase<T extends StackTestDtoBase<T>> extends Ab
     @Override
     public String getName() {
         return getRequest().getName();
+    }
+
+    public StackTestDtoBase<T> withTelemetry(String key) {
+        TelemetryTestDto telemetry = getTestContext().get(key);
+        getRequest().setTelemetry(telemetry.getRequest());
+        return this;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/hybrid/AwsYcloudHybridCloudTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/hybrid/AwsYcloudHybridCloudTest.java
@@ -171,6 +171,9 @@ public class AwsYcloudHybridCloudTest extends AbstractE2ETest {
                 .validate();
 
         testContext
+                .given("telemetry", TelemetryTestDto.class)
+                    .withLogging(CHILD_CLOUD_PLATFORM)
+                    .withReportClusterLogs()
                 .given(cmProduct, ClouderaManagerProductTestDto.class, CHILD_CLOUD_PLATFORM)
                     .withName(CDH)
                     .withVersion(cdhVersion.get())
@@ -187,6 +190,7 @@ public class AwsYcloudHybridCloudTest extends AbstractE2ETest {
                 .given(stack, StackTestDto.class, CHILD_CLOUD_PLATFORM).withCluster(cluster)
                     .withInstanceGroups(MASTER_INSTANCE_GROUP, IDBROKER_INSTANCE_GROUP)
                     .withStackAuthentication(STACK_AUTHENTICATION)
+                    .withTelemetry("telemetry")
                 .given(sdxInternal, SdxInternalTestDto.class, CHILD_CLOUD_PLATFORM)
                     .withStackRequest(key(cluster), key(stack))
                     .withEnvironmentKey(RunningParameter.key(CHILD_ENVIRONMENT_KEY))


### PR DESCRIPTION
E2E test uses the internal API to post the datalake request.
In this case, the cluster ogging feature needs to be enabled
in the request.