### PR TITLE
CB-9296 Creating a new edit credential object for put requests becaus…

### DIFF
--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/credential/endpoint/AuditCredentialEndpoint.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/credential/endpoint/AuditCredentialEndpoint.java
@@ -21,6 +21,7 @@ import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
 import com.sequenceiq.environment.api.doc.credential.CredentialDescriptor;
 import com.sequenceiq.environment.api.doc.credential.CredentialOpDescription;
 import com.sequenceiq.environment.api.v1.credential.model.request.CredentialRequest;
+import com.sequenceiq.environment.api.v1.credential.model.request.EditCredentialRequest;
 import com.sequenceiq.environment.api.v1.credential.model.response.CredentialResponse;
 import com.sequenceiq.environment.api.v1.credential.model.response.CredentialResponses;
 
@@ -66,7 +67,7 @@ public interface AuditCredentialEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = CredentialOpDescription.PUT, produces = MediaType.APPLICATION_JSON, notes = CredentialDescriptor.CREDENTIAL_NOTES,
             nickname = "putAuditCredentialV1", httpMethod = "PUT")
-    CredentialResponse put(@Valid CredentialRequest credentialRequest);
+    CredentialResponse put(@Valid EditCredentialRequest credentialRequest);
 
     @GET
     @Path("prerequisites/{cloudPlatform}")

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/credential/endpoint/CredentialEndpoint.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/credential/endpoint/CredentialEndpoint.java
@@ -24,6 +24,7 @@ import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
 import com.sequenceiq.environment.api.doc.credential.CredentialDescriptor;
 import com.sequenceiq.environment.api.doc.credential.CredentialOpDescription;
 import com.sequenceiq.environment.api.v1.credential.model.request.CredentialRequest;
+import com.sequenceiq.environment.api.v1.credential.model.request.EditCredentialRequest;
 import com.sequenceiq.environment.api.v1.credential.model.response.CredentialResponse;
 import com.sequenceiq.environment.api.v1.credential.model.response.CredentialResponses;
 import com.sequenceiq.environment.api.v1.credential.model.response.InteractiveCredentialResponse;
@@ -105,7 +106,7 @@ public interface CredentialEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = CredentialOpDescription.PUT, produces = MediaType.APPLICATION_JSON, notes = CredentialDescriptor.CREDENTIAL_NOTES,
             nickname = "putCredentialV1", httpMethod = "PUT")
-    CredentialResponse put(@Valid CredentialRequest credentialRequest);
+    CredentialResponse put(@Valid EditCredentialRequest credentialRequest);
 
     @POST
     @Path("interactive_login")

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/credential/model/CredentialBase.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/credential/model/CredentialBase.java
@@ -4,12 +4,8 @@ import java.io.Serializable;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
-import com.sequenceiq.authorization.annotation.ResourceObjectField;
-import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
-import com.sequenceiq.authorization.resource.AuthorizationVariableType;
 import com.sequenceiq.environment.api.doc.ModelDescriptions;
 import com.sequenceiq.environment.api.doc.credential.CredentialModelDescription;
 import com.sequenceiq.environment.api.v1.credential.model.parameters.aws.AwsCredentialParameters;
