### PR TITLE
CB-9220. Account id is not passed properly for delete machine user ca…

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
@@ -290,12 +290,13 @@ public class GrpcUmsClient {
      * @param userCrn         actor
      * @param requestId       request id for deleting machine user
      */
-    public void deleteMachineUser(String machineUserName, String userCrn, Optional<String> requestId) {
+    public void deleteMachineUser(String machineUserName, String userCrn, String accountId, Optional<String> requestId) {
         try (ManagedChannelWrapper channelWrapper = makeWrapper()) {
             UmsClient client = makeClient(channelWrapper.getChannel(), userCrn);
             String generatedRequestId = requestId.orElse(UUID.randomUUID().toString());
-            LOGGER.debug("Deleting machine user {} by {} using request ID {}", machineUserName, userCrn, generatedRequestId);
-            client.deleteMachineUser(generatedRequestId, userCrn, machineUserName);
+            LOGGER.debug("Deleting machine user {} by {} using request ID {} (for accountId: {})",
+                    machineUserName, userCrn, generatedRequestId, accountId);
+            client.deleteMachineUser(generatedRequestId, userCrn, accountId, machineUserName);
         }
     }
 
@@ -621,7 +622,7 @@ public class GrpcUmsClient {
             unassignMachineUserRole(userCrn, machineUserName, roleCrn, MDCUtils.getRequestId());
         }
         deleteMachineUserAccessKeys(userCrn, accountId, machineUserName, MDCUtils.getRequestId());
-        deleteMachineUser(machineUserName, userCrn, MDCUtils.getRequestId());
+        deleteMachineUser(machineUserName, userCrn, accountId, MDCUtils.getRequestId());
     }
 
     /**

--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/UmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/UmsClient.java
@@ -321,14 +321,14 @@ public class UmsClient {
      * @param userCrn         actor identifier
      * @param machineUserName machine user to remove
      */
-    public void deleteMachineUser(String requestId, String userCrn, String machineUserName) {
+    public void deleteMachineUser(String requestId, String userCrn, String  accountId, String machineUserName) {
         checkNotNull(requestId);
         checkNotNull(userCrn);
         checkNotNull(machineUserName);
         try {
             newStub(requestId).deleteMachineUser(
                     UserManagementProto.DeleteMachineUserRequest.newBuilder()
-                            .setAccountId(Crn.fromString(userCrn).getAccountId())
+                            .setAccountId(accountId)
                             .setMachineUserNameOrCrn(machineUserName)
                             .build());
         } catch (StatusRuntimeException e) {

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerDatabusServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerDatabusServiceTest.java
@@ -35,6 +35,7 @@ public class ClouderaManagerDatabusServiceTest {
         User creator = new User();
         creator.setUserCrn(USER_CRN);
         stack.setCreator(creator);
+        stack.setResourceCrn(USER_CRN);
         Cluster cluster = new Cluster();
         cluster.setId(1L);
         stack.setCluster(cluster);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/AltusMachineUserService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/AltusMachineUserService.java
@@ -4,43 +4,40 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.auth.altus.model.AltusCredential;
 import com.sequenceiq.cloudbreak.auth.altus.service.AltusIAMService;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
 import com.sequenceiq.freeipa.entity.Stack;
-import com.sequenceiq.freeipa.util.CrnService;
 
 @Service
 public class AltusMachineUserService {
 
     private static final String FREEIPA_FLUENT_DATABUS_MACHINE_USER_PATTERN = "freeipa-fluent-databus-uploader-%s";
 
-    private final CrnService crnService;
-
     private final AltusIAMService altusIAMService;
 
-    public AltusMachineUserService(AltusIAMService altusIAMService, CrnService crnService) {
+    public AltusMachineUserService(AltusIAMService altusIAMService) {
         this.altusIAMService = altusIAMService;
-        this.crnService = crnService;
     }
 
     public Optional<AltusCredential> createMachineUserWithAccessKeys(Stack stack, Telemetry telemetry) {
-        String userCrn = crnService.getUserCrn();
         String machineUserName = getFluentMachineUser(stack);
-        return altusIAMService.generateMachineUserWithAccessKey(machineUserName,
-                userCrn,
-                Crn.fromString(stack.getResourceCrn()).getAccountId(),
-                telemetry.isUseSharedAltusCredentialEnabled());
+        return ThreadBasedUserCrnProvider.doAsInternalActor(
+                () -> altusIAMService.generateMachineUserWithAccessKey(machineUserName,
+                        ThreadBasedUserCrnProvider.getUserCrn(),
+                        Crn.fromString(stack.getResourceCrn()).getAccountId(),
+                        telemetry.isUseSharedAltusCredentialEnabled()));
     }
 
     public void cleanupMachineUser(Stack stack, Telemetry telemetry) {
-        String userCrn = crnService.getUserCrn();
         String machineUserName = getFluentMachineUser(stack);
-        altusIAMService.clearMachineUser(machineUserName,
-                userCrn,
-                Crn.fromString(stack.getResourceCrn()).getAccountId(),
-                telemetry.isUseSharedAltusCredentialEnabled());
+        ThreadBasedUserCrnProvider.doAsInternalActor(
+                () -> altusIAMService.clearMachineUser(machineUserName,
+                        ThreadBasedUserCrnProvider.getUserCrn(),
+                        Crn.fromString(stack.getResourceCrn()).getAccountId(),
+                        telemetry.isUseSharedAltusCredentialEnabled()));
     }
 
     private String getFluentMachineUser(Stack stack) {


### PR DESCRIPTION
…ll if internal actor is used

details:
- account id is set from user crn for delete machine user call -> for internal actor, that will be "altus"
- some refactor to use internal call everywhere (in the exact same way)

See detailed description in the commit message.