### PR TITLE
CB-9230 Quick workaround: add parcel to the cluster when we are unable to verify the parcel's manifest. Further investigation is needed to handle parcel activation properly.

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/parcel/ParcelService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/parcel/ParcelService.java
@@ -82,11 +82,13 @@ public class ParcelService {
             if (manifest.right != null && ManifestStatus.SUCCESS.equals(manifest.left)) {
                 Set<String> componentNamesInParcel = getAllComponentNameInParcel(manifest.right);
                 if (componentNamesInParcel.stream().anyMatch(serviceNamesInBlueprint::contains)) {
+                    LOGGER.info("Add parcel '{}' as there is at least one service both in the manifest and in the blueprint.", parcel.getDisplayName());
                     ret.add(parcel);
+                } else {
+                    LOGGER.info("Skip parcel '{}' as there isn't any service both in the manifest and in the blueprint.", parcel.getDisplayName());
                 }
-            } else if (ManifestStatus.COULD_NOT_PARSE.equals(manifest.left)) {
-                ret.add(parcel);
-            } else if (ManifestStatus.FAILED.equals(manifest.left) && !baseImage) {
+            } else {
+                LOGGER.info("Add parcel '{}' as we were unable to check parcel's manifest.", parcel.getDisplayName());
                 ret.add(parcel);
             }
         });

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/parcel/ParcelServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/parcel/ParcelServiceTest.java
@@ -60,8 +60,8 @@ public class ParcelServiceTest {
                         "http://parcel1.com/", OK, "NIFI", Optional.of("{..ewwer"), true, 1},
 
                 {"Trying to download the parcel manifest in case of BASE image, when we can NOT reach the manifest file " +
-                        "then it should NOT assign the parcel because probably not available anymore. (RELENG deleted a released artifact usecase)",
-                        "http://parcel1.com/", NOT_FOUND, "NIFI", Optional.empty(), true, 0},
+                        "then it should assign the parcel, because we can't check that it is required, or not. (authentication required usecase)",
+                        "http://parcel1.com/", NOT_FOUND, "NIFI", Optional.empty(), true, 1},
 
                 {"Trying to download the parcel manifest in case of PREWARMED image, when we can reach the file which is a standard " +
                         "manifest file and it DOES NOT contains the component then DO NOT assign the parcel.",


### PR DESCRIPTION
See detailed description in the commit message.