### PR TITLE
CB-9149. Splitting large (> 16K) JSON logs on CB level in order to av…

### DIFF
--- a/autoscale/src/main/resources/logback.xml
+++ b/autoscale/src/main/resources/logback.xml
@@ -7,7 +7,6 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
             <layout class="com.sequenceiq.cloudbreak.logger.MaskingPatternLayout">
-                <loggerNameFilter>com.sequenceiq</loggerNameFilter>
                 <pattern>%date{ISO8601} [%thread] %method:%line %-5level %logger{5} - [owner:%X{owner:-spring}] [id:%X{resourceId:-}] [cb-stack-id:%X{cbStack:-}] %msg%n</pattern>
             </layout>
         </encoder>
@@ -20,7 +19,6 @@
         </filter>
         <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
             <layout class="com.sequenceiq.cloudbreak.logger.MaskingPatternLayout">
-                <loggerNameFilter>com.sequenceiq</loggerNameFilter>
                 <pattern>%date{ISO8601} [%thread] %method:%line %-5level %logger{5} - [owner:%X{owner:-spring}] [id:%X{resourceId:-}] [cb-stack-id:%X{cbStack:-}] %msg%n</pattern>
             </layout>
         </encoder>

--- a/common/src/main/java/com/sequenceiq/cloudbreak/logger/LoggerConfiguration.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/logger/LoggerConfiguration.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.cloudbreak.logger;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class LoggerConfiguration {
+
+    private LoggerConfiguration() {
+    }
+
+    public static Boolean isJsonFormatEnabled() {
+        return Boolean.parseBoolean(getProperty("logger.format.json.enabled", null));
+    }
+
+    public static String getJsonFormatMdcName() {
+        return getProperty("logger.format.json.mdc.name", "context");
+    }
+
+    public static Integer getSplitterMaxChunLength() {
+        return Integer.parseInt(getProperty("logger.appender.splitter.max.chunk.length", "12000"));
+    }
+
+    private static String getProperty(String property, String defaultValue) {
+        String envProperty = property.toUpperCase().replace(".", "_");
+        if (StringUtils.isNotEmpty(System.getenv(envProperty))) {
+            return System.getenv(envProperty);
+        } else if (StringUtils.isNotEmpty(System.getProperty(property))) {
+            return System.getProperty(property);
+        }
+        return defaultValue;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/logger/MaskingPatternLayout.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/logger/MaskingPatternLayout.java
@@ -9,22 +9,10 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 
 public class MaskingPatternLayout extends PatternLayout {
 
-    private String loggerNameFilter;
-
     private final LayoutFormat layoutFormat = LayoutFormatFactory.getLayoutFormat();
-
-    public String getLoggerNameFilter() {
-        return loggerNameFilter;
-    }
-
-    public void setLoggerNameFilter(String loggerNameFilter) {
-        if (loggerNameFilter != null) {
-            this.loggerNameFilter = loggerNameFilter.trim();
-        }
-    }
 
     @Override
     public String doLayout(ILoggingEvent event) {
-        return layoutFormat.format(event, super.doLayout(event), loggerNameFilter);
+        return layoutFormat.format(event, super.doLayout(event));
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/logger/PartialMessageMetadata.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/logger/PartialMessageMetadata.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.cloudbreak.logger;
+
+public class PartialMessageMetadata {
+
+    private final String partialId;
+
+    private final String partialOrdinal;
+
+    private final String partialLast;
+
+    public PartialMessageMetadata(String partialId, Integer partialOrdinal, Boolean partialLast) {
+        this.partialId = partialId;
+        this.partialOrdinal = String.valueOf(partialOrdinal);
+        this.partialLast = String.valueOf(partialLast);
+    }
+
+    public String getPartialId() {
+        return partialId;
+    }
+
+    public String getPartialOrdinal() {
+        return partialOrdinal;
+    }
+
+    public String getPartialLast() {
+        return partialLast;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/logger/format/CustomJsonLayout.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/logger/format/CustomJsonLayout.java
@@ -1,7 +1,13 @@
 package com.sequenceiq.cloudbreak.logger.format;
 
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.google.common.base.Splitter;
+import com.sequenceiq.cloudbreak.logger.PartialMessageMetadata;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.contrib.json.classic.JsonLayout;
@@ -9,21 +15,53 @@ import ch.qos.logback.core.CoreConstants;
 
 public class CustomJsonLayout extends JsonLayout {
 
+    private static final String PARTIAL_MESSAGE_FIELD = "partial_message";
+
+    private static final String PARTIAL_CHUNK_ID_FIELD = "partial_id";
+
+    private static final String PARTIAL_CHUNK_INDEX_FIELD = "partial_ordinal";
+
+    private static final String PARTIAL_LAST_FIELD = "partial_last";
+
+    private static final String PARTIAL_MESSAGE_FLAG = "true";
+
     private final String contextName;
 
-    CustomJsonLayout(String contextName) {
+    private final Integer maxChunkLength;
+
+    private final Splitter splitter;
+
+    CustomJsonLayout(String contextName, Integer maxChunkLength) {
         this.contextName = contextName;
+        this.maxChunkLength = maxChunkLength;
+        this.splitter = Splitter.fixedLength(this.maxChunkLength);
     }
 
-    public String doLayout(ILoggingEvent event, String fullLogMessage, String loggerNameFilter) {
-        Map map = toJsonMap(event, fullLogMessage, loggerNameFilter);
-        if (map == null || map.isEmpty()) {
+    public String doLayout(ILoggingEvent event, String fullLogMessage) {
+        if (StringUtils.length(fullLogMessage) > maxChunkLength) {
+            StringBuilder stringBuilder = new StringBuilder();
+            String chunkId = Integer.toHexString(event.hashCode());
+            Iterable<String> messages = splitter.split(fullLogMessage);
+            Iterator<String> messageIterator = messages.iterator();
+            for (int currentIndex = 0; messageIterator.hasNext(); currentIndex++) {
+                String message = messageIterator.next();
+                PartialMessageMetadata partialMessageMetadata = new PartialMessageMetadata(chunkId, currentIndex, !messageIterator.hasNext());
+                stringBuilder.append(toJsonRecordString(toJsonMap(event, message, partialMessageMetadata)));
+            }
+            return stringBuilder.toString();
+        } else {
+            return toJsonRecordString(toJsonMap(event, fullLogMessage, null));
+        }
+    }
+
+    private String toJsonRecordString(Map<String, Object> map) {
+        if (map.isEmpty()) {
             return null;
         }
         return toJsonString(map) + CoreConstants.LINE_SEPARATOR;
     }
 
-    private Map toJsonMap(ILoggingEvent event, String fullLogMessage, String loggerNameFilter) {
+    private Map<String, Object> toJsonMap(ILoggingEvent event, String fullLogMessage, PartialMessageMetadata partialMessageMetadata) {
         Map<String, Object> map = new LinkedHashMap<>();
         addTimestamp(TIMESTAMP_ATTR_NAME, this.includeTimestamp, event.getTimeStamp(), map);
         add(LEVEL_ATTR_NAME, this.includeLevel, String.valueOf(event.getLevel()), map);
@@ -32,11 +70,17 @@ public class CustomJsonLayout extends JsonLayout {
         if (event.getMDCPropertyMap() != null && !event.getMDCPropertyMap().isEmpty()) {
             map.put(contextName, event.getMDCPropertyMap());
         }
+        if (partialMessageMetadata != null) {
+            add(PARTIAL_CHUNK_ID_FIELD, true, partialMessageMetadata.getPartialId(), map);
+            add(PARTIAL_CHUNK_INDEX_FIELD, true, partialMessageMetadata.getPartialOrdinal(), map);
+            add(PARTIAL_MESSAGE_FIELD, true, PARTIAL_MESSAGE_FLAG, map);
+            add(PARTIAL_LAST_FIELD, true, partialMessageMetadata.getPartialLast(), map);
+        }
         add(FORMATTED_MESSAGE_ATTR_NAME, true, fullLogMessage, map);
         return map;
     }
 
-    private String toJsonString(Map map) {
+    private String toJsonString(Map<String, Object> map) {
         try {
             return getJsonFormatter().toJsonString(map);
         } catch (Exception e) {

--- a/common/src/main/java/com/sequenceiq/cloudbreak/logger/format/JsonLayoutFormat.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/logger/format/JsonLayoutFormat.java
@@ -10,8 +10,8 @@ public class JsonLayoutFormat extends SimpleLayoutFormat {
 
     private final CustomJsonLayout jsonLayout;
 
-    JsonLayoutFormat(String contextName) {
-        this.jsonLayout = new CustomJsonLayout(contextName);
+    JsonLayoutFormat(String contextName, Integer maxChunkLength) {
+        jsonLayout = new CustomJsonLayout(contextName, maxChunkLength);
         jsonLayout.setIncludeMessage(true);
         jsonLayout.setAppendLineSeparator(true);
         jsonLayout.setJsonFormatter(m -> new ObjectMapper().writeValueAsString(m));
@@ -19,8 +19,8 @@ public class JsonLayoutFormat extends SimpleLayoutFormat {
     }
 
     @Override
-    public String format(ILoggingEvent event, String message, String loggerNameFilter) {
-        String filteredLogMessage = super.format(event, message, loggerNameFilter);
-        return jsonLayout.doLayout(event, filteredLogMessage, loggerNameFilter);
+    public String format(ILoggingEvent event, String message) {
+        String filteredLogMessage = super.format(event, message);
+        return jsonLayout.doLayout(event, filteredLogMessage);
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/logger/format/LayoutFormat.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/logger/format/LayoutFormat.java
@@ -3,5 +3,5 @@ package com.sequenceiq.cloudbreak.logger.format;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 
 public interface LayoutFormat {
-    String format(ILoggingEvent event, String message, String loggerNameFilter);
+    String format(ILoggingEvent event, String message);
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/logger/format/LayoutFormatFactory.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/logger/format/LayoutFormatFactory.java
@@ -1,6 +1,6 @@
 package com.sequenceiq.cloudbreak.logger.format;
 
-import org.apache.commons.lang3.StringUtils;
+import com.sequenceiq.cloudbreak.logger.LoggerConfiguration;
 
 public class LayoutFormatFactory {
 
@@ -8,22 +8,9 @@ public class LayoutFormatFactory {
     }
 
     public static LayoutFormat getLayoutFormat() {
-        final String property = getProperty("logger.format.json.enabled", null);
-        if (Boolean.parseBoolean(property)) {
-            final String mdcContextName = getProperty(
-                    "logger.format.json.mdc.name", "context");
-            return new JsonLayoutFormat(mdcContextName);
+        if (LoggerConfiguration.isJsonFormatEnabled()) {
+            return new JsonLayoutFormat(LoggerConfiguration.getJsonFormatMdcName(), LoggerConfiguration.getSplitterMaxChunLength());
         }
         return new SimpleLayoutFormat();
-    }
-
-    private static String getProperty(String property, String defaultValue) {
-        String envProperty = property.toUpperCase().replace(".", "_");
-        if (StringUtils.isNotEmpty(System.getenv(envProperty))) {
-            return System.getenv(envProperty);
-        } else if (StringUtils.isNotEmpty(System.getProperty(property))) {
-            return System.getProperty(property);
-        }
-        return defaultValue;
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/logger/format/SimpleLayoutFormat.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/logger/format/SimpleLayoutFormat.java
@@ -5,7 +5,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 public class SimpleLayoutFormat implements LayoutFormat {
 
     @Override
-    public String format(ILoggingEvent event, String message, String loggerNameFilter) {
+    public String format(ILoggingEvent event, String message) {
         return message;
     }
 }

--- a/common/src/test/java/com/sequenceiq/cloudbreak/logger/format/CustomJsonLayoutTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/logger/format/CustomJsonLayoutTest.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.cloudbreak.logger.format;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import ch.qos.logback.classic.spi.LoggingEvent;
+
+public class CustomJsonLayoutTest {
+
+    private CustomJsonLayout underTest;
+
+    @Before
+    public void setUp() {
+        underTest = new CustomJsonLayout("context", 10);
+    }
+
+    @Test
+    public void testLogIsSplitted() {
+        LoggingEvent loggingEvent = new LoggingEvent();
+        String result = underTest.doLayout(loggingEvent, "LONG MESSAGE");
+        assertTrue(result.contains("partial_message=true"));
+    }
+
+    @Test
+    public void testLogIsNotSplitted() {
+        LoggingEvent loggingEvent = new LoggingEvent();
+        String result = underTest.doLayout(loggingEvent, "MESSAGE");
+        assertFalse(result.contains("partial_message=true"));
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/logger/MaskingPatternLayout.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/logger/MaskingPatternLayout.java
@@ -8,22 +8,10 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 
 public class MaskingPatternLayout extends PatternLayout {
 
-    private String loggerNameFilter;
-
     private final LayoutFormat layoutFormat = LayoutFormatFactory.getLayoutFormat();
-
-    public String getLoggerNameFilter() {
-        return loggerNameFilter;
-    }
-
-    public void setLoggerNameFilter(String loggerNameFilter) {
-        if (loggerNameFilter != null) {
-            this.loggerNameFilter = loggerNameFilter.trim();
-        }
-    }
 
     @Override
     public String doLayout(ILoggingEvent event) {
-        return layoutFormat.format(event, super.doLayout(event), loggerNameFilter);
+        return layoutFormat.format(event, super.doLayout(event));
     }
 }

--- a/core/src/main/resources/logback.xml
+++ b/core/src/main/resources/logback.xml
@@ -11,7 +11,6 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
             <layout class="com.sequenceiq.cloudbreak.logger.MaskingPatternLayout">
-                <loggerNameFilter>com.sequenceiq</loggerNameFilter>
                 <pattern>%date{ISO8601} [%thread] %method:%line %-5level %logger{5} - [type:%X{resourceType:-springLog}] [crn:%X{resourceCrn:-}] [name:%X{resourceName:-}] [flow:%X{flowId:-}] [requestid:%X{requestId:-}] [tenant:%X{tenant:-}] [userCrn:%X{userCrn:-}] [environment:%X{environmentCrn:-}] [traceId:%X{traceId:-}] [spanId:%X{spanId:-}] %msg%n</pattern>
             </layout>
         </encoder>
@@ -24,7 +23,6 @@
         </filter>
         <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
             <layout class="com.sequenceiq.cloudbreak.logger.MaskingPatternLayout">
-                <loggerNameFilter>com.sequenceiq</loggerNameFilter>
                 <pattern>%date{ISO8601} [%thread] %method:%line %-5level %logger{5} - [type:%X{resourceType:-springLog}] [crn:%X{resourceCrn:-}] [name:%X{resourceName:-}] [flow:%X{flowId:-}] [requestid:%X{requestId:-}] [tenant:%X{tenant:-}] [userCrn:%X{userCrn:-}] [environment:%X{environmentCrn:-}] [traceId:%X{traceId:-}] [spanId:%X{spanId:-}] %msg%n</pattern>
             </layout>
         </encoder>

--- a/datalake/src/main/resources/logback.xml
+++ b/datalake/src/main/resources/logback.xml
@@ -8,7 +8,6 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
             <layout class="com.sequenceiq.cloudbreak.logger.MaskingPatternLayout">
-                <loggerNameFilter>com.sequenceiq</loggerNameFilter>
                 <pattern>%date{ISO8601} [%thread] %method:%line %-5level %logger{5} - [type:%X{resourceType:-springLog}] [crn:%X{resourceCrn:-}] [name:%X{resourceName:-}] [flow:%X{flowId:-}] [requestid:%X{requestId:-}] [tenant:%X{tenant:-}] [userCrn:%X{userCrn:-}] [environment:%X{environmentCrn:-}] [traceId:%X{traceId:-}] [spanId:%X{spanId:-}] %msg%n</pattern>
             </layout>
         </encoder>
@@ -22,7 +21,6 @@
         </filter>
         <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
             <layout class="com.sequenceiq.cloudbreak.logger.MaskingPatternLayout">
-                <loggerNameFilter>com.sequenceiq</loggerNameFilter>
                 <pattern>%date{ISO8601} [%thread] %method:%line %-5level %logger{5} - [type:%X{resourceType:-springLog}] [crn:%X{resourceCrn:-}] [name:%X{resourceName:-}] [flow:%X{flowId:-}] [requestid:%X{requestId:-}] [tenant:%X{tenant:-}] [userCrn:%X{userCrn:-}] [environment:%X{environmentCrn:-}] [traceId:%X{traceId:-}] [spanId:%X{spanId:-}] %msg%n</pattern>
             </layout>
         </encoder>

--- a/environment/src/main/resources/logback.xml
+++ b/environment/src/main/resources/logback.xml
@@ -11,7 +11,6 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
             <layout class="com.sequenceiq.cloudbreak.logger.MaskingPatternLayout">
-                <loggerNameFilter>com.sequenceiq</loggerNameFilter>
                 <pattern>%date{ISO8601} [%thread] %method:%line %-5level %logger{5} - [type:%X{resourceType:-springLog}] [crn:%X{resourceCrn:-}] [name:%X{resourceName:-}] [flow:%X{flowId:-}] [requestid:%X{requestId:-}] [tenant:%X{tenant:-}] [userCrn:%X{userCrn:-}] [environment:%X{environmentCrn:-}] [traceId:%X{traceId:-}] [spanId:%X{spanId:-}] %msg%n</pattern>
             </layout>
         </encoder>
@@ -24,7 +23,6 @@
         </filter>
         <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
             <layout class="com.sequenceiq.cloudbreak.logger.MaskingPatternLayout">
-                <loggerNameFilter>com.sequenceiq</loggerNameFilter>
                 <pattern>%date{ISO8601} [%thread] %method:%line %-5level %logger{5} - [type:%X{resourceType:-springLog}] [crn:%X{resourceCrn:-}] [name:%X{resourceName:-}] [flow:%X{flowId:-}] [requestid:%X{requestId:-}] [tenant:%X{tenant:-}] [userCrn:%X{userCrn:-}] [environment:%X{environmentCrn:-}] [traceId:%X{traceId:-}] [spanId:%X{spanId:-}] %msg%n</pattern>
             </layout>
         </encoder>

--- a/freeipa/src/main/resources/logback.xml
+++ b/freeipa/src/main/resources/logback.xml
@@ -11,7 +11,6 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
             <layout class="com.sequenceiq.cloudbreak.logger.MaskingPatternLayout">
-                <loggerNameFilter>com.sequenceiq</loggerNameFilter>
                 <pattern>%date{ISO8601} [%thread] %method:%line %-5level %logger{5} - [type:%X{resourceType:-springLog}] [crn:%X{resourceCrn:-}] [name:%X{resourceName:-}] [flow:%X{flowId:-}] [requestid:%X{requestId:-}] [tenant:%X{tenant:-}] [userCrn:%X{userCrn:-}] [environment:%X{environmentCrn:-}] [traceId:%X{traceId:-}] [spanId:%X{spanId:-}] [operationId:%X{operationId:-}] %msg%n</pattern>
             </layout>
         </encoder>
@@ -24,7 +23,6 @@
         </filter>
         <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
             <layout class="com.sequenceiq.cloudbreak.logger.MaskingPatternLayout">
-                <loggerNameFilter>com.sequenceiq</loggerNameFilter>
                 <pattern>%date{ISO8601} [%thread] %method:%line %-5level %logger{5} - [type:%X{resourceType:-springLog}] [crn:%X{resourceCrn:-}] [name:%X{resourceName:-}] [flow:%X{flowId:-}] [requestid:%X{requestId:-}] [tenant:%X{tenant:-}] [userCrn:%X{userCrn:-}] [environment:%X{environmentCrn:-}] [traceId:%X{traceId:-}] [spanId:%X{spanId:-}] [operationId:%X{operationId:-}] %msg%n</pattern>
             </layout>
         </encoder>

--- a/redbeams/src/main/resources/logback.xml
+++ b/redbeams/src/main/resources/logback.xml
@@ -11,7 +11,6 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
             <layout class="com.sequenceiq.cloudbreak.logger.MaskingPatternLayout">
-                <loggerNameFilter>com.sequenceiq</loggerNameFilter>
                 <pattern>%date{ISO8601} [%thread] %method:%line %-5level %logger{5} - [type:%X{resourceType:-springLog}] [crn:%X{resourceCrn:-}] [name:%X{resourceName:-}] [flow:%X{flowId:-}] [requestid:%X{requestId:-}] [tenant:%X{tenant:-}] [userCrn:%X{userCrn:-}] [environment:%X{environmentCrn:-}] [traceId:%X{traceId:-}] [spanId:%X{spanId:-}] %msg%n</pattern>
             </layout>
         </encoder>
@@ -24,7 +23,6 @@
         </filter>        
         <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
             <layout class="com.sequenceiq.cloudbreak.logger.MaskingPatternLayout">
-                <loggerNameFilter>com.sequenceiq</loggerNameFilter>
                 <pattern>%date{ISO8601} [%thread] %method:%line %-5level %logger{5} - [type:%X{resourceType:-springLog}] [crn:%X{resourceCrn:-}] [name:%X{resourceName:-}] [flow:%X{flowId:-}] [requestid:%X{requestId:-}] [tenant:%X{tenant:-}] [userCrn:%X{userCrn:-}] [environment:%X{environmentCrn:-}] [traceId:%X{traceId:-}] [spanId:%X{spanId:-}] %msg%n</pattern>
             </layout>
         </encoder>


### PR DESCRIPTION
…oid log rotation related issues by docker logging driver on K8s

details:
- in order to avoid large messages use a 12K max message length for JSON based logging (12K can be safe as we have many other fields, not only message)
- split message into chunks based on the max chunk length
- add partial metadata about the chunks, that can be handled by fluentd
- using the same field names for partial metadata that is used by docker fluentd logging driver: partial_message, partial_id, partial_ordinal and partial_last
- refactor: removed loggerFilterName from masking pattern layout

See detailed description in the commit message.

additional info:
fluent logger for docker: https://github.com/moby/moby/blob/master/daemon/logger/fluentd/fluentd.go#L116
all the keys are deleted by fluent-conat plugin if the events are merged, see:  https://github.com/fluent-plugins-nursery/fluent-plugin-concat/blob/master/lib/fluent/plugin/filter_concat.rb#L149
if this is deployed, it will split json logs, so until fluent-concat plugin config is not updated, the logs will be in splitted in kibana (!! but you can find those based on the component names)
