### PR TITLE
CB-9051 [AuthZ] Improve error pop up message for non entitled users

### DIFF
--- a/authorization-common/src/main/java/com/sequenceiq/authorization/service/CommonPermissionCheckingUtils.java
+++ b/authorization-common/src/main/java/com/sequenceiq/authorization/service/CommonPermissionCheckingUtils.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Component;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.sequenceiq.authorization.annotation.DisableCheckPermissions;
@@ -32,6 +31,7 @@ import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
 import com.sequenceiq.authorization.resource.AuthorizationResourceType;
 import com.sequenceiq.authorization.service.defaults.CrnsByCategory;
 import com.sequenceiq.authorization.service.defaults.DefaultResourceChecker;
+import com.sequenceiq.authorization.utils.AuthorizationMessageUtils;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 
@@ -188,9 +188,9 @@ public class CommonPermissionCheckingUtils {
             DefaultResourceChecker defaultResourceChecker) {
         if (!defaultResourceChecker.isAllowedAction(action)) {
             String right = umsRightProvider.getRight(action);
-            String msg = String.format("You have no right to perform %s on resources [%s]", right, Joiner.on(",").join(resourceCrns));
-            LOGGER.error(msg);
-            throw new AccessDeniedException(msg);
+            String unauthorizedMessage = AuthorizationMessageUtils.formatTemplate(right, resourceCrns);
+            LOGGER.error(unauthorizedMessage);
+            throw new AccessDeniedException(unauthorizedMessage);
         }
     }
 

--- a/authorization-common/src/main/java/com/sequenceiq/authorization/utils/AuthorizationMessageUtils.java
+++ b/authorization-common/src/main/java/com/sequenceiq/authorization/utils/AuthorizationMessageUtils.java
@@ -1,0 +1,45 @@
+package com.sequenceiq.authorization.utils;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import com.cloudera.thunderhead.service.authorization.AuthorizationProto;
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
+
+public class AuthorizationMessageUtils {
+
+    public static final String INSUFFICIENT_RIGHTS = "You have insufficient rights to perform the following action(s): ";
+
+    public static final String INSUFFICIENT_RIGHTS_TEMPLATE = "'%s' on a(n) '%s' type resource with resource identifier: '%s'";
+
+    private AuthorizationMessageUtils() {
+    }
+
+    public static String formatTemplate(String right, String resourceCrn) {
+        return INSUFFICIENT_RIGHTS + formatTemplateMessage(right, resourceCrn);
+    }
+
+    private static String formatTemplateMessage(String right, String resourceCrn) {
+        return String.format(INSUFFICIENT_RIGHTS_TEMPLATE, right, extractResourceName(resourceCrn), resourceCrn);
+    }
+
+    private static String extractResourceName(String resourceCrn) {
+        return Optional.ofNullable(resourceCrn)
+                .map(Crn::fromString)
+                .map(Crn::getResourceType)
+                .map(Crn.ResourceType::getName)
+                .orElse("unknown");
+    }
+
+    public static String formatTemplate(String right, Collection<String> resourceCrns) {
+        return INSUFFICIENT_RIGHTS + resourceCrns.stream().map(crn -> formatTemplateMessage(right, crn)).collect(Collectors.joining(","));
+    }
+
+    public static String formatTemplate(List<AuthorizationProto.RightCheck> rightCheckList) {
+        return INSUFFICIENT_RIGHTS + rightCheckList.stream()
+                .map(rightCheck -> formatTemplateMessage(rightCheck.getRight(), rightCheck.getResource()))
+                .collect(Collectors.joining(","));
+    }
+}

--- a/authorization-common/src/test/java/com/sequenceiq/authorization/service/UmsResourceAuthorizationServiceTest.java
+++ b/authorization-common/src/test/java/com/sequenceiq/authorization/service/UmsResourceAuthorizationServiceTest.java
@@ -1,10 +1,15 @@
 package com.sequenceiq.authorization.service;
 
+import static com.sequenceiq.authorization.utils.AuthorizationMessageUtils.INSUFFICIENT_RIGHTS;
+import static com.sequenceiq.authorization.utils.AuthorizationMessageUtils.INSUFFICIENT_RIGHTS_TEMPLATE;
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
@@ -21,6 +26,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
 
