### PR TITLE
CB-9251 Fix Kerberos-/LdapConfig creation race condition

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/kerberos/KerberosConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/kerberos/KerberosConfig.java
@@ -305,4 +305,29 @@ public class KerberosConfig implements ArchivableResource, AuthResource, Account
     public void setNameServers(String nameServers) {
         this.nameServers = nameServers;
     }
+
+    @Override
+    public String toString() {
+        return "KerberosConfig{" +
+                "id=" + id +
+                ", resourceCrn='" + resourceCrn + '\'' +
+                ", name='" + name + '\'' +
+                ", description='" + description + '\'' +
+                ", accountId='" + accountId + '\'' +
+                ", environmentCrn='" + environmentCrn + '\'' +
+                ", clusterName='" + clusterName + '\'' +
+                ", archived=" + archived +
+                ", deletionTimestamp=" + deletionTimestamp +
+                ", type=" + type +
+                ", url='" + url + '\'' +
+                ", adminUrl='" + adminUrl + '\'' +
+                ", realm='" + realm + '\'' +
+                ", tcpAllowed=" + tcpAllowed +
+                ", ldapUrl='" + ldapUrl + '\'' +
+                ", containerDn='" + containerDn + '\'' +
+                ", verifyKdcTrust=" + verifyKdcTrust +
+                ", domain='" + domain + '\'' +
+                ", nameServers='" + nameServers + '\'' +
+                '}';
+    }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/kerberos/KerberosConfigService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/kerberos/KerberosConfigService.java
@@ -37,6 +37,7 @@ public class KerberosConfigService extends AbstractArchivistService<KerberosConf
     public KerberosConfig createKerberosConfig(KerberosConfig kerberosConfig, String accountId) {
         kerberosConfig.setAccountId(accountId);
         kerberosConfig.setResourceCrn(crnService.createCrn(kerberosConfig.getAccountId(), Crn.ResourceType.KERBEROS));
+        LOGGER.debug("Trying to save KerberosConfig: {}", kerberosConfig);
         checkIfExists(kerberosConfig);
         return kerberosConfigRepository.save(kerberosConfig);
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/ldap/LdapConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/ldap/LdapConfig.java
@@ -341,4 +341,35 @@ public class LdapConfig implements ArchivableResource, AuthResource, AccountAwar
     public int hashCode() {
         return Objects.hash(id);
     }
+
+    @Override
+    public String toString() {
+        return "LdapConfig{" +
+                "id=" + id +
+                ", resourceCrn='" + resourceCrn + '\'' +
+                ", name='" + name + '\'' +
+                ", description='" + description + '\'' +
+                ", accountId='" + accountId + '\'' +
+                ", environmentCrn='" + environmentCrn + '\'' +
+                ", clusterName='" + clusterName + '\'' +
+                ", archived=" + archived +
+                ", deletionTimestamp=" + deletionTimestamp +
+                ", serverHost='" + serverHost + '\'' +
+                ", serverPort=" + serverPort +
+                ", protocol='" + protocol + '\'' +
+                ", directoryType=" + directoryType +
+                ", userSearchBase='" + userSearchBase + '\'' +
+                ", userDnPattern='" + userDnPattern + '\'' +
+                ", userNameAttribute='" + userNameAttribute + '\'' +
+                ", userObjectClass='" + userObjectClass + '\'' +
+                ", groupSearchBase='" + groupSearchBase + '\'' +
+                ", groupNameAttribute='" + groupNameAttribute + '\'' +
+                ", groupObjectClass='" + groupObjectClass + '\'' +
+                ", groupMemberAttribute='" + groupMemberAttribute + '\'' +
+                ", domain='" + domain + '\'' +
+                ", adminGroup='" + adminGroup + '\'' +
+                ", userGroup='" + userGroup + '\'' +
+                ", certificate='" + certificate + '\'' +
+                '}';
+    }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/ldap/LdapConfigService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/ldap/LdapConfigService.java
@@ -40,6 +40,7 @@ public class LdapConfigService extends AbstractArchivistService<LdapConfig> {
     public LdapConfig createLdapConfig(LdapConfig ldapConfig, String accountId) {
         ldapConfig.setAccountId(accountId);
         ldapConfig.setResourceCrn(crnService.createCrn(ldapConfig.getAccountId(), Crn.ResourceType.LDAP));
+        LOGGER.debug("Trying to save LdapConfig: {}", ldapConfig);
         checkIfExists(ldapConfig);
         return ldapConfigRepository.save(ldapConfig);
     }


### PR DESCRIPTION
The issue is caused by a race condition while we are creating kerberos
configuration for a cluster. The process looks like the following if
the kerberos configuration doesn't exists:

1. Requests arrives
2. We check the DB for existing configuration (in this case this returns it's missing)
3. Check FreeIPA if the desired bind user exists
4. Create the bind user
5. Set the bind user password
6. Create configuration in the database
7. Return the kerberos configuration response

The main issue is step 3->5 can take up a few seconds. If there are 2
requests coming in, let's say about 2 sec difference, the first can be
in the phase to set the password, when the second will still not find
any kerberos config in the database and tries to create a new one. In
this case the first one will finish, the second one will modify the
password but cannot create the kerberos config in the database as it's
already exists. This will leave us a setup where there is a different
password in our database than on the FreeIPA.

The fix is to skip checking if the user already exists. We will try to create one and it will fail if already exists.
This way we won't modify the password for an already existing user.