### PR TITLE
CB-9174 - Creation of cluster definitions through the CLI is broken

### DIFF
--- a/common-model/src/main/java/com/sequenceiq/common/api/cloudstorage/query/ConfigQueryEntries.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/cloudstorage/query/ConfigQueryEntries.java
@@ -9,7 +9,15 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ConfigQueryEntries {
 
-    private final Set<ConfigQueryEntry> entries = new HashSet<>();
+    private final Set<ConfigQueryEntry> entries;
+
+    public ConfigQueryEntries() {
+        entries = new HashSet<>();
+    }
+
+    public ConfigQueryEntries(Set<ConfigQueryEntry> entries) {
+        this.entries = entries;
+    }
 
     public Set<ConfigQueryEntry> getEntries() {
         return entries
@@ -17,4 +25,5 @@ public class ConfigQueryEntries {
                 .map(ConfigQueryEntry::copy)
                 .collect(Collectors.toSet());
     }
+
 }

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/CloudStorageDecorator.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/CloudStorageDecorator.java
@@ -2,18 +2,27 @@ package com.sequenceiq.distrox.v1.distrox.converter;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.validation.constraints.NotNull;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.google.common.base.Strings;
+import com.sequenceiq.cloudbreak.cmtemplate.cloudstorage.CmCloudStorageConfigProvider;
+import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.service.blueprint.BlueprintService;
 import com.sequenceiq.cloudbreak.service.datalake.SdxClientService;
+import com.sequenceiq.cloudbreak.template.filesystem.FileSystemConfigQueryObject;
 import com.sequenceiq.common.api.cloudstorage.AwsStorageParameters;
 import com.sequenceiq.common.api.cloudstorage.CloudStorageRequest;
 import com.sequenceiq.common.api.cloudstorage.S3Guard;
@@ -23,6 +32,7 @@ import com.sequenceiq.common.api.cloudstorage.query.ConfigQueryEntry;
 import com.sequenceiq.common.api.telemetry.response.LoggingResponse;
 import com.sequenceiq.common.api.telemetry.response.TelemetryResponse;
 import com.sequenceiq.common.model.CloudIdentityType;
+import com.sequenceiq.common.model.CloudStorageCdpService;
 import com.sequenceiq.common.model.FileSystemType;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.sdx.api.model.SdxClusterResponse;
@@ -30,16 +40,21 @@ import com.sequenceiq.sdx.api.model.SdxClusterResponse;
 @Component
 public class CloudStorageDecorator {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(CloudStorageDecorator.class);
+
     @Inject
     private BlueprintService blueprintService;
 
     @Inject
     private SdxClientService sdxClientService;
 
+    @Inject
+    private CmCloudStorageConfigProvider cmCloudStorageConfigProvider;
+
     public CloudStorageRequest decorate(String blueprintName,
-        String clusterName,
-        CloudStorageRequest request,
-        DetailedEnvironmentResponse environment) {
+            String clusterName,
+            CloudStorageRequest request,
+            DetailedEnvironmentResponse environment) {
         if (environment != null) {
             if (request == null) {
                 request = new CloudStorageRequest();
@@ -86,29 +101,95 @@ public class CloudStorageDecorator {
     }
 
     public CloudStorageRequest updateCloudStorageLocations(String blueprintName, String clusterName,
-        CloudStorageRequest request, List<SdxClusterResponse> datalakes) {
-        if (hasDatalake(datalakes) && storageLocationsNotDefined(request)) {
-            if (request == null) {
-                request = new CloudStorageRequest();
-            }
-            SdxClusterResponse sdxClusterResponse = datalakes.get(0);
-            String baseLocation = sdxClusterResponse.getCloudStorageBaseLocation();
-            FileSystemType fileSystemType = sdxClusterResponse.getCloudStorageFileSystemType();
-            Set<ConfigQueryEntry> recommendations = new HashSet<>();
-            if (!Strings.isNullOrEmpty(baseLocation) && fileSystemType != null) {
-                recommendations = getFileSystemRecommendations(blueprintName, clusterName, baseLocation, fileSystemType.name());
-            }
-            if (request.getLocations() == null) {
-                request.setLocations(new ArrayList<>());
-            }
-            for (ConfigQueryEntry recommendation : recommendations) {
-                StorageLocationBase storageLocationBase = new StorageLocationBase();
-                storageLocationBase.setType(recommendation.getType());
-                storageLocationBase.setValue(recommendation.getDefaultPath());
-                request.getLocations().add(storageLocationBase);
+            CloudStorageRequest request, List<SdxClusterResponse> datalakes) {
+        if (hasDatalake(datalakes)) {
+            Pair<String, FileSystemType> sdxBaseLocationFileSystemType = getBaseLocationWithFileSystemTypeFromSdx(datalakes.get(0));
+            Set<ConfigQueryEntry> recommendations = getRecommendations(blueprintName, clusterName, sdxBaseLocationFileSystemType);
+            if (storageLocationsNotDefined(request)) {
+                if (request == null) {
+                    request = new CloudStorageRequest();
+                }
+                if (request.getLocations() == null) {
+                    request.setLocations(new ArrayList<>());
+                }
+                for (ConfigQueryEntry recommendation : recommendations) {
+                    request.getLocations().add(createStorageLocationBaseByTypeAndDefaultPath(recommendation.getType(), recommendation.getDefaultPath()));
+                }
+            } else {
+                Map<CloudStorageCdpService, String> templatedLocations = findLocationsThatContainsTemplatedValue(request);
+                if (!templatedLocations.isEmpty()) {
+                    LOGGER.info("Cloud storage location(s) has found with template placeholder(s). About to replace them with the recommended one(s).");
+                    Set<ConfigQueryEntry> filtered = filterConfigsWithTemplatePlaceholder(request, recommendations);
+                    Set<ConfigQueryEntry> replaced = queryParameters(filtered, blueprintName, clusterName, sdxBaseLocationFileSystemType);
+                    replaceTemplatedLocationValuesWithFilledValues(request, replaced, templatedLocations);
+                }
             }
         }
         return request;
+    }
+
+    private Set<ConfigQueryEntry> filterConfigsWithTemplatePlaceholder(CloudStorageRequest request, Set<ConfigQueryEntry> recommendations) {
+        Set<ConfigQueryEntry> filtered = new LinkedHashSet<>();
+        for (StorageLocationBase location : request.getLocations()) {
+            recommendations
+                    .stream()
+                    .filter(configQueryEntry -> configQueryEntry.getType().equals(location.getType()))
+                    .findFirst()
+                    .ifPresent(configQueryEntry -> {
+                        ConfigQueryEntry custom = configQueryEntry.copy();
+                        custom.setDefaultPath(location.getValue());
+                        filtered.add(custom);
+                    });
+        }
+        return filtered;
+    }
+
+    private Set<ConfigQueryEntry> queryParameters(Set<ConfigQueryEntry> filtered, String blueprintName, String clusterName,
+            Pair<String, FileSystemType> sdxBaseLocationFileSystemType) {
+        Pair<Blueprint, String> bt = blueprintService.getBlueprintAndText(blueprintName, 0L);
+        FileSystemConfigQueryObject fsConfigO = blueprintService.createFileSystemConfigQueryObject(bt, clusterName,
+                sdxBaseLocationFileSystemType.getLeft(), sdxBaseLocationFileSystemType.getRight().name(), "", true, false);
+        return cmCloudStorageConfigProvider.queryParameters(filtered, fsConfigO);
+    }
+
+    private Set<ConfigQueryEntry> getRecommendations(String blueprintName, String clusterName, Pair<String, FileSystemType> sdxBaseLocationFileSystemType) {
+        Set<ConfigQueryEntry> recommendations = new HashSet<>();
+        if (!Strings.isNullOrEmpty(sdxBaseLocationFileSystemType.getLeft()) && sdxBaseLocationFileSystemType.getRight() != null) {
+            LOGGER.debug("Getting file system recommendations for cluster: {}, blueprint: {}, base location: {}, file system type: {}",
+                    clusterName, blueprintName, sdxBaseLocationFileSystemType.getLeft(), sdxBaseLocationFileSystemType.getRight().name());
+            recommendations = getFileSystemRecommendations(blueprintName, clusterName, sdxBaseLocationFileSystemType.getLeft(),
+                    sdxBaseLocationFileSystemType.getRight().name());
+        }
+        return recommendations;
+    }
+
+    private Pair<String, FileSystemType> getBaseLocationWithFileSystemTypeFromSdx(SdxClusterResponse sdxClusterResponse) {
+        return Pair.of(sdxClusterResponse.getCloudStorageBaseLocation(), sdxClusterResponse.getCloudStorageFileSystemType());
+    }
+
+    private void replaceTemplatedLocationValuesWithFilledValues(CloudStorageRequest request, Set<ConfigQueryEntry> recommendations,
+            Map<CloudStorageCdpService, String> templatedLocations) {
+        recommendations
+                .stream()
+                .filter(entry -> templatedLocations.containsKey(entry.getType()))
+                .forEach(cqe -> {
+                    request.getLocations().removeIf(slb -> slb.getType().equals(cqe.getType()));
+                    request.getLocations().add(createStorageLocationBaseByTypeAndDefaultPath(cqe.getType(), cqe.getDefaultPath()));
+                });
+    }
+
+    private StorageLocationBase createStorageLocationBaseByTypeAndDefaultPath(CloudStorageCdpService type, String defaultPath) {
+        StorageLocationBase storageLocationBase = new StorageLocationBase();
+        storageLocationBase.setType(type);
+        storageLocationBase.setValue(defaultPath);
+        return storageLocationBase;
+    }
+
+    private Map<CloudStorageCdpService, String> findLocationsThatContainsTemplatedValue(CloudStorageRequest request) {
+        return request.getLocations()
+                .stream()
+                .filter(slb -> slb.getValue().matches(".+\\/\\{{3}.+\\}{3}\\/?.*"))
+                .collect(Collectors.toMap(slb -> slb.getType(), slb -> slb.getValue()));
     }
 
     private boolean hasDatalake(List<SdxClusterResponse> clusterResponses) {
@@ -120,10 +201,10 @@ public class CloudStorageDecorator {
     }
 
     private Set<ConfigQueryEntry> getFileSystemRecommendations(
-        String blueprint,
-        String clusterName,
-        String storageName,
-        String type) {
+            String blueprint,
+            String clusterName,
+            String storageName,
+            String type) {
         Set<ConfigQueryEntry> entries = blueprintService.queryFileSystemParameters(
                 blueprint,
                 clusterName,

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/CloudStorageDecoratorTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/CloudStorageDecoratorTest.java
@@ -6,19 +6,26 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.sequenceiq.cloudbreak.cmtemplate.cloudstorage.CmCloudStorageConfigProvider;
+import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.service.blueprint.BlueprintService;
 import com.sequenceiq.cloudbreak.service.datalake.SdxClientService;
+import com.sequenceiq.cloudbreak.template.filesystem.FileSystemConfigQueryObject;
 import com.sequenceiq.common.api.cloudstorage.CloudStorageRequest;
 import com.sequenceiq.common.api.cloudstorage.StorageLocationBase;
 import com.sequenceiq.common.api.cloudstorage.query.ConfigQueryEntry;
@@ -42,6 +49,9 @@ class CloudStorageDecoratorTest {
 
     @Mock
     private SdxClientService sdxClientService;
+
+    @Mock
+    private CmCloudStorageConfigProvider cmCloudStorageConfigProvider;
 
     @InjectMocks
     private CloudStorageDecorator underTest;
@@ -186,6 +196,104 @@ class CloudStorageDecoratorTest {
 
         assertNotNull(result);
         assertTrue(result.getLocations().stream().anyMatch(loc -> storageLocationType.equals(loc.getType()) && eStorageLocationValue.equals(loc.getValue())));
-
     }
+
+    @Test
+    void testUpdateCloudStorageLocationsWhenRequestContainsTemplatedLocationThenItShouldBeReplaced() {
+        CloudStorageCdpService storageLocationType = CloudStorageCdpService.DEFAULT_FS;
+        String eStorageLocationValue = "s3a://some-dir/some-other-dir/{{{clusterName}}}";
+        StorageLocationBase storageLocationBase = new StorageLocationBase();
+        storageLocationBase.setType(storageLocationType);
+        storageLocationBase.setValue(eStorageLocationValue);
+        List<StorageLocationBase> storageLocations = new ArrayList<>(1);
+        storageLocations.add(storageLocationBase);
+        CloudStorageRequest request = new CloudStorageRequest();
+        request.setLocations(storageLocations);
+        SdxClusterResponse sdxResponse = new SdxClusterResponse();
+        String storageLocationValue = "s3a://some-dir/some-other-dir/" + CLUSTER_NAME;
+        sdxResponse.setCloudStorageBaseLocation(storageLocationValue);
+        sdxResponse.setCloudStorageFileSystemType(FileSystemType.S3);
+
+        ConfigQueryEntry cqe = new ConfigQueryEntry();
+        cqe.setType(CloudStorageCdpService.DEFAULT_FS);
+        cqe.setDefaultPath(storageLocationValue);
+
+        Set<ConfigQueryEntry> cqes = new LinkedHashSet<>(1);
+        cqes.add(cqe);
+
+        when(blueprintService.queryFileSystemParameters(BLUEPRINT_NAME, CLUSTER_NAME, storageLocationValue, FileSystemType.S3.name(), "", true, false, 0L))
+                .thenReturn(cqes);
+
+        Pair<Blueprint, String> mockBt = mock(Pair.class);
+        when(blueprintService.getBlueprintAndText(BLUEPRINT_NAME, 0L)).thenReturn(mockBt);
+
+        FileSystemConfigQueryObject mockfscqo = mock(FileSystemConfigQueryObject.class);
+        when(blueprintService.createFileSystemConfigQueryObject(mockBt, CLUSTER_NAME, sdxResponse.getCloudStorageBaseLocation(),
+                sdxResponse.getCloudStorageFileSystemType().name(), "", true, false)).thenReturn(mockfscqo);
+
+        when(cmCloudStorageConfigProvider.queryParameters(any(), eq(mockfscqo))).thenReturn(cqes);
+
+        CloudStorageRequest result = underTest.updateCloudStorageLocations(BLUEPRINT_NAME, CLUSTER_NAME, request, List.of(sdxResponse));
+
+        assertNotNull(result);
+        assertEquals(0, result.getLocations().stream().filter(slb -> slb.getValue().contains("{{{") && slb.getValue().contains("}}}")).count());
+    }
+
+    @Test
+    void testUpdateCloudStorageLocationsWhenRequestContainsOneTemplatedLocationAndOneWithoutTemplatePlaceholderThenThatShouldBeReplaced() {
+        String templatedStorageLocationBaseValue = "s3a://some-dir/some-other-dir/";
+
+        CloudStorageCdpService templatedStorageLocationType = CloudStorageCdpService.DEFAULT_FS;
+        String templatedStorageLocationValue = templatedStorageLocationBaseValue + "{{{clusterName}}}";
+        StorageLocationBase templatedStorageLocationBase = new StorageLocationBase();
+        templatedStorageLocationBase.setType(templatedStorageLocationType);
+        templatedStorageLocationBase.setValue(templatedStorageLocationValue);
+
+        CloudStorageCdpService storageLocationType = CloudStorageCdpService.FLINK_JOBMANAGER_ARCHIVE;
+        String eStorageLocationValue = "s3a://some-awesome-dir/some-other-awesome-dir/" + CLUSTER_NAME;
+        StorageLocationBase storageLocationBase = new StorageLocationBase();
+        storageLocationBase.setType(storageLocationType);
+        storageLocationBase.setValue(eStorageLocationValue);
+
+        List<StorageLocationBase> storageLocations = new ArrayList<>(2);
+        storageLocations.add(storageLocationBase);
+        storageLocations.add(templatedStorageLocationBase);
+
+        ConfigQueryEntry cqe = new ConfigQueryEntry();
+        cqe.setType(CloudStorageCdpService.DEFAULT_FS);
+        cqe.setDefaultPath(templatedStorageLocationBaseValue + CLUSTER_NAME);
+
+        CloudStorageRequest request = new CloudStorageRequest();
+        request.setLocations(storageLocations);
+        SdxClusterResponse sdxReponse = new SdxClusterResponse();
+        String storageLocationValue = eStorageLocationValue;
+        sdxReponse.setCloudStorageBaseLocation(storageLocationValue);
+        sdxReponse.setCloudStorageFileSystemType(FileSystemType.S3);
+
+        ConfigQueryEntry cqeFlink = new ConfigQueryEntry();
+        cqeFlink.setType(CloudStorageCdpService.FLINK_JOBMANAGER_ARCHIVE);
+        cqeFlink.setDefaultPath(storageLocationValue);
+
+        Set<ConfigQueryEntry> cqes = new LinkedHashSet<>(1);
+        cqes.add(cqe);
+        cqes.add(cqeFlink);
+
+        when(blueprintService.queryFileSystemParameters(BLUEPRINT_NAME, CLUSTER_NAME, storageLocationValue, FileSystemType.S3.name(), "", true, false, 0L))
+                .thenReturn(cqes);
+
+        Pair<Blueprint, String> mockBt = mock(Pair.class);
+        when(blueprintService.getBlueprintAndText(BLUEPRINT_NAME, 0L)).thenReturn(mockBt);
+
+        FileSystemConfigQueryObject mockfscqo = mock(FileSystemConfigQueryObject.class);
+        when(blueprintService.createFileSystemConfigQueryObject(mockBt, CLUSTER_NAME, sdxReponse.getCloudStorageBaseLocation(),
+                sdxReponse.getCloudStorageFileSystemType().name(), "", true, false)).thenReturn(mockfscqo);
+
+        when(cmCloudStorageConfigProvider.queryParameters(any(), eq(mockfscqo))).thenReturn(cqes);
+
+        CloudStorageRequest result = underTest.updateCloudStorageLocations(BLUEPRINT_NAME, CLUSTER_NAME, request, List.of(sdxReponse));
+
+        assertNotNull(result);
+        assertEquals(0, result.getLocations().stream().filter(slb -> slb.getValue().contains("{{{") && slb.getValue().contains("}}}")).count());
+    }
+
 }

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/cloudstorage/CmCloudStorageConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/cloudstorage/CmCloudStorageConfigProvider.java
@@ -53,6 +53,11 @@ public class CmCloudStorageConfigProvider {
         return cloudStorageConfigDetails.queryParameters(cmTemplateProcessor, configQueryEntries, request);
     }
 
+    public Set<ConfigQueryEntry> queryParameters(Set<ConfigQueryEntry> entries, FileSystemConfigQueryObject request) {
+        CmTemplateProcessor cmTemplateProcessor = cmTemplateProcessorFactory.get(request.getBlueprintText());
+        return cloudStorageConfigDetails.queryParameters(cmTemplateProcessor, new ConfigQueryEntries(entries), request);
+    }
+
     public ConfigQueryEntries getConfigQueryEntries() {
         return configQueryEntries;
     }


### PR DESCRIPTION
When a DH cluster creation has triggered with an existing custom cluster definition that contains storage location with template indicators (handlebars), the cluster creation fails because CB didn't replace the template placeholders with the actual value.

See detailed description in the commit message.