### PR TITLE
CB-9374: Use last FreeIPA cookie when there are multiple

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/util/CookieComparator.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/util/CookieComparator.java
@@ -1,0 +1,46 @@
+package com.sequenceiq.freeipa.util;
+
+import java.io.Serializable;
+import java.util.Comparator;
+import java.util.Date;
+
+import org.apache.http.cookie.Cookie;
+import org.apache.http.cookie.CookieIdentityComparator;
+
+// Sort precedence:
+//   1. Cookie name (backwards - doesn't matter)
+//   2. Domain name (backwards - doesn't matter)
+//   3. Cookie path (more specific path is listed first) per RFC-6265 section 5.4.2
+//   4. Expiration (no expiratation is listed first, latest expiration is listed next)
+public class CookieComparator implements Serializable, Comparator<Cookie> {
+
+    private CookieIdentityComparator baseRules = new CookieIdentityComparator();
+
+    @Override
+    public int compare(final Cookie lhs, final Cookie rhs) {
+        // The base rules handles cookie name, domain, and path, but it has inverted logic for the more specific paths
+        int res = negate(baseRules.compare(lhs, rhs));
+        if (res == 0) {
+            Date lhsExpiry = lhs.getExpiryDate();
+            Date rhsExpiry = rhs.getExpiryDate();
+            if (lhsExpiry != null && rhsExpiry == null) {
+                res = 1;
+            } else if (lhsExpiry == null && rhsExpiry != null) {
+                res = -1;
+            } else if (lhsExpiry != null && rhsExpiry != null) {
+                res = lhsExpiry.compareTo(rhsExpiry);
+            }
+        }
+        return res;
+    }
+
+    private int negate(int res) {
+        if (res > 0) {
+            res = -1;
+        } else if (res < 0) {
+            res = 1;
+        }
+        return res;
+    }
+
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/util/FreeIpaCookieStore.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/util/FreeIpaCookieStore.java
@@ -1,0 +1,53 @@
+package com.sequenceiq.freeipa.util;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.apache.http.client.CookieStore;
+import org.apache.http.cookie.Cookie;
+
+public class FreeIpaCookieStore implements CookieStore {
+
+    private final Set<Cookie> cookies = new TreeSet<>(new CookieComparator());
+
+    @Override
+    public void addCookie(Cookie cookie) {
+        cookies.add(cookie);
+    }
+
+    @Override
+    public List<Cookie> getCookies() {
+        return new ArrayList<Cookie>(cookies);
+    }
+
+    @Override
+    public boolean clearExpired(Date date) {
+        if (date == null) {
+            return false;
+        }
+        boolean removed = false;
+        Iterator<Cookie> it = cookies.iterator();
+        while (it.hasNext()) {
+            if (it.next().isExpired(date)) {
+                it.remove();
+                removed = true;
+            }
+        }
+        return removed;
+    }
+
+    @Override
+    public void clear() {
+        cookies.clear();
+    }
+
+    @Override
+    public String toString() {
+        return cookies.toString();
+    }
+}
+

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/util/CookieComparatorTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/util/CookieComparatorTest.java
@@ -1,0 +1,116 @@
+package com.sequenceiq.freeipa.util;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.text.SimpleDateFormat;
+import java.util.List;
+
+import org.apache.http.cookie.Cookie;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class CookieComparatorTest {
+
+    private CookieComparator underTest;
+
+    @Before
+    public void before() {
+        underTest = new CookieComparator();
+    }
+
+    @Test
+    public void testCookieName() {
+        Cookie c1 = mock(Cookie.class);
+        Cookie c2 = mock(Cookie.class);
+
+        when(c1.getName()).thenReturn("name1");
+        when(c2.getName()).thenReturn("name2");
+
+        assertTrue(underTest.compare(c1, c2) > 0);
+        assertTrue(underTest.compare(c2, c1) < 0);
+    }
+
+    @Test
+    public void testCookieDomain() {
+        Cookie c1 = mock(Cookie.class);
+        Cookie c2 = mock(Cookie.class);
+
+        for (Cookie c : List.of(c1, c2)) {
+            when(c.getName()).thenReturn("name");
+        }
+        when(c1.getDomain()).thenReturn("example1.com");
+        when(c2.getDomain()).thenReturn("example2.com");
+
+        assertTrue(underTest.compare(c1, c2) > 0);
+        assertTrue(underTest.compare(c2, c1) < 0);
+    }
+
+    @Test
+    public void testCookiePath() {
+        Cookie c1 = mock(Cookie.class);
+        Cookie c2 = mock(Cookie.class);
+        Cookie c3 = mock(Cookie.class);
+
+        for (Cookie c : List.of(c1, c2, c3)) {
+            when(c.getName()).thenReturn("name");
+            when(c.getDomain()).thenReturn("example.com");
+        }
+        when(c1.getPath()).thenReturn("/a");
+        when(c2.getPath()).thenReturn("/path");
+        when(c3.getPath()).thenReturn("/path/longer");
+
+        assertTrue(underTest.compare(c1, c2) > 0);
+        assertTrue(underTest.compare(c2, c1) < 0);
+        assertTrue(underTest.compare(c1, c3) > 0);
+        assertTrue(underTest.compare(c3, c1) < 0);
+        assertTrue(underTest.compare(c2, c3) > 0);
+        assertTrue(underTest.compare(c3, c2) < 0);
+    }
+
+    @Test
+    public void testCookieExpiration() throws Exception {
+        Cookie c1 = mock(Cookie.class);
+        Cookie c2 = mock(Cookie.class);
+        Cookie c3 = mock(Cookie.class);
+        Cookie c4 = mock(Cookie.class);
+        Cookie c5 = mock(Cookie.class);
+        Cookie c6 = mock(Cookie.class);
+
+        for (Cookie c : List.of(c1, c2, c3, c4, c5, c6)) {
+            when(c.getName()).thenReturn("name");
+            when(c.getDomain()).thenReturn("example.com");
+            when(c.getPath()).thenReturn("/path");
+        }
+
+        when(c1.getExpiryDate()).thenReturn(null);
+        when(c2.getExpiryDate()).thenReturn(null);
+        when(c3.getExpiryDate()).thenReturn(new SimpleDateFormat("yyyy-mm-dd").parse("2020-01-01"));
+        when(c4.getExpiryDate()).thenReturn(new SimpleDateFormat("yyyy-mm-dd").parse("2020-01-02"));
+        when(c5.getExpiryDate()).thenReturn(new SimpleDateFormat("yyyy-mm-dd").parse("2020-01-03"));
+        when(c6.getExpiryDate()).thenReturn(new SimpleDateFormat("yyyy-mm-dd").parse("2020-01-03"));
+
+        assertTrue(underTest.compare(c1, c2) == 0);
+        assertTrue(underTest.compare(c2, c1) == 0);
+        for (Cookie c : List.of(c3, c4, c5, c6)) {
+            assertTrue(underTest.compare(c1, c) < 0);
+            assertTrue(underTest.compare(c, c1) > 0);
+            assertTrue(underTest.compare(c2, c) < 0);
+            assertTrue(underTest.compare(c, c2) > 0);
+        }
+        for (Cookie c : List.of(c4, c5, c6)) {
+            assertTrue(underTest.compare(c3, c) < 0);
+            assertTrue(underTest.compare(c, c3) > 0);
+        }
+        for (Cookie c : List.of(c5, c6)) {
+            assertTrue(underTest.compare(c4, c) < 0);
+            assertTrue(underTest.compare(c, c4) > 0);
+        }
+        assertTrue(underTest.compare(c5, c6) == 0);
+        assertTrue(underTest.compare(c6, c5) == 0);
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/util/FreeIpaCookieStoreTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/util/FreeIpaCookieStoreTest.java
@@ -1,0 +1,142 @@
+package com.sequenceiq.freeipa.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+
+import org.apache.http.cookie.Cookie;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class FreeIpaCookieStoreTest {
+
+    private FreeIpaCookieStore underTest;
+
+    private Cookie cookie1;
+
+    private Cookie cookie2;
+
+    private Cookie cookie3;
+
+    private Cookie expiredCookie;
+
+    @Before
+    public void before() throws Exception {
+        underTest = new FreeIpaCookieStore();
+        cookie1 = createCookie("name", "example.com", "/path", new SimpleDateFormat("yyyy-mm-dd").parse("2050-01-01"));
+        cookie2 = createCookie("name", "example.com", "/path", null);
+        cookie3 = createCookie("name", "example.com", "/path/longer", new SimpleDateFormat("yyyy-mm-dd").parse("2050-01-01"));
+        expiredCookie = createCookie("name", "example.com", "/path", new SimpleDateFormat("yyyy-mm-dd").parse("2000-01-01"));
+    }
+
+    @Test
+    public void testAddCookie() {
+        assertEquals(underTest.getCookies().size(), 0);
+        underTest.addCookie(cookie1);
+        assertEquals(underTest.getCookies().size(), 1);
+        assertTrue(underTest.getCookies().containsAll(List.of(cookie1)));
+        underTest.addCookie(cookie2);
+        assertEquals(underTest.getCookies().size(), 2);
+        assertTrue(underTest.getCookies().containsAll(List.of(cookie1, cookie2)));
+    }
+
+    @Test
+    public void testGetCookiesOrder() {
+        underTest.addCookie(cookie1);
+        underTest.addCookie(cookie2);
+        assertEquals(underTest.getCookies(), List.of(cookie2, cookie1));
+        underTest.addCookie(cookie3);
+        assertEquals(underTest.getCookies(), List.of(cookie3, cookie2, cookie1));
+    }
+
+    @Test
+    public void testClear() {
+        underTest.addCookie(cookie1);
+        assertFalse(underTest.getCookies().isEmpty());
+        underTest.clear();
+        assertTrue(underTest.getCookies().isEmpty());
+    }
+
+    @Test
+    public void testClearExpired() throws Exception {
+        underTest.addCookie(cookie1);
+        underTest.addCookie(cookie2);
+        underTest.addCookie(expiredCookie);
+        assertEquals(underTest.getCookies().size(), 3);
+        underTest.clearExpired(new SimpleDateFormat("yyyy-mm-dd").parse("2020-01-01"));
+        assertEquals(underTest.getCookies().size(), 2);
+        assertTrue(underTest.getCookies().containsAll(List.of(cookie1, cookie2)));
+        assertFalse(underTest.getCookies().contains(expiredCookie));
+    }
+
+    private Cookie createCookie(String name, String domain, String path, Date expiry) {
+        return new Cookie() {
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public String getValue() {
+                return null;
+            }
+
+            @Override
+            public String getComment() {
+                return null;
+            }
+
+            @Override
+            public String getCommentURL() {
+                return null;
+            }
+
+            @Override
+            public Date getExpiryDate() {
+                return expiry;
+            }
+
+            @Override
+            public boolean isPersistent() {
+                return false;
+            }
+
+            @Override
+            public String getDomain() {
+                return domain;
+            }
+
+            @Override
+            public String getPath() {
+                return path;
+            }
+
+            @Override
+            public int[] getPorts() {
+                return new int[0];
+            }
+
+            @Override
+            public boolean isSecure() {
+                return false;
+            }
+
+            @Override
+            public int getVersion() {
+                return 0;
+            }
+
+            @Override
+            public boolean isExpired(Date date) {
+                return expiry != null && date.after(expiry);
+            }
+        };
+    }
+}


### PR DESCRIPTION
When there are multiple FreeIPA ipa_session cookies, use the last one.
This is the same behavior as FreeIPA does.
See https://github.com/freeipa/freeipa/blob/139d60d74706d2ba9855db5faefee322b23b0ba5/ipapython/cookie.py#L322-L349
for details.

See detailed description in the commit message.