### PR TITLE
CB-9180 Freeipa install in GCP does not populate reverse DNS entries

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaConfigService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaConfigService.java
@@ -52,7 +52,9 @@ public class FreeIpaConfigService {
 
         FreeIpa freeIpa = freeIpaService.findByStack(stack);
         Map<String, String> subnetWithCidr = networkService.getFilteredSubnetWithCidr(stack);
+        LOGGER.debug("Subnets for reverse zone calculation : {}", subnetWithCidr);
         String reverseZones = reverseDnsZoneCalculator.reverseDnsZoneForCidrs(subnetWithCidr.values());
+        LOGGER.debug("Reverse zones : {}", reverseZones);
 
         return builder
                 .withRealm(freeIpa.getDomain().toUpperCase())

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/NetworkService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/NetworkService.java
@@ -57,11 +57,11 @@ public class NetworkService {
                     // support for azure
                     String[] splittedNetworkId = cloudNetwork.getId().split("/");
                     String cloudNetworkId = splittedNetworkId[splittedNetworkId.length - 1];
-                    return networkId.equals(cloudNetworkId);
+                    return networkId.equals(cloudNetworkId) || networkId.equals(cloudNetwork.getName());
                 })
                 .flatMap(cloudNetwork -> cloudNetwork.getSubnetsMeta().stream())
                 .filter(cloudSubnet -> StringUtils.isNoneBlank(cloudSubnet.getId(), cloudSubnet.getCidr()))
-                .filter(cloudSubnet -> subnetIds.contains(cloudSubnet.getId()))
+                .filter(cloudSubnet -> subnetIds.contains(cloudSubnet.getId()) || subnetIds.contains(cloudSubnet.getName()))
                 .collect(Collectors.toMap(CloudSubnet::getId, CloudSubnet::getCidr));
     }
 }

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_install.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_install.sh
@@ -15,9 +15,11 @@ ipa-server-install \
           -p "$FPW" \
           --setup-dns \
           --auto-reverse \
-{%- for zone in salt['pillar.get']('freeipa:reverseZones').split(',') %}
+{%- if salt['pillar.get']('freeipa:reverseZones') %}
+  {%- for zone in salt['pillar.get']('freeipa:reverseZones').split(',') %}
           --reverse-zone {{ zone }} \
-{%- endfor %}
+  {%- endfor %}
+{%- endif %}
           --allow-zone-overlap \
           --ssh-trust-dns \
           --mkhomedir \


### PR DESCRIPTION
1. We accept the subnet name from the user for GCP.
2. When we fetch the subnet information back from GCP, it gives the internal subnet id.
3. So make the subnet filtering logic in NetworkService similar to CloudNetworkService https://github.com/hortonworks/cloudbreak/blob/master/environment/src/main/java/com/sequenceiq/environment/network/CloudNetworkService.java#L130
4. We saw that the jinja2 template picked the next argument as the reverse zone value if the zones is an empty list, fixed that part also.

Tested in private stack

```
    $ ipa dnszone-find
      Zone name: 114.10.in-addr.arpa.
      Active zone: TRUE
      Authoritative nameserver: ipaserver0.demo5.r6zv-kv2u.dev.cldr.work.
      Administrator e-mail address: hostmaster.demo5.r6zv-kv2u.dev.cldr.work.
      SOA serial: 1602118320
      SOA refresh: 3600
      SOA retry: 900
      SOA expire: 1209600
      SOA minimum: 3600
      Allow query: any;
      Allow transfer: none;
    
      Zone name: demo5.r6zv-kv2u.dev.cldr.work.
      Active zone: TRUE
      Authoritative nameserver: ipaserver0.demo5.r6zv-kv2u.dev.cldr.work.
      Administrator e-mail address: hostmaster.demo5.r6zv-kv2u.dev.cldr.work.
      SOA serial: 1602118320
      SOA refresh: 3600
      SOA retry: 900
      SOA expire: 1209600
      SOA minimum: 3600
      Allow query: any;
      Allow transfer: none;
    ----------------------------
    Number of entries returned 2
    ----------------------------
```