@@ -31,9 +37,9 @@ public class UmsResourceAuthorizationServiceTest {
 
     private static final String USER_CRN = "crn:cdp:iam:us-west-1:1234:user:" + USER_ID;
 
-    private static final String RESOURCE_CRN = "crn:cdp:datalake:us-west-1:1234:resource:1";
+    private static final String RESOURCE_CRN = "crn:cdp:datalake:us-west-1:1234:environment:1";
 
-    private static final String RESOURCE_CRN2 = "crn:cdp:datalake:us-west-1:1234:resource:2";
+    private static final String RESOURCE_CRN2 = "crn:cdp:datalake:us-west-1:1234:environment:2";
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -52,8 +58,11 @@ public class UmsResourceAuthorizationServiceTest {
 
     @Before
     public void init() {
-        when(umsRightProvider.getRight(any())).thenReturn("environments/describeEnvironment");
-        when(entitlementService.isAuthorizationEntitlementRegistered(anyString(), anyString())).thenReturn(Boolean.TRUE);
+        when(umsRightProvider.getRight(any())).thenAnswer(invocation -> {
+            AuthorizationResourceAction action = invocation.getArgument(0);
+            return action.getRight();
+        });
+        when(entitlementService.isAuthorizationEntitlementRegistered(anyString(), anyString())).thenReturn(TRUE);
     }
 
     @Test
@@ -61,7 +70,8 @@ public class UmsResourceAuthorizationServiceTest {
         when(umsClient.checkRight(anyString(), anyString(), anyString(), anyString(), any())).thenReturn(false);
 
         thrown.expect(AccessDeniedException.class);
-        thrown.expectMessage("You have no right to perform environments/describeEnvironment on resource " + RESOURCE_CRN);
+        thrown.expectMessage(INSUFFICIENT_RIGHTS);
+        thrown.expectMessage(formatTemplate("environments/describeEnvironment", RESOURCE_CRN));
 
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.
                 checkRightOfUserOnResource(USER_CRN, AuthorizationResourceAction.DESCRIBE_ENVIRONMENT, RESOURCE_CRN));
@@ -72,7 +82,9 @@ public class UmsResourceAuthorizationServiceTest {
         when(umsClient.hasRights(anyString(), anyString(), anyList(), anyString(), any())).thenReturn(hasRightsResultMap());
 
         thrown.expect(AccessDeniedException.class);
-        thrown.expectMessage("You have no right to perform environments/describeEnvironment on resources [" + RESOURCE_CRN + "," + RESOURCE_CRN2 + "]");
+        thrown.expectMessage(INSUFFICIENT_RIGHTS);
+        thrown.expectMessage(formatTemplate("environments/describeEnvironment", RESOURCE_CRN));
+        thrown.expectMessage(formatTemplate("environments/describeEnvironment", RESOURCE_CRN2));
 
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.
                 checkRightOfUserOnResources(USER_CRN, AuthorizationResourceAction.DESCRIBE_ENVIRONMENT, Lists.newArrayList(RESOURCE_CRN, RESOURCE_CRN2)));
@@ -81,7 +93,7 @@ public class UmsResourceAuthorizationServiceTest {
     @Test
     public void testCheckRightOnResources() {
         Map<String, Boolean> resultMap = hasRightsResultMap();
-        resultMap.put(RESOURCE_CRN2, Boolean.TRUE);
+        resultMap.put(RESOURCE_CRN2, TRUE);
         when(umsClient.hasRights(anyString(), anyString(), anyList(), anyString(), any())).thenReturn(resultMap);
 
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.
@@ -90,8 +102,26 @@ public class UmsResourceAuthorizationServiceTest {
 
     private Map<String, Boolean> hasRightsResultMap() {
         Map<String, Boolean> result = Maps.newHashMap();
-        result.put(RESOURCE_CRN, Boolean.TRUE);
-        result.put(RESOURCE_CRN2, Boolean.FALSE);
+        result.put(RESOURCE_CRN, TRUE);
+        result.put(RESOURCE_CRN2, FALSE);
         return result;
+    }
+
+    @Test
+    public void testCheckIfUserHasAtLeastOneRigthFailure() {
+        when(umsClient.hasRights(anyString(), anyString(), anyList(), any())).thenReturn(List.of(FALSE, FALSE));
+
+        thrown.expect(AccessDeniedException.class);
+        thrown.expectMessage(INSUFFICIENT_RIGHTS);
+        thrown.expectMessage(formatTemplate("environments/describeEnvironment", RESOURCE_CRN));
+        thrown.expectMessage(formatTemplate("environments/accessEnvironment", RESOURCE_CRN2));
+
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.
+                checkIfUserHasAtLeastOneRight(USER_CRN, Map.of(RESOURCE_CRN, AuthorizationResourceAction.DESCRIBE_ENVIRONMENT,
+                        RESOURCE_CRN2, AuthorizationResourceAction.ACCESS_ENVIRONMENT)));
+    }
+
+    private String formatTemplate(String right, String resourceCrn) {
+        return String.format(INSUFFICIENT_RIGHTS_TEMPLATE, right, Crn.fromString(resourceCrn).getResourceType().getName(), resourceCrn);
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/CreateDhWithDatahubCreator.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/CreateDhWithDatahubCreator.java
@@ -89,12 +89,14 @@ public class CreateDhWithDatahubCreator extends AbstractIntegrationTest {
                 // testing unauthorized calls for environment
                 .when(environmentTestClient.describe(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_B)))
                 .expect(ForbiddenException.class,
-                        RunningParameter.expectedMessage("You have no right to perform any of these actions: environments/describeEnvironment " +
-                                "on crn:cdp:environments:.*").withKey("EnvironmentGetAction"))
+                        RunningParameter.expectedMessage("You have insufficient rights to perform the following action[(]s[)]: " +
+                                "'environments/describeEnvironment' on a[(]n[)] 'environment' type resource with resource identifier: .*")
+                                .withKey("EnvironmentGetAction"))
                 .when(environmentTestClient.describe(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ZERO_RIGHTS)))
                 .expect(ForbiddenException.class,
-                        RunningParameter.expectedMessage("You have no right to perform any of these actions: environments/describeEnvironment " +
-                                "on crn:cdp:environments:.*").withKey("EnvironmentGetAction"))
+                        RunningParameter.expectedMessage("You have insufficient rights to perform the following action[(]s[)]: " +
+                                "'environments/describeEnvironment' on a[(]n[)] 'environment' type resource with resource identifier: .*")
+                                .withKey("EnvironmentGetAction"))
                 .validate();
         String recipe1Name = testContext
                 .given(RecipeTestDto.class).valid()
@@ -117,7 +119,8 @@ public class CreateDhWithDatahubCreator extends AbstractIntegrationTest {
                 .withRecipe(recipe1Name)
                 .when(distroXClient.create(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_B)))
                 .expect(ForbiddenException.class,
-                        RunningParameter.expectedMessage("You have no right to perform environments/useSharedResource*")
+                        RunningParameter.expectedMessage("You have insufficient rights to perform the following action[(]s[)]: " +
+                                "'environments/useSharedResource'.*")
                                 .withKey("DistroXCreateAction"))
                 .withRecipe(recipe2Name)
                 .when(distroXClient.create(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_B)))
@@ -126,7 +129,8 @@ public class CreateDhWithDatahubCreator extends AbstractIntegrationTest {
                 .given(RenewDistroXCertificateTestDto.class)
                 .when(distroXClient.renewDistroXCertificateV4(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ZERO_RIGHTS)))
                 .expect(ForbiddenException.class,
-                        RunningParameter.expectedMessage("You have no right to perform any of these actions: datahub/repairDatahub on.*")
+                        RunningParameter.expectedMessage("You have insufficient rights to perform the following action[(]s[)]: " +
+                                "'datahub/repairDatahub'.*")
                                 .withKey("RenewDistroXCertificateAction"))
                 .validate();
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/CredentialCreateTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/CredentialCreateTest.java
@@ -60,7 +60,8 @@ public class CredentialCreateTest extends AbstractIntegrationTest {
                 .when(credentialTestClient.create())
                 .when(credentialTestClient.get(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_B)))
                 .expect(ForbiddenException.class, RunningParameter.key("CredentialGetAction")
-                        .withExpectedMessage("You have no right to perform any of these actions: environments/describeCredential on crn:cdp:environments:.*"))
+                        .withExpectedMessage("You have insufficient rights to perform the following action[(]s[)]: " +
+                                "'environments/describeCredential.*"))
                 .validate();
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/DatalakeDatahubCreateAuthTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/DatalakeDatahubCreateAuthTest.java
@@ -89,13 +89,14 @@ public class DatalakeDatahubCreateAuthTest extends AbstractIntegrationTest {
                 .when(sdxTestClient.detailedDescribeInternal(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_B)))
                 .when(sdxTestClient.detailedDescribeInternal(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ZERO_RIGHTS)))
                 .expect(ForbiddenException.class,
-                        RunningParameter.expectedMessage("You have no right to perform any of these actions: datalake/describeDetailedDatalake.*")
+                        RunningParameter.expectedMessage("You have insufficient rights to perform the following action[(]s[)]: " +
+                                "'datalake/describeDetailedDatalake'.*")
                                 .withKey("SdxDetailedDescribeInternalAction"))
                 .given(RenewDatalakeCertificateTestDto.class)
                 .withStackCrn(testContext.get(sdxInternal).getCrn())
                 .when(sdxTestClient.renewDatalakeCertificateV4(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ZERO_RIGHTS)))
                 .expect(ForbiddenException.class,
-                        RunningParameter.expectedMessage("You have no right to perform any of these actions: datalake/repairDatalake on.*")
+                        RunningParameter.expectedMessage("You have insufficient rights to perform the following action[(]s[)]: 'datalake/repairDatalake'.*")
                                 .withKey("RenewDatalakeCertificateAction"))
                 .validate();
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/EnvironmentCreateTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/EnvironmentCreateTest.java
@@ -78,12 +78,14 @@ public class EnvironmentCreateTest extends AbstractIntegrationTest {
                 // testing unauthorized calls for environment
                 .when(environmentTestClient.describe(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_B)))
                 .expect(ForbiddenException.class,
-                        RunningParameter.expectedMessage("You have no right to perform any of these actions: environments/describeEnvironment " +
-                                "on crn:cdp:environments:.*").withKey("EnvironmentGetAction"))
+                        RunningParameter.expectedMessage("You have insufficient rights to perform the following action[(]s[)]: " +
+                                "'environments/describeEnvironment' on a[(]n[)] 'environment' type resource with resource identifier: 'crn:cdp:environments:.*")
+                                .withKey("EnvironmentGetAction"))
                 .when(environmentTestClient.describe(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ZERO_RIGHTS)))
                 .expect(ForbiddenException.class,
-                        RunningParameter.expectedMessage("You have no right to perform any of these actions: environments/describeEnvironment " +
-                                "on crn:cdp:environments:.*").withKey("EnvironmentGetAction"));
+                        RunningParameter.expectedMessage("You have insufficient rights to perform the following action[(]s[)]: " +
+                                "'environments/describeEnvironment' on a[(]n[)] 'environment' type resource with resource identifier: 'crn:cdp:environments:.*")
+                                .withKey("EnvironmentGetAction"));
         testFreeipaCreation(testContext, mockedTestContext);
         testContext
                 //after assignment describe should work for the environment
