### PR TITLE
CB-9188 Change image copy metric from long task timer to timer

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/metrics/AbstractMetricService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/metrics/AbstractMetricService.java
@@ -2,14 +2,15 @@ package com.sequenceiq.cloudbreak.common.metrics;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import com.sequenceiq.cloudbreak.common.metrics.type.Metric;
 
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
 
 public abstract class AbstractMetricService implements MetricService {
 
@@ -56,9 +57,11 @@ public abstract class AbstractMetricService implements MetricService {
         return metric.getMetricName().contains("state") || metric.getMetricName().contains("leader") || metric.getMetricName().contains("threadpool");
     }
 
-    protected void recordLongTaskTimer(Metric metric, Runnable func, String... tags) {
-        LongTaskTimer longTaskTimer = Metrics.more().longTaskTimer(getMetricName(metric), tags);
-        longTaskTimer.record(func);
+    protected void recordTimer(long millisToRecord, Metric metric, String... tags) {
+        Timer.builder(getMetricName(metric))
+                .tags(tags)
+                .register(Metrics.globalRegistry)
+                .record(millisToRecord, TimeUnit.MILLISECONDS);
     }
 
     private String getMetricName(Metric metric) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/image/update/StackImageUpdateActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/image/update/StackImageUpdateActions.java
@@ -108,7 +108,7 @@ public class StackImageUpdateActions {
         return new AbstractStackImageUpdateAction<>(StackEvent.class) {
             @Override
             protected void doExecute(StackContext context, StackEvent payload, Map<Object, Object> variables) {
-                getStackCreationService().prepareImage(context.getStack());
+                getStackCreationService().prepareImage(context.getStack(), variables);
                 try {
                     CloudStack cloudStack = getCloudStackConverter().convert(context.getStack());
                     Image image = getImageService().getImage(context.getCloudContext().getId());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/action/StackCreationActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/action/StackCreationActions.java
@@ -133,7 +133,7 @@ public class StackCreationActions {
         return new AbstractStackCreationAction<>(SetupResult.class) {
             @Override
             protected void doExecute(StackContext context, SetupResult payload, Map<Object, Object> variables) {
-                stackCreationService.prepareImage(context.getStack());
+                stackCreationService.prepareImage(context.getStack(), variables);
                 sendEvent(context);
             }
 
@@ -156,7 +156,7 @@ public class StackCreationActions {
             @Override
             protected void doExecute(StackContext context, StackEvent payload, Map<Object, Object> variables) {
                 variables.put(START_DATE, new Date());
-                stackCreationService.startProvisioning(context);
+                stackCreationService.startProvisioning(context, variables);
                 sendEvent(context);
             }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/metrics/CloudbreakMetricService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/metrics/CloudbreakMetricService.java
@@ -1,5 +1,8 @@
 package com.sequenceiq.cloudbreak.service.metrics;
 
+import java.util.ArrayList;
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.common.metrics.AbstractMetricService;
@@ -7,9 +10,6 @@ import com.sequenceiq.cloudbreak.common.metrics.type.MetricTag;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.view.StackView;
 import com.sequenceiq.cloudbreak.workspace.model.Tenant;
-
-import java.util.ArrayList;
-import java.util.Optional;
 
 @Service("MetricService")
 public class CloudbreakMetricService extends AbstractMetricService {
@@ -55,13 +55,6 @@ public class CloudbreakMetricService extends AbstractMetricService {
         return METRIC_PREFIX;
     }
 
-    public void recordImageCopyTime(Stack stack, Runnable checkImage) {
-        String[] tags = {MetricTag.TENANT.name(), Optional.ofNullable(stack.getTenant()).map(Tenant::getName).orElse("NA"),
-                MetricTag.CLOUD_PROVIDER.name(), Optional.ofNullable(stack.cloudPlatform()).orElse("NA"),
-                MetricTag.REGION.name(), Optional.ofNullable(stack.getRegion()).orElse("NA")};
-        recordLongTaskTimer(MetricType.STACK_IMAGE_COPY, checkImage, tags);
-    }
-
     private String[] nullableValueTags(String... tags) {
         if (tags.length % 2 == 1) {
             throw new IllegalArgumentException("tags size must be even, it is a set of key=value pairs of tags");
@@ -76,5 +69,14 @@ public class CloudbreakMetricService extends AbstractMetricService {
         String[] arrAccumulatedTags = new String[accumulatedTags.size()];
         arrAccumulatedTags = accumulatedTags.toArray(arrAccumulatedTags);
         return arrAccumulatedTags;
+    }
+
+    public void recordImageCopyTime(Stack stack, long startMillis) {
+        String[] tags = {MetricTag.TENANT.name(), Optional.ofNullable(stack.getTenant()).map(Tenant::getName).orElse("NA"),
+                MetricTag.CLOUD_PROVIDER.name(), Optional.ofNullable(stack.cloudPlatform()).orElse("NA"),
+                MetricTag.REGION.name(), Optional.ofNullable(stack.getRegion()).orElse("NA")};
+
+        long millispassed = System.currentTimeMillis() - startMillis;
+        recordTimer(millispassed, MetricType.STACK_IMAGE_COPY, tags);
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/stack/image/update/StackImageUpdateActionsTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/stack/image/update/StackImageUpdateActionsTest.java
@@ -322,7 +322,7 @@ public class StackImageUpdateActionsTest {
 
         prepareImageAction.execute(stateContext);
 
-        verify(stackCreationService, times(1)).prepareImage(any(Stack.class));
+        verify(stackCreationService, times(1)).prepareImage(any(Stack.class), eq(variables));
         verify(eventBus, times(1)).notify(eq(CloudPlatformRequest.selector(PrepareImageRequest.class)), any(Event.class));
     }
 


### PR DESCRIPTION
Prometheus was not presenting correctly the values from LongTaskTimer
type metric. CHanged the image copy metric to type Timer and now
Prometheus shows copy times correctly.

See detailed description in the commit message.