### PR TITLE
CB-8960 Adding multiple gateway nodes and mini node for DL HA

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.2/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.2/cdp-sdx-medium-ha.bp
@@ -9,7 +9,7 @@
     "hostTemplates": [
       {
         "cardinality": 2,
-        "refName": "master",
+        "refName": "main",
         "roleConfigGroupsRefNames": [
           "hdfs-DATANODE-BASE",
           "hdfs-JOURNALNODE-BASE",
@@ -27,17 +27,14 @@
         ]
       },
       {
-        "cardinality": 1,
+        "cardinality": 2,
         "refName": "gateway",
         "roleConfigGroupsRefNames": [
           "hdfs-DATANODE-BASE",
           "hdfs-JOURNALNODE-BASE",
           "ranger-RANGER_ADMIN-BASE",
-          "ranger-RANGER_USERSYNC-BASE",
-          "ranger-RANGER_TAGSYNC-BASE",
           "zookeeper-SERVER-BASE",
           "knox-KNOX_GATEWAY-BASE",
-          "atlas-ATLAS_SERVER-BASE",
           "hbase-REGIONSERVER-BASE",
           "hbase-MASTER-BASE",
           "solr-GATEWAY-BASE",
@@ -45,6 +42,16 @@
           "kafka-GATEWAY-BASE",
           "hive-GATEWAY-BASE",
           "hbase-GATEWAY-BASE"
+        ]
+      },
+      {
+        "cardinality": 1,
+        "refName": "auxiliary",
+        "roleConfigGroupsRefNames": [
+          "hdfs-JOURNALNODE-BASE",
+          "ranger-RANGER_USERSYNC-BASE",
+          "ranger-RANGER_TAGSYNC-BASE",
+          "atlas-ATLAS_SERVER-BASE"
         ]
       },
       {

--- a/core/src/main/resources/defaults/blueprints/7.2.3/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.3/cdp-sdx-medium-ha.bp
@@ -9,7 +9,7 @@
     "hostTemplates": [
       {
         "cardinality": 2,
-        "refName": "master",
+        "refName": "main",
         "roleConfigGroupsRefNames": [
           "hdfs-DATANODE-BASE",
           "hdfs-JOURNALNODE-BASE",
@@ -27,17 +27,14 @@
         ]
       },
       {
-        "cardinality": 1,
+        "cardinality": 2,
         "refName": "gateway",
         "roleConfigGroupsRefNames": [
           "hdfs-DATANODE-BASE",
           "hdfs-JOURNALNODE-BASE",
           "ranger-RANGER_ADMIN-BASE",
-          "ranger-RANGER_USERSYNC-BASE",
-          "ranger-RANGER_TAGSYNC-BASE",
           "zookeeper-SERVER-BASE",
           "knox-KNOX_GATEWAY-BASE",
-          "atlas-ATLAS_SERVER-BASE",
           "hbase-REGIONSERVER-BASE",
           "hbase-MASTER-BASE",
           "solr-GATEWAY-BASE",
@@ -45,6 +42,16 @@
           "kafka-GATEWAY-BASE",
           "hive-GATEWAY-BASE",
           "hbase-GATEWAY-BASE"
+        ]
+      },
+      {
+        "cardinality": 1,
+        "refName": "auxiliary",
+        "roleConfigGroupsRefNames": [
+        "hdfs-JOURNALNODE-BASE",
+        "ranger-RANGER_USERSYNC-BASE",
+        "ranger-RANGER_TAGSYNC-BASE",
+        "atlas-ATLAS_SERVER-BASE"
         ]
       },
       {

--- a/datalake/src/main/resources/duties/7.2.2/aws/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.2/aws/medium_duty_ha.json
@@ -9,7 +9,7 @@
   },
   "instanceGroups": [
     {
-      "name": "master",
+      "name": "main",
       "template": {
         "instanceType": "m5.2xlarge",
         "attachedVolumes": [
@@ -43,8 +43,28 @@
           "size": 100
         }
       },
-      "nodeCount": 1,
+      "nodeCount": 2,
       "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "auxiliary",
+      "template": {
+        "instanceType": "m5.xlarge",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 1,
+      "type": "CORE",
       "recoveryMode": "MANUAL",
       "recipeNames": []
     },

--- a/datalake/src/main/resources/duties/7.2.2/azure/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.2/azure/medium_duty_ha.json
@@ -9,7 +9,7 @@
   },
   "instanceGroups": [
     {
-      "name": "master",
+      "name": "main",
       "template": {
         "instanceType": "Standard_D16s_v3",
         "attachedVolumes": [
@@ -43,8 +43,28 @@
           "size": 100
         }
       },
-      "nodeCount": 1,
+      "nodeCount": 2,
       "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "auxiliary",
+      "template": {
+        "instanceType": "Standard_D4s_v3",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "StandardSSD_LRS"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 1,
+      "type": "CORE",
       "recoveryMode": "MANUAL",
       "recipeNames": []
     },

--- a/datalake/src/main/resources/duties/7.2.2/yarn/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.2/yarn/medium_duty_ha.json
@@ -9,7 +9,7 @@
   },
   "instanceGroups": [
     {
-      "name": "master",
+      "name": "main",
       "template": {
         "yarn": {
           "cpus": 4,
@@ -27,8 +27,19 @@
           "memory": 16384
         }
       },
-      "nodeCount": 1,
+      "nodeCount": 2,
       "type": "GATEWAY"
+    },
+    {
+      "name": "auxiliary",
+      "template": {
+        "yarn": {
+          "cpus": 4,
+          "memory": 16384
+        }
+      },
+      "nodeCount": 1,
+      "type": "CORE"
     },
     {
       "name": "idbroker",

--- a/datalake/src/main/resources/duties/7.2.3/aws/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.3/aws/medium_duty_ha.json
@@ -9,7 +9,7 @@
   },
   "instanceGroups": [
     {
-      "name": "master",
+      "name": "main",
       "template": {
         "instanceType": "m5.2xlarge",
         "attachedVolumes": [
@@ -43,8 +43,28 @@
           "size": 100
         }
       },
-      "nodeCount": 1,
+      "nodeCount": 2,
       "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "auxiliary",
+      "template": {
+        "instanceType": "m5.xlarge",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 1,
+      "type": "CORE",
       "recoveryMode": "MANUAL",
       "recipeNames": []
     },

--- a/datalake/src/main/resources/duties/7.2.3/azure/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.3/azure/medium_duty_ha.json
@@ -9,7 +9,7 @@
   },
   "instanceGroups": [
     {
-      "name": "master",
+      "name": "main",
       "template": {
         "instanceType": "Standard_D16s_v3",
         "attachedVolumes": [
@@ -43,8 +43,28 @@
           "size": 100
         }
       },
-      "nodeCount": 1,
+      "nodeCount": 2,
       "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "auxiliary",
+      "template": {
+        "instanceType": "Standard_D4s_v3",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "StandardSSD_LRS"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 1,
+      "type": "CORE",
       "recoveryMode": "MANUAL",
       "recipeNames": []
     },

--- a/datalake/src/main/resources/duties/7.2.3/yarn/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.3/yarn/medium_duty_ha.json
@@ -9,7 +9,7 @@
   },
   "instanceGroups": [
     {
-      "name": "master",
+      "name": "main",
       "template": {
         "yarn": {
           "cpus": 4,
@@ -27,8 +27,19 @@
           "memory": 16384
         }
       },
-      "nodeCount": 1,
+      "nodeCount": 2,
       "type": "GATEWAY"
+    },
+    {
+      "name": "auxiliary",
+      "template": {
+        "yarn": {
+          "cpus": 4,
+          "memory": 16384
+        }
+      },
+      "nodeCount": 1,
+      "type": "CORE"
     },
     {
       "name": "idbroker",


### PR DESCRIPTION
This adds 2 gateway nodes and a small alpha node.  The alpha node currently
contains Atlas due to OPSAPS-57449 and will be put on the gateway node later.