### PR TITLE
CB-9299: Install FreeIPA repair script to /opt/salt/scripts/repair.sh

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/init.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/init.sls
@@ -51,3 +51,11 @@ net.ipv6.conf.lo.disable_ipv6:
     - group: root
     - mode: 700
     - source: salt://freeipa/scripts/update_cnames.sh
+
+/opt/salt/scripts/repair.sh:
+  file.managed:
+    - makedirs: True
+    - user: root
+    - group: root
+    - mode: 700
+    - source: salt://freeipa/scripts/repair.sh


### PR DESCRIPTION
Install FreeIPA repair script to /opt/salt/scripts/repair.sh.

I chose to not include it in the base AMI image since this script depends on logic from the FMS codebase since it cleans up configuration that was initialized by the FMS. So it will change from time to time.

See detailed description in the commit message.