### PR TITLE
CB-8982 Indefinitely long loop when deleting environment. When we fet…

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/clustertemplate/ClusterTemplateV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/clustertemplate/ClusterTemplateV4Endpoint.java
@@ -47,6 +47,13 @@ public interface ClusterTemplateV4Endpoint {
     ClusterTemplateViewV4Responses list(@PathParam("workspaceId") Long workspaceId);
 
     @GET
+    @Path("env/{environmentCrn}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = ClusterTemplateOpDescription.LIST_BY_ENV, produces = MediaType.APPLICATION_JSON,
+            notes = CLUSTER_TEMPLATE_NOTES, nickname = "listClusterTemplatesByEnv")
+    ClusterTemplateViewV4Responses listByEnv(@PathParam("workspaceId") Long workspaceId, @PathParam("environmentCrn") String environmentCrn);
+
+    @GET
     @Path("name/{name}")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = ClusterTemplateOpDescription.GET_BY_NAME_IN_WORKSPACE, produces = MediaType.APPLICATION_JSON, notes = CLUSTER_TEMPLATE_NOTES,

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
@@ -77,6 +77,7 @@ public class OperationDescriptions {
         public static final String DELETE_BY_NAME_IN_WORKSPACE = "delete cluster template by name in workspace";
         public static final String DELETE_BY_CRN_IN_WORKSPACE = "delete cluster template by crn in workspace";
         public static final String DELETE_MULTIPLE_BY_NAME_IN_WORKSPACE = "delete multiple cluster templates by name in workspace";
+        public static final String LIST_BY_ENV = "list cluster templates by environment crn";
     }
 
     public static class RecipeOpDescription {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/ClusterTemplateV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/ClusterTemplateV4Controller.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.controller.v4;
 
+import static com.sequenceiq.cloudbreak.util.Benchmark.measure;
 import static java.util.stream.Collectors.toSet;
 
 import java.util.Objects;
@@ -31,15 +32,16 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.responses.Clust
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.responses.ClusterTemplateV4Responses;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.responses.ClusterTemplateViewV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.responses.ClusterTemplateViewV4Responses;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
 import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
 import com.sequenceiq.cloudbreak.common.service.TransactionService.TransactionExecutionException;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterTemplate;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterTemplateView;
 import com.sequenceiq.cloudbreak.service.blueprint.BlueprintService;
 import com.sequenceiq.cloudbreak.service.template.ClusterTemplateService;
+import com.sequenceiq.cloudbreak.service.template.ClusterTemplateViewService;
 import com.sequenceiq.cloudbreak.workspace.controller.WorkspaceEntityType;
 import com.sequenceiq.distrox.v1.distrox.service.EnvironmentServiceDecorator;
 
@@ -65,6 +67,9 @@ public class ClusterTemplateV4Controller extends NotificationController implemen
     @Inject
     private EnvironmentServiceDecorator environmentServiceDecorator;
 
+    @Inject
+    private ClusterTemplateViewService clusterTemplateViewService;
+
     @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.CREATE_CLUSTER_DEFINITION)
     public ClusterTemplateV4Response post(Long workspaceId, @Valid ClusterTemplateV4Request request) {
@@ -78,9 +83,18 @@ public class ClusterTemplateV4Controller extends NotificationController implemen
     @Override
     @DisableCheckPermissions
     public ClusterTemplateViewV4Responses list(Long workspaceId) {
-        blueprintService.updateDefaultBlueprintCollection(workspaceId);
-        clusterTemplateService.updateDefaultClusterTemplates(workspaceId);
-        Set<ClusterTemplateViewV4Response> result = clusterTemplateService.listInWorkspaceAndCleanUpInvalids(workspaceId);
+        measure(() -> blueprintService.updateDefaultBlueprintCollection(workspaceId), LOGGER, "Blueprints fetched in {}ms");
+        measure(() -> clusterTemplateService.updateDefaultClusterTemplates(workspaceId), LOGGER, "Cluster templates fetched in {}ms");
+        Set<ClusterTemplateViewV4Response> result = measure(() -> clusterTemplateService.listInWorkspaceAndCleanUpInvalids(workspaceId),
+                LOGGER, "cluster templates cleaned in {}ms");
+        return new ClusterTemplateViewV4Responses(result);
+    }
+
+    @Override
+    @DisableCheckPermissions
+    public ClusterTemplateViewV4Responses listByEnv(Long workspaceId, String environmentCrn) {
+        Set<ClusterTemplateView> clusterTemplateViews = clusterTemplateViewService.findAllByEnvironmentCrn(environmentCrn);
+        Set<ClusterTemplateViewV4Response> result = converterUtil.convertAllAsSet(clusterTemplateViews, ClusterTemplateViewV4Response.class);
         return new ClusterTemplateViewV4Responses(result);
     }
 
@@ -137,11 +151,10 @@ public class ClusterTemplateV4Controller extends NotificationController implemen
         if (Objects.nonNull(names) && !names.isEmpty()) {
             clusterTemplates = clusterTemplateService.deleteMultiple(names, workspaceId);
         } else {
-            NameOrCrn environmentNameOrCrn = NameOrCrn.ofCrn(environmentCrn);
             Set<String> namesByEnv = clusterTemplateService
-                    .findAllByEnvironment(environmentNameOrCrn)
+                    .findAllByEnvironment(environmentCrn)
                     .stream()
-                    .map(ClusterTemplate::getName)
+                    .map(ClusterTemplateView::getName)
                     .collect(toSet());
             clusterTemplates = clusterTemplateService.deleteMultiple(namesByEnv, workspaceId);
         }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/init/clustertemplate/DefaultClusterTemplateCache.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/init/clustertemplate/DefaultClusterTemplateCache.java
@@ -4,6 +4,7 @@ import static com.sequenceiq.cloudbreak.util.FileReaderUtils.readFileFromClasspa
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
@@ -114,6 +115,27 @@ public class DefaultClusterTemplateCache {
             DefaultClusterTemplateV4Request defaultClusterTemplate = getDefaultClusterTemplate(defaultTemplateJson);
             ClusterTemplate clusterTemplate = converterUtil.convert(defaultClusterTemplate, ClusterTemplate.class);
             defaultTemplates.put(key, clusterTemplate);
+        });
+        return defaultTemplates;
+    }
+
+    public List<ClusterTemplate> defaultClusterTemplatesByNames(Collection<String> templateNamesMissingFromDb) {
+        List<ClusterTemplate> defaultTemplates = new ArrayList<>();
+        defaultClusterTemplateRequests().forEach((key, value) -> {
+            if (templateNamesMissingFromDb.contains(key)) {
+                String defaultTemplateJson = new String(Base64.getDecoder().decode(value));
+                DefaultClusterTemplateV4Request defaultClusterTemplate = getDefaultClusterTemplate(defaultTemplateJson);
+                ClusterTemplate clusterTemplate = converterUtil.convert(defaultClusterTemplate, ClusterTemplate.class);
+                defaultTemplates.add(clusterTemplate);
+            }
+        });
+        return defaultTemplates;
+    }
+
+    public Collection<String> defaultClusterTemplateNames() {
+        Collection<String> defaultTemplates = new ArrayList<>();
+        defaultClusterTemplateRequests().forEach((key, value) -> {
+            defaultTemplates.add(key);
         });
         return defaultTemplates;
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/cluster/ClusterTemplateRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/cluster/ClusterTemplateRepository.java
@@ -28,9 +28,6 @@ public interface ClusterTemplateRepository extends WorkspaceResourceRepository<C
     @Query("SELECT c FROM ClusterTemplate c WHERE c.resourceCrn= :crn AND c.workspace.id= :workspaceId AND c.status <> 'DEFAULT_DELETED'")
     Optional<ClusterTemplate> getByCrnForWorkspaceId(@Param("crn") String crn, @Param("workspaceId") Long workspaceId);
 
-    @Query("SELECT c FROM ClusterTemplate c WHERE c.stackTemplate.environmentCrn= :environmentCrn AND c.status <> 'DEFAULT_DELETED'")
-    Set<ClusterTemplate> getAllByEnvironmentCrn(@Param("environmentCrn") String environmentCrn);
-
     @Query("SELECT c FROM ClusterTemplate c WHERE c.stackTemplate.cluster.blueprint.id = :blueprintId AND c.workspace.id= :workspaceId "
             + "AND (c.status <> 'DEFAULT_DELETED' AND c.status <> 'DELETED')")
     Set<ClusterTemplate> getTemplatesByBlueprintId(@Param("blueprintId") Long blueprintId, @Param("workspaceId") Long workspaceId);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/cluster/ClusterTemplateViewRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/cluster/ClusterTemplateViewRepository.java
@@ -21,6 +21,9 @@ public interface ClusterTemplateViewRepository extends WorkspaceResourceReposito
             "WHERE b.workspace.id= :workspaceId AND b.status <> 'DEFAULT_DELETED'")
     Set<ClusterTemplateView> findAllActive(@Param("workspaceId") Long workspaceId);
 
