### PR TITLE
CB-9154: Add ssl root cert and ssl mode to backup and restore PGSQL settings.

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/pillar/postgresql/disaster_recovery.sls
+++ b/orchestrator-salt/src/main/resources/salt/pillar/postgresql/disaster_recovery.sls
@@ -1,2 +1,3 @@
 disaster_recovery:
   object_storage_url:
+  root_cert_path: /hadoopfs/fs1/database-cacerts/certs.pem

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/backup.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/backup.sls
@@ -6,7 +6,7 @@ include:
 {% if 'None' != configure_remote_db %}
 backup_postgresql_db:
   cmd.run:
-    - name: /opt/salt/scripts/backup_db.sh {{salt['pillar.get']('disaster_recovery:object_storage_url')}} {{salt['pillar.get']('postgres:remote_db_url')}} {{salt['pillar.get']('postgres:remote_db_port')}} {{salt['pillar.get']('postgres:remote_admin')}} {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}}
+    - name: /opt/salt/scripts/backup_db.sh {{salt['pillar.get']('disaster_recovery:object_storage_url')}} {{salt['pillar.get']('postgres:remote_db_url')}} {{salt['pillar.get']('postgres:remote_db_port')}} {{salt['pillar.get']('postgres:remote_admin')}} {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}} {{salt['pillar.get']('disaster_recovery:root_cert_path')}}
     - require:
       - sls: postgresql.disaster_recovery
 
@@ -23,7 +23,7 @@ add_root_role_to_database:
 
 backup_postgresql_db:
   cmd.run:
-    - name: /opt/salt/scripts/backup_db.sh {{salt['pillar.get']('disaster_recovery:object_storage_url')}} "" "" "" {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}} "/var/lib/pgsql"
+    - name: /opt/salt/scripts/backup_db.sh {{salt['pillar.get']('disaster_recovery:object_storage_url')}} "" "" "" {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}} {{salt['pillar.get']('disaster_recovery:root_cert_path')}} "/var/lib/pgsql"
     - require:
       - cmd: add_root_role_to_database
 {% endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/backup.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/backup.sls
@@ -1,6 +1,5 @@
 {% set configure_remote_db = salt['pillar.get']('postgres:configure_remote_db', 'None') %}
 
-
 include:
   - postgresql.disaster_recovery
 

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/restore.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/restore.sls
@@ -6,7 +6,7 @@ include:
 {% if 'None' != configure_remote_db %}
 restore_postgresql_db:
   cmd.run:
-    - name: /opt/salt/scripts/restore_db.sh {{salt['pillar.get']('disaster_recovery:object_storage_url')}} {{salt['pillar.get']('postgres:remote_db_url')}} {{salt['pillar.get']('postgres:remote_db_port')}} {{salt['pillar.get']('postgres:remote_admin')}} {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}}
+    - name: /opt/salt/scripts/restore_db.sh {{salt['pillar.get']('disaster_recovery:object_storage_url')}} {{salt['pillar.get']('postgres:remote_db_url')}} {{salt['pillar.get']('postgres:remote_db_port')}} {{salt['pillar.get']('postgres:remote_admin')}} {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}} {{salt['pillar.get']('disaster_recovery:root_cert_path')}}
     - require:
         - sls: postgresql.disaster_recovery
 
@@ -23,7 +23,7 @@ add_root_role_to_database:
 
 restore_postgresql_db:
   cmd.run:
