### PR TITLE
CB-8209: Adding the Cloudbreak version to the environment API.

### DIFF
--- a/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
@@ -108,6 +108,8 @@ public class EnvironmentModelDescription {
     public static final String PROXYCONFIG_NAME = "Name of the proxyconfig of the environment.";
     public static final String PROXYCONFIG_RESPONSE = "ProxyConfig attached to the environment.";
 
+    public static final String CLOUDBREAK_VERSION = "The cloudbreak version used to create the environment.";
+
     private EnvironmentModelDescription() {
     }
 }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/DetailedEnvironmentResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/DetailedEnvironmentResponse.java
@@ -106,6 +106,8 @@ public class DetailedEnvironmentResponse extends EnvironmentBaseResponse {
 
         private YarnEnvironmentParameters yarn;
 
+        private String cloudbreakVersion;
+
         private Builder() {
         }
 
@@ -263,6 +265,11 @@ public class DetailedEnvironmentResponse extends EnvironmentBaseResponse {
             return this;
         }
 
+        public Builder withCloudbreakVersion(String cloudbreakVersion) {
+            this.cloudbreakVersion = cloudbreakVersion;
+            return this;
+        }
+
         public DetailedEnvironmentResponse build() {
             DetailedEnvironmentResponse detailedEnvironmentResponse = new DetailedEnvironmentResponse();
             detailedEnvironmentResponse.setCrn(crn);
@@ -295,6 +302,7 @@ public class DetailedEnvironmentResponse extends EnvironmentBaseResponse {
             detailedEnvironmentResponse.setAzure(azure);
             detailedEnvironmentResponse.setGcp(gcp);
             detailedEnvironmentResponse.setYarn(yarn);
+            detailedEnvironmentResponse.setCloudbreakVersion(cloudbreakVersion);
             return detailedEnvironmentResponse;
         }
     }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentBaseResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentBaseResponse.java
@@ -105,6 +105,9 @@ public abstract class EnvironmentBaseResponse implements ResourceCrnAwareApiMode
     @ApiModelProperty(EnvironmentModelDescription.YARN_PARAMETERS)
     private YarnEnvironmentParameters yarn;
 
+    @ApiModelProperty(EnvironmentModelDescription.CLOUDBREAK_VERSION)
+    private String cloudbreakVersion;
+
     public String getCrn() {
         return crn;
     }
@@ -340,5 +343,13 @@ public abstract class EnvironmentBaseResponse implements ResourceCrnAwareApiMode
 
     public void setYarn(YarnEnvironmentParameters yarn) {
         this.yarn = yarn;
+    }
+
+    public String getCloudbreakVersion() {
+        return cloudbreakVersion;
+    }
+
+    public void setCloudbreakVersion(String cloudbreakVersion) {
+        this.cloudbreakVersion = cloudbreakVersion;
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverter.java
@@ -5,6 +5,7 @@ import static com.sequenceiq.cloudbreak.util.NullUtil.getIfNotNull;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.util.NullUtil;
@@ -55,6 +56,9 @@ public class EnvironmentResponseConverter {
 
     private final NetworkDtoToResponseConverter networkDtoToResponseConverter;
 
+    @Value("${info.app.version:}")
+    private String serviceVersion;
+
     public EnvironmentResponseConverter(CredentialToCredentialV1ResponseConverter credentialConverter,
             RegionConverter regionConverter, CredentialViewConverter credentialViewConverter,
             ProxyConfigToProxyResponseConverter proxyConfigToProxyResponseConverter,
@@ -97,7 +101,8 @@ public class EnvironmentResponseConverter {
                 .withGcp(getIfNotNull(environmentDto.getParameters(), this::gcpEnvParamsToGcpEnvironmentParams))
                 .withParentEnvironmentCrn(environmentDto.getParentEnvironmentCrn())
                 .withParentEnvironmentName(environmentDto.getParentEnvironmentName())
-                .withParentEnvironmentCloudPlatform(environmentDto.getParentEnvironmentCloudPlatform());
+                .withParentEnvironmentCloudPlatform(environmentDto.getParentEnvironmentCloudPlatform())
+                .withCloudbreakVersion(serviceVersion);
 
         NullUtil.doIfNotNull(environmentDto.getProxyConfig(),
                 proxyConfig -> builder.withProxyConfig(proxyConfigToProxyResponseConverter.convert(environmentDto.getProxyConfig())));


### PR DESCRIPTION
The main use case for this is to enable the describe-environment call in the CDP CLI to return the Cloudbreak version as well.
I want to specify that I am new to Cloudbreak development and am not very familiar with how to test this correctly to ensure it is set up correctly, nor am I familiar with how to update these API files on Thunderhead (I assume this is done automatically after a Cloudbreak release/promotion).

Any more information for this process would be very helpful and I am happy to answer any questions. Thanks!