### PR TITLE
CDPCP-3121 - Filter internal machine users for user sync

### DIFF
--- a/auth-connector/src/generated/main/grpc/com/cloudera/thunderhead/service/usermanagement/UserManagementGrpc.java
+++ b/auth-connector/src/generated/main/grpc/com/cloudera/thunderhead/service/usermanagement/UserManagementGrpc.java
@@ -1068,6 +1068,43 @@ public final class UserManagementGrpc {
      return getCreateC1CAccountMethod;
   }
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getVerifyC1CEmailMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.VerifyC1CEmailRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.VerifyC1CEmailResponse> METHOD_VERIFY_C1CEMAIL = getVerifyC1CEmailMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.VerifyC1CEmailRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.VerifyC1CEmailResponse> getVerifyC1CEmailMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.VerifyC1CEmailRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.VerifyC1CEmailResponse> getVerifyC1CEmailMethod() {
+    return getVerifyC1CEmailMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.VerifyC1CEmailRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.VerifyC1CEmailResponse> getVerifyC1CEmailMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.VerifyC1CEmailRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.VerifyC1CEmailResponse> getVerifyC1CEmailMethod;
+    if ((getVerifyC1CEmailMethod = UserManagementGrpc.getVerifyC1CEmailMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getVerifyC1CEmailMethod = UserManagementGrpc.getVerifyC1CEmailMethod) == null) {
+          UserManagementGrpc.getVerifyC1CEmailMethod = getVerifyC1CEmailMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.VerifyC1CEmailRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.VerifyC1CEmailResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "usermanagement.UserManagement", "VerifyC1CEmail"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.VerifyC1CEmailRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.VerifyC1CEmailResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("VerifyC1CEmail"))
+                  .build();
+          }
+        }
+     }
+     return getVerifyC1CEmailMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getGrantEntitlementMethod()} instead. 
   public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GrantEntitlementRequest,
       com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GrantEntitlementResponse> METHOD_GRANT_ENTITLEMENT = getGrantEntitlementMethodHelper();
@@ -3584,6 +3621,43 @@ public final class UserManagementGrpc {
      return getListServicePrincipalCloudIdentitiesMethod;
   }
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getGetDefaultIdentityProviderConnectorMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetDefaultIdentityProviderConnectorRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetDefaultIdentityProviderConnectorResponse> METHOD_GET_DEFAULT_IDENTITY_PROVIDER_CONNECTOR = getGetDefaultIdentityProviderConnectorMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetDefaultIdentityProviderConnectorRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetDefaultIdentityProviderConnectorResponse> getGetDefaultIdentityProviderConnectorMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetDefaultIdentityProviderConnectorRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetDefaultIdentityProviderConnectorResponse> getGetDefaultIdentityProviderConnectorMethod() {
+    return getGetDefaultIdentityProviderConnectorMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetDefaultIdentityProviderConnectorRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetDefaultIdentityProviderConnectorResponse> getGetDefaultIdentityProviderConnectorMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetDefaultIdentityProviderConnectorRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetDefaultIdentityProviderConnectorResponse> getGetDefaultIdentityProviderConnectorMethod;
+    if ((getGetDefaultIdentityProviderConnectorMethod = UserManagementGrpc.getGetDefaultIdentityProviderConnectorMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getGetDefaultIdentityProviderConnectorMethod = UserManagementGrpc.getGetDefaultIdentityProviderConnectorMethod) == null) {
+          UserManagementGrpc.getGetDefaultIdentityProviderConnectorMethod = getGetDefaultIdentityProviderConnectorMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetDefaultIdentityProviderConnectorRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetDefaultIdentityProviderConnectorResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "usermanagement.UserManagement", "GetDefaultIdentityProviderConnector"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetDefaultIdentityProviderConnectorRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetDefaultIdentityProviderConnectorResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("GetDefaultIdentityProviderConnector"))
+                  .build();
+          }
+        }
+     }
+     return getGetDefaultIdentityProviderConnectorMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getGetUserSyncStateModelMethod()} instead. 
   public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetUserSyncStateModelRequest,
       com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetUserSyncStateModelResponse> METHOD_GET_USER_SYNC_STATE_MODEL = getGetUserSyncStateModelMethodHelper();
@@ -3941,6 +4015,17 @@ public final class UserManagementGrpc {
     public void createC1CAccount(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateC1CAccountRequest request,
         io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateC1CAccountResponse> responseObserver) {
       asyncUnimplementedUnaryCall(getCreateC1CAccountMethodHelper(), responseObserver);
+    }
+
+    /**
+     * <pre>
+     * An endpoint called when a user verifies their email by clicking the link we sent
+     * them.
+     * </pre>
+     */
+    public void verifyC1CEmail(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.VerifyC1CEmailRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.VerifyC1CEmailResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getVerifyC1CEmailMethodHelper(), responseObserver);
     }
 
     /**
@@ -4651,6 +4736,16 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
+     * Retrieves the CRN of identity provider connector used for CDP initiated logins.
+     * </pre>
+     */
+    public void getDefaultIdentityProviderConnector(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetDefaultIdentityProviderConnectorRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetDefaultIdentityProviderConnectorResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getGetDefaultIdentityProviderConnectorMethodHelper(), responseObserver);
+    }
+
+    /**
+     * <pre>
      * Get user sync state model, including actors, groups, workload administration groups, etc
      * </pre>
      */
