### PR TITLE
CB-9209

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/status/AzureInstanceStatus.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/status/AzureInstanceStatus.java
@@ -1,14 +1,20 @@
 package com.sequenceiq.cloudbreak.cloud.azure.status;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.microsoft.azure.management.compute.PowerState;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
 
 public class AzureInstanceStatus {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(AzureInstanceStatus.class);
+
     private AzureInstanceStatus() {
     }
 
     public static InstanceStatus get(PowerState powerState) {
+        LOGGER.debug("Powerstate is: {}", powerState);
         if (PowerState.RUNNING.equals(powerState)) {
             return InstanceStatus.STARTED;
         } else if (PowerState.STOPPED.equals(powerState) || PowerState.DEALLOCATED.equals(powerState)) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/InterruptSyncingException.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/InterruptSyncingException.java
@@ -1,0 +1,9 @@
+package com.sequenceiq.freeipa.sync;
+
+public class InterruptSyncingException extends RuntimeException {
+
+    public InterruptSyncingException(String message) {
+        super(message);
+    }
+
+}


### PR DESCRIPTION
FMS syncer was updating the status of Freeipa instance while state was not yet stable or flow could start during syncronization.