### PR TITLE
CB-8664: Use new FreeIPA health checks for instance status

### DIFF
--- a/freeipa-client/build.gradle
+++ b/freeipa-client/build.gradle
@@ -23,6 +23,9 @@ dependencies {
   implementation     group: 'org.bouncycastle',                 name: 'bcprov-jdk15on',              version: bouncycastleVersion
   implementation     group: 'org.bouncycastle',                 name: 'bcpkix-jdk15on',              version: bouncycastleVersion
   implementation     group: 'org.springframework',              name: 'spring-web',                  version: springFrameworkVersion
+  compile            group: 'org.glassfish.jersey.core',        name: 'jersey-common',               version: jerseyCoreVersion
   testImplementation group: 'org.mockito',                      name: 'mockito-core',                version: mockitoVersion
   testCompile        group: 'junit',                            name: 'junit',                       version: junitVersion
+
+  implementation project(':common')
 }

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
@@ -589,12 +589,12 @@ public class FreeIpaClient {
             }
             return response;
         } catch (Exception e) {
-            String message = String.format("Invoke FreeIpa failed: %s", e.getLocalizedMessage());
+            String message = String.format("Invoke FreeIPA failed: %s", e.getLocalizedMessage());
             LOGGER.warn(message);
             OptionalInt responseCode = extractResponseCode(e);
             throw FreeIpaClientExceptionUtil.convertToRetryableIfNeeded(new FreeIpaClientException(message, e, responseCode));
         } catch (Throwable throwable) {
-            String message = String.format("Invoke FreeIpa failed: %s", throwable.getLocalizedMessage());
+            String message = String.format("Invoke FreeIPA failed: %s", throwable.getLocalizedMessage());
             LOGGER.warn(message);
             throw new FreeIpaClientException(message, throwable);
         }

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaHealthCheckClient.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaHealthCheckClient.java
@@ -1,0 +1,107 @@
+package com.sequenceiq.freeipa.client;
+
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.freeipa.client.healthcheckmodel.CheckResult;
+import com.sequenceiq.freeipa.client.healthcheckmodel.ClusterCheckResult;
+import com.sequenceiq.freeipa.client.model.RPCMessage;
+import com.sequenceiq.freeipa.client.model.RPCResponse;
+
+public class FreeIpaHealthCheckClient implements AutoCloseable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FreeIpaHealthCheckClient.class);
+
+    private final Client restClient;
+
+    private final WebTarget rpcTarget;
+
+    private final MultivaluedMap<String, Object> headers;
+
+    private final FreeIpaHealthCheckRpcListener listener;
+
+    public FreeIpaHealthCheckClient(Client restClient, URL url, Map<String, String> headers, FreeIpaHealthCheckRpcListener listener) {
+        this.restClient = restClient;
+        this.headers = new MultivaluedHashMap<>(headers);
+        this.listener = listener;
+
+        rpcTarget = restClient.target(url.toString());
+    }
+
+    @Override
+    public void close() throws Exception {
+        restClient.close();
+    }
+
+    public RPCResponse<CheckResult> nodeHealth() throws FreeIpaClientException {
+        return invoke("node health check", "", CheckResult.class);
+    }
+
+    public RPCResponse<ClusterCheckResult> clusterHealth() throws FreeIpaClientException {
+        return invoke("cluster health from node", "/cluster", ClusterCheckResult.class);
+    }
+
+    private <T> RPCResponse<T> invoke(String name, String path, Class<T> resultType) throws FreeIpaClientException {
+        Invocation.Builder builder = rpcTarget.path(path)
+                .request()
+                .headers(headers);
+        try (Response response = builder.get()) {
+            bufferResponseEntity(response);
+            processRpcListener(response);
+            checkResponseStatus(response);
+            return toRpcResponse(name, response, resultType);
+        } catch (FreeIpaClientException e) {
+            throw e;
+        } catch (Throwable throwable) {
+            String message = String.format("Invoke FreeIPA health check failed: %s", throwable.getLocalizedMessage());
+            LOGGER.warn(message);
+            throw new FreeIpaClientException(message, throwable);
+        }
+    }
+
+    private void bufferResponseEntity(Response response) throws FreeIpaClientException {
+        if (!response.bufferEntity()) {
+            throw new FreeIpaClientException("Unable to buffer the response from FreeIPA");
+        }
+    }
+
+    private void processRpcListener(Response response) throws Exception {
+        if (listener != null) {
+            listener.onBeforeResponseProcessed(response);
+        }
+    }
+
+    private void checkResponseStatus(Response response) throws FreeIpaClientException {
+        if (response.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL &&
+                response.getStatus() != Response.Status.SERVICE_UNAVAILABLE.getStatusCode()) {
+            String message = String.format("Invoke FreeIPA health check failed: %d", response.getStatus());
+            throw new FreeIpaClientException(message, response.getStatus());
+        }
+    }
+
+    private <T> RPCResponse<T> toRpcResponse(String name, Response response, Class<T> resultType) {
+        T resultResponse = response.readEntity(resultType);
+        RPCResponse<T> rpcResponse = new RPCResponse<>();
+        RPCMessage rpcMessage = new RPCMessage();
+        rpcMessage.setName(name);
+        rpcMessage.setCode(response.getStatus());
+        rpcMessage.setMessage(response.readEntity(String.class));
+        rpcResponse.setSummary(name);
+        rpcResponse.setMessages(List.of(rpcMessage));
+        rpcResponse.setResult(resultResponse);
+        rpcResponse.setCount(1);
+        rpcResponse.setTruncated(Boolean.FALSE);
+        return rpcResponse;
+    }
+}

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaHealthCheckRpcListener.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaHealthCheckRpcListener.java
@@ -1,0 +1,7 @@
+package com.sequenceiq.freeipa.client;
+
+import javax.ws.rs.core.Response;
+
+public interface FreeIpaHealthCheckRpcListener {
+    void onBeforeResponseProcessed(Response response) throws Exception;
+}

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/healthcheckmodel/CheckEntry.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/healthcheckmodel/CheckEntry.java
@@ -1,0 +1,48 @@
+package com.sequenceiq.freeipa.client.healthcheckmodel;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CheckEntry {
+
+    private String status;
+
+    @JsonProperty("check_id")
+    private String checkId;
+
+    private String plugin;
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getCheckId() {
+        return checkId;
+    }
+
+    public void setCheckId(String checkId) {
+        this.checkId = checkId;
+    }
+
+    public String getPlugin() {
+        return plugin;
+    }
+
+    public void setPlugin(String plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public String toString() {
+        return "Health{"
+                + "status='" + status + "\',"
+                + "check_id='" + checkId + "\',"
+                + "plugin='" + plugin + "\'"
+                + '}';
+    }
+}

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/healthcheckmodel/CheckResult.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/healthcheckmodel/CheckResult.java
@@ -1,0 +1,63 @@
+package com.sequenceiq.freeipa.client.healthcheckmodel;
+
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CheckResult {
+
+    private String status;
+
+    private String host;
+
+    private List<CheckEntry> checks;
+
+    @JsonProperty("plugin_stat")
+    private List<PluginStatusEntry> pluginStat;
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public List<CheckEntry> getChecks() {
+        return checks;
+    }
+
+    public void setChecks(List<CheckEntry> checks) {
+        this.checks = checks;
+    }
+
+    public List<PluginStatusEntry> getPluginStats() {
+        return pluginStat;
+    }
+
+    public void setPluginStats(List<PluginStatusEntry> pluginStat) {
+        this.pluginStat = pluginStat;
+    }
+
+    @Override
+    public String toString() {
+        return "CheckResult{"
+                + "status='" + status + "\',"
+                + "host='" + host + "\',"
+                + "checks={" + StringUtils.join(checks, ",") + "},"
+                + "plugin_stat={" + StringUtils.join(pluginStat, ",") +  "}"
+                + '}';
+    }
+}

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/healthcheckmodel/ClusterCheckResult.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/healthcheckmodel/ClusterCheckResult.java
@@ -1,0 +1,63 @@
+package com.sequenceiq.freeipa.client.healthcheckmodel;
+
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ClusterCheckResult {
+
+    private String status;
+
+    private String host;
+
+    private List<CheckResult> replicas;
+
+    @JsonProperty("plugin_stat")
+    private List<PluginStatusEntry> pluginStat;
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public List<CheckResult> getReplicas() {
+        return replicas;
+    }
+
+    public void setReplicas(List<CheckResult> replicas) {
+        this.replicas = replicas;
+    }
+
+    public List<PluginStatusEntry> getPluginStats() {
+        return pluginStat;
+    }
+
+    public void setPluginStats(List<PluginStatusEntry> pluginStat) {
+        this.pluginStat = pluginStat;
+    }
+
+    @Override
+    public String toString() {
+        return "ClusterCheckResult{"
+                + "status='" + status + "\',"
+                + "host='" + host + "\',"
+                + "replicas={" + StringUtils.join(replicas, ",") + "},"
+                + "plugin_stat={" + StringUtils.join(pluginStat, ",") + "}"
+                + '}';
+    }
+}

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/healthcheckmodel/PluginStatusEntry.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/healthcheckmodel/PluginStatusEntry.java
@@ -1,0 +1,59 @@
+package com.sequenceiq.freeipa.client.healthcheckmodel;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PluginStatusEntry {
+
+    private String status;
+
+    private String host;
+
+    private String plugin;
+
+    @JsonProperty("response_time")
+    private Integer responseTime;
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public String getPlugin() {
+        return plugin;
+    }
+
+    public void setPlugin(String plugin) {
+        this.plugin = plugin;
+    }
+
+    public Integer getResponseTime() {
+        return responseTime;
+    }
+
+    public void setResponseTime(Integer responseTime) {
+        this.responseTime = responseTime;
+    }
+
+    @Override
+    public String toString() {
+        return "PluginStatusEntry{"
+                + "status='" + status + "\',"
+                + "host='" + host + "\',"
+                + "plugin='" + plugin + "\',"
+                + "response_time=" + responseTime
+                + '}';
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaHealthCheckClientFactory.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaHealthCheckClientFactory.java
@@ -1,0 +1,104 @@
+package com.sequenceiq.freeipa.client;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.inject.Inject;
+import javax.ws.rs.client.Client;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.ccm.endpoint.ServiceFamilies;
+import com.sequenceiq.cloudbreak.client.HttpClientConfig;
+import com.sequenceiq.cloudbreak.client.RestClientUtil;
+import com.sequenceiq.cloudbreak.clusterproxy.ClusterProxyConfiguration;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.TlsSecurityService;
+import com.sequenceiq.freeipa.service.stack.ClusterProxyService;
+
+@Component
+public class FreeIpaHealthCheckClientFactory {
+
+    private static final String DEFAULT_BASE_PATH = "/freeipahealthcheck";
+
+    @Value("${rest.debug}")
+    private boolean restDebug;
+
+    @Value("${freeipa.healthcheck.connectionTimeoutMs}")
+    private int connetionTimeoutMillis;
+
+    @Value("${freeipa.healthcheck.readTimeoutMs}")
+    private int readTimeoutMillis;
+
+    @Inject
+    private ClusterProxyService clusterProxyService;
+
+    @Inject
+    private TlsSecurityService tlsSecurityService;
+
+    @Inject
+    private ClusterProxyConfiguration clusterProxyConfiguration;
+
+    public FreeIpaHealthCheckClient getClient(Stack stack, InstanceMetaData instance)
+            throws FreeIpaClientException, MalformedURLException {
+        FreeIpaHealthCheckClient client;
+        if (clusterProxyService.isCreateConfigForClusterProxy(stack)) {
+            client = buildFreeIpaHealthCheckClientForClusterProxy(stack, instance);
+        } else {
+            client = buildFreeIpaHealthCheckClientForDirectConnect(stack, instance);
+        }
+        return client;
+    }
+
+    private FreeIpaHealthCheckClient buildFreeIpaHealthCheckClientForClusterProxy(Stack stack, InstanceMetaData instanceMetaData)
+            throws FreeIpaClientException, MalformedURLException {
+        HttpClientConfig httpClientConfig = new HttpClientConfig(clusterProxyConfiguration.getClusterProxyHost());
+        String clusterProxyPath = toClusterProxyBasepath(stack, instanceMetaData.getDiscoveryFQDN());
+        return buildFreeIpaHealthCheckClient(httpClientConfig, clusterProxyConfiguration.getClusterProxyPort(), clusterProxyPath, clusterProxyHeaders(),
+                new FreeIpaHealthCheckClusterProxyErrorRpcListener());
+    }
+
+    private FreeIpaHealthCheckClient buildFreeIpaHealthCheckClientForDirectConnect(Stack stack, InstanceMetaData instanceMetaData)
+            throws FreeIpaClientException, MalformedURLException {
+        HttpClientConfig httpClientConfig = tlsSecurityService.buildTLSClientConfig(stack, instanceMetaData.getPublicIpWrapper(), instanceMetaData);
+        int gatewayPort = Optional.ofNullable(stack.getGatewayport()).orElse(ServiceFamilies.GATEWAY.getDefaultPort());
+        return buildFreeIpaHealthCheckClient(httpClientConfig, gatewayPort, DEFAULT_BASE_PATH, Map.of(), null);
+    }
+
+    private FreeIpaHealthCheckClient buildFreeIpaHealthCheckClient(HttpClientConfig clientConfig, int port, String basePath,
+            Map<String, String> headers, FreeIpaHealthCheckRpcListener listener)
+            throws FreeIpaClientException, MalformedURLException {
+
+        Client restClient;
+        try {
+            restClient = RestClientUtil.createClient(clientConfig.getServerCert(), clientConfig.getClientCert(), clientConfig.getClientKey(),
+                    connetionTimeoutMillis, readTimeoutMillis, restDebug);
+        } catch (Exception e) {
+            throw new FreeIpaClientException("Unable to create client for FreeIPA health checks", e);
+        }
+        URL freeIpaHealthCheckUrl = getIpaHealthCheckUrl(clientConfig, port, basePath);
+        return new FreeIpaHealthCheckClient(restClient, freeIpaHealthCheckUrl, headers, listener);
+    }
+
+    private String toClusterProxyBasepath(Stack stack, String clusterProxyServiceName) {
+        return String.format("%s%s", clusterProxyService.getProxyPath(stack, Optional.of(clusterProxyServiceName)), DEFAULT_BASE_PATH);
+    }
+
+    private URL getIpaHealthCheckUrl(HttpClientConfig clientConfig, int port, String basePath) throws MalformedURLException {
+        String scheme = clientConfig.hasSSLConfigs() ? "https://" : "http://";
+        String path = StringUtils.isBlank(basePath) ? "" : basePath;
+        return new URL(scheme + clientConfig.getApiAddress() + ':' + port + path);
+    }
+
+    private Map<String, String> clusterProxyHeaders() {
+        return Map.of(
+                "Proxy-Ignore-Auth", "true",
+                "Proxy-With-Timeout", Integer.toString(connetionTimeoutMillis)
+        );
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaHealthCheckClusterProxyErrorRpcListener.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaHealthCheckClusterProxyErrorRpcListener.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.freeipa.client;
+
+import java.util.Optional;
+
+import javax.ws.rs.core.Response;
+
+import com.sequenceiq.cloudbreak.clusterproxy.ClusterProxyException;
+
+public class FreeIpaHealthCheckClusterProxyErrorRpcListener implements FreeIpaHealthCheckRpcListener {
+
+    private Optional<ClusterProxyError> deserializeAsClusterProxyError(Response response) {
+        try {
+            ClusterProxyError clusterProxyError = response.readEntity(ClusterProxyError.class);
+            if (clusterProxyError.getCode().contains("cluster-proxy")) {
+                return Optional.of(clusterProxyError);
+            } else {
+                return Optional.empty();
+            }
+        } catch (Exception ex) {
+            return Optional.empty();
+        }
+    }
+
+    private void throwIfClusterProxyError(Response response) {
+        Optional<ClusterProxyError> clusterProxyError = deserializeAsClusterProxyError(response);
+        if (clusterProxyError.isPresent()) {
+            throw new ClusterProxyException(String.format("Cluster proxy service returned error: %s", clusterProxyError.get()));
+        }
+    }
+
+    @Override
+    public void onBeforeResponseProcessed(Response response) throws Exception {
+        throwIfClusterProxyError(response);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactory.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactory.java
@@ -179,7 +179,7 @@ public class FreeIpaClientFactory {
         return getFreeIpaClient(stack, false, false, Optional.of(freeIpaFqdn));
     }
 
-    public FreeIpaClient getFreeIpaClientForStackWithPing(Stack stack, String freeIpaFqdn) throws Exception {
+    public FreeIpaClient getFreeIpaClientForStackWithPing(Stack stack, String freeIpaFqdn) throws FreeIpaClientException {
         LOGGER.debug("Ping the login endpoint and creating FreeIpaClient for stack {} for {}", stack.getResourceCrn(), freeIpaFqdn);
         return getFreeIpaClient(stack, true, true, Optional.of(freeIpaFqdn));
     }

--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -100,6 +100,9 @@ freeipa:
     poller:
       timeoutMs: 4000
       sleepIntervalMs: 400
+  healthcheck:
+    connectionTimeoutMs: 5000
+    readTimeoutMs: 5000
 
 info:
   app:

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/client/FreeIpaHealthCheckClusterProxyErrorRpcListenerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/client/FreeIpaHealthCheckClusterProxyErrorRpcListenerTest.java
@@ -1,0 +1,49 @@
+package com.sequenceiq.freeipa.client;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import javax.ws.rs.core.Response;
+
+import org.junit.Test;
+
+import com.sequenceiq.cloudbreak.clusterproxy.ClusterProxyException;
+
+public class FreeIpaHealthCheckClusterProxyErrorRpcListenerTest {
+
+    private final FreeIpaHealthCheckClusterProxyErrorRpcListener clusterProxyErrorRpcListener = new FreeIpaHealthCheckClusterProxyErrorRpcListener();
+
+    @Test
+    public void testClusterProxyError() throws IOException {
+        ClusterProxyError clusterProxyError = new ClusterProxyError("status", "cluster-proxy.proxy.timeout", "message");
+        Response response = mock(Response.class);
+        when(response.readEntity(any(Class.class))).thenReturn(clusterProxyError);
+        assertThrows(ClusterProxyException.class, () -> {
+            clusterProxyErrorRpcListener.onBeforeResponseProcessed(response);
+        });
+    }
+
+    @Test
+    public void testClusterProxyNotAClusterProxyError() throws IOException {
+        ClusterProxyError clusterProxyError = new ClusterProxyError("status", "error from something other than cluster proxy", "message");
+        Response response = mock(Response.class);
+        when(response.readEntity(any(Class.class))).thenReturn(clusterProxyError);
+        assertDoesNotThrow(() -> {
+            clusterProxyErrorRpcListener.onBeforeResponseProcessed(response);
+        });
+    }
+
+    @Test
+    public void testClusterProxyNoError() throws IOException {
+        Response response = mock(Response.class);
+        when(response.readEntity(any(Class.class))).thenThrow(new RuntimeException("no cluster proxy error"));
+        assertDoesNotThrow(() -> {
+            clusterProxyErrorRpcListener.onBeforeResponseProcessed(response);
+        });
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/sync/StackStatusTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/sync/StackStatusTest.java
@@ -36,7 +36,7 @@ import com.sequenceiq.freeipa.entity.InstanceGroup;
 import com.sequenceiq.freeipa.entity.InstanceMetaData;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.entity.StackStatus;
-import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
+import com.sequenceiq.freeipa.service.stack.FreeIpaHealthDetailsService;
 import com.sequenceiq.freeipa.service.stack.StackService;
 import com.sequenceiq.freeipa.service.stack.StackUpdater;
 import com.sequenceiq.freeipa.service.stack.instance.InstanceMetaDataService;
@@ -63,7 +63,7 @@ class StackStatusTest {
     private FlowLogService flowLogService;
 
     @MockBean
-    private FreeIpaClientFactory freeIpaClientFactory;
+    private FreeIpaHealthDetailsService freeIpaHealthDetailsService;
 
     @MockBean
     private StackInstanceProviderChecker stackInstanceProviderChecker;
@@ -114,7 +114,8 @@ class StackStatusTest {
         notTerminatedInstances = instances;
         when(instanceMetaDataService.findNotTerminatedForStack(STACK_ID)).thenReturn(notTerminatedInstances);
 
-        setUpFreeIpaClient();
+        rpcResponse = new RPCResponse<>();
+        when(freeIpaHealthDetailsService.checkFreeIpaHealth(eq(stack), any())).thenReturn(rpcResponse);
     }
 
     private InstanceMetaData createInstance(String instanceName) {
@@ -123,15 +124,6 @@ class StackStatusTest {
         instanceMetaData.setInstanceId(instanceName);
         instanceMetaData.setDiscoveryFQDN(instanceName);
         return instanceMetaData;
-    }
-
-    private void setUpFreeIpaClient() throws Exception {
-        when(freeIpaClientFactory.getFreeIpaClientForStackWithPing(stack, INSTANCE_1)).thenReturn(freeIpaClient);
-        String freeIpaClientHostname = "freeIpaClientHostname";
-        when(freeIpaClient.getHostname()).thenReturn(freeIpaClientHostname);
-
-        rpcResponse = new RPCResponse<>();
-        when(freeIpaClient.serverConnCheck(freeIpaClientHostname, INSTANCE_1)).thenReturn(rpcResponse);
     }
 
     @Test

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/ITResponse.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/ITResponse.java
@@ -23,6 +23,8 @@ public abstract class ITResponse implements Route {
 
     public static final String FREEIPA_ROOT = "/ipa";
 
+    public static final String FREEIPA_HEALTH_CHECK_ROOT = "/freeipahealthcheck";
+
     public static final String IMAGE_CATALOG = "/imagecatalog";
 
     public static final String FREEIPA_IMAGE_CATALOG = "/freeipaimagecatalog";

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/freeipa/healthcheck/FreeIpaNodeHealthCheckHandler.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/freeipa/healthcheck/FreeIpaNodeHealthCheckHandler.java
@@ -1,0 +1,43 @@
+package com.sequenceiq.it.cloudbreak.mock.freeipa.healthcheck;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.freeipa.client.healthcheckmodel.CheckResult;
+import com.sequenceiq.it.cloudbreak.mock.ITResponse;
+
+import spark.Request;
+import spark.Response;
+
+@Component
+public class FreeIpaNodeHealthCheckHandler extends ITResponse {
+
+    private CheckResult result;
+
+    private HttpStatus status;
+
+    public FreeIpaNodeHealthCheckHandler() {
+        setHealthy();
+    }
+
+    public void setHealthy() {
+        status = HttpStatus.OK;
+        result = new CheckResult();
+        result.setHost("host");
+        result.setStatus("healthy");
+    }
+
+    public void setUnreachable() {
+        status = HttpStatus.SERVICE_UNAVAILABLE;
+        result = null;
+    }
+
+    @Override
+    public Object handle(Request request, Response response) throws Exception {
+        response.status(status.value());
+        if (result == null) {
+            return "";
+        }
+        return result;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/AbstractIntegrationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/AbstractIntegrationTest.java
@@ -46,6 +46,7 @@ import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.dto.telemetry.TelemetryTestDto;
 import com.sequenceiq.it.cloudbreak.mock.ITResponse;
 import com.sequenceiq.it.cloudbreak.mock.freeipa.FreeIpaRouteHandler;
+import com.sequenceiq.it.cloudbreak.mock.freeipa.healthcheck.FreeIpaNodeHealthCheckHandler;
 import com.sequenceiq.it.cloudbreak.spark.DynamicRouteStack;
 import com.sequenceiq.it.cloudbreak.util.azure.azurecloudblob.AzureCloudBlobUtil;
 import com.sequenceiq.sdx.api.model.SdxCloudStorageRequest;
@@ -91,6 +92,9 @@ public abstract class AbstractIntegrationTest extends AbstractMinimalTest {
     private FreeIpaRouteHandler freeIpaRouteHandler;
 
     @Inject
+    private FreeIpaNodeHealthCheckHandler freeIpaNodeHealthCheckHandler;
+
+    @Inject
     private AzureCloudBlobUtil azureCloudBlobUtil;
 
     @BeforeMethod
@@ -119,6 +123,7 @@ public abstract class AbstractIntegrationTest extends AbstractMinimalTest {
     protected void createDefaultFreeIpa(TestContext testContext) {
         MockedTestContext mockedTestContext = (MockedTestContext) testContext;
         setUpFreeIpaRouteStubbing(mockedTestContext);
+        setUpFreeIpaHealthCheckRouteStubbing(mockedTestContext);
         testContext
                 .given(FreeIpaTestDto.class).withCatalog(mockedTestContext
                     .getImageCatalogMockServerSetup()
@@ -150,6 +155,11 @@ public abstract class AbstractIntegrationTest extends AbstractMinimalTest {
         dynamicRouteStack.get(ITResponse.FREEIPA_ROOT + "/host_del", freeIpaRouteHandler);
         dynamicRouteStack.get(ITResponse.FREEIPA_ROOT + "/role_find", freeIpaRouteHandler);
         dynamicRouteStack.get(ITResponse.FREEIPA_ROOT + "/server_conncheck", freeIpaRouteHandler);
+    }
+
+    protected void setUpFreeIpaHealthCheckRouteStubbing(MockedTestContext mockedTestContext) {
+        DynamicRouteStack dynamicRouteStack = mockedTestContext.getModel().getClouderaManagerMock().getDynamicRouteStack();
+        dynamicRouteStack.get(ITResponse.FREEIPA_HEALTH_CHECK_ROOT, freeIpaNodeHealthCheckHandler);
     }
 
     protected void createImageValidationSourceCatalog(TestContext testContext, String url, String name) {
@@ -363,5 +373,9 @@ public abstract class AbstractIntegrationTest extends AbstractMinimalTest {
 
     public FreeIpaRouteHandler getFreeIpaRouteHandler() {
         return freeIpaRouteHandler;
+    }
+
+    public FreeIpaNodeHealthCheckHandler getFreeIpaHealthCheckHandler() {
+        return freeIpaNodeHealthCheckHandler;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/FreeIpaStartStopTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/FreeIpaStartStopTest.java
@@ -17,7 +17,6 @@ import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.mock.ITResponse;
 import com.sequenceiq.it.cloudbreak.mock.freeipa.FreeIpaRouteHandler;
-import com.sequenceiq.it.cloudbreak.mock.freeipa.ServerConnCheckFreeipaRpcResponse;
 import com.sequenceiq.it.cloudbreak.spark.DynamicRouteStack;
 import com.sequenceiq.it.cloudbreak.testcase.AbstractIntegrationTest;
 
@@ -58,16 +57,16 @@ public class FreeIpaStartStopTest extends AbstractIntegrationTest {
             return "";
         });
         dynamicRouteStack.post(ITResponse.FREEIPA_ROOT + "/session/json", freeIpaRouteHandler);
-        getFreeIpaRouteHandler().updateResponse("server_conncheck", new ServerConnCheckFreeipaRpcResponse());
+        getFreeIpaHealthCheckHandler().setHealthy();
         testContext
                 .given(FreeIpaTestDto.class).withCatalog(testContext.getImageCatalogMockServerSetup().getFreeIpaImageCatalogUrl())
                 .when(freeIpaTestClient.create())
                 .await(Status.AVAILABLE);
-        getFreeIpaRouteHandler().updateResponse("server_conncheck", ServerConnCheckFreeipaRpcResponse.unreachable());
+        getFreeIpaHealthCheckHandler().setUnreachable();
         testContext.given(FreeIpaTestDto.class)
                 .when(freeIpaTestClient.stop())
                 .await(Status.STOPPED);
-        getFreeIpaRouteHandler().updateResponse("server_conncheck", new ServerConnCheckFreeipaRpcResponse());
+        getFreeIpaHealthCheckHandler().setHealthy();
         testContext.given(FreeIpaTestDto.class)
                 .when(freeIpaTestClient.start())
                 .await(Status.AVAILABLE)

--- a/mock-thunderhead/src/main/resources/application.yml
+++ b/mock-thunderhead/src/main/resources/application.yml
@@ -17,7 +17,7 @@ auth:
       ha:
         enable: true
         repair.enable: true
-      healthcheck.enable: false
+      healthcheck.enable: true
     cloudstoragevalidation.enable: true
     runtime.upgrade.enable: true
     sshpublickey.file: key.pub


### PR DESCRIPTION
Use the new FreeIPA health checks for the instance status. This is
used for the periodic polling of the status, the on demand status for
the health API, and for the internal repair status.

Unit tests were added and this was tested manually using a local
deployment of cloudbreak.

See detailed description in the commit message.