### PR TITLE
CB-9379 Rotate krb5kdc log by size

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/logrotate/conf/krb5kdc
+++ b/freeipa/src/main/resources/freeipa-salt/salt/logrotate/conf/krb5kdc
@@ -1,0 +1,10 @@
+/var/log/krb5kdc.log {
+    missingok
+    notifempty
+    monthly
+    size 1G
+    rotate 12
+    postrotate
+	    /bin/kill -HUP `cat /var/run/krb5kdc.pid 2>/dev/null` 2> /dev/null || true
+    endscript
+}

--- a/freeipa/src/main/resources/freeipa-salt/salt/logrotate/init.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/logrotate/init.sls
@@ -1,0 +1,7 @@
+logrotate-krb5kdc:
+  file.managed:
+    - name: /etc/logrotate.d/krb5kdc
+    - source: salt://logrotate/conf/krb5kdc
+    - user: root
+    - group: root
+    - mode: 644

--- a/freeipa/src/main/resources/freeipa-salt/salt/top.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/top.sls
@@ -7,6 +7,7 @@ base:
              - freeipa
              - freeipa.services
              - dns
+             - logrotate
 
            'roles:freeipa_primary':
              - match: grain


### PR DESCRIPTION
By default krb5kdc log was rotated monthly. From now a 1GB limit is introduced.
After a month or 1GB in size the log will be rotated and compressed.
Max 12 files will be kept.

See detailed description in the commit message.