### PR TITLE
Revert "CB-8982 Indefinitely long loop when deleting environment. Whe…

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/clustertemplate/ClusterTemplateV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/clustertemplate/ClusterTemplateV4Endpoint.java
@@ -47,13 +47,6 @@ public interface ClusterTemplateV4Endpoint {
     ClusterTemplateViewV4Responses list(@PathParam("workspaceId") Long workspaceId);
 
     @GET
-    @Path("env/{environmentCrn}")
-    @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = ClusterTemplateOpDescription.LIST_BY_ENV, produces = MediaType.APPLICATION_JSON,
-            notes = CLUSTER_TEMPLATE_NOTES, nickname = "listClusterTemplatesByEnv")
-    ClusterTemplateViewV4Responses listByEnv(@PathParam("workspaceId") Long workspaceId, @PathParam("environmentCrn") String environmentCrn);
-
-    @GET
     @Path("name/{name}")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = ClusterTemplateOpDescription.GET_BY_NAME_IN_WORKSPACE, produces = MediaType.APPLICATION_JSON, notes = CLUSTER_TEMPLATE_NOTES,

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
@@ -77,7 +77,6 @@ public class OperationDescriptions {
         public static final String DELETE_BY_NAME_IN_WORKSPACE = "delete cluster template by name in workspace";
         public static final String DELETE_BY_CRN_IN_WORKSPACE = "delete cluster template by crn in workspace";
         public static final String DELETE_MULTIPLE_BY_NAME_IN_WORKSPACE = "delete multiple cluster templates by name in workspace";
-        public static final String LIST_BY_ENV = "list cluster templates by environment crn";
     }
 
     public static class RecipeOpDescription {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/init/clustertemplate/ClusterTemplateLoaderService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/init/clustertemplate/ClusterTemplateLoaderService.java
@@ -1,7 +1,5 @@
 package com.sequenceiq.cloudbreak.init.clustertemplate;
 
-import static com.sequenceiq.cloudbreak.util.Benchmark.measure;
-
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -23,6 +21,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ResourceStatus;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterTemplate;
 import com.sequenceiq.cloudbreak.service.template.ClusterTemplateService;
+import com.sequenceiq.cloudbreak.workspace.model.Workspace;
 
 @Service
 public class ClusterTemplateLoaderService {
@@ -78,13 +77,11 @@ public class ClusterTemplateLoaderService {
         return defaultTemplatesInDb.stream().allMatch(s -> defaultTemplates.keySet().contains(s.getName()));
     }
 
-    public Set<ClusterTemplate> loadClusterTemplatesForWorkspace(Set<ClusterTemplate> templatesInDb,
+    public Set<ClusterTemplate> loadClusterTemplatesForWorkspace(Set<ClusterTemplate> templatesInDb, Workspace workspace,
             Function<Iterable<ClusterTemplate>, Collection<ClusterTemplate>> saveMethod) {
-        Set<ClusterTemplate> clusterTemplatesToSave = collectClusterTemplatesToSaveInDb(templatesInDb);
-        LOGGER.debug("{} cluster templates in the db and {} cluster templates want to save", templatesInDb.size(), clusterTemplatesToSave.size());
+        Set<ClusterTemplate> clusterTemplatesToSave = collectClusterTemplatesToSaveInDb(templatesInDb, workspace);
         decorateWithCrn(clusterTemplatesToSave);
-        Iterable<ClusterTemplate> savedClusterTemplates = measure(() -> saveMethod.apply(clusterTemplatesToSave), LOGGER,
-                "saved in {}ms {} cluster templates", clusterTemplatesToSave.size());
+        Iterable<ClusterTemplate> savedClusterTemplates = saveMethod.apply(clusterTemplatesToSave);
         return unifyTemplatesUpdatedAndUnmodified(templatesInDb, clusterTemplatesToSave, savedClusterTemplates);
     }
 
@@ -108,26 +105,26 @@ public class ClusterTemplateLoaderService {
         return unionOfTemplates;
     }
 
-    private Set<ClusterTemplate> collectClusterTemplatesToSaveInDb(Set<ClusterTemplate> templatesInDb) {
-        Collection<String> defaultTemplateNames = measure(() -> defaultClusterTemplateCache.defaultClusterTemplateNames(), LOGGER,
-                "Default cluster templates fetched in {}ms");
+    private Set<ClusterTemplate> collectClusterTemplatesToSaveInDb(Set<ClusterTemplate> templatesInDb, Workspace workspace) {
+        Map<String, ClusterTemplate> defaultTemplates = defaultClusterTemplateCache.defaultClusterTemplates();
         List<ClusterTemplate> defaultTemplatesInDb = filterTemplatesForDefaults(templatesInDb);
-        Collection<String> templateNamesMissingFromDb = collectTemplatesMissingFromDb(defaultTemplateNames, defaultTemplatesInDb);
+        Collection<ClusterTemplate> templatesMissingFromDb = collectTemplatesMissingFromDb(defaultTemplates, defaultTemplatesInDb, workspace);
         Collection<ClusterTemplate> updatedTemplates = collectOutdatedTemplatesInDb(defaultTemplatesInDb);
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Templates missing from DB: {}", templateNamesMissingFromDb);
+            LOGGER.debug("Templates missing from DB: {}",
+                    templatesMissingFromDb.stream().map(ClusterTemplate::getName).collect(Collectors.joining(", ")));
         }
-        Collection<ClusterTemplate> templatesMissingFromDb = measure(() ->
-                        defaultClusterTemplateCache.defaultClusterTemplatesByNames(templateNamesMissingFromDb), LOGGER,
-                "Missed cluster templates fetched in {}ms");
         return Stream.concat(templatesMissingFromDb.stream(), updatedTemplates.stream()).collect(Collectors.toSet());
     }
 
-    public Collection<String> collectTemplatesMissingFromDb(Collection<String> defaultTemplateNames, Collection<ClusterTemplate> defaultTemplatesInDb) {
+    public Collection<ClusterTemplate> collectTemplatesMissingFromDb(Map<String, ClusterTemplate> defaultTemplates,
+            Collection<ClusterTemplate> defaultTemplatesInDb, Workspace workspace) {
         Set<String> defaultTemplateInDbNames = defaultTemplatesInDb.stream().map(ClusterTemplate::getName).collect(Collectors.toSet());
-        return defaultTemplateNames.stream()
-                .filter(defaultTemplateName -> !defaultTemplateInDbNames.contains(defaultTemplateName))
+        Set<ClusterTemplate> templatesMissingFromDb = defaultTemplates.values().stream()
+                .filter(defaultTemplate -> !defaultTemplateInDbNames.contains(defaultTemplate.getName()))
                 .collect(Collectors.toSet());
+        templatesMissingFromDb.forEach(template -> template.setWorkspace(workspace));
+        return templatesMissingFromDb;
     }
 
     public Collection<ClusterTemplate> collectOutdatedTemplatesInDb(Collection<ClusterTemplate> clusterTemplates) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/init/clustertemplate/DefaultClusterTemplateCache.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/init/clustertemplate/DefaultClusterTemplateCache.java
@@ -4,7 +4,6 @@ import static com.sequenceiq.cloudbreak.util.FileReaderUtils.readFileFromClasspa
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
@@ -115,27 +114,6 @@ public class DefaultClusterTemplateCache {
             DefaultClusterTemplateV4Request defaultClusterTemplate = getDefaultClusterTemplate(defaultTemplateJson);
             ClusterTemplate clusterTemplate = converterUtil.convert(defaultClusterTemplate, ClusterTemplate.class);
             defaultTemplates.put(key, clusterTemplate);
-        });
-        return defaultTemplates;
-    }
-
-    public List<ClusterTemplate> defaultClusterTemplatesByNames(Collection<String> templateNamesMissingFromDb) {
-        List<ClusterTemplate> defaultTemplates = new ArrayList<>();
-        defaultClusterTemplateRequests().forEach((key, value) -> {
-            if (templateNamesMissingFromDb.contains(key)) {
-                String defaultTemplateJson = new String(Base64.getDecoder().decode(value));
-                DefaultClusterTemplateV4Request defaultClusterTemplate = getDefaultClusterTemplate(defaultTemplateJson);
-                ClusterTemplate clusterTemplate = converterUtil.convert(defaultClusterTemplate, ClusterTemplate.class);
-                defaultTemplates.add(clusterTemplate);
-            }
-        });
-        return defaultTemplates;
-    }
-
-    public Collection<String> defaultClusterTemplateNames() {
-        Collection<String> defaultTemplates = new ArrayList<>();
-        defaultClusterTemplateRequests().forEach((key, value) -> {
-            defaultTemplates.add(key);
         });
         return defaultTemplates;
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/cluster/ClusterTemplateRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/cluster/ClusterTemplateRepository.java
@@ -28,6 +28,9 @@ public interface ClusterTemplateRepository extends WorkspaceResourceRepository<C
     @Query("SELECT c FROM ClusterTemplate c WHERE c.resourceCrn= :crn AND c.workspace.id= :workspaceId AND c.status <> 'DEFAULT_DELETED'")
     Optional<ClusterTemplate> getByCrnForWorkspaceId(@Param("crn") String crn, @Param("workspaceId") Long workspaceId);
 
+    @Query("SELECT c FROM ClusterTemplate c WHERE c.stackTemplate.environmentCrn= :environmentCrn AND c.status <> 'DEFAULT_DELETED'")
+    Set<ClusterTemplate> getAllByEnvironmentCrn(@Param("environmentCrn") String environmentCrn);
+
     @Query("SELECT c FROM ClusterTemplate c WHERE c.stackTemplate.cluster.blueprint.id = :blueprintId AND c.workspace.id= :workspaceId "
             + "AND (c.status <> 'DEFAULT_DELETED' AND c.status <> 'DELETED')")
     Set<ClusterTemplate> getTemplatesByBlueprintId(@Param("blueprintId") Long blueprintId, @Param("workspaceId") Long workspaceId);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/cluster/ClusterTemplateViewRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/cluster/ClusterTemplateViewRepository.java
@@ -21,9 +21,6 @@ public interface ClusterTemplateViewRepository extends WorkspaceResourceReposito
             "WHERE b.workspace.id= :workspaceId AND b.status <> 'DEFAULT_DELETED'")
     Set<ClusterTemplateView> findAllActive(@Param("workspaceId") Long workspaceId);
 
-    @Query("SELECT c FROM ClusterTemplateView c WHERE c.stackTemplate.environmentCrn= :environmentCrn AND c.status <> 'DEFAULT_DELETED'")
-    Set<ClusterTemplateView> getAllByEnvironmentCrn(@Param("environmentCrn") String environmentCrn);
-
     @Override
     default <S extends ClusterTemplateView> S save(S entity) {
         throw new UnsupportedOperationException("Creation is not supported from ClusterTemplateViewRepository");

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/template/ClusterTemplateService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/template/ClusterTemplateService.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.cloudbreak.service.template;
 
-import static com.sequenceiq.cloudbreak.util.Benchmark.measure;
 import static java.lang.String.format;
 import static java.util.Objects.nonNull;
 import static java.util.stream.Collectors.toSet;
@@ -29,6 +28,7 @@ import com.sequenceiq.authorization.service.ResourceBasedCrnProvider;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.responses.ClusterTemplateViewV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.CompactViewV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ResourceStatus;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
 import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
@@ -50,18 +50,20 @@ import com.sequenceiq.cloudbreak.logger.MDCUtils;
 import com.sequenceiq.cloudbreak.repository.cluster.ClusterTemplateRepository;
 import com.sequenceiq.cloudbreak.service.AbstractWorkspaceAwareResourceService;
 import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
+import com.sequenceiq.cloudbreak.structuredevent.LegacyRestRequestThreadLocalService;
 import com.sequenceiq.cloudbreak.service.blueprint.BlueprintService;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
+import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
 import com.sequenceiq.cloudbreak.service.network.NetworkService;
 import com.sequenceiq.cloudbreak.service.orchestrator.OrchestratorService;
 import com.sequenceiq.cloudbreak.service.runtimes.SupportedRuntimes;
 import com.sequenceiq.cloudbreak.service.stack.InstanceGroupService;
 import com.sequenceiq.cloudbreak.service.stack.StackTemplateService;
 import com.sequenceiq.cloudbreak.service.user.UserService;
-import com.sequenceiq.cloudbreak.structuredevent.LegacyRestRequestThreadLocalService;
 import com.sequenceiq.cloudbreak.workspace.model.Workspace;
 import com.sequenceiq.cloudbreak.workspace.repository.workspace.WorkspaceResourceRepository;
 import com.sequenceiq.distrox.v1.distrox.service.EnvironmentServiceDecorator;
+import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 
 @Service
 public class ClusterTemplateService extends AbstractWorkspaceAwareResourceService<ClusterTemplate> implements ResourceBasedCrnProvider {
@@ -103,6 +105,9 @@ public class ClusterTemplateService extends AbstractWorkspaceAwareResourceServic
 
     @Inject
     private ComponentConfigProviderService componentConfigProviderService;
+
+    @Inject
+    private EnvironmentClientService environmentClientService;
 
     @Inject
     private TransactionService transactionService;
@@ -157,7 +162,7 @@ public class ClusterTemplateService extends AbstractWorkspaceAwareResourceServic
     @Override
     protected void prepareCreation(ClusterTemplate resource) {
 
-        measure(() -> validateBeforeCreate(resource), LOGGER, "Cluster template validated in {}ms");
+        validateBeforeCreate(resource);
 
         Stack stackTemplate = resource.getStackTemplate();
         stackTemplate.setName(UUID.randomUUID().toString());
@@ -221,9 +226,10 @@ public class ClusterTemplateService extends AbstractWorkspaceAwareResourceServic
         return clusterTemplateRepository.findAllByNotDeletedInWorkspace(workspace.getId());
     }
 
-    public Set<ClusterTemplateView> findAllByEnvironment(String environmenCrn) {
-        LOGGER.debug("About to collect cluster definitions by environment: [crn: {}]", environmenCrn);
-        return clusterTemplateViewService.findAllByEnvironmentCrn(environmenCrn);
+    public Set<ClusterTemplate> findAllByEnvironment(NameOrCrn environmentNameOrCrn) {
+        DetailedEnvironmentResponse env = getEnvironmentByNameOrCrn(environmentNameOrCrn);
+        LOGGER.debug("About to collect cluster definitions by environment: {} - [crn: {}]", env.getName(), env.getCrn());
+        return clusterTemplateRepository.getAllByEnvironmentCrn(env.getCrn());
     }
 
     @Override
@@ -308,12 +314,9 @@ public class ClusterTemplateService extends AbstractWorkspaceAwareResourceServic
         if (clusterTemplateLoaderService.isDefaultClusterTemplateUpdateNecessaryForUser(clusterTemplates)) {
             LOGGER.debug("Modifying clusterTemplates based on the defaults for the '{} ({})' workspace.", workspace.getName(), workspace.getId());
             Collection<ClusterTemplate> outdatedTemplates = clusterTemplateLoaderService.collectOutdatedTemplatesInDb(clusterTemplates);
-            LOGGER.debug("Outdated clusterTemplates collected: '{}'.", outdatedTemplates.size());
             delete(new HashSet<>(outdatedTemplates));
-            LOGGER.debug("Outdated clusterTemplates deleted: '{}'.", outdatedTemplates.size());
             clusterTemplates = clusterTemplateRepository.findAllByNotDeletedInWorkspace(workspace.getId());
-            LOGGER.debug("None deleted clusterTemplates collected: '{}'.", clusterTemplates.size());
-            clusterTemplateLoaderService.loadClusterTemplatesForWorkspace(clusterTemplates, this::createAll);
+            clusterTemplateLoaderService.loadClusterTemplatesForWorkspace(clusterTemplates, workspace, this::createAll);
             LOGGER.debug("ClusterTemplate modifications finished based on the defaults for '{}' workspace.", workspace.getId());
         }
     }
@@ -322,8 +325,7 @@ public class ClusterTemplateService extends AbstractWorkspaceAwareResourceServic
         return StreamSupport.stream(clusterTemplates.spliterator(), false)
                 .map(ct -> {
                     try {
-                        return measure(() -> create(ct, ct.getWorkspace(), userService.getOrCreate(legacyRestRequestThreadLocalService.getCloudbreakUser())),
-                                LOGGER, "Cluster template created in {}ms");
+                        return create(ct, ct.getWorkspace(), userService.getOrCreate(legacyRestRequestThreadLocalService.getCloudbreakUser()));
                     } catch (DuplicateClusterTemplateException duplicateClusterTemplateException) {
                         LOGGER.info("Template was found, try to get it", duplicateClusterTemplateException);
                         return getByNameForWorkspace(ct.getName(), ct.getWorkspace());
@@ -362,6 +364,12 @@ public class ClusterTemplateService extends AbstractWorkspaceAwareResourceServic
         clusterTemplate = delete(clusterTemplate);
         stackTemplateService.delete(clusterTemplate.getStackTemplate());
         return clusterTemplate;
+    }
+
+    private DetailedEnvironmentResponse getEnvironmentByNameOrCrn(NameOrCrn environmentNameOrCrn) {
+        return environmentNameOrCrn.hasCrn()
+                ? environmentClientService.getByCrn(environmentNameOrCrn.getCrn())
+                : environmentClientService.getByName(environmentNameOrCrn.getName());
     }
 
     private void cleanUpInvalidClusterDefinitions(final long workspaceId, Set<ClusterTemplateViewV4Response> envPreparedTemplates) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/template/ClusterTemplateViewService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/template/ClusterTemplateViewService.java
@@ -37,7 +37,4 @@ public class ClusterTemplateViewService extends AbstractWorkspaceAwareResourceSe
         return repository.findAllActive(workspaceId);
     }
 
-    public Set<ClusterTemplateView> findAllByEnvironmentCrn(String environmentCrn) {
-        return repository.getAllByEnvironmentCrn(environmentCrn);
-    }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentResourceDeletionService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentResourceDeletionService.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.environment.environment.service;
 
-import static com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider.doAsInternalActor;
 import static com.sequenceiq.environment.TempConstants.TEMP_WORKSPACE_ID;
 
 import java.util.HashSet;
@@ -16,9 +15,9 @@ import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.ClusterTemplateV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.responses.ClusterTemplateViewV4Response;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.responses.ClusterTemplateViewV4Responses;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.DatalakeV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Response;
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.exception.UnableToDeleteClusterDefinitionException;
 import com.sequenceiq.distrox.api.v1.distrox.endpoint.DistroXV1Endpoint;
 import com.sequenceiq.environment.environment.domain.Environment;
@@ -49,12 +48,8 @@ public class EnvironmentResourceDeletionService {
 
     public void deleteClusterDefinitionsOnCloudbreak(String environmentCrn) {
         try {
-            Set<String> names = getClusterDefinitionNamesInEnvironment(environmentCrn);
-            if (!names.isEmpty()) {
-                clusterTemplateV4Endpoint.deleteMultiple(TEMP_WORKSPACE_ID, names, null, environmentCrn);
-            } else {
-                LOGGER.info("Cannot find any Cluster Definition for the environment");
-            }
+            Set<String> names = getClusterDefinitionNamesInEnvironment(TEMP_WORKSPACE_ID, environmentCrn);
+            clusterTemplateV4Endpoint.deleteMultiple(TEMP_WORKSPACE_ID, names, null, environmentCrn);
         } catch (WebApplicationException e) {
             propagateException("Failed to delete cluster definition(s) from Cloudbreak due to:", e);
         } catch (ProcessingException | UnableToDeleteClusterDefinitionException e) {
@@ -62,9 +57,9 @@ public class EnvironmentResourceDeletionService {
         }
     }
 
-    private Set<String> getClusterDefinitionNamesInEnvironment(String environmentCrn) {
-        ClusterTemplateViewV4Responses responses = doAsInternalActor(() -> clusterTemplateV4Endpoint.listByEnv(TEMP_WORKSPACE_ID, environmentCrn));
-        return responses.getResponses().stream()
+    private Set<String> getClusterDefinitionNamesInEnvironment(long tempWorkspaceId, String environmentCrn) {
+        return clusterTemplateV4Endpoint.list(TEMP_WORKSPACE_ID).getResponses().stream()
+                .filter(clusterTemplate -> environmentCrn.equals(clusterTemplate.getEnvironmentCrn()))
                 .map(ClusterTemplateViewV4Response::getName)
                 .collect(Collectors.toSet());
     }
@@ -91,7 +86,7 @@ public class EnvironmentResourceDeletionService {
         Set<String> clusterNames = new HashSet<>();
         LOGGER.debug("Get Datalake clusters of the environment: '{}'", environment.getName());
         try {
-            Set<String> datalakeClusterNames = doAsInternalActor(() -> datalakeV4Endpoint
+            Set<String> datalakeClusterNames = ThreadBasedUserCrnProvider.doAsInternalActor(() -> datalakeV4Endpoint
                     .list(null, environment.getResourceCrn())
                     .getResponses()
                     .stream()

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentResourceDeletionServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentResourceDeletionServiceTest.java
@@ -8,12 +8,10 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
-import java.util.Set;
 
 import javax.inject.Inject;
 import javax.ws.rs.ProcessingException;
@@ -32,7 +30,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.ClusterTemplateV4Endpoint;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.responses.ClusterTemplateViewV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.responses.ClusterTemplateViewV4Responses;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.DatalakeV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Responses;
@@ -109,10 +106,8 @@ class EnvironmentResourceDeletionServiceTest {
     @Test
     void testWhenDeleteClusterDefinitionsOnCloudbreakThrowsWebApplicationExceptionThenItShouldBeCatchedAndEnvironmentServiceExceptionShouldBeThrown() {
         WebApplicationException exception = Mockito.mock(WebApplicationException.class);
-        ClusterTemplateViewV4Response templateViewV4Response = new ClusterTemplateViewV4Response();
-        templateViewV4Response.setName("name");
-        when(clusterTemplateViewV4Responses.getResponses()).thenReturn(Set.of(templateViewV4Response));
-        when(clusterTemplateV4Endpoint.listByEnv(anyLong(), anyString())).thenReturn(clusterTemplateViewV4Responses);
+        when(clusterTemplateViewV4Responses.getResponses()).thenReturn(Collections.emptySet());
+        when(clusterTemplateV4Endpoint.list(anyLong())).thenReturn(clusterTemplateViewV4Responses);
         doThrow(exception).when(clusterTemplateV4Endpoint).deleteMultiple(eq(WORKSPACE_ID), any(), any(), eq(ENVIRONMENT_CRN));
         Response response = Mockito.mock(Response.class);
         when(exception.getResponse()).thenReturn(response);
@@ -128,10 +123,8 @@ class EnvironmentResourceDeletionServiceTest {
     @Test
     void testWhenDeleteClusterDefinitionsOnCloudbreakThrowsProcessingExceptionThenItShouldBeCatchedAndEnvironmentServiceExceptionShouldBeThrown() {
         doThrow(ProcessingException.class).when(clusterTemplateV4Endpoint).deleteMultiple(eq(WORKSPACE_ID), any(), any(), eq(ENVIRONMENT_CRN));
-        ClusterTemplateViewV4Response templateViewV4Response = new ClusterTemplateViewV4Response();
-        templateViewV4Response.setName("name");
-        when(clusterTemplateViewV4Responses.getResponses()).thenReturn(Set.of(templateViewV4Response));
-        when(clusterTemplateV4Endpoint.listByEnv(anyLong(), anyString())).thenReturn(clusterTemplateViewV4Responses);
+        when(clusterTemplateViewV4Responses.getResponses()).thenReturn(Collections.emptySet());
+        when(clusterTemplateV4Endpoint.list(anyLong())).thenReturn(clusterTemplateViewV4Responses);
 
         Assertions.assertThrows(EnvironmentServiceException.class,
                 () -> environmentResourceDeletionServiceUnderTest.deleteClusterDefinitionsOnCloudbreak(ENVIRONMENT_CRN));
@@ -144,27 +137,14 @@ class EnvironmentResourceDeletionServiceTest {
     void testWhenDeleteClusterDefinitionsThrowsUnableToDeleteClusterDefinitionExceptionThenItShouldBeCatchedAndEnvironmentServiceExceptionShouldBeThrown() {
         doThrow(UnableToDeleteClusterDefinitionException.class).when(clusterTemplateV4Endpoint).deleteMultiple(eq(WORKSPACE_ID), any(), any(),
                 eq(ENVIRONMENT_CRN));
-        ClusterTemplateViewV4Response templateViewV4Response = new ClusterTemplateViewV4Response();
-        templateViewV4Response.setName("name");
-        when(clusterTemplateViewV4Responses.getResponses()).thenReturn(Set.of(templateViewV4Response));
-        when(clusterTemplateV4Endpoint.listByEnv(anyLong(), anyString())).thenReturn(clusterTemplateViewV4Responses);
+        when(clusterTemplateViewV4Responses.getResponses()).thenReturn(Collections.emptySet());
+        when(clusterTemplateV4Endpoint.list(anyLong())).thenReturn(clusterTemplateViewV4Responses);
 
         Assertions.assertThrows(EnvironmentServiceException.class,
                 () -> environmentResourceDeletionServiceUnderTest.deleteClusterDefinitionsOnCloudbreak(ENVIRONMENT_CRN));
 
         verify(clusterTemplateV4Endpoint).deleteMultiple(anyLong(), any(), any(), anyString());
         verify(clusterTemplateV4Endpoint).deleteMultiple(eq(WORKSPACE_ID), any(), any(), eq(ENVIRONMENT_CRN));
-    }
-
-    @Test
-    void testWhenDeleteClusterDefinitionsWhenNamesEmpty() {
-        when(clusterTemplateViewV4Responses.getResponses()).thenReturn(Collections.emptySet());
-        when(clusterTemplateV4Endpoint.listByEnv(anyLong(), anyString())).thenReturn(clusterTemplateViewV4Responses);
-
-        environmentResourceDeletionServiceUnderTest.deleteClusterDefinitionsOnCloudbreak(ENVIRONMENT_CRN);
-
-        verify(clusterTemplateV4Endpoint, never()).deleteMultiple(anyLong(), any(), any(), anyString());
-        verify(clusterTemplateV4Endpoint, never()).deleteMultiple(eq(WORKSPACE_ID), any(), any(), eq(ENVIRONMENT_CRN));
     }
 
     @Configuration

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/clustertemplate/ClusterTemplateListAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/clustertemplate/ClusterTemplateListAction.java
@@ -1,9 +1,6 @@
 package com.sequenceiq.it.cloudbreak.action.v4.clustertemplate;
 
-import java.time.Duration;
 import java.util.Collection;
-
-import javax.ws.rs.ServerErrorException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,7 +10,6 @@ import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.action.Action;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.clustertemplate.ClusterTemplateTestDto;
-import com.sequenceiq.it.cloudbreak.exception.TestFailException;
 import com.sequenceiq.it.cloudbreak.log.Log;
 import com.sequenceiq.it.cloudbreak.util.ClusterTemplateUtil;
 
@@ -24,33 +20,11 @@ public class ClusterTemplateListAction implements Action<ClusterTemplateTestDto,
     @Override
     public ClusterTemplateTestDto action(TestContext testContext, ClusterTemplateTestDto testDto, CloudbreakClient client) throws Exception {
         Log.when(LOGGER, " ClusterTemplateEntity list request");
-        // because the default list is too slow, we need to check until finished, approx 3 mins
-        boolean run = true;
-        int maxRetry = 10;
-        int count = 0;
-        int waitInSec = 20;
-        long start = System.currentTimeMillis();
-        boolean success = false;
-        while (run && count < maxRetry) {
-            try {
-                Collection<ClusterTemplateViewV4Response> responses = client.getCloudbreakClient()
-                        .clusterTemplateV4EndPoint()
-                        .list(client.getWorkspaceId()).getResponses();
-                testDto.setResponses(ClusterTemplateUtil.getResponseFromViews(responses));
-                Log.whenJson(LOGGER, " ClusterTemplateEntity list successfully:\n", responses);
-                run = false;
-                success = true;
-            } catch (ServerErrorException e) {
-                LOGGER.info("Server exception occurred: {}", e.getMessage(), e);
-                Thread.sleep(Duration.ofSeconds(waitInSec).toMillis());
-            }
-            count++;
-        }
-        long duration = System.currentTimeMillis() - start;
-        if (!success) {
-            throw new TestFailException("Listing of cluster template timed out, cannot fetched in " + duration);
-        }
-        LOGGER.info("Cluster template listed in {}ms", duration);
+        Collection<ClusterTemplateViewV4Response> responses = client.getCloudbreakClient()
+                .clusterTemplateV4EndPoint()
+                .list(client.getWorkspaceId()).getResponses();
+        testDto.setResponses(ClusterTemplateUtil.getResponseFromViews(responses));
+        Log.whenJson(LOGGER, " ClusterTemplateEntity list successfully:\n", responses);
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
@@ -266,7 +266,6 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
                 .given(ClusterTemplateTestDto.class)
                 .withName(name)
                 .when(clusterTemplateTestClient.createV4(), RunningParameter.key(generatedKey))
-                .when(clusterTemplateTestClient.listV4())
                 .then((testContext1, testDto, client) -> clusterTemplateHasCreatedAndCanBeListed(testDto, client, name))
                 .validate();
     }
@@ -443,7 +442,7 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
     private ClusterTemplateTestDto clusterTemplateHasDeletedAlongTheEnvironment(ClusterTemplateTestDto entity, CloudbreakClient client, String templateName) {
         client.getCloudbreakClient()
                 .clusterTemplateV4EndPoint()
-                .listByEnv(client.getWorkspaceId(), entity.getResponse().getEnvironmentCrn())
+                .list(client.getWorkspaceId())
                 .getResponses()
                 .stream()
                 .filter(response -> templateName.equals(response.getName()))
@@ -455,7 +454,10 @@ public class ClusterTemplateTest extends AbstractIntegrationTest {
     }
 
     private ClusterTemplateTestDto clusterTemplateHasCreatedAndCanBeListed(ClusterTemplateTestDto entity, CloudbreakClient client, String templateName) {
-        entity.getResponses()
+        client.getCloudbreakClient()
+                .clusterTemplateV4EndPoint()
+                .list(client.getWorkspaceId())
+                .getResponses()
                 .stream()
                 .filter(response -> templateName.equals(response.getName()))
                 .findFirst().orElseThrow(() -> new TestFailException("The expected cluster definition does not exist in the list!"));


### PR DESCRIPTION
…n we fetched the cluster definition, we checked the default templates but this step was unnecessary, because we should delete the user managed only."

This reverts commit 0cea0a7f0a7e1c98b410c9b4873128d878cc1178.

See detailed description in the commit message.