@@ -25,13 +21,6 @@ import io.swagger.annotations.ApiModelProperty;
 
 @ApiModel(subTypes = {CredentialRequest.class, CredentialResponse.class})
 public abstract class CredentialBase implements Serializable {
-
-    @Size(max = 100, min = 5, message = "The length of the credential's name has to be in range of 5 to 100")
-    @Pattern(regexp = "(^[a-z][-a-z0-9]*[a-z0-9]$)",
-            message = "The name of the credential can only contain lowercase alphanumeric characters and hyphens and has start with an alphanumeric character")
-    @ApiModelProperty(value = ModelDescriptions.NAME, required = true, allowableValues = "length range[5, 100]")
-    @ResourceObjectField(action = AuthorizationResourceAction.EDIT_CREDENTIAL, variableType = AuthorizationVariableType.NAME)
-    private String name;
 
     @NotNull
     @ApiModelProperty(value = CredentialModelDescription.CLOUD_PLATFORM, required = true)
@@ -81,14 +70,6 @@ public abstract class CredentialBase implements Serializable {
 
     public void setDescription(String description) {
         this.description = description;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
     }
 
     public String getCloudPlatform() {

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/credential/model/request/EditCredentialRequest.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/credential/model/request/EditCredentialRequest.java
@@ -1,12 +1,13 @@
 package com.sequenceiq.environment.api.v1.credential.model.request;
 
 import javax.validation.Valid;
-import javax.validation.constraints.Pattern;
-import javax.validation.constraints.Size;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.sequenceiq.authorization.annotation.ResourceObjectField;
+import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
+import com.sequenceiq.authorization.resource.AuthorizationVariableType;
 import com.sequenceiq.environment.api.doc.ModelDescriptions;
 import com.sequenceiq.environment.api.doc.credential.CredentialDescriptor;
 import com.sequenceiq.environment.api.doc.credential.CredentialModelDescription;
@@ -19,25 +20,15 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = CredentialDescriptor.CREDENTIAL_NOTES, parent = CredentialBase.class, value = "CredentialV1Request")
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(Include.NON_NULL)
-public class CredentialRequest extends CredentialBase {
+public class EditCredentialRequest extends CredentialBase {
 
-    @Size(max = 100, min = 5, message = "The length of the credential's name has to be in range of 5 to 100")
-    @Pattern(regexp = "(^[a-z][-a-z0-9]*[a-z0-9]$)",
-            message = "The name of the credential can only contain lowercase alphanumeric characters and hyphens and has start with an alphanumeric character")
-    @ApiModelProperty(value = ModelDescriptions.NAME, required = true, allowableValues = "length range[5, 100]")
+    @ApiModelProperty(value = ModelDescriptions.NAME, required = true)
+    @ResourceObjectField(action = AuthorizationResourceAction.EDIT_CREDENTIAL, variableType = AuthorizationVariableType.NAME)
     private String name;
 
     @Valid
     @ApiModelProperty(CredentialModelDescription.AZURE_PARAMETERS)
     private AzureCredentialRequestParameters azure;
-
-    public AzureCredentialRequestParameters getAzure() {
-        return azure;
-    }
-
-    public void setAzure(AzureCredentialRequestParameters azure) {
-        this.azure = azure;
-    }
 
     public String getName() {
         return name;
@@ -47,10 +38,18 @@ public class CredentialRequest extends CredentialBase {
         this.name = name;
     }
 
+    public AzureCredentialRequestParameters getAzure() {
+        return azure;
+    }
+
+    public void setAzure(AzureCredentialRequestParameters azure) {
+        this.azure = azure;
+    }
+
     @Override
     public String toString() {
         return "CredentialRequest{"
-            + "name='" + getName()
+            + "',name='" + getName()
             + "',cloudPlatform='" + getCloudPlatform()
             + "'}";
     }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/credential/model/response/CredentialResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/credential/model/response/CredentialResponse.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.sequenceiq.authorization.resource.ResourceCrnAwareApiModel;
 import com.sequenceiq.cloudbreak.service.secret.model.SecretResponse;
 import com.sequenceiq.common.model.CredentialType;
+import com.sequenceiq.environment.api.doc.ModelDescriptions;
 import com.sequenceiq.environment.api.doc.credential.CredentialDescriptor;
 import com.sequenceiq.environment.api.doc.credential.CredentialModelDescription;
 import com.sequenceiq.environment.api.v1.credential.model.CredentialBase;
@@ -19,6 +20,9 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = CredentialDescriptor.CREDENTIAL, parent = CredentialBase.class, value = "CredentialV1Response")
 @JsonInclude(Include.NON_NULL)
 public class CredentialResponse extends CredentialBase implements ResourceCrnAwareApiModel {
+
+    @ApiModelProperty(value = ModelDescriptions.NAME, required = true, allowableValues = "length range[5, 100]")
+    private String name;
 
     @ApiModelProperty(CredentialModelDescription.ATTRIBUTES)
     private SecretResponse attributes;
@@ -40,6 +44,14 @@ public class CredentialResponse extends CredentialBase implements ResourceCrnAwa
 
     @ApiModelProperty(value = CredentialModelDescription.CREDENTIAL_TYPE, required = true)
     private CredentialType type;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
 
     public Long getCreated() {
         return created;

--- a/environment/src/main/java/com/sequenceiq/environment/credential/v1/AuditCredentialV1Controller.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/v1/AuditCredentialV1Controller.java
@@ -19,6 +19,7 @@ import com.sequenceiq.cloudbreak.event.ResourceEvent;
 import com.sequenceiq.cloudbreak.exception.BadRequestException;
 import com.sequenceiq.environment.api.v1.credential.endpoint.AuditCredentialEndpoint;
 import com.sequenceiq.environment.api.v1.credential.model.request.CredentialRequest;
+import com.sequenceiq.environment.api.v1.credential.model.request.EditCredentialRequest;
 import com.sequenceiq.environment.api.v1.credential.model.response.CredentialResponse;
 import com.sequenceiq.environment.api.v1.credential.model.response.CredentialResponses;
 import com.sequenceiq.environment.credential.domain.Credential;
@@ -92,7 +93,7 @@ public class AuditCredentialV1Controller extends NotificationController implemen
 
     @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.MODIFY_AUDIT_CREDENTIAL)
-    public CredentialResponse put(@Valid CredentialRequest credentialRequest) {
+    public CredentialResponse put(@Valid EditCredentialRequest credentialRequest) {
         Credential credential = credentialConverter.convert(credentialRequest);
         credential.setType(AUDIT);
         credential = credentialService.updateByAccountId(credential, ThreadBasedUserCrnProvider.getAccountId(), AUDIT);

--- a/environment/src/main/java/com/sequenceiq/environment/credential/v1/CredentialV1Controller.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/v1/CredentialV1Controller.java
@@ -30,6 +30,7 @@ import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.event.ResourceEvent;
 import com.sequenceiq.environment.api.v1.credential.endpoint.CredentialEndpoint;
 import com.sequenceiq.environment.api.v1.credential.model.request.CredentialRequest;
+import com.sequenceiq.environment.api.v1.credential.model.request.EditCredentialRequest;
 import com.sequenceiq.environment.api.v1.credential.model.response.CredentialResponse;
 import com.sequenceiq.environment.api.v1.credential.model.response.CredentialResponses;
 import com.sequenceiq.environment.api.v1.credential.model.response.EmptyResponse;
@@ -140,7 +141,7 @@ public class CredentialV1Controller extends NotificationController implements Cr
 
     @Override
     @CheckPermissionByResourceObject
-    public CredentialResponse put(@ResourceObject @Valid CredentialRequest credentialRequest) {
+    public CredentialResponse put(@ResourceObject @Valid EditCredentialRequest credentialRequest) {
         Credential credential = credentialConverter.convert(credentialRequest);
         credential.setType(ENVIRONMENT);
         credential = credentialService.updateByAccountId(credential, ThreadBasedUserCrnProvider.getAccountId(), ENVIRONMENT);

--- a/environment/src/test/java/com/sequenceiq/environment/service/integration/CredentialAuthorizationIntegrationTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/service/integration/CredentialAuthorizationIntegrationTest.java
@@ -43,6 +43,7 @@ import com.sequenceiq.common.model.CredentialType;
 import com.sequenceiq.environment.api.v1.credential.model.parameters.aws.AwsCredentialParameters;
 import com.sequenceiq.environment.api.v1.credential.model.parameters.aws.KeyBasedParameters;
 import com.sequenceiq.environment.api.v1.credential.model.request.CredentialRequest;
+import com.sequenceiq.environment.api.v1.credential.model.request.EditCredentialRequest;
 import com.sequenceiq.environment.client.EnvironmentServiceClientBuilder;
 import com.sequenceiq.environment.client.EnvironmentServiceCrnEndpoints;
 import com.sequenceiq.environment.credential.domain.Credential;
@@ -148,7 +149,7 @@ public class CredentialAuthorizationIntegrationTest {
 
         assertThrows(ForbiddenException.class, () -> client.credentialV1Endpoint().getByName(wrongCredentialName));
         assertThrows(ForbiddenException.class, () -> client.credentialV1Endpoint().getByResourceCrn(wrongCredentialCrn));
-        assertThrows(ForbiddenException.class, () -> client.credentialV1Endpoint().put(getAwsCredentialRequest(wrongCredentialName)));
+        assertThrows(ForbiddenException.class, () -> client.credentialV1Endpoint().put(getAwsEditCredentialRequest(wrongCredentialName)));
         assertThrows(ForbiddenException.class, () -> client.credentialV1Endpoint().deleteMultiple(Sets.newHashSet(wrongCredentialName)));
         assertThrows(ForbiddenException.class, () -> client.credentialV1Endpoint().deleteByName(wrongCredentialName));
         assertThrows(ForbiddenException.class, () -> client.credentialV1Endpoint().deleteByResourceCrn(wrongCredentialCrn));
@@ -250,6 +251,14 @@ public class CredentialAuthorizationIntegrationTest {
 
     private CredentialRequest getAwsCredentialRequest(String name) {
         CredentialRequest credentialRequest = new CredentialRequest();
+        credentialRequest.setAws(getAwsKeyBasedCredentialParameters());
+        credentialRequest.setCloudPlatform("AWS");
+        credentialRequest.setName(name);
+        return credentialRequest;
+    }
+
+    private EditCredentialRequest getAwsEditCredentialRequest(String name) {
+        EditCredentialRequest credentialRequest = new EditCredentialRequest();
         credentialRequest.setAws(getAwsKeyBasedCredentialParameters());
         credentialRequest.setCloudPlatform("AWS");
         credentialRequest.setName(name);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/credential/CredentialModifyAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/credential/CredentialModifyAction.java
@@ -19,7 +19,7 @@ public class CredentialModifyAction implements Action<CredentialTestDto, Environ
         testDto.setResponse(
                 cloudbreakClient.getEnvironmentClient()
                         .credentialV1Endpoint()
-                        .put(testDto.getRequest()));
+                        .put(testDto.modifyRequest()));
         Log.whenJson(LOGGER, " Credential modified successfully:\n", testDto.getResponse());
         Log.when(LOGGER, String.format(" CRN: %s", testDto.getResponse().getCrn()));
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/credential/CredentialTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/credential/CredentialTestDto.java
@@ -13,6 +13,7 @@ import com.sequenceiq.environment.api.v1.credential.model.parameters.mock.MockPa
 import com.sequenceiq.environment.api.v1.credential.model.parameters.openstack.OpenstackParameters;
 import com.sequenceiq.environment.api.v1.credential.model.parameters.yarn.YarnParameters;
 import com.sequenceiq.environment.api.v1.credential.model.request.CredentialRequest;
+import com.sequenceiq.environment.api.v1.credential.model.request.EditCredentialRequest;
 import com.sequenceiq.environment.api.v1.credential.model.response.CredentialResponse;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.EnvironmentClient;
@@ -56,6 +57,23 @@ public class CredentialTestDto extends DeletableEnvironmentTestDto<CredentialReq
     @Override
     public String getResourceNameType() {
         return CREDENTIAL_RESOURCE_NAME;
+    }
+
+    public EditCredentialRequest modifyRequest() {
+        EditCredentialRequest editRequest = new EditCredentialRequest();
+        CredentialRequest request = getRequest();
+
+        editRequest.setName(request.getName());
+        editRequest.setAzure(request.getAzure());
+        editRequest.setAws(request.getAws());
+        editRequest.setGcp(request.getGcp());
+        editRequest.setMock(request.getMock());
+        editRequest.setOpenstack(request.getOpenstack());
+        editRequest.setYarn(request.getYarn());
+        editRequest.setCloudPlatform(request.getName());
+        editRequest.setDescription(request.getName());
+        editRequest.setCloudPlatform(getCloudPlatform().name());
+        return editRequest;
     }
 
     public CredentialTestDto withDescription(String description) {

--- a/integration-test/src/main/java/com/sequenceiq/it/util/cleanup/CleanupUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/util/cleanup/CleanupUtil.java
@@ -30,7 +30,7 @@ import org.springframework.util.MultiValueMap;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Response;
 import com.sequenceiq.cloudbreak.client.CloudbreakClient;
-import com.sequenceiq.environment.api.v1.credential.model.CredentialBase;
+import com.sequenceiq.environment.api.v1.credential.model.response.CredentialResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentBaseResponse;
 import com.sequenceiq.environment.client.EnvironmentClient;
 import com.sequenceiq.it.cloudbreak.MicroserviceClient;
@@ -165,7 +165,7 @@ public class CleanupUtil extends CleanupClientUtil {
 
     public List<String> getCredentials(EnvironmentClient environment) {
         return environment.credentialV1Endpoint().list().getResponses().stream()
-                .map(CredentialBase::getName)
+                .map(CredentialResponse::getName)
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
…e in case of audit credential we are using a uuid and we would like to avoid the unnecessary validation on the name object in case of put

See detailed description in the commit message.