### PR TITLE
CB-9136. Create scheduled job for machine user cleanup for FreeIPA/DL+DH

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/service/AltusIAMService.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/service/AltusIAMService.java
@@ -102,4 +102,8 @@ public class AltusIAMService {
     public void clearMachineUser(String machineUserName, String actorCrn, String accountId) {
         clearMachineUser(machineUserName, actorCrn, accountId, false);
     }
+
+    public List<UserManagementProto.MachineUser> getAllMachineUsersForAccount(String actorCrn, String accountId) {
+        return umsClient.listAllMachineUsers(actorCrn, accountId, true, Optional.empty());
+    }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/quartz/cleanup/UMSCleanupConfig.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/quartz/cleanup/UMSCleanupConfig.java
@@ -1,0 +1,41 @@
+package com.sequenceiq.cloudbreak.quartz.cleanup;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class UMSCleanupConfig {
+
+    @Value("${umscleanup.enabled:false}")
+    private boolean enabled;
+
+    @Value("${umscleanup.quartz.cron.expression:0 0 0 ? * SUN}")
+    private String cronExpression;
+
+    @Value("${umscleanup.max.age.days:3}")
+    private int maxAgeDays;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public int getMaxAgeDays() {
+        return maxAgeDays;
+    }
+
+    public void setMaxAgeDays(int maxAgeDays) {
+        this.maxAgeDays = maxAgeDays;
+    }
+
+    public String getCronExpression() {
+        return cronExpression;
+    }
+
+    public void setCronExpression(String cronExpression) {
+        this.cronExpression = cronExpression;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/quartz/cleanup/job/UMSCleanupJob.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/quartz/cleanup/job/UMSCleanupJob.java
@@ -1,0 +1,6 @@
+package com.sequenceiq.cloudbreak.quartz.cleanup.job;
+
+import org.springframework.scheduling.quartz.QuartzJobBean;
+
+public abstract class UMSCleanupJob extends QuartzJobBean {
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/quartz/cleanup/service/UMSCleanupJobService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/quartz/cleanup/service/UMSCleanupJobService.java
@@ -1,0 +1,83 @@
+package com.sequenceiq.cloudbreak.quartz.cleanup.service;
+
+import java.security.SecureRandom;
+import java.util.Random;
+
+import javax.inject.Inject;
+
+import org.quartz.CronScheduleBuilder;
+import org.quartz.JobBuilder;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.quartz.cleanup.UMSCleanupConfig;
+import com.sequenceiq.cloudbreak.quartz.cleanup.job.UMSCleanupJob;
+
+public abstract class UMSCleanupJobService<T extends UMSCleanupJob> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UMSCleanupJobService.class);
+
+    private static final String JOB_NAME = "ums-cleanup-job";
+
+    private static final String JOB_GROUP = "ums-cleanup-job-group";
+
+    private static final String TRIGGER_GROUP = "ums-cleanup-triggers";
+
+    private static final Random RANDOM = new SecureRandom();
+
+    @Inject
+    private Scheduler scheduler;
+
+    @Inject
+    private UMSCleanupConfig umsCleanupConfig;
+
+    public void schedule() {
+        JobDetail jobDetail = buildJobDetail();
+        Trigger trigger = buildJobTrigger(jobDetail);
+        try {
+            unschedule();
+            scheduler.scheduleJob(jobDetail, trigger);
+        } catch (SchedulerException e) {
+            LOGGER.error(String.format("Error during scheduling quartz job: %s", jobDetail), e);
+        }
+    }
+
+    public abstract Class<T> getJobClass();
+
+    private JobDetail buildJobDetail() {
+        JobDataMap jobDataMap = new JobDataMap();
+        return JobBuilder.newJob(getJobClass())
+                .withIdentity(JOB_NAME, JOB_GROUP)
+                .withDescription("Removing unused UMS resources (machine users)")
+                .usingJobData(jobDataMap)
+                .storeDurably()
+                .build();
+    }
+
+    private Trigger buildJobTrigger(JobDetail jobDetail) {
+        return TriggerBuilder.newTrigger()
+                .forJob(jobDetail)
+                .withIdentity(jobDetail.getKey().getName(), TRIGGER_GROUP)
+                .withDescription("Trigger for removing unused UMS resources (machine users)")
+                .withSchedule(CronScheduleBuilder.cronSchedule(umsCleanupConfig.getCronExpression()))
+                .build();
+    }
+
+    public void unschedule() {
+        JobKey jobKey = JobKey.jobKey(JOB_NAME, JOB_GROUP);
+        try {
+            if (scheduler.getJobDetail(jobKey) != null) {
+                scheduler.deleteJob(jobKey);
+            }
+        } catch (SchedulerException e) {
+            LOGGER.error(String.format("Error during unscheduling quartz job: %s", jobKey), e);
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/altus/CloudbreakUMSCleanupJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/altus/CloudbreakUMSCleanupJob.java
@@ -1,0 +1,139 @@
+package com.sequenceiq.cloudbreak.job.altus;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.cloudbreak.quartz.cleanup.UMSCleanupConfig;
+import com.sequenceiq.cloudbreak.quartz.cleanup.job.UMSCleanupJob;
+import com.sequenceiq.cloudbreak.service.altus.AltusMachineUserService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+
+@Component
+public class CloudbreakUMSCleanupJob extends UMSCleanupJob {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CloudbreakUMSCleanupJob.class);
+
+    private static final String DATABUS_TP_MACHINUE_USER_PATTERN = "datahub-wa-publisher-%s";
+
+    private final UMSCleanupConfig umsCleanupConfig;
+
+    private final AltusMachineUserService altusMachineUserService;
+
+    private final StackService stackService;
+
+    public CloudbreakUMSCleanupJob(UMSCleanupConfig umsCleanupConfig,
+            AltusMachineUserService altusMachineUserService, StackService stackService) {
+        this.umsCleanupConfig = umsCleanupConfig;
+        this.altusMachineUserService = altusMachineUserService;
+        this.stackService = stackService;
+    }
+
+    @Override
+    protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
+        LOGGER.debug("Cleaning up unused UMS resources (machine users) has started.");
+        List<Crn> allStackCrns = getAllStackCrns();
+        String datalakeName = Crn.Service.DATALAKE.getName();
+        Map<String, Set<String>> datalakeMachineUsers = getPossibleDatalakeMachineUsers(allStackCrns, datalakeName);
+        String datahubName = Crn.Service.DATAHUB.getName();
+        List<DatahubMachineUsers> datahubMachineUsers = getPossibleDatahubMachineUsers(allStackCrns, datahubName);
+        Map<String, Set<String>> datahubFluentUsers = getPossibleDatahubFluentUsers(datahubMachineUsers);
+        Map<String, Set<String>> datahubTpUsers = getPossibleDatahubTpUsers(datahubMachineUsers);
+        for (Map.Entry<String, Set<String>> entry : datalakeMachineUsers.entrySet()) {
+            String accountId = entry.getKey();
+            List<UserManagementProto.MachineUser> machineUsers =
+                    altusMachineUserService.getAllInternalMachineUsers(accountId);
+            Set<String> datalakeMachineUsersForAccount = entry.getValue();
+            Set<String> datahubFluentMachineForAccount = datahubFluentUsers.getOrDefault(accountId, new HashSet<>());
+            Set<String> datahubTPMachineForAccount = datahubTpUsers.getOrDefault(accountId, new HashSet<>());
+            for (UserManagementProto.MachineUser machineUser : machineUsers) {
+                String name = machineUser.getMachineUserName();
+                if (name.startsWith("datalake-fluent") && !datalakeMachineUsersForAccount.contains(name)) {
+                    cleanupMachineUser(accountId, machineUser, name);
+                } else if (name.startsWith("datahub-fluent") && !datahubFluentMachineForAccount.contains(name)) {
+                    cleanupMachineUser(accountId, machineUser, name);
+                } else if (name.startsWith("datahub-wa-publisher") && !datahubTPMachineForAccount.contains(name)) {
+                    cleanupMachineUser(accountId, machineUser, name);
+                }
+            }
+        }
+        LOGGER.debug("Cleaning up unused UMS resources (machine users) has finished.");
+    }
+
+    private Map<String, Set<String>> getPossibleDatahubTpUsers(List<DatahubMachineUsers> datahubMachineUsers) {
+        return datahubMachineUsers
+                .stream()
+                .collect(Collectors.groupingBy(DatahubMachineUsers::getAccountId,
+                        Collectors.mapping(
+                                DatahubMachineUsers::getTelemetryPublisherUser,
+                                Collectors.toSet()
+                        )));
+    }
+
+    private Map<String, Set<String>> getPossibleDatahubFluentUsers(List<DatahubMachineUsers> datahubMachineUsers) {
+        return datahubMachineUsers
+                .stream()
+                .collect(Collectors.groupingBy(DatahubMachineUsers::getAccountId,
+                Collectors.mapping(
+                        DatahubMachineUsers::getFluentUser,
+                        Collectors.toSet()
+                )));
+    }
+
+    private List<DatahubMachineUsers> getPossibleDatahubMachineUsers(List<Crn> allStackCrns, String datahubName) {
+        return allStackCrns
+                .stream()
+                .filter(crn -> datahubName.equals(crn.getService().getName()))
+                .map(crn -> {
+                    String fluentUserName = altusMachineUserService.getFluentDatabusMachineUserName(datahubName, crn.getResource());
+                    String tpUserName = String.format(DATABUS_TP_MACHINUE_USER_PATTERN, crn.getResource());
+                    return new DatahubMachineUsers(crn.getAccountId(), fluentUserName, tpUserName);
+                })
+                .collect(Collectors.toList());
+    }
+
+    private Map<String, Set<String>> getPossibleDatalakeMachineUsers(List<Crn> allStackCrns, String datalakeName) {
+        return allStackCrns
+                .stream()
+                .filter(crn -> datalakeName.equals(crn.getService().getName()))
+                .collect(Collectors.groupingBy(Crn::getAccountId,
+                        Collectors.mapping(
+                                s -> altusMachineUserService.getFluentDatabusMachineUserName(datalakeName, s.getResource()),
+                                Collectors.toSet()
+                        )));
+    }
+
+    private List<Crn> getAllStackCrns() {
+        return stackService
+                .getAllAlive()
+                .stream()
+                .map(s -> Crn.fromString(s.getCrn()))
+                .collect(Collectors.toList());
+    }
+
+    private void cleanupMachineUser(String accountId, UserManagementProto.MachineUser machineUser, String name) {
+        LOGGER.debug("Cannot found stack for machine user {} (account: {}). Checks that if it can be deleted.",
+                name, accountId);
+        Instant beforeTime = Instant.now().minus(umsCleanupConfig.getMaxAgeDays(), ChronoUnit.DAYS);
+        Instant creationTime = new Date(machineUser.getCreationDateMs()).toInstant();
+        if (creationTime.isBefore(beforeTime)) {
+            altusMachineUserService.cleanupMachineUser(name, accountId);
+        } else {
+            LOGGER.debug("Machine user with name {} is not old enough yet, skipping cleanup. (account id: {})",
+                    name, accountId);
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/altus/CloudbreakUMSCleanupJobInitializer.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/altus/CloudbreakUMSCleanupJobInitializer.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.cloudbreak.job.altus;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.quartz.cleanup.UMSCleanupConfig;
+import com.sequenceiq.cloudbreak.quartz.model.JobInitializer;
+
+@Component
+public class CloudbreakUMSCleanupJobInitializer implements JobInitializer {
+
+    @Inject
+    private UMSCleanupConfig umsCleanupConfig;
+
+    @Inject
+    private CloudbreakUMSCleanupJobService cloudbreakUmsCleanupJobService;
+
+    @Override
+    public void initJobs() {
+        if (umsCleanupConfig.isEnabled()) {
+            cloudbreakUmsCleanupJobService.schedule();
+        } else {
+            cloudbreakUmsCleanupJobService.unschedule();
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/altus/CloudbreakUMSCleanupJobService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/altus/CloudbreakUMSCleanupJobService.java
@@ -1,0 +1,14 @@
+package com.sequenceiq.cloudbreak.job.altus;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.quartz.cleanup.service.UMSCleanupJobService;
+
+@Service
+public class CloudbreakUMSCleanupJobService extends UMSCleanupJobService<CloudbreakUMSCleanupJob> {
+
+    @Override
+    public Class<CloudbreakUMSCleanupJob> getJobClass() {
+        return CloudbreakUMSCleanupJob.class;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/altus/DatahubMachineUsers.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/altus/DatahubMachineUsers.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.cloudbreak.job.altus;
+
+public class DatahubMachineUsers {
+
+    private final String accountId;
+
+    private final String fluentUser;
+
+    private final String telemetryPublisherUser;
+
+    public DatahubMachineUsers(String accountId, String fluentUser, String telemetryPublisherUser) {
+        this.accountId = accountId;
+        this.fluentUser = fluentUser;
+        this.telemetryPublisherUser = telemetryPublisherUser;
+    }
+
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public String getFluentUser() {
+        return fluentUser;
+    }
+
+    public String getTelemetryPublisherUser() {
+        return telemetryPublisherUser;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/altus/AltusMachineUserService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/altus/AltusMachineUserService.java
@@ -1,9 +1,11 @@
 package com.sequenceiq.cloudbreak.service.altus;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
@@ -45,7 +47,7 @@ public class AltusMachineUserService {
     }
 
     /**
-     * Delete machine user with its access keys (and unassign databus role if required)
+     * Delete machine user for fluent based upload with its access keys (and unassign databus role if required)
      */
     public void clearFluentMachineUser(Stack stack, Telemetry telemetry) {
         if (isMeteringOrAnyDataBusBasedFeatureSupported(stack, telemetry)) {
@@ -57,6 +59,18 @@ public class AltusMachineUserService {
                             Crn.fromString(stack.getResourceCrn()).getAccountId(),
                             telemetry.isUseSharedAltusCredentialEnabled()));
         }
+    }
+
+    /**
+     * Delete machine user with access keys (and unassign databus role if required) by provided machine user name and account id
+     */
+    public void cleanupMachineUser(String machineUserName, String accountId) {
+        ThreadBasedUserCrnProvider.doAsInternalActor(
+                () -> altusIAMService.clearMachineUser(machineUserName,
+                        ThreadBasedUserCrnProvider.getUserCrn(),
+                        accountId
+                )
+        );
     }
 
     /**
@@ -103,6 +117,18 @@ public class AltusMachineUserService {
                 && !StackType.DATALAKE.equals(stack.getType())));
     }
 
+    public List<UserManagementProto.MachineUser> getAllInternalMachineUsers(String accountId) {
+        return ThreadBasedUserCrnProvider.doAsInternalActor(
+                () -> altusIAMService.getAllMachineUsersForAccount(
+                        ThreadBasedUserCrnProvider.getUserCrn(),
+                        accountId)
+        );
+    }
+
+    public String getFluentDatabusMachineUserName(String clusterType, String resource) {
+        return String.format(FLUENT_DATABUS_MACHINE_USER_NAME_PATTERN, clusterType, resource);
+    }
+
     private String getFluentDatabusMachineUserName(Stack stack) {
         String clusterType = "cb";
         if (StackType.DATALAKE.equals(stack.getType())) {
@@ -110,7 +136,6 @@ public class AltusMachineUserService {
         } else if (StackType.WORKLOAD.equals(stack.getType())) {
             clusterType = "datahub";
         }
-        return String.format(FLUENT_DATABUS_MACHINE_USER_NAME_PATTERN, clusterType,
-                Crn.fromString(stack.getResourceCrn()).getResource());
+        return getFluentDatabusMachineUserName(clusterType, Crn.fromString(stack.getResourceCrn()).getResource());
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/job/altus/CloudbreakUMSCleanupJobTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/job/altus/CloudbreakUMSCleanupJobTest.java
@@ -1,0 +1,192 @@
+package com.sequenceiq.cloudbreak.job.altus;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
+import com.sequenceiq.cloudbreak.domain.projection.StackTtlView;
+import com.sequenceiq.cloudbreak.domain.stack.StackStatus;
+import com.sequenceiq.cloudbreak.quartz.cleanup.UMSCleanupConfig;
+import com.sequenceiq.cloudbreak.service.altus.AltusMachineUserService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.workspace.model.Workspace;
+
+@ExtendWith(MockitoExtension.class)
+public class CloudbreakUMSCleanupJobTest {
+
+    @InjectMocks
+    private CloudbreakUMSCleanupJob underTest;
+
+    @Mock
+    private UMSCleanupConfig umsCleanupConfig;
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private AltusMachineUserService altusMachineUserService;
+
+    @Mock
+    private JobExecutionContext jobExecutionContext;
+
+    @BeforeEach
+    public void setUp() {
+        underTest = new CloudbreakUMSCleanupJob(umsCleanupConfig, altusMachineUserService, stackService);
+    }
+
+    @Test
+    public void testExecuteInternal() throws JobExecutionException {
+        // GIVEN
+        given(stackService.getAllAlive()).willReturn(createStacks());
+        fluentMachineUserMocks();
+        given(altusMachineUserService.getAllInternalMachineUsers("acc1")).willReturn(getMachineUsers("acc1"));
+        given(altusMachineUserService.getAllInternalMachineUsers("acc2")).willReturn(getMachineUsers("acc2"));
+        given(altusMachineUserService.getAllInternalMachineUsers("acc3")).willReturn(getMachineUsers("acc3"));
+        given(umsCleanupConfig.getMaxAgeDays()).willReturn(100);
+        // WHEN
+        underTest.executeInternal(jobExecutionContext);
+        // THEN
+        verify(altusMachineUserService, times(6)).getFluentDatabusMachineUserName(anyString(), anyString());
+        verify(altusMachineUserService, times(5)).cleanupMachineUser(anyString(), anyString());
+    }
+
+    @Test
+    public void testExecuteInternalWithoutStacks() throws JobExecutionException {
+        // GIVEN
+        given(stackService.getAllAlive()).willReturn(new ArrayList<>());
+        // WHEN
+        underTest.executeInternal(jobExecutionContext);
+        // THEN
+        verify(altusMachineUserService, times(0)).getFluentDatabusMachineUserName(anyString(), anyString());
+        verify(altusMachineUserService, times(0)).cleanupMachineUser(anyString(), anyString());
+    }
+
+    @Test
+    public void testExecuteInternalWithoutMachineUsers() throws JobExecutionException {
+        // GIVEN
+        given(stackService.getAllAlive()).willReturn(createStacks());
+        fluentMachineUserMocks();
+        given(altusMachineUserService.getAllInternalMachineUsers(anyString())).willReturn(new ArrayList<>());
+        // WHEN
+        underTest.executeInternal(jobExecutionContext);
+        // THEN
+        verify(altusMachineUserService, times(6)).getFluentDatabusMachineUserName(anyString(), anyString());
+        verify(altusMachineUserService, times(0)).cleanupMachineUser(anyString(), anyString());
+    }
+
+    private List<UserManagementProto.MachineUser> getMachineUsers(String accountId) {
+        List<UserManagementProto.MachineUser> machineUsers = new ArrayList<>();
+        machineUsers.add(createMachineUser("do-not-delete", old()));
+        machineUsers.add(createMachineUser("datahub-fluent-databus-uploader-deleteme", old()));
+        if ("acc1".equals(accountId)) {
+            machineUsers.add(createMachineUser("datalake-fluent-databus-uploader-cluster1", now()));
+            machineUsers.add(createMachineUser("datahub-fluent-databus-uploader-cluster2", now()));
+            machineUsers.add(createMachineUser("datahub-wa-publisher-cluster2", now()));
+            machineUsers.add(createMachineUser("datahub-fluent-databus-uploader-cluster3", now()));
+        } else if ("acc2".equals(accountId)) {
+            machineUsers.add(createMachineUser("datahub-fluent-databus-uploader-cluster4", now()));
+            machineUsers.add(createMachineUser("datahub-fluent-databus-uploader-cluster5", old()));
+        } else if ("acc3".equals(accountId)) {
+            machineUsers.add(createMachineUser("datalake-fluent-databus-uploader-cluster6", old()));
+            machineUsers.add(createMachineUser("datahub-wa-publisher-cluster6", old()));
+            machineUsers.add(createMachineUser("datahub-fluent-databus-uploader-cluster6", old()));
+        }
+        return machineUsers;
+    }
+
+    private long now() {
+        return Instant.now().toEpochMilli();
+    }
+
+    private long old() {
+        return Instant.now().minus(1000, ChronoUnit.DAYS).toEpochMilli();
+    }
+
+    private UserManagementProto.MachineUser createMachineUser(String name, long createTs) {
+        return UserManagementProto.MachineUser.newBuilder()
+                .setMachineUserName(name)
+                .setCreationDateMs(createTs)
+                .build();
+    }
+
+    private List<StackTtlView> createStacks() {
+        List<StackTtlView> stacks = new ArrayList<>();
+        stacks.add(new StackTtlViewImpl("crn:cdp:datalake:us-west-1:acc1:datalake:cluster1"));
+        stacks.add(new StackTtlViewImpl("crn:cdp:datahub:us-west-1:acc1:stack:cluster2"));
+        stacks.add(new StackTtlViewImpl("crn:cdp:datahub:us-west-1:acc1:stack:cluster3"));
+        stacks.add(new StackTtlViewImpl("crn:cdp:datalake:us-west-1:acc2:datalake:cluster4"));
+        stacks.add(new StackTtlViewImpl("crn:cdp:datahub:us-west-1:acc2:stack:cluster5"));
+        stacks.add(new StackTtlViewImpl("crn:cdp:datalake:us-west-1:acc3:datalake:cluster6"));
+        return stacks;
+    }
+
+    private void fluentMachineUserMocks() {
+        given(altusMachineUserService.getFluentDatabusMachineUserName("datalake", "cluster1"))
+                .willReturn("datalake-fluent-databus-uploader-cluster1");
+        given(altusMachineUserService.getFluentDatabusMachineUserName("datahub", "cluster2"))
+                .willReturn("datahub-fluent-databus-uploader-cluster2");
+        given(altusMachineUserService.getFluentDatabusMachineUserName("datahub", "cluster3"))
+                .willReturn("datahub-fluent-databus-uploader-cluster3");
+        given(altusMachineUserService.getFluentDatabusMachineUserName("datalake", "cluster4"))
+                .willReturn("datalake-fluent-databus-uploader-cluster4");
+        given(altusMachineUserService.getFluentDatabusMachineUserName("datahub", "cluster5"))
+                .willReturn("datahub-fluent-databus-uploader-cluster5");
+        given(altusMachineUserService.getFluentDatabusMachineUserName("datalake", "cluster6"))
+                .willReturn("datalake-fluent-databus-uploader-cluster6");
+    }
+
+    private static class StackTtlViewImpl implements StackTtlView {
+
+        private final String crn;
+
+        StackTtlViewImpl(String crn) {
+            this.crn = crn;
+        }
+
+        @Override
+        public Long getId() {
+            return null;
+        }
+
+        @Override
+        public String getName() {
+            return null;
+        }
+
+        @Override
+        public String getCrn() {
+            return this.crn;
+        }
+
+        @Override
+        public Workspace getWorkspace() {
+            return null;
+        }
+
+        @Override
+        public StackStatus getStatus() {
+            return null;
+        }
+
+        @Override
+        public Long getCreationFinished() {
+            return null;
+        }
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/altus/FreeIpaUMSCleanupJob.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/altus/FreeIpaUMSCleanupJob.java
@@ -1,0 +1,75 @@
+package com.sequenceiq.freeipa.altus;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
+import com.sequenceiq.cloudbreak.quartz.cleanup.UMSCleanupConfig;
+import com.sequenceiq.cloudbreak.quartz.cleanup.job.UMSCleanupJob;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.AltusMachineUserService;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+@Component
+public class FreeIpaUMSCleanupJob extends UMSCleanupJob {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FreeIpaUMSCleanupJob.class);
+
+    private final UMSCleanupConfig umsCleanupConfig;
+
+    private final AltusMachineUserService altusMachineUserService;
+
+    private final StackService stackService;
+
+    public FreeIpaUMSCleanupJob(UMSCleanupConfig umsCleanupConfig,
+            AltusMachineUserService altusMachineUserService, StackService stackService) {
+        this.umsCleanupConfig = umsCleanupConfig;
+        this.altusMachineUserService = altusMachineUserService;
+        this.stackService = stackService;
+    }
+
+    @Override
+    protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
+        LOGGER.debug("Cleaning up unused UMS resources (machine users) has started.");
+        Map<String, Set<String>> expectedMachineUsers = stackService
+                .findAllRunning()
+                .stream()
+                .collect(Collectors.groupingBy(Stack::getAccountId,
+                        Collectors.mapping(
+                                altusMachineUserService::getFluentMachineUser,
+                                Collectors.toSet()
+                        )));
+        for (Map.Entry<String, Set<String>> machineUsersPerAccount : expectedMachineUsers.entrySet()) {
+            String accountId = machineUsersPerAccount.getKey();
+            List<UserManagementProto.MachineUser> machineUsers =
+                    altusMachineUserService.getAllInternalMachineUsers(accountId);
+            Set<String> machineUserValues = machineUsersPerAccount.getValue();
+            for (UserManagementProto.MachineUser machineUser : machineUsers) {
+                String name = machineUser.getMachineUserName();
+                if (name.startsWith("freeipa-fluent") && !machineUserValues.contains(name)) {
+                    LOGGER.debug("Cannot found stack for machine user {} (account: {}). Checks that if it can be deleted.",
+                            name, accountId);
+                    Instant beforeTime = Instant.now().minus(umsCleanupConfig.getMaxAgeDays(), ChronoUnit.DAYS);
+                    Instant creationTime = new Date(machineUser.getCreationDateMs()).toInstant();
+                    if (creationTime.isBefore(beforeTime)) {
+                        altusMachineUserService.cleanupMachineUser(name, accountId);
+                    } else {
+                        LOGGER.debug("Machine user with name {} is not old enough yet, skipping cleanup. (account id: {})",
+                                name, accountId);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/altus/FreeIpaUMSCleanupJobInitializer.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/altus/FreeIpaUMSCleanupJobInitializer.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.freeipa.altus;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.quartz.cleanup.UMSCleanupConfig;
+import com.sequenceiq.cloudbreak.quartz.model.JobInitializer;
+
+@Component
+public class FreeIpaUMSCleanupJobInitializer implements JobInitializer {
+
+    @Inject
+    private UMSCleanupConfig umsCleanupConfig;
+
+    @Inject
+    private FreeIpaUMSCleanupJobService freeIpaUmsCleanupJobService;
+
+    @Override
+    public void initJobs() {
+        if (umsCleanupConfig.isEnabled()) {
+            freeIpaUmsCleanupJobService.schedule();
+        } else {
+            freeIpaUmsCleanupJobService.unschedule();
+        }
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/altus/FreeIpaUMSCleanupJobService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/altus/FreeIpaUMSCleanupJobService.java
@@ -1,0 +1,14 @@
+package com.sequenceiq.freeipa.altus;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.quartz.cleanup.service.UMSCleanupJobService;
+
+@Service
+public class FreeIpaUMSCleanupJobService extends UMSCleanupJobService<FreeIpaUMSCleanupJob> {
+
+    @Override
+    public Class<FreeIpaUMSCleanupJob> getJobClass() {
+        return FreeIpaUMSCleanupJob.class;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/AltusMachineUserService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/AltusMachineUserService.java
@@ -1,9 +1,11 @@
 package com.sequenceiq.freeipa.service;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.auth.altus.model.AltusCredential;
@@ -31,6 +33,15 @@ public class AltusMachineUserService {
                         telemetry.isUseSharedAltusCredentialEnabled()));
     }
 
+    public void cleanupMachineUser(String machineUserName, String accountId) {
+        ThreadBasedUserCrnProvider.doAsInternalActor(
+                () -> altusIAMService.clearMachineUser(machineUserName,
+                        ThreadBasedUserCrnProvider.getUserCrn(),
+                        accountId
+                )
+        );
+    }
+
     public void cleanupMachineUser(Stack stack, Telemetry telemetry) {
         String machineUserName = getFluentMachineUser(stack);
         ThreadBasedUserCrnProvider.doAsInternalActor(
@@ -40,7 +51,15 @@ public class AltusMachineUserService {
                         telemetry.isUseSharedAltusCredentialEnabled()));
     }
 
-    private String getFluentMachineUser(Stack stack) {
+    public List<UserManagementProto.MachineUser> getAllInternalMachineUsers(String accountId) {
+        return ThreadBasedUserCrnProvider.doAsInternalActor(
+                () -> altusIAMService.getAllMachineUsersForAccount(
+                        ThreadBasedUserCrnProvider.getUserCrn(),
+                        accountId)
+        );
+    }
+
+    public String getFluentMachineUser(Stack stack) {
         return String.format(FREEIPA_FLUENT_DATABUS_MACHINE_USER_PATTERN,
                 Crn.fromString(stack.getResourceCrn()).getResource());
     }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/altus/FreeIpaUMSCleanupJobTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/altus/FreeIpaUMSCleanupJobTest.java
@@ -1,0 +1,148 @@
+package com.sequenceiq.freeipa.altus;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
+import com.sequenceiq.cloudbreak.quartz.cleanup.UMSCleanupConfig;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.AltusMachineUserService;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+@ExtendWith(MockitoExtension.class)
+public class FreeIpaUMSCleanupJobTest {
+
+    @InjectMocks
+    private FreeIpaUMSCleanupJob underTest;
+
+    @Mock
+    private UMSCleanupConfig umsCleanupConfig;
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private AltusMachineUserService altusMachineUserService;
+
+    @Mock
+    private JobExecutionContext jobExecutionContext;
+
+    @BeforeEach
+    public void setUp() {
+        underTest = new FreeIpaUMSCleanupJob(umsCleanupConfig, altusMachineUserService, stackService);
+    }
+
+    @Test
+    public void testExecuteInternal() throws JobExecutionException {
+        // GIVEN
+        given(stackService.findAllRunning()).willReturn(createStacks());
+        fluentMachineUserMocks();
+        given(altusMachineUserService.getAllInternalMachineUsers("acc1")).willReturn(getMachineUsers("acc1"));
+        given(altusMachineUserService.getAllInternalMachineUsers("acc2")).willReturn(getMachineUsers("acc2"));
+        given(altusMachineUserService.getAllInternalMachineUsers("acc3")).willReturn(getMachineUsers("acc3"));
+        given(umsCleanupConfig.getMaxAgeDays()).willReturn(100);
+        // WHEN
+        underTest.executeInternal(jobExecutionContext);
+        // THEN
+        verify(altusMachineUserService, times(4)).cleanupMachineUser(anyString(), anyString());
+    }
+
+    @Test
+    public void testExecuteInternalWithoutStacks() throws JobExecutionException {
+        // GIVEN
+        given(stackService.findAllRunning()).willReturn(new ArrayList<>());
+        // WHEN
+        underTest.executeInternal(jobExecutionContext);
+        // THEN
+        verify(altusMachineUserService, times(0)).cleanupMachineUser(anyString(), anyString());
+    }
+
+    @Test
+    public void testExecuteInternalWithoutMachineUsers() throws JobExecutionException {
+        // GIVEN
+        given(stackService.findAllRunning()).willReturn(createStacks());
+        fluentMachineUserMocks();
+        given(altusMachineUserService.getAllInternalMachineUsers(anyString())).willReturn(new ArrayList<>());
+        // WHEN
+        underTest.executeInternal(jobExecutionContext);
+        // THEN
+        verify(altusMachineUserService, times(0)).cleanupMachineUser(anyString(), anyString());
+    }
+
+    private void fluentMachineUserMocks() {
+        given(altusMachineUserService.getFluentMachineUser(any()))
+                .willReturn("freeipa-fluent-databus-uploader-cluster1")
+                .willReturn("freeipa-fluent-databus-uploader-cluster2")
+                .willReturn("freeipa-fluent-databus-uploader-cluster3")
+                .willReturn("freeipa-fluent-databus-uploader-cluster4");
+    }
+
+    private List<Stack> createStacks() {
+        List<Stack> stacks = new ArrayList<>();
+        stacks.add(createStack("cluster1", "acc1"));
+        stacks.add(createStack("cluster2", "acc1"));
+        stacks.add(createStack("cluster3", "acc2"));
+        stacks.add(createStack("cluster4", "acc3"));
+        return stacks;
+    }
+
+    private Stack createStack(String resource, String accountId) {
+        Stack stack = new Stack();
+        stack.setResourceCrn(getCrn(accountId, resource));
+        stack.setAccountId(accountId);
+        return stack;
+    }
+
+    private String getCrn(String resource, String accountId) {
+        return String.format("crn:cdp:freeipa:us-west-1:%s:freeipa:%s", accountId, resource);
+    }
+
+    private List<UserManagementProto.MachineUser> getMachineUsers(String accountId) {
+        List<UserManagementProto.MachineUser> machineUsers = new ArrayList<>();
+        machineUsers.add(createMachineUser("do-not-delete", old()));
+        machineUsers.add(createMachineUser("freeipa-fluent-databus-uploader-deleteme", old()));
+        if ("acc1".equals(accountId)) {
+            machineUsers.add(createMachineUser("freeipa-fluent-databus-uploader-cluster1", now()));
+        } else if ("acc2".equals(accountId)) {
+            machineUsers.add(createMachineUser("freeipa-fluent-databus-uploader-cluster2", now()));
+            machineUsers.add(createMachineUser("freeipa-fluent-databus-uploader-cluster3", old()));
+        } else if ("acc3".equals(accountId)) {
+            machineUsers.add(createMachineUser("freeipa-fluent-databus-uploader-cluster4", old()));
+            machineUsers.add(createMachineUser("freeipa-fluent-databus-uploader-cluster5", old()));
+        }
+        return machineUsers;
+    }
+
+    private long now() {
+        return Instant.now().toEpochMilli();
+    }
+
+    private long old() {
+        return Instant.now().minus(1000, ChronoUnit.DAYS).toEpochMilli();
+    }
+
+    private UserManagementProto.MachineUser createMachineUser(String name, long createTs) {
+        return UserManagementProto.MachineUser.newBuilder()
+                .setMachineUserName(name)
+                .setCreationDateMs(createTs)
+                .build();
+    }
+
+}


### PR DESCRIPTION
details:
We should clean up generated machine users if those were not delete during cluster destroy (no significant increase with those users, but it's useful if we will have some cleanup scripts)
that should be done for 2 components:
- freeipa service
- cloudbreak (core) service (against datalake/datahub)
machine users:
- 1 fluent user for freeipa (if cluster logs collection enabled)
- 1 fluent user for datalake (if cluster logs collection enabled)
- 1 fluent user for datahub (if cluster logs collection or metering enabled) and 1 TP user if WA enabled
(overall freeipa/datalake: max. 1-1, datahub: max 2.)
(all users have specific patterns)
-> Using quartz job scheduler to do the cleanup on every sSunday (0:00) clean users that has no attached clusters + user creation date is older than 3 days

See detailed description in the commit message.