### PR TITLE
CB-8209: Adding the Cloudbreak version to the environment API.

### DIFF
--- a/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
@@ -108,6 +108,8 @@ public class EnvironmentModelDescription {
     public static final String PROXYCONFIG_NAME = "Name of the proxyconfig of the environment.";
     public static final String PROXYCONFIG_RESPONSE = "ProxyConfig attached to the environment.";
 
+    public static final String ENVIRONMENT_SERVICE_VERSION = "The version of the Cloudbreak build used to create the environment.";
+
     private EnvironmentModelDescription() {
     }
 }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/EnvironmentRequest.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/EnvironmentRequest.java
@@ -113,6 +113,9 @@ public class EnvironmentRequest extends EnvironmentBaseRequest implements Creden
     @ApiModelProperty(EnvironmentModelDescription.GCP_PARAMETERS)
     private GcpEnvironmentParameters gcp;
 
+    @ApiModelProperty(EnvironmentModelDescription.ENVIRONMENT_SERVICE_VERSION)
+    private String environmentServiceVersion;
+
     public AttachedFreeIpaRequest getFreeIpa() {
         return freeIpa;
     }
@@ -272,6 +275,14 @@ public class EnvironmentRequest extends EnvironmentBaseRequest implements Creden
         this.regions = regions == null ? new HashSet<>() : regions;
     }
 
+    public String getEnvironmentServiceVersion() {
+        return environmentServiceVersion;
+    }
+
+    public void setEnvironmentServiceVersion(String environmentServiceVersion) {
+        this.environmentServiceVersion = environmentServiceVersion;
+    }
+
     @Override
     public String toString() {
         return "EnvironmentRequest{" +
@@ -294,6 +305,7 @@ public class EnvironmentRequest extends EnvironmentBaseRequest implements Creden
                 ", azure=" + azure +
                 ", tags=" + tags +
                 ", parentEnvironmentName='" + parentEnvironmentName + '\'' +
+                ", environmentServiceVersion='" + environmentServiceVersion + '\'' +
                 '}';
     }
 

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/DetailedEnvironmentResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/DetailedEnvironmentResponse.java
@@ -106,6 +106,8 @@ public class DetailedEnvironmentResponse extends EnvironmentBaseResponse {
 
         private YarnEnvironmentParameters yarn;
 
+        private String environmentServiceVersion;
+
         private Builder() {
         }
 
@@ -263,6 +265,11 @@ public class DetailedEnvironmentResponse extends EnvironmentBaseResponse {
             return this;
         }
 
+        public Builder withEnvironmentServiceVersion(String environmentServiceVersion) {
+            this.environmentServiceVersion = environmentServiceVersion;
+            return this;
+        }
+
         public DetailedEnvironmentResponse build() {
             DetailedEnvironmentResponse detailedEnvironmentResponse = new DetailedEnvironmentResponse();
             detailedEnvironmentResponse.setCrn(crn);
@@ -295,6 +302,7 @@ public class DetailedEnvironmentResponse extends EnvironmentBaseResponse {
             detailedEnvironmentResponse.setAzure(azure);
             detailedEnvironmentResponse.setGcp(gcp);
             detailedEnvironmentResponse.setYarn(yarn);
+            detailedEnvironmentResponse.setEnvironmentServiceVersion(environmentServiceVersion);
             return detailedEnvironmentResponse;
         }
     }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentBaseResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentBaseResponse.java
@@ -105,6 +105,9 @@ public abstract class EnvironmentBaseResponse implements ResourceCrnAwareApiMode
     @ApiModelProperty(EnvironmentModelDescription.YARN_PARAMETERS)
     private YarnEnvironmentParameters yarn;
 
+    @ApiModelProperty(EnvironmentModelDescription.ENVIRONMENT_SERVICE_VERSION)
+    private String environmentServiceVersion;
+
     public String getCrn() {
         return crn;
     }
@@ -340,5 +343,13 @@ public abstract class EnvironmentBaseResponse implements ResourceCrnAwareApiMode
 
     public void setYarn(YarnEnvironmentParameters yarn) {
         this.yarn = yarn;
+    }
+
+    public String getEnvironmentServiceVersion() {
+        return environmentServiceVersion;
+    }
+
+    public void setEnvironmentServiceVersion(String environmentServiceVersion) {
+        this.environmentServiceVersion = environmentServiceVersion;
     }
 }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/SimpleEnvironmentResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/SimpleEnvironmentResponse.java
