### PR TITLE
DISTX-534 use v1 committer for spark

### DIFF
--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-710.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-710.bp
@@ -18,6 +18,12 @@
       {
         "refName": "hdfs",
         "serviceType": "HDFS",
+        "serviceConfigs": [
+          {
+            "name": "core_site_safety_valve",
+            "value": "<property><name>fs.s3a.committer.name</name><value>directory</value></property>"
+          }
+        ],
         "roleConfigGroups": [
           {
             "refName": "hdfs-NAMENODE-BASE",
@@ -77,6 +83,10 @@
           {
             "name": "yarn_log_aggregation_IFile_remote_app_log_dir",
             "value": ""
+          },
+          {
+            "name": "yarn_service_mapred_safety_valve",
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -147,7 +157,13 @@
           {
             "refName": "spark_on_yarn-GATEWAY-BASE",
             "roleType": "GATEWAY",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                "name": "spark-conf/spark-defaults.conf_client_config_safety_valve",
+                "value": "spark.hadoop.mapreduce.fileoutputcommitter.algorithm.version=1"
+              }
+            ]
           }
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-720.bp
@@ -22,6 +22,10 @@
           {
             "name": "hdfs_verify_ec_with_topology_enabled",
             "value": false
+          },
+          {
+            "name": "core_site_safety_valve",
+            "value": "<property><name>fs.s3a.committer.name</name><value>directory</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -87,6 +91,10 @@
           {
             "name": "yarn_admin_acl",
             "value": "yarn,hive,hdfs"
+          },
+          {
+            "name": "yarn_service_mapred_safety_valve",
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -165,7 +173,7 @@
             "configs": [
               {
                 "name": "spark-conf/spark-defaults.conf_client_config_safety_valve",
-                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl"
+                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl\nspark.hadoop.mapreduce.fileoutputcommitter.algorithm.version=1"
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-721.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-721.bp
@@ -22,6 +22,10 @@
           {
             "name": "hdfs_verify_ec_with_topology_enabled",
             "value": false
+          },
+          {
+            "name": "core_site_safety_valve",
+            "value": "<property><name>fs.s3a.committer.name</name><value>directory</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -87,6 +91,10 @@
           {
             "name": "yarn_admin_acl",
             "value": "yarn,hive,hdfs,mapred"
+          },
+          {
+            "name": "yarn_service_mapred_safety_valve",
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -165,7 +173,7 @@
             "configs": [
               {
                 "name": "spark-conf/spark-defaults.conf_client_config_safety_valve",
-                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl"
+                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl\nspark.hadoop.mapreduce.fileoutputcommitter.algorithm.version=1"
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-722.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-722.bp
@@ -22,6 +22,10 @@
           {
             "name": "hdfs_verify_ec_with_topology_enabled",
             "value": false
+          },
+          {
+            "name": "core_site_safety_valve",
+            "value": "<property><name>fs.s3a.committer.name</name><value>directory</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -87,6 +91,10 @@
           {
             "name": "yarn_admin_acl",
             "value": "yarn,hive,hdfs,mapred"
+          },
+          {
+            "name": "yarn_service_mapred_safety_valve",
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -165,7 +173,7 @@
             "configs": [
               {
                 "name": "spark-conf/spark-defaults.conf_client_config_safety_valve",
-                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl"
+                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl\nspark.hadoop.mapreduce.fileoutputcommitter.algorithm.version=1"
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-723.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-723.bp
@@ -28,6 +28,10 @@
           {
             "name": "hdfs_verify_ec_with_topology_enabled",
             "value": false
+          },
+          {
+            "name": "core_site_safety_valve",
+            "value": "<property><name>fs.s3a.committer.name</name><value>directory</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -101,6 +105,10 @@
           {
             "name": "yarn_admin_acl",
             "value": "yarn,hive,hdfs,mapred"
+          },
+          {
+            "name": "yarn_service_mapred_safety_valve",
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -179,7 +187,7 @@
             "configs": [
               {
                 "name": "spark-conf/spark-defaults.conf_client_config_safety_valve",
-                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl"
+                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl\nspark.hadoop.mapreduce.fileoutputcommitter.algorithm.version=1"
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-710.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-710.bp
@@ -22,6 +22,10 @@
           {
             "name": "zookeeper_service",
             "ref": "zookeeper"
+          },
+          {
+            "name": "core_site_safety_valve",
+            "value": "<property><name>fs.s3a.committer.name</name><value>directory</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -202,6 +206,10 @@
           {
             "name": "yarn_log_aggregation_IFile_remote_app_log_dir",
             "value": ""
+          },
+          {
+            "name": "yarn_service_mapred_safety_valve",
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -272,7 +280,13 @@
           {
             "refName": "spark_on_yarn-GATEWAY-BASE",
             "roleType": "GATEWAY",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                "name": "spark-conf/spark-defaults.conf_client_config_safety_valve",
+                "value": "spark.hadoop.mapreduce.fileoutputcommitter.algorithm.version=1"
+              }
+            ]
           }
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-720.bp
@@ -26,6 +26,10 @@
           {
             "name": "hdfs_verify_ec_with_topology_enabled",
             "value": false
+          },
+          {
+            "name": "core_site_safety_valve",
+            "value": "<property><name>fs.s3a.committer.name</name><value>directory</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -236,6 +240,10 @@
           {
             "name": "yarn_admin_acl",
             "value": "yarn,hive,hdfs"
+          },
+          {
+            "name": "yarn_service_mapred_safety_valve",
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -314,7 +322,7 @@
             "configs": [
               {
                 "name": "spark-conf/spark-defaults.conf_client_config_safety_valve",
-                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl"
+                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl\nspark.hadoop.mapreduce.fileoutputcommitter.algorithm.version=1"
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-721.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-721.bp
@@ -26,6 +26,10 @@
           {
             "name": "hdfs_verify_ec_with_topology_enabled",
             "value": false
+          },
+          {
+            "name": "core_site_safety_valve",
+            "value": "<property><name>fs.s3a.committer.name</name><value>directory</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -236,6 +240,10 @@
           {
             "name": "yarn_admin_acl",
             "value": "yarn,hive,hdfs,mapred"
+          },
+          {
+            "name": "yarn_service_mapred_safety_valve",
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -314,7 +322,7 @@
             "configs": [
               {
                 "name": "spark-conf/spark-defaults.conf_client_config_safety_valve",
-                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl"
+                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl\nspark.hadoop.mapreduce.fileoutputcommitter.algorithm.version=1"
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-722.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-722.bp
@@ -26,6 +26,10 @@
           {
             "name": "hdfs_verify_ec_with_topology_enabled",
             "value": false
+          },
+          {
+            "name": "core_site_safety_valve",
+            "value": "<property><name>fs.s3a.committer.name</name><value>directory</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -236,6 +240,10 @@
           {
             "name": "yarn_admin_acl",
             "value": "yarn,hive,hdfs,mapred"
+          },
+          {
+            "name": "yarn_service_mapred_safety_valve",
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -314,7 +322,7 @@
             "configs": [
               {
                 "name": "spark-conf/spark-defaults.conf_client_config_safety_valve",
-                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl"
+                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl\nspark.hadoop.mapreduce.fileoutputcommitter.algorithm.version=1"
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-723.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-ha-723.bp
@@ -26,6 +26,10 @@
           {
             "name": "hdfs_verify_ec_with_topology_enabled",
             "value": false
+          },
+          {
+            "name": "core_site_safety_valve",
+            "value": "<property><name>fs.s3a.committer.name</name><value>directory</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -244,6 +248,10 @@
           {
             "name": "yarn_admin_acl",
             "value": "yarn,hive,hdfs,mapred"
+          },
+          {
+            "name": "yarn_service_mapred_safety_valve",
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -322,7 +330,7 @@
             "configs": [
               {
                 "name": "spark-conf/spark-defaults.conf_client_config_safety_valve",
-                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl"
+                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl\nspark.hadoop.mapreduce.fileoutputcommitter.algorithm.version=1"
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-710.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-710.bp
@@ -7,6 +7,12 @@
       {
         "refName": "hdfs",
         "serviceType": "HDFS",
+        "serviceConfigs": [
+          {
+            "name": "core_site_safety_valve",
+            "value": "<property><name>fs.s3a.committer.name</name><value>directory</value></property>"
+          }
+        ],
         "roleConfigGroups": [
           {
             "refName": "hdfs-NAMENODE-BASE",
@@ -62,6 +68,10 @@
           {
             "name": "yarn_admin_acl",
             "value": "yarn,hdfs"
+          },
+          {
+            "name": "yarn_service_mapred_safety_valve",
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -117,7 +127,13 @@
           {
             "refName": "spark3_on_yarn-GATEWAY-BASE",
             "roleType": "GATEWAY",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                "name": "spark-conf/spark-defaults.conf_client_config_safety_valve",
+                "value": "spark.hadoop.mapreduce.fileoutputcommitter.algorithm.version=1"
+              }
+            ]
           }
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-720.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-720.bp
@@ -22,6 +22,10 @@
           {
             "name": "hdfs_verify_ec_with_topology_enabled",
             "value": false
+          },
+          {
+            "name": "core_site_safety_valve",
+            "value": "<property><name>fs.s3a.committer.name</name><value>directory</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -87,6 +91,10 @@
           {
             "name": "yarn_admin_acl",
             "value": "yarn,hdfs"
+          },
+          {
+            "name": "yarn_service_mapred_safety_valve",
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -165,7 +173,7 @@
             "configs": [
               {
                 "name": "spark3-conf/spark-defaults.conf_client_config_safety_valve",
-                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl"
+                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl\nspark.hadoop.mapreduce.fileoutputcommitter.algorithm.version=1"
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-721.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-721.bp
@@ -22,6 +22,10 @@
           {
             "name": "hdfs_verify_ec_with_topology_enabled",
             "value": false
+          },
+          {
+            "name": "core_site_safety_valve",
+            "value": "<property><name>fs.s3a.committer.name</name><value>directory</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -87,6 +91,10 @@
           {
             "name": "yarn_admin_acl",
             "value": "yarn,hdfs,mapred"
+          },
+          {
+            "name": "yarn_service_mapred_safety_valve",
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -165,7 +173,7 @@
             "configs": [
               { 
                 "name": "spark3-conf/spark-defaults.conf_client_config_safety_valve",
-                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl"
+                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl\nspark.hadoop.mapreduce.fileoutputcommitter.algorithm.version=1"
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-722.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-722.bp
@@ -22,6 +22,10 @@
           {
             "name": "hdfs_verify_ec_with_topology_enabled",
             "value": false
+          },
+          {
+            "name": "core_site_safety_valve",
+            "value": "<property><name>fs.s3a.committer.name</name><value>directory</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -87,6 +91,10 @@
           {
             "name": "yarn_admin_acl",
             "value": "yarn,hive,hdfs,mapred"
+          },
+          {
+            "name": "yarn_service_mapred_safety_valve",
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -165,7 +173,7 @@
             "configs": [
               {
                 "name": "spark3-conf/spark-defaults.conf_client_config_safety_valve",
-                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl"
+                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl\nspark.hadoop.mapreduce.fileoutputcommitter.algorithm.version=1"
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-723.bp
+++ b/core/src/main/resources/defaults/blueprints/cdp-data-engineering-spark3-723.bp
@@ -22,6 +22,10 @@
           {
             "name": "hdfs_verify_ec_with_topology_enabled",
             "value": false
+          },
+          {
+            "name": "core_site_safety_valve",
+            "value": "<property><name>fs.s3a.committer.name</name><value>directory</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -95,6 +99,10 @@
           {
             "name": "yarn_admin_acl",
             "value": "yarn,hive,hdfs,mapred"
+          },
+          {
+            "name": "yarn_service_mapred_safety_valve",
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -173,7 +181,7 @@
             "configs": [
               {
                 "name": "spark3-conf/spark-defaults.conf_client_config_safety_valve",
-                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl"
+                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl\nspark.hadoop.mapreduce.fileoutputcommitter.algorithm.version=1"
               }
             ]
           }


### PR DESCRIPTION
DISTX-534 As per TSB-437, FileOutputCommitter algorithm v2 may result into
bad output data. Hence it has been advised to go back to v1 version.
This commit makes following config changes in 710, 720, 721, 722, 723
DE, DE HA & Spark3 templates so that v1 algorithm is configured ootb
in DH clusters :

  fs.s3a.committer.name=directory
  mapreduce.fileoutputcommitter.algorithm.version=1
  spark.hadoop.mapreduce.fileoutputcommitter.algorithm.version=1

Testing done :
Have created a DE cluster using a modified 7.2.2 template that includes above mentioned config changes. Cluster creation was successful on AWS using m5d.2xl instance types.