### PR TITLE
CB-9250 mock idbroker mapping should be only applied if there is file…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/StackToTemplatePreparationObjectConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/StackToTemplatePreparationObjectConverter.java
@@ -304,7 +304,7 @@ public class StackToTemplatePreparationObjectConverter extends AbstractConversio
             AccountMapping accountMapping = isCloudStorageConfigured(source) ? source.getCluster().getFileSystem().getCloudStorage().getAccountMapping() : null;
             if (accountMapping != null) {
                 builder.withAccountMappingView(new AccountMappingView(accountMapping.getGroupMappings(), accountMapping.getUserMappings()));
-            } else if (environment.getIdBrokerMappingSource() == IdBrokerMappingSource.MOCK) {
+            } else if (environment.getIdBrokerMappingSource() == IdBrokerMappingSource.MOCK && source.getCluster().getFileSystem() != null) {
                 Map<String, String> groupMappings;
                 Map<String, String> userMappings;
                 String virtualGroup = getMockVirtualGroup(virtualGroupRequest);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v2/StackToTemplatePreparationObjectConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v2/StackToTemplatePreparationObjectConverterTest.java
@@ -469,12 +469,23 @@ public class StackToTemplatePreparationObjectConverterTest {
     @Test
     public void testMockAccountMappings() {
         when(virtualGroupService.getVirtualGroup(any(VirtualGroupRequest.class), eq(UmsRight.CLOUDER_MANAGER_ADMIN.getRight()))).thenReturn("mockAdmins");
+        when(stackMock.getCluster().getFileSystem()).thenReturn(new FileSystem());
         TemplatePreparationObject result = underTest.convert(stackMock);
 
         AccountMappingView accountMappingView = result.getAccountMappingView();
         assertNotNull(accountMappingView);
         assertEquals(MOCK_GROUP_MAPPINGS, accountMappingView.getGroupMappings());
         assertEquals(MOCK_USER_MAPPINGS, accountMappingView.getUserMappings());
+    }
+
+    @Test
+    public void testMockAccountMappingsWhenNoFileSystemShouldReturnEmptyList() {
+        when(virtualGroupService.getVirtualGroup(any(VirtualGroupRequest.class), eq(UmsRight.CLOUDER_MANAGER_ADMIN.getRight()))).thenReturn("mockAdmins");
+        when(stackMock.getCluster().getFileSystem()).thenReturn(null);
+        TemplatePreparationObject result = underTest.convert(stackMock);
+
+        AccountMappingView accountMappingView = result.getAccountMappingView();
+        assertNull(accountMappingView);
     }
 
     @Test


### PR DESCRIPTION
…system in the cluster object

See detailed description in the commit message.