@@ -89,6 +89,8 @@ public class SimpleEnvironmentResponse extends EnvironmentBaseResponse {
 
         private YarnEnvironmentParameters yarn;
 
+        private String environmentServiceVersion;
+
         private Builder() {
         }
 
@@ -212,6 +214,11 @@ public class SimpleEnvironmentResponse extends EnvironmentBaseResponse {
             return this;
         }
 
+        public Builder withEnvironmentServiceVersion(String environmentServiceVersion) {
+            this.environmentServiceVersion = environmentServiceVersion;
+            return this;
+        }
+
         public SimpleEnvironmentResponse build() {
             SimpleEnvironmentResponse simpleEnvironmentResponse = new SimpleEnvironmentResponse();
             simpleEnvironmentResponse.setCrn(crn);
@@ -238,6 +245,7 @@ public class SimpleEnvironmentResponse extends EnvironmentBaseResponse {
             simpleEnvironmentResponse.setTags(tags);
             simpleEnvironmentResponse.setParentEnvironmentName(parentEnvironmentName);
             simpleEnvironmentResponse.setProxyConfig(proxyConfig);
+            simpleEnvironmentResponse.setEnvironmentServiceVersion(environmentServiceVersion);
             return simpleEnvironmentResponse;
         }
     }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/domain/Environment.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/domain/Environment.java
@@ -136,6 +136,9 @@ public class Environment implements AuthResource, AccountAwareResource {
     @ManyToOne
     private ProxyConfig proxyConfig;
 
+    @Column(name = "environment_service_version")
+    private String environmentServiceVersion;
+
     public Environment() {
         regions = new Json(new HashSet<Region>());
         tags = new Json(new EnvironmentTags(new HashMap<>(), new HashMap<>()));
@@ -443,6 +446,14 @@ public class Environment implements AuthResource, AccountAwareResource {
 
     public void setProxyConfig(ProxyConfig proxyConfig) {
         this.proxyConfig = proxyConfig;
+    }
+
+    public String getEnvironmentServiceVersion() {
+        return environmentServiceVersion;
+    }
+
+    public void setEnvironmentServiceVersion(String environmentServiceVersion) {
+        this.environmentServiceVersion = environmentServiceVersion;
     }
 
     @Override

--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentDto.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentDto.java
@@ -79,6 +79,8 @@ public class EnvironmentDto implements Payload, AccountAwareResource {
 
     private ProxyConfig proxyConfig;
 
+    private String environmentServiceVersion;
+
     @Override
     public Long getResourceId() {
         return id;
@@ -320,6 +322,14 @@ public class EnvironmentDto implements Payload, AccountAwareResource {
         this.proxyConfig = proxyConfig;
     }
 
+    public String getEnvironmentServiceVersion() {
+        return environmentServiceVersion;
+    }
+
+    public void setEnvironmentServiceVersion(String environmentServiceVersion) {
+        this.environmentServiceVersion = environmentServiceVersion;
+    }
+
     public Map<String, String> mergeTags(CostTagging costTagging) {
         CDPTagMergeRequest mergeRequest = CDPTagMergeRequest.Builder
                 .builder()
@@ -402,6 +412,8 @@ public class EnvironmentDto implements Payload, AccountAwareResource {
         private String parentEnvironmentCloudPlatform;
 
         private ProxyConfig proxyConfig;
+
+        private String environmentServiceVersion;
 
         private Builder() {
         }
@@ -551,6 +563,11 @@ public class EnvironmentDto implements Payload, AccountAwareResource {
             return this;
         }
 
+        public Builder withEnvironmentServiceVersion(String environmentServiceVersion) {
+            this.environmentServiceVersion = environmentServiceVersion;
+            return this;
+        }
+
         public EnvironmentDto build() {
             EnvironmentDto environmentDto = new EnvironmentDto();
             environmentDto.setId(id);
@@ -582,6 +599,7 @@ public class EnvironmentDto implements Payload, AccountAwareResource {
             environmentDto.setParentEnvironmentName(parentEnvironmentName);
             environmentDto.setParentEnvironmentCloudPlatform(parentEnvironmentCloudPlatform);
             environmentDto.setProxyConfig(proxyConfig);
+            environmentDto.setEnvironmentServiceVersion(environmentServiceVersion);
             return environmentDto;
         }
     }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentDtoConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentDtoConverter.java
@@ -109,7 +109,8 @@ public class EnvironmentDtoConverter {
                 .withTags(environment.getEnvironmentTags())
                 .withSecurityAccess(environmentToSecurityAccessDto(environment))
                 .withAdminGroupName(environment.getAdminGroupName())
-                .withProxyConfig(environment.getProxyConfig());
+                .withProxyConfig(environment.getProxyConfig())
+                .withEnvironmentServiceVersion(environment.getEnvironmentServiceVersion());
 
         CloudPlatform cloudPlatform = CloudPlatform.valueOf(environment.getCloudPlatform());
         doIfNotNull(environment.getParameters(), parameters -> builder.withParameters(

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentCreationService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentCreationService.java
@@ -11,6 +11,7 @@ import javax.ws.rs.BadRequestException;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
@@ -51,6 +52,9 @@ public class EnvironmentCreationService {
     private final ParametersService parametersService;
 
     private final EntitlementService entitlementService;
+
+    @Value("${info.app.version}")
+    private String environmentServiceVersion;
 
     public EnvironmentCreationService(
             EnvironmentService environmentService,
@@ -113,6 +117,7 @@ public class EnvironmentCreationService {
         proxyConfig.ifPresent(pc -> environment.setProxyConfig(pc));
         environment.setCloudPlatform(credential.getCloudPlatform());
         environment.setAuthentication(authenticationDtoConverter.dtoToAuthentication(creationDto.getAuthentication()));
+        environment.setEnvironmentServiceVersion(environmentServiceVersion);
         LOGGER.info("Environment is initialized for creation.");
         return environment;
     }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverter.java
@@ -97,7 +97,8 @@ public class EnvironmentResponseConverter {
                 .withGcp(getIfNotNull(environmentDto.getParameters(), this::gcpEnvParamsToGcpEnvironmentParams))
                 .withParentEnvironmentCrn(environmentDto.getParentEnvironmentCrn())
                 .withParentEnvironmentName(environmentDto.getParentEnvironmentName())
-                .withParentEnvironmentCloudPlatform(environmentDto.getParentEnvironmentCloudPlatform());
+                .withParentEnvironmentCloudPlatform(environmentDto.getParentEnvironmentCloudPlatform())
+                .withEnvironmentServiceVersion(environmentDto.getEnvironmentServiceVersion());
 
         NullUtil.doIfNotNull(environmentDto.getProxyConfig(),
                 proxyConfig -> builder.withProxyConfig(proxyConfigToProxyResponseConverter.convert(environmentDto.getProxyConfig())));

--- a/environment/src/main/resources/schema/app/20201009154412_CB-8209_Adding_cloudbreak_version_to_environment_info.sql
+++ b/environment/src/main/resources/schema/app/20201009154412_CB-8209_Adding_cloudbreak_version_to_environment_info.sql
@@ -1,0 +1,10 @@
+-- // CB-8209 Adding cloudbreak version to environment info
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE environment ADD COLUMN IF NOT EXISTS environment_service_version VARCHAR(128) DEFAULT 'No Info';
+UPDATE environment SET environment_service_version = 'No Info' WHERE environment_service_version IS NULL;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE environment DROP COLUMN IF EXISTS environment_service_version;


### PR DESCRIPTION
The main reason for this change is to be able to retrieve the exact Cloudbreak version used during the creation of the environment, as this will help with QE purposes.

Let me know if I did all of this right, but essentially I tried to:

- Add a new column to the environment database table for the cloudbreak version
- Update the existing table to include that column
- Set the cloudbreak version when the environment is first created using the info.app.version value
- Have the cloudbreak version present in the DetailedEnvironmentResponse and the EnvironmentDto classes so that it is obtained with any describe environment calls