### PR TITLE
CB-8228 remove the base 7.1.0 version check for Runtime upgrade

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/UpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/UpgradeService.java
@@ -88,9 +88,6 @@ public class UpgradeService {
     @Inject
     private ClusterBootstrapper clusterBootstrapper;
 
-    @Inject
-    private ClusterUpgradeAvailabilityService clusterUpgradeAvailabilityService;
-
     public UpgradeOptionV4Response getOsUpgradeOptionByStackNameOrCrn(Long workspaceId, NameOrCrn nameOrCrn, User user) {
         Stack stack = stackService.getByNameOrCrnInWorkspace(nameOrCrn, workspaceId);
         MDCBuilder.buildMdcContext(stack);
@@ -127,7 +124,6 @@ public class UpgradeService {
     public FlowIdentifier upgradeCluster(Long workspaceId, NameOrCrn stackNameOrCrn, String imageId) {
         Stack stack = stackService.getByNameOrCrnInWorkspace(stackNameOrCrn, workspaceId);
         MDCBuilder.buildMdcContext(stack);
-        clusterUpgradeAvailabilityService.checkUpgradeSupported(stack);
         return flowManager.triggerDatalakeClusterUpgrade(stack.getId(), imageId);
     }
 

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -125,7 +125,6 @@ cb:
     contextPath: /redbeams
   runtimes:
     latest: "7.2.3"
-    upgradeSupported: "7.1.0"
 
   host.discovery.custom.hostname.enabled: false
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeAvailabilityServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeAvailabilityServiceTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -25,7 +24,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.tags.upgrade.UpgradeV4Request;
@@ -35,7 +33,6 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.image.ImageComp
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.image.ImageInfoV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.upgrade.UpgradeV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.views.ClusterViewV4Response;
-import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakImageCatalogV3;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Images;
@@ -127,10 +124,6 @@ public class ClusterUpgradeAvailabilityServiceTest {
     public void setUp() {
         when(clusterApiConnectors.getConnector(any(Stack.class))).thenReturn(clusterApi);
         activatedParcels = new HashMap<>();
-        ClouderaManagerRepo clouderaManagerRepo = new ClouderaManagerRepo();
-        clouderaManagerRepo.setVersion(V_7_0_3);
-        when(clusterComponentConfigProvider.getClouderaManagerRepoDetails(anyLong())).thenReturn(clouderaManagerRepo);
-        ReflectionTestUtils.setField(underTest, "upgradeSupportedVersion", V_7_0_3);
     }
 
     @Test


### PR DESCRIPTION
We have limited the Runtime upgrade that it's only possible from version 7.1.0.
However, since we have the upgrade matrix in place we don't need this extra
check. Besides if we would allow 7.0.2 upgrade in the matrix this extra
check would still stop the process.

See detailed description in the commit message.