### PR TITLE
CB-9249 API E2E JUnit XML report names should contain the Cloud Provider as well

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
@@ -1155,8 +1155,10 @@ public abstract class TestContext implements ApplicationContextAware {
                         : testResult.getThrowable().getMessage();
                 LOGGER.info("Failed test results are: Test Case: {} | Status: {} | Failure Type: {} | Message: {}", methodName, status,
                         testFailureType, message);
-                testResult.getTestContext().setAttribute(methodName + OUTPUT_FAILURE_TYPE, testFailureType);
-                testResult.getTestContext().setAttribute(methodName + OUTPUT_FAILURE, testResult.getThrowable());
+
+                testResult.setTestName(String.join("_", commonCloudProperties.getCloudProvider().toLowerCase(), methodName));
+                testResult.getTestContext().setAttribute(testResult.getTestName() + OUTPUT_FAILURE_TYPE, testFailureType);
+                testResult.getTestContext().setAttribute(testResult.getTestName() + OUTPUT_FAILURE, testResult.getThrowable());
             } else {
                 LOGGER.error("Test Context TestFailException is null! So cannot get the correct test fail result!");
             }


### PR DESCRIPTION
Unfortunately not all the API E2E JUnit XML reports are included for Quanta uploads, because of reports with same name are going to be overwritten. So we should introduce an additional tag for XML file generation. On this way all the XML files will be present for Quanta uploads.