### PR TITLE
CB-9086 Enable host cert rotation on older runtimes

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.cluster.api;
 
+import java.security.KeyPair;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -108,8 +109,8 @@ public interface ClusterApi {
         clusterModificationService().restartAll(withMgmtServices);
     }
 
-    default void rotateHostCertificates() throws CloudbreakException {
-        clusterSecurityService().rotateHostCertificates();
+    default void rotateHostCertificates(String sshUser, KeyPair sshKeyPair) throws CloudbreakException {
+        clusterSecurityService().rotateHostCertificates(sshUser, sshKeyPair);
     }
 
     default ClusterStatus getStatus(boolean blueprintPresent) {

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterSecurityService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterSecurityService.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.cluster.api;
 
+import java.security.KeyPair;
+
 import com.sequenceiq.cloudbreak.dto.LdapView;
 import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.cloudbreak.auth.altus.VirtualGroupRequest;
@@ -40,5 +42,5 @@ public interface ClusterSecurityService {
 
     String getMasterKey();
 
-    void rotateHostCertificates() throws CloudbreakException;
+    void rotateHostCertificates(String sshUser, KeyPair sshKeyPair) throws CloudbreakException;
 }

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerSecurityServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerSecurityServiceTest.java
@@ -299,7 +299,7 @@ ClouderaManagerSecurityServiceTest {
         ArgumentCaptor<ApiBatchRequest> batchRequestArgumentCaptor = ArgumentCaptor.forClass(ApiBatchRequest.class);
         when(batchResourceApi.execute(batchRequestArgumentCaptor.capture())).thenReturn(createApiBatchResponse(hostList, true));
         // WHEN
-        underTest.rotateHostCertificates();
+        underTest.rotateHostCertificates(null, null);
         // THEN no exception
         Assert.assertEquals(2, batchRequestArgumentCaptor.getValue().getItems().size());
     }
@@ -319,7 +319,7 @@ ClouderaManagerSecurityServiceTest {
         ArgumentCaptor<ApiBatchRequest> batchRequestArgumentCaptor = ArgumentCaptor.forClass(ApiBatchRequest.class);
         when(batchResourceApi.execute(batchRequestArgumentCaptor.capture())).thenReturn(createApiBatchResponse(hostList, false));
         // WHEN
-        assertThrows(ClouderaManagerOperationFailedException.class, () -> underTest.rotateHostCertificates());
+        assertThrows(ClouderaManagerOperationFailedException.class, () -> underTest.rotateHostCertificates(null, null));
         // THEN exception
     }
 
@@ -340,7 +340,7 @@ ClouderaManagerSecurityServiceTest {
         when(clouderaManagerPollingServiceProvider.startPollingCommandList(eq(stack), eq(apiClient), any(List.class), eq("Rotate host certificates")))
                 .thenReturn(PollingResult.EXIT);
         // WHEN
-        assertThrows(CancellationException.class, () -> underTest.rotateHostCertificates());
+        assertThrows(CancellationException.class, () -> underTest.rotateHostCertificates(null, null));
         // THEN exception
     }
 
@@ -361,7 +361,7 @@ ClouderaManagerSecurityServiceTest {
         when(clouderaManagerPollingServiceProvider.startPollingCommandList(eq(stack), eq(apiClient), any(List.class), eq("Rotate host certificates")))
                 .thenReturn(PollingResult.TIMEOUT);
         // WHEN
-        assertThrows(ClouderaManagerOperationFailedException.class, () -> underTest.rotateHostCertificates());
+        assertThrows(ClouderaManagerOperationFailedException.class, () -> underTest.rotateHostCertificates(null, null));
         // THEN exception
     }
 
@@ -377,7 +377,7 @@ ClouderaManagerSecurityServiceTest {
         when(clouderaManagerApiFactory.getBatchResourceApi(apiClient)).thenReturn(batchResourceApi);
         when(hostsResourceApi.readHosts(null, null, "SUMMARY")).thenThrow(new ApiException());
         // WHEN
-        assertThrows(CloudbreakException.class, () -> underTest.rotateHostCertificates());
+        assertThrows(CloudbreakException.class, () -> underTest.rotateHostCertificates(null, null));
         // THEN exception
     }
 

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -83,11 +83,11 @@ cluster.certificate.renewal.failed=Renewal of the cluster's certificate failed: 
 
 cluster.certificates.rotation.started=Certificates rotation of the cluster has been started.
 cluster.host.certificates.rotation=Host certificates rotation of the cluster has been started.
-cluster.certificates.rotation.finished=Rotation of the cluster's certificates finished.
-cluster.certificates.rotation.failed=Rotations of the cluster's certificates failed: '{0}'.
+cluster.certificates.rotation.finished=Rotation of the cluster's certificates have finished.
+cluster.certificates.rotation.failed=Rotations of the cluster's certificates have failed: '{0}'.
 
-cluster.manager.server.restarting=Restarting Cluster Manager Server...
-cluster.services.restarting=Restarting Cluster services...
+cluster.manager.server.restarting=Restarting Cluster Manager Server
+cluster.services.restarting=Restarting Cluster services
 
 cluster.scaling.up=Scaling up host group: {0}
 cluster.re.register.with.cluster.proxy=Re-registering with Cluster Proxy service

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/FlowChainTriggers.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/FlowChainTriggers.java
@@ -39,6 +39,8 @@ public class FlowChainTriggers {
 
     public static final String DATALAKE_CLUSTER_UPGRADE_CHAIN_TRIGGER_EVENT = "DATALAKE_CLUSTER_UPGRADE_CHAIN_TRIGGER_EVENT";
 
+    public static final String ROTATE_CLUSTER_CERTIFICATES_CHAIN_TRIGGER_EVENT = "ROTATE_CLUSTER_CERTIFICATES_CHAIN_TRIGGER_EVENT";
+
     private FlowChainTriggers() {
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/RotateClusterCertificatesFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/RotateClusterCertificatesFlowEventChainFactory.java
@@ -1,0 +1,30 @@
+package com.sequenceiq.cloudbreak.core.flow2.chain;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.certrotate.ClusterCertificatesRotationEvent;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.salt.update.SaltUpdateEvent;
+import com.sequenceiq.cloudbreak.core.flow2.event.ClusterCertificatesRotationTriggerEvent;
+import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
+
+@Component
+public class RotateClusterCertificatesFlowEventChainFactory implements FlowEventChainFactory<ClusterCertificatesRotationTriggerEvent> {
+    @Override
+    public String initEvent() {
+        return FlowChainTriggers.ROTATE_CLUSTER_CERTIFICATES_CHAIN_TRIGGER_EVENT;
+    }
+
+    @Override
+    public Queue<Selectable> createFlowTriggerEventQueue(ClusterCertificatesRotationTriggerEvent event) {
+        Queue<Selectable> chain = new ConcurrentLinkedQueue<>();
+        chain.add(new StackEvent(SaltUpdateEvent.SALT_UPDATE_EVENT.event(), event.getResourceId(), event.accepted()));
+        chain.add(new ClusterCertificatesRotationTriggerEvent(ClusterCertificatesRotationEvent.CLUSTER_CMCA_ROTATION_EVENT.event(), event.getResourceId(),
+                event.accepted(), event.getCertificateRotationType()));
+        return chain;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/certrotate/ClusterCertificatesRotationActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/certrotate/ClusterCertificatesRotationActions.java
@@ -14,6 +14,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.statemachine.action.Action;
 
 import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.core.flow2.event.ClusterCertificatesRotationTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.stack.AbstractStackFailureAction;
 import com.sequenceiq.cloudbreak.core.flow2.stack.StackContext;
 import com.sequenceiq.cloudbreak.core.flow2.stack.StackFailureContext;
@@ -37,9 +38,9 @@ public class ClusterCertificatesRotationActions {
 
     @Bean(name = "CLUSTER_CMCA_ROTATION_STATE")
     public Action<?, ?> clusterCMCARotationAction() {
-        return new AbstractStackCreationAction<>(StackEvent.class) {
+        return new AbstractStackCreationAction<>(ClusterCertificatesRotationTriggerEvent.class) {
             @Override
-            protected void doExecute(StackContext context, StackEvent payload, Map<Object, Object> variables) {
+            protected void doExecute(StackContext context, ClusterCertificatesRotationTriggerEvent payload, Map<Object, Object> variables) {
                 clusterCertificatesRotationService.initClusterCertificatesRotation(payload.getResourceId());
                 sendEvent(context);
             }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
@@ -34,7 +34,6 @@ import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.common.event.Acceptable;
 import com.sequenceiq.cloudbreak.common.type.ScalingType;
 import com.sequenceiq.cloudbreak.core.flow2.chain.FlowChainTriggers;
-import com.sequenceiq.cloudbreak.core.flow2.cluster.certrotate.ClusterCertificatesRotationEvent;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.EphemeralClusterEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterAndStackDownscaleTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterCertificatesRotationTriggerEvent;
@@ -287,7 +286,7 @@ public class ReactorFlowManager {
     }
 
     public FlowIdentifier triggerAutoTlsCertificatesRotation(Long stackId, CertificatesRotationV4Request certificatesRotationV4Request) {
-        String selector = ClusterCertificatesRotationEvent.CLUSTER_CMCA_ROTATION_EVENT.event();
+        String selector = FlowChainTriggers.ROTATE_CLUSTER_CERTIFICATES_CHAIN_TRIGGER_EVENT;
         ClusterCertificatesRotationTriggerEvent clusterCertificatesRotationTriggerEvent = new ClusterCertificatesRotationTriggerEvent(selector, stackId,
                 certificatesRotationV4Request.getRotateCertificatesType());
         return reactorNotifier.notify(stackId, selector, clusterCertificatesRotationTriggerEvent);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/certrotate/ClusterHostCertificatesRotationHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/certrotate/ClusterHostCertificatesRotationHandler.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.reactor.handler.cluster.certrotate;
 
+import java.security.KeyPair;
+
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
@@ -7,6 +9,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
+import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
+import com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.certrotate.ClusterCertificatesRotationFailed;
@@ -14,6 +18,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.certrotate.ClusterHos
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.certrotate.ClusterHostCertificatesRotationSuccess;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.ssh.SshKeyService;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
 
@@ -23,11 +28,21 @@ import reactor.bus.Event;
 public class ClusterHostCertificatesRotationHandler extends ExceptionCatcherEventHandler<ClusterHostCertificatesRotationRequest> {
     private static final Logger LOGGER = LoggerFactory.getLogger(ClusterHostCertificatesRotationHandler.class);
 
+    private static final String ROOT_USER = "root";
+
+    private static final String TEMPORARY_SSH_KEY = "temporary ssh key for CM host cert rotation";
+
     @Inject
     private StackService stackService;
 
     @Inject
     private ClusterApiConnectors apiConnectors;
+
+    @Inject
+    private SshKeyService sshKeyService;
+
+    @Inject
+    private ClusterComponentConfigProvider clusterComponentConfigProvider;
 
     @Override
     public String selector() {
@@ -39,7 +54,6 @@ public class ClusterHostCertificatesRotationHandler extends ExceptionCatcherEven
         return new ClusterCertificatesRotationFailed(resourceId, e);
     }
 
-    @Override
     protected Selectable doAccept(HandlerEvent event) {
         LOGGER.debug("Accepting Cluster Manager host certificates rotation request...");
         ClusterHostCertificatesRotationRequest request = event.getData();
@@ -47,12 +61,28 @@ public class ClusterHostCertificatesRotationHandler extends ExceptionCatcherEven
         try {
             Stack stack = stackService.getByIdWithListsInTransaction(request.getResourceId());
             ClusterApi clusterApi = apiConnectors.getConnector(stack);
-            clusterApi.rotateHostCertificates();
+            if (isRootSshAccessNeededForHostCertRotation(stack)) {
+                rotateCertsWithSsh(stack, clusterApi);
+            } else {
+                clusterApi.rotateHostCertificates(null, null);
+            }
             result = new ClusterHostCertificatesRotationSuccess(request.getResourceId());
         } catch (Exception e) {
             LOGGER.info("Cluster Manager host certificates rotation failed", e);
             result = new ClusterCertificatesRotationFailed(request.getResourceId(), e);
         }
         return result;
+    }
+
+    private boolean isRootSshAccessNeededForHostCertRotation(Stack stack) {
+        return CMRepositoryVersionUtil.isRootSshAccessNeededForHostCertRotation(
+                clusterComponentConfigProvider.getClouderaManagerRepoDetails(stack.getCluster().getId()));
+    }
+
+    private void rotateCertsWithSsh(Stack stack, ClusterApi clusterApi) throws Exception {
+        KeyPair sshKeyPair = sshKeyService.generateKeyPair();
+        sshKeyService.addSshPublicKeyToHosts(stack, ROOT_USER, sshKeyPair, TEMPORARY_SSH_KEY);
+        clusterApi.rotateHostCertificates(ROOT_USER, sshKeyPair);
+        sshKeyService.removeSshPublicKeyFromHosts(stack, ROOT_USER, TEMPORARY_SSH_KEY);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/ssh/SshKeyService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/ssh/SshKeyService.java
@@ -1,0 +1,82 @@
+package com.sequenceiq.cloudbreak.ssh;
+
+import java.security.KeyPair;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.certificate.PkiUtil;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterDeletionBasedExitCriteriaModel;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.orchestrator.host.OrchestratorStateParams;
+import com.sequenceiq.cloudbreak.orchestrator.host.OrchestratorStateRetryParams;
+import com.sequenceiq.cloudbreak.orchestrator.model.Node;
+import com.sequenceiq.cloudbreak.service.GatewayConfigService;
+import com.sequenceiq.cloudbreak.util.StackUtil;
+
+@Component
+public class SshKeyService {
+    private static final String REMOVE_SSH_PUBLICKEY_STATE = "ssh.remove_ssh_publickey";
+
+    private static final String ADD_SSH_PUBLICKEY_STATE = "ssh.add_ssh_publickey";
+
+    private static final int SSH_KEY_OPERATION_RETRY_COUNT = 10;
+
+    @Inject
+    private HostOrchestrator hostOrchestrator;
+
+    @Inject
+    private GatewayConfigService gatewayConfigService;
+
+    @Inject
+    private StackUtil stackUtil;
+
+    public KeyPair generateKeyPair() {
+        return PkiUtil.generateKeypair();
+    }
+
+    public void addSshPublicKeyToHosts(Stack stack, String user, KeyPair keyPair, String authKeysComment) throws Exception {
+        OrchestratorStateParams stateParams = createSshStateParams(stack, user, keyPair, authKeysComment, REMOVE_SSH_PUBLICKEY_STATE);
+        hostOrchestrator.runOrchestratorState(stateParams);
+        stateParams.setState(ADD_SSH_PUBLICKEY_STATE);
+        hostOrchestrator.runOrchestratorState(stateParams);
+    }
+
+    public void removeSshPublicKeyFromHosts(Stack stack, String user, String authKeysComment) throws Exception {
+        OrchestratorStateParams stateParams = createSshStateParams(stack, user, null, authKeysComment, REMOVE_SSH_PUBLICKEY_STATE);
+        hostOrchestrator.runOrchestratorState(stateParams);
+    }
+
+    private OrchestratorStateParams createSshStateParams(Stack stack, String user, KeyPair keyPair, String authKeysComment, String saltState) {
+        Cluster cluster = stack.getCluster();
+        Set<Node> nodes = stackUtil.collectReachableNodes(stack);
+        OrchestratorStateParams stateParams = new OrchestratorStateParams();
+        stateParams.setState(saltState);
+        stateParams.setPrimaryGatewayConfig(gatewayConfigService.getGatewayConfig(stack, stack.getPrimaryGatewayInstance(), stack.getCluster().hasGateway()));
+        stateParams.setTargetHostNames(nodes.stream().map(Node::getHostname).collect(Collectors.toSet()));
+        stateParams.setAllNodes(nodes);
+        stateParams.setExitCriteriaModel(ClusterDeletionBasedExitCriteriaModel.clusterDeletionBasedModel(stack.getId(), cluster.getId()));
+        stateParams.setStateParams(createSshParams(user, keyPair, authKeysComment));
+        OrchestratorStateRetryParams retryParams = new OrchestratorStateRetryParams();
+        retryParams.setMaxRetry(SSH_KEY_OPERATION_RETRY_COUNT);
+        stateParams.setStateRetryParams(retryParams);
+        return stateParams;
+    }
+
+    private Map<String, Object> createSshParams(String user, KeyPair keyPair, String authKeysComment) {
+        Map<String, String> sshParams = new HashMap<>();
+        sshParams.put("user", user);
+        sshParams.put("comment", authKeysComment);
+        if (keyPair != null) {
+            sshParams.put("publickey", PkiUtil.convertOpenSshPublicKey(keyPair.getPublic()));
+        }
+        return Map.of("tmpssh", sshParams);
+    }
+}

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
@@ -105,4 +105,5 @@ public interface HostOrchestrator extends HostRecipeExecutor {
     void uploadGatewayPillar(List<GatewayConfig> allGatewayConfigs, Set<Node> allNodes, ExitCriteriaModel exitModel, SaltConfig saltConfig)
             throws CloudbreakOrchestratorFailedException;
 
+    void runOrchestratorState(OrchestratorStateParams stateParameters) throws CloudbreakOrchestratorFailedException;
 }

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/OrchestratorStateParams.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/OrchestratorStateParams.java
@@ -1,0 +1,107 @@
+package com.sequenceiq.cloudbreak.orchestrator.host;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.commons.collections.MapUtils;
+
+import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.cloudbreak.orchestrator.model.Node;
+import com.sequenceiq.cloudbreak.orchestrator.state.ExitCriteriaModel;
+
+public class OrchestratorStateParams {
+    private String state;
+
+    private GatewayConfig primaryGatewayConfig;
+
+    private Set<String> targetHostNames;
+
+    private Set<Node> allNodes;
+
+    private ExitCriteriaModel exitCriteriaModel;
+
+    private OrchestratorStateRetryParams stateRetryParams;
+
+    private Map<String, Object> stateParams = Map.of();
+
+    private boolean concurrent;
+
+    private String errorMessage = "";
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public GatewayConfig getPrimaryGatewayConfig() {
+        return primaryGatewayConfig;
+    }
+
+    public void setPrimaryGatewayConfig(GatewayConfig primaryGatewayConfig) {
+        this.primaryGatewayConfig = primaryGatewayConfig;
+    }
+
+    public Set<String> getTargetHostNames() {
+        return targetHostNames;
+    }
+
+    public void setTargetHostNames(Set<String> targetHostNames) {
+        this.targetHostNames = targetHostNames;
+    }
+
+    public Set<Node> getAllNodes() {
+        return allNodes;
+    }
+
+    public void setAllNodes(Set<Node> allNodes) {
+        this.allNodes = allNodes;
+    }
+
+    public ExitCriteriaModel getExitCriteriaModel() {
+        return exitCriteriaModel;
+    }
+
+    public void setExitCriteriaModel(ExitCriteriaModel exitCriteriaModel) {
+        this.exitCriteriaModel = exitCriteriaModel;
+    }
+
+    public Optional<OrchestratorStateRetryParams> getStateRetryParams() {
+        return Optional.ofNullable(stateRetryParams);
+    }
+
+    public void setStateRetryParams(OrchestratorStateRetryParams stateRetryParams) {
+        this.stateRetryParams = stateRetryParams;
+    }
+
+    public Map<String, Object> getStateParams() {
+        return stateParams;
+    }
+
+    public void setStateParams(Map<String, Object> stateParams) {
+        this.stateParams = stateParams;
+    }
+
+    public boolean isParameterized() {
+        return !MapUtils.isEmpty(stateParams);
+    }
+
+    public boolean isConcurrent() {
+        return concurrent;
+    }
+
+    public void setConcurrent(boolean concurrent) {
+        this.concurrent = concurrent;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+}

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/OrchestratorStateRetryParams.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/OrchestratorStateRetryParams.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.cloudbreak.orchestrator.host;
+
+public class OrchestratorStateRetryParams {
+    private int maxRetry;
+
+    private int maxRetryOnError = -1;
+
+    public int getMaxRetry() {
+        return maxRetry;
+    }
+
+    public void setMaxRetry(int maxRetry) {
+        this.maxRetry = maxRetry;
+    }
+
+    public int getMaxRetryOnError() {
+        return maxRetryOnError != -1 ? maxRetryOnError : maxRetry;
+    }
+
+    public void setMaxRetryOnError(int maxRetryOnError) {
+        this.maxRetryOnError = maxRetryOnError;
+    }
+}

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/runner/SaltRunner.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/runner/SaltRunner.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.orchestrator.OrchestratorBootstrap;
 import com.sequenceiq.cloudbreak.orchestrator.OrchestratorBootstrapRunner;
+import com.sequenceiq.cloudbreak.orchestrator.host.OrchestratorStateRetryParams;
 import com.sequenceiq.cloudbreak.orchestrator.state.ExitCriteria;
 import com.sequenceiq.cloudbreak.orchestrator.state.ExitCriteriaModel;
 
@@ -40,5 +41,11 @@ public class SaltRunner {
 
     public Callable<Boolean> runnerWithUsingErrorCount(OrchestratorBootstrap bootstrap, ExitCriteria exitCriteria, ExitCriteriaModel exitCriteriaModel) {
         return runner(bootstrap, exitCriteria, exitCriteriaModel, maxRetry, true);
+    }
+
+    public Callable<Boolean> runner(OrchestratorBootstrap bootstrap, ExitCriteria exitCriteria, ExitCriteriaModel exitCriteriaModel,
+            OrchestratorStateRetryParams orchestratorStateRetryParams) {
+        return runner(bootstrap, exitCriteria, exitCriteriaModel, orchestratorStateRetryParams.getMaxRetry(),
+                orchestratorStateRetryParams.getMaxRetryOnError());
     }
 }

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/restart.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/restart.sls
@@ -1,3 +1,9 @@
+/var/lib/cloudera-scm-agent/agent-cert:
+  file.directory:
+    - user: root
+    - group: root
+    - mode: 755
+
 stop-cloudera-scm-server:
   service.dead:
     - name: cloudera-scm-server

--- a/orchestrator-salt/src/main/resources/salt/salt/ssh/add_ssh_publickey.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/ssh/add_ssh_publickey.sls
@@ -1,0 +1,7 @@
+
+{{ salt['user.info'](salt['pillar.get']('tmpssh:user')).home }}/.ssh/authorized_keys:
+  file.append:
+    - text:
+      - '# {{ salt['pillar.get']('tmpssh:comment') }}'
+      - '{{ salt['pillar.get']('tmpssh:publickey') }}'
+      - '# end of {{ salt['pillar.get']('tmpssh:comment') }}'

--- a/orchestrator-salt/src/main/resources/salt/salt/ssh/remove_ssh_publickey.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/ssh/remove_ssh_publickey.sls
@@ -1,0 +1,19 @@
+
+{{ salt['user.info'](salt['pillar.get']('tmpssh:user')).home }}/.ssh/authorized_keys:
+  file.blockreplace:
+    - marker_start: "# {{ salt['pillar.get']('tmpssh:comment') }}"
+    - marker_end: "# end of {{ salt['pillar.get']('tmpssh:comment') }}"
+    - append_if_not_found: True
+    - append_newline: False
+
+remove_leading_comment:
+  file.line:
+    - name: {{ salt['user.info'](salt['pillar.get']('tmpssh:user')).home }}/.ssh/authorized_keys
+    - match: "# {{ salt['pillar.get']('tmpssh:comment') }}"
+    - mode: delete
+
+remove_trailing_comment:
+  file.line:
+    - name: {{ salt['user.info'](salt['pillar.get']('tmpssh:user')).home }}/.ssh/authorized_keys
+    - match: "# end of {{ salt['pillar.get']('tmpssh:comment') }}"
+    - mode: delete

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
@@ -85,6 +85,11 @@ public class CMRepositoryVersionUtil {
         return isVersionOlderThanLimited(clouderaManagerRepoDetails::getVersion, CLOUDERAMANAGER_VERSION_7_2_3);
     }
 
+    public static boolean isRootSshAccessNeededForHostCertRotation(ClouderaManagerRepo clouderaManagerRepoDetails) {
+        LOGGER.info("ClouderaManagerRepo is compared for Host certs rotation root ssh access");
+        return isVersionOlderThanLimited(clouderaManagerRepoDetails::getVersion, CLOUDERAMANAGER_VERSION_7_2_1);
+    }
+
     public static boolean isVersionNewerOrEqualThanLimited(Versioned currentVersion, Versioned limitedAPIVersion) {
         LOGGER.info("Compared: Versioned {} with Versioned {}", currentVersion.getVersion(), limitedAPIVersion.getVersion());
         Comparator<Versioned> versionComparator = new VersionComparator();


### PR DESCRIPTION
CB-9086 Enable host cert rotation on older runtimes

On clusters with older than 7.2.1 version for CM host certificates rotation root ssh access is needed.
The following changes are introduced  for this:
- Extend HostOrchestrator / SaltOrchestrator with new method for execute specific saltstates
- Introducing new salt states for ssh key adding / removal for given users on hosts
- Extend host certs rotation with adding temporary ssh access for root user during host cert rotation api call. This is only needed on clusters with older than 7.2.1 version.

CB-9297 add 755 permission for CM agent cert directory after host certs rotation on all hosts. This is needed to workaround OPSAPS-58475.