@@ -144,16 +146,19 @@ public class EnvironmentCreateTest extends AbstractIntegrationTest {
                 //testing unathorized freeipa calls for the environment
                 .when(freeIpaTestClient.describe(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_B)))
                 .expect(ForbiddenException.class,
-                        RunningParameter.expectedMessage("You have no right to perform any of these actions: environments/describeEnvironment on " +
-                                "crn:cdp:environments:.*").withKey("FreeIpaDescribeAction"))
+                        RunningParameter.expectedMessage("You have insufficient rights to perform the following action[(]s[)]: " +
+                                "'environments/describeEnvironment' on a[(]n[)] 'environment' type resource with resource identifier: 'crn:cdp:environments:.*")
+                                .withKey("FreeIpaDescribeAction"))
                 .when(freeIpaTestClient.stop(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_B)))
                 .expect(ForbiddenException.class,
-                        RunningParameter.expectedMessage("You have no right to perform any of these actions: environments/stopEnvironment on " +
-                                "crn:cdp:environments:.*").withKey("FreeIpaStopAction"))
+                        RunningParameter.expectedMessage("You have insufficient rights to perform the following action[(]s[)]: " +
+                                "'environments/stopEnvironment' on a[(]n[)] 'environment' type resource with resource identifier: 'crn:cdp:environments:.*")
+                                .withKey("FreeIpaStopAction"))
                 .when(freeIpaTestClient.start(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_B)))
                 .expect(ForbiddenException.class,
-                        RunningParameter.expectedMessage("You have no right to perform any of these actions: environments/startEnvironment on " +
-                                "crn:cdp:environments:.*").withKey("FreeIpaStartAction"));
+                        RunningParameter.expectedMessage("You have insufficient rights to perform the following action[(]s[)]: " +
+                                "'environments/startEnvironment' on a[(]n[)] 'environment' type resource with resource identifier: 'crn:cdp:environments:.*")
+                                .withKey("FreeIpaStartAction"));
     }
 
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/RecipeTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/RecipeTest.java
@@ -49,20 +49,22 @@ public class RecipeTest extends AbstractIntegrationTest {
                 })
                 .when(recipeTestClient.getV4(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_B)))
                 .expect(ForbiddenException.class,
-                        RunningParameter.expectedMessage("You have no right to perform any of these actions: environments/useSharedResource " +
-                                "on crn:cdp:datahub:.*").withKey("RecipeGetAction"))
+                        RunningParameter.expectedMessage("You have insufficient rights to perform the following action[(]s[)]: " +
+                                "'environments/useSharedResource'" +
+                                ".*crn:cdp:datahub:.*").withKey("RecipeGetAction"))
                 .when(recipeTestClient.getV4(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ZERO_RIGHTS)))
                 .expect(ForbiddenException.class,
-                        RunningParameter.expectedMessage("You have no right to perform any of these actions: environments/useSharedResource " +
-                                "on crn:cdp:datahub:.*").withKey("RecipeGetAction"))
+                        RunningParameter.expectedMessage("You have insufficient rights to perform the following action[(]s[)]: " +
+                                "'environments/useSharedResource'" +
+                                ".*crn:cdp:datahub:.*").withKey("RecipeGetAction"))
                 .when(recipeTestClient.deleteV4(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_B)))
                 .expect(ForbiddenException.class,
-                        RunningParameter.expectedMessage("You have no right to perform any of these actions: environments/deleteRecipe on crn:cdp:datahub:.*")
-                                .withKey("RecipeDeleteAction"))
+                        RunningParameter.expectedMessage("You have insufficient rights to perform the following action[(]s[)]: 'environments/deleteRecipe'" +
+                                ".*crn:cdp:datahub:.*").withKey("RecipeDeleteAction"))
                 .when(recipeTestClient.deleteV4(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ZERO_RIGHTS)))
                 .expect(ForbiddenException.class,
-                        RunningParameter.expectedMessage("You have no right to perform any of these actions: environments/deleteRecipe on crn:cdp:datahub:.*")
-                                .withKey("RecipeDeleteAction"))
+                        RunningParameter.expectedMessage("You have insufficient rights to perform the following action[(]s[)]: 'environments/deleteRecipe'" +
+                                ".*crn:cdp:datahub:.*").withKey("RecipeDeleteAction"))
                 .when(recipeTestClient.deleteV4())
                 .when(recipeTestClient.listV4())
                 .then((context, dto, client) -> {


### PR DESCRIPTION
The error message for authz was confusing for users.
This pull request introduce a new format for this error message and unify the messages at different locations.

New format of the message:

You have insufficient rights to perform the following action(s): "environments/describeCredential" on a(n) 'credential' type resource with resource identifier: '<crn of resource>'