### PR TITLE
CB-9110 Persist managed image status -- follow up refactorings

### DIFF
--- a/cloud-azure/build.gradle
+++ b/cloud-azure/build.gradle
@@ -47,10 +47,6 @@ dependencies {
   testCompile (group: 'org.mockito',             name: 'mockito-core',          version: mockitoVersion) {
     exclude group: 'org.hamcrest'
   }
-  testCompile (group: 'org.powermock',             name: 'powermock-module-junit4',        version: powermockVersion)
-  testCompile (group: 'org.powermock',             name: 'powermock-api-mockito2',          version: powermockVersion) {
-    exclude group: 'org.hamcrest'
-  }
   testCompile (group: 'org.hamcrest', name: 'java-hamcrest', version: hamcrestVersion)
   testCompile project(path: ':cloud-common', configuration: 'tests')
 

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStorage.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStorage.java
@@ -29,7 +29,7 @@ import com.microsoft.azure.management.storage.StorageAccount;
 import com.microsoft.azure.management.storage.StorageAccounts;
 import com.microsoft.azure.management.storage.implementation.StorageAccountInner;
 import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
-import com.sequenceiq.cloudbreak.cloud.azure.client.AzureImageService;
+import com.sequenceiq.cloudbreak.cloud.azure.image.AzureImageService;
 import com.sequenceiq.cloudbreak.cloud.azure.connector.resource.AzureStorageAccountBuilderService;
 import com.sequenceiq.cloudbreak.cloud.azure.connector.resource.StorageAccountParameters;
 import com.sequenceiq.cloudbreak.cloud.azure.storage.SkuTypeResolver;

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureImageSetupService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureImageSetupService.java
@@ -21,7 +21,6 @@ import com.sequenceiq.cloudbreak.cloud.azure.AzureResourceGroupMetadataProvider;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureStorage;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureStorageAccountService;
 import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
-import com.sequenceiq.cloudbreak.cloud.azure.client.AzureImageService;
 import com.sequenceiq.cloudbreak.cloud.azure.view.AzureCredentialView;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureManagedImageService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureManagedImageService.java
@@ -1,9 +1,6 @@
 package com.sequenceiq.cloudbreak.cloud.azure.image;
 
 import java.util.Optional;
-import java.util.function.Supplier;
-
-import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,18 +8,14 @@ import org.springframework.stereotype.Service;
 
 import com.microsoft.azure.management.compute.VirtualMachineCustomImage;
 import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
-import com.sequenceiq.cloudbreak.cloud.azure.util.AzureAuthExceptionHandler;
 
 @Service
 public class AzureManagedImageService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AzureManagedImageService.class);
 
-    @Inject
-    private AzureAuthExceptionHandler azureAuthExceptionHandler;
-
     public Optional<VirtualMachineCustomImage> findVirtualMachineCustomImage(String resourceGroup, String imageName, AzureClient client) {
-        VirtualMachineCustomImage image = findImage(resourceGroup, imageName, client);
+        VirtualMachineCustomImage image = client.findImage(resourceGroup, imageName);
         if (image != null) {
             LOGGER.debug("Custom image {} is present in resource group {}", imageName, resourceGroup);
             return Optional.of(image);
@@ -30,16 +23,5 @@ public class AzureManagedImageService {
             LOGGER.debug("Custom image {} is not present in resource group {}", imageName, resourceGroup);
             return Optional.empty();
         }
-    }
-
-    private VirtualMachineCustomImage findImage(String resourceGroup, String imageName, AzureClient client) {
-        LOGGER.debug("Searching custom image {} in resource group {}", imageName, resourceGroup);
-        return azureAuthExceptionHandler.handleAuthException(() -> client.getAzure()
-                .virtualMachineCustomImages()
-                .getByResourceGroup(resourceGroup, imageName));
-    }
-
-    private <T> T handleAuthException(Supplier<T> function) {
-        return azureAuthExceptionHandler.handleAuthException(function);
     }
 }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/util/CustomVMImageNameProvider.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/util/CustomVMImageNameProvider.java
@@ -1,14 +1,14 @@
 package com.sequenceiq.cloudbreak.cloud.azure.util;
 
