### PR TITLE
CB-9224: Added cloudbreak version used to create datalake to datalake API.

### DIFF
--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterDetailResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterDetailResponse.java
@@ -18,7 +18,8 @@ public class SdxClusterDetailResponse extends SdxClusterResponse implements Tagg
                 sdxClusterResponse.getEnvironmentCrn(), sdxClusterResponse.getStackCrn(),
                 sdxClusterResponse.getClusterShape(), sdxClusterResponse.getCloudStorageBaseLocation(),
                 sdxClusterResponse.getCloudStorageFileSystemType(), sdxClusterResponse.getRuntime(),
-                sdxClusterResponse.getRangerRazEnabled(), sdxClusterResponse.getTags(), sdxClusterResponse.getCertExpirationState());
+                sdxClusterResponse.getRangerRazEnabled(), sdxClusterResponse.getTags(), sdxClusterResponse.getCertExpirationState(),
+                sdxClusterResponse.getSdxClusterServiceVersion());
         this.stackV4Response = stackV4Response;
     }
 

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterResponse.java
@@ -48,6 +48,8 @@ public class SdxClusterResponse implements ResourceCrnAwareApiModel {
     @ApiModelProperty(ClusterModelDescription.CERT_EXPIRATION)
     private CertExpirationState certExpirationState;
 
+    private String sdxClusterServiceVersion;
+
     public SdxClusterResponse() {
     }
 
@@ -55,7 +57,8 @@ public class SdxClusterResponse implements ResourceCrnAwareApiModel {
             String statusReason, String environmentName, String environmentCrn, String stackCrn,
             SdxClusterShape clusterShape, String cloudStorageBaseLocation,
             FileSystemType cloudStorageFileSystemType, String runtime,
-            boolean rangerRazEnabled, Map<String, String> tags, CertExpirationState certExpirationState) {
+            boolean rangerRazEnabled, Map<String, String> tags, CertExpirationState certExpirationState,
+            String sdxClusterServiceVersion) {
         this.crn = crn;
         this.name = name;
         this.status = status;
@@ -70,6 +73,7 @@ public class SdxClusterResponse implements ResourceCrnAwareApiModel {
         this.rangerRazEnabled = rangerRazEnabled;
         this.tags = tags;
         this.certExpirationState = certExpirationState;
+        this.sdxClusterServiceVersion = sdxClusterServiceVersion;
     }
 
     public String getCrn() {
@@ -208,6 +212,14 @@ public class SdxClusterResponse implements ResourceCrnAwareApiModel {
         this.certExpirationState = certExpirationState;
     }
 
+    public String getSdxClusterServiceVersion() {
+        return sdxClusterServiceVersion;
+    }
+
+    public void setSdxClusterServiceVersion(String sdxClusterServiceVersion) {
+        this.sdxClusterServiceVersion = sdxClusterServiceVersion;
+    }
+
     @JsonIgnore
     @Override
     public String getResourceCrn() {
@@ -234,6 +246,7 @@ public class SdxClusterResponse implements ResourceCrnAwareApiModel {
                 ", rangerRazEnabled=" + rangerRazEnabled +
                 ", tags=" + tags +
                 ", certExpirationState=" + certExpirationState +
+                ", sdxClusterServiceVersion=" + sdxClusterServiceVersion +
                 '}';
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxClusterConverter.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxClusterConverter.java
@@ -50,6 +50,7 @@ public class SdxClusterConverter {
         sdxClusterResponse.setRangerRazEnabled(sdxCluster.isRangerRazEnabled());
         sdxClusterResponse.setTags(getTags(sdxCluster.getTags()));
         sdxClusterResponse.setCertExpirationState(sdxCluster.getCertExpirationState());
+        sdxClusterResponse.setSdxClusterServiceVersion(sdxCluster.getSdxClusterServiceVersion());
         return sdxClusterResponse;
     }
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/entity/SdxCluster.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/entity/SdxCluster.java
@@ -111,6 +111,9 @@ public class SdxCluster implements AccountIdAwareResource {
     @Convert(converter = CertExpirationStateConverter.class)
     private CertExpirationState certExpirationState = CertExpirationState.VALID;
 
+    @Column(name = "sdx_cluster_service_version")
+    private String sdxClusterServiceVersion;
+
     public Long getId() {
         return id;
     }
@@ -332,6 +335,14 @@ public class SdxCluster implements AccountIdAwareResource {
         this.rangerRazEnabled = rangerRazEnabled;
     }
 
+    public String getSdxClusterServiceVersion() {
+        return sdxClusterServiceVersion;
+    }
+
+    public void setSdxClusterServiceVersion(String sdxClusterServiceVersion) {
+        this.sdxClusterServiceVersion = sdxClusterServiceVersion;
+    }
+
     //CHECKSTYLE:OFF
     @Override
     public boolean equals(Object o) {
@@ -359,14 +370,15 @@ public class SdxCluster implements AccountIdAwareResource {
                 cloudStorageFileSystemType == that.cloudStorageFileSystemType &&
                 databaseAvailabilityType == that.databaseAvailabilityType &&
                 rangerRazEnabled == that.rangerRazEnabled &&
-                certExpirationState == that.certExpirationState;
+                certExpirationState == that.certExpirationState &&
+                Objects.equals(sdxClusterServiceVersion, that.sdxClusterServiceVersion);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(id, accountId, crn, clusterName, initiatorUserCrn, envName, envCrn, stackCrn, clusterShape, tags, stackId, stackRequest,
                 stackRequestToCloudbreak, deleted, created, createDatabase, databaseCrn, cloudStorageBaseLocation, cloudStorageFileSystemType,
-                databaseAvailabilityType, rangerRazEnabled, certExpirationState);
+                databaseAvailabilityType, rangerRazEnabled, certExpirationState, sdxClusterServiceVersion);
     }
 
     @Override
@@ -382,6 +394,7 @@ public class SdxCluster implements AccountIdAwareResource {
                 ", cloudStorageBaseLocation='" + cloudStorageBaseLocation + '\'' +
                 ", rangerRazEnabled=" + rangerRazEnabled +
                 ", certExpirationState=" + certExpirationState +
+                ", sdxClusterServiceVersion=" + sdxClusterServiceVersion +
                 '}';
     }
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -134,6 +135,9 @@ public class SdxService implements ResourceIdProvider, ResourceBasedCrnProvider 
     @Inject
     private EntitlementService entitlementService;
 
+    @Value("${info.app.version}")
+    private String sdxClusterServiceVersion;
+
     public String getStackCrnByClusterCrn(String crn) {
         return sdxClusterRepository.findStackCrnByClusterCrn(crn)
                 .orElseThrow(notFound("SdxCluster", crn));
@@ -207,6 +211,7 @@ public class SdxService implements ResourceIdProvider, ResourceBasedCrnProvider 
         sdxCluster.setEnvName(environment.getName());
         sdxCluster.setEnvCrn(environment.getCrn());
         sdxCluster.setRangerRazEnabled(sdxClusterRequest.isEnableRangerRaz());
+        sdxCluster.setSdxClusterServiceVersion(sdxClusterServiceVersion);
         setTagsSafe(sdxClusterRequest, sdxCluster);
 
         CloudPlatform cloudPlatform = CloudPlatform.valueOf(environment.getCloudPlatform());

--- a/datalake/src/main/resources/schema/app/20201019203538_CB-9224_Adding_cloudbreak_version_to_datalake_DB.sql
+++ b/datalake/src/main/resources/schema/app/20201019203538_CB-9224_Adding_cloudbreak_version_to_datalake_DB.sql
@@ -1,0 +1,10 @@
+-- // CB-9224 Adding cloudbreak version to datalake DB
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE sdxcluster ADD COLUMN IF NOT EXISTS sdx_cluster_service_version VARCHAR(128) DEFAULT 'No Info';
+UPDATE sdxcluster SET sdx_cluster_service_version = 'No Info' WHERE sdx_cluster_service_version IS NULL;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE sdxcluster DROP COLUMN IF EXISTS sdx_cluster_service_version;


### PR DESCRIPTION
Jira is here: https://jira.cloudera.com/browse/CB-9224

This PR is meant to enable the following:

* Cloudbreak version used to create a datalake is saved into the datalakedb in the new column specifically for it
* The same Cloudbreak version (from the creation of the datalake) is retrieved from the datalakedb every time the datalake is "described" (i.e. is a part of the SdxClusterResponse object and is populated from the database when this is called).