@@ -4857,6 +4952,13 @@ public final class UserManagementGrpc {
                 com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateC1CAccountRequest,
                 com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateC1CAccountResponse>(
                   this, METHODID_CREATE_C1CACCOUNT)))
+          .addMethod(
+            getVerifyC1CEmailMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.VerifyC1CEmailRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.VerifyC1CEmailResponse>(
+                  this, METHODID_VERIFY_C1CEMAIL)))
           .addMethod(
             getGrantEntitlementMethodHelper(),
             asyncUnaryCall(
@@ -5334,6 +5436,13 @@ public final class UserManagementGrpc {
                 com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesResponse>(
                   this, METHODID_LIST_SERVICE_PRINCIPAL_CLOUD_IDENTITIES)))
           .addMethod(
+            getGetDefaultIdentityProviderConnectorMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetDefaultIdentityProviderConnectorRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetDefaultIdentityProviderConnectorResponse>(
+                  this, METHODID_GET_DEFAULT_IDENTITY_PROVIDER_CONNECTOR)))
+          .addMethod(
             getGetUserSyncStateModelMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
@@ -5683,6 +5792,18 @@ public final class UserManagementGrpc {
         io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateC1CAccountResponse> responseObserver) {
       asyncUnaryCall(
           getChannel().newCall(getCreateC1CAccountMethodHelper(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * An endpoint called when a user verifies their email by clicking the link we sent
+     * them.
+     * </pre>
+     */
+    public void verifyC1CEmail(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.VerifyC1CEmailRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.VerifyC1CEmailResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getVerifyC1CEmailMethodHelper(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -6461,6 +6582,17 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
+     * Retrieves the CRN of identity provider connector used for CDP initiated logins.
+     * </pre>
+     */
+    public void getDefaultIdentityProviderConnector(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetDefaultIdentityProviderConnectorRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetDefaultIdentityProviderConnectorResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getGetDefaultIdentityProviderConnectorMethodHelper(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
      * Get user sync state model, including actors, groups, workload administration groups, etc
      * </pre>
      */
@@ -6782,6 +6914,17 @@ public final class UserManagementGrpc {
     public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateC1CAccountResponse createC1CAccount(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateC1CAccountRequest request) {
       return blockingUnaryCall(
           getChannel(), getCreateC1CAccountMethodHelper(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * An endpoint called when a user verifies their email by clicking the link we sent
+     * them.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.VerifyC1CEmailResponse verifyC1CEmail(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.VerifyC1CEmailRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getVerifyC1CEmailMethodHelper(), getCallOptions(), request);
     }
 
     /**
@@ -7492,6 +7635,16 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
+     * Retrieves the CRN of identity provider connector used for CDP initiated logins.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetDefaultIdentityProviderConnectorResponse getDefaultIdentityProviderConnector(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetDefaultIdentityProviderConnectorRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getGetDefaultIdentityProviderConnectorMethodHelper(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
      * Get user sync state model, including actors, groups, workload administration groups, etc
      * </pre>
      */
@@ -7840,6 +7993,18 @@ public final class UserManagementGrpc {
         com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateC1CAccountRequest request) {
       return futureUnaryCall(
           getChannel().newCall(getCreateC1CAccountMethodHelper(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
+     * An endpoint called when a user verifies their email by clicking the link we sent
+     * them.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.VerifyC1CEmailResponse> verifyC1CEmail(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.VerifyC1CEmailRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getVerifyC1CEmailMethodHelper(), getCallOptions()), request);
     }
 
     /**
@@ -8618,6 +8783,17 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
+     * Retrieves the CRN of identity provider connector used for CDP initiated logins.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetDefaultIdentityProviderConnectorResponse> getDefaultIdentityProviderConnector(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetDefaultIdentityProviderConnectorRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getGetDefaultIdentityProviderConnectorMethodHelper(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
      * Get user sync state model, including actors, groups, workload administration groups, etc
      * </pre>
      */
@@ -8656,75 +8832,77 @@ public final class UserManagementGrpc {
   private static final int METHODID_CREATE_ACCOUNT = 25;
   private static final int METHODID_CREATE_TRIAL_ACCOUNT = 26;
   private static final int METHODID_CREATE_C1CACCOUNT = 27;
-  private static final int METHODID_GRANT_ENTITLEMENT = 28;
-  private static final int METHODID_REVOKE_ENTITLEMENT = 29;
-  private static final int METHODID_ENSURE_DEFAULT_ENTITLEMENTS_GRANTED = 30;
-  private static final int METHODID_ASSIGN_ROLE = 31;
-  private static final int METHODID_UNASSIGN_ROLE = 32;
-  private static final int METHODID_LIST_ASSIGNED_ROLES = 33;
-  private static final int METHODID_ASSIGN_RESOURCE_ROLE = 34;
-  private static final int METHODID_UNASSIGN_RESOURCE_ROLE = 35;
-  private static final int METHODID_LIST_ASSIGNED_RESOURCE_ROLES = 36;
-  private static final int METHODID_LIST_ROLES = 37;
-  private static final int METHODID_LIST_RESOURCE_ROLES = 38;
-  private static final int METHODID_LIST_RESOURCE_ASSIGNEES = 39;
-  private static final int METHODID_UPDATE_CLOUDERA_MANAGER_LICENSE_KEY = 40;
-  private static final int METHODID_INITIATE_SUPPORT_CASE = 41;
-  private static final int METHODID_NOTIFY_RESOURCE_DELETED = 42;
-  private static final int METHODID_CREATE_MACHINE_USER = 43;
-  private static final int METHODID_LIST_MACHINE_USERS = 44;
-  private static final int METHODID_DELETE_MACHINE_USER = 45;
-  private static final int METHODID_LIST_RESOURCE_ROLE_ASSIGNMENTS = 46;
-  private static final int METHODID_SET_ACCOUNT_MESSAGES = 47;
-  private static final int METHODID_ACCEPT_TERMS = 48;
-  private static final int METHODID_CLEAR_ACCEPTED_TERMS = 49;
-  private static final int METHODID_DESCRIBE_TERMS = 50;
-  private static final int METHODID_LIST_TERMS = 51;
-  private static final int METHODID_LIST_ENTITLEMENTS = 52;
-  private static final int METHODID_SET_TERMS_ACCEPTANCE_EXPIRY = 53;
-  private static final int METHODID_CONFIRM_AZURE_SUBSCRIPTION_VERIFIED = 54;
-  private static final int METHODID_INSERT_AZURE_SUBSCRIPTION = 55;
-  private static final int METHODID_CREATE_GROUP = 56;
-  private static final int METHODID_DELETE_GROUP = 57;
-  private static final int METHODID_LIST_GROUPS = 58;
-  private static final int METHODID_UPDATE_GROUP = 59;
-  private static final int METHODID_ADD_MEMBER_TO_GROUP = 60;
-  private static final int METHODID_REMOVE_MEMBER_FROM_GROUP = 61;
-  private static final int METHODID_LIST_GROUP_MEMBERS = 62;
-  private static final int METHODID_LIST_GROUPS_FOR_MEMBER = 63;
-  private static final int METHODID_LIST_WORKLOAD_ADMINISTRATION_GROUPS_FOR_MEMBER = 64;
-  private static final int METHODID_CREATE_CLUSTER_SSH_PRIVATE_KEY = 65;
-  private static final int METHODID_GET_CLUSTER_SSH_PRIVATE_KEY = 66;
-  private static final int METHODID_GET_ASSIGNEE_AUTHORIZATION_INFORMATION = 67;
-  private static final int METHODID_CREATE_IDENTITY_PROVIDER_CONNECTOR = 68;
-  private static final int METHODID_LIST_IDENTITY_PROVIDER_CONNECTORS = 69;
-  private static final int METHODID_DELETE_IDENTITY_PROVIDER_CONNECTOR = 70;
-  private static final int METHODID_DESCRIBE_IDENTITY_PROVIDER_CONNECTOR = 71;
-  private static final int METHODID_UPDATE_IDENTITY_PROVIDER_CONNECTOR = 72;
-  private static final int METHODID_SET_CLOUDERA_SSOLOGIN_ENABLED = 73;
-  private static final int METHODID_GET_ID_PMETADATA_FOR_WORKLOAD_SSO = 74;
-  private static final int METHODID_PROCESS_WORKLOAD_SSOAUTHN_REQ = 75;
-  private static final int METHODID_SET_WORKLOAD_SUBDOMAIN = 76;
-  private static final int METHODID_CREATE_WORKLOAD_MACHINE_USER = 77;
-  private static final int METHODID_DELETE_WORKLOAD_MACHINE_USER = 78;
-  private static final int METHODID_GET_WORKLOAD_ADMINISTRATION_GROUP_NAME = 79;
-  private static final int METHODID_SET_WORKLOAD_ADMINISTRATION_GROUP_NAME = 80;
-  private static final int METHODID_DELETE_WORKLOAD_ADMINISTRATION_GROUP_NAME = 81;
-  private static final int METHODID_LIST_WORKLOAD_ADMINISTRATION_GROUPS = 82;
-  private static final int METHODID_SET_ACTOR_WORKLOAD_CREDENTIALS = 83;
-  private static final int METHODID_GET_ACTOR_WORKLOAD_CREDENTIALS = 84;
-  private static final int METHODID_GET_EVENT_GENERATION_IDS = 85;
-  private static final int METHODID_ADD_ACTOR_SSH_PUBLIC_KEY = 86;
-  private static final int METHODID_LIST_ACTOR_SSH_PUBLIC_KEYS = 87;
-  private static final int METHODID_DESCRIBE_ACTOR_SSH_PUBLIC_KEY = 88;
-  private static final int METHODID_DELETE_ACTOR_SSH_PUBLIC_KEY = 89;
-  private static final int METHODID_SET_WORKLOAD_PASSWORD_POLICY = 90;
-  private static final int METHODID_ASSIGN_CLOUD_IDENTITY = 91;
-  private static final int METHODID_UNASSIGN_CLOUD_IDENTITY = 92;
-  private static final int METHODID_ASSIGN_SERVICE_PRINCIPAL_CLOUD_IDENTITY = 93;
-  private static final int METHODID_UNASSIGN_SERVICE_PRINCIPAL_CLOUD_IDENTITY = 94;
-  private static final int METHODID_LIST_SERVICE_PRINCIPAL_CLOUD_IDENTITIES = 95;
-  private static final int METHODID_GET_USER_SYNC_STATE_MODEL = 96;
+  private static final int METHODID_VERIFY_C1CEMAIL = 28;
+  private static final int METHODID_GRANT_ENTITLEMENT = 29;
+  private static final int METHODID_REVOKE_ENTITLEMENT = 30;
+  private static final int METHODID_ENSURE_DEFAULT_ENTITLEMENTS_GRANTED = 31;
+  private static final int METHODID_ASSIGN_ROLE = 32;
+  private static final int METHODID_UNASSIGN_ROLE = 33;
+  private static final int METHODID_LIST_ASSIGNED_ROLES = 34;
+  private static final int METHODID_ASSIGN_RESOURCE_ROLE = 35;
+  private static final int METHODID_UNASSIGN_RESOURCE_ROLE = 36;
+  private static final int METHODID_LIST_ASSIGNED_RESOURCE_ROLES = 37;
+  private static final int METHODID_LIST_ROLES = 38;
+  private static final int METHODID_LIST_RESOURCE_ROLES = 39;
+  private static final int METHODID_LIST_RESOURCE_ASSIGNEES = 40;
+  private static final int METHODID_UPDATE_CLOUDERA_MANAGER_LICENSE_KEY = 41;
+  private static final int METHODID_INITIATE_SUPPORT_CASE = 42;
+  private static final int METHODID_NOTIFY_RESOURCE_DELETED = 43;
+  private static final int METHODID_CREATE_MACHINE_USER = 44;
+  private static final int METHODID_LIST_MACHINE_USERS = 45;
+  private static final int METHODID_DELETE_MACHINE_USER = 46;
+  private static final int METHODID_LIST_RESOURCE_ROLE_ASSIGNMENTS = 47;
+  private static final int METHODID_SET_ACCOUNT_MESSAGES = 48;
+  private static final int METHODID_ACCEPT_TERMS = 49;
+  private static final int METHODID_CLEAR_ACCEPTED_TERMS = 50;
+  private static final int METHODID_DESCRIBE_TERMS = 51;
+  private static final int METHODID_LIST_TERMS = 52;
+  private static final int METHODID_LIST_ENTITLEMENTS = 53;
+  private static final int METHODID_SET_TERMS_ACCEPTANCE_EXPIRY = 54;
+  private static final int METHODID_CONFIRM_AZURE_SUBSCRIPTION_VERIFIED = 55;
+  private static final int METHODID_INSERT_AZURE_SUBSCRIPTION = 56;
+  private static final int METHODID_CREATE_GROUP = 57;
+  private static final int METHODID_DELETE_GROUP = 58;
+  private static final int METHODID_LIST_GROUPS = 59;
+  private static final int METHODID_UPDATE_GROUP = 60;
+  private static final int METHODID_ADD_MEMBER_TO_GROUP = 61;
+  private static final int METHODID_REMOVE_MEMBER_FROM_GROUP = 62;
+  private static final int METHODID_LIST_GROUP_MEMBERS = 63;
+  private static final int METHODID_LIST_GROUPS_FOR_MEMBER = 64;
+  private static final int METHODID_LIST_WORKLOAD_ADMINISTRATION_GROUPS_FOR_MEMBER = 65;
+  private static final int METHODID_CREATE_CLUSTER_SSH_PRIVATE_KEY = 66;
+  private static final int METHODID_GET_CLUSTER_SSH_PRIVATE_KEY = 67;
+  private static final int METHODID_GET_ASSIGNEE_AUTHORIZATION_INFORMATION = 68;
+  private static final int METHODID_CREATE_IDENTITY_PROVIDER_CONNECTOR = 69;
+  private static final int METHODID_LIST_IDENTITY_PROVIDER_CONNECTORS = 70;
+  private static final int METHODID_DELETE_IDENTITY_PROVIDER_CONNECTOR = 71;
+  private static final int METHODID_DESCRIBE_IDENTITY_PROVIDER_CONNECTOR = 72;
+  private static final int METHODID_UPDATE_IDENTITY_PROVIDER_CONNECTOR = 73;
+  private static final int METHODID_SET_CLOUDERA_SSOLOGIN_ENABLED = 74;
+  private static final int METHODID_GET_ID_PMETADATA_FOR_WORKLOAD_SSO = 75;
+  private static final int METHODID_PROCESS_WORKLOAD_SSOAUTHN_REQ = 76;
+  private static final int METHODID_SET_WORKLOAD_SUBDOMAIN = 77;
+  private static final int METHODID_CREATE_WORKLOAD_MACHINE_USER = 78;
+  private static final int METHODID_DELETE_WORKLOAD_MACHINE_USER = 79;
+  private static final int METHODID_GET_WORKLOAD_ADMINISTRATION_GROUP_NAME = 80;
+  private static final int METHODID_SET_WORKLOAD_ADMINISTRATION_GROUP_NAME = 81;
+  private static final int METHODID_DELETE_WORKLOAD_ADMINISTRATION_GROUP_NAME = 82;
+  private static final int METHODID_LIST_WORKLOAD_ADMINISTRATION_GROUPS = 83;
+  private static final int METHODID_SET_ACTOR_WORKLOAD_CREDENTIALS = 84;
+  private static final int METHODID_GET_ACTOR_WORKLOAD_CREDENTIALS = 85;
+  private static final int METHODID_GET_EVENT_GENERATION_IDS = 86;
+  private static final int METHODID_ADD_ACTOR_SSH_PUBLIC_KEY = 87;
+  private static final int METHODID_LIST_ACTOR_SSH_PUBLIC_KEYS = 88;
+  private static final int METHODID_DESCRIBE_ACTOR_SSH_PUBLIC_KEY = 89;
+  private static final int METHODID_DELETE_ACTOR_SSH_PUBLIC_KEY = 90;
+  private static final int METHODID_SET_WORKLOAD_PASSWORD_POLICY = 91;
+  private static final int METHODID_ASSIGN_CLOUD_IDENTITY = 92;
+  private static final int METHODID_UNASSIGN_CLOUD_IDENTITY = 93;
+  private static final int METHODID_ASSIGN_SERVICE_PRINCIPAL_CLOUD_IDENTITY = 94;
+  private static final int METHODID_UNASSIGN_SERVICE_PRINCIPAL_CLOUD_IDENTITY = 95;
+  private static final int METHODID_LIST_SERVICE_PRINCIPAL_CLOUD_IDENTITIES = 96;
+  private static final int METHODID_GET_DEFAULT_IDENTITY_PROVIDER_CONNECTOR = 97;
+  private static final int METHODID_GET_USER_SYNC_STATE_MODEL = 98;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -8854,6 +9032,10 @@ public final class UserManagementGrpc {
         case METHODID_CREATE_C1CACCOUNT:
           serviceImpl.createC1CAccount((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateC1CAccountRequest) request,
               (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.CreateC1CAccountResponse>) responseObserver);
+          break;
+        case METHODID_VERIFY_C1CEMAIL:
+          serviceImpl.verifyC1CEmail((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.VerifyC1CEmailRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.VerifyC1CEmailResponse>) responseObserver);
           break;
         case METHODID_GRANT_ENTITLEMENT:
           serviceImpl.grantEntitlement((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GrantEntitlementRequest) request,
@@ -9127,6 +9309,10 @@ public final class UserManagementGrpc {
           serviceImpl.listServicePrincipalCloudIdentities((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesRequest) request,
               (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListServicePrincipalCloudIdentitiesResponse>) responseObserver);
           break;
+        case METHODID_GET_DEFAULT_IDENTITY_PROVIDER_CONNECTOR:
+          serviceImpl.getDefaultIdentityProviderConnector((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetDefaultIdentityProviderConnectorRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetDefaultIdentityProviderConnectorResponse>) responseObserver);
+          break;
         case METHODID_GET_USER_SYNC_STATE_MODEL:
           serviceImpl.getUserSyncStateModel((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetUserSyncStateModelRequest) request,
               (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetUserSyncStateModelResponse>) responseObserver);
@@ -9220,6 +9406,7 @@ public final class UserManagementGrpc {
               .addMethod(getCreateAccountMethodHelper())
               .addMethod(getCreateTrialAccountMethodHelper())
               .addMethod(getCreateC1CAccountMethodHelper())
+              .addMethod(getVerifyC1CEmailMethodHelper())
               .addMethod(getGrantEntitlementMethodHelper())
               .addMethod(getRevokeEntitlementMethodHelper())
               .addMethod(getEnsureDefaultEntitlementsGrantedMethodHelper())
@@ -9288,6 +9475,7 @@ public final class UserManagementGrpc {
               .addMethod(getAssignServicePrincipalCloudIdentityMethodHelper())
               .addMethod(getUnassignServicePrincipalCloudIdentityMethodHelper())
               .addMethod(getListServicePrincipalCloudIdentitiesMethodHelper())
+              .addMethod(getGetDefaultIdentityProviderConnectorMethodHelper())
               .addMethod(getGetUserSyncStateModelMethodHelper())
               .build();
         }

--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
@@ -216,12 +216,17 @@ public class GrpcUmsClient {
      *
      * @param accountId the account Id
      * @param includeInternal whether to include internal machine users
+     * @param includeWorkloadMachineUsers whether to include workload machine users
      * @param requestId an optional request Id
      * @return the user associated with this user CRN
      */
     public List<MachineUser> listAllMachineUsers(
-            String actorCrn, String accountId, boolean includeInternal, Optional<String> requestId) {
-        return listMachineUsers(actorCrn, accountId, null, includeInternal, requestId);
+            String actorCrn, String accountId,
+            boolean includeInternal, boolean includeWorkloadMachineUsers,
+            Optional<String> requestId) {
+        return listMachineUsers(actorCrn, accountId, null,
+                includeInternal, includeWorkloadMachineUsers,
+                requestId);
     }
 
     /**
@@ -230,17 +235,20 @@ public class GrpcUmsClient {
      * @param accountId       the account Id
      * @param machineUserCrns machine users to list. if null or empty then all machine users will be listed
      * @param includeInternal whether to include internal machine users
+     * @param includeWorkloadMachineUsers whether to include workload machine users
      * @param requestId       an optional request Id
      * @return the user associated with this user CRN
      */
     public List<MachineUser> listMachineUsers(
-            String actorCrn, String accountId, List<String> machineUserCrns, boolean includeInternal, Optional<String> requestId) {
+            String actorCrn, String accountId, List<String> machineUserCrns,
+            boolean includeInternal, boolean includeWorkloadMachineUsers,
+            Optional<String> requestId) {
 
         try (ManagedChannelWrapper channelWrapper = makeWrapper()) {
             UmsClient client = makeClient(channelWrapper.getChannel(), actorCrn);
             LOGGER.debug("Listing machine user information for account {} using request ID {}", accountId, requestId);
             List<MachineUser> machineUsers = client.listMachineUsers(requestId.orElse(UUID.randomUUID().toString()),
-                    accountId, machineUserCrns, includeInternal);
+                    accountId, machineUserCrns, includeInternal, includeWorkloadMachineUsers);
             LOGGER.debug("{} Machine users found for account {}", machineUsers.size(), accountId);
             return machineUsers;
         }

--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/UmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/UmsClient.java
@@ -253,10 +253,12 @@ public class UmsClient {
      * @param accountId                the account ID
      * @param machineUserNameOrCrnList a list of users to list. If null or empty then all users will be listed
      * @param includeInternal          whether to include internal machine users
+     * @param includeWorkloadMachineUsers whether to include workload machine users
      * @return the list of machine users
      */
     public List<MachineUser> listMachineUsers(
-            String requestId, String accountId, List<String> machineUserNameOrCrnList, boolean includeInternal) {
+            String requestId, String accountId, List<String> machineUserNameOrCrnList,
+            boolean includeInternal, boolean includeWorkloadMachineUsers) {
 
         checkNotNull(requestId);
         checkNotNull(accountId);
@@ -266,6 +268,7 @@ public class UmsClient {
         ListMachineUsersRequest.Builder requestBuilder = ListMachineUsersRequest.newBuilder()
                 .setAccountId(accountId)
                 .setIncludeInternal(includeInternal)
+                .setIncludeWorkloadMachineUsers(includeWorkloadMachineUsers)
                 .setPageSize(umsClientConfig.getListMachineUsersPageSize());
 
         if (machineUserNameOrCrnList != null && !machineUserNameOrCrnList.isEmpty()) {

--- a/auth-connector/src/main/proto/usermanagement.proto
+++ b/auth-connector/src/main/proto/usermanagement.proto
@@ -137,7 +137,12 @@ service UserManagement {
 
   // Create an email based account.
   rpc CreateC1CAccount (CreateC1CAccountRequest)
-  returns (CreateC1CAccountResponse) {}
+    returns (CreateC1CAccountResponse) {}
+
+  // An endpoint called when a user verifies their email by clicking the link we sent
+  // them.
+  rpc VerifyC1CEmail (VerifyC1CEmailRequest)
+    returns (VerifyC1CEmailResponse) {}
 
   // Grant Entitlement to an Account
   rpc GrantEntitlement (GrantEntitlementRequest)
@@ -438,6 +443,10 @@ service UserManagement {
   // List cloud identity mappings for service principals.
   rpc ListServicePrincipalCloudIdentities (ListServicePrincipalCloudIdentitiesRequest)
     returns (ListServicePrincipalCloudIdentitiesResponse) {}
+
+  // Retrieves the CRN of identity provider connector used for CDP initiated logins.
+  rpc GetDefaultIdentityProviderConnector (GetDefaultIdentityProviderConnectorRequest)
+      returns (GetDefaultIdentityProviderConnectorResponse) {}
 
   // Get user sync state model, including actors, groups, workload administration groups, etc
   rpc GetUserSyncStateModel (GetUserSyncStateModelRequest)
@@ -1328,10 +1337,21 @@ message CreateC1CAccountRequest {
   string firstName = 2;
   // This may be an empty string.
   string lastName = 3;
+  // The user's password;
+  string password = 4 [(options.FieldExtension.sensitive) = true];
 }
 
 message CreateC1CAccountResponse {
   Account account = 1;
+}
+
+message VerifyC1CEmailRequest {
+  // The registration token passed by the caller
+  string registrationToken = 1 [(options.FieldExtension.sensitive) = true];
+}
+
+message VerifyC1CEmailResponse {
+  string userCrn = 1;
 }
 
 message AccountId {
@@ -1419,6 +1439,7 @@ message AssignRoleRequest {
 }
 
 message AssignRoleResponse {
+  string assigneeCrn = 1;
 }
 
 message UnassignRoleRequest {
@@ -1430,6 +1451,7 @@ message UnassignRoleRequest {
 }
 
 message UnassignRoleResponse {
+  string assigneeCrn = 1;
 }
 
 message ListAssignedRolesRequest {
@@ -1458,6 +1480,7 @@ message AssignResourceRoleRequest {
 }
 
 message AssignResourceRoleResponse {
+  string assigneeCrn = 1;
 }
 
 message UnassignResourceRoleRequest {
@@ -1470,6 +1493,7 @@ message UnassignResourceRoleRequest {
 }
 
 message UnassignResourceRoleResponse {
+  string assigneeCrn = 1;
 }
 
 message ListAssignedResourceRolesRequest {
@@ -1703,6 +1727,13 @@ message ListMachineUsersRequest {
   bool includeInternal = 5;
   // Whether to include deleted machine users.
   bool includeDeleted = 6;
+  // Whether to include workload machine users. All regular machine users are
+  // workload machine users. This is a subset of the internal machine users,
+  // which have a password set. This field has no effect if internal machine
+  // users are requested because all workload machine users will already be
+  // included in the results. Note that this has no impact when listing by name
+  // or CRN. For those calls, internal machine users are always returned.
+  bool includeWorkloadMachineUsers = 7;
   // See the PageToken comment in paging.proto on paging usage.
   int32 pageSize = 3;
   paging.PageToken pageToken = 4;
@@ -1981,6 +2012,7 @@ message AddMemberToGroupRequest {
 }
 
 message AddMemberToGroupResponse {
+  string memberCrn = 1;
 }
 
 message RemoveMemberFromGroupRequest {
@@ -1991,6 +2023,7 @@ message RemoveMemberFromGroupRequest {
 }
 
 message RemoveMemberFromGroupResponse {
+  string memberCrn = 1;
 }
 
 message ListGroupMembersRequest {
@@ -2872,6 +2905,7 @@ message GetActorWorkloadCredentialsRequest {
   string actorCrn = 1;
 }
 
+// TODO CDPCP-3033 - migrate this object to use ActorWorkloadCredentials
 message GetActorWorkloadCredentialsResponse {
   // The password hash.
   string passwordHash = 1 [(options.FieldExtension.sensitive) = true];
@@ -3163,26 +3197,43 @@ message ListServicePrincipalCloudIdentitiesResponse {
   paging.PageToken nextPageToken = 2;
 }
 
+message GetDefaultIdentityProviderConnectorRequest {
+  // The account ID for which default identity provider connector is retrieved.
+  string accountId = 1;
+}
+
+message GetDefaultIdentityProviderConnectorResponse {
+  // The CRN of the identity provider connector used for CDP initiated logins. The CRN is a user defined
+  // identity provider or one of the CDP built-ins (like Cloudera SSO).
+  string crn = 1;
+}
+
 message GetUserSyncStateModelRequest {
   // The account id.
   string accountId = 1;
-  // The rights checks to be performed on each actor.
+  // The rights checks to be performed on each actor. The response model contains
+  // all actors and the results of these rights checks for each actor.
   repeated RightsCheck rightsCheck = 2;
 }
 
 message GetUserSyncStateModelResponse {
+  // Event generation ids when the user sync state model is created. The responses are guaranteed
+  // to be at least as recent as the event generation ids.
   EventGenerationIds eventGenerationIds = 1;
-  // Users and machine users, along with supporting information needed for user sync.
+  // All users and machine users in this account, along with supporting information needed for
+  // user sync.
   repeated UserSyncActor actor = 2;
-  // Groups.
+  // All groups in this account.
   repeated Group group = 3;
-  // Workload administration groups.
+  // All workload administration groups in this account.
   repeated WorkloadAdministrationGroup workloadAdministrationGroup = 4;
 }
 
 // Actor workload credentials object. This contains fields needed to set
 // workload credentials through user sync.
+// TODO CDPCP-3033 - migrate GetActorWorkloadCredentialsResponse to use this object
 message ActorWorkloadCredentials {
+  reserved 4;
   // The password hash.
   string passwordHash = 1 [(options.FieldExtension.sensitive) = true];
   // The date, in ms from the Java epoch of 1970-01-01T00:00:00Z, when the
@@ -3219,9 +3270,14 @@ message UserSyncActor {
 }
 
 message UserSyncActorDetails {
+  // The name user sync will store in the first name field
   string firstName = 1;
+  // The name user sync will store in the last name field
   string lastName = 2;
+  // The actor's CRN
   string crn = 3;
+  // The actor's workload username
   string workloadUsername = 4;
+  // The actor's cloud identities
   repeated CloudIdentity cloudIdentity = 5;
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/ums/DefaultUmsUsersStateProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/ums/DefaultUmsUsersStateProvider.java
@@ -33,7 +33,10 @@ import static java.util.Objects.requireNonNull;
 @Component
 public class DefaultUmsUsersStateProvider extends BaseUmsUsersStateProvider {
     @VisibleForTesting
-    static final boolean INCLUDE_INTERNAL_MACHINE_USERS = true;
+    static final boolean DONT_INCLUDE_INTERNAL_MACHINE_USERS = false;
+
+    @VisibleForTesting
+    static final boolean INCLUDE_WORKLOAD_MACHINE_USERS = true;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultUmsUsersStateProvider.class);
 
@@ -165,10 +168,12 @@ public class DefaultUmsUsersStateProvider extends BaseUmsUsersStateProvider {
             boolean fullSync, Set<String> machineUserCrns) {
         if (fullSync) {
             return grpcUmsClient.listAllMachineUsers(actorCrn, accountId,
-                    INCLUDE_INTERNAL_MACHINE_USERS, requestIdOptional);
+                    DONT_INCLUDE_INTERNAL_MACHINE_USERS, INCLUDE_WORKLOAD_MACHINE_USERS,
+                    requestIdOptional);
         } else if (!machineUserCrns.isEmpty()) {
             return grpcUmsClient.listMachineUsers(actorCrn, accountId, List.copyOf(machineUserCrns),
-                    INCLUDE_INTERNAL_MACHINE_USERS, requestIdOptional);
+                    DONT_INCLUDE_INTERNAL_MACHINE_USERS, INCLUDE_WORKLOAD_MACHINE_USERS,
+                    requestIdOptional);
         } else {
             return List.of();
         }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/ums/DefaultUmsUsersStateProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/ums/DefaultUmsUsersStateProviderTest.java
@@ -84,7 +84,9 @@ class DefaultUmsUsersStateProviderTest extends BaseUmsUsersStateProviderTest {
                 .thenReturn(testData.users);
 
         when(grpcUmsClient.listAllMachineUsers(eq(ACTOR_CRN), eq(ACCOUNT_ID),
-                eq(DefaultUmsUsersStateProvider.INCLUDE_INTERNAL_MACHINE_USERS), any(Optional.class)))
+                eq(DefaultUmsUsersStateProvider.DONT_INCLUDE_INTERNAL_MACHINE_USERS),
+                eq(DefaultUmsUsersStateProvider.INCLUDE_WORKLOAD_MACHINE_USERS),
+                any(Optional.class)))
                 .thenReturn(testData.machineUsers);
 
         doAnswer(invocation -> {


### PR DESCRIPTION
See detailed description in the commit message.

This changes the flag we use when retrieving machine users. Rather than retrieving all internal machine users, most of which are not workload identities, we've added another flag to the usermanagement.proto to indicate that we want all the workload machine users.

This change is needed because we've discovered that we have an unknown and likely large number of orphaned internal machine users. Processing all internal machine users negatively impacts user sync performance. E.g., in mow-dev, we move from syncing 2500 actors to 8000+ actors.