+    @Query("SELECT c FROM ClusterTemplateView c WHERE c.stackTemplate.environmentCrn= :environmentCrn AND c.status <> 'DEFAULT_DELETED'")
+    Set<ClusterTemplateView> getAllByEnvironmentCrn(@Param("environmentCrn") String environmentCrn);
+
     @Override
     default <S extends ClusterTemplateView> S save(S entity) {
         throw new UnsupportedOperationException("Creation is not supported from ClusterTemplateViewRepository");

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/template/ClusterTemplateViewService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/template/ClusterTemplateViewService.java
@@ -37,4 +37,7 @@ public class ClusterTemplateViewService extends AbstractWorkspaceAwareResourceSe
         return repository.findAllActive(workspaceId);
     }
 
+    public Set<ClusterTemplateView> findAllByEnvironmentCrn(String environmentCrn) {
+        return repository.getAllByEnvironmentCrn(environmentCrn);
+    }
 }

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentResourceDeletionServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentResourceDeletionServiceTest.java
@@ -8,10 +8,12 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.Set;
 
 import javax.inject.Inject;
 import javax.ws.rs.ProcessingException;
@@ -30,6 +32,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.ClusterTemplateV4Endpoint;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.responses.ClusterTemplateViewV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.responses.ClusterTemplateViewV4Responses;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.DatalakeV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Responses;
@@ -106,8 +109,10 @@ class EnvironmentResourceDeletionServiceTest {
     @Test
     void testWhenDeleteClusterDefinitionsOnCloudbreakThrowsWebApplicationExceptionThenItShouldBeCatchedAndEnvironmentServiceExceptionShouldBeThrown() {
         WebApplicationException exception = Mockito.mock(WebApplicationException.class);
-        when(clusterTemplateViewV4Responses.getResponses()).thenReturn(Collections.emptySet());
-        when(clusterTemplateV4Endpoint.list(anyLong())).thenReturn(clusterTemplateViewV4Responses);
+        ClusterTemplateViewV4Response templateViewV4Response = new ClusterTemplateViewV4Response();
+        templateViewV4Response.setName("name");
+        when(clusterTemplateViewV4Responses.getResponses()).thenReturn(Set.of(templateViewV4Response));
+        when(clusterTemplateV4Endpoint.listByEnv(anyLong(), anyString())).thenReturn(clusterTemplateViewV4Responses);
         doThrow(exception).when(clusterTemplateV4Endpoint).deleteMultiple(eq(WORKSPACE_ID), any(), any(), eq(ENVIRONMENT_CRN));
         Response response = Mockito.mock(Response.class);
         when(exception.getResponse()).thenReturn(response);
@@ -123,8 +128,10 @@ class EnvironmentResourceDeletionServiceTest {
     @Test
     void testWhenDeleteClusterDefinitionsOnCloudbreakThrowsProcessingExceptionThenItShouldBeCatchedAndEnvironmentServiceExceptionShouldBeThrown() {
         doThrow(ProcessingException.class).when(clusterTemplateV4Endpoint).deleteMultiple(eq(WORKSPACE_ID), any(), any(), eq(ENVIRONMENT_CRN));
-        when(clusterTemplateViewV4Responses.getResponses()).thenReturn(Collections.emptySet());
-        when(clusterTemplateV4Endpoint.list(anyLong())).thenReturn(clusterTemplateViewV4Responses);
+        ClusterTemplateViewV4Response templateViewV4Response = new ClusterTemplateViewV4Response();
+        templateViewV4Response.setName("name");
+        when(clusterTemplateViewV4Responses.getResponses()).thenReturn(Set.of(templateViewV4Response));
+        when(clusterTemplateV4Endpoint.listByEnv(anyLong(), anyString())).thenReturn(clusterTemplateViewV4Responses);
 
         Assertions.assertThrows(EnvironmentServiceException.class,
                 () -> environmentResourceDeletionServiceUnderTest.deleteClusterDefinitionsOnCloudbreak(ENVIRONMENT_CRN));
@@ -137,14 +144,27 @@ class EnvironmentResourceDeletionServiceTest {
     void testWhenDeleteClusterDefinitionsThrowsUnableToDeleteClusterDefinitionExceptionThenItShouldBeCatchedAndEnvironmentServiceExceptionShouldBeThrown() {
         doThrow(UnableToDeleteClusterDefinitionException.class).when(clusterTemplateV4Endpoint).deleteMultiple(eq(WORKSPACE_ID), any(), any(),
                 eq(ENVIRONMENT_CRN));
-        when(clusterTemplateViewV4Responses.getResponses()).thenReturn(Collections.emptySet());
-        when(clusterTemplateV4Endpoint.list(anyLong())).thenReturn(clusterTemplateViewV4Responses);
+        ClusterTemplateViewV4Response templateViewV4Response = new ClusterTemplateViewV4Response();
+        templateViewV4Response.setName("name");
+        when(clusterTemplateViewV4Responses.getResponses()).thenReturn(Set.of(templateViewV4Response));
+        when(clusterTemplateV4Endpoint.listByEnv(anyLong(), anyString())).thenReturn(clusterTemplateViewV4Responses);
 
         Assertions.assertThrows(EnvironmentServiceException.class,
                 () -> environmentResourceDeletionServiceUnderTest.deleteClusterDefinitionsOnCloudbreak(ENVIRONMENT_CRN));
 
         verify(clusterTemplateV4Endpoint).deleteMultiple(anyLong(), any(), any(), anyString());
         verify(clusterTemplateV4Endpoint).deleteMultiple(eq(WORKSPACE_ID), any(), any(), eq(ENVIRONMENT_CRN));
+    }
+
+    @Test
+    void testWhenDeleteClusterDefinitionsWhenNamesEmpty() {
+        when(clusterTemplateViewV4Responses.getResponses()).thenReturn(Collections.emptySet());
+        when(clusterTemplateV4Endpoint.listByEnv(anyLong(), anyString())).thenReturn(clusterTemplateViewV4Responses);
+
+        environmentResourceDeletionServiceUnderTest.deleteClusterDefinitionsOnCloudbreak(ENVIRONMENT_CRN);
+
+        verify(clusterTemplateV4Endpoint, never()).deleteMultiple(anyLong(), any(), any(), anyString());
+        verify(clusterTemplateV4Endpoint, never()).deleteMultiple(eq(WORKSPACE_ID), any(), any(), eq(ENVIRONMENT_CRN));
     }
 
     @Configuration

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/clustertemplate/ClusterTemplateListAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/clustertemplate/ClusterTemplateListAction.java
@@ -1,6 +1,9 @@
 package com.sequenceiq.it.cloudbreak.action.v4.clustertemplate;
 
+import java.time.Duration;
 import java.util.Collection;
+
+import javax.ws.rs.ServerErrorException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,6 +13,7 @@ import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.action.Action;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.clustertemplate.ClusterTemplateTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
 import com.sequenceiq.it.cloudbreak.log.Log;
 import com.sequenceiq.it.cloudbreak.util.ClusterTemplateUtil;
 
@@ -20,11 +24,33 @@ public class ClusterTemplateListAction implements Action<ClusterTemplateTestDto,
     @Override
     public ClusterTemplateTestDto action(TestContext testContext, ClusterTemplateTestDto testDto, CloudbreakClient client) throws Exception {
         Log.when(LOGGER, " ClusterTemplateEntity list request");
-        Collection<ClusterTemplateViewV4Response> responses = client.getCloudbreakClient()
-                .clusterTemplateV4EndPoint()
-                .list(client.getWorkspaceId()).getResponses();
-        testDto.setResponses(ClusterTemplateUtil.getResponseFromViews(responses));
-        Log.whenJson(LOGGER, " ClusterTemplateEntity list successfully:\n", responses);
+        // because the default list is too slow, we need to check until finished, approx 3 mins
+        boolean run = true;
+        int maxRetry = 10;
+        int count = 0;
+        int waitInSec = 20;
+        long start = System.currentTimeMillis();
+        boolean success = false;
+        while (run && count < maxRetry) {
+            try {
+                Collection<ClusterTemplateViewV4Response> responses = client.getCloudbreakClient()
+                        .clusterTemplateV4EndPoint()
+                        .list(client.getWorkspaceId()).getResponses();
+                testDto.setResponses(ClusterTemplateUtil.getResponseFromViews(responses));
+                Log.whenJson(LOGGER, " ClusterTemplateEntity list successfully:\n", responses);
+                run = false;
+                success = true;
+            } catch (ServerErrorException e) {
+                LOGGER.info("Server exception occurred: {}", e.getMessage(), e);
+                Thread.sleep(Duration.ofSeconds(waitInSec).toMillis());
+            }
+            count++;
+        }
+        long duration = System.currentTimeMillis() - start;
+        if (!success) {
+            throw new TestFailException("Listing of cluster template timed out, cannot fetched in " + duration);
+        }
+        LOGGER.info("Cluster template listed in {}ms", duration);
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
@@ -266,6 +266,7 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
                 .given(ClusterTemplateTestDto.class)
                 .withName(name)
                 .when(clusterTemplateTestClient.createV4(), RunningParameter.key(generatedKey))
+                .when(clusterTemplateTestClient.listV4())
                 .then((testContext1, testDto, client) -> clusterTemplateHasCreatedAndCanBeListed(testDto, client, name))
                 .validate();
     }
@@ -442,7 +443,7 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
     private ClusterTemplateTestDto clusterTemplateHasDeletedAlongTheEnvironment(ClusterTemplateTestDto entity, CloudbreakClient client, String templateName) {
         client.getCloudbreakClient()
                 .clusterTemplateV4EndPoint()
-                .list(client.getWorkspaceId())
+                .listByEnv(client.getWorkspaceId(), entity.getResponse().getEnvironmentCrn())
                 .getResponses()
                 .stream()
                 .filter(response -> templateName.equals(response.getName()))
@@ -454,10 +455,7 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
     }
 
     private ClusterTemplateTestDto clusterTemplateHasCreatedAndCanBeListed(ClusterTemplateTestDto entity, CloudbreakClient client, String templateName) {
-        client.getCloudbreakClient()
-                .clusterTemplateV4EndPoint()
-                .list(client.getWorkspaceId())
-                .getResponses()
+        entity.getResponses()
                 .stream()
                 .filter(response -> templateName.equals(response.getName()))
                 .findFirst().orElseThrow(() -> new TestFailException("The expected cluster definition does not exist in the list!"));


### PR DESCRIPTION
…ched the cluster definition, we checked the default templates but this step was unnecessary, because we should delete the user managed only.

See detailed description in the commit message.