### PR TITLE
CB-9293 - added tracing to cluster proxy from client side.

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/config/DatabaseConfig.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/config/DatabaseConfig.java
@@ -96,7 +96,7 @@ public class DatabaseConfig {
         if (periscopeNodeConfig.isNodeIdSpecified()) {
             config.addDataSourceProperty("ApplicationName", periscopeNodeConfig.getId());
         }
-        config.setJdbcUrl(String.format("jdbc:postgresql://%s/%s?currentSchema=%s", databaseAddress, dbName, dbSchemaName));
+        config.setJdbcUrl(String.format("jdbc:postgresql://%s/%s?currentSchema=%s&traceWithActiveSpanOnly=true", databaseAddress, dbName, dbSchemaName));
         config.setUsername(dbUser);
         config.setPassword(dbPassword);
         config.setMaximumPoolSize(poolSize);

--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ClusterProxyRegistrationServiceConfig.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ClusterProxyRegistrationServiceConfig.java
@@ -1,15 +1,28 @@
 package com.sequenceiq.cloudbreak.clusterproxy;
 
+import java.util.List;
+
+import javax.inject.Inject;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
 
+import io.opentracing.Tracer;
+import io.opentracing.contrib.spring.web.client.TracingRestTemplateInterceptor;
+
 @Configuration
 public class ClusterProxyRegistrationServiceConfig {
 
+    @Inject
+    private Tracer tracer;
+
     @Bean
     public RestTemplate restTemplate() {
-        return new RestTemplate();
+        TracingRestTemplateInterceptor tracingInterceptor = new TracingRestTemplateInterceptor(tracer);
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setInterceptors(List.of(tracingInterceptor));
+        return restTemplate;
     }
 
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -61,9 +61,11 @@ dependencies {
   compile group: 'io.swagger',                            name: 'swagger-annotations',            version: swaggerVersion
   compile group: 'net.sf.json-lib',                       name: 'json-lib',                       version: '2.4',  classifier: 'jdk15'
 
-  compile group: 'io.opentracing.contrib',                name: 'opentracing-jaxrs2',                      version: opentracingJaxrs2Version
-  compile group: 'io.opentracing.contrib',                name: 'opentracing-jdbc',                        version: opentracingJdbcVersion
-  compile group: 'io.opentracing.contrib',                name: 'opentracing-spring-jaeger-starter',       version: opentracingSpringJaegerStarterVersion
+  compile group: 'io.opentracing.contrib',                name: 'opentracing-jaxrs2',                     version: opentracingJaxrs2Version
+  compile group: 'io.opentracing.contrib',                name: 'opentracing-jdbc',                       version: opentracingJdbcVersion
+  compile group: 'io.opentracing.contrib',                name: 'opentracing-spring-jaeger-starter',      version: opentracingSpringJaegerStarterVersion
+  compile group: 'io.opentracing.contrib',                name: 'opentracing-spring-web',                 version: opentracingSpringWebVersion
+
 
   compile (group: 'com.fasterxml.jackson.core',   name: 'jackson-databind',               version: jacksonVersion) {
     force = true

--- a/core/src/main/java/com/sequenceiq/cloudbreak/conf/DatabaseConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/conf/DatabaseConfig.java
@@ -97,7 +97,7 @@ public class DatabaseConfig {
             config.addDataSourceProperty("ApplicationName", nodeConfig.getId());
         }
         config.setDriverClassName("io.opentracing.contrib.jdbc.TracingDriver");
-        config.setJdbcUrl(String.format("jdbc:tracing:postgresql://%s/%s?currentSchema=%s", databaseAddress, dbName, dbSchemaName));
+        config.setJdbcUrl(String.format("jdbc:tracing:postgresql://%s/%s?currentSchema=%s&traceWithActiveSpanOnly=true", databaseAddress, dbName, dbSchemaName));
         config.setUsername(dbUser);
         config.setPassword(dbPassword);
         config.setMaximumPoolSize(poolSize);

--- a/datalake/src/main/java/com/sequenceiq/datalake/configuration/DatabaseConfig.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/configuration/DatabaseConfig.java
@@ -95,7 +95,7 @@ public class DatabaseConfig {
             config.addDataSourceProperty("ApplicationName", nodeConfig.getId());
         }
         config.setDriverClassName("io.opentracing.contrib.jdbc.TracingDriver");
-        config.setJdbcUrl(String.format("jdbc:tracing:postgresql://%s/%s?currentSchema=%s", databaseAddress, dbName, dbSchemaName));
+        config.setJdbcUrl(String.format("jdbc:tracing:postgresql://%s/%s?currentSchema=%s&traceWithActiveSpanOnly=true", databaseAddress, dbName, dbSchemaName));
         config.setUsername(dbUser);
         config.setPassword(dbPassword);
         config.setMaximumPoolSize(poolSize);

--- a/environment/src/main/java/com/sequenceiq/environment/configuration/DatabaseConfig.java
+++ b/environment/src/main/java/com/sequenceiq/environment/configuration/DatabaseConfig.java
@@ -102,7 +102,7 @@ public class DatabaseConfig {
             config.addDataSourceProperty("ApplicationName", nodeConfig.getId());
         }
         config.setDriverClassName("io.opentracing.contrib.jdbc.TracingDriver");
-        config.setJdbcUrl(String.format("jdbc:tracing:postgresql://%s/%s?currentSchema=%s", databaseAddress, dbName, dbSchemaName));
+        config.setJdbcUrl(String.format("jdbc:tracing:postgresql://%s/%s?currentSchema=%s&traceWithActiveSpanOnly=true", databaseAddress, dbName, dbSchemaName));
         config.setUsername(dbUser);
         config.setPassword(dbPassword);
         config.setMaximumPoolSize(poolSize);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/DatabaseConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/DatabaseConfig.java
@@ -95,7 +95,7 @@ public class DatabaseConfig {
             config.addDataSourceProperty("ApplicationName", nodeConfig.getId());
         }
         config.setDriverClassName("io.opentracing.contrib.jdbc.TracingDriver");
-        config.setJdbcUrl(String.format("jdbc:tracing:postgresql://%s/%s?currentSchema=%s", databaseAddress, dbName, dbSchemaName));
+        config.setJdbcUrl(String.format("jdbc:tracing:postgresql://%s/%s?currentSchema=%s&traceWithActiveSpanOnly=true", databaseAddress, dbName, dbSchemaName));
         config.setUsername(dbUser);
         config.setPassword(dbPassword);
         config.setMaximumPoolSize(poolSize);

--- a/gradle.properties
+++ b/gradle.properties
@@ -45,6 +45,7 @@ xStream=1.4.11.1
 xerces=2.12.0
 javaxValidationVersion=2.0.1.Final
 javaxActivationVersion=1.1.1
+opentracingSpringWebVersion=4.1.0
 opentracingSpringJaegerStarterVersion=3.1.2
 opentracingJaxrs2Version=1.0.0
 opentracingJdbcVersion=0.2.11

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/DatabaseConfig.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/DatabaseConfig.java
@@ -95,7 +95,7 @@ public class DatabaseConfig {
             config.addDataSourceProperty("ApplicationName", nodeConfig.getId());
         }
         config.setDriverClassName("io.opentracing.contrib.jdbc.TracingDriver");
-        config.setJdbcUrl(String.format("jdbc:tracing:postgresql://%s/%s?currentSchema=%s", databaseAddress, dbName, dbSchemaName));
+        config.setJdbcUrl(String.format("jdbc:tracing:postgresql://%s/%s?currentSchema=%s&traceWithActiveSpanOnly=true", databaseAddress, dbName, dbSchemaName));
         config.setUsername(dbUser);
         config.setPassword(dbPassword);
         config.setMaximumPoolSize(poolSize);


### PR DESCRIPTION
Additionally added traceWithActiveSpanOnly=true parameter to jdbc configurations so jaeger is spammed with lonely database query spans.

Most part of cluster proxy tracing related code will go to the cluster proxy service itself.