### PR TITLE
CB-9331 Ensure that N+1 queries are caught in pull request time, for …

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/database/JpaPropertiesFacory.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/database/JpaPropertiesFacory.java
@@ -33,6 +33,7 @@ public class JpaPropertiesFacory {
                 properties.setProperty("hibernate.session.events.auto", HibernateNPlusOneLogger.class.getName());
                 break;
             case BREAK:
+                LOGGER.warn("Hibernate NPlusOne Circuit Breaker has been enabled!");
                 properties.setProperty("hibernate.session.events.auto", HibernateNPlusOneCircuitBreaker.class.getName());
                 break;
             default:

--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/tx/HibernateNPlusOneLogger.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/tx/HibernateNPlusOneLogger.java
@@ -26,9 +26,9 @@ public class HibernateNPlusOneLogger extends HibernateStatementStatistics {
     private void log(int queryCount) {
         String message = constructLogline();
         if (queryCount > maxStatementWarning) {
-            LOGGER.warn(message, new HibernateNPlusOneException(queryCount));
+            LOGGER.warn("Warning threshold: {}, {}", maxStatementWarning, message, new HibernateNPlusOneException(queryCount));
         } else {
-            LOGGER.debug(message);
+            LOGGER.debug("Warning threshold: {}, {}", maxStatementWarning, message);
         }
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/tx/HibernateStatementStatistics.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/tx/HibernateStatementStatistics.java
@@ -4,6 +4,10 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import org.hibernate.BaseSessionEventListener;
 
+/**
+ * Collecting the most important JDBC statistics. This class is similar to @org.hibernate.engine.internal.StatisticalLoggingSessionEventListener, but
+ * it is more targeted and has less footprint.
+ */
 public class HibernateStatementStatistics extends BaseSessionEventListener {
 
     private int jdbcPrepareStatementCount;
@@ -47,7 +51,7 @@ public class HibernateStatementStatistics extends BaseSessionEventListener {
     }
 
     public String constructLogline() {
-        return String.format("Session Metrics " +
+        return String.format("Hibernate Session Metrics " +
                         "%d s spent preparing %d JDBC statements; " +
                         "%d s spent executing %d JDBC statements",
                 NANOSECONDS.toSeconds(jdbcPrepareStatementTime),

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/view/ClusterTemplateView.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/view/ClusterTemplateView.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.cloudbreak.domain.stack.cluster;
+package com.sequenceiq.cloudbreak.domain.view;
 
 import javax.persistence.Convert;
 import javax.persistence.Entity;
@@ -13,9 +13,6 @@ import com.sequenceiq.cloudbreak.domain.converter.ClusterTemplateV4TypeConverter
 import com.sequenceiq.cloudbreak.domain.converter.DatalakeRequiredConverter;
 import com.sequenceiq.cloudbreak.domain.converter.FeatureStateConverter;
 import com.sequenceiq.cloudbreak.domain.converter.ResourceStatusConverter;
-import com.sequenceiq.cloudbreak.domain.view.CompactView;
-import com.sequenceiq.cloudbreak.domain.view.InstanceGroupView;
-import com.sequenceiq.cloudbreak.domain.view.StackApiView;
 
 @Entity
 @Table(name = "ClusterTemplate")
@@ -88,14 +85,6 @@ public class ClusterTemplateView extends CompactView {
 
     public void setResourceCrn(String resourceCrn) {
         this.resourceCrn = resourceCrn;
-    }
-
-    public Integer getFullNodeCount() {
-        return stackTemplate.getInstanceGroups()
-                .stream()
-                .mapToInt(InstanceGroupView::getNodeCount)
-                .sum();
-
     }
 
     public FeatureState getFeatureState() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/clustertemplate/ClusterTemplateViewToClusterTemplateViewV4ResponseConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/clustertemplate/ClusterTemplateViewToClusterTemplateViewV4ResponseConverter.java
@@ -4,8 +4,9 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.responses.ClusterTemplateViewV4Response;
 import com.sequenceiq.cloudbreak.converter.AbstractConversionServiceAwareConverter;
-import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterTemplateView;
+import com.sequenceiq.cloudbreak.domain.view.ClusterTemplateView;
 import com.sequenceiq.cloudbreak.domain.view.ClusterApiView;
+import com.sequenceiq.cloudbreak.domain.view.InstanceGroupView;
 import com.sequenceiq.cloudbreak.domain.view.StackApiView;
 
 @Component
@@ -24,10 +25,10 @@ public class ClusterTemplateViewToClusterTemplateViewV4ResponseConverter
         clusterTemplateViewV4Response.setDatalakeRequired(source.getDatalakeRequired());
         clusterTemplateViewV4Response.setStatus(source.getStatus());
         clusterTemplateViewV4Response.setType(source.getType());
-        clusterTemplateViewV4Response.setNodeCount(source.getFullNodeCount());
         clusterTemplateViewV4Response.setFeatureState(source.getFeatureState());
         if (source.getStackTemplate() != null) {
             StackApiView stackTemplate = source.getStackTemplate();
+            clusterTemplateViewV4Response.setNodeCount(getFullNodeCount(stackTemplate));
             if (stackTemplate.getCluster() != null) {
                 ClusterApiView cluster = stackTemplate.getCluster();
                 clusterTemplateViewV4Response.setStackType(cluster.getBlueprint() != null ? cluster.getBlueprint().getStackType() : "");
@@ -39,5 +40,13 @@ public class ClusterTemplateViewToClusterTemplateViewV4ResponseConverter
         }
         clusterTemplateViewV4Response.setCreated(source.getCreated());
         return clusterTemplateViewV4Response;
+    }
+
+    public Integer getFullNodeCount(StackApiView stackTemplate) {
+        return stackTemplate.getInstanceGroups()
+                .stream()
+                .mapToInt(InstanceGroupView::getNodeCount)
+                .sum();
+
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackApiViewRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackApiViewRepository.java
@@ -1,9 +1,6 @@
 package com.sequenceiq.cloudbreak.repository;
 
-import static com.sequenceiq.cloudbreak.repository.snippets.ShowTerminatedClustersSnippets.SHOW_TERMINATED_CLUSTERS_IF_REQUESTED;
-
 import java.util.Optional;
-import java.util.Set;
 
 import javax.transaction.Transactional;
 import javax.transaction.Transactional.TxType;
@@ -32,14 +29,4 @@ public interface StackApiViewRepository extends WorkspaceResourceRepository<Stac
             + "LEFT JOIN FETCH s.userView LEFT JOIN FETCH s.workspace w LEFT JOIN FETCH w.tenant WHERE s.resourceCrn= :crn AND s.type = :type")
     Optional<StackApiView> findByResourceCrnAndStackType(@Param("crn") String crn, @Param("type") StackType type);
 
-    @Query("SELECT s FROM StackApiView s LEFT JOIN FETCH s.cluster c LEFT JOIN FETCH c.blueprint "
-            + "LEFT JOIN FETCH c.hostGroups hg"
-            + "LEFT JOIN FETCH s.stackStatus LEFT JOIN FETCH s.instanceGroups ig LEFT JOIN FETCH ig.instanceMetaData "
-            + "LEFT JOIN FETCH s.userView LEFT JOIN FETCH s.workspace w LEFT JOIN FETCH w.tenant WHERE s.workspace.id= :id AND "
-            + SHOW_TERMINATED_CLUSTERS_IF_REQUESTED + "AND (s.type is not 'TEMPLATE' OR s.type is null)")
-    Set<StackApiView> findAllByWorkspaceId(
-            @Param("id") Long id,
-            @Param("showTerminated") Boolean showTerminated,
-            @Param("terminatedAfter") Long terminatedAfter
-    );
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/cluster/ClusterTemplateViewRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/cluster/ClusterTemplateViewRepository.java
@@ -8,7 +8,7 @@ import javax.transaction.Transactional.TxType;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterTemplateView;
+import com.sequenceiq.cloudbreak.domain.view.ClusterTemplateView;
 import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
 import com.sequenceiq.cloudbreak.workspace.repository.workspace.WorkspaceResourceRepository;
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/InstanceMetaDataService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/InstanceMetaDataService.java
@@ -130,10 +130,6 @@ public class InstanceMetaDataService {
         return repository.save(instanceMetaData);
     }
 
-    public Set<InstanceMetaData> findAllInStack(Long stackId) {
-        return repository.findAllInStack(stackId);
-    }
-
     public Set<InstanceMetaData> findNotTerminatedForStack(Long stackId) {
         return repository.findNotTerminatedForStack(stackId);
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/template/ClusterTemplateService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/template/ClusterTemplateService.java
@@ -42,7 +42,7 @@ import com.sequenceiq.cloudbreak.domain.projection.ClusterTemplateStatusView;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterTemplate;
-import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterTemplateView;
+import com.sequenceiq.cloudbreak.domain.view.ClusterTemplateView;
 import com.sequenceiq.cloudbreak.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.init.clustertemplate.ClusterTemplateLoaderService;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/template/ClusterTemplateViewService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/template/ClusterTemplateViewService.java
@@ -6,7 +6,7 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Service;
 
-import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterTemplateView;
+import com.sequenceiq.cloudbreak.domain.view.ClusterTemplateView;
 import com.sequenceiq.cloudbreak.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.repository.cluster.ClusterTemplateViewRepository;
 import com.sequenceiq.cloudbreak.service.AbstractWorkspaceAwareResourceService;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/template/ClusterTemplateServiceFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/template/ClusterTemplateServiceFilterTest.java
@@ -25,7 +25,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ResourceStatus;
 import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
-import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterTemplateView;
+import com.sequenceiq.cloudbreak.domain.view.ClusterTemplateView;
 import com.sequenceiq.cloudbreak.service.runtimes.SupportedRuntimes;
 import com.sequenceiq.distrox.v1.distrox.service.EnvironmentServiceDecorator;
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/template/ClusterTemplateViewServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/template/ClusterTemplateViewServiceTest.java
@@ -21,7 +21,7 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.sequenceiq.cloudbreak.exception.BadRequestException;
-import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterTemplateView;
+import com.sequenceiq.cloudbreak.domain.view.ClusterTemplateView;
 import com.sequenceiq.cloudbreak.repository.cluster.ClusterTemplateViewRepository;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/integration-test/integcb/Profile_template
+++ b/integration-test/integcb/Profile_template
@@ -7,22 +7,17 @@ export DOCKER_TAG_DATALAKE=dev
 export DOCKER_TAG_REDBEAMS=dev
 export DOCKER_TAG_PERISCOPE=dev
 export THUNDERHEAD_MOCK_VOLUME_HOST=$(PWD)/../../mock-thunderhead/build/libs/mock-thunderhead.jar
-export CB_JAVA_OPTS="-Dthunderhead.url=thunderhead-mock:8080 -Drest.debug=true -Dmock.spi.endpoint=https://test:9443"
-export UAA_DEFAULT_SECRET=cbsecret2015
-export UAA_DEFAULT_USER_PW=cloudbreak
 export REMOVE_CONTAINER=
 export DPS_VERSION=2.0.0.0-142
 export CB_ENABLEDPLATFORMS=AZURE,AWS,GCP,OPENSTACK,YARN,MOCK
 export ENVIRONMENT_ENABLEDPLATFORMS=AZURE,AWS,YARN,MOCK
 export CB_DEFAULT_SUBSCRIPTION_ADDRESS=""
-export UMS_HOST=thunderhead-mock
 export CB_CLIENT_SECRET=cloudbreak
 export INGRESS_URLS=dev-gateway,localhost
 export CLUSTERPROXY_ENABLED=false
 export ENVIRONMENT_AUTOSYNC_ENABLED=false
 export ENVIRONMENT_FREEIPA_SYNCHRONIZEONSTART=false
 
-export CB_CLUSTERDEFINITION_AMBARI_INTERNAL="HDP 3.0 - Data Science: Apache Spark 2, Apache Zeppelin=hdp30-data-science-spark2;                HDP 3.0 - EDW-Analytics: Apache Hive 2 LLAP, Apache Zeppelin=hdp30-edw-analytics;                HDP 3.0 - Data Lake: Apache Ranger, Apache Hive Metastore=hdp30-shared-services;                HDP 3.0 - Data Lake: Apache Ranger, Apache Atlas, Infrastructure Services=hdp30-shared-services-v2;                HDP 3.0 - Data Science Attached: Apache Spark 2, Apache Zeppelin=hdp30-data-science-spark2-attached-v2;                HDP 3.0 - Data Science Standalone: Apache Spark 2, Apache Zeppelin=hdp30-data-science-spark2-standalone-v2;                HDP 3.0 - EDW-Analytics Attached: Apache Hive 3 LLAP=hdp30-edw-analytics-attached-v2;                HDP 3.0 - EDW-Analytics Standalone: Apache Hive 3 LLAP=hdp30-edw-analytics-standalone-v2"
 export CLUSTERPROXY_ENABLED=false
 export ALTUS_AUDIT_ENDPOINT=thunderhead-mock
 
@@ -30,3 +25,11 @@ export CPUS_FOR_CLOUDBREAK=8.0
 export CPUS_FOR_SERVICES=4.0
 export MEMORY_FOR_CLOUDBREAK=4096M
 export MEMORY_FOR_SERVICES=2048M
+
+# hibernate.session.circuitbreak.* is intended to catch inefficient queries in IT time
+export CB_JAVA_OPTS="-Drest.debug=true -Dcb.hibernate.circuitbreaker=BREAK -Dhibernate.session.warning.max.count=250 -Dhibernate.session.circuitbreak.max.count=2500"
+export PERISCOPE_JAVA_OPTS="-Dperiscope.hibernate.circuitbreaker=BREAK -Dhibernate.session.warning.max.count=10 -Dhibernate.session.circuitbreak.max.count=25"
+export FREEIPA_JAVA_OPTS="-Dfreeipa.hibernate.circuitbreaker=BREAK -Dhibernate.session.warning.max.count=25 -Dhibernate.session.circuitbreak.max.count=50"
+export REDBEAMS_JAVA_OPTS="-Dredbeams.hibernate.circuitbreaker=BREAK -Dhibernate.session.warning.max.count=10 -Dhibernate.session.circuitbreak.max.count=25"
+export DATALAKE_JAVA_OPTS="-Ddatalake.hibernate.circuitbreaker=BREAK -Dhibernate.session.warning.max.count=10 -Dhibernate.session.circuitbreak.max.count=25"
+export ENVIRONMENT_JAVA_OPTS="-Denvironment.hibernate.circuitbreaker=BREAK -Dhibernate.session.warning.max.count=10 -Dhibernate.session.circuitbreak.max.count=25"


### PR DESCRIPTION
…every component CB.

Cloudbreak values are relatively high, because we need to fix the ClusterTemplate queries first which will be addressed in CB-9127.

This commit also contains a small refactor, to make sure that cluster template view is in the right package and also contains some extra loglines for easier debuggability.

See detailed description in the commit message.