### PR TITLE
CB-9249 Stabilise JUnit XML report generation in case test failure

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
@@ -1153,12 +1153,12 @@ public abstract class TestContext implements ApplicationContextAware {
                 String message = testResult.getThrowable().getCause().getMessage() != null
                         ? testResult.getThrowable().getCause().getMessage()
                         : testResult.getThrowable().getMessage();
-                LOGGER.info("Failed test results are: Test Case: {} | Status: {} | Failure Type: {} | Message: {}", methodName, status,
-                        testFailureType, message);
+                String testName = String.join("_", commonCloudProperties.getCloudProvider().toLowerCase(), methodName);
+                LOGGER.info("Failed test results are: Test Case: {} | Test Name: {} | Status: {} | Failure Type: {} | Message: {}", methodName, testName,
+                        status, testFailureType, message);
 
-                testResult.setTestName(String.join("_", commonCloudProperties.getCloudProvider().toLowerCase(), methodName));
-                testResult.getTestContext().setAttribute(testResult.getTestName() + OUTPUT_FAILURE_TYPE, testFailureType);
-                testResult.getTestContext().setAttribute(testResult.getTestName() + OUTPUT_FAILURE, testResult.getThrowable());
+                testResult.getTestContext().setAttribute(testName + OUTPUT_FAILURE_TYPE, testFailureType);
+                testResult.getTestContext().setAttribute(testName + OUTPUT_FAILURE, testResult.getThrowable());
             } else {
                 LOGGER.error("Test Context TestFailException is null! So cannot get the correct test fail result!");
             }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/search/CustomJUnitXMLReporter.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/search/CustomJUnitXMLReporter.java
@@ -162,6 +162,7 @@ public class CustomJUnitXMLReporter extends JUnitXMLReporter {
                 Throwable testResultException = testResult.getThrowable();
                 String methodName = testResult.getName();
                 int status = testResult.getStatus();
+                String testName = String.join("_", commonCloudProperties.getCloudProvider().toLowerCase(), methodName);
 
                 if (testResultException != null) {
                     try {
@@ -173,8 +174,8 @@ public class CustomJUnitXMLReporter extends JUnitXMLReporter {
                         if (message == null || message.isEmpty()) {
                             LOGGER.warn("Test Case: {} have been failed with empty test result!", methodName);
                         } else {
-                            LOGGER.info("Failed test results are: Test Case: {} | Status: {} | Failure Type: {} | Message: {}",
-                                    methodName, status, testFailureType, message);
+                            LOGGER.info("Failed test results are: Test Case: {} | Test Name: {} | Status: {} | Failure Type: {} | Message: {}",
+                                    methodName, testName, status, testFailureType, message);
                         }
                     } catch (Exception e) {
                         LOGGER.error("Test case: {} got Unexpected Exception: {}", methodName, e.getMessage());
@@ -183,7 +184,7 @@ public class CustomJUnitXMLReporter extends JUnitXMLReporter {
                     getTestErrorFromTestOutput(testResult, methodName, status);
                 }
 
-                testResult.setTestName(String.join("_", commonCloudProperties.getCloudProvider().toLowerCase(), methodName));
+                testResult.setTestName(testName);
                 getResultsForClass(flattenedResults, testResult).addResult(testResult);
             } else {
                 LOGGER.error("Test result is NULL!");


### PR DESCRIPTION
Test failures have been shown `Unknown` as Exception and Error at latest Quanta report. So I've changed the test result attribute setup at TestContext and refactored the set test name at CustomXMLReporter.