### PR TITLE
CB-9103 move renew certificate endpoint to datalake and distrox endpoint

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
@@ -77,6 +77,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.upgrade.Upgrade
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.upgrade.UpgradeV4Response;
 import com.sequenceiq.cloudbreak.auth.security.internal.AccountId;
 import com.sequenceiq.cloudbreak.doc.Notes;
+import com.sequenceiq.cloudbreak.doc.OperationDescriptions;
 import com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescription;
 import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
@@ -410,5 +411,13 @@ public interface StackV4Endpoint {
     @ApiOperation(value = DATABASE_RESTORE_INTERNAL, nickname = "databaseRestoreInternal")
     RestoreV4Response restoreDatabaseByNameInternal(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name,
             @QueryParam("backupLocation") String backupLocation, @QueryParam("backupId") String backupId,
+            @QueryParam("initiatorUserCrn") String initiatorUserCrn);
+
+    @POST
+    @Path("internal/{name}/renew_certificate")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = OperationDescriptions.StackOpDescription.RENEW_CERTIFICATE, produces = MediaType.APPLICATION_JSON,
+            notes = Notes.RENEW_CERTIFICATE_NOTES, nickname = "renewStackCertificate")
+    FlowIdentifier renewCertificate(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name,
             @QueryParam("initiatorUserCrn") String initiatorUserCrn);
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
@@ -57,6 +57,7 @@ public class OperationDescriptions {
         public static final String DATABASE_BACKUP_INTERNAL = "Performs a backup of the database to a provided location, internal only";
         public static final String DATABASE_RESTORE = "Performs a restore of the database from a provided location";
         public static final String DATABASE_RESTORE_INTERNAL = "Performs a restore of the database from a provided location, internal only";
+        public static final String RENEW_CERTIFICATE = "Trigger a certificate renewal on the desired cluster which is identified via stack's name";
     }
 
     public static class ClusterOpDescription {

--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/doc/DistroXOpDescription.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/doc/DistroXOpDescription.java
@@ -39,6 +39,7 @@ public class DistroXOpDescription {
     public static final String CHECK_IMAGE = "checks image in stack by name";
     public static final String GENERATE_HOSTS_INVENTORY = "Generate hosts inventory";
     public static final String CLI_COMMAND = "produce cli command input";
+    public static final String RENEW_CERTIFICATE = "Trigger a certificate renewal on the desired cluster which is identified via crn";
 
     private DistroXOpDescription() {
     }

--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/endpoint/DistroXV1Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/endpoint/DistroXV1Endpoint.java
@@ -20,6 +20,7 @@ import static com.sequenceiq.distrox.api.v1.distrox.doc.DistroXOpDescription.GET
 import static com.sequenceiq.distrox.api.v1.distrox.doc.DistroXOpDescription.GET_STATUS_BY_NAME;
 import static com.sequenceiq.distrox.api.v1.distrox.doc.DistroXOpDescription.LIST;
 import static com.sequenceiq.distrox.api.v1.distrox.doc.DistroXOpDescription.POST_STACK_FOR_BLUEPRINT;
+import static com.sequenceiq.distrox.api.v1.distrox.doc.DistroXOpDescription.RENEW_CERTIFICATE;
 import static com.sequenceiq.distrox.api.v1.distrox.doc.DistroXOpDescription.REPAIR_CLUSTER_BY_CRN;
 import static com.sequenceiq.distrox.api.v1.distrox.doc.DistroXOpDescription.REPAIR_CLUSTER_BY_NAME;
 import static com.sequenceiq.distrox.api.v1.distrox.doc.DistroXOpDescription.RETRY_BY_CRN;
@@ -351,4 +352,11 @@ public interface DistroXV1Endpoint {
     @ApiOperation(value = DiagnosticsOperationDescriptions.GET_CM_ROLES, produces = MediaType.APPLICATION_JSON,
             nickname = "getDistroxCmRoles")
     List<String> getCmRoles(@PathParam("stackCrn") String stackCrn);
+
+    @POST
+    @Path("crn/{crn}/renew_certificate")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = RENEW_CERTIFICATE, produces = MediaType.APPLICATION_JSON, notes = Notes.RENEW_CERTIFICATE_NOTES,
+            nickname = "renewDistroXCertificate")
+    FlowIdentifier renewCertificate(@PathParam("crn") String crn);
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
@@ -42,6 +42,7 @@ import com.sequenceiq.cloudbreak.auth.security.internal.InitiatorUserCrn;
 import com.sequenceiq.cloudbreak.auth.security.internal.TenantAwareParam;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.service.stack.flow.StackOperationService;
 import com.sequenceiq.cloudbreak.structuredevent.CloudbreakRestRequestThreadLocalService;
 import com.sequenceiq.cloudbreak.workspace.controller.WorkspaceEntityType;
 import com.sequenceiq.distrox.v1.distrox.StackOperations;
@@ -54,6 +55,9 @@ public class StackV4Controller extends NotificationController implements StackV4
 
     @Inject
     private StackOperations stackOperations;
+
+    @Inject
+    private StackOperationService stackOperationService;
 
     @Inject
     private CloudbreakRestRequestThreadLocalService restRequestThreadLocalService;
@@ -344,5 +348,11 @@ public class StackV4Controller extends NotificationController implements StackV4
         FlowIdentifier flowIdentifier = stackOperations.restoreClusterDatabase(NameOrCrn.ofName(name),
                 restRequestThreadLocalService.getRequestedWorkspaceId(), backupLocation, backupId);
         return new RestoreV4Response(flowIdentifier);
+    }
+
+    @Override
+    @InternalOnly
+    public FlowIdentifier renewCertificate(Long workspaceId, String name, @InitiatorUserCrn String initiatorUserCrn) {
+        return stackOperationService.renewCertificate(name);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/UtilV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/UtilV4Controller.java
@@ -8,7 +8,10 @@ import javax.ws.rs.core.Response;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 
+import com.sequenceiq.authorization.annotation.AuthorizationResource;
+import com.sequenceiq.authorization.annotation.CheckPermissionByAccount;
 import com.sequenceiq.authorization.annotation.DisableCheckPermissions;
+import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.UtilV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.requests.CheckResourceRightsV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.requests.CheckRightV4Request;
@@ -40,7 +43,7 @@ import com.sequenceiq.common.api.util.versionchecker.ClientVersionUtil;
 import com.sequenceiq.common.api.util.versionchecker.VersionCheckResult;
 
 @Controller
-@DisableCheckPermissions
+@AuthorizationResource
 public class UtilV4Controller extends NotificationController implements UtilV4Endpoint {
 
     @Inject
@@ -77,31 +80,37 @@ public class UtilV4Controller extends NotificationController implements UtilV4En
     private String cbVersion;
 
     @Override
+    @DisableCheckPermissions
     public VersionCheckResult checkClientVersion(String version) {
         return ClientVersionUtil.checkClientVersion(cbVersion, version);
     }
 
     @Override
+    @DisableCheckPermissions
     public StackMatrixV4Response getStackMatrix(String imageCatalogName, String platform) throws Exception {
         return stackMatrixService.getStackMatrix(restRequestThreadLocalService.getRequestedWorkspaceId(), platform, imageCatalogName);
     }
 
     @Override
+    @DisableCheckPermissions
     public CloudStorageSupportedV4Responses getCloudStorageMatrix(String stackVersion) {
         return new CloudStorageSupportedV4Responses(fileSystemSupportMatrixService.getCloudStorageMatrix(stackVersion));
     }
 
     @Override
+    @DisableCheckPermissions
     public RepoConfigValidationV4Response repositoryConfigValidationRequest(RepoConfigValidationV4Request repoConfigValidationV4Request) {
         return validationService.validate(repoConfigValidationV4Request);
     }
 
     @Override
+    @DisableCheckPermissions
     public SecurityRulesV4Response getDefaultSecurityRules() {
         return securityRuleService.getDefaultSecurityRules();
     }
 
     @Override
+    @DisableCheckPermissions
     public DeploymentPreferencesV4Response deployment() {
         DeploymentPreferencesV4Response response = new DeploymentPreferencesV4Response();
         response.setFeatureSwitchV4s(preferencesService.getFeatureSwitches());
@@ -114,6 +123,7 @@ public class UtilV4Controller extends NotificationController implements UtilV4En
     }
 
     @Override
+    @DisableCheckPermissions
     public ResourceEventResponse postNotificationTest() {
         CloudbreakUser cloudbreakUser = restRequestThreadLocalService.getCloudbreakUser();
         notificationSender.sendTestNotification(cloudbreakUser.getUserId());
@@ -123,16 +133,19 @@ public class UtilV4Controller extends NotificationController implements UtilV4En
     }
 
     @Override
+    @DisableCheckPermissions
     public CheckRightV4Response checkRightInAccount(CheckRightV4Request checkRightV4Request) {
         return utilAuthorizationService.getRightResult(checkRightV4Request);
     }
 
     @Override
+    @DisableCheckPermissions
     public CheckResourceRightsV4Response checkRightByCrn(CheckResourceRightsV4Request checkResourceRightsV4Request) {
         return utilAuthorizationService.getResourceRightsResult(checkResourceRightsV4Request);
     }
 
     @Override
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.POWERUSER_ONLY)
     public Response renewCertificate(RenewCertificateV4Request renewCertificateV4Request) {
         stackOperationService.renewCertificate(renewCertificateV4Request.getStackName());
         return Response.ok().build();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
@@ -245,9 +245,9 @@ public class ReactorFlowManager {
         return reactorNotifier.notify(stackId, selector, new MaintenanceModeValidationTriggerEvent(selector, stackId));
     }
 
-    public void triggerClusterCertificationRenewal(Long stackId) {
+    public FlowIdentifier triggerClusterCertificationRenewal(Long stackId) {
         String selector = CLUSTER_CERTIFICATE_REISSUE_EVENT.event();
-        reactorNotifier.notify(stackId, selector, new StackEvent(selector, stackId));
+        return reactorNotifier.notify(stackId, selector, new StackEvent(selector, stackId));
     }
 
     public void triggerClusterTermination(Stack stack, boolean forced, String userCrn) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
@@ -246,10 +246,14 @@ public class StackOperationService {
         return flowIdentifier;
     }
 
-    public void renewCertificate(String stackName) {
+    public FlowIdentifier renewCertificate(String stackName) {
         Workspace workspace = workspaceService.getForCurrentUser();
         Stack stack = stackService.getByNameInWorkspace(stackName, workspace.getId());
-        flowManager.triggerClusterCertificationRenewal(stack.getId());
+        return renewCertificate(stack);
+    }
+
+    public FlowIdentifier renewCertificate(Stack stack) {
+        return flowManager.triggerClusterCertificationRenewal(stack.getId());
     }
 
     private boolean isStopNeeded(Stack stack) {

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXV1Controller.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXV1Controller.java
@@ -42,9 +42,11 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Responses;
 import com.sequenceiq.cloudbreak.auth.security.internal.TenantAwareParam;
 import com.sequenceiq.cloudbreak.core.flow2.service.DiagnosticsTriggerService;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.retry.RetryableFlow;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterDiagnosticsService;
+import com.sequenceiq.cloudbreak.service.stack.flow.StackOperationService;
 import com.sequenceiq.cloudbreak.service.workspace.WorkspaceService;
 import com.sequenceiq.cloudbreak.structuredevent.CloudbreakRestRequestThreadLocalService;
 import com.sequenceiq.cloudbreak.telemetry.VmLogsService;
@@ -108,6 +110,9 @@ public class DistroXV1Controller implements DistroXV1Endpoint {
 
     @Inject
     private ClusterDiagnosticsService clusterDiagnosticsService;
+
+    @Inject
+    private StackOperationService stackOperationService;
 
     @Override
     @DisableCheckPermissions
@@ -462,6 +467,13 @@ public class DistroXV1Controller implements DistroXV1Endpoint {
     @DisableCheckPermissions
     public List<String> getCmRoles(String stackCrn) {
         return clusterDiagnosticsService.getClusterComponents(stackCrn);
+    }
+
+    @Override
+    @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.REPAIR_DATAHUB)
+    public FlowIdentifier renewCertificate(@ResourceCrn String crn) {
+        Stack stack = stackOperations.getStackByCrn(crn);
+        return stackOperationService.renewCertificate(stack);
     }
 
     private Object getCreateAWSClusterRequest(StackV4Request stackV4Request) {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxEndpoint.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxEndpoint.java
@@ -113,6 +113,12 @@ public interface SdxEndpoint {
     FlowIdentifier repairClusterByCrn(@PathParam("crn") String crn, SdxRepairRequest clusterRepairRequest);
 
     @POST
+    @Path("/crn/{crn}/renew_certificate")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "renew certificate on SDX cluster by crn", nickname = "renewCertificateOnSdxByCrn")
+    void renewCertificate(@PathParam("crn") String crn);
+
+    @POST
     @Path("{name}/sync")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "sync SDX cluster by name", produces = MediaType.APPLICATION_JSON, nickname = "syncSdx")

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
@@ -183,6 +183,14 @@ public class SdxController implements SdxEndpoint {
     }
 
     @Override
+    @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.REPAIR_DATALAKE)
+    public void renewCertificate(@ResourceCrn String crn) {
+        String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
+        SdxCluster sdxCluster = sdxService.getByCrn(userCrn, crn);
+        sdxService.renewCertificate(sdxCluster, userCrn);
+    }
+
+    @Override
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.SYNC_DATALAKE)
     public void sync(@ResourceName String name) {
         sdxService.sync(name, ThreadBasedUserCrnProvider.getAccountId());

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -725,4 +725,8 @@ public class SdxService implements ResourceIdProvider, ResourceBasedCrnProvider 
     public SdxCluster save(SdxCluster sdxCluster) {
         return sdxClusterRepository.save(sdxCluster);
     }
+
+    public void renewCertificate(SdxCluster sdxCluster, String userCrn) {
+        stackV4Endpoint.renewCertificate(0L, sdxCluster.getClusterName(), userCrn);
+    }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/RenewDatalakeCertificateAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/RenewDatalakeCertificateAction.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.it.cloudbreak.action.v4.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.SdxClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.util.RenewDatalakeCertificateTestDto;
+
+public class RenewDatalakeCertificateAction implements Action<RenewDatalakeCertificateTestDto, SdxClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RenewDatalakeCertificateAction.class);
+
+    @Override
+    public RenewDatalakeCertificateTestDto action(TestContext testContext, RenewDatalakeCertificateTestDto renewCertificateTestDto, SdxClient sdxClient)
+            throws Exception {
+        sdxClient.getSdxClient().sdxEndpoint().renewCertificate(renewCertificateTestDto.getStackCrn());
+        return renewCertificateTestDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/RenewDistroXCertificateAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/RenewDistroXCertificateAction.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.it.cloudbreak.action.v4.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.util.RenewDistroXCertificateTestDto;
+
+public class RenewDistroXCertificateAction implements Action<RenewDistroXCertificateTestDto, CloudbreakClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RenewDistroXCertificateAction.class);
+
+    @Override
+    public RenewDistroXCertificateTestDto action(TestContext testContext, RenewDistroXCertificateTestDto renewCertificateTestDto,
+            CloudbreakClient cloudbreakClient) throws Exception {
+        cloudbreakClient.getCloudbreakClient().distroXV1Endpoint().renewCertificate(renewCertificateTestDto.getStackCrn());
+        return renewCertificateTestDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/DistroXTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/DistroXTestClient.java
@@ -15,7 +15,9 @@ import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXScaleAction;
 import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXShowBlueprintAction;
 import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXStartAction;
 import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXStopAction;
+import com.sequenceiq.it.cloudbreak.action.v4.util.RenewDistroXCertificateAction;
 import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
+import com.sequenceiq.it.cloudbreak.dto.util.RenewDistroXCertificateTestDto;
 
 @Service
 public class DistroXTestClient {
@@ -62,5 +64,9 @@ public class DistroXTestClient {
 
     public Action<DistroXTestDto, CloudbreakClient> postStackForBlueprint() {
         return new DistroXShowBlueprintAction();
+    }
+
+    public Action<RenewDistroXCertificateTestDto, CloudbreakClient> renewDistroXCertificateV4() {
+        return new RenewDistroXCertificateAction();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/SdxTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/SdxTestClient.java
@@ -26,10 +26,12 @@ import com.sequenceiq.it.cloudbreak.action.sdx.SdxStopAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxSyncAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxSyncInternalAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxUpgradeAction;
+import com.sequenceiq.it.cloudbreak.action.v4.util.RenewDatalakeCertificateAction;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCMDiagnosticsTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxDiagnosticsTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
+import com.sequenceiq.it.cloudbreak.dto.util.RenewDatalakeCertificateTestDto;
 
 @Service
 public class SdxTestClient {
@@ -120,6 +122,10 @@ public class SdxTestClient {
 
     public Action<SdxCMDiagnosticsTestDto, SdxClient> collectCMDiagnostics() {
         return new SdxCollectCMDiagnosticsAction();
+    }
+
+    public Action<RenewDatalakeCertificateTestDto, SdxClient> renewDatalakeCertificateV4() {
+        return new RenewDatalakeCertificateAction();
     }
 
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/util/RenewDatalakeCertificateTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/util/RenewDatalakeCertificateTestDto.java
@@ -1,0 +1,47 @@
+package com.sequenceiq.it.cloudbreak.dto.util;
+
+import javax.ws.rs.core.Response;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.Prototype;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractSdxTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
+
+@Prototype
+public class RenewDatalakeCertificateTestDto extends AbstractSdxTestDto<Object, Response, RenewDatalakeCertificateTestDto> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RenewDatalakeCertificateTestDto.class);
+
+    private String stackCrn;
+
+    protected RenewDatalakeCertificateTestDto(TestContext testContext) {
+        super(null, testContext);
+    }
+
+    @Override
+    public RenewDatalakeCertificateTestDto valid() {
+        SdxTestDto sdxTestDto = getTestContext().get(SdxTestDto.class);
+        if (sdxTestDto != null) {
+            this.stackCrn = sdxTestDto.getCrn();
+        }
+        return this;
+    }
+
+    public RenewDatalakeCertificateTestDto withStackCrn(String stackCrn) {
+        this.stackCrn = stackCrn;
+        return this;
+    }
+
+    public String getStackCrn() {
+        return stackCrn;
+    }
+
+    @Override
+    public int order() {
+        return 500;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/util/RenewDistroXCertificateTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/util/RenewDistroXCertificateTestDto.java
@@ -1,0 +1,45 @@
+package com.sequenceiq.it.cloudbreak.dto.util;
+
+import javax.ws.rs.core.Response;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.Prototype;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
+import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
+
+@Prototype
+public class RenewDistroXCertificateTestDto extends AbstractCloudbreakTestDto<Object, Response, RenewDistroXCertificateTestDto> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RenewDistroXCertificateTestDto.class);
+
+    private String stackCrn;
+
+    protected RenewDistroXCertificateTestDto(TestContext testContext) {
+        super(null, testContext);
+    }
+
+    @Override
+    public RenewDistroXCertificateTestDto valid() {
+        DistroXTestDto distroXTestDto = getTestContext().get(DistroXTestDto.class);
+        this.stackCrn = distroXTestDto.getCrn();
+        return this;
+    }
+
+    public RenewDistroXCertificateTestDto withStackCrn(String stackCrn) {
+        this.stackCrn = stackCrn;
+        return this;
+    }
+
+    public String getStackCrn() {
+        return stackCrn;
+    }
+
+    @Override
+    public int order() {
+        return 500;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/CreateDhWithDatahubCreator.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/CreateDhWithDatahubCreator.java
@@ -31,6 +31,7 @@ import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.recipe.RecipeTestDto;
 import com.sequenceiq.it.cloudbreak.dto.ums.UmsTestDto;
+import com.sequenceiq.it.cloudbreak.dto.util.RenewDistroXCertificateTestDto;
 import com.sequenceiq.it.cloudbreak.mock.freeipa.FreeIpaRouteHandler;
 import com.sequenceiq.it.cloudbreak.testcase.AbstractIntegrationTest;
 import com.sequenceiq.it.cloudbreak.util.AuthorizationTestUtil;
@@ -122,7 +123,13 @@ public class CreateDhWithDatahubCreator extends AbstractIntegrationTest {
                 .when(distroXClient.create(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_B)))
                 .awaitForFlow(key("DistroXCreateAction"))
                 .await(STACK_AVAILABLE, RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ACCOUNT_ADMIN)))
+                .given(RenewDistroXCertificateTestDto.class)
+                .when(distroXClient.renewDistroXCertificateV4(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ZERO_RIGHTS)))
+                .expect(ForbiddenException.class,
+                        RunningParameter.expectedMessage("You have no right to perform any of these actions: datahub/repairDatahub on.*")
+                                .withKey("RenewDistroXCertificateAction"))
                 .validate();
+
         testCheckRightUtil(testContext, testContext.given(DistroXTestDto.class).getCrn());
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/DatalakeDatahubCreateAuthTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/DatalakeDatahubCreateAuthTest.java
@@ -23,6 +23,7 @@ import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.dto.stack.StackTestDto;
 import com.sequenceiq.it.cloudbreak.dto.ums.UmsTestDto;
+import com.sequenceiq.it.cloudbreak.dto.util.RenewDatalakeCertificateTestDto;
 import com.sequenceiq.it.cloudbreak.mock.freeipa.FreeIpaRouteHandler;
 import com.sequenceiq.it.cloudbreak.testcase.AbstractIntegrationTest;
 import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
@@ -90,6 +91,12 @@ public class DatalakeDatahubCreateAuthTest extends AbstractIntegrationTest {
                 .expect(ForbiddenException.class,
                         RunningParameter.expectedMessage("You have no right to perform any of these actions: datalake/describeDetailedDatalake.*")
                                 .withKey("SdxDetailedDescribeInternalAction"))
+                .given(RenewDatalakeCertificateTestDto.class)
+                .withStackCrn(testContext.get(sdxInternal).getCrn())
+                .when(sdxTestClient.renewDatalakeCertificateV4(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ZERO_RIGHTS)))
+                .expect(ForbiddenException.class,
+                        RunningParameter.expectedMessage("You have no right to perform any of these actions: datalake/repairDatalake on.*")
+                                .withKey("RenewDatalakeCertificateAction"))
                 .validate();
     }
 


### PR DESCRIPTION
Anybody in the tenant is able to do a renew certificate process on any stack. With this change only the users with REPAIR_DATALAKE on the specific datalake or REPAIR_DATAHUB on the specific datahub are able to do cert renewal.

See detailed description in the commit message.