-    - name: /opt/salt/scripts/restore_db.sh {{salt['pillar.get']('disaster_recovery:object_storage_url')}} "" "" "" {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}} "/var/lib/pgsql"
+    - name: /opt/salt/scripts/restore_db.sh {{salt['pillar.get']('disaster_recovery:object_storage_url')}} "" "" "" {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}} {{salt['pillar.get']('disaster_recovery:root_cert_path')}} "/var/lib/pgsql"
     - require:
         - cmd: add_root_role_to_database
 {% endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
@@ -29,6 +29,11 @@ RANGERGROUP="$5"
 LOGFILE=${6:-/var/log/}/dl_postgres_backup.log
 echo "Logs at ${LOGFILE}"
 
+if [[ -f /hadoopfs/fs1/database-cacerts/certs.pem ]]; then
+  export PGSSLROOTCERT=/hadoopfs/fs1/database-cacerts/certs.pem
+  export PGSSLMODE=verify-full
+fi
+
 doLog() {
   set +x
   type_of_msg=$(echo "$@" | cut -d" " -f1)

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
@@ -9,15 +9,16 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-if [[ $# -ne 5 && $# -ne 6 ]]; then
+if [[ $# -ne 6 && $# -ne 7 ]]; then
   echo "Invalid inputs provided"
-  echo "Script accepts 5 inputs:"
+  echo "Script accepts 6 inputs:"
   echo "  1. Object Storage Service url to place backups."
   echo "  2. PostgreSQL host name."
   echo "  3. PostgreSQL port."
   echo "  4. PostgreSQL user name."
   echo "  5. Ranger admin group."
-  echo "  6. (optional) Log file location."
+  echo "  6. Root certificate path."
+  echo "  7. (optional) Log file location."
   exit 1
 fi
 
@@ -26,11 +27,12 @@ HOST="$2"
 PORT="$3"
 USERNAME="$4"
 RANGERGROUP="$5"
-LOGFILE=${6:-/var/log/}/dl_postgres_backup.log
+ROOT_CERT_PATH="$6"
+LOGFILE=${7:-/var/log/}/dl_postgres_backup.log
 echo "Logs at ${LOGFILE}"
 
-if [[ -f /hadoopfs/fs1/database-cacerts/certs.pem ]]; then
-  export PGSSLROOTCERT=/hadoopfs/fs1/database-cacerts/certs.pem
+if [[ -f ${ROOT_CERT_PATH} ]]; then
+  export PGSSLROOTCERT=${ROOT_CERT_PATH}
   export PGSSLMODE=verify-full
 fi
 

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/restore_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/restore_db.sh
@@ -30,6 +30,11 @@ echo "Logs at ${LOGFILE}"
 
 BACKUPS_DIR="/var/tmp/postgres_restore_staging"
 
+if [[ -f /hadoopfs/fs1/database-cacerts/certs.pem ]]; then
+  export PGSSLROOTCERT=/hadoopfs/fs1/database-cacerts/certs.pem
+  export PGSSLMODE=verify-full
+fi
+
 doLog() {
   set +x
   type_of_msg=$(echo "$@" | cut -d" " -f1)

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/restore_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/restore_db.sh
@@ -8,15 +8,16 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-if [[ $# -ne 5 && $# -ne 6 ]]; then
+if [[ $# -ne 6 && $# -ne 7 ]]; then
   echo "Invalid inputs provided"
-  echo "Script accepts 5 inputs:"
+  echo "Script accepts 6 inputs:"
   echo "  1. Object Storage Service url to retrieve backups."
   echo "  2. PostgreSQL host name."
   echo "  3. PostgreSQL port."
   echo "  4. PostgreSQL user name."
   echo "  5. Ranger admin group."
-  echo "  6. (optional) Log file location."
+  echo "  6. Root certificate path."
+  echo "  7. (optional) Log file location."
   exit 1
 fi
 
@@ -25,13 +26,14 @@ HOST="$2"
 PORT="$3"
 USERNAME="$4"
 RANGERGROUP="$5"
-LOGFILE=${6:-/var/log/}/dl_postgres_restore.log
+ROOT_CERT_PATH="$6"
+LOGFILE=${7:-/var/log/}/dl_postgres_restore.log
 echo "Logs at ${LOGFILE}"
 
 BACKUPS_DIR="/var/tmp/postgres_restore_staging"
 
-if [[ -f /hadoopfs/fs1/database-cacerts/certs.pem ]]; then
-  export PGSSLROOTCERT=/hadoopfs/fs1/database-cacerts/certs.pem
+if [[ -f ${ROOT_CERT_PATH} ]]; then
+  export PGSSLROOTCERT=${ROOT_CERT_PATH}
   export PGSSLMODE=verify-full
 fi
 


### PR DESCRIPTION
Check if a root cert exists on the instance.
* Run backup/restore with ssl-full, using the root cert if it's there.
* Fallback to default behavior if the root cert is not present.

Tested by `rsync`ing salt scripts on to a datalake master node and manually running salt backup and restore commands.
* `rsync` salt scripts
* `rsync` rds root certs to `/hadoopfs/fs1/database-cacerts/certs.pem`
* update pillar values with `ranger_admin_group` and `backup_location`
* run backup and restore:
```sh
salt $(hostname -f) state.apply postgresql.disaster_recovery.backup
salt $(hostname -f) state.apply postgresql.disaster_recovery.restore
```

Tested backup and restore when:
* Root cert present
* Root cert not present

And when `force_ssl` rds option is `0` and `1` in AWS.