### PR TITLE
CB-9397 Don't purge `FlowChainLog` which has a child `FlowChain`

### DIFF
--- a/flow/src/main/java/com/sequenceiq/flow/repository/FlowChainLogRepository.java
+++ b/flow/src/main/java/com/sequenceiq/flow/repository/FlowChainLogRepository.java
@@ -22,6 +22,8 @@ public interface FlowChainLogRepository extends CrudRepository<FlowChainLog, Lon
     Optional<FlowChainLog> findFirstByFlowChainIdOrderByCreatedDesc(String flowChainId);
 
     @Modifying
-    @Query("DELETE FROM FlowChainLog fch WHERE fch.flowChainId NOT IN ( SELECT DISTINCT fl.flowChainId FROM FlowLog fl )")
+    @Query("DELETE FROM FlowChainLog fch "
+            + "WHERE fch.flowChainId NOT IN ( SELECT DISTINCT fl.flowChainId FROM FlowLog fl )"
+            + " AND fch.flowChainId NOT IN (SELECT DISTINCT fc.parentFlowChainId FROM FlowChainLog fc)")
     int purgeOrphanFLowChainLogs();
 }


### PR DESCRIPTION
We can create FlowChains which are parent of other FlowChains. The
current logic checked only FlowLogs which resulted in deleting these
parent FlowChains. The SQL query has been extended with a condition to
check if a FlowChain has child FlowChain.