+import org.springframework.stereotype.Component;
+
+@Component
 public class CustomVMImageNameProvider {
     private static final int NAME_MAXIMUM_LENGTH = 80;
 
     private static final char DELIMITER = '-';
 
-    private CustomVMImageNameProvider() {
-    }
-
-    public static String get(String region, String vhdName) {
+    public String get(String region, String vhdName) {
         String name = vhdName + DELIMITER + region.toLowerCase().replaceAll("\\s", "");
         if (name.length() > NAME_MAXIMUM_LENGTH) {
             int diff = name.length() - NAME_MAXIMUM_LENGTH;

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureImageServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureImageServiceTest.java
@@ -1,0 +1,217 @@
+package com.sequenceiq.cloudbreak.cloud.azure.image;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.microsoft.azure.CloudException;
+import com.microsoft.azure.management.compute.VirtualMachineCustomImage;
+import com.microsoft.azure.management.resources.Subscription;
+import com.sequenceiq.cloudbreak.cloud.azure.AzureImage;
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.azure.task.image.AzureManagedImageCreationCheckerContext;
+import com.sequenceiq.cloudbreak.cloud.azure.task.image.AzureManagedImageCreationPoller;
+import com.sequenceiq.cloudbreak.cloud.azure.util.CustomVMImageNameProvider;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+import com.sequenceiq.cloudbreak.cloud.model.Location;
+import com.sequenceiq.cloudbreak.cloud.model.Region;
+import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
+import com.sequenceiq.cloudbreak.cloud.notification.PersistenceRetriever;
+import com.sequenceiq.common.api.type.CommonStatus;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AzureImageServiceTest {
+
+    private static final String RESOURCE_GROUP_NAME = "resourceGroupName";
+
+    private static final String FROM_VHD_URI = "fromVhdUri";
+
+    private static final String CUSTOM_IMAGE_NAME = "customImageName";
+
+    private static final String CUSTOM_IMAGE_ID = "customImageId";
+
+    private static final String REGION_NAME = "regionName";
+
+    private static final String SUBSCRIPTION_ID = "subscriptionId";
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Mock
+    private PersistenceRetriever resourcePersistenceRetriever;
+
+    @Mock
+    private PersistenceNotifier persistenceNotifier;
+
+    @Mock
+    private AzureImageIdProviderService azureImageIdProviderService;
+
+    @Mock
+    private AzureManagedImageCreationPoller azureManagedImageCreationPoller;
+
+    @Mock
+    private AzureManagedImageService azureManagedImageService;
+
+    @Mock
+    private AuthenticatedContext authenticatedContext;
+
+    @Mock
+    private AzureClient azureClient;
+
+    @Mock
+    private VirtualMachineCustomImage virtualMachineCustomImage;
+
+    @Mock
+    private CustomVMImageNameProvider customVMImageNameProvider;
+
+    @InjectMocks
+    private AzureImageService underTest;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        setupAuthenticatedContext();
+        setupAzureClient();
+        when(customVMImageNameProvider.get(anyString(), anyString())).thenReturn(CUSTOM_IMAGE_NAME);
+        when(azureImageIdProviderService.generateImageId(anyString(), anyString(), anyString())).thenReturn(CUSTOM_IMAGE_ID);
+    }
+
+    @Test
+    public void testGetCustomImageIdWhenImageExistsOnAzure() {
+        when(azureManagedImageService.findVirtualMachineCustomImage(anyString(), anyString(), any())).thenReturn(Optional.of(virtualMachineCustomImage));
+
+        AzureImage azureImage = underTest.getCustomImageId(RESOURCE_GROUP_NAME, FROM_VHD_URI, authenticatedContext, false, azureClient);
+
+        assertEquals(CUSTOM_IMAGE_ID, azureImage.getId());
+        assertEquals(CUSTOM_IMAGE_NAME, azureImage.getName());
+        verifyPollingStarted();
+    }
+
+    @Test
+    public void testGetCustomImageIdWhenImageIsRequested() {
+        when(azureManagedImageService.findVirtualMachineCustomImage(anyString(), anyString(), any())).thenReturn(Optional.empty());
+        when(resourcePersistenceRetriever.notifyRetrieve(anyString(), any(), any())).thenReturn(Optional.of(mock(CloudResource.class)));
+
+        AzureImage azureImage = underTest.getCustomImageId(RESOURCE_GROUP_NAME, FROM_VHD_URI, authenticatedContext, false, azureClient);
+
+        assertEquals(CUSTOM_IMAGE_ID, azureImage.getId());
+        assertEquals(CUSTOM_IMAGE_NAME, azureImage.getName());
+        verifyPollingStarted();
+    }
+
+    @Test
+    public void testGetCustomImageIdWhenImageWasNotRequestedAndDoNotCreateIfNotFound() {
+        when(azureManagedImageService.findVirtualMachineCustomImage(anyString(), anyString(), any())).thenReturn(Optional.empty());
+
+        AzureImage azureImage = underTest.getCustomImageId(RESOURCE_GROUP_NAME, FROM_VHD_URI, authenticatedContext, false, azureClient);
+
+        assertNull(azureImage);
+        verify(azureManagedImageCreationPoller, never()).startPolling(any(), any());
+        verify(azureClient, never()).createCustomImage(anyString(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    public void testGetCustomImageIdWhenImageWasNotRequestedAndCreateIfNotFoundAndSuccess() {
+        when(azureManagedImageService.findVirtualMachineCustomImage(anyString(), anyString(), any())).thenReturn(Optional.empty());
+        when(azureClient.createCustomImage(anyString(), anyString(), anyString(), anyString())).thenReturn(virtualMachineCustomImage);
+        when(virtualMachineCustomImage.name()).thenReturn(CUSTOM_IMAGE_NAME);
+        when(virtualMachineCustomImage.id()).thenReturn(CUSTOM_IMAGE_ID);
+
+        AzureImage azureImage = underTest.getCustomImageId(RESOURCE_GROUP_NAME, FROM_VHD_URI, authenticatedContext, true, azureClient);
+
+        assertEquals(CUSTOM_IMAGE_ID, azureImage.getId());
+        assertEquals(CUSTOM_IMAGE_NAME, azureImage.getName());
+        verifyPersistenceNotification(cr -> verify(persistenceNotifier).notifyAllocation(cr.capture(), any()), CommonStatus.REQUESTED);
+        verifyPersistenceNotification(cr -> verify(persistenceNotifier).notifyUpdate(cr.capture(), any()), CommonStatus.CREATED);
+        verify(azureClient).createCustomImage(CUSTOM_IMAGE_NAME, RESOURCE_GROUP_NAME, FROM_VHD_URI, REGION_NAME);
+    }
+
+    @Test
+    public void testGetCustomImageIdWhenImageWasNotRequestedAndCreateIfNotFoundAndError() {
+        when(azureManagedImageService.findVirtualMachineCustomImage(anyString(), anyString(), any())).thenReturn(Optional.empty());
+        when(azureClient.createCustomImage(anyString(), anyString(), anyString(), anyString())).thenThrow(new CloudException("", null));
+        thrown.expect(CloudConnectorException.class);
+
+        try {
+            underTest.getCustomImageId(RESOURCE_GROUP_NAME, FROM_VHD_URI, authenticatedContext, true, azureClient);
+
+        } catch (CloudConnectorException e) {
+            verifyPersistenceNotification(cr -> verify(persistenceNotifier).notifyAllocation(cr.capture(), any()), CommonStatus.REQUESTED);
+            verifyPersistenceNotification(cr -> verify(persistenceNotifier).notifyUpdate(cr.capture(), any()), CommonStatus.FAILED);
+            verify(azureClient).createCustomImage(CUSTOM_IMAGE_NAME, RESOURCE_GROUP_NAME, FROM_VHD_URI, REGION_NAME);
+            throw e;
+        }
+    }
+
+    @Test
+    public void testGetCustomImageIdWhenImageWasNotRequestedAndCreateIfNotFoundAndErrorButImagePresent() {
+        when(azureManagedImageService.findVirtualMachineCustomImage(anyString(), anyString(), any()))
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.of(virtualMachineCustomImage));
+        when(azureClient.createCustomImage(anyString(), anyString(), anyString(), anyString())).thenThrow(new CloudException("", null));
+        when(virtualMachineCustomImage.name()).thenReturn(CUSTOM_IMAGE_NAME);
+        when(virtualMachineCustomImage.id()).thenReturn(CUSTOM_IMAGE_ID);
+
+        AzureImage azureImage = underTest.getCustomImageId(RESOURCE_GROUP_NAME, FROM_VHD_URI, authenticatedContext, true, azureClient);
+
+        assertEquals(CUSTOM_IMAGE_ID, azureImage.getId());
+        assertEquals(CUSTOM_IMAGE_NAME, azureImage.getName());
+        verifyPersistenceNotification(cr -> verify(persistenceNotifier).notifyAllocation(cr.capture(), any()), CommonStatus.REQUESTED);
+        verifyPersistenceNotification(cr -> verify(persistenceNotifier).notifyUpdate(cr.capture(), any()), CommonStatus.CREATED);
+        verify(azureClient).createCustomImage(CUSTOM_IMAGE_NAME, RESOURCE_GROUP_NAME, FROM_VHD_URI, REGION_NAME);
+    }
+
+    private void setupAzureClient() {
+        Subscription subscription = mock(Subscription.class);
+        when(subscription.subscriptionId()).thenReturn(SUBSCRIPTION_ID);
+        when(azureClient.getCurrentSubscription()).thenReturn(subscription);
+    }
+
+    private void setupAuthenticatedContext() {
+        Region region = mock(Region.class);
+        Location location = mock(Location.class);
+        CloudContext cloudContext = mock(CloudContext.class);
+        when(region.getRegionName()).thenReturn(REGION_NAME);
+        when(location.getRegion()).thenReturn(region);
+        when(cloudContext.getLocation()).thenReturn(location);
+        when(authenticatedContext.getCloudContext()).thenReturn(cloudContext);
+    }
+
+    private void verifyPersistenceNotification(Consumer<ArgumentCaptor<CloudResource>> argumentCaptorConsumer, CommonStatus imageStatus) {
+        ArgumentCaptor<CloudResource> argumentCaptor = ArgumentCaptor.forClass(CloudResource.class);
+        argumentCaptorConsumer.accept(argumentCaptor);
+        assertEquals(CUSTOM_IMAGE_NAME, argumentCaptor.getValue().getName());
+        assertEquals(CUSTOM_IMAGE_ID, argumentCaptor.getValue().getReference());
+        assertEquals(imageStatus, argumentCaptor.getValue().getStatus());
+
+    }
+
+    private void verifyPollingStarted() {
+        ArgumentCaptor<AzureManagedImageCreationCheckerContext> captor = ArgumentCaptor.forClass(AzureManagedImageCreationCheckerContext.class);
+        verify(azureManagedImageCreationPoller).startPolling(any(), captor.capture());
+        assertEquals(CUSTOM_IMAGE_NAME, captor.getValue().getImageName());
+        assertEquals(RESOURCE_GROUP_NAME, captor.getValue().getResourceGroupName());
+    }
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureManagedImageServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureManagedImageServiceTest.java
@@ -13,18 +13,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.Spy;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-import com.microsoft.azure.management.Azure;
 import com.microsoft.azure.management.compute.VirtualMachineCustomImage;
-import com.microsoft.azure.management.compute.VirtualMachineCustomImages;
 import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
 import com.sequenceiq.cloudbreak.cloud.azure.util.AzureAuthExceptionHandler;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({ Azure.class })
+@RunWith(MockitoJUnitRunner.class)
 public class AzureManagedImageServiceTest {
 
     private static final String RESOURCE_GROUP = "resource-group";
@@ -37,43 +32,29 @@ public class AzureManagedImageServiceTest {
     @Mock
     private AzureClient azureClient;
 
-    @Mock
-    private VirtualMachineCustomImages virtualMachineCustomImages;
-
     @Spy
     private final AzureAuthExceptionHandler azureAuthExceptionHandler = new AzureAuthExceptionHandler();
 
     @Test
     public void testGetVirtualMachineCustomImageShouldReturnTheImageWhenExistsOnProviderSide() {
         VirtualMachineCustomImage image = Mockito.mock(VirtualMachineCustomImage.class);
-        Azure azure = PowerMockito.mock(Azure.class);
 
-        when(azureClient.getAzure()).thenReturn(azure);
-        when(azure.virtualMachineCustomImages()).thenReturn(virtualMachineCustomImages);
-        when(virtualMachineCustomImages.getByResourceGroup(RESOURCE_GROUP, IMAGE_NAME)).thenReturn(image);
+        when(azureClient.findImage(RESOURCE_GROUP, IMAGE_NAME)).thenReturn(image);
 
         Optional<VirtualMachineCustomImage> actual = underTest.findVirtualMachineCustomImage(RESOURCE_GROUP, IMAGE_NAME, azureClient);
 
         assertTrue(actual.isPresent());
         assertEquals(image, actual.get());
-        verify(azureClient).getAzure();
-        verify(azure).virtualMachineCustomImages();
-        verify(virtualMachineCustomImages).getByResourceGroup(RESOURCE_GROUP, IMAGE_NAME);
+        verify(azureClient).findImage(RESOURCE_GROUP, IMAGE_NAME);
     }
 
     @Test
     public void testGetVirtualMachineCustomImageShouldReturnTheImageWhenDoesNotExistsOnProviderSide() {
-        Azure azure = PowerMockito.mock(Azure.class);
-
-        when(azureClient.getAzure()).thenReturn(azure);
-        when(azure.virtualMachineCustomImages()).thenReturn(virtualMachineCustomImages);
-        when(virtualMachineCustomImages.getByResourceGroup(RESOURCE_GROUP, IMAGE_NAME)).thenReturn(null);
+        when(azureClient.findImage(RESOURCE_GROUP, IMAGE_NAME)).thenReturn(null);
 
         Optional<VirtualMachineCustomImage> actual = underTest.findVirtualMachineCustomImage(RESOURCE_GROUP, IMAGE_NAME, azureClient);
 
         assertTrue(actual.isEmpty());
-        verify(azureClient).getAzure();
-        verify(azure).virtualMachineCustomImages();
-        verify(virtualMachineCustomImages).getByResourceGroup(RESOURCE_GROUP, IMAGE_NAME);
+        verify(azureClient).findImage(RESOURCE_GROUP, IMAGE_NAME);
     }
 }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/util/CustomVMImageNameProviderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/util/CustomVMImageNameProviderTest.java
@@ -10,12 +10,14 @@ public class CustomVMImageNameProviderTest {
 
     private static final Pattern IMAGE_NAME_PATTERN = Pattern.compile(AZURE_IMAGE_NAME_REGULAR_EXPRESSION);
 
+    private CustomVMImageNameProvider underTest = new CustomVMImageNameProvider();
+
     @Test
     public void testNameGenerationWhenRegionAndWhdNameWithDelimiterDoesNotExceedMaximumLength() {
         String vhdName = "cb-hdp-26-1907121707-osDisk.cc5baaaa-717e-4551-b7ae-aaaa03c72a6a.vhd";
         String region = "West US";
 
-        String actual = CustomVMImageNameProvider.get(region, vhdName);
+        String actual = underTest.get(region, vhdName);
 
         Assert.assertTrue(IMAGE_NAME_PATTERN.matcher(actual).matches());
         Assert.assertEquals("cb-hdp-26-1907121707-osDisk.cc5baaaa-717e-4551-b7ae-aaaa03c72a6a.vhd-westus", actual);
@@ -26,7 +28,7 @@ public class CustomVMImageNameProviderTest {
         String vhdName = "cb-hdp-26-1907121707-osDisk.cc5baaaa-717e-4551-b7ae-aaaa03c72a6a.vhd";
         String region = "South East Asia";
 
-        String actual = CustomVMImageNameProvider.get(region, vhdName);
+        String actual = underTest.get(region, vhdName);
 
         Assert.assertTrue(IMAGE_NAME_PATTERN.matcher(actual).matches());
         Assert.assertEquals("cb-hdp-26-1907121707-osDisk.cc5baaaa-717e-4551-b7ae-aaaa03c72a6a.v-southeastasia", actual);
@@ -37,7 +39,7 @@ public class CustomVMImageNameProviderTest {
         String vhdName = "cb-hdp-26-1907121707-osDisk.cc5baaaa-717e-4551-b7ae-aaaa03c72a6aa.vhd";
         String region = "South East Asia";
 
-        String actual = CustomVMImageNameProvider.get(region, vhdName);
+        String actual = underTest.get(region, vhdName);
 
         Assert.assertTrue(IMAGE_NAME_PATTERN.matcher(actual).matches());
         Assert.assertEquals("cb-hdp-26-1907121707-osDisk.cc5baaaa-717e-4551-b7ae-aaaa03c72a6aa.-southeastasia", actual);
@@ -48,7 +50,7 @@ public class CustomVMImageNameProviderTest {
         String vhdName = "cb-hdp-26-1907121707-osDisk.cc5baaaa-717e-4551-b7ae-aaaa03c72a6aa-.vhd";
         String region = "South East Asia";
 
-        String actual = CustomVMImageNameProvider.get(region, vhdName);
+        String actual = underTest.get(region, vhdName);
 
         Assert.assertTrue(IMAGE_NAME_PATTERN.matcher(actual).matches());
         Assert.assertEquals("cb-hdp-26-1907121707-osDisk.cc5baaaa-717e-4551-b7ae-aaaa03c72a6aa--southeastasia", actual);
@@ -59,7 +61,7 @@ public class CustomVMImageNameProviderTest {
         String vhdName = "cb-hdp-26-1907121707-osDisk123.cc5baaaa-717e-4551-b7ae-aaaa03c72a6a-12345678.vhd";
         String region = "South East Asia";
 
-        String actual = CustomVMImageNameProvider.get(region, vhdName);
+        String actual = underTest.get(region, vhdName);
 
         Assert.assertTrue(IMAGE_NAME_PATTERN.matcher(actual).matches());
         Assert.assertEquals("cb-hdp-26-1907121707-osDisk123.cc5baaaa-717e-4551-b7ae-aaaa03c72a6-southeastasia", actual);


### PR DESCRIPTION
Some azure calls were outside of AzureClient class, and some tests were added.

See detailed description in the commit message.