### PR TITLE
CB-9162 we are using the workspace 0 from application code

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/UtilV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/UtilV4Controller.java
@@ -83,7 +83,7 @@ public class UtilV4Controller extends NotificationController implements UtilV4En
 
     @Override
     public StackMatrixV4Response getStackMatrix(String imageCatalogName, String platform) throws Exception {
-        return stackMatrixService.getStackMatrix(0L, platform, imageCatalogName);
+        return stackMatrixService.getStackMatrix(restRequestThreadLocalService.getRequestedWorkspaceId(), platform, imageCatalogName);
     }
 
     @Override


### PR DESCRIPTION
UI sends in the request without workspace id, but the translation only happens via a Filter which can't be invoked in this case.


Verified locally with curl call